### PR TITLE
Icons Control Inline Skin - Fixes and Tweaks

### DIFF
--- a/assets/dev/js/editor/controls/icons.js
+++ b/assets/dev/js/editor/controls/icons.js
@@ -307,14 +307,17 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 			} );
 		}
 
-		const previewHTML = '<i class="' + iconValue + '"></i>';
+		if ( 'media' === skin || 'svg' !== iconType ) {
+			const previewHTML = '<i class="' + iconValue + '"></i>';
 
-		iconContainer.html( previewHTML );
+			iconContainer.html( previewHTML );
+		}
 
 		this.enqueueIconFonts( iconType );
 	}
 
 	setDefaultIconLibraryLabel( defaultIcon, iconContainer ) {
+		console.log( defaultIcon );
 		// Check if the control has a default icon
 		if ( '' !== defaultIcon.value && 'svg' !== defaultIcon.library ) {
 			// If the default icon is not an SVG, set the icon-library label's icon to the default icon

--- a/assets/dev/js/editor/controls/icons.js
+++ b/assets/dev/js/editor/controls/icons.js
@@ -40,8 +40,8 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 			skin = this.model.get( 'skin' );
 
 		ui.controlMedia = '.elementor-control-media';
-		ui.svgUploader = 'media' === skin ? '.elementor-control-svg-uploader' : 'elementor-control-icons--inline__svg';
-		ui.iconPickers = 'media' === skin ? '.elementor-control-icon-picker, .elementor-control-media__preview, .elementor-control-media-upload-button' : 'elementor-control-icons--inline__icon';
+		ui.svgUploader = 'media' === skin ? '.elementor-control-svg-uploader' : '.elementor-control-icons--inline__svg';
+		ui.iconPickers = 'media' === skin ? '.elementor-control-icon-picker, .elementor-control-media__preview, .elementor-control-media-upload-button' : '.elementor-control-icons--inline__icon';
 		ui.deleteButton = 'media' === skin ? '.elementor-control-media__remove' : '.elementor-control-icons--inline__remove';
 		ui.previewPlaceholder = '.elementor-control-media__preview';
 		ui.previewContainer = '.elementor-control-preview-area';

--- a/assets/dev/js/editor/controls/icons.js
+++ b/assets/dev/js/editor/controls/icons.js
@@ -317,7 +317,6 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 	}
 
 	setDefaultIconLibraryLabel( defaultIcon, iconContainer ) {
-		console.log( defaultIcon );
 		// Check if the control has a default icon
 		if ( '' !== defaultIcon.value && 'svg' !== defaultIcon.library ) {
 			// If the default icon is not an SVG, set the icon-library label's icon to the default icon

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -111,14 +111,14 @@ class Control_Icons extends Control_Base_Multiple {
 						<i class="eicon-ban" aria-hidden="true"></i>
 						<span class="elementor-screen-only"><?php echo __( 'Remove', 'elementor' ); ?></span>
 					</label>
-					<# if ( ! data.inline_options.exclude.includes( 'svg' ) ) { #>
+					<# if ( ! data.exclude_inline_options.includes( 'svg' ) ) { #>
 						<input id="<?php echo $control_uid; ?>-svg" type="radio" value="svg">
 						<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__svg" for="<?php echo $control_uid; ?>-svg" data-tooltip="<?php echo __( 'Upload SVG', 'elementor' ); ?>" title="<?php echo __( 'Upload SVG', 'elementor' ); ?>">
 							<span aria-hidden="true">SVG</span>
 							<span class="elementor-screen-only"><?php echo __( 'Upload SVG', 'elementor' ); ?></span>
 						</label>
 					<# }
-					if ( ! data.inline_options.exclude.includes( 'icon' ) ) { #>
+					if ( ! data.exclude_inline_options.includes( 'icon' ) ) { #>
 						<input id="<?php echo $control_uid; ?>-icon" type="radio" value="icon">
 						<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__icon" for="<?php echo $control_uid; ?>-icon" data-tooltip="<?php echo __( 'Icon Library', 'elementor' ); ?>" title="<?php echo __( 'Icon Library', 'elementor' ); ?>">
 							<span class="elementor-control-icons--inline__displayed-icon">
@@ -159,9 +159,7 @@ class Control_Icons extends Control_Base_Multiple {
 			'recommended' => false,
 			'is_svg_enabled' => Svg_Handler::is_enabled(),
 			'skin' => 'media',
-			'inline_options' => [
-				'exclude' => [],
-			],
+			'exclude_inline_options' => [],
 		];
 	}
 

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -112,20 +112,20 @@ class Control_Icons extends Control_Base_Multiple {
 						<span class="elementor-screen-only"><?php echo __( 'Remove', 'elementor' ); ?></span>
 					</label>
 					<# if ( ! data.inline_options.exclude.includes( 'svg' ) ) { #>
-					<input id="<?php echo $control_uid; ?>-svg" type="radio" value="svg">
-					<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__svg" for="<?php echo $control_uid; ?>-svg" data-tooltip="<?php echo __( 'Upload SVG', 'elementor' ); ?>" title="<?php echo __( 'Upload SVG', 'elementor' ); ?>">
-						<span aria-hidden="true">SVG</span>
-						<span class="elementor-screen-only"><?php echo __( 'Upload SVG', 'elementor' ); ?></span>
-					</label>
+						<input id="<?php echo $control_uid; ?>-svg" type="radio" value="svg">
+						<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__svg" for="<?php echo $control_uid; ?>-svg" data-tooltip="<?php echo __( 'Upload SVG', 'elementor' ); ?>" title="<?php echo __( 'Upload SVG', 'elementor' ); ?>">
+							<span aria-hidden="true">SVG</span>
+							<span class="elementor-screen-only"><?php echo __( 'Upload SVG', 'elementor' ); ?></span>
+						</label>
 					<# }
 					if ( ! data.inline_options.exclude.includes( 'icon' ) ) { #>
-					<input id="<?php echo $control_uid; ?>-icon" type="radio" value="icon">
-					<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__icon" for="<?php echo $control_uid; ?>-icon" data-tooltip="<?php echo __( 'Icon Library', 'elementor' ); ?>" title="<?php echo __( 'Icon Library', 'elementor' ); ?>">
+						<input id="<?php echo $control_uid; ?>-icon" type="radio" value="icon">
+						<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__icon" for="<?php echo $control_uid; ?>-icon" data-tooltip="<?php echo __( 'Icon Library', 'elementor' ); ?>" title="<?php echo __( 'Icon Library', 'elementor' ); ?>">
 							<span class="elementor-control-icons--inline__displayed-icon">
 								<i class="eicon-circle" aria-hidden="true"></i>
 							</span>
-						<span class="elementor-screen-only"><?php echo __( 'Icon Library', 'elementor' ); ?></span>
-					</label>
+							<span class="elementor-screen-only"><?php echo __( 'Icon Library', 'elementor' ); ?></span>
+						</label>
 					<# } #>
 				</div>
 			</div>

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -111,18 +111,22 @@ class Control_Icons extends Control_Base_Multiple {
 						<i class="eicon-ban" aria-hidden="true"></i>
 						<span class="elementor-screen-only"><?php echo __( 'Remove', 'elementor' ); ?></span>
 					</label>
+					<# if ( ! data.inline_options.exclude.includes( 'svg' ) ) { #>
 					<input id="<?php echo $control_uid; ?>-svg" type="radio" value="svg">
 					<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__svg" for="<?php echo $control_uid; ?>-svg" data-tooltip="<?php echo __( 'Upload SVG', 'elementor' ); ?>" title="<?php echo __( 'Upload SVG', 'elementor' ); ?>">
 						<span aria-hidden="true">SVG</span>
 						<span class="elementor-screen-only"><?php echo __( 'Upload SVG', 'elementor' ); ?></span>
 					</label>
+					<# }
+					if ( ! data.inline_options.exclude.includes( 'icon' ) ) { #>
 					<input id="<?php echo $control_uid; ?>-icon" type="radio" value="icon">
 					<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__icon" for="<?php echo $control_uid; ?>-icon" data-tooltip="<?php echo __( 'Icon Library', 'elementor' ); ?>" title="<?php echo __( 'Icon Library', 'elementor' ); ?>">
-						<span class="elementor-control-icons--inline__displayed-icon">
-							<i class="eicon-circle" aria-hidden="true"></i>
-						</span>
+							<span class="elementor-control-icons--inline__displayed-icon">
+								<i class="eicon-circle" aria-hidden="true"></i>
+							</span>
 						<span class="elementor-screen-only"><?php echo __( 'Icon Library', 'elementor' ); ?></span>
 					</label>
+					<# } #>
 				</div>
 			</div>
 		</div>
@@ -155,6 +159,9 @@ class Control_Icons extends Control_Base_Multiple {
 			'recommended' => false,
 			'is_svg_enabled' => Svg_Handler::is_enabled(),
 			'skin' => 'media',
+			'inline_options' => [
+				'exclude' => [],
+			],
 		];
 	}
 

--- a/includes/widgets/accordion.php
+++ b/includes/widgets/accordion.php
@@ -152,6 +152,22 @@ class Widget_Accordion extends Widget_Base {
 					'value' => 'fas fa-plus',
 					'library' => 'fa-solid',
 				],
+				'recommended' => [
+					'fa-solid' => [
+						'plus',
+						'plus-square',
+						'folder-plus',
+						'cart-plus',
+						'calendar-plus',
+						'search-plus',
+					],
+					'fa-regular' => [
+						'plus-square',
+						'plus-circle',
+						'calendar-plus',
+					],
+				],
+				'skin' => 'inline',
 			]
 		);
 
@@ -165,6 +181,21 @@ class Widget_Accordion extends Widget_Base {
 					'value' => 'fas fa-minus',
 					'library' => 'fa-solid',
 				],
+				'recommended' => [
+					'fa-solid' => [
+						'minus',
+						'minus-circle',
+						'minus-square',
+						'folder-minus',
+						'calendar-minus',
+						'search-minus',
+					],
+					'fa-regular' => [
+						'minus-square',
+						'calendar-minus',
+					],
+				],
+				'skin' => 'inline',
 				'condition' => [
 					'selected_icon[value]!' => '',
 				],

--- a/includes/widgets/toggle.php
+++ b/includes/widgets/toggle.php
@@ -149,6 +149,29 @@ class Widget_Toggle extends Widget_Base {
 					'value' => 'fas fa-caret' . ( is_rtl() ? '-left' : '-right' ),
 					'library' => 'fa-solid',
 				],
+				'recommended' => [
+					'fa-solid' => [
+						'caret-right',
+						'caret-left',
+						'caret-up',
+						'caret-down',
+						'caret-square-right',
+						'caret-square-left',
+						'caret-square-up',
+						'caret-square-down',
+					],
+					'fa-regular' => [
+						'caret-right',
+						'caret-left',
+						'caret-up',
+						'caret-down',
+						'caret-square-right',
+						'caret-square-left',
+						'caret-square-up',
+						'caret-square-down',
+					],
+				],
+				'skin' => 'inline',
 			]
 		);
 
@@ -162,6 +185,29 @@ class Widget_Toggle extends Widget_Base {
 					'value' => 'fas fa-caret-up',
 					'library' => 'fa-solid',
 				],
+				'recommended' => [
+					'fa-solid' => [
+						'caret-right',
+						'caret-left',
+						'caret-up',
+						'caret-down',
+						'caret-square-right',
+						'caret-square-left',
+						'caret-square-up',
+						'caret-square-down',
+					],
+					'fa-regular' => [
+						'caret-right',
+						'caret-left',
+						'caret-up',
+						'caret-down',
+						'caret-square-right',
+						'caret-square-left',
+						'caret-square-up',
+						'caret-square-down',
+					],
+				],
+				'skin' => 'inline',
 				'condition' => [
 					'selected_icon[value]!' => '',
 				],


### PR DESCRIPTION
- Fixed: Bugs in the Icons Control's Inline Skin
- Added the ability to exclude icon types (icon/svg) from the inline control skin.
- Changed the `ICONS` controls to `inline` skin and added recommended icons - in Accordion and Toggle widgets

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [X] Feature

Fixes #
Missing class prefix in the `ui` object building.