### PR TITLE
Fix: UI Glitch in widget Style/Advanced tab (#23402) [ED-11956]

### DIFF
--- a/assets/dev/js/editor/views/controls-stack.js
+++ b/assets/dev/js/editor/views/controls-stack.js
@@ -210,9 +210,9 @@ ControlsStack = Marionette.CompositeView.extend( {
 	handlePopovers( view ) {
 		let popover;
 
-		view.popovers = [];
-
 		this.removePopovers( view );
+
+		view.popovers = [];
 
 		view.children.each( ( control ) => {
 			if ( popover ) {
@@ -237,7 +237,7 @@ ControlsStack = Marionette.CompositeView.extend( {
 		} );
 	},
 	removePopovers( view ) {
-		view.popovers.forEach( ( popover ) => popover.destroy() );
+		view.popovers?.forEach( ( popover ) => popover.destroy() );
 	},
 } );
 


### PR DESCRIPTION
We don't delete the popovers properly, so they still exist even when they shouldn't, and it breaks the CSS selectors