### PR TITLE
Added playsinline option to the self-hosted video tag for autoplay in iOS browsers

### DIFF
--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -1044,6 +1044,10 @@ class Widget_Video extends Widget_Base {
 			$video_params['muted'] = 'muted';
 		}
 
+		if ( $settings['play_on_mobile'] ) {
+			$video_params['playsinline'] = '';
+		}
+
 		if ( ! $settings['download_button'] ) {
 			$video_params['controlsList'] = 'nodownload';
 		}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Enabled autoplay on iOS mobile browsers for self-hosted videos

## Description
An explanation of what is done in this PR

* Added `playsinline` attribute to the self-hosted `<video>` tag.

## Test instructions
This PR can be tested by following these steps:

* Add a video widget with a self-hosted video to a page
* Open the page in an iOS browser (e.g. Safari)