### PR TITLE
CSS select only elementor related iframes

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-@charset "UTF-8";
+﻿@charset "UTF-8";
 .dialog-widget {
   position: fixed;
   height: 100%;
@@ -130,7 +130,9 @@ body.admin-bar .dialog-close-button {
   .elementor .elementor-widget:not(.elementor-widget-text-editor) figure {
     margin: 0; }
   .elementor embed,
-  .elementor iframe,
+  .elementor-custom-embed iframe,
+  .elementor-soundcloud-wrapper iframe,
+  .elementor-video-wrapper iframe,
   .elementor object,
   .elementor video {
     max-width: 100%;


### PR DESCRIPTION
Hello,
I would like to use iframes like this:
```
<div style="text-align:center;">
    <iframe src="localhost" width="800"></iframe>
</div>
```
iframes are indeed inline elements. so the above method should work fine...
However, Elementor is over-zealously selecting all iframes with the width 100% css rule.

Would be great if Elementor would only select the iframes that it inserts.

In this PR, I had a go at changing the `frontend.css` to do the above, but I can't be sure that I didn't break something that requires the iframe rules - may have accidentally ommited a few selectors because I don't know the project well enough yet.

Please, let me know your thoughts!