### PR TITLE
Fix: Control Conditions - Using respon. values in selector placeholders causes fatal error [ED-8355]

### DIFF
--- a/core/files/css/base.php
+++ b/core/files/css/base.php
@@ -440,7 +440,7 @@ abstract class Base extends Base_File {
 			if ( ! empty( $control['responsive'] ) && ! empty( $controls_stack[ $parser_control_name ]['responsive'] ) ) {
 				$device_suffix = Controls_Manager::get_responsive_control_device_suffix( $control );
 
-				$control = $controls_stack[ $parser_control_name . $device_suffix ];
+				$control = $controls_stack[ $parser_control_name . $device_suffix ] ?? $controls_stack[ $parser_control_name ];
 			} else {
 				$control = $controls_stack[ $parser_control_name ];
 			}

--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -1409,8 +1409,8 @@ abstract class Controls_Stack extends Base_Object {
 
 				$condition_name_to_check = $pure_condition_key . $device_suffix;
 
-				// If the control is not desktop, take the value of the conditioning control of the corresponding device.
-				$instance_value = $values[ $pure_condition_key . $device_suffix ];
+				// If the control is not desktop, and a conditioning control for the corresponding device exists, use it.
+				$instance_value = $values[ $pure_condition_key . $device_suffix ] ?? $values[ $pure_condition_key ];
 			} else {
 				$instance_value = $values[ $pure_condition_key ];
 			}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Control Conditions - Using responsive control values in selectors and selector values causes a fatal error [ED-8355]

[ED-8355]: https://elementor.atlassian.net/browse/ED-8355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