### PR TITLE
Add "caption_space" control to the Image Widget

### DIFF
--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -319,23 +319,6 @@ class Widget_Image extends Widget_Base {
 			]
 		);
 
-		$this->add_responsive_control(
-			'caption_space',
-			[
-				'label' => __( 'Spacing', 'elementor' ),
-				'type' => Controls_Manager::SLIDER,
-				'range' => [
-					'px' => [
-						'min' => 0,
-						'max' => 100,
-					],
-				],
-				'selectors' => [
-					'{{WRAPPER}} .widget-image-caption' => 'margin-top: {{SIZE}}{{UNIT}};',
-				],
-			]
-		);
-
 		$this->add_control(
 			'text_color',
 			[
@@ -358,6 +341,23 @@ class Widget_Image extends Widget_Base {
 				'name' => 'caption_typography',
 				'selector' => '{{WRAPPER}} .widget-image-caption',
 				'scheme' => Scheme_Typography::TYPOGRAPHY_3,
+			]
+		);
+
+		$this->add_responsive_control(
+			'caption_space',
+			[
+				'label' => __( 'Spacing', 'elementor' ),
+				'type' => Controls_Manager::SLIDER,
+				'range' => [
+					'px' => [
+						'min' => 0,
+						'max' => 100,
+					],
+				],
+				'selectors' => [
+					'{{WRAPPER}} .widget-image-caption' => 'margin-top: {{SIZE}}{{UNIT}};',
+				],
 			]
 		);
 

--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -319,6 +319,23 @@ class Widget_Image extends Widget_Base {
 			]
 		);
 
+		$this->add_responsive_control(
+			'caption_space',
+			[
+				'label' => __( 'Spacing', 'elementor' ),
+				'type' => Controls_Manager::SLIDER,
+				'range' => [
+					'px' => [
+						'min' => 0,
+						'max' => 100,
+					],
+				],
+				'selectors' => [
+					'{{WRAPPER}} .widget-image-caption' => 'margin-top: {{SIZE}}{{UNIT}};',
+				],
+			]
+		);
+
 		$this->add_control(
 			'text_color',
 			[


### PR DESCRIPTION
The **Image Widget** allows us to add a caption. But the user can't control the space between the image and the caption.

This PR adds new slider control that adds top margin to the caption.

Note that the control was copied from the Image Box control.

![image-spacing](https://user-images.githubusercontent.com/576623/36106324-aa3b9e4e-101f-11e8-8a6f-bc08d9647fc1.png)
