### PR TITLE
Fix warnings in control condtions

### DIFF
--- a/assets/dev/js/editor/utils/conditions.js
+++ b/assets/dev/js/editor/utils/conditions.js
@@ -46,10 +46,18 @@ Conditions = function() {
 				comparisonResult = self.check( term, comparisonObject );
 			} else {
 				var parsedName = term.name.match( /(\w+)(?:\[(\w+)])?/ ),
+					value = null;
+
+				if ( typeof( comparisonObject[ parsedName[ 1 ] ] ) !== 'undefined' ) {
 					value = comparisonObject[ parsedName[ 1 ] ];
+				}
 
 				if ( parsedName[ 2 ] ) {
-					value = value[ parsedName[ 2 ] ];
+					if ( typeof( value[ parsedName[ 2 ] ] ) !== 'undefined' ) {
+            value = value[parsedName[2]];
+          } else {
+						value = null;
+					}
 				}
 
 				comparisonResult = self.compare( value, term.value, term.operator );

--- a/assets/dev/js/editor/utils/conditions.js
+++ b/assets/dev/js/editor/utils/conditions.js
@@ -54,7 +54,7 @@ Conditions = function() {
 
 				if ( parsedName[ 2 ] ) {
 					if ( typeof( value[ parsedName[ 2 ] ] ) !== 'undefined' ) {
-            value = value[parsedName[2]];
+            value = value[ parsedName[ 2 ] ];
           } else {
 						value = null;
 					}

--- a/includes/conditions.php
+++ b/includes/conditions.php
@@ -82,15 +82,15 @@ class Conditions {
 
 				$value = null;
 				if ( !empty( $parsed_name[1] ) && isset( $comparison[$parsed_name[1]] ) ) {
-                    $value = $comparison[$parsed_name[1]];
-                }
+					$value = $comparison[$parsed_name[1]];
+				}
 
 				if ( ! empty( $parsed_name[2] ) ) {
-                    if ( isset( $value[$parsed_name[2]] ) ) {
-                        $value = $value[$parsed_name[2]];
-                    } else {
-                        $value = null;
-                    }
+					if ( isset( $value[$parsed_name[2]] ) ) {
+						$value = $value[$parsed_name[2]];
+					} else {
+						$value = null;
+					}
 				}
 
 				$operator = null;

--- a/includes/conditions.php
+++ b/includes/conditions.php
@@ -81,13 +81,13 @@ class Conditions {
 				preg_match( '/(\w+)(?:\[(\w+)])?/', $term['name'], $parsed_name );
 
 				$value = null;
-				if ( !empty( $parsed_name[1] ) && isset( $comparison[$parsed_name[1]] ) ) {
-					$value = $comparison[$parsed_name[1]];
+				if ( !empty( $parsed_name[1] ) && isset( $comparison[ $parsed_name[1] ] ) ) {
+					$value = $comparison[ $parsed_name[1] ];
 				}
 
 				if ( ! empty( $parsed_name[2] ) ) {
-					if ( isset( $value[$parsed_name[2]] ) ) {
-						$value = $value[$parsed_name[2]];
+					if ( isset( $value[ $parsed_name[2] ] ) ) {
+						$value = $value[ $parsed_name[2] ];
 					} else {
 						$value = null;
 					}

--- a/includes/conditions.php
+++ b/includes/conditions.php
@@ -80,10 +80,17 @@ class Conditions {
 			} else {
 				preg_match( '/(\w+)(?:\[(\w+)])?/', $term['name'], $parsed_name );
 
-				$value = $comparison[ $parsed_name[1] ];
+				$value = null;
+				if ( !empty( $parsed_name[1] ) && isset( $comparison[$parsed_name[1]] ) ) {
+                    $value = $comparison[$parsed_name[1]];
+                }
 
 				if ( ! empty( $parsed_name[2] ) ) {
-					$value = $value[ $parsed_name[2] ];
+                    if ( isset( $value[$parsed_name[2]] ) ) {
+                        $value = $value[$parsed_name[2]];
+                    } else {
+                        $value = null;
+                    }
 				}
 
 				$operator = null;

--- a/includes/conditions.php
+++ b/includes/conditions.php
@@ -81,7 +81,7 @@ class Conditions {
 				preg_match( '/(\w+)(?:\[(\w+)])?/', $term['name'], $parsed_name );
 
 				$value = null;
-				if ( !empty( $parsed_name[1] ) && isset( $comparison[ $parsed_name[1] ] ) ) {
+				if ( ! empty( $parsed_name[1] ) && isset( $comparison[ $parsed_name[1] ] ) ) {
 					$value = $comparison[ $parsed_name[1] ];
 				}
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

* Prevent warnings on nested control conditions

## Description

* If you want to check a dynamicTag is selected, you will get javascript-errors in editor and php-warnings in frontend. This fix will prevent this.

## Test instructions

Add two controls, one with a dynamic tag. If you check the condition in second control, you will get javascript and php warnings, if nothing is selected in the dynamic tag.

Example:
```php

        $element->add_control(
            'myControl',
            [
                'label' => __( 'My DynamicTag', 'myPlugin' ),
                'type' => Controls_Manager::MEDIA,
                'dynamic' => [
                    'active' => true,
                    'categories' => [
                        Module::BASE_GROUP,
                        Module::TEXT_CATEGORY,
                        Module::URL_CATEGORY,
                        Module::GALLERY_CATEGORY,
                        Module::IMAGE_CATEGORY,
                        Module::MEDIA_CATEGORY,
                        Module::POST_META_CATEGORY,
                    ],
                ],
            ]
        );


        $element->add_control(
            'mySecondControl',
            [
                'label' => __( 'Show/Hide' ),
                'type' => Controls_Manager::SELECT,
                'default' => 'hide',
                'options' => [
                    'show' => __( 'Show' ),
                    'hide' => __( 'Hide' ),
                ],
                'conditions' => [
                    'relation' => 'and',
                    'terms' => [
                        [
                            'name' => '__dynamic__',
                            'operator' => '!=',
                            'value' => null,
                        ],
                        [
                            'name' => '__dynamic__[myControl]',
                            'operator' => '!=',
                            'value' => null,
                        ],
                    ],
                ],
            ]
        );
```

It happens also if you check the value of the tag like
```php
'terms' => [
                        [
                            'name' => 'myControl',
                            'operator' => '!=',
                            'value' => null,
                        ],
                        [
                            'name' => 'myControl[url]',
                            'operator' => '!=',
                            'value' => null,
                        ],
                    ],
```

*

## Quality assurance

- [ x ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
