### PR TITLE
Hooks: rename hook names to match Elementor naming convention

### DIFF
--- a/core/settings/base/manager.php
+++ b/core/settings/base/manager.php
@@ -25,7 +25,8 @@ abstract class Manager {
 
 		add_action( 'elementor/ajax/register_actions', [ $this, 'register_ajax_actions' ] );
 
-		add_action( 'elementor/' . $this->get_css_file_name() . '-css-file/parse', [ $this, 'add_settings_css_rules' ] );
+		$name = $this->get_css_file_name();
+		add_action( "elementor/css-file/{$name}/parse", [ $this, 'add_settings_css_rules' ] );
 	}
 
 	/**

--- a/core/settings/base/manager.php
+++ b/core/settings/base/manager.php
@@ -107,11 +107,31 @@ abstract class Manager {
 		 *
 		 * The dynamic portion of the hook name, `$settings_name`, refers to the settings name.
 		 *
+		 * @todo Need to be hard deprecated using `apply_filters_deprecated()`.
+		 *
+		 * @since 1.6.0
+		 * @deprecated 2.0.0 Use `elementor/settings/{$settings_name}/success_response_data` filter.
+		 *
 		 * @param array $success_response_data Success response data.
 		 * @param int   $id                    Settings ID.
 		 * @param array $data                  Settings data.
 		 */
 		$success_response_data = apply_filters( "elementor/{$settings_name}/settings/success_response_data", $success_response_data, $id, $data );
+
+		/**
+		 * Settings success response data.
+		 *
+		 * Filters the success response data when saving settings using ajax.
+		 *
+		 * The dynamic portion of the hook name, `$settings_name`, refers to the settings name.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param array $success_response_data Success response data.
+		 * @param int   $id                    Settings ID.
+		 * @param array $data                  Settings data.
+		 */
+		$success_response_data = apply_filters( "elementor/settings/{$settings_name}/success_response_data", $success_response_data, $id, $data );
 
 		return $success_response_data;
 	}

--- a/includes/css-file/css-file.php
+++ b/includes/css-file/css-file.php
@@ -275,11 +275,14 @@ abstract class CSS_File {
 		 *
 		 * The dynamic portion of the hook name, `$name`, refers to the CSS file name.
 		 *
+		 * @todo Need to be hard deprecated using `do_action_deprecated()`.
+		 *
 		 * @since 1.9.0
+		 * @deprecated 2.0.0 Use `elementor/css-file/{$name}/enqueue` action.
 		 *
 		 * @param CSS_File $this The current CSS file.
 		 */
-		Utils::do_action_deprecated( "elementor/{$name}-css-file/enqueue", array( $this ), '2.0.0', "elementor/css-file/{$name}/enqueue" );
+		do_action( "elementor/{$name}-css-file/enqueue", $this );
 
 		/**
 		 * Enqueue CSS file.
@@ -640,11 +643,14 @@ abstract class CSS_File {
 		 *
 		 * The dynamic portion of the hook name, `$name`, refers to the CSS file name.
 		 *
+		 * @todo Need to be hard deprecated using `do_action_deprecated()`.
+		 *
 		 * @since 1.2.0
+		 * @deprecated 2.0.0 Use `elementor/css-file/{$name}/parse` action.
 		 *
 		 * @param CSS_File $this The current CSS file.
 		 */
-		Utils::do_action_deprecated( "elementor/{$name}-css-file/parse", array( $this ), '2.0.0', "elementor/css-file/{$name}/parse" );
+		do_action( "elementor/{$name}-css-file/parse", $this );
 
 		/**
 		 * Parse CSS file.

--- a/includes/css-file/css-file.php
+++ b/includes/css-file/css-file.php
@@ -269,7 +269,7 @@ abstract class CSS_File {
 		$name = $this->get_name();
 
 		/**
-		 * CSS file enqueue.
+		 * Enqueue CSS file.
 		 *
 		 * Fires when CSS file is enqueued on Elementor.
 		 *
@@ -279,7 +279,20 @@ abstract class CSS_File {
 		 *
 		 * @param CSS_File $this The current CSS file.
 		 */
-		do_action( "elementor/{$name}-css-file/enqueue", $this );
+		Utils::do_action_deprecated( "elementor/{$name}-css-file/enqueue", array( $this ), '2.0.0', "elementor/css-file/{$name}/enqueue" );
+
+		/**
+		 * Enqueue CSS file.
+		 *
+		 * Fires when CSS file is enqueued on Elementor.
+		 *
+		 * The dynamic portion of the hook name, `$name`, refers to the CSS file name.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param CSS_File $this The current CSS file.
+		 */
+		do_action( "elementor/css-file/{$name}/enqueue", $this );
 	}
 
 	/**
@@ -621,7 +634,7 @@ abstract class CSS_File {
 		$name = $this->get_name();
 
 		/**
-		 * CSS file parse.
+		 * Parse CSS file.
 		 *
 		 * Fires when CSS file is parsed on Elementor.
 		 *
@@ -631,7 +644,20 @@ abstract class CSS_File {
 		 *
 		 * @param CSS_File $this The current CSS file.
 		 */
-		do_action( "elementor/{$name}-css-file/parse", $this );
+		Utils::do_action_deprecated( "elementor/{$name}-css-file/parse", array( $this ), '2.0.0', "elementor/css-file/{$name}/parse" );
+
+		/**
+		 * Parse CSS file.
+		 *
+		 * Fires when CSS file is parsed on Elementor.
+		 *
+		 * The dynamic portion of the hook name, `$name`, refers to the CSS file name.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param CSS_File $this The current CSS file.
+		 */
+		do_action( "elementor/css-file/{$name}/parse", $this );
 
 		$this->css = $this->stylesheet_obj->__toString();
 	}


### PR DESCRIPTION
Rename action name to match Elementor hooks naming convention that says that the first we prefix the component ( _css-file_ ) and then add the dynamic portion ( _$name_ )

**Old Hooks:**

* `"elementor/{$name}-css-file/parse"`
* `"elementor/{$name}-css-file/enqueue"`

**New Hooks:**

* `"elementor/css-file/{$name}/parse"`
* `"elementor/css-file/{$name}/enqueue"`

**Note:**

Both hooks have `do_action_deprecated()` for backwards compatibility.
