### PR TITLE
Fix: Admin/Admin-top-bar - Search field in templates categories in wrong location. [ED-3592]

### DIFF
--- a/modules/admin-top-bar/assets/scss/admin.scss
+++ b/modules/admin-top-bar/assets/scss/admin.scss
@@ -112,8 +112,14 @@ $top-bar-height: 50px;
 				margin-top: $top-bar-height;
 			}
 
-			.wrap h1 {
-				display: none;
+			.wrap {
+				// Since there is no h1 tag (in the normal place of the admin page) we need to break the page content under screen options button.
+				clear: both;
+				padding-top: 10px;
+
+				h1 {
+					display: none;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8281268/121515877-53343400-c9f6-11eb-82ec-9701a7671a31.png)

After:
![image](https://user-images.githubusercontent.com/8281268/121515747-339d0b80-c9f6-11eb-9b9e-2bbf4ba05c39.png)