### PR TITLE
Fix: Large images are fully displayed before the swiper is initialized [ED-1247]

### DIFF
--- a/assets/dev/scss/frontend/widgets/image-carousel.scss
+++ b/assets/dev/scss/frontend/widgets/image-carousel.scss
@@ -18,3 +18,11 @@
 		text-align: center;
 	}
 }
+
+// Before the image-carousel layout is calculated by JS. //
+.elementor-image-carousel-wrapper:not(.swiper-container-initialized) {
+
+	.swiper-slide {
+		max-width: calc(100% / var(--e-image-carousel-slides-to-show, 3));
+	}
+}

--- a/includes/widgets/image-carousel.php
+++ b/includes/widgets/image-carousel.php
@@ -122,6 +122,10 @@ class Widget_Image_Carousel extends Widget_Base {
 					'' => esc_html__( 'Default', 'elementor' ),
 				] + $slides_to_show,
 				'frontend_available' => true,
+				'render_type' => 'template',
+				'selectors' => [
+					'{{WRAPPER}}' => '--e-image-carousel-slides-to-show: {{VALUE}}',
+				],
 			]
 		);
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
