### PR TITLE
Toggle widget: fix content styling missing when no icon closes #5735

### DIFF
--- a/includes/widgets/toggle.php
+++ b/includes/widgets/toggle.php
@@ -409,9 +409,6 @@ class Widget_Toggle extends Widget_Base {
 			[
 				'label' => __( 'Content', 'elementor' ),
 				'tab' => Controls_Manager::TAB_STYLE,
-				'condition' => [
-					'icon!' => '',
-				],
 			]
 		);
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/pojome/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- Bugfix

## Summary

Toggle widget: fix content styling missing when no icon closes #5735


## Quality assurance

Fixes #5735
