### PR TITLE
Fix: Desktop max point when widescreen is inactive is 1439px instead of 99999px (ED-4595)

### DIFF
--- a/assets/dev/scss/frontend/breakpoints/values.scss
+++ b/assets/dev/scss/frontend/breakpoints/values.scss
@@ -23,7 +23,6 @@ $screen-md-min: $screen-tablet-min;
 $screen-md-max: $screen-tablet-max;
 $screen-lg-min: $screen-desktop-min;
 
-$screen-desktop-max: map_get($breakpoints, xl) - 1;
 $screen-xl-min: map_get($breakpoints, xl);
 $screen-xl-max: map_get($breakpoints, xxl) - 1;
 $screen-xxl-min: map_get($breakpoints, xxl);


### PR DESCRIPTION
Fixes the report in the comment: https://github.com/elementor/elementor/issues/15797#issuecomment-892778545

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Breakpoints - Desktop max point when widescreen is inactive is 1439px instead of 99999px