### PR TITLE
DevTools Deprecation Module Improvements (ED-620)

### DIFF
--- a/modules/dev-tools/assets/js/editor/dev-tools.js
+++ b/modules/dev-tools/assets/js/editor/dev-tools.js
@@ -5,12 +5,10 @@ export default class extends elementorModules.editor.utils.Module {
 
 	notifyDeprecated() {
 		// eslint-disable-next-line camelcase
-		const notices = elementor.config.dev_tools?.deprecation.soft_notices;
+		const notices = elementor.config.dev_tools.deprecation.soft_notices;
 
-		if ( notices?.length ) {
-			notices.forEach( ( notice ) => {
-				elementorCommon.helpers.softDeprecated( ... notice );
-			} );
-		}
+		Object.entries( notices ).forEach( ( [ key, notice ] ) => {
+			elementorCommon.helpers.softDeprecated( key, ... notice );
+		} );
 	}
 }

--- a/modules/dev-tools/assets/js/editor/dev-tools.js
+++ b/modules/dev-tools/assets/js/editor/dev-tools.js
@@ -8,7 +8,7 @@ export default class extends elementorModules.editor.utils.Module {
 		const notices = elementor.config.dev_tools.deprecation.soft_notices;
 
 		Object.entries( notices ).forEach( ( [ key, notice ] ) => {
-			elementorCommon.helpers.softDeprecated( key, ... notice );
+			elementorCommon.helpers.softDeprecated( key, ...notice );
 		} );
 	}
 }

--- a/modules/dev-tools/deprecation.php
+++ b/modules/dev-tools/deprecation.php
@@ -259,4 +259,23 @@ class Deprecation {
 			_deprecated_argument( $function, $version );
 		}
 	}
+
+	/**
+	 * @param string $hook
+	 * @param array $args
+	 * @param string $version
+	 * @param string $replacement
+	 * @param null|string $base_version
+	 *
+	 * @throws \Exception
+	 */
+	public function do_deprecated_action( $hook, $args, $version, $replacement = '', $base_version = null ) {
+		if ( ! has_action( $hook  ) ) {
+			return;
+		}
+
+		$this->deprecated_hook( $hook, $version, $replacement, $base_version );
+
+		do_action_ref_array( $hook, $args );
+	}
 }

