### PR TITLE
Fix: The kit-library info-modal didn't work [ED-3911]

### DIFF
--- a/core/app/modules/kit-library/assets/js/pages/index/index-header.js
+++ b/core/app/modules/kit-library/assets/js/pages/index/index-header.js
@@ -1,5 +1,5 @@
 import Header from '../../components/layout/header';
-import { Modal, Heading, Text, Button } from '@elementor/app-ui';
+import { ModalProvider, Heading, Text, Button } from '@elementor/app-ui';
 import { useMemo, useState } from 'react';
 import { useNavigate } from '@reach/router';
 
@@ -36,7 +36,7 @@ export default function IndexHeader( props ) {
 	return (
 		<>
 			<Header buttons={ buttons }/>
-			<Modal title={ __( 'Welcome to the Library', 'elementor' ) } modalProps={ { show: isInfoModalOpen, hideModal: () => setIsInfoModalOpen( false ) } }>
+			<ModalProvider title={ __( 'Welcome to the Library', 'elementor' ) } show={ isInfoModalOpen } setShow={ setIsInfoModalOpen }>
 				<div className="e-kit-library-header-info-modal-container">
 					<Heading tag="h3" variant="h3">{ __( 'What\'s a kit?', 'elementor' ) }</Heading>
 					<Text>{ __( 'A Template Kit is full, ready-made design that you can apply to your site. It includes all the pages, parts, settings and content that you\'d expect in a fully functional website.', 'elementor' ) }</Text>
@@ -62,7 +62,7 @@ export default function IndexHeader( props ) {
 						{ __( 'about using templates', 'elementor' ) }
 					</Text>
 				</div>
-			</Modal>
+			</ModalProvider>
 		</>
 	);
 }


### PR DESCRIPTION
The kit-library info-modal didn't work due to converting the ModalProvider and Modal components from class to function-based.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
