### PR TITLE
Text Editor Widget: Add a separator before columns control

### DIFF
--- a/includes/widgets/text-editor.php
+++ b/includes/widgets/text-editor.php
@@ -198,6 +198,7 @@ class Widget_Text_Editor extends Widget_Base {
 			[
 				'label' => __( 'Columns', 'elementor' ),
 				'type' => Controls_Manager::SELECT,
+				'separator' => 'before',
 				'options' => $text_columns,
 				'selectors' => [
 					'{{WRAPPER}} .elementor-text-editor' => 'columns: {{VALUE}};',


### PR DESCRIPTION
Before:

![columns-before](https://user-images.githubusercontent.com/576623/53839795-19675e00-3fa1-11e9-8d91-a9c9f6556ec8.png)


After:

![columns-after](https://user-images.githubusercontent.com/576623/53839806-1f5d3f00-3fa1-11e9-8a42-e3e170bce8d0.png)
