### PR TITLE
Added: Filter to Meta Viewport tag closes #7043

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -625,4 +625,20 @@ class Utils {
 
 		return implode( ' ', $rendered_attributes );
 	}
+
+	public static function get_meta_viewport( $template_type = 'canvas' ) {
+		$meta_tag = '<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />';
+		/**
+		 * Viewport meta tag.
+		 *
+		 * Filters the Elementor preview URL.
+		 *
+		 * The dynamic portion of the hook name, `$template_type`, refers to the template type.
+		 *
+		 * @since 2.5.0
+		 *
+		 * @param string $meta_tag Viewport meta tag.
+		 */
+		return apply_filters( "elementor/template/{$template_type}/viewport_tag", $meta_tag );
+	}
 }

--- a/modules/page-templates/templates/canvas.php
+++ b/modules/page-templates/templates/canvas.php
@@ -16,9 +16,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php endif; ?>
 	<?php wp_head(); ?>
 	<?php
+
 	// Keep the following line after `wp_head()` call, to ensure it's not overridden by another templates.
+	echo \Elementor\Utils::get_meta_viewport();
 	?>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 </head>
 <body <?php body_class(); ?>>
 	<?php


### PR DESCRIPTION
* `get_meta_viewport()`
* `elementor/template/{$template_type}/viewport_tag`
