### PR TITLE
Issue #12994 origin parameter for YouTube privacy mode added

### DIFF
--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -957,6 +957,8 @@ class Widget_Video extends Widget_Base {
 			$params['end'] = $settings['end'];
 
 			$params['wmode'] = 'opaque';
+
+			$params['origin'] = get_site_url();
 		} elseif ( 'vimeo' === $settings['video_type'] ) {
 			$params_dictionary = [
 				'loop',


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Parameter origin added for YouTube privacy mode

## Description
An explanation of what is done in this PR

* Embedded YouTube videos in privacy mode now send the site url as the origin parameter to prevent cross-origin errors.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #12994
