### PR TITLE
Fix: Additional Breakpoints - Conditional respon. controls disappear if exper. is active [ED-5362]

### DIFF
--- a/assets/dev/js/editor/controls/base.js
+++ b/assets/dev/js/editor/controls/base.js
@@ -105,6 +105,12 @@ ControlBaseView = Marionette.CompositeView.extend( {
 		const settings = this.container ? this.container.settings : this.elementSettingsModel;
 
 		this.listenTo( settings, 'change', this.onAfterChange );
+
+		elementor.listenTo( elementor.channels.deviceMode, 'change', () => this.onDeviceModeChange() );
+	},
+
+	onDeviceModeChange: function() {
+		this.toggleControlVisibility();
 	},
 
 	onAfterChange: function() {

--- a/assets/dev/js/editor/controls/base.js
+++ b/assets/dev/js/editor/controls/base.js
@@ -106,7 +106,9 @@ ControlBaseView = Marionette.CompositeView.extend( {
 
 		this.listenTo( settings, 'change', this.onAfterChange );
 
-		elementor.listenTo( elementor.channels.deviceMode, 'change', () => this.onDeviceModeChange() );
+		if ( this.model.attributes.responsive ) {
+			elementor.listenTo( elementor.channels.deviceMode, 'change', () => this.onDeviceModeChange() );
+		}
 	},
 
 	onDeviceModeChange: function() {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: In some cases, conditional controls disappear in cascaded devices if Additional Custom Breakpoint experiment was enabled.