### PR TITLE
a11y: Video widget accessibility

### DIFF
--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -628,7 +628,7 @@ class Widget_Video extends Widget_Base {
 						<img src="<?php echo $settings['image_overlay']['url']; ?>">
 					<?php endif; ?>
 					<?php if ( 'yes' === $settings['show_play_icon'] ) : ?>
-						<div class="elementor-custom-embed-play">
+						<div class="elementor-custom-embed-play" role="button">
 							<i class="eicon-play" aria-hidden="true"></i>
 							<span class="elementor-screen-only"><?php esc_html_e( 'Play Video', 'elementor' ); ?></span>
 						</div>

--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -630,6 +630,7 @@ class Widget_Video extends Widget_Base {
 					<?php if ( 'yes' === $settings['show_play_icon'] ) : ?>
 						<div class="elementor-custom-embed-play">
 							<i class="eicon-play" aria-hidden="true"></i>
+							<span class="elementor-screen-only"><?php esc_html_e( 'Play Video', 'elementor' ); ?></span>
 						</div>
 					<?php endif; ?>
 				</div>


### PR DESCRIPTION
## Description

The video widget need some accessibility love!

1. **Name** - The iframe should have an accessibility name (https://fae.disability.illinois.edu/rulesets/FRAME_2/), either `title` or `aria-label` tags.

2. **Action** - The play icon should have some text saying "Play video" or some thing like that. Currently, regular visitors **see** the play button and understand that clicking the icon actives the video, but blind people **don't see** the icon. We need to add an assistive text for them.

3. **Markup** - The play icon wrapper is a `<div>`, it should be a `<button>`. The second approach is to add `role="button"` to the `<div>` tag.

![video-a11y](https://user-images.githubusercontent.com/576623/35197381-2c328a24-fee7-11e7-96c7-6ddf18ae6e20.png)