### PR TITLE
Allow overriding of default button styles

### DIFF
--- a/includes/widgets/button.php
+++ b/includes/widgets/button.php
@@ -110,19 +110,23 @@ class Widget_Button extends Widget_Base {
 			]
 		);
 
+		$styles = [
+			'' => __( 'Default', 'elementor' ),
+			'info' => __( 'Info', 'elementor' ),
+			'success' => __( 'Success', 'elementor' ),
+			'warning' => __( 'Warning', 'elementor' ),
+			'danger' => __( 'Danger', 'elementor' ),
+		];
+
+		$styles = apply_filters( 'elementor/widgets/button/override_button_styles', $styles );
+
 		$this->add_control(
 			'button_type',
 			[
 				'label' => __( 'Type', 'elementor' ),
 				'type' => Controls_Manager::SELECT,
 				'default' => '',
-				'options' => [
-					'' => __( 'Default', 'elementor' ),
-					'info' => __( 'Info', 'elementor' ),
-					'success' => __( 'Success', 'elementor' ),
-					'warning' => __( 'Warning', 'elementor' ),
-					'danger' => __( 'Danger', 'elementor' ),
-				],
+				'options' => $styles,
 				'prefix_class' => 'elementor-button-',
 			]
 		);


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Allow overriding of default button styles

## Description
An explanation of what is done in this PR

* Add a new filter to allow theme builders to override the default elementor button styles

## Test instructions
This PR can be tested by following these steps:

Hook into the filter and return a custom array of styles.
```
function override_elementor_button_styles() {
    return [
        'primary' => 'Primary',
        'secondary' => 'Secondary',
    ];
}
add_filter( 'elementor/widgets/button/override_button_styles', 'override_elementor_button_styles', 10 );
```

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)
