### PR TITLE
i18n: use %s placeholder in translation strings

### DIFF
--- a/includes/widgets/read-more.php
+++ b/includes/widgets/read-more.php
@@ -90,7 +90,7 @@ class Widget_Read_More extends Widget_Base {
 			'theme_support',
 			[
 				'type' => Controls_Manager::RAW_HTML,
-				'raw' => __( 'Note: This widget only affects themes that use `the_content` in archive pages.', 'elementor' ),
+				'raw' => sprintf( __( 'Note: This widget only affects themes that use `%s` in archive pages.', 'elementor' ), 'the_content' ),
 				'content_classes' => 'elementor-panel-alert elementor-panel-alert-warning',
 			]
 		);


### PR DESCRIPTION
Don't allow translators to change the function name! Hard-code it. This way no-one can accidentally change the function.

![elementor-i18n-5](https://user-images.githubusercontent.com/576623/51431902-09d1c700-1c38-11e9-9568-43075bddac83.png)
