### PR TITLE
Icon Box Widget: update position icons

### DIFF
--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -183,15 +183,15 @@ class Widget_Icon_Box extends Widget_Base {
 				'options' => [
 					'left' => [
 						'title' => __( 'Left', 'elementor' ),
-						'icon' => 'fa fa-align-left',
+						'icon' => 'eicon-h-align-left',
 					],
 					'top' => [
 						'title' => __( 'Top', 'elementor' ),
-						'icon' => 'fa fa-align-center',
+						'icon' => 'eicon-v-align-top',
 					],
 					'right' => [
 						'title' => __( 'Right', 'elementor' ),
-						'icon' => 'fa fa-align-right',
+						'icon' => 'eicon-h-align-right',
 					],
 				],
 				'prefix_class' => 'elementor-position-',


### PR DESCRIPTION
Replace confusing "align" icons with "position" icons.

![position-icons](https://user-images.githubusercontent.com/576623/55683440-81b2b200-5948-11e9-97ab-216fcf0e6b2a.png)

Because this control positions the icon on the Top/Left/Right side of the text.