### PR TITLE
Fix: Error after connecting from a promotion page and refreshing the page [ED-8259]

### DIFF
--- a/modules/promotions/admin-menu-items/base-promotion-item.php
+++ b/modules/promotions/admin-menu-items/base-promotion-item.php
@@ -42,7 +42,7 @@ abstract class Base_Promotion_Item implements Promotion_Menu_Item {
 
 				<p><?php $this->render_promotion_description(); ?></p>
 
-				<a class="elementor-button elementor-button-default elementor-button-go-pro" target="_blank" href="<?php echo esc_url( $this->get_cta_url() ); ?>">
+				<a class="elementor-button elementor-button-default elementor-button-go-pro" href="<?php echo esc_url( $this->get_cta_url() ); ?>">
 					<?php Utils::print_unescaped_internal_string( $this->get_cta_text() ); ?>
 				</a>
 			</div>


### PR DESCRIPTION
Force redirect the user to the connect URL instead of opening a new tab, since the promotion menu item isn't available anymore after connecting.