### PR TITLE
Fix: Prevent Placeholder image import to media library #17933

### DIFF
--- a/includes/controls/media.php
+++ b/includes/controls/media.php
@@ -65,15 +65,7 @@ class Control_Media extends Control_Base_Multiple {
 	 * @return array Control settings.
 	 */
 	public function on_import( $settings ) {
-		if ( empty( $settings['url'] ) ) {
-			return $settings;
-		}
-
-		if ( strpos( $settings['url'], 'images/placeholder.png' ) !== false ) {
-			$settings = [
-				'id' => '',
-				'url' => Utils::get_placeholder_image_src(),
-			];
+		if ( empty( $settings['url'] ) || strpos( $settings['url'], 'images/placeholder.png' ) !== false ) {
 			return $settings;
 		}
 

--- a/includes/controls/media.php
+++ b/includes/controls/media.php
@@ -69,7 +69,15 @@ class Control_Media extends Control_Base_Multiple {
 			return $settings;
 		}
 
-		$settings = Plugin::$instance->templates_manager->get_import_images_instance()->import( $settings );
+		if ( strpos( $settings['url'], 'images/placeholder.png' ) !== false ) {
+			$settings = [
+				'id' => '',
+				'url' => Utils::get_placeholder_image_src(),
+			];
+			return $settings;
+		}
+
+		$settings = Plugin::$instance->templates_manager->get_import_images_instance()->import($settings);
 
 		if ( ! $settings ) {
 			$settings = [

--- a/includes/controls/media.php
+++ b/includes/controls/media.php
@@ -69,7 +69,7 @@ class Control_Media extends Control_Base_Multiple {
 			return $settings;
 		}
 
-		$settings = Plugin::$instance->templates_manager->get_import_images_instance()->import($settings);
+		$settings = Plugin::$instance->templates_manager->get_import_images_instance()->import( $settings );
 
 		if ( ! $settings ) {
 			$settings = [

--- a/includes/controls/media.php
+++ b/includes/controls/media.php
@@ -65,7 +65,7 @@ class Control_Media extends Control_Base_Multiple {
 	 * @return array Control settings.
 	 */
 	public function on_import( $settings ) {
-		if ( empty( $settings['url'] ) || strpos( $settings['url'], 'images/placeholder.png' ) !== false ) {
+		if ( empty( $settings['url'] ) ) {
 			return $settings;
 		}
 

--- a/includes/template-library/classes/class-import-images.php
+++ b/includes/template-library/classes/class-import-images.php
@@ -114,8 +114,15 @@ class Import_Images {
 			return $attachment;
 		}
 
-		if ( ! empty( $attachment['id'] ) ) {
-			$saved_image = $this->get_saved_image( $attachment );
+		if ( isset( $attachment['tmp_name'] ) ) {
+			// Used when called to import a directly-uploaded file.
+			$filename = $attachment['name'];
+
+			$file_content = Utils::file_get_contents( $attachment['tmp_name'] );
+		} else {
+			// Used when attachment information is passed to this method.
+			if ( ! empty( $attachment['id'] ) ) {
+				$saved_image = $this->get_saved_image( $attachment );
 
 				if ( $saved_image ) {
 					return $saved_image;

--- a/includes/template-library/classes/class-import-images.php
+++ b/includes/template-library/classes/class-import-images.php
@@ -108,15 +108,14 @@ class Import_Images {
 	 * @return false|array Imported image data, or false.
 	 */
 	public function import( $attachment, $parent_post_id = null ) {
-		if ( isset( $attachment['tmp_name'] ) ) {
-			// Used when called to import a directly-uploaded file.
-			$filename = $attachment['name'];
 
-			$file_content = Utils::file_get_contents( $attachment['tmp_name'] );
-		} else {
-			// Used when attachment information is passed to this method.
-			if ( ! empty( $attachment['id'] ) ) {
-				$saved_image = $this->get_saved_image( $attachment );
+		// Check for placeholder image and return if placeholder image is found
+		if( strpos( $attachment['url'], 'elementor/assets/images/placeholder.png' ) !== false ) {
+			return $attachment;
+		}
+
+		if ( ! empty( $attachment['id'] ) ) {
+			$saved_image = $this->get_saved_image( $attachment );
 
 				if ( $saved_image ) {
 					return $saved_image;


### PR DESCRIPTION
Continued from here: https://github.com/elementor/elementor/pull/17933

Added check for placeholder image. if URL contains images/placeholder.png then don't import image to the media library

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Prevent duplicate placeholder images while importing templates. 

## Description
An explanation of what is done in this PR

* Fixed #17932

## Test instructions
This PR can be tested by following these steps:

* I can't write unit test

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #17932