### PR TITLE
Fix post title potentially breaking editor

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -1048,7 +1048,7 @@ class Frontend extends App {
 			$post = get_post();
 			$settings['post'] = [
 				'id' => $post->ID,
-				'title' => $post->post_title,
+				'title' => esc_attr($post->post_title),
 				'excerpt' => $post->post_excerpt,
 			];
 		} else {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

Fix post title potentially breaking editor, if it containing a single quote, for example.

## Description
An explanation of what is done in this PR

Using esc_attr on the post_title as it is enqueued for frontend settings.

## Test instructions
This PR can be tested by following these steps:

Create a new Page/Post/<other post_type>, and put an single quote - ' -  in the title (French users are particularly likely to do so organically). Before this fix, you would get a "Preview could not be loaded" error, because the JSON generated from the frontend settings would have been corrupted by the stray quote.

By using esc_attr, it gets encoded to &#039; which fixes the error.

## Quality assurance

- [ x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #


P.S. Should I have added some tests/docs for this?