### PR TITLE
Fix: unnecessary scroll bars for recommended icons

### DIFF
--- a/assets/dev/scss/editor/_icons-manager.scss
+++ b/assets/dev/scss/editor/_icons-manager.scss
@@ -88,7 +88,7 @@
 	&__tab {
 
 		&__wrapper {
-			overflow: scroll;
+			overflow: auto;
 			margin: 25px -15px 0;
 			padding: 0 15px 15px;
 		}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Removed unnecessary scroll bars that appeared in the icon library when displaying recommended icons

## Description
An explanation of what is done in this PR

* The container for the list of icons had an `overflow: scroll` property attached to it. The commit changes it to `overflow: auto`.

## Test instructions
This PR can be tested by following these steps:

* D&D a widget with recommended icons such as Accordion or Tabs. 
* Check if you see scroll bars around the list of recommended icons.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)