### PR TITLE
Tweak: Use consistent variable names

### DIFF
--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -1377,7 +1377,7 @@ abstract class Controls_Stack extends Base_Object {
 	 * @param array  $args       Section arguments Optional.
 	 */
 	public function start_controls_section( $section_id, array $args = [] ) {
-		$section_name = $this->get_name();
+		$stack_name = $this->get_name();
 
 		/**
 		 * Before section start.
@@ -1397,14 +1397,14 @@ abstract class Controls_Stack extends Base_Object {
 		 *
 		 * Fires before Elementor section starts in the editor panel.
 		 *
-		 * The dynamic portions of the hook name, `$section_name` and `$section_id`, refers to the section name and section ID, respectively.
+		 * The dynamic portions of the hook name, `$stack_name` and `$section_id`, refers to the stack name and section ID, respectively.
 		 *
 		 * @since 1.4.0
 		 *
 		 * @param Controls_Stack $this The control.
 		 * @param array          $args Section arguments.
 		 */
-		do_action( "elementor/element/{$section_name}/{$section_id}/before_section_start", $this, $args );
+		do_action( "elementor/element/{$stack_name}/{$section_id}/before_section_start", $this, $args );
 
 		$args['type'] = Controls_Manager::SECTION;
 
@@ -1438,14 +1438,14 @@ abstract class Controls_Stack extends Base_Object {
 		 *
 		 * Fires after Elementor section starts in the editor panel.
 		 *
-		 * The dynamic portions of the hook name, `$section_name` and `$section_id`, refers to the section name and section ID, respectively.
+		 * The dynamic portions of the hook name, `$stack_name` and `$section_id`, refers to the stack name and section ID, respectively.
 		 *
 		 * @since 1.4.0
 		 *
 		 * @param Controls_Stack $this The control.
 		 * @param array          $args Section arguments.
 		 */
-		do_action( "elementor/element/{$section_name}/{$section_id}/after_section_start", $this, $args );
+		do_action( "elementor/element/{$stack_name}/{$section_id}/after_section_start", $this, $args );
 	}
 
 	/**
@@ -1516,7 +1516,7 @@ abstract class Controls_Stack extends Base_Object {
 		 *
 		 * Fires after Elementor section ends in the editor panel.
 		 *
-		 * The dynamic portions of the hook name, `$stack_name` and `$section_id`, refers to the section name and section ID, respectively.
+		 * The dynamic portions of the hook name, `$stack_name` and `$section_id`, refers to the stack name and section ID, respectively.
 		 *
 		 * @since 1.4.0
 		 *


### PR DESCRIPTION
In https://github.com/elementor/elementor/commit/bca6b1a0fde3d295d887bd8deea02f7b120e1340 the dynamic portions of the hook name was changed. But it was changed only on `end_controls_section()` method. This PR makes the same changes to the `start_controls_section()` for consistency.

