### PR TITLE
Custom control hooks

### DIFF
--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -622,7 +622,9 @@ abstract class Element_Base {
 	private function _init_controls() {
 		Plugin::instance()->controls_manager->open_stack( $this );
 
+		do_action( 'elementor/element/before_register_controls', $this );
 		$this->_register_controls();
+		do_action( 'elementor/element/after_register_controls', $this );
 	}
 
 	private function _init_children() {

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -115,6 +115,9 @@ abstract class Element_Base {
 	}
 
 	public function add_control( $id, $args ) {
+		$args = apply_filters( 'elementor/elements/add_control', $args, $id, $this );
+		$args = apply_filters( 'elementor/elements/add_control/' . $id, $args, $id, $this );
+
 		if ( empty( $args['type'] ) || ! in_array( $args['type'], [ Controls_Manager::SECTION, Controls_Manager::WP_WIDGET ] ) ) {
 			if ( null !== $this->_current_section ) {
 				if ( ! empty( $args['section'] ) || ! empty( $args['tab'] ) ) {

--- a/includes/base/widget-base.php
+++ b/includes/base/widget-base.php
@@ -167,6 +167,9 @@ abstract class Widget_Base extends Element_Base {
 		if ( Plugin::instance()->editor->is_edit_mode() ) {
 			$this->_render_settings();
 		}
+
+		do_action( 'elementor/widget/before_render_content', $this );
+
 		?>
 		<div class="elementor-widget-container">
 			<?php

--- a/includes/controls/groups/base.php
+++ b/includes/controls/groups/base.php
@@ -73,8 +73,11 @@ abstract class Group_Control_Base implements Group_Control_Interface {
 
 	private function _filter_controls() {
 		$args = $this->get_args();
+		$args = apply_filters( 'elementor/elements/filter_controls/args', $args, $this );
 
 		$controls = $this->_get_controls( $args );
+
+		$controls = apply_filters( 'elementor/elements/filter_controls/controls', $controls, $this, $args );
 
 		if ( ! is_array( $args['fields'] ) ) {
 			return $controls;

--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -357,7 +357,10 @@ class Widget_Image extends Widget_Base {
 				link_url = settings.image.url;
 			}
 
-			#><div class="elementor-image{{ settings.shape ? ' elementor-image-shape-' + settings.shape : '' }}"><#
+			var wrapper_class_name = settings.shape ? ' elementor-image-shape-' + settings.shape : '';
+			wrapper_class_name += ' ' + <?php echo apply_filters( 'elementor/widgets/image/content_template/wrapper_class_name', '' ); ?>;
+			console.log(wrapper_class_name, settings)
+			#><div class="elementor-image{{ wrapper_class_name }}"><#
 			var imgClass = '',
 				hasCaption = '' !== settings.caption;
 


### PR DESCRIPTION
This is a tweaked version of one of my previous PR. #889 

This will allow you to do this:

1. tweak/edit existing fields via `elementor/elements/add_control` filter;
1. tweak existing fields output (e.g. add a custom `add_render_attribute`) via `elementor/widget/before_render_content`
1. Allow registering custom sections on existing fields, either before or after via `elementor/element/after_register_controls` hook;
1. Tweak the image field class.

This last point is added because i noticed there is no way of adding a custom class on the preview image.