### PR TITLE
Fix: Template Library - Empty view jumps when searching [ED-8288]

### DIFF
--- a/assets/dev/scss/global/_modal-wrapper.scss
+++ b/assets/dev/scss/global/_modal-wrapper.scss
@@ -53,7 +53,7 @@
 		&-message {
 			height: 750px;
 			max-height: 85vh;
-			overflow: auto;
+			overflow-y: scroll;
 			padding-top: 25px;
 		}
 


### PR DESCRIPTION
When switching from full to empty view, the scrollbar disappears and the UI jumps.