### PR TITLE
Tweak: Delete deprecated 'Core\Ajax' class alias [ED-5291]

### DIFF
--- a/includes/autoloader.php
+++ b/includes/autoloader.php
@@ -195,10 +195,6 @@ class Autoloader {
 
 	private static function init_classes_aliases() {
 		self::$classes_aliases = [
-			'Core\Ajax' => [
-				'replacement' => 'Core\Common\Modules\Ajax\Module',
-				'version' => '2.3.0',
-			],
 			'Editor' => [
 				'replacement' => 'Core\Editor\Editor',
 				'version' => '2.6.0',


### PR DESCRIPTION
Soft Deprecation: **2.3.0**

Hard Deprecation: **2.5.0**

Should have been deleted in **2.9.0** (!) but no one did it. Deleting in **3.5.0**
