### PR TITLE
Tweak: Adjusted the inline icon control for design flexibility [OBXT-…

### DIFF
--- a/assets/dev/js/editor/controls/icons.js
+++ b/assets/dev/js/editor/controls/icons.js
@@ -261,6 +261,8 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 		const controlValue = this.getControlValue(),
 			skin = this.model.get( 'skin' ),
 			iconContainer = 'inline' === skin ? this.ui.inlineDisplayedIcon : this.ui.previewPlaceholder,
+			skinOptions = this.model.get( 'skin_settings' ),
+			disableActiveState = this.model.get( 'disable_initial_active_state' ),
 			defaultIcon = this.model.get( 'default' );
 
 		let iconValue = controlValue.value,
@@ -273,13 +275,15 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 
 		if ( 'media' === skin ) {
 			this.ui.controlMedia.toggleClass( 'elementor-media-empty', ! iconValue );
-		} else {
+		}
+
+		if ( ( 'inline' === skin && ! disableActiveState ) || iconType ) {
 			this.markChecked( iconType );
 		}
 
 		if ( ! iconValue ) {
 			if ( 'inline' === skin ) {
-				this.setDefaultIconLibraryLabel( defaultIcon, iconContainer );
+				this.setDefaultIconLibraryLabel( defaultIcon, iconContainer, skinOptions );
 				return;
 			}
 
@@ -302,7 +306,7 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 		this.enqueueIconFonts( iconType );
 	}
 
-	setDefaultIconLibraryLabel( defaultIcon, iconContainer ) {
+	setDefaultIconLibraryLabel( defaultIcon, iconContainer, skinOptions ) {
 		// Check if the control has a default icon
 		if ( '' !== defaultIcon.value && 'svg' !== defaultIcon.library ) {
 			// If the default icon is not an SVG, set the icon-library label's icon to the default icon
@@ -311,7 +315,7 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 			// If (1) the control does NOT have a default icon,
 			// OR (2) the control DOES have a default icon BUT the default icon is an SVG,
 			// set the default icon-library label's icon to a simple circle
-			iconContainer.html( '<i class="eicon-circle"></i>' );
+			iconContainer.html( '<i class="' + skinOptions.inline.icon.icon + '"></i>' );
 		}
 	}
 

--- a/assets/dev/js/editor/controls/icons.js
+++ b/assets/dev/js/editor/controls/icons.js
@@ -261,7 +261,6 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 		const controlValue = this.getControlValue(),
 			skin = this.model.get( 'skin' ),
 			iconContainer = 'inline' === skin ? this.ui.inlineDisplayedIcon : this.ui.previewPlaceholder,
-			skinOptions = this.model.get( 'skin_settings' ),
 			disableActiveState = this.model.get( 'disable_initial_active_state' ),
 			defaultIcon = this.model.get( 'default' );
 
@@ -283,7 +282,7 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 
 		if ( ! iconValue ) {
 			if ( 'inline' === skin ) {
-				this.setDefaultIconLibraryLabel( defaultIcon, iconContainer, skinOptions );
+				this.setDefaultIconLibraryLabel( defaultIcon, iconContainer );
 				return;
 			}
 
@@ -306,7 +305,7 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 		this.enqueueIconFonts( iconType );
 	}
 
-	setDefaultIconLibraryLabel( defaultIcon, iconContainer, skinOptions ) {
+	setDefaultIconLibraryLabel( defaultIcon, iconContainer ) {
 		// Check if the control has a default icon
 		if ( '' !== defaultIcon.value && 'svg' !== defaultIcon.library ) {
 			// If the default icon is not an SVG, set the icon-library label's icon to the default icon
@@ -315,6 +314,7 @@ class ControlIconsView extends ControlMultipleBaseItemView {
 			// If (1) the control does NOT have a default icon,
 			// OR (2) the control DOES have a default icon BUT the default icon is an SVG,
 			// set the default icon-library label's icon to a simple circle
+			const skinOptions = this.model.get( 'skin_settings' );
 			iconContainer.html( '<i class="' + skinOptions.inline.icon.icon + '"></i>' );
 		}
 	}

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -217,15 +217,15 @@ class Control_Icons extends Control_Base_Multiple {
 			'skin_settings' => [
 				'inline' => [
 					'none' => [
-						'label' => 'None',
+						'label' => esc_html__( 'None', 'elementor' ),
 						'icon' => 'eicon-ban',
 					],
 					'svg' => [
-						'label' => 'Upload SVG',
+						'label' => esc_html__( 'Upload SVG', 'elementor' ),
 						'icon' => 'eicon-upload',
 					],
 					'icon' => [
-						'label' => 'Icon Library',
+						'label' => esc_html__( 'Icon Library', 'elementor' ),
 						'icon' => 'eicon-circle',
 					],
 				],

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -100,29 +100,85 @@ class Control_Icons extends Control_Base_Multiple {
 
 	public function render_inline_skin() {
 		?>
+		<#
+			const getLabel = ( choice, data ) => {
+				switch( choice ) {
+					case 'none':					
+						if ( data.skin_settings.inline.none.label ) {
+							return data.skin_settings.inline.none.label;
+						} else {
+							return '<?php echo esc_html__( 'None', 'elementor' ); ?>';
+						}
+					case 'svg':
+						if ( data.skin_settings.inline.svg.label !== undefined ) {
+							return data.skin_settings.inline.svg.label;
+						} else {
+							return '<?php echo esc_html__( 'Upload SVG', 'elementor' ); ?>';
+						}
+
+					case 'icon':
+						if ( data.skin_settings.inline.icon.label !== undefined ) {
+							return data.skin_settings.inline.icon.label;
+						} else {
+							return '<?php echo esc_html__( 'Icon Library', 'elementor' ); ?>';
+						}
+
+					default:
+						return '<?php echo esc_html__( 'None', 'elementor' ); ?>';
+				}
+			}
+
+			const getIcon = ( choice, data ) => {
+				switch( choice ) {
+					case 'none':
+						if ( data.skin_settings.inline.none.icon ) {
+							return data.skin_settings.inline.none.icon;
+						} else {
+							return 'eicon-ban';
+						}
+
+					case 'svg':
+						if ( data.skin_settings.inline.svg.icon ) {
+							return data.skin_settings.inline.svg.icon;
+						} else {
+							return 'eicon-upload';
+						}
+
+					case 'icon':
+						if ( data.skin_settings.inline.icon.icon ) {
+							return data.skin_settings.inline.icon.icon;
+						} else {
+							return 'eicon-circle';
+						}
+
+					default:
+						return 'eicon-ban';
+				}
+			}
+		#>
 		<div class="elementor-control-field elementor-control-inline-icon">
 			<label class="elementor-control-title">{{{ data.label }}}</label>
 			<div class="elementor-control-input-wrapper">
 				<div class="elementor-choices">
 					<input id="<?php $this->print_control_uid(); ?>-none" type="radio" value="none">
-					<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__none" for="<?php $this->print_control_uid(); ?>-none" data-tooltip="<?php echo esc_html__( 'None', 'elementor' ); ?>" title="<?php echo esc_html__( 'None', 'elementor' ); ?>">
-						<i class="eicon-ban" aria-hidden="true"></i>
-						<span class="elementor-screen-only"><?php echo esc_html__( 'None', 'elementor' ); ?></span>
+					<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__none" for="<?php $this->print_control_uid(); ?>-none" data-tooltip="{{{ getLabel( 'none', data ) }}}" title="{{{ getLabel( 'none', data ) }}}">
+						<i class="{{{ getIcon( 'none', data ) }}}" aria-hidden="true"></i>
+						<span class="elementor-screen-only">{{{ getLabel( 'none', data ) }}}</span>
 					</label>
 					<# if ( ! data.exclude_inline_options.includes( 'svg' ) ) { #>
 						<input id="<?php $this->print_control_uid(); ?>-svg" type="radio" value="svg">
-						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__svg" for="<?php $this->print_control_uid(); ?>-svg" data-tooltip="<?php echo esc_html__( 'Upload SVG', 'elementor' ); ?>" title="<?php echo esc_html__( 'Upload SVG', 'elementor' ); ?>">
-							<i class="eicon-upload" aria-hidden="true"></i>
-							<span class="elementor-screen-only"><?php echo esc_html__( 'Upload SVG', 'elementor' ); ?></span>
+						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__svg" for="<?php $this->print_control_uid(); ?>-svg" data-tooltip="{{{ getLabel( 'svg', data ) }}}" title="{{{ getLabel( 'svg', data ) }}}">
+							<i class="{{{ getIcon( 'svg', data ) }}}" aria-hidden="true"></i>
+							<span class="elementor-screen-only">{{{ getLabel( 'svg', data ) }}}</span>
 						</label>
 					<# }
 					if ( ! data.exclude_inline_options.includes( 'icon' ) ) { #>
 						<input id="<?php $this->print_control_uid(); ?>-icon" type="radio" value="icon">
-						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__icon" for="<?php $this->print_control_uid(); ?>-icon" data-tooltip="<?php echo esc_html__( 'Icon Library', 'elementor' ); ?>" title="<?php echo esc_html__( 'Icon Library', 'elementor' ); ?>">
+						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__icon" for="<?php $this->print_control_uid(); ?>-icon" data-tooltip="{{{ getLabel( 'icon', data ) }}}" title="{{{ getLabel( 'icon', data ) }}}">
 							<span class="elementor-control-icons--inline__displayed-icon">
-								<i class="eicon-circle" aria-hidden="true"></i>
+								<i class="{{{ getIcon( 'icon', data ) }}}" aria-hidden="true"></i>
 							</span>
-							<span class="elementor-screen-only"><?php echo esc_html__( 'Icon Library', 'elementor' ); ?></span>
+							<span class="elementor-screen-only">{{{ getLabel( 'icon', data ) }}}</span>
 						</label>
 					<# } #>
 				</div>
@@ -157,6 +213,23 @@ class Control_Icons extends Control_Base_Multiple {
 			'recommended' => false,
 			'skin' => 'media',
 			'exclude_inline_options' => [],
+			'disable_initial_active_state' => false,
+			'skin_settings' => [
+				'inline' => [
+					'none' => [
+						'label' => 'None',
+						'icon' => 'eicon-ban',
+					],
+					'svg' => [
+						'label' => 'Upload SVG',
+						'icon' => 'eicon-upload',
+					],
+					'icon' => [
+						'label' => 'Icon Library',
+						'icon' => 'eicon-circle',
+					],
+				],
+			],
 		];
 	}
 

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -117,7 +117,7 @@ class Control_Icons extends Control_Base_Multiple {
 			const getIcon = ( choice, data ) => {
 				switch( choice ) {
 					case 'none':
-						eturn data.skin_settings.inline.none.icon;
+						return data.skin_settings.inline.none.icon;
 					case 'svg':
 						return data.skin_settings.inline.svg.icon;
 					case 'icon':

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -104,25 +104,11 @@ class Control_Icons extends Control_Base_Multiple {
 			const getLabel = ( choice, data ) => {
 				switch( choice ) {
 					case 'none':					
-						if ( data.skin_settings.inline.none.label ) {
-							return data.skin_settings.inline.none.label;
-						} else {
-							return '<?php echo esc_html__( 'None', 'elementor' ); ?>';
-						}
+						return data.skin_settings.inline.none.label;
 					case 'svg':
-						if ( data.skin_settings.inline.svg.label !== undefined ) {
-							return data.skin_settings.inline.svg.label;
-						} else {
-							return '<?php echo esc_html__( 'Upload SVG', 'elementor' ); ?>';
-						}
-
+						return data.skin_settings.inline.svg.label;
 					case 'icon':
-						if ( data.skin_settings.inline.icon.label !== undefined ) {
-							return data.skin_settings.inline.icon.label;
-						} else {
-							return '<?php echo esc_html__( 'Icon Library', 'elementor' ); ?>';
-						}
-
+						return data.skin_settings.inline.icon.label;
 					default:
 						return '<?php echo esc_html__( 'None', 'elementor' ); ?>';
 				}
@@ -131,26 +117,11 @@ class Control_Icons extends Control_Base_Multiple {
 			const getIcon = ( choice, data ) => {
 				switch( choice ) {
 					case 'none':
-						if ( data.skin_settings.inline.none.icon ) {
-							return data.skin_settings.inline.none.icon;
-						} else {
-							return 'eicon-ban';
-						}
-
+						eturn data.skin_settings.inline.none.icon;
 					case 'svg':
-						if ( data.skin_settings.inline.svg.icon ) {
-							return data.skin_settings.inline.svg.icon;
-						} else {
-							return 'eicon-upload';
-						}
-
+						return data.skin_settings.inline.svg.icon;
 					case 'icon':
-						if ( data.skin_settings.inline.icon.icon ) {
-							return data.skin_settings.inline.icon.icon;
-						} else {
-							return 'eicon-circle';
-						}
-
+						return data.skin_settings.inline.icon.icon;
 					default:
 						return 'eicon-ban';
 				}

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -101,6 +101,39 @@ class Control_Icons extends Control_Base_Multiple {
 	public function render_inline_skin() {
 		?>
 		<#
+			const defaultSkinSettings = {
+				inline: {
+					none: {
+						label: '<?php echo esc_html__( 'None', 'elementor' ); ?>',
+						icon: 'eicon-ban',
+					},
+					svg: {
+						label: '<?php echo esc_html__( 'Upload SVG', 'elementor' ); ?>',
+						icon: 'eicon-upload',
+					},
+					icon: {
+						label: '<?php echo esc_html__( 'Icon Library', 'elementor' ); ?>',
+						icon: 'eicon-circle',
+					},
+				}
+			};
+
+			const getIcon = ( type, skinSettings ) => {
+				if ( skinSettings[ type ] ) {
+					return skinSettings[ type ]?.icon || defaultSkinSettings['inline'][ type ].icon;
+				}
+
+				return defaultSkinSettings['inline'][ type ].icon;
+			}
+
+			const getLabel = ( type, skinSettings ) => {
+				if ( skinSettings[ type ] ) {
+					return skinSettings[ type ]?.label || defaultSkinSettings['inline'][ type ].label;
+				}
+
+				return defaultSkinSettings['inline'][ type ].label;
+			}
+
 			const skinSettings = data.skin_settings.inline;
 		#>
 		<div class="elementor-control-field elementor-control-inline-icon">
@@ -108,24 +141,24 @@ class Control_Icons extends Control_Base_Multiple {
 			<div class="elementor-control-input-wrapper">
 				<div class="elementor-choices">
 					<input id="<?php $this->print_control_uid(); ?>-none" type="radio" value="none">
-					<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__none" for="<?php $this->print_control_uid(); ?>-none" data-tooltip="{{{ skinSettings.none.label }}}" title="{{{ skinSettings.none.label }}}">
-						<i class="{{{ skinSettings.none.icon }}}" aria-hidden="true"></i>
-						<span class="elementor-screen-only">{{{ skinSettings.none.label }}}</span>
+					<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__none" for="<?php $this->print_control_uid(); ?>-none" data-tooltip="{{{ getLabel( 'none', skinSettings ) }}}" title="{{{ getLabel( 'none', skinSettings ) }}}">
+						<i class="{{{ getIcon( 'none', skinSettings ) }}}" aria-hidden="true"></i>
+						<span class="elementor-screen-only">{{{ getLabel( 'none', skinSettings ) }}}</span>
 					</label>
 					<# if ( ! data.exclude_inline_options.includes( 'svg' ) ) { #>
 						<input id="<?php $this->print_control_uid(); ?>-svg" type="radio" value="svg">
-						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__svg" for="<?php $this->print_control_uid(); ?>-svg" data-tooltip="{{{ skinSettings.svg.label }}}" title="{{{ skinSettings.svg.label }}}">
-							<i class="{{{ skinSettings.svg.icon }}}" aria-hidden="true"></i>
-							<span class="elementor-screen-only">{{{ skinSettings.svg.label }}}</span>
+						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__svg" for="<?php $this->print_control_uid(); ?>-svg" data-tooltip="{{{ getLabel( 'svg', skinSettings ) }}}" title="{{{ getLabel( 'svg', skinSettings ) }}}">
+							<i class="{{{ getIcon( 'svg', skinSettings ) }}}" aria-hidden="true"></i>
+							<span class="elementor-screen-only">{{{ getLabel( 'svg', skinSettings ) }}}</span>
 						</label>
 					<# }
 					if ( ! data.exclude_inline_options.includes( 'icon' ) ) { #>
 						<input id="<?php $this->print_control_uid(); ?>-icon" type="radio" value="icon">
-						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__icon" for="<?php $this->print_control_uid(); ?>-icon" data-tooltip="{{{ skinSettings.icon.label }}}" title="{{{ skinSettings.icon.label }}}">
+						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__icon" for="<?php $this->print_control_uid(); ?>-icon" data-tooltip="{{{ getLabel( 'icon', skinSettings ) }}}" title="{{{ getLabel( 'icon', skinSettings ) }}}">
 							<span class="elementor-control-icons--inline__displayed-icon">
-								<i class="{{{ skinSettings.icon.icon }}}" aria-hidden="true"></i>
+								<i class="{{{ getIcon( 'icon', skinSettings ) }}}" aria-hidden="true"></i>
 							</span>
-							<span class="elementor-screen-only">{{{ skinSettings.icon.label }}}</span>
+							<span class="elementor-screen-only">{{{ getLabel( 'icon', skinSettings ) }}}</span>
 						</label>
 					<# } #>
 				</div>

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -118,47 +118,39 @@ class Control_Icons extends Control_Base_Multiple {
 				}
 			};
 
-			const getIcon = ( type, skinSettings ) => {
-				if ( skinSettings[ type ] ) {
-					return skinSettings[ type ]?.icon || defaultSkinSettings['inline'][ type ].icon;
-				}
-
-				return defaultSkinSettings['inline'][ type ].icon;
-			}
-
-			const getLabel = ( type, skinSettings ) => {
-				if ( skinSettings[ type ] ) {
-					return skinSettings[ type ]?.label || defaultSkinSettings['inline'][ type ].label;
-				}
-
-				return defaultSkinSettings['inline'][ type ].label;
-			}
-
 			const skinSettings = data.skin_settings.inline;
+
+			const get = ( type, key ) => {
+				if ( skinSettings[ type ] ) {
+					return skinSettings[ type ]?.[ key ] || defaultSkinSettings['inline'][ type ][ key ];
+				}
+
+				return defaultSkinSettings['inline'][ type ][ key ];
+			}
 		#>
 		<div class="elementor-control-field elementor-control-inline-icon">
 			<label class="elementor-control-title">{{{ data.label }}}</label>
 			<div class="elementor-control-input-wrapper">
 				<div class="elementor-choices">
 					<input id="<?php $this->print_control_uid(); ?>-none" type="radio" value="none">
-					<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__none" for="<?php $this->print_control_uid(); ?>-none" data-tooltip="{{{ getLabel( 'none', skinSettings ) }}}" title="{{{ getLabel( 'none', skinSettings ) }}}">
-						<i class="{{{ getIcon( 'none', skinSettings ) }}}" aria-hidden="true"></i>
-						<span class="elementor-screen-only">{{{ getLabel( 'none', skinSettings ) }}}</span>
+					<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__none" for="<?php $this->print_control_uid(); ?>-none" data-tooltip="{{{ get( 'none', 'label' ) }}}" title="{{{ get( 'none', 'label' ) }}}">
+						<i class="{{{ get( 'none', 'icon' ) }}}" aria-hidden="true"></i>
+						<span class="elementor-screen-only">{{{ get( 'none', 'label' ) }}}</span>
 					</label>
 					<# if ( ! data.exclude_inline_options.includes( 'svg' ) ) { #>
 						<input id="<?php $this->print_control_uid(); ?>-svg" type="radio" value="svg">
-						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__svg" for="<?php $this->print_control_uid(); ?>-svg" data-tooltip="{{{ getLabel( 'svg', skinSettings ) }}}" title="{{{ getLabel( 'svg', skinSettings ) }}}">
-							<i class="{{{ getIcon( 'svg', skinSettings ) }}}" aria-hidden="true"></i>
-							<span class="elementor-screen-only">{{{ getLabel( 'svg', skinSettings ) }}}</span>
+						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__svg" for="<?php $this->print_control_uid(); ?>-svg" data-tooltip="{{{ get( 'svg', 'label' ) }}}" title="{{{ get( 'svg', 'label' ) }}}">
+							<i class="{{{ get( 'svg', 'icon' ) }}}" aria-hidden="true"></i>
+							<span class="elementor-screen-only">{{{ get( 'svg', 'label' ) }}}</span>
 						</label>
 					<# }
 					if ( ! data.exclude_inline_options.includes( 'icon' ) ) { #>
 						<input id="<?php $this->print_control_uid(); ?>-icon" type="radio" value="icon">
-						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__icon" for="<?php $this->print_control_uid(); ?>-icon" data-tooltip="{{{ getLabel( 'icon', skinSettings ) }}}" title="{{{ getLabel( 'icon', skinSettings ) }}}">
+						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__icon" for="<?php $this->print_control_uid(); ?>-icon" data-tooltip="{{{ get( 'icon', 'label' ) }}}" title="{{{ get( 'icon', 'label' ) }}}">
 							<span class="elementor-control-icons--inline__displayed-icon">
-								<i class="{{{ getIcon( 'icon', skinSettings ) }}}" aria-hidden="true"></i>
+								<i class="{{{ get( 'icon', 'icon' ) }}}" aria-hidden="true"></i>
 							</span>
-							<span class="elementor-screen-only">{{{ getLabel( 'icon', skinSettings ) }}}</span>
+							<span class="elementor-screen-only">{{{ get( 'icon', 'label' ) }}}</span>
 						</label>
 					<# } #>
 				</div>

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -102,19 +102,17 @@ class Control_Icons extends Control_Base_Multiple {
 		?>
 		<#
 			const defaultSkinSettings = {
-				inline: {
-					none: {
-						label: '<?php echo esc_html__( 'None', 'elementor' ); ?>',
-						icon: 'eicon-ban',
-					},
-					svg: {
-						label: '<?php echo esc_html__( 'Upload SVG', 'elementor' ); ?>',
-						icon: 'eicon-upload',
-					},
-					icon: {
-						label: '<?php echo esc_html__( 'Icon Library', 'elementor' ); ?>',
-						icon: 'eicon-circle',
-					},
+				none: {
+					label: '<?php echo esc_html__( 'None', 'elementor' ); ?>',
+					icon: 'eicon-ban',
+				},
+				svg: {
+					label: '<?php echo esc_html__( 'Upload SVG', 'elementor' ); ?>',
+					icon: 'eicon-upload',
+				},
+				icon: {
+					label: '<?php echo esc_html__( 'Icon Library', 'elementor' ); ?>',
+					icon: 'eicon-circle',
 				}
 			};
 
@@ -122,10 +120,10 @@ class Control_Icons extends Control_Base_Multiple {
 
 			const get = ( type, key ) => {
 				if ( skinSettings[ type ] ) {
-					return skinSettings[ type ]?.[ key ] || defaultSkinSettings['inline'][ type ][ key ];
+					return skinSettings[ type ]?.[ key ] || defaultSkinSettings[ type ][ key ];
 				}
 
-				return defaultSkinSettings['inline'][ type ][ key ];
+				return defaultSkinSettings[ type ][ key ];
 			}
 		#>
 		<div class="elementor-control-field elementor-control-inline-icon">

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -101,55 +101,31 @@ class Control_Icons extends Control_Base_Multiple {
 	public function render_inline_skin() {
 		?>
 		<#
-			const getLabel = ( choice, data ) => {
-				switch( choice ) {
-					case 'none':					
-						return data.skin_settings.inline.none.label;
-					case 'svg':
-						return data.skin_settings.inline.svg.label;
-					case 'icon':
-						return data.skin_settings.inline.icon.label;
-					default:
-						return '<?php echo esc_html__( 'None', 'elementor' ); ?>';
-				}
-			}
-
-			const getIcon = ( choice, data ) => {
-				switch( choice ) {
-					case 'none':
-						return data.skin_settings.inline.none.icon;
-					case 'svg':
-						return data.skin_settings.inline.svg.icon;
-					case 'icon':
-						return data.skin_settings.inline.icon.icon;
-					default:
-						return 'eicon-ban';
-				}
-			}
+			const skinSettings = data.skin_settings.inline;
 		#>
 		<div class="elementor-control-field elementor-control-inline-icon">
 			<label class="elementor-control-title">{{{ data.label }}}</label>
 			<div class="elementor-control-input-wrapper">
 				<div class="elementor-choices">
 					<input id="<?php $this->print_control_uid(); ?>-none" type="radio" value="none">
-					<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__none" for="<?php $this->print_control_uid(); ?>-none" data-tooltip="{{{ getLabel( 'none', data ) }}}" title="{{{ getLabel( 'none', data ) }}}">
-						<i class="{{{ getIcon( 'none', data ) }}}" aria-hidden="true"></i>
-						<span class="elementor-screen-only">{{{ getLabel( 'none', data ) }}}</span>
+					<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__none" for="<?php $this->print_control_uid(); ?>-none" data-tooltip="{{{ skinSettings.none.label }}}" title="{{{ skinSettings.none.label }}}">
+						<i class="{{{ skinSettings.none.icon }}}" aria-hidden="true"></i>
+						<span class="elementor-screen-only">{{{ skinSettings.none.label }}}</span>
 					</label>
 					<# if ( ! data.exclude_inline_options.includes( 'svg' ) ) { #>
 						<input id="<?php $this->print_control_uid(); ?>-svg" type="radio" value="svg">
-						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__svg" for="<?php $this->print_control_uid(); ?>-svg" data-tooltip="{{{ getLabel( 'svg', data ) }}}" title="{{{ getLabel( 'svg', data ) }}}">
-							<i class="{{{ getIcon( 'svg', data ) }}}" aria-hidden="true"></i>
-							<span class="elementor-screen-only">{{{ getLabel( 'svg', data ) }}}</span>
+						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__svg" for="<?php $this->print_control_uid(); ?>-svg" data-tooltip="{{{ skinSettings.svg.label }}}" title="{{{ skinSettings.svg.label }}}">
+							<i class="{{{ skinSettings.svg.icon }}}" aria-hidden="true"></i>
+							<span class="elementor-screen-only">{{{ skinSettings.svg.label }}}</span>
 						</label>
 					<# }
 					if ( ! data.exclude_inline_options.includes( 'icon' ) ) { #>
 						<input id="<?php $this->print_control_uid(); ?>-icon" type="radio" value="icon">
-						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__icon" for="<?php $this->print_control_uid(); ?>-icon" data-tooltip="{{{ getLabel( 'icon', data ) }}}" title="{{{ getLabel( 'icon', data ) }}}">
+						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__icon" for="<?php $this->print_control_uid(); ?>-icon" data-tooltip="{{{ skinSettings.icon.label }}}" title="{{{ skinSettings.icon.label }}}">
 							<span class="elementor-control-icons--inline__displayed-icon">
-								<i class="{{{ getIcon( 'icon', data ) }}}" aria-hidden="true"></i>
+								<i class="{{{ skinSettings.icon.icon }}}" aria-hidden="true"></i>
 							</span>
-							<span class="elementor-screen-only">{{{ getLabel( 'icon', data ) }}}</span>
+							<span class="elementor-screen-only">{{{ skinSettings.icon.label }}}</span>
 						</label>
 					<# } #>
 				</div>

--- a/includes/controls/icons.php
+++ b/includes/controls/icons.php
@@ -131,24 +131,24 @@ class Control_Icons extends Control_Base_Multiple {
 			<div class="elementor-control-input-wrapper">
 				<div class="elementor-choices">
 					<input id="<?php $this->print_control_uid(); ?>-none" type="radio" value="none">
-					<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__none" for="<?php $this->print_control_uid(); ?>-none" data-tooltip="{{{ get( 'none', 'label' ) }}}" title="{{{ get( 'none', 'label' ) }}}">
-						<i class="{{{ get( 'none', 'icon' ) }}}" aria-hidden="true"></i>
-						<span class="elementor-screen-only">{{{ get( 'none', 'label' ) }}}</span>
+					<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__none" for="<?php $this->print_control_uid(); ?>-none" data-tooltip="{{ get( 'none', 'label' ) }}" title="{{ get( 'none', 'label' ) }}">
+						<i class="{{ get( 'none', 'icon' ) }}" aria-hidden="true"></i>
+						<span class="elementor-screen-only">{{ get( 'none', 'label' ) }}</span>
 					</label>
 					<# if ( ! data.exclude_inline_options.includes( 'svg' ) ) { #>
 						<input id="<?php $this->print_control_uid(); ?>-svg" type="radio" value="svg">
-						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__svg" for="<?php $this->print_control_uid(); ?>-svg" data-tooltip="{{{ get( 'svg', 'label' ) }}}" title="{{{ get( 'svg', 'label' ) }}}">
-							<i class="{{{ get( 'svg', 'icon' ) }}}" aria-hidden="true"></i>
-							<span class="elementor-screen-only">{{{ get( 'svg', 'label' ) }}}</span>
+						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__svg" for="<?php $this->print_control_uid(); ?>-svg" data-tooltip="{{ get( 'svg', 'label' ) }}" title="{{ get( 'svg', 'label' ) }}">
+							<i class="{{ get( 'svg', 'icon' ) }}" aria-hidden="true"></i>
+							<span class="elementor-screen-only">{{ get( 'svg', 'label' ) }}</span>
 						</label>
 					<# }
 					if ( ! data.exclude_inline_options.includes( 'icon' ) ) { #>
 						<input id="<?php $this->print_control_uid(); ?>-icon" type="radio" value="icon">
-						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__icon" for="<?php $this->print_control_uid(); ?>-icon" data-tooltip="{{{ get( 'icon', 'label' ) }}}" title="{{{ get( 'icon', 'label' ) }}}">
+						<label class="elementor-choices-label elementor-control-unit-1 tooltip-target elementor-control-icons--inline__icon" for="<?php $this->print_control_uid(); ?>-icon" data-tooltip="{{ get( 'icon', 'label' ) }}" title="{{ get( 'icon', 'label' ) }}">
 							<span class="elementor-control-icons--inline__displayed-icon">
-								<i class="{{{ get( 'icon', 'icon' ) }}}" aria-hidden="true"></i>
+								<i class="{{ get( 'icon', 'icon' ) }}" aria-hidden="true"></i>
 							</span>
-							<span class="elementor-screen-only">{{{ get( 'icon', 'label' ) }}}</span>
+							<span class="elementor-screen-only">{{ get( 'icon', 'label' ) }}</span>
 						</label>
 					<# } #>
 				</div>


### PR DESCRIPTION
…546]

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

Tweak: Adjusted the inline icon control for design flexibility

## Description
An explanation of what is done in this PR

On the Icons control "inline skin" we added the ability for a developer to add the following settings:

1) Option to toggle on/off the control (Allow no active state)
2) Option to change the icons
3) Option to change the tooltip text

The current icons and labels were hard coded not giving us much flexibility.

## Test instructions
This PR can be tested by following these steps:

You can test this by adding the following settings to icon controls:

```
'disable_initial_active_state' => false,
'skin_settings' => [
    'inline' => [
        'none' => [
            'label' => 'Tes',
            'icon' => 'eicon-ban',
        ],
        'svg' => [
            'label' => 'Test',
            'icon' => 'eicon-ban',
        ],
        'icon' => [
            'label' => 'Testtt',
            'icon' => 'eicon-upload',
        ],
    ],
],
```

`disable_initial_active_state` will give the ability to not have any of the icons marked as checked on initial DD of the widget. Before this change 'None' was always selected if no default icon was specified.

I created the array in the format of `$skin_settings['inline']['...']` so that if we want to make any changes to the "media skin" later on it can just form part of this same array `$skin_settings['media']['...']`