### PR TITLE
Patched set-env deprication

### DIFF
--- a/.github/workflows/image-compare.yml
+++ b/.github/workflows/image-compare.yml
@@ -40,8 +40,8 @@ jobs:
           mv build elementor
           zip -r $PLUGIN_ZIP_FILENAME elementor
           curl --fail -F "package=@${PLUGIN_ZIP_FILENAME}" "${{ secrets.DEPLOY_BUILDS_ENDPOINT }}&type=by-commit"
-          echo ::set-env name=BUILD_PATH::"builds/by-commit/$(date '+%Y-%m')/${PLUGIN_ZIP_FILENAME}"
-          echo ::set-env name=PACKAGE_VERSION::${PACKAGE_VERSION}
+          echo "builds/by-commit/$(date '+%Y-%m')/${PLUGIN_ZIP_FILENAME}" >> $BUILD_PATH
+          echo "${PACKAGE_VERSION}" >> $PACKAGE_VERSION
       - name: Run Tests
         run: |
           git clone ${{ secrets.BACKSTOP_CONFIG_REPO_URL }} backstop-config


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary
github actions changelog
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

*

## Description
An explanation of what is done in this PR
Patching deprecation of set-env inside image-compare workflow 
*


## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

