### PR TITLE
Fix: Navigation arrow icons display as "[object Object]" when opening media in lightbox [ED-10171]

### DIFF
--- a/assets/dev/js/frontend/utils/lightbox/lightbox.js
+++ b/assets/dev/js/frontend/utils/lightbox/lightbox.js
@@ -698,8 +698,8 @@ module.exports = elementorModules.ViewModule.extend( {
 				$prevButtonLabel = $( '<span>', { class: 'screen-reader-text' } ).html( i18n.previous ),
 				$nextButtonLabel = $( '<span>', { class: 'screen-reader-text' } ).html( i18n.next );
 
-			$prevButton = $( '<div>', { class: slideshowClasses.prevButton + ' ' + classes.preventClose } ).html( $prevButtonIcon + $prevButtonLabel );
-			$nextButton = $( '<div>', { class: slideshowClasses.nextButton + ' ' + classes.preventClose } ).html( $nextButtonIcon + $nextButtonLabel );
+			$prevButton = $( '<div>', { class: slideshowClasses.prevButton + ' ' + classes.preventClose } ).append( $prevButtonIcon, $prevButtonLabel );
+			$nextButton = $( '<div>', { class: slideshowClasses.nextButton + ' ' + classes.preventClose } ).append( $nextButtonIcon, $nextButtonLabel );
 
 			$container.append(
 				$nextButton,


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Navigation arrow icons display as "[object Object]" when opening media in lightbox [ED-10171]

[ED-10171]: https://elementor.atlassian.net/browse/ED-10171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