### PR TITLE
Kit: Fix  - On open global panel, preview elements lose their style.

### DIFF
--- a/assets/dev/js/editor/elements/views/widget.js
+++ b/assets/dev/js/editor/elements/views/widget.js
@@ -200,6 +200,12 @@ WidgetView = BaseElementView.extend( {
 		}
 
 		this.$el.removeClass( 'elementor-loading' );
+
+		// If container document has been changed during the remote request, don't render.
+		if ( this.container.document.id !== elementor.documents.getCurrent().id ) {
+			return;
+		}
+
 		this.render();
 	},
 


### PR DESCRIPTION
Avoid render elements that not belongs to current document.