### PR TITLE
Fix: Box shadow of widgets in panel is cropped [ED-4428]

### DIFF
--- a/assets/dev/scss/editor/panel/_panel.scss
+++ b/assets/dev/scss/editor/panel/_panel.scss
@@ -43,7 +43,6 @@
 	}
 
 	.elementor-responsive-panel {
-		overflow: hidden;
 		padding: 5px 10px;
 		display: grid;
 		gap: 10px;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/32631382/127273451-af8f385f-264e-4dc1-8869-bc4753850a75.png)


After:
![image](https://user-images.githubusercontent.com/32631382/127273525-3f5e4e38-cfbf-4c3a-946b-af2bf33381fc.png)
