### PR TITLE
Fix Attempt to read property "post_status" on null

### DIFF
--- a/core/base/document.php
+++ b/core/base/document.php
@@ -1516,7 +1516,7 @@ abstract class Document extends Controls_Stack {
 		if ( $is_published || $can_publish || ! Plugin::$instance->editor->is_edit_mode() ) {
 
 			$statuses = $this->get_post_statuses();
-			if ( 'future' === $this->get_main_post()->post_status ) {
+			if ( $this->get_main_post() && 'future' === $this->get_main_post()->post_status ) {
 				$statuses['future'] = esc_html__( 'Future', 'elementor' );
 			}
 
@@ -1525,7 +1525,7 @@ abstract class Document extends Controls_Stack {
 				[
 					'label' => esc_html__( 'Status', 'elementor' ),
 					'type' => Controls_Manager::SELECT,
-					'default' => $this->get_main_post()->post_status,
+					'default' => $this->get_main_post() ? $this->get_main_post()->post_status : '',
 					'options' => $statuses,
 				]
 			);

--- a/core/kits/manager.php
+++ b/core/kits/manager.php
@@ -218,7 +218,7 @@ class Manager {
 
 		if ( $is_kit_preview ) {
 			$kit = Plugin::$instance->documents->get_doc_or_auto_save( $active_kit->get_main_id(), get_current_user_id() );
-		} elseif ( 'publish' === $active_kit->get_main_post()->post_status ) {
+		} elseif ($active_kit->get_main_post() && 'publish' === $active_kit->get_main_post()->post_status ) {
 			$kit = $active_kit;
 		}
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Attempt to read property "post_status" on null


## Description
An explanation of what is done in this PR

* Fix PHP warning  Attempt to read property "post_status" on null


## Test instructions
This PR can be tested by following these steps:

* If you view any not post screen (where is no post object is available) such as 404, search page, archive page you will get a warning.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] I have added unittests to verify the code works as intended

Fixes #
