### PR TITLE
Fix: Utils - Return back the `replace-urls` filter [ED-3659]

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -155,6 +155,9 @@ class Utils {
 			throw new \Exception( __( 'An error occurred', 'elementor' ) );
 		}
 
+		// Allow externals to replace-urls, when they have to.
+		$rows_affected += (int) apply_filters( 'elementor/tools/replace-urls', 0, $from, $to );
+
 		Plugin::$instance->files_manager->clear_cache();
 
 		return sprintf(


### PR DESCRIPTION
Fix the revert #15331 