### PR TITLE
Admin Bar: Fix - "edit with elementor" not works for empty pages.

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -943,6 +943,8 @@ class Frontend extends App {
 		 */
 		$data = apply_filters( 'elementor/frontend/builder_content_data', $data, $post_id );
 
+		do_action( 'elementor/frontend/before_get_builder_content', $document, $this->_is_excerpt );
+
 		if ( empty( $data ) ) {
 			return '';
 		}
@@ -991,6 +993,8 @@ class Frontend extends App {
 
 		Plugin::$instance->documents->restore_document();
 
+		// BC
+		// TODO: use Deprecation::do_deprecated_action() in 3.1.0
 		do_action( 'elementor/frontend/get_builder_content', $document, $this->_is_excerpt, $with_css );
 
 		return $content;

--- a/modules/admin-bar/module.php
+++ b/modules/admin-bar/module.php
@@ -121,7 +121,7 @@ class Module extends BaseApp {
 	 * Module constructor.
 	 */
 	public function __construct() {
-		add_action( 'elementor/frontend/get_builder_content', [ $this, 'add_document_to_admin_bar' ], 10, 2 );
+		add_action( 'elementor/frontend/before_get_builder_content', [ $this, 'add_document_to_admin_bar' ], 10, 2 );
 		add_action( 'wp_footer', [ $this, 'enqueue_scripts' ], 11 /* after third party scripts */ );
 	}
 }

--- a/tests/phpunit/elementor/modules/admin-bar/test-module.php
+++ b/tests/phpunit/elementor/modules/admin-bar/test-module.php
@@ -41,8 +41,8 @@ class Elementor_Test_Module extends Elementor_Test_Base {
 
 		query_posts( [ 'p' => $active_document->get_id() ] );
 
-		do_action('elementor/frontend/get_builder_content', $active_document, false, false);
-		do_action('elementor/frontend/get_builder_content', $document, false, false);
+		do_action('elementor/frontend/before_get_builder_content', $active_document, false, false);
+		do_action('elementor/frontend/before_get_builder_content', $document, false, false);
 
 		$config = $this->module->get_settings();
 
@@ -60,7 +60,7 @@ class Elementor_Test_Module extends Elementor_Test_Base {
 		$excerpt_document = $this->create_document();
 
 		// Emulate an excerpt on frontend.
-		do_action('elementor/frontend/get_builder_content', $excerpt_document, true, false);
+		do_action('elementor/frontend/before_get_builder_content', $excerpt_document, true, false);
 
 		$config = $this->module->get_settings();
 
@@ -75,7 +75,7 @@ class Elementor_Test_Module extends Elementor_Test_Base {
 			],
 		] );
 
-		do_action('elementor/frontend/get_builder_content', $not_supported_document, false, false);
+		do_action('elementor/frontend/before_get_builder_content', $not_supported_document, false, false);
 
 		$config = $this->module->get_settings();
 
@@ -87,7 +87,7 @@ class Elementor_Test_Module extends Elementor_Test_Base {
 
 		$document = $this->create_document();
 
-		do_action('elementor/frontend/get_builder_content', $document, false, false);
+		do_action('elementor/frontend/before_get_builder_content', $document, false, false);
 
 		$config = $this->module->get_settings();
 


### PR DESCRIPTION
The action that catches the documents was triggered after the rendering of an empty pages.
