### PR TITLE
Allow responsive control class suffixes

### DIFF
--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -738,7 +738,7 @@ abstract class Controls_Stack {
 	final public function get_class_controls() {
 		return array_filter(
 			$this->get_active_controls(), function( $control ) {
-				return ( isset( $control['prefix_class'] ) );
+				return ( isset( $control['prefix_class'] || isset( $control['suffix_class'] ) );
 			}
 		);
 	}

--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -738,7 +738,7 @@ abstract class Controls_Stack {
 	final public function get_class_controls() {
 		return array_filter(
 			$this->get_active_controls(), function( $control ) {
-				return ( isset( $control['prefix_class'] || isset( $control['suffix_class'] ) );
+				return ( isset( $control['prefix_class'] ) || isset( $control['suffix_class'] ) );
 			}
 		);
 	}

--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -810,6 +810,11 @@ abstract class Controls_Stack {
 
 				$control_args['prefix_class'] = sprintf( $args['prefix_class'], $device_to_replace );
 			}
+			if ( ! empty( $args['suffix_class'] ) ) {
+				$device_to_replace = self::RESPONSIVE_DESKTOP === $device_name ? '' : '-' . $device_name;
+
+				$control_args['suffix_class'] = sprintf( $args['suffix_class'], $device_to_replace );
+			}
 
 			$control_args['responsive']['max'] = $device_name;
 

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -794,7 +794,7 @@ abstract class Element_Base extends Controls_Stack {
 				continue;
 			}
 
-			$this->add_render_attribute( '_wrapper', 'class', $control['prefix_class'] . $settings[ $control['name'] ] . $control['suffix_class'] );
+			$this->add_render_attribute( '_wrapper', 'class', $control['prefix_class'] . $settings[ $control['name'] ] . isset($control['suffix_class']) ? $control['suffix_class'] : '' );
 		}
 
 		if ( ! empty( $settings['animation'] ) || ! empty( $settings['_animation'] ) ) {

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -794,7 +794,11 @@ abstract class Element_Base extends Controls_Stack {
 				continue;
 			}
 
-			$this->add_render_attribute( '_wrapper', 'class', $control['prefix_class'] . $settings[ $control['name'] ] . isset($control['suffix_class']) ? $control['suffix_class'] : '' );
+			$this->add_render_attribute(
+				'_wrapper',
+				'class',
+				isset($control['prefix_class']) ? $control['prefix_class'] : '' . $settings[ $control['name'] ] . isset($control['suffix_class']) ? $control['suffix_class'] : ''
+			);
 		}
 
 		if ( ! empty( $settings['animation'] ) || ! empty( $settings['_animation'] ) ) {

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -794,7 +794,7 @@ abstract class Element_Base extends Controls_Stack {
 				continue;
 			}
 
-			$this->add_render_attribute( '_wrapper', 'class', $control['prefix_class'] . $settings[ $control['name'] ] );
+			$this->add_render_attribute( '_wrapper', 'class', $control['prefix_class'] . $settings[ $control['name'] ] . $control['suffix_class'] );
 		}
 
 		if ( ! empty( $settings['animation'] ) || ! empty( $settings['_animation'] ) ) {


### PR DESCRIPTION
This PR would enable devs to set a cluss suffix for responsive controls like this:
```
'prefix_class' => 'align-',
'suffix_class' => '%s',
```

This way one can create responsive classes like ``.align-center-tablet`` which gives the framework more flexibility.