### PR TITLE
i18n: merge similar translation strings

### DIFF
--- a/includes/editor-templates/panel.php
+++ b/includes/editor-templates/panel.php
@@ -81,7 +81,7 @@ $document = Plugin::$instance->documents->get( Plugin::$instance->editor->get_po
 				<div class="elementor-panel-footer-sub-menu-item" data-device-mode="mobile">
 					<i class="elementor-icon eicon-device-mobile" aria-hidden="true"></i>
 					<span class="elementor-title"><?php echo __( 'Mobile', 'elementor' ); ?></span>
-					<span class="elementor-description"><?php echo __( 'Preview for 360px', 'elementor' ); ?></span>
+					<span class="elementor-description"><?php echo sprintf( __( 'Preview for %s', 'elementor' ), '360px' ); ?></span>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Merge two similar translation strings. And hard-code the `360px` value, this way translators won't  be able enter wrong value by mistake.

![elementor](https://user-images.githubusercontent.com/576623/51340974-f5a39380-1a98-11e9-8836-b72ceb826ffd.png)

The original translation string located in the same file, 6 lines above.