### PR TITLE
fix svg image contrainted to 48px issue

### DIFF
--- a/assets/dev/scss/frontend/widgets/image.scss
+++ b/assets/dev/scss/frontend/widgets/image.scss
@@ -8,7 +8,8 @@
 		display: inline-block; //For alignment image with link - Changed to 'inline-block' instead of 'block' to handle with this issue https://github.com/elementor/elementor/issues/5897
 
 		img[src$=".svg"] {
-			width: 48px; //Fix SVG image src, issue: https://github.com/elementor/elementor/issues/5987
+			width: auto; // for IE support
+			width: fit-content; // made image size fit widget container
 		}
 	}
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix issue #16525 

## Description
An explanation of what is done in this PR

* remove ```width:48px``` 
* replace with ``` width: auto;``` and ```width: fit-content;```

## Test instructions
This PR can be tested by following these steps:

1. add a image widget
2. set image with link
3. select a svg image file
4. press preview button
5. check svg image width is equal to original svg size

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #16525 
