### PR TITLE
Fix-Editor/Panel: Panel width does not preserve after refresh  (ED-2187)

### DIFF
--- a/assets/dev/js/editor/regions/panel/panel.js
+++ b/assets/dev/js/editor/regions/panel/panel.js
@@ -50,7 +50,7 @@ module.exports = BaseRegion.extend( {
 
 				elementor.getPanelView().updateScrollbar();
 
-				self.saveSize( ui.size.width + 'px' );
+				self.saveSize( { width: ui.size.width + 'px' } );
 			},
 			resize: function( event, ui ) {
 				elementorCommon.elements.$body.css( '--e-editor-panel-width', ui.size.width + 'px' );


### PR DESCRIPTION
Now when user resize the width of the panel, the size of the panel width is preserve after refreshing page.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
