### PR TITLE
wptexturize moved before do_shortcode

### DIFF
--- a/includes/base/widget-base.php
+++ b/includes/base/widget-base.php
@@ -369,8 +369,8 @@ abstract class Widget_Base extends Element_Base {
 		$content = apply_filters( 'widget_text', $content, $this->get_settings() );
 
 		$content = shortcode_unautop( $content );
-		$content = do_shortcode( $content );
 		$content = wptexturize( $content );
+		$content = do_shortcode( $content );
 
 		if ( $GLOBALS['wp_embed'] instanceof \WP_Embed ) {
 			$content = $GLOBALS['wp_embed']->autoembed( $content );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* wptexturize moved before do_shortcode to prevent breaking shortcodes

## Quality assurance

- [x] I have tested this code to the best of my abilities

Fixes https://github.com/elementor/elementor/issues/9340
