### PR TITLE
Grunt CSSnano: Fix - The CSS calc function deleted parts of the function content on complex calculations - ED-1127

### DIFF
--- a/.grunt-config/postcss.js
+++ b/.grunt-config/postcss.js
@@ -27,8 +27,11 @@ module.exports = {
 					browsers: 'last 10 versions'
 				} ),
 				require( 'cssnano' )( {
-					reduceIdents: false,
-					zindex: false,
+					preset: [ 'default', {
+						reduceIdents: false,
+						zindex: false,
+						calc: false
+					}]
 				} )
 			]
 		},


### PR DESCRIPTION
The CSSnano process changed the following syntax:

margin-top: calc(var(--e-form-steps-indicator-padding, 30px) / 2 - var(--e-form-steps-divider-width, 1px) / 2);

Into:

margin-top:calc(var(--e-form-steps-indicator-padding, 30px) - var(--e-form-steps-divider-width, 1px))}

The " / 2" was removed by the process and the fix instructs CSSnano to ignore the "calc" function content while minifying.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
