### PR TITLE
ED-2276 Fix: Template widget clears control value after save & reload

### DIFF
--- a/includes/controls/select2.php
+++ b/includes/controls/select2.php
@@ -112,17 +112,8 @@ class Control_Select2 extends Base_Data_Control {
 	 * @return string|array
 	 */
 	private function validate_value( $value, array $config ) {
-		// Handle multiple select.
+		// Multiple select are not relevant to check.
 		if ( ! empty( $config['multiple'] ) ) {
-			$validated_value = [];
-
-			foreach ( $value as $index => $item ) {
-				if ( isset( $config['options'][ $item ] ) ) {
-					$validated_value[ $index ] = $item;
-				}
-			}
-
-			$value = $validated_value;
 			$is_valid = true;
 		} else {
 			$is_valid = isset( $config['options'][ $value ] );


### PR DESCRIPTION
Some plugins add the multi-select values via ajax. so the validation against the options will always fail. This validation has been removed because there is no real reason to validate the multi-select because it's not designed for print raw HTML.