### PR TITLE
Adding a general hook 'elementor/frontend/before_render' to element-base

### DIFF
--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -590,11 +590,11 @@ abstract class Element_Base extends Controls_Stack {
 		 *
 		 * Fires before Elementor element is rendered in the frontend.
 		 *
-		 * @since 2.1.0
+		 * @since 2.2.0
 		 *
 		 * @param Element_Base $this The element.
 		 */
-		do_action( "elementor/frontend/before_render", $this );
+		do_action( 'elementor/frontend/before_render', $this );
 
 		/**
 		 * Before frontend element render.

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -590,6 +590,17 @@ abstract class Element_Base extends Controls_Stack {
 		 *
 		 * Fires before Elementor element is rendered in the frontend.
 		 *
+		 * @since 2.1.0
+		 *
+		 * @param Element_Base $this The element.
+		 */
+		do_action( "elementor/frontend/before_render", $this );
+
+		/**
+		 * Before frontend element render.
+		 *
+		 * Fires before Elementor element is rendered in the frontend.
+		 *
 		 * The dynamic portion of the hook name, `$element_type`, refers to the element type.
 		 *
 		 * @since 1.0.0


### PR DESCRIPTION
Handy hook for applying new attributes to the main wrapper for multiple elements with one single hook.