### PR TITLE
FIxes a bug in Internet Explorer with images

### DIFF
--- a/assets/dev/scss/frontend/widgets/image.scss
+++ b/assets/dev/scss/frontend/widgets/image.scss
@@ -13,6 +13,7 @@
 			img[src$=".svg"] {
 				width: 48px; //Fix SVG image src, issue: https://github.com/elementor/elementor/issues/5987
 			}
+			width: 100%;
 		}
 
 		img {


### PR DESCRIPTION
Related to Image box dispay on IE Win 10.
Image expands to full defined Images size.
Size bubbling in IE seems to be buggy..

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
