### PR TITLE
Fix: `is_current_user_can_edit` not working correctly when `$post_id` missing [ED-8136]

### DIFF
--- a/includes/user.php
+++ b/includes/user.php
@@ -84,7 +84,7 @@ class User {
 			return false;
 		}
 
-		if ( 'trash' === get_post_status( $post_id ) ) {
+		if ( 'trash' === get_post_status( $post->ID ) ) {
 			return false;
 		}
 
@@ -99,11 +99,11 @@ class User {
 		}
 
 		$edit_cap = $post_type_object->cap->edit_post;
-		if ( ! current_user_can( $edit_cap, $post_id ) ) {
+		if ( ! current_user_can( $edit_cap, $post->ID ) ) {
 			return false;
 		}
 
-		if ( intval( get_option( 'page_for_posts' ) ) === $post_id ) {
+		if ( intval( get_option( 'page_for_posts' ) ) === $post->ID ) {
 			return false;
 		}
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
- [x] Bugfix

## Summary

When calling `User::is_current_user_can_edit()` without passing a `$post_id` the method checks for current global `$post` but fails to update the `$post_id` and continue to validate/check based on this default `$post_id` so its always set to zero which causes later checks to fail:
```PHP
if ( 'trash' === get_post_status( $post_id ) ) { // post_id is set to zero
	return false;
}

// ...

if ( ! current_user_can( $edit_cap, $post_id ) ) { // post_id is set to zero
	return false;
}

if ( intval( get_option( 'page_for_posts' ) ) === $post_id ) { // post_id is set to zero
	return false;
}
```

*

## Description
Once the local `$post` variable is instantiated all checks should use the ID property of the that `$post` object.

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)
