### PR TITLE
Fix: Repeater Controls - When added to advanced tab, repeaters cause JS error on page load [ED-8414]

### DIFF
--- a/assets/dev/js/editor/elements/models/base-settings.js
+++ b/assets/dev/js/editor/elements/models/base-settings.js
@@ -118,24 +118,35 @@ BaseSettingsModel = Backbone.Model.extend( {
 		} );
 	},
 
+	convertFieldsToControlsObj( fields ) {
+		const controls = {};
+
+		Object.values( fields ).forEach( ( field ) => controls[ field.name ] = field );
+
+		return controls;
+	},
+
 	getStyleControls( controls, attributes ) {
-		var self = this;
+		const self = this;
 
 		controls = elementorCommon.helpers.cloneObject( self.getActiveControls( controls, attributes ) );
 
-		var styleControls = [];
+		const styleControls = [];
 
 		jQuery.each( controls, function() {
-			var control = this,
-				controlDefaultSettings = elementor.config.controls[ control.type ];
+			let control = this;
+
+			const controlDefaultSettings = elementor.config.controls[ control.type ];
 
 			control = jQuery.extend( {}, controlDefaultSettings, control );
 
 			if ( control.fields ) {
-				var styleFields = [];
+				const styleFields = [];
+
+				const fieldsControlsObj = self.convertFieldsToControlsObj( control.fields );
 
 				self.attributes[ control.name ].each( function( item ) {
-					styleFields.push( self.getStyleControls( control.fields, item.attributes ) );
+					styleFields.push( self.getStyleControls( fieldsControlsObj, item.attributes ) );
 				} );
 
 				control.styleFields = styleFields;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Repeater Controls - When added to advanced tab, repeater controls cause JS error on page load

## Description
An explanation of what is done in this PR

* Fixes #19673