### PR TITLE
Fix: Responsive columns didn't reacted to the appropriate breakpoints (ED-4556)

### DIFF
--- a/includes/elements/column.php
+++ b/includes/elements/column.php
@@ -125,6 +125,16 @@ class Element_Column extends Element_Base {
 			]
 		);
 
+		$active_breakpoint_keys = array_reverse( array_keys( Plugin::$instance->breakpoints->get_active_breakpoints() ) );
+		$inline_size_device_args = [];
+
+		foreach ( $active_breakpoint_keys as $breakpoint_key ) {
+			$inline_size_device_args[ $breakpoint_key ] = [
+				'max' => 100,
+				'required' => false,
+			];
+		}
+
 		$this->add_responsive_control(
 			'_inline_size',
 			[
@@ -133,18 +143,11 @@ class Element_Column extends Element_Base {
 				'min' => 2,
 				'max' => 98,
 				'required' => true,
-				'device_args' => [
-					Breakpoints_Manager::BREAKPOINT_KEY_TABLET => [
-						'max' => 100,
-						'required' => false,
-					],
-					Breakpoints_Manager::BREAKPOINT_KEY_MOBILE => [
-						'max' => 100,
-						'required' => false,
-					],
-				],
+				'device_args' => $inline_size_device_args,
 				'min_affected_device' => [
 					Breakpoints_Manager::BREAKPOINT_KEY_DESKTOP => Breakpoints_Manager::BREAKPOINT_KEY_TABLET,
+					Breakpoints_Manager::BREAKPOINT_KEY_LAPTOP => Breakpoints_Manager::BREAKPOINT_KEY_TABLET,
+					Breakpoints_Manager::BREAKPOINT_KEY_TABLET_EXTRA => Breakpoints_Manager::BREAKPOINT_KEY_TABLET,
 					Breakpoints_Manager::BREAKPOINT_KEY_TABLET => Breakpoints_Manager::BREAKPOINT_KEY_TABLET,
 				],
 				'selectors' => [

--- a/includes/stylesheet.php
+++ b/includes/stylesheet.php
@@ -317,11 +317,11 @@ class Stylesheet {
 		$hash = array_filter( explode( '-', $hash ) );
 
 		foreach ( $hash as $single_query ) {
-			$query_parts = explode( '_', $single_query );
+			preg_match( '/(min|max)_(.*)/', $single_query, $query_parts );
 
-			$end_point = $query_parts[0];
+			$end_point = $query_parts[1];
 
-			$device_name = $query_parts[1];
+			$device_name = $query_parts[2];
 
 			$query[ $end_point ] = 'max' === $end_point ? $this->devices[ $device_name ] : Plugin::$instance->breakpoints->get_device_min_breakpoint( $device_name );
 		}


### PR DESCRIPTION
Fixes issue mentioned in comment: https://github.com/elementor/elementor/issues/15797#issuecomment-891842894

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Responsive columns didn't reacted to the appropriate breakpoints
* Fix: 'Mobile Extra' and 'Tablet Extra' values were not supported in the front end for responsive controls

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)