### PR TITLE
Ending number of Counter define with shortcode

### DIFF
--- a/includes/widgets/counter.php
+++ b/includes/widgets/counter.php
@@ -113,7 +113,7 @@ class Widget_Counter extends Widget_Base {
 			'ending_number',
 			[
 				'label' => __( 'Ending Number', 'elementor' ),
-				'type' => Controls_Manager::NUMBER,
+				'type' => Controls_Manager::TEXT,
 				'default' => 100,
 			]
 		);
@@ -304,7 +304,7 @@ class Widget_Counter extends Widget_Base {
 		$this->add_render_attribute( 'counter', [
 			'class' => 'elementor-counter-number',
 			'data-duration' => $settings['duration'],
-			'data-to-value' => $settings['ending_number'],
+			'data-to-value' => do_shortcode($settings['ending_number']),
 		] );
 
 		if ( ! empty( $settings['thousand_separator'] ) ) {

--- a/includes/widgets/counter.php
+++ b/includes/widgets/counter.php
@@ -304,7 +304,7 @@ class Widget_Counter extends Widget_Base {
 		$this->add_render_attribute( 'counter', [
 			'class' => 'elementor-counter-number',
 			'data-duration' => $settings['duration'],
-			'data-to-value' => do_shortcode($settings['ending_number']),
+			'data-to-value' => do_shortcode( $settings['ending_number'] ),
 		] );
 
 		if ( ! empty( $settings['thousand_separator'] ) ) {


### PR DESCRIPTION
This modification gives the possibility to define the ending number of the counter widget via a shortcode.
Really helpful if you want to display dynamic statistics (number of members, of posts etc.)

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Added the possibility to define Counter Ending number via shortcode

## Description

* Change brought to the Counter Widget:
I transformed the Ending number parameter field from Number to Text.
Then I added the do_shortcode() function around the Ending number parameter to give the possibility to define the ending number via a shortcode.

## Test instructions
This PR can be tested by following these steps:

- Create a shortcode that returns a value. Ex: Number of members, of posts, job offers etc.

- Write the shortcode in the Ending number field: [my_shortcode].

- Test the page

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
