### PR TITLE
Internal: Allow Plugin::$instance->breakpoints->get_active_devices_list() to return a reversed list (ED-4410)

### DIFF
--- a/core/breakpoints/manager.php
+++ b/core/breakpoints/manager.php
@@ -114,9 +114,10 @@ class Manager extends Module {
 	 *
 	 * @since 3.2.0
 	 *
+	 * @param $reverse
 	 * @return array
 	 */
-	public function get_active_devices_list() {
+	public function get_active_devices_list( $reverse = null ) {
 		$active_devices = array_keys( Plugin::$instance->breakpoints->get_active_breakpoints() );
 
 		// Insert the 'desktop' device in the correct position.
@@ -126,6 +127,10 @@ class Manager extends Module {
 			array_splice( $active_devices, $widescreen_index, 0, [ 'desktop' ] );
 		} else {
 			$active_devices[] = 'desktop';
+		}
+
+		if ( $reverse ) {
+			$active_devices = array_reverse( $active_devices );
 		}
 
 		return $active_devices;

--- a/core/breakpoints/manager.php
+++ b/core/breakpoints/manager.php
@@ -114,22 +114,31 @@ class Manager extends Module {
 	 *
 	 * @since 3.2.0
 	 *
-	 * @param $reverse
+	 * @param array $args
 	 * @return array
 	 */
-	public function get_active_devices_list( $reverse = null ) {
+	public function get_active_devices_list( $args = [] ) {
+		$default_args = [
+			'add_desktop' => true,
+			'reverse' => false,
+		];
+
+		$args = array_merge( $default_args, $args );
+
 		$active_devices = array_keys( Plugin::$instance->breakpoints->get_active_breakpoints() );
 
-		// Insert the 'desktop' device in the correct position.
-		if ( in_array( 'widescreen', $active_devices, true ) ) {
-			$widescreen_index = array_search( 'widescreen', $active_devices, true );
+		if ( $args['add_desktop'] ) {
+			// Insert the 'desktop' device in the correct position.
+			if ( in_array( 'widescreen', $active_devices, true ) ) {
+				$widescreen_index = array_search( 'widescreen', $active_devices, true );
 
-			array_splice( $active_devices, $widescreen_index, 0, [ 'desktop' ] );
-		} else {
-			$active_devices[] = 'desktop';
+				array_splice( $active_devices, $widescreen_index, 0, [ 'desktop' ] );
+			} else {
+				$active_devices[] = 'desktop';
+			}
 		}
 
-		if ( $reverse ) {
+		if ( $args['reverse'] ) {
 			$active_devices = array_reverse( $active_devices );
 		}
 

--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -802,7 +802,7 @@ abstract class Controls_Stack extends Base_Object {
 
 		$active_breakpoints = Plugin::$instance->breakpoints->get_active_breakpoints();
 
-		$devices = Plugin::$instance->breakpoints->get_active_devices_list( true );
+		$devices = Plugin::$instance->breakpoints->get_active_devices_list( [ 'reverse' => true ] );
 
 		if ( isset( $args['devices'] ) ) {
 			$devices = array_intersect( $devices, $args['devices'] );

--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -802,7 +802,7 @@ abstract class Controls_Stack extends Base_Object {
 
 		$active_breakpoints = Plugin::$instance->breakpoints->get_active_breakpoints();
 
-		$devices = array_reverse( Plugin::$instance->breakpoints->get_active_devices_list() );
+		$devices = Plugin::$instance->breakpoints->get_active_devices_list( true );
 
 		if ( isset( $args['devices'] ) ) {
 			$devices = array_intersect( $devices, $args['devices'] );

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -674,7 +674,7 @@ abstract class Element_Base extends Controls_Stack {
 	 */
 	protected function add_hidden_device_controls() {
 		// The 'Hide On X' controls are displayed from largest to smallest, while the method returns smallest to largest.
-		$active_devices = array_reverse( Plugin::$instance->breakpoints->get_active_devices_list() );
+		$active_devices = Plugin::$instance->breakpoints->get_active_devices_list( true );
 		$active_breakpoints = Plugin::$instance->breakpoints->get_active_breakpoints();
 
 		foreach ( $active_devices as $breakpoint_key ) {

--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -674,7 +674,7 @@ abstract class Element_Base extends Controls_Stack {
 	 */
 	protected function add_hidden_device_controls() {
 		// The 'Hide On X' controls are displayed from largest to smallest, while the method returns smallest to largest.
-		$active_devices = Plugin::$instance->breakpoints->get_active_devices_list( true );
+		$active_devices = Plugin::$instance->breakpoints->get_active_devices_list( [ 'reverse' => true ] );
 		$active_breakpoints = Plugin::$instance->breakpoints->get_active_breakpoints();
 
 		foreach ( $active_devices as $breakpoint_key ) {

--- a/includes/editor-templates/responsive-bar.php
+++ b/includes/editor-templates/responsive-bar.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // TODO: Use API data instead of this static array, once it is available.
 $active_breakpoints = Plugin::$instance->breakpoints->get_active_breakpoints();
-$active_devices = Plugin::$instance->breakpoints->get_active_devices_list( true );
+$active_devices = Plugin::$instance->breakpoints->get_active_devices_list( [ 'reverse' => true ] );
 
 $breakpoint_classes_map = array_intersect_key( Plugin::$instance->breakpoints->get_responsive_icons_classes_map(), array_flip( $active_devices ) );
 

--- a/includes/editor-templates/responsive-bar.php
+++ b/includes/editor-templates/responsive-bar.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // TODO: Use API data instead of this static array, once it is available.
 $active_breakpoints = Plugin::$instance->breakpoints->get_active_breakpoints();
-$active_devices = array_reverse( Plugin::$instance->breakpoints->get_active_devices_list() );
+$active_devices = Plugin::$instance->breakpoints->get_active_devices_list( true );
 
 $breakpoint_classes_map = array_intersect_key( Plugin::$instance->breakpoints->get_responsive_icons_classes_map(), array_flip( $active_devices ) );
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Internal: Allow Plugin::$instance->breakpoints->get_active_devices_list() to return a reversed list