### PR TITLE
Fix: Tabs widget title color not working on mobile (PT 516)

### DIFF
--- a/includes/widgets/tabs.php
+++ b/includes/widgets/tabs.php
@@ -251,7 +251,7 @@ class Widget_Tabs extends Widget_Base {
 				'label' => __( 'Color', 'elementor' ),
 				'type' => Controls_Manager::COLOR,
 				'selectors' => [
-					'{{WRAPPER}} .elementor-tab-title a' => 'color: {{VALUE}};',
+					'{{WRAPPER}} .elementor-tab-title, {{WRAPPER}} .elementor-tab-title a' => 'color: {{VALUE}};',
 				],
 				'scheme' => [
 					'type' => Schemes\Color::get_type(),


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Tabs widget title color not working on mobile

## Description
An explanation of what is done in this PR

* Problem was: color control selector targeted an `<a>` tag, but on mobile, the title is in a `<div>`, not an `<a>` tag. I chose to add another selector to the control rather than start adding/changing classes in the markup itself

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)