### PR TITLE
Roboto font looks blurry after "Admin Top Bar" feature.

### DIFF
--- a/modules/admin-top-bar/module.php
+++ b/modules/admin-top-bar/module.php
@@ -55,7 +55,7 @@ class Module extends BaseApp {
 	 * Enqueue admin scripts
 	 */
 	private function enqueue_scripts() {
-		wp_enqueue_style( 'elementor-admin-top-bar-fonts', 'https://fonts.googleapis.com/css2?family=Roboto&display=swap', [], ELEMENTOR_VERSION );
+		wp_enqueue_style( 'elementor-admin-top-bar-fonts', 'https://fonts.googleapis.com/css2?family=Roboto:400,700&display=swap', [], ELEMENTOR_VERSION );
 
 		wp_enqueue_style( 'elementor-admin-top-bar', $this->get_css_assets_url( 'admin-top-bar', null, 'default', true ), [], ELEMENTOR_VERSION );
 


### PR DESCRIPTION
Roboto font looks blurry because there is missing **700/bold**.

![screenshot_94ab1506a](https://user-images.githubusercontent.com/11369109/128742920-dc72e53e-4339-4263-acd7-715a0cd8a0bb.png)

vs

![screenshot_7468e1894](https://user-images.githubusercontent.com/11369109/128742981-452c1f0d-d3bf-4ddf-ba34-023c1881e597.png)

