### PR TITLE
Feature/Rank Math SEO Breadcrumbs Support

### DIFF
--- a/assets/lib/eicons/css/elementor-icons.css
+++ b/assets/lib/eicons/css/elementor-icons.css
@@ -573,6 +573,12 @@
 .eicon-yoast:before {
   content: '\e8b5'; }
 
+  .eicon-rank-math {
+    width: 20px;
+    height: 20px;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 462.03 462.03' xmlns='http://www.w3.org/2000/svg' width='20' class='rank-math-icon'%3E%3Cg fill='%23000'%3E%3Cpath d='m462 234.84-76.17 3.43 13.43 21-127 81.18-126-52.93-146.26 60.97 10.14 24.34 136.1-56.71 128.57 54 138.69-88.61 13.43 21z'/%3E%3Cpath d='m54.1 312.78 92.18-38.41 4.49 1.89v-54.58h-96.67zm210.9-223.57v235.05l7.26 3 89.43-57.05v-181zm-105.44 190.79 96.67 40.62v-165.19h-96.67z'/%3E%3C/g%3E%3C/svg%3E");
+  }
+
 .eicon-nerd-chuckle:before {
   content: '\e8b6'; }
 

--- a/includes/managers/widgets.php
+++ b/includes/managers/widgets.php
@@ -73,6 +73,10 @@ class Widgets_Manager {
 			'read-more',
 		];
 
