### PR TITLE
fix for overlapping image slides in single slide mode

### DIFF
--- a/assets/dev/js/frontend/handlers/image-carousel.js
+++ b/assets/dev/js/frontend/handlers/image-carousel.js
@@ -62,6 +62,10 @@ class ImageCarouselHandler extends elementorModules.frontend.handlers.Base {
 
 		if ( isSingleSlide ) {
 			swiperOptions.effect = elementSettings.effect;
+
+			if ( 'fade' === elementSettings.effect ) {
+				swiperOptions.fadeEffect = { crossFade: true };
+			}
 		} else {
 			swiperOptions.slidesPerGroup = +elementSettings.slides_to_scroll || 1;
 		}


### PR DESCRIPTION
Ticket in Wordpress repo support: https://wordpress.org/support/topic/elementor-image-carousel-2/#post-11943476

### ## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
