### PR TITLE
add_responsive_control added in position selection

### DIFF
--- a/includes/widgets/common.php
+++ b/includes/widgets/common.php
@@ -765,7 +765,7 @@ class Widget_Common extends Widget_Base {
 			]
 		);
 
-		$this->add_control(
+		$this->add_responsive_control(
 			'_position',
 			[
 				'label' => __( 'Position', 'elementor' ),
@@ -784,7 +784,7 @@ class Widget_Common extends Widget_Base {
 		$start = is_rtl() ? __( 'Right', 'elementor' ) : __( 'Left', 'elementor' );
 		$end = ! is_rtl() ? __( 'Right', 'elementor' ) : __( 'Left', 'elementor' );
 
-		$this->add_control(
+		$this->add_responsive_control(
 			'_offset_orientation_h',
 			[
 				'label' => __( 'Horizontal Orientation', 'elementor' ),


### PR DESCRIPTION
add_responsive_control added in position selection because user may need default position in mobile device.
<img width="289" alt="Screenshot 2021-08-09 at 11 36 16 AM" src="https://user-images.githubusercontent.com/5499301/128664657-49ccf04b-6dc2-40eb-8899-4876e2e51592.png">
