### PR TITLE
i18n: avoid using HTML tags in translation strings

### DIFF
--- a/core/common/modules/connect/apps/connect.php
+++ b/core/common/modules/connect/apps/connect.php
@@ -22,7 +22,7 @@ class Connect extends Common_App {
 	public function render_admin_widget() {
 		if ( $this->is_connected() ) {
 			$remote_user = $this->get( 'user' );
-			$title = sprintf( __( 'Connected to Elementor as <strong>%s</strong>', 'elementor' ), $remote_user->email ) . get_avatar( $remote_user->email, 20, '' );
+			$title = sprintf( __( 'Connected to Elementor as %s', 'elementor' ), '<strong>' . $remote_user->email . '</strong>' ) . get_avatar( $remote_user->email, 20, '' );
 			$label = __( 'Disconnect', 'elementor' );
 			$url = $this->get_admin_url( 'disconnect' );
 			$attr = '';


### PR DESCRIPTION
Not all the translators know HTML, this is why you should avoid using unneeded HTML tags where they are not needed.

![elementor-i18n-4](https://user-images.githubusercontent.com/576623/51343632-7f565f80-1a9f-11e9-9847-1c4f1e9d730e.png)

Replace: `<strong>%s</strong>` with simple `%s`, moving the HTML tags out of the string.
