### PR TITLE
added action hook for caching plugins when clearing css files

### DIFF
--- a/includes/managers/css-files.php
+++ b/includes/managers/css-files.php
@@ -136,6 +136,15 @@ class Posts_CSS_Manager {
 			}
 		}
 
+		/**
+		 * Elementor clear CSS files.
+		 *
+		 * Fires after Elementor clears CSS files
+		 *
+		 * @since 2.0.8
+		 */
+		do_action( 'elementor/css-file/clear' );
+
 		return $errors;
 	}
 

--- a/includes/managers/css-files.php
+++ b/includes/managers/css-files.php
@@ -143,7 +143,7 @@ class Posts_CSS_Manager {
 		 *
 		 * @since 2.0.8
 		 */
-		do_action( 'elementor/css-file/clear' );
+		do_action( 'elementor/css-file/clear_cache' );
 
 		return $errors;
 	}


### PR DESCRIPTION
fixes #4179 
`elementor/css-file/clear_cache`