### PR TITLE
Allow developer filter the get template data api url to insert custom template

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -215,6 +215,8 @@ class Api {
 	 */
 	public static function get_template_content( $template_id ) {
 		$url = sprintf( self::$api_get_template_content_url, $template_id );
+		// Allow developer filter this url to use custom template.
+		$url = apply_filters( 'elementor/api/get_templates/url', $url, $template_id );
 
 		$body_args = [
 			// Which API version is used.


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/pojome/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Allow developer filter api url to insert custom template. More info at #5860 

## Description
An explanation of what is done in this PR

* Add a filter named `elementor/api/get_templates/url` for `$url` in `get_template_content` function.

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #