### PR TITLE
revert - Frontend Assets Loader: Fix - Using more than one dynamic asset in optimized mode caused a JS error - ED-2828 (#14684)

### DIFF
--- a/assets/dev/js/frontend/utils/assets-loader.js
+++ b/assets/dev/js/frontend/utils/assets-loader.js
@@ -17,25 +17,21 @@ export default class AssetsLoader {
 	}
 
 	load( type, key ) {
-		return new Promise( ( resolve ) => {
-			const assetData = this.constructor.assets[ type ][ key ];
+		const assetData = AssetsLoader.assets[ type ][ key ];
 
-			if ( assetData.isLoaded ) {
-				resolve( true );
+		if ( ! assetData.loader ) {
+			assetData.loader = new Promise( ( resolve ) => {
+				const element = 'style' === type ? this.getStyleElement( assetData.src ) : this.getScriptElement( assetData.src );
 
-				return;
-			}
+				element.onload = () => resolve( true );
 
-			this.constructor.assets[ type ][ key ].isLoaded = true;
+				const parent = 'head' === assetData.parent ? assetData.parent : 'body';
 
-			const element = 'style' === type ? this.getStyleElement( assetData.src ) : this.getScriptElement( assetData.src );
+				document[ parent ].appendChild( element );
+			} );
+		}
 
-			element.onload = () => resolve( true );
-
-			const parent = 'head' === assetData.parent ? assetData.parent : 'body';
-
-			document[ parent ].appendChild( element );
-		} );
+		return assetData.loader;
 	}
 }
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1,8 +1,6 @@
 <?php
 namespace Elementor;
 
-use Elementor\Core\Settings\Page\Manager;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -152,22 +150,9 @@ class Utils {
 			"WHERE `meta_key` = '_elementor_data' AND `meta_value` LIKE '[%' ;" ); // meta_value LIKE '[%' are json formatted
 		// @codingStandardsIgnoreEnd
 
-		$second_rows_affected = $wpdb->query(
-			"UPDATE {$wpdb->postmeta} " .
-			$wpdb->prepare( 'SET `meta_value` = REPLACE(`meta_value`, %s, %s) ', $from, $to ) .
-			'WHERE `meta_key` = \'' . Manager::META_KEY . '\''
-		);
-
-		if ( $second_rows_affected ) {
-			$rows_affected += $second_rows_affected;
-		}
-
 		if ( false === $rows_affected ) {
 			throw new \Exception( __( 'An error occurred', 'elementor' ) );
 		}
-
-		// Allow externals to replace-urls, when they have to.
-		$rows_affected += (int) apply_filters( 'elementor/tools/replace-urls', 0, $from, $to );
 
 		Plugin::$instance->files_manager->clear_cache();
 

--- a/tests/phpunit/elementor/includes/test-utils.php
+++ b/tests/phpunit/elementor/includes/test-utils.php
@@ -1,7 +1,6 @@
 <?php
 namespace Elementor\Testing\Includes;
 
-use Elementor\Core\Settings\Page\Manager;
 use Elementor\Plugin;
 use Elementor\Utils;
 use Elementor\Testing\Elementor_Test_Base;
@@ -180,23 +179,5 @@ class Elementor_Test_Utils extends Elementor_Test_Base {
 
 		$this->assertEquals( false, Utils::is_empty( [ 'key' => '0' ], 'key' ),
 			"[ 'key' => '0' ] is empty" );
-	}
-
-	public function test_replace_urls__ensure_page_settings() {
-		// Arrange.
-		$setting_key = 'some-url';
-		$from_url = 'http://localhost/';
-		$to_url = 'http://127.0.0.1/';
-
-		$document = self::factory()->create_post();
-
-		$document->update_meta( Manager::META_KEY, [ $setting_key => $from_url ] );
-
-		// Act.
-		$affected_rows = Utils::replace_urls( $from_url, $to_url );
-
-		// Assert.
-		$this->assertSame( '1 row affected.', $affected_rows );
-		$this->assertSame( [ $setting_key => $to_url ], $document->get_meta( Manager::META_KEY ) );
 	}
 }


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
* Frontend Assets Loader: Fix - Using more than one dynamic asset in optimized mode caused a JS error.

* Frontend Assets Loader: Tweak - Refactoring code.