### PR TITLE
Fix: elementor stuck on loader instead of no content found

### DIFF
--- a/.grunt-config/postcss.js
+++ b/.grunt-config/postcss.js
@@ -27,7 +27,8 @@ module.exports = {
 					browsers: 'last 10 versions'
 				} ),
 				require( 'cssnano' )( {
-					reduceIdents: false
+					reduceIdents: false,
+					zindex: false,
 				} )
 			]
 		},


### PR DESCRIPTION
stop cssnano from changing the z-index