### PR TITLE
Fix: When the "Optimized DOM" experiment is off and custom breakpoints are defined... [ED-4994]

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,7 +86,14 @@ module.exports = function( grunt ) {
 			files: [ {
 				expand: true,
 				cwd: 'assets/dev/scss/direction',
-				src: [ 'frontend.scss', 'frontend-rtl.scss', 'frontend-lite.scss', 'frontend-lite-rtl.scss' ],
+				src: [
+					'frontend.scss',
+					'frontend-rtl.scss',
+					'frontend-lite.scss',
+					'frontend-lite-rtl.scss',
+					'frontend-legacy.scss',
+					'frontend-legacy-rtl.scss',
+				],
 				dest: 'assets/css/templates',
 				ext: '.css',
 			} ],

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -141,18 +141,6 @@ class Frontend extends App {
 	];
 
 	/**
-	 * Has Custom Breakpoints
-	 *
-	 * Whether custom breakpoints are active in the system.
-	 *
-	 * @since 3.4.5
-	 * @access private
-	 *
-	 * @var bool
-	 */
-	private $has_custom_breakpoints;
-
-	/**
 	 * Front End constructor.
 	 *
 	 * Initializing Elementor front end. Make sure we are not in admin, not and
@@ -545,13 +533,13 @@ class Frontend extends App {
 
 		$frontend_dependencies = [];
 
-		$this->has_custom_breakpoints = Plugin::$instance->breakpoints->has_custom_breakpoints();
+		$has_custom_breakpoints = Plugin::$instance->breakpoints->has_custom_breakpoints();
 
 		if ( ! Plugin::$instance->experiments->is_feature_active( 'e_dom_optimization' ) ) {
 			// If The Dom Optimization feature is disabled, register the legacy CSS
 			wp_register_style(
 				'elementor-frontend-legacy',
-				$this->get_frontend_file_url( 'frontend-legacy' . $direction_suffix . $min_suffix . '.css' ),
+				$this->get_frontend_file_url( 'frontend-legacy' . $direction_suffix . $min_suffix . '.css', $has_custom_breakpoints ),
 				[],
 				ELEMENTOR_VERSION
 			);
@@ -561,9 +549,9 @@ class Frontend extends App {
 
 		wp_register_style(
 			'elementor-frontend',
-			$this->get_frontend_file_url( $frontend_file_name ),
+			$this->get_frontend_file_url( $frontend_file_name, $has_custom_breakpoints ),
 			$frontend_dependencies,
-			$this->has_custom_breakpoints ? null : ELEMENTOR_VERSION
+			$has_custom_breakpoints ? null : ELEMENTOR_VERSION
 		);
 
 		/**
@@ -681,19 +669,20 @@ class Frontend extends App {
 	/**
 	 * Get Frontend File URL
 	 *
-	 * Returns the URL for the CSS file to be loaded in the front end. If there are custom breakpoints, a custom file
-	 * is generated based on a passed template file name. Otherwise, the URL for the default CSS file is returned.
+	 * Returns the URL for the CSS file to be loaded in the front end. If requested via the second parameter, a custom
+	 * file is generated based on a passed template file name. Otherwise, the URL for the default CSS file is returned.
 	 *
 	 * @since 3.4.5
 	 *
 	 * @access private
 	 *
 	 * @param string $frontend_file_name
+	 * @param boolean $custom_file
 	 *
 	 * @return string frontend file URL
 	 */
-	private function get_frontend_file_url( $frontend_file_name ) {
-		if ( $this->has_custom_breakpoints ) {
+	private function get_frontend_file_url( $frontend_file_name, $custom_file ) {
+		if ( $custom_file ) {
 			$frontend_file = new FrontendFile( 'custom-' . $frontend_file_name, Breakpoints_Manager::get_stylesheet_templates_path() . $frontend_file_name );
 
 			$time = $frontend_file->get_meta( 'time' );

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -535,15 +535,7 @@ class Frontend extends App {
 		$has_custom_file = Plugin::$instance->breakpoints->has_custom_breakpoints();
 
 		if ( $has_custom_file ) {
-			$frontend_file = new FrontendFile( 'custom-' . $frontend_file_name, Breakpoints_Manager::get_stylesheet_templates_path() . $frontend_file_name );
-
-			$time = $frontend_file->get_meta( 'time' );
-
-			if ( ! $time ) {
-				$frontend_file->update();
-			}
-
-			$frontend_file_url = $frontend_file->get_url();
+			$frontend_file_url = $this->get_custom_frontend_file_url( $frontend_file_name );
 		} else {
 			$frontend_file_url = ELEMENTOR_ASSETS_URL . 'css/' . $frontend_file_name;
 		}
@@ -552,9 +544,17 @@ class Frontend extends App {
 
 		if ( ! Plugin::$instance->experiments->is_feature_active( 'e_dom_optimization' ) ) {
 			// If The Dom Optimization feature is disabled, register the legacy CSS
+			$frontend_legacy_file_name = 'frontend-legacy' . $direction_suffix . $min_suffix . '.css';
+
+			if ( $has_custom_file ) {
+				$frontend_legacy_file_url = $this->get_custom_frontend_file_url( $frontend_legacy_file_name );
+			} else {
+				$frontend_legacy_file_url = ELEMENTOR_ASSETS_URL . 'css/' . $frontend_legacy_file_name;
+			}
+
 			wp_register_style(
 				'elementor-frontend-legacy',
-				ELEMENTOR_ASSETS_URL . 'css/frontend-legacy' . $direction_suffix . $min_suffix . '.css',
+				$frontend_legacy_file_url,
 				[],
 				ELEMENTOR_VERSION
 			);
@@ -679,6 +679,26 @@ class Frontend extends App {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Get Custom Frontend File URL
+	 *
+	 * Generate a custom frontend CSS file based on a passed template file name, and return the generated file's URL.
+	 *
+	 * @since 3.4.5
+	 * @access public
+	 */
+	private function get_custom_frontend_file_url( $frontend_file_name ) {
+		$frontend_file = new FrontendFile( 'custom-' . $frontend_file_name, Breakpoints_Manager::get_stylesheet_templates_path() . $frontend_file_name );
+
+		$time = $frontend_file->get_meta( 'time' );
+
+		if ( ! $time ) {
+			$frontend_file->update();
+		}
+
+		return $frontend_file->get_url();
 	}
 
 	/**


### PR DESCRIPTION
…, some responsive CSS receives default breakpoint values.

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: When the "Optimized DOM" experiment is off and custom breakpoints are defined, some responsive CSS receives default breakpoint values. Fixes #16322