### PR TITLE
Stretch Section: Fix - In WP 5.6+, Stretch Section causes horizontal scroll when the vertical scrollbar is visible (ED-1125)

### DIFF
--- a/assets/dev/js/frontend/tools/stretch-element.js
+++ b/assets/dev/js/frontend/tools/stretch-element.js
@@ -30,7 +30,7 @@ module.exports = elementorModules.ViewModule.extend( {
 		this.reset();
 
 		var $element = this.elements.$element,
-			containerWidth = $container.outerWidth(),
+			containerWidth = $container.innerWidth(),
 			elementOffset = $element.offset().left,
 			isFixed = 'fixed' === $element.css( 'position' ),
 			correctOffset = isFixed ? 0 : elementOffset;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Stretch Section: Fix - In WP 5.6+, Stretch Section causes horizontal scroll when the vertical scrollbar is visible.

## Description
An explanation of what is done in this PR

* In WP 5.6, jQuery was upgraded to latest 3.5.1. Between the previously used v1.12.4 and the newly used v3.5.1, `jQuery.outerWidth()` changed. See [jQuery repo commit](https://github.com/jquery/jquery/commit/7d44d7f9e7cb73ff2b373f08cea13ea9958bb462).

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)