### PR TITLE
Fix: Media Carousel widget - The Cube effect behave in a strange way

### DIFF
--- a/assets/dev/scss/frontend/_swiper.scss
+++ b/assets/dev/scss/frontend/_swiper.scss
@@ -317,7 +317,6 @@ button.swiper-pagination-bullet {
 
 .swiper-container-cube .swiper-slide, .swiper-container-flip .swiper-slide {
 	pointer-events: none;
-	backface-visibility: hidden;
 	z-index: 1;
 }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fixed problem with Media Carousel widget rendering in Cube mode in Google Chrome

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)