### PR TITLE
Add do_action to file's delete and write methods

### DIFF
--- a/core/files/base.php
+++ b/core/files/base.php
@@ -191,7 +191,39 @@ abstract class Base {
 	 * @access public
 	 */
 	public function write() {
-		return file_put_contents( $this->path, $this->content );
+
+		$name = $this->get_name();
+
+		/**
+		 * Write CSS file.
+		 *
+		 * Fires before CSS file is written to filesystem.
+		 *
+		 * The dynamic portion of the hook name, `$name`, refers to the CSS file name.
+		 *
+		 * @since 3.7.8
+		 *
+		 * @param \Elementor\Core\Files\Base $this The current file.
+		 */
+		do_action( "elementor/css-file/{$name}/before_write", $this );
+
+		$write = file_put_contents( $this->path, $this->content );
+
+		/**
+		 * Write CSS file.
+		 *
+		 * Fires after CSS file is written to filesystem.
+		 *
+		 * The dynamic portion of the hook name, `$name`, refers to the CSS file name.
+		 *
+		 * @since 3.7.8
+		 *
+		 * @param \Elementor\Core\Files\Base $this The current file.
+		 * @param int|false $write The output of file_put_contents.
+		 */
+		do_action( "elementor/css-file/{$name}/after_write", $this, $write );
+
+		return $write;
 	}
 
 	/**
@@ -199,11 +231,40 @@ abstract class Base {
 	 * @access public
 	 */
 	public function delete() {
+
+		$name = $this->get_name();
+
+		/**
+		 * Delete CSS file.
+		 *
+		 * Fires before CSS file is removed.
+		 *
+		 * The dynamic portion of the hook name, `$name`, refers to the CSS file name.
+		 *
+		 * @since 3.7.8
+		 *
+		 * @param \Elementor\Core\Files\Base $this The current file.
+		 */
+		do_action( "elementor/css-file/{$name}/before_delete", $this );
+
 		if ( file_exists( $this->path ) ) {
 			unlink( $this->path );
 		}
 
 		$this->delete_meta();
+
+		/**
+		 * Delete CSS file.
+		 *
+		 * Fires after CSS file is removed.
+		 *
+		 * The dynamic portion of the hook name, `$name`, refers to the CSS file name.
+		 *
+		 * @since 3.7.8
+		 *
+		 * @param \Elementor\Core\Files\Base $this The current file.
+		 */
+		do_action( "elementor/css-file/{$name}/after_delete", $this );
 	}
 
 	/**


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [X] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Added action-hooks to file's write and delete methods.

## Description
An explanation of what is done in this PR

* Allows users to hook into file writing logic. This allows programatic cache purging after CSS files are written.

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #
