### PR TITLE
Allow CSS grid to collapse empty columns (fill available width) Fixes #13558

### DIFF
--- a/assets/dev/scss/frontend/_grid.scss
+++ b/assets/dev/scss/frontend/_grid.scss
@@ -314,7 +314,7 @@ ul.elementor-icon-list-items.elementor-inline-items {
 
 			&#{$device}-#{$i} {
 				.elementor-grid {
-					grid-template-columns: repeat(#{$i} , 1fr);
+					grid-template-columns: repeat(auto-fit, minmax(#{(100%/$i)}, 1fr))!important;
 				}
 			}
 		}

--- a/assets/dev/scss/frontend/_grid.scss
+++ b/assets/dev/scss/frontend/_grid.scss
@@ -314,7 +314,7 @@ ul.elementor-icon-list-items.elementor-inline-items {
 
 			&#{$device}-#{$i} {
 				.elementor-grid {
-					grid-template-columns: repeat(auto-fit, minmax(#{(100%/$i)}, 1fr))!important;
+					grid-template-columns: repeat(auto-fit, minmax(#{(100%/$i)}, 1fr));
 				}
 			}
 		}


### PR DESCRIPTION
See: https://css-tricks.com/auto-sizing-columns-css-grid-auto-fill-vs-auto-fit/

## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Allow CSS grid to collapse empty columns (fill available width)

## Description
An explanation of what is done in this PR

* Uses CSS Grid `auto-fit` on the `.elementor-grid` class's `grid-template-columns` property's `repeat` value (with `minmax` set to `100% / columns`) to allow the grid to collapse empty columns.
* See: https://css-tricks.com/auto-sizing-columns-css-grid-auto-fill-vs-auto-fit/

## Test instructions
This PR can be tested by following these steps:

1. Add "Posts widget"
2. Set number of columns to (`total posts` + `n`)
3. Without this fix the posts are crammed onto the left half of the page, with `n` empty columns to the right, with this fix the grid collapses the empty columns so the available content fits the width of the container.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [n/a] I have added unittests to verify the code works as intended
- [n/a] Docs have been added / updated (for bug fixes / features)

Fixes #13558
