### PR TITLE
Fix: Slides per view controls disappeared in multiple breakpoints in Testimonial Carousel [ED-5025]

### DIFF
--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -818,7 +818,7 @@ abstract class Controls_Stack extends Base_Object {
 		$is_frontend_available = ! empty( $args['frontend_available'] );
 		$has_prefix_class = ! empty( $args['prefix_class'] );
 
-		if ( $options['overwrite'] ) {
+		if ( ! empty( $options['overwrite'] ) ) {
 			// If this is an updated control, check if it needs to be duplicated or not.
 			$is_duplicated_overwrite = $this->is_duplicated_overwrite( $id );
 		} else {


### PR DESCRIPTION
This has a complementary PR in E Pro.

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Slides per view controls disappeared in multiple breakpoints in Testimonial Carousel

## Description
An explanation of what is done in this PR

* When a responsive control is updated, the `update_responsive_control()` or `add_responsive_control()` methods don't have any way of knowing if the original control needs to be duplicated or not (such as in cases where the control is `frontend_available`, has a `prefix_class` property or is `dynamic => active => true`). This PR adds a check for that before overwriting an updated responsive control.