### PR TITLE
Fix: Centre Images not being Aligned Properly

### DIFF
--- a/assets/dev/scss/frontend/_global.scss
+++ b/assets/dev/scss/frontend/_global.scss
@@ -31,7 +31,7 @@
 		box-shadow: none;
 	}
 
-	.elementor-widget:not(.elementor-widget-text-editor) figure {
+	.elementor-widget:not(.elementor-widget-text-editor) figure:not(.aligncentre) {
 		margin: 0;
 	}
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

- Prevents images that are intended to be centred from not being aligned properly

## Description
An explanation of what is done in this PR

* I'm not really familiar with Elementor, but it does seem bizarre to be overriding the margin styles of `figure` if it's intended to be centred.

## Test instructions
This PR can be tested by following these steps:

Centre an image with Gutenberg and verify that the `figure` styling is no longer overridden.

**Before:**

<img width="1178" alt="Screenshot 2019-10-05 at 15 23 47" src="https://user-images.githubusercontent.com/43215253/66256278-31e06680-e784-11e9-82bd-15b525d33149.png">

**After:**

<img width="1191" alt="Screenshot 2019-10-05 at 15 23 57" src="https://user-images.githubusercontent.com/43215253/66256285-3a38a180-e784-11e9-84b3-00525f10b65e.png">

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #9259 (initially an issue reported in Automattic/wp-calypso#28756)
