### PR TITLE
Fix: Item custom colors being overridden by global colors and added svg support

### DIFF
--- a/includes/widgets/social-icons.php
+++ b/includes/widgets/social-icons.php
@@ -204,7 +204,7 @@ class Widget_Social_Icons extends Widget_Base {
 					'item_icon_color' => 'custom',
 				],
 				'selectors' => [
-					'{{WRAPPER}} {{CURRENT_ITEM}}' => 'background-color: {{VALUE}};',
+					'{{WRAPPER}} {{CURRENT_ITEM}}.elementor-social-icon' => 'background-color: {{VALUE}};',
 				],
 			]
 		);
@@ -218,8 +218,8 @@ class Widget_Social_Icons extends Widget_Base {
 					'item_icon_color' => 'custom',
 				],
 				'selectors' => [
-					'{{WRAPPER}} {{CURRENT_ITEM}} i' => 'color: {{VALUE}};',
-					'{{WRAPPER}} {{CURRENT_ITEM}} svg' => 'fill: {{VALUE}};',
+					'{{WRAPPER}} {{CURRENT_ITEM}}.elementor-social-icon i' => 'color: {{VALUE}};',
+					'{{WRAPPER}} {{CURRENT_ITEM}}.elementor-social-icon svg' => 'fill: {{VALUE}};',
 				],
 			]
 		);
@@ -475,7 +475,7 @@ class Widget_Social_Icons extends Widget_Base {
 				],
 				'selectors' => [
 					'{{WRAPPER}} .elementor-social-icon:hover i' => 'color: {{VALUE}};',
-					'{{WRAPPER}} .elementor-social-icon:hover svg' => 'color: {{VALUE}};',
+					'{{WRAPPER}} .elementor-social-icon:hover svg' => 'fill: {{VALUE}};',
 				],
 			]
 		);


### PR DESCRIPTION
* Fix: Item custom colors being overridden by styling custom colors in Social Icons widget added svg support
* Fix:  Added `svg` custom color support for Social Icons widget 