### PR TITLE
Site Settings: Breakpoints - Added a validator for the breakpoint controls (ED-2605)

### DIFF
--- a/assets/dev/js/editor/components/validator/breakpoint.js
+++ b/assets/dev/js/editor/components/validator/breakpoint.js
@@ -50,12 +50,12 @@ export default class BreakpointValidator extends NumberValidator {
 		// If there is a breakpoint below the currently edited breakpoint
 		if ( this.bottomBreakpoint ) {
 			// Check that the new value is not under the bottom breakpoint's value.
-			if ( newValue && newValue <= this.bottomBreakpoint ) {
+			if ( '' !== newValue && newValue <= this.bottomBreakpoint ) {
 				isValid = false;
 			}
 
 			// If the new value is empty, check that the default breakpoint value is not below the bottom breakpoint.
-			if ( ! newValue && breakpointDefaultValue <= this.bottomBreakpoint ) {
+			if ( '' === newValue && breakpointDefaultValue <= this.bottomBreakpoint ) {
 				isValid = false;
 			}
 		}
@@ -63,12 +63,12 @@ export default class BreakpointValidator extends NumberValidator {
 		// If there is a breakpoint above the currently edited breakpoint.
 		if ( this.topBreakpoint ) {
 			// Check that the value is not above the top breakpoint's value.
-			if ( newValue && newValue >= this.topBreakpoint ) {
+			if ( '' !== newValue && newValue >= this.topBreakpoint ) {
 				isValid = false;
 			}
 
 			// If the new value is empty, check that the default breakpoint value is not above the top breakpoint.
-			if ( ! newValue && breakpointDefaultValue >= this.topBreakpoint ) {
+			if ( '' === newValue && breakpointDefaultValue >= this.topBreakpoint ) {
 				isValid = false;
 			}
 		}

--- a/assets/dev/js/editor/components/validator/breakpoint.js
+++ b/assets/dev/js/editor/components/validator/breakpoint.js
@@ -1,20 +1,18 @@
+import Stylesheet from 'elementor-editor-utils/stylesheet';
+
 const NumberValidator = require( 'elementor-validator/number' );
 
-module.exports = NumberValidator.extend( {
-	breakpointKeysArray: [],
-
-	getDefaultSettings: function() {
+export default class BreakpointValidator extends NumberValidator {
+	getDefaultSettings() {
 		return {
 			validationTerms: {
-				// Min width we allow for mobile
-				min: 320,
 				// Max width we allow in general
 				max: 5120,
 			},
 		};
-	},
+	}
 
-	validationMethod: function( newValue ) {
+	validationMethod( newValue ) {
 		const validationTerms = this.getSettings( 'validationTerms' ),
 			errors = NumberValidator.prototype.validationMethod.call( this, newValue );
 
@@ -25,22 +23,28 @@ module.exports = NumberValidator.extend( {
 		}
 
 		return errors;
-	},
+	}
 
-	validateMinMaxForBreakpoint: function( newValue, validationTerms ) {
+	validateMinMaxForBreakpoint( newValue, validationTerms ) {
 		let isValid = true;
 
-		if ( ! this.breakpointKeysArray.length ) {
+		if ( ! this.breakpointKeysArray ) {
 			this.breakpointKeysArray = Object.keys( elementorFrontend.config.responsive.activeBreakpoints );
 		}
 
 		const breakpointIndex = this.breakpointKeysArray.indexOf( validationTerms.breakpointName ),
-			bottomBreakpointKey = this.breakpointKeysArray[ breakpointIndex - 1 ],
 			topBreakpointKey = this.breakpointKeysArray[ breakpointIndex + 1 ];
+
+		let bottomBreakpoint = Stylesheet.getDeviceMinBreakpoint( validationTerms.breakpointName );
+
+		// Since the following comparison is <=, allow usage of the 320px value for the mobile breakpoint.
+		if ( 'mobile' === validationTerms.breakpointName ) {
+			bottomBreakpoint -= 1;
+		}
 
 		// If there is a breakpoint below the currently edited breakpoint, check that the value is not under the bottom
 		// breakpoint's value.
-		if ( bottomBreakpointKey && newValue <= elementorFrontend.config.responsive.activeBreakpoints[ bottomBreakpointKey ].value ) {
+		if ( bottomBreakpoint && ( newValue <= bottomBreakpoint ) ) {
 			isValid = false;
 		}
 
@@ -51,5 +55,5 @@ module.exports = NumberValidator.extend( {
 		}
 
 		return isValid;
-	},
-} );
+	}
+}

--- a/assets/dev/js/editor/components/validator/breakpoint.js
+++ b/assets/dev/js/editor/components/validator/breakpoint.js
@@ -50,7 +50,7 @@ export default class BreakpointValidator extends NumberValidator {
 
 		// If there is a breakpoint above the currently edited breakpoint, check that the value is not above the top
 		// breakpoint's value.
-		if ( topBreakpointKey && newValue >= elementorFrontend.config.responsive.activeBreakpoints[ topBreakpointKey ].value ) {
+		if ( topBreakpointKey && newValue > elementorFrontend.config.responsive.activeBreakpoints[ topBreakpointKey ].value ) {
 			isValid = false;
 		}
 

--- a/assets/dev/js/editor/components/validator/breakpoint.js
+++ b/assets/dev/js/editor/components/validator/breakpoint.js
@@ -12,11 +12,21 @@ export default class BreakpointValidator extends NumberValidator {
 		};
 	}
 
+	initBreakpointProperties() {
+		const validationTerms = this.getSettings( 'validationTerms' );
+
+		this.breakpointKeysArray = Object.keys( elementorFrontend.config.responsive.activeBreakpoints );
+		this.breakpointIndex = this.breakpointKeysArray.indexOf( validationTerms.breakpointName );
+		this.topBreakpoint = elementorFrontend.config.responsive.activeBreakpoints[ this.breakpointKeysArray[ this.breakpointIndex + 1 ] ]?.value;
+		this.bottomBreakpoint = Stylesheet.getDeviceMinBreakpoint( validationTerms.breakpointName );
+	}
+
 	validationMethod( newValue ) {
 		const validationTerms = this.getSettings( 'validationTerms' ),
 			errors = NumberValidator.prototype.validationMethod.call( this, newValue );
 
-		if ( _.isFinite( newValue ) ) {
+		// Validate both numeric and empty values, since breakpoints utilize default values when empty.
+		if ( _.isFinite( newValue ) || '' === newValue ) {
 			if ( ! this.validateMinMaxForBreakpoint( newValue, validationTerms ) ) {
 				errors.push( 'Value is not between the breakpoints above or under the edited breakpoint' );
 			}
@@ -26,32 +36,41 @@ export default class BreakpointValidator extends NumberValidator {
 	}
 
 	validateMinMaxForBreakpoint( newValue, validationTerms ) {
+		const breakpointDefaultValue = elementorFrontend.config.responsive.breakpoints[ validationTerms.breakpointName ].default_value;
+
 		let isValid = true;
 
-		if ( ! this.breakpointKeysArray ) {
-			this.breakpointKeysArray = Object.keys( elementorFrontend.config.responsive.activeBreakpoints );
-		}
-
-		const breakpointIndex = this.breakpointKeysArray.indexOf( validationTerms.breakpointName ),
-			topBreakpointKey = this.breakpointKeysArray[ breakpointIndex + 1 ];
-
-		let bottomBreakpoint = Stylesheet.getDeviceMinBreakpoint( validationTerms.breakpointName );
+		this.initBreakpointProperties();
 
 		// Since the following comparison is <=, allow usage of the 320px value for the mobile breakpoint.
-		if ( 'mobile' === validationTerms.breakpointName ) {
-			bottomBreakpoint -= 1;
+		if ( 'mobile' === validationTerms.breakpointName && 320 === this.bottomBreakpoint ) {
+			this.bottomBreakpoint -= 1;
 		}
 
-		// If there is a breakpoint below the currently edited breakpoint, check that the value is not under the bottom
-		// breakpoint's value.
-		if ( bottomBreakpoint && ( newValue <= bottomBreakpoint ) ) {
-			isValid = false;
+		// If there is a breakpoint below the currently edited breakpoint
+		if ( this.bottomBreakpoint ) {
+			// Check that the new value is not under the bottom breakpoint's value.
+			if ( newValue && newValue <= this.bottomBreakpoint ) {
+				isValid = false;
+			}
+
+			// If the new value is empty, check that the default breakpoint value is not below the bottom breakpoint.
+			if ( ! newValue && breakpointDefaultValue <= this.bottomBreakpoint ) {
+				isValid = false;
+			}
 		}
 
-		// If there is a breakpoint above the currently edited breakpoint, check that the value is not above the top
-		// breakpoint's value.
-		if ( topBreakpointKey && newValue > elementorFrontend.config.responsive.activeBreakpoints[ topBreakpointKey ].value ) {
-			isValid = false;
+		// If there is a breakpoint above the currently edited breakpoint.
+		if ( this.topBreakpoint ) {
+			// Check that the value is not above the top breakpoint's value.
+			if ( newValue && newValue >= this.topBreakpoint ) {
+				isValid = false;
+			}
+
+			// If the new value is empty, check that the default breakpoint value is not above the top breakpoint.
+			if ( ! newValue && breakpointDefaultValue >= this.topBreakpoint ) {
+				isValid = false;
+			}
 		}
 
 		return isValid;

--- a/assets/dev/js/editor/components/validator/breakpoint.js
+++ b/assets/dev/js/editor/components/validator/breakpoint.js
@@ -1,0 +1,55 @@
+const NumberValidator = require( 'elementor-validator/number' );
+
+module.exports = NumberValidator.extend( {
+	breakpointKeysArray: [],
+
+	getDefaultSettings: function() {
+		return {
+			validationTerms: {
+				// Min width we allow for mobile
+				min: 320,
+				// Max width we allow in general
+				max: 5120,
+			},
+		};
+	},
+
+	validationMethod: function( newValue ) {
+		const validationTerms = this.getSettings( 'validationTerms' ),
+			errors = NumberValidator.prototype.validationMethod.call( this, newValue );
+
+		if ( _.isFinite( newValue ) ) {
+			if ( ! this.validateMinMaxForBreakpoint( newValue, validationTerms ) ) {
+				errors.push( 'Value is not between the breakpoints above or under the edited breakpoint' );
+			}
+		}
+
+		return errors;
+	},
+
+	validateMinMaxForBreakpoint: function( newValue, validationTerms ) {
+		let isValid = true;
+
+		if ( ! this.breakpointKeysArray.length ) {
+			this.breakpointKeysArray = Object.keys( elementorFrontend.config.responsive.activeBreakpoints );
+		}
+
+		const breakpointIndex = this.breakpointKeysArray.indexOf( validationTerms.breakpointName ),
+			bottomBreakpointKey = this.breakpointKeysArray[ breakpointIndex - 1 ],
+			topBreakpointKey = this.breakpointKeysArray[ breakpointIndex + 1 ];
+
+		// If there is a breakpoint below the currently edited breakpoint, check that the value is not under the bottom
+		// breakpoint's value.
+		if ( bottomBreakpointKey && newValue <= elementorFrontend.config.responsive.activeBreakpoints[ bottomBreakpointKey ].value ) {
+			isValid = false;
+		}
+
+		// If there is a breakpoint above the currently edited breakpoint, check that the value is not above the top
+		// breakpoint's value.
+		if ( topBreakpointKey && newValue >= elementorFrontend.config.responsive.activeBreakpoints[ topBreakpointKey ].value ) {
+			isValid = false;
+		}
+
+		return isValid;
+	},
+} );

--- a/assets/dev/js/editor/controls/base-data.js
+++ b/assets/dev/js/editor/controls/base-data.js
@@ -1,9 +1,17 @@
 var ControlBaseView = require( 'elementor-controls/base' ),
 	TagsBehavior = require( 'elementor-dynamic-tags/control-behavior' ),
 	Validator = require( 'elementor-validator/base' ),
+	NumberValidator = require( 'elementor-validator/number' ),
+	BreakpointValidator = require( 'elementor-validator/breakpoint' ),
 	ControlBaseDataView;
 
 ControlBaseDataView = ControlBaseView.extend( {
+	validatorTypes: {
+		base: Validator,
+		number: NumberValidator,
+		breakpoint: BreakpointValidator,
+	},
+
 	ui: function() {
 		var ui = ControlBaseView.prototype.ui.apply( this, arguments );
 
@@ -217,6 +225,16 @@ ControlBaseDataView = ControlBaseView.extend( {
 			this.addValidator( new Validator( {
 				validationTerms: validationTerms,
 			} ) );
+		}
+
+		const validators = this.model.get( 'validators' );
+
+		if ( validators ) {
+			Object.entries( validators ).forEach( ( [ key, args ] ) => {
+				this.addValidator( new this.validatorTypes[ key ]( {
+					validationTerms: args,
+				} ) );
+			} );
 		}
 	},
 

--- a/assets/dev/js/editor/controls/base-data.js
+++ b/assets/dev/js/editor/controls/base-data.js
@@ -223,7 +223,7 @@ ControlBaseDataView = ControlBaseView.extend( {
 		}
 
 		if ( ! jQuery.isEmptyObject( validationTerms ) ) {
-			this.addValidator( new Validator( {
+			this.addValidator( new this.validatorTypes.Base( {
 				validationTerms: validationTerms,
 			} ) );
 		}

--- a/assets/dev/js/editor/controls/base-data.js
+++ b/assets/dev/js/editor/controls/base-data.js
@@ -1,15 +1,16 @@
+import BreakpointValidator from 'elementor-validator/breakpoint';
+
 var ControlBaseView = require( 'elementor-controls/base' ),
 	TagsBehavior = require( 'elementor-dynamic-tags/control-behavior' ),
 	Validator = require( 'elementor-validator/base' ),
 	NumberValidator = require( 'elementor-validator/number' ),
-	BreakpointValidator = require( 'elementor-validator/breakpoint' ),
 	ControlBaseDataView;
 
 ControlBaseDataView = ControlBaseView.extend( {
 	validatorTypes: {
-		base: Validator,
-		number: NumberValidator,
-		breakpoint: BreakpointValidator,
+		Base: Validator,
+		Number: NumberValidator,
+		Breakpoint: BreakpointValidator,
 	},
 
 	ui: function() {

--- a/assets/dev/js/editor/controls/number.js
+++ b/assets/dev/js/editor/controls/number.js
@@ -1,5 +1,4 @@
 var ControlBaseDataView = require( 'elementor-controls/base-data' ),
-	NumberValidator = require( 'elementor-validator/number' ),
 	ControlNumberItemView;
 
 ControlNumberItemView = ControlBaseDataView.extend( {
@@ -19,7 +18,7 @@ ControlNumberItemView = ControlBaseDataView.extend( {
 		} );
 
 		if ( ! jQuery.isEmptyObject( validationTerms ) ) {
-			this.addValidator( new NumberValidator( {
+			this.addValidator( new this.validatorTypes.Number( {
 				validationTerms: validationTerms,
 			} ) );
 		}

--- a/core/kits/assets/js/hooks/ui/document/elements/settings/update-breakpoints-preview.js
+++ b/core/kits/assets/js/hooks/ui/document/elements/settings/update-breakpoints-preview.js
@@ -41,6 +41,11 @@ export class KitUpdateBreakpointsPreview extends $e.modules.hookUI.After {
 			if ( key.startsWith( 'viewport_' ) ) {
 				const keyWithoutPrefix = key.replace( 'viewport_', '' );
 				// Update both the config for all breakpoints and the one for active breakpoints.
+
+				if ( ! value ) {
+					value = elementorFrontend.config.responsive.breakpoints[ keyWithoutPrefix ].default_value;
+				}
+
 				elementorFrontend.config.responsive.breakpoints[ keyWithoutPrefix ].value = value;
 			}
 		} );

--- a/core/kits/documents/tabs/settings-layout.php
+++ b/core/kits/documents/tabs/settings-layout.php
@@ -288,7 +288,7 @@ class Settings_Layout extends Tab_Base {
 				'placeholder' => $default_breakpoint_config['default_value'],
 				'frontend_available' => true,
 				'validators' => [
-					'breakpoint' => [
+					'Breakpoint' => [
 						'breakpointName' => $breakpoint_key,
 					],
 				],

--- a/core/kits/documents/tabs/settings-layout.php
+++ b/core/kits/documents/tabs/settings-layout.php
@@ -287,6 +287,11 @@ class Settings_Layout extends Tab_Base {
 				'type' => Controls_Manager::NUMBER,
 				'placeholder' => $default_breakpoint_config['default_value'],
 				'frontend_available' => true,
+				'validators' => [
+					'breakpoint' => [
+						'breakpointName' => $breakpoint_key,
+					],
+				],
 				'conditions' => [
 					'terms' => [
 						[

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -1278,6 +1278,7 @@ class Frontend extends App {
 				'value' => $breakpoint->get_value(),
 				'direction' => $breakpoint->get_direction(),
 				'is_enabled' => $breakpoint->is_enabled(),
+				'default_value' => $breakpoint->get_default_value(),
 			];
 		}
 


### PR DESCRIPTION
Site Settings: Breakpoints - Added a validator for the breakpoint controls, which makes sure selected breakpoint values remain within the bounds of neighboring breakpoints' min/max limits. For example: If a mobile's max value is 600px, the validator makes sure that if a user edits the tablet breakpoint, and tries to give it a value of 599px, the value will automatically reset itself to the previous selected value which was above 600px. Same goes for upper-limit breakpoints.

In addition, a total minimum of 320px and maximum of 5120px was added into the validation conditions.

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Site Settings: Breakpoints - Added a validator for the breakpoint controls to prevent invalid values.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)