### PR TITLE
Tweak: Removed deprecated methods. (ED-3142)

### DIFF
--- a/core/base/document.php
+++ b/core/base/document.php
@@ -206,15 +206,6 @@ abstract class Document extends Controls_Stack {
 	}
 
 	/**
-	 * @since 2.0.12
-	 * @deprecated 2.4.0 Use `Document::get_remote_library_config()` instead
-	 * @access public
-	 */
-	public function get_remote_library_type() {
-		_deprecated_function( __METHOD__, '2.4.0', __CLASS__ . '::get_remote_library_config()' );
-	}
-
-	/**
 	 * @since 2.0.0
 	 * @access public
 	 */
@@ -268,17 +259,6 @@ abstract class Document extends Controls_Stack {
 	 */
 	public function get_main_post() {
 		return get_post( $this->get_main_id() );
-	}
-
-	/**
-	 * @since 2.0.6
-	 * @deprecated 2.4.0 Use `Document::get_container_attributes()` instead
-	 * @access public
-	 */
-	public function get_container_classes() {
-		_deprecated_function( __METHOD__, '2.4.0', __CLASS__ . '::get_container_attributes()' );
-
-		return '';
 	}
 
 	public function get_container_attributes() {

--- a/core/documents-manager.php
+++ b/core/documents-manager.php
@@ -653,21 +653,6 @@ class Documents_Manager {
 		return $this->current_doc;
 	}
 
-	/**
-	 * Get groups.
-	 *
-	 * @since 2.0.0
-	 * @deprecated 2.4.0
-	 * @access public
-	 *
-	 * @return array
-	 */
-	public function get_groups() {
-		_deprecated_function( __METHOD__, '2.4.0' );
-
-		return [];
-	}
-
 	public function localize_settings( $settings ) {
 		$translations = [];
 

--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -807,30 +807,6 @@ class Editor {
 	}
 
 	/**
-	 * Add editor template.
-	 *
-	 * Registers new editor templates.
-	 *
-	 * @since 1.0.0
-	 * @deprecated 2.3.0 Use `Plugin::$instance->common->add_template()`
-	 * @access public
-	 *
-	 * @param string $template Can be either a link to template file or template
-	 *                         HTML content.
-	 * @param string $type     Optional. Whether to handle the template as path
-	 *                         or text. Default is `path`.
-	 */
-	public function add_editor_template( $template, $type = 'path' ) {
-		_deprecated_function( __METHOD__, '2.3.0', 'Plugin::$instance->common->add_template()' );
-
-		$common = Plugin::$instance->common;
-
-		if ( $common ) {
-			Plugin::$instance->common->add_template( $template, $type );
-		}
-	}
-
-	/**
 	 * WP footer.
 	 *
 	 * Prints Elementor editor with all the editor templates, and render controls,
@@ -932,96 +908,6 @@ class Editor {
 		}
 
 		return $results;
-	}
-
-	/**
-	 * Create nonce.
-	 *
-	 * If the user has edit capabilities, it creates a cryptographic token to
-	 * give him access to Elementor editor.
-	 *
-	 * @since 1.8.1
-	 * @since 1.8.7 The `$post_type` parameter was introduces.
-	 * @deprecated 2.3.0 Use `Plugin::$instance->common->get_component( 'ajax' )->create_nonce()` instead
-	 * @access public
-	 *
-	 * @param string $post_type The post type to check capabilities.
-	 *
-	 * @return null|string The nonce token, or `null` if the user has no edit
-	 *                     capabilities.
-	 */
-	public function create_nonce( $post_type ) {
-		_deprecated_function( __METHOD__, '2.3.0', 'Plugin::$instance->common->get_component( \'ajax\' )->create_nonce()' );
-
-		/** @var Ajax $ajax */
-		$ajax = Plugin::$instance->common->get_component( 'ajax' );
-
-		return $ajax->create_nonce();
-	}
-
-	/**
-	 * Verify nonce.
-	 *
-	 * The user is given an amount of time to use the token, so therefore, since
-	 * the user ID and `$action` remain the same, the independent variable is
-	 * the time.
-	 *
-	 * @since 1.8.1
-	 * @deprecated 2.3.0
-	 * @access public
-	 *
-	 * @param string $nonce Nonce to verify.
-	 *
-	 * @return false|int If the nonce is invalid it returns `false`. If the
-	 *                   nonce is valid and generated between 0-12 hours ago it
-	 *                   returns `1`. If the nonce is valid and generated
-	 *                   between 12-24 hours ago it returns `2`.
-	 */
-	public function verify_nonce( $nonce ) {
-		_deprecated_function( __METHOD__, '2.3.0', 'wp_verify_nonce()' );
-
-		return wp_verify_nonce( $nonce );
-	}
-
-	/**
-	 * Verify request nonce.
-	 *
-	 * Whether the request nonce verified or not.
-	 *
-	 * @since 1.8.1
-	 * @deprecated 2.3.0 Use `Plugin::$instance->common->get_component( 'ajax' )->verify_request_nonce()` instead
-	 * @access public
-	 *
-	 * @return bool True if request nonce verified, False otherwise.
-	 */
-	public function verify_request_nonce() {
-		_deprecated_function( __METHOD__, '2.3.0', 'Plugin::$instance->common->get_component( \'ajax\' )->verify_request_nonce()' );
-
-		/** @var Ajax $ajax */
-		$ajax = Plugin::$instance->common->get_component( 'ajax' );
-
-		return $ajax->verify_request_nonce();
-	}
-
-	/**
-	 * Verify ajax nonce.
-	 *
-	 * Verify request nonce and send a JSON request, if not verified returns an
-	 * error.
-	 *
-	 * @since 1.9.0
-	 * @deprecated 2.3.0
-	 * @access public
-	 */
-	public function verify_ajax_nonce() {
-		_deprecated_function( __METHOD__, '2.3.0' );
-
-		/** @var Ajax $ajax */
-		$ajax = Plugin::$instance->common->get_component( 'ajax' );
-
-		if ( ! $ajax->verify_request_nonce() ) {
-			wp_send_json_error( new \WP_Error( 'token_expired', 'Nonce token expired.' ) );
-		}
 	}
 
 	/**


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Other... Please describe: Deprecations

## Summary

This PR can be summarized in the following changelog entry:

* Deprecations: Removed method `Core\Base\Document::get_remote_library_type()`
* Deprecations: Removed method `Core\Base\Document::get_container_classes()`
* Deprecations: Removed method `Core\Documents_Manager::get_groups()`
* Deprecations: Removed method `Editor::add_editor_template()`
* Deprecations: Removed method `Editor::create_nonce()`
* Deprecations: Removed method `Editor::verify_ajax_nonce()`
* Deprecations: Removed method `Editor::verify_nonce()`
* Deprecations: Removed method `Editor::verify_request_nonce()`