### PR TITLE
Panel Categories: Fix - Categories items are not shown in WordPress 5.6

### DIFF
--- a/assets/dev/js/editor/regions/panel/pages/elements/views/category.js
+++ b/assets/dev/js/editor/regions/panel/pages/elements/views/category.js
@@ -37,7 +37,7 @@ PanelElementsCategoryView = Marionette.CompositeView.extend( {
 		if ( isActive ) {
 			this.$el.addClass( 'elementor-active' );
 
-			this.ui.items.show();
+			this.ui.items.css( 'display', 'block' );
 		}
 	},
 


### PR DESCRIPTION
jQuery v3 `show` method doesn't change an element 'display' property unless the element is attached to the DOM