### PR TITLE
Convert repeater data array to Backbone.Collection

### DIFF
--- a/assets/dev/js/editor/elements/models/base-settings.js
+++ b/assets/dev/js/editor/elements/models/base-settings.js
@@ -113,8 +113,8 @@ BaseSettingsModel = Backbone.Model.extend( {
 			if ( control.fields ) {
 				var styleFields = [];
 				
-				if (!(self.attributes[control.name] instanceof Backbone.Collection)) {
-					self.handleRepeaterData(self.attributes);
+				if ( ! ( self.attributes[ control.name ] instanceof Backbone.Collection ) ) {
+					self.handleRepeaterData( self.attributes );
 				}
 
 				self.attributes[ control.name ].each( function( item ) {

--- a/assets/dev/js/editor/elements/models/base-settings.js
+++ b/assets/dev/js/editor/elements/models/base-settings.js
@@ -112,7 +112,7 @@ BaseSettingsModel = Backbone.Model.extend( {
 
 			if ( control.fields ) {
 				var styleFields = [];
-				
+
 				if ( ! ( self.attributes[ control.name ] instanceof Backbone.Collection ) ) {
 					self.handleRepeaterData( self.attributes );
 				}

--- a/assets/dev/js/editor/elements/models/base-settings.js
+++ b/assets/dev/js/editor/elements/models/base-settings.js
@@ -112,6 +112,10 @@ BaseSettingsModel = Backbone.Model.extend( {
 
 			if ( control.fields ) {
 				var styleFields = [];
+				
+				if (!(self.attributes[control.name] instanceof Backbone.Collection)) {
+					self.handleRepeaterData(self.attributes);
+				}
 
 				self.attributes[ control.name ].each( function( item ) {
 					styleFields.push( self.getStyleControls( control.fields, item.attributes ) );


### PR DESCRIPTION
Repeater field in page/section settings tab causes an error on page/section revision change, because type of repeater data is Array instead of Collection. So this fix checks for data type in repeater fields and converts it from Array to Backbone Collection if needed.
