### PR TITLE
Fix: WP Widget hooks support closes #5844

### DIFF
--- a/includes/widgets/wordpress.php
+++ b/includes/widgets/wordpress.php
@@ -156,7 +156,9 @@ class Widget_WordPress extends Widget_Base {
 		echo '<input type="hidden" class="id_base" value="' . esc_attr( $instance->id_base ) . '" />';
 		echo '<input type="hidden" class="widget-id" value="widget-' . esc_attr( $this->get_id() ) . '" />';
 		echo '<div class="widget-content">';
-		$instance->form( $this->get_settings( 'wp' ) );
+		$widget_data = $this->get_settings( 'wp' );
+		$instance->form( $widget_data );
+		do_action( 'in_widget_form', $instance, null, $widget_data );
 		echo '</div></div></div>';
 		return ob_get_clean();
 	}
@@ -200,7 +202,9 @@ class Widget_WordPress extends Widget_Base {
 		$settings = parent::_get_parsed_settings();
 
 		if ( ! empty( $settings['wp'] ) ) {
-			$settings['wp'] = $this->get_widget_instance()->update( $settings['wp'], [] );
+			$widget = $this->get_widget_instance();
+			$instance = $widget->update( $settings['wp'], [] );
+			$settings['wp'] = apply_filters( 'widget_update_callback', $instance, $settings['wp'], [], $widget );
 		}
 
 		return $settings;


### PR DESCRIPTION
## PR Checklist 
- [x] The commit message follows our guidelines:  https://github.com/pojome/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

Added native WordPress Widget hooks support

*

## Description
Added native WordPress Widget hooks support

Hooks added are:
- `in_widget_form` - to support adding extra widget form fields
- `widget_update_callback` - to support saving extra widget form fields

## Test instructions
This PR can be tested by following these steps:

* use the following snippets to add a field and save it.

```PHP
/*
 * add custom field to WP widget form
 */
add_action('in_widget_form', function ( $widget, $return, $instance ) {
	echo 'This Is visible in Elementor too.';
	$my_custom_field = isset( $instance['my_custom_field'] ) ? $instance['my_custom_field'] : '';
    ?>
	<p>
		<label for="<?php echo $widget->get_field_id( 'my_custom_field' ); ?>"><?php _e( 'My custom field:' ) ?></label>
		<input type="text" class="widefat" id="<?php echo $widget->get_field_id( 'my_custom_field' ); ?>" name="<?php echo $widget->get_field_name( 'my_custom_field' ); ?>" value="<?php echo esc_attr( $my_custom_field ); ?>"/>
	</p>
    <?php
}, 10, 3 );

/**
 * save custom field of WP widget form
 */
add_filter( 'widget_update_callback', function ($instance, $new_instance, $old_instance, $widget ){
	$instance['my_custom_field'] = isset( $new_instance['my_custom_field'] ) ? sanitize_text_field( $new_instance['my_custom_field'] ) : '';
	return $instance;
}, 12, 4 );
```

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #5844 
