### PR TITLE
Video Widget: Fix - Due to a Youtube Embed API bug, when there are tw… (ED-1902)

### DIFF
--- a/assets/dev/js/frontend/handlers/section/background-video.js
+++ b/assets/dev/js/frontend/handlers/section/background-video.js
@@ -161,9 +161,7 @@ export default class BackgroundVideo extends elementorModules.frontend.handlers.
 			startStateCode = YT.PlayerState.UNSTARTED;
 		}
 
-		$backgroundVideoContainer.addClass( 'elementor-loading elementor-invisible' );
-
-		this.player = new YT.Player( this.elements.$backgroundVideoEmbed[ 0 ], {
+		const playerOptions = {
 			videoId: videoID,
 			events: {
 				onReady: () => {
@@ -194,7 +192,17 @@ export default class BackgroundVideo extends elementorModules.frontend.handlers.
 				rel: 0,
 				playsinline: 1,
 			},
-		} );
+		};
+
+		// To handle CORS issues, when the default host is changed, the origin parameter has to be set.
+		if ( elementSettings.background_privacy_mode ) {
+			playerOptions.host = 'http://www.youtube-nocookie.com';
+			playerOptions.origin = window.location.hostname;
+		}
+
+		$backgroundVideoContainer.addClass( 'elementor-loading elementor-invisible' );
+
+		this.player = new YT.Player( this.elements.$backgroundVideoEmbed[ 0 ], playerOptions );
 	}
 
 	activate() {

--- a/assets/dev/js/frontend/handlers/section/background-video.js
+++ b/assets/dev/js/frontend/handlers/section/background-video.js
@@ -196,7 +196,7 @@ export default class BackgroundVideo extends elementorModules.frontend.handlers.
 
 		// To handle CORS issues, when the default host is changed, the origin parameter has to be set.
 		if ( elementSettings.background_privacy_mode ) {
-			playerOptions.host = 'http://www.youtube-nocookie.com';
+			playerOptions.host = 'https://www.youtube-nocookie.com';
 			playerOptions.origin = window.location.hostname;
 		}
 

--- a/assets/dev/js/frontend/handlers/video.js
+++ b/assets/dev/js/frontend/handlers/video.js
@@ -133,7 +133,17 @@ export default class Video extends elementorModules.frontend.handlers.Base {
 			return;
 		}
 
-		this.apiProvider.onApiReady( ( apiObject ) => this.prepareYTVideo( apiObject ) );
+		// When Optimized asset loading is set to off, the video type is set to 'Youtube', and 'Privacy Mode' is set
+		// to 'On', there might be a conflict with other videos that are loaded WITHOUT privacy mode, such as a
+		// video bBackground in a section. In these cases, to avoid the conflict, a timeout is added to postpone the
+		// initialization of the Youtube API object.
+		if ( ! elementorFrontend.config.experimentalFeatures[ 'e_optimized_assets_loading' ] && elementSettings.yt_privacy ) {
+			setTimeout( () => {
+				this.apiProvider.onApiReady( ( apiObject ) => this.prepareYTVideo( apiObject ) );
+			}, 0 );
+		} else {
+			this.apiProvider.onApiReady( ( apiObject ) => this.prepareYTVideo( apiObject ) );
+		}
 	}
 
 	onElementChange( propertyName ) {

--- a/assets/dev/js/frontend/handlers/video.js
+++ b/assets/dev/js/frontend/handlers/video.js
@@ -102,9 +102,10 @@ export default class Video extends elementorModules.frontend.handlers.Base {
 				},
 			};
 
+		// To handle CORS issues, when the default host is changed, the origin parameter has to be set.
 		if ( elementSettings.yt_privacy ) {
 			playerOptions.host = 'https://www.youtube-nocookie.com';
-			playerOptions.playerVars.origin = window.location.hostname;
+			playerOptions.origin = window.location.hostname;
 		}
 
 		this.youtubePlayer = new YT.Player( this.elements.$video[ 0 ], playerOptions );
@@ -133,17 +134,13 @@ export default class Video extends elementorModules.frontend.handlers.Base {
 			return;
 		}
 
