### PR TITLE
Internal: Exclude `/test-results`  folder from the build process [ED-6960]

### DIFF
--- a/.grunt-config/copy.js
+++ b/.grunt-config/copy.js
@@ -39,6 +39,7 @@ const getBuildFiles = [
 	'!README.md',
 	'!phpcs.xml',
 	'!tests/**',
+	'!test-results/',
 	'!tmp/**',
 	'!vendor/**',
 	'!yarn.lock',


### PR DESCRIPTION
Exclude \test-results  folder and its content from build process.
This folders IS included in the build files what inflated the elementor build weight.