### PR TITLE
Fix: Unable to upload SVG to media control with unfiltered files enabled

### DIFF
--- a/includes/settings/settings.php
+++ b/includes/settings/settings.php
@@ -623,7 +623,7 @@ class Settings extends Settings_Page {
 									'desc' => __( 'For troubleshooting server configuration conflicts.', 'elementor' ),
 								],
 							],
-							'enable_unfiltered_files_upload' => [
+							'unfiltered_files_upload' => [
 								'label' => __( 'Enable Unfiltered Files Uploads', 'elementor' ),
 								'field_args' => [
 									'type' => 'select',


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix bug with enabling unfiltered files upload from advanced settings

## Description
An explanation of what is done in this PR

* Renamed `enable_unfiltered_files_upload` to `unfiltered_files_upload` to match the option key used in https://github.com/elementor/elementor/blob/master/core/files/assets/files-upload-handler.php

## Test instructions
This PR can be tested by following these steps:

* Enable unfiltered files upload within the advanced tab of the settings page
* Try to upload an SVG file to a media control
* You should no longer get an error "SVG file is not allowed for security reasons"

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
