### PR TITLE
Page Settings: Fix - Custom Panel tab not working. 

### DIFF
--- a/core/settings/page/manager.php
+++ b/core/settings/page/manager.php
@@ -165,7 +165,8 @@ class Manager extends CSS_Manager {
 
 		if ( Object.values( tabs ).length > 1 ) { #>
 		<div class="elementor-panel-navigation">
-			<# _.each( tabs, function( tabTitle, tabSlug ) { #>
+			<# _.each( tabs, function( tabTitle, tabSlug ) {
+			$e.bc.ensureTab( 'panel/page-settings', tabSlug ); #>
 			<div class="elementor-component-tab elementor-panel-navigation-tab elementor-tab-control-{{ tabSlug }}" data-tab="{{ tabSlug }}">
 				<a href="#">{{{ tabTitle }}}</a>
 			</div>


### PR DESCRIPTION
On register a tab from the server side, it can't work without a JS component route.