### PR TITLE
Tweak: Delete deprecated editor constant [ED-5289]

### DIFF
--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -35,12 +35,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Editor {
 
 	/**
-	 * The nonce key for Elementor editor.
-	 * @deprecated 2.3.0
-	 */
-	const EDITING_NONCE_KEY = 'elementor-editing';
-
-	/**
 	 * User capability required to access Elementor editor.
 	 */
 	const EDITING_CAPABILITY = 'edit_posts';


### PR DESCRIPTION
Soft Deprecation: **2.3.0**

Hard Deprecation: **2.7.0**

Should have been deleted in **3.1.0** (!) but no one did it. Deleting in **3.5.0**

Related: #16158
