### PR TITLE
Fix: Theme Builder - user shouldn't be able to press on the THEME BUILDER logo button [ED-7923]

### DIFF
--- a/core/app/modules/site-editor/assets/js/templates/layout.js
+++ b/core/app/modules/site-editor/assets/js/templates/layout.js
@@ -7,7 +7,6 @@ import './site-editor.scss';
 export default function Layout( props ) {
 	const config = {
 		title: __( 'Theme Builder', 'elementor' ),
-		titleRedirectRoute: '/site-editor',
 		headerButtons: props.headerButtons,
 		sidebar: <Menu allPartsButton={ props.allPartsButton } promotion={ props.promotion } />,
 		content: props.children,


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Other... Please describe: tweak

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Theme Builder - user shouldn't be able to press on the THEME BLDER logo button