### PR TITLE
Dev-Tools Module: Deprecations - Modified the `deprecated_argument()` method (ED-1021)

### DIFF
--- a/modules/dev-tools/deprecation.php
+++ b/modules/dev-tools/deprecation.php
@@ -267,15 +267,35 @@ class Deprecation {
 	 *
 	 * @since 3.1.0
 	 *
-	 * @param string $function
+	 * @param string $argument
 	 * @param string $version
+	 * @param string $replacement
+	 * @param string $message
 	 * @throws \Exception
 	 */
-	public function deprecated_argument( $function, $version ) {
-		$print_deprecated = $this->check_deprecation( $function, $version, '' );
+	public function deprecated_argument( $argument, $version, $replacement = '', $message = '' ) {
+		$print_deprecated = $this->check_deprecation( $argument, $version, $replacement );
 
 		if ( $print_deprecated ) {
-			_deprecated_argument( $function, $version );
+			$message = empty( $message ) ? '' : ' ' . $message;
+			$error_message_args = [ $argument, $version ];
+
+			if ( $replacement ) {
+				/* translators: 1: Function argument, 2: Elementor version number, 3: Replacement argument name. */
+				$translation_string = __( 'The %1$s argument is <strong>deprecated</strong> since version %2$s! Use %3$s instead.', 'elementor' );
+				$error_message_args[] = $replacement;
+			} else {
+				/* translators: 1: Function argument, 2: Elementor version number. */
+				$translation_string = __( 'The %1$s argument is <strong>deprecated</strong> since version %2$s!', 'elementor' );
+			}
+
+			trigger_error(
+				vsprintf(
+					$translation_string,
+					$error_message_args
+				) . $message,
+				E_USER_DEPRECATED
+			);
 		}
 	}
 


### PR DESCRIPTION
… to handle arguments by name and run `trigger_error()` messages instead of using WordPress's _deprecated_argument() function.

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Developer Tools: Deprecations class - modified the `deprecated_argument()` method to use argument variable names.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)