### PR TITLE
a11y: Use `aria-hidden=true` in screen-readers to hide icons used purely for decoration

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -123,7 +123,7 @@ class Admin {
 			<button id="elementor-switch-mode-button" class="elementor-button button button-primary button-hero">
 				<span class="elementor-switch-mode-on"><?php _e( '&#8592; Back to WordPress Editor', 'elementor' ); ?></span>
 				<span class="elementor-switch-mode-off">
-					<i class="eicon-elementor"></i>
+					<i class="eicon-elementor" aria-hidden="true"></i>
 					<?php _e( 'Edit with Elementor', 'elementor' ); ?>
 				</span>
 			</button>
@@ -131,7 +131,7 @@ class Admin {
 		<div id="elementor-editor">
 			<a id="elementor-go-to-edit-page-link" href="<?php echo Utils::get_edit_link( $post->ID ); ?>">
 				<div id="elementor-editor-button" class="elementor-button button button-primary button-hero">
-					<i class="eicon-elementor"></i>
+					<i class="eicon-elementor" aria-hidden="true"></i>
 					<?php _e( 'Edit with Elementor', 'elementor' ); ?>
 				</div>
 				<div class="elementor-loader-wrapper">
@@ -299,7 +299,7 @@ class Admin {
 		<div class="notice updated is-dismissible elementor-message elementor-message-dismissed" data-notice_id="<?php echo esc_attr( $notice_id ); ?>">
 			<div class="elementor-message-inner">
 				<div class="elementor-message-icon">
-					<i class="eicon-elementor-square"></i>
+					<i class="eicon-elementor-square" aria-hidden="true"></i>
 				</div>
 				<div class="elementor-message-content">
 					<strong><?php _e( 'Update Notification', 'elementor' ); ?></strong>
@@ -324,7 +324,10 @@ class Admin {
 					</p>
 				</div>
 				<div class="elementor-message-action">
-					<a class="button elementor-button" href="<?php echo $upgrade_url; ?>"><i class="dashicons dashicons-update"></i><?php _e( 'Update Now', 'elementor' ); ?></a>
+					<a class="button elementor-button" href="<?php echo $upgrade_url; ?>">
+						<i class="dashicons dashicons-update" aria-hidden="true"></i>
+						<?php _e( 'Update Now', 'elementor' ); ?>
+					</a>
 				</div>
 			</div>
 		</div>
@@ -415,7 +418,7 @@ class Admin {
 		?>
 		<div id="elementor-deactivate-feedback-dialog-wrapper">
 			<div id="elementor-deactivate-feedback-dialog-header">
-				<i class="eicon-elementor-square"></i>
+				<i class="eicon-elementor-square" aria-hidden="true"></i>
 				<span id="elementor-deactivate-feedback-dialog-header-title"><?php _e( 'Quick Feedback', 'elementor' ); ?></span>
 			</div>
 			<form id="elementor-deactivate-feedback-dialog-form" method="post">

--- a/includes/controls/choose.php
+++ b/includes/controls/choose.php
@@ -115,7 +115,8 @@ class Control_Choose extends Base_Data_Control {
 					<# _.each( data.options, function( options, value ) { #>
 					<input id="<?php echo $control_uid; ?>" type="radio" name="elementor-choose-{{ data.name }}-{{ data._cid }}" value="{{ value }}">
 					<label class="elementor-choices-label tooltip-target" for="<?php echo $control_uid; ?>" data-tooltip="{{ options.title }}" title="{{ options.title }}">
-						<i class="{{ options.icon }}"></i>
+						<i class="{{ options.icon }}" aria-hidden="true"></i>
+						<span class="elementor-screen-only">{{ options.title }}</span>
 					</label>
 					<# } ); #>
 				</div>

--- a/includes/controls/choose.php
+++ b/includes/controls/choose.php
@@ -116,7 +116,7 @@ class Control_Choose extends Base_Data_Control {
 					<input id="<?php echo $control_uid; ?>" type="radio" name="elementor-choose-{{ data.name }}-{{ data._cid }}" value="{{ value }}">
 					<label class="elementor-choices-label tooltip-target" for="<?php echo $control_uid; ?>" data-tooltip="{{ options.title }}" title="{{ options.title }}">
 						<i class="{{ options.icon }}" aria-hidden="true"></i>
-						<span class="elementor-screen-only">{{ options.title }}</span>
+						<span class="elementor-screen-only">{{{ options.title }}}</span>
 					</label>
 					<# } ); #>
 				</div>

--- a/includes/controls/dimensions.php
+++ b/includes/controls/dimensions.php
@@ -188,8 +188,14 @@ class Control_Dimensions extends Control_Base_Units {
 					<?php endforeach; ?>
 					<li>
 						<button class="elementor-link-dimensions tooltip-target" data-tooltip="<?php _e( 'Link values together', 'elementor' ); ?>">
-							<span class="elementor-linked"><i class="fa fa-link"></i></span>
-							<span class="elementor-unlinked"><i class="fa fa-chain-broken"></i></span>
+							<span class="elementor-linked">
+								<i class="fa fa-link" aria-hidden="true"></i>
+								<span class="elementor-screen-only"><?php esc_html_e( 'Link values together', 'elementor' ); ?></span>
+							</span>
+							<span class="elementor-unlinked">
+								<i class="fa fa-chain-broken" aria-hidden="true"></i>
+								<span class="elementor-screen-only"><?php esc_html_e( 'Unlinked values', 'elementor' ); ?></span>
+							</span>
 						</button>
 					</li>
 				</ul>

--- a/includes/controls/icon.php
+++ b/includes/controls/icon.php
@@ -38,11 +38,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * PHP usage (inside `Widget_Base::render()` method):
  *
- *    echo '<i class="' . esc_attr( $this->get_settings( 'icon' ) ) . '"></i>';
+ *    echo '<i class="' . esc_attr( $this->get_settings( 'icon' ) ) . '" aria-hidden="true"></i>';
  *
  * JS usage (inside `Widget_Base::_content_template()` method):
  *
- *    <i class="{{ settings.icon }}"></i>
+ *    <i class="{{ settings.icon }}" aria-hidden="true"></i>
  *
  * @since 1.0.0
  *

--- a/includes/controls/media.php
+++ b/includes/controls/media.php
@@ -183,7 +183,7 @@ class Control_Media extends Control_Base_Multiple {
 			<div class="elementor-control-input-wrapper">
 				<div class="elementor-control-media">
 					<div class="elementor-control-media-upload-button">
-						<i class="fa fa-plus-circle"></i>
+						<i class="fa fa-plus-circle" aria-hidden="true"></i>
 					</div>
 					<div class="elementor-control-media-image-area">
 						<div class="elementor-control-media-image" style="background-image: url({{ data.controlValue.url }});"></div>

--- a/includes/controls/order.php
+++ b/includes/controls/order.php
@@ -110,7 +110,7 @@ class Control_Order extends Control_Base_Multiple {
 					</select>
 					<input id="<?php echo $reverse_order_control_uid; ?>" type="checkbox" data-setting="reverse_order">
 					<label for="<?php echo $reverse_order_control_uid; ?>" class="elementor-control-order-label">
-						<i class="fa fa-sort-amount-desc"></i>
+						<i class="fa fa-sort-amount-desc" aria-hidden="true"></i>
 					</label>
 				</div>
 			</div>

--- a/includes/controls/popover-toggle.php
+++ b/includes/controls/popover-toggle.php
@@ -105,7 +105,7 @@ class Control_Popover_Toggle extends Base_Data_Control {
 						<input id="<?php echo $control_uid; ?>-default" type="radio" name="elementor-choose-{{ data.name }}-{{ data._cid }}" value="">
 						<label class="elementor-choices-label" for="<?php echo $control_uid; ?>-default">{{{ data.label_off }}}</label>
 						<input id="<?php echo $control_uid; ?>-custom" class="elementor-control-popover-toggle-toggle" type="radio" name="elementor-choose-{{ data.name }}-{{ data._cid }}" value="{{ data.return_value }}">
-						<label class="elementor-choices-label" for="<?php echo $control_uid; ?>-custom">{{{ data.label_on }}}<i class="eicon-sort-down"></i></label>
+						<label class="elementor-choices-label" for="<?php echo $control_uid; ?>-custom">{{{ data.label_on }}}<i class="eicon-sort-down" aria-hidden="true"></i></label>
 					</div>
 				<# } else { #>
 					<label class="elementor-control-popover-toggle-toggle elementor-control-popover-toggle-simple-toggle">{{{ data.toggle_title }}}</label>

--- a/includes/controls/section.php
+++ b/includes/controls/section.php
@@ -74,7 +74,7 @@ class Control_Section extends Base_UI_Control {
 		?>
 		<div class="elementor-panel-heading">
 			<div class="elementor-panel-heading-toggle elementor-section-toggle" data-collapse_id="{{ data.name }}">
-				<i class="fa"></i>
+				<i class="fa" aria-hidden="true"></i>
 			</div>
 			<div class="elementor-panel-heading-title elementor-section-title">{{{ data.label }}}</div>
 		</div>

--- a/includes/controls/structure.php
+++ b/includes/controls/structure.php
@@ -78,7 +78,10 @@ class Control_Structure extends Base_Data_Control {
 				<div class="elementor-control-structure-preset elementor-control-structure-current-preset">
 					{{{ elementor.presetsFactory.getPresetSVG( currentPreset.preset, 233, 72, 5 ).outerHTML }}}
 				</div>
-				<div class="elementor-control-structure-reset"><i class="fa fa-undo"></i><?php _e( 'Reset Structure', 'elementor' ); ?></div>
+				<div class="elementor-control-structure-reset">
+					<i class="fa fa-undo" aria-hidden="true"></i>
+					<?php _e( 'Reset Structure', 'elementor' ); ?>
+				</div>
 				<#
 				var morePresets = getMorePresets();
 

--- a/includes/controls/url.php
+++ b/includes/controls/url.php
@@ -147,7 +147,7 @@ class Control_URL extends Control_Base_Multiple {
 			<div class="elementor-control-input-wrapper">
 				<input id="<?php echo $control_uid; ?>" type="url" class="elementor-input" data-setting="url" placeholder="{{ data.placeholder }}" />
 				<label for="<?php echo $more_input_control_uid; ?>" class="elementor-control-url-more tooltip-target" data-tooltip="<?php _e( 'Link Options', 'elementor' ); ?>">
-					<i class="fa fa-cog"></i>
+					<i class="fa fa-cog" aria-hidden="true"></i>
 				</label>
 				<input id="<?php echo $more_input_control_uid; ?>" type="checkbox" class="elementor-control-url-more-input">
 				<div class="elementor-control-url-more-options">

--- a/includes/editor-templates/editor-wrapper.php
+++ b/includes/editor-templates/editor-wrapper.php
@@ -34,7 +34,7 @@ global $wp_version;
 		</div>
 		<div id="elementor-preview-responsive-wrapper" class="elementor-device-desktop elementor-device-rotate-portrait">
 			<div id="elementor-preview-loading">
-				<i class="fa fa-spin fa-circle-o-notch"></i>
+				<i class="fa fa-spin fa-circle-o-notch" aria-hidden="true"></i>
 			</div>
 			<?php
 			// IFrame will be create here by the Javascript later.

--- a/includes/editor-templates/global.php
+++ b/includes/editor-templates/global.php
@@ -18,7 +18,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <script type="text/template" id="tmpl-elementor-add-section">
 	<div class="elementor-add-section-inner">
 		<div class="elementor-add-section-close">
-			<i class="eicon-close"></i>
+			<i class="eicon-close" aria-hidden="true"></i>
+			<span class="elementor-screen-only"><?php esc_html_e( 'Close', 'elementor' ); ?></span>
 		</div>
 		<div class="elementor-add-new-section">
 			<button class="elementor-add-section-button elementor-button"><?php _e( 'Add New Section', 'elementor' ); ?></button>

--- a/includes/editor-templates/panel-elements.php
+++ b/includes/editor-templates/panel-elements.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<div id="elementor-panel-categories"></div>
 
 	<div id="elementor-panel-get-pro-elements" class="elementor-panel-nerd-box">
-		<i class="elementor-panel-nerd-box-icon eicon-hypster"></i>
+		<i class="elementor-panel-nerd-box-icon eicon-hypster" aria-hidden="true"></i>
 		<div class="elementor-panel-nerd-box-message"><?php _e( 'Get more with Elementor Pro', 'elementor' ); ?></div>
 		<a class="elementor-button elementor-button-default elementor-panel-nerd-box-link" target="_blank" href="<?php echo Utils::get_pro_link( 'https://elementor.com/pro/?utm_source=panel-widgets&utm_campaign=gopro&utm_medium=wp-dash' ); ?>"><?php _e( 'Go Pro', 'elementor' ); ?></a>
 	</div>
@@ -32,13 +32,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 <script type="text/template" id="tmpl-elementor-panel-element-search">
 	<label for="elementor-panel-elements-search-input" class="screen-reader-text"><?php echo __( 'Search Widget:', 'elementor' ); ?></label>
 	<input type="search" id="elementor-panel-elements-search-input" placeholder="<?php esc_attr_e( 'Search Widget...', 'elementor' ); ?>" />
-	<i class="fa fa-search"></i>
+	<i class="fa fa-search" aria-hidden="true"></i>
 </script>
 
 <script type="text/template" id="tmpl-elementor-element-library-element">
 	<div class="elementor-element">
 		<div class="icon">
-			<i class="{{ icon }}"></i>
+			<i class="{{ icon }}" aria-hidden="true"></i>
 		</div>
 		<div class="elementor-element-title-wrapper">
 			<div class="title">{{{ title }}}</div>
@@ -48,7 +48,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <script type="text/template" id="tmpl-elementor-panel-global">
 	<div class="elementor-panel-nerd-box">
-		<i class="elementor-panel-nerd-box-icon eicon-hypster"></i>
+		<i class="elementor-panel-nerd-box-icon eicon-hypster" aria-hidden="true"></i>
 		<div class="elementor-panel-nerd-box-title"><?php echo __( 'Meet Our Global Widget', 'elementor' ); ?></div>
 		<div class="elementor-panel-nerd-box-message"><?php echo __( 'With this feature, you can save a widget as global, then add it to multiple areas. All areas will be editable from one single place.', 'elementor' ); ?></div>
 		<div class="elementor-panel-nerd-box-message"><?php echo __( 'This feature is only available on Elementor Pro.', 'elementor' ); ?></div>

--- a/includes/editor-templates/panel.php
+++ b/includes/editor-templates/panel.php
@@ -24,34 +24,38 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <script type="text/template" id="tmpl-elementor-panel-header">
 	<div id="elementor-panel-header-menu-button" class="elementor-header-button">
-		<i class="elementor-icon eicon-menu-bar tooltip-target" data-tooltip="<?php esc_attr_e( 'Menu', 'elementor' ); ?>"></i>
+		<i class="elementor-icon eicon-menu-bar tooltip-target" aria-hidden="true" data-tooltip="<?php esc_attr_e( 'Menu', 'elementor' ); ?>"></i>
+		<span class="elementor-screen-only"><?php esc_html_e( 'Menu', 'elementor' ); ?></span>
 	</div>
 	<div id="elementor-panel-header-title"></div>
 	<div id="elementor-panel-header-add-button" class="elementor-header-button">
-		<i class="elementor-icon eicon-apps tooltip-target" data-tooltip="<?php esc_attr_e( 'Widgets Panel', 'elementor' ); ?>"></i>
+		<i class="elementor-icon eicon-apps tooltip-target" aria-hidden="true" data-tooltip="<?php esc_attr_e( 'Widgets Panel', 'elementor' ); ?>"></i>
+		<span class="elementor-screen-only"><?php esc_html_e( 'Widgets Panel', 'elementor' ); ?></span>
 	</div>
 </script>
 
 <script type="text/template" id="tmpl-elementor-panel-footer-content">
 	<div id="elementor-panel-footer-settings" class="elementor-panel-footer-tool elementor-leave-open tooltip-target" data-tooltip="<?php esc_html_e( 'Settings', 'elementor' ); ?>">
-		<i class="fa fa-cog"></i>
+		<i class="fa fa-cog" aria-hidden="true"></i>
+		<span class="elementor-screen-only"><?php esc_html_e( 'Settings', 'elementor' ); ?></span>
 	</div>
 	<div id="elementor-panel-footer-responsive" class="elementor-panel-footer-tool tooltip-target" data-tooltip="<?php esc_attr_e( 'Responsive Mode', 'elementor' ); ?>">
-		<i class="eicon-device-desktop"></i>
+		<i class="eicon-device-desktop" aria-hidden="true"></i>
+		<span class="elementor-screen-only"><?php esc_html_e( 'Responsive Mode', 'elementor' ); ?></span>
 		<div class="elementor-panel-footer-sub-menu-wrapper">
 			<div class="elementor-panel-footer-sub-menu">
 				<div class="elementor-panel-footer-sub-menu-item" data-device-mode="desktop">
-					<i class="elementor-icon eicon-device-desktop"></i>
+					<i class="elementor-icon eicon-device-desktop" aria-hidden="true"></i>
 					<span class="elementor-title"><?php esc_html_e( 'Desktop', 'elementor' ); ?></span>
 					<span class="elementor-description"><?php esc_html_e( 'Default Preview', 'elementor' ); ?></span>
 				</div>
 				<div class="elementor-panel-footer-sub-menu-item" data-device-mode="tablet">
-					<i class="elementor-icon eicon-device-tablet"></i>
+					<i class="elementor-icon eicon-device-tablet" aria-hidden="true"></i>
 					<span class="elementor-title"><?php esc_html_e( 'Tablet', 'elementor' ); ?></span>
 					<span class="elementor-description"><?php esc_html_e( 'Preview for 768px', 'elementor' ); ?></span>
 				</div>
 				<div class="elementor-panel-footer-sub-menu-item" data-device-mode="mobile">
-					<i class="elementor-icon eicon-device-mobile"></i>
+					<i class="elementor-icon eicon-device-mobile" aria-hidden="true"></i>
 					<span class="elementor-title"><?php esc_html_e( 'Mobile', 'elementor' ); ?></span>
 					<span class="elementor-description"><?php esc_html_e( 'Preview for 360px', 'elementor' ); ?></span>
 				</div>
@@ -59,21 +63,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 	</div>
 	<div id="elementor-panel-footer-history" class="elementor-panel-footer-tool elementor-leave-open tooltip-target" data-tooltip="<?php esc_attr_e( 'History', 'elementor' ); ?>">
+		<i class="fa fa-history" aria-hidden="true"></i>
 		<span class="elementor-screen-only"><?php esc_html_e( 'History', 'elementor' ); ?></span>
-		<i class="fa fa-history"></i>
 	</div>
 	<div id="elementor-panel-saver-button-preview" class="elementor-panel-footer-tool tooltip-target" data-tooltip="<?php esc_attr_e( 'Preview Changes', 'elementor' ); ?>">
 		<span id="elementor-panel-saver-button-preview-label">
+			<i class="fa fa-eye" aria-hidden="true"></i>
 			<span class="elementor-screen-only"><?php esc_html_e( 'Preview Changes', 'elementor' ); ?></span>
-			<i class="fa fa-eye"></i>
 		</span>
 	</div>
 	<div id="elementor-panel-saver-save" class="elementor-panel-footer-tool">
 		<button id="elementor-panel-saver-button-save" class="elementor-button">
 			<span class="elementor-state-icon">
-				<i class="fa fa-spin fa-circle-o-notch"></i>
+				<i class="fa fa-spin fa-circle-o-notch" aria-hidden="true"></i>
 			</span>
-
 			<span id="elementor-panel-saver-save-label">
 				<?php esc_html_e( 'Save', 'elementor' ); ?>
 			</span>
@@ -81,33 +84,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div id="elementor-panel-saver-publish" class="elementor-panel-footer-tool" >
 		<button id="elementor-panel-saver-button-publish" class="elementor-button elementor-button-success tooltip-target" data-tooltip="<?php esc_attr_e( 'Publish & Exit', 'elementor' ); ?>">
+			<i class="fa fa-paper-plane" aria-hidden="true"></i>
             <span class="elementor-screen-only"><?php esc_html_e( 'Publish & Exit', 'elementor' ); ?></span>
-            <i class="fa fa-paper-plane"></i>
 		</button>
 		<div class="elementor-panel-footer-sub-menu-wrapper">
 			<div class="elementor-panel-footer-sub-menu">
 				<div id="elementor-panel-saver-menu-publish" class="elementor-panel-footer-sub-menu-item">
-					<i class="elementor-icon fa fa-paper-plane"></i>
+					<i class="elementor-icon fa fa-paper-plane" aria-hidden="true"></i>
 					<span class="elementor-title"><?php esc_html_e( 'Publish', 'elementor' ); ?></span>
 				</div>
 				<div id="elementor-panel-saver-menu-publish-changes" class="elementor-panel-footer-sub-menu-item">
-					<i class="elementor-icon fa fa-paper-plane"></i>
+					<i class="elementor-icon fa fa-paper-plane" aria-hidden="true"></i>
 					<span class="elementor-title"><?php esc_html_e( 'Publish Changes', 'elementor' ); ?></span>
 				</div>
 				<div id="elementor-panel-saver-menu-submit-for-review" class="elementor-panel-footer-sub-menu-item">
-					<i class="elementor-icon fa fa-paper-plane"></i>
+					<i class="elementor-icon fa fa-paper-plane" aria-hidden="true"></i>
 					<span class="elementor-title"><?php esc_html_e( 'Submit for Review', 'elementor' ); ?></span>
 				</div>
 				<div id="elementor-panel-saver-menu-update" class="elementor-panel-footer-sub-menu-item">
-					<i class="elementor-icon fa fa-save"></i>
+					<i class="elementor-icon fa fa-save" aria-hidden="true"></i>
 					<span class="elementor-title"><?php esc_html_e( 'Update', 'elementor' ); ?></span>
 				</div>
 				<div id="elementor-panel-saver-menu-save-template" class="elementor-panel-footer-sub-menu-item">
-					<i class="elementor-icon fa fa-save"></i>
+					<i class="elementor-icon fa fa-save" aria-hidden="true"></i>
 					<span class="elementor-title"><?php esc_html_e( 'Save to Library', 'elementor' ); ?></span>
 				</div>
 				<a id="elementor-panel-footer-saver-exit" class="elementor-panel-footer-sub-menu-item" href="<?php echo esc_attr( get_edit_post_link() ); ?>">
-					<i class="elementor-icon fa fa-times"></i>
+					<i class="elementor-icon fa fa-times" aria-hidden="true"></i>
 					<span class="elementor-title"><?php esc_html_e( 'Exit to Dashboard', 'elementor' ); ?></span>
 				</a>
 			</div>
@@ -143,7 +146,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 </script>
 
 <script type="text/template" id="tmpl-elementor-panel-schemes-disabled">
-	<i class="elementor-panel-nerd-box-icon eicon-nerd"></i>
+	<i class="elementor-panel-nerd-box-icon eicon-nerd" aria-hidden="true"></i>
 	<div class="elementor-panel-nerd-box-title">{{{ '<?php echo __( '{0} are disabled', 'elementor' ); ?>'.replace( '{0}', disabledTitle ) }}}</div>
 	<div class="elementor-panel-nerd-box-message"><?php printf( __( 'You can enable it from the <a href="%s" target="_blank">Elementor settings page</a>.', 'elementor' ), Settings::get_url() ); ?></div>
 </script>
@@ -158,7 +161,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <script type="text/template" id="tmpl-elementor-panel-scheme-typography-item">
 	<div class="elementor-panel-heading">
 		<div class="elementor-panel-heading-toggle">
-			<i class="fa"></i>
+			<i class="fa" aria-hidden="true"></i>
 		</div>
 		<div class="elementor-panel-heading-title">{{{ title }}}</div>
 	</div>

--- a/includes/editor-templates/repeater.php
+++ b/includes/editor-templates/repeater.php
@@ -9,14 +9,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 <script type="text/template" id="tmpl-elementor-repeater-row">
 	<div class="elementor-repeater-row-tools">
 		<div class="elementor-repeater-row-handle-sortable">
-			<i class="fa fa-ellipsis-v"></i>
+			<i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+			<span class="elementor-screen-only"><?php esc_html_e( 'Drag & Drop', 'elementor' ); ?></span>
 		</div>
 		<div class="elementor-repeater-row-item-title"></div>
 		<div class="elementor-repeater-row-tool elementor-repeater-tool-duplicate">
-			<i class="fa fa-copy"></i>
+			<i class="fa fa-copy" aria-hidden="true"></i>
+			<span class="elementor-screen-only"><?php esc_html_e( 'Duplicate', 'elementor' ); ?></span>
 		</div>
 		<div class="elementor-repeater-row-tool elementor-repeater-tool-remove">
-			<i class="fa fa-remove"></i>
+			<i class="fa fa-remove" aria-hidden="true"></i>
+			<span class="elementor-screen-only"><?php esc_html_e( 'Remove', 'elementor' ); ?></span>
 		</div>
 	</div>
 	<div class="elementor-repeater-row-controls"></div>

--- a/includes/editor-templates/templates.php
+++ b/includes/editor-templates/templates.php
@@ -51,7 +51,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 </script>
 
 <script type="text/template" id="tmpl-elementor-template-library-header-back">
-	<i class="eicon-"></i><span><?php echo __( 'Back to Library', 'elementor' ); ?></span>
+	<i class="eicon-" aria-hidden="true"></i>
+	<span><?php echo __( 'Back to Library', 'elementor' ); ?></span>
 </script>
 
 <script type="text/template" id="tmpl-elementor-template-library-loading">
@@ -84,7 +85,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<div id="elementor-template-library-my-favorites">
 					<input id="elementor-template-library-filter-my-favorites" type="checkbox">
 					<label id="elementor-template-library-filter-my-favorites-label" for="elementor-template-library-filter-my-favorites">
-						<i class="fa"></i>
+						<i class="fa" aria-hidden="true"></i>
 						<?php echo __( 'My Favorites', 'elementor' ); ?>
 					</label>
 				</div>
@@ -122,7 +123,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<div id="elementor-template-library-templates-container"></div>
 	<# if ( 'remote' === activeSource ) { #>
 		<div id="elementor-template-library-footer-banner">
-			<i class="eicon-nerd"></i>
+			<i class="eicon-nerd" aria-hidden="true"></i>
 			<div class="elementor-excerpt"><?php echo __( 'Stay tuned! More awesome templates coming real soon.', 'elementor' ); ?></div>
 		</div>
 	<# } #>
@@ -133,7 +134,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="elementor-template-library-template-screenshot" style="background-image: url({{ thumbnail }});"></div>
 		<div class="elementor-template-library-template-controls">
 			<div class="elementor-template-library-template-preview">
-				<i class="fa fa-search-plus"></i>
+				<i class="fa fa-search-plus" aria-hidden="true"></i>
 			</div>
 			{{{ elementor.templates.getLayout().getTemplateActionButton( obj ) }}}
 		</div>
@@ -143,7 +144,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="elementor-template-library-favorite">
 			<input id="elementor-template-library-template-{{ template_id }}-favorite-input" class="elementor-template-library-template-favorite-input" type="checkbox"{{ favorite ? " checked" : "" }}>
 			<label for="elementor-template-library-template-{{ template_id }}-favorite-input" class="elementor-template-library-template-favorite-label">
-				<i class="fa fa-heart-o"></i>
+				<i class="fa fa-heart-o" aria-hidden="true"></i>
 			</label>
 		</div>
 	</div>
@@ -156,21 +157,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<div class="elementor-template-library-template-meta elementor-template-library-template-date elementor-template-library-local-column-4">{{{ human_date }}}</div>
 	<div class="elementor-template-library-template-controls elementor-template-library-local-column-5">
 		<div class="elementor-template-library-template-preview">
-			<i class="fa fa-eye"></i><span class="elementor-template-library-template-control-title"><?php echo __( 'Preview', 'elementor' ); ?></span>
+			<i class="fa fa-eye" aria-hidden="true"></i>
+			<span class="elementor-template-library-template-control-title"><?php echo __( 'Preview', 'elementor' ); ?></span>
 		</div>
 		<button class="elementor-template-library-template-action elementor-template-library-template-insert elementor-button elementor-button-success">
-			<i class="eicon-file-download"></i><span class="elementor-button-title"><?php echo __( 'Insert', 'elementor' ); ?></span>
+			<i class="eicon-file-download" aria-hidden="true"></i>
+			<span class="elementor-button-title"><?php echo __( 'Insert', 'elementor' ); ?></span>
 		</button>
 		<div class="elementor-template-library-template-more-toggle">
-			<i class="fa fa-ellipsis-h"></i>
+			<i class="fa fa-ellipsis-h" aria-hidden="true"></i>
 		</div>
 		<div class="elementor-template-library-template-more">
 			<div class="elementor-template-library-template-delete">
-				<i class="fa fa-trash-o"></i><span class="elementor-template-library-template-control-title"><?php echo __( 'Delete', 'elementor' ); ?></span>
+				<i class="fa fa-trash-o" aria-hidden="true"></i>
+				<span class="elementor-template-library-template-control-title"><?php echo __( 'Delete', 'elementor' ); ?></span>
 			</div>
 			<div class="elementor-template-library-template-export">
 				<a href="{{ export_link }}">
-					<i class="fa fa-sign-out"></i><span class="elementor-template-library-template-control-title"><?php echo __( 'Export', 'elementor' ); ?></span>
+					<i class="fa fa-sign-out" aria-hidden="true"></i>
+					<span class="elementor-template-library-template-control-title"><?php echo __( 'Export', 'elementor' ); ?></span>
 				</a>
 			</div>
 		</div>
@@ -179,21 +184,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <script type="text/template" id="tmpl-elementor-template-library-insert-button">
 	<button class="elementor-template-library-template-action elementor-template-library-template-insert elementor-button elementor-button-success">
-		<i class="eicon-file-download"></i><span class="elementor-button-title"><?php echo __( 'Insert', 'elementor' ); ?></span>
+		<i class="eicon-file-download" aria-hidden="true"></i>
+		<span class="elementor-button-title"><?php echo __( 'Insert', 'elementor' ); ?></span>
 	</button>
 </script>
 
 <script type="text/template" id="tmpl-elementor-template-library-get-pro-button">
 	<a href="<?php echo Utils::get_pro_link( 'https://elementor.com/pro/?utm_source=panel-library&utm_campaign=gopro&utm_medium=wp-dash' ); ?>" target="_blank">
 		<button class="elementor-template-library-template-action elementor-button elementor-button-go-pro">
-			<i class="fa fa-external-link-square"></i><span class="elementor-button-title"><?php echo __( 'Go Pro', 'elementor' ); ?></span>
+			<i class="fa fa-external-link-square" aria-hidden="true"></i>
+			<span class="elementor-button-title"><?php echo __( 'Go Pro', 'elementor' ); ?></span>
 		</button>
 	</a>
 </script>
 
 <script type="text/template" id="tmpl-elementor-template-library-save-template">
 	<div class="elementor-template-library-blank-icon">
-		<i class="eicon-library-save"></i>
+		<i class="eicon-library-save" aria-hidden="true"></i>
 	</div>
 	<div class="elementor-template-library-blank-title">{{{ title }}}</div>
 	<div class="elementor-template-library-blank-message">{{{ description }}}</div>
@@ -202,7 +209,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<input id="elementor-template-library-save-template-name" name="title" placeholder="<?php echo __( 'Enter Template Name', 'elementor' ); ?>" required>
 		<button id="elementor-template-library-save-template-submit" class="elementor-button elementor-button-success">
 			<span class="elementor-state-icon">
-				<i class="fa fa-spin fa-circle-o-notch "></i>
+				<i class="fa fa-spin fa-circle-o-notch" aria-hidden="true"></i>
 			</span>
 			<?php echo __( 'Save', 'elementor' ); ?>
 		</button>
@@ -216,7 +223,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <script type="text/template" id="tmpl-elementor-template-library-import">
 	<form id="elementor-template-library-import-form">
 		<div class="elementor-template-library-blank-icon">
-			<i class="eicon-library-upload"></i>
+			<i class="eicon-library-upload" aria-hidden="true"></i>
 		</div>
 		<div class="elementor-template-library-blank-title"><?php echo __( 'Import Template to Your Library', 'elementor' ); ?></div>
 		<div class="elementor-template-library-blank-message"><?php echo __( 'Drag & drop your .JSON or .zip template file', 'elementor' ); ?></div>
@@ -232,7 +239,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <script type="text/template" id="tmpl-elementor-template-library-templates-empty">
 	<div class="elementor-template-library-blank-icon">
-		<i class="eicon-nerd"></i>
+		<i class="eicon-nerd" aria-hidden="true"></i>
 	</div>
 	<div class="elementor-template-library-blank-title"></div>
 	<div class="elementor-template-library-blank-message"></div>

--- a/includes/managers/controls.php
+++ b/includes/managers/controls.php
@@ -532,7 +532,7 @@ class Controls_Manager {
 			[
 				'type' => Controls_Manager::RAW_HTML,
 				'raw' => '<div class="elementor-panel-nerd-box">
-						<i class="elementor-panel-nerd-box-icon eicon-hypster"></i>
+						<i class="elementor-panel-nerd-box-icon eicon-hypster" aria-hidden="true"></i>
 						<div class="elementor-panel-nerd-box-title">' .
 							__( 'Meet Our Custom CSS', 'elementor' ) .
 						'</div>

--- a/includes/schemes/base.php
+++ b/includes/schemes/base.php
@@ -96,12 +96,14 @@ abstract class Scheme_Base implements Scheme_Interface {
 			<div class="elementor-panel-scheme-buttons">
 				<div class="elementor-panel-scheme-button-wrapper elementor-panel-scheme-reset">
 					<button class="elementor-button">
-						<i class="fa fa-undo"></i><?php _e( 'Reset', 'elementor' ); ?>
+						<i class="fa fa-undo" aria-hidden="true"></i>
+						<?php _e( 'Reset', 'elementor' ); ?>
 					</button>
 				</div>
 				<div class="elementor-panel-scheme-button-wrapper elementor-panel-scheme-discard">
 					<button class="elementor-button">
-						<i class="fa fa-times"></i><?php _e( 'Discard', 'elementor' ); ?>
+						<i class="fa fa-times" aria-hidden="true"></i>
+						<?php _e( 'Discard', 'elementor' ); ?>
 					</button>
 				</div>
 				<div class="elementor-panel-scheme-button-wrapper elementor-panel-scheme-save">

--- a/includes/widgets/button.php
+++ b/includes/widgets/button.php
@@ -452,7 +452,7 @@ class Widget_Button extends Widget_Base {
 				<span class="elementor-button-content-wrapper">
 					<# if ( settings.icon ) { #>
 					<span class="elementor-button-icon elementor-align-icon-{{ settings.icon_align }}">
-						<i class="{{ settings.icon }}"></i>
+						<i class="{{ settings.icon }}" aria-hidden="true"></i>
 					</span>
 					<# } #>
 					<span {{{ view.getRenderAttributeString( 'text' ) }}}>{{{ settings.text }}}</span>
@@ -483,7 +483,7 @@ class Widget_Button extends Widget_Base {
 		<span <?php echo $this->get_render_attribute_string( 'content-wrapper' ); ?>>
 			<?php if ( ! empty( $settings['icon'] ) ) : ?>
 			<span <?php echo $this->get_render_attribute_string( 'icon-align' ); ?>>
-				<i class="<?php echo esc_attr( $settings['icon'] ); ?>"></i>
+				<i class="<?php echo esc_attr( $settings['icon'] ); ?>" aria-hidden="true"></i>
 			</span>
 			<?php endif; ?>
 			<span <?php echo $this->get_render_attribute_string( 'text' ); ?>><?php echo $settings['text']; ?></span>

--- a/includes/widgets/icon-list.php
+++ b/includes/widgets/icon-list.php
@@ -131,7 +131,7 @@ class Widget_Icon_List extends Widget_Base {
 						'placeholder' => __( 'http://your-link.com', 'elementor' ),
 					],
 				],
-				'title_field' => '<i class="{{ icon }}"></i> {{{ text }}}',
+				'title_field' => '<i class="{{ icon }}" aria-hidden="true"></i> {{{ text }}}',
 			]
 		);
 
@@ -431,7 +431,7 @@ class Widget_Icon_List extends Widget_Base {
 					if ( $item['icon'] ) :
 					?>
 						<span class="elementor-icon-list-icon">
-							<i class="<?php echo esc_attr( $item['icon'] ); ?>"></i>
+							<i class="<?php echo esc_attr( $item['icon'] ); ?>" aria-hidden="true"></i>
 						</span>
 					<?php endif; ?>
 					<span <?php echo $this->get_render_attribute_string( $repeater_setting_key ); ?>><?php echo $item['text']; ?></span>
@@ -473,7 +473,7 @@ class Widget_Icon_List extends Widget_Base {
 							<a href="{{ item.link.url }}">
 						<# } #>
 						<span class="elementor-icon-list-icon">
-							<i class="{{ item.icon }}"></i>
+							<i class="{{ item.icon }}" aria-hidden="true"></i>
 						</span>
 						<span {{{ view.getRenderAttributeString( iconTextKey ) }}}>{{{ item.text }}}</span>
 						<# if ( item.link && item.link.url ) { #>

--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -629,7 +629,7 @@ class Widget_Video extends Widget_Base {
 					<?php endif; ?>
 					<?php if ( 'yes' === $settings['show_play_icon'] ) : ?>
 						<div class="elementor-custom-embed-play">
-							<i class="eicon-play"></i>
+							<i class="eicon-play" aria-hidden="true"></i>
 						</div>
 					<?php endif; ?>
 				</div>


### PR DESCRIPTION
Finishing the work started in #2861