### PR TITLE
Global Colors: Fix - After upgrading from Elementor 2.x to 3.0, the color picker shrinks when displaying RGBA colors created in the older version

### DIFF
--- a/core/kits/assets/css/panel.scss
+++ b/core/kits/assets/css/panel.scss
@@ -187,4 +187,6 @@
 	color: $editor-lightest;
 	font-size: 10px;
 	padding: 0 5px;
+	text-align: $end;
+	@include ellipsis;
 }

--- a/core/kits/assets/js/repeater-row.js
+++ b/core/kits/assets/js/repeater-row.js
@@ -38,7 +38,7 @@ export default class extends RepeaterRow {
 		let globalType = '';
 
 		if ( isColor ) {
-			this.$colorValue = jQuery( '<div>', { class: 'e-global-colors__color-value' } );
+			this.$colorValue = jQuery( '<div>', { class: 'e-global-colors__color-value elementor-control-unit-3' } );
 
 			childView.$el
 				.find( '.elementor-control-input-wrapper' )


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Global Colors: Fix - After upgrading from Elementor 2.x to 3.0, the color picker shrinks when displaying RGBA colors created in the older version

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)