### PR TITLE
Add the playsinline attribute to background videos

### DIFF
--- a/includes/elements/section.php
+++ b/includes/elements/section.php
@@ -1429,7 +1429,7 @@ class Element_Section extends Element_Base {
 		<# if ( settings.background_video_link ) { #>
 			<div class="elementor-background-video-container elementor-hidden-phone">
 				<div class="elementor-background-video-embed"></div>
-				<video class="elementor-background-video-hosted elementor-html5-video" autoplay loop muted></video>
+				<video class="elementor-background-video-hosted elementor-html5-video" autoplay loop muted playsinline></video>
 			</div>
 		<# } #>
 		<div class="elementor-background-overlay"></div>
@@ -1463,7 +1463,7 @@ class Element_Section extends Element_Base {
 						<?php if ( $video_properties ) : ?>
 							<div class="elementor-background-video-embed"></div>
 						<?php else : ?>
-							<video class="elementor-background-video-hosted elementor-html5-video" autoplay loop muted></video>
+							<video class="elementor-background-video-hosted elementor-html5-video" autoplay loop muted playsinline></video>
 						<?php endif; ?>
 					</div>
 					<?php


### PR DESCRIPTION
Add the playsinline attribute to background videos so that they'll correctly autoplay on iOS

See here for more details about Apple's requirements: https://webkit.org/blog/6784/new-video-policies-for-ios/

Fixes #8198 and #3442

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
