### PR TITLE
Tweak: Add responsive capability to BG image opacity [ED-8344]

### DIFF
--- a/includes/elements/column.php
+++ b/includes/elements/column.php
@@ -369,7 +369,7 @@ class Element_Column extends Element_Base {
 			]
 		);
 
-		$this->add_control(
+		$this->add_responsive_control(
 			'background_overlay_opacity',
 			[
 				'label' => esc_html__( 'Opacity', 'elementor' ),

--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -689,7 +689,7 @@ class Container extends Element_Base {
 			]
 		);
 
-		$this->add_control(
+		$this->add_responsive_control(
 			'background_overlay_opacity',
 			[
 				'label' => esc_html__( 'Opacity', 'elementor' ),

--- a/includes/elements/section.php
+++ b/includes/elements/section.php
@@ -645,7 +645,7 @@ class Element_Section extends Element_Base {
 			]
 		);
 
-		$this->add_control(
+		$this->add_responsive_control(
 			'background_overlay_opacity',
 			[
 				'label' => esc_html__( 'Opacity', 'elementor' ),


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Tweak: Add responsive capability to BG image opacity

## Description
An explanation of what is done in this PR

* Tweak: Add responsive capability to BG image opacity

## Test instructions
This PR can be tested by following these steps:

**Sections:**

* Create a section and edit it.
* Style tab > Background overlay.
* Set a bg image > change the opacity.
* Change the Responsive Mode to Tablet/mobile.

**Columns:**

* Create a section and edit column.
* Style tab > Background overlay.
* Set a bg image > change the opacity.
* Change the Responsive Mode to Tablet/mobile.

**Containers:**

Same as sections and columns...

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #19659
