### PR TITLE
Remove all scripts hooked into after_wp_tiny_mce

### DIFF
--- a/includes/editor.php
+++ b/includes/editor.php
@@ -123,6 +123,9 @@ class Editor {
 		// Handle `wp_enqueue_scripts`
 		remove_all_actions( 'wp_enqueue_scripts' );
 
+		// Also remove all scripts hooked into after_wp_tiny_mce.
+		remove_all_actions( 'after_wp_tiny_mce' );
+
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ], 999999 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_styles' ], 999999 );
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Remove all scripts hooked after the Tiny MCE editor.

## Description

Some plugins add their own scripts that depend on Tiny MCE by hooking into the `after_wp_tiny_mce` hook:
https://developer.wordpress.org/reference/hooks/after_wp_tiny_mce/

This causes some issues when the scripts rely on JavaScript for example.
Since Elementor removed all other enqueues that come on that page, it causes errors. Removing those scripts solves the issue.

Here is an example of such an error: 
https://github.com/Automattic/jetpack/issues/9989

## Test instructions
This PR can be tested by following these steps:

1. Use plugin Elementor and Jetpack.
2. Activate Markdown support in Jetpack (under Jetpack > Settings, search for "Markdown" and activate)
3. Edit page with Elementor
4. You should not see any JavaScript errors on the page.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)
