### PR TITLE
Added hooks to allow changing container class names

### DIFF
--- a/includes/base/widget-base.php
+++ b/includes/base/widget-base.php
@@ -126,10 +126,10 @@ abstract class Widget_Base extends Element_Base {
 		?>
 		<script type="text/html" id="tmpl-elementor-<?php echo static::get_type(); ?>-<?php echo esc_attr( $this->get_name() ); ?>-content">
 			<?php self::_render_settings();
-			$container_class_name = apply_filters( 'elementor/widget/print_template/container_class_name', ["'elementor-widget-container '"], $this );
+			$container_class_name = apply_filters( 'elementor/widget/print_template/container_class_name', [ "'elementor-widget-container '" ], $this );
 			?>
 			<#
-				var container_class_name = <?php echo implode(" + ", $container_class_name); ?>;
+				var container_class_name = <?php echo implode( ' + ', $container_class_name ); ?>;
 			#>
 
 			<div class="{{ container_class_name }}">
@@ -173,9 +173,9 @@ abstract class Widget_Base extends Element_Base {
 		if ( Plugin::instance()->editor->is_edit_mode() ) {
 			$this->_render_settings();
 		}
-		$container_class_name = apply_filters( 'elementor/widget/render/container_class_name', ['elementor-widget-container'], $this );
+		$container_class_name = apply_filters( 'elementor/widget/render/container_class_name', [ 'elementor-widget-container' ], $this );
 		?>
-		<div class="<?php echo implode(' ', $container_class_name) ?>">
+		<div class="<?php echo implode( ' ', $container_class_name ) ?>">
 			<?php
 			ob_start();
 

--- a/includes/base/widget-base.php
+++ b/includes/base/widget-base.php
@@ -125,8 +125,14 @@ abstract class Widget_Base extends Element_Base {
 		}
 		?>
 		<script type="text/html" id="tmpl-elementor-<?php echo static::get_type(); ?>-<?php echo esc_attr( $this->get_name() ); ?>-content">
-			<?php self::_render_settings(); ?>
-			<div class="elementor-widget-container">
+			<?php self::_render_settings();
+			$container_class_name = apply_filters( 'elementor/widget/print_template/container_class_name', ["'elementor-widget-container '"], $this );
+			?>
+			<#
+				var container_class_name = <?php echo implode(" + ", $container_class_name); ?>;
+			#>
+
+			<div class="{{ container_class_name }}">
 				<?php echo $content_template; ?>
 			</div>
 		</script>
@@ -167,8 +173,9 @@ abstract class Widget_Base extends Element_Base {
 		if ( Plugin::instance()->editor->is_edit_mode() ) {
 			$this->_render_settings();
 		}
+		$container_class_name = apply_filters( 'elementor/widget/render/container_class_name', ['elementor-widget-container'], $this );
 		?>
-		<div class="elementor-widget-container">
+		<div class="<?php echo implode(' ', $container_class_name) ?>">
 			<?php
 			ob_start();
 


### PR DESCRIPTION
### Use case

Although there are hooks that will allow you to add custom controls, there is no reasonable way of toggling a class name.

### Usage

```
add_action('elementor/element/before_section_end', function ($instance, $id, $args) {
	if ($id == 'section_counter') {
		$instance->add_control(
			'is_rounded',
			[
				'label' => __( 'Is Rounded Box?', 'elementor' ),
				'type' => \Elementor\Controls_Manager::SWITCHER,
				'default' => 0,
				'return_value' => 1,
				'label_on' => __('Yes', 'elementor'),
				'label_off' => __('No', 'elementor'),
				'selector' => '{{WRAPPER}}',
			]
		);
	}
}, 10, 3);


add_filter('elementor/widget/render/container_class_name', function ($classNames, $instance) {
	$settings = $instance->get_settings();

	if ($instance->get_name() == 'counter') {
		$classNames[] = $settings['is_rounded'] ? ' is-rounded' : '';
	}

	return $classNames;
}, 10, 2);


add_filter('elementor/widget/print_template/container_class_name', function ($classNames, $instance)
{
	if ($instance->get_name() == 'counter') {
		$classNames[] = '(settings.is_rounded ? "is-rounded" : "")';
	}

	return $classNames;
}, 10, 2);
```