### PR TITLE
Required wp_slash() if WordPress importer is NOT exist.

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -357,12 +357,14 @@ class Compatibility {
 	public static function is_wp_importer_before_0_7() {
 		$wp_importer = get_plugins( '/wordpress-importer' );
 
-		if ( ! empty( $wp_importer ) ) {
-			$wp_importer_version = $wp_importer['wordpress-importer.php']['Version'];
+		if( empty( $wp_importer ) ) {
+			return true;
+		}
 
-			if ( version_compare( $wp_importer_version, '0.7', '<' ) ) {
-				return true;
-			}
+		$wp_importer_version = $wp_importer['wordpress-importer.php']['Version'];
+
+		if ( version_compare( $wp_importer_version, '0.7', '<' ) ) {
+			return true;
 		}
 
 		return false;


### PR DESCRIPTION
#12186  PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

Slashes are required if WordPress importer is NOT exist.

*

## Description

Regarding the issue https://github.com/elementor/elementor/issues/11466 the fix is valid.

But, There is one condition missing which is below:

```
if( empty( $wp_importer ) ) {
	return true;
}
```

If there is WordPress importer exist then we can skip the **wp_slash()**.

But, If it is NOT exist then we need **wp_slash()** for the `_elementor_data`.

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [] I have tested this code to the best of my abilities
- [] I have added unittests to verify the code works as intended
- [] Docs have been added / updated (for bug fixes / features)

Fixes #11466 
