### PR TITLE
a11y: Icon widget accessibility

### DIFF
--- a/includes/widgets/icon.php
+++ b/includes/widgets/icon.php
@@ -359,6 +359,7 @@ class Widget_Icon extends Widget_Base {
 
 		if ( ! empty( $settings['icon'] ) ) {
 			$this->add_render_attribute( 'icon', 'class', $settings['icon'] );
+			$this->add_render_attribute( 'icon', 'aria-hidden', 'true' );
 		}
 
 		?>
@@ -384,7 +385,7 @@ class Widget_Icon extends Widget_Base {
 				iconTag = link ? 'a' : 'div'; #>
 		<div class="elementor-icon-wrapper">
 			<{{{ iconTag }}} class="elementor-icon elementor-animation-{{ settings.hover_animation }}" {{{ link }}}>
-				<i class="{{ settings.icon }}"></i>
+				<i class="{{ settings.icon }}" aria-hidden="true"></i>
 			</{{{ iconTag }}}>
 		</div>
 		<?php


### PR DESCRIPTION
## Description

The icon widget need some accessibility love!

The current `<i>` tag should have an aria tags for better accessibility.  As icons are used for pure decoration or visual styling they should not be displayed to an assistive technology-using user. We need to make sure it's not read, by adding the `aria-hidden="true"` to the markup.

![icon-widget](https://user-images.githubusercontent.com/576623/35198743-16531cea-fefc-11e7-81d9-5a58beb19895.png)
