### PR TITLE
Fix : Shapes SVG include PHP Parse Error elementor#9693

### DIFF
--- a/includes/elements/section.php
+++ b/includes/elements/section.php
@@ -1530,7 +1530,7 @@ class Element_Section extends Element_Base {
 		$negative = ! empty( $settings[ $base_setting_key . '_negative' ] );
 		?>
 		<div class="elementor-shape elementor-shape-<?php echo esc_attr( $side ); ?>" data-negative="<?php echo var_export( $negative ); ?>">
-			<?php include Shapes::get_shape_path( $settings[ $base_setting_key ], ! empty( $settings[ $base_setting_key . '_negative' ] ) ); ?>
+			<?php echo file_get_contents( Shapes::get_shape_path( $settings[ $base_setting_key ], ! empty( $settings[ $base_setting_key . '_negative' ] ) ) ); ?>
 		</div>
 		<?php
 	}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

* This PR propose a fix for the issue about PHP Parse Error explained here https://github.com/elementor/elementor/issues/9693

## Test instructions
This PR can be tested by following these steps:

* Add a custom SVG shape, the SVG file must begin with <?xml version="1.0" encoding="UTF-8"?>
For example :
`<?xml version="1.0" encoding="UTF-8"?> <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 111.859 500 42.943"><path d="M.366 156.606h498.56v-45.71L.366 156.606z" fill="#bada55"></path></svg>`

## Quality assurance

- [x ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
