### PR TITLE
Fixed: WP Media 'Image details' fields are 100% width instead of contained (PT 359)

### DIFF
--- a/assets/dev/scss/editor/_forms.scss
+++ b/assets/dev/scss/editor/_forms.scss
@@ -28,6 +28,11 @@ input, select, textarea, .elementor-input-style {
 	}
 }
 
+// Normalize form elements in WP's core media management modal
+.media-modal select {
+	width: initial;
+}
+
 .elementor-error {
 
 	input, select, textarea {

--- a/assets/dev/scss/editor/_forms.scss
+++ b/assets/dev/scss/editor/_forms.scss
@@ -28,11 +28,6 @@ input, select, textarea, .elementor-input-style {
 	}
 }
 
-// Normalize form elements in WP's core media management modal
-.media-modal select {
-	width: initial;
-}
-
 .elementor-error {
 
 	input, select, textarea {

--- a/assets/dev/scss/editor/panel/_panel.scss
+++ b/assets/dev/scss/editor/panel/_panel.scss
@@ -106,6 +106,11 @@
 		width: auto;
 	}
 
+	// Normalize form elements in WP's core media management modal
+	select {
+		width: initial;
+	}
+
 	fieldset {
 		padding: 0;
 		border: 0;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fixed: WP core media modal - form elements' CSS distorted by Elementor Editor's CSS

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
