### PR TITLE
Linter: New - Add JQuery linter for deprecated functions (ED-1862)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,11 +3,13 @@ module.exports = {
 		'wordpress',
 		'plugin:wordpress/esnext',
 		'plugin:react/recommended',
+		'plugin:no-jquery/deprecated',
 	],
 	plugins: [
 		'wordpress',
 		'babel',
 		'react',
+		'no-jquery',
 	],
 	parser: 'babel-eslint',
 	globals: {

--- a/assets/dev/js/admin/admin.js
+++ b/assets/dev/js/admin/admin.js
@@ -311,7 +311,7 @@ import ExperimentsModule from 'elementor/core/experiments/assets/js/admin/module
 
 			self.elements.$formAnchor = $( 'h1' );
 
-			$( '#wpbody-content' ).find( '.page-title-action:last' ).after( $importButton );
+			$( '#wpbody-content' ).find( '.page-title-action' ).last().after( $importButton );
 
 			self.elements.$formAnchor.after( $importArea );
 

--- a/assets/dev/js/editor/elements/views/behaviors/sortable.js
+++ b/assets/dev/js/editor/elements/views/behaviors/sortable.js
@@ -51,7 +51,6 @@ SortableBehavior = Marionette.Behavior.extend( {
 
 		var $childViewContainer = this.getChildViewContainer(),
 			defaultSortableOptions = {
-				connectWith: $childViewContainer,
 				placeholder: 'elementor-sortable-placeholder elementor-' + this.getOption( 'elChildType' ) + '-placeholder',
 				cursorAt: {
 					top: 20,

--- a/assets/dev/js/editor/elements/views/behaviors/sortable.js
+++ b/assets/dev/js/editor/elements/views/behaviors/sortable.js
@@ -51,7 +51,7 @@ SortableBehavior = Marionette.Behavior.extend( {
 
 		var $childViewContainer = this.getChildViewContainer(),
 			defaultSortableOptions = {
-				connectWith: $childViewContainer.selector,
+				connectWith: $childViewContainer,
 				placeholder: 'elementor-sortable-placeholder elementor-' + this.getOption( 'elChildType' ) + '-placeholder',
 				cursorAt: {
 					top: 20,

--- a/assets/dev/js/editor/utils/helpers.js
+++ b/assets/dev/js/editor/utils/helpers.js
@@ -31,7 +31,7 @@ module.exports = {
 		}
 
 		if ( ! $document.find( selector ).length ) {
-			$document.find( 'link:last' ).after( link );
+			$document.find( 'link' ).last().after( link );
 		}
 	},
 

--- a/assets/dev/js/editor/utils/jquery-html5-dnd.js
+++ b/assets/dev/js/editor/utils/jquery-html5-dnd.js
@@ -38,7 +38,7 @@
 		};
 
 		var onDragEnd = function( event ) {
-			if ( $.isFunction( settings.onDragEnd ) ) {
+			if ( 'function' === typeof settings.onDragEnd ) {
 				settings.onDragEnd.call( elementsCache.$element, event, self );
 			}
 		};
@@ -53,7 +53,7 @@
 				event.originalEvent.dataTransfer.setData( JSON.stringify( dataContainer ), true );
 			}
 
-			if ( $.isFunction( settings.onDragStart ) ) {
+			if ( 'function' === typeof settings.onDragStart ) {
 				settings.onDragStart.call( elementsCache.$element, event, self );
 			}
 		};
@@ -230,7 +230,7 @@
 				}
 			}
 
-			if ( $.isFunction( settings.isDroppingAllowed ) ) {
+			if ( 'function' === typeof settings.isDroppingAllowed ) {
 				droppingAllowed = settings.isDroppingAllowed.call( currentElement, currentSide, event, self );
 
 				if ( ! droppingAllowed ) {
@@ -272,7 +272,7 @@
 
 			$( currentElement ).addClass( settings.currentElementClass );
 
-			if ( $.isFunction( settings.onDragEnter ) ) {
+			if ( 'function' === typeof settings.onDragEnter ) {
 				settings.onDragEnter.call( currentElement, currentSide, event, self );
 			}
 		};
@@ -298,7 +298,7 @@
 				insertPlaceholder();
 			}
 
-			if ( $.isFunction( settings.onDragging ) ) {
+			if ( 'function' === typeof settings.onDragging ) {
 				settings.onDragging.call( this, currentSide, event, self );
 			}
 		};
@@ -329,7 +329,7 @@
 
 			event.preventDefault();
 
-			if ( $.isFunction( settings.onDropping ) ) {
+			if ( 'function' === typeof settings.onDropping ) {
 				settings.onDropping.call( this, currentSide, event, self );
 			}
 		};
@@ -357,7 +357,7 @@
 
 			elementsCache.$element.removeClass( settings.hasDraggingOnChildClass );
 
-			if ( $.isFunction( settings.onDragLeave ) ) {
+			if ( 'function' === typeof settings.onDragLeave ) {
 				settings.onDragLeave.call( currentElement, event, self );
 			}
 

--- a/assets/dev/js/frontend/handlers/base-tabs.js
+++ b/assets/dev/js/frontend/handlers/base-tabs.js
@@ -79,13 +79,11 @@ export default class baseTabs extends elementorModules.frontend.handlers.Base {
 				break;
 			case 'Home':
 				event.preventDefault();
-				$tabs.first().trigger( 'focus' );
-				$tabs.first().trigger( 'click' );
+				$tabs.first().focus();
 				return;
 			case 'End':
 				event.preventDefault();
-				$tabs.last().trigger( 'focus' );
-				$tabs.last().trigger( 'click' );
+				$tabs.last().focus();
 				return;
 			default:
 				return;
@@ -97,13 +95,10 @@ export default class baseTabs extends elementorModules.frontend.handlers.Base {
 
 		if ( nextTab ) {
 			nextTab.focus();
-			nextTab.click();
 		} else if ( -1 === tabIndex + direction ) {
-			$tabs.last().trigger( 'focus' );
-			$tabs.last().trigger( 'click' );
+			$tabs.last().focus();
 		} else {
-			$tabs.first().trigger( 'focus' );
-			$tabs.first().trigger( 'click' );
+			$tabs.first().focus();
 		}
 	}
 
@@ -149,7 +144,7 @@ export default class baseTabs extends elementorModules.frontend.handlers.Base {
 		this.elements.$tabTitles.on( {
 			keydown: ( event ) => {
 				// Support for old markup that includes an `<a>` tag in the tab
-				if ( jQuery( event.target ).is( 'a' ) && `Enter` === event.key ) {
+				if ( $( event.target ).is( 'a' ) && `Enter` === event.key ) {
 					event.preventDefault();
 				}
 

--- a/assets/dev/js/frontend/handlers/base-tabs.js
+++ b/assets/dev/js/frontend/handlers/base-tabs.js
@@ -79,11 +79,13 @@ export default class baseTabs extends elementorModules.frontend.handlers.Base {
 				break;
 			case 'Home':
 				event.preventDefault();
-				$tabs.first().focus();
+				$tabs.first().trigger( 'focus' );
+				$tabs.first().trigger( 'click' );
 				return;
 			case 'End':
 				event.preventDefault();
-				$tabs.last().focus();
+				$tabs.last().trigger( 'focus' );
+				$tabs.last().trigger( 'click' );
 				return;
 			default:
 				return;
@@ -95,10 +97,13 @@ export default class baseTabs extends elementorModules.frontend.handlers.Base {
 
 		if ( nextTab ) {
 			nextTab.focus();
+			nextTab.click();
 		} else if ( -1 === tabIndex + direction ) {
-			$tabs.last().focus();
+			$tabs.last().trigger( 'focus' );
+			$tabs.last().trigger( 'click' );
 		} else {
-			$tabs.first().focus();
+			$tabs.first().trigger( 'focus' );
+			$tabs.first().trigger( 'click' );
 		}
 	}
 
@@ -144,7 +149,7 @@ export default class baseTabs extends elementorModules.frontend.handlers.Base {
 		this.elements.$tabTitles.on( {
 			keydown: ( event ) => {
 				// Support for old markup that includes an `<a>` tag in the tab
-				if ( $( event.target ).is( 'a' ) && `Enter` === event.key ) {
+				if ( jQuery( event.target ).is( 'a' ) && `Enter` === event.key ) {
 					event.preventDefault();
 				}
 

--- a/assets/dev/js/frontend/handlers/section/handles-position.js
+++ b/assets/dev/js/frontend/handlers/section/handles-position.js
@@ -4,7 +4,7 @@ export default class HandlesPosition extends elementorModules.frontend.handlers.
 	}
 
 	isFirstSection() {
-		return this.$element.is( '.elementor-edit-mode .elementor-top-section:first' );
+		return this.$element[ 0 ] === document.querySelector( '.elementor-edit-mode .elementor-top-section' );
 	}
 
 	isOverflowHidden() {

--- a/assets/dev/js/frontend/utils/lightbox/lightbox.js
+++ b/assets/dev/js/frontend/utils/lightbox/lightbox.js
@@ -662,12 +662,12 @@ module.exports = elementorModules.ViewModule.extend( {
 				if ( isFirst ) {
 					event.preventDefault();
 
-					$buttons.last().focus();
+					$buttons.last().trigger( 'focus' );
 				}
 			} else if ( isLast || ! focusedButton ) {
 				event.preventDefault();
 
-				$buttons.first().focus();
+				$buttons.first().trigger( 'focus' );
 			}
 		}
 	},

--- a/assets/dev/js/modules/imports/instance-type.js
+++ b/assets/dev/js/modules/imports/instance-type.js
@@ -1,5 +1,5 @@
 export default class InstanceType {
-	static [Symbol.hasInstance]( target ) {
+	static [ Symbol.hasInstance ]( target ) {
 		/**
 		 * This is function extending being called each time JS uses instanceOf, since babel use it each time it create new class
 		 * its give's opportunity to mange capabilities of instanceOf operator.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "elementor",
-	"version": "3.0.16",
+	"version": "3.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -4838,6 +4838,12 @@
 					"dev": true
 				}
 			}
+		},
+		"eslint-plugin-no-jquery": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-2.5.0.tgz",
+			"integrity": "sha512-RrQ380mUJJKdjgpQ/tZAJ3B3W1n3LbVmULooS2Pv5pUDcc5uVHVSJMTdUlsbvQyfo6hWP2LJ4FbOoDzENWcF7A==",
+			"dev": true
 		},
 		"eslint-plugin-node": {
 			"version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"eslint-loader": "^2.1.2",
 		"eslint-plugin-babel": "^5.3.0",
 		"eslint-plugin-jsx-a11y": "^6.1.1",
+		"eslint-plugin-no-jquery": "^2.5.0",
 		"eslint-plugin-react": "^7.11.1",
 		"eslint-plugin-wordpress": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#1774343f6226052a46b081e01db3fca8793cc9f1",
 		"extract-text-webpack-plugin": "^3.0.2",


### PR DESCRIPTION
Added a `no-jquery` extension to ESlint to prevent JQuery deprecated functions.

Ref: https://www.npmjs.com/package/eslint-plugin-no-jquery
