### PR TITLE
Add filter to document container attributes

### DIFF
--- a/core/base/document.php
+++ b/core/base/document.php
@@ -314,6 +314,16 @@ abstract class Document extends Controls_Stack {
 		} else {
 			$attributes['data-elementor-settings'] = wp_json_encode( $this->get_frontend_settings() );
 		}
+		
+		/**
+		 * Filters document container attributes, allowing to add, remove or alter them.
+		 * 
+		 * Be aware that altering core attributes (data-elementor-*) may have severe side effects that may break functionality.
+		 *
+		 * @param array                         $attributes The container attributes.
+		 * @param \Elementor\Core\Base\Document $this       The document instance.
+		 */
+		$attributes = apply_filters( 'elementor/document/container_attributes', $attributes, $this );
 
 		return $attributes;
 	}


### PR DESCRIPTION
Adds a filter "elementor/document/container_attributes" to ElementorPro\Modules\ThemeBuilder\Documents\Single_Post::get_container_attributes().

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

See description at top of PR.

## Description
An explanation of what is done in this PR

See description at top of PR.

## Test instructions
This PR can be tested by following these steps:

By adding a filter and checking the output for the attributes applied, eg.:

```
add_filter( 'elementor/document/container_attributes', function ($attributes, $document ) {

    if ($document instanceof ElementorPro\Modules\ThemeBuilder\Documents\Single_Post) {
        $attributes['data-clarity-region'] = 'article';
    }

    return $attributes;

}, 10, 2 );
```

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #
