### PR TITLE
Added filter to customize layout structures

### DIFF
--- a/includes/elements/section.php
+++ b/includes/elements/section.php
@@ -82,6 +82,8 @@ class Element_Section extends Element_Base {
 			],
 		];
 
+		$additional_presets = apply_filters( 'elementor/element/section/column_preset', $additional_presets );
+
 		foreach ( range( 1, 10 ) as $columns_count ) {
 			self::$presets[ $columns_count ] = [
 				[


### PR DESCRIPTION
Sometimes you may need other/extra defaults on the structure templates. You can add them like this:

```
add_filter('elementor/element/section/column_preset', function($presets)
{
	$presets[3][] = [
		'preset' => [10, 20, 70]
	];

	return $presets;
});
```

The result: 

![](http://img.iamntz.com/jing/2016-12-06__56_14.jpg)