### PR TITLE
[FIX] Check if repeaters[this.mode.get('name')] exist before calling …

### DIFF
--- a/assets/dev/js/editor/controls/repeater.js
+++ b/assets/dev/js/editor/controls/repeater.js
@@ -32,7 +32,7 @@ ControlRepeaterItemView = ControlBaseDataView.extend( {
 		const elementContainer = this.getOption( 'container' );
 
 		return {
-			container: elementContainer.repeaters[ this.model.get( 'name' ) ].children[ index ],
+			container: elementContainer.repeaters[ this.model.get( 'name' ) ]?.children[ index ],
 			controlFields: this.model.get( 'fields' ),
 			titleField: this.model.get( 'title_field' ),
 			itemActions: this.model.get( 'item_actions' ),


### PR DESCRIPTION
…children.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix the repeater fields showing empty options

## Description
An explanation of what is done in this PR

* Test if the item is not undefined before calling its children. This cause a js error when the 'title_field' is empty or removed.

## Test instructions
This PR can be tested by following these steps:

* Create a a widget using repeater
* Set a text control with id "text_field" for example
* Add the repeater control with "title_field" => "{{{ text_field }}}
* Insert your widget, remove the first item
* Save and reload
* Edit your repeater widget => You get no option due to a Javascript error

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #
