### PR TITLE
Fix: Kit Library - Apply Kit throws an error with PHP 8 [ED-4974]

### DIFF
--- a/core/app/modules/import-export/module.php
+++ b/core/app/modules/import-export/module.php
@@ -105,7 +105,7 @@ class Module extends BaseModule {
 		// PHPCS - Already validated in caller function.
 		if ( ! empty( $_POST['e_import_file'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$file_url = $_POST['e_import_file']; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			if ( ! filter_var( $file_url, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED ) || 0 !== strpos( $file_url, 'http' ) ) {
+			if ( ! filter_var( $file_url, FILTER_VALIDATE_URL ) || 0 !== strpos( $file_url, 'http' ) ) {
 				throw new \Error( __( 'Invalid URL', 'elementor' ) );
 			}
 


### PR DESCRIPTION
FILTER_FLAG_SCHEME_REQUIRED is removed, and it is included by default from PHP 5.2.1
ref: https://php.watch/versions/7.3/filter-var-flag-deprecation
ref: https://php.watch/versions/8.0/filter_var-flags

