### PR TITLE
Fix: Wrong additonal icon classes with custom icon sets

### DIFF
--- a/assets/dev/js/editor/components/icons-manager/classes/icon-library.js
+++ b/assets/dev/js/editor/components/icons-manager/classes/icon-library.js
@@ -34,7 +34,7 @@ export default class {
 					.split( '-' )
 					.join( ' ' ),
 				filter: name.trim( ':' ),
-				displayPrefix: library.displayPrefix || library.prefix.replace( '-', '' ),
+				displayPrefix: library.displayPrefix || '',
 			};
 		} );
 


### PR DESCRIPTION
Fixes #25084

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Custom icon set classes

## Description
An explanation of what is done in this PR

* The backed-in icon sets in Elementor use the `displayPrefix` attribute to set to icon style. Custom icon sets, however, don't have this attribute. For custom icon sets, the code now forces additional (incomplete) class names onto the icon element, using the icon set's prefix. This results in partial, duplicate and wrong class names added to the icon element on the front-end (see #25084 for more detail). This PR fixes that.

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #25084 
