### PR TITLE
Fix: Import-Export - Import only site-settings + previous button in import-content screen [ED-3513]

### DIFF
--- a/core/app/modules/import-export/assets/js/context/context-reducer.js
+++ b/core/app/modules/import-export/assets/js/context/context-reducer.js
@@ -37,6 +37,8 @@ export const reducer = ( state, action ) => {
 			return { ...state, kitInfo: { ...state.kitInfo, description: action.payload } };
 		case 'SET_REFERRER':
 			return { ...state, referrer: action.payload };
+		case 'SET_INCLUDES':
+			return { ...state, includes: action.payload };
 		default:
 			return state;
 	}

--- a/core/app/modules/import-export/assets/js/pages/import/import-content/import-content.js
+++ b/core/app/modules/import-export/assets/js/pages/import/import-content/import-content.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useNavigate } from '@reach/router';
 
 import { Context } from '../../../context/context-provider';
@@ -20,10 +20,7 @@ export default function ImportContent() {
 				<Button
 					text={ __( 'Previous', 'elementor' ) }
 					variant="contained"
-					onClick={ () => {
-						context.dispatch( { type: 'SET_FILE', payload: null } );
-						navigate( 'import' );
-					} }
+					onClick={ () => context.dispatch( { type: 'SET_FILE', payload: null } ) }
 				/>
 
 				<ImportButton />
@@ -34,6 +31,12 @@ export default function ImportContent() {
 				{ __( 'Learn More', 'elementor' ) }
 			</InlineLink>
 		);
+
+	useEffect( () => {
+		if ( ! context.data.file ) {
+			navigate( 'import' );
+		}
+	}, [ context.data.file ] );
 
 	return (
 		<Layout type="import" footer={ getFooter() }>

--- a/core/app/modules/import-export/assets/js/pages/import/import-kit/import-kit.js
+++ b/core/app/modules/import-export/assets/js/pages/import/import-kit/import-kit.js
@@ -56,6 +56,10 @@ export default function ImportKit() {
 		}
 	}, [ context.data.fileResponse ] );
 
+	useEffect( () => {
+		context.dispatch( { type: 'SET_INCLUDES', payload: [] } );
+	}, [] );
+
 	return (
 		<Layout type="import">
 			<section className="e-app-import">

--- a/core/app/modules/import-export/assets/js/pages/import/import-kit/import-kit.js
+++ b/core/app/modules/import-export/assets/js/pages/import/import-kit/import-kit.js
@@ -51,7 +51,7 @@ export default function ImportKit() {
 	}, [ ajaxState.status ] );
 
 	useEffect( () => {
-		if ( context.data.fileResponse ) {
+		if ( context.data.fileResponse && context.data.file ) {
 			navigate( '/import/content' );
 		}
 	}, [ context.data.fileResponse ] );

--- a/core/app/modules/import-export/assets/js/pages/import/import-process/import-process.js
+++ b/core/app/modules/import-export/assets/js/pages/import/import-process/import-process.js
@@ -22,6 +22,8 @@ export default function ImportProcess() {
 
 			if ( fileURL || context.data.fileResponse ) {
 				if ( fileURL ) {
+					context.dispatch( { type: 'SET_FILE', payload: fileURL } );
+
 					ajaxConfig.data.e_import_file = fileURL[ 1 ];
 					ajaxConfig.data.data = JSON.stringify( {
 						stage: 1,

--- a/core/app/modules/import-export/assets/js/pages/import/import-process/import-process.js
+++ b/core/app/modules/import-export/assets/js/pages/import/import-process/import-process.js
@@ -67,7 +67,7 @@ export default function ImportProcess() {
 
 	useEffect( () => {
 		if ( 'success' === ajaxState.status ) {
-			if ( context.data.fileResponse.stage2 ) {
+			if ( context.data.fileResponse.hasOwnProperty( 'stage2' ) ) {
 				navigate( '/import/complete' );
 			} else {
 				navigate( '/import/content' );

--- a/core/app/modules/import-export/assets/js/pages/import/import-resolver/components/conflict/components/conflict-checkbox/conflict-checkbox.js
+++ b/core/app/modules/import-export/assets/js/pages/import/import-resolver/components/conflict/components/conflict-checkbox/conflict-checkbox.js
@@ -15,7 +15,9 @@ export default function ConflictCheckbox( props ) {
 		};
 
 	useEffect( () => {
-		context.dispatch( { type: 'ADD_OVERRIDE_CONDITION', payload: props.id } );
+		if ( ! context.data.overrideConditions.length ) {
+			context.dispatch( { type: 'ADD_OVERRIDE_CONDITION', payload: props.id } );
+		}
 	}, [] );
 
 	return (

--- a/core/app/modules/import-export/assets/js/shared/kit-content/components/kit-content-checkbox/kit-content-checkbox.js
+++ b/core/app/modules/import-export/assets/js/shared/kit-content/components/kit-content-checkbox/kit-content-checkbox.js
@@ -15,7 +15,9 @@ export default function KitContentCheckbox( props ) {
 		};
 
 	useEffect( () => {
-		context.dispatch( { type: 'ADD_INCLUDE', payload: props.type } );
+		if ( ! context.data.includes.length ) {
+			context.dispatch( { type: 'ADD_INCLUDE', payload: props.type } );
+		}
 	}, [] );
 
 	return useMemo( () => (


### PR DESCRIPTION
- When trying to import a kit that contains only site settings, the import process was leading to the import-content screen instead of getting the import-complete screen.
- The previous button of the import-content screen didn't work after the file was selected.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
