### PR TITLE
Add support for Envato Template Kit import

### DIFF
--- a/core/app/modules/import-export/directories/templates.php
+++ b/core/app/modules/import-export/directories/templates.php
@@ -55,6 +55,12 @@ class Templates extends Base {
 					continue;
 				}
 
+				if ( ! empty( $template_settings['metadata']['template_type'] ) && $template_settings['metadata']['template_type'] === 'global-styles' ) {
+					// We've just imported some global kit styles from an Envato template kit.
+					// We need to activate these as the new global styles
+					Plugin::$instance->kits_manager->set_active_kit( $import );
+				}
+
 				$result['success'][] = $import;
 			} catch ( \Error $error ) {
 				$result['failed'][ $id ] = $error->getMessage();
@@ -66,6 +72,16 @@ class Templates extends Base {
 
 	private function import_template( $id, array $template_settings ) {
 		$template = $this->importer->read_json_file( $id );
+
+		// Envato uses "page_settings", Elementor uses "settings". Make them compatible.
+		if ( ! empty( $template['page_settings'] ) ) {
+			$template['settings'] = $template['page_settings'];
+		}
+
+		// Envato uses "type", Elementor uses "doc_type". Make them compatible.
+		if ( ! empty( $template['type'] ) ) {
+			$template['doc_type'] = $template['type'];
+		}
 
 		$doc_type = $template_settings['doc_type'];
 

--- a/core/app/modules/import-export/import.php
+++ b/core/app/modules/import-export/import.php
@@ -20,6 +20,29 @@ class Import extends Iterator {
 
 		$settings = $this->read_json_file( 'manifest' );
 
+		if ( ! empty( $settings['manifest_version'] ) ) {
+			// The user is attempting to import one of the thousands of Template Kits available from https://themeforest.net/category/template-kits
+			// These template kits have a slightly different JSON and file structure to the ones exported by the new beta Elementor Export feature.
+			// To make this compatible we slightly adjust the format of the Envato manifest file.
+			// This works for majority of cases, but there are still a few that fail such as:
+			// - When required plugins are missing
+			// - When there is a global Kit style
+			$original_templates    = $settings['templates'];
+			$settings['templates'] = [];
+			foreach ( $original_templates as $original_template ) {
+				$new_template = $original_template;
+				// Elementor looks for "doc_type" instead of "type"
+				$new_template['doc_type'] = $original_template['type'];
+				// Elementor looks for "title" instead of "name"
+				$new_template['title'] = $original_template['name'];
+				// Elementor uses the template file name as the "ID" of its indexing, rather than specifying an exact path to the template.
+				// This extracts the "file name" part out of our exact source list and we treat that as an ID.
+				$file_name_without_extension = str_replace( '.json', '', basename( $original_template['source'] ) );
+				// Append our template to the global list:
+				$settings['templates'][ $file_name_without_extension ] = $new_template;
+			}
+		}
+
 		$root_directory = new Root( $this );
 
 		$import_result = $root_directory->run_import( $settings );

--- a/core/app/modules/import-export/import.php
+++ b/core/app/modules/import-export/import.php
@@ -33,6 +33,10 @@ class Import extends Iterator {
 				$new_template = $original_template;
 				// Elementor looks for "doc_type" instead of "type"
 				$new_template['doc_type'] = $original_template['type'];
+				// Envato template kits store their global kit styles as a separate JSON file, these need to be imported as a "kit" document type
+				if ( ! empty( $original_template['metadata']['template_type'] ) && $original_template['metadata']['template_type'] === 'global-styles' ) {
+					$new_template['doc_type'] = 'kit';
+				}
 				// Elementor looks for "title" instead of "name"
 				$new_template['title'] = $original_template['name'];
 				// Elementor uses the template file name as the "ID" of its indexing, rather than specifying an exact path to the template.

--- a/core/kits/manager.php
+++ b/core/kits/manager.php
@@ -41,6 +41,12 @@ class Manager {
 		return Plugin::$instance->documents->get( $id );
 	}
 
+	public function set_active_kit( $post_id ) {
+		if ( $this->is_kit( $post_id ) ) {
+			update_option( self::OPTION_ACTIVE, $post_id );
+		}
+	}
+
 	public function get_active_kit_for_frontend() {
 		$id = $this->get_active_id();
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Add basic support for Envato Template Kit import

## Description

There are thousands of template kits available at https://themeforest.net/category/template-kits and these have a slightly different JSON and file format to what the built in import feature is expecting.

We can modify some keys in the JSON structure to support the Envato Template Kit import process.

This isn't perfect but works most of the time.
Also a lot of the other "Template Kit Import plugin" features (such as Required 3rd Party Plugins) are not supported in this just yet. Hopefully one day!


## Screenshot

Successful ajax import process after upload ZIP file:

![image](https://user-images.githubusercontent.com/543073/117613121-b8072f00-b1a9-11eb-9c1e-5e542b87e7f4.png)

Template showing in Elementor library:

![image](https://user-images.githubusercontent.com/543073/117616523-95c3e000-b1ae-11eb-8b33-5c2024a28b97.png)

Template looks as expected, reflecting the global kit styles that were also imported (font styles / global colors etc..)

![image](https://user-images.githubusercontent.com/543073/117616016-e71f9f80-b1ad-11eb-8e03-b192ae13dd09.png)


## Test instructions

This PR can be tested by following these steps:

* Enable the alpha Import/Export feature
* Download a template kit from Envato, here is an example template kit: [home-pro.zip](https://github.com/elementor/elementor/files/6449960/home-pro.zip)
* Import Template Kit through the Elementor -> Tools -> Import/Export Kit
* Confirm the templates are now available in the Elementor library

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)
