### PR TITLE
Page Settings: Fix - Don't override `_wp_page_template`

### DIFF
--- a/core/settings/page/manager.php
+++ b/core/settings/page/manager.php
@@ -178,10 +178,14 @@ class Manager extends BaseManager {
 		}
 
 		if ( Utils::is_cpt_custom_templates_supported() ) {
-			$template = 'default';
+			$template = get_metadata( 'post', $post->ID, '_wp_page_template', true );
 
 			if ( isset( $data['template'] ) ) {
 				$template = $data['template'];
+			}
+
+			if ( empty( $template ) ) {
+				$template = 'default';
 			}
 
 			// Use `update_metadata` in order to save also for revisions.


### PR DESCRIPTION
Fix @mariovalney Patch.
(https://github.com/pojome/elementor/pull/5054)
