### PR TITLE
Tabs Widget: Fix -  Tab Widget with 2 tabs, Element with entrance animation disappeared (PT 631)

### DIFF
--- a/assets/dev/js/frontend/handlers/base-tabs.js
+++ b/assets/dev/js/frontend/handlers/base-tabs.js
@@ -70,9 +70,7 @@ export default class baseTabs extends elementorModules.frontend.handlers.Base {
 
 		$requestedTitle.add( $requestedContent ).addClass( activeClass );
 
-		$requestedContent[ settings.showTabFn ]();
-
-		jQuery( window ).resize();
+		$requestedContent[ settings.showTabFn ]( () => elementorFrontend.elements.$window.trigger( 'resize' ) );
 	}
 
 	isActiveTab( tabIndex ) {

--- a/assets/dev/js/frontend/handlers/base-tabs.js
+++ b/assets/dev/js/frontend/handlers/base-tabs.js
@@ -71,6 +71,8 @@ export default class baseTabs extends elementorModules.frontend.handlers.Base {
 		$requestedTitle.add( $requestedContent ).addClass( activeClass );
 
 		$requestedContent[ settings.showTabFn ]();
+
+		jQuery( window ).resize();
 	}
 
 	isActiveTab( tabIndex ) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Tabs widget: Fix - Very long tabs together with very short tabs interfere with the entrance animation of elements located after the tabs widget.

## Description
An explanation of what is done in this PR

* Motion Effects - In cases where there is a significant difference in the height of the content between different tabs, triggering a resize when changing tabs is necessary in order for motion effects to recalculate their trigger position in the page. Triggering a resize when showing a tab causes the motion effects module to recalculate its position, making sure it is triggered in the right place and time.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)