### PR TITLE
Tweak: Improve lightbox accessibility [ED-9975]

### DIFF
--- a/assets/dev/js/frontend/utils/lightbox/lightbox.js
+++ b/assets/dev/js/frontend/utils/lightbox/lightbox.js
@@ -328,7 +328,7 @@ module.exports = elementorModules.ViewModule.extend( {
 		$.each( socialNetworks, ( key, data ) => {
 			const networkLabel = data.label,
 				$link = $( '<a>', { href: this.createShareLink( key, itemUrl, $activeSlide.attr( 'data-e-action-hash' ) ), target: '_blank' } ).text( networkLabel ),
-				$socialNetworkIconElement = this.isFontIconSvgExperiment ? $( data.iconElement.element ) : $( '<i>', { class: 'eicon-' + key } );
+				$socialNetworkIconElement = this.isFontIconSvgExperiment ? $( data.iconElement.element ) : $( '<i>', { class: 'eicon-' + key, 'aria-hidden': 'true' } );
 
 			$link.prepend( $socialNetworkIconElement );
 			$linkList.append( $link );
@@ -406,6 +406,7 @@ module.exports = elementorModules.ViewModule.extend( {
 				showZoomElements = [],
 				showZoomAttrs = {
 					role: 'switch',
+					'tabindex': 0,
 					'aria-checked': false,
 					'aria-label': i18n.zoom,
 				},
@@ -440,6 +441,7 @@ module.exports = elementorModules.ViewModule.extend( {
 				fullScreenElements = [],
 				fullScreenAttrs = {
 					role: 'switch',
+					'tabindex': 0,
 					'aria-checked': false,
 					'aria-label': i18n.fullscreen,
 				},
@@ -690,11 +692,13 @@ module.exports = elementorModules.ViewModule.extend( {
 			.append( $slidesWrapper );
 
 		if ( ! isSingleSlide ) {
-			const $prevButtonIcon = this.isFontIconSvgExperiment ? $( chevronLeft.element ) : $( '<i>', { class: slideshowClasses.prevButtonIcon } ),
-				$nextButtonIcon = this.isFontIconSvgExperiment ? $( chevronRight.element ) : $( '<i>', { class: slideshowClasses.nextButtonIcon } );
+			const $prevButtonIcon = this.isFontIconSvgExperiment ? $( chevronLeft.element ) : $( '<i>', { class: slideshowClasses.prevButtonIcon, 'aria-hidden': 'true' } ),
+				$nextButtonIcon = this.isFontIconSvgExperiment ? $( chevronRight.element ) : $( '<i>', { class: slideshowClasses.nextButtonIcon, 'aria-hidden': 'true' } ),
+				$prevButtonLabel = $( '<span>', { class: 'screen-reader-text' } ).html( i18n.previous ),
+				$nextButtonLabel = $( '<span>', { class: 'screen-reader-text' } ).html( i18n.next );
 
-			$prevButton = $( '<div>', { class: slideshowClasses.prevButton + ' ' + classes.preventClose, 'aria-label': i18n.previous } ).html( $prevButtonIcon );
-			$nextButton = $( '<div>', { class: slideshowClasses.nextButton + ' ' + classes.preventClose, 'aria-label': i18n.next } ).html( $nextButtonIcon );
+			$prevButton = $( '<div>', { class: slideshowClasses.prevButton + ' ' + classes.preventClose } ).html( $prevButtonIcon + $prevButtonLabel);
+			$nextButton = $( '<div>', { class: slideshowClasses.nextButton + ' ' + classes.preventClose } ).html( $nextButtonIcon + $nextButtonLabel );
 
 			$container.append(
 				$nextButton,

--- a/assets/dev/js/frontend/utils/lightbox/lightbox.js
+++ b/assets/dev/js/frontend/utils/lightbox/lightbox.js
@@ -110,8 +110,8 @@ module.exports = elementorModules.ViewModule.extend( {
 			closeButtonOptions: {
 				...closeIcon,
 				attributes: {
-					tabindex: 0,
 					role: 'button',
+					tabindex: 0,
 					'aria-label': elementorFrontend.config.i18n.close + ' (Esc)',
 				},
 			},

--- a/assets/dev/js/frontend/utils/lightbox/lightbox.js
+++ b/assets/dev/js/frontend/utils/lightbox/lightbox.js
@@ -697,7 +697,7 @@ module.exports = elementorModules.ViewModule.extend( {
 				$prevButtonLabel = $( '<span>', { class: 'screen-reader-text' } ).html( i18n.previous ),
 				$nextButtonLabel = $( '<span>', { class: 'screen-reader-text' } ).html( i18n.next );
 
-			$prevButton = $( '<div>', { class: slideshowClasses.prevButton + ' ' + classes.preventClose } ).html( $prevButtonIcon + $prevButtonLabel);
+			$prevButton = $( '<div>', { class: slideshowClasses.prevButton + ' ' + classes.preventClose } ).html( $prevButtonIcon + $prevButtonLabel );
 			$nextButton = $( '<div>', { class: slideshowClasses.nextButton + ' ' + classes.preventClose } ).html( $nextButtonIcon + $nextButtonLabel );
 
 			$container.append(

--- a/assets/dev/js/frontend/utils/lightbox/lightbox.js
+++ b/assets/dev/js/frontend/utils/lightbox/lightbox.js
@@ -406,7 +406,7 @@ module.exports = elementorModules.ViewModule.extend( {
 				showZoomElements = [],
 				showZoomAttrs = {
 					role: 'switch',
-					'tabindex': 0,
+					tabindex: 0,
 					'aria-checked': false,
 					'aria-label': i18n.zoom,
 				},
@@ -441,7 +441,7 @@ module.exports = elementorModules.ViewModule.extend( {
 				fullScreenElements = [],
 				fullScreenAttrs = {
 					role: 'switch',
-					'tabindex': 0,
+					tabindex: 0,
 					'aria-checked': false,
 					'aria-label': i18n.fullscreen,
 				},

--- a/assets/dev/js/frontend/utils/lightbox/lightbox.js
+++ b/assets/dev/js/frontend/utils/lightbox/lightbox.js
@@ -382,6 +382,7 @@ module.exports = elementorModules.ViewModule.extend( {
 			elements.$iconShare = $( iconElement, {
 				class: slideshowClasses.iconShare,
 				role: 'button',
+				tabindex: 0,
 				'aria-label': i18n.share,
 				'aria-expanded': false,
 			} ).append( $( '<span>' ) );


### PR DESCRIPTION
The current lightbox accessibility can be improved.

1. Add `tabindex=0` to zoom icon, to make it keyboard accessible.
2. Add `tabindex=0` to full-screen icon, to make it keyboard accessible.
3. Hide social sharing icons from screen readers using `aria-hidden=true`, it has labels.
4. Next/Prev buttons, add label text for screen readers and hide the icons.