### PR TITLE
i18n: Remove required PHP version from the translation string

### DIFF
--- a/elementor.php
+++ b/elementor.php
@@ -77,7 +77,8 @@ function elementor_load_plugin_textdomain() {
  * @return void
  */
 function elementor_fail_php_version() {
-	$message = esc_html__( 'Elementor requires PHP version 5.4+, plugin is currently NOT ACTIVE.', 'elementor' );
+	/* translators: %s: PHP version */
+	$message = sprintf( esc_html__( 'Elementor requires PHP version %s+, plugin is currently NOT ACTIVE.', 'elementor' ), '5.4' );
 	$html_message = sprintf( '<div class="error">%s</div>', wpautop( $message ) );
 	echo wp_kses_post( $html_message );
 }


### PR DESCRIPTION
The minimum required PHP version is part of the translation string. It should not be there. Translators can accidentally translate to wrong version.

All variables, function names and class names should be replaced with `%s` placeholders. This is the best practice. The same is currently done in WordPress 4.9 (the next major release).

Old translation string: 

* `Elementor requires PHP version 5.4+, plugin is currently NOT ACTIVE.`

New translation string:

* `Elementor requires PHP version %s+, plugin is currently NOT ACTIVE.`