### PR TITLE
Flatpickr script should be enqueued in the footer like the others

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -267,7 +267,8 @@ class Frontend {
 			[
 				'jquery',
 			],
-			'4.1.4'
+			'4.1.4',
+			true
 		);
 
 		wp_register_script(


### PR DESCRIPTION
Is there a reason for not enqueing flatpickr.js in the footer?
It is render blocking. 

Thanks.