### PR TITLE
Remove gzip-compression

### DIFF
--- a/core/common/modules/ajax/module.php
+++ b/core/common/modules/ajax/module.php
@@ -261,17 +261,9 @@ class Module extends BaseModule {
 			ob_end_clean();
 		}
 
-		if ( function_exists( 'gzencode' ) ) {
-			$response = gzencode( $json );
-
-			header( 'Content-Type: application/json; charset=utf-8' );
-			header( 'Content-Encoding: gzip' );
-			header( 'Content-Length: ' . strlen( $response ) );
-
-			echo $response;
-		} else {
-			echo $json;
-		}
+		header( 'Content-Type: application/json; charset=utf-8' );
+		header( 'Content-Length: ' . strlen( $json ) );
+		echo $json;
 
 		wp_die( '', '', [ 'response' => null ] );
 	}


### PR DESCRIPTION
The compression code doesn't conform to RFC2616

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ X] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

The ajax response is in violation of RFC2616 by not properly checking accepted encodings

*

## Description
Removed Gzip-compression. It can be properly implemented with ob_start() in the calling code.

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #9486
