### PR TITLE
Tweak: Add more units to border width controls in various elements [ED-8465]

### DIFF
--- a/includes/widgets/accordion.php
+++ b/includes/widgets/accordion.php
@@ -247,12 +247,10 @@ class Widget_Accordion extends Widget_Base {
 				'size_units' => [ 'px', '%', 'em' ],
 				'range' => [
 					'px' => [
-						'min' => 0,
 						'max' => 20,
 					],
 					'em' => [
 						'max' => 2,
-						'step' => 0.1,
 					],
 				],
 				'selectors' => [

--- a/includes/widgets/accordion.php
+++ b/includes/widgets/accordion.php
@@ -244,10 +244,15 @@ class Widget_Accordion extends Widget_Base {
 			[
 				'label' => esc_html__( 'Border Width', 'elementor' ),
 				'type' => Controls_Manager::SLIDER,
+				'size_units' => [ 'px', '%', 'em' ],
 				'range' => [
 					'px' => [
 						'min' => 0,
-						'max' => 10,
+						'max' => 20,
+					],
+					'em' => [
+						'max' => 2,
+						'step' => 0.1,
 					],
 				],
 				'selectors' => [

--- a/includes/widgets/alert.php
+++ b/includes/widgets/alert.php
@@ -229,10 +229,13 @@ class Widget_Alert extends Widget_Base {
 			[
 				'label' => esc_html__( 'Left Border Width', 'elementor' ),
 				'type' => Controls_Manager::SLIDER,
+				'size_units' => [ 'px', '%', 'em' ],
 				'range' => [
 					'px' => [
-						'min' => 0,
 						'max' => 100,
+					],
+					'em' => [
+						'max' => 10,
 					],
 				],
 				'selectors' => [

--- a/includes/widgets/divider.php
+++ b/includes/widgets/divider.php
@@ -938,6 +938,17 @@ class Widget_Divider extends Widget_Base {
 			[
 				'label' => esc_html__( 'Border Width', 'elementor' ),
 				'type' => Controls_Manager::SLIDER,
+				'size_units' => [ 'px', '%', 'em' ],
+				'range' => [
+					'px' => [
+						'min' => 0,
+						'max' => 20,
+					],
+					'em' => [
+						'max' => 2,
+						'step' => 0.1,
+					],
+				],
 				'selectors' => [
 					'{{WRAPPER}} .elementor-icon' => 'border-width: {{SIZE}}{{UNIT}}',
 				],

--- a/includes/widgets/divider.php
+++ b/includes/widgets/divider.php
@@ -941,12 +941,10 @@ class Widget_Divider extends Widget_Base {
 				'size_units' => [ 'px', '%', 'em' ],
 				'range' => [
 					'px' => [
-						'min' => 0,
 						'max' => 20,
 					],
 					'em' => [
 						'max' => 2,
-						'step' => 0.1,
 					],
 				],
 				'selectors' => [

--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -444,6 +444,17 @@ class Widget_Icon_Box extends Widget_Base {
 			[
 				'label' => esc_html__( 'Border Width', 'elementor' ),
 				'type' => Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', '%', 'em' ],
+				'range' => [
+					'px' => [
+						'min' => 0,
+						'max' => 20,
+					],
+					'em' => [
+						'max' => 2,
+						'step' => 0.1,
+					],
+				],
 				'selectors' => [
 					'{{WRAPPER}} .elementor-icon' => 'border-width: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
 				],

--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -445,16 +445,6 @@ class Widget_Icon_Box extends Widget_Base {
 				'label' => esc_html__( 'Border Width', 'elementor' ),
 				'type' => Controls_Manager::DIMENSIONS,
 				'size_units' => [ 'px', '%', 'em' ],
-				'range' => [
-					'px' => [
-						'min' => 0,
-						'max' => 20,
-					],
-					'em' => [
-						'max' => 2,
-						'step' => 0.1,
-					],
-				],
 				'selectors' => [
 					'{{WRAPPER}} .elementor-icon' => 'border-width: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
 				],

--- a/includes/widgets/icon.php
+++ b/includes/widgets/icon.php
@@ -357,6 +357,17 @@ class Widget_Icon extends Widget_Base {
 			[
 				'label' => esc_html__( 'Border Width', 'elementor' ),
 				'type' => Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', '%', 'em' ],
+				'range' => [
+					'px' => [
+						'min' => 0,
+						'max' => 20,
+					],
+					'em' => [
+						'max' => 2,
+						'step' => 0.1,
+					],
+				],
 				'selectors' => [
 					'{{WRAPPER}} .elementor-icon' => 'border-width: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
 				],

--- a/includes/widgets/icon.php
+++ b/includes/widgets/icon.php
@@ -358,16 +358,6 @@ class Widget_Icon extends Widget_Base {
 				'label' => esc_html__( 'Border Width', 'elementor' ),
 				'type' => Controls_Manager::DIMENSIONS,
 				'size_units' => [ 'px', '%', 'em' ],
-				'range' => [
-					'px' => [
-						'min' => 0,
-						'max' => 20,
-					],
-					'em' => [
-						'max' => 2,
-						'step' => 0.1,
-					],
-				],
 				'selectors' => [
 					'{{WRAPPER}} .elementor-icon' => 'border-width: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
 				],

--- a/includes/widgets/tabs.php
+++ b/includes/widgets/tabs.php
@@ -259,13 +259,19 @@ class Widget_Tabs extends Widget_Base {
 			[
 				'label' => esc_html__( 'Border Width', 'elementor' ),
 				'type' => Controls_Manager::SLIDER,
+				'size_units' => [ 'px', '%', 'em' ],
 				'default' => [
+					'unit' => 'px',
 					'size' => 1,
 				],
 				'range' => [
 					'px' => [
 						'min' => 0,
-						'max' => 10,
+						'max' => 20,
+					],
+					'em' => [
+						'max' => 2,
+						'step' => 0.1,
 					],
 				],
 				'selectors' => [

--- a/includes/widgets/tabs.php
+++ b/includes/widgets/tabs.php
@@ -266,12 +266,10 @@ class Widget_Tabs extends Widget_Base {
 				],
 				'range' => [
 					'px' => [
-						'min' => 0,
 						'max' => 20,
 					],
 					'em' => [
 						'max' => 2,
-						'step' => 0.1,
 					],
 				],
 				'selectors' => [

--- a/includes/widgets/text-editor.php
+++ b/includes/widgets/text-editor.php
@@ -376,6 +376,17 @@ class Widget_Text_Editor extends Widget_Base {
 			'drop_cap_border_width', [
 				'label' => esc_html__( 'Border Width', 'elementor' ),
 				'type' => Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', '%', 'em' ],
+				'range' => [
+					'px' => [
+						'min' => 0,
+						'max' => 20,
+					],
+					'em' => [
+						'max' => 2,
+						'step' => 0.1,
+					],
+				],
 				'selectors' => [
 					'{{WRAPPER}} .elementor-drop-cap' => 'border-width: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
 				],

--- a/includes/widgets/text-editor.php
+++ b/includes/widgets/text-editor.php
@@ -377,16 +377,6 @@ class Widget_Text_Editor extends Widget_Base {
 				'label' => esc_html__( 'Border Width', 'elementor' ),
 				'type' => Controls_Manager::DIMENSIONS,
 				'size_units' => [ 'px', '%', 'em' ],
-				'range' => [
-					'px' => [
-						'min' => 0,
-						'max' => 20,
-					],
-					'em' => [
-						'max' => 2,
-						'step' => 0.1,
-					],
-				],
 				'selectors' => [
 					'{{WRAPPER}} .elementor-drop-cap' => 'border-width: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
 				],

--- a/includes/widgets/toggle.php
+++ b/includes/widgets/toggle.php
@@ -248,10 +248,15 @@ class Widget_Toggle extends Widget_Base {
 			[
 				'label' => esc_html__( 'Border Width', 'elementor' ),
 				'type' => Controls_Manager::SLIDER,
+				'size_units' => [ 'px', '%', 'em' ],
 				'range' => [
 					'px' => [
 						'min' => 0,
-						'max' => 10,
+						'max' => 20,
+					],
+					'em' => [
+						'max' => 2,
+						'step' => 0.1,
 					],
 				],
 				'selectors' => [

--- a/includes/widgets/toggle.php
+++ b/includes/widgets/toggle.php
@@ -251,12 +251,10 @@ class Widget_Toggle extends Widget_Base {
 				'size_units' => [ 'px', '%', 'em' ],
 				'range' => [
 					'px' => [
-						'min' => 0,
 						'max' => 20,
 					],
 					'em' => [
 						'max' => 2,
-						'step' => 0.1,
 					],
 				],
 				'selectors' => [


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Tweak: Add more units to border width controls in various elements

## Description
An explanation of what is done in this PR

* Tweak: Add more units to border width controls in various elements

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
