### PR TITLE
Revert "Fix: Editor is slow in Safari and Firefox on WordPress 6.4+ [ED-12794]"[ED-13022]

### DIFF
--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -343,11 +343,6 @@ class Editor {
 
 		$this->get_loader()->register_scripts();
 
-		// Remove polyfill script
-		// See: https://github.com/elementor/elementor/issues/24260
-		$wp_scripts->remove( 'wp-polyfill' );
-		$wp_scripts->add( 'wp-polyfill', '' );
-
 		/**
 		 * Before editor enqueue scripts.
 		 *


### PR DESCRIPTION
Reverts elementor/elementor#24406