### PR TITLE
Fix: Templates responsive setting won't update unless 'Regenerate CSS' is used [ED-9329]

### DIFF
--- a/core/files/css/base.php
+++ b/core/files/css/base.php
@@ -648,6 +648,10 @@ abstract class Base extends Base_File {
 
 		Plugin::$instance->breakpoints->set_responsive_control_duplication_mode( $this->get_responsive_control_duplication_mode() );
 
+		// The Common widget instance used in all widgets needs to be refreshed so the controls are re-registered
+		// according to the CSS file's control duplication mode.
+		$this->delete_common_widget_instance_controls_stack();
+
 		$this->render_css();
 
 		$name = $this->get_name();
@@ -668,6 +672,21 @@ abstract class Base extends Base_File {
 		Plugin::$instance->breakpoints->set_responsive_control_duplication_mode( $initial_responsive_controls_duplication_mode );
 
 		return $this->get_stylesheet()->__toString();
+	}
+
+	/**
+	 * Delete Common Widget Instance Controls Stack
+	 *
+	 * This method is used when you want to refresh the Common stack before re-registering controls.
+	 * The common stack will be re-registered the next time its controls are called for (e.g. when any widget's CSS
+	 * needs to be rendered).
+	 *
+	 * @return void
+	 */
+	private function delete_common_widget_instance_controls_stack() {
+		$common_widget_instance = Plugin::$instance->widgets_manager->get_widget_types( 'common' );
+
+		Plugin::$instance->controls_manager->delete_stack( $common_widget_instance );
 	}
 
 	/**

--- a/core/files/css/base.php
+++ b/core/files/css/base.php
@@ -671,6 +671,9 @@ abstract class Base extends Base_File {
 
 		Plugin::$instance->breakpoints->set_responsive_control_duplication_mode( $initial_responsive_controls_duplication_mode );
 
+		// Refresh the Common widget instance's stack again to restore the controls to their original state.
+		$this->delete_common_widget_instance_controls_stack();
+
 		return $this->get_stylesheet()->__toString();
 	}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Templates responsive setting won't update unless 'Regenerate CSS' is used

## Description
An explanation of what is done in this PR

* Fixes https://github.com/elementor/elementor/issues/19394
* Fixes: https://github.com/elementor/elementor/issues/20555