### PR TITLE
Fix: Site Settings - Widescreen input not rejecting illegal values (ED-4349)

### DIFF
--- a/assets/dev/js/editor/components/validator/breakpoint.js
+++ b/assets/dev/js/editor/components/validator/breakpoint.js
@@ -10,9 +10,30 @@ export default class BreakpointValidator extends NumberValidator {
 		};
 	}
 
+	/**
+	 * Get Panel Active Breakpoints
+	 *
+	 * Since the active kit used in the Site Settings panel could be a draft, we need to use the panel's active
+	 * breakpoints settings and not the elementorFrontend.config values (which come from the DB).
+	 *
+	 * @returns Object
+	 */
+	getPanelActiveBreakpoints() {
+		const panelBreakpoints = elementor.documents.currentDocument.config.settings.settings.active_breakpoints.map( ( breakpointName ) => {
+			return breakpointName.replace( 'viewport_', '' );
+		} ),
+			panelActiveBreakpoints = {};
+
+		panelBreakpoints.forEach( ( breakpointName ) => {
+			panelActiveBreakpoints[ breakpointName ] = elementorFrontend.config.responsive.breakpoints[ breakpointName ];
+		} );
+
+		return panelActiveBreakpoints;
+	}
+
 	initBreakpointProperties() {
 		const validationTerms = this.getSettings( 'validationTerms' ),
-			activeBreakpoints = elementorFrontend.config.responsive.activeBreakpoints,
+			activeBreakpoints = this.getPanelActiveBreakpoints(),
 			breakpointKeys = Object.keys( activeBreakpoints );
 
 		this.breakpointIndex = breakpointKeys.indexOf( validationTerms.breakpointName );

--- a/assets/dev/js/utils/breakpoints.js
+++ b/assets/dev/js/utils/breakpoints.js
@@ -137,10 +137,16 @@ export default class Breakpoints extends elementorModules.Module {
 		if ( breakpointNames[ 0 ] === device ) {
 			// For the lowest breakpoint, the min point is always 320.
 			minBreakpoint = 320;
-		} else if ( 'min' === activeBreakpoints[ device ].direction ) {
+		} else if ( 'widescreen' === device ) {
 			// Widescreen only has a minimum point. In this case, the breakpoint
 			// value in the Breakpoints config is itself the device min point.
-			minBreakpoint = activeBreakpoints[ device ].value;
+			if ( activeBreakpoints[ device ] ) {
+				minBreakpoint = activeBreakpoints[ device ].value;
+			} else {
+				// If the widescreen breakpoint does not exist in the active breakpoints config (for example, in the
+				// case this method runs as the breakpoint is being added), get the value from the full config.
+				minBreakpoint = this.responsiveConfig.breakpoints.widescreen;
+			}
 		} else {
 			const deviceNameIndex = breakpointNames.indexOf( device ),
 				previousIndex = deviceNameIndex - 1;

--- a/core/kits/assets/js/hooks/ui/document/elements/settings/update-breakpoints-preview.js
+++ b/core/kits/assets/js/hooks/ui/document/elements/settings/update-breakpoints-preview.js
@@ -19,32 +19,15 @@ export class KitUpdateBreakpointsPreview extends $e.modules.hookUI.After {
 		const { settings } = args;
 
 		if ( settings.active_breakpoints ) {
-			// Updating the config is necessary, even if the page has to be reloaded for these settings to take place,
-			// because users can add breakpoints and then immediately give them a value, before saving the site
-			// settings. The breakpoint control's validator needs to have the updated active breakpoints config in
-			// order to validate the user input properly.
+			// Updating the current document config necessary, even if the page has to be reloaded for these settings
+			// to take place, because users can add breakpoints and then immediately choose a value for them, before
+			// saving the site settings. The breakpoint control's validator needs to have the actual active breakpoints
+			// in the panel at that moment breakpoints config in order to validate the user input properly.
 			elementor.documents.currentDocument.config.settings.settings.active_breakpoints = settings.active_breakpoints;
 
 			// This flag is used to notify users that if they make a change to the active breakpoints list, they need
 			// to reload the editor for the changes to take effect.
 			elementor.activeBreakpointsUpdated = true;
-
-			// Reset all breakpoints in the config to not-enabled, to make sure the config is updated with only the
-			// enabled breakpoints following the input change.
-			Object.keys( elementorFrontend.config.responsive.breakpoints ).forEach( ( breakpointName ) => {
-				elementorFrontend.config.responsive.breakpoints[ breakpointName ].is_enabled = false;
-			} );
-
-			// Clear the active breakpoints object before repopulating it, to make sure unselected breakpoints are removed.
-			elementorFrontend.config.responsive.activeBreakpoints = {};
-
-			settings.active_breakpoints.forEach( ( breakpointName ) => {
-				breakpointName = breakpointName.replace( 'viewport_', '' );
-				// Set its state to enabled.
-				elementorFrontend.config.responsive.breakpoints[ breakpointName ].is_enabled = true;
-				// Add/re-add the breakpoint to the emptied activeBreakpoints object.
-				elementorFrontend.config.responsive.activeBreakpoints[ breakpointName ] = elementorFrontend.config.responsive.breakpoints[ breakpointName ];
-			} );
 
 			// If this is the modified setting, no need to do further checks.
 			return;

--- a/core/kits/assets/js/hooks/ui/document/elements/settings/update-breakpoints-preview.js
+++ b/core/kits/assets/js/hooks/ui/document/elements/settings/update-breakpoints-preview.js
@@ -19,7 +19,35 @@ export class KitUpdateBreakpointsPreview extends $e.modules.hookUI.After {
 		const { settings } = args;
 
 		if ( settings.active_breakpoints ) {
+			// Updating the config is necessary, even if the page has to be reloaded for these settings to take place,
+			// because users can add breakpoints and then immediately give them a value, before saving the site
+			// settings. The breakpoint control's validator needs to have the updated active breakpoints config in
+			// order to validate the user input properly.
+			elementor.documents.currentDocument.config.settings.settings.active_breakpoints = settings.active_breakpoints;
+
+			// This flag is used to notify users that if they make a change to the active breakpoints list, they need
+			// to reload the editor for the changes to take effect.
 			elementor.activeBreakpointsUpdated = true;
+
+			// Reset all breakpoints in the config to not-enabled, to make sure the config is updated with only the
+			// enabled breakpoints following the input change.
+			Object.keys( elementorFrontend.config.responsive.breakpoints ).forEach( ( breakpointName ) => {
+				elementorFrontend.config.responsive.breakpoints[ breakpointName ].is_enabled = false;
+			} );
+
+			// Clear the active breakpoints object before repopulating it, to make sure unselected breakpoints are removed.
+			elementorFrontend.config.responsive.activeBreakpoints = {};
+
+			settings.active_breakpoints.forEach( ( breakpointName ) => {
+				breakpointName = breakpointName.replace( 'viewport_', '' );
+				// Set its state to enabled.
+				elementorFrontend.config.responsive.breakpoints[ breakpointName ].is_enabled = true;
+				// Add/re-add the breakpoint to the emptied activeBreakpoints object.
+				elementorFrontend.config.responsive.activeBreakpoints[ breakpointName ] = elementorFrontend.config.responsive.breakpoints[ breakpointName ];
+			} );
+
+			// If this is the modified setting, no need to do further checks.
+			return;
 		}
 
 		// If a breakpoint value was updated, update the value in the config.


### PR DESCRIPTION
Also fixed a bug where a console error is thrown after adding the widescreen breakpoint in the Active Breakpoints control.

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Site Settings/Additional Breakpoints - Widescreen input not rejecting illegal values.
*Fix: Site Settings/Additional Breakpoints - a console error is thrown after adding the widescreen breakpoint in the Active Breakpoints control.