### PR TITLE
fix Uncaught Error: Call to a member function load_reports() on null

### DIFF
--- a/includes/tracker.php
+++ b/includes/tracker.php
@@ -332,14 +332,17 @@ class Tracker {
 	 * @return array The data from system reports.
 	 */
 	private static function get_system_reports_data() {
-		$reports = Plugin::$instance->system_info->load_reports( System_Info\Main::get_allowed_reports() );
-
 		$system_reports = [];
-		foreach ( $reports as $report_key => $report_details ) {
-			$system_reports[ $report_key ] = [];
-			foreach ( $report_details['report'] as $sub_report_key => $sub_report_details ) {
-				$system_reports[ $report_key ][ $sub_report_key ] = $sub_report_details['value'];
+		try {
+			$reports = Plugin::$instance->system_info->load_reports( System_Info\Main::get_allowed_reports() );
+
+			foreach ( $reports as $report_key => $report_details ) {
+				$system_reports[ $report_key ] = [];
+				foreach ( $report_details['report'] as $sub_report_key => $sub_report_details ) {
+					$system_reports[ $report_key ][ $sub_report_key ] = $sub_report_details['value'];
+				}
 			}
+		} catch (Exception $e) {
 		}
 		return $system_reports;
 	}


### PR DESCRIPTION
## PR Checklist

- [ ] The commit message follows our guidelines:  https://github.com/pojome/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

I got an error, every week probably because of a wp cli script executed by the system cron.

*

## Description
An explanation of what is done in this PR

* If the code generate an issue don't rise the exception
```
[30-Sep-2018 12:40:06 UTC] PHP Fatal error:  Uncaught Error: Call to a member function load_reports() on null in /home/domain/wp-content/plugins/elementor/includes/tracker.php:335
Stack trace:
#0 /home/domain/wp-content/plugins/elementor/includes/tracker.php(136): Elementor\Tracker::get_system_reports_data()
#1 /home/domain/wp-includes/class-wp-hook.php(286): Elementor\Tracker::send_tracking_data()
#2 /home/domain/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters('', Array)
#3 /home/domain/wp-includes/plugin.php(515): WP_Hook->do_action(Array)
#4 /home/domain/wp-cron.php(126): do_action_ref_array('elementor/track...', Array)
#5 {main}
  thrown in /home/domain/wp-content/plugins/elementor/includes/tracker.php on line 335
```

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
