### PR TITLE
Fix: PHP notice when conditional control doesn't exist

### DIFF
--- a/includes/conditions.php
+++ b/includes/conditions.php
@@ -84,9 +84,13 @@ class Conditions {
 			} else {
 				preg_match( '/(\w+)(?:\[(\w+)])?/', $term['name'], $parsed_name );
 
-				$value = $comparison[ $parsed_name[1] ];
+				if ( ! isset( $comparison[ $parsed_name[1] ] ) ) {
+					return true;
+				}
+				
+				$value = isset( $comparison[ $parsed_name[1] ] ) ? $comparison[ $parsed_name[1] ] : '';
 
-				if ( ! empty( $parsed_name[2] ) ) {
+				if ( ! empty( $parsed_name[2] ) && ! empty( $value ) ) {
 					$value = $value[ $parsed_name[2] ];
 				}
 

--- a/includes/conditions.php
+++ b/includes/conditions.php
@@ -84,10 +84,6 @@ class Conditions {
 			} else {
 				preg_match( '/(\w+)(?:\[(\w+)])?/', $term['name'], $parsed_name );
 
-				if ( ! isset( $comparison[ $parsed_name[1] ] ) ) {
-					return true;
-				}
-				
 				$value = isset( $comparison[ $parsed_name[1] ] ) ? $comparison[ $parsed_name[1] ] : '';
 
 				if ( ! empty( $parsed_name[2] ) && ! empty( $value ) ) {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Added extra check in conditions to avoid php notice when the control doesn't exist

## Description
An explanation of what is done in this PR

* PHP notice occurs when you have condition that includes a control that isn't registered for the current widget. It helps to condition the common widget controls too since now you can add conditions that are related to widget without causing a PHP notice

## Test instructions
This PR can be tested by following these steps:

* Add a condition for a widget control using update_control method or add a control name that doesn't exist.
* You then should see a PHP notice that the array index doesn't exist

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