-		// When Optimized asset loading is set to off, the video type is set to 'Youtube', and 'Privacy Mode' is set
-		// to 'On', there might be a conflict with other videos that are loaded WITHOUT privacy mode, such as a
-		// video bBackground in a section. In these cases, to avoid the conflict, a timeout is added to postpone the
-		// initialization of the Youtube API object.
-		if ( ! elementorFrontend.config.experimentalFeatures[ 'e_optimized_assets_loading' ] && elementSettings.yt_privacy ) {
-			setTimeout( () => {
-				this.apiProvider.onApiReady( ( apiObject ) => this.prepareYTVideo( apiObject ) );
-			}, 0 );
-		} else {
+		// Due to a bug in the YouTube Embed API, there might be a conflict when privacy mode is set to ON, and the
+		// page contains additional YouTube videos that are loaded WITHOUT privacy mode, such as a video background
+		// in a section. In these cases, to avoid the conflict, a timeout is added to defer the initialization of
+		// the Youtube API object.
+		setTimeout( () => {
 			this.apiProvider.onApiReady( ( apiObject ) => this.prepareYTVideo( apiObject ) );
-		}
+		}, 0 );
 	}
 
 	onElementChange( propertyName ) {

--- a/assets/dev/js/frontend/handlers/video.js
+++ b/assets/dev/js/frontend/handlers/video.js
@@ -134,13 +134,17 @@ export default class Video extends elementorModules.frontend.handlers.Base {
 			return;
 		}
 
-		// Due to a bug in the YouTube Embed API, there might be a conflict when privacy mode is set to ON, and the
-		// page contains additional YouTube videos that are loaded WITHOUT privacy mode, such as a video background
-		// in a section. In these cases, to avoid the conflict, a timeout is added to defer the initialization of
-		// the Youtube API object.
-		setTimeout( () => {
+		// When Optimized asset loading is set to off, the video type is set to 'Youtube', and 'Privacy Mode' is set
+		// to 'On', there might be a conflict with other videos that are loaded WITHOUT privacy mode, such as a
+		// video bBackground in a section. In these cases, to avoid the conflict, a timeout is added to postpone the
+		// initialization of the Youtube API object.
+		if ( ! elementorFrontend.config.experimentalFeatures[ 'e_optimized_assets_loading' ] ) {
+			setTimeout( () => {
+				this.apiProvider.onApiReady( ( apiObject ) => this.prepareYTVideo( apiObject ) );
+			}, 0 );
+		} else {
 			this.apiProvider.onApiReady( ( apiObject ) => this.prepareYTVideo( apiObject ) );
-		}, 0 );
+		}
 	}
 
 	onElementChange( propertyName ) {

--- a/includes/controls/groups/background.php
+++ b/includes/controls/groups/background.php
@@ -614,6 +614,21 @@ class Group_Control_Background extends Group_Control_Base {
 			'frontend_available' => true,
 		];
 
+		// This control was added to handle a bug with the Youtube Embed API. The bug: If there is a video with Privacy
+		// Mode on, and at the same time the page contains another video WITHOUT privacy mode on, one of the videos
+		// will not run properly. This added control allows users to align all their videos to one host (either
+		// youtube.com or youtube-nocookie.com, depending on whether the user wants privacy mode on or not).
+		$fields['privacy_mode'] = [
+			'label' => __( 'Privacy mode', 'elementor' ),
+			'type' => Controls_Manager::SWITCHER,
+			'description' => __( 'Only works for YouTube videos.', 'elementor' ),
+			'condition' => [
+				'background' => [ 'video' ],
+			],
+			'of_type' => 'video',
+			'frontend_available' => true,
+		];
+
 		$fields['video_fallback'] = [
 			'label' => _x( 'Background Fallback', 'Background Control', 'elementor' ),
 			'description' => __( 'This cover image will replace the background video in case that the video could not be loaded.', 'elementor' ),


### PR DESCRIPTION
…o (or more) videos on the same page, while one has Privacy Mode on and the other does not, the second video will not work properly. This problem occurs only when Optimized Assets Loading is off.

Fixes #13711.

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Video Widget; Fix - When there are two videos in a single page, while one of them has Privacy mode on, the second video does not work properly.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)