### PR TITLE
Tweak: Improve keyboard navigation accessibility for "Icon Box" with a link [ED-11557]

### DIFF
--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -657,10 +657,10 @@ class Widget_Icon_Box extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
+		$has_link = ! empty( $settings['link']['url'] );
+		$html_tag = $has_link ? 'a' : 'span';
 
 		$this->add_render_attribute( 'icon', 'class', [ 'elementor-icon', 'elementor-animation-' . $settings['hover_animation'] ] );
-
-		$icon_tag = 'span';
 
 		if ( ! isset( $settings['icon'] ) && ! Icons_Manager::is_migration_allowed() ) {
 			// add old default
@@ -669,10 +669,9 @@ class Widget_Icon_Box extends Widget_Base {
 
 		$has_icon = ! empty( $settings['icon'] );
 
-		if ( ! empty( $settings['link']['url'] ) ) {
-			$icon_tag = 'a';
-
+		if ( $has_link ) {
 			$this->add_link_attributes( 'link', $settings['link'] );
+			$this->add_render_attribute( 'icon', 'tabindex', '-1' );
 		}
 
 		if ( $has_icon ) {
@@ -694,7 +693,7 @@ class Widget_Icon_Box extends Widget_Base {
 		<div class="elementor-icon-box-wrapper">
 			<?php if ( $has_icon ) : ?>
 			<div class="elementor-icon-box-icon">
-				<<?php Utils::print_validated_html_tag( $icon_tag ); ?> <?php $this->print_render_attribute_string( 'icon' ); ?> <?php $this->print_render_attribute_string( 'link' ); ?>>
+				<<?php Utils::print_validated_html_tag( $html_tag ); ?> <?php $this->print_render_attribute_string( 'link' ); ?> <?php $this->print_render_attribute_string( 'icon' ); ?>>
 				<?php
 				if ( $is_new || $migrated ) {
 					Icons_Manager::render_icon( $settings['selected_icon'], [ 'aria-hidden' => 'true' ] );
@@ -702,14 +701,14 @@ class Widget_Icon_Box extends Widget_Base {
 					?><i <?php $this->print_render_attribute_string( 'i' ); ?>></i><?php
 				}
 				?>
-				</<?php Utils::print_validated_html_tag( $icon_tag ); ?>>
+				</<?php Utils::print_validated_html_tag( $html_tag ); ?>>
 			</div>
 			<?php endif; ?>
 			<div class="elementor-icon-box-content">
 				<<?php Utils::print_validated_html_tag( $settings['title_size'] ); ?> class="elementor-icon-box-title">
-					<<?php Utils::print_validated_html_tag( $icon_tag ); ?> <?php $this->print_render_attribute_string( 'link' ); ?> <?php $this->print_render_attribute_string( 'title_text' ); ?>>
+					<<?php Utils::print_validated_html_tag( $html_tag ); ?> <?php $this->print_render_attribute_string( 'link' ); ?> <?php $this->print_render_attribute_string( 'title_text' ); ?>>
 						<?php $this->print_unescaped_setting( 'title_text' ); ?>
-					</<?php Utils::print_validated_html_tag( $icon_tag ); ?>>
+					</<?php Utils::print_validated_html_tag( $html_tag ); ?>>
 				</<?php Utils::print_validated_html_tag( $settings['title_size'] ); ?>>
 				<?php if ( ! Utils::is_empty( $settings['description_text'] ) ) : ?>
 					<p <?php $this->print_render_attribute_string( 'description_text' ); ?>>
@@ -732,10 +731,17 @@ class Widget_Icon_Box extends Widget_Base {
 	protected function content_template() {
 		?>
 		<#
-		var link = settings.link.url ? 'href="' + settings.link.url + '"' : '',
-			iconTag = link ? 'a' : 'span',
+		var hasLink = settings.link.url,
+			htmlTag = hasLink ? 'a' : 'span',
 			iconHTML = elementor.helpers.renderIcon( view, settings.selected_icon, { 'aria-hidden': true }, 'i' , 'object' ),
 			migrated = elementor.helpers.isIconMigrated( settings, 'selected_icon' );
+
+		view.addRenderAttribute( 'icon', 'class', 'elementor-icon elementor-animation-' + settings.hover_animation );
+
+		if ( hasLink ) {
+			view.addRenderAttribute( 'link', 'href', settings.link.url );
+			view.addRenderAttribute( 'icon', 'tabindex', '-1' );
+		}
 
 		view.addRenderAttribute( 'description_text', 'class', 'elementor-icon-box-description' );
 
@@ -746,19 +752,21 @@ class Widget_Icon_Box extends Widget_Base {
 			<?php // settings.icon is needed for older version ?>
 			<# if ( settings.icon || settings.selected_icon.value ) { #>
 			<div class="elementor-icon-box-icon">
-				<{{{ iconTag + ' ' + link }}} class="elementor-icon elementor-animation-{{ settings.hover_animation }}">
+				<{{{ htmlTag }}} {{{ view.getRenderAttributeString( 'link' ) }}} {{{ view.getRenderAttributeString( 'icon' ) }}}>
 					<# if ( iconHTML && iconHTML.rendered && ( ! settings.icon || migrated ) ) { #>
 						{{{ iconHTML.value }}}
-						<# } else { #>
-							<i class="{{ settings.icon }}" aria-hidden="true"></i>
-						<# } #>
-				</{{{ iconTag }}}>
+					<# } else { #>
+						<i class="{{ settings.icon }}" aria-hidden="true"></i>
+					<# } #>
+				</{{{ htmlTag }}}>
 			</div>
 			<# } #>
 			<div class="elementor-icon-box-content">
 				<# var titleSizeTag = elementor.helpers.validateHTMLTag( settings.title_size ); #>
 				<{{{ titleSizeTag }}} class="elementor-icon-box-title">
-					<{{{ iconTag + ' ' + link }}} {{{ view.getRenderAttributeString( 'title_text' ) }}}>{{{ settings.title_text }}}</{{{ iconTag }}}>
+					<{{{ htmlTag }}} {{{ view.getRenderAttributeString( 'link' ) }}} {{{ view.getRenderAttributeString( 'title_text' ) }}}>
+						{{{ settings.title_text }}}
+					</{{{ htmlTag }}}>
 				</{{{ titleSizeTag }}}>
 				<# if ( settings.description_text ) { #>
 				<p {{{ view.getRenderAttributeString( 'description_text' ) }}}>{{{ settings.description_text }}}</p>


### PR DESCRIPTION
Fixes https://github.com/elementor/elementor/issues/17741

The main part of this PR is to add `tabindex="-1"` to icon links, removing the icon from the tab index when navigating with a keyboard.