### PR TITLE
Allow to modify urls in cached files

### DIFF
--- a/core/files/base.php
+++ b/core/files/base.php
@@ -155,6 +155,9 @@ abstract class Base {
 	public function update_file() {
 		$this->content = $this->parse_content();
 
+		// Allow other plugins to interact with the content, before being saved
+		$this->content = apply_filters( ‘elementor/files/content’, $this->content );
+
 		if ( $this->content ) {
 			$this->write();
 		} else {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary
There is no way for the cache content to be interacted with, before being save locally. 

## Description
I’am the developer of WP Hide plugin https://wordpress.org/plugins/wp-hide-security-enhancer/ 
Mainly, our plugin change default WordPress urls to something else, so default urls like /wp-content/uploads/image.jpg are not available anymore. but re-maped like /media/image.jpg. While using your Elementor internal cache, it still save the style using the default (old) urls, since there’s no filter to use in our code, to update such urls.

## Test instructions
Install both plugins. The cached assets should include at least an url to any images or font file. 

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
