### PR TITLE
Image Widget: add background color to captions

### DIFF
--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -504,6 +504,22 @@ class Widget_Image extends Widget_Base {
 			]
 		);
 
+		$this->add_control(
+			'text_background_color',
+			[
+				'label' => __( 'Background Color', 'elementor' ),
+				'type' => Controls_Manager::COLOR,
+				'default' => '',
+				'selectors' => [
+					'{{WRAPPER}} .widget-image-caption' => 'background-color: {{VALUE}};',
+				],
+				'scheme' => [
+					'type' => Scheme_Color::get_type(),
+					'value' => Scheme_Color::COLOR_3,
+				],
+			]
+		);
+
 		$this->add_group_control(
 			Group_Control_Typography::get_type(),
 			[

--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -505,7 +505,7 @@ class Widget_Image extends Widget_Base {
 		);
 
 		$this->add_control(
-			'text_background_color',
+			'caption_background_color',
 			[
 				'label' => __( 'Background Color', 'elementor' ),
 				'type' => Controls_Manager::COLOR,


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/pojome/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* New: Added background color control to image widget caption

## Description
An explanation of what is done in this PR

* Add new control to the image widget.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

## More Info

![elementor-image-widget-style-tab-captions](https://user-images.githubusercontent.com/576623/52856341-d0a05000-312c-11e9-8765-41959507f12d.png)

Currently the **Image Widget** allows the user to display **image caption**.

On the Style tab we can set **text-color of the caption** but we can't set the **background-color of the caption**.

This PR adds a new control that allows the user to do exactly that - set the caption background color.