### PR TITLE
Internal: Add a short "System Info" video tutorial to GitHub bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -58,4 +58,4 @@ body:
       required: true
     attributes:
       label: "System Info"
-      description: "For faster debugging copy your system environment from `Elementor` => `System info`, and paste it here or in https://pastebin.com/"
+      description: "For faster debugging [copy your system environment](https://www.youtube.com/watch?v=tDXdynsnYuA) from `Elementor` => `System info`, and paste it here or in https://pastebin.com/"


### PR DESCRIPTION
Add a link to the bug template, linking to a short video tutorial - https://www.youtube.com/watch?v=tDXdynsnYuA

Hopefully, it will help users to add "System Info" to bug reports.