### PR TITLE
Add filter to change which CPT are supported by Elementor in the UI

### DIFF
--- a/includes/settings/controls.php
+++ b/includes/settings/controls.php
@@ -127,7 +127,7 @@ class Settings_Controls {
 		foreach ( $field['options'] as $option_key => $option_value ) :
 			?>
 			<label>
-				<input type="checkbox" name="<?php echo $field['id']; ?>[]" value="<?php echo $option_key; ?>"<?php checked( in_array( $option_key, $old_value ), true ); ?> />
+				<input type="checkbox" name="<?php echo esc_attr( $field['id'] ); ?>[]" value="<?php echo esc_attr( $option_key ); ?>"<?php checked( in_array( $option_key, $old_value ), true ); ?> />
 				<?php echo $option_value; ?>
 			</label><br />
 		<?php endforeach; ?>
@@ -189,6 +189,16 @@ class Settings_Controls {
 				'public' => true,
 			], 'objects'
 		);
+
+		/**
+		 * Filters the list of post type objects used by Elementor.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $post_types_objects List of post type objects used by Elementor.
+		 */
+		$post_types_objects = apply_filters( 'elementor/settings/controls/checkbox_list_cpt/post_type_objects', $post_types_objects );
+
 		$field['options'] = [];
 		foreach ( $post_types_objects as $cpt_slug => $post_type ) {
 			if ( in_array( $cpt_slug, $field['exclude'] ) ) {

--- a/includes/settings/controls.php
+++ b/includes/settings/controls.php
@@ -201,7 +201,7 @@ class Settings_Controls {
 
 		$field['options'] = [];
 		foreach ( $post_types_objects as $cpt_slug => $post_type ) {
-			if ( in_array( $cpt_slug, $field['exclude'] ) ) {
+			if ( in_array( $cpt_slug, $field['exclude'], true ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix: Fixing output escaping
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Adding a new filter

## Summary

This PR can be summarized in the following changelog entry:

* Added: New filter that allows overriding which custom post types show up in the admin settings screen for Elementor support
* Fixed: Added better output escaping in the attributes for checkbox lists in our admin forms

## Description

This PR allows plugins like Pods to customize which post types are supported by Elementor. For instance, we have private post types we would like Elementor to be able to interact with.

By default only public post types are shown in the admin options for Elementor which will exclude our Pod Templates CPT. By using this new filter, we (and others) can add custom post types that we intentionally want to integrate with Elementor without making them public post types.

*Note: This PR also fixes some bad output escaping by the checkbox_list function which I noticed when I was initially putting this PR together. Please excuse my putting both of these together at once, but I thought they were pretty well related once this filter is in place.*

Related threads:

* https://wordpress.org/support/topic/how-to-use-with-pods-as-a-template/#post-9275549
* https://wordpress.org/support/topic/integrate-elementor-templates-with-pods/

## Test instructions
This PR can be tested by following these steps:

* Add code to make use of the new filter and add a private CPT to the list of supported post types shown to admin
* Confirm private CPT now shows in the list

```php
add_filter( 'elementor/settings/controls/checkbox_list_cpt/post_type_objects', function( array $post_type_objects ) {
	$post_type_objects['your_private_cpt'] = get_post_type_object( 'your_private_cpt' );

	return $post_type_objects;
} );
```

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)