### PR TITLE
i18n: use %s placeholder in translation strings

### DIFF
--- a/includes/widgets/menu-anchor.php
+++ b/includes/widgets/menu-anchor.php
@@ -102,7 +102,7 @@ class Widget_Menu_Anchor extends Widget_Base {
 			'anchor_note',
 			[
 				'type' => Controls_Manager::RAW_HTML,
-				'raw' => __( 'Note: The ID link ONLY accepts these chars: `A-Z, a-z, 0-9, _ , -`', 'elementor' ),
+				'raw' => sprintf( __( 'Note: The ID link ONLY accepts these chars: %s', 'elementor' ), '`A-Z, a-z, 0-9, _ , -`' ),
 				'content_classes' => 'elementor-panel-alert elementor-panel-alert-warning',
 			]
 		);


### PR DESCRIPTION
Don't allow translators to control those chars! Hard-code them. This way no-one can accidentally change them.

![elementor-i18n-5](https://user-images.githubusercontent.com/576623/51431518-a002ee80-1c32-11e9-9de3-9adb2c4e895e.png)
