### PR TITLE
Avoid errors caused by third-party Dynamic Tags improperly returning strings

### DIFF
--- a/includes/conditions.php
+++ b/includes/conditions.php
@@ -86,7 +86,7 @@ class Conditions {
 
 				$value = $comparison[ $parsed_name[1] ];
 
-				if ( ! empty( $parsed_name[2] ) ) {
+				if ( ! empty( $parsed_name[2] ) && is_array( $value ) ) {
 					$value = $value[ $parsed_name[2] ];
 				}
 


### PR DESCRIPTION
This change was discussed on [slack](https://dynamicooo.slack.com/archives/C01RUPJ8R2S/p1672759065862169). Feel free to close if not intersted.