### PR TITLE
Revert fix from PR 10081 to fix Box Shadow bug in Toggle widget

### DIFF
--- a/assets/dev/scss/frontend/widgets/toggle.scss
+++ b/assets/dev/scss/frontend/widgets/toggle.scss
@@ -2,15 +2,6 @@
 // Toggle
 //
 
-.elementor-widget-toggle {
-
-	.elementor-widget-container {
-		// This overflow: hidden prevents the overflow of backgrounds on widget elements (like toggle tab title)
-		// in case where a border radius is applied to the widget container in the Advanced > Border section
-		overflow: hidden;
-	}
-}
-
 .elementor-toggle {
 	text-align: $start;
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Toggle widget - box shadow not displaying properly since v2.8.4

## Description
An explanation of what is done in this PR

* We reverted a fix made in 2.8.4 to address issue #5156 
* This means that the problem raised in issue #5156 returns

Anyone dealing with the problem in issue 5156 and are Elementor Pro users, can overcome it using the custom CSS feature, and entering the following in their widget's custom CSS box:
```
selector .elementor-widget-container {
      overflow: hidden;
}
```

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)