### PR TITLE
Change switch mode button text to "Elementor"

### DIFF
--- a/modules/gutenberg/module.php
+++ b/modules/gutenberg/module.php
@@ -92,7 +92,7 @@ class Module extends BaseModule {
 					<span class="elementor-switch-mode-on"><?php echo __( '&#8592; Back to WordPress Editor', 'elementor' ); ?></span>
 					<span class="elementor-switch-mode-off">
 						<i class="eicon-elementor-square" aria-hidden="true"></i>
-						<?php echo __( 'Edit with Elementor', 'elementor' ); ?>
+						<?php echo __( 'Elementor', 'elementor' ); ?>
 					</span>
 				</button>
 			</div>


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

Change switch mode button text from "Edit with Elementor" to "Elementor" in Gutenberg top panel.

## Quality assurance

- [x] I have tested this code to the best of my abilities

Fixes #8191
