### PR TITLE
Tweak: Delete deprecated ajax method [ED-5272]

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -88,24 +88,6 @@ class Utils {
 	];
 
 	/**
-	 * Is ajax.
-	 *
-	 * Whether the current request is a WordPress ajax request.
-	 *
-	 * @since 1.0.0
-	 * @deprecated 2.6.0 Use `wp_doing_ajax()` instead.
-	 * @access public
-	 * @static
-	 *
-	 * @return bool True if it's a WordPress ajax request, false otherwise.
-	 */
-	public static function is_ajax() {
-		 _deprecated_function( __METHOD__, '2.6.0', 'wp_doing_ajax()' );
-
-		return wp_doing_ajax();
-	}
-
-	/**
 	 * Is WP CLI.
 	 *
 	 * @return bool


### PR DESCRIPTION
Soft Deprecation: **2.6.0**

Hard Deprecation: **3.0.0**

Should have been deleted in **3.4.0** but no one did it. Deleting in **3.5.0**
