### PR TITLE
Fix: Admin Top Bar experiment caus the WP pages title disappear [ED-5090]

### DIFF
--- a/modules/admin-top-bar/assets/scss/admin.scss
+++ b/modules/admin-top-bar/assets/scss/admin.scss
@@ -111,10 +111,20 @@ $top-bar-height: 50px;
 			#wpbody-content {
 				margin-top: $top-bar-height;
 			}
+
+			.wrap {
+				// Since there is no h1 tag (in the normal place of the admin page) we need to break the page content under screen options button.
+				clear: both;
+				padding-top: 10px;
+
+				h1 {
+					display: none;
+				}
+			}
 		}
 	}
 
-	&.e-admin-top-bar--inactive ~ #wpbody {
+	&:not(.e-admin-top-bar--active) ~ #wpbody {
 		.wrap {
 			h1, .page-title-action {
 				display: inline-block;
@@ -155,7 +165,7 @@ $top-bar-height: 50px;
 		line-height: normal;
 	}
 
-	// The title and buttons are not visible by default in the original place. They might be visible according to the result of the admin tp bar.
+	// The title and buttons are not visible by default in the original place. They might be visible according to the result of the admin top bar.
 	&~ #wpbody {
 		.wrap {
 			h1, .page-title-action {


### PR DESCRIPTION
https://share.vidyard.com/watch/2gWfPxa3YsFdved2XTz1Dc