### PR TITLE
Fix: Controls in the Editor's JS system have to have an empty string value as default (ED-4772)

### DIFF
--- a/assets/dev/js/editor/editor-base.js
+++ b/assets/dev/js/editor/editor-base.js
@@ -1354,7 +1354,8 @@ export default class EditorBase extends Marionette.Application {
 						controlArgs.default = controlArgs[ device + '_default' ];
 					}
 				} else if ( deleteControlDefault ) {
-					delete controlArgs.default;
+					// In the Editor, controls without default values should have an empty string as the default value.
+					controlArgs.default = '';
 				}
 
 				// If the control belongs to a group control with a popover, and this control is the last one, add the


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Controls in the Editor's JS system always have an empty string value as default, so they cannot be deleted