### PR TITLE
Allow wysiwyg content in icon box description

### DIFF
--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -701,9 +701,9 @@ class Widget_Icon_Box extends Widget_Base {
 					</<?php Utils::print_validated_html_tag( $icon_tag ); ?>>
 				</<?php Utils::print_validated_html_tag( $settings['title_size'] ); ?>>
 				<?php if ( ! Utils::is_empty( $settings['description_text'] ) ) : ?>
-					<p <?php $this->print_render_attribute_string( 'description_text' ); ?>>
+					<div <?php $this->print_render_attribute_string( 'description_text' ); ?>>
 						<?php $this->print_unescaped_setting( 'description_text' ); ?>
-					</p>
+					</div>
 				<?php endif; ?>
 			</div>
 		</div>
@@ -750,7 +750,7 @@ class Widget_Icon_Box extends Widget_Base {
 					<{{{ iconTag + ' ' + link }}} {{{ view.getRenderAttributeString( 'title_text' ) }}}>{{{ settings.title_text }}}</{{{ iconTag }}}>
 				</{{{ titleSizeTag }}}>
 				<# if ( settings.description_text ) { #>
-				<p {{{ view.getRenderAttributeString( 'description_text' ) }}}>{{{ settings.description_text }}}</p>
+				<div {{{ view.getRenderAttributeString( 'description_text' ) }}}>{{{ settings.description_text }}}</div>
 				<# } #>
 			</div>
 		</div>


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Icon Box Description changed from `<p>` tag to `<div>` to allow for `<p>` inside the content

## Description
An explanation of what is done in this PR

* Icon Box Description changed from `<p>` tag to `<div>` to allow for `<p>` inside the content

## Test instructions
This PR can be tested by following these steps:

* Insert content into the icon box description that contains a `<p>` tag

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

As soon as your content for the icon box description has a `<p>` tag it breaks out of the description element. Changing to a `<div>` would resolve this issue