### PR TITLE
Tweak: Make typography weight strings translatable [ED-6392]

### DIFF
--- a/includes/controls/groups/typography.php
+++ b/includes/controls/groups/typography.php
@@ -128,19 +128,24 @@ class Group_Control_Typography extends Group_Control_Base {
 			'selector_value' => 'font-size: {{SIZE}}{{UNIT}}',
 		];
 
-		$typo_weight_options = [
-			'' => esc_html__( 'Default', 'elementor' ),
-		];
-
-		foreach ( array_merge( [ 'normal', 'bold' ], range( 100, 900, 100 ) ) as $weight ) {
-			$typo_weight_options[ $weight ] = ucfirst( $weight );
-		}
-
 		$fields['font_weight'] = [
 			'label' => _x( 'Weight', 'Typography Control', 'elementor' ),
 			'type' => Controls_Manager::SELECT,
 			'default' => '',
-			'options' => $typo_weight_options,
+			'options' => [
+				'100' => '100',
+				'200' => '200',
+				'300' => '300',
+				'400' => '400',
+				'500' => '500',
+				'600' => '600',
+				'700' => '700',
+				'800' => '800',
+				'900' => '900',
+				'' => esc_html__( 'Default', 'elementor' ),
+				'normal' => esc_html__( 'Normal', 'elementor' ),
+				'bold' => esc_html__( 'Bold', 'elementor' ),
+			],
 		];
 
 		$fields['text_transform'] = [

--- a/includes/controls/groups/typography.php
+++ b/includes/controls/groups/typography.php
@@ -133,6 +133,7 @@ class Group_Control_Typography extends Group_Control_Base {
 			'type' => Controls_Manager::SELECT,
 			'default' => '',
 			'options' => [
+				'' => esc_html__( 'Default', 'elementor' ),
 				'100' => '100',
 				'200' => '200',
 				'300' => '300',
@@ -142,7 +143,6 @@ class Group_Control_Typography extends Group_Control_Base {
 				'700' => '700',
 				'800' => '800',
 				'900' => '900',
-				'' => esc_html__( 'Default', 'elementor' ),
 				'normal' => esc_html__( 'Normal', 'elementor' ),
 				'bold' => esc_html__( 'Bold', 'elementor' ),
 			],

--- a/includes/controls/groups/typography.php
+++ b/includes/controls/groups/typography.php
@@ -133,7 +133,6 @@ class Group_Control_Typography extends Group_Control_Base {
 			'type' => Controls_Manager::SELECT,
 			'default' => '',
 			'options' => [
-				'' => esc_html__( 'Default', 'elementor' ),
 				'100' => '100',
 				'200' => '200',
 				'300' => '300',
@@ -143,6 +142,7 @@ class Group_Control_Typography extends Group_Control_Base {
 				'700' => '700',
 				'800' => '800',
 				'900' => '900',
+				'' => esc_html__( 'Default', 'elementor' ),
 				'normal' => esc_html__( 'Normal', 'elementor' ),
 				'bold' => esc_html__( 'Bold', 'elementor' ),
 			],


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Tweak: Make typography weight strings translatable

## Description
An explanation of what is done in this PR

* Tweak: Make typography weight strings translatable

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
