### PR TITLE
Compatibility: Fix - Elementor content imported when WP Importer is not installed is overridden

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -338,17 +338,13 @@ class Compatibility {
 		if ( ! empty( $wp_importer ) ) {
 			$wp_importer_version = $wp_importer['wordpress-importer.php']['Version'];
 
-			if ( ! empty( $wp_importer_version ) ) {
-				if ( version_compare( $wp_importer_version, '0.7', '>=' ) ) {
-					return $post_meta;
+			if ( version_compare( $wp_importer_version, '0.7', '<' ) ) {
+				foreach ( $post_meta as &$meta ) {
+					if ( '_elementor_data' === $meta['key'] ) {
+						$meta['value'] = wp_slash( $meta['value'] );
+						break;
+					}
 				}
-			}
-		}
-
-		foreach ( $post_meta as &$meta ) {
-			if ( '_elementor_data' === $meta['key'] ) {
-				$meta['value'] = wp_slash( $meta['value'] );
-				break;
 			}
 		}
 


### PR DESCRIPTION
This PR refactors the `on_wp_import_post_meta` method, so when Elementor content is imported while WP Importer is **not** installed, the content is not overridden.

Fixes #11591 

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Compatibility: WP Importer - refactored the method that runs when posts are imported into WordPress, in order to avoid modifying Elementor content when the WP Importer is not installed