### PR TITLE
Add filter to allow changing WP widget categories

### DIFF
--- a/includes/widgets/wordpress.php
+++ b/includes/widgets/wordpress.php
@@ -90,7 +90,7 @@ class Widget_WordPress extends Widget_Base {
 		} else {
 			$category = 'wordpress'; // WPCS: spelling ok.
 		}
-		return [ $category ];
+		return apply_filters( 'elementor/widgets/wordpress/get_categories', [ $category ], $this );
 	}
 
 	/**


### PR DESCRIPTION
Allow filtering of the categories for WP widgets.

Use case, I have all my plugin widgets as WP plugins but I am adding a new category for my plugin, I just want to be able to organize them there.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* WP Widgets categories can now be filtered to show in other sections - ADDED

## Description
An explanation of what is done in this PR

* Filter added

## Test instructions
This PR can be tested by following these steps:

* Using the filter?

## Quality assurance

- [x ] I have tested this code to the best of my abilities
- [N/A ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #10970 10970
