### PR TITLE
Fix: Editor - Some respon. controls pass the desktop default to other devices accidentally (ED-4670)

### DIFF
--- a/assets/dev/js/editor/editor-base.js
+++ b/assets/dev/js/editor/editor-base.js
@@ -1289,10 +1289,14 @@ export default class EditorBase extends Marionette.Application {
 
 			const multipleDefaultValue = this.config.controls[ controlConfig.type ].default_value;
 
+			let deleteControlDefault = true;
+
 			// For multiple controls that implement get_default_value() in the control class, make sure the duplicated
 			// controls receive that default value.
 			if ( multipleDefaultValue ) {
 				controlConfig.default = multipleDefaultValue;
+
+				deleteControlDefault = false;
 			}
 
 			devices.forEach( ( device, index ) => {
@@ -1358,6 +1362,10 @@ export default class EditorBase extends Marionette.Application {
 				devices.forEach( ( breakpoint ) => {
 					delete controlArgs[ breakpoint + '_default' ];
 				} );
+
+				if ( deleteControlDefault ) {
+					delete controlArgs.default;
+				}
 
 				delete controlArgs.is_responsive;
 

--- a/assets/dev/js/editor/editor-base.js
+++ b/assets/dev/js/editor/editor-base.js
@@ -1348,6 +1348,8 @@ export default class EditorBase extends Marionette.Application {
 					} else {
 						controlArgs.default = controlArgs[ device + '_default' ];
 					}
+				} else if ( deleteControlDefault ) {
+					delete controlArgs.default;
 				}
 
 				// If the control belongs to a group control with a popover, and this control is the last one, add the
@@ -1362,10 +1364,6 @@ export default class EditorBase extends Marionette.Application {
 				devices.forEach( ( breakpoint ) => {
 					delete controlArgs[ breakpoint + '_default' ];
 				} );
-
-				if ( deleteControlDefault ) {
-					delete controlArgs.default;
-				}
 
 				delete controlArgs.is_responsive;
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Editor - Certain responsive controls pass the desktop default to other devices accidentally