### PR TITLE
FIX Bug causing Form style rendering to break during the rendering of the Editor.

### DIFF
--- a/assets/dev/js/editor/elements/models/base-settings.js
+++ b/assets/dev/js/editor/elements/models/base-settings.js
@@ -131,9 +131,12 @@ BaseSettingsModel = Backbone.Model.extend( {
 			if ( control.fields ) {
 				var styleFields = [];
 
-				self.attributes[ control.name ].each( function( item ) {
-					styleFields.push( self.getStyleControls( control.fields, item.attributes ) );
-				} );
+				// Avoid this when control is a Fields_Map
+				if ( typeof self.attributes[ control.name ].each !== 'undefined' ){
+					self.attributes[ control.name ].each( function( item ) {
+						styleFields.push( self.getStyleControls( control.fields, item.attributes ) );
+					} );
+				}
 
 				control.styleFields = styleFields;
 			}


### PR DESCRIPTION
 ## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* FIXED Fields_Map control causing Form style rendering to break during the loading of the editor.

## Description
An explanation of what is done in this PR

* Resolved the bug by checking to see if the provided control is a repeater field or a Fields_Map

## Test instructions
This PR can be tested by following these steps:

* By using any of the available integrations which us a Fields_Map control, saving the post and refreshing the editor.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #9313
