### PR TITLE
[FIX] Check settings.link not undefined before calling settings.link.url

### DIFF
--- a/includes/widgets/heading.php
+++ b/includes/widgets/heading.php
@@ -343,7 +343,7 @@ class Widget_Heading extends Widget_Base {
 		<#
 		var title = settings.title;
 
-		if ( '' !== settings.link.url ) {
+		if ( !!settings.link && '' !== settings.link.url ) {
 			title = '<a href="' + settings.link.url + '">' + title + '</a>';
 		}
 

--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -730,7 +730,7 @@ class Widget_Icon_Box extends Widget_Base {
 	protected function content_template() {
 		?>
 		<#
-		var hasLink = settings.link.url,
+		var hasLink = !!settings.link && settings.link.url,
 			htmlTag = hasLink ? 'a' : 'span',
 			iconHTML = elementor.helpers.renderIcon( view, settings.selected_icon, { 'aria-hidden': true }, 'i' , 'object' ),
 			migrated = elementor.helpers.isIconMigrated( settings, 'selected_icon' );

--- a/includes/widgets/icon.php
+++ b/includes/widgets/icon.php
@@ -465,7 +465,7 @@ class Widget_Icon extends Widget_Base {
 	 */
 	protected function content_template() {
 		?>
-		<# const link = settings.link.url ? 'href="' + settings.link.url + '"' : '',
+		<# const link = (!!settings.link && settings.link.url) ? 'href="' + settings.link.url + '"' : '',
 				iconHTML = elementor.helpers.renderIcon( view, settings.selected_icon, { 'aria-hidden': true }, 'i' , 'object' ),
 				migrated = elementor.helpers.isIconMigrated( settings, 'selected_icon' ),
 				iconTag = link ? 'a' : 'div';

--- a/includes/widgets/image-box.php
+++ b/includes/widgets/image-box.php
@@ -680,7 +680,7 @@ class Widget_Image_Box extends Widget_Base {
 
 			var imageHtml = '<img src="' + image_url + '" class="elementor-animation-' + settings.hover_animation + '" />';
 
-			if ( settings.link.url ) {
+			if ( !!settings.link && settings.link.url ) {
 				imageHtml = '<a href="' + settings.link.url + '" tabindex="-1">' + imageHtml + '</a>';
 			}
 
@@ -696,7 +696,7 @@ class Widget_Image_Box extends Widget_Base {
 				var title_html = settings.title_text,
 					titleSizeTag = elementor.helpers.validateHTMLTag( settings.title_size );
 
-				if ( settings.link.url ) {
+				if ( !!settings.link && settings.link.url ) {
 					title_html = '<a href="' + settings.link.url + '">' + title_html + '</a>';
 				}
 

--- a/includes/widgets/image.php
+++ b/includes/widgets/image.php
@@ -795,7 +795,7 @@ class Widget_Image extends Widget_Base {
 
 			var link_url;
 
-			if ( 'custom' === settings.link_to ) {
+			if ( 'custom' === settings.link_to && !!settings.link ) {
 				link_url = settings.link.url;
 			}
 

--- a/includes/widgets/testimonial.php
+++ b/includes/widgets/testimonial.php
@@ -532,7 +532,7 @@ class Widget_Testimonial extends Widget_Base {
 			hasImage = ' elementor-has-image';
 
 			var imageHtml = '<img src="' + imageUrl + '" alt="testimonial" />';
-			if ( settings.link.url ) {
+			if ( !!settings.link && settings.link.url ) {
 				imageHtml = '<a href="' + settings.link.url + '">' + imageHtml + '</a>';
 			}
 		}
@@ -573,7 +573,7 @@ class Widget_Testimonial extends Widget_Base {
 
 			view.addInlineEditingAttributes( 'testimonial_name', 'none' );
 
-			if ( settings.link.url ) {
+			if ( !!settings.link && settings.link.url ) {
 				#>
 				<a href="{{{ settings.link.url }}}" {{{ view.getRenderAttributeString( 'testimonial_name' ) }}}>{{{ settings.testimonial_name }}}</a>
 				<#
@@ -589,7 +589,7 @@ class Widget_Testimonial extends Widget_Base {
 
 			view.addInlineEditingAttributes( 'testimonial_job', 'none' );
 
-			if ( settings.link.url ) {
+			if ( !!settings.link && settings.link.url ) {
 				#>
 				<a href="{{{ settings.link.url }}}" {{{ view.getRenderAttributeString( 'testimonial_job' ) }}}>{{{ settings.testimonial_job }}}</a>
 				<#

--- a/includes/widgets/traits/button-trait.php
+++ b/includes/widgets/traits/button-trait.php
@@ -482,7 +482,7 @@ trait Button_Trait {
 
 		view.addRenderAttribute( 'button', 'class', 'elementor-button' );
 
-		if ( '' !== settings.link.url ) {
+		if ( !!settings.link && '' !== settings.link.url ) {
 			view.addRenderAttribute( 'button', 'href', settings.link.url );
 			view.addRenderAttribute( 'button', 'class', 'elementor-button-link' );
 		} else {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix Elementor not always loading due to some widgets used on page.

## Description
An explanation of what is done in this PR

* Test if the link is empty before calling the link.url

## Test instructions
This PR can be tested by following these steps:

* Insert a button without setting a link

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #

## WARNING:
Elementor team should also fix this bug for the pro widget : animated-headline.php at lines 581 and 611
