### PR TITLE
Fix: The image carousel is blocked in case you set the slides to show…

### DIFF
--- a/assets/dev/js/frontend/utils/swiper.js
+++ b/assets/dev/js/frontend/utils/swiper.js
@@ -39,7 +39,7 @@ export default class Swiper {
 			// Then reset the settings in the original breakpoint key to the default values
 			this.config.breakpoints[ configBPKey ] = {
 				slidesPerView: this.config.slidesPerView,
-				slidesPerGroup: this.config.slidesPerGroup,
+				slidesPerGroup: this.config.slidesPerGroup ? this.config.slidesPerGroup : 1,
 			};
 		} );
 	}


### PR DESCRIPTION
… to 1 or default (PT 474)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: The image carousel is blocked in case you set the slides to show to 1 or default

## Description
An explanation of what is done in this PR

* Added a missing default option for Swiper's slidesPerGroup parameter in the breakpoints handler in the Swiper wrapper.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)