### PR TITLE
Fix: Responsive Choose control is in reversed order in RTL sites [ED-5461]

### DIFF
--- a/assets/dev/scss/editor/panel/controls/_choose.scss
+++ b/assets/dev/scss/editor/panel/controls/_choose.scss
@@ -65,23 +65,26 @@
 
 .rtl {
 
-	.elementor-control-text_align,
-	.elementor-control-align,
-	.elementor-control-position {
+	.elementor-control-type-choose {
 
-		.elementor-choices {
-			flex-direction: row-reverse; // Force ltr also in RTL languages
+		&[class*="elementor-control-text_align"],
+		&[class*="elementor-control-align"],
+		&[class*="elementor-control-position"] {
 
-			.elementor-choices-label {
+			.elementor-choices {
+				flex-direction: row-reverse; // Force ltr also in RTL languages
 
-				&:nth-child(2) {
-					@include border-end(1px solid $editor-lightest);
-					border-radius: 3px 0 0 3px;
-				}
+				.elementor-choices-label {
 
-				&:last-child {
-					@include border-end(none);
-					border-radius: 0 3px 3px 0;
+					&:nth-child(2) {
+						@include border-end(1px solid $editor-lightest);
+						border-radius: 3px 0 0 3px;
+					}
+
+					&:last-child {
+						@include border-end(none);
+						border-radius: 0 3px 3px 0;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Responsive Choose control is in reversed order in RTL sites