### PR TITLE
Select2: Fix - Validation failed on 3rd party plugins.

### DIFF
--- a/includes/controls/select2.php
+++ b/includes/controls/select2.php
@@ -112,8 +112,22 @@ class Control_Select2 extends Base_Data_Control {
 	 * @return string|array
 	 */
 	private function validate_value( $value, array $config ) {
-		// Multiple select are not relevant to check.
+		// If there is no `allowed` list, don't touch it.
+		if ( empty( $config['options'] ) ) {
+			return $value;
+		}
+
+		// Handle multiple select.
 		if ( ! empty( $config['multiple'] ) ) {
+			$validated_value = [];
+
+			foreach ( $value as $index => $item ) {
+				if ( isset( $config['options'][ $item ] ) ) {
+					$validated_value[ $index ] = $item;
+				}
+			}
+
+			$value = $validated_value;
 			$is_valid = true;
 		} else {
 			$is_valid = isset( $config['options'][ $value ] );


### PR DESCRIPTION
Some plugins add the multi-select values via ajax. so the validation against the options will always fail. This validation has been removed if the `options` are empty.