### PR TITLE
Fix: The row-reversed direction for containers is not working in mobile portrait [ED-12248] (#23710)

### DIFF
--- a/assets/dev/scss/frontend/_container.scss
+++ b/assets/dev/scss/frontend/_container.scss
@@ -47,6 +47,7 @@
 	z-index: var(--z-index);
 	overflow: var(--overflow);
 	transition: background var(--background-transition, 0.3s), border var(--border-transition, 0.3s), box-shadow var(--border-transition, 0.3s), transform var(--e-con-transform-transition-duration, 0.4s);
+	--flex-wrap-mobile: wrap;
 
 	& {
 		--margin-block-start: var(--margin-top);
@@ -282,6 +283,6 @@
 @media (max-width: $editor-screen-sm-max) {
 	.e-con.e-flex {
 		--width: 100%;
-		--flex-wrap: wrap;
+		--flex-wrap: var(--flex-wrap-mobile);
 	}
 }

--- a/includes/controls/groups/flex-container.php
+++ b/includes/controls/groups/flex-container.php
@@ -50,10 +50,10 @@ class Group_Control_Flex_Container extends Group_Control_Base {
 			// The `--container-widget-width` CSS variable is used for handling widgets that get an undefined width in column mode.
 			// The `--container-widget-flex-grow` CSS variable is used to give certain widgets a default `flex-grow: 1` value for the `flex row` combination.
 			'selectors_dictionary' => [
-				'row' => '--flex-direction: row; --container-widget-width: initial; --container-widget-height: 100%; --container-widget-flex-grow: 1; --container-widget-align-self: stretch;',
-				'column' => '--flex-direction: column; --container-widget-width: 100%; --container-widget-height: initial; --container-widget-flex-grow: 0; --container-widget-align-self: initial;',
-				'row-reverse' => '--flex-direction: row-reverse; --container-widget-width: initial; --container-widget-height: 100%; --container-widget-flex-grow: 1; --container-widget-align-self: stretch;',
-				'column-reverse' => '--flex-direction: column-reverse; --container-widget-width: 100%; --container-widget-height: initial; --container-widget-flex-grow: 0; --container-widget-align-self: initial;',
+				'row' => '--flex-direction: row; --container-widget-width: initial; --container-widget-height: 100%; --container-widget-flex-grow: 1; --container-widget-align-self: stretch; --flex-wrap-mobile: wrap;',
+				'column' => '--flex-direction: column; --container-widget-width: 100%; --container-widget-height: initial; --container-widget-flex-grow: 0; --container-widget-align-self: initial; --flex-wrap-mobile: wrap;',
+				'row-reverse' => '--flex-direction: row-reverse; --container-widget-width: initial; --container-widget-height: 100%; --container-widget-flex-grow: 1; --container-widget-align-self: stretch; --flex-wrap-mobile: wrap-reverse;',
+				'column-reverse' => '--flex-direction: column-reverse; --container-widget-width: 100%; --container-widget-height: initial; --container-widget-flex-grow: 0; --container-widget-align-self: initial; --flex-wrap-mobile: wrap;',
 			],
 			'selectors' => [
 				'{{SELECTOR}}' => '{{VALUE}};',


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->

## Description
The Row-reversed direction for containers is not working in mobile portrait view

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

*




## Quality assurance

- [x] I have tested this code to the best of my abilities
