### PR TITLE
Fix: Allow ajax requests without 'data' index

### DIFF
--- a/core/common/modules/ajax/module.php
+++ b/core/common/modules/ajax/module.php
@@ -259,13 +259,14 @@ class Module extends BaseModule {
 			],
 		];
 
-		$json = wp_json_encode( $response );
+		$is_testing = Utils::is_elementor_tests();
+		$json       = wp_json_encode( $response );
 
-		while ( ob_get_status() ) {
+		while ( ! $is_testing && ob_get_status() ) {
 			ob_end_clean();
 		}
 
-		if ( function_exists( 'gzencode' ) ) {
+		if ( ! $is_testing && function_exists( 'gzencode' ) ) {
 			$response = gzencode( $json );
 
 			header( 'Content-Type: application/json; charset=utf-8' );

--- a/core/common/modules/ajax/module.php
+++ b/core/common/modules/ajax/module.php
@@ -172,7 +172,7 @@ class Module extends BaseModule {
 			}
 
 			try {
-				$results = call_user_func( $this->ajax_actions[ $action_data['action'] ]['callback'], $action_data['data'], $this );
+				$results = call_user_func( $this->ajax_actions[ $action_data['action'] ]['callback'], $action_data['data'] ?? null, $this );
 
 				if ( false === $results ) {
 					$this->add_response_data( false );

--- a/tests/phpunit/elementor/core/common/modules/ajax/test-ajax-module.php
+++ b/tests/phpunit/elementor/core/common/modules/ajax/test-ajax-module.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Elementor\Core\Common\Modules\Ajax;
+
+use ElementorEditorTesting\Elementor_Test_AJAX;
+use ElementorEditorTesting\Traits\Auth_Helpers;
+use Elementor\Core\Common\Modules\Ajax\Module;
+use Elementor\Plugin;
+
+class Test_Ajax_Module extends Elementor_Test_AJAX {
+
+	use Auth_Helpers;
+
+	public function fill_ajax_params( array $params ) {
+
+		foreach ( $params as $key => $value ) {
+
+			$_POST[ $key ] = $value;
+			$_GET[ $key ]  = $value;
+		}
+
+		$_REQUEST = array_merge( $_POST, $_GET );
+	}
+
+	/**
+	 * Trick:
+	 *
+	 * The Plugin::$instance->common->get_component get the latest instance
+	 * BUT
+	 *
+	 * With the following trick, we can find all instances of the ajax Module class created during the test process.
+	 *
+	 * @return \Generator
+	 */
+	public function find_ajax_module_instances() {
+
+		global $wp_filter;
+
+		foreach ( $wp_filter['wp_ajax_elementor_ajax']->callbacks as $callbacks ) {
+
+			foreach ( $callbacks as $callback ) {
+
+				if ( isset( $callback['function'][0] ) && $callback['function'][0] instanceof Module ) {
+
+					yield $callback['function'][0];
+				}
+			}
+		}
+	}
+
+	/***
+	 * @param $tag
+	 * @param $callable
+	 *
+	 * @return void
+	 */
+	public function register_ajax_action( $tag, $callable = null ) {
+
+		if ( ! $callable ) {
+
+			$callable = static function () {
+
+				return 'correct-response';
+			};
+		}
+
+		$this->setExpectedIncorrectUsage( sprintf( '%s::register_ajax_action', Module::class ) );
+
+		/**
+		 * Trick!
+		 *
+		 * Find all instances and bind the new action to them to prevent 'Action not found' Error.
+		 */
+		foreach ( $this->find_ajax_module_instances() as $instance ) {
+
+			$instance->register_ajax_action( $tag, $callable );
+		}
+	}
+
+
+	public function elementor_ajax_request( $elementor_action ) {
+
+		// Make the request.
+		try {
+
+			$elementor_actions = [ $elementor_action => [ 'action' => $elementor_action ] ];
+			$elementor_actions = json_encode( $elementor_actions );
+
+			$this->fill_ajax_params( [
+				'actions' => $elementor_actions,
+				'_nonce'  => wp_create_nonce( Module::NONCE_KEY ),
+			] );
+
+			$this->_handleAjax( 'elementor_ajax' );
+
+		} catch ( \WPAjaxDieContinueException $error ) {
+
+			unset( $error );
+		} catch ( \WPAjaxDieStopException $error ) {
+			unset( $error );
+		}
+
+		$response_all = json_decode( $this->_last_response, true );
+
+		return $response_all['data']['responses'][ $elementor_action ] ?? $response_all;
+	}
+
+	/**
+	 * If the ajax request does not include the 'data' parameter, the php undefined index error should not occur.
+	 *
+	 * @covers Module::handle_ajax_request()
+	 */
+	public function test_should_handle_undefined_data() {
+
+		$this->act_as_admin();
+		$this->register_ajax_action( 'sample_action' );
+
+		$response = $this->elementor_ajax_request( 'sample_action' );
+		$data     = $response['data'] ?? null;
+
+		$this->assertEquals( 'correct-response', $data, 'Something wrong in ajax request: ' . $data );
+	}
+}


### PR DESCRIPTION
## PR Checklist

- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

When the 'data' parameter isn't sent to an ajax request, do not throw a PHP undefined error.

## Description
An explanation of what is done in this PR

While designing my customer website I ran into a annoying problem.
The following error displayed in Templates -> Theme Builder Page
And with a simple null coalescing operator the problem has been solved.

<img width="307" alt="Screen Shot 2023-08-09 at 8 37 01 PM" src="https://github.com/elementor/elementor/assets/4455418/734434b1-c2c3-4fd1-9389-df46638e04b1">


## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)