+		if ( defined( 'RANK_MATH_FILE' ) ) {
+			$build_widgets_filename[] = 'breadcrumbs';
+		}
+
 		$this->_widget_types = [];
 
 		foreach ( $build_widgets_filename as $widget_filename ) {

--- a/includes/widgets/breadcrumbs.php
+++ b/includes/widgets/breadcrumbs.php
@@ -1,0 +1,189 @@
+<?php
+namespace Elementor;
+
+use Elementor\Controls_Manager;
+use Elementor\Group_Control_Typography;
+use Elementor\Scheme_Typography;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class Widget_Breadcrumbs extends Widget_Base {
+
+	public function get_name() {
+		return 'breadcrumbs';
+	}
+
+	public function get_title() {
+		return __( 'Breadcrumbs', 'elementor' );
+	}
+
+	public function get_icon() {
+		return 'eicon-rank-math';
+	}
+
+	public function get_keywords() {
+		return [ 'rank-math', 'seo', 'breadcrumbs', 'rank math' ];
+	}
+
+	private function is_breadcrumbs_enabled() {
+		return \RankMath\Helper::get_settings( 'general.breadcrumbs' );
+	}
+
+	protected function _register_controls() {
+		$this->start_controls_section(
+			'section_breadcrumbs_content',
+			[
+				'label' => __( 'Breadcrumbs', 'elementor' ),
+			]
+		);
+
+		if ( ! $this->is_breadcrumbs_enabled() ) {
+			$this->add_control(
+				'html_disabled_alert',
+				[
+					'raw' => __( 'Breadcrumbs are disabled in the Rank Math SEO', 'elementor' ) . ' ' . sprintf( '<a href="%s" target="_blank">%s</a>', admin_url( 'admin.php?page=rank-math-options-general#setting-panel-breadcrumbs' ), __( 'Breadcrumbs Panel', 'elementor' ) ),
+					'type' => Controls_Manager::RAW_HTML,
+					'content_classes' => 'elementor-panel-alert elementor-panel-alert-danger',
+				]
+			);
+		}
+
+		$this->add_responsive_control(
+			'align',
+			[
+				'label' => __( 'Alignment', 'elementor' ),
+				'type' => Controls_Manager::CHOOSE,
+				'options' => [
+					'left' => [
+						'title' => __( 'Left', 'elementor' ),
+						'icon' => 'eicon-text-align-left',
+					],
+					'center' => [
+						'title' => __( 'Center', 'elementor' ),
+						'icon' => 'eicon-text-align-center',
+					],
+					'right' => [
+						'title' => __( 'Right', 'elementor' ),
+						'icon' => 'eicon-text-align-right',
+					],
+				],
+				'prefix_class' => 'elementor%s-align-',
+			]
+		);
+
+		$this->add_control(
+			'html_tag',
+			[
+				'label' => __( 'HTML Tag', 'elementor' ),
+				'type' => Controls_Manager::SELECT,
+				'options' => [
+					'' => __( 'Default', 'elementor' ),
+					'p' => 'p',
+					'div' => 'div',
+					'nav' => 'nav',
+					'span' => 'span',
+				],
+				'default' => '',
+			]
+		);
+
+		$this->add_control(
+			'html_description',
+			[
+				'raw' => __( 'Additional settings are available in the Rank Math SEO', 'elementor' ) . ' ' . sprintf( '<a href="%s" target="_blank">%s</a>', admin_url( 'admin.php?page=rank-math-options-general#setting-panel-breadcrumbs' ), __( 'Breadcrumbs Panel', 'elementor' ) ),
+				'type' => Controls_Manager::RAW_HTML,
+				'content_classes' => 'elementor-descriptor',
+			]
+		);
+
+		$this->end_controls_section();
+
+		$this->start_controls_section(
+			'section_style',
+			[
+				'label' => __( 'Breadcrumbs', 'elementor' ),
+				'tab' => Controls_Manager::TAB_STYLE,
+			]
+		);
+
+		$this->add_group_control(
+			Group_Control_Typography::get_type(),
+			[
+				'name' => 'typography',
+				'selector' => '{{WRAPPER}}',
+				'scheme' => Scheme_Typography::TYPOGRAPHY_2,
+			]
+		);
+
+		$this->add_control(
+			'text_color',
+			[
+				'label' => __( 'Text Color', 'elementor' ),
+				'type' => Controls_Manager::COLOR,
+				'default' => '',
+				'selectors' => [
+					'{{WRAPPER}}' => 'color: {{VALUE}};',
+				],
+			]
+		);
+
+		$this->start_controls_tabs( 'tabs_breadcrumbs_style' );
+
+		$this->start_controls_tab(
+			'tab_color_normal',
+			[
+				'label' => __( 'Normal', 'elementor' ),
+			]
+		);
+
+		$this->add_control(
+			'link_color',
+			[
+				'label' => __( 'Link Color', 'elementor' ),
+				'type' => Controls_Manager::COLOR,
+				'default' => '',
+				'selectors' => [
+					'{{WRAPPER}} a' => 'color: {{VALUE}};',
+				],
+			]
+		);
+
+		$this->end_controls_tab();
+
+		$this->start_controls_tab(
+			'tab_color_hover',
+			[
+				'label' => __( 'Hover', 'elementor' ),
+			]
+		);
+
+		$this->add_control(
+			'link_hover_color',
+			[
+				'label' => __( 'Color', 'elementor' ),
+				'type' => Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} a:hover' => 'color: {{VALUE}};',
+				],
+			]
+		);
+
+		$this->end_controls_section();
+	}
+
+	public function get_html_tag( $args ) {
+		$html_tag = $this->get_settings( 'html_tag' );
+		if ( $html_tag ) {
+			$args['wrap_before'] = "<{$html_tag}>";
+			$args['wrap_after'] = "</{$html_tag}>";
+		}
+		return $args;
+	}
+
+	protected function render() {
+		add_filter( 'rank_math/frontend/breadcrumb/args', [ $this, 'get_html_tag' ] );
+		rank_math_the_breadcrumbs();
+	}
+}


### PR DESCRIPTION
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary
This PR can be summarized in the following changelog entry:
* New: Added Rank Math SEO plugin's capability to edit Breadcrumbs using Elementor page builder

## Description
An explanation of what is done in this PR
* This PR adds Rank Math Breadcrumbs in the ELementor Sidebar. Users can use this to add Rank Math Breadcrumbs simply by dragging the Breadcrumb module in the content area.

## Test instructions
This PR can be tested by following these steps:
1) Install & Activate the Rank Math SEO plugin.
2) Enable Breadcrumbs by navigating to Dashboard >> Rank Math >> General Settings >> Breadcrumbs.
3) Create a new Page/Post and in the modules search Breadcrumbs.
4) Drag it and drop it in the content.

## Quality assurance
- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended - I don't see any unit tests added for the other modules so I am not adding it for this module.