### PR TITLE
Tweak: Use template literals in Elementor filter names

### DIFF
--- a/assets/dev/js/editor/controls/wp_widget.js
+++ b/assets/dev/js/editor/controls/wp_widget.js
@@ -50,7 +50,7 @@ ControlWPWidgetItemView = ControlBaseDataView.extend( {
 					}
 				}
 
-				var widgetType = self.model.get( 'widget' );
+				const widgetType = self.model.get( 'widget' );
 
 				elementor.hooks.doAction( `panel/widgets/${widgetType}/controls/wp_widget/loaded`, self );
 			},

--- a/assets/dev/js/editor/controls/wp_widget.js
+++ b/assets/dev/js/editor/controls/wp_widget.js
@@ -52,7 +52,7 @@ ControlWPWidgetItemView = ControlBaseDataView.extend( {
 
 				const widgetType = self.model.get( 'widget' );
 
-				elementor.hooks.doAction( `panel/widgets/${widgetType}/controls/wp_widget/loaded`, self );
+				elementor.hooks.doAction( `panel/widgets/${ widgetType }/controls/wp_widget/loaded`, self );
 			},
 		} );
 	},

--- a/assets/dev/js/editor/controls/wp_widget.js
+++ b/assets/dev/js/editor/controls/wp_widget.js
@@ -50,7 +50,9 @@ ControlWPWidgetItemView = ControlBaseDataView.extend( {
 					}
 				}
 
-				elementor.hooks.doAction( 'panel/widgets/' + self.model.get( 'widget' ) + '/controls/wp_widget/loaded', self );
+				var widgetType = self.model.get( 'widget' );
+
+				elementor.hooks.doAction( `panel/widgets/${widgetType}/controls/wp_widget/loaded`, self );
 			},
 		} );
 	},

