### PR TITLE
Tweak: Add new "Word Spacing" control to typography controls [ED-4621]

### DIFF
--- a/includes/controls/groups/typography.php
+++ b/includes/controls/groups/typography.php
@@ -209,6 +209,23 @@ class Group_Control_Typography extends Group_Control_Base {
 			'selector_value' => 'letter-spacing: {{SIZE}}{{UNIT}}',
 		];
 
+		$fields['word_spacing'] = [
+			'label' => _x( 'Word Spacing', 'Typography Control', 'elementor' ),
+			'type' => Controls_Manager::SLIDER,
+			'desktop_default' => [
+				'unit' => 'em',
+			],
+			'tablet_default' => [
+				'unit' => 'em',
+			],
+			'mobile_default' => [
+				'unit' => 'em',
+			],
+			'size_units' => [ 'px', 'em' ],
+			'responsive' => true,
+			'selector_value' => 'word-spacing: {{SIZE}}{{UNIT}}',
+		];
+
 		return $fields;
 	}
 


### PR DESCRIPTION
With current **Letter Spacing** we can control the space between letters, but with **Word Spacing** we will be able to increase the space between the words without any workarounds like `&nbsp;` or several elements with `inline-block` display property and paddings / margins.

-----

For more info, see MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/word-spacing

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* New: Added word spacing to typography control.

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
