### PR TITLE
frontend.js fix:  Uncaught ReferenceError: elementorCommon is not defined

### DIFF
--- a/assets/dev/js/frontend/frontend.js
+++ b/assets/dev/js/frontend/frontend.js
@@ -22,7 +22,7 @@ class Frontend extends elementorModules.ViewModule {
 	// TODO: BC since 2.5.0
 	get Module() {
 		if ( this.isEditMode() ) {
-			parent.elementorCommon.helpers.hardDeprecated( 'elementorFrontend.Module', '2.5.0', 'elementorModules.frontend.handlers.Base' );
+			window.elementorCommon.helpers.hardDeprecated( 'elementorFrontend.Module', '2.5.0', 'elementorModules.frontend.handlers.Base' );
 		}
 
 		return elementorModules.frontend.handlers.Base;
@@ -75,7 +75,9 @@ class Frontend extends elementorModules.ViewModule {
 	}
 
 	getGeneralSettings( settingName ) {
-		elementorCommon.helpers.softDeprecated( 'getGeneralSettings', '3.0.0', 'getKitSettings and remove the `elementor_` prefix' );
+		if ( this.isEditMode() ) {
+			window.elementorCommon.helpers.softDeprecated( 'getGeneralSettings', '3.0.0', 'getKitSettings and remove the `elementor_` prefix' );
+		}
 		return this.getKitSettings( `elementor_${ settingName }` );
 	}
 

--- a/assets/dev/js/frontend/frontend.js
+++ b/assets/dev/js/frontend/frontend.js
@@ -22,7 +22,7 @@ class Frontend extends elementorModules.ViewModule {
 	// TODO: BC since 2.5.0
 	get Module() {
 		if ( this.isEditMode() ) {
-			window.elementorCommon.helpers.hardDeprecated( 'elementorFrontend.Module', '2.5.0', 'elementorModules.frontend.handlers.Base' );
+			if(window.elementorCommon)window.elementorCommon.helpers.hardDeprecated( 'elementorFrontend.Module', '2.5.0', 'elementorModules.frontend.handlers.Base' );
 		}
 
 		return elementorModules.frontend.handlers.Base;
@@ -76,7 +76,7 @@ class Frontend extends elementorModules.ViewModule {
 
 	getGeneralSettings( settingName ) {
 		if ( this.isEditMode() ) {
-			window.elementorCommon.helpers.softDeprecated( 'getGeneralSettings', '3.0.0', 'getKitSettings and remove the `elementor_` prefix' );
+			if(window.elementorCommon)window.elementorCommon.helpers.softDeprecated( 'getGeneralSettings', '3.0.0', 'getKitSettings and remove the `elementor_` prefix' );
 		}
 		return this.getKitSettings( `elementor_${ settingName }` );
 	}

--- a/assets/dev/js/frontend/frontend.js
+++ b/assets/dev/js/frontend/frontend.js
@@ -21,10 +21,10 @@ class Frontend extends elementorModules.ViewModule {
 
 	// TODO: BC since 2.5.0
 	get Module() {
-		if ( this.isEditMode() ) {
-			if(window.elementorCommon) {
-				window.elementorCommon.helpers.hardDeprecated( 'elementorFrontend.Module', '2.5.0', 'elementorModules.frontend.handlers.Base' );
-			}
+
+		var elementorCommon=window.parent.elementorCommon||window.elementorCommon;
+		if(elementorCommon) {
+			elementorCommon.helpers.hardDeprecated( 'elementorFrontend.Module', '2.5.0', 'elementorModules.frontend.handlers.Base' );
 		}
 
 		return elementorModules.frontend.handlers.Base;
@@ -77,10 +77,9 @@ class Frontend extends elementorModules.ViewModule {
 	}
 
 	getGeneralSettings( settingName ) {
-		if ( this.isEditMode() ) {
-			if( window.elementorCommon ) {
-				window.elementorCommon.helpers.softDeprecated( 'getGeneralSettings', '3.0.0', 'getKitSettings and remove the `elementor_` prefix' );
-			}
+		var elementorCommon=window.parent.elementorCommon||window.elementorCommon;
+		if(elementorCommon) {
+			elementorCommon.elementorCommon.helpers.softDeprecated( 'getGeneralSettings', '3.0.0', 'getKitSettings and remove the `elementor_` prefix' );
 		}
 		return this.getKitSettings( `elementor_${ settingName }` );
 	}

--- a/assets/dev/js/frontend/frontend.js
+++ b/assets/dev/js/frontend/frontend.js
@@ -22,7 +22,9 @@ class Frontend extends elementorModules.ViewModule {
 	// TODO: BC since 2.5.0
 	get Module() {
 		if ( this.isEditMode() ) {
-			if(window.elementorCommon)window.elementorCommon.helpers.hardDeprecated( 'elementorFrontend.Module', '2.5.0', 'elementorModules.frontend.handlers.Base' );
+			if(window.elementorCommon) {
+				window.elementorCommon.helpers.hardDeprecated( 'elementorFrontend.Module', '2.5.0', 'elementorModules.frontend.handlers.Base' );
+			}
 		}
 
 		return elementorModules.frontend.handlers.Base;
@@ -76,7 +78,9 @@ class Frontend extends elementorModules.ViewModule {
 
 	getGeneralSettings( settingName ) {
 		if ( this.isEditMode() ) {
-			if(window.elementorCommon)window.elementorCommon.helpers.softDeprecated( 'getGeneralSettings', '3.0.0', 'getKitSettings and remove the `elementor_` prefix' );
+			if( window.elementorCommon ) {
+				window.elementorCommon.helpers.softDeprecated( 'getGeneralSettings', '3.0.0', 'getKitSettings and remove the `elementor_` prefix' );
+			}
 		}
 		return this.getKitSettings( `elementor_${ settingName }` );
 	}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

frontend.js fix:  Uncaught ReferenceError: elementorCommon is not defined

*

## Description

4 months ago in frontend.js there as added a depreciation message using functions that were only available when the user was signed in and had permission 'manage_options' as admin. 

this was causing a tricky frustrating error:  while logged in the website was viewed ok but while not logged in the website was viewed incorrectly. on some themes it was working, on pojo.me themes with additional pojo plugins, it was not working.
the video in the content was working during design, but not while viewed by the end-user.

after many hours of debugging php, I found that the js variable elementorCommon in only available while logged-in and has permission 'manage_options'.

a frustrating bug, but I fixed it.  :)

*

## Test instructions
This PR can be tested by following these steps:

install fully a free pojo theme :

    # install there should be elementor plugin
    # install all suggested plugins by the theme
    # install demo content

open an incognito window and browse to the website
open the javascript inspector and see the error message.

frontend.js?ver=3.0.3:6157 Uncaught ReferenceError: elementorCommon is not defined
    at Frontend.getGeneralSettings (frontend.js?ver=3.0.3:6157)
    at Object.cacheElements (app.min.js?ver=5.5:2)
    at Object.init (app.min.js?ver=5.5:2)
    at HTMLDocument.<anonymous> (app.min.js?ver=5.5:2)
    at i (jquery.js?ver=1.12.4-wp:2)
    at Object.fireWith [as resolveWith] (jquery.js?ver=1.12.4-wp:2)
    at Function.ready (jquery.js?ver=1.12.4-wp:2)
    at HTMLDocument.J (jquery.js?ver=1.12.4-wp:2)

*

## Quality assurance

- [x ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

I have checked my changes, by manually applying them to my installed version, and it was working.

Fixes #
Fixes #