### PR TITLE
Fix default width for linked SVG files

### DIFF
--- a/assets/dev/scss/frontend/widgets/image.scss
+++ b/assets/dev/scss/frontend/widgets/image.scss
@@ -11,7 +11,7 @@
 			display: inline-block; //For alignment image with link - Changed to 'inline-block' instead of 'block' to handle with this issue https://github.com/elementor/elementor/issues/5897
 
 			img[src$=".svg"] {
-				width: 48px; //Fix SVG image src, issue: https://github.com/elementor/elementor/issues/5987
+				width: 100%; //Fix SVG image src, issue: https://github.com/elementor/elementor/issues/5987
 			}
 		}
 


### PR DESCRIPTION
Any linked SVG images should not be hard coded to a width of 48px. 

(this severely broke an old website I updated, all my linked images were suddenly resized to 48px wide).

Setting the default to 100% here, as it's a better default than 48px. 

If 100% doesn't work for a user, they can choose their own width, rather than defaulting to 48px. 


## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Change default linked SVG width from 48px to 100%

## Description
An explanation of what is done in this PR

* Change default linked SVG width from 48px to 100%

## Test instructions
This PR can be tested by following these steps:

* Insert an SVG image, give it a link, save the page. Confirm the SVG hasn't been resized to 48px

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #
