### PR TITLE
Tweak: Replace the remaining 'Go Pro' labels [ED-8566]

### DIFF
--- a/app/assets/js/molecules/go-pro-button.js
+++ b/app/assets/js/molecules/go-pro-button.js
@@ -27,5 +27,5 @@ GoProButton.defaultProps = {
 	color: 'cta',
 	target: '_blank',
 	rel: 'noopener noreferrer',
-	text: __( 'Go Pro', 'elementor' ),
+	text: __( 'Upgrade Now', 'elementor' ),
 };

--- a/app/modules/onboarding/assets/js/components/go-pro-popover.js
+++ b/app/modules/onboarding/assets/js/components/go-pro-popover.js
@@ -49,7 +49,7 @@ export default function GoProPopover( props ) {
 		} );
 	}, [] );
 
-	// The buttonsConfig prop is an array of objects. To find the 'Go Pro' button, we need to iterate over the object.
+	// The buttonsConfig prop is an array of objects. To find the 'Upgrade Now' button, we need to iterate over the object.
 	const goProButton = props.buttonsConfig.find( ( button ) => 'go-pro' === button.id ),
 		getElProButton = {
 			text: __( 'Upgrade Now', 'elementor' ),
@@ -75,7 +75,7 @@ export default function GoProPopover( props ) {
 			wrapperClass="e-onboarding__go-pro"
 		>
 			<div className="e-onboarding__go-pro-content">
-				<h2 className="e-onboarding__go-pro-title">{ __( 'Ready to Go Pro?', 'elementor' ) }</h2>
+				<h2 className="e-onboarding__go-pro-title">{ __( 'Ready to Get Elementor Pro?', 'elementor' ) }</h2>
 				<Checklist>
 					<ChecklistItem>{ __( '90+ Basic & Pro widgets', 'elementor' ) }</ChecklistItem>
 					<ChecklistItem>{ __( '300+ Basic & Pro templates', 'elementor' ) }</ChecklistItem>

--- a/app/modules/site-editor/assets/js/organisms/menu.js
+++ b/app/modules/site-editor/assets/js/organisms/menu.js
@@ -11,7 +11,7 @@ export default function Menu( props ) {
 			const className = 'eps-menu-item__action-button';
 
 			if ( props.promotion ) {
-				return <Button text={ __( 'Go Pro', 'elementor' ) } hideText icon="eicon-lock" className={ className } />;
+				return <Button text={ __( 'Upgrade Now', 'elementor' ) } hideText icon="eicon-lock" className={ className } />;
 			}
 
 			const goToCreate = () => {

--- a/core/admin/admin.php
+++ b/core/admin/admin.php
@@ -299,7 +299,7 @@ class Admin extends App {
 
 		array_unshift( $links, $settings_link );
 
-		$links['go_pro'] = sprintf( '<a href="%1$s" target="_blank" class="elementor-plugins-gopro">%2$s</a>', 'https://go.elementor.com/go-pro-wp-plugins/', esc_html__( 'Go Pro', 'elementor' ) );
+		$links['go_pro'] = sprintf( '<a href="%1$s" target="_blank" class="elementor-plugins-gopro">%2$s</a>', 'https://go.elementor.com/go-pro-wp-plugins/', esc_html__( 'Get Elementor Pro', 'elementor' ) );
 
 		return $links;
 	}

--- a/includes/managers/controls.php
+++ b/includes/managers/controls.php
@@ -1066,7 +1066,7 @@ class Controls_Manager {
 				<div class="elementor-nerd-box-message"><?php Utils::print_unescaped_internal_string( $message ); ?></div>
 			<?php }
 
-			// Show a `Go Pro` button only if the user doesn't have Pro.
+			// Show the upgrade button only if the user doesn't have Pro.
 			if ( $texts['link'] && ! Utils::has_pro() ) { ?>
 				<a class="elementor-nerd-box-link elementor-button elementor-button-default elementor-button-go-pro" href="<?php echo esc_url( ( $texts['link'] ) ); ?>" target="_blank">
 					<?php echo esc_html__( 'Upgrade Now', 'elementor' ); ?>

--- a/includes/settings/settings.php
+++ b/includes/settings/settings.php
@@ -28,7 +28,7 @@ class Settings extends Settings_Page {
 	const PAGE_ID = 'elementor';
 
 	/**
-	 * Go Pro menu priority.
+	 * Upgrade menu priority.
 	 */
 	const MENU_PRIORITY_GO_PRO = 502;
 

--- a/modules/promotions/admin-menu-items/popups-promotion-item.php
+++ b/modules/promotions/admin-menu-items/popups-promotion-item.php
@@ -27,7 +27,7 @@ class Popups_Promotion_Item extends Base_Promotion_Item {
 
 	public function render_promotion_description() {
 		echo esc_html__(
-			'Popup Builder lets you take advantage of all the amazing features in Elementor, so you can build beautiful & highly converting popups. Go pro and start designing your popups today.',
+			'The Popup Builder lets you take advantage of all the amazing features in Elementor, so you can build beautiful & highly converting popups. Get Elementor Pro and start designing your popups today.',
 			'elementor'
 		);
 	}

--- a/tests/playwright/sanity/core/app/modules/onboarding/onboarding.test.js
+++ b/tests/playwright/sanity/core/app/modules/onboarding/onboarding.test.js
@@ -1,9 +1,9 @@
 const { test, expect } = require( '@playwright/test' );
 
 /**
- *  Test that the "Go Pro" popover appears when overing over the "Go Pro" button.
+ *  Test that the "Upgrade" popover appears when overing over the "Upgrade" button.
  */
-test( 'Onboarding Go Pro Popover', async ( { page } ) => {
+test( 'Onboarding Upgrade Popover', async ( { page } ) => {
 	await page.goto( '/wp-admin/admin.php?page=elementor-app#onboarding' );
 
 	const goProHeaderButton = await page.locator( '#eps-app-header-btn-go-pro' );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Tweak: Replace the remaining 'Go Pro' labels

## Description
An explanation of what is done in this PR:

Elementor replaced all the "**Go Pro**" labels with "**Upgrade**", "**Upgrade Now**" or "**Get Elementor Pro**".

There are still [translation strings](https://translate.wordpress.org/projects/wp-plugins/elementor/dev/he/default/?filters%5Bterm%5D=Go+Pro&filters%5Bterm_scope%5D=scope_any&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filters%5Buser_login%5D=&filter=Apply+Filters&sort%5Bby%5D=priority&sort%5Bhow%5D=desc) that use "**Go Pro**", 3 different translation strings that are displayed in 8 different places.

This PR fixes them.

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
