### PR TITLE
Add support for processing Template Kit ZIP files.

### DIFF
--- a/includes/template-library/sources/local.php
+++ b/includes/template-library/sources/local.php
@@ -787,14 +787,6 @@ class Source_Local extends Source_Base {
 	 * [
 	 *  0 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-2-col-marble-title.json',
 	 *  1 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-2-col-text-and-photo.json',
-	 *  2 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-3-col-articles.json',
-	 *  3 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-3-col-icon-boxes.json',
-	 *  4 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-3-col-pricing-table.json',
-	 *  5 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-4-col-staff-circles.json',
-	 *  6 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-call-to-action-bar-tall.json',
-	 *  7 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-call-to-action-bar-with-button.json',
-	 *  8 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-contact-form-and-details.json',
-	 *  9 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-footer.json',
 	 * ]
 	 *
 	 * @since 2.9.8
@@ -865,7 +857,7 @@ class Source_Local extends Source_Base {
 				$zipped_file_name = $zip->getNameIndex( $i );
 				$zipped_extension = pathinfo( $zipped_file_name, PATHINFO_EXTENSION );
 				// Template Kit zip files contain a `manifest.json` file, this is not a valid Elementor template so ensure we skip it.
-				if ( 'manifest.json' !== $zipped_file_name && 'json' === $zipped_extension ) {
+				if ( 'json' === $zipped_extension && 'manifest.json' !== $zipped_file_name ) {
 					$valid_entries[] = $zipped_file_name;
 				}
 			}

--- a/includes/template-library/sources/local.php
+++ b/includes/template-library/sources/local.php
@@ -778,6 +778,52 @@ class Source_Local extends Source_Base {
 	}
 
 	/**
+	 * Find temporary files.
+	 *
+	 * Recursively finds a list of temporary files from the extracted zip file.
+	 *
+	 * Example return data:
+	 *
+	 * [
+	 *  0 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-2-col-marble-title.json',
+	 *  1 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-2-col-text-and-photo.json',
+	 *  2 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-3-col-articles.json',
+	 *  3 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-3-col-icon-boxes.json',
+	 *  4 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-3-col-pricing-table.json',
+	 *  5 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-4-col-staff-circles.json',
+	 *  6 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-call-to-action-bar-tall.json',
+	 *  7 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-call-to-action-bar-with-button.json',
+	 *  8 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-contact-form-and-details.json',
+	 *  9 => '/www/wp-content/uploads/elementor/tmp/5eb3a7a411d44/templates/block-footer.json',
+	 * ]
+	 *
+	 * @since 2.9.8
+	 * @access private
+	 *
+	 * @param string $temp_path - The temporary file path to scan for template files
+	 *
+	 * @return array An array of temporary files on the filesystem
+	 */
+	private function find_temp_files( $temp_path ) {
+
+		$file_names = [];
+
+		$possible_file_names = array_diff( scandir( $temp_path ), [ '.', '..' ] );
+
+		// Find nested files in the unzipped path. This happens for example when the user imports a Template Kit.
+		foreach ( $possible_file_names as $possible_file_name ) {
+			$full_possible_file_name = $temp_path . '/' . $possible_file_name;
+			if ( is_dir( $full_possible_file_name ) ) {
+				$file_names = $file_names + $this->find_temp_files( $full_possible_file_name );
+			} else {
+				$file_names[] = $full_possible_file_name;
+			}
+		}
+
+		return $file_names;
+	}
+
+	/**
 	 * Import local template.
 	 *
 	 * Import template from a file.
@@ -818,7 +864,8 @@ class Source_Local extends Source_Base {
 			for ( $i = 0; $i < $zip->numFiles; $i++ ) {
 				$zipped_file_name = $zip->getNameIndex( $i );
 				$zipped_extension = pathinfo( $zipped_file_name, PATHINFO_EXTENSION );
-				if ( 'json' === $zipped_extension ) {
+				// Template Kit zip files contain a `manifest.json` file, this is not a valid Elementor template so ensure we skip it.
+				if ( 'manifest.json' !== $zipped_file_name && 'json' === $zipped_extension ) {
 					$valid_entries[] = $zipped_file_name;
 				}
 			}
@@ -829,11 +876,9 @@ class Source_Local extends Source_Base {
 
 			$zip->close();
 
-			$file_names = array_diff( scandir( $temp_path ), [ '.', '..' ] );
+			$file_names = $this->find_temp_files( $temp_path );
 
-			foreach ( $file_names as $file_name ) {
-				$full_file_name = $temp_path . '/' . $file_name;
-
+			foreach ( $file_names as $full_file_name ) {
 				$import_result = $this->import_single_template( $full_file_name );
 
 				unlink( $full_file_name );
@@ -1324,7 +1369,7 @@ class Source_Local extends Source_Base {
 		$content = $data['content'];
 
 		if ( ! is_array( $content ) ) {
-			return new \WP_Error( 'file_error', 'Invalid File' );
+			return new \WP_Error( 'file_error', 'Invalid Content In File' );
 		}
 
 		$content = $this->process_export_import_content( $content, 'on_import' );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Add support for importing Template Kit ZIP files

## Description

Template Kit ZIP files contain a main `manifest.json` file and a folder of json `templates/` like this:

![image](https://user-images.githubusercontent.com/543073/81261748-f0989800-907f-11ea-9283-0bc30329338d.png)

When trying to upload this to Elementor it returns a generic error:

![image](https://user-images.githubusercontent.com/543073/81261796-0908b280-9080-11ea-9f1f-1f722894f64d.png)

This is because the code doesn't support unzipping a file with nested folders of json templates, and it tries to parse the main `manifest.json` file as an Elementor template (it's not).

## Changes

- Replace the single directory level `scandir` with a new recursive file finder.
- Ignore files named `manifest.json` in the ZIP 
- This allows the ZIP import process to find templates nested in temporary extracted folders.

## Why?

We would like to add basic support for Template Kit ZIP files into Elementor core, rather than making users download the separate [Template Kit Import](https://wordpress.org/plugins/template-kit-import/) plugin each time. This change is a step in the right direction to making Elementor core support Template Kit ZIP format. 

## Test instructions

* ZIP up some Elementor templates, but put them into a `templates/` folder in the ZIP file
* Upload ZIP file to Elementor as usual
* Check they all import

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)


