### PR TITLE
Deprecations 2.8.0

### DIFF
--- a/assets/dev/js/editor/controls/icons.js
+++ b/assets/dev/js/editor/controls/icons.js
@@ -40,8 +40,8 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 			skin = this.model.get( 'skin' );
 
 		ui.controlMedia = '.elementor-control-media';
-		ui.svgUploader = 'media' === skin ? '.elementor-control-svg-uploader' : 'elementor-control-icons--inline__svg';
-		ui.iconPickers = 'media' === skin ? '.elementor-control-icon-picker, .elementor-control-media__preview, .elementor-control-media-upload-button' : 'elementor-control-icons--inline__icon';
+		ui.svgUploader = 'media' === skin ? '.elementor-control-svg-uploader' : '.elementor-control-icons--inline__svg';
+		ui.iconPickers = 'media' === skin ? '.elementor-control-icon-picker, .elementor-control-media__preview, .elementor-control-media-upload-button' : '.elementor-control-icons--inline__icon';
 		ui.deleteButton = 'media' === skin ? '.elementor-control-media__remove' : '.elementor-control-icons--inline__remove';
 		ui.previewPlaceholder = '.elementor-control-media__preview';
 		ui.previewContainer = '.elementor-control-preview-area';

--- a/core/base/document.php
+++ b/core/base/document.php
@@ -162,7 +162,7 @@ abstract class Document extends Controls_Stack {
 	 * @access public
 	 */
 	public function get_remote_library_type() {
-		// _deprecated_function( __METHOD__, '2.4.0', __CLASS__ . '::get_remote_library_config()' );
+		_deprecated_function( __METHOD__, '2.4.0', __CLASS__ . '::get_remote_library_config()' );
 	}
 
 	/**
@@ -227,7 +227,7 @@ abstract class Document extends Controls_Stack {
 	 * @access public
 	 */
 	public function get_container_classes() {
-		// _deprecated_function( __METHOD__, '2.4.0', __CLASS__ . '::get_container_attributes()' );
+		_deprecated_function( __METHOD__, '2.4.0', __CLASS__ . '::get_container_attributes()' );
 
 		return '';
 	}

--- a/core/documents-manager.php
+++ b/core/documents-manager.php
@@ -634,7 +634,7 @@ class Documents_Manager {
 	 * @return array
 	 */
 	public function get_groups() {
-		// _deprecated_function( __METHOD__, '2.4.0' );
+		_deprecated_function( __METHOD__, '2.4.0' );
 
 		return [];
 	}

--- a/includes/autoloader.php
+++ b/includes/autoloader.php
@@ -83,7 +83,6 @@ class Autoloader {
 
 	private static function init_classes_map() {
 		self::$classes_map = [
-			'Admin' => 'includes/admin.php',
 			'Api' => 'includes/api.php',
 			'Base_Control' => 'includes/controls/base.php',
 			'Base_Data_Control' => 'includes/controls/base-data.php',
@@ -179,10 +178,6 @@ class Autoloader {
 
 	private static function init_classes_aliases() {
 		self::$classes_aliases = [
-			'Admin' => [
-				'replacement' => 'Core\Admin\Admin',
-				'version' => '2.2.0',
-			],
 			'Core\Ajax' => [
 				'replacement' => 'Core\Common\Modules\Ajax\Module',
 				'version' => '2.3.0',

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -111,20 +111,22 @@ class Control_Icons extends Control_Base_Multiple {
 						<i class="eicon-ban" aria-hidden="true"></i>
 						<span class="elementor-screen-only"><?php echo __( 'Remove', 'elementor' ); ?></span>
 					</label>
-					<# if ( ! data.hide_svg_uploader ) { #>
+					<# if ( ! data.inline_options.exclude.includes( 'svg' ) ) { #>
 						<input id="<?php echo $control_uid; ?>-svg" type="radio" value="svg">
 						<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__svg" for="<?php echo $control_uid; ?>-svg" data-tooltip="<?php echo __( 'Upload SVG', 'elementor' ); ?>" title="<?php echo __( 'Upload SVG', 'elementor' ); ?>">
 							<span aria-hidden="true">SVG</span>
 							<span class="elementor-screen-only"><?php echo __( 'Upload SVG', 'elementor' ); ?></span>
 						</label>
+					<# }
+					if ( ! data.inline_options.exclude.includes( 'icon' ) ) { #>
+						<input id="<?php echo $control_uid; ?>-icon" type="radio" value="icon">
+						<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__icon" for="<?php echo $control_uid; ?>-icon" data-tooltip="<?php echo __( 'Icon Library', 'elementor' ); ?>" title="<?php echo __( 'Icon Library', 'elementor' ); ?>">
+							<span class="elementor-control-icons--inline__displayed-icon">
+								<i class="eicon-circle" aria-hidden="true"></i>
+							</span>
+							<span class="elementor-screen-only"><?php echo __( 'Icon Library', 'elementor' ); ?></span>
+						</label>
 					<# } #>
-					<input id="<?php echo $control_uid; ?>-icon" type="radio" value="icon">
-					<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__icon" for="<?php echo $control_uid; ?>-icon" data-tooltip="<?php echo __( 'Icon Library', 'elementor' ); ?>" title="<?php echo __( 'Icon Library', 'elementor' ); ?>">
-						<span class="elementor-control-icons--inline__displayed-icon">
-							<i class="eicon-circle" aria-hidden="true"></i>
-						</span>
-						<span class="elementor-screen-only"><?php echo __( 'Icon Library', 'elementor' ); ?></span>
-					</label>
 				</div>
 			</div>
 		</div>
@@ -157,7 +159,9 @@ class Control_Icons extends Control_Base_Multiple {
 			'recommended' => false,
 			'is_svg_enabled' => Svg_Handler::is_enabled(),
 			'skin' => 'media',
-			'hide_svg_uploader' => false,
+			'inline_options' => [
+				'exclude' => [],
+			],
 		];
 	}
 

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -111,11 +111,13 @@ class Control_Icons extends Control_Base_Multiple {
 						<i class="eicon-ban" aria-hidden="true"></i>
 						<span class="elementor-screen-only"><?php echo __( 'Remove', 'elementor' ); ?></span>
 					</label>
-					<input id="<?php echo $control_uid; ?>-svg" type="radio" value="svg">
-					<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__svg" for="<?php echo $control_uid; ?>-svg" data-tooltip="<?php echo __( 'Upload SVG', 'elementor' ); ?>" title="<?php echo __( 'Upload SVG', 'elementor' ); ?>">
-						<span aria-hidden="true">SVG</span>
-						<span class="elementor-screen-only"><?php echo __( 'Upload SVG', 'elementor' ); ?></span>
-					</label>
+					<# if ( ! data.hide_svg_uploader ) { #>
+						<input id="<?php echo $control_uid; ?>-svg" type="radio" value="svg">
+						<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__svg" for="<?php echo $control_uid; ?>-svg" data-tooltip="<?php echo __( 'Upload SVG', 'elementor' ); ?>" title="<?php echo __( 'Upload SVG', 'elementor' ); ?>">
+							<span aria-hidden="true">SVG</span>
+							<span class="elementor-screen-only"><?php echo __( 'Upload SVG', 'elementor' ); ?></span>
+						</label>
+					<# } #>
 					<input id="<?php echo $control_uid; ?>-icon" type="radio" value="icon">
 					<label class="elementor-choices-label tooltip-target elementor-control-icons--inline__icon" for="<?php echo $control_uid; ?>-icon" data-tooltip="<?php echo __( 'Icon Library', 'elementor' ); ?>" title="<?php echo __( 'Icon Library', 'elementor' ); ?>">
 						<span class="elementor-control-icons--inline__displayed-icon">
@@ -155,6 +157,7 @@ class Control_Icons extends Control_Base_Multiple {
 			'recommended' => false,
 			'is_svg_enabled' => Svg_Handler::is_enabled(),
 			'skin' => 'media',
+			'hide_svg_uploader' => false,
 		];
 	}
 


### PR DESCRIPTION
**Deprecated Methods:**
- `Document::get_container_classes()` - Hard Deprecation
- `Document::get_remote_library_type()` - Hard Deprecation
- `Documents_Manager::get_groups()` - Hard Deprecation

**Deprecated Class Alias:**
- `Elementor\Admin` (in `autoloader.php`) - Deletion