### PR TITLE
Added missing $this param in control stack method_exists call

### DIFF
--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -959,7 +959,7 @@ abstract class Controls_Stack extends Base_Object {
 		if ( null === $this->config ) {
 			// TODO: This is for backwards compatibility starting from 2.9.0
 			// This if statement should be removed when the method is hard-deprecated
-			if ( method_exists( '_get_initial_config' ) ) {
+			if ( method_exists( $this, '_get_initial_config' ) ) {
 				$this->config = $this->_get_initial_config();
 			} else {
 				$this->config = $this->get_initial_config();


### PR DESCRIPTION


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description
An explanation of what is done in this PR

* Added missing `$this` param in method_exists() call

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)