### PR TITLE
Fix: Widescreen tooltip text is wrong (ED-4503)

### DIFF
--- a/includes/editor-templates/panel.php
+++ b/includes/editor-templates/panel.php
@@ -146,7 +146,7 @@ $document = Plugin::$instance->documents->get( Plugin::$instance->editor->get_po
 	</div>
 	<# if ( elementData.reload_preview ) { #>
 		<div class="elementor-update-preview">
-			<div class="elementor-update-preview-title"><?php echo __( 'Update changes to page', 'elementor' ); ?></div>
+			<div class="elementor-update-preview-title"><?php echo esc_html__( 'Update changes to page', 'elementor' ); ?></div>
 			<div class="elementor-update-preview-button-wrapper">
 				<button class="elementor-update-preview-button elementor-button elementor-button-success"><?php echo esc_html__( 'Apply', 'elementor' ); ?></button>
 			</div>

--- a/includes/editor-templates/responsive-bar.php
+++ b/includes/editor-templates/responsive-bar.php
@@ -14,7 +14,7 @@ $active_devices = array_reverse( Plugin::$instance->breakpoints->get_active_devi
 $breakpoint_classes_map = array_intersect_key( Plugin::$instance->breakpoints->get_responsive_icons_classes_map(), array_flip( $active_devices ) );
 
 /* translators: %1$s: Device Name */
-$breakpoint_label = __( '%1$s <br> Settings added to %1$s device will apply to %2$spx screens and down', 'elementor' );
+$breakpoint_label = esc_html__( '%1$s <br> Settings added for the %1$s device will apply to %2$spx screens and down', 'elementor' );
 ?>
 
 <script type="text/template" id="tmpl-elementor-templates-responsive-bar">
@@ -22,7 +22,11 @@ $breakpoint_label = __( '%1$s <br> Settings added to %1$s device will apply to %
 		<div id="e-responsive-bar-switcher" class="e-responsive-bar--pipe">
 			<?php foreach ( $active_devices as $device_key ) {
 				if ( 'desktop' === $device_key ) {
-					$tooltip_label = __( 'Desktop <br> Settings added to Base device will apply to all breakpoints unless edited', 'elementor' );
+					$tooltip_label = esc_html__( 'Desktop <br> Settings added for the base device will apply to all breakpoints unless edited', 'elementor' );
+				} elseif ( 'widescreen' === $device_key ) {
+					$tooltip_label = esc_html__( 'Widescreen <br> Settings added for the Widescreen device will apply to screen sizes %dpx and up', 'elementor' );
+
+					$tooltip_label = sprintf( $tooltip_label, $active_breakpoints[ $device_key ]->get_value() );
 				} else {
 					$tooltip_label = sprintf( $breakpoint_label, $active_breakpoints[ $device_key ]->get_label(), $active_breakpoints[ $device_key ]->get_value() );
 				}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Responsive Bar - Widescreen device's tooltip text is wrong, tweaked the other tooltip texts.