### PR TITLE
Default HTML "section" tag for containers

### DIFF
--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -577,14 +577,13 @@ class Container extends Element_Base {
 			'footer' => 'footer',
 			'main' => 'main',
 			'article' => 'article',
-			'section' => 'section',
 			'aside' => 'aside',
 			'nav' => 'nav',
 			'a' => 'a ' . esc_html__( '(link)', 'elementor' ),
 		];
 
 		$options = [
-			'' => esc_html__( 'Default', 'elementor' ),
+			'section' => esc_html__( 'Default', 'elementor' ),
 		] + $possible_tags;
 
 		$this->add_control(


### PR DESCRIPTION
By default, when adding a container, the HTML tag will be `section`, but it will still be possible to customize it