### PR TITLE
Modules/Admin-Bar: Fix - Editor cannot see "edit with elementor" button

### DIFF
--- a/modules/admin-bar/assets/js/frontend/module.js
+++ b/modules/admin-bar/assets/js/frontend/module.js
@@ -134,4 +134,4 @@ class AdminBar extends elementorModules.ViewModule {
 	}
 }
 
-jQuery( () => new AdminBar() );
+new AdminBar();

--- a/modules/admin-bar/module.php
+++ b/modules/admin-bar/module.php
@@ -57,7 +57,7 @@ class Module extends BaseApp {
 		wp_enqueue_script(
 			'elementor-admin-bar',
 			$this->get_js_assets_url( 'admin-bar' ),
-			[ 'elementor-common' ],
+			[ 'elementor-frontend-modules' ],
 			ELEMENTOR_VERSION,
 			true
 		);


### PR DESCRIPTION
The dependency of the admin bar script was script that loaded only for admins.