### PR TITLE
Add the "main" HTML tag to sections and columns

### DIFF
--- a/includes/elements/column.php
+++ b/includes/elements/column.php
@@ -187,6 +187,7 @@ class Element_Column extends Element_Base {
 			'div',
 			'header',
 			'footer',
+			'main',
 			'article',
 			'section',
 			'aside',

--- a/includes/elements/section.php
+++ b/includes/elements/section.php
@@ -454,6 +454,7 @@ class Element_Section extends Element_Base {
 			'div',
 			'header',
 			'footer',
+			'main',
 			'article',
 			'section',
 			'aside',


### PR DESCRIPTION
Commit abe2248bce04641099da65367f40efd9872d2d7d added the support of custom HTML tags for sections and columns (Elementor 1.5).

Commit edc5e1d395e379750f21bcc4c40737c6624dd051 match the HTML tags for both sections and columns (Elementor 2.0).

This PR adds the `<main>` HTML tag to sections and columns (Elementor 2.1).

Ref: http://html5doctor.com/the-main-element/