### PR TITLE
Landing Pages: Fix - In some cases, after publishing a landing page, it becomes uneditable by Elementor and returns a 404 when visited. (ED-1713)

### DIFF
--- a/modules/landing-pages/module.php
+++ b/modules/landing-pages/module.php
@@ -29,6 +29,15 @@ class Module extends BaseModule {
 		return 'landing-pages';
 	}
 
+	/**
+	 * Get Experimental Data
+	 *
+	 * Implementation of this method makes the module an experiment.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @return array
+	 */
 	public static function get_experimental_data() {
 		return [
 			'name' => 'landing-pages',
@@ -42,13 +51,22 @@ class Module extends BaseModule {
 		];
 	}
 
+	/**
+	 * Get Trashed Landing Pages Posts
+	 *
+	 * Returns the posts property of a WP_Query run for Landing Pages with post_status of 'trash'.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @return array trashed posts
+	 */
 	private function get_trashed_landing_page_posts() {
 		if ( $this->trashed_posts ) {
 			return $this->trashed_posts;
 		}
 
 		// `'posts_per_page' => 1` is because this is only used as an indicator to whether there are any trashed landing pages.
-		$this->trashed_posts = new \WP_Query( [
+		$trashed_posts_query = new \WP_Query( [
 			'post_type' => self::CPT,
 			'post_status' => 'trash',
 			'posts_per_page' => 1,
@@ -56,23 +74,35 @@ class Module extends BaseModule {
 			'meta_value' => self::DOCUMENT_TYPE,
 		] );
 
+		$this->trashed_posts = $trashed_posts_query->posts;
+
 		return $this->trashed_posts;
 	}
 
+	/**
+	 * Get Landing Pages Posts
+	 *
+	 * Returns the posts property of a WP_Query run for posts with the Landing Pages CPT.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @return array posts
+	 */
 	private function get_landing_page_posts() {
 		if ( $this->posts ) {
 			return $this->posts;
 		}
 
 		// `'posts_per_page' => 1` is because this is only used as an indicator to whether there are any landing pages.
-		$this->posts = new \WP_Query( [
+		$posts_query = new \WP_Query( [
 			'post_type' => self::CPT,
-			// 'post_status' is not 'any' because 'any' does not include auto-drafts and revisions.
-			'post_status' => [ 'publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit' ],
+			'post_status' => 'any',
 			'posts_per_page' => 1,
 			'meta_key' => '_elementor_template_type',
 			'meta_value' => self::DOCUMENT_TYPE,
 		] );
+
+		$this->posts = $posts_query->posts;
 
 		return $this->posts;
 	}
@@ -105,7 +135,7 @@ class Module extends BaseModule {
 
 		// If there are no Landing Pages, show the "Create Your First Landing Page" page.
 		// If there are, show the pages table.
-		if ( ! empty( $posts->posts ) ) {
+		if ( ! empty( $posts ) ) {
 			$landing_page_menu_slug = self::ADMIN_PAGE_SLUG;
 			$landing_page_menu_callback = null;
 		} else {
@@ -125,6 +155,17 @@ class Module extends BaseModule {
 		);
 	}
 
+	/**
+	 * Get 'Add New' Landing Page URL
+	 *
+	 * Retrieves the custom URL for the admin dashboard's 'Add New' button in the Landing Pages admin screen. This URL
+	 * creates a new Landing Pages and directly opens the Elementor Editor with the Template Library modal open on the
+	 * Landing Pages tab.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @return string
+	 */
 	private function get_add_new_landing_page_url() {
 		if ( ! $this->new_lp_url ) {
 			$this->new_lp_url = Utils::get_create_new_post_url( self::CPT, self::DOCUMENT_TYPE ) . '#library';
@@ -151,11 +192,11 @@ class Module extends BaseModule {
 		/** @var Source_Local $source_local */
 		$source_local->print_blank_state_template( __( 'Landing Page', 'elementor' ), $this->get_add_new_landing_page_url(), __( 'Build Effective Landing Pages for your business\' marketing campaigns.', 'elementor' ) );
 
-		if ( ! empty( $trashed_posts->posts ) ) { ?>
+		if ( ! empty( $trashed_posts ) ) : ?>
 			<div class="e-trashed-items">
 				<?php echo sprintf( __( 'Or view <a href="%s">Trashed Items</a>', 'elementor' ), admin_url( 'edit.php?post_status=trash&post_type=' . self::CPT ) ); ?>
 			</div>
-		<?php } ?>
+		<?php endif; ?>
 		</div>
 		<?php
 	}
@@ -175,6 +216,17 @@ class Module extends BaseModule {
 		return false;
 	}
 
+	/**
+	 * Admin Localize Settings
+	 *
+	 * Enables adding properties to the globally available elementorAdmin.config JS object in the Admin Dashboard.
+	 * Runs on the 'elementor/admin/localize_settings' filter.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param $settings
+	 * @return array|null
+	 */
 	private function admin_localize_settings( $settings ) {
 		$additional_settings = [
 			'urls' => [
@@ -189,6 +241,11 @@ class Module extends BaseModule {
 		return array_replace_recursive( $settings, $additional_settings );
 	}
 
+	/**
+	 * Register Landing Pages CPT
+	 *
+	 * @since 3.1.0
+	 */
 	private function register_landing_page_cpt() {
 		$labels = [
 			'name' => __( 'Landing Pages', 'elementor' ),
@@ -215,33 +272,140 @@ class Module extends BaseModule {
 			'supports' => [ 'title', 'editor', 'comments', 'revisions', 'trackbacks', 'author', 'excerpt', 'page-attributes', 'thumbnail', 'custom-fields', 'post-formats', 'elementor' ],
 		];
 
-		if ( false !== strpos( $this->permalink_structure, '/%postname%/' ) ) {
-			// For rewriting the Landing Page's permalink to act like a page in case the site's permalink structure
-			// is '/%postname%/'.
-			$args['rewrite'] = [
-				'slug' => '/',
-				'with_front' => false,
-			];
-		}
-
 		register_post_type( self::CPT, $args );
 	}
 
-	public function remove_post_type_slug( $post_link, $post, $leavename ) {
+	/**
+	 * Remove Post Type Slug
+	 *
+	 * Landing Pages are supposed to act exactly like pages. This includes their URLs being directly under the site's
+	 * domain name. Since "Landing Pages" is a CPT, WordPress automatically adds the landing page slug as a prefix to
+	 * it's posts' permalinks. This method checks if the post's post type is Landing Pages, and if it is, it removes
+	 * the CPT slug from the requested post URL.
+	 *
+	 * Runs on the 'post_type_link' filter.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param $post_link
+	 * @param $post
+	 * @param $leavename
+	 * @return string|string[]
+	 */
+	private function remove_post_type_slug( $post_link, $post, $leavename ) {
+		// Only try to modify the permalink if the post is a Landing Page.
 		if ( self::CPT !== $post->post_type || 'publish' !== $post->post_status ) {
 			return $post_link;
 		}
 
-		return str_replace( '/' . $post->post_type . '/', '/', $post_link );
+		// Any slug prefixes need to be removed from the post link.
+		return get_home_url() . '/' . $post->post_name;
 	}
 
-	public function adjust_landing_page_query( $query ) {
-		if ( ! $query->is_main_query() || 2 !== count( $query->query ) || ! isset( $query->query['page'] ) ) {
+	/**
+	 * Adjust Landing Page Query
+	 *
+	 * Since Landing Pages are a CPT but should act like pages, the WP_Query that is used to fetch the page from the
+	 * database needs to be adjusted. This method adds the Landing Pages CPT to the list of queried post types, to
+	 * make sure the database query finds the correct Landing Page to display.
+	 * Runs on the 'pre_get_posts' action.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param \WP_Query $query
+	 */
+	private function adjust_landing_page_query( \WP_Query $query ) {
+		// Only handle actual pages.
+		if ( ! $query->is_main_query() || ! isset( $query->query['page'] ) ) {
 			return;
 		}
-		if ( ! empty( $query->query['name'] ) ) {
-			$query->set( 'post_type', [ 'post', self::CPT, 'page' ] );
+
+		$query_post_types = $query->get( 'post_type' );
+
+		// If the post type field is empty, create it as an array.
+		if ( empty( $query_post_types ) ) {
+			// If the post types query is empty, create it as an array and include the landing pages CPT in it.
+			$query_post_types = [ 'post', 'page' ];
 		}
+
+		// If it is not empty but it is not an array (for example, if it is a single post type string), change it into
+		// an array.
+		if ( ! is_array( $query_post_types ) ) {
+			$query_post_types = [ $query_post_types ];
+		}
+
+		// Add the Landing Page CPT to the list of post types for the query.
+		$query_post_types[] = self::CPT;
+
+		// Since WordPress determined this is supposed to be a page, we'll pre-set the post_type query arg to make sure
+		// it includes the Landing Page CPT, so when the query is parsed, our CPT will be a legitimate match to the
+		// Landing Page's permalink (that is directly under the domain, without a CPT slug prefix). In some cases,
+		// The 'name' property will be set, and in others it is the 'pagename', so we have to cover both cases.
+		if ( ! empty( $query->query['name'] ) ) {
+			$query->set( 'post_type', $query_post_types );
+		} elseif ( ! empty( $query->query['pagename'] ) && false === strpos( $query->query['pagename'], '/' ) ) {
+			$query->set( 'post_type', $query_post_types );
+
+			// We also need to set the name query var since redirect_guess_404_permalink() relies on it.
+			$query->set( 'name', $query->query['pagename'] );
+		}
+	}
+
+	/**
+	 * Handle 404
+	 *
+	 * This method runs after a page is not found in the database, but before a page is returned as a 404.
+	 * These cases are handled in this filter callback, that runs on the 'pre_handle_404' filter.
+	 *
+	 * In some cases (such as when a site uses custom permalink structures), WordPress's WP_Query does not identify a
+	 * Landing Page's URL as a post belonging to the Landing Page CPT. Some cases are handled successfully by the
+	 * adjust_landing_page_query() method, but some are not and still trigger a 404 process. This method handles such
+	 * cases by overriding the $wp_query global to fetch the correct landing page post entry.
+	 *
+	 * For example, since Landing Pages slugs come directly after the site domain name, WP_Query might parse the post
+	 * as a category page. Since there is no category matching the slug, it triggers a 404 process. In this case, we
+	 * run a query for a Landing Page post with the passed slug ($query->query['category_name']. If a Landing Page
+	 * with the passed slug is found, we override the global $wp_query with the new, correct query.
+	 *
+	 * @param $current_value
+	 * @param $query
+	 * @return false
+	 */
+	private function handle_404( $current_value, $query ) {
+		global $wp_query;
+
+		// If another plugin/theme already used this filter, exit here to avoid conflicts.
+		if ( $current_value ) {
+			return $current_value;
+		}
+
+		if (
+			// Make sure we only intervene in the main query.
+			! $query->is_main_query()
+			// If a post was found, this is not a 404 case, so do not intervene.
+			|| ! empty( $query->posts )
+			// This filter is only meant to deal with wrong queries where the only query var is 'category_name'.
+			// If there is no 'category_name' query var, do not intervene.
+			|| empty( $query->query['category_name'] )
+			// If the query is for a real taxonomy (determined by it including a table to search in, such as the
+			// wp_term_relationships table), do not intervene.
+			|| ! empty( $query->tax_query->table_aliases )
+		) {
+			return false;
+		}
+
+		// Search for a Landing Page with the same name passed as the 'category name'.
+		$possible_new_query = new \WP_Query( [
+			'post_type' => self::CPT,
+			'name' => $query->query['category_name'],
+		] );
+
+		// Only if such a Landing Page is found, override the query to fetch the correct page.
+		if ( ! empty( $possible_new_query->posts ) ) {
+			$wp_query = $possible_new_query; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
+		return false;
 	}
 
 	public function __construct() {
@@ -249,16 +413,26 @@ class Module extends BaseModule {
 
 		$this->register_landing_page_cpt();
 
-		// Landing Pages should act like pages, including in their permalink structure. If the permalink structure is
-		// `/%postname%/`, the following hooks change the permalink to remove the CPT slug from it.
-		if ( ! is_admin() && false !== strpos( $this->permalink_structure, '/%postname%/' ) ) {
+		// If there is a permalink structure set to the site, run the hooks that modify the Landing Pages permalinks to
+		// match WordPress' native 'Pages' post type.
+		if ( '' !== $this->permalink_structure ) {
+			// Landing Pages' post link needs to be modified to be identical to the pages permalink structure. This
+			// needs to happen in both the admin and the front end, since post links are also used in the admin pages.
 			add_filter( 'post_type_link', function( $post_link, $post, $leavename ) {
 				return $this->remove_post_type_slug( $post_link, $post, $leavename );
 			}, 10, 3 );
 
-			add_action( 'pre_get_posts', function( $query ) {
-				$this->adjust_landing_page_query( $query );
-			} );
+			// The query itself only has to be manipulated when pages are viewed in the front end.
+			if ( ! is_admin() || is_ajax() ) {
+				add_action( 'pre_get_posts', function ( $query ) {
+					$this->adjust_landing_page_query( $query );
+				} );
+
+				// Handle cases where visiting a Landing Page's URL returns 404.
+				add_filter( 'pre_handle_404', function ( $value, $query ) {
+					return $this->handle_404( $value, $query );
+				}, 10, 2 );
+			}
 		}
 
 		add_action( 'elementor/documents/register', function( Documents_Manager $documents_manager ) {


### PR DESCRIPTION
Landing Pages: Changed the pre_get_posts filter to make sure it doesn't remove post types from the existing query (ED-1713)