### PR TITLE
Fix: Copy-Paste Style prevents saving the page when Repeaters exist in "non-content" tabs [ED-8548]

### DIFF
--- a/assets/dev/js/editor/document/elements/commands-internal/set-settings.js
+++ b/assets/dev/js/editor/document/elements/commands-internal/set-settings.js
@@ -29,7 +29,8 @@ export class SetSettings extends $e.modules.editor.CommandContainerInternalBase 
 				this.component.store.actions.settings( {
 					documentId: elementor.documents.getCurrentId(),
 					elementId: container.id,
-					settings,
+					// Deep copy in order to avoid making container setting properties immutable.
+					settings: JSON.parse( JSON.stringify( settings ) ),
 				} ),
 			);
 		} );

--- a/tests/playwright/pages/editor-page.js
+++ b/tests/playwright/pages/editor-page.js
@@ -157,6 +157,24 @@ module.exports = class EditorPage extends BasePage {
 		await this.getPreviewFrame().waitForSelector( '.elementor-element-' + elementId + ':not( .elementor-sticky__spacer ).elementor-element-editable' );
 	}
 
+	async copyElement( elementId ) {
+		const element = this.getPreviewFrame().locator( '.elementor-edit-mode .elementor-element-' + elementId );
+		await element.click( { button: 'right' } );
+
+		const copyListItemSelector = '.elementor-context-menu-list__item-copy:visible';
+		await this.page.waitForSelector( copyListItemSelector );
+		await this.page.locator( copyListItemSelector ).click();
+	}
+
+	async pasteStyleElement( elementId ) {
+		const element = this.getPreviewFrame().locator( '.elementor-edit-mode .elementor-element-' + elementId );
+		await element.click( { button: 'right' } );
+
+		const pasteListItemSelector = '.elementor-context-menu-list__item-pasteStyle:visible';
+		await this.page.waitForSelector( pasteListItemSelector );
+		await this.page.locator( pasteListItemSelector ).click();
+	}
+
 	/**
 	 * Activate a tab inside the panel editor.
 	 *

--- a/tests/playwright/sanity/assets/dev/js/editor/document/elements/copy-paste-style.test.js
+++ b/tests/playwright/sanity/assets/dev/js/editor/document/elements/copy-paste-style.test.js
@@ -1,0 +1,43 @@
+const { test, expect } = require( '@playwright/test' );
+const WpAdminPage = require( '../../../../../../../pages/wp-admin-page' );
+
+test( 'A page can be saved successfully after copy-paste style', async ( { page }, testInfo ) => {
+	// Arrange.
+	const wpAdmin = new WpAdminPage( page, testInfo );
+	const editor = await wpAdmin.useElementorCleanPost();
+
+	// Close Navigator
+	await editor.closeNavigatorIfOpen();
+
+	const heading1 = await editor.addWidget( 'heading' );
+	const heading2 = await editor.addWidget( 'heading' );
+
+	await editor.selectElement( heading1 );
+
+	await editor.activatePanelTab( 'style' );
+
+	await page.locator( '.elementor-control-title_color .pcr-button' ).click();
+	await page.locator( '.pcr-app.visible .pcr-interaction input.pcr-result' ).fill( '#77A5BD' );
+
+	// Act.
+	await editor.copyElement( heading1 );
+
+	await editor.pasteStyleElement( heading2 );
+
+	const heading2Title = await editor.getFrame().locator( '.elementor-element-' + heading2 + ' .elementor-heading-title' );
+
+	// Assert.
+	await expect( heading2Title ).toHaveCSS( 'color', 'rgb(119, 165, 189)' );
+
+	const publishButton = page.locator( '#elementor-panel-saver-button-publish' );
+
+	// Check that the panel footer save button is green.
+	await expect( publishButton ).toHaveCSS( 'background-color', 'rgb(57, 181, 74)' );
+
+	// Act.
+	await publishButton.click();
+	await page.waitForLoadState( 'networkidle' );
+
+	// Assert.
+	await expect( page.locator( '#elementor-panel-saver-button-publish' ) ).toHaveCSS( 'background-color', 'rgb(85, 96, 104)' );
+} );


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Copy-Paste Style prevents saving the page when Repeater controls exist in "non-content" tabs [ED-8548]

## Description

* Fixes #19895 #20637

[ED-8548]: https://elementor.atlassian.net/browse/ED-8548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