### PR TITLE
Fix: Some Shape Dividers overlap other elements since Chrome 85 (#12393)

### DIFF
--- a/assets/dev/scss/frontend/_shapes.scss
+++ b/assets/dev/scss/frontend/_shapes.scss
@@ -12,10 +12,24 @@
 
 	&-top {
 		top: -1px;
+
+		&:not([data-negative="false"]) {
+
+			svg {
+				z-index: -1;
+			}
+		}
 	}
 
 	&-bottom {
 		bottom: -1px;
+
+		&:not([data-negative="true"]) {
+
+			svg {
+				z-index: -1;
+			}
+		}
 	}
 
 	&[data-negative="false"] {


### PR DESCRIPTION
`## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Shape Divider: Fix - Shape divider covers section content even when "Bring to Front" is set to "No"

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)