### PR TITLE
Internal: Grunt - Added a task for watch production scripts [ED-8229]

### DIFF
--- a/.grunt-config/webpack.js
+++ b/.grunt-config/webpack.js
@@ -276,10 +276,15 @@ const developmentNoWatchConfig = webpackConfig.map( ( config ) => {
 	return { ...config, watch: false };
 } );
 
+const productionWatchConfig = webpackProductionConfig.map( ( config ) => {
+	return { ...config, watch: true };
+} );
+
 const gruntWebpackConfig = {
 	development: webpackConfig,
 	developmentNoWatch: developmentNoWatchConfig,
-	production: webpackProductionConfig
+	production: webpackProductionConfig,
+	productionWatch: productionWatchConfig,
 };
 
 module.exports = gruntWebpackConfig;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,6 +66,10 @@ module.exports = function( grunt ) {
 		grunt.task.run( 'webpack:development' );
 	} );
 
+	grunt.registerTask( 'watch_scripts:production', () => {
+		grunt.task.run( 'webpack:productionWatch' );
+	} );
+
 	grunt.registerTask( 'styles', ( isDevMode = false ) => {
 		if ( ! isDevMode ) {
 			grunt.task.run( 'create_widgets_temp_scss_files' );


### PR DESCRIPTION
The QUnit tests should run on the scripts after the build, in order to easy debug them, the new task allows to automatically rebuild the scripts while debugging