### PR TITLE
My Templates: make the global widget tab translatable

### DIFF
--- a/includes/template-library/sources/local.php
+++ b/includes/template-library/sources/local.php
@@ -1390,6 +1390,11 @@ class Source_Local extends Source_Base {
 			$template_label = __( 'Content', 'elementor' );
 		}
 
+		// TODO: remove this when global widgets becomes a document type with `get_title()` method.
+		if ( 'widget' === $template_type ) {
+			$template_label = __( 'Global Widget', 'elementor' );
+		}
+
 		/**
 		 * Template label by template type.
 		 *


### PR DESCRIPTION
The "**Global Widget**" tab is not translatable.

![tabs](https://user-images.githubusercontent.com/576623/39928928-52089d48-553f-11e8-9af4-99f1a012ca68.png)
