### PR TITLE
Tweak: Remove unneeded CSS vendor prefixes [ED-8633]

### DIFF
--- a/app/assets/js/ui/atoms/checkbox.scss
+++ b/app/assets/js/ui/atoms/checkbox.scss
@@ -3,7 +3,7 @@
 
 // checkbox label
 .#{$eps-prefix}checkbox {
-	-webkit-appearance: none;
+	appearance: none;
 	border-radius: $eps-checkbox-border-radius;
 	width: $eps-checkbox-size;
 	height: $eps-checkbox-size;

--- a/app/assets/styles/base/_reset.scss
+++ b/app/assets/styles/base/_reset.scss
@@ -166,7 +166,7 @@ button,
 [type="button"],
 [type="reset"],
 [type="submit"] {
-  -webkit-appearance: button;
+  appearance: button;
 }
 
 // Opinionated: add "hand" cursor to non-disabled button elements.

--- a/assets/dev/scss/admin/_global.scss
+++ b/assets/dev/scss/admin/_global.scss
@@ -234,7 +234,6 @@ body {
 	}
 
 	&.loading:before {
-		-webkit-animation: rotation 1s infinite linear;
 		animation: rotation 1s infinite linear;
 	}
 

--- a/assets/dev/scss/admin/_new-template-dialog.scss
+++ b/assets/dev/scss/admin/_new-template-dialog.scss
@@ -135,8 +135,6 @@
 
 			&__select {
 				appearance: none;
-				-webkit-appearance: none;
-				-moz-appearance: none;
 				cursor: pointer;
 
 				&__wrapper {

--- a/assets/dev/scss/editor/navigator/navigator.scss
+++ b/assets/dev/scss/editor/navigator/navigator.scss
@@ -218,7 +218,7 @@ body {
 
 			&__text {
 				white-space: nowrap;
-				-webkit-user-select: text;
+				user-select: text;
 
 				&[contenteditable="true"] {
 					outline: none;
@@ -298,7 +298,7 @@ body {
 		}
 
 		&-section,
-		&-container, {
+		&-container {
 			background-color: $white;
 		}
 	}

--- a/assets/dev/scss/editor/panel/_controls.scss
+++ b/assets/dev/scss/editor/panel/_controls.scss
@@ -156,8 +156,6 @@
 
 			select {
 				appearance: none;
-				-webkit-appearance: none;
-				-moz-appearance: none;
 				font-size: 12px;
 				font-family: inherit;
 				font-weight: inherit;

--- a/assets/dev/scss/editor/panel/_elements.scss
+++ b/assets/dev/scss/editor/panel/_elements.scss
@@ -61,8 +61,6 @@
 	transition: all 1s;
 	border-radius: 3px;
 	appearance: none;
-	-webkit-appearance: none;
-	-moz-appearance: none;
 
 	+ i {
 		position: absolute;

--- a/assets/dev/scss/editor/panel/controls/_url.scss
+++ b/assets/dev/scss/editor/panel/controls/_url.scss
@@ -68,9 +68,8 @@
 				border-radius: 2px;
 				@include margin-end(5px);
 
-				//hid the browser input style
-				-webkit-appearance: none;
-				-moz-appearance: none;
+				//hide the browser input style
+				appearance: none;
 				outline: none;
 				content: none;
 

--- a/assets/dev/scss/frontend/_forms.scss
+++ b/assets/dev/scss/frontend/_forms.scss
@@ -61,8 +61,6 @@
 
 		select {
 			appearance: none;
-			-webkit-appearance: none;
-			-moz-appearance: none;
 			color: inherit;
 			font-size: inherit;
 			font-family: inherit;

--- a/assets/dev/scss/frontend/_swiper.scss
+++ b/assets/dev/scss/frontend/_swiper.scss
@@ -181,8 +181,6 @@ button.swiper-pagination-bullet {
 	padding: 0;
 	box-shadow: none;
 	appearance: none;
-	-webkit-appearance: none;
-	-moz-appearance: none;
 }
 
 .swiper-pagination-clickable .swiper-pagination-bullet {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Tweak: Remove unneeded CSS vendor prefixes

## Description
An explanation of what is done in this PR

* CSS vendor prefixes should be covered by “**autoprefixer**” and based on the `.browserslistrc` file settings. We should not hardcode vendor prefixes in our `.scss` files.

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #16330
Related: #20000