### PR TITLE
Kit: Change - Allow add menu items to site settings.

### DIFF
--- a/core/kits/assets/js/component.js
+++ b/core/kits/assets/js/component.js
@@ -8,66 +8,6 @@ export default class extends $e.modules.ComponentBase {
 		return 'panel/global';
 	}
 
-	defaultTabs() {
-		return {
-			'global-colors': {
-				title: elementor.translate( 'global_colors' ),
-				icon: 'eicon-global-colors',
-				helpUrl: 'https://go.elementor.com/global-colors',
-			},
-			'global-typography': {
-				title: elementor.translate( 'global_fonts' ),
-				icon: 'eicon-t-letter',
-				helpUrl: 'https://go.elementor.com/global-fonts',
-			},
-			'theme-style-typography': {
-				title: elementor.translate( 'typography' ),
-				icon: 'eicon-typography-1',
-				helpUrl: 'https://go.elementor.com/global-theme-style-typography',
-			},
-			'theme-style-buttons': {
-				title: elementor.translate( 'buttons' ),
-				icon: 'eicon-button',
-				helpUrl: 'https://go.elementor.com/global-theme-style-buttons',
-			},
-			'theme-style-images': {
-				title: elementor.translate( 'images' ),
-				icon: 'eicon-image',
-				helpUrl: 'https://go.elementor.com/global-theme-style-images',
-			},
-			'theme-style-form-fields': {
-				title: elementor.translate( 'form_fields' ),
-				icon: 'eicon-form-horizontal',
-				helpUrl: 'https://go.elementor.com/global-theme-style-form-fields',
-			},
-			'settings-site-identity': {
-				title: elementor.translate( 'site_identity' ),
-				icon: 'eicon-site-identity',
-				helpUrl: 'https://go.elementor.com/global-site-identity',
-			},
-			'settings-background': {
-				title: elementor.translate( 'background' ),
-				icon: 'eicon-background',
-				helpUrl: 'https://go.elementor.com/global-background',
-			},
-			'settings-layout': {
-				title: elementor.translate( 'layout' ),
-				icon: 'eicon-layout-settings',
-				helpUrl: 'https://go.elementor.com/global-layout',
-			},
-			'settings-lightbox': {
-				title: elementor.translate( 'lightbox' ),
-				icon: 'eicon-lightbox-expand',
-				helpUrl: 'https://go.elementor.com/global-lightbox',
-			},
-			'settings-custom-css': {
-				title: elementor.translate( 'custom_css' ),
-				icon: 'eicon-custom-css',
-				helpUrl: 'https://go.elementor.com/global-custom-css',
-			},
-		};
-	}
-
 	defaultRoutes() {
 		return {
 			menu: () => {

--- a/core/kits/assets/js/hooks/index.js
+++ b/core/kits/assets/js/hooks/index.js
@@ -9,3 +9,4 @@ export { KitRemoveEditorActiveCSSDocumentsOpen } from './ui/editor/documents/ope
 export { KitRemoveEditorActiveCSSPanelOpen } from './ui/panel/open/remove-editor-active-css';
 export { KitBackToRouteHistory } from './ui/panel/global/close/back-to-route-history';
 export { KitRemovePreviewDeletedVariables } from './ui/document/repeater/remove/remove-preview-deleted-variables';
+export { KitAddMenuItems } from './ui/editor/documents/load/add-menu-items';

--- a/core/kits/assets/js/hooks/ui/editor/documents/load/add-menu-items.js
+++ b/core/kits/assets/js/hooks/ui/editor/documents/load/add-menu-items.js
@@ -1,0 +1,21 @@
+export class KitAddMenuItems extends $e.modules.hookUI.After {
+	getCommand() {
+		return 'editor/documents/load';
+	}
+
+	getId() {
+		return 'kit-add-menu-item';
+	}
+
+	getConditions() {
+		return 'kit' === elementor.documents.getCurrent().config.type && ! Object.keys( $e.components.get( 'panel/global' ).getTabs() ).length;
+	}
+
+	apply( { config } ) {
+		Object.entries( config.tabs ).forEach( ( [ tabId, tabConfig ] ) => {
+			$e.components.get( 'panel/global' ).addTab( tabId, tabConfig );
+		} );
+	}
+}
+
+export default KitAddMenuItems;

--- a/core/kits/assets/js/panel-menu.js
+++ b/core/kits/assets/js/panel-menu.js
@@ -8,24 +8,22 @@ export default class PanelMenu extends MenuPageView {
 
 PanelMenu.groups = null;
 
-PanelMenu.createGroupItems = ( groupName, keys ) => {
-	const tabs = $e.components.get( 'panel/global' ).getTabs();
+PanelMenu.createGroupItems = ( groupName ) => {
+	const tabs = $e.components.get( 'panel/global' ).getTabs(),
+		groupTabs = Object.entries( tabs ).filter( ( [ tabId, tabConfig ] ) => groupName === tabConfig.group );
 
-	return keys.map( ( key ) => {
-		const fullKey = groupName + '-' + key,
-			tab = tabs[ fullKey ];
-
+	return groupTabs.map( ( [ tabId, tabConfig ] ) => {
 		return {
-			name: fullKey,
-			icon: tab.icon,
-			title: tab.title,
-			callback: () => $e.route( 'panel/global/' + fullKey ),
+			name: tabId,
+			icon: tabConfig.icon,
+			title: tabConfig.title,
+			callback: () => $e.route( 'panel/global/' + tabId ),
 		};
 	} );
 };
 
 PanelMenu.initGroups = () => {
-	const settingsItems = PanelMenu.createGroupItems( 'settings', [ 'site-identity', 'background', 'layout', 'lightbox', 'custom-css' ] ),
+	const settingsItems = PanelMenu.createGroupItems( 'settings' ),
 		additionalSettingsProps = {
 			name: 'settings-additional-settings',
 			icon: 'eicon-tools',
@@ -41,12 +39,12 @@ PanelMenu.initGroups = () => {
 		{
 			name: 'design_system',
 			title: elementor.translate( 'design_system' ),
-			items: PanelMenu.createGroupItems( 'global', [ 'colors', 'typography' ] ),
+			items: PanelMenu.createGroupItems( 'global' ),
 		},
 		{
 			name: 'theme_style',
 			title: elementor.translate( 'theme_style' ),
-			items: PanelMenu.createGroupItems( 'theme-style', [ 'typography', 'buttons', 'images', 'form-fields' ] ),
+			items: PanelMenu.createGroupItems( 'theme-style' ),
 		},
 		{
 			name: 'settings',

--- a/core/kits/documents/kit.php
+++ b/core/kits/documents/kit.php
@@ -21,19 +21,7 @@ class Kit extends PageBase {
 	public function __construct( array $data = [] ) {
 		parent::__construct( $data );
 
-		$this->tabs = [
-			'global-colors' => new Tabs\Global_Colors( $this ),
-			'global-typography' => new Tabs\Global_Typography( $this ),
-			'theme-style-typography' => new Tabs\Theme_Style_Typography( $this ),
-			'theme-style-buttons' => new Tabs\Theme_Style_Buttons( $this ),
-			'theme-style-images' => new Tabs\Theme_Style_Images( $this ),
-			'theme-style-form-fields' => new Tabs\Theme_Style_Form_Fields( $this ),
-			'settings-site-identity' => new Tabs\Settings_Site_Identity( $this ),
-			'settings-background' => new Tabs\Settings_Background( $this ),
-			'settings-layout' => new Tabs\Settings_Layout( $this ),
-			'settings-lightbox' => new Tabs\Settings_Lightbox( $this ),
-			'settings-custom-css' => new Tabs\Settings_Custom_CSS( $this ),
-		];
+		$this->register_tabs();
 	}
 
 	public static function get_properties() {
@@ -99,6 +87,34 @@ class Kit extends PageBase {
 	}
 
 	/**
+	 * Register a kit settings menu.
+	 *
+	 * @param $id
+	 * @param $class
+	 */
+	public function register_tab( $id, $class ) {
+		$this->tabs[ $id ] = new $class( $this );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function get_initial_config() {
+		$config = parent::get_initial_config();
+
+		foreach ( $this->tabs as $id => $tab ) {
+			$config['tabs'][ $id ] = [
+				'title' => $tab->get_title(),
+				'icon' => $tab->get_icon(),
+				'group' => $tab->get_group(),
+				'helpUrl' => $tab->get_help_url(),
+			];
+		}
+
+		return $config;
+	}
+
+	/**
 	 * @since 2.0.0
 	 * @access protected
 	 */
@@ -152,5 +168,30 @@ class Kit extends PageBase {
 		$post_css = Post_CSS::create( $this->post->ID );
 
 		$post_css->enqueue();
+	}
+
+	/**
+	 * Register default tabs (menu pages) for site settings.
+	 */
+	private function register_tabs() {
+		$tabs = [
+			'global-colors' => Tabs\Global_Colors::class,
+			'global-typography' => Tabs\Global_Typography::class,
+			'theme-style-typography' => Tabs\Theme_Style_Typography::class,
+			'theme-style-buttons' => Tabs\Theme_Style_Buttons::class,
+			'theme-style-images' => Tabs\Theme_Style_Images::class,
+			'theme-style-form-fields' => Tabs\Theme_Style_Form_Fields::class,
+			'settings-site-identity' => Tabs\Settings_Site_Identity::class,
+			'settings-background' => Tabs\Settings_Background::class,
+			'settings-layout' => Tabs\Settings_Layout::class,
+			'settings-lightbox' => Tabs\Settings_Lightbox::class,
+			'settings-custom-css' => Tabs\Settings_Custom_CSS::class,
+		];
+
+		foreach ( $tabs as $id => $class ) {
+			$this->register_tab( $id, $class );
+		}
+
+		do_action( 'elementor/kit/register_tabs', $this );
 	}
 }

--- a/core/kits/documents/tabs/global-colors.php
+++ b/core/kits/documents/tabs/global-colors.php
@@ -24,6 +24,18 @@ class Global_Colors extends Tab_Base {
 		return __( 'Global Colors', 'elementor' );
 	}
 
+	public function get_group() {
+		return 'global';
+	}
+
+	public function get_icon() {
+		return 'eicon-global-colors';
+	}
+
+	public function get_help_url() {
+		return 'https://go.elementor.com/global-colors';
+	}
+
 	protected function register_tab_controls() {
 		$this->start_controls_section(
 			'section_global_colors',

--- a/core/kits/documents/tabs/global-typography.php
+++ b/core/kits/documents/tabs/global-typography.php
@@ -28,6 +28,18 @@ class Global_Typography extends Tab_Base {
 		return __( 'Global Fonts', 'elementor' );
 	}
 
+	public function get_group() {
+		return 'global';
+	}
+
+	public function get_icon() {
+		return 'eicon-t-letter';
+	}
+
+	public function get_help_url() {
+		return 'https://go.elementor.com/global-fonts';
+	}
+
 	protected function register_tab_controls() {
 		$this->start_controls_section(
 			'section_text_style',

--- a/core/kits/documents/tabs/settings-background.php
+++ b/core/kits/documents/tabs/settings-background.php
@@ -18,6 +18,18 @@ class Settings_Background extends Tab_Base {
 		return __( 'Background', 'elementor' );
 	}
 
+	public function get_group() {
+		return 'settings';
+	}
+
+	public function get_icon() {
+		return 'eicon-background';
+	}
+
+	public function get_help_url() {
+		return 'https://go.elementor.com/global-background';
+	}
+
 	protected function register_tab_controls() {
 		$this->start_controls_section(
 			'section_background',

--- a/core/kits/documents/tabs/settings-custom-css.php
+++ b/core/kits/documents/tabs/settings-custom-css.php
@@ -17,6 +17,18 @@ class Settings_Custom_CSS extends Tab_Base {
 		return __( 'Custom CSS', 'elementor' );
 	}
 
+	public function get_group() {
+		return 'settings';
+	}
+
+	public function get_icon() {
+		return 'eicon-custom-css';
+	}
+
+	public function get_help_url() {
+		return 'https://go.elementor.com/global-custom-css';
+	}
+
 	protected function register_tab_controls() {
 		Plugin::$instance->controls_manager->add_custom_css_controls( $this->parent, $this->get_id() );
 	}

--- a/core/kits/documents/tabs/settings-layout.php
+++ b/core/kits/documents/tabs/settings-layout.php
@@ -21,6 +21,18 @@ class Settings_Layout extends Tab_Base {
 		return __( 'Layout', 'elementor' );
 	}
 
+	public function get_group() {
+		return 'settings';
+	}
+
+	public function get_icon() {
+		return 'eicon-layout-settings';
+	}
+
+	public function get_help_url() {
+		return 'https://go.elementor.com/global-layout';
+	}
+
 	protected function register_tab_controls() {
 		$default_breakpoints = Responsive::get_default_breakpoints();
 

--- a/core/kits/documents/tabs/settings-lightbox.php
+++ b/core/kits/documents/tabs/settings-lightbox.php
@@ -18,6 +18,18 @@ class Settings_Lightbox extends Tab_Base {
 		return __( 'Lightbox', 'elementor' );
 	}
 
+	public function get_group() {
+		return 'settings';
+	}
+
+	public function get_icon() {
+		return 'eicon-lightbox-expand';
+	}
+
+	public function get_help_url() {
+		return 'https://go.elementor.com/global-lightbox';
+	}
+
 	protected function register_tab_controls() {
 		$this->start_controls_section(
 			'section_' . $this->get_id(),

--- a/core/kits/documents/tabs/settings-site-identity.php
+++ b/core/kits/documents/tabs/settings-site-identity.php
@@ -20,6 +20,18 @@ class Settings_Site_Identity extends Tab_Base {
 		return __( 'Site Identity', 'elementor' );
 	}
 
+	public function get_group() {
+		return 'settings';
+	}
+
+	public function get_icon() {
+		return 'eicon-site-identity';
+	}
+
+	public function get_help_url() {
+		return 'https://go.elementor.com/global-site-identity';
+	}
+
 	protected function register_tab_controls() {
 		$custom_logo_id = get_theme_mod( 'custom_logo' );
 		$custom_logo_src = wp_get_attachment_image_src( $custom_logo_id, 'full' );

--- a/core/kits/documents/tabs/tab-base.php
+++ b/core/kits/documents/tabs/tab-base.php
@@ -21,6 +21,18 @@ abstract class Tab_Base extends Sub_Controls_Stack {
 
 	abstract protected function register_tab_controls();
 
+	public function get_group() {
+		return 'settings';
+	}
+
+	public function get_icon() {
+		return '';
+	}
+
+	public function get_help_url() {
+		return '';
+	}
+
 	public function register_controls() {
 		$this->register_tab();
 

--- a/core/kits/documents/tabs/theme-style-buttons.php
+++ b/core/kits/documents/tabs/theme-style-buttons.php
@@ -22,6 +22,18 @@ class Theme_Style_Buttons extends Tab_Base {
 		return __( 'Buttons', 'elementor' );
 	}
 
+	public function get_group() {
+		return 'theme-style';
+	}
+
+	public function get_icon() {
+		return 'eicon-button';
+	}
+
+	public function get_help_url() {
+		return 'https://go.elementor.com/global-theme-style-buttons';
+	}
+
 	protected function register_tab_controls() {
 		$button_selectors = [
 			'{{WRAPPER}} button',

--- a/core/kits/documents/tabs/theme-style-form-fields.php
+++ b/core/kits/documents/tabs/theme-style-form-fields.php
@@ -21,6 +21,18 @@ class Theme_Style_Form_Fields extends Tab_Base {
 		return __( 'Form Fields', 'elementor' );
 	}
 
+	public function get_group() {
+		return 'theme-style';
+	}
+
+	public function get_icon() {
+		return 'eicon-form-horizontal';
+	}
+
+	public function get_help_url() {
+		return 'https://go.elementor.com/global-theme-style-form-fields';
+	}
+
 	protected function register_tab_controls() {
 		$label_selectors = [
 			'{{WRAPPER}} label',

--- a/core/kits/documents/tabs/theme-style-images.php
+++ b/core/kits/documents/tabs/theme-style-images.php
@@ -21,6 +21,18 @@ class Theme_Style_Images extends Tab_Base {
 		return __( 'Images', 'elementor' );
 	}
 
+	public function get_group() {
+		return 'theme-style';
+	}
+
+	public function get_icon() {
+		return 'eicon-image';
+	}
+
+	public function get_help_url() {
+		return 'https://go.elementor.com/global-theme-style-images';
+	}
+
 	protected function register_tab_controls() {
 		$image_selectors = [
 			'{{WRAPPER}} img',

--- a/core/kits/documents/tabs/theme-style-typography.php
+++ b/core/kits/documents/tabs/theme-style-typography.php
@@ -19,6 +19,18 @@ class Theme_Style_Typography extends Tab_Base {
 		return __( 'Typography', 'elementor' );
 	}
 
+	public function get_group() {
+		return 'theme-style';
+	}
+
+	public function get_icon() {
+		return 'eicon-typography-1';
+	}
+
+	public function get_help_url() {
+		return 'https://go.elementor.com/global-theme-style-typography';
+	}
+
 	public function register_tab_controls() {
 		$this->start_controls_section(
 			'section_typography',


### PR DESCRIPTION
Change the hard-coded menu with a dynamic flow that allows register additional  tabs on `elementor/kit/register_tabs`.

Example:

```
add_action( 'elementor/init', function() {
	class Hello_Settings extends \Elementor\Core\Kits\Documents\Tabs\Tab_Base {

		public function get_id() {
			return 'hello-settings';
		}

		public function get_title() {
			return 'Hello Settings';
		}

		public function get_icon() {
			return 'eicon-logo';
		}

		protected function register_tab_controls() {
			$this->start_controls_section(
				'hello-settings',
				[
					'label' => 'Settings',
					'tab' => $this->get_id(),
				]
			);

			$this->add_control(
				'title',
				[
					'label' => 'Text',
				]
			);

			$this->end_controls_section();
		}
	}

	add_action( 'elementor/kit/register_tabs', function( \Elementor\Core\Kits\Documents\Kit $kit ) {
		$kit->register_tab( 'hello-settings', Hello_Settings::class );
	} );
} );
```