### PR TITLE
Fix: If a responsive control is the first in a popover, it breaks for non-desktop devices [ED-4979]

### DIFF
--- a/assets/dev/js/editor/editor-base.js
+++ b/assets/dev/js/editor/editor-base.js
@@ -1358,8 +1358,15 @@ export default class EditorBase extends Marionette.Application {
 					controlArgs.default = '';
 				}
 
-				// If the control belongs to a group control with a popover, and this control is the last one, add the
-				// popover.end = true value to it to make sure it closes the popover.
+				// If the control is the first inside a popover, only the first device starts the popover,
+				// so the 'start' property has to be deleted from all other devices.
+				if ( 0 !== index && controlArgs.popover?.start ) {
+					delete controlArgs.popover.start;
+				}
+
+				// If the control is inside a popover, AND this control is the last one in the popover, AND this is the
+				// last device in the devices array - add the 'popover.end = true' value to it to make sure it closes
+				// the popover.
 				if ( index === ( devices.length - 1 ) && popoverEndProperty ) {
 					controlArgs.popover = {
 						end: true,


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: If a responsive control is the first control in a popover, it breaks the popover for non-desktop devices (Fixes https://github.com/elementor/elementor/issues/16312)