### PR TITLE
Fix: Web CLI requires jQuery [ED-8059]

### DIFF
--- a/modules/web-cli/module.php
+++ b/modules/web-cli/module.php
@@ -24,7 +24,9 @@ class Module extends App {
 		wp_register_script(
 			'elementor-web-cli',
 			$this->get_js_assets_url( 'web-cli' ),
-			[],
+			[ 
+				'jquery'
+			],
 			ELEMENTOR_VERSION,
 			true
 		);

--- a/modules/web-cli/module.php
+++ b/modules/web-cli/module.php
@@ -24,8 +24,8 @@ class Module extends App {
 		wp_register_script(
 			'elementor-web-cli',
 			$this->get_js_assets_url( 'web-cli' ),
-			[ 
-				'jquery'
+			[
+				'jquery',
 			],
 			ELEMENTOR_VERSION,
 			true


### PR DESCRIPTION
Web CLI requires Jquery so it should be part of dependencies to avoid errors when Jquery is loaded in the footer.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

When Jquery is loaded in the footer, Web CLI is loaded before Jquery creating "Jquery is not defined" errors.
*

## Description
This PR adds Jquery as a dependency of Web CLI.

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

