### PR TITLE
a11y: Button widget accessibility

### DIFF
--- a/includes/widgets/button.php
+++ b/includes/widgets/button.php
@@ -412,6 +412,7 @@ class Widget_Button extends Widget_Base {
 		}
 
 		$this->add_render_attribute( 'button', 'class', 'elementor-button' );
+		$this->add_render_attribute( 'button', 'role', 'button' );
 
 		if ( ! empty( $settings['size'] ) ) {
 			$this->add_render_attribute( 'button', 'class', 'elementor-size-' . $settings['size'] );
@@ -446,7 +447,7 @@ class Widget_Button extends Widget_Base {
 		view.addInlineEditingAttributes( 'text', 'none' );
 		#>
 		<div class="elementor-button-wrapper">
-			<a class="elementor-button elementor-size-{{ settings.size }} elementor-animation-{{ settings.hover_animation }}" href="{{ settings.link.url }}">
+			<a class="elementor-button elementor-size-{{ settings.size }} elementor-animation-{{ settings.hover_animation }}" href="{{ settings.link.url }}" role="button">
 				<span class="elementor-button-content-wrapper">
 					<# if ( settings.icon ) { #>
 					<span class="elementor-button-icon elementor-align-icon-{{ settings.icon_align }}">


### PR DESCRIPTION
## Description

The button widget need some accessibility love!

Currently the button wrapper is an `<a>` tag. We can either replace it with a `<button>`, but it can cause UI issues in some sites that has custom CSS for the button tag. The second approach is to add `role="button"` to the `<a>` tag.