### PR TITLE
Tweak: Added filter to add global settings controls closes #7118

### DIFF
--- a/core/settings/general/model.php
+++ b/core/settings/general/model.php
@@ -84,6 +84,30 @@ class Model extends BaseModel {
 	 * @return array Controls list.
 	 */
 	public static function get_controls_list() {
+		$additional_controls = [];
+		/**
+		 * Additional Controls.
+		 *
+		 * Filters the Controls used by Elementor to add additional controls to global settings.
+		 *
+		 * @since 2.5.0
+		 *
+		 * @param array $additional_controls Additional Elementor Controls.
+		 */
+		$additional_controls = apply_filters( 'elementor/global/settings/additional_controls', $additional_controls );
+		return array_replace_recursive( $additional_controls, self::get_default_control_list() );
+	}
+
+	/**
+	 * Get Default Control List
+	 *
+	 * Returns Elementor Default Global Settings controls.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @return array
+	 */
+	public static function get_default_control_list() {
 		return [
 			Controls_Manager::TAB_STYLE => [
 				'style' => [


### PR DESCRIPTION
Test case:

```PHP
add_filter( 'elementor/global/settings/additional_controls', function( $controls ) {
	$controls[ \Elementor\Controls_Manager::TAB_STYLE ] = [
		'custom_section' => [ //Section ID
			'label' => 'My Custom Section', //Section Label
			'controls' => [
				'custom_text_control' => [ //Control ID
					'label' => 'Text',
					'type' => \Elementor\Controls_Manager::TEXT,
				],
			],
		],
	];
	return $controls;
} );
```