### PR TITLE
Tweak: Add safe print methods

### DIFF
--- a/includes/controls/base-data.php
+++ b/includes/controls/base-data.php
@@ -121,4 +121,18 @@ abstract class Base_Data_Control extends Base_Control {
 	protected function get_control_uid( $input_type = 'default' ) {
 		return 'elementor-control-' . $input_type . '-{{{ data._cid }}}';
 	}
+
+	/**
+	 * Safe Print data control unique ID.
+	 *
+	 * Retrieve the unique ID of the control. Used to set a unique CSS ID for the
+	 * element.
+	 *
+	 * @access protected
+	 *
+	 * @param string $input_type Input type. Default is 'default'.
+	 */
+	protected function print_control_uid( $input_type = 'default' ) {
+		echo esc_attr( $this->get_control_uid( $input_type ) );
+	}
 }

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -476,6 +476,18 @@ class Utils {
 		return implode( ' ', $rendered_attributes );
 	}
 
+	/**
+	 * Safe print html attributes
+	 *
+	 * @access public
+	 * @static
+	 * @param array $attributes
+	 */
+	public static function print_html_attributes( array $attributes ) {
+		// PHPCS - the method render_html_attributes is safe.
+		echo self::render_html_attributes( $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
 	public static function get_meta_viewport( $context = '' ) {
 		$meta_tag = '<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />';
 		/**
@@ -670,6 +682,16 @@ class Utils {
 	 */
 	public static function validate_html_tag( $tag ) {
 		return in_array( strtolower( $tag ), self::ALLOWED_HTML_WRAPPER_TAGS ) ? $tag : 'div';
+	}
+
+	/**
+	 * Safe print a validated HTML tag.
+	 *
+	 * @param string $tag
+	 */
+	public static function print_validated_html_tag( $tag ) {
+		// PHPCS - the method validate_html_tag is safe.
+		echo self::validate_html_tag( $tag ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**


### PR DESCRIPTION
The safe print methods are a workaround since the WPCS can't receive class methods as `safe functions`.