### PR TITLE
Fix: Remove focusable title from within toggle/accordion button

### DIFF
--- a/includes/widgets/accordion.php
+++ b/includes/widgets/accordion.php
@@ -598,7 +598,7 @@ class Widget_Accordion extends Widget_Base {
 							<?php } ?>
 							</span>
 						<?php endif; ?>
-						<a class="elementor-accordion-title" tabindex="0"><?php
+						<a class="elementor-accordion-title"><?php
 							$this->print_unescaped_setting( 'tab_title', 'tabs', $index );
 						?></a>
 					</<?php Utils::print_validated_html_tag( $settings['title_html_tag'] ); ?>>
@@ -690,7 +690,7 @@ class Widget_Accordion extends Widget_Base {
 								<# } #>
 							</span>
 							<# } #>
-							<a class="elementor-accordion-title" tabindex="0">{{{ item.tab_title }}}</a>
+							<a class="elementor-accordion-title">{{{ item.tab_title }}}</a>
 						</{{{ titleHTMLTag }}}>
 						<div {{{ view.getRenderAttributeString( tabContentKey ) }}}>{{{ item.tab_content }}}</div>
 					</div>

--- a/includes/widgets/toggle.php
+++ b/includes/widgets/toggle.php
@@ -618,7 +618,7 @@ class Widget_Toggle extends Widget_Base {
 							<?php } ?>
 						</span>
 						<?php endif; ?>
-						<a class="elementor-toggle-title" tabindex="0"><?php $this->print_unescaped_setting( 'tab_title', 'tabs', $index ); ?></a>
+						<a class="elementor-toggle-title"><?php $this->print_unescaped_setting( 'tab_title', 'tabs', $index ); ?></a>
 					</<?php Utils::print_validated_html_tag( $settings['title_html_tag'] ); ?>>
 
 					<div <?php $this->print_render_attribute_string( $tab_content_setting_key ); ?>><?php Utils::print_unescaped_internal_string( $this->parse_text_editor( $item['tab_content'] ) ); ?></div>
@@ -705,7 +705,7 @@ class Widget_Toggle extends Widget_Base {
 								<# } #>
 							</span>
 							<# } #>
-							<a class="elementor-toggle-title" tabindex="0">{{{ item.tab_title }}}</a>
+							<a class="elementor-toggle-title">{{{ item.tab_title }}}</a>
 						</{{{ titleHTMLTag }}}>
 						<div {{{ view.getRenderAttributeString( tabContentKey ) }}}>{{{ item.tab_content }}}</div>
 					</div>


### PR DESCRIPTION
The ARIA button role cannot have focusable content inside of it.

Ref: https://github.com/orgs/elementor/discussions/15524#discussioncomment-6367825

## PR Checklist

- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Remove keyboard focus from implied hidden content in toggle widget

## Description
An explanation of what is done in this PR

* Removes `tabIndex="0"` from `<a>` element inside toggle `<div>` element with `role="button"`. This seems to fix the accessibility issue without negatively impacting the functionality of the widget.

## Test instructions
This PR can be tested by following these steps:

* Create an toggle widget on a page.
* Run an accessibility checker like Siteimprove.
* See if results flag for something like https://help.siteimprove.com/support/solutions/articles/80001058756-accessibility-rule-role-with-implied-hidden-content-has-keyboard-focus-explained as they currently do.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #22977
