### PR TITLE
Fix issue with overriding media queries 

### DIFF
--- a/includes/stylesheet.php
+++ b/includes/stylesheet.php
@@ -384,12 +384,12 @@ class Stylesheet {
 
 				$b_query = $this->hash_to_query( $b );
 
-				if ( isset( $a_query['max'] ) && !isset($b_query['max']) ) {
+				if ( isset( $a_query['max'] ) xor isset( $b_query['max'] ) ) {
 					return -1;
 				}
 
 				if ( isset( $a_query['min'] ) xor isset( $b_query['min'] ) ) {
-					return 1;
+					return -1;
 				}
 
 				if ( isset( $a_query['min'] ) ) {

--- a/includes/stylesheet.php
+++ b/includes/stylesheet.php
@@ -384,6 +384,10 @@ class Stylesheet {
 
 				$b_query = $this->hash_to_query( $b );
 
+				if ( isset( $a_query['max'] ) && !isset($b_query['max']) ) {
+					return -1;
+				}
+
 				if ( isset( $a_query['min'] ) xor isset( $b_query['min'] ) ) {
 					return 1;
 				}


### PR DESCRIPTION
Throwing queries with "max-width" and "min-width" values lower in CSS than queries with only "min-width".

When Elementor generate CSS, puts media query with max and min value before query with only min value, so ex. "width" value couldn't be overridden. This generate problem with the columns sizes in responsive. In my case column size on tablet could override column size on desktop.

After this fix, when media queries are sorting and first element have max value but second doesn't, puts first element lower in CSS file.