### PR TITLE
Added Fixed Height

### DIFF
--- a/includes/elements/section.php
+++ b/includes/elements/section.php
@@ -352,6 +352,7 @@ class Element_Section extends Element_Base {
 					'default' => __( 'Default', 'elementor' ),
 					'full' => __( 'Fit To Screen', 'elementor' ),
 					'min-height' => __( 'Min Height', 'elementor' ),
+					'fixed-height' => __( 'Fixed Height', 'elementor' ),
 				],
 				'prefix_class' => 'elementor-section-height-',
 				'hide_in_inner' => true,
@@ -382,6 +383,30 @@ class Element_Section extends Element_Base {
 				],
 				'condition' => [
 					'height' => [ 'min-height' ],
+				],
+				'hide_in_inner' => true,
+			]
+		);
+		
+		$this->add_responsive_control(
+			'custom_height_fixed',
+			[
+				'label' => __( 'Fixed Height', 'elementor' ),
+				'type' => Controls_Manager::SLIDER,
+				'default' => [
+					'size' => 400,
+				],
+				'range' => [
+					'px' => [
+						'min' => 0,
+						'max' => 1440,
+					],
+				],
+				'selectors' => [
+					'{{WRAPPER}} > .elementor-container' => 'height: {{SIZE}}{{UNIT}};',
+				],
+				'condition' => [
+					'height' => [ 'fixed-height' ],
 				],
 				'hide_in_inner' => true,
 			]


### PR DESCRIPTION
- Added fixed height to Section, so a forced height could be added instead of just having min-height.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [X] The commit message follows our guidelines:  https://github.com/pojome/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Added Fixed Height to Sections as a responsive option.

## Description
An explanation of what is done in this PR

* Along with the min-height, there was no way to force an item to be a fixed height. This can resolve the issue in which the element/image you have has a height of 200 px, while you only want to show the top of the image. Min-Height does not allow this, while fixed height does.

## Test instructions
This PR can be tested by following these steps:

* The only file changed is the section.php file. Simply test that file, and it will be good to go. I have been using this change on my own personal installations since 2.06

## Quality assurance

- [X ] I have tested this code to the best of my abilities
- [X ] I have added unittests to verify the code works as intended
- [X ] Docs have been added / updated (for bug fixes / features)

Fixes #
