### PR TITLE
Tweak: The Regenerate-Files admin button should reset all page-assets data [ED-3789]

### DIFF
--- a/core/files/manager.php
+++ b/core/files/manager.php
@@ -121,7 +121,7 @@ class Manager {
 		delete_option( Global_CSS::META_KEY );
 		delete_option( Frontend::META_KEY );
 
-		$this->reset_assets_data_css();
+		$this->reset_assets_data();
 
 		/**
 		 * Elementor clear files.
@@ -163,22 +163,14 @@ class Manager {
 	}
 
 	/**
-	 * Reset Assets Data CSS.
+	 * Reset Assets Data.
 	 *
-	 * Reset the page assets CSS data.
+	 * Reset the page assets data.
 	 *
 	 * @since 3.3.0
 	 * @access private
 	 */
-	private function reset_assets_data_css() {
-		$assets_data_key = Page_Assets_Data_Manager::ASSETS_DATA_KEY;
-
-		$assets_inline_content = get_option( $assets_data_key, [] );
-
-		if ( isset( $assets_inline_content['css'] ) ) {
-			unset( $assets_inline_content['css'] );
-
-			update_option( $assets_data_key, $assets_inline_content );
-		}
+	private function reset_assets_data() {
+		delete_option( Page_Assets_Data_Manager::ASSETS_DATA_KEY );
 	}
 }

--- a/includes/settings/tools.php
+++ b/includes/settings/tools.php
@@ -254,11 +254,11 @@ class Tools extends Settings_Page {
 					'tools' => [
 						'fields' => [
 							'clear_cache' => [
-								'label' => __( 'Regenerate CSS', 'elementor' ),
+								'label' => __( 'Regenerate CSS & Data', 'elementor' ),
 								'field_args' => [
 									'type' => 'raw_html',
 									'html' => sprintf( '<button data-nonce="%s" class="button elementor-button-spinner" id="elementor-clear-cache-button">%s</button>', wp_create_nonce( 'elementor_clear_cache' ), __( 'Regenerate Files & Data', 'elementor' ) ),
-									'desc' => __( 'Styles set in Elementor are saved in CSS files in the uploads folder and in the site’s database. Recreate those files and settings, according to the most recent settings.', 'elementor' ),
+									'desc' => __( 'Styles set in Elementor are saved in CSS files in the uploads folder. Recreate those files, according to the most recent settings.', 'elementor' ),
 								],
 							],
 							'reset_api_data' => [

--- a/includes/settings/tools.php
+++ b/includes/settings/tools.php
@@ -258,7 +258,7 @@ class Tools extends Settings_Page {
 								'field_args' => [
 									'type' => 'raw_html',
 									'html' => sprintf( '<button data-nonce="%s" class="button elementor-button-spinner" id="elementor-clear-cache-button">%s</button>', wp_create_nonce( 'elementor_clear_cache' ), __( 'Regenerate Files & Data', 'elementor' ) ),
-									'desc' => __( 'Styles set in Elementor are saved in CSS files in the uploads folder. Recreate those files, according to the most recent settings.', 'elementor' ),
+									'desc' => __( 'Styles set in Elementor are saved in CSS files in the uploads folder and in the site’s database. Recreate those files and settings, according to the most recent settings.', 'elementor' ),
 								],
 							],
 							'reset_api_data' => [

--- a/includes/settings/tools.php
+++ b/includes/settings/tools.php
@@ -257,8 +257,8 @@ class Tools extends Settings_Page {
 								'label' => __( 'Regenerate CSS', 'elementor' ),
 								'field_args' => [
 									'type' => 'raw_html',
-									'html' => sprintf( '<button data-nonce="%s" class="button elementor-button-spinner" id="elementor-clear-cache-button">%s</button>', wp_create_nonce( 'elementor_clear_cache' ), __( 'Regenerate Files', 'elementor' ) ),
-									'desc' => __( 'Styles set in Elementor are saved in CSS files in the uploads folder. Recreate those files, according to the most recent settings.', 'elementor' ),
+									'html' => sprintf( '<button data-nonce="%s" class="button elementor-button-spinner" id="elementor-clear-cache-button">%s</button>', wp_create_nonce( 'elementor_clear_cache' ), __( 'Regenerate Files & Data', 'elementor' ) ),
+									'desc' => __( 'Styles set in Elementor are saved in CSS files in the uploads folder and in the site’s database. Recreate those files and settings, according to the most recent settings.', 'elementor' ),
 								],
 							],
 							'reset_api_data' => [


### PR DESCRIPTION
The Regenerate-Files admin button should reset all page-assets data instead of just the CSS assets data.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
