### PR TITLE
PHP 8 Compatibility: Fix - libxml throws a deprecation error for the libxml_disable_entity_loader function in PHP 8 (ED-1314)

### DIFF
--- a/core/files/assets/svg/svg-handler.php
+++ b/core/files/assets/svg/svg-handler.php
@@ -507,8 +507,11 @@ class Svg_Handler extends Files_Upload_Handler {
 
 		$content = substr( $content, $start, ( $end - $start + 6 ) );
 
-		// Make sure to Disable the ability to load external entities
-		$libxml_disable_entity_loader = libxml_disable_entity_loader( true );
+		// If the server's PHP version is 8 or up, make sure to Disable the ability to load external entities
+		$php_version_under_eight = version_compare( PHP_VERSION, '8.0.0', '<' );
+		if ( $php_version_under_eight ) {
+			$libxml_disable_entity_loader = libxml_disable_entity_loader( true ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.libxml_disable_entity_loaderDeprecated
+		}
 		// Suppress the errors
 		$libxml_use_internal_errors = libxml_use_internal_errors( true );
 
@@ -531,7 +534,9 @@ class Svg_Handler extends Files_Upload_Handler {
 		$sanitized = $this->svg_dom->saveXML( $this->svg_dom->documentElement, LIBXML_NOEMPTYTAG );
 
 		// Restore defaults
-		libxml_disable_entity_loader( $libxml_disable_entity_loader );
+		if ( $php_version_under_eight ) {
+			libxml_disable_entity_loader( $libxml_disable_entity_loader ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.libxml_disable_entity_loaderDeprecated
+		}
 		libxml_use_internal_errors( $libxml_use_internal_errors );
 
 		return $sanitized;

--- a/core/files/assets/svg/svg-handler.php
+++ b/core/files/assets/svg/svg-handler.php
@@ -510,7 +510,7 @@ class Svg_Handler extends Files_Upload_Handler {
 		// If the server's PHP version is 8 or up, make sure to Disable the ability to load external entities
 		$php_version_under_eight = version_compare( PHP_VERSION, '8.0.0', '<' );
 		if ( $php_version_under_eight ) {
-			$libxml_disable_entity_loader = libxml_disable_entity_loader( true ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.libxml_disable_entity_loaderDeprecated
+			$libxml_disable_entity_loader = libxml_disable_entity_loader( true ); // phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated
 		}
 		// Suppress the errors
 		$libxml_use_internal_errors = libxml_use_internal_errors( true );
@@ -535,7 +535,7 @@ class Svg_Handler extends Files_Upload_Handler {
 
 		// Restore defaults
 		if ( $php_version_under_eight ) {
-			libxml_disable_entity_loader( $libxml_disable_entity_loader ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.libxml_disable_entity_loaderDeprecated
+			libxml_disable_entity_loader( $libxml_disable_entity_loader ); // phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated
 		}
 		libxml_use_internal_errors( $libxml_use_internal_errors );
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* PHP 8 Compatibility: Fix - A deprecation error appears for the libxml_disable_entity_loader function in PHP 8.