### PR TITLE
Match HTML tags for the section and the column

### DIFF
--- a/includes/elements/column.php
+++ b/includes/elements/column.php
@@ -182,7 +182,10 @@ class Element_Column extends Element_Base {
 
 		$possible_tags = [
 			'div',
+			'header',
+			'footer',
 			'article',
+			'section',
 			'aside',
 			'nav',
 		];

--- a/includes/elements/section.php
+++ b/includes/elements/section.php
@@ -447,13 +447,13 @@ class Element_Section extends Element_Base {
 		);
 
 		$possible_tags = [
-			'section',
+			'div',
 			'header',
 			'footer',
-			'aside',
 			'article',
+			'section',
+			'aside',
 			'nav',
-			'div',
 		];
 
 		$options = [


### PR DESCRIPTION
Both the **Section** and the **Column** should have the same HTML tags available. This way the user can choose his own HTML structure.