### PR TITLE
Add new modal - wrong select sizing since WP v5.3

### DIFF
--- a/assets/dev/scss/admin/_new-template-dialog.scss
+++ b/assets/dev/scss/admin/_new-template-dialog.scss
@@ -76,7 +76,7 @@
 
 		&__template-type.elementor-form-field__select {
 			// Override new wp-core-ui class <select> width starting WP v5.3/5.4
-			max-width: 100%;
+			max-width: initial;
 		}
 
 		.elementor-form-field {

--- a/assets/dev/scss/admin/_new-template-dialog.scss
+++ b/assets/dev/scss/admin/_new-template-dialog.scss
@@ -74,6 +74,11 @@
 			color: $editor-darker;
 		}
 
+		&__template-type.elementor-form-field__select {
+			// Override new wp-core-ui class <select> width starting WP v5.3/5.4
+			max-width: 100%;
+		}
+
 		.elementor-form-field {
 
 			&__label {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Other... Please describe: Design adaptation

## Summary

This PR can be summarized in the following changelog entry:

* In Elementor Pro's "New Template" screen, fix the `select` element width that was affected by styling changes in WP v5.3/5.4

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)