### PR TITLE
Fix: Container - Direction control selection is not being reflected in responsive devices [ED-6710]

### DIFF
--- a/assets/dev/js/editor/document/hooks/ui/settings/set-direction-mode.js
+++ b/assets/dev/js/editor/document/hooks/ui/settings/set-direction-mode.js
@@ -5,7 +5,7 @@ import After from 'elementor-api/modules/hooks/ui/after';
  * Currently used to determine the direction of the flex icons in the Container element.
  * It should be generic and work with any element, and since each element might use a different
  * setting to determine its direction mode, the hook should listen to any setting change.
- * Therefore, there isn't a `getConditions()` method.
+ * Therefore, the `getConditions()` method just checks if the view exists and has UI states.
  */
 export class SetDirectionMode extends After {
 	getCommand() {
@@ -14,6 +14,10 @@ export class SetDirectionMode extends After {
 
 	getId() {
 		return 'set-direction-mode--document/elements/settings';
+	}
+
+	getConditions( args = {} ) {
+		return ! ! args.container.renderer?.view?.getCurrentUiStates;
 	}
 
 	apply( args ) {

--- a/assets/dev/js/editor/elements/views/container.js
+++ b/assets/dev/js/editor/elements/views/container.js
@@ -1,7 +1,7 @@
 // Most of the code has been copied from `section.js`.
 import AddSectionView from 'elementor-views/add-section/inline';
 import WidgetResizable from './behaviors/widget-resizeable';
-import { DIRECTION_ROW } from 'elementor-document/ui-states/direction-mode';
+import { DIRECTION_COLUMN } from 'elementor-document/ui-states/direction-mode';
 
 const BaseElementView = require( 'elementor-elements/views/base' ),
 	ColumnEmptyView = require( 'elementor-elements/views/column-empty' );
@@ -35,7 +35,7 @@ const ContainerView = BaseElementView.extend( {
 		const currentDirection = this.container.settings.get( 'flex_direction' );
 
 		return {
-			directionMode: currentDirection || DIRECTION_ROW,
+			directionMode: currentDirection || DIRECTION_COLUMN,
 		};
 	},
 

--- a/assets/dev/scss/frontend/_container.scss
+++ b/assets/dev/scss/frontend/_container.scss
@@ -2,6 +2,7 @@
 	// Set to initial values in order to avoid inheritance which might cause unexpected behavior.
 	--border-radius: 0;
 	--display: flex;
+	--flex-direction: column;
 	--flex-basis: auto;
 	--flex-grow: 0;
 	--flex-shrink: 1;
@@ -31,6 +32,7 @@
 	position: var( --position );
 	display: var( --display );
 	text-align: var( --text-align );
+	flex-direction: var( --flex-direction );
 	flex: var( --flex-grow ) var( --flex-shrink ) var( --flex-basis );
 	width: var( --width );
 	// Set `min-width` to fix nested Containers shrink bug (ED-4964).

--- a/includes/controls/groups/flex-container.php
+++ b/includes/controls/groups/flex-container.php
@@ -53,7 +53,6 @@ class Group_Control_Flex_Container extends Group_Control_Base {
 			'default' => 'row',
 			'condition' => [
 				'direction' => [
-					'',
 					'row',
 					'row-reverse',
 				],
@@ -66,6 +65,7 @@ class Group_Control_Flex_Container extends Group_Control_Base {
 			'default' => 'column',
 			'condition' => [
 				'direction' => [
+					'',
 					'column',
 					'column-reverse',
 				],

--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -505,9 +505,6 @@ class Container extends Element_Base {
 						// Use the default "elements gap" from the kit as a placeholder.
 						'placeholder' => $this->active_kit->get_settings_for_display( 'space_between_widgets' ),
 					],
-					'direction' => [
-						'default' => 'column',
-					],
 				],
 				'condition' => [
 					'container_type' => 'flex',

--- a/includes/widgets/common.php
+++ b/includes/widgets/common.php
@@ -211,7 +211,6 @@ class Widget_Common extends Widget_Base {
 		$experiments_manager = Plugin::$instance->experiments;
 		$is_container_active = $experiments_manager->is_feature_active( 'container' );
 
-		// TODO: For BC - Remove in the future.
 		$this->add_responsive_control(
 			'_element_width',
 			[
@@ -227,7 +226,6 @@ class Widget_Common extends Widget_Base {
 				'selectors_dictionary' => [
 					'inherit' => '100%',
 				],
-				'condition' => $is_container_active ? [ '_element_width!' => 'initial' ] : [], // TODO: For BC.
 				'prefix_class' => 'elementor-widget%s__width-',
 				'selectors' => [
 					'{{WRAPPER}}' => 'width: {{VALUE}}; max-width: {{VALUE}}',


### PR DESCRIPTION
The `choose` control doesn't show a placeholder for default values, so it should've been moved to the CSS as a default.