### PR TITLE
Internal: Upgrade PHPUnit CI machine to Ubuntu-18.04

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   run:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     if: startsWith( github.repository, 'elementor/' )
     strategy:
       fail-fast: false


### PR DESCRIPTION
In the PHPUnit CI, we using with `shivammathur/setup-php` action.
The author of the action removes support for Ubuntu 16.04.

For more information: https://github.com/shivammathur/setup-php/issues/452