### PR TITLE
Fix play-icon styling conditions in the Video Widget

### DIFF
--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -396,6 +396,7 @@ class Widget_Video extends Widget_Base {
 				'label' => __( 'Play Icon', 'elementor' ),
 				'type' => Controls_Manager::HEADING,
 				'condition' => [
+					'show_image_overlay' => 'yes',
 					'show_play_icon' => 'yes',
 				],
 			]
@@ -411,6 +412,7 @@ class Widget_Video extends Widget_Base {
 				],
 				'separator' => 'before',
 				'condition' => [
+					'show_image_overlay' => 'yes',
 					'show_play_icon' => 'yes',
 				],
 			]
@@ -431,6 +433,7 @@ class Widget_Video extends Widget_Base {
 					'{{WRAPPER}} .elementor-custom-embed-play i' => 'font-size: {{SIZE}}{{UNIT}}',
 				],
 				'condition' => [
+					'show_image_overlay' => 'yes',
 					'show_play_icon' => 'yes',
 				],
 			]
@@ -447,6 +450,7 @@ class Widget_Video extends Widget_Base {
 					],
 				],
 				'condition' => [
+					'show_image_overlay' => 'yes',
 					'show_play_icon' => 'yes',
 				],
 			]

--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -396,7 +396,7 @@ class Widget_Video extends Widget_Base {
 				'label' => __( 'Play Icon', 'elementor' ),
 				'type' => Controls_Manager::HEADING,
 				'condition' => [
-					'show_image_overlay' => 'yes',
+					'show_play_icon' => 'yes',
 				],
 			]
 		);
@@ -411,7 +411,7 @@ class Widget_Video extends Widget_Base {
 				],
 				'separator' => 'before',
 				'condition' => [
-					'show_image_overlay' => 'yes',
+					'show_play_icon' => 'yes',
 				],
 			]
 		);
@@ -431,7 +431,7 @@ class Widget_Video extends Widget_Base {
 					'{{WRAPPER}} .elementor-custom-embed-play i' => 'font-size: {{SIZE}}{{UNIT}}',
 				],
 				'condition' => [
-					'show_image_overlay' => 'yes',
+					'show_play_icon' => 'yes',
 				],
 			]
 		);
@@ -447,7 +447,7 @@ class Widget_Video extends Widget_Base {
 					],
 				],
 				'condition' => [
-					'show_image_overlay' => 'yes',
+					'show_play_icon' => 'yes',
 				],
 			]
 		);


### PR DESCRIPTION
The styling conditions for the **Play Icon** control are using conditions of the overlay control instead of the play icon control.

For example, I can enable **Image Overlay** and hide **Play Icon** on the content tab, but it will display the play icon styling controls while they should be hidden.