### PR TITLE
String Translations: Fix - when using core 3.1.0, 'edit_element' string translations are broken for E Pro versions <3.1.0 (ED-1411)

### DIFF
--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -589,8 +589,11 @@ class Editor {
 				'darkModeStylesheetURL' => ELEMENTOR_ASSETS_URL . 'css/editor-dark-mode' . $suffix . '.css',
 				'defaultGenericFonts' => $kits_manager->get_current_settings( 'default_generic_fonts' ),
 			],
-			// Empty array for BC to avoid errors.
-			'i18n' => [],
+			// Array for BC to avoid errors.
+			'i18n' => [
+				// 'edit_element' is here for Backwards Compatibility for Elementor Pro versions <3.1.0
+				'edit_element' => __( 'Edit %s', 'elementor' ),
+			],
 			'experimentalFeatures' => $active_experimental_features,
 		];
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary
This PR can be summarized in the following changelog entry:

* String Translations: Fix - when using E-Core 3.1.0, 'edit_element' string translations are broken for E-Pro versions <3.1.0

## Description
An explanation of what is done in this PR

* PR for 3.1.0, bring back the `'edit_element'` translation string in PHP for BC, to support E-Pro versions <3.1.0

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)