### PR TITLE
WIP: Dynamic Color Control

### DIFF
--- a/assets/dev/js/editor/controls/color.js
+++ b/assets/dev/js/editor/controls/color.js
@@ -5,7 +5,7 @@ export default class extends ControlBaseDataView {
 	ui() {
 		const ui = super.ui();
 
-		ui.pickerContainer = '.elementor-control-input-wrapper';
+		ui.pickerContainer = '.elementor-color-picker-placeholder';
 
 		return ui;
 	}

--- a/assets/dev/scss/editor/panel/controls/_color.scss
+++ b/assets/dev/scss/editor/panel/controls/_color.scss
@@ -3,4 +3,9 @@
 	.elementor-control-title {
 		flex-grow: 1;
 	}
+
+	.elementor-control-input-wrapper {
+		display: flex;
+		justify-content: flex-end;
+	}
 }

--- a/includes/controls/color.php
+++ b/includes/controls/color.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elementor;
 
+use Elementor\Modules\DynamicTags\Module as TagsModule;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -45,7 +47,9 @@ class Control_Color extends Base_Data_Control {
 		?>
 		<div class="elementor-control-field">
 			<label class="elementor-control-title">{{{ data.label || '' }}}</label>
-			<div class="elementor-control-input-wrapper"></div>
+			<div class="elementor-control-input-wrapper elementor-control-tag-area">
+				<div class="elementor-color-picker-placeholder"></div>
+			</div>
 		</div>
 		<?php
 	}
@@ -65,6 +69,11 @@ class Control_Color extends Base_Data_Control {
 		return [
 			'alpha' => true,
 			'scheme' => '',
+			'dynamic' => [
+				'categories' => [
+					TagsModule::COLOR_CATEGORY,
+				],
+			],
 		];
 	}
 }

--- a/modules/dynamic-tags/module.php
+++ b/modules/dynamic-tags/module.php
@@ -61,6 +61,11 @@ class Module extends BaseModule {
 	const NUMBER_CATEGORY = 'number';
 
 	/**
+	 * Dynamic tags number category.
+	 */
+	const COLOR_CATEGORY = 'color';
+
+	/**
 	 * Dynamic tags module constructor.
 	 *
 	 * Initializing Elementor dynamic tags module.


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Added dynamic value capabilities to the Color control

## Description
An explanation of what is done in this PR

* Added dynamic value capabilities to the Color control - Starting from Elementor Pro 2.9.0

## Test instructions
This PR can be tested by following these steps:

1. Make sure you have Elementor Core+Pro version 2.9.0 or above, and ACF installed
2. Add a color control to a widget and activate it as dynamic (dynamic > active > true)
3. Add a Color Picker field in ACF and assign it to an Elementor-editable post type/template (such as page/post)
4. Create a new page/post/template, and in the edit page (the WP dashboard one, not the Elementor edit page), set a value to the ACF Color Picker field for that post.
5. Edit with Elementor
6. Drag and drop the dynamic widget from step 2
7. Set a dynamic value in the color control you activated as dynamic.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
