### PR TITLE
Fix: Separate "Default" and "None" values in "Border Type" [ED-8511]

### DIFF
--- a/includes/controls/groups/border.php
+++ b/includes/controls/groups/border.php
@@ -60,7 +60,8 @@ class Group_Control_Border extends Group_Control_Base {
 			'label' => _x( 'Border Type', 'Border Control', 'elementor' ),
 			'type' => Controls_Manager::SELECT,
 			'options' => [
-				'' => esc_html__( 'None', 'elementor' ),
+				'' => esc_html__( 'Default', 'elementor' ),
+				'none' => esc_html__( 'None', 'elementor' ),
 				'solid' => _x( 'Solid', 'Border Control', 'elementor' ),
 				'double' => _x( 'Double', 'Border Control', 'elementor' ),
 				'dotted' => _x( 'Dotted', 'Border Control', 'elementor' ),
@@ -79,7 +80,7 @@ class Group_Control_Border extends Group_Control_Base {
 				'{{SELECTOR}}' => 'border-width: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
 			],
 			'condition' => [
-				'border!' => '',
+				'border!' => [ '', 'none' ],
 			],
 			'responsive' => true,
 		];
@@ -92,7 +93,7 @@ class Group_Control_Border extends Group_Control_Base {
 				'{{SELECTOR}}' => 'border-color: {{VALUE}};',
 			],
 			'condition' => [
-				'border!' => '',
+				'border!' => [ '', 'none' ],
 			],
 		];
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Separate "Default" and "None" values in "Border Type"

## Description
An explanation of what is done in this PR

* This PR fixes several bug. It changes the initial label to "Default". In addition it adds the ability to set border none.

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes: #11565, #13328, #11723