### PR TITLE
Fix - Fatal error: Uncaught Error: Call to a member function attributes()

### DIFF
--- a/core/files/assets/svg/svg-handler.php
+++ b/core/files/assets/svg/svg-handler.php
@@ -653,10 +653,12 @@ class Svg_Handler extends Files_Upload_Handler {
 			if ( empty( $data ) || empty( $data['width'] ) || empty( $data['height'] ) ) {
 
 				$xml = simplexml_load_file( wp_get_attachment_url( $id ) );
-				$attr = $xml->attributes();
-				$view_box = explode( ' ', $attr->viewBox );// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$data['width'] = isset( $attr->width ) && preg_match( '/\d+/', $attr->width, $value ) ? (int) $value[0] : ( 4 === count( $view_box ) ? (int) $view_box[2] : null );
-				$data['height'] = isset( $attr->height ) && preg_match( '/\d+/', $attr->height, $value ) ? (int) $value[0] : ( 4 === count( $view_box ) ? (int) $view_box[3] : null );
+				if( $xml ) {
+					$attr = $xml->attributes();
+					$view_box = explode( ' ', $attr->viewBox );// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					$data['width'] = isset( $attr->width ) && preg_match( '/\d+/', $attr->width, $value ) ? (int) $value[0] : ( 4 === count( $view_box ) ? (int) $view_box[2] : null );
+					$data['height'] = isset( $attr->height ) && preg_match( '/\d+/', $attr->height, $value ) ? (int) $value[0] : ( 4 === count( $view_box ) ? (int) $view_box[3] : null );
+				}
 			}
 		}
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

Avoid Fatal error if allow_url_fopen is disabled (Off/0).

## Description

If on the server the `allow_url_fopen` is disabled then we face a fatal error:

```
Uncaught Error: Call to a member function attributes() on bool in ...
```

Screenshot: https://share.bsf.io/04uxOX1p

Some providers disable it for that we can face such issues.

With this PR we can see the warnings but we can avoid the fatal error.

Screenshot: https://share.bsf.io/6quYPgko

## Test instructions

We can reproduce the issue by disabling it from the php.ini file.

Screenshot - https://share.bsf.io/L1urQj7R

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
