### PR TITLE
Fix: Toggle Widget | Toggle Widget background color overrides border radius (PT 308)

### DIFF
--- a/assets/dev/scss/frontend/widgets/toggle.scss
+++ b/assets/dev/scss/frontend/widgets/toggle.scss
@@ -2,6 +2,15 @@
 // Toggle
 //
 
+.elementor-widget-toggle {
+
+	.elementor-widget-container {
+		// This overflow: hidden prevents the overflow of backgrounds on widget elements (like toggle tab title)
+		// in case where a border radius is applied to the widget container in the Advanced > Border section
+		overflow: hidden;
+	}
+}
+
 .elementor-toggle {
 	text-align: $start;
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fixed: Toggle Widget - when applying border radius in the `Advanced > Border` section, the radius is overridden by adding a background color to the toggle tab title

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)