### PR TITLE
Added ability to set render attributes on widget containers.  

### DIFF
--- a/includes/base/widget-base.php
+++ b/includes/base/widget-base.php
@@ -344,8 +344,9 @@ abstract class Widget_Base extends Element_Base {
 	 * @param string $template_content Template content.
 	 */
 	protected function print_template_content( $template_content ) {
+		$this->add_render_attribute('_widget_container', 'class', 'elementor-widget-container');
 		?>
-		<div class="elementor-widget-container">
+			<div <?php $this->print_render_attribute_string( '_widget_container' ); ?>>
 			<?php
 			echo $template_content; // XSS ok.
 			?>
@@ -536,8 +537,9 @@ abstract class Widget_Base extends Element_Base {
 		if ( empty( $widget_content ) ) {
 			return;
 		}
+		$this->add_render_attribute('_widget_container', 'class', 'elementor-widget-container');
 		?>
-		<div class="elementor-widget-container">
+		<div <?php $this->print_render_attribute_string( '_widget_container' ); ?>>
 			<?php
 
 			/**

--- a/includes/base/widget-base.php
+++ b/includes/base/widget-base.php
@@ -344,7 +344,7 @@ abstract class Widget_Base extends Element_Base {
 	 * @param string $template_content Template content.
 	 */
 	protected function print_template_content( $template_content ) {
-		$this->add_render_attribute('_widget_container', 'class', 'elementor-widget-container');
+		$this->add_render_attribute( '_widget_container', 'class', 'elementor-widget-container' );
 		?>
 			<div <?php $this->print_render_attribute_string( '_widget_container' ); ?>>
 			<?php
@@ -537,7 +537,7 @@ abstract class Widget_Base extends Element_Base {
 		if ( empty( $widget_content ) ) {
 			return;
 		}
-		$this->add_render_attribute('_widget_container', 'class', 'elementor-widget-container');
+		$this->add_render_attribute( '_widget_container', 'class', 'elementor-widget-container' );
 		?>
 		<div <?php $this->print_render_attribute_string( '_widget_container' ); ?>>
 			<?php


### PR DESCRIPTION
This will allow developers to do things like add lazy loading to background images set on the widget container.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [X] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Added the ability to set render attributes on widget containers.

## Description
An explanation of what is done in this PR

*. Modified the Widget_Base class to identify the widget container div element as '_widget_container' in the render attributes, and use render attributes for adding the 'elementor-widget-container' class to the container div.

## Test instructions
This PR can be tested by following these steps:

* Add a hook to 'elementor/frontend/widget/before_render', and add a class or any other attribute to the widget containers with "$element->add_render_attribute('_widget_container', ['class' => 'my-test']);".  Inspect the generated html to see that the new class or other attribute is added.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

There do not seem to be unit tests related to this type of functionality that already exists for other containers, so there are no tests to extend.  This is also a very minor change with no backwards compatibility breaks  There is also already documentation on the add_render_attribute method, this just adds it to a container so I do not think docs are justified.

Fixes #
