### PR TITLE
Fix animation class remove on lightbox modal close

### DIFF
--- a/assets/dev/js/frontend/utils/lightbox.js
+++ b/assets/dev/js/frontend/utils/lightbox.js
@@ -98,7 +98,8 @@ LightboxModule = ViewModule.extend( {
 		modal.onHide = function() {
 			DialogsManager.getWidgetType( 'lightbox' ).prototype.onHide.apply( modal, arguments );
 
-			modal.getElements( 'widgetContent' ).removeClass( 'animated' );
+			var animation = this.getSettings( 'modalOptions.entranceAnimation' );
+			modal.getElements( 'message' ).removeClass( 'animated ' + animation );
 		};
 
 		switch ( options.type ) {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/pojome/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* lightbox modal close removes animation class from correct element

## Description
An explanation of what is done in this PR

* `onHide` callback in lightbox module was clearing `animated` class from incorrect widget element (`widgetContent` rather than `message`). It also wasn't removing `modalOptions.entranceAnimation` class from settings. 
* I found this issue when I needed to customize lightbox a little. I needed image property `width` which was equal to 0 on every but first modal opening. Normally - animation is added after [10ms timeout](https://github.com/pojome/elementor/blob/dfb718e98a1fe9cf9f5f4a5dbae6406dadccf710/assets/dev/js/frontend/utils/lightbox.js#L93) which enables to get proper `width` of the image. Because animation is not removed correctly, every next modal showing has animation class already there.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)
