### PR TITLE
pass a reference to init hook

### DIFF
--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -480,7 +480,7 @@ class Plugin {
 		 *
 		 * @since 1.0.0
 		 */
-		do_action( 'elementor/init' );
+		do_action( 'elementor/init', $this );
 	}
 
 	public function on_rest_api_init() {


### PR DESCRIPTION
## Description
By passing a reference to the init hook, other developers can use that reference directly without having to instantiate the class again while adding actions to the hook. For example:

Instead of this:
```php
add_action( 'elementor/init', function() {
   \Elementor\Plugin::$instance->elements_manager->add_category( 
   	'theme-elements',
   	[
            'title' => __( 'Theme Elements', 'theme-domain' ),
   	    'icon' => 'fa fa-plug', //default icon
   	]
   );
} );
```

We can do this:
```php
add_action( 'elementor/init', function($elementor) {
  $elementor->elements_manager->add_category( 
   	'theme-elements',
   	[
   	    'title' => __( 'Theme Elements', 'theme-domain' ),
   	    'icon' => 'fa fa-plug', //default icon
   	]
   );
} );
```
It's more handy.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

