### PR TITLE
Force array for settings

### DIFF
--- a/core/settings/page/manager.php
+++ b/core/settings/page/manager.php
@@ -231,7 +231,7 @@ class Manager extends CSS_Manager {
 	protected function get_saved_settings( $id ) {
 		$settings = get_post_meta( $id, self::META_KEY, true );
 
-		if ( ! $settings ) {
+		if ( ! is_array( $settings ) ) {
 			$settings = [];
 		}
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

Forcing an array for `$settings` if it is saved as anything else.

## Description
An explanation of what is done in this PR

Since version 3, sometimes this line produces a fatal error
`$settings['template'] = $saved_template;`
as `$settings` is not an array.
This PR is forcing an array if it is saved as anything else.

## Test instructions
This PR can be tested by following these steps:

* After update from 2x to 3x some pages have a fatal error.

## Quality assurance

- [x ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

