### PR TITLE
Fix: Advanced tab > Background > Transition Duration (PT 112)

### DIFF
--- a/includes/widgets/common.php
+++ b/includes/widgets/common.php
@@ -248,6 +248,9 @@ class Widget_Common extends Widget_Base {
 				],
 				'render_type' => 'ui',
 				'separator' => 'before',
+				'selectors' => [
+					'{{WRAPPER}} > .elementor-widget-container' => 'transition: background {{SIZE}}s',
+				],
 			]
 		);
 


### PR DESCRIPTION
Fix: Advanced tab > Background > Transition Duration not working on any widget (PT 112)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix

## Summary

This PR can be summarized in the following changelog entry:
* Fix: Background Transition duration in the Advanced tab not working

## Test instructions
This PR can be tested by following these steps:

* Edit any widget, go to Advanced tab > Background > Hover
* Give the widget a background color on hover
* Choose a transition duration value
* Hover over the widget - check that the background transitions in the speed you selected

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
