### PR TITLE
Tweak: Add control for apply link on full width or inline

### DIFF
--- a/assets/dev/scss/frontend/widgets/icon-list.scss
+++ b/assets/dev/scss/frontend/widgets/icon-list.scss
@@ -59,10 +59,6 @@
 			display: flex;
 			align-items: flex-start;
 		}
-
-		a {
-			width: 100%;
-		}
 	}
 
 	.elementor-icon-list-icon + .elementor-icon-list-text {
@@ -79,6 +75,13 @@
 
 		svg {
 			width: 1em;
+		}
+	}
+
+	&.elementor-list-item-link-full_width {
+
+		a {
+			width: 100%;
 		}
 	}
 

--- a/includes/widgets/icon-list.php
+++ b/includes/widgets/icon-list.php
@@ -186,6 +186,21 @@ class Widget_Icon_List extends Widget_Base {
 			]
 		);
 
+		$this->add_control(
+			'link_click',
+			[
+				'label' => __( 'Apply Link On', 'elementor' ),
+				'type' => Controls_Manager::SELECT,
+				'options' => [
+					'full_width' => __( 'Full Width', 'elementor' ),
+					'inline' => __( 'Inline', 'elementor' ),
+				],
+				'default' => 'full_width',
+				'separator' => 'before',
+				'prefix_class' => 'elementor-list-item-link-',
+			]
+		);
+
 		$this->end_controls_section();
 
 		$this->start_controls_section(


### PR DESCRIPTION
Ref: https://github.com/elementor/elementor/issues/11945

Link full width (default) - useful for menus and compatibility with legacy versions:
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/1778512/88380448-4a6e4b80-cdad-11ea-9509-8919b2cf46ca.png">


Link inline:
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/1778512/88380345-11ce7200-cdad-11ea-953e-26bb9fa60d4d.png">

