### PR TITLE
Tweak: Small refactoring in image widget

### DIFF
--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -254,7 +254,7 @@ class Widget_Image extends Widget_Base {
 			[
 				'label' => esc_html__( 'Width', 'elementor' ),
 				'type' => Controls_Manager::SLIDER,
-				'size_units' => [ '%', 'px', 'vw' ],
+				'size_units' => [ 'px', '%', 'vw' ],
 				'default' => [
 					'unit' => '%',
 				],
@@ -265,13 +265,13 @@ class Widget_Image extends Widget_Base {
 					'unit' => '%',
 				],
 				'range' => [
-					'%' => [
-						'min' => 1,
-						'max' => 100,
-					],
 					'px' => [
 						'min' => 1,
 						'max' => 1000,
+					],
+					'%' => [
+						'min' => 1,
+						'max' => 100,
 					],
 					'vw' => [
 						'min' => 1,
@@ -289,7 +289,7 @@ class Widget_Image extends Widget_Base {
 			[
 				'label' => esc_html__( 'Max Width', 'elementor' ),
 				'type' => Controls_Manager::SLIDER,
-				'size_units' => [ '%', 'px', 'vw' ],
+				'size_units' => [ 'px', '%', 'vw' ],
 				'default' => [
 					'unit' => '%',
 				],
@@ -300,13 +300,13 @@ class Widget_Image extends Widget_Base {
 					'unit' => '%',
 				],
 				'range' => [
-					'%' => [
-						'min' => 1,
-						'max' => 100,
-					],
 					'px' => [
 						'min' => 1,
 						'max' => 1000,
+					],
+					'%' => [
+						'min' => 1,
+						'max' => 100,
 					],
 					'vw' => [
 						'min' => 1,

--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -254,6 +254,7 @@ class Widget_Image extends Widget_Base {
 			[
 				'label' => esc_html__( 'Width', 'elementor' ),
 				'type' => Controls_Manager::SLIDER,
+				'size_units' => [ '%', 'px', 'vw' ],
 				'default' => [
 					'unit' => '%',
 				],
@@ -263,7 +264,6 @@ class Widget_Image extends Widget_Base {
 				'mobile_default' => [
 					'unit' => '%',
 				],
-				'size_units' => [ '%', 'px', 'vw' ],
 				'range' => [
 					'%' => [
 						'min' => 1,
@@ -289,6 +289,7 @@ class Widget_Image extends Widget_Base {
 			[
 				'label' => esc_html__( 'Max Width', 'elementor' ),
 				'type' => Controls_Manager::SLIDER,
+				'size_units' => [ '%', 'px', 'vw' ],
 				'default' => [
 					'unit' => '%',
 				],
@@ -298,7 +299,6 @@ class Widget_Image extends Widget_Base {
 				'mobile_default' => [
 					'unit' => '%',
 				],
-				'size_units' => [ '%', 'px', 'vw' ],
 				'range' => [
 					'%' => [
 						'min' => 1,
@@ -324,6 +324,7 @@ class Widget_Image extends Widget_Base {
 			[
 				'label' => esc_html__( 'Height', 'elementor' ),
 				'type' => Controls_Manager::SLIDER,
+				'size_units' => [ 'px', 'vh' ],
 				'default' => [
 					'unit' => 'px',
 				],
@@ -333,7 +334,6 @@ class Widget_Image extends Widget_Base {
 				'mobile_default' => [
 					'unit' => 'px',
 				],
-				'size_units' => [ 'px', 'vh' ],
 				'range' => [
 					'px' => [
 						'min' => 1,


### PR DESCRIPTION
I moved the table that proposes the list of icons to put it directly below the range resolution operator, as on the other widgets when it comes to units