### PR TITLE
Use core WordPress `wp_doing_ajax()` function

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -20,7 +20,8 @@ class Utils {
 	 * @access public
 	*/
 	public static function is_ajax() {
-		return wp_doing_ajax();
+		// TODO: When minimum required version will be 4.7, use `wp_doing_ajax()`.
+		return defined( 'DOING_AJAX' ) && DOING_AJAX;
 	}
 
 	/**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -20,7 +20,7 @@ class Utils {
 	 * @access public
 	*/
 	public static function is_ajax() {
-		return defined( 'DOING_AJAX' ) && DOING_AJAX;
+		return wp_doing_ajax();
 	}
 
 	/**


### PR DESCRIPTION
Update `Utils::is_ajax()` to use core WordPress `wp_doing_ajax()` function add in wp4.7