### PR TITLE
Added BC Fix for Elementor Pro Carousels with new Swiper wrapper

### DIFF
--- a/assets/dev/js/frontend/utils/swiper.js
+++ b/assets/dev/js/frontend/utils/swiper.js
@@ -27,7 +27,10 @@ export default class Swiper {
 				breakpointToUpdate = elementorBreakpoints.xs;
 			} else {
 				// Find the index of the current config breakpoint in the Elementor Breakpoints array
-				const currentBPIndexInElementorBPs = elementorBreakpointValues.findIndex( ( elementorBP ) => configBPKeyInt === elementorBP );
+				const currentBPIndexInElementorBPs = elementorBreakpointValues.findIndex( ( elementorBP ) => {
+					// BC Fix for Elementor Pro Carousels from 2.8.0-2.8.3 used with Elementor >= 2.9.0
+					return configBPKeyInt === elementorBP || ( configBPKeyInt + 1 ) === elementorBP;
+				} );
 
 				// For all other Swiper config breakpoints, move them one breakpoint down on the breakpoint list,
 				// according to the array of Elementor's global breakpoints


### PR DESCRIPTION
Swiper wrapper was added Core v2.9.0.
This BC fix is for users with Core >=2.9.0 and Pro >=2.8.0

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Testimonial Carousel/Media Carousel/Reviews widget | Slides to show doesn't get in the responsive mode

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)