### PR TITLE
Fix deprecated error on performance_lab_get_webp_src

### DIFF
--- a/modules/performance-lab/module.php
+++ b/modules/performance-lab/module.php
@@ -28,7 +28,7 @@ class Module extends BaseModule {
 		return false;
 	}
 
-	private function performance_lab_get_webp_src( $attachment_id, $size = 'full', $url ) {
+	private function performance_lab_get_webp_src( $attachment_id, $url, $size = 'full' ) {
 		$image_object = wp_get_attachment_image_src( $attachment_id, $size );
 		$image_src = call_user_func( self::PERFORMANCE_LAB_FUNCTION_NAME, $image_object[0], 'webp', $attachment_id );
 		if ( ! empty( $image_src ) ) {
@@ -39,7 +39,7 @@ class Module extends BaseModule {
 
 	private function replace_css_with_webp( $value, $css_property, $matches ) {
 		if ( 0 === strpos( $css_property, 'background-image' ) && '{{URL}}' === $matches[0] ) {
-			$value['url'] = $this->performance_lab_get_webp_src( $value['id'], 'full', $value['url'] );
+			$value['url'] = $this->performance_lab_get_webp_src( $value['id'], $value['url'] );
 		}
 		return $value;
 	}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix a deprecated issue with PHP 8.0

## Description

* There is a deprecated error on Elementor Dev: `Required parameter $url follows optional parameter $size in wp-content/plugins/elementor/modules/performance-lab/module.php on line 31`
* In PHP 8.0, use an optional parameter before a required param is deprecated. This PR change the order of parameters of `performance_lab_get_webp_src` function to avoid a deprecated error on all pages.

## Test instructions

*  Before the patch, go to any page on front or back and see a deprecated error. After, the error has disappeared.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
