### PR TITLE
Fix: Setting zero offset in sticky motion effects not working properly [ED-3514]

### DIFF
--- a/assets/dev/js/frontend/frontend.js
+++ b/assets/dev/js/frontend/frontend.js
@@ -332,7 +332,7 @@ export default class Frontend extends elementorModules.ViewModule {
 	 * Initialize the modules' widgets handlers.
 	 */
 	initModules() {
-		const handlers = {
+		let handlers = {
 			shapes: Shapes,
 		};
 

--- a/assets/dev/js/frontend/frontend.js
+++ b/assets/dev/js/frontend/frontend.js
@@ -125,7 +125,8 @@ export default class Frontend extends elementorModules.ViewModule {
 				fullSettingKey = settingKey + '_' + currentDevice,
 				deviceValue = settings[ fullSettingKey ];
 
-			if ( deviceValue ) {
+			// Accept 0 as value.
+			if ( deviceValue || 0 === deviceValue ) {
 				return deviceValue;
 			}
 
@@ -331,7 +332,7 @@ export default class Frontend extends elementorModules.ViewModule {
 	 * Initialize the modules' widgets handlers.
 	 */
 	initModules() {
-		let handlers = {
+		const handlers = {
 			shapes: Shapes,
 		};
 


### PR DESCRIPTION
The value was parsed as a integer instead of string. Therefore, it was considered an empty value.