### PR TITLE
Added hooks to allow customizing default elementor widgets

### DIFF
--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -115,6 +115,9 @@ abstract class Element_Base {
 	}
 
 	public function add_control( $id, $args ) {
+		$args = apply_filters( 'elementor/elements/add_control', $args, $id, $this );
+		$args = apply_filters( 'elementor/elements/add_control/' . $id, $args, $id, $this );
+		
 		if ( empty( $args['type'] ) || ! in_array( $args['type'], [ Controls_Manager::SECTION, Controls_Manager::WP_WIDGET ] ) ) {
 			if ( null !== $this->_current_section ) {
 				if ( ! empty( $args['section'] ) || ! empty( $args['tab'] ) ) {
@@ -129,9 +132,6 @@ abstract class Element_Base {
 				wp_die( __CLASS__ . '::' . __FUNCTION__ . ': Cannot add a control outside a section (use `start_controls_section`).' );
 			}
 		}
-
-		$args = apply_filters( 'elementor/elements/add_control', $args, $id );
-		$args = apply_filters( 'elementor/elements/add_control/' . $id, $args, $id );
 
 		return Plugin::instance()->controls_manager->add_control_to_stack( $this, $id, $args );
 	}

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -130,6 +130,9 @@ abstract class Element_Base {
 			}
 		}
 
+		$args = apply_filters( 'elementor/elements/add_control', $args, $id );
+		$args = apply_filters( 'elementor/elements/add_control/' . $id, $args, $id );
+
 		return Plugin::instance()->controls_manager->add_control_to_stack( $this, $id, $args );
 	}
 


### PR DESCRIPTION
Hey guys, so here is the thing: I wanted to add some custom button style and i found out that there is no way. So I thought I should add a filter to allow just that. And instead of adding a filter only for button, I thought: what if... I add a filter for _all_ fields? So here it is :)

Usage:

```
add_filter('elementor/elements/add_control/button_type', function($args, $id)
{
  $args['options']['my-button'] = __('My Button Style!');
  return $args;
}, 10, 2);
```

![2016-11-19__27_10](https://cloud.githubusercontent.com/assets/132062/20457545/948c363a-ae96-11e6-9fd7-27af7c8b6aa7.jpg)
