### PR TITLE
Fix: ARIA `role` attributes in Accordion widget [ED-10711]

### DIFF
--- a/includes/widgets/accordion.php
+++ b/includes/widgets/accordion.php
@@ -546,6 +546,7 @@ class Widget_Accordion extends Widget_Base {
 					'id' => 'elementor-tab-title-' . $id_int . $tab_count,
 					'class' => [ 'elementor-tab-title' ],
 					'data-tab' => $tab_count,
+					'role' => 'button',
 					'aria-controls' => 'elementor-tab-content-' . $id_int . $tab_count,
 					'aria-expanded' => 'false',
 				] );
@@ -636,6 +637,7 @@ class Widget_Accordion extends Widget_Base {
 						'class': [ 'elementor-tab-title' ],
 						'tabindex': tabindex + tabCount,
 						'data-tab': tabCount,
+						'role': 'button',
 						'aria-controls': 'elementor-tab-content-' + tabindex + tabCount,
 						'aria-expanded': 'false',
 					} );


### PR DESCRIPTION
Minor fix to https://github.com/elementor/elementor/pull/22409