### PR TITLE
Image Widget: add text shadow to captions

### DIFF
--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -513,6 +513,14 @@ class Widget_Image extends Widget_Base {
 			]
 		);
 
+		$this->add_group_control(
+			Group_Control_Text_Shadow::get_type(),
+			[
+				'name' => 'caption_text_shadow',
+				'selector' => '{{WRAPPER}} .widget-image-caption',
+			]
+		);
+
 		$this->add_responsive_control(
 			'caption_space',
 			[


### PR DESCRIPTION
Allow the user to add **text shadows** to image captions.

**Note:** Copy & paste from the heading widget (with updated selector).