### PR TITLE
i18n: add new translators comments and update old ones

### DIFF
--- a/core/settings/page/model.php
+++ b/core/settings/page/model.php
@@ -87,8 +87,11 @@ class Model extends BaseModel {
 				'type' => Controls_Manager::SWITCHER,
 				'label_off' => __( 'No', 'elementor' ),
 				'label_on' => __( 'Yes', 'elementor' ),
-				// translators: %s: Setting Page link
-				'description' => sprintf( __( 'Not working? You can set a different selector for the title in the <a href="%s" target="_blank">Settings page</a>.', 'elementor' ), Settings::get_url() ),
+				'description' => sprintf(
+					/* translators: %s: Setting Page URL */
+					__( 'Not working? You can set a different selector for the title in the <a href="%s" target="_blank">Settings page</a>.', 'elementor' ),
+					Settings::get_url()
+				),
 				'selectors' => [
 					'{{WRAPPER}} ' . $page_title_selector => 'display: none',
 				],

--- a/elementor.php
+++ b/elementor.php
@@ -108,7 +108,7 @@ function elementor_fail_php_version() {
  * @return void
  */
 function elementor_fail_wp_version() {
-	/* translators: %s: WP version */
+	/* translators: %s: WordPress version */
 	$message = sprintf( esc_html__( 'Elementor requires WordPress version %s+. Because you are using an earlier version, the plugin is currently NOT ACTIVE.', 'elementor' ), '4.5' );
 	$html_message = sprintf( '<div class="error">%s</div>', wpautop( $message ) );
 	echo wp_kses_post( $html_message );

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -368,19 +368,17 @@ class Admin {
 					<p>
 					<?php
 						printf(
-							/* translators: 1: details URL, 2: accessibility text, 3: version number, 4: update URL, 5: accessibility text */
+							/* translators: 1: Details URL, 2: Accessibility text, 3: Version number, 4: Update URL, 5: Accessibility text */
 							__( 'There is a new version of Elementor Page Builder available. <a href="%1$s" class="thickbox open-plugin-details-modal" aria-label="%2$s">View version %3$s details</a> or <a href="%4$s" class="update-link" aria-label="%5$s">update now</a>.', 'elementor' ),
 							esc_url( $details_url ),
-							esc_attr(
-								sprintf(
-									/* translators: %s: Elementor version */
-									__( 'View Elementor version %s details', 'elementor' ),
-									$product->new_version
-								)
-							),
+							esc_attr( sprintf(
+								/* translators: %s: Elementor version */
+								__( 'View Elementor version %s details', 'elementor' ),
+								$product->new_version
+							) ),
 							$product->new_version,
 							esc_url( $upgrade_url ),
-							esc_attr( __( 'Update Now', 'elementor' ) )
+							esc_attr( __( 'Update Elementor Now', 'elementor' ) )
 						);
 						?>
 					</p>

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -373,7 +373,7 @@ class Admin {
 							esc_url( $details_url ),
 							esc_attr(
 								sprintf(
-									/* translators: %s: version number */
+									/* translators: %s: Elementor version */
 									__( 'View Elementor version %s details', 'elementor' ),
 									$product->new_version
 								)
@@ -416,7 +416,7 @@ class Admin {
 
 		if ( $is_elementor_screen ) {
 			$footer_text = sprintf(
-				/* translators: %s: link to plugin review */
+				/* translators: %s: Link to plugin review */
 				__( 'Enjoyed <strong>Elementor</strong>? Please leave us a %s rating. We really appreciate your support!', 'elementor' ),
 				'<a href="https://wordpress.org/support/plugin/elementor/reviews/?filter=5#new-post" target="_blank">&#9733;&#9733;&#9733;&#9733;&#9733;</a>'
 			);

--- a/includes/settings/system-info/classes/theme.php
+++ b/includes/settings/system-info/classes/theme.php
@@ -76,9 +76,9 @@ class Theme_Reporter extends Base_Reporter {
 
 		if ( ! $is_child_theme ) {
 			$result['recommendation'] = sprintf(
-				/* translators: %s: codex child theme URL */
+				/* translators: %s: Codex URL */
 				_x( 'If you want to modify the source code of your theme, we recommend using a <a href="%s">child theme</a>.', 'System Info', 'elementor' ),
-				esc_html( 'https://codex.wordpress.org/Child_Themes' )
+				esc_url( 'https://codex.wordpress.org/Child_Themes' )
 			);
 		}
 

--- a/includes/settings/tools.php
+++ b/includes/settings/tools.php
@@ -68,7 +68,11 @@ class Tools extends Settings_Page {
 			wp_send_json_error( __( 'An error occurred', 'elementor' ) );
 		} else {
 			Plugin::$instance->posts_css_manager->clear_cache();
-			wp_send_json_success( sprintf( __( '%d Rows Affected', 'elementor' ), $rows_affected ) );
+			wp_send_json_success( sprintf(
+				/* translators: %s: Number of rows */
+				__( '%d Rows Affected', 'elementor' ),
+				$rows_affected
+			) );
 		}
 	}
 
@@ -152,7 +156,11 @@ class Tools extends Settings_Page {
 				'sections' => [
 					'replace_url' => [
 						'callback' => function() {
-							$intro_text = sprintf( __( '<strong>Important:</strong> It is strongly recommended that you <a target="_blank" href="%s">backup your database</a> before using Replace URL.', 'elementor' ), 'https://codex.wordpress.org/WordPress_Backups' );
+							$intro_text = sprintf(
+								/* translators: %s: Codex URL */
+								__( '<strong>Important:</strong> It is strongly recommended that you <a target="_blank" href="%s">backup your database</a> before using Replace URL.', 'elementor' ),
+								'https://codex.wordpress.org/WordPress_Backups'
+							);
 							$intro_text = '<div>' . $intro_text . '</div>';
 
 							echo $intro_text;
@@ -176,7 +184,11 @@ class Tools extends Settings_Page {
 					'rollback' => [
 						'label' => __( 'Rollback to Previous Version', 'elementor' ),
 						'callback' => function() {
-							$intro_text = sprintf( __( 'Experiencing an issue with Elementor version %s? Rollback to a previous version before the issue appeared.', 'elementor' ), ELEMENTOR_VERSION );
+							$intro_text = sprintf(
+								/* translators: %s: Elementor version */
+								__( 'Experiencing an issue with Elementor version %s? Rollback to a previous version before the issue appeared.', 'elementor' ),
+								ELEMENTOR_VERSION
+							);
 							$intro_text = '<p>' . $intro_text . '</p>';
 
 							echo $intro_text;
@@ -186,7 +198,15 @@ class Tools extends Settings_Page {
 								'label' => __( 'Rollback Version', 'elementor' ),
 								'field_args' => [
 									'type' => 'raw_html',
-									'html' => sprintf( '<a href="%s" class="button elementor-button-spinner elementor-rollback-button">%s</a>', wp_nonce_url( admin_url( 'admin-post.php?action=elementor_rollback' ), 'elementor_rollback' ), sprintf( __( 'Reinstall v%s', 'elementor' ), ELEMENTOR_PREVIOUS_STABLE_VERSION ) ),
+									'html' => sprintf(
+										'<a href="%s" class="button elementor-button-spinner elementor-rollback-button">%s</a>',
+										wp_nonce_url( admin_url( 'admin-post.php?action=elementor_rollback' ), 'elementor_rollback' ),
+										sprintf(
+											/* translators: %s: Elementor previous stable version */
+											__( 'Reinstall v%s', 'elementor' ),
+											ELEMENTOR_PREVIOUS_STABLE_VERSION
+										)
+									),
 									'desc' => '<span style="color: red;">' . __( 'Warning: Please backup your database before making the rollback.', 'elementor' ) . '</span>',
 								],
 							],
@@ -195,7 +215,11 @@ class Tools extends Settings_Page {
 					'beta' => [
 						'label' => __( 'Become a Beta Tester', 'elementor' ),
 						'callback' => function() {
-							$intro_text = sprintf( __( 'Turn-on Beta Tester, to get notified when a new beta version of Elementor or E-Pro is available. The Beta version will not install automatically. You always have the option to ignore it.', 'elementor' ), ELEMENTOR_VERSION );
+							$intro_text = sprintf(
+								/* translators: %s: Elementor version */
+								__( 'Turn-on Beta Tester, to get notified when a new beta version of Elementor or E-Pro is available. The Beta version will not install automatically. You always have the option to ignore it.', 'elementor' ),
+								ELEMENTOR_VERSION
+							);
 							$intro_text = '<p>' . $intro_text . '</p>';
 
 							echo $intro_text;

--- a/modules/history/revisions-manager.php
+++ b/modules/history/revisions-manager.php
@@ -76,7 +76,12 @@ class Revisions_Manager {
 			$revisions[] = [
 				'id' => $revision->ID,
 				'author' => self::$authors[ $revision->post_author ]['display_name'],
-				'date' => sprintf( __( '%1$s ago (%2$s)', 'elementor' ), $human_time, $date ),
+				'date' => sprintf(
+					/* translators: 1: Human readable time difference, 2: Date */
+					__( '%1$s ago (%2$s)', 'elementor' ),
+					$human_time,
+					$date
+				),
 				'type' => $type,
 				'gravatar' => self::$authors[ $revision->post_author ]['avatar'],
 			];
@@ -220,8 +225,11 @@ class Revisions_Manager {
 				'revision' => __( 'Revision', 'elementor' ),
 				'revision_history' => __( 'Revision History', 'elementor' ),
 				'revisions_disabled_1' => __( 'It looks like the post revision feature is unavailable in your website.', 'elementor' ),
-				// translators: %s: WordPress Revision docs.,
-				'revisions_disabled_2' => sprintf( __( 'Learn more about <a targe="_blank" href="%s">WordPress revisions</a>', 'elementor' ), 'https://codex.wordpress.org/Revisions#Revision_Options)' ),
+				'revisions_disabled_2' => sprintf(
+					/* translators: %s: Codex URL */
+					__( 'Learn more about <a targe="_blank" href="%s">WordPress revisions</a>', 'elementor' ),
+					'https://codex.wordpress.org/Revisions#Revision_Options'
+				),
 			],
 		] );
 


### PR DESCRIPTION
Make it easier for translators to [translate Elementor string](https://translate.wordpress.org/locale/he/default/wp-plugins/elementor) with `%s` placeholders.