### PR TITLE
Change the "merge tag" that the acceptance check box generate

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,14 @@
-<!--  
+<!--  ## BEFORE POSTING YOUR ISSUE
 
-## BEFORE POSTING YOUR ISSUE
+- Please create GitHub issues only for bugs and feature requests. GitHub issues ARE NOT FOR SUPPORT!
 
-Please create GitHub issues only for bugs and feature requests. GitHub issues ARE NOT FOR SUPPORT!
+- If you have questions or need general support,  Please use:  https://wordpress.org/support/plugin/elementor 
 
-- If you have questions, or need general support, send the issue to: https://wordpress.org/support/plugin/elementor 
 - For help and support from the Elementor community, see: https://www.facebook.com/groups/Elementors/
+
 - To read more about Elementor, check out our documentation: https://docs.elementor.com
+
+- Developers docs are located at: https://developers.elementor.com/
 
 ===== Guidelines ====
 
@@ -18,14 +20,38 @@ Please create GitHub issues only for bugs and feature requests. GitHub issues AR
 
 -->
 
+## Prerequisites
+<!-- MARK COMPLETED ITEMS WITH AN [x] -->
+
+- [ ] I have searched for similar issues in both open and closed tickets and cannot find a duplicate.
+- [ ] The issue still exists against the latest stable version of Elementor.
+
+
 ## Description
 
-<!-- Describe which problem you've encountered. What caused the issue, and what did you expect to happen. Attach screenshots and related links to help us understand the issue in more detail. -->
+<!-- 
+Describe which problem you've encountered. What caused the issue, and what did you expect to happen. Attach screenshots and related links to help us understand the issue in more detail. 
+
+Please be as descriptive as possible; issues lacking the below details, or for any other reason than to report a bug, may be closed without action. 
+-->
 
 ## Steps to reproduce
 
-<!-- For bug reports, list all the steps needed to reproduce your issue, so we can replicate it ourselves. -->
+<!-- 
+For bug reports, list all the steps needed to reproduce your issue, so we can replicate it ourselves. 
+-->
+
+## Isolating the problem
+<!-- MARK COMPLETED ITEMS WITH AN [x] -->
+- [ ] This bug happens with only Elementor plugin active (and Elementor Pro).
+- [ ] This bug happens with a default WordPress theme active.
+- [ ] I can reproduce this bug consistently using the steps above.
 
 ## Environment
 
-<!-- For bug reports, let us know about your system environment, or just grab the system info report from Elementor => System info, and paste it here or in http://pastebin.com/ -->
+<details>
+<summary>System Info</summary>
+```
+<!-- For bug reports, let us know about your system environment: Copy and paste the system info report from Elementor => System info, and paste it here or in http://pastebin.com/ -->
+```
+</details>


### PR DESCRIPTION
At the moment is "ON" but is better something like "acepted and confirm" or "read and acepted" or just "acept" that "on", special on mailchimp. Or better, if we can personalized by ourselves. 