### PR TITLE
Fix: Responsive bar - Widescreen breakpoint reject values entered in the Responsive bar [ED-4216]

### DIFF
--- a/assets/dev/js/editor/editor-base.js
+++ b/assets/dev/js/editor/editor-base.js
@@ -598,7 +598,8 @@ export default class EditorBase extends Marionette.Application {
 	getCurrentDeviceConstrains() {
 		const currentBreakpoint = elementor.channels.deviceMode.request( 'currentMode' ),
 			{ activeBreakpoints } = elementorFrontend.config.responsive,
-			currentBreakpointData = activeBreakpoints[ currentBreakpoint ];
+			currentBreakpointData = activeBreakpoints[ currentBreakpoint ],
+			currentBreakpointMaxPoint = ( 'widescreen' === currentBreakpoint ) ? 9999 : currentBreakpointData.value;
 
 		let currentBreakpointMinPoint = Stylesheet.getDeviceMinBreakpoint( currentBreakpoint );
 
@@ -609,7 +610,7 @@ export default class EditorBase extends Marionette.Application {
 		}
 
 		return {
-			maxWidth: currentBreakpointData.value,
+			maxWidth: currentBreakpointMaxPoint,
 			minWidth: currentBreakpointMinPoint,
 		};
 	}


### PR DESCRIPTION
…the Responsive bar [ED-4216]

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #


[ED-4216]: https://elementor.atlassian.net/browse/ED-4216