### PR TITLE
Added 'https' protocol to hyperlink

### DIFF
--- a/docs/content/hooks/php-hooks.md
+++ b/docs/content/hooks/php-hooks.md
@@ -1,6 +1,6 @@
 ## Documentation has Moved
 
-This document in now available on [Developer API for Elementor](developers.elementor.com)
+This document in now available on [Developer API for Elementor](https://developers.elementor.com/)
 
 ### Quick Links
 


### PR DESCRIPTION
The Developer API for Elementor link directs users to a github 404.
Adding https:// to the link should fix it.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/pojome/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
