### PR TITLE
Tweak: Use accessible dismiss notices [ED-9672]

### DIFF
--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -577,7 +577,7 @@ class Admin_Notices extends Module {
 		}
 
 		if ( $options['dismissible'] ) {
-			$label = esc_html__( 'Dismiss', 'elementor' );
+			$label = esc_html__( 'Dismiss this notice.', 'elementor' );
 			$notice_classes[] = 'e-notice--dismissible';
 			$dismiss_button = '<i class="e-notice__dismiss" role="button" aria-label="' . $label . '" tabindex="0"></i>';
 		}

--- a/includes/widgets/alert.php
+++ b/includes/widgets/alert.php
@@ -493,7 +493,7 @@ class Widget_Alert extends Widget_Base {
 					} else { ?>
 						<span aria-hidden="true">&times;</span>
 					<?php } ?>
-					<span class="elementor-screen-only"><?php echo esc_html__( 'Dismiss alert', 'elementor' ); ?></span>
+					<span class="elementor-screen-only"><?php echo esc_html__( 'Dismiss this alert.', 'elementor' ); ?></span>
 				</button>
 			<?php endif; ?>
 		</div>
@@ -532,7 +532,7 @@ class Widget_Alert extends Widget_Base {
 						<# } else { #>
 							<span aria-hidden="true">&times;</span>
 						<# } #>
-						<span class="elementor-screen-only"><?php echo esc_html__( 'Dismiss alert', 'elementor' ); ?></span>
+						<span class="elementor-screen-only"><?php echo esc_html__( 'Dismiss this alert.', 'elementor' ); ?></span>
 					</button>
 				<# } #>
 			</div>


### PR DESCRIPTION
Users using assistive technologies not always can see the surrounding context.

When there is a simple close button, it is not always clear what is being closed. It is recommended to add context to the message / label.