### PR TITLE
Fix: Re-migrate Kit - The migration fails in some cases [ED-4457]

### DIFF
--- a/core/upgrade/elementor-3-re-migrate-globals.php
+++ b/core/upgrade/elementor-3-re-migrate-globals.php
@@ -73,7 +73,7 @@ class Elementor_3_Re_Migrate_Globals {
 
 		// Apply a default value for $kit_raw_settings in case it's not defined.
 		if ( empty( $kit_raw_settings )) {
-			$kit_raw_settings = array();
+			$kit_raw_settings = [];
 		}
 
 		if ( $this->has_typography() ) {

--- a/core/upgrade/elementor-3-re-migrate-globals.php
+++ b/core/upgrade/elementor-3-re-migrate-globals.php
@@ -72,7 +72,7 @@ class Elementor_3_Re_Migrate_Globals {
 		$kit_raw_settings = $kit->get_meta( $meta_key );
 
 		// Apply a default value for $kit_raw_settings in case it's not defined.
-		if ( empty( $kit_raw_settings )) {
+		if ( empty( $kit_raw_settings ) ) {
 			$kit_raw_settings = [];
 		}
 

--- a/core/upgrade/elementor-3-re-migrate-globals.php
+++ b/core/upgrade/elementor-3-re-migrate-globals.php
@@ -71,6 +71,11 @@ class Elementor_3_Re_Migrate_Globals {
 		$meta_key = SettingsPageManager::META_KEY;
 		$kit_raw_settings = $kit->get_meta( $meta_key );
 
+		// Apply a default value for $kit_raw_settings in case it's not defined.
+		if ( empty( $kit_raw_settings )) {
+			$kit_raw_settings = array();
+		}
+
 		if ( $this->has_typography() ) {
 			$callbacks[] = [ Upgrades::class, '_v_3_0_0_move_default_typography_to_kit' ];
 			unset( $kit_raw_settings['system_typography'] );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Apply a default value for $kit_raw_settings in re-migrate-globals functionality

## Description

* See #15477 for an explanation of the problem being addressed
* Apply a default value for the $kit_raw_settings value before it gets used (in case the backing database entry wasn't found or didn't contain a valid value)

## Test instructions

* See #15477 for steps to reproduce the original issue. That issue should be resolved if this works correctly.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #15477 
