### PR TITLE
Landing Pages: Fixes and Tweaks (ED-1585, ED-1588, ED-1596, ED-1592, ED-1629, ED-1632)

### DIFF
--- a/assets/dev/js/editor/components/template-library/views/parts/templates.js
+++ b/assets/dev/js/editor/components/template-library/views/parts/templates.js
@@ -189,7 +189,7 @@ TemplateLibraryCollectionView = Marionette.CompositeView.extend( {
 	},
 
 	onRender() {
-		if ( 'remote' === elementor.templates.getFilter( 'source' ) && ! this.isPageOrLandingPageTemplates() ) {
+		if ( 'remote' === elementor.templates.getFilter( 'source' ) && 'page' !== elementor.templates.getFilter( 'type' ) ) {
 			this.setFiltersUI();
 		}
 	},

--- a/includes/editor-templates/templates.php
+++ b/includes/editor-templates/templates.php
@@ -60,7 +60,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			var activeType = elementor.templates.getFilter('type');
 			#>
 			<div id="elementor-template-library-filter-toolbar-remote" class="elementor-template-library-filter-toolbar">
-				<# if ( 'page' === activeType || 'landing-page' === activeType ) { #>
+				<# if ( 'page' === activeType ) { #>
 					<div id="elementor-template-library-order">
 						<input type="radio" id="elementor-template-library-order-new" class="elementor-template-library-order-input" name="elementor-template-library-order" value="date">
 						<label for="elementor-template-library-order-new" class="elementor-template-library-order-label"><?php echo __( 'New', 'elementor' ); ?></label>

--- a/modules/landing-pages/assets/js/editor/hooks/ui/editor/documents/close/remove-landing-pages-tab.js
+++ b/modules/landing-pages/assets/js/editor/hooks/ui/editor/documents/close/remove-landing-pages-tab.js
@@ -14,6 +14,9 @@ export class LandingPageRemoveLibraryTab extends $e.modules.hookUI.After {
 
 	apply() {
 		$e.components.get( 'library' ).removeTab( 'templates/landing-pages' );
+
+		// Pages are replaced by landing pages so when Landing Pages are removed, the Pages have to be re-added.
+		$e.components.get( 'library' ).addTab( 'templates/pages' );
 	}
 }
 

--- a/modules/landing-pages/assets/js/editor/hooks/ui/editor/documents/open/add-landing-pages-tab.js
+++ b/modules/landing-pages/assets/js/editor/hooks/ui/editor/documents/open/add-landing-pages-tab.js
@@ -20,6 +20,9 @@ export class LandingPageAddLibraryTab extends $e.modules.hookUI.After {
 				type: 'lp',
 			},
 		}, 2 );
+
+		// Pages are replaced by landing pages so they need to be removed.
+		$e.components.get( 'library' ).removeTab( 'templates/pages' );
 	}
 }
 

--- a/modules/landing-pages/documents/landing-page.php
+++ b/modules/landing-pages/documents/landing-page.php
@@ -3,7 +3,9 @@ namespace Elementor\Modules\LandingPages\Documents;
 
 use Elementor\Core\DocumentTypes\PageBase;
 use Elementor\Modules\LandingPages\Module as Landing_Pages_Module;
+use Elementor\Modules\Library\Traits\Library;
 use Elementor\Modules\PageTemplates\Module as Page_Templates_Module;
