### PR TITLE
Fix: Divider widget + text longer from the screen width = the line is…

### DIFF
--- a/assets/dev/scss/frontend/widgets/divider.scss
+++ b/assets/dev/scss/frontend/widgets/divider.scss
@@ -29,6 +29,7 @@
 		&__text {
 			font-size: 15px;
 			line-height: 1;
+			max-width: 95%;
 		}
 
 		&__element {


### PR DESCRIPTION
… not breaking and the divider is missing (PT 248)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fixed: Divider widget with text longer than the container overflows

## Test instructions
This PR can be tested by following these steps:

* Edit a page/post/template in Elementor
* Drag a Divider widget onto the page
* Enter divider text that is longer than the container

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)