### PR TITLE
Feature Request for two stage registration process on forms/pop up forms

### DIFF
--- a/assets/dev/js/editor/components/icons-manager/icons-manager.js
+++ b/assets/dev/js/editor/components/icons-manager/icons-manager.js
@@ -87,9 +87,10 @@ export default class extends elementorModules.Module {
 
 		if ( iconManagerConfig.recommended ) {
 			let hasRecommended = false;
-			icons.forEach( ( library ) => {
+			icons.forEach( ( library, index ) => {
 				if ( 'recommended' === library.name ) {
 					hasRecommended = true;
+					icons[ index ].icons = iconManagerConfig.recommended;
 				}
 			} );
 			if ( ! hasRecommended ) {

--- a/assets/dev/js/frontend/handlers/image-carousel.js
+++ b/assets/dev/js/frontend/handlers/image-carousel.js
@@ -104,11 +104,23 @@ class ImageCarouselHandler extends elementorModules.frontend.handlers.Base {
 	onInit( ...args ) {
 		super.onInit( ...args );
 
+		const elementSettings = this.getElementSettings();
+
 		if ( ! this.elements.$carousel.length || 2 > this.elements.$swiperSlides.length ) {
 			return;
 		}
 
 		this.swiper = new Swiper( this.elements.$carousel, this.getSwiperSettings() );
+
+		if ( !! elementSettings.pause_on_hover ) {
+			this.elements.$carousel.on( 'mouseenter', () => {
+				this.swiper.autoplay.stop();
+			} );
+
+			this.elements.$carousel.on( 'mouseleave', () => {
+				this.swiper.autoplay.start();
+			} );
+		}
 	}
 
 	onElementChange( propertyName ) {

--- a/assets/dev/js/frontend/handlers/image-carousel.js
+++ b/assets/dev/js/frontend/handlers/image-carousel.js
@@ -112,13 +112,14 @@ class ImageCarouselHandler extends elementorModules.frontend.handlers.Base {
 
 		this.swiper = new Swiper( this.elements.$carousel, this.getSwiperSettings() );
 
-		if ( !! elementSettings.pause_on_hover ) {
-			this.elements.$carousel.on( 'mouseenter', () => {
-				this.swiper.autoplay.stop();
-			} );
-
-			this.elements.$carousel.on( 'mouseleave', () => {
-				this.swiper.autoplay.start();
+		if ( elementSettings.pause_on_hover ) {
+			this.elements.$carousel.on( {
+				mouseenter: () => {
+					this.swiper.autoplay.stop();
+				},
+				mouseleave: () => {
+					this.swiper.autoplay.start();
+				},
 			} );
 		}
 	}

--- a/assets/dev/js/frontend/handlers/image-carousel.js
+++ b/assets/dev/js/frontend/handlers/image-carousel.js
@@ -52,7 +52,7 @@ class ImageCarouselHandler extends elementorModules.frontend.handlers.Base {
 		if ( ! this.isEdit && 'yes' === elementSettings.autoplay ) {
 			swiperOptions.autoplay = {
 				delay: elementSettings.autoplay_speed,
-				disableOnInteraction: !! elementSettings.pause_on_hover,
+				disableOnInteraction: !! elementSettings.pause_on_interaction,
 			};
 		}
 

--- a/assets/dev/js/frontend/utils/anchors.js
+++ b/assets/dev/js/frontend/utils/anchors.js
@@ -45,7 +45,7 @@ module.exports = elementorModules.ViewModule.extend( {
 
 		var scrollTop = $anchor.offset().top,
 			$wpAdminBar = elementorFrontend.elements.$wpAdminBar,
-			$activeStickies = jQuery( '.elementor-section.elementor-sticky--active' ),
+			$activeStickies = jQuery( '.elementor-section.elementor-sticky--active:visible' ),
 			maxStickyHeight = 0;
 
 		if ( $wpAdminBar.length > 0 ) {

--- a/assets/dev/scss/frontend/widgets/testimonial.scss
+++ b/assets/dev/scss/frontend/widgets/testimonial.scss
@@ -13,11 +13,13 @@
 	.elementor-testimonial-name {
 		line-height: 1.5;
 		color: inherit;
+		display: block;
 	}
 
 	.elementor-testimonial-job {
 		font-size: 0.85em;
 		color: inherit;
+		display: block;
 	}
 
 	&.elementor-testimonial-text-align- {

--- a/core/logger/items/js.php
+++ b/core/logger/items/js.php
@@ -15,7 +15,7 @@ class JS extends File {
 		parent::__construct( $args );
 		$this->column = $args['column'];
 		$this->file = $args['url'];
-		$this->date = date( 'Y-m-d H:i:s', $args['timestamp'] );
+		$this->date = gmdate( 'Y-m-d H:i:s', $args['timestamp'] );
 	}
 
 	public function jsonSerialize() {

--- a/core/logger/log-reporter.php
+++ b/core/logger/log-reporter.php
@@ -61,13 +61,14 @@ class Log_Reporter extends Base_Reporter {
 		}
 
 		$log_string = 'No entries to display';
-		$log_entries = $logger->get_formatted_log_entries( self::MAX_ENTRIES, true );
+		$log_entries = $logger->get_formatted_log_entries( self::MAX_ENTRIES, false );
 
 		if ( ! empty( $log_entries ) ) {
 			$entries_string = '';
 			foreach ( $log_entries as $key => $log_entry ) {
 				if ( $log_entry['count'] ) {
-					$entries_string .= '<table><thead><th>' . sprintf( '%s: showing %s of %s', $key, $log_entry['count'], $log_entry['total_count'] ) . '</th></thead><tbody class="elementor-log-entries">' . $log_entry['entries'] . '</tbody></table>';
+					$entries_string .= '<h3>' . sprintf( '%s: showing %s of %s', $key, $log_entry['count'], $log_entry['total_count'] ) . '</h3>';
+					$entries_string .= '<div class="elementor-log-entries">' . $log_entry['entries'] . '</div>';
 				}
 			}
 
@@ -82,7 +83,6 @@ class Log_Reporter extends Base_Reporter {
 	}
 
 	public function get_raw_log_entries() {
-
 		$log_string = 'No entries to display';
 
 		/** @var \Elementor\Core\Logger\Manager $manager */

--- a/core/logger/manager.php
+++ b/core/logger/manager.php
@@ -206,7 +206,7 @@ class Manager extends BaseModule {
 	public function __construct() {
 		register_shutdown_function( [ $this, 'shutdown' ] );
 
-		add_action( 'admin_init', [ $this, 'add_system_info_report' ] );
+		add_action( 'admin_init', [ $this, 'add_system_info_report' ], 80 );
 
 		add_action( 'wp_ajax_elementor_js_log', [ $this, 'js_log' ] );
 

--- a/includes/embed.php
+++ b/includes/embed.php
@@ -114,7 +114,7 @@ class Embed {
 			$time_text = '';
 
 			if ( ! empty( $options['start'] ) ) {
-				$time_text = date( 'H\hi\ms\s', $options['start'] );
+				$time_text = date( 'H\hi\ms\s', $options['start'] ); // PHPCS:Ignore WordPress.DateTime.RestrictedFunctions.date_date
 			}
 
 			$replacements['{TIME}'] = $time_text;

--- a/includes/settings/system-info/main.php
+++ b/includes/settings/system-info/main.php
@@ -202,7 +202,7 @@ class Main {
 		$domain = parse_url( site_url(), PHP_URL_HOST );
 
 		header( 'Content-Type: text/plain' );
-		header( 'Content-Disposition:attachment; filename=system-info-' . $domain . '-' . date( 'd-m-Y' ) . '.txt' );
+		header( 'Content-Disposition:attachment; filename=system-info-' . $domain . '-' . gmdate( 'd-m-Y' ) . '.txt' );
 
 		$this->print_report( $reports );
 

--- a/includes/settings/system-info/templates/html.php
+++ b/includes/settings/system-info/templates/html.php
@@ -62,8 +62,7 @@ foreach ( $reports as $report_name => $report ) : ?>
 						if ( ! empty( $field['recommendation'] ) ) :
 							echo $field['recommendation'];
 						endif;
-						?>
-						</td>
+						?></td>
 					</tr>
 					<?php
 				}

--- a/includes/settings/system-info/templates/html.php
+++ b/includes/settings/system-info/templates/html.php
@@ -20,28 +20,28 @@ foreach ( $reports as $report_name => $report ) : ?>
 			<?php
 			foreach ( $report['report'] as $field_name => $field ) :
 				if ( in_array( $report_name, [ 'plugins', 'network_plugins', 'mu_plugins' ], true ) ) {
-					foreach ( $field['value'] as $plugin ) :
+					foreach ( $field['value'] as $plugin_info ) :
 						?>
 						<tr>
 							<td><?php
-							if ( $plugin['PluginURI'] ) :
-								$plugin_name = "<a href='{$plugin['PluginURI']}'>{$plugin['Name']}</a>";
+							if ( $plugin_info['PluginURI'] ) :
+								$plugin_name = "<a href='{$plugin_info['PluginURI']}'>{$plugin_info['Name']}</a>";
 							else :
-								$plugin_name = $plugin['Name'];
+								$plugin_name = $plugin_info['Name'];
 							endif;
 
-							if ( $plugin['Version'] ) :
-								$plugin_name .= ' - ' . $plugin['Version'];
+							if ( $plugin_info['Version'] ) :
+								$plugin_name .= ' - ' . $plugin_info['Version'];
 							endif;
 
 							echo $plugin_name;
 							?></td>
 							<td><?php
-							if ( $plugin['Author'] ) :
-								if ( $plugin['AuthorURI'] ) :
-									$author = "<a href='{$plugin['AuthorURI']}'>{$plugin['Author']}</a>";
+							if ( $plugin_info['Author'] ) :
+								if ( $plugin_info['AuthorURI'] ) :
+									$author = "<a href='{$plugin_info['AuthorURI']}'>{$plugin_info['Author']}</a>";
 								else :
-									$author = $plugin['Author'];
+									$author = $plugin_info['Author'];
 								endif;
 
 								echo "By $author";

--- a/includes/settings/system-info/templates/html.php
+++ b/includes/settings/system-info/templates/html.php
@@ -23,34 +23,30 @@ foreach ( $reports as $report_name => $report ) : ?>
 					foreach ( $field['value'] as $plugin ) :
 						?>
 						<tr>
-							<td>
-								<?php
-								if ( $plugin['PluginURI'] ) :
-									$plugin_name = "<a href='{$plugin['PluginURI']}'>{$plugin['Name']}</a>";
+							<td><?php
+							if ( $plugin['PluginURI'] ) :
+								$plugin_name = "<a href='{$plugin['PluginURI']}'>{$plugin['Name']}</a>";
+							else :
+								$plugin_name = $plugin['Name'];
+							endif;
+
+							if ( $plugin['Version'] ) :
+								$plugin_name .= ' - ' . $plugin['Version'];
+							endif;
+
+							echo $plugin_name;
+							?></td>
+							<td><?php
+							if ( $plugin['Author'] ) :
+								if ( $plugin['AuthorURI'] ) :
+									$author = "<a href='{$plugin['AuthorURI']}'>{$plugin['Author']}</a>";
 								else :
-									$plugin_name = $plugin['Name'];
+									$author = $plugin['Author'];
 								endif;
 
-								if ( $plugin['Version'] ) :
-									$plugin_name .= ' - ' . $plugin['Version'];
-								endif;
-
-								echo $plugin_name;
-								?>
-							</td>
-							<td>
-								<?php
-								if ( $plugin['Author'] ) :
-									if ( $plugin['AuthorURI'] ) :
-										$author = "<a href='{$plugin['AuthorURI']}'>{$plugin['Author']}</a>";
-									else :
-										$author = $plugin['Author'];
-									endif;
-
-									echo "By $author";
-								endif;
-								?>
-							</td>
+								echo "By $author";
+							endif;
+							?></td>
 							<td></td>
 						</tr>
 						<?php

--- a/includes/settings/system-info/templates/raw.php
+++ b/includes/settings/system-info/templates/raw.php
@@ -36,10 +36,10 @@ foreach ( $reports as $report_name => $report ) :
 		if ( $is_plugins ) {
 			echo "== {$field['label']} ==" . PHP_EOL;
 
-			foreach ( $field['value'] as $plugin ) :
-				$plugin_properties = array_intersect_key( $plugin, $required_plugins_properties );
+			foreach ( $field['value'] as $plugin_info ) :
+				$plugin_properties = array_intersect_key( $plugin_info, $required_plugins_properties );
 
-				echo $sub_indent . $plugin['Name'];
+				echo $sub_indent . $plugin_info['Name'];
 
 				foreach ( $plugin_properties as $property_name => $property ) :
 					echo PHP_EOL . "{$sub_indent}\t{$property_name}: {$property}";

--- a/includes/template-library/sources/local.php
+++ b/includes/template-library/sources/local.php
@@ -744,7 +744,7 @@ class Source_Local extends Source_Base {
 		}
 
 		// Create temporary .zip file
-		$zip_archive_filename = 'elementor-templates-' . date( 'Y-m-d' ) . '.zip';
+		$zip_archive_filename = 'elementor-templates-' . gmdate( 'Y-m-d' ) . '.zip';
 
 		$zip_archive = new \ZipArchive();
 
@@ -1396,7 +1396,7 @@ class Source_Local extends Source_Base {
 		$export_data += $template_data;
 
 		return [
-			'name' => 'elementor-' . $template_id . '-' . date( 'Y-m-d' ) . '.json',
+			'name' => 'elementor-' . $template_id . '-' . gmdate( 'Y-m-d' ) . '.json',
 			'content' => wp_json_encode( $export_data ),
 		];
 	}

--- a/includes/user.php
+++ b/includes/user.php
@@ -249,7 +249,7 @@ class User {
 
 	public static function register_as_beta_tester( array $data ) {
 		update_user_meta( get_current_user_id(), self::BETA_TESTER_META_KEY, true );
-		wp_safe_remote_post(
+		$response = wp_safe_remote_post(
 			self::BETA_TESTER_API_URL,
 			[
 				'timeout' => 25,
@@ -260,6 +260,14 @@ class User {
 				],
 			]
 		);
+
+		$body = wp_remote_retrieve_body( $response );
+
+		if ( 'success' === $body ) {
+			self::set_introduction_viewed( [
+				'introductionKey' => 'beta_tester_signup',
+			] );
+		}
 	}
 
 	/**

--- a/includes/widgets/common.php
+++ b/includes/widgets/common.php
@@ -248,6 +248,9 @@ class Widget_Common extends Widget_Base {
 				],
 				'render_type' => 'ui',
 				'separator' => 'before',
+				'selectors' => [
+					'{{WRAPPER}} > .elementor-widget-container' => 'transition: background {{SIZE}}s',
+				],
 			]
 		);
 

--- a/includes/widgets/image-carousel.php
+++ b/includes/widgets/image-carousel.php
@@ -260,6 +260,20 @@ class Widget_Image_Carousel extends Widget_Base {
 		);
 
 		$this->add_control(
+			'pause_on_interaction',
+			[
+				'label' => __( 'Pause on Interaction', 'elementor' ),
+				'type' => Controls_Manager::SELECT,
+				'default' => 'yes',
+				'options' => [
+					'yes' => __( 'Yes', 'elementor' ),
+					'no' => __( 'No', 'elementor' ),
+				],
+				'frontend_available' => true,
+			]
+		);
+
+		$this->add_control(
 			'autoplay',
 			[
 				'label' => __( 'Autoplay', 'elementor' ),

--- a/includes/widgets/testimonial.php
+++ b/includes/widgets/testimonial.php
@@ -426,7 +426,6 @@ class Widget_Testimonial extends Widget_Base {
 			<?php
 			if ( $has_content ) :
 				$this->add_render_attribute( 'testimonial_content', 'class', 'elementor-testimonial-content' );
-
 				$this->add_inline_editing_attributes( 'testimonial_content' );
 				?>
 				<div <?php echo $this->get_render_attribute_string( 'testimonial_content' ); ?>><?php echo $settings['testimonial_content']; ?></div>
@@ -452,20 +451,19 @@ class Widget_Testimonial extends Widget_Base {
 						<?php
 						if ( $has_name ) :
 							$this->add_render_attribute( 'testimonial_name', 'class', 'elementor-testimonial-name' );
-
 							$this->add_inline_editing_attributes( 'testimonial_name', 'none' );
 
 							$testimonial_name_html = $settings['testimonial_name'];
 
-							if ( ! empty( $settings['link']['url'] ) ) {
+							if ( ! empty( $settings['link']['url'] ) ) :
 								?>
 								<a <?php echo $this->get_render_attribute_string( 'testimonial_name' ) . ' ' . $this->get_render_attribute_string( 'link' ); ?>><?php echo $testimonial_name_html; ?></a>
 								<?php
-							} else {
+							else :
 								?>
 								<div <?php echo $this->get_render_attribute_string( 'testimonial_name' ); ?>><?php echo $testimonial_name_html; ?></div>
 								<?php
-							}
+							endif;
 						endif; ?>
 						<?php
 						if ( $has_job ) :
@@ -475,15 +473,15 @@ class Widget_Testimonial extends Widget_Base {
 
 							$testimonial_job_html = $settings['testimonial_job'];
 
-							if ( ! empty( $settings['link']['url'] ) ) {
+							if ( ! empty( $settings['link']['url'] ) ) :
 								?>
 								<a <?php echo $this->get_render_attribute_string( 'testimonial_job' ) . ' ' . $this->get_render_attribute_string( 'link' ); ?>><?php echo $testimonial_job_html; ?></a>
 								<?php
-							} else {
+							else :
 								?>
 								<div <?php echo $this->get_render_attribute_string( 'testimonial_job' ); ?>><?php echo $testimonial_job_html; ?></div>
 								<?php
-							}
+							endif;
 						endif; ?>
 					</div>
 					<?php endif; ?>

--- a/includes/widgets/testimonial.php
+++ b/includes/widgets/testimonial.php
@@ -456,12 +456,17 @@ class Widget_Testimonial extends Widget_Base {
 							$this->add_inline_editing_attributes( 'testimonial_name', 'none' );
 
 							$testimonial_name_html = $settings['testimonial_name'];
-							if ( ! empty( $settings['link']['url'] ) ) :
-								$testimonial_name_html = '<a ' . $this->get_render_attribute_string( 'link' ) . '>' . $testimonial_name_html . '</a>';
-							endif;
-							?>
-							<div <?php echo $this->get_render_attribute_string( 'testimonial_name' ); ?>><?php echo $testimonial_name_html; ?></div>
-						<?php endif; ?>
+
+							if ( ! empty( $settings['link']['url'] ) ) {
+								?>
+								<a <?php echo $this->get_render_attribute_string( 'testimonial_name' ) . ' ' . $this->get_render_attribute_string( 'link' ); ?>><?php echo $testimonial_name_html; ?></a>
+								<?php
+							} else {
+								?>
+								<div <?php echo $this->get_render_attribute_string( 'testimonial_name' ); ?>><?php echo $testimonial_name_html; ?></div>
+								<?php
+							}
+						endif; ?>
 						<?php
 						if ( $has_job ) :
 							$this->add_render_attribute( 'testimonial_job', 'class', 'elementor-testimonial-job' );
@@ -469,12 +474,17 @@ class Widget_Testimonial extends Widget_Base {
 							$this->add_inline_editing_attributes( 'testimonial_job', 'none' );
 
 							$testimonial_job_html = $settings['testimonial_job'];
-							if ( ! empty( $settings['link']['url'] ) ) :
-								$testimonial_job_html = '<a ' . $this->get_render_attribute_string( 'link' ) . '>' . $testimonial_job_html . '</a>';
-							endif;
-							?>
-							<div <?php echo $this->get_render_attribute_string( 'testimonial_job' ); ?>><?php echo $testimonial_job_html; ?></div>
-						<?php endif; ?>
+
+							if ( ! empty( $settings['link']['url'] ) ) {
+								?>
+								<a <?php echo $this->get_render_attribute_string( 'testimonial_job' ) . ' ' . $this->get_render_attribute_string( 'link' ); ?>><?php echo $testimonial_job_html; ?></a>
+								<?php
+							} else {
+								?>
+								<div <?php echo $this->get_render_attribute_string( 'testimonial_job' ); ?>><?php echo $testimonial_job_html; ?></div>
+								<?php
+							}
+						endif; ?>
 					</div>
 					<?php endif; ?>
 				</div>
@@ -528,39 +538,52 @@ class Widget_Testimonial extends Widget_Base {
 			<div class="elementor-testimonial-meta{{ hasImage }}{{ testimonial_image_position }}">
 				<div class="elementor-testimonial-meta-inner">
 					<# if ( imageUrl ) { #>
-					<div class="elementor-testimonial-image">{{{ imageHtml }}}</div>
+						<div class="elementor-testimonial-image">{{{ imageHtml }}}</div>
 					<# } #>
-
 					<div class="elementor-testimonial-details">
-						<# if ( '' !== settings.testimonial_name ) {
-							view.addRenderAttribute( 'testimonial_name', 'class', 'elementor-testimonial-name' );
-
-							view.addInlineEditingAttributes( 'testimonial_name', 'none' );
-
-							var testimonialNameHtml = settings.testimonial_name;
-							if ( settings.link.url ) {
-								testimonialNameHtml = '<a href="' + settings.link.url + '">' + testimonialNameHtml + '</a>';
-							}
-							#>
-							<div {{{ view.getRenderAttributeString( 'testimonial_name' ) }}}>{{{ testimonialNameHtml }}}</div>
-						<# } #>
-
-						<# if ( '' !== settings.testimonial_job ) {
-							view.addRenderAttribute( 'testimonial_job', 'class', 'elementor-testimonial-job' );
-
-							view.addInlineEditingAttributes( 'testimonial_job', 'none' );
-
-							var testimonialJobHtml = settings.testimonial_job;
-							if ( settings.link.url ) {
-								testimonialJobHtml = '<a href="' + settings.link.url + '">' + testimonialJobHtml + '</a>';
-							}
-							#>
-							<div {{{ view.getRenderAttributeString( 'testimonial_job' ) }}}>{{{ testimonialJobHtml }}}</div>
-						<# } #>
+						<?php $this->render_testimonial_description(); ?>
 					</div>
 				</div>
 			</div>
 		</div>
+		<?php
+	}
+
+	protected function render_testimonial_description() {
+		?>
+		<#
+		if ( '' !== settings.testimonial_name ) {
+			view.addRenderAttribute( 'testimonial_name', 'class', 'elementor-testimonial-name' );
+
+			view.addInlineEditingAttributes( 'testimonial_name', 'none' );
+
+			if ( settings.link.url ) {
+				#>
+				<a href="{{{ settings.link.url }}}" {{{ view.getRenderAttributeString( 'testimonial_name' ) }}}>{{{ settings.testimonial_name }}}</a>
+				<#
+			} else {
+				#>
+				<div {{{ view.getRenderAttributeString( 'testimonial_name' ) }}}>{{{ settings.testimonial_name }}}</div>
+				<#
+			}
+		}
+
+		if ( '' !== settings.testimonial_job ) {
+			view.addRenderAttribute( 'testimonial_job', 'class', 'elementor-testimonial-job' );
+
+			view.addInlineEditingAttributes( 'testimonial_job', 'none' );
+
+			if ( settings.link.url ) {
+				#>
+				<a href="{{{ settings.link.url }}}" {{{ view.getRenderAttributeString( 'testimonial_job' ) }}}>{{{ settings.testimonial_job }}}</a>
+				<#
+			} else {
+				#>
+				<div {{{ view.getRenderAttributeString( 'testimonial_job' ) }}}>{{{ settings.testimonial_job }}}</div>
+				<#
+			}
+		}
+		#>
 		<?php
 	}
 }

--- a/modules/history/assets/js/revisions/manager.js
+++ b/modules/history/assets/js/revisions/manager.js
@@ -43,8 +43,6 @@ RevisionsManager = function() {
 			success: ( data ) => {
 				revisions = new RevisionsCollection( data );
 
-				revisions.on( 'update', this.onRevisionsUpdate.bind( this ) );
-
 				callback( revisions );
 			},
 		} );
@@ -112,12 +110,6 @@ RevisionsManager = function() {
 		attachEvents();
 
 		$e.components.register( new Component( { manager: self } ) );
-	};
-
-	this.onRevisionsUpdate = function() {
-		if ( $e.routes.is( 'panel/history/revisions' ) ) {
-			$e.routes.refreshContainer( 'panel' );
-		}
 	};
 };
 

--- a/modules/usage/module.php
+++ b/modules/usage/module.php
@@ -541,6 +541,6 @@ class Module extends BaseModule {
 
 		add_filter( 'elementor/tracker/send_tracking_data_params', [ $this, 'add_tracking_data' ] );
 
-		add_action( 'admin_init', [ $this, 'add_system_info_report' ] );
+		add_action( 'admin_init', [ $this, 'add_system_info_report' ], 50 );
 	}
 }

--- a/tests/phpunit/elementor/modules/history/test-revisions-manager.php
+++ b/tests/phpunit/elementor/modules/history/test-revisions-manager.php
@@ -275,16 +275,6 @@ class Elementor_Test_Revisions_Manager extends Elementor_Test_Base {
 		Revisions_Manager::ajax_delete_revision( $args );
 	}
 
-	public function test_should_delete_revision_on_request() {
-		wp_set_current_user( $this->factory()->create_and_get_administrator_user()->ID );
-		$args['id'] = $this->factory()->create_and_get_parent_and_child_posts()['child_id'];
-
-		$response = Revisions_Manager::ajax_delete_revision( $args );
-
-		$this->assertNull( $response,
-			'the function "on_delete_revision_request" should not return data' );
-	}
-
 	private function setup_revision_check() {
 		$parent_and_child_posts = $this->factory()->create_and_get_parent_and_child_posts();
 		$post_id = $parent_and_child_posts['parent_id'];


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x ] Feature
- [ x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:
To add a two stage registration process on the forms/popup forms 
*

## Description
An explanation of what is done in this PR
I have never used Github and I'm not a techy, so please forgive me if this is wrong! The support at Elementor suggested I posted a request on here
I would like to suggest a two stage sign up process on the forms/popup forms, where for example on the first stage you can ask for 3-4 different fields (Name, email, company, tel etc), then click a 'next button' to be taken to the second stage, where there are a further number of fields to complete before registering.
This is to make detailed forms less daunting to complete and also not take up so much space.

*

## Test instructions
This PR can be tested by following these steps:
I have an example but not keen to post it on here
*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
