### PR TITLE
i18n: split translation strings

### DIFF
--- a/modules/safe-mode/module.php
+++ b/modules/safe-mode/module.php
@@ -263,7 +263,7 @@ class Module extends \Elementor\Core\Base\Module {
 				<ul class="elementor-safe-mode-list">
 					<li class="elementor-safe-mode-list-item">
 						<div class="elementor-safe-mode-list-item-title"><?php echo __( 'Editor successfully loaded?', 'elementor' ); ?></div>
-						<div class="elementor-safe-mode-list-item-content"><?php printf( __( 'The issue was probably caused by one of your plugins or theme. <a href="%s" target="_blank">Click here</a> to troubleshoot', 'elementor' ), self::DOCS_HELPED_URL ); ?></div>
+						<div class="elementor-safe-mode-list-item-content"><?php echo __( 'The issue was probably caused by one of your plugins or theme.', 'elementor' ); ?> <?php printf( __( '<a href="%s" target="_blank">Click here</a> to troubleshoot', 'elementor' ), self::DOCS_HELPED_URL ); ?></div>
 					</li>
 					<li class="elementor-safe-mode-list-item">
 						<div class="elementor-safe-mode-list-item-title"><?php echo __( 'Still experiencing issues?', 'elementor' ); ?></div>


### PR DESCRIPTION
Make it easier to translate the Translation String, by splitting it into two smaller strings. The second string already exist.

![elementor-i18n-3](https://user-images.githubusercontent.com/576623/51342981-f1c64000-1a9d-11e9-9f24-99357e0f8327.png)
