### PR TITLE
Internal: Editor Preview - On disable drop area it affect other previews [ED-14325]

### DIFF
--- a/assets/dev/js/editor/views/preview.js
+++ b/assets/dev/js/editor/views/preview.js
@@ -3,12 +3,12 @@ import AddSectionView from './add-section/independent';
 const BaseSectionsContainerView = require( 'elementor-views/base-sections-container' );
 
 const Preview = BaseSectionsContainerView.extend( {
-	config: {
-		allowEdit: true,
-	},
-
 	initialize() {
 		this.$childViewContainer = jQuery( '<div>', { class: 'elementor-section-wrap' } );
+
+		this.config = {
+			allowEdit: true,
+		};
 
 		BaseSectionsContainerView.prototype.initialize.apply( this, arguments );
 	},


### PR DESCRIPTION
Using `Marionette.CompositeView.extend` to create a class does not result in a truly clean class structure; configuration settings are shared by reference.