### PR TITLE
WP_Query reset in local.php

### DIFF
--- a/includes/template-library/sources/local.php
+++ b/includes/template-library/sources/local.php
@@ -443,7 +443,7 @@ class Source_Local extends Source_Base {
 				$templates[] = $this->get_item( $post->ID );
 			}
 		}
-
+		wp_reset_query();
 		return $templates;
 	}
 


### PR DESCRIPTION
WP_Query dose not reset.
> added check for placeholder image. if URL contains images/placeholder.png then don't import image to the media library
> 
> ## PR Checklist
> * [x]  The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md
> 
> ## PR Type
> What kind of change does this PR introduce?
> 
> * [x]  Bugfix
> * [ ]  Feature
> * [ ]  Code style update (formatting, local variables)
> * [ ]  Refactoring (no functional changes, no api changes)
> * [ ]  Build related changes
> * [ ]  CI related changes
> * [ ]  Documentation content changes
> * [ ]  Other... Please describe:
> 
> ## Summary
> This PR can be summarized in the following changelog entry:
> 
> * Prevent duplicate placeholder images while importing templates.
> 
> ## Description
> An explanation of what is done in this PR
> 
> ## Test instructions
> This PR can be tested by following these steps:
> 
> * I can't write unit test
> 
> ## Quality assurance
> * [ ]  I have tested this code to the best of my abilities
> * [ ]  I have added unittests to verify the code works as intended
> * [ ]  Docs have been added / updated (for bug fixes / features)
> 
> Fixes #17932

