### PR TITLE
Removed source map comment so browsers don't look for source map (PT 639)

### DIFF
--- a/assets/lib/swiper/swiper.js
+++ b/assets/lib/swiper/swiper.js
@@ -8659,4 +8659,3 @@
   return Swiper;
 
 }));
-//# sourceMappingURL=swiper.js.map


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Removed source map comment from the Swiper library

## Description
An explanation of what is done in this PR

* Removed source map comment from the Swiper library so browsers don't look for its source map, which we don't include in Elementor (PT 639)