### PR TITLE
Fix: Switch from uglify to terser plugin

### DIFF
--- a/.grunt-config/webpack.js
+++ b/.grunt-config/webpack.js
@@ -4,7 +4,7 @@
  */
 const path = require( 'path' );
 
-const UglifyJsPlugin = require( 'uglifyjs-webpack-plugin' );
+const TerserPlugin = require( 'terser-webpack-plugin' );
 
 const aliasList = {
 	alias: {
@@ -112,7 +112,10 @@ const webpackProductionConfig = {
 	optimization: {
 		minimize: true,
 		minimizer: [
-			new UglifyJsPlugin( {
+			new TerserPlugin( {
+				terserOptions: {
+					keep_fnames: true,
+				},
 				include: /\.min\.js$/
 			} ),
 		],

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
 		"grunt-checktextdomain": "~1.0.1",
 		"grunt-contrib-clean": "~1.1.0",
 		"grunt-contrib-copy": "~1.0.0",
-		"grunt-contrib-sass": "~1.0.0",
 		"grunt-contrib-qunit": "^3.1.0",
+		"grunt-contrib-sass": "~1.0.0",
 		"grunt-contrib-watch": "^1.1.0",
 		"grunt-postcss": "~0.9.0",
 		"grunt-release": "~0.14.0",
@@ -48,7 +48,7 @@
 		"load-grunt-tasks": "^4.0.0",
 		"mini-css-extract-plugin": "^0.4.3",
 		"path": "^0.12.7",
-		"uglifyjs-webpack-plugin": "^1.3.0",
+		"terser-webpack-plugin": "^1.4.1",
 		"webpack": "^4.16.5"
 	},
 	"dependencies": {


### PR DESCRIPTION
Updating js minifier to terser because uglify removes class name, probably due to some dependant module change, and that broke our event handling logic: 
we used to use full class names to bind to events but now those classes names are minified to 'e' or 'r' etc.
Probably issue: https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/269