### PR TITLE
Bug Fix: styling image widget captions

### DIFF
--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -453,7 +453,7 @@ class Widget_Image extends Widget_Base {
 				'label' => __( 'Caption', 'elementor' ),
 				'tab'   => Controls_Manager::TAB_STYLE,
 				'condition' => [
-					'caption!' => '',
+					'caption_source!' => 'none',
 				],
 			]
 		);


### PR DESCRIPTION
This PR fixes the wrong condition used when displaying the caption styling section.

Currently the "**Caption**" section under the "**Style**" tab displayed only when `"caption_source" = "custom"` and when `"caption_source" != ""`.

The user can't really style the caption when he choose to use "Attachment Caption" because of this wrong condition set to display the section.