### PR TITLE
Fix W3C validation on multiple google fonts

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -343,7 +343,7 @@ class Frontend {
 				$font = str_replace( ' ', '+', $font ) . ':100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic,900,900italic';
 			}
 
-			$fonts_url = sprintf( 'https://fonts.googleapis.com/css?family=%s', implode( '|', $this->google_fonts ) );
+			$fonts_url = sprintf( 'https://fonts.googleapis.com/css?family=%s', implode( urlencode('|'), $this->google_fonts ) );
 
 			$subsets = [
 				'ru_RU' => 'cyrillic',


### PR DESCRIPTION
Urlencode pipe joining fonts to avoid breaking W3C validation when multiple fonts are joined in a single URL