### PR TITLE
Fix: Accordion and Toggle Title color & Typography being overridden by Theme Style fixes #10900

### DIFF
--- a/includes/widgets/accordion.php
+++ b/includes/widgets/accordion.php
@@ -316,7 +316,7 @@ class Widget_Accordion extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name' => 'title_typography',
-				'selector' => '{{WRAPPER}} .elementor-accordion .elementor-tab-title',
+				'selector' => '{{WRAPPER}} .elementor-accordion .elementor-accordion-title',
 				'scheme' => Schemes\Typography::TYPOGRAPHY_1,
 			]
 		);

--- a/includes/widgets/accordion.php
+++ b/includes/widgets/accordion.php
@@ -316,7 +316,7 @@ class Widget_Accordion extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name' => 'title_typography',
-				'selector' => '{{WRAPPER}} .elementor-accordion .elementor-accordion-title',
+				'selector' => '{{WRAPPER}} .elementor-accordion .elementor-accordion-title, {{WRAPPER}} .elementor-accordion .elementor-tab-title a',
 				'scheme' => Schemes\Typography::TYPOGRAPHY_1,
 			]
 		);

--- a/includes/widgets/accordion.php
+++ b/includes/widgets/accordion.php
@@ -316,7 +316,7 @@ class Widget_Accordion extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name' => 'title_typography',
-				'selector' => '{{WRAPPER}} .elementor-accordion .elementor-accordion-title, {{WRAPPER}} .elementor-accordion .elementor-tab-title a',
+				'selector' => '{{WRAPPER}} .elementor-accordion .elementor-accordion-title',
 				'scheme' => Schemes\Typography::TYPOGRAPHY_1,
 			]
 		);

--- a/includes/widgets/toggle.php
+++ b/includes/widgets/toggle.php
@@ -340,7 +340,7 @@ class Widget_Toggle extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name' => 'title_typography',
-				'selector' => '{{WRAPPER}} .elementor-toggle .elementor-tab-title',
+				'selector' => '{{WRAPPER}} .elementor-toggle .elementor-toggle-title',
 				'scheme' => Schemes\Typography::TYPOGRAPHY_1,
 			]
 		);
@@ -560,7 +560,7 @@ class Widget_Toggle extends Widget_Base {
 							<?php } ?>
 						</span>
 						<?php endif; ?>
-						<a href=""><?php echo $item['tab_title']; ?></a>
+						<a href="" class="elementor-toggle-title"><?php echo $item['tab_title']; ?></a>
 					</<?php echo esc_html( $settings['title_html_tag'] ); ?>>
 					<div <?php echo $this->get_render_attribute_string( $tab_content_setting_key ); ?>><?php echo $this->parse_text_editor( $item['tab_content'] ); ?></div>
 				</div>

--- a/includes/widgets/toggle.php
+++ b/includes/widgets/toggle.php
@@ -313,7 +313,7 @@ class Widget_Toggle extends Widget_Base {
 				'label' => __( 'Color', 'elementor' ),
 				'type' => Controls_Manager::COLOR,
 				'selectors' => [
-					'{{WRAPPER}} .elementor-tab-title a, {{WRAPPER}} .elementor-toggle-title, {{WRAPPER}} .elementor-toggle-icon' => 'color: {{VALUE}};',
+					'{{WRAPPER}} .elementor-toggle-title, {{WRAPPER}} .elementor-toggle-icon' => 'color: {{VALUE}};',
 				],
 				'scheme' => [
 					'type' => Schemes\Color::get_type(),
@@ -341,7 +341,7 @@ class Widget_Toggle extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name' => 'title_typography',
-				'selector' => '{{WRAPPER}} .elementor-toggle .elementor-tab-title, {{WRAPPER}} .elementor-toggle .elementor-toggle-title',
+				'selector' => '{{WRAPPER}} .elementor-toggle .elementor-toggle-title',
 				'scheme' => Schemes\Typography::TYPOGRAPHY_1,
 			]
 		);

--- a/includes/widgets/toggle.php
+++ b/includes/widgets/toggle.php
@@ -306,13 +306,14 @@ class Widget_Toggle extends Widget_Base {
 			]
 		);
 
+		// The title selector specificity is to override Theme Style
 		$this->add_control(
 			'title_color',
 			[
 				'label' => __( 'Color', 'elementor' ),
 				'type' => Controls_Manager::COLOR,
 				'selectors' => [
-					'{{WRAPPER}} .elementor-tab-title a, {{WRAPPER}} .elementor-toggle-icon' => 'color: {{VALUE}};',
+					'{{WRAPPER}} .elementor-toggle-title, {{WRAPPER}} .elementor-toggle-icon' => 'color: {{VALUE}};',
 				],
 				'scheme' => [
 					'type' => Schemes\Color::get_type(),

--- a/includes/widgets/toggle.php
+++ b/includes/widgets/toggle.php
@@ -313,7 +313,7 @@ class Widget_Toggle extends Widget_Base {
 				'label' => __( 'Color', 'elementor' ),
 				'type' => Controls_Manager::COLOR,
 				'selectors' => [
-					'{{WRAPPER}} .elementor-toggle-title, {{WRAPPER}} .elementor-toggle-icon' => 'color: {{VALUE}};',
+					'{{WRAPPER}} .elementor-tab-title a, {{WRAPPER}} .elementor-toggle-title, {{WRAPPER}} .elementor-toggle-icon' => 'color: {{VALUE}};',
 				],
 				'scheme' => [
 					'type' => Schemes\Color::get_type(),
@@ -341,7 +341,7 @@ class Widget_Toggle extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name' => 'title_typography',
-				'selector' => '{{WRAPPER}} .elementor-toggle .elementor-toggle-title',
+				'selector' => '{{WRAPPER}} .elementor-toggle .elementor-tab-title, {{WRAPPER}} .elementor-toggle .elementor-toggle-title',
 				'scheme' => Schemes\Typography::TYPOGRAPHY_1,
 			]
 		);


### PR DESCRIPTION
PT 450

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Title color & Typography are being overridden by Theme Style - Accordion and Toggle widgets

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)