### PR TITLE
Fix: Error when trying to edit widget with inline icons control before FA migration

### DIFF
--- a/assets/dev/js/editor/controls/icons.js
+++ b/assets/dev/js/editor/controls/icons.js
@@ -45,6 +45,7 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 		ui.deleteButton = 'media' === skin ? '.elementor-control-media__remove' : '.elementor-control-icons--inline__none';
 		ui.previewPlaceholder = '.elementor-control-media__preview';
 		ui.previewContainer = '.elementor-control-preview-area';
+		ui.inlineIconContainer = '.elementor-control-inline-icon';
 		ui.inlineDisplayedIcon = '.elementor-control-icons--inline__displayed-icon';
 		ui.radioInputs = '[type="radio"]';
 
@@ -124,8 +125,13 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 	onReady() {
 		// is migration allowed from fa4
 		if ( ! this.isMigrationAllowed() ) {
-			this.ui.previewContainer[ 0 ].addEventListener( 'click', ( event ) => {
+			const migrationPopupTrigger = 'media' === this.model.get( 'skin' ) ? this.ui.previewContainer[ 0 ] : this.ui.inlineIconContainer[ 0 ];
+
+			migrationPopupTrigger.addEventListener( 'click', ( event ) => {
+				// Prevent default to prevent marking the inline icons as selected on click when migration is not allowed
+				event.preventDefault();
 				event.stopPropagation();
+
 				const onConfirm = () => {
 					window.location.href = ElementorConfig.tools_page_link + '&redirect_to=' + encodeURIComponent( document.location.href ) + '#tab-fontawesome4_migration';
 				};

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -102,7 +102,7 @@ class Control_Icons extends Control_Base_Multiple {
 	public function render_inline_skin() {
 		$control_uid = $this->get_control_uid();
 		?>
-		<div class="elementor-control-field">
+		<div class="elementor-control-field elementor-control-inline-icon">
 			<label class="elementor-control-title">{{{ data.label }}}</label>
 			<div class="elementor-control-input-wrapper">
 				<div class="elementor-choices">


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fixed: JS Error when trying to edit widget with icons control before FontAwesome 4 to 5 migration

## Test instructions
This PR can be tested by following these steps:

* Create a widget with an inline icons control
* Reverse the FontAwesome migration
* Try to edit the widget

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)