--- a/assets/dev/js/editor/elements/views/base.js
+++ b/assets/dev/js/editor/elements/views/base.js
@@ -45,7 +45,9 @@ BaseElementView = BaseContainer.extend( {
 	},
 
 	behaviors() {
-		const groups = elementor.hooks.applyFilters( 'elements/' + this.options.model.get( 'elType' ) + '/contextMenuGroups', this.getContextMenuGroups(), this );
+		const elementType = this.options.model.get( 'elType' );
+
+		const groups = elementor.hooks.applyFilters( `elements/${elementType}/contextMenuGroups`, this.getContextMenuGroups(), this );
 
 		const behaviors = {
 			contextMenu: {

--- a/assets/dev/js/editor/elements/views/base.js
+++ b/assets/dev/js/editor/elements/views/base.js
@@ -47,7 +47,7 @@ BaseElementView = BaseContainer.extend( {
 	behaviors() {
 		const elementType = this.options.model.get( 'elType' );
 
-		const groups = elementor.hooks.applyFilters( `elements/${elementType}/contextMenuGroups`, this.getContextMenuGroups(), this );
+		const groups = elementor.hooks.applyFilters( `elements/${ elementType }/contextMenuGroups`, this.getContextMenuGroups(), this );
 
 		const behaviors = {
 			contextMenu: {

--- a/assets/dev/js/editor/regions/panel/pages/editor/commands/open.js
+++ b/assets/dev/js/editor/regions/panel/pages/editor/commands/open.js
@@ -10,14 +10,16 @@ export class Open extends CommandBase {
 			$e.route( this.component.getDefaultRoute(), args );
 		}
 
-		// BC: Run hooks after the route render's the view.
-		const action = 'panel/open_editor/' + args.model.get( 'elType' );
+		// BC: Run hooks after the route render's the view
+
+		const elementType = args.model.get( 'elType' );
+		const widgetType = args.model.get( 'widgetType' );
 
 		// Example: panel/open_editor/widget
-		elementor.hooks.doAction( action, this.component.manager, args.model, args.view );
+		elementor.hooks.doAction( `panel/open_editor/${elementType}`, this.component.manager, args.model, args.view );
 
 		// Example: panel/open_editor/widget/heading
-		elementor.hooks.doAction( action + '/' + args.model.get( 'widgetType' ),
+		elementor.hooks.doAction( `panel/open_editor/${elementType}/${widgetType}`,
 			this.component.manager,
 			args.model,
 			args.view

--- a/assets/dev/js/editor/regions/panel/pages/editor/commands/open.js
+++ b/assets/dev/js/editor/regions/panel/pages/editor/commands/open.js
@@ -16,10 +16,10 @@ export class Open extends CommandBase {
 			widgetType = args.model.get( 'widgetType' );
 
 		// Example: panel/open_editor/widget
-		elementor.hooks.doAction( `panel/open_editor/${elementType}`, this.component.manager, args.model, args.view );
+		elementor.hooks.doAction( `panel/open_editor/${ elementType }`, this.component.manager, args.model, args.view );
 
 		// Example: panel/open_editor/widget/heading
-		elementor.hooks.doAction( `panel/open_editor/${elementType}/${widgetType}`,
+		elementor.hooks.doAction( `panel/open_editor/${ elementType }/${ widgetType }`,
 			this.component.manager,
 			args.model,
 			args.view

--- a/assets/dev/js/editor/regions/panel/pages/editor/commands/open.js
+++ b/assets/dev/js/editor/regions/panel/pages/editor/commands/open.js
@@ -12,8 +12,8 @@ export class Open extends CommandBase {
 
 		// BC: Run hooks after the route render's the view
 
-		const elementType = args.model.get( 'elType' );
-		const widgetType = args.model.get( 'widgetType' );
+		const elementType = args.model.get( 'elType' ),
+			widgetType = args.model.get( 'widgetType' );
 
 		// Example: panel/open_editor/widget
 		elementor.hooks.doAction( `panel/open_editor/${elementType}`, this.component.manager, args.model, args.view );

--- a/assets/dev/js/frontend/elements-handlers-manager.js
+++ b/assets/dev/js/frontend/elements-handlers-manager.js
@@ -134,10 +134,11 @@ module.exports = function( $ ) {
 
 		elementorFrontend.hooks.doAction( 'frontend/element_ready/global', $scope, $ );
 
-		elementorFrontend.hooks.doAction( 'frontend/element_ready/' + elementType, $scope, $ );
+		elementorFrontend.hooks.doAction( `frontend/element_ready/${elementType}`, $scope, $ );
 
 		if ( 'widget' === elementType ) {
-			elementorFrontend.hooks.doAction( 'frontend/element_ready/' + $scope.attr( 'data-widget_type' ), $scope, $ );
+			const widgetType = $scope.attr( 'data-widget_type' );
+			elementorFrontend.hooks.doAction( `frontend/element_ready/${widgetType}`, $scope, $ );
 		}
 	};
 

--- a/assets/dev/js/frontend/elements-handlers-manager.js
+++ b/assets/dev/js/frontend/elements-handlers-manager.js
@@ -134,11 +134,11 @@ module.exports = function( $ ) {
 
 		elementorFrontend.hooks.doAction( 'frontend/element_ready/global', $scope, $ );
 
-		elementorFrontend.hooks.doAction( `frontend/element_ready/${elementType}`, $scope, $ );
+		elementorFrontend.hooks.doAction( `frontend/element_ready/${ elementType }`, $scope, $ );
 
 		if ( 'widget' === elementType ) {
 			const widgetType = $scope.attr( 'data-widget_type' );
-			elementorFrontend.hooks.doAction( `frontend/element_ready/${widgetType}`, $scope, $ );
+			elementorFrontend.hooks.doAction( `frontend/element_ready/${ widgetType }`, $scope, $ );
 		}
 	};
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Use curly braces around JS filter name while declaring variables as part of hook name.

Reviewed by @matipojo on #15686