### PR TITLE
Fix: Inline Font Icons Experiment making the Hotspot Widget Label Icon height bigger [ED-7740]

### DIFF
--- a/includes/managers/icons.php
+++ b/includes/managers/icons.php
@@ -280,14 +280,14 @@ class Icons_Manager {
 
 		$attributes['class'][] = self::FONT_ICON_SVG_CLASS_NAME;
 		$attributes['class'][] = 'e-' . $icon_data['key'];
+		$attributes['viewBox'] = '0 0 ' . $icon_data['width'] . ' ' . $icon_data['height'];
 
 		/**
 		 * If in edit mode inline the full svg, otherwise use the symbol.
 		 * Will be displayed only after page update or widget "blur".
 		 */
 		if ( Plugin::$instance->editor->is_edit_mode() ) {
-			return '<svg xmlns="http://www.w3.org/2000/svg" ' . Utils::render_html_attributes( $attributes ) . '
-				viewBox="0 0 ' . esc_attr( $icon_data['width'] ) . ' ' . esc_attr( $icon_data['height'] ) . '">
+			return '<svg xmlns="http://www.w3.org/2000/svg" ' . Utils::render_html_attributes( $attributes ) . '">
 				<path d="' . esc_attr( $icon_data['path'] ) . '"></path>
 			</svg>';
 		}


### PR DESCRIPTION
We need to always print the `viewBox` since the SVG element doesn't inherit that from the `symbol` tag and looses its aspect-ratio.

Before:
![image](https://user-images.githubusercontent.com/32631382/187833971-324e3695-9aa6-42f2-961a-7e1214289631.png)


After:
![image](https://user-images.githubusercontent.com/32631382/187833832-8f9bdec8-06ab-4ebd-8ef7-b61eef638ee6.png)
