### PR TITLE
Icon Widgets

### DIFF
--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -221,6 +221,15 @@ class Widget_Icon_Box extends Widget_Base {
 			]
 		);
 
+		$this->start_controls_tabs( 'icon_colors' );
+
+		$this->start_controls_tab(
+			'icon_colors_normal',
+			[
+				'label' => __( 'Normal', 'elementor' ),
+			]
+		);
+
 		$this->add_control(
 			'primary_color',
 			[
@@ -253,6 +262,56 @@ class Widget_Icon_Box extends Widget_Base {
 				],
 			]
 		);
+
+		$this->end_controls_tab();
+
+		$this->start_controls_tab(
+			'icon_colors_hover',
+			[
+				'label' => __( 'Hover', 'elementor' ),
+			]
+		);
+
+		$this->add_control(
+			'hover_primary_color',
+			[
+				'label' => __( 'Primary Color', 'elementor' ),
+				'type' => Controls_Manager::COLOR,
+				'default' => '',
+				'selectors' => [
+					'{{WRAPPER}}.elementor-view-stacked .elementor-icon:hover' => 'background-color: {{VALUE}};',
+					'{{WRAPPER}}.elementor-view-framed .elementor-icon:hover, {{WRAPPER}}.elementor-view-default .elementor-icon:hover' => 'color: {{VALUE}}; border-color: {{VALUE}};',
+				],
+			]
+		);
+
+		$this->add_control(
+			'hover_secondary_color',
+			[
+				'label' => __( 'Secondary Color', 'elementor' ),
+				'type' => Controls_Manager::COLOR,
+				'default' => '',
+				'condition' => [
+					'view!' => 'default',
+				],
+				'selectors' => [
+					'{{WRAPPER}}.elementor-view-framed .elementor-icon:hover' => 'background-color: {{VALUE}};',
+					'{{WRAPPER}}.elementor-view-stacked .elementor-icon:hover' => 'color: {{VALUE}};',
+				],
+			]
+		);
+
+		$this->add_control(
+			'hover_animation',
+			[
+				'label' => __( 'Hover Animation', 'elementor' ),
+				'type' => Controls_Manager::HOVER_ANIMATION,
+			]
+		);
+
+		$this->end_controls_tab();
+
+		$this->end_controls_tabs();
 
 		$this->add_responsive_control(
 			'icon_space',
@@ -355,56 +414,6 @@ class Widget_Icon_Box extends Widget_Base {
 				'condition' => [
 					'view!' => 'default',
 				],
-			]
-		);
-
-		$this->end_controls_section();
-
-		$this->start_controls_section(
-			'section_hover',
-			[
-				'label' => __( 'Icon Hover', 'elementor' ),
-				'tab' => Controls_Manager::TAB_STYLE,
-				'condition' => [
-					'icon!' => '',
-				],
-			]
-		);
-
-		$this->add_control(
-			'hover_primary_color',
-			[
-				'label' => __( 'Primary Color', 'elementor' ),
-				'type' => Controls_Manager::COLOR,
-				'default' => '',
-				'selectors' => [
-					'{{WRAPPER}}.elementor-view-stacked .elementor-icon:hover' => 'background-color: {{VALUE}};',
-					'{{WRAPPER}}.elementor-view-framed .elementor-icon:hover, {{WRAPPER}}.elementor-view-default .elementor-icon:hover' => 'color: {{VALUE}}; border-color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_control(
-			'hover_secondary_color',
-			[
-				'label' => __( 'Secondary Color', 'elementor' ),
-				'type' => Controls_Manager::COLOR,
-				'default' => '',
-				'condition' => [
-					'view!' => 'default',
-				],
-				'selectors' => [
-					'{{WRAPPER}}.elementor-view-framed .elementor-icon:hover' => 'background-color: {{VALUE}};',
-					'{{WRAPPER}}.elementor-view-stacked .elementor-icon:hover' => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_control(
-			'hover_animation',
-			[
-				'label' => __( 'Hover Animation', 'elementor' ),
-				'type' => Controls_Manager::HOVER_ANIMATION,
 			]
 		);
 

--- a/includes/widgets/icon-list.php
+++ b/includes/widgets/icon-list.php
@@ -204,6 +204,9 @@ class Widget_Icon_List extends Widget_Base {
 				'selectors' => [
 					'{{WRAPPER}} .elementor-icon-list-item:not(:last-child):after' => 'content: ""',
 				],
+				'condition' => [
+					'view' => 'traditional',
+				],
 				'separator' => 'before',
 			]
 		);
@@ -221,6 +224,7 @@ class Widget_Icon_List extends Widget_Base {
 				],
 				'default' => 'solid',
 				'condition' => [
+					'view' => 'traditional',
 					'divider' => 'yes',
 				],
 				'selectors' => [
@@ -244,6 +248,7 @@ class Widget_Icon_List extends Widget_Base {
 					],
 				],
 				'condition' => [
+					'view' => 'traditional',
 					'divider' => 'yes',
 				],
 				'selectors' => [
@@ -263,6 +268,7 @@ class Widget_Icon_List extends Widget_Base {
 					'value' => Scheme_Color::COLOR_3,
 				],
 				'condition' => [
+					'view' => 'traditional',
 					'divider' => 'yes',
 				],
 				'selectors' => [
@@ -281,6 +287,7 @@ class Widget_Icon_List extends Widget_Base {
 					'unit' => '%',
 				],
 				'condition' => [
+					'view' => 'traditional',
 					'divider' => 'yes',
 				],
 				'selectors' => [

--- a/includes/widgets/icon-list.php
+++ b/includes/widgets/icon-list.php
@@ -360,7 +360,7 @@ class Widget_Icon_List extends Widget_Base {
 		$this->add_control(
 			'text_color',
 			[
-				'label' => __( 'Text Color', 'elementor' ),
+				'label' => __( 'Color', 'elementor' ),
 				'type' => Controls_Manager::COLOR,
 				'default' => '',
 				'selectors' => [

--- a/includes/widgets/icon.php
+++ b/includes/widgets/icon.php
@@ -178,6 +178,15 @@ class Widget_Icon extends Widget_Base {
 			]
 		);
 
+		$this->start_controls_tabs( 'icon_colors' );
+
+		$this->start_controls_tab(
+			'icon_colors_normal',
+			[
+				'label' => __( 'Normal', 'elementor' ),
+			]
+		);
+
 		$this->add_control(
 			'primary_color',
 			[
@@ -210,6 +219,56 @@ class Widget_Icon extends Widget_Base {
 				],
 			]
 		);
+
+		$this->end_controls_tab();
+
+		$this->start_controls_tab(
+			'icon_colors_hover',
+			[
+				'label' => __( 'Hover', 'elementor' ),
+			]
+		);
+
+		$this->add_control(
+			'hover_primary_color',
+			[
+				'label' => __( 'Primary Color', 'elementor' ),
+				'type' => Controls_Manager::COLOR,
+				'default' => '',
+				'selectors' => [
+					'{{WRAPPER}}.elementor-view-stacked .elementor-icon:hover' => 'background-color: {{VALUE}};',
+					'{{WRAPPER}}.elementor-view-framed .elementor-icon:hover, {{WRAPPER}}.elementor-view-default .elementor-icon:hover' => 'color: {{VALUE}}; border-color: {{VALUE}};',
+				],
+			]
+		);
+
+		$this->add_control(
+			'hover_secondary_color',
+			[
+				'label' => __( 'Secondary Color', 'elementor' ),
+				'type' => Controls_Manager::COLOR,
+				'default' => '',
+				'condition' => [
+					'view!' => 'default',
+				],
+				'selectors' => [
+					'{{WRAPPER}}.elementor-view-framed .elementor-icon:hover' => 'background-color: {{VALUE}};',
+					'{{WRAPPER}}.elementor-view-stacked .elementor-icon:hover' => 'color: {{VALUE}};',
+				],
+			]
+		);
+
+		$this->add_control(
+			'hover_animation',
+			[
+				'label' => __( 'Hover Animation', 'elementor' ),
+				'type' => Controls_Manager::HOVER_ANIMATION,
+			]
+		);
+
+		$this->end_controls_tab();
+
+		$this->end_controls_tabs();
 
 		$this->add_control(
 			'size',
@@ -289,53 +348,6 @@ class Widget_Icon extends Widget_Base {
 				'condition' => [
 					'view!' => 'default',
 				],
-			]
-		);
-
-		$this->end_controls_section();
-
-		$this->start_controls_section(
-			'section_hover',
-			[
-				'label' => __( 'Icon Hover', 'elementor' ),
-				'tab' => Controls_Manager::TAB_STYLE,
-			]
-		);
-
-		$this->add_control(
-			'hover_primary_color',
-			[
-				'label' => __( 'Primary Color', 'elementor' ),
-				'type' => Controls_Manager::COLOR,
-				'default' => '',
-				'selectors' => [
-					'{{WRAPPER}}.elementor-view-stacked .elementor-icon:hover' => 'background-color: {{VALUE}};',
-					'{{WRAPPER}}.elementor-view-framed .elementor-icon:hover, {{WRAPPER}}.elementor-view-default .elementor-icon:hover' => 'color: {{VALUE}}; border-color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_control(
-			'hover_secondary_color',
-			[
-				'label' => __( 'Secondary Color', 'elementor' ),
-				'type' => Controls_Manager::COLOR,
-				'default' => '',
-				'condition' => [
-					'view!' => 'default',
-				],
-				'selectors' => [
-					'{{WRAPPER}}.elementor-view-framed .elementor-icon:hover' => 'background-color: {{VALUE}};',
-					'{{WRAPPER}}.elementor-view-stacked .elementor-icon:hover' => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_control(
-			'hover_animation',
-			[
-				'label' => __( 'Hover Animation', 'elementor' ),
-				'type' => Controls_Manager::HOVER_ANIMATION,
 			]
 		);
 


### PR DESCRIPTION
In the **Style** tab, the "**Hover**" controls are displayed in a separate **Section**. This PR moves those controls to the main section into a **Tab** view. Less section, easier and more intuitive navigation.

The PR updates the "Icon Widget" and the "Icon Box Widget". In the Style Tab it adds the "**Normal**" / "**Hover**" tabs, displaying there all the icon colors.

## OLD VIEW:
![aa1](https://user-images.githubusercontent.com/576623/38488943-9bf92744-3bed-11e8-9de0-9db1c3a3facc.png)

## NEW VIEW:
![aa2](https://user-images.githubusercontent.com/576623/38488944-9c1f8808-3bed-11e8-8dbe-2ff3ea75f5b0.png)
