### PR TITLE
Typography CSS: Fix - Fallback fonts are not being printed as fallbacks to Global fonts

### DIFF
--- a/assets/dev/js/editor/utils/controls-css-parser.js
+++ b/assets/dev/js/editor/utils/controls-css-parser.js
@@ -94,13 +94,19 @@ ControlsCSSParser = elementorModules.ViewModule.extend( {
 			var outputCssProperty;
 
 			if ( globalKey ) {
-				const selectorGlobalValue = this.getSelectorGlobalValue( control, globalKey );
+				let selectorGlobalValue = this.getSelectorGlobalValue( control, globalKey );
 
 				if ( selectorGlobalValue ) {
 					if ( 'font' === control.type ) {
 						$e.data.get( globalKey ).then( ( response ) => {
 								elementor.helpers.enqueueFont( response.data.value.typography_font_family );
 						} );
+
+						if ( 'Family' === control.label ) {
+							const fallbackFonts = elementorFrontend.getKitSettings( 'default_generic_fonts' ) ? elementorFrontend.getKitSettings( 'default_generic_fonts' ) : 'Sans-serif';
+
+							selectorGlobalValue += ', ' + fallbackFonts;
+						}
 					}
 
 					// This regex handles a case where a control's selector property value includes more than one CSS selector.

--- a/core/files/css/base.php
+++ b/core/files/css/base.php
@@ -14,6 +14,7 @@ use Elementor\Plugin;
 use Elementor\Core\Responsive\Responsive;
 use Elementor\Stylesheet;
 use Elementor\Icons_Manager;
+use Elementor\Core\Settings\Page\Manager as PageManager;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -322,6 +323,15 @@ abstract class Base extends Base_File {
 
 			if ( $global_key ) {
 				$selector_global_value = $this->get_selector_global_value( $control, $global_key );
+
+				if ( 'font' === $control['type'] && 'Family' === $control['label'] ) {
+					$kit = Plugin::$instance->kits_manager->get_active_kit_for_frontend();
+
+					$kit_settings = $kit->get_meta( PageManager::META_KEY );
+					$default_fonts = isset( $kit_settings['default_generic_fonts'] ) ? $kit_settings['default_generic_fonts'] : 'Sans-serif';
+
+					$selector_global_value .= ', ' . $default_fonts;
+				}
 
 				if ( $selector_global_value ) {
 					$output_css_property = preg_replace( '/(:)[^;]+(;?)/', '$1' . $selector_global_value . '$2', $css_property );

--- a/core/kits/documents/tabs/global-typography.php
+++ b/core/kits/documents/tabs/global-typography.php
@@ -166,6 +166,7 @@ class Global_Typography extends Tab_Base {
 				'description' => __( 'The list of fonts used if the chosen font is not available.', 'elementor' ),
 				'label_block' => true,
 				'separator' => 'before',
+				'frontend_available' => true,
 			]
 		);
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Typography CSS: Fix - Fallback fonts from Site Settings > Fonts are not being printed as fallbacks to Global font values.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)
