### PR TITLE
Landing Pages: Fix - The '+ New > Landing Page' link in the WP Admin Bar... (ED-1775, ED-1764)

### DIFF
--- a/modules/landing-pages/module.php
+++ b/modules/landing-pages/module.php
@@ -464,5 +464,16 @@ class Module extends BaseModule {
 
 			$document->admin_columns_content( $column_name );
 		}, 10, 2 );
+
+		// Overwrite the Admin Bar's 'New +' Landing Page URL with the link that creates the new LP in Elementor
+		// with the Template Library modal open.
+		add_action( 'admin_bar_menu', function( $admin_bar ) {
+			// Get the Landing Page menu node.
+			$new_landing_page_node = $admin_bar->get_node( 'new-e-landing-page' );
+
+			$new_landing_page_node->href = $this->get_add_new_landing_page_url();
+
+			$admin_bar->add_node( $new_landing_page_node );
+		}, 100 );
 	}
 }


### PR DESCRIPTION
… doesn't open in Elementor with the Template Library.

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Landing Pages: Fix - The '+ New > Landing Page' link in the WP Admin Bar doesn't open in Elementor with the Template Library.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)