### PR TITLE
Fix the wp_the_query global when doing "Maintenance" redirection

### DIFF
--- a/includes/maintenance-mode.php
+++ b/includes/maintenance-mode.php
@@ -146,6 +146,8 @@ class Maintenance_Mode {
 			'p' => self::get( 'template_id' ),
 			'post_type' => Source_Local::CPT,
 		] );
+
+		$GLOBALS['wp_the_query'] = $GLOBALS['wp_query'];
 	}
 
 	/**


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description
Elementor is using `query_posts` function in order to "fix" the `$wp_query` with the Coming Soon page and it is working pretty well. However, it must also fix the global `$wp_the_query`, because if you later call the function `wp_reset_query` anywhere, it will reset the main query, basically replacing `$wp_query` with `$wp_the_query`. Then, instead of showing the coming soon page, it will display the original page that you have when you don't have the maintenance mode active.

This fix simply adjusts the `$wp_the_query` with the same value of `$wp_query`.

## Test instructions
This PR can be tested by following these steps:

- Enable Coming Soon feature
- Open the single.php file of your current theme and add this:

```php
get_header();

wp_reset_query();
```

- Access the site as a visitor and notice that the Coming Soon page is not displayed

## Quality assurance

- [ x ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

https://github.com/pojome/elementor/issues/6365