### PR TITLE
Temp fix for issue #11728

### DIFF
--- a/includes/true
+++ b/includes/true
@@ -884,6 +884,12 @@ class Frontend extends App {
 			$menu_args['href'] = $this->admin_bar_edit_documents[ $queried_object_id ]->get_edit_url();
 			unset( $this->admin_bar_edit_documents[ $queried_object_id ] );
 		}
+		
+		//Temporary workaround for issue #11728
+		if (false === empty($queried_object_id) && false === isset($menu_args['href']))
+		{
+			$menu_args['href'] = home_url() . '/wp-admin/post.php?post=' . get_queried_object_id() . '&action=elementor';
+		}
 
 		$wp_admin_bar->add_node( $menu_args );
 


### PR DESCRIPTION
Temp fix for issue #11728

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Issue #11728 

## Description
This code checks to see whether the `$menu_args['href']` variable is unset; if so, it generates a value for it based on the home_url and queried object ID.

I'm pretty sure that this isn't the correct way to do this, plus it doesn't solve the underlying bug, but it serves a temporary fix for an annoying issue that's been present for months.


## Test instructions
This PR can be tested by following these steps:

* See the reproduction steps in issue #11728; note that the issue no longer occurs after this fix is applied.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #11728 
