### PR TITLE
Revert: Fix: Gradient control doesn't work on frontend when using Global Colors (ED-4790, ED-4781)

### DIFF
--- a/core/files/css/base.php
+++ b/core/files/css/base.php
@@ -701,10 +701,6 @@ abstract class Base extends Base_File {
 		}
 
 		if ( ! is_numeric( $value ) && ! is_float( $value ) && empty( $value ) ) {
-			if ( ! empty( $control['global']['default'] ) ) {
-				return $this->get_selector_global_value( $control, $control['global']['default'] );
-			}
-
 			return null;
 		}
 


### PR DESCRIPTION
Reverts: https://github.com/elementor/elementor/pull/16002

This is a temporary fix because in the Front End, global colors are applied even when they are disabled

## Summary

This PR can be summarized in the following changelog entry:

* Revert: Fix: Gradient control doesn't work on frontend when using Global Colors