### PR TITLE
Accessibility: accessible widget search

### DIFF
--- a/includes/editor-templates/panel-elements.php
+++ b/includes/editor-templates/panel-elements.php
@@ -30,7 +30,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 </script>
 
 <script type="text/template" id="tmpl-elementor-panel-element-search">
-	<input id="elementor-panel-elements-search-input" placeholder="<?php _e( 'Search Widget...', 'elementor' ); ?>" />
+	<label for="elementor-panel-elements-search-input" class="screen-reader-text"><?php echo __( 'Search Widget:', 'elementor' ); ?></label>
+	<input type="search" id="elementor-panel-elements-search-input" placeholder="<?php esc_attr_e( 'Search Widget...', 'elementor' ); ?>" />
 	<i class="fa fa-search"></i>
 </script>
 


### PR DESCRIPTION
The widget search is not accessible. It should either use `role="search"` or `type="search"`.

In addition, the `input` field should have a `label` for screen readers. We hide the `label` for regular users using `class="screen-reader-text"`, this way only screen readers "see" it.

Ref: https://www.w3.org/TR/html-aria/

![elementor-widget-search](https://user-images.githubusercontent.com/576623/33266487-8a68bb8e-d37e-11e7-978c-73ff934a0dff.png)