--- a/modules/dev-tools/deprecation.php
+++ b/modules/dev-tools/deprecation.php
@@ -28,6 +28,8 @@ class Deprecation {
 	 * Since `get_total_major` cannot determine how much really versions between 2.9.0 and 3.3.0 if there is 2.10.0 version for example,
 	 * versions with major2 more then 9 will be added to total.
 	 *
+	 * @since 3.1.0
+	 *
 	 * @param array $parsed_version
 	 *
 	 * @return int
@@ -55,6 +57,8 @@ class Deprecation {
 
 	/**
 	 * Get next version.
+	 *
+	 * @since 3.1.0
 	 *
 	 * @param string $version
 	 * @param int $count
@@ -88,6 +92,8 @@ class Deprecation {
 	/**
 	 * Implode parsed version to string version.
 	 *
+	 * @since 3.1.0
+	 *
 	 * @param array $parsed_version
 	 *
 	 * @return string
@@ -102,6 +108,8 @@ class Deprecation {
 
 	/**
 	 * Parse to an informative array.
+	 *
+	 * @since 3.1.0
 	 *
 	 * @param string $version
 	 *
@@ -137,6 +145,8 @@ class Deprecation {
 	 * Notice: If you want to compare between 2.9.0 and 3.3.0, and there is also a 2.10.0 version, you cannot get the right comparison
 	 * Since $this->deprecation->get_total_major cannot determine how much really versions between 2.9.0 and 3.3.0.
 	 *
+	 * @since 3.1.0
+	 *
 	 * @param {string} $version1
 	 * @param {string} $version2
 	 *
@@ -164,6 +174,8 @@ class Deprecation {
 	 *
 	 * Checks whether the given entity is valid. If valid, this method checks whether the deprecation
 	 * should be soft (browser console notice) or hard (use WordPress' native deprecation methods).
+	 *
+	 * @since 3.1.0
 	 *
 	 * @param string $entity - The Deprecated entity (the function/hook itself)
 	 * @param string $version
@@ -210,6 +222,8 @@ class Deprecation {
 	 *
 	 * Handles the deprecation process for functions.
 	 *
+	 * @since 3.1.0
+	 *
 	 * @param string $function
 	 * @param string $version
 	 * @param string $replacement Optional. Default is ''
@@ -228,6 +242,8 @@ class Deprecation {
 	 * Deprecated Hook
 	 *
 	 * Handles the deprecation process for hooks.
+	 *
+	 * @since 3.1.0
 	 *
 	 * @param string $hook
 	 * @param string $version
@@ -248,6 +264,8 @@ class Deprecation {
 	 *
 	 * Handles the deprecation process for function arguments.
 	 *
+	 * @since 3.1.0
+	 *
 	 * @param string $function
 	 * @param string $version
 	 * @throws \Exception
@@ -261,6 +279,12 @@ class Deprecation {
 	}
 
 	/**
+	 * Do Deprecated Action
+	 *
+	 * A method used to run deprecated actions through Elementor's deprecation process.
+	 *
+	 * @since 3.1.0
+	 *
 	 * @param string $hook
 	 * @param array $args
 	 * @param string $version
@@ -270,7 +294,7 @@ class Deprecation {
 	 * @throws \Exception
 	 */
 	public function do_deprecated_action( $hook, $args, $version, $replacement = '', $base_version = null ) {
-		if ( ! has_action( $hook  ) ) {
+		if ( ! has_action( $hook ) ) {
 			return;
 		}
 

--- a/modules/dev-tools/deprecation.php
+++ b/modules/dev-tools/deprecation.php
@@ -200,11 +200,12 @@ class Deprecation {
 
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG && $diff <= self::SOFT_VERSIONS_COUNT ) {
 			// Soft deprecated.
-			$this->soft_deprecated_notices [] = [
-				$entity,
-				$version,
-				$replacement,
-			];
+			if ( ! isset( $this->soft_deprecated_notices[ $entity ] ) ) {
+				$this->soft_deprecated_notices[ $entity ] = [
+					$version,
+					$replacement,
+				];
+			}
 
 			if ( defined( 'ELEMENTOR_DEBUG' ) && ELEMENTOR_DEBUG ) {
 				$print_deprecated = true;

--- a/tests/phpunit/elementor/modules/dev-tools/test-deprecation.php
+++ b/tests/phpunit/elementor/modules/dev-tools/test-deprecation.php
@@ -193,11 +193,10 @@ class Test_Deprecation extends Elementor_Test_Base {
 
 		$settings = $this->deprecation->get_settings();
 
-		$this->assertContains( [
-			'test_deprecated_function_soft',
+		$this->assertEquals( [
 			'0.0.0',
 			'',
-		], $settings['soft_notices'] );
+		], $settings['soft_notices']['test_deprecated_function_soft'] );
 	}
 
 	public function test_deprecated_function_hard() {
@@ -222,7 +221,7 @@ class Test_Deprecation extends Elementor_Test_Base {
 		$this->assertEquals( $result, 'Testing Do Deprecated Action' );
 	}
 
-	public function test_do_deprecated_action_soft() {
+	public function test_do_deprecated_action__soft() {
 		add_action( 'elementor/test/deprecated_action_soft', function() {
 			echo 'Testing Do Deprecated Action';
 		} );
@@ -231,10 +230,9 @@ class Test_Deprecation extends Elementor_Test_Base {
 
 		$settings = $this->deprecation->get_settings();
 
-		$this->assertContains( [
-			'elementor/test/deprecated_action_soft',
+		$this->assertEquals( [
 			'0.0.0',
 			'',
-		], $settings['soft_notices'] );
+		], $settings['soft_notices']['elementor/test/deprecated_action_soft'] );
 	}
 }

--- a/tests/phpunit/elementor/modules/dev-tools/test-deprecation.php
+++ b/tests/phpunit/elementor/modules/dev-tools/test-deprecation.php
@@ -205,4 +205,36 @@ class Test_Deprecation extends Elementor_Test_Base {
 
 		$this->deprecation->deprecated_function( __FUNCTION__, '0.0.0', '', '0.5.0' );
 	}
+
+	public function test_do_deprecated_action() {
+		$this->setExpectedDeprecated( 'elementor/test/deprecated_action' );
+
+		add_action( 'elementor/test/deprecated_action', function() {
+			echo 'Testing Do Deprecated Action';
+		} );
+
+		ob_start();
+
+		$this->deprecation->do_deprecated_action( 'elementor/test/deprecated_action', [], '0.0.0', '', '0.5.0' );
+
+		$result = ob_get_clean();
+
+		$this->assertEquals( $result, 'Testing Do Deprecated Action' );
+	}
+
+	public function test_do_deprecated_action_soft() {
+		add_action( 'elementor/test/deprecated_action_soft', function() {
+			echo 'Testing Do Deprecated Action';
+		} );
+
+		$this->deprecation->do_deprecated_action( 'elementor/test/deprecated_action_soft', [], '0.0.0', '', '0.4.0' );
+
+		$settings = $this->deprecation->get_settings();
+
+		$this->assertContains( [
+			'elementor/test/deprecated_action_soft',
+			'0.0.0',
+			'',
+		], $settings['soft_notices'] );
+	}
 }

--- a/tests/phpunit/elementor/modules/dev-tools/test-module.php
+++ b/tests/phpunit/elementor/modules/dev-tools/test-module.php
@@ -23,9 +23,7 @@ class Elementor_Test_Module extends Elementor_Test_Base {
 		$result = $this->module->localize_settings( [] );
 
 		$this->assertEqualSets( [
-			__FUNCTION__,
 			'0.0.0',
 			'',
-		], $result['dev_tools']['deprecation']['soft_notices'][0] );
-	}
+		], $result['dev_tools']['deprecation']['soft_notices'][ __FUNCTION__ ] );	}
 }

--- a/tests/qunit/mock/config/editor.json
+++ b/tests/qunit/mock/config/editor.json
@@ -29,5 +29,10 @@
 	  "colors": true,
 	  "typography": true
 	}
+  },
+  "dev_tools": {
+  	"deprecation": {
+		"soft_notices": []
+	}
   }
 }

