### PR TITLE
Fix: Icon library - Recommended icons don't change on multiple Icons controls per widget

### DIFF
--- a/assets/dev/js/editor/components/icons-manager/icons-manager.js
+++ b/assets/dev/js/editor/components/icons-manager/icons-manager.js
@@ -87,9 +87,10 @@ export default class extends elementorModules.Module {
 
 		if ( iconManagerConfig.recommended ) {
 			let hasRecommended = false;
-			icons.forEach( ( library ) => {
+			icons.forEach( ( library, index ) => {
 				if ( 'recommended' === library.name ) {
 					hasRecommended = true;
+					icons[ index ].icons = iconManagerConfig.recommended;
 				}
 			} );
 			if ( ! hasRecommended ) {


### PR DESCRIPTION
Fixed: Icon library - Recommended icons don't change when there is more than one Icons control per widget

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Fixed bug in icon library recommended icons - in cases there are multiple `Icons` controls in one widget, the recommended icons don't change when going to one control's icon library after the other

## Description
An explanation of what is done in this PR

- This bug happened in widgets that have more than one `Icons` controls, when multiple icons controls have recommended icons. 
- When opening the icon library, the list of icons is filtered to only show the recommended icons
- The bug: after opening one control's icon library, then opening the other, the recommended icons remain the first control's icons

## Test instructions
This PR can be tested by following these steps:

- D&D a widget with multiple `Icons` controls that have recommended icons
- Open the icon library on one `Icons` control, note the recommended icons appearing
- Open the icon library on a different `Icons` control and see that the recommended icons have changed appropriately

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
