### PR TITLE
Fix gallery control with dynamic (filled state)

### DIFF
--- a/assets/dev/scss/editor/panel/controls/_gallery.scss
+++ b/assets/dev/scss/editor/panel/controls/_gallery.scss
@@ -125,8 +125,7 @@
 	&.elementor-control-dynamic {
 
 		.elementor-control-gallery-clear {
-			border: solid $editor-lightest;
-			border-width: 0 1px;
+			@include border-start(1px solid $editor-lightest);
 		}
 	}
 


### PR DESCRIPTION
See the border between the buttons:
<img width="694" alt="image" src="https://user-images.githubusercontent.com/1778512/96364855-79465480-1145-11eb-8e5b-4bad4ebcb61c.png">
