### PR TITLE
Fixing URI parsing

### DIFF
--- a/assets/lib/share-link/share-link.js
+++ b/assets/lib/share-link/share-link.js
@@ -46,12 +46,18 @@
 				}
 			} );
 		};
+		
+		var decodeHTMLEntities = function(text) {
+		    var textArea = document.createElement('textarea');
+		    textArea.innerHTML = text;
+		    return textArea.value;
+		}
 
 		var initSettings = function() {
 			$.extend( settings, ShareLink.defaultSettings, userSettings );
 
 			[ 'title', 'text' ].forEach( function( propertyName ) {
-				settings[ propertyName ] = settings[ propertyName ].replace( '#', '' );
+				settings[ propertyName ] = encodeURI(decodeHTMLEntities(settings[ propertyName ]).replace( '#', '' ));
 			} );
 
 			settings.classPrefixLength = settings.classPrefix.length;


### PR DESCRIPTION
#11729  PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:
* Fixing URI parsing on custom posts

## Description

* Fixes a bug caused by malformed URI strings.
* Some info from Wordpress come with html entities, like "Gabriel Sancho &#8211; Post", when the "&" breaks the URI.

## Test instructions
This PR can be tested by following these steps:
* Create a Link share in custom post page 
* Create a link to Whatsapp
* Set the target url as Current Page
* The message sent to Whatsapp API will be malformed

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
*  Before it removes the "#", remove the html entity and then encode the string with encodeURI function.