### PR TITLE
Add a general hook 'elementor/frontend/after_render' to element-base

### DIFF
--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -621,10 +621,22 @@ abstract class Element_Base extends Controls_Stack {
 
 		$this->enqueue_scripts();
 		$this->enqueue_styles();
+
 		/**
 		 * After frontend element render.
 		 *
-		 * Fires after Elementor element was rendered in the frontend.
+		 * Fires after Elementor element is rendered in the frontend.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param Element_Base $this The element.
+		 */
+		do_action( 'elementor/frontend/after_render', $this );
+
+		/**
+		 * After frontend element render.
+		 *
+		 * Fires after Elementor element is rendered in the frontend.
 		 *
 		 * The dynamic portion of the hook name, `$element_type`, refers to the element type.
 		 *

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -627,7 +627,7 @@ abstract class Element_Base extends Controls_Stack {
 		 *
 		 * Fires after Elementor element is rendered in the frontend.
 		 *
-		 * @since 2.2.0
+		 * @since 2.3.0
 		 *
 		 * @param Element_Base $this The element.
 		 */


### PR DESCRIPTION
PR #5025 added the `elementor/frontend/before_render` hook, this PR adds `elementor/frontend/after_render` hook. This way the frontend element render function will have 4 hooks:

**Before:**

* `elementor/frontend/before_render` - added in PR #5025
* `elementor/frontend/{$element_type}/before_render`

**After:**

* `elementor/frontend/after_render` - added in this PR
* `elementor/frontend/{$element_type}/after_render`
