### PR TITLE
Tests: Fix - Document config test fails.

### DIFF
--- a/tests/phpunit/elementor/core/base/test-document.php
+++ b/tests/phpunit/elementor/core/base/test-document.php
@@ -16,6 +16,13 @@ class Test_Document extends Elementor_Test_Base {
 
 		$default_route_excepted = 'panel/elements/categories';
 		$document = Plugin::$instance->documents->get( $this->factory()->create_and_get_default_post()->ID );
+
+		query_posts( [
+			'p' => $document->get_main_id(),
+		] );
+
+		the_post();
+
 		$config = $document->get_config();
 
 		$this->assertEquals( $default_route_excepted, $config['panel']['default_route'],


### PR DESCRIPTION
`get_model_for_config` method returns null if it's not in the loop of a singular query.