### PR TITLE
Fix: Bug in global widgets cause in 3.3.0 core [ED-4223]

### DIFF
--- a/assets/dev/js/editor/container/container.js
+++ b/assets/dev/js/editor/container/container.js
@@ -217,7 +217,11 @@ export default class Container extends ArgsObject {
 				}
 				const container = view.container;
 
-				container.parent.children[ view._index ] = container;
+				// Since the way 'global-widget' rendered, it does not have parent sometimes.
+				if ( container.parent.children ) {
+					container.parent.children[ view._index ] = container;
+				}
+
 				container.handleChildrenRecursive();
 			} );
 		} else {


### PR DESCRIPTION
The `handleChildrenRecursive` is unable to work without a parent 