### PR TITLE
Kit: Fix - Theme style global typography is missing on frontend. (Fix #12363, PT#994)

### DIFF
--- a/core/settings/base/css-manager.php
+++ b/core/settings/base/css-manager.php
@@ -110,7 +110,7 @@ abstract class CSS_Manager extends Manager {
 
 		$css_file->add_controls_stack_style_rules(
 			$model,
-			$css_file->get_style_controls( $model ),
+			$css_file->get_style_controls( $model, null, $model->get_settings() ),
 			$model->get_settings(),
 			[ '{{WRAPPER}}' ],
 			[ $model->get_css_wrapper_selector() ]


### PR DESCRIPTION
Without the `get_settings` - it uses `get_controls_settings` that filters out the `__globals__` from settings list.