### PR TITLE
Image Widget: add "height" & "Image Fit" controls

### DIFF
--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -318,6 +318,52 @@ class Widget_Image extends Widget_Base {
 			]
 		);
 
+		$this->add_responsive_control(
+			'height',
+			[
+				'label' => __( 'Height', 'elementor' ),
+				'type' => Controls_Manager::SLIDER,
+				'default' => [
+					'unit' => 'px',
+				],
+				'tablet_default' => [
+					'unit' => 'px',
+				],
+				'mobile_default' => [
+					'unit' => 'px',
+				],
+				'size_units' => [ 'px' ],
+				'range' => [
+					'px' => [
+						'min' => 1,
+						'max' => 500,
+					],
+				],
+				'selectors' => [
+					'{{WRAPPER}} .elementor-image img' => 'height: {{SIZE}}{{UNIT}};',
+				],
+			]
+		);
+
+		$this->add_responsive_control(
+			'object-fit',
+			[
+				'label' => __( 'Image Fit', 'elementor' ),
+				'type' => Controls_Manager::SELECT,
+				'options' => [
+					'' => __( 'Default', 'elementor' ),
+					'fill' => __( 'Fill', 'elementor' ),
+					'cover' => __( 'Cover', 'elementor' ),
+					'contain' => __( 'Contain', 'elementor' ),
+					'scale-down' => __( 'Scale Down', 'elementor' ),
+				],
+				'default' => '',
+				'selectors' => [
+					'{{WRAPPER}} .elementor-image img' => 'object-fit: {{VALUE}};',
+				],
+			]
+		);
+
 		$this->add_control(
 			'separator_panel_style',
 			[


### PR DESCRIPTION
See #7626

@KingYes asked to change branches.

----

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Tweak: Added height & image-fit controls to Image widget.

## Description
An explanation of what is done in this PR

Elementor sections /columns has the option to set background images with
`background-size: auto | cover | contain ;`
We can't do the same with a simple **Image Widget**.

The PR adds **Height** control to set the image height, and **Image Fit** control to set the image resize type.
`object-fit: fill | contain | cover | scale-down | none ;`

----

Note that `object-fit` has a good browser compatibility.

See on [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit#Browser_compatibility) and on [can I use](https://caniuse.com/#search=object-fit). Even Opera Mini support this feature.

----

I prefer to use the **Image Widget** instead of Sections / Spacers with background-image, as the `<img>` has accessibility benefits.

Currently, only with a **Section** and a **Spacer Widget** I can set the height with contained image position.

The **Image Widget** don't have a height control, and it does not allow the user to control the image resize method. With object fit we solve this issue and gain better accessibility.

----

![new-controls](https://user-images.githubusercontent.com/576623/55099811-11df3480-50c9-11e9-8553-6e08fc59bbf5.png)

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
