### PR TITLE
Upgrades: Fix - `space_between_widgets` is missing. (Fix #12298)

### DIFF
--- a/core/upgrade/upgrades.php
+++ b/core/upgrade/upgrades.php
@@ -688,7 +688,7 @@ class Upgrades {
 			];
 
 			foreach ( $settings_to_slider as $setting ) {
-				if ( ! empty( $current_settings[ $setting ] ) ) {
+				if ( isset( $current_settings[ $setting ] ) ) {
 					$current_settings[ $setting ] = [
 						'unit' => 'px',
 						'size' => $current_settings[ $setting ],
@@ -859,47 +859,6 @@ class Upgrades {
 		};
 
 		return self::move_settings_to_kit( $callback, $updater, $include_revisions );
-	}
-
-	/**
-	 * Re move `space_between_widgets` settings to kit.
-	 *
-	 * Due to a bug in previous upgrade, the setting `space_between_widgets` with a value `0` didn't upgraded properly.
-	 * Try to re move it, if it's not already set manually in the kit.
-	 *
-	 * @param $updater
-	 *
-	 * @return false|mixed
-	 */
-	public static function _v_3_0_5_re_move_space_between_widgets_to_kit( $updater ) {
-		$callback = function( $kit_id ) {
-			$kit = Plugin::$instance->documents->get( $kit_id );
-
-			if ( ! $kit ) {
-				self::notice( 'Kit not found. nothing to do.' );
-				return;
-			}
-
-			$meta_key = \Elementor\Core\Settings\Page\Manager::META_KEY;
-			$old_settings = get_option( '_elementor_general_settings', [] );
-			$kit_settings = $kit->get_meta( $meta_key );
-
-			if ( ! $kit_settings ) {
-				$kit_settings = [];
-			}
-
-			if ( isset( $old_settings['space_between_widgets'] ) && ! isset( $kit_settings['space_between_widgets'] ) ) {
-				$kit_settings['space_between_widgets'] = [
-					'unit' => 'px',
-					'size' => $old_settings['space_between_widgets'],
-				];
-
-				$page_settings_manager = SettingsManager::get_settings_managers( 'page' );
-				$page_settings_manager->save_settings( $kit_settings, $kit_id );
-			}
-		};
-
-		return self::move_settings_to_kit( $callback, $updater );
 	}
 
 	/**

--- a/tests/phpunit/elementor/core/upgrades/test-upgrades.php
+++ b/tests/phpunit/elementor/core/upgrades/test-upgrades.php
@@ -114,7 +114,7 @@ class Test_Upgrades extends Elementor_Test_Base {
 		$generic_font = 'some-generic-font';
 		$lightbox_color = '#e1e3ef';
 		$container_width = '1000';
-		$space_between_widgets = '25';
+		$space_between_widgets = '0'; // Ensure that value 0 is also upgraded (#12298).
 		$viewport_lg = '900';
 		$viewport_md = '800';
 
@@ -428,83 +428,6 @@ class Test_Upgrades extends Elementor_Test_Base {
 			$this->assertEquals( $saved_typography[4]['value']['font_family'], $revision_saved_typography[3]['typography_font_family'] );
 		}
 	}
-
-	public function test_v_3_0_5_re_move_space_between_widgets_to_kit() {
-		$updater = $this->create_updater();
-
-		// Prepare.
-		$space_between_widgets = '0';
-
-		$general_settings = [
-			'space_between_widgets' => $space_between_widgets,
-		];
-
-		update_option( '_elementor_general_settings', $general_settings );
-
-		$user_id = $this->factory()->create_and_get_administrator_user()->ID;
-		wp_set_current_user( $user_id );
-
-		$kit_id = Plugin::$instance->kits_manager->get_active_id();
-		$kit = Plugin::$instance->documents->get( $kit_id );
-
-		// Create revisions.
-		$revisions_count = 10;
-		$query_limit = 3;
-		$expected_iterations = (int) ceil( $revisions_count / $query_limit );
-		$upgrade_iterations = 1;
-
-		for ( $i = 0; $i < $revisions_count; $i++ ) {
-			$kit->save( [
-				'elements' => [],
-			] );
-		}
-
-		// Ensure the testable values are not default values of the kit.
-		$kit_space_between_widgets_before = $kit->get_settings( 'space_between_widgets' );
-
-		$this->assertNotEquals( $space_between_widgets, $kit_space_between_widgets_before );
-
-		$updater->set_limit( $query_limit );
-
-		// Run upgrade.
-		while ( Upgrades::_v_3_0_5_re_move_space_between_widgets_to_kit( $updater ) ) {
-			$upgrade_iterations++;
-
-			$updater->set_current_item( [
-				'iterate_num' => $upgrade_iterations,
-			] );
-
-			// Avoid infinity loop.
-			if ( $upgrade_iterations > $revisions_count ) {
-				break;
-			}
-		}
-
-		// Assert iterations.
-		$this->assertEquals( $expected_iterations, $upgrade_iterations );
-
-		// Refresh kit.
-		$kit = Plugin::$instance->documents->get( $kit_id, false );
-
-		// Assert kit upgraded.
-		$kit_space_between_widgets_after = $kit->get_settings( 'space_between_widgets' );
-
-		$this->assertEquals( $space_between_widgets, $kit_space_between_widgets_after['size'] );
-
-		// Assert revisions upgraded.
-		$revisions_ids = wp_get_post_revisions( $kit_id, [
-			'fields' => 'ids',
-		] );
-
-		foreach ( $revisions_ids as $revision_id ) {
-			$revision = Plugin::$instance->documents->get( $revision_id, false );
-
-			$revision_space_between_widgets_after = $revision->get_settings( 'space_between_widgets' );
-
-			$this->assertEquals( $space_between_widgets, $revision_space_between_widgets_after['size'] );
-		}
-	}
-
 
 	/**
 	 * @param string $post_type


### PR DESCRIPTION
There was a wrong try to re-upgrade the `space_between_widgets`. it has been removed and the fix will work only for new upgrades where E < 3.0.0.

Ref: https://github.com/elementor/elementor/issues/12398