### PR TITLE
Editor Elements: Revert - Cannot move a global widget after fix #12514.

### DIFF
--- a/assets/dev/js/editor/elements/views/base.js
+++ b/assets/dev/js/editor/elements/views/base.js
@@ -113,7 +113,7 @@ BaseElementView = BaseContainer.extend( {
 			this.container = new elementorModules.editor.Container( {
 				type: this.model.get( 'elType' ),
 				id: this.model.id,
-				model: this.getEditModel(),
+				model: this.model,
 				settings: settingsModel,
 				view: this,
 				parent: this._parent ? this._parent.getContainer() : {},


### PR DESCRIPTION
The `getEditModel` returns a wrong model.