### PR TITLE
Custom Breakpoints: Fix - When using custom breakpoints, responsive custom CSS is not properly generated (ED-3004)

### DIFF
--- a/core/responsive/files/frontend.php
+++ b/core/responsive/files/frontend.php
@@ -39,6 +39,9 @@ class Frontend extends Base {
 		$file_content = file_get_contents( $this->template_file );
 
 		$file_content = preg_replace_callback( '/ELEMENTOR_SCREEN_([A-Z]+)_([A-Z]+)/', function ( $placeholder_data ) use ( $breakpoints_keys, $breakpoints ) {
+			// Handle BC for legacy template files.
+			$placeholder_data = $this->maybe_convert_placeholder_data( $placeholder_data );
+
 			if ( 'DESKTOP' === $placeholder_data[1] ) {
 				$value = Plugin::$instance->breakpoints->get_desktop_min_point();
 			} else {
@@ -145,5 +148,30 @@ class Frontend extends Base {
 		}
 
 		return $option;
+	}
+
+	/**
+	 * Maybe Convert Placeholder Data
+	 *
+	 * Converts responsive placeholders in Elementor CSS template files from the legacy format into the new format.
+	 *
+	 * @since 3.2.3
+	 *
+	 * @param $placeholder_data
+	 * @return mixed
+	 */
+	private function maybe_convert_placeholder_data( $placeholder_data ) {
+		switch ( $placeholder_data[1] ) {
+			case 'SM':
+				$placeholder_data[1] = 'MOBILE';
+				break;
+			case 'MD':
+				$placeholder_data[1] = 'TABLET';
+				break;
+			case 'LG':
+				$placeholder_data[1] = 'DESKTOP';
+		}
+
+		return $placeholder_data;
 	}
 }

--- a/core/responsive/files/frontend.php
+++ b/core/responsive/files/frontend.php
@@ -39,7 +39,7 @@ class Frontend extends Base {
 		$file_content = file_get_contents( $this->template_file );
 
 		$file_content = preg_replace_callback( '/ELEMENTOR_SCREEN_([A-Z]+)_([A-Z]+)/', function ( $placeholder_data ) use ( $breakpoints_keys, $breakpoints ) {
-			// Handle BC for legacy template files.
+			// Handle BC for legacy template files and Elementor Pro builds.
 			$placeholder_data = $this->maybe_convert_placeholder_data( $placeholder_data );
 
 			if ( 'DESKTOP' === $placeholder_data[1] ) {
@@ -154,6 +154,7 @@ class Frontend extends Base {
 	 * Maybe Convert Placeholder Data
 	 *
 	 * Converts responsive placeholders in Elementor CSS template files from the legacy format into the new format.
+	 * Used for backwards compatibility for old Pro versions that were built with an Elementor Core version <3.2.0.
 	 *
 	 * @since 3.2.3
 	 *


### PR DESCRIPTION
Closes #14711

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Custom Breakpoints: Fix - When using custom breakpoints, responsive custom CSS is not properly generated (affects Nav Menu Widget responsive  behavior).
* Responsive CSS: Backwards compatibility for old Pro versions that were built with an Elementor Core version >3.2.0.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)