### PR TITLE
E-icons: Fix - When using custom breakpoints, the e-icons font-face URL was called from the custom-frontend CSS file that is located in a different path - ED-2903

### DIFF
--- a/assets/dev/scss/frontend/_eicons.scss
+++ b/assets/dev/scss/frontend/_eicons.scss
@@ -1,11 +1,3 @@
-@font-face {
-	font-family: 'eicons';
-	src: url("../lib/eicons/fonts/eicons.eot?5.10.0");
-	src: url("../lib/eicons/fonts/eicons.eot?5.10.0#iefix") format("embedded-opentype"), url("../lib/eicons/fonts/eicons.woff2?5.10.0") format("woff2"), url("../lib/eicons/fonts/eicons.woff?5.10.0") format("woff"), url("../lib/eicons/fonts/eicons.ttf?5.10.0") format("truetype"), url("../lib/eicons/fonts/eicons.svg?5.10.0#eicon") format("svg");
-	font-weight: normal;
-	font-style: normal;
-}
-
 [class^="eicon"],
 [class*=" eicon-"] {
 	display: inline-block;

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -1388,7 +1388,7 @@ class Frontend extends App {
 		 * The custom frontend file is located in a different path ('uploads' folder).
 		 * Therefore, it cannot be called from a CSS file that its relative path can vary.
 		 */
-		$elementor_icons_inline_css = sprintf( '@font-face{font-family:eicons;src:url(%1$s/lib/eicons/fonts/eicons.eot?5.10.0);src:url(%1$s/lib/eicons/fonts/eicons.eot?5.10.0#iefix) format("embedded-opentype"),url(%1$s/lib/eicons/fonts/eicons.woff2?5.10.0) format("woff2"),url(%1$s/lib/eicons/fonts/eicons.woff?5.10.0) format("woff"),url(%1$s/lib/eicons/fonts/eicons.ttf?5.10.0) format("truetype"),url(%1$s/lib/eicons/fonts/eicons.svg?5.10.0#eicon) format("svg");font-weight:400;font-style:normal}', ELEMENTOR_ASSETS_URL );
+		$elementor_icons_inline_css = sprintf( '@font-face{font-family:eicons;src:url(%1$slib/eicons/fonts/eicons.eot?5.10.0);src:url(%1$slib/eicons/fonts/eicons.eot?5.10.0#iefix) format("embedded-opentype"),url(%1$slib/eicons/fonts/eicons.woff2?5.10.0) format("woff2"),url(%1$slib/eicons/fonts/eicons.woff?5.10.0) format("woff"),url(%1$slib/eicons/fonts/eicons.ttf?5.10.0) format("truetype"),url(%1$slib/eicons/fonts/eicons.svg?5.10.0#eicon) format("svg");font-weight:400;font-style:normal}', ELEMENTOR_ASSETS_URL );
 
 		wp_add_inline_style( 'elementor-frontend', $elementor_icons_inline_css );
 	}

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -160,6 +160,10 @@ class Frontend extends App {
 		add_action( 'template_redirect', [ $this, 'init' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_scripts' ], 5 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_styles' ], 5 );
+		
+		add_action( 'elementor/frontend/before_enqueue_styles', function() {
+			$this->add_elementor_icons_inline_css();
+		} );
 
 		$this->add_content_filter();
 
@@ -1371,5 +1375,23 @@ class Frontend extends App {
 		}
 
 		return $dependencies;
+	}
+
+	private function add_elementor_icons_inline_css() {
+		static $is_elementor_icons_inline_css_printed;
+
+		if ( ! $is_elementor_icons_inline_css_printed ) {
+			$is_elementor_icons_inline_css_printed = true;
+
+			/**
+			 * The e-icons font-face must be printed inline due to custom breakpoints.
+			 * When using custom breakpoints, the frontend CSS is loaded from the custom-frontend CSS file.
+			 * The custom frontend file is located in a different path ('uploads' folder).
+			 * Therefore, it cannot be called from a CSS file that its relative path can vary.
+			 */
+			$elementor_icons_inline_css = sprintf( '@font-face{font-family:eicons;src:url(%1$s/lib/eicons/fonts/eicons.eot?5.10.0);src:url(%1$s/lib/eicons/fonts/eicons.eot?5.10.0#iefix) format("embedded-opentype"),url(%1$s/lib/eicons/fonts/eicons.woff2?5.10.0) format("woff2"),url(%1$s/lib/eicons/fonts/eicons.woff?5.10.0) format("woff"),url(%1$s/lib/eicons/fonts/eicons.ttf?5.10.0) format("truetype"),url(%1$s/lib/eicons/fonts/eicons.svg?5.10.0#eicon) format("svg");font-weight:400;font-style:normal}', ELEMENTOR_ASSETS_URL );
+
+			wp_add_inline_style( 'elementor-frontend', $elementor_icons_inline_css );
+		}
 	}
 }

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -1382,13 +1382,15 @@ class Frontend extends App {
 	}
 
 	private function add_elementor_icons_inline_css() {
+		$elementor_icons_library_version = '5.10.0';
+
 		/**
 		 * The e-icons font-face must be printed inline due to custom breakpoints.
 		 * When using custom breakpoints, the frontend CSS is loaded from the custom-frontend CSS file.
 		 * The custom frontend file is located in a different path ('uploads' folder).
 		 * Therefore, it cannot be called from a CSS file that its relative path can vary.
 		 */
-		$elementor_icons_inline_css = sprintf( '@font-face{font-family:eicons;src:url(%1$slib/eicons/fonts/eicons.eot?5.10.0);src:url(%1$slib/eicons/fonts/eicons.eot?5.10.0#iefix) format("embedded-opentype"),url(%1$slib/eicons/fonts/eicons.woff2?5.10.0) format("woff2"),url(%1$slib/eicons/fonts/eicons.woff?5.10.0) format("woff"),url(%1$slib/eicons/fonts/eicons.ttf?5.10.0) format("truetype"),url(%1$slib/eicons/fonts/eicons.svg?5.10.0#eicon) format("svg");font-weight:400;font-style:normal}', ELEMENTOR_ASSETS_URL );
+		$elementor_icons_inline_css = sprintf( '@font-face{font-family:eicons;src:url(%1$slib/eicons/fonts/eicons.eot?%2$s);src:url(%1$slib/eicons/fonts/eicons.eot?%2$s#iefix) format("embedded-opentype"),url(%1$slib/eicons/fonts/eicons.woff2?%2$s) format("woff2"),url(%1$slib/eicons/fonts/eicons.woff?%2$s) format("woff"),url(%1$slib/eicons/fonts/eicons.ttf?%2$s) format("truetype"),url(%1$slib/eicons/fonts/eicons.svg?%2$s#eicon) format("svg");font-weight:400;font-style:normal}', ELEMENTOR_ASSETS_URL, $elementor_icons_library_version );
 
 		wp_add_inline_style( 'elementor-frontend', $elementor_icons_inline_css );
 	}

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -160,10 +160,6 @@ class Frontend extends App {
 		add_action( 'template_redirect', [ $this, 'init' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_scripts' ], 5 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_styles' ], 5 );
-		
-		add_action( 'elementor/frontend/before_enqueue_styles', function() {
-			$this->add_elementor_icons_inline_css();
-		} );
 
 		$this->add_content_filter();
 
@@ -624,39 +620,47 @@ class Frontend extends App {
 	 * @access public
 	 */
 	public function enqueue_styles() {
-		/**
-		 * Before frontend styles enqueued.
-		 *
-		 * Fires before Elementor frontend styles are enqueued.
-		 *
-		 * @since 1.0.0
-		 */
-		do_action( 'elementor/frontend/before_enqueue_styles' );
+		static $is_enqueue_styles_already_triggered;
 
-		// The e-icons are needed in preview mode for the editor icons (plus-icon for new section, folder-icon for the templates library etc.).
-		if ( ! $this->is_improved_assets_loading() || Plugin::$instance->preview->is_preview_mode() ) {
-			wp_enqueue_style( 'elementor-icons' );
-		}
-		wp_enqueue_style( 'elementor-animations' );
-		wp_enqueue_style( 'elementor-frontend' );
+		if ( ! $is_enqueue_styles_already_triggered ) {
+			$is_enqueue_styles_already_triggered = true;
 
-		/**
-		 * After frontend styles enqueued.
-		 *
-		 * Fires after Elementor frontend styles are enqueued.
-		 *
-		 * @since 1.0.0
-		 */
-		do_action( 'elementor/frontend/after_enqueue_styles' );
+			/**
+			 * Before frontend styles enqueued.
+			 *
+			 * Fires before Elementor frontend styles are enqueued.
+			 *
+			 * @since 1.0.0
+			 */
+			do_action( 'elementor/frontend/before_enqueue_styles' );
 
-		if ( ! Plugin::$instance->preview->is_preview_mode() ) {
-			$this->parse_global_css_code();
+			$this->add_elementor_icons_inline_css();
 
-			$post_id = get_the_ID();
-			// Check $post_id for virtual pages. check is singular because the $post_id is set to the first post on archive pages.
-			if ( $post_id && is_singular() ) {
-				$css_file = Post_CSS::create( get_the_ID() );
-				$css_file->enqueue();
+			// The e-icons are needed in preview mode for the editor icons (plus-icon for new section, folder-icon for the templates library etc.).
+			if ( ! $this->is_improved_assets_loading() || Plugin::$instance->preview->is_preview_mode() ) {
+				wp_enqueue_style( 'elementor-icons' );
+			}
+			wp_enqueue_style( 'elementor-animations' );
+			wp_enqueue_style( 'elementor-frontend' );
+
+			/**
+			 * After frontend styles enqueued.
+			 *
+			 * Fires after Elementor frontend styles are enqueued.
+			 *
+			 * @since 1.0.0
+			 */
+			do_action( 'elementor/frontend/after_enqueue_styles' );
+
+			if ( ! Plugin::$instance->preview->is_preview_mode() ) {
+				$this->parse_global_css_code();
+
+				$post_id = get_the_ID();
+				// Check $post_id for virtual pages. check is singular because the $post_id is set to the first post on archive pages.
+				if ( $post_id && is_singular() ) {
+					$css_file = Post_CSS::create( get_the_ID() );
+					$css_file->enqueue();
+				}
 			}
 		}
 	}
@@ -1378,20 +1382,14 @@ class Frontend extends App {
 	}
 
 	private function add_elementor_icons_inline_css() {
-		static $is_elementor_icons_inline_css_printed;
+		/**
+		 * The e-icons font-face must be printed inline due to custom breakpoints.
+		 * When using custom breakpoints, the frontend CSS is loaded from the custom-frontend CSS file.
+		 * The custom frontend file is located in a different path ('uploads' folder).
+		 * Therefore, it cannot be called from a CSS file that its relative path can vary.
+		 */
+		$elementor_icons_inline_css = sprintf( '@font-face{font-family:eicons;src:url(%1$s/lib/eicons/fonts/eicons.eot?5.10.0);src:url(%1$s/lib/eicons/fonts/eicons.eot?5.10.0#iefix) format("embedded-opentype"),url(%1$s/lib/eicons/fonts/eicons.woff2?5.10.0) format("woff2"),url(%1$s/lib/eicons/fonts/eicons.woff?5.10.0) format("woff"),url(%1$s/lib/eicons/fonts/eicons.ttf?5.10.0) format("truetype"),url(%1$s/lib/eicons/fonts/eicons.svg?5.10.0#eicon) format("svg");font-weight:400;font-style:normal}', ELEMENTOR_ASSETS_URL );
 
-		if ( ! $is_elementor_icons_inline_css_printed ) {
-			$is_elementor_icons_inline_css_printed = true;
-
-			/**
-			 * The e-icons font-face must be printed inline due to custom breakpoints.
-			 * When using custom breakpoints, the frontend CSS is loaded from the custom-frontend CSS file.
-			 * The custom frontend file is located in a different path ('uploads' folder).
-			 * Therefore, it cannot be called from a CSS file that its relative path can vary.
-			 */
-			$elementor_icons_inline_css = sprintf( '@font-face{font-family:eicons;src:url(%1$s/lib/eicons/fonts/eicons.eot?5.10.0);src:url(%1$s/lib/eicons/fonts/eicons.eot?5.10.0#iefix) format("embedded-opentype"),url(%1$s/lib/eicons/fonts/eicons.woff2?5.10.0) format("woff2"),url(%1$s/lib/eicons/fonts/eicons.woff?5.10.0) format("woff"),url(%1$s/lib/eicons/fonts/eicons.ttf?5.10.0) format("truetype"),url(%1$s/lib/eicons/fonts/eicons.svg?5.10.0#eicon) format("svg");font-weight:400;font-style:normal}', ELEMENTOR_ASSETS_URL );
-
-			wp_add_inline_style( 'elementor-frontend', $elementor_icons_inline_css );
-		}
+		wp_add_inline_style( 'elementor-frontend', $elementor_icons_inline_css );
 	}
 }


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
