### PR TITLE
i18n: simplify translations string

### DIFF
--- a/modules/safe-mode/module.php
+++ b/modules/safe-mode/module.php
@@ -336,7 +336,8 @@ class Module extends \Elementor\Core\Base\Module {
 				</a>
 			</header>
 			<div class="elementor-toast-content">
-				<?php printf( __( 'Having problems loading Elementor? Please enable Safe Mode to troubleshoot. <a href="%1$s" target="_blank">%2$s.</a>', 'elementor' ), self::DOCS_TRY_SAFE_MODE_URL, __( 'Learn More', 'elementor' ) ); ?>
+				<?php echo __( 'Having problems loading Elementor? Please enable Safe Mode to troubleshoot.', 'elementor' ); ?>
+				<a href="<?php echo self::DOCS_TRY_SAFE_MODE_URL; ?>" target="_blank"><?php echo __( 'Learn More', 'elementor' ); ?></a>
 			</div>
 		</div>
 


### PR DESCRIPTION
Make it easier to translate the Translation String, by removing the HTML tags out of the string into a separate line.

![elementor-i18n-2](https://user-images.githubusercontent.com/576623/51342418-8cbe1a80-1a9c-11e9-829b-1558506ca8f5.png)
