### PR TITLE
i18n: use %s placeholder in translation strings

### DIFF
--- a/core/common/modules/ajax/module.php
+++ b/core/common/modules/ajax/module.php
@@ -109,7 +109,7 @@ class Module extends BaseModule {
 	 */
 	public function register_ajax_action( $tag, $callback ) {
 		if ( ! did_action( 'elementor/ajax/register_actions' ) ) {
-			_doing_it_wrong( __METHOD__, esc_html( __( 'Use `elementor/ajax/register_actions` hook to register ajax action.', 'elementor' ) ), '2.0.0' );
+			_doing_it_wrong( __METHOD__, esc_html( sprintf( __( 'Use `%s` hook to register ajax action.', 'elementor' ), 'elementor/ajax/register_actions' ) ), '2.0.0' );
 		}
 
 		$this->ajax_actions[ $tag ] = compact( 'tag', 'callback' );


### PR DESCRIPTION
Don't allow translators to change the action name! Hard-code it. This way no-one can accidentally change the action.

![elementor-i18n-5](https://user-images.githubusercontent.com/576623/51431565-549d1000-1c33-11e9-8886-1d905d2c225e.png)
