### PR TITLE
Small typos

### DIFF
--- a/includes/widgets-manager.php
+++ b/includes/widgets-manager.php
@@ -130,7 +130,7 @@ class Widgets_Manager {
 		ob_start();
 
 		if ( empty( $_POST['post_id'] ) ) {
-			wp_send_json_error( new \WP_Error( 'no_post_id', __( 'No put post_id', 'elementor' ) ) );
+			wp_send_json_error( new \WP_Error( 'no_post_id', __( 'No post_id', 'elementor' ) ) );
 		}
 
 		// Override the global $post for the render

--- a/includes/widgets/testimonial.php
+++ b/includes/widgets/testimonial.php
@@ -103,7 +103,7 @@ class Widget_testimonial extends Widget_Base {
 		$this->add_control(
 			'testimonial_detailes_position',
 			[
-				'label' => __( 'Testimonial Detailes Position', 'elementor' ),
+				'label' => __( 'Testimonial Details Position', 'elementor' ),
 				'type' => Controls_Manager::CHOOSE,
 				'default' => 'Elementor',
 				'section' => 'section_testimonial',


### PR DESCRIPTION
Typos in strings below:
'No **put** post_id'
'Testimonial Detail**e**s Position' *(if this was correctly found as a typo, there are a lot of coded variables with the same typo in `testemonial.php`and css files)
