### PR TITLE
Upgrades: Fix - `space_between_widgets` is missing. (Fix #12298)

### DIFF
--- a/core/upgrade/upgrades.php
+++ b/core/upgrade/upgrades.php
@@ -661,6 +661,8 @@ class Upgrades {
 
 			$meta_key = \Elementor\Core\Settings\Page\Manager::META_KEY;
 			$current_settings = get_option( '_elementor_general_settings', [] );
+			// Take the `space_between_widgets` from the option due to a bug on E < 3.0.0 that the value `0` is stored separated.
+			$current_settings['space_between_widgets'] = get_option( 'elementor_space_between_widgets', '' );
 			$current_settings[ Responsive::BREAKPOINT_OPTION_PREFIX . 'md' ] = get_option( 'elementor_viewport_md', '' );
 			$current_settings[ Responsive::BREAKPOINT_OPTION_PREFIX . 'lg' ] = get_option( 'elementor_viewport_lg', '' );
 

--- a/tests/phpunit/elementor/core/upgrades/test-upgrades.php
+++ b/tests/phpunit/elementor/core/upgrades/test-upgrades.php
@@ -122,10 +122,12 @@ class Test_Upgrades extends Elementor_Test_Base {
 			'default_generic_fonts' => $generic_font,
 			'lightbox_color' => $lightbox_color,
 			'container_width' => $container_width,
-			'space_between_widgets' => $space_between_widgets,
 		];
 
 		update_option( '_elementor_general_settings', $general_settings );
+
+		// Take the `space_between_widgets` from the option due to a bug on E < 3.0.0 that the value `0` is stored separated.
+		update_option( 'elementor_space_between_widgets', $space_between_widgets );
 		update_option( 'elementor_viewport_lg', $viewport_lg );
 		update_option( 'elementor_viewport_md', $viewport_md );
 


### PR DESCRIPTION
Due to a bug on E < 3.0.0 a value `0` is stored in a separated option, so, on upgrade take the `space_between_widgets` from it's option.