### PR TITLE
a11y: Google Maps widget accessibility

### DIFF
--- a/includes/widgets/google-maps.php
+++ b/includes/widgets/google-maps.php
@@ -165,9 +165,10 @@ class Widget_Google_Maps extends Widget_Base {
 		}
 
 		printf(
-			'<div class="elementor-custom-embed"><iframe frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://maps.google.com/maps?q=%s&amp;t=m&amp;z=%d&amp;output=embed&amp;iwloc=near"></iframe></div>',
+			'<div class="elementor-custom-embed"><iframe frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://maps.google.com/maps?q=%s&amp;t=m&amp;z=%d&amp;output=embed&amp;iwloc=near" aria-label="%s"></iframe></div>',
 			rawurlencode( $settings['address'] ),
-			absint( $settings['zoom']['size'] )
+			absint( $settings['zoom']['size'] ),
+			esc_attr( $settings['address'] )
 		);
 	}
 


### PR DESCRIPTION
## Description

The google maps widget need some accessibility love!

The current `iframe` should have an accessibility name, we can either add a `title` or an `aria-label` tag. The content of the tag will be the **Address** field.

![google-map-widget](https://user-images.githubusercontent.com/576623/35197681-933f456e-feeb-11e7-85d7-a633e372c7c2.png)
