### PR TITLE
Admin Bar: Fix - "edit with elementor" button hidden in old wordpress versions.

### DIFF
--- a/modules/admin-bar/assets/js/frontend/module.js
+++ b/modules/admin-bar/assets/js/frontend/module.js
@@ -134,4 +134,4 @@ class AdminBar extends elementorModules.ViewModule {
 	}
 }
 
-new AdminBar();
+jQuery( () => new AdminBar() );

--- a/modules/admin-bar/module.php
+++ b/modules/admin-bar/module.php
@@ -54,11 +54,23 @@ class Module extends BaseApp {
 			return;
 		}
 
+		// Should load 'elementor-admin-bar' before 'admin-bar'
+		wp_dequeue_script( 'admin-bar' );
+
 		wp_enqueue_script(
 			'elementor-admin-bar',
 			$this->get_js_assets_url( 'elementor-admin-bar' ),
 			[ 'elementor-frontend-modules' ],
 			ELEMENTOR_VERSION,
+			true
+		);
+
+		// This is a core script of WordPress, it is not required to pass the 'ver' argument.
+		wp_enqueue_script( // phpcs:ignore WordPress.WP.EnqueuedResourceParameters
+			'admin-bar',
+			null,
+			[ 'elementor-admin-bar' ],
+			false,
 			true
 		);
 

--- a/tests/phpunit/elementor/modules/admin-bar/test-module.php
+++ b/tests/phpunit/elementor/modules/admin-bar/test-module.php
@@ -35,6 +35,28 @@ class Elementor_Test_Module extends Elementor_Test_Base {
 		] );
 	}
 
+	public function test_enqueue_scripts() {
+		// Arrange
+		$document = $this->create_document();
+		$this->module->add_document_to_admin_bar($document, false);
+
+		// Act
+		$this->module->enqueue_scripts();
+
+		do_action( 'wp_enqueue_scripts' );
+
+		// Assert
+		$queue = wp_scripts()->queue;
+
+		$admin_bar_key = array_search( 'admin-bar', $queue );
+		$elementor_admin_bar_key = array_search( 'elementor-admin-bar', $queue );
+
+		$this->assertTrue( $admin_bar_key >= 0 );
+		$this->assertTrue( $elementor_admin_bar_key >= 0 );
+
+		$this->assertTrue( $admin_bar_key > $elementor_admin_bar_key );
+	}
+
 	public function test_it_should_returns_a_valid_config() {
 		$active_document = $this->create_document();
 		$document = $this->create_document();

--- a/tests/phpunit/factories/documents.php
+++ b/tests/phpunit/factories/documents.php
@@ -23,7 +23,7 @@ class Documents extends \WP_UnitTest_Factory_For_Post {
 		$type = 'page';
 		$meta = [];
 
-		if ( ! isset( $args['type'] ) ) {
+		if ( isset( $args['type'] ) ) {
 			$type = $args['type'];
 
 			unset( $args['type'] );
@@ -33,7 +33,7 @@ class Documents extends \WP_UnitTest_Factory_For_Post {
 			$meta = $args['meta_input'];
 		}
 
-		return Plugin::$instance->documents->create( $type, $args, $meta );
+		return Plugin::$instance->documents->create( $type, $args, $meta )->get_id();
 	}
 
 	public function update_object( $document_id, $fields ) {


### PR DESCRIPTION
~Depends on: https://github.com/elementor/elementor/pull/12902~