### PR TITLE
Internal: Unmount React empty view in elements [ED-11748]

### DIFF
--- a/assets/dev/js/editor/elements/views/container/empty-view.js
+++ b/assets/dev/js/editor/elements/views/container/empty-view.js
@@ -38,11 +38,13 @@ export default class EmptyView extends Marionette.ItemView {
 		ReactDOM.render( defaultElement, this.el );
 	}
 
-	attachElContent() {
+	onRender() {
 		this.$el.addClass( this.className );
 
-		setTimeout( () => {
-			this.renderReactDefaultElement( this.ownerView.container );
-		} );
+		this.renderReactDefaultElement( this.ownerView.container );
+	}
+
+	onDestroy() {
+		ReactDOM.unmountComponentAtNode( this.el );
 	}
 }

--- a/modules/nested-elements/assets/js/editor/views/add-section-area.js
+++ b/modules/nested-elements/assets/js/editor/views/add-section-area.js
@@ -7,10 +7,6 @@ export default function AddSectionArea( props ) {
 
 	// Make droppable area.
 	useEffect( () => {
-		if ( props.container.view.isDisconnected() ) {
-			return;
-		}
-
 		const $addAreaElementRef = jQuery( addAreaElementRef.current ),
 			defaultDroppableOptions = props.container.view.getDroppableOptions();
 


### PR DESCRIPTION
This PR ensures that the "empty view" components gets removed from the DOM and from React's tree, to avoid zombie elements and memory leaks.

Before:

![image](https://github.com/elementor/elementor/assets/32631382/6f600a4e-ddb7-4fc5-90a2-56bded9c4d82)


After:

![image](https://github.com/elementor/elementor/assets/32631382/7b4cc96a-a47c-4738-b418-9775d6e94b7f)


STR:
- DnD a heading to a container
- Remove the heading
- Repeat multiple times
- Open React devtools
- You'll see many of those zombie components