### PR TITLE
Fix: Malformed CSS around page header title selector CSS

### DIFF
--- a/core/kits/documents/tabs/settings-layout.php
+++ b/core/kits/documents/tabs/settings-layout.php
@@ -151,8 +151,9 @@ class Settings_Layout extends Tab_Base {
 					'active' => false,
 				],
 				'selectors' => [
-					// Hack to convert the value into a CSS selector.
-					'' => '}{{VALUE}}{display: var(--page-title-display)',
+					// Hack to convert the value into a CSS selector. (The dummy selector will be empty
+					// and have no properties but is required for the CSS to be syntaxically correct.)
+					'.elementor-page-title-dummy-selector' => '}{{VALUE}}{display: var(--page-title-display)',
 				],
 			]
 		);


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fixed erroneous CSS block with no valid selector (created in relation to the 'Page Title Selector' layout setting)

## Description
An explanation of what is done in this PR

* The 'Page Title Selector' setting creates an empty CSS block in order to allow users to specify a CSS selector to use when searching for page titles. A CSS rule set must have a selector followed by a declaration block (per https://www.w3.org/TR/CSS2/syndata.html#rule-sets); hence, this patch adds a dummy selector (`.elementor-page-title-dummy-selector`) that will never be referenced but will satisfy CSS parsing requirements.

## Test instructions
This PR can be tested by following these steps:

* Currently, any Elementor-generated page contains invalid CSS flowing from the 'default kit' styles: see #24852 for examples. Testing is simply a matter of ensuring that `{}` does not appear as a stand-alone CSS block with no selector in the output.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #24852
