### PR TITLE
Update button.scss

### DIFF
--- a/assets/dev/scss/frontend/widgets/button.scss
+++ b/assets/dev/scss/frontend/widgets/button.scss
@@ -14,7 +14,6 @@
 	&:focus,
 	&:visited {
 		color: #fff;
-		opacity: .9;
 	}
 
 	&.elementor-size- {


### PR DESCRIPTION
Removed unwanted :hover state opacity .9 when the editor controls already allow for alpha state to be defined.  See issue #4406