### PR TITLE
Tweak: Make Elementor Editor tabs keyboard accessible [ED-10200]

### DIFF
--- a/assets/dev/scss/editor/panel/_element-settings.scss
+++ b/assets/dev/scss/editor/panel/_element-settings.scss
@@ -12,6 +12,7 @@
 		flex: auto;
 		transition: var(--e-a-transition-hover);
 		border-bottom: 3px solid transparent;
+		cursor: pointer;
 
 		&:hover,
 		&:focus {


### PR DESCRIPTION
Part of #21733

This PR adds missing `cursor: pointer;`