### PR TITLE
Fix: Pinterest social sharing cannot share posts with large featured images (PT 240)

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -1163,11 +1163,32 @@ class Frontend extends App {
 
 			$title = Utils::urlencode_html_entities( wp_get_document_title() );
 
+			$thumb_id = get_post_thumbnail_id();
+			$thumb_size = 'full';
+			$full_thumb_meta = wp_get_attachment_image_src( $thumb_id, $thumb_size );
+
+			// If thumb is wider than 1600px, get the closest thumbnail size to it
+			// This is done because Pinterest has a problem sharing large images
+			if ( $thumb_id && $full_thumb_meta && ( 1600 < $full_thumb_meta[1] ) ) {
+				$thumbnail_sizes = Group_Control_Image_Size::get_all_image_sizes();
+
+				uasort( $thumbnail_sizes, function( $a, $b ) {
+					return $b['width'] - $a['width'];
+				} );
+
+				foreach ( $thumbnail_sizes as $size_slug => $size_meta ) {
+					if ( 1600 > $size_meta['width'] ) {
+						$thumb_size = $size_slug;
+						break;
+					}
+				}
+			}
+
 			$settings['post'] = [
 				'id' => $post->ID,
 				'title' => $title,
 				'excerpt' => $post->post_excerpt,
-				'featuredImage' => get_the_post_thumbnail_url(),
+				'featuredImage' => get_the_post_thumbnail_url( null, $thumb_size ),
 			];
 		} else {
 			$settings['post'] = [

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -1163,32 +1163,19 @@ class Frontend extends App {
 
 			$title = Utils::urlencode_html_entities( wp_get_document_title() );
 
-			$thumb_id = get_post_thumbnail_id();
-			$thumb_size = 'full';
-			$full_thumb_meta = wp_get_attachment_image_src( $thumb_id, $thumb_size );
+			// Try to get the 'large' size featured image thumbnail
+			$featured_image_url = get_the_post_thumbnail_url( null, 'large' );
 
-			// If thumb is wider than 1600px, get the closest thumbnail size to it
-			// This is done because Pinterest has a problem sharing large images
-			if ( $thumb_id && $full_thumb_meta && ( 1600 < $full_thumb_meta[1] ) ) {
-				$thumbnail_sizes = Group_Control_Image_Size::get_all_image_sizes();
-
-				uasort( $thumbnail_sizes, function( $a, $b ) {
-					return $b['width'] - $a['width'];
-				} );
-
-				foreach ( $thumbnail_sizes as $size_slug => $size_meta ) {
-					if ( 1600 > $size_meta['width'] ) {
-						$thumb_size = $size_slug;
-						break;
-					}
-				}
+			// If the large size was nullified, use the full size which cannot be nullified/deleted
+			if ( ! $featured_image_url ) {
+				$featured_image_url = get_the_post_thumbnail_url( null, 'full' );
 			}
 
 			$settings['post'] = [
 				'id' => $post->ID,
 				'title' => $title,
 				'excerpt' => $post->post_excerpt,
-				'featuredImage' => get_the_post_thumbnail_url( null, $thumb_size ),
+				'featuredImage' => $featured_image_url,
 			];
 		} else {
 			$settings['post'] = [

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -1163,7 +1163,9 @@ class Frontend extends App {
 
 			$title = Utils::urlencode_html_entities( wp_get_document_title() );
 
-			// Try to get the 'large' size featured image thumbnail
+			// Try to use the 'large' WP image size because the Pinterest share API
+			// has problems accepting shares with large images sometimes, and the WP 'large' thumbnail is
+			// the largest default WP image size that will probably not be changed in most sites
 			$featured_image_url = get_the_post_thumbnail_url( null, 'large' );
 
 			// If the large size was nullified, use the full size which cannot be nullified/deleted


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Pinterest social sharing returns error in posts with large featured images

## Description
An explanation of what is done in this PR

* Since Pinterest has a problem sharing large images, I limited the featured image used to 1600px width, and use the closest thumbnail under that width.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)