### PR TITLE
fixed support for CSS generation of dynamic fields within repeaters

### DIFF
--- a/assets/dev/js/frontend/handlers/base.js
+++ b/assets/dev/js/frontend/handlers/base.js
@@ -31,10 +31,6 @@ module.exports = elementorModules.ViewModule.extend( {
 		} );
 	},
 
-	getID: function() {
-		return this.$element.attr( 'data-id' );
-	},
-
 	getUniqueHandlerID: function( cid, $element ) {
 		if ( ! cid ) {
 			cid = this.getModelCID();

--- a/assets/dev/js/frontend/handlers/base.js
+++ b/assets/dev/js/frontend/handlers/base.js
@@ -31,6 +31,10 @@ module.exports = elementorModules.ViewModule.extend( {
 		} );
 	},
 
+	getID: function() {
+		return this.$element.attr( 'data-id' );
+	},
+
 	getUniqueHandlerID: function( cid, $element ) {
 		if ( ! cid ) {
 			cid = this.getModelCID();

--- a/core/dynamic-tags/dynamic-css.php
+++ b/core/dynamic-tags/dynamic-css.php
@@ -85,8 +85,17 @@ class Dynamic_CSS extends Post {
 	 * @since 2.0.13
 	 * @access public
 	 */
-	public function add_controls_stack_style_rules( Controls_Stack $controls_stack, array $controls, array $values, array $placeholders, array $replacements, array $all_controls = null ) {
+	public function add_controls_stack_style_rules( Controls_Stack $controls_stack, array $controls, array $values, array $placeholders, array $replacements, array $all_controls = null, $is_repeater_item = false ) {
 		$dynamic_settings = $controls_stack->get_settings( '__dynamic__' );
+
+		$has_repeaters = array_filter( $controls, function( $control ) {
+			return 'repeater' === $control['type'];
+		} );
+
+		if ( empty( $dynamic_settings ) && ! empty( $has_repeaters ) ) {
+			$dynamic_settings = $has_repeaters;
+		}
+
 		if ( ! empty( $dynamic_settings ) ) {
 			$controls = array_intersect_key( $controls, $dynamic_settings );
 
@@ -96,7 +105,7 @@ class Dynamic_CSS extends Post {
 
 			foreach ( $controls as $control ) {
 				if ( ! empty( $control['style_fields'] ) ) {
-					$this->add_repeater_control_style_rules( $controls_stack, $control, $values[ $control['name'] ], $placeholders, $replacements );
+					$this->add_repeater_control_style_rules( $controls_stack, $control, $parsed_dynamic_settings[ $control['name'] ], $placeholders, $replacements );
 				}
 
 				if ( empty( $control['selectors'] ) ) {
@@ -104,6 +113,12 @@ class Dynamic_CSS extends Post {
 				}
 
 				$this->add_control_style_rules( $control, $parsed_dynamic_settings, $all_controls, $placeholders, $replacements );
+			}
+		}
+
+		if ( true === $is_repeater_item ) {
+			foreach ( $controls as $control ) {
+				$this->add_control_style_rules( $control, $values, $all_controls, $placeholders, $replacements );
 			}
 		}
 

--- a/core/files/css/base.php
+++ b/core/files/css/base.php
@@ -722,7 +722,8 @@ abstract class Base extends Base_File {
 				$repeater_values[ $index ],
 				$placeholders,
 				array_merge( $replacements, [ '.elementor-repeater-item-' . $repeater_values[ $index ]['_id'] ] ),
-				$repeater_control['fields']
+				$repeater_control['fields'],
+				true
 			);
 		}
 	}


### PR DESCRIPTION
The problem was initially identified in the Slides widget (background image dynamic field).

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
