### PR TITLE
Add font-display swap to eicons font-face rule

### DIFF
--- a/assets/lib/eicons/css/elementor-icons.css
+++ b/assets/lib/eicons/css/elementor-icons.css
@@ -3,6 +3,7 @@
   src: url("../fonts/eicons.eot?5.11.0");
   src: url("../fonts/eicons.eot?5.11.0#iefix") format("embedded-opentype"), url("../fonts/eicons.woff2?5.11.0") format("woff2"), url("../fonts/eicons.woff?5.11.0") format("woff"), url("../fonts/eicons.ttf?5.11.0") format("truetype"), url("../fonts/eicons.svg?5.11.0#eicon") format("svg");
   font-weight: normal;
+  font-display: swap;
   font-style: normal; }
 
 [class^="eicon"],


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Adds `font-display: swap` to resolve "Ensure text remains visible during webfont load" issue in Lighthouse.

## Description

* This PR adds the `font-display: swap` rule to the "eicons" font in `elementor-icons.css`.

## Test instructions

This PR can be tested by following these steps:

* Before applying this change, run Lighthouse test and see that under "Ensure text remains visible during webfont load", `eicons.woff` is listed.
* Apply the change and run Lighthouse and see that "Ensure text remains visible during webfont load" issue has been removed.

## Quality assurance

- [x] I have tested this code to the best of my abilities

Fixes #10095