+use Elementor\Plugin;
 use Elementor\TemplateLibrary\Source_Local;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -11,6 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Landing_Page extends PageBase {
+
+	// Library Document Trait
+	use Library;
 
 	public static function get_properties() {
 		$properties = parent::get_properties();
@@ -60,19 +65,17 @@ class Landing_Page extends PageBase {
 	}
 
 	/**
-	 * Save Template type.
-	 *
-	 * Set new/updated document type (Page/landing Page). This method is called whenever a page is saved.
+	 * Admin Columns Content
 	 *
 	 * @since 3.1.0
+	 *
+	 * @param $column_name
 	 * @access public
 	 */
-	public function save_template_type() {
-		// Make sure it is saved as a Landing Page in the Elementor Library Taxonomy.
-		wp_set_object_terms( $this->get_id(), Landing_Pages_Module::DOCUMENT_TYPE, Source_Local::TAXONOMY_TYPE_SLUG );
-
-		// Make sure it is saved as a Landing Page Elementor Template Type Meta.
-		return $this->update_main_meta( self::TYPE_META_KEY, $this->get_name() );
+	public function admin_columns_content( $column_name ) {
+		if ( 'elementor_library_type' === $column_name ) {
+			$this->print_admin_column_type();
+		}
 	}
 
 	protected function get_remote_library_config() {

--- a/modules/landing-pages/module.php
+++ b/modules/landing-pages/module.php
@@ -48,6 +48,8 @@ class Module extends BaseModule {
 			'post_type' => self::CPT,
 			'post_status' => 'trash',
 			'posts_per_page' => 1,
+			'meta_key' => '_elementor_template_type',
+			'meta_value' => self::DOCUMENT_TYPE,
 		] );
 
 		return $this->trashed_posts;
@@ -64,6 +66,8 @@ class Module extends BaseModule {
 			// 'post_status' is not 'any' because 'any' does not include auto-drafts and revisions.
 			'post_status' => [ 'publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit' ],
 			'posts_per_page' => 1,
+			'meta_key' => '_elementor_template_type',
+			'meta_value' => self::DOCUMENT_TYPE,
 		] );
 
 		return $this->posts;

--- a/modules/landing-pages/module.php
+++ b/modules/landing-pages/module.php
@@ -5,6 +5,7 @@ use Elementor\Core\Base\Module as BaseModule;
 use Elementor\Core\Documents_Manager;
 use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\Modules\LandingPages\Documents\Landing_Page;
+use Elementor\Modules\LandingPages\Module as Landing_Pages_Module;
 use Elementor\Plugin;
 use Elementor\TemplateLibrary\Source_Local;
 use Elementor\Utils;
@@ -152,34 +153,6 @@ class Module extends BaseModule {
 	}
 
 	/**
-	 * Add Finder Items
-	 *
-	 * Adds Items to the Finder index to make them searchable in the Elementor Editor Finder modal.
-	 *
-	 * @since 3.1.0
-	 *
-	 * @param array $categories
-	 * @return array $categories
-	 */
-	private function add_finder_items( array $categories ) {
-		$categories['general']['items']['landing-pages'] = [
-			'title' => __( 'Landing Pages', 'elementor' ),
-			'icon' => 'single-page',
-			'url' => admin_url( self::ADMIN_PAGE_SLUG ),
-			'keywords' => [ self::DOCUMENT_TYPE, 'landing', 'page', 'library' ],
-		];
-
-		$categories['create']['items']['landing-pages'] = [
-			'title' => __( 'Add New Landing Page', 'elementor' ),
-			'icon' => 'single-page',
-			'url' => $this->get_add_new_landing_page_url(),
-			'keywords' => [ self::DOCUMENT_TYPE, 'landing', 'page', 'new', 'create', 'library' ],
-		];
-
-		return $categories;
-	}
-
-	/**
 	 * Is Current Admin Page Edit LP
 	 *
 	 * Checks whether the current page is a native WordPress edit page for a landing page.
@@ -272,7 +245,7 @@ class Module extends BaseModule {
 		// `/%postname%/`, the following hooks change the permalink to remove the CPT slug from it.
 		if ( ! is_admin() && false !== strpos( $this->permalink_structure, '/%postname%/' ) ) {
 			add_filter( 'post_type_link', function( $post_link, $post, $leavename ) {
-				$this->remove_post_type_slug( $post_link, $post, $leavename );
+				return $this->remove_post_type_slug( $post_link, $post, $leavename );
 			}, 10, 3 );
 
 			add_action( 'pre_get_posts', function( $query ) {
@@ -293,14 +266,26 @@ class Module extends BaseModule {
 			return $this->admin_localize_settings( $settings );
 		} );
 
-		add_filter( 'elementor/finder/categories', function( array $categories ) {
-			return $this->add_finder_items( $categories );
-		} );
-
 		add_filter( 'elementor/template_library/sources/local/register_taxonomy_cpts', function( array $cpts ) {
 			$cpts[] = self::CPT;
 
 			return $cpts;
 		} );
+
+		// In the Landing Pages Admin Table page - Overwrite Template type column header title.
+		add_action( 'manage_' . Landing_Pages_Module::CPT . '_posts_columns', function( $posts_columns ) {
+			/** @var Source_Local $source_local */
+			$source_local = Plugin::$instance->templates_manager->get_source( 'local' );
+
+			return $source_local->admin_columns_headers( $posts_columns );
+		} );
+
+		// In the Landing Pages Admin Table page - Overwrite Template type column row values.
+		add_action( 'manage_' . Landing_Pages_Module::CPT . '_posts_custom_column', function( $column_name, $post_id ) {
+			/** @var Landing_Page $document */
+			$document = Plugin::$instance->documents->get( $post_id );
+
+			$document->admin_columns_content( $column_name );
+		}, 10, 2 );
 	}
 }

