### PR TITLE
Fix: Select2 gets a value of `null` when cleared in single value mode [ED-7698]

### DIFF
--- a/assets/dev/js/editor/controls/select2.js
+++ b/assets/dev/js/editor/controls/select2.js
@@ -79,6 +79,25 @@ ControlSelect2ItemView = ControlBaseDataView.extend( {
 		elementorDevTools.deprecation.deprecated( 'onReady', '3.0.0' );
 	},
 
+	/**
+	 * Get Input Value
+	 *
+	 * This method is an override of the base method. It is needed because when clearing the Select2 value in single
+	 * value mode, the library sets that value to `null`, and an empty string is the system's default empty value.
+	 *
+	 * @param {*} input current control input
+	 * @return {*} potentially modified input value
+	 */
+	getInputValue( input ) {
+		let inputValue = super.get( input );
+
+		if ( null === inputValue ) {
+			inputValue = '';
+		}
+
+		return inputValue;
+	},
+
 	onBaseInputChange() {
 		ControlBaseDataView.prototype.onBaseInputChange.apply( this, arguments );
 

--- a/assets/dev/js/editor/controls/select2.js
+++ b/assets/dev/js/editor/controls/select2.js
@@ -89,13 +89,9 @@ ControlSelect2ItemView = ControlBaseDataView.extend( {
 	 * @return {*} potentially modified input value
 	 */
 	getInputValue( input ) {
-		let inputValue = super.get( input );
+		const inputValue = super.get( input );
 
-		if ( null === inputValue ) {
-			inputValue = '';
-		}
-
-		return inputValue;
+		return null === inputValue ? '' : inputValue;
 	},
 
 	onBaseInputChange() {

--- a/assets/dev/js/editor/controls/select2.js
+++ b/assets/dev/js/editor/controls/select2.js
@@ -89,9 +89,7 @@ ControlSelect2ItemView = ControlBaseDataView.extend( {
 	 * @return {*} potentially modified input value
 	 */
 	getInputValue( input ) {
-		const inputValue = super.get( input );
-
-		return null === inputValue ? '' : inputValue;
+		return super.get( input ) ?? '';
 	},
 
 	onBaseInputChange() {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Select2 gets a value of `null` when cleared in single value mode when its `frontend_available`