### PR TITLE
Internal: ScreenShotter fixes

### DIFF
--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -28,6 +28,7 @@ jobs:
           sudo chown -R $USER /usr/local/lib/node_modules
           sudo chown -R $USER /usr/local/bin/
           npm i -g @elementor/screenshotter
+          npm i -g grunt-cli
       - name: Install Dependencies
         run: |
           elementor-screenshotter-install --config=${screenshotter_config_path} --debug=true


### PR DESCRIPTION
After force use node.js 14, the ScreenShotter can't install `grunt-cli`
