### PR TITLE
Fix: Internal - `{device}_default` control properties are not deleted for responsive controls (ED-4741)

### DIFF
--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -886,9 +886,9 @@ abstract class Controls_Stack extends Base_Object {
 				$control_args['default'] = $control_args[ $device_name . '_default' ];
 			}
 
-			unset( $control_args['desktop_default'] );
-			unset( $control_args['tablet_default'] );
-			unset( $control_args['mobile_default'] );
+			foreach ( $devices as $device ) {
+				unset( $control_args[ $device . '_default' ] );
+			}
 
 			$id_suffix = Breakpoints_Manager::BREAKPOINT_KEY_DESKTOP === $device_name ? '' : '_' . $device_name;
 			$control_name = $id . $id_suffix;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Internal: Fix - `{device}_default` control properties are not deleted for responsive controls