### PR TITLE
Theme Builder: Fix - Template display level select caret disappears in dark mode

### DIFF
--- a/assets/dev/scss/direction/editor-dark-mode.scss
+++ b/assets/dev/scss/direction/editor-dark-mode.scss
@@ -1161,6 +1161,13 @@ label.elementor-template-library-order-label,
 			}
 		}
 
+		.elementor-control-type-select {
+
+			.elementor-control-input-wrapper:after {
+				color: inherit;
+			}
+		}
+
 		.elementor-theme-builder-conditions-repeater-row-controls {
 
 			.elementor-control:not(:first-child) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Theme Builder: Fix - Template Display Conditions - display level Select input - caret down icon disappears in dark mode.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)