### PR TITLE
Source image replace with placeholder image due to server timeout

### DIFF
--- a/includes/template-library/classes/class-import-images.php
+++ b/includes/template-library/classes/class-import-images.php
@@ -113,7 +113,7 @@ class Import_Images {
 		$file_content = wp_remote_retrieve_body( wp_safe_remote_get( $attachment['url'] ) );
 
 		if ( empty( $file_content ) ) {
-			return false;
+			return $attachment;
 		}
 
 		$upload = wp_upload_bits(


### PR DESCRIPTION
The images are downloaded with `wp_safe_remote_get()`. Some times due to large image or server timeout, the function returns the empty file content.

And it returns `false`. It should be `$attachment` which holds the source image url.

When image not downloaded, then for blank images, the `placeholder.png` is loaded on the front end.

---

With filter `http_request_timeout`, we can increase the timeout, but, somehow the image is not downloaded, then it should show the source image.