### PR TITLE
Added aria-label to icon links in icon box widgets

### DIFF
--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -621,6 +621,8 @@ class Widget_Icon_Box extends Widget_Base {
 			if ( $settings['link']['nofollow'] ) {
 				$this->add_render_attribute( 'link', 'rel', 'nofollow' );
 			}
+			
+			$this->add_render_attribute( 'link', 'aria-label', 'Link to ' . $settings['title_text']);
 		}
 
 		if ( $has_icon ) {


### PR DESCRIPTION
Icon box widgets were failing accessibility testing as the icon links had no descriptive text

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:
Accessibility update
## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

* Added aria-label to icon link in icon box widget

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
