### PR TITLE
Fix: Image Carousel - the carousel spins a number of times when loading (PT 557)

### DIFF
--- a/assets/dev/js/frontend/handlers/image-carousel.js
+++ b/assets/dev/js/frontend/handlers/image-carousel.js
@@ -57,10 +57,6 @@ class ImageCarouselHandler extends elementorModules.frontend.handlers.Base {
 			};
 		}
 
-		if ( true === swiperOptions.loop ) {
-			swiperOptions.loopedSlides = this.getSlidesCount();
-		}
-
 		if ( isSingleSlide ) {
 			swiperOptions.effect = elementSettings.effect;
 


### PR DESCRIPTION
It is possible that in Swiper 5.3.6 (current Swiper lib version at this time), this parameter causes an issue.

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Image Carousel widget - the carousel spins a number of times when loading

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)