### PR TITLE
Fix issue #9847

### DIFF
--- a/core/dynamic-tags/tag.php
+++ b/core/dynamic-tags/tag.php
@@ -38,20 +38,20 @@ abstract class Tag extends Base_Tag {
 
 		if ( $value ) {
 			// TODO: fix spaces in `before`/`after` if WRAPPED_TAG ( conflicted with .elementor-tag { display: inline-flex; } );
-			if ( ! Utils::is_empty( $settings['before'] ) ) {
-				$value = wp_kses_post( $settings['before'] ) . $value;
+			if ( ! Utils::is_empty( $settings_before = &$settings['before'] ) ) {
+				$value = wp_kses_post( $settings_before ) . $value;
 			}
 
-			if ( ! Utils::is_empty( $settings['after'] ) ) {
-				$value .= wp_kses_post( $settings['after'] );
+			if ( ! Utils::is_empty( $settings_after = &$settings['after'] ) ) {
+				$value .= wp_kses_post( $settings_after );
 			}
 
 			if ( static::WRAPPED_TAG ) :
 				$value = '<span id="elementor-tag-' . esc_attr( $this->get_id() ) . '" class="elementor-tag">' . $value . '</span>';
 			endif;
 
-		} elseif ( ! Utils::is_empty( $settings['fallback'] ) ) {
-			$value = $settings['fallback'];
+		} elseif ( ! Utils::is_empty( $settings_fallback = &$settings['fallback'] ) ) {
+			$value = $settings_fallback;
 		}
 
 		return $value;


### PR DESCRIPTION
Possible fix to issue #9847 

another solution would be to inline the `Utils::is_empty` function. Example below
```
if ( ! ( empty( $settings['before'] ) && '0' !== $settings['before'] ) ) {
...
```

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
