### PR TITLE
Deprecated methods + the Elementor\Admin class alias

### DIFF
--- a/assets/dev/js/editor/utils/helpers.js
+++ b/assets/dev/js/editor/utils/helpers.js
@@ -438,18 +438,6 @@ helpers = {
 		return _.isEmpty( hasFields );
 	},
 
-	cloneObject( object ) {
-		elementorCommon.helpers.deprecatedMethod( 'elementor.helpers.cloneObject', '2.3.0', 'elementorCommon.helpers.cloneObject' );
-
-		return elementorCommon.helpers.cloneObject( object );
-	},
-
-	firstLetterUppercase( string ) {
-		elementorCommon.helpers.deprecatedMethod( 'elementor.helpers.upperCaseWords', '2.3.0', 'elementorCommon.helpers.upperCaseWords' );
-
-		return elementorCommon.helpers.upperCaseWords( string );
-	},
-
 	disableElementEvents( $element ) {
 		$element.each( function() {
 			const currentPointerEvents = this.style.pointerEvents;

--- a/assets/dev/js/editor/utils/helpers.js
+++ b/assets/dev/js/editor/utils/helpers.js
@@ -438,6 +438,12 @@ helpers = {
 		return _.isEmpty( hasFields );
 	},
 
+	cloneObject( object ) {
+		elementorCommon.helpers.deprecatedMethod( 'elementor.helpers.cloneObject', '2.3.0', 'elementorCommon.helpers.cloneObject' );
+
+		return elementorCommon.helpers.cloneObject( object );
+	},
+
 	disableElementEvents( $element ) {
 		$element.each( function() {
 			const currentPointerEvents = this.style.pointerEvents;

--- a/core/base/document.php
+++ b/core/base/document.php
@@ -162,7 +162,7 @@ abstract class Document extends Controls_Stack {
 	 * @access public
 	 */
 	public function get_remote_library_type() {
-		// _deprecated_function( __METHOD__, '2.4.0', __CLASS__ . '::get_remote_library_config()' );
+		_deprecated_function( __METHOD__, '2.4.0', __CLASS__ . '::get_remote_library_config()' );
 	}
 
 	/**
@@ -227,7 +227,7 @@ abstract class Document extends Controls_Stack {
 	 * @access public
 	 */
 	public function get_container_classes() {
-		// _deprecated_function( __METHOD__, '2.4.0', __CLASS__ . '::get_container_attributes()' );
+		_deprecated_function( __METHOD__, '2.4.0', __CLASS__ . '::get_container_attributes()' );
 
 		return '';
 	}

--- a/core/documents-manager.php
+++ b/core/documents-manager.php
@@ -634,7 +634,7 @@ class Documents_Manager {
 	 * @return array
 	 */
 	public function get_groups() {
-		// _deprecated_function( __METHOD__, '2.4.0' );
+		_deprecated_function( __METHOD__, '2.4.0' );
 
 		return [];
 	}

--- a/includes/autoloader.php
+++ b/includes/autoloader.php
@@ -83,7 +83,6 @@ class Autoloader {
 
 	private static function init_classes_map() {
 		self::$classes_map = [
-			'Admin' => 'includes/admin.php',
 			'Api' => 'includes/api.php',
 			'Base_Control' => 'includes/controls/base.php',
 			'Base_Data_Control' => 'includes/controls/base-data.php',
@@ -179,10 +178,6 @@ class Autoloader {
 
 	private static function init_classes_aliases() {
 		self::$classes_aliases = [
-			'Admin' => [
-				'replacement' => 'Core\Admin\Admin',
-				'version' => '2.2.0',
-			],
 			'Core\Ajax' => [
 				'replacement' => 'Core\Common\Modules\Ajax\Module',
 				'version' => '2.3.0',


### PR DESCRIPTION
**Method Deprecations:**
- `Document::get_container_classes()` - Hard Deprecation
- `Document::get_remote_library_type()` - Hard Deprecation
- `Documents_Manager::get_groups()` - Hard Deprecation

**Class Alias Deprecations:**
- `Elementor\Admin` (in `autoloader.php`) - Deletion

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Other... Please describe: Method deprecations

## Description
An explanation of what is done in this PR
* Method deprecations