### PR TITLE
Fix: Yoast SEO compatibility issue with Elementor 3.13.0 beta [ED-10503]

### DIFF
--- a/assets/dev/scss/editor/panel/_element-settings.scss
+++ b/assets/dev/scss/editor/panel/_element-settings.scss
@@ -27,11 +27,15 @@
 			border-color: var(--e-a-border-color-accent);
 			color: var(--e-a-color-txt-accent);
 
+			// TODO: Remove `a` in Elementor 3.14.0
+			a,
 			span {
 				color: var(--e-a-color-txt-accent);
 			}
 		}
 
+		// TODO: Remove `a` in Elementor 3.14.0
+		a,
 		span {
 			color: inherit;
 			display: block;
@@ -50,12 +54,16 @@
 }
 
 .elementor-tab-control-content {
+	// TODO: Remove `a` in Elementor 3.14.0
+	a:before,
 	span:before {
 		content: '\e92c';
 	}
 }
 
 .elementor-tab-control-style {
+	// TODO: Remove `a` in Elementor 3.14.0
+	a:before,
 	span:before {
 		content: '\e921';
 	}
@@ -64,6 +72,8 @@
 .elementor-tab-control-advanced,
 .elementor-tab-control-settings,
 .elementor-tab-control-general_style {
+	// TODO: Remove `a` in Elementor 3.14.0
+	a:before,
 	span:before {
 		content: '\e916';
 	}
@@ -71,12 +81,16 @@
 
 //TODO: Remove
 .elementor-tab-control-responsive {
+	// TODO: Remove `a` in Elementor 3.14.0
+	a:before,
 	span:before {
 		content: '\e885';
 	}
 }
 
 .elementor-tab-control-lightbox {
+	// TODO: Remove `a` in Elementor 3.14.0
+	a:before,
 	span:before {
 		content: '\e922';
 	}
@@ -85,6 +99,8 @@
 
 .elementor-tab-control-layout,
 .elementor-tab-control-column {
+	// TODO: Remove `a` in Elementor 3.14.0
+	a:before,
 	span:before {
 		content: '\e899';
 	}

--- a/core/settings/page/manager.php
+++ b/core/settings/page/manager.php
@@ -168,7 +168,8 @@ class Manager extends CSS_Manager {
 			<# _.each( tabs, function( tabTitle, tabSlug ) {
 			$e.bc.ensureTab( 'panel/page-settings', tabSlug ); #>
 			<button class="elementor-component-tab elementor-panel-navigation-tab elementor-tab-control-{{ tabSlug }}" data-tab="{{ tabSlug }}">
-				<span>{{{ tabTitle }}}</span>
+				<?php /* TODO: raplace `<a>` tag with `<span>` tag in Elementor 3.14.0 */ ?>
+				<a>{{{ tabTitle }}}</a>
 			</button>
 			<# } ); #>
 		</div>


### PR DESCRIPTION
Revert some of the Editor-Accessibility changes made in 3.13.0 due to compatibility issues between Elementor and other plugins.

Implement the change in 3.14.0, after making sure our partners update their code to reflect the changes in Elementor Editor.