### PR TITLE
Extracted button styles in another method

### DIFF
--- a/includes/widgets/button.php
+++ b/includes/widgets/button.php
@@ -94,6 +94,16 @@ class Widget_Button extends Widget_Base {
 		];
 	}
 
+	public static function get_button_types() {
+		return [
+			'' => __( 'Default', 'elementor' ),
+			'info' => __( 'Info', 'elementor' ),
+			'success' => __( 'Success', 'elementor' ),
+			'warning' => __( 'Warning', 'elementor' ),
+			'danger' => __( 'Danger', 'elementor' ),
+		];
+	}
+
 	/**
 	 * Register button widget controls.
 	 *
@@ -116,13 +126,7 @@ class Widget_Button extends Widget_Base {
 				'label' => __( 'Type', 'elementor' ),
 				'type' => Controls_Manager::SELECT,
 				'default' => '',
-				'options' => [
-					'' => __( 'Default', 'elementor' ),
-					'info' => __( 'Info', 'elementor' ),
-					'success' => __( 'Success', 'elementor' ),
-					'warning' => __( 'Warning', 'elementor' ),
-					'danger' => __( 'Danger', 'elementor' ),
-				],
+				'options' => self::get_button_types(),
 				'prefix_class' => 'elementor-button-',
 			]
 		);

--- a/includes/widgets/button.php
+++ b/includes/widgets/button.php
@@ -94,6 +94,17 @@ class Widget_Button extends Widget_Base {
 		];
 	}
 
+	/**
+	 * Get button styles.
+	 *
+	 * Retrieve an array of button styles for the button widget.
+	 *
+	 * @since 1.0.0
+	 * @access public
+	 * @static
+	 *
+	 * @return array An array containing button styles.
+	 */
 	public static function get_button_types() {
 		return [
 			'' => __( 'Default', 'elementor' ),


### PR DESCRIPTION
The reasoning is simple: while you can get the default sizing, you can't also get the default styling, which is pretty bad when you want to extend stuff a bit.