### PR TITLE
Added attribute printing for column wrappers

### DIFF
--- a/includes/elements/column.php
+++ b/includes/elements/column.php
@@ -885,17 +885,25 @@ class Element_Column extends Element_Base {
 		$has_background_overlay = in_array( $settings['background_overlay_background'], [ 'classic', 'gradient' ], true ) ||
 								  in_array( $settings['background_overlay_hover_background'], [ 'classic', 'gradient' ], true );
 
-		$column_wrap_class = 'elementor-column-wrap';
-		if ( $this->get_children() ) {
-			$column_wrap_class .= ' elementor-element-populated';
+		if ( $has_background_overlay ) {
+			$this->add_render_attribute( '_background_overlay', 'class', [ 'elementor-background-overlay' ] );
 		}
+
+		$column_wrap_classes = [ 'elementor-column-wrap' ];
+		if ( $this->get_children() ) {
+			$column_wrap_classes[] = ' elementor-element-populated';
+		}
+		$this->add_render_attribute( '_inner_wrapper', 'class', $column_wrap_classes );
+
+		$this->add_render_attribute( '_widget_wrapper', 'class', [ 'elementor-widget-wrap' ] );
+
 		?>
 		<<?php echo $this->get_html_tag() . ' ' . $this->get_render_attribute_string( '_wrapper' ); ?>>
-			<div class="<?php echo $column_wrap_class; ?>">
+			<div <?php echo( $this->get_render_attribute_string( '_inner_wrapper' ) ); ?>>
 			<?php if ( $has_background_overlay ) : ?>
-				<div class="elementor-background-overlay"></div>
+				<div <?php echo( $this->get_render_attribute_string( '_background_overlay' ) ); ?>></div>
 			<?php endif; ?>
-		<div class="elementor-widget-wrap">
+		<div <?php echo( $this->get_render_attribute_string( '_widget_wrapper' ) ); ?>>
 		<?php
 	}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Summary

This PR can be summarized in the following changelog entry:

Added the Attributes "_inner_wrapper", "_background_overlay" and "_widget_wrapper" for columns

## Description
An explanation of what is done in this PR:

Added the Attributes "_inner_wrapper", "_background_overlay" and "_widget_wrapper" to columns to be able to manipulate the according attributes of these elements. This implementation mimics the one for https://code.elementor.com/php-hooks/#elementorfrontendelement_typebefore_render. This documentation may be updated. 

## Test instructions
This PR can be tested by following these steps:

* Use the "elementor/frontend/element/before_render" hook and register new attributes via the "add_render_attribute" function of the element.
* Check that the attributes where added

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended (No tests to extend found)
- [ ] Docs have been added / updated (for bug fixes / features) (Could not update docs)

Fixes #