### PR TITLE
Fix: Gradient control doesn't work on frontend when using Global Colors (#13288) [ED-3517]

### DIFF
--- a/core/files/css/base.php
+++ b/core/files/css/base.php
@@ -696,6 +696,22 @@ abstract class Base extends Base_File {
 
 		$value = $values[ $control['name'] ];
 
+		// If the control value is empty, and the control has a global default set, fetch the global value and use it.
+		if ( ! $value && ! empty( $control['global']['default'] ) ) {
+			$global_enabled = false;
+
+			if ( 'color' === $control['type'] ) {
+				$global_enabled = Plugin::$instance->kits_manager->is_custom_colors_enabled();
+			} elseif ( isset( $control['groupType'] ) && 'typography' === $control['groupType'] ) {
+				$global_enabled = Plugin::$instance->kits_manager->is_custom_typography_enabled();
+			}
+
+			// Only apply the global default if Global Colors are enabled.
+			if ( $global_enabled ) {
+				$value = $this->get_selector_global_value( $control, $control['global']['default'] );
+			}
+		}
+
 		if ( isset( $control['selectors_dictionary'][ $value ] ) ) {
 			$value = $control['selectors_dictionary'][ $value ];
 		}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Gradient control doesn't work on frontend when using Global Colors (Fixes #13288)