### PR TITLE
Access to a shop in maintenance mode for super admins

### DIFF
--- a/includes/maintenance-mode.php
+++ b/includes/maintenance-mode.php
@@ -115,7 +115,7 @@ class Maintenance_Mode {
 			return;
 		}
 
-		if (self::get( 'super_admin_access', 'no' ) === 'yes' && is_super_admin()) {
+		if ( self::get( 'super_admin_access', 'no' ) === 'yes' && is_super_admin() ) {
 			return;
 		}
 
@@ -234,8 +234,8 @@ class Maintenance_Mode {
 								'setting_args' => [ __NAMESPACE__ . '\Settings_Validations', 'checkbox_list' ],
 							],
 							'maintenance_mode_super_admin_access' => [
-									'label' => __( 'Access for super admins', 'elementor' ),
-									'field_args' => [
+								'label' => __( 'Access for super admins', 'elementor' ),
+								'field_args' => [
 									'type' => 'checkbox',
 									'value' => 'yes',
 									'sub_desc' => __( 'Super admins will have access to the blog. Also if it is in maintenance mode.', 'elementor' ),

--- a/includes/maintenance-mode.php
+++ b/includes/maintenance-mode.php
@@ -115,6 +115,10 @@ class Maintenance_Mode {
 			return;
 		}
 
+		if (self::get( 'super_admin_access', 'no' ) === 'yes' && is_super_admin()) {
+			return;
+		}
+
 		if ( 'logged_in' === $exclude_mode && is_user_logged_in() ) {
 			return;
 		}
@@ -228,6 +232,14 @@ class Maintenance_Mode {
 									'type' => 'checkbox_list_roles',
 								],
 								'setting_args' => [ __NAMESPACE__ . '\Settings_Validations', 'checkbox_list' ],
+							],
+							'maintenance_mode_super_admin_access' => [
+									'label' => __( 'Access for super admins', 'elementor' ),
+									'field_args' => [
+									'type' => 'checkbox',
+									'value' => 'yes',
+									'sub_desc' => __( 'Super admins will have access to the blog. Also if it is in maintenance mode.', 'elementor' ),
+							 	],
 							],
 							'maintenance_mode_template_id' => [
 								'label' => __( 'Choose Template', 'elementor' ),

--- a/includes/maintenance-mode.php
+++ b/includes/maintenance-mode.php
@@ -239,7 +239,7 @@ class Maintenance_Mode {
 									'type' => 'checkbox',
 									'value' => 'yes',
 									'sub_desc' => __( 'Super admins will have access to the blog. Also if it is in maintenance mode.', 'elementor' ),
-							 	],
+								],
 							],
 							'maintenance_mode_template_id' => [
 								'label' => __( 'Choose Template', 'elementor' ),


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/pojome/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Access to blogs with maintenance mode for super admins.

## Description
An explanation of what is done in this PR

* The option `maintenance_mode_super_admin_access` was added. You can change it there: wp-admin/admin.php?page=elementor-tools#tab-maintenance_mode
* In the function `template_redirect()` there is checking of this option.

## Test instructions
This PR can be tested by following these steps:

* Create new blog in your network
* Set up checkbox "Access for super admins": wp-admin/admin.php?page=elementor-tools#tab-maintenance_mode
* Activate mainenance mode
* Check if you have access to the blog as a super admin.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [not needed] I have added unittests to verify the code works as intended
- [not needed] Docs have been added / updated (for bug fixes / features)