### PR TITLE
Tabs, Accordion, Toggle Widgets: Fix - aria-selected attribute missing for a11y accessibility.

### DIFF
--- a/assets/dev/js/frontend/handlers/base-tabs.js
+++ b/assets/dev/js/frontend/handlers/base-tabs.js
@@ -57,7 +57,8 @@ export default class baseTabs extends elementorModules.frontend.handlers.Base {
 			$activeTitle = this.elements.$tabTitles.filter( activeFilter ),
 			$activeContent = this.elements.$tabContents.filter( activeFilter );
 
-		$activeTitle.add( $activeContent ).removeClass( activeClass );
+		// aria-selected should be applied only on the title and not on the content.
+		$activeTitle.attr( 'aria-selected', 'false' ).add( $activeContent ).removeClass( activeClass );
 
 		$activeContent[ settings.hideTabFn ]();
 	}
@@ -68,7 +69,8 @@ export default class baseTabs extends elementorModules.frontend.handlers.Base {
 			$requestedTitle = this.elements.$tabTitles.filter( '[data-tab="' + tabIndex + '"]' ),
 			$requestedContent = this.elements.$tabContents.filter( '[data-tab="' + tabIndex + '"]' );
 
-		$requestedTitle.add( $requestedContent ).addClass( activeClass );
+		// aria-selected should be applied only on the title and not on the content.
+		$requestedTitle.attr( 'aria-selected', 'true' ).add( $requestedContent ).addClass( activeClass );
 
 		$requestedContent[ settings.showTabFn ]( () => elementorFrontend.elements.$window.trigger( 'resize' ) );
 	}

--- a/includes/widgets/accordion.php
+++ b/includes/widgets/accordion.php
@@ -510,6 +510,7 @@ class Widget_Accordion extends Widget_Base {
 					'data-tab' => $tab_count,
 					'role' => 'tab',
 					'aria-controls' => 'elementor-tab-content-' . $id_int . $tab_count,
+					'aria-selected' => 1 === $tab_count ? 'true' : 'false',
 				] );
 
 				$this->add_render_attribute( $tab_content_setting_key, [
@@ -574,7 +575,8 @@ class Widget_Accordion extends Widget_Base {
 						'tabindex': tabindex + tabCount,
 						'data-tab': tabCount,
 						'role': 'tab',
-						'aria-controls': 'elementor-tab-content-' + tabindex + tabCount
+						'aria-controls': 'elementor-tab-content-' + tabindex + tabCount,
+						'aria-selected': 'false'
 					} );
 
 					view.addRenderAttribute( tabContentKey, {

--- a/includes/widgets/tabs.php
+++ b/includes/widgets/tabs.php
@@ -349,6 +349,7 @@ class Widget_Tabs extends Widget_Base {
 						'data-tab' => $tab_count,
 						'role' => 'tab',
 						'aria-controls' => 'elementor-tab-content-' . $id_int . $tab_count,
+						'aria-selected' => 1 === $tab_count ? 'true' : 'false',
 					] );
 					?>
 					<div <?php echo $this->get_render_attribute_string( $tab_title_setting_key ); ?>><a href=""><?php echo $item['tab_title']; ?></a></div>
@@ -375,11 +376,13 @@ class Widget_Tabs extends Widget_Base {
 						'class' => [ 'elementor-tab-title', 'elementor-tab-mobile-title' ],
 						'data-tab' => $tab_count,
 						'role' => 'tab',
+						'aria-controls' => 'elementor-tab-content-' . $id_int . $tab_count,
+						'aria-selected' => 1 === $tab_count ? 'true' : 'false',
 					] );
 
 					$this->add_inline_editing_attributes( $tab_content_setting_key, 'advanced' );
 					?>
-					<div <?php echo $this->get_render_attribute_string( $tab_title_mobile_setting_key ); ?>><?php echo $item['tab_title']; ?></div>
+					<div <?php echo $this->get_render_attribute_string( $tab_title_mobile_setting_key ); ?>><a href=""><?php echo $item['tab_title']; ?></a></div>
 					<div <?php echo $this->get_render_attribute_string( $tab_content_setting_key ); ?>><?php echo $this->parse_text_editor( $item['tab_content'] ); ?></div>
 				<?php endforeach; ?>
 			</div>
@@ -407,7 +410,7 @@ class Widget_Tabs extends Widget_Base {
 					_.each( settings.tabs, function( item, index ) {
 						var tabCount = index + 1;
 						#>
-						<div id="elementor-tab-title-{{ tabindex + tabCount }}" class="elementor-tab-title elementor-tab-desktop-title" data-tab="{{ tabCount }}" role="tab" aria-controls="elementor-tab-content-{{ tabindex + tabCount }}"><a href="">{{{ item.tab_title }}}</a></div>
+						<div id="elementor-tab-title-{{ tabindex + tabCount }}" class="elementor-tab-title elementor-tab-desktop-title" data-tab="{{ tabCount }}" role="tab" aria-controls="elementor-tab-content-{{ tabindex + tabCount }}" aria-selected="false"><a href="">{{{ item.tab_title }}}</a></div>
 					<# } ); #>
 				</div>
 				<div class="elementor-tabs-content-wrapper">
@@ -426,7 +429,7 @@ class Widget_Tabs extends Widget_Base {
 
 						view.addInlineEditingAttributes( tabContentKey, 'advanced' );
 						#>
-						<div class="elementor-tab-title elementor-tab-mobile-title" data-tab="{{ tabCount }}" role="tab">{{{ item.tab_title }}}</div>
+						<div class="elementor-tab-title elementor-tab-mobile-title" data-tab="{{ tabCount }}" role="tab" aria-selected="false">{{{ item.tab_title }}}</div>
 						<div {{{ view.getRenderAttributeString( tabContentKey ) }}}>{{{ item.tab_content }}}</div>
 					<# } ); #>
 				</div>

--- a/includes/widgets/toggle.php
+++ b/includes/widgets/toggle.php
@@ -537,6 +537,7 @@ class Widget_Toggle extends Widget_Base {
 					'data-tab' => $tab_count,
 					'role' => 'tab',
 					'aria-controls' => 'elementor-tab-content-' . $id_int . $tab_count,
+					'aria-selected' => 'false',
 				] );
 
 				$this->add_render_attribute( $tab_content_setting_key, [
@@ -600,7 +601,8 @@ class Widget_Toggle extends Widget_Base {
 						'class': [ 'elementor-tab-title' ],
 						'data-tab': tabCount,
 						'role': 'tab',
-						'aria-controls': 'elementor-tab-content-' + tabindex + tabCount
+						'aria-controls': 'elementor-tab-content-' + tabindex + tabCount,
+						'aria-selected': 'false'
 					} );
 
 					view.addRenderAttribute( tabContentKey, {


### PR DESCRIPTION
In addition, in mobile devices, the titles of the Tabs widget were missing a link tag, that also was missing to get proper accessibility support.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
