### PR TITLE
Frontend: Fix - Conflict between Async JS loading and `wp.i8n` [ED-1898]

### DIFF
--- a/assets/dev/js/frontend/utils/lightbox/lightbox.js
+++ b/assets/dev/js/frontend/utils/lightbox/lightbox.js
@@ -86,7 +86,7 @@ module.exports = elementorModules.ViewModule.extend( {
 				attributes: {
 					tabindex: 0,
 					role: 'button',
-					'aria-label': wp.i18n.__( 'Close', 'elementor' ) + ' (Esc)',
+					'aria-label': elementorFrontend.config.i18n.close + ' (Esc)',
 				},
 			},
 			selectors: {
@@ -215,9 +215,9 @@ module.exports = elementorModules.ViewModule.extend( {
 	getShareLinks: function() {
 		const { i18n } = elementorFrontend.config,
 			socialNetworks = {
-				facebook: wp.i18n.__( 'Share on Facebook', 'elementor' ),
-				twitter: wp.i18n.__( 'Share on Twitter', 'elementor' ),
-				pinterest: wp.i18n.__( 'Share on Twitter', 'elementor' ),
+				facebook: i18n.shareOnFacebook,
+				twitter: i18n.shareOnTwitter,
+				pinterest: i18n.pinIt,
 			},
 			$ = jQuery,
 			classes = this.getSettings( 'classes' ),
@@ -244,8 +244,8 @@ module.exports = elementorModules.ViewModule.extend( {
 
 		if ( ! videoUrl ) {
 			$linkList.append( $( '<a>', { href: itemUrl, download: '' } )
-				.text( wp.i18n.__( 'Download image', 'elementor' ) )
-				.prepend( $( '<i>', { class: 'eicon-download-bold', 'aria-label': wp.i18n.__( 'Download', 'elementor' ) } ) ) );
+				.text( i18n.downloadImage )
+				.prepend( $( '<i>', { class: 'eicon-download-bold', 'aria-label': i18n.download } ) ) );
 		}
 
 		return $linkList;
@@ -289,7 +289,7 @@ module.exports = elementorModules.ViewModule.extend( {
 			elements.$iconShare = $( '<i>', {
 				class: slideshowClasses.iconShare,
 				role: 'button',
-				'aria-label': wp.i18n.__( 'Share', 'elementor' ),
+				'aria-label': i18n.share,
 				'aria-expanded': false,
 			} ).append( $( '<span>' ) );
 
@@ -313,7 +313,7 @@ module.exports = elementorModules.ViewModule.extend( {
 				class: slideshowClasses.iconZoomIn,
 				role: 'switch',
 				'aria-checked': false,
-				'aria-label': wp.i18n.__( 'Zoom', 'elementor' ),
+				'aria-label': i18n.zoom,
 			} );
 
 			elements.$iconZoom.on( 'click', this.toggleZoomMode );
@@ -328,7 +328,7 @@ module.exports = elementorModules.ViewModule.extend( {
 				class: slideshowClasses.iconExpand,
 				role: 'switch',
 				'aria-checked': false,
-				'aria-label': wp.i18n.__( 'Fullscreen', 'elementor' ),
+				'aria-label': i18n.fullscreen,
 			} ).append( $( '<span>' ), $( '<span>' ) );
 			elements.$iconExpand.on( 'click', this.toggleFullscreen );
 			elements.$header.append( elements.$iconExpand );
@@ -481,7 +481,7 @@ module.exports = elementorModules.ViewModule.extend( {
 			if ( slide.video ) {
 				$slide.attr( 'data-elementor-slideshow-video', slide.video );
 
-				const $playIcon = $( '<div>', { class: classes.playButton } ).html( $( '<i>', { class: classes.playButtonIcon, 'aria-label': wp.i18n.__( 'Play Video', 'elementor' ) } ) );
+				const $playIcon = $( '<div>', { class: classes.playButton } ).html( $( '<i>', { class: classes.playButtonIcon, 'aria-label': i18n.playVideo } ) );
 
 				$slide.append( $playIcon );
 			} else {
@@ -519,8 +519,8 @@ module.exports = elementorModules.ViewModule.extend( {
 			.append( $slidesWrapper );
 
 		if ( ! isSingleSlide ) {
-			$prevButton = $( '<div>', { class: slideshowClasses.prevButton + ' ' + classes.preventClose, 'aria-label': wp.i18n.__( 'Previous', 'elementor' ) } ).html( $( '<i>', { class: slideshowClasses.prevButtonIcon } ) );
-			$nextButton = $( '<div>', { class: slideshowClasses.nextButton + ' ' + classes.preventClose, 'aria-label': wp.i18n.__( 'Next', 'elementor' ) } ).html( $( '<i>', { class: slideshowClasses.nextButtonIcon } ) );
+			$prevButton = $( '<div>', { class: slideshowClasses.prevButton + ' ' + classes.preventClose, 'aria-label': i18n.previous } ).html( $( '<i>', { class: slideshowClasses.prevButtonIcon } ) );
+			$nextButton = $( '<div>', { class: slideshowClasses.nextButton + ' ' + classes.preventClose, 'aria-label': i18n.next } ).html( $( '<i>', { class: slideshowClasses.nextButtonIcon } ) );
 
 			$container.append(
 				$nextButton,

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -580,8 +580,6 @@ class Frontend extends App {
 
 		wp_enqueue_script( 'elementor-frontend' );
 
-		wp_set_script_translations( 'elementor-frontend', 'elementor' );
-
 		if ( ! $this->is_improved_assets_loading() ) {
 			wp_enqueue_script(
 				'preloaded-elements-handlers',
@@ -1173,8 +1171,20 @@ class Frontend extends App {
 				'isScriptDebug' => Utils::is_script_debug(),
 				'isImprovedAssetsLoading' => $this->is_improved_assets_loading(),
 			],
-			// Empty array for BC to avoid errors.
-			'i18n' => [],
+			'i18n' => [
+				'shareOnFacebook' => __( 'Share on Facebook', 'elementor' ),
+				'shareOnTwitter' => __( 'Share on Twitter', 'elementor' ),
+				'pinIt' => __( 'Pin it', 'elementor' ),
+				'download' => __( 'Download', 'elementor' ),
+				'downloadImage' => __( 'Download image', 'elementor' ),
+				'fullscreen' => __( 'Fullscreen', 'elementor' ),
+				'zoom' => __( 'Zoom', 'elementor' ),
+				'share' => __( 'Share', 'elementor' ),
+				'playVideo' => __( 'Play Video', 'elementor' ),
+				'previous' => __( 'Previous', 'elementor' ),
+				'next' => __( 'Next', 'elementor' ),
+				'close' => __( 'Close', 'elementor' ),
+			],
 			'is_rtl' => is_rtl(),
 			'breakpoints' => Responsive::get_breakpoints(),
 			'version' => ELEMENTOR_VERSION,


### PR DESCRIPTION
Reverted back use of `wp.i18n` in frontend code

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
