### PR TITLE
New Feature: Element Attributes

### DIFF
--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -758,7 +758,7 @@ abstract class Element_Base extends Controls_Stack {
 			$attributes = explode( "\n", $settings['_attributes'] );
 
 			// Not allowed attributes
-			$black_list = [ 'id', 'class', 'data-id', 'data-settings', 'data-element_type', 'data-model-cid', 'onload', 'onclick', 'onfocus', 'onchange', 'onresize', 'onmouseover', 'onmouseout', 'onkeydown' ];
+			$black_list = [ 'id', 'class', 'data-id', 'data-settings', 'data-element_type', 'data-model-cid', 'onload', 'onclick', 'onfocus', 'onblur', 'onchange', 'onresize', 'onmouseover', 'onmouseout', 'onkeydown', 'onkeyup' ];
 
 			/**
 			 * Elementor attributes black list.

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -733,9 +733,13 @@ abstract class Element_Base extends Controls_Stack {
 	protected function _add_render_attributes() {
 		$id = $this->get_id();
 
-		$this->add_render_attribute( '_wrapper', 'class', [ 'elementor-element', 'elementor-element-' . $id ] );
-
 		$settings = $this->get_active_settings();
+
+		if ( ! empty( $settings['_element_id'] ) ) {
+			$this->add_render_attribute( '_wrapper', 'id', trim( $settings['_element_id'] ) );
+		}
+
+		$this->add_render_attribute( '_wrapper', 'class', [ 'elementor-element', 'elementor-element-' . $id ] );
 
 		foreach ( self::get_class_controls() as $control ) {
 			if ( empty( $settings[ $control['name'] ] ) ) {
@@ -750,14 +754,34 @@ abstract class Element_Base extends Controls_Stack {
 			$this->add_render_attribute( '_wrapper', 'class', 'elementor-invisible' );
 		}
 
-		if ( ! empty( $settings['_element_id'] ) ) {
-			$this->add_render_attribute( '_wrapper', 'id', trim( $settings['_element_id'] ) );
-		}
-
 		if ( ! empty( $settings['_attributes'] ) ) {
-			foreach (  $settings['_attributes'] as $attr ) {
-				if ( ! empty( $attr['attribute_key'] ) ) {
-					$this->add_render_attribute( '_wrapper', trim( $attr['attribute_key'] ), trim( $attr['attribute_value'] ) );
+			$attributes = explode( "\n", $settings['_attributes'] );
+
+			// Not allowed attributes
+			$black_list = [ 'id', 'data-id', 'data-settings', 'data-element_type', 'data-model-cid', 'onload', 'onclick', 'onfocus', 'onchange', 'onresize', 'onmouseover', 'onmouseout', 'onkeydown' ];
+
+			/**
+			 * Elementor attributes black list.
+			 *
+			 * Filters the attributes that won't be rendered in the wrapper element.
+			 *
+			 * By default Elementor don't render some attributes to prevent things
+			 * from breaking down. But this list of attributes can be changed.
+			 *
+			 * @since 2.1.0
+			 *
+			 * @param array $black_list A black list of attributes.
+			 */
+			$black_list = apply_filters( 'elementor/attributes/black_list', $black_list );
+
+			foreach ( $attributes as $attribute ) {
+				if ( ! empty( $attribute ) ) {
+					$attr = explode( "|", $attribute, 2 );
+					if ( ! isset( $attr[1] ) ) $attr[1] = '';
+
+					if ( ! in_array( strtolower( $attr[0] ), $black_list ) ) {
+						$this->add_render_attribute( '_wrapper', trim( $attr[0] ), trim( $attr[1] ) );
+					}
 				}
 			}
 		}

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -733,8 +733,6 @@ abstract class Element_Base extends Controls_Stack {
 	protected function _add_render_attributes() {
 		$id = $this->get_id();
 
-		$this->add_render_attribute( '_wrapper', 'data-id', $id );
-
 		$this->add_render_attribute(
 			'_wrapper', 'class', [
 				'elementor-element',
@@ -768,6 +766,8 @@ abstract class Element_Base extends Controls_Stack {
 				}
 			}
 		}
+
+		$this->add_render_attribute( '_wrapper', 'data-id', $id );
 
 		$frontend_settings = $this->get_frontend_settings();
 

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -733,12 +733,7 @@ abstract class Element_Base extends Controls_Stack {
 	protected function _add_render_attributes() {
 		$id = $this->get_id();
 
-		$this->add_render_attribute(
-			'_wrapper', 'class', [
-				'elementor-element',
-				'elementor-element-' . $id,
-			]
-		);
+		$this->add_render_attribute( '_wrapper', 'class', [ 'elementor-element', 'elementor-element-' . $id ] );
 
 		$settings = $this->get_active_settings();
 

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -758,7 +758,7 @@ abstract class Element_Base extends Controls_Stack {
 			$attributes = explode( "\n", $settings['_attributes'] );
 
 			// Not allowed attributes
-			$black_list = [ 'id', 'data-id', 'data-settings', 'data-element_type', 'data-model-cid', 'onload', 'onclick', 'onfocus', 'onchange', 'onresize', 'onmouseover', 'onmouseout', 'onkeydown' ];
+			$black_list = [ 'id', 'class', 'data-id', 'data-settings', 'data-element_type', 'data-model-cid', 'onload', 'onclick', 'onfocus', 'onchange', 'onresize', 'onmouseover', 'onmouseout', 'onkeydown' ];
 
 			/**
 			 * Elementor attributes black list.

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -761,6 +761,12 @@ abstract class Element_Base extends Controls_Stack {
 			$this->add_render_attribute( '_wrapper', 'id', trim( $settings['_element_id'] ) );
 		}
 
+		if ( ! empty( $settings['_attributes'] ) ) {
+			foreach (  $settings['_attributes'] as $attr ) {
+				$this->add_render_attribute( '_wrapper', trim( $attr['attribute_key'] ), trim( $attr['attribute_value'] ) );
+			}
+		}
+
 		$frontend_settings = $this->get_frontend_settings();
 
 		if ( $frontend_settings ) {

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -763,7 +763,9 @@ abstract class Element_Base extends Controls_Stack {
 
 		if ( ! empty( $settings['_attributes'] ) ) {
 			foreach (  $settings['_attributes'] as $attr ) {
-				$this->add_render_attribute( '_wrapper', trim( $attr['attribute_key'] ), trim( $attr['attribute_value'] ) );
+				if ( ! empty( $attr['attribute_key'] ) ) {
+					$this->add_render_attribute( '_wrapper', trim( $attr['attribute_key'] ), trim( $attr['attribute_value'] ) );
+				}
 			}
 		}
 

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -772,7 +772,7 @@ abstract class Element_Base extends Controls_Stack {
 			 *
 			 * @param array $black_list A black list of attributes.
 			 */
-			$black_list = apply_filters( 'elementor/attributes/black_list', $black_list );
+			$black_list = apply_filters( 'elementor/element/attributes/black_list', $black_list );
 
 			foreach ( $attributes as $attribute ) {
 				if ( ! empty( $attribute ) ) {

--- a/includes/widgets/common.php
+++ b/includes/widgets/common.php
@@ -442,6 +442,7 @@ class Widget_Common extends Widget_Base {
 				],
 				'title_field' => '{{{ attribute_key }}}',
 				'prevent_empty' => false,
+				'show_label' => false,
 			]
 		);
 

--- a/includes/widgets/common.php
+++ b/includes/widgets/common.php
@@ -427,22 +427,9 @@ class Widget_Common extends Widget_Base {
 			'_attributes',
 			[
 				'label' => __( 'Attributes', 'elementor' ),
-				'type' => Controls_Manager::REPEATER,
-				'fields' => [
-					[
-						'name' => 'attribute_key',
-						'label' => __( 'Attribute Key', 'elementor' ),
-						'type' => Controls_Manager::TEXT,
-					],
-					[
-						'name' => 'attribute_value',
-						'label' => __( 'Attribute Value', 'elementor' ),
-						'type' => Controls_Manager::TEXT,
-					],
-				],
-				'title_field' => '{{{ attribute_key }}}',
-				'prevent_empty' => false,
-				'show_label' => false,
+				'type' => Controls_Manager::TEXTAREA,
+				'placeholder' => __( 'key|value', 'elementor' ),
+				'description' => __( 'Set custom HTML attributes for the wrapper element. Each attribute in a separate line. Separate attribute key from attribute value using | character.', 'elementor' ),
 			]
 		);
 

--- a/includes/widgets/common.php
+++ b/includes/widgets/common.php
@@ -144,29 +144,6 @@ class Widget_Common extends Widget_Base {
 			]
 		);
 
-		$this->add_control(
-			'_element_id',
-			[
-				'label' => __( 'CSS ID', 'elementor' ),
-				'type' => Controls_Manager::TEXT,
-				'default' => '',
-				'title' => __( 'Add your custom id WITHOUT the Pound key. e.g: my-id', 'elementor' ),
-				'label_block' => false,
-			]
-		);
-
-		$this->add_control(
-			'_css_classes',
-			[
-				'label' => __( 'CSS Classes', 'elementor' ),
-				'type' => Controls_Manager::TEXT,
-				'default' => '',
-				'prefix_class' => '',
-				'title' => __( 'Add your custom class WITHOUT the dot. e.g: my-class', 'elementor' ),
-				'label_block' => false,
-			]
-		);
-
 		$this->end_controls_section();
 
 		$this->start_controls_section(
@@ -424,12 +401,35 @@ class Widget_Common extends Widget_Base {
 		);
 
 		$this->add_control(
+			'_element_id',
+			[
+				'label' => __( 'CSS ID', 'elementor' ),
+				'type' => Controls_Manager::TEXT,
+				'default' => '',
+				'title' => __( 'Add your custom id WITHOUT the Pound key. e.g: my-id', 'elementor' ),
+				'label_block' => false,
+			]
+		);
+
+		$this->add_control(
+			'_css_classes',
+			[
+				'label' => __( 'CSS Classes', 'elementor' ),
+				'type' => Controls_Manager::TEXT,
+				'default' => '',
+				'prefix_class' => '',
+				'title' => __( 'Add your custom class WITHOUT the dot. e.g: my-class', 'elementor' ),
+				'label_block' => false,
+			]
+		);
+
+		$this->add_control(
 			'_attributes',
 			[
-				'label' => __( 'Attributes', 'elementor' ),
+				'label' => __( 'Custom Attributes', 'elementor' ),
 				'type' => Controls_Manager::TEXTAREA,
 				'placeholder' => __( 'key|value', 'elementor' ),
-				'description' => __( 'Set custom HTML attributes for the wrapper element. Each attribute in a separate line. Separate attribute key from attribute value using | character.', 'elementor' ),
+				'description' => sprintf( __( 'Set custom attributes for the wrapper element. Each attribute in a separate line. Separate attribute key from the value using %s character.', 'elementor' ), '<code>|</code>' ),
 			]
 		);
 

--- a/includes/widgets/common.php
+++ b/includes/widgets/common.php
@@ -415,6 +415,38 @@ class Widget_Common extends Widget_Base {
 
 		$this->end_controls_section();
 
+		$this->start_controls_section(
+			'_section_attributes',
+			[
+				'label' => __( 'Attributes', 'elementor' ),
+				'tab' => Controls_Manager::TAB_ADVANCED,
+			]
+		);
+
+		$this->add_control(
+			'_attributes',
+			[
+				'label' => __( 'Attributes', 'elementor' ),
+				'type' => Controls_Manager::REPEATER,
+				'fields' => [
+					[
+						'name' => 'attribute_key',
+						'label' => __( 'Attribute Key', 'elementor' ),
+						'type' => Controls_Manager::TEXT,
+					],
+					[
+						'name' => 'attribute_value',
+						'label' => __( 'Attribute Value', 'elementor' ),
+						'type' => Controls_Manager::TEXT,
+					],
+				],
+				'title_field' => '{{{ attribute_key }}}',
+				'prevent_empty' => false,
+			]
+		);
+
+		$this->end_controls_section();
+
 		Plugin::$instance->controls_manager->add_custom_css_controls( $this );
 	}
 }


### PR DESCRIPTION
Add the ability to define custom "**Attributes**" under the "**Advanced Tab**".

With this new feature you can add your own custom HTML attributes to all your widgets.

You can add any attribute:

* **Global** attribute - `id`, `class`, `style`, `dir`, `title`, `tabindex`, `rel` and others
* **Accessibility** attribute - `role`, `aria-*`
* **JS Data** attribute - `data-*`
* **JS Event** attribute - `onClick`, `onLoad`, `onResize`, `onFocus`, `on*`
* **Schema.org** attribute - `itemscope`, `itemtype`, `itemprop`
* other custom attribute you need

## Attributes Section

A new section added to the advanced tab, with a new repeater where you can define the widget attributes.

![element-attributes](https://user-images.githubusercontent.com/576623/38469605-234d2b84-3b60-11e8-960e-6ef04f0b4aba.png)

## Open Attribute

In each repeater item you can define the attribute key and the attribute value.

![element-attributes-open](https://user-images.githubusercontent.com/576623/38469608-2c0a7fba-3b60-11e8-9f3d-c3850f561c9b.png)
