### PR TITLE
Data: New - Allow the option to abort data request.

### DIFF
--- a/core/common/assets/js/api/core/data.js
+++ b/core/common/assets/js/api/core/data.js
@@ -265,6 +265,7 @@ export default class Data extends Commands {
 		const type = requestData.type,
 			nonce = wpApiSettings.nonce,
 			params = {
+				signal: requestData.args?.options?.signal,
 				credentials: 'include', // cookies is required for wp reset.
 			},
 			headers = { 'X-WP-Nonce': nonce };


### PR DESCRIPTION
A developer can send an AbortController signal and abort the request when the request is still pending.

ref: ED-1505
