### PR TITLE
Use (node) lib sass instead of the ruby gem

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,6 +52,9 @@ module.exports = function( grunt ) {
 		},
 
 		sass: {
+			options: {
+				sourceMap: true
+			},
 			dist: {
 				files: [ {
 					expand: true,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
 		"grunt-contrib-watch": "^1.0.0",
 		"grunt-postcss": "~0.8.0",
 		"grunt-contrib-uglify": "~2.0.0",
-		"grunt-contrib-sass": "~1.0.0",
 		"autoprefixer": "~6.5.3",
 		"cssnano": "~3.8.0",
 		"grunt-checktextdomain": "~1.0.1",
@@ -27,7 +26,8 @@
 		"grunt-contrib-copy": "~1.0.0",
 		"grunt-contrib-clean": "~1.0.0",
 		"remapify": "2.1.0",
-		"matchdep": "~1.0.1"
+		"matchdep": "~1.0.1",
+		"grunt-sass": "^2.0.0"
 	},
 	"browserify": {
 		"transform": [


### PR DESCRIPTION
[Libsass ](http://sass-lang.com/libsass) is the native version of sass, which is faster and doesn't required Ruby to be installed. 

How much faster you may ask?

```
Execution Time (2016-12-14 20:21:30 UTC+2)
loading tasks    3.6s  ████████████████████████████████████████████████████ 40%
sass:dist        3.2s  ██████████████████████████████████████████████ 36%
postcss:dev     893ms  █████████████ 10%
postcss:minify   1.3s  ███████████████████ 14%
Total 9s
```

```
Execution Time (2016-12-14 20:22:12 UTC+2)
loading tasks    3.6s  ████████████████████████████████████████████████████████████████████████████ 59%
sass:dist       170ms  ████ 3%
postcss:dev     982ms  █████████████████████ 16%
postcss:minify   1.4s  █████████████████████████████ 22%
Total 6.1s
```

Yup, _that_ faster.

But for some reason it can't be merged into `develop`. Basically, this is drop-in replacement (ish): you only need `sourceMap` option set in order to place the sourcemap in a separate file, not at the end of the compiled file.
