### PR TITLE
Fix: PHP errors caused by deprecation module [ED-8650]

### DIFF
--- a/core/breakpoints/manager.php
+++ b/core/breakpoints/manager.php
@@ -530,7 +530,7 @@ class Manager extends Module {
 		$deprecation_module = Plugin::$instance->modules_manager->get_modules( 'dev-tools' )->deprecation;
 
 		// TODO: REMOVE THIS DEPRECATED HOOK IN ELEMENTOR v3.10.0/v4.0.0
-		$templates = $deprecation_module->apply_deprecated_filter( $deprecated_hook, $templates, '3.2.0', $replacement_hook );
+		$templates = $deprecation_module->apply_deprecated_filter( $deprecated_hook, [ $templates ], '3.2.0', $replacement_hook );
 
 		return apply_filters( $replacement_hook, $templates );
 	}

--- a/modules/dev-tools/deprecation.php
+++ b/modules/dev-tools/deprecation.php
@@ -347,7 +347,7 @@ class Deprecation {
 	 * @return mixed
 	 * @throws \Exception
 	 */
-	public function apply_deprecated_filter( $hook, $args, $version, $replacement = '', $base_version = null ) {
+	public function apply_deprecated_filter( $hook, array $args, $version, $replacement = '', $base_version = null ) {
 		if ( ! has_action( $hook ) ) {
 			return $args[0];
 		}

--- a/modules/dev-tools/deprecation.php
+++ b/modules/dev-tools/deprecation.php
@@ -347,7 +347,7 @@ class Deprecation {
 	 * @return mixed
 	 * @throws \Exception
 	 */
-	public function apply_deprecated_filter( $hook, array $args, $version, $replacement = '', $base_version = null ) {
+	public function apply_deprecated_filter( $hook, $args, $version, $replacement = '', $base_version = null ) {
 		if ( ! has_action( $hook ) ) {
 			return $args[0] ?? null;
 		}

--- a/modules/dev-tools/deprecation.php
+++ b/modules/dev-tools/deprecation.php
@@ -349,7 +349,12 @@ class Deprecation {
 	 */
 	public function apply_deprecated_filter( $hook, $args, $version, $replacement = '', $base_version = null ) {
 		if ( ! has_action( $hook ) ) {
-			return $args[0] ?? null;
+			// `$args` should be an array, but in order to keep BC, we need to support non-array values.
+			if ( is_array( $args ) ) {
+				return $args[0] ?? null;
+			}
+
+			return $args;
 		}
 
 		$this->deprecated_hook( $hook, $version, $replacement, $base_version );

--- a/modules/dev-tools/deprecation.php
+++ b/modules/dev-tools/deprecation.php
@@ -349,7 +349,7 @@ class Deprecation {
 	 */
 	public function apply_deprecated_filter( $hook, array $args, $version, $replacement = '', $base_version = null ) {
 		if ( ! has_action( $hook ) ) {
-			return $args[0];
+			return $args[0] ?? null;
 		}
 
 		$this->deprecated_hook( $hook, $version, $replacement, $base_version );

--- a/modules/dev-tools/deprecation.php
+++ b/modules/dev-tools/deprecation.php
@@ -349,7 +349,7 @@ class Deprecation {
 	 */
 	public function apply_deprecated_filter( $hook, $args, $version, $replacement = '', $base_version = null ) {
 		if ( ! has_action( $hook ) ) {
-			return $args;
+			return $args[0];
 		}
 
 		$this->deprecated_hook( $hook, $version, $replacement, $base_version );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix. PHP errors caused by deprecation module

## Description
An explanation of what is done in this PR

* Deprecation module method [apply_deprecated_filter](https://github.com/elementor/elementor/blob/97f2db9d04a34dd3b1fc9fc101ab2536d6834528/modules/dev-tools/deprecation.php#L350) uses [apply_filters_ref_array](https://developer.wordpress.org/reference/functions/apply_filters_ref_array/) which expect the second argument to be an array of filter arguments, but in [/core/breakpoints/manager.php](https://github.com/elementor/elementor/blob/master/core/breakpoints/manager.php#L533)  actual value is given. It causes PHP errors when "Site Settings" is saved. In PHP 8.0+ it causes fatal errors.

## Test instructions
This PR can be tested by following these steps:

* Activate Elementor Pro
* Add global color in "Site Settings"
* Save

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #20062 
