### PR TITLE
Fix: Additional Breakpoints - Responsive 'base-multiple' controls wit… (ED-4515)

### DIFF
--- a/assets/dev/js/editor/editor-base.js
+++ b/assets/dev/js/editor/editor-base.js
@@ -1280,6 +1280,19 @@ export default class EditorBase extends Marionette.Application {
 				delete controlConfig.popover?.end;
 			}
 
+			// Move the control's default to the desktop control
+			if ( controlConfig.default ) {
+				controlConfig.desktop_default = controlConfig.default;
+			}
+
+			const multipleDefaultValue = this.config.controls[ controlConfig.type ].default_value;
+
+			// For multiple controls that implement get_default_value() in the control class, make sure the duplicated
+			// controls receive that default value.
+			if ( multipleDefaultValue ) {
+				controlConfig.default = defaultValue;
+			}
+
 			devices.forEach( ( device, index ) => {
 				let controlArgs = elementorCommon.helpers.cloneObject( controlConfig );
 

--- a/includes/controls/base-data.php
+++ b/includes/controls/base-data.php
@@ -15,6 +15,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 abstract class Base_Data_Control extends Base_Control {
 
+	public function __construct() {
+		parent::__construct();
+
+		$default_value = $this->get_default_value();
+
+		if ( '' !== $default_value ) {
+			$this->set_settings( 'default_value', $default_value );
+		}
+	}
+
 	/**
 	 * Get data control default value.
 	 *


### PR DESCRIPTION
…h a default value inherit the desktop default as an actual value and not passively

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Additional Breakpoints - Editor - Responsive 'base-multiple' controls with a default value actively inherit the desktop default.