### PR TITLE
Fix: Additional Breakpoints - The widescreen value was overridden by the desktop value [ED-4384]

### DIFF
--- a/assets/dev/scss/frontend/_devices.scss
+++ b/assets/dev/scss/frontend/_devices.scss
@@ -2,12 +2,13 @@
 
 	&:after {
 
-		@media (min-width: $screen-widescreen-min) {
-			content: 'widescreen';
-		}
-
 		@media (min-width: $screen-desktop-min) {
 			content: 'desktop';
+		}
+
+		// 'widescreen' is under 'desktop' to make sure the 'desktop' media query doesn't override it.
+		@media (min-width: $screen-widescreen-min) {
+			content: 'widescreen';
 		}
 
 		@media (max-width: $screen-laptop-max) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: elementor-device-mode - desktop media query overrides widescreen (ED-4384)