### PR TITLE
Shape Divider: Fix - the shape divider is shown in front of the content

### DIFF
--- a/assets/dev/scss/frontend/_shapes.scss
+++ b/assets/dev/scss/frontend/_shapes.scss
@@ -9,6 +9,7 @@
 	width: 100%;
 	line-height: 0;
 	direction: ltr; // Fix for RTL pages
+	z-index: -1; // Fix for Chrome 85 bug that brings shape to front when flipped and inverted
 
 	&-top {
 		top: -1px;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Shape Divider: Fix - since Chrome 85, in some cases the shape divider is shown in front of the content

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)