### PR TITLE
YouTube JS API support

### DIFF
--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -280,6 +280,27 @@ class Widget_Video extends Widget_Base {
 		);
 
 		$this->add_control(
+			'enablejsapi',
+			[
+				'label' => __( 'Enable YouTube JS API Access', 'elementor' ),
+				'type' => Controls_Manager::SWITCHER,
+			]
+		);
+
+		$this->add_control(
+			'yt_iframe_id',
+			[
+				'label' => __( 'YouTube IFrame ID', 'elementor' ),
+				'type' => Controls_Manager::TEXT,
+				'default' => 'player',
+				'condition' => [
+					'enablejsapi'=>'yes',
+				],
+			]
+		);
+
+
+		$this->add_control(
 			'mute',
 			[
 				'label' => __( 'Mute', 'elementor' ),
@@ -790,7 +811,9 @@ class Widget_Video extends Widget_Base {
 
 			$embed_options = $this->get_embed_options();
 
-			$video_html = Embed::get_embed_html( $video_url, $embed_params, $embed_options );
+			$frame_options = $this->get_frame_options();
+
+			$video_html = Embed::get_embed_html( $video_url, $embed_params, $embed_options, $frame_options );
 		}
 
 		if ( empty( $video_html ) ) {
@@ -918,6 +941,7 @@ class Widget_Video extends Widget_Base {
 				'mute',
 				'rel',
 				'modestbranding',
+				'enablejsapi',
 			];
 
 			if ( $settings['loop'] ) {
@@ -1007,6 +1031,22 @@ class Widget_Video extends Widget_Base {
 		$embed_options['lazy_load'] = ! empty( $settings['lazy_load'] );
 
 		return $embed_options;
+	}
+
+	/**
+	 * @since 2.1.0
+	 * @access private
+	 */
+	private function get_frame_options() {
+		$settings = $this->get_settings_for_display();
+
+		$frame_options = [];
+
+		if ( 'youtube' === $settings['video_type'] ) {
+			$frame_options['id'] = $settings['yt_iframe_id'];
+		}
+
+		return $frame_options;
 	}
 
 	/**

--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -945,6 +945,7 @@ class Widget_Video extends Widget_Base {
 				'mute',
 				'rel',
 				'modestbranding',
+				'enablejsapi',
 			];
 
 			if ( $settings['loop'] ) {

--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -284,6 +284,9 @@ class Widget_Video extends Widget_Base {
 			[
 				'label' => __( 'Enable YouTube JS API Access', 'elementor' ),
 				'type' => Controls_Manager::SWITCHER,
+				'condition' => [
+					'video_type' => 'youtube',
+				],
 			]
 		);
 
@@ -295,6 +298,7 @@ class Widget_Video extends Widget_Base {
 				'default' => 'player',
 				'condition' => [
 					'enablejsapi'=>'yes',
+					'video_type' => 'youtube',
 				],
 			]
 		);

--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -945,7 +945,6 @@ class Widget_Video extends Widget_Base {
 				'mute',
 				'rel',
 				'modestbranding',
-				'enablejsapi',
 			];
 
 			if ( $settings['loop'] ) {


### PR DESCRIPTION
Hi Elementor team, this is my first ever PR so a few things on the checklist have not been completed. I was hoping someone could take a  glance at it and let me know what else needs to be done.

The motivation for this feature is to add support to access YouTube IFrames through the YouTube JS API.

## PR Checklist

- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Enables [YouTube IFrame API](https://developers.google.com/youtube/iframe_api_reference) support

## Description
An explanation of what is done in this PR

* This PR adds the `enablejsapi` attribute to a YouTube video `<iframe>` tag and also adds an `id` attribute so it is possible to reference the `<iframe>` from JS.

## Test instructions
This PR can be tested by following these steps:

* Add a video element in the Elementor designer
* Toggle the "Enable YouTube JS API Access" switch
* Supply an IFrame ID (or leave as default `player`)

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)
