### PR TITLE
Fix: Testimonial + link = the color style not displayed (PT 155)

### DIFF
--- a/assets/dev/scss/frontend/widgets/testimonial.scss
+++ b/assets/dev/scss/frontend/widgets/testimonial.scss
@@ -13,11 +13,13 @@
 	.elementor-testimonial-name {
 		line-height: 1.5;
 		color: inherit;
+		display: block;
 	}
 
 	.elementor-testimonial-job {
 		font-size: 0.85em;
 		color: inherit;
+		display: block;
 	}
 
 	&.elementor-testimonial-text-align- {

--- a/includes/widgets/testimonial.php
+++ b/includes/widgets/testimonial.php
@@ -456,12 +456,17 @@ class Widget_Testimonial extends Widget_Base {
 							$this->add_inline_editing_attributes( 'testimonial_name', 'none' );
 
 							$testimonial_name_html = $settings['testimonial_name'];
-							if ( ! empty( $settings['link']['url'] ) ) :
-								$testimonial_name_html = '<a ' . $this->get_render_attribute_string( 'link' ) . '>' . $testimonial_name_html . '</a>';
-							endif;
-							?>
-							<div <?php echo $this->get_render_attribute_string( 'testimonial_name' ); ?>><?php echo $testimonial_name_html; ?></div>
-						<?php endif; ?>
+
+							if ( ! empty( $settings['link']['url'] ) ) {
+								?>
+								<a <?php echo $this->get_render_attribute_string( 'testimonial_name' ) . ' ' . $this->get_render_attribute_string( 'link' ); ?>><?php echo $testimonial_name_html; ?></a>
+								<?php
+							} else {
+								?>
+								<div <?php echo $this->get_render_attribute_string( 'testimonial_name' ); ?>><?php echo $testimonial_name_html; ?></div>
+								<?php
+							}
+						endif; ?>
 						<?php
 						if ( $has_job ) :
 							$this->add_render_attribute( 'testimonial_job', 'class', 'elementor-testimonial-job' );
@@ -469,12 +474,17 @@ class Widget_Testimonial extends Widget_Base {
 							$this->add_inline_editing_attributes( 'testimonial_job', 'none' );
 
 							$testimonial_job_html = $settings['testimonial_job'];
-							if ( ! empty( $settings['link']['url'] ) ) :
-								$testimonial_job_html = '<a ' . $this->get_render_attribute_string( 'link' ) . '>' . $testimonial_job_html . '</a>';
-							endif;
-							?>
-							<div <?php echo $this->get_render_attribute_string( 'testimonial_job' ); ?>><?php echo $testimonial_job_html; ?></div>
-						<?php endif; ?>
+
+							if ( ! empty( $settings['link']['url'] ) ) {
+								?>
+								<a <?php echo $this->get_render_attribute_string( 'testimonial_job' ) . ' ' . $this->get_render_attribute_string( 'link' ); ?>><?php echo $testimonial_job_html; ?></a>
+								<?php
+							} else {
+								?>
+								<div <?php echo $this->get_render_attribute_string( 'testimonial_job' ); ?>><?php echo $testimonial_job_html; ?></div>
+								<?php
+							}
+						endif; ?>
 					</div>
 					<?php endif; ?>
 				</div>
@@ -528,39 +538,52 @@ class Widget_Testimonial extends Widget_Base {
 			<div class="elementor-testimonial-meta{{ hasImage }}{{ testimonial_image_position }}">
 				<div class="elementor-testimonial-meta-inner">
 					<# if ( imageUrl ) { #>
-					<div class="elementor-testimonial-image">{{{ imageHtml }}}</div>
+						<div class="elementor-testimonial-image">{{{ imageHtml }}}</div>
 					<# } #>
-
 					<div class="elementor-testimonial-details">
-						<# if ( '' !== settings.testimonial_name ) {
-							view.addRenderAttribute( 'testimonial_name', 'class', 'elementor-testimonial-name' );
-
-							view.addInlineEditingAttributes( 'testimonial_name', 'none' );
-
-							var testimonialNameHtml = settings.testimonial_name;
-							if ( settings.link.url ) {
-								testimonialNameHtml = '<a href="' + settings.link.url + '">' + testimonialNameHtml + '</a>';
-							}
-							#>
-							<div {{{ view.getRenderAttributeString( 'testimonial_name' ) }}}>{{{ testimonialNameHtml }}}</div>
-						<# } #>
-
-						<# if ( '' !== settings.testimonial_job ) {
-							view.addRenderAttribute( 'testimonial_job', 'class', 'elementor-testimonial-job' );
-
-							view.addInlineEditingAttributes( 'testimonial_job', 'none' );
-
-							var testimonialJobHtml = settings.testimonial_job;
-							if ( settings.link.url ) {
-								testimonialJobHtml = '<a href="' + settings.link.url + '">' + testimonialJobHtml + '</a>';
-							}
-							#>
-							<div {{{ view.getRenderAttributeString( 'testimonial_job' ) }}}>{{{ testimonialJobHtml }}}</div>
-						<# } #>
+						<?php $this->render_testimonial_description(); ?>
 					</div>
 				</div>
 			</div>
 		</div>
+		<?php
+	}
+
+	protected function render_testimonial_description() {
+		?>
+		<#
+		if ( '' !== settings.testimonial_name ) {
+			view.addRenderAttribute( 'testimonial_name', 'class', 'elementor-testimonial-name' );
+
+			view.addInlineEditingAttributes( 'testimonial_name', 'none' );
+
+			if ( settings.link.url ) {
+				#>
+				<a href="{{{ settings.link.url }}}" {{{ view.getRenderAttributeString( 'testimonial_name' ) }}}>{{{ settings.testimonial_name }}}</a>
+				<#
+			} else {
+				#>
+				<div {{{ view.getRenderAttributeString( 'testimonial_name' ) }}}>{{{ settings.testimonial_name }}}</div>
+				<#
+			}
+		}
+
+		if ( '' !== settings.testimonial_job ) {
+			view.addRenderAttribute( 'testimonial_job', 'class', 'elementor-testimonial-job' );
+
+			view.addInlineEditingAttributes( 'testimonial_job', 'none' );
+
+			if ( settings.link.url ) {
+				#>
+				<a href="{{{ settings.link.url }}}" {{{ view.getRenderAttributeString( 'testimonial_job' ) }}}>{{{ settings.testimonial_job }}}</a>
+				<#
+			} else {
+				#>
+				<div {{{ view.getRenderAttributeString( 'testimonial_job' ) }}}>{{{ settings.testimonial_job }}}</div>
+				<#
+			}
+		}
+		#>
 		<?php
 	}
 }


### PR DESCRIPTION
I changed the markup for the testimonial name/job.
When the user entered a link, the markup nested an `<a>` tag under the `<div>` with the class `elementor-testimonial-name`/`elementor-testimonial-job`.

The controls for color and typography used the above-mentioned class names as selectors, so the nested `<a>` tag wasn't targeted by them.

I changed the markup for these tags to either be a `<div>` or an `<a>`, both with the classes `elementor-testimonial-name`/`elementor-testimonial-job`, so the `<a>` isn't nested when the name/job are a link.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
