### PR TITLE
Kit: Fix - PHP error undefined method `add_repeater_row`. (Fix #12305) )

### DIFF
--- a/core/kits/manager.php
+++ b/core/kits/manager.php
@@ -21,16 +21,14 @@ class Manager {
 
 	public function get_active_id() {
 		$id = get_option( self::OPTION_ACTIVE );
-		$kit_post = null;
 
-		if ( $id ) {
-			$kit_post = get_post( $id );
-		}
+		$kit_document = Plugin::$instance->documents->get( $id );
 
-		if ( ! $id || ! $kit_post || 'trash' === $kit_post->post_status ) {
+		if ( ! $kit_document || ! $kit_document instanceof Kit || 'trash' === $kit_document->get_main_post()->post_status ) {
 			$id = $this->create_default();
 			update_option( self::OPTION_ACTIVE, $id );
 		}
+
 		return $id;
 	}
 

--- a/tests/phpunit/elementor/core/kits/test-manager.php
+++ b/tests/phpunit/elementor/core/kits/test-manager.php
@@ -1,0 +1,41 @@
+<?php
+namespace Elementor\Tests\Phpunit\Elementor\Core\Kits;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Plugin;
+use Elementor\Testing\Elementor_Test_Base;
+
+class Test_Upgrades extends Elementor_Test_Base {
+
+	public function test_get_active_id() {
+		// Test deleted kit.
+		$test_description = 'active id should return a new kit id after delete kit';
+		$active_id = Plugin::$instance->kits_manager->get_active_id();
+		wp_delete_post( $active_id, true );
+		$active_id_after_delete = Plugin::$instance->kits_manager->get_active_id();
+		$this->assertNotEquals( $active_id, $active_id_after_delete, $test_description );
+
+		// Test trashed kit.
+		$test_description = 'active id should return a new kit id after trash kit';
+		$active_id = Plugin::$instance->kits_manager->get_active_id();
+		wp_trash_post( $active_id );
+		$active_id_after_trash = Plugin::$instance->kits_manager->get_active_id();
+		$this->assertNotEquals( $active_id, $active_id_after_trash, $test_description );
+
+		// Test unpublished kit.
+		$test_description = 'active id should return a new kit id after trash kit';
+		$active_id = Plugin::$instance->kits_manager->get_active_id();
+		wp_trash_post( $active_id );
+		$active_id_after_trash = Plugin::$instance->kits_manager->get_active_id();
+		$this->assertNotEquals( $active_id, $active_id_after_trash, $test_description );
+
+		// Test invalid kit.
+		$test_description = 'active id should return a new kit id after for invalid kit';
+		$active_id = Plugin::$instance->kits_manager->get_active_id();
+		update_post_meta( $active_id, Kit::TYPE_META_KEY, 'invalid-type' );
+		// Invalidate cache.
+		Plugin::$instance->documents->get( $active_id, false );
+		$active_id_after_invalidate = Plugin::$instance->kits_manager->get_active_id();
+		$this->assertNotEquals( $active_id, $active_id_after_invalidate, $test_description );
+	}
+}


### PR DESCRIPTION
In some cases the a kit loses his "template type" and the instance of `get_active_kit`returns a document that doesn't have the `add_repeater_row` method.