### PR TITLE
Fix: Elementor posts aren't properly imported with WordPress Importer v0.7

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -338,7 +338,7 @@ class Compatibility {
 		if ( ! empty( $wp_importer ) ) {
 			$wp_importer_version = $wp_importer['wordpress-importer.php']['Version'];
 
-			if ( isset( $wp_importer_version ) && ! empty( $wp_importer_version ) ) {
+			if ( ! empty( $wp_importer_version ) ) {
 				if ( version_compare( $wp_importer_version, '0.7', '>=' ) ) {
 					return $post_meta;
 				}

--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -333,6 +333,18 @@ class Compatibility {
 	 * @return array Updated post meta.
 	 */
 	public static function on_wp_import_post_meta( $post_meta ) {
+		$wp_importer = get_plugins( '/wordpress-importer' );
+
+		if ( ! empty( $wp_importer ) ) {
+			$wp_importer_version = $wp_importer['wordpress-importer.php']['Version'];
+
+			if ( isset( $wp_importer_version ) && ! empty( $wp_importer_version ) ) {
+				if ( version_compare( $wp_importer_version, '0.7', '>=' ) ) {
+					return $post_meta;
+				}
+			}
+		}
+
 		foreach ( $post_meta as &$meta ) {
 			if ( '_elementor_data' === $meta['key'] ) {
 				$meta['value'] = wp_slash( $meta['value'] );


### PR DESCRIPTION
Added a check for the WP Importer version - if it is at least 0.7, it will not wp_slash the '_elementor_data' contents

Fixes #11466 #10774 

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Elementor posts aren't properly imported when using the WordPress Importer v0.7 and above

## Test instructions
This PR can be tested by following these steps:

* Export a post, then import it without the fix. Make sure it is imported badly.
* Import the same post with the fix. Make sure it is imported correctly.