### PR TITLE
Fix: flex container input width

### DIFF
--- a/assets/dev/scss/editor/_forms.scss
+++ b/assets/dev/scss/editor/_forms.scss
@@ -35,6 +35,12 @@ input, select, textarea, .elementor-input-style {
 	}
 }
 
+input {
+	// This fixes an issue in Firefox, in cases where a container with `display: flex` has a defined width,
+	// an input element inside this container cannot be given its own defined width.
+	min-width: 0;
+}
+
 input, textarea, .elementor-input-style {
 	padding: 5px;
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description
An explanation of what is done in this PR

* Fix: an issue in Firefox, in cases where a container with `display: flex` has a defined width, an input element inside this container cannot be given its own defined width.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)