### PR TITLE
Tweak: Add `accent-color` support to Form fields in Site Settings panel [ED-8579]

### DIFF
--- a/assets/dev/scss/frontend/_global.scss
+++ b/assets/dev/scss/frontend/_global.scss
@@ -10,6 +10,9 @@
 		}
 	}
 
+	// Reset Style for some themes and browsers
+	hyphens: manual;
+
 	a {
 		box-shadow: none;
 		text-decoration: none;
@@ -49,6 +52,10 @@
 		margin: 0;
 		line-height: 1;
 		border: none;
+	}
+
+	.elementor-custom-embed {
+		line-height: 0; //for google maps margin bottom
 	}
 
 	// Background Video
@@ -397,3 +404,4 @@
 .eicon-animation-spin {
 	animation: eicon-spin 2s infinite linear;
 }
+

--- a/assets/dev/scss/frontend/_global.scss
+++ b/assets/dev/scss/frontend/_global.scss
@@ -10,9 +10,6 @@
 		}
 	}
 
-	// Reset Style for some themes and browsers
-	hyphens: manual;
-
 	a {
 		box-shadow: none;
 		text-decoration: none;
@@ -52,10 +49,6 @@
 		margin: 0;
 		line-height: 1;
 		border: none;
-	}
-
-	.elementor-custom-embed {
-		line-height: 0; //for google maps margin bottom
 	}
 
 	// Background Video
@@ -404,4 +397,3 @@
 .eicon-animation-spin {
 	animation: eicon-spin 2s infinite linear;
 }
-

--- a/assets/dev/scss/frontend/widgets/google_maps.scss
+++ b/assets/dev/scss/frontend/widgets/google_maps.scss
@@ -8,6 +8,10 @@
 		overflow: hidden; // Allow border-radius
 	}
 
+	.elementor-custom-embed {
+		line-height: 0; // Remove space
+	}
+
 	iframe {
 		height: 300px;
 	}

--- a/assets/dev/scss/frontend/widgets/google_maps.scss
+++ b/assets/dev/scss/frontend/widgets/google_maps.scss
@@ -8,10 +8,6 @@
 		overflow: hidden; // Allow border-radius
 	}
 
-	.elementor-custom-embed {
-		line-height: 0; // Remove space
-	}
-
 	iframe {
 		height: 300px;
 	}

