### PR TITLE
Control Settings: remove 'placeholder' and 'title' settings from base settings

### DIFF
--- a/includes/controls/base.php
+++ b/includes/controls/base.php
@@ -27,8 +27,6 @@ abstract class Base_Control {
 	 */
 	private $_base_settings = [
 		'label' => '',
-		'title' => '',
-		'placeholder' => '',
 		'description' => '',
 		'separator' => 'default',
 		'show_label' => true,

--- a/includes/controls/number.php
+++ b/includes/controls/number.php
@@ -44,6 +44,8 @@ class Control_Number extends Base_Data_Control {
 			'min' => '',
 			'max' => '',
 			'step' => '',
+			'placeholder' => '',
+			'title' => '',
 		];
 	}
 

--- a/includes/controls/text.php
+++ b/includes/controls/text.php
@@ -69,6 +69,8 @@ class Control_Text extends Base_Data_Control {
 	protected function get_default_settings() {
 		return [
 			'input_type' => 'text',
+			'placeholder' => '',
+			'title' => '',
 			'dynamic' => [
 				'categories' => [ TagsModule::TEXT_CATEGORY ],
 			],

--- a/includes/controls/textarea.php
+++ b/includes/controls/textarea.php
@@ -45,6 +45,7 @@ class Control_Textarea extends Base_Data_Control {
 		return [
 			'label_block' => true,
 			'rows' => 5,
+			'placeholder' => '',
 			'dynamic' => [
 				'categories' => [ TagsModule::TEXT_CATEGORY ],
 			],

--- a/includes/controls/url.php
+++ b/includes/controls/url.php
@@ -65,6 +65,7 @@ class Control_URL extends Control_Base_Multiple {
 		return [
 			'label_block' => true,
 			'show_external' => true,
+			'placeholder' => '',
 			'dynamic' => [
 				'categories' => [ TagsModule::URL_CATEGORY ],
 				'property' => 'url',


### PR DESCRIPTION
The `$_base_settings` property in `Base_Control` holds the common settings relevant for all the controls (`label`, `description`, `separator`, `label_block`, `show_label`), but it also has two settings that are relevant to few very specific controls (`title`, `placeholder`). Those settings should be moved to those specific controls to their `get_default_settings()` methods.