### PR TITLE
Section Handler: Fix - The StretchedSection must run before the BackgroundSlideshow to first stretch the section and only then to calculate the slideshow slides width - ED-1911

### DIFF
--- a/assets/dev/js/frontend/handlers/section/section.js
+++ b/assets/dev/js/frontend/handlers/section/section.js
@@ -5,9 +5,9 @@ import StretchedSection from './stretched-section';
 import Shapes from './shapes';
 
 export default [
+	StretchedSection, // Must run before BackgroundSlideshow to init the slideshow only after the stretch.
 	BackgroundSlideshow,
 	BackgroundVideo,
 	HandlesPosition,
-	StretchedSection,
 	Shapes,
 ];


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
