### PR TITLE
Prevent PHP 8.1 warnings on null content

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -724,7 +724,7 @@ class Utils {
 	 * @return string
 	 */
 	public static function validate_html_tag( $tag ) {
-		return in_array( strtolower( $tag ), self::ALLOWED_HTML_WRAPPER_TAGS ) ? $tag : 'div';
+		return in_array( strtolower( $tag ?? '' ), self::ALLOWED_HTML_WRAPPER_TAGS ) ? $tag : 'div';
 	}
 
 	/**


### PR DESCRIPTION
Call To action sometimes send null `elementor-pro/modules/call-to-action/widgets/call-to-action.php:1594` here:

```
$description_tag = Utils::validate_html_tag( $settings['description_tag'] );
```

I have no idea if this is a migration gone wrong or there is something else, but on PHP 8.1 it throws:

```
Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/wp-content/plugins/elementor/includes/utils.php on line 727
```

---


## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
