### PR TITLE
Fix: 2.8.1 update - Image Carousel Widget = Autoplay doesn't stop (PT 291)

### DIFF
--- a/includes/widgets/image-carousel.php
+++ b/includes/widgets/image-carousel.php
@@ -248,6 +248,20 @@ class Widget_Image_Carousel extends Widget_Base {
 		);
 
 		$this->add_control(
+			'autoplay',
+			[
+				'label' => __( 'Autoplay', 'elementor' ),
+				'type' => Controls_Manager::SELECT,
+				'default' => 'yes',
+				'options' => [
+					'yes' => __( 'Yes', 'elementor' ),
+					'no' => __( 'No', 'elementor' ),
+				],
+				'frontend_available' => true,
+			]
+		);
+
+		$this->add_control(
 			'pause_on_hover',
 			[
 				'label' => __( 'Pause on Hover', 'elementor' ),
@@ -256,6 +270,9 @@ class Widget_Image_Carousel extends Widget_Base {
 				'options' => [
 					'yes' => __( 'Yes', 'elementor' ),
 					'no' => __( 'No', 'elementor' ),
+				],
+				'condition' => [
+					'autoplay' => 'yes',
 				],
 				'frontend_available' => true,
 			]
@@ -271,19 +288,8 @@ class Widget_Image_Carousel extends Widget_Base {
 					'yes' => __( 'Yes', 'elementor' ),
 					'no' => __( 'No', 'elementor' ),
 				],
-				'frontend_available' => true,
-			]
-		);
-
-		$this->add_control(
-			'autoplay',
-			[
-				'label' => __( 'Autoplay', 'elementor' ),
-				'type' => Controls_Manager::SELECT,
-				'default' => 'yes',
-				'options' => [
-					'yes' => __( 'Yes', 'elementor' ),
-					'no' => __( 'No', 'elementor' ),
+				'condition' => [
+					'autoplay' => 'yes',
 				],
 				'frontend_available' => true,
 			]
@@ -295,6 +301,9 @@ class Widget_Image_Carousel extends Widget_Base {
 				'label' => __( 'Autoplay Speed', 'elementor' ),
 				'type' => Controls_Manager::NUMBER,
 				'default' => 5000,
+				'condition' => [
+					'autoplay' => 'yes',
+				],
 				'frontend_available' => true,
 			]
 		);


### PR DESCRIPTION
Fix: 2.8.1 update - Image Carousel Widget = Autoplay doesn't stop (PT 291)
Issue 9872

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fixed image carousel issue - autoplay started `onmouseout` off the image carousel, even if `autoplay` was set to `off` in the widget settings.

## Test instructions
This PR can be tested by following these steps:

1. Add an image carousel widget to a page/post
2. Set `autoplay` to `off`
3. preview the page front-end, move the mouse over the image carousel then out of it
4. Autoplay should not start onmouseout.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