--- a/modules/library/documents/library-document.php
+++ b/modules/library/documents/library-document.php
@@ -2,6 +2,7 @@
 namespace Elementor\Modules\Library\Documents;
 
 use Elementor\Core\Base\Document;
+use Elementor\Modules\Library\Traits\Library;
 use Elementor\TemplateLibrary\Source_Local;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -17,6 +18,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 2.0.0
  */
 abstract class Library_Document extends Document {
+
+	// Library Document Trait
+	use Library;
 
 	/**
 	 * The taxonomy type slug for the library document.
@@ -65,25 +69,5 @@ abstract class Library_Document extends Document {
 		];
 
 		return $config;
-	}
-
-	public function print_admin_column_type() {
-		$admin_filter_url = admin_url( Source_Local::ADMIN_MENU_SLUG . '&elementor_library_type=' . $this->get_name() );
-
-		printf( '<a href="%s">%s</a>', $admin_filter_url, $this->get_title() );
-	}
-
-	/**
-	 * Save document type.
-	 *
-	 * Set new/updated document type.
-	 *
-	 * @since 2.0.0
-	 * @access public
-	 */
-	public function save_template_type() {
-		parent::save_template_type();
-
-		wp_set_object_terms( $this->post->ID, $this->get_name(), self::TAXONOMY_TYPE_SLUG );
 	}
 }

--- a/modules/library/traits/library.php
+++ b/modules/library/traits/library.php
@@ -1,0 +1,41 @@
+<?php
+namespace Elementor\Modules\Library\Traits;
+
+use Elementor\TemplateLibrary\Source_Local;
+
+/**
+ * Elementor Library Trait
+ *
+ * This trait is used by all Library Documents and Landing Pages.
+ *
+ * @since 3.1.0
+ */
+trait Library {
+	/**
+	 * Print Admin Column Type
+	 *
+	 * Runs on WordPress' 'manage_{custom post type}_posts_custom_column' hook to modify each row's content.
+	 *
+	 * @since 3.1.0
+	 * @access public
+	 */
+	public function print_admin_column_type() {
+		$admin_filter_url = admin_url( Source_Local::ADMIN_MENU_SLUG . '&elementor_library_type=' . $this->get_name() );
+
+		printf( '<a href="%s">%s</a>', $admin_filter_url, $this->get_title() );
+	}
+
+	/**
+	 * Save document type.
+	 *
+	 * Set new/updated document type.
+	 *
+	 * @since 3.1.0
+	 * @access public
+	 */
+	public function save_template_type() {
+		parent::save_template_type();
+
+		wp_set_object_terms( $this->post->ID, $this->get_name(), Source_Local::TAXONOMY_TYPE_SLUG );
+	}
+}


### PR DESCRIPTION
- Template Library - Added a Category filter to the Landing Pages tab in the Template Library modal. 
- Fix - Viewing new Landing Page redirects to the wrong permalink. 
- Fix - Landing Page is duplicated in the Finder. 
- Fix - In WP Dashboard Landing Pages page, update 'landing-page' type to 'Landing Page'.