### PR TITLE
Fix: Image Widget - avoid processing images with Jetpack's Photon

### DIFF
--- a/includes/controls/groups/image-size.php
+++ b/includes/controls/groups/image-size.php
@@ -105,7 +105,25 @@ class Group_Control_Image_Size extends Group_Control_Base {
 				'class' => trim( $image_class ),
 			];
 
+			/*
+			 * If you use the Jetpack plugin and its image CDN feature,
+			 * the image strings returned will use the CDN URL.
+			 * We don't want that.
+			 * The CDN URL will be added later on on the front end.
+			 *
+			 * @see https://ethitter.com/p/897/
+			 * @see https://github.com/Automattic/jetpack/issues/22052
+			 */
+			if ( class_exists( '\Automattic\Jetpack\Image_CDN\Image_CDN' ) ) {
+				remove_filter( 'image_downsize', array( \Automattic\Jetpack\Image_CDN\Image_CDN::instance(), 'filter_image_downsize' ) );
+			}
+
 			$html .= wp_get_attachment_image( $image['id'], $size, false, $image_attr );
+
+			// Re-enable Photon now that the image URL has been built.
+			if ( class_exists( '\Automattic\Jetpack\Image_CDN\Image_CDN' ) ) {
+				add_filter( 'image_downsize', array( \Automattic\Jetpack\Image_CDN\Image_CDN::instance(), 'filter_image_downsize' ), 10, 3 );
+			}
 		} else {
 			$image_src = self::get_attachment_image_src( $image['id'], $image_size_key, $settings );
 


### PR DESCRIPTION

## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Image Widget: avoid conflicts with the Jetpack plugin's Image CDN feature

## Description

This change addresses [a conflict with the Jetpack plugin and its image CDN feature](https://github.com/Automattic/jetpack/issues/22052).
The image CDN feature, also known as Photon, attempts to process images as you display them on the frontend of your site, to serve them from a CDN instead of locally.

This should only happen on the frontend though, not when the images are being fetched before they're inserted.

## Test instructions
This PR can be tested by following these steps:

* Start with a site where you've activated Elementor, as well as the Jetpack plugin.
* Go to Jetpack > Settings > Performance, and enable the Site Accelerator feature.
* Go to Pages > Add New, and create a new page using the Elementor editor.
* In the Elementor editor, add an image widget.
* In the widget, upload a new image, and set the size to custom.
* Set a width of `500` and a height of `100`.
* Save your changes, and visit the page. You'll see that the image is smaller than that.
* Apply this patch.
* Refresh the page; the image will have the right size.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes https://github.com/Automattic/jetpack/issues/22052
