### PR TITLE
Fix: Sticky section in header hidden on Desktop causes scroll offset to on-page anchors (PT 158)

### DIFF
--- a/assets/dev/js/frontend/utils/anchors.js
+++ b/assets/dev/js/frontend/utils/anchors.js
@@ -45,7 +45,7 @@ module.exports = elementorModules.ViewModule.extend( {
 
 		var scrollTop = $anchor.offset().top,
 			$wpAdminBar = elementorFrontend.elements.$wpAdminBar,
-			$activeStickies = jQuery( '.elementor-section.elementor-sticky--active' ),
+			$activeStickies = jQuery( '.elementor-section.elementor-sticky--active:visible' ),
 			maxStickyHeight = 0;
 
 		if ( $wpAdminBar.length > 0 ) {


### PR DESCRIPTION
Fix: Anchor menu + Sticky header: sticky section in header hidden on Desktop causes scroll offset (PT 158)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Anchor menu + Sticky header: sticky section in header hidden on Desktop causes scroll offset 

## Description
An explanation of what is done in this PR

* In our anchors handler, in the selector for active sticky elements on the page, added the `:visible` tag in order to filter hidden sticky elements.

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [X] I have tested this code to the best of my abilities