### PR TITLE
Fix: Media Carousel swiper previous and next button is not displaying…

### DIFF
--- a/assets/dev/scss/frontend/_swiper.scss
+++ b/assets/dev/scss/frontend/_swiper.scss
@@ -343,11 +343,6 @@ button.swiper-pagination-bullet {
 		height: 100%;
 	}
 
-	.elementor-swiper-button {
-		// Fix for Safari - Navigation arrows don't appear in cube mode without adding a 1px translateZ
-		transform: translate3d( 0, -50%, 1px );
-	}
-
 	&.swiper-container-rtl .swiper-slide {
 		transform-origin: 100% 0;
 	}
@@ -512,7 +507,8 @@ button.swiper-pagination-bullet {
 	font-size: 25px;
 	color: $slides_gui;
 	top: 50%;
-	transform: translateY(-50%);
+	// Fix for Safari - Navigation arrows don't appear in cube mode without adding a 1px translateZ
+	transform: translate3d( 0, -50%, 1px );
 
 	&-prev {
 		left: 10px;

--- a/assets/dev/scss/frontend/_swiper.scss
+++ b/assets/dev/scss/frontend/_swiper.scss
@@ -343,6 +343,11 @@ button.swiper-pagination-bullet {
 		height: 100%;
 	}
 
+	.elementor-swiper-button {
+		// Fix for Safari - Navigation arrows don't appear in cube mode without adding a 1px translateZ
+		transform: translate3d( 0, -50%, 1px );
+	}
+
 	&.swiper-container-rtl .swiper-slide {
 		transform-origin: 100% 0;
 	}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Media Carousel - previous and next buttons is not displaying on Safari in Cube mode

## Test instructions
This PR can be tested by following these steps:

* Open Elementor in the Safari browser on a Mac
* Add Media Carousel widget to a page/post
* Choose Skin = Slideshow + Effect = Cube
* Check if the navigation arrows on the sides of the main slide are visible

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)