### PR TITLE
Replicated the way how the rotate control is initialized from the ico…

### DIFF
--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -400,21 +400,6 @@ class Widget_Icon_Box extends Widget_Base {
 			]
 		);
 
-		$active_breakpoints = Plugin::$instance->breakpoints->get_active_breakpoints();
-
-		$rotate_device_args = [];
-
-		$rotate_device_settings = [
-			'default' => [
-				'unit' => 'deg',
-				'size' => '',
-			],
-		];
-
-		foreach ( $active_breakpoints as $breakpoint_name => $breakpoint ) {
-			$rotate_device_args[ $breakpoint_name ] = $rotate_device_settings;
-		}
-
 		$this->add_responsive_control(
 			'rotate',
 			[
@@ -432,7 +417,12 @@ class Widget_Icon_Box extends Widget_Base {
 					'unit' => 'deg',
 					'size' => '',
 				],
-				'device_args' => $rotate_device_args,
+				'tablet_default' => [
+					'unit' => 'deg',
+				],
+				'mobile_default' => [
+					'unit' => 'deg',
+				],
 				'selectors' => [
 					'{{WRAPPER}} .elementor-icon i' => 'transform: rotate({{SIZE}}{{UNIT}});',
 				],


### PR DESCRIPTION
Elementor icon box widget

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [X] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* When we try to edit the Icon Box's style, an exception is thrown and the element panel got blank.

![image](https://user-images.githubusercontent.com/651325/191565384-c3a77b0b-6ee1-49d8-a580-058ea0a47e7c.png)

![image](https://user-images.githubusercontent.com/651325/191566084-c2498fbe-e804-4e5d-9af6-f24501e98e98.png)

## Description
An explanation of what is done in this PR

* Replicated the way how the rotate control is initialized from the icon widget.

## Test instructions
This PR can be tested by following these steps:

* Added Icon Box element and try to edit the styles

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

Fix: Uncaught Error: noUiSlider (13.0.0): 'start' option is incorrect.