### PR TITLE
Fix: Elementor reset Page Template

### DIFF
--- a/core/settings/page/manager.php
+++ b/core/settings/page/manager.php
@@ -178,14 +178,12 @@ class Manager extends BaseManager {
 		}
 
 		if ( Utils::is_cpt_custom_templates_supported() ) {
-			$template = 'default';
-
 			if ( isset( $data['template'] ) ) {
 				$template = $data['template'];
+				
+				// Use `update_metadata` in order to save also for revisions.
+				update_metadata( 'post', $post->ID, '_wp_page_template', $template );
 			}
-
-			// Use `update_metadata` in order to save also for revisions.
-			update_metadata( 'post', $post->ID, '_wp_page_template', $template );
 		}
 	}
 


### PR DESCRIPTION
Elementor saving process is reseting page templates ( `_wp_page_template` ) when we uses `Elementor:instance()->document->save()` to create pages (like in a updater script).

I found template is being replaced by default if no `$settings['template']` value is there:
https://github.com/pojome/elementor/blob/master/core/settings/page/manager.php#L181

Some points:

1. Maybe it's related to #4498 
2. A review is very needed as I was not able to check all the impact of this PR.
