### PR TITLE
Possibility to override easily default widget

### DIFF
--- a/includes/managers/widgets.php
+++ b/includes/managers/widgets.php
@@ -47,6 +47,12 @@ class Widgets_Manager {
 
 		foreach ( $build_widgets_filename as $widget_filename ) {
 			include( ELEMENTOR_PATH . 'includes/widgets/' . $widget_filename . '.php' );
+			
+			$override_file = get_template_directory() . '/elementor/widgets/' . $widget_filename . '_override.php';
+			if ( file_exists( $override_file ) ) {
+				include( $override_file );
+				$widget_filename .= '_override';
+			}
 
 			$class_name = str_replace( '-', '_', $widget_filename );
 


### PR DESCRIPTION
I don't know if you agree with that. But I purpose because it's overkill to create a complete button widget if I only want add/edit a simple control. It is enough for the developer to create a file in a specific location of his theme.
Example : I've created elementor/widgets/button_override.php in my template folder
"_override" must be respected to avoid mistakes with other classes.

```php
<?php

namespace Elementor;

class Widget_Button_Override extends Widget_Button
{
    // Write override here...
}
```
