### PR TITLE
Widgets/Text Path: Fix - Text path not working on frontend (ED-2521)

### DIFF
--- a/modules/shapes/assets/js/frontend/handlers/text-path.js
+++ b/modules/shapes/assets/js/frontend/handlers/text-path.js
@@ -177,7 +177,7 @@ export default class TextPathHandler extends elementorModules.frontend.handlers.
 	 */
 	isRTL() {
 		const { text_path_direction: direction } = this.getElementSettings();
-		let isRTL = elementorCommon.config.isRTL;
+		let isRTL = elementorFrontend.config.is_rtl;
 
 		if ( direction ) {
 			isRTL = ( 'rtl' === direction );


### PR DESCRIPTION
#ED-2521
Used `elementorFrontend` instead of `elementorCommon`.