### PR TITLE
Fix: Translation

### DIFF
--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -492,7 +492,7 @@ class Container extends Element_Base {
 			'section' => 'section',
 			'aside' => 'aside',
 			'nav' => 'nav',
-			'a' => 'a ' . __( '(link)', 'elementor' ),
+			'a' => 'a ' . esc_html__( '(link)', 'elementor' ),
 		];
 
 		$options = [


### PR DESCRIPTION
The native translation method of Wordpress esc_html__() is missing for adding the HTML tag 'a' to the container