### PR TITLE
fix array check

### DIFF
--- a/includes/managers/controls.php
+++ b/includes/managers/controls.php
@@ -786,7 +786,7 @@ class Controls_Manager {
 		if ( $control_type_instance instanceof Base_Data_Control ) {
 			$control_default_value = $control_type_instance->get_default_value();
 
-			if ( is_array( $control_default_value ) ) {
+			if ( is_array( $control_default_value ) && is_array( $control_data['default'] ) {
 				$control_data['default'] = isset( $control_data['default'] ) ? array_merge( $control_default_value, $control_data['default'] ) : $control_default_value;
 			} else {
 				$control_data['default'] = isset( $control_data['default'] ) ? $control_data['default'] : $control_default_value;


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

Fixed php warning when 2nd parameter in array_merge isn't array.

*

## Description
An explanation of what is done in this PR

Added is_array to ensure 2nd parameter in array_merge is array.

*

## Test instructions
This PR can be tested by following these steps:

Assign $control_data['default'] in add_control_to_stack method on Controls_Manager.

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #

Issue [https://github.com/elementor/elementor/issues/20004](https://github.com/elementor/elementor/issues/20004)
