### PR TITLE
Update main post meta alongside revision meta during save action

### DIFF
--- a/includes/db.php
+++ b/includes/db.php
@@ -45,7 +45,7 @@ class DB {
 			$this->remove_draft( $post_id );
 
 			// Don't use `update_post_meta` that can't handle `revision` post type
-			$is_meta_updated = update_metadata( 'post', $post_id, '_elementor_data', $json_value );
+			$is_meta_updated = update_metadata( 'post', $post_id, '_elementor_data', $json_value ) && update_post_meta( $post_id, '_elementor_data', $json_value );
 
 			do_action( 'elementor/db/before_save', $status, $is_meta_updated );
 


### PR DESCRIPTION
Elementor's way of changing metadata so far was to save initial data into the post and all other changes into revisions, for example:
```
+----+-----------+----------------------------+-------------+
| ID | post_type | _elementor_data            | post_parent |
+----+-----------+----------------------------+-------------+
| 1  | post      | [first data that is saved]  | 0           |
+----+-----------+----------------------------+-------------+
| 2  | revision  | [a change]                 | 1           |
+----+-----------+----------------------------+-------------+
| 3  | revision  | [a second change]          | 2           |
+----+-----------+----------------------------+-------------+
```
Original post meta is never changed after post creation.

But that is raising couple issues and concerns:
1. WordPress XML export does not export revisions, so we always get only original elementor data (which is obsolete after editing the original post)
2. There are plugins to clear post revisions, and users might be tricked to think that it's safe to clear them for Elementor and it would be disastrous to find out later that all their changes have been lost. (also, some cache clearing/website speedup plugins *might* do the same)

So, this fix is "making a backup" of the most recent revision.

Also, WordPress saves revision as a copy of main post, it does not update revision directly, so the most recent revision always matches the post. ([source for the function call](https://core.trac.wordpress.org/browser/trunk/src/wp-includes/default-filters.php#L313) and [source for the function](https://core.trac.wordpress.org/browser/trunk/src/wp-includes/revision.php#L112))

This fix would mimic the WordPress behavior while still having compatibility with Elementor.