### PR TITLE
register_controls method should be private

### DIFF
--- a/includes/managers/controls.php
+++ b/includes/managers/controls.php
@@ -85,7 +85,7 @@ class Controls_Manager {
 	/**
 	 * @since 1.0.0
 	 */
-	public function register_controls() {
+	private function register_controls() {
 		$this->_controls = [];
 
 		$available_controls = [


### PR DESCRIPTION
register_controls method should be private as it can be called only once as the second time it throws class already defined errors. Proper access to this method is through: get_controls()