### PR TITLE
Add visual bootstrap grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Requires at least:** 5.0  
 **Tested up to:** 5.4  
 **Requires PHP:** 5.6  
-**Stable tag:** 2.9.12  
+**Stable tag:** 2.9.13  
 **License:** GPLv3  
 **License URI:** https://www.gnu.org/licenses/gpl-3.0.html  
 
@@ -223,10 +223,10 @@ No. Elementor supports WordPress 5.0 or greater, and is compatible with PHP 5.6 
 
 ## Changelog ##
 
-### 2.9.12 - 2020-06-14
+### 2.9.13 - 2020-06-23 ###
 * Fix: Duplicated Hidden type form fields inherited required attribute in Form widget ([#11578](https://github.com/elementor/elementor/issues/11578))
 * Fix: Select2 control width glitch
-###
+
 ### 2.9.12 - 2020-06-14 ###
 * Fix: Dynamic default value not working in Form widget ([#11578](https://github.com/elementor/elementor/issues/11578), [#11609](https://github.com/elementor/elementor/issues/11609))
 * Fix: Dark mode glitches in Form Step items ([#11579](https://github.com/elementor/elementor/issues/11579))

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Requires at least:** 5.0  
 **Tested up to:** 5.5  
 **Requires PHP:** 5.6  
-**Stable tag:** 2.9.13  
+**Stable tag:** 2.9.14  
 **License:** GPLv3  
 **License URI:** https://www.gnu.org/licenses/gpl-3.0.html  
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Contributors:** [elemntor](https://profiles.wordpress.org/elemntor), [KingYes](https://profiles.wordpress.org/KingYes), [ariel.k](https://profiles.wordpress.org/ariel.k), [jzaltzberg](https://profiles.wordpress.org/jzaltzberg), [mati1000](https://profiles.wordpress.org/mati1000), [pojosh](https://profiles.wordpress.org/pojosh), [bainternet](https://profiles.wordpress.org/bainternet)  
 **Tags:** page builder, editor, landing page, drag-and-drop, elementor, visual editor, wysiwyg, design, maintenance mode, coming soon, under construction, website builder, landing page builder, front-end builder  
 **Requires at least:** 5.0  
-**Tested up to:** 5.4  
+**Tested up to:** 5.5  
 **Requires PHP:** 5.6  
 **Stable tag:** 2.9.13  
 **License:** GPLv3  
@@ -222,6 +222,11 @@ No. Elementor supports WordPress 5.0 or greater, and is compatible with PHP 5.6 
 7. **Shape Divider.** Choose from a wide array of shape dividers and separate your sections in endless ways, that until now were simply not possible.
 
 ## Changelog ##
+
+### 2.9.14 - 2020-07-21 ###
+* Tweak: Added compatibility with WordPress v5.5 ([#11820](https://github.com/elementor/elementor/issues/11820), [#11830](https://github.com/elementor/elementor/issues/11830))
+* Fix: Elementor posts aren't properly imported with WordPress Importer v0.7 ([#11466](https://github.com/elementor/elementor/issues/11466), [#10744](https://github.com/elementor/elementor/issues/10744))
+* Fix: Added sanitization to post titles in WordPress dashboard for better security
 
 ### 2.9.13 - 2020-06-23 ###
 * Fix: Duplicated Hidden type form fields inherited required attribute in Form widget ([#11578](https://github.com/elementor/elementor/issues/11578))

--- a/assets/dev/js/admin/gutenberg.js
+++ b/assets/dev/js/admin/gutenberg.js
@@ -5,20 +5,18 @@
 	var ElementorGutenbergApp = {
 
 		cacheElements: function() {
-			this.isElementorMode = ElementorGutenbergSettings.isElementorMode;
-
-			this.cache = {};
-
-			this.cache.$gutenberg = $( '#editor' );
-			this.cache.$switchMode = $( $( '#elementor-gutenberg-button-switch-mode' ).html() );
-
-			this.cache.$gutenberg.find( '.edit-post-header-toolbar' ).append( this.cache.$switchMode );
-			this.cache.$switchModeButton = this.cache.$switchMode.find( '#elementor-switch-mode-button' );
-
-			this.toggleStatus();
-			this.buildPanel();
-
 			var self = this;
+
+			self.isElementorMode = ElementorGutenbergSettings.isElementorMode;
+
+			self.cache = {};
+
+			self.cache.$gutenberg = $( '#editor' );
+			self.cache.$switchMode = $( $( '#elementor-gutenberg-button-switch-mode' ).html() );
+			self.cache.$switchModeButton = self.cache.$switchMode.find( '#elementor-switch-mode-button' );
+
+			self.bindEvents();
+			self.toggleStatus();
 
 			wp.data.subscribe( function() {
 				setTimeout( function() {
@@ -29,6 +27,10 @@
 
 		buildPanel: function() {
 			var self = this;
+
+			if ( ! self.cache.$gutenberg.find( '#elementor-switch-mode' ).length ) {
+				self.cache.$gutenberg.find( '.edit-post-header-toolbar' ).append( self.cache.$switchMode );
+			}
 
 			if ( ! $( '#elementor-editor' ).length ) {
 				self.cache.$editorPanel = $( $( '#elementor-gutenberg-panel' ).html() );
@@ -107,11 +109,7 @@
 		},
 
 		init: function() {
-			var self = this;
-			setTimeout( function() {
-				self.cacheElements();
-				self.bindEvents();
-			}, 1 );
+			this.cacheElements();
 		},
 	};
 

--- a/core/common/modules/connect/apps/base-app.php
+++ b/core/common/modules/connect/apps/base-app.php
@@ -71,7 +71,18 @@ abstract class Base_App {
 		} else {
 			echo 'Not Connected';
 		}
+
+		echo '<hr>';
+
+		$this->print_app_info();
+
+		if ( current_user_can( 'manage_options' ) ) {
+			printf( '<div><a href="%s">%s</a></div>', $this->get_admin_url( 'reset' ), __( 'Reset Data', 'elementor' ) );
+		}
+
+		echo '<hr>';
 	}
+
 
 	/**
 	 * @since 2.3.0
@@ -126,6 +137,17 @@ abstract class Base_App {
 		$this->set_request_state();
 
 		$this->redirect_to_remote_authorize_url();
+	}
+
+	public function action_reset() {
+		delete_user_option( get_current_user_id(), 'elementor_connect_common_data' );
+
+		if ( current_user_can( 'manage_options' ) ) {
+			delete_option( 'elementor_connect_site_key' );
+			delete_option( 'elementor_remote_info_library' );
+		}
+
+		$this->redirect_to_admin_page();
 	}
 
 	/**
@@ -548,6 +570,27 @@ abstract class Base_App {
 
 				echo '</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">' . __( 'Dismiss', 'elementor' ) . '</span></button></div>';
 		}
+	}
+
+	protected function get_app_info() {
+		return [];
+	}
+
+	protected function print_app_info() {
+		$app_info = $this->get_app_info();
+
+		foreach ( $app_info as $key => $item ) {
+			if ( $item['value'] ) {
+				$status = 'Exist';
+				$color = 'green';
+			} else {
+				$status = 'Empty';
+				$color = 'red';
+			}
+
+			printf( '%s: <strong style="color:%s">%s</strong><br>', $item['label'], $color, $status );
+		}
+
 	}
 
 	/**

--- a/core/common/modules/connect/apps/library.php
+++ b/core/common/modules/connect/apps/library.php
@@ -79,6 +79,23 @@ class Library extends Common_App {
 		$ajax_manager->register_ajax_action( 'library_connect_popup_seen', [ $this, 'library_connect_popup_seen' ] );
 	}
 
+	protected function get_app_info() {
+		return [
+			'user_common_data' => [
+				'label' => 'User Common Data',
+				'value' => get_user_option( $this->get_option_name(), get_current_user_id() ),
+			],
+			'connect_site_key' => [
+				'label' => 'Site Key',
+				'value' => get_option( 'elementor_connect_site_key' ),
+			],
+			'remote_info_library' => [
+				'label' => 'Remote Library Info',
+				'value' => get_option( 'elementor_remote_info_library' ),
+			],
+		];
+	}
+
 	protected function init() {
 		add_filter( 'elementor/editor/localize_settings', [ $this, 'localize_settings' ] );
 		add_action( 'elementor/ajax/register_actions', [ $this, 'register_ajax_actions' ] );

--- a/elementor.php
+++ b/elementor.php
@@ -4,7 +4,7 @@
  * Description: The most advanced frontend drag & drop page builder. Create high-end, pixel perfect websites at record speeds. Any theme, any page, any design.
  * Plugin URI: https://elementor.com/?utm_source=wp-plugins&utm_campaign=plugin-uri&utm_medium=wp-dash
  * Author: Elementor.com
- * Version: 2.9.13
+ * Version: 2.9.14
  * Author URI: https://elementor.com/?utm_source=wp-plugins&utm_campaign=author-uri&utm_medium=wp-dash
  *
  * Text Domain: elementor
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'ELEMENTOR_VERSION', '2.9.13' );
+define( 'ELEMENTOR_VERSION', '2.9.14' );
 define( 'ELEMENTOR_PREVIOUS_STABLE_VERSION', '2.8.5' );
 
 define( 'ELEMENTOR__FILE__', __FILE__ );

--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -338,17 +338,13 @@ class Compatibility {
 		if ( ! empty( $wp_importer ) ) {
 			$wp_importer_version = $wp_importer['wordpress-importer.php']['Version'];
 
-			if ( ! empty( $wp_importer_version ) ) {
-				if ( version_compare( $wp_importer_version, '0.7', '>=' ) ) {
-					return $post_meta;
+			if ( version_compare( $wp_importer_version, '0.7', '<' ) ) {
+				foreach ( $post_meta as &$meta ) {
+					if ( '_elementor_data' === $meta['key'] ) {
+						$meta['value'] = wp_slash( $meta['value'] );
+						break;
+					}
 				}
-			}
-		}
-
-		foreach ( $post_meta as &$meta ) {
-			if ( '_elementor_data' === $meta['key'] ) {
-				$meta['value'] = wp_slash( $meta['value'] );
-				break;
 			}
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elementor",
 	"slug": "elementor",
-	"version": "2.9.13",
+	"version": "2.9.14",
 	"prev_stable_version": "2.8.5",
 	"author": "Elementor Team",
 	"homepage": "https://elementor.com/",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: page builder, editor, landing page, drag-and-drop, elementor, visual edito
 Requires at least: 5.0
 Tested up to: 5.4
 Requires PHP: 5.6
-Stable tag: 2.9.12
+Stable tag: 2.9.13
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -221,7 +221,7 @@ No. Elementor supports WordPress 5.0 or greater, and is compatible with PHP 5.6 
 
 == Changelog ==
 
-= 2.9.12 - 2020-06-14
+= 2.9.13 - 2020-06-23 =
 * Fix: Duplicated Hidden type form fields inherited required attribute in Form widget ([#11578](https://github.com/elementor/elementor/issues/11578))
 * Fix: Select2 control width glitch
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: elemntor, KingYes, ariel.k, jzaltzberg, mati1000, pojosh, bainternet
 Tags: page builder, editor, landing page, drag-and-drop, elementor, visual editor, wysiwyg, design, maintenance mode, coming soon, under construction, website builder, landing page builder, front-end builder
 Requires at least: 5.0
-Tested up to: 5.4
+Tested up to: 5.5
 Requires PHP: 5.6
 Stable tag: 2.9.13
 License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: page builder, editor, landing page, drag-and-drop, elementor, visual edito
 Requires at least: 5.0
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 2.9.13
+Stable tag: 2.9.14
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -222,7 +222,7 @@ No. Elementor supports WordPress 5.0 or greater, and is compatible with PHP 5.6 
 == Changelog ==
 
 = 2.9.14 - 2020-07-21 =
-* Tweak: Added compatibility with WordPress v5.4 ([#11820](https://github.com/elementor/elementor/issues/11820), [#11830](https://github.com/elementor/elementor/issues/11830))
+* Tweak: Added compatibility with WordPress v5.5 ([#11820](https://github.com/elementor/elementor/issues/11820), [#11830](https://github.com/elementor/elementor/issues/11830))
 * Fix: Elementor posts aren't properly imported with WordPress Importer v0.7 ([#11466](https://github.com/elementor/elementor/issues/11466), [#10744](https://github.com/elementor/elementor/issues/10744))
 * Fix: Added sanitization to post titles in WordPress dashboard for better security
 

--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,11 @@ No. Elementor supports WordPress 5.0 or greater, and is compatible with PHP 5.6 
 
 == Changelog ==
 
+= 2.9.14 - 2020-07-21 =
+* Tweak: Added compatibility with WordPress v5.4 ([#11820](https://github.com/elementor/elementor/issues/11820), [#11830](https://github.com/elementor/elementor/issues/11830))
+* Fix: Elementor posts aren't properly imported with WordPress Importer v0.7 ([#11466](https://github.com/elementor/elementor/issues/11466), [#10744](https://github.com/elementor/elementor/issues/10744))
+* Fix: Added sanitization to post titles in WordPress dashboard for better security
+
 = 2.9.13 - 2020-06-23 =
 * Fix: Duplicated Hidden type form fields inherited required attribute in Form widget ([#11578](https://github.com/elementor/elementor/issues/11578))
 * Fix: Select2 control width glitch


### PR DESCRIPTION
Hello please add visual bootstrap and baseline grid for better transfer project from photoshop or any program in to a elementor.

Best reference is 
BOOTSTRAP: Designer powerup for elementor
BASELINE GRID: Ooohboi steroid for elementor (and have more feature dor elementor) 

for simple site it is enough that there is, however, to create complex sites you need a grid, I was personally convinced by making my site how very good grids help in the speed of work and accurate transfer of the project. I and many who have already bought a full license would like to get more ease of use from what they already have, and not buy more plugins just for the sake of one function. The grid is important, it will take you to another level of design, I can give you an example of how and why you need a grid.