--- a/assets/dev/scss/global/_aspect_ratio.scss
+++ b/assets/dev/scss/global/_aspect_ratio.scss
@@ -3,55 +3,61 @@
 	&219 {
 
 		.elementor-fit-aspect-ratio {
-			aspect-ratio: 21 / 9;
+			padding-bottom: 42.8571%;
 		}
 	}
 
 	&169 {
 
 		.elementor-fit-aspect-ratio {
-			aspect-ratio: 16 / 9;
+			padding-bottom: 56.25%;
 		}
 	}
 
 	&43 {
 
 		.elementor-fit-aspect-ratio {
-			aspect-ratio: 4 / 3;
+			padding-bottom: 75%;
 		}
 	}
 
 	&32 {
 
 		.elementor-fit-aspect-ratio {
-			aspect-ratio: 3 / 2;
+			padding-bottom: 66.6666%;
 		}
 	}
 
 	&11 {
 
 		.elementor-fit-aspect-ratio {
-			aspect-ratio: 1 / 1;
+			padding-bottom: 100%;
 		}
 	}
 
 	&916 {
 
 		.elementor-fit-aspect-ratio {
-			aspect-ratio: 9 / 16;
+			padding-bottom: 177.8%;
 		}
 	}
 }
 
 .elementor-fit-aspect-ratio {
+	position: relative;
+	height: 0;
 
-	.elementor-video,
-	.elementor-video-iframe,
-	iframe,
-	video {
+	iframe {
+		position: absolute;
+		top: 0;
+		left: 0;
 		height: 100%;
 		width: 100%;
-		border: none;
-		background-color: $black;
+		border: 0;
+		background-color: #000;
+	}
+
+	video {
+		width: 100%;
 	}
 }

--- a/assets/dev/scss/global/_aspect_ratio.scss
+++ b/assets/dev/scss/global/_aspect_ratio.scss
@@ -3,61 +3,55 @@
 	&219 {
 
 		.elementor-fit-aspect-ratio {
-			padding-bottom: 42.8571%;
+			aspect-ratio: 21 / 9;
 		}
 	}
 
 	&169 {
 
 		.elementor-fit-aspect-ratio {
-			padding-bottom: 56.25%;
+			aspect-ratio: 16 / 9;
 		}
 	}
 
 	&43 {
 
 		.elementor-fit-aspect-ratio {
-			padding-bottom: 75%;
+			aspect-ratio: 4 / 3;
 		}
 	}
 
 	&32 {
 
 		.elementor-fit-aspect-ratio {
-			padding-bottom: 66.6666%;
+			aspect-ratio: 3 / 2;
 		}
 	}
 
 	&11 {
 
 		.elementor-fit-aspect-ratio {
-			padding-bottom: 100%;
+			aspect-ratio: 1 / 1;
 		}
 	}
 
 	&916 {
 
 		.elementor-fit-aspect-ratio {
-			padding-bottom: 177.8%;
+			aspect-ratio: 9 / 16;
 		}
 	}
 }
 
 .elementor-fit-aspect-ratio {
-	position: relative;
-	height: 0;
 
-	iframe {
-		position: absolute;
-		top: 0;
-		left: 0;
+	.elementor-video,
+	.elementor-video-iframe,
+	iframe,
+	video {
 		height: 100%;
 		width: 100%;
-		border: 0;
-		background-color: #000;
-	}
-
-	video {
-		width: 100%;
+		border: none;
+		background-color: $black;
 	}
 }

--- a/core/kits/documents/tabs/theme-style-form-fields.php
+++ b/core/kits/documents/tabs/theme-style-form-fields.php
@@ -170,6 +170,18 @@ class Theme_Style_Form_Fields extends Tab_Base {
 
 	private function add_form_field_state_tab_controls( $prefix, $selector ) {
 		$this->add_control(
+			$prefix . '_accent_color',
+			[
+				'label' => esc_html__( 'Accent Color', 'elementor' ),
+				'type' => Controls_Manager::COLOR,
+				'dynamic' => [],
+				'selectors' => [
+					$selector => 'accent-color: {{VALUE}};',
+				],
+			]
+		);
+
+		$this->add_control(
 			$prefix . '_text_color',
 			[
 				'label' => esc_html__( 'Text Color', 'elementor' ),

--- a/core/kits/documents/tabs/theme-style-form-fields.php
+++ b/core/kits/documents/tabs/theme-style-form-fields.php
@@ -192,7 +192,7 @@ class Theme_Style_Form_Fields extends Tab_Base {
 				],
 			]
 		);
-		
+
 		$this->add_control(
 			$prefix . '_background_color',
 			[

--- a/core/kits/documents/tabs/theme-style-form-fields.php
+++ b/core/kits/documents/tabs/theme-style-form-fields.php
@@ -170,18 +170,6 @@ class Theme_Style_Form_Fields extends Tab_Base {
 
 	private function add_form_field_state_tab_controls( $prefix, $selector ) {
 		$this->add_control(
-			$prefix . '_accent_color',
-			[
-				'label' => esc_html__( 'Accent Color', 'elementor' ),
-				'type' => Controls_Manager::COLOR,
-				'dynamic' => [],
-				'selectors' => [
-					$selector => 'accent-color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_control(
 			$prefix . '_text_color',
 			[
 				'label' => esc_html__( 'Text Color', 'elementor' ),
@@ -193,6 +181,18 @@ class Theme_Style_Form_Fields extends Tab_Base {
 			]
 		);
 
+		$this->add_control(
+			$prefix . '_accent_color',
+			[
+				'label' => esc_html__( 'Accent Color', 'elementor' ),
+				'type' => Controls_Manager::COLOR,
+				'dynamic' => [],
+				'selectors' => [
+					$selector => 'accent-color: {{VALUE}};',
+				],
+			]
+		);
+		
 		$this->add_control(
 			$prefix . '_background_color',
 			[


### PR DESCRIPTION
Accent color sets the user-interface color for special input field elements like checkboxes, radio buttons, and range sliders.
Read more: https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color

<img width="389" alt="image" src="https://user-images.githubusercontent.com/1778512/206914732-2e09eb36-63e4-4d79-9caf-321e6c027caa.png">

<img width="164" alt="image" src="https://user-images.githubusercontent.com/1778512/206914436-c806ca78-60c3-410f-998a-4297ef77fdb2.png">


[ED-8579]: https://elementor.atlassian.net/browse/ED-8579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ED-8875]: https://elementor.atlassian.net/browse/ED-8875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