### PR TITLE
Internal: CI for change log

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,6 +13,8 @@ jobs:
     name: Build plugin
     runs-on: ubuntu-latest
     if: startsWith( github.repository, 'elementor/' )
+    outputs:
+      changelog_diff: ${{ steps.changelog_diff_files.outputs.diff }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
@@ -29,12 +31,12 @@ jobs:
             .*/**/*
             !readme.txt
       - name: Install Node.js 18.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
       - name: Cache node modules
         if: steps.changelog_diff_files.outputs.diff
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -72,54 +74,54 @@ jobs:
             wpCoreVersion: 'latest'
     steps:
       - name: Checkout source code
-        if: matrix.wpCoreVersion != 'master' || github.event_name == 'schedule'
+        if: matrix.wpCoreVersion != 'master'
         uses: actions/checkout@v3
       - name: Install Node.js 18.x
-        if: matrix.wpCoreVersion != 'master' || github.event_name == 'schedule'
+        if: matrix.wpCoreVersion != 'master'
         uses: actions/setup-node@v2
         with:
           node-version: 18.x
       - name: Restore build from cache
-        if: matrix.wpCoreVersion != 'master' || github.event_name == 'schedule'
+        if: matrix.wpCoreVersion != 'master'
         uses: actions/cache@v2
         id: restore-build
         with:
           path: ./build/*
           key: ${{ github.sha }}
       - name: Run wp-env
-        if: matrix.wpCoreVersion != 'master' || github.event_name == 'schedule'
+        if: matrix.wpCoreVersion != 'master'
         uses: ./.github/workflows/run-wp-env
         with:
           TEMPLATES: './tests/lighthouse/templates'
           PHP_VERSION: ${{ matrix.phpVersion }}
           WP_CORE_VERSION: ${{ matrix.wpCoreVersion }}
       - name: Install lhci
-        if: matrix.wpCoreVersion != 'master' || github.event_name == 'schedule'
+        if: matrix.wpCoreVersion != 'master'
         run: |
           npm ci
           npm install --no-package-lock --no-save @lhci/cli@0.11.1
       - name: WordPress debug information
-        if: matrix.wpCoreVersion != 'master' || github.event_name == 'schedule'
+        if: matrix.wpCoreVersion != 'master'
         run: |
           npx wp-env run cli "wp core version"
           npx wp-env run cli "wp --info"
       - name: Run Lighthouse tests
-        if: matrix.wpCoreVersion != 'master' || github.event_name == 'schedule'
+        if: matrix.wpCoreVersion != 'master'
         run: |
           bash "${GITHUB_WORKSPACE}/.github/scripts/run-lighthouse-tests.sh"
       - name: Save HTML dumps on failure
-        if: failure() || matrix.wpCoreVersion != 'master' || github.event_name == 'schedule'
+        if: failure() || matrix.wpCoreVersion != 'master'
         run: |
           bash "${GITHUB_WORKSPACE}/.github/scripts/save-lighthouse-pages-html-dumps.sh"
       - name: Upload Lighthouse reports on failure
-        if: failure() || matrix.wpCoreVersion != 'master' || github.event_name == 'schedule'
+        if: failure() || matrix.wpCoreVersion != 'master'
         uses: actions/upload-artifact@v2
         with:
           name: lighthouseci-reports
           path: ${{ github.workspace }}/.lighthouseci/reports/**/*
           retention-days: 7
       - name: Upload Lighthouse HTML dumps on failure
-        if: failure() || matrix.wpCoreVersion != 'master' || github.event_name == 'schedule'
+        if: failure() || matrix.wpCoreVersion != 'master'
         uses: actions/upload-artifact@v2
         with:
           name: lighthouseci-htmls

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,10 +1,7 @@
 name: Lighthouse
 
 on:
-  push:
   pull_request:
-  schedule:
-    - cron: '0 10 * * 0' # run at 10 AM UTC on Sunday
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -19,11 +16,24 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
+      - name: Check if this is only a changelog PR
+        id: changelog_diff_files
+        uses: technote-space/get-diff-action@v6
+        with:
+          # PATTERNS are:
+          # Everything: **/*
+          # Everything in directories starting with a period: .*/**/*
+          # Not readme.txt: !readme.txt
+          PATTERNS: |
+            **/*
+            .*/**/*
+            !readme.txt
       - name: Install Node.js 18.x
         uses: actions/setup-node@v2
         with:
           node-version: 18.x
       - name: Cache node modules
+        if: steps.changelog_diff_files.outputs.diff
         uses: actions/cache@v2
         env:
           cache-name: cache-node-modules
@@ -35,20 +45,24 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: Install dependencies
+        if: steps.changelog_diff_files.outputs.diff
         run: npm ci
       - name: Build
+        if: steps.changelog_diff_files.outputs.diff
         run: npx grunt build
       - name: Save build to cache
+        if: steps.changelog_diff_files.outputs.diff
         uses: actions/cache@v2
         id: restore-build
         with:
           path: ./build/*
           key: ${{ github.sha }}
 
-  lighthouse:
+  lighthouse_test:
     name: Lighthouse test - WP ${{ matrix.wpCoreVersion }} on PHP ${{ matrix.phpVersion }}
     runs-on: ubuntu-latest
     needs: [build-plugin]
+    if: ${{ needs.build-plugin.outputs.changelog_diff }}
     strategy:
       matrix:
         include:
@@ -120,3 +134,15 @@ jobs:
         run: |
           MESSAGE_TEXT="@channel Repo: *$GITHUB_REPOSITORY* Workflow: *$GITHUB_WORKFLOW* is FAILED - <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|link>"
           curl -X POST "https://slack.com/api/chat.postMessage" -d "username=${SLACK_BOT_NAME}&token=${SLACK_TOKEN}&channel=${SLACK_CHANNEL}&text=${MESSAGE_TEXT}&link_names=true"
+
+  lighthouse:
+    needs: lighthouse_test
+    if: ${{ always() }} # Will be run even if 'Lighthouse' matrix will be skipped
+    runs-on: ubuntu-22.04
+    name: Lighthouse - Test Results
+    steps:
+      - name: Test status
+        run: echo "Test status is - ${{ needs.lighthouse_test.result }}"
+      - name: Check lighthouse_test matrix status
+        if: ${{ needs.lighthouse_test.result != 'success' && needs.lighthouse_test.result != 'skipped' }}
+        run: exit 1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           PATTERNS: |
             **
-            !readme.txt
+            # !readme.txt
       - name: Install Node.js 18.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -53,7 +53,7 @@ jobs:
     name: Playwright test (Performance on) - ${{ matrix.testSuite }} on PHP 7.4
     runs-on: ubuntu-latest
     needs: [build-plugin]
-    if: ${{ needs.file-diff.outputs.changelog_diff.diff }}
+    if: ${{ needs.file-diff.outputs.changelog_diff.count > 0 }}
     strategy:
       matrix:
         testSuite: ['elements-regression', 'default', 'nested-tabs', 'reverse-columns', 'container']

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -40,15 +40,19 @@ jobs:
           path: ~/.npm
           key: npm-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
       - name: Install dependencies
+        if: steps.changelog_diff_files.outputs.diff
         run: npm ci
       - name: Build
+        if: steps.changelog_diff_files.outputs.diff
         run: npx grunt build
       - name: Cache node modules
+        if: steps.changelog_diff_files.outputs.diff
         uses: actions/cache/save@v3
         with:
           path: ~/.npm
           key: npm-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
       - name: Save build to cache
+        if: steps.changelog_diff_files.outputs.diff
         uses: actions/cache/save@v3
         with:
           path: ./build/*

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,9 +22,7 @@ jobs:
         id: changelog_diff_files
         uses: technote-space/get-diff-action@v6
         with:
-          PATTERNS: |
-            **
-            # !readme.txt
+          PATTERNS: '**/*,!readme.txt'
       - name: Install Node.js 18.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,6 +23,7 @@ jobs:
         uses: technote-space/get-diff-action@v6
         with:
           PATTERNS: |
+            **/*
             !readme.txt
       - name: Install Node.js 18.x
         uses: actions/setup-node@v3

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -55,7 +55,7 @@ jobs:
     name: Playwright test (Performance on) - ${{ matrix.testSuite }} on PHP 7.4
     runs-on: ubuntu-latest
     needs: [build-plugin]
-    if: ${{ needs.file-diff.outputs.changelog_diff.count > 0 }}
+    if: ${{ needs.file-diff.outputs.changelog_diff }}
     strategy:
       matrix:
         testSuite: ['elements-regression', 'default', 'nested-tabs', 'reverse-columns', 'container']

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,6 +27,7 @@ jobs:
             .github/**/*
             .grunt-config/**/*
             !readme.txt
+            !.github/workflows/playwright.yml
       - name: Install Node.js 18.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,7 +22,11 @@ jobs:
         id: changelog_diff_files
         uses: technote-space/get-diff-action@v6
         with:
-          PATTERNS: '**/*'
+          PATTERNS: |
+            **/*
+            .github/**/*
+            .grunt-config/**/*
+            !readme.txt
       - name: Install Node.js 18.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,7 +22,7 @@ jobs:
         id: changelog_diff_files
         uses: technote-space/get-diff-action@v6
         with:
-          PATTERNS: '**/*,!readme.txt'
+          PATTERNS: '**/*'
       - name: Install Node.js 18.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,9 +13,17 @@ jobs:
     name: Build plugin
     runs-on: ubuntu-latest
     if: startsWith( github.repository, 'elementor/' )
+    outputs:
+      changelog_diff: ${{ steps.changelog_diff_files.outputs.diff }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
+      - name: Check If this is only a change log PR
+        id: changelog_diff_files
+        uses: technote-space/get-diff-action@v6
+        with:
+          PATTERNS: |
+            !readme.txt
       - name: Install Node.js 18.x
         uses: actions/setup-node@v3
         with:
@@ -44,6 +52,7 @@ jobs:
     name: Playwright test (Performance on) - ${{ matrix.testSuite }} on PHP 7.4
     runs-on: ubuntu-latest
     needs: [build-plugin]
+    if: ${{ needs.file-diff.outputs.changelog_diff }}
     strategy:
       matrix:
         testSuite: ['elements-regression', 'default', 'nested-tabs', 'reverse-columns', 'container']
@@ -102,3 +111,15 @@ jobs:
           name: playwright-test-results-${{ matrix.testSuite }}
           path: test-results/
           retention-days: 3
+
+  test-result:
+    needs: Playwright
+    if: ${{ always() }} # Will be run even if 'Playwright' matrix will be skipped
+    runs-on: ubuntu-22.04
+    name: Playwright - Test Results
+    steps:
+      - name: Test status
+        run: echo "Test status is - ${{ needs.Playwright.result }}"
+      - name: Check Playwright matrix status
+        if: ${{ needs.Playwright.result != 'success' && needs.Playwright.result != 'skipped' }}
+        run: exit 1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -53,7 +53,7 @@ jobs:
     name: Playwright test (Performance on) - ${{ matrix.testSuite }} on PHP 7.4
     runs-on: ubuntu-latest
     needs: [build-plugin]
-    if: env.GIT_DIFF
+    if: ${{ needs.file-diff.outputs.changelog_diff.diff }}
     strategy:
       matrix:
         testSuite: ['elements-regression', 'default', 'nested-tabs', 'reverse-columns', 'container']

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
         uses: technote-space/get-diff-action@v6
         with:
           PATTERNS: |
-            **/*
+            **
             !readme.txt
       - name: Install Node.js 18.x
         uses: actions/setup-node@v3

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -55,7 +55,7 @@ jobs:
     name: Playwright test (Performance on) - ${{ matrix.testSuite }} on PHP 7.4
     runs-on: ubuntu-latest
     needs: [build-plugin]
-    if: ${{ needs.file-diff.outputs.changelog_diff }}
+    if: ${{ needs.build-plugin.outputs.changelog_diff }}
     strategy:
       matrix:
         testSuite: ['elements-regression', 'default', 'nested-tabs', 'reverse-columns', 'container']

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -53,7 +53,7 @@ jobs:
     name: Playwright test (Performance on) - ${{ matrix.testSuite }} on PHP 7.4
     runs-on: ubuntu-latest
     needs: [build-plugin]
-    if: ${{ needs.file-diff.outputs.changelog_diff }}
+    if: env.GIT_DIFF
     strategy:
       matrix:
         testSuite: ['elements-regression', 'default', 'nested-tabs', 'reverse-columns', 'container']

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,16 +18,18 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
-      - name: Check If this is only a change log PR
+      - name: Check if this is only a changelog PR
         id: changelog_diff_files
         uses: technote-space/get-diff-action@v6
         with:
+          # PATTERNS are:
+          # Everything: **/*
+          # Everything in directories starting with a period: .*/**/*
+          # Not readme.txt: !readme.txt
           PATTERNS: |
             **/*
-            .github/**/*
-            .grunt-config/**/*
+            .*/**/*
             !readme.txt
-            !.github/workflows/playwright.yml
       - name: Install Node.js 18.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -27,11 +27,24 @@ jobs:
           php-version: 7.4
       - name: Checkout source code
         uses: actions/checkout@v3
+      - name: Check if this is only a changelog PR
+        id: changelog_diff_files
+        uses: technote-space/get-diff-action@v6
+        with:
+          # PATTERNS are:
+          # Everything: **/*
+          # Everything in directories starting with a period: .*/**/*
+          # Not readme.txt: !readme.txt
+          PATTERNS: |
+            **/*
+            .*/**/*
+            !readme.txt
       - name: Install Node.js 18.x
         uses: actions/setup-node@v2
         with:
           node-version: 18.x
       - name: Install Elementor-ScreenShotter
+        if: steps.changelog_diff_files.outputs.diff
         run: | ##### TO DO: Remove all sudo
           sudo ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
           sudo chown -R $USER /usr/local/lib/node_modules
@@ -39,9 +52,11 @@ jobs:
           npm i -g @elementor/screenshotter
           npm i -g grunt-cli
       - name: Install Dependencies
+        if: steps.changelog_diff_files.outputs.diff
         run: |
           elementor-screenshotter-install --config=${screenshotter_config_path} --debug=true
       - name: Prepare Test
+        if: steps.changelog_diff_files.outputs.diff
         run: | # Enable the container experiment & enable import SVG
           cd /tmp/wordpress
           wp elementor experiments activate container
@@ -49,23 +64,25 @@ jobs:
           wp option update elementor_unfiltered_files_upload 1
           wp option update blogdescription 'Just another WordPress site' # WP >= 6.1
       - name: Import Templates
+        if: steps.changelog_diff_files.outputs.diff
         run: |
           elementor-screenshotter-import-templates --config=${screenshotter_config_path} --debug=true
       - name: Build Package & Run Test
+        if: steps.changelog_diff_files.outputs.diff
         run: |
           elementor-screenshotter-run-test --config=${screenshotter_config_path} --debug=true
       - name: Clean up report data
-        if: failure()
+        if: failure() && steps.changelog_diff_files.outputs.diff
         run: |
           npm i canvas@^2.8.0 merge-images@^2.0.0
           node ./.github/scripts/screenshotter-cleanup.js
       - uses: actions/upload-artifact@master
-        if: failure()
+        if: failure() && steps.changelog_diff_files.outputs.diff
         with:
           name: backstop-output
           path: /tmp/wordpress/backstop_data
       - uses: actions/upload-artifact@master
-        if: failure()
+        if: failure() && steps.changelog_diff_files.outputs.diff
         with:
           name: backstop-summary-core
           path: /tmp/merged-screenshots


### PR DESCRIPTION
This PR does 2 things:
* Unify the test results for the Playwright test suites so we can make the test-results job the only mandatory job and stop maintaining the list of mandatory Playwright actions
* Skips test runs when only the change log is modified, making it easier to release a new version