### PR TITLE
Select/Select2: Fix - Validation failed on 3rd party plugins.

### DIFF
--- a/includes/controls/select.php
+++ b/includes/controls/select.php
@@ -118,6 +118,10 @@ class Control_Select extends Base_Data_Control {
 	 * @return mixed|string
 	 */
 	private function validate_value( $value, array $config ) {
+		if ( empty( $config['validate'] ) ) {
+			return $value;
+		}
+
 		$is_valid = false;
 
 		// Handle options groups.

--- a/includes/controls/select2.php
+++ b/includes/controls/select2.php
@@ -112,8 +112,7 @@ class Control_Select2 extends Base_Data_Control {
 	 * @return string|array
 	 */
 	private function validate_value( $value, array $config ) {
-		// If there is no `allowed` list, don't touch it.
-		if ( empty( $config['options'] ) ) {
+		if ( empty( $config['validate'] ) ) {
 			return $value;
 		}
 

--- a/includes/elements/column.php
+++ b/includes/elements/column.php
@@ -241,6 +241,7 @@ class Element_Column extends Element_Base {
 				'type' => Controls_Manager::SELECT,
 				'options' => $options,
 				'render_type' => 'none',
+				'validate' => true,
 			]
 		);
 

--- a/includes/elements/section.php
+++ b/includes/elements/section.php
@@ -518,6 +518,7 @@ class Element_Section extends Element_Base {
 				'type' => Controls_Manager::SELECT,
 				'options' => $options,
 				'separator' => 'before',
+				'validate' => true,
 			]
 		);
 

--- a/includes/widgets/accordion.php
+++ b/includes/widgets/accordion.php
@@ -217,6 +217,7 @@ class Widget_Accordion extends Widget_Base {
 				],
 				'default' => 'div',
 				'separator' => 'before',
+				'validate' => true,
 			]
 		);
 

--- a/includes/widgets/divider.php
+++ b/includes/widgets/divider.php
@@ -539,6 +539,7 @@ class Widget_Divider extends Widget_Base {
 					'p' => 'p',
 				],
 				'default' => 'span',
+				'validate' => true,
 			]
 		);
 

--- a/includes/widgets/heading.php
+++ b/includes/widgets/heading.php
@@ -167,6 +167,7 @@ class Widget_Heading extends Widget_Base {
 					'p' => 'p',
 				],
 				'default' => 'h2',
+				'validate' => true,
 			]
 		);
 

--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -230,6 +230,7 @@ class Widget_Icon_Box extends Widget_Base {
 					'p' => 'p',
 				],
 				'default' => 'h3',
+				'validate' => true,
 			]
 		);
 

--- a/includes/widgets/image-box.php
+++ b/includes/widgets/image-box.php
@@ -197,6 +197,7 @@ class Widget_Image_Box extends Widget_Base {
 					'p' => 'p',
 				],
 				'default' => 'h3',
+				'validate' => true,
 			]
 		);
 

--- a/includes/widgets/toggle.php
+++ b/includes/widgets/toggle.php
@@ -221,6 +221,7 @@ class Widget_Toggle extends Widget_Base {
 				],
 				'default' => 'div',
 				'separator' => 'before',
+				'validate' => true,
 			]
 		);
 

--- a/tests/phpunit/elementor/core/base/test-document.php
+++ b/tests/phpunit/elementor/core/base/test-document.php
@@ -88,7 +88,7 @@ class Test_Document extends Elementor_Test_Base {
 								'widgetType' => 'heading',
 							],
 							[
-								'id' => '5a1e8ehtml_tag5',
+								'id' => '5a1e86',
 								'elType' => 'widget',
 								'settings' => [
 									'style' => 'dots_tribal',
@@ -121,6 +121,7 @@ class Test_Document extends Elementor_Test_Base {
 				'options' => [
 					'' => 'Empty' // Pass `test_controlsDefaultData`.
 				],
+				'validate' => true,
 			]
 		);
 
@@ -134,6 +135,7 @@ class Test_Document extends Elementor_Test_Base {
 					'a' => 'A',
 					'b' => 'B',
 				],
+				'validate' => true,
 			]
 		);
 	}
@@ -180,6 +182,7 @@ class Test_Document extends Elementor_Test_Base {
 				[
 					'type' => Controls_Manager::SELECT,
 					'options' => [],
+					'validate' => true,
 				]
 			);
 


### PR DESCRIPTION
Some plugins add the select options via ajax. so the validation against the options will always fail. The validations were limited to controls that set `validate => true`.