### PR TITLE
Delete php54 and php55 for latest WP build from .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,12 +69,6 @@ job-references:
         path: ~/phpunit
 
 jobs:
-  php54-wp-latest-build:
-    <<: *php_job
-    docker:
-    - image: pojome/php-cli:5.4
-    - image: *mysql_image
-
   php54-wp48-build:
     <<: *php_job
     environment:
@@ -89,12 +83,6 @@ jobs:
     - WP_VERSION: "4.7"
     docker:
     - image: pojome/php-cli:5.4
-    - image: *mysql_image
-
-  php55-wp-latest-build:
-    <<: *php_job
-    docker:
-    - image: pojome/php-cli:5.5
     - image: *mysql_image
 
   php55-wp48-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,8 @@ workflows:
   version: 2
   tests:
     jobs:
-    - php54-wp-latest-build
     - php54-wp48-build
     - php54-wp47-build
-    - php55-wp-latest-build
     - php55-wp48-build
     - php55-wp47-build
     - php56-wp-latest-build


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

Latest WordPress version requires PHP version at least 5.6.20
I've deleted php54 and php55 for latest WP build from [.circleci/config.yml](https://github.com/elementor/elementor/blob/master/.circleci/config.yml) file.

## Quality assurance

- [x] I have tested this code to the best of my abilities

Fixes #
