### PR TITLE
 Video Widget - Play Icon: Replace the select control with a switcher control

### DIFF
--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -335,12 +335,11 @@ class Widget_Video extends Widget_Base {
 			'show_play_icon',
 			[
 				'label' => __( 'Play Icon', 'elementor' ),
-				'type' => Controls_Manager::SELECT,
+				'type' => Controls_Manager::SWITCHER,
 				'default' => 'yes',
-				'options' => [
-					'yes' => __( 'Yes', 'elementor' ),
-					'no' => __( 'No', 'elementor' ),
-				],
+				'label_off' => __( 'No', 'elementor' ),
+				'label_on' => __( 'Yes', 'elementor' ),
+				'return_value' => 'yes',
 				'condition' => [
 					'show_image_overlay' => 'yes',
 					'image_overlay[url]!' => '',


### PR DESCRIPTION
Fix #3241

## Current

![video-play-icon](https://user-images.githubusercontent.com/576623/35132019-da83f576-fcd1-11e7-8fe3-ca596c17df27.png)

## New

![video-play-icon2](https://user-images.githubusercontent.com/576623/35195106-2b593a0a-fec7-11e7-9fd9-4017e5ded981.png)
