### PR TITLE
Image Widget: add "Image Height" & "Image Fit" controls

### DIFF
--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -308,6 +308,52 @@ class Widget_Image extends Widget_Base {
 			]
 		);
 
+		$this->add_responsive_control(
+			'height',
+			[
+				'label' => __( 'Height', 'elementor' ),
+				'type' => Controls_Manager::SLIDER,
+				'default' => [
+					'unit' => 'px',
+				],
+				'tablet_default' => [
+					'unit' => 'px',
+				],
+				'mobile_default' => [
+					'unit' => 'px',
+				],
+				'size_units' => [ 'px' ],
+				'range' => [
+					'px' => [
+						'min' => 1,
+						'max' => 500,
+					],
+				],
+				'selectors' => [
+					'{{WRAPPER}} .elementor-image img' => 'height: {{SIZE}}{{UNIT}};',
+				],
+			]
+		);
+
+		$this->add_responsive_control(
+			'object-fit',
+			[
+				'label' => __( 'Object Fit', 'elementor' ),
+				'type' => Controls_Manager::SELECT,
+				'options' => [
+					'' => __( 'Default', 'elementor' ),
+					'fill' => __( 'Fill', 'elementor' ),
+					'cover' => __( 'Cover', 'elementor' ),
+					'contain' => __( 'Contain', 'elementor' ),
+					'scale-down' => __( 'Scale Down', 'elementor' ),
+				],
+				'default' => '',
+				'selectors' => [
+					'{{WRAPPER}} .elementor-image img' => 'object-fit: {{VALUE}};',
+				],
+			]
+		);
+
 		$this->add_control(
 			'separator_panel_style',
 			[

--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -338,7 +338,7 @@ class Widget_Image extends Widget_Base {
 		$this->add_responsive_control(
 			'object-fit',
 			[
-				'label' => __( 'Object Fit', 'elementor' ),
+				'label' => __( 'Image Fit', 'elementor' ),
 				'type' => Controls_Manager::SELECT,
 				'options' => [
 					'' => __( 'Default', 'elementor' ),


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Tweak: Added height & object-fix controls to Image widget.

## Description
An explanation of what is done in this PR

Elementor sections /columns has the option to set background images with
`background-size: auto | cover | contain ;`
We can't do the same with a simple **Image Widget**.

The PR adds **Height** control to set the image height, and **Object Fit** control to set the image resize type.
`object-fit: fill | contain | cover | scale-down | none ;`

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)
