### PR TITLE
Fix: Responsive Site settings dont apply on frontend when Additional Breakpoints is active (ED-4787)

### DIFF
--- a/core/kits/documents/kit.php
+++ b/core/kits/documents/kit.php
@@ -142,10 +142,24 @@ class Kit extends PageBase {
 	 * @access protected
 	 */
 	protected function register_controls() {
+		$is_edit_mode = Plugin::$instance->editor->is_edit_mode();
+
+		if ( ! $is_edit_mode ) {
+			// In the Front End, the Kit is initialized before CSS is generated, so we always duplicate controls in
+			// the kit.
+			$initial_responsive_controls_duplication_mode = Plugin::$instance->breakpoints->get_responsive_control_duplication_mode();
+
+			Plugin::$instance->breakpoints->set_responsive_control_duplication_mode( 'on' );
+		}
+
 		$this->register_document_controls();
 
 		foreach ( $this->tabs as $tab ) {
 			$tab->register_controls();
+		}
+
+		if ( ! $is_edit_mode ) {
+			Plugin::$instance->breakpoints->set_responsive_control_duplication_mode( $initial_responsive_controls_duplication_mode );
 		}
 	}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Responsive Site settings dont apply on frontend when Additional Breakpoints is active (Fixes #16055, #16033)