--- a/tests/qunit/tests/modules/dev-tools/assets/js/editor/dev-tools.spec.js
+++ b/tests/qunit/tests/modules/dev-tools/assets/js/editor/dev-tools.spec.js
@@ -2,12 +2,11 @@ QUnit.module( 'File: modules/dev-tools/assets/js/editor/dev-tools.js', () => {
 	QUnit.test( 'notifyDeprecated()', ( assert ) => {
 		const softDeprecatedOrig = elementorCommon.helpers.softDeprecated;
 
-		elementor.config.dev_tools = {
-			deprecation: { soft_notices: [ [ 'name', 'version', 'replacement' ] ] },
-		};
+		// The soft notices object structure changed, instead of a nested array, it is now an object, for caching.
+		elementor.config.dev_tools.deprecation.soft_notices = { test: [ 'version', 'replacement' ] };
 
 		elementorCommon.helpers.softDeprecated = ( ... args ) => {
-			assert.deepEqual( [ args ], elementor.config.dev_tools.deprecation.soft_notices );
+			assert.deepEqual( { test: [ 'version', 'replacement' ] }, elementor.config.dev_tools.deprecation.soft_notices );
 		};
 
 		elementor.devTools.notifyDeprecated();


### PR DESCRIPTION
DevTools Deprecation Module: 
- Added a `do_deprecated_action()` method.
- Added a `run_compatible_method()` method which detects whether a method belongs to the current instance or to its parent and runs the compatible method.

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe: