### PR TITLE
Empty Category crashes Templates manager...

### DIFF
--- a/includes/template-library/manager.php
+++ b/includes/template-library/manager.php
@@ -198,7 +198,9 @@ class Manager {
 	 */
 	public function get_library_data( array $args ) {
 		$library_data = Api::get_library_data( ! empty( $args['sync'] ) );
-
+		if (empty($library_data['categories'])) {
+			$library_data['categories'] = [];
+		}
 		return [
 			'templates' => $this->get_templates(),
 			'config' => [


### PR DESCRIPTION
Fixed with an empty und Array generation