### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - 'develop'
       - 'release/*'
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-20.04

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -2,8 +2,14 @@ name: Jest
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   file-diff:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-20.04
     name: File Diff
     if: startsWith( github.repository, 'elementor/' )

--- a/.github/workflows/js-qunit.yml
+++ b/.github/workflows/js-qunit.yml
@@ -2,8 +2,14 @@ name: Qunit
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   file-diff:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-18.04
     name: Qunit - File Diff
     if: startsWith( github.repository, 'elementor/' )

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 10 * * 0' # run at 10 AM UTC on Sunday
 
+permissions:
+  contents: read
+
 jobs:
   build-plugin:
     name: Build plugin

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,14 @@ name: Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   file-diff:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-18.04
     name: Lint - File Diff
     if: startsWith( github.repository, 'elementor/' )

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,8 +2,14 @@ name: PHPUnit
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   file-diff:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-20.04
     name: File Diff
     if: startsWith( github.repository, 'elementor/' )
@@ -61,6 +67,8 @@ jobs:
           composer run test
 
   test-result:
+    permissions:
+      contents: none
     needs: test
     if: ${{ always() }} # Will be run even if 'test' matrix will be skipped
     runs-on: ubuntu-20.04

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-plugin:
     name: Build plugin

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: ['opened', 'edited', 'reopened', 'synchronize']
 
+permissions:
+  contents: read
+
 jobs:
   pr_name_lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote-canary-release.yml
+++ b/.github/workflows/promote-canary-release.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   update-readme-develop:
+    permissions:
+      contents: none
     if: (github.actor == 'ronkelementor' || github.actor == 'KingYes' || github.actor == 'shilo-ey' || github.actor == 'matipojo') && startsWith(github.repository, 'elementor/')
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   bump-version:
+    permissions:
+      contents: none
     if: (github.actor == 'ronkelementor' || github.actor == 'KingYes' || github.actor == 'shilo-ey' || github.actor == 'matipojo') && startsWith(github.repository, 'elementor/')
     runs-on: ubuntu-20.04
     outputs:

--- a/.github/workflows/publish-patch.yml
+++ b/.github/workflows/publish-patch.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   bump-version:
+    permissions:
+      contents: none
     if: (github.actor == 'ronkelementor' || github.actor == 'KingYes' || github.actor == 'shilo-ey' || github.actor == 'matipojo') && startsWith(github.repository, 'elementor/')
     runs-on: ubuntu-20.04
     outputs:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -43,6 +43,8 @@ jobs:
           target_branch: develop
           github_token: ${{ secrets.MAINTAIN_TOKEN }}
   bump-version:
+    permissions:
+      contents: none
     needs: merge-release-branch-to-develop
     runs-on: ubuntu-20.04
     outputs:

--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -2,6 +2,9 @@ name: Elementor-ScreenShotter
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-20.04

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -5,8 +5,13 @@ on:
   schedule:
     - cron: '0 */2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   run:
+    permissions:
+      contents: none
     runs-on: ubuntu-20.04
     if: startsWith( github.repository, 'elementor/' )
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
