### PR TITLE
Fix class definition by defining properties in Container class

### DIFF
--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -26,6 +26,8 @@ class Container extends Element_Base {
 	 * @var \Elementor\Core\Kits\Documents\Kit
 	 */
 	private $active_kit;
+	private $logical_dimensions_inline_start;
+	private $logical_dimensions_inline_end;
 
 	/**
 	 * Container constructor.


### PR DESCRIPTION
Fixes #23830 

Errors: 

PHP Deprecated:  Creation of dynamic property Elementor\Includes\Elements\Container::$logical_dimensions_inline_start is deprecated in /wp-content/plugins/elementor/includes/elements/container.php on line 42

PHP Deprecated:  Creation of dynamic property Elementor\Includes\Elements\Container::$logical_dimensions_inline_end is deprecated in /wp-content/plugins/elementor/includes/elements/container.php on line 43

## PR Checklist

- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: PHP 8.2 dynamic property creation is deprecated in container layout.

## Description
An explanation of what is done in this PR

* Fix PHP 8.2 dynamic property creation by defining the properties on the Container class.

## Test instructions
This PR can be tested by following these steps:

* See: https://github.com/elementor/elementor/issues/23830 for replication instructions

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #23830 
