### PR TITLE
Fix error within getCurrentDeviceMode function

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -272,6 +272,7 @@ module.exports = ElementsHandler;
 		};
 
 		this.getCurrentDeviceMode = function() {
+			if ( elements.$elementor[ 0 ] === undefined ) return;
 			return getComputedStyle( elements.$elementor[ 0 ], ':after' ).content.replace( /"/g, '' );
 		};
 


### PR DESCRIPTION
Throws the following error:
Uncaught TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
<img width="1122" alt="screen shot 2017-08-26 at 3 26 22 pm" src="https://user-images.githubusercontent.com/1505631/29740394-2959861a-8a73-11e7-864e-823a31dcfa42.png">
