### PR TITLE
Widget Settings Panel: Fix - When a panel tab has only sections with …

### DIFF
--- a/assets/dev/js/editor/views/controls-stack.js
+++ b/assets/dev/js/editor/views/controls-stack.js
@@ -119,8 +119,14 @@ ControlsStack = Marionette.CompositeView.extend( {
 			return 'section' === controlModel.get( 'type' ) && self.isVisibleSectionControl( controlModel );
 		} );
 
+		let sectionToActivate;
+
 		if ( ! sectionControls[ 0 ] ) {
-			return;
+			self.activeSection = null;
+
+			sectionToActivate = null;
+		} else {
+			sectionToActivate = sectionControls[ 0 ].get( 'name' );
 		}
 
 		var preActivatedSection = sectionControls.filter( function( controlModel ) {
@@ -131,7 +137,7 @@ ControlsStack = Marionette.CompositeView.extend( {
 			return;
 		}
 
-		self.activateSection( sectionControls[ 0 ].get( 'name' ) );
+		self.activateSection( sectionToActivate );
 
 		return this;
 	},


### PR DESCRIPTION
…display conditions that are unmet, navigating to it from another tab shows the controls from that other tab, instead of an empty tab.

Fixes #12658 

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Widget Settings Panel: Fix - When a panel tab has only sections with display conditions that are unmet, navigating to it from another tab shows the controls from that other tab, instead of an empty tab.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)