### PR TITLE
Tweak: Controls Stack: use `-` in control_id

### DIFF
--- a/assets/dev/js/editor/utils/helpers.js
+++ b/assets/dev/js/editor/utils/helpers.js
@@ -117,7 +117,7 @@ helpers = {
 		}
 
 		var hasFields = _.filter( condition, function( conditionValue, conditionName ) {
-			var conditionNameParts = conditionName.match( /([a-z_\-0-9]+)(?:\[([a-z_\-]+)])?(!?)$/i ),
+			var conditionNameParts = conditionName.match( /([a-z_\-0-9]+)(?:\[([a-z_]+)])?(!?)$/i ),
 				conditionRealName = conditionNameParts[ 1 ],
 				conditionSubKey = conditionNameParts[ 2 ],
 				isNegativeCondition = !! conditionNameParts[ 3 ],

--- a/assets/dev/js/editor/utils/helpers.js
+++ b/assets/dev/js/editor/utils/helpers.js
@@ -117,7 +117,7 @@ helpers = {
 		}
 
 		var hasFields = _.filter( condition, function( conditionValue, conditionName ) {
-			var conditionNameParts = conditionName.match( /([a-z_0-9]+)(?:\[([a-z_]+)])?(!?)$/i ),
+			var conditionNameParts = conditionName.match( /([a-z_\-0-9]+)(?:\[([a-z_\-]+)])?(!?)$/i ),
 				conditionRealName = conditionNameParts[ 1 ],
 				conditionSubKey = conditionNameParts[ 2 ],
 				isNegativeCondition = !! conditionNameParts[ 3 ],

--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -1273,7 +1273,7 @@ abstract class Controls_Stack extends Base_Object {
 		}
 
 		foreach ( $control['condition'] as $condition_key => $condition_value ) {
-			preg_match( '/([a-z_0-9]+)(?:\[([a-z_]+)])?(!?)$/i', $condition_key, $condition_key_parts );
+			preg_match( '/([a-z_\-0-9]+)(?:\[([a-z_\-]+)])?(!?)$/i', $condition_key, $condition_key_parts );
 
 			$pure_condition_key = $condition_key_parts[1];
 			$condition_sub_key = $condition_key_parts[2];

--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -1273,7 +1273,7 @@ abstract class Controls_Stack extends Base_Object {
 		}
 
 		foreach ( $control['condition'] as $condition_key => $condition_value ) {
-			preg_match( '/([a-z_\-0-9]+)(?:\[([a-z_\-]+)])?(!?)$/i', $condition_key, $condition_key_parts );
+			preg_match( '/([a-z_\-0-9]+)(?:\[([a-z_]+)])?(!?)$/i', $condition_key, $condition_key_parts );
 
 			$pure_condition_key = $condition_key_parts[1];
 			$condition_sub_key = $condition_key_parts[2];


### PR DESCRIPTION
Relevant for group control that use the widget name as the group prefix.