### PR TITLE
Elementor background video no longer discards video link parameters [ED-8191]

### DIFF
--- a/assets/dev/js/frontend/handlers/section/background-video.js
+++ b/assets/dev/js/frontend/handlers/section/background-video.js
@@ -205,7 +205,7 @@ export default class BackgroundVideo extends elementorModules.frontend.handlers.
 		let videoLink = this.getElementSettings( 'background_video_link' ),
 			videoID;
 		// Extract any URL param options passed in by the user
-		const videoLinkOptions = Object.fromEntries(new URLSearchParams(new URL(videoLink).search));
+		const videoLinkOptions = Object.fromEntries( new URLSearchParams( new URL( videoLink ).search ) );
 
 		const playOnce = this.getElementSettings( 'background_play_once' );
 

--- a/assets/dev/js/frontend/handlers/section/background-video.js
+++ b/assets/dev/js/frontend/handlers/section/background-video.js
@@ -93,7 +93,7 @@ export default class BackgroundVideo extends elementorModules.frontend.handlers.
 		}
 	}
 
-	prepareVimeoVideo( Vimeo, videoId ) {
+	prepareVimeoVideo( Vimeo, videoId, videoLinkOptions ) {
 		const elementSettings = this.getElementSettings(),
 			startTime = elementSettings.background_video_start ? elementSettings.background_video_start : 0,
 			videoSize = this.elements.$backgroundVideoContainer.outerWidth(),
@@ -105,6 +105,8 @@ export default class BackgroundVideo extends elementorModules.frontend.handlers.
 				transparent: false,
 				background: true,
 				muted: true,
+				// Any custom URL param options passed in by the user via the video link
+				...videoLinkOptions,
 			};
 
 		this.player = new Vimeo.Player( this.elements.$backgroundVideoContainer, vimeoOptions );
@@ -151,7 +153,7 @@ export default class BackgroundVideo extends elementorModules.frontend.handlers.
 		} );
 	}
 
-	prepareYTVideo( YT, videoID ) {
+	prepareYTVideo( YT, videoID, videoLinkOptions ) {
 		const $backgroundVideoContainer = this.elements.$backgroundVideoContainer,
 			elementSettings = this.getElementSettings();
 		let startStateCode = YT.PlayerState.PLAYING;
@@ -193,6 +195,8 @@ export default class BackgroundVideo extends elementorModules.frontend.handlers.
 				controls: 0,
 				rel: 0,
 				playsinline: 1,
+				// Any custom URL param options passed in by the user via the video link
+				...videoLinkOptions,
 			},
 		} );
 	}
@@ -200,6 +204,8 @@ export default class BackgroundVideo extends elementorModules.frontend.handlers.
 	activate() {
 		let videoLink = this.getElementSettings( 'background_video_link' ),
 			videoID;
+		// Extract any URL param options passed in by the user
+		const videoLinkOptions = Object.fromEntries(new URLSearchParams(new URL(videoLink).search));
 
 		const playOnce = this.getElementSettings( 'background_play_once' );
 
@@ -216,11 +222,11 @@ export default class BackgroundVideo extends elementorModules.frontend.handlers.
 
 			this.apiProvider.onApiReady( ( apiObject ) => {
 				if ( 'youtube' === this.videoType ) {
-					this.prepareYTVideo( apiObject, videoID );
+					this.prepareYTVideo( apiObject, videoID, videoLinkOptions );
 				}
 
 				if ( 'vimeo' === this.videoType ) {
-					this.prepareVimeoVideo( apiObject, videoID );
+					this.prepareVimeoVideo( apiObject, videoID, videoLinkOptions );
 				}
 			} );
 		} else {


### PR DESCRIPTION
Carry background video URL parameters into the YouTube/Vimeo player options instead of discarding them. URL parameters are combined with parameters set in the UI.

## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Elementor background video no longer discards video link parameters.

## Description

Previously, if the background video of a section was set with a video link that contained URL parameters, the URL parameters would be discarded. With this fix, those parameters are combined with any parameters set in the Elementor UI.

**Why is this useful?**
* `?dnt=true` - Elementor users can now ask Vimeo not to track users.
* `?quality=720p` - Videos are heavy and expensive, background videos defaulting to the highest quality available is often undesirable. With URL parameters, users can choose the quality that meets their needs.
* As well as many other player options documented below:

**YouTube player parameters:** https://developers.google.com/youtube/player_parameters
**Vimeo player parameters:** https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Using-Player-Parameters

**Things to note with this fix**
* This fix gives URL parameters precedence. For example, if the start time was set to `0` in the UI, but the URL of a YouTube video has `?start=10`, then the YouTube player will start at 10 seconds. The thought process was that the user would have to go through extra effort to set the URL parameters, therefore the user probably prefers any configuration set in the URL over the UI. However, if this undesirable and may cause confusion, moving the position of the `videoLinkOptions` object to earlier in the code will reverse this behavior.
* This code uses the [URL](https://caniuse.com/url) and [URLSearchParams](https://caniuse.com/urlsearchparams) APIs to simplify implementation and guarantee a robust solution. However, Opera Mini does not support these APIs. I'm not aware of Elementor's stance on Opera Mini support, so if this is a problem I can switch to more Vanilla solutions.


## Test instructions
This PR can be tested by following these steps:

**YouTube links**
* Give an Elementor section a background video with the following YouTube link: https://www.youtube.com/watch?v=QC8iQqtG0hg&loop=1
* The video should now loop.

**Vimeo links**
* Give an Elementor section a background video with the following Vimeo link: https://player.vimeo.com/video/96208258?loop=1
* The video should now loop.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

*This is my first Elementor PR - I tested the code that was added; however, it wasn't tested all together. Please advise if and how to do that.

Fixes #13797 and #13631

*#13631 specifies a UI toggle for a `dnt` parameter. This fix does not change the UI, but it does allow for a `dnt` parameter to be added. (Previously Elementor would discard the `dnt` parameter)
