### PR TITLE
Fix: Elementor does not save new page some times

### DIFF
--- a/core/base/elements-iteration-actions/assets.php
+++ b/core/base/elements-iteration-actions/assets.php
@@ -173,7 +173,7 @@ class Assets extends Base {
 		$page_assets = $this->get_saved_page_assets();
 
 		// If $page_assets is not empty then enabling the assets for loading.
-		if ( $page_assets ) {
+		if ( $page_assets && is_array($page_assets) ) {
 			Plugin::$instance->assets_loader->enable_assets( $page_assets );
 		}
 	}


### PR DESCRIPTION
enable_assets method only accept array input

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

[24-Mar-2022 09:00:20 UTC] PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Elementor\Core\Page_Assets\Loader::enable_assets() must be of the type array, string given, called in x\wp-content\plugins\elementor\core\base\elements-iteration-actions\assets.php on line 177 and defined in x\wp-content\plugins\elementor\core\page-assets\loader.php:52
Stack trace:
#0 x\wp-content\plugins\elementor\core\base\elements-iteration-actions\assets.php(177): Elementor\Core\Page_Assets\Loader->enable_assets('a:0:{}')
#1 x\wp-content\plugins\elementor\core\base\document.php(1662): Elementor\Core\Base\Elements_Iteration_Actions\Assets->__construct(Object(Elementor\Core\DocumentTypes\Page))
#2 x\wp-content\plugins\elementor\core\base\document.php(1615): Elementor\Core\Base\Document->get_elements_iteration_actions()
#3 x\wp-content\plugins\elementor\core\base\document.php(1516): Elementor\Core\Base\Document->get_runtime_elements_iteration_a in x\wp-content\plugins\elementor\core\page-assets\loader.php on line 52
[24-Mar-2022 09:00:21 UTC] PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Elementor\Core\Page_Assets\Loader::enable_assets() must be of the type array, string given, called in x\wp-content\plugins\elementor\core\base\elements-iteration-actions\assets.php on line 177 and defined in x\wp-content\plugins\elementor\core\page-assets\loader.php:52


*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
