### PR TITLE
a11y: Icon Box widget accessibility

### DIFF
--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -573,6 +573,7 @@ class Widget_Icon_Box extends Widget_Base {
 		}
 
 		$this->add_render_attribute( 'i', 'class', $settings['icon'] );
+		$this->add_render_attribute( 'i', 'aria-hidden', 'true' );
 
 		$icon_attributes = $this->get_render_attribute_string( 'icon' );
 		$link_attributes = $this->get_render_attribute_string( 'link' );
@@ -621,7 +622,7 @@ class Widget_Icon_Box extends Widget_Base {
         <div class="elementor-icon-box-wrapper">
             <div class="elementor-icon-box-icon">
                 <{{{ iconTag + ' ' + link }}} class="elementor-icon elementor-animation-{{ settings.hover_animation }}">
-                    <i class="{{ settings.icon }}"></i>
+                    <i class="{{ settings.icon }}" aria-hidden="true"></i>
                 </{{{ iconTag }}}>
             </div>
             <div class="elementor-icon-box-content">


### PR DESCRIPTION
## Description

The icon box widget need some accessibility love!

The Icon box has 3 elements: `<i>` icon, the title with custom HTML tag controlled by the user, and a description paragraph in `<p>`.

The `<i>` icon is used for pure decoration or visual styling, and it should not be displayed to an assistive technology-using user. We need to add `aria-hidden="true"` to the markup.

![icon-box](https://user-images.githubusercontent.com/576623/35198862-b389d926-fefd-11e7-937d-1f28ec1fd869.png)