### PR TITLE
Tweak: Rely on just-in-time translation loading [ED-14578]

### DIFF
--- a/elementor.php
+++ b/elementor.php
@@ -43,27 +43,12 @@ define( 'ELEMENTOR_MODULES_PATH', plugin_dir_path( ELEMENTOR__FILE__ ) . '/modul
 define( 'ELEMENTOR_ASSETS_PATH', ELEMENTOR_PATH . 'assets/' );
 define( 'ELEMENTOR_ASSETS_URL', ELEMENTOR_URL . 'assets/' );
 
-add_action( 'plugins_loaded', 'elementor_load_plugin_textdomain' );
-
 if ( ! version_compare( PHP_VERSION, '7.4', '>=' ) ) {
 	add_action( 'admin_notices', 'elementor_fail_php_version' );
 } elseif ( ! version_compare( get_bloginfo( 'version' ), '6.0', '>=' ) ) {
 	add_action( 'admin_notices', 'elementor_fail_wp_version' );
 } else {
 	require ELEMENTOR_PATH . 'includes/plugin.php';
-}
-
-/**
- * Load Elementor textdomain.
- *
- * Load gettext translate for Elementor text domain.
- *
- * @since 1.0.0
- *
- * @return void
- */
-function elementor_load_plugin_textdomain() {
-	load_plugin_textdomain( 'elementor' );
 }
 
 /**


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Improves the way translations are loaded for the plugin.

## Description
An explanation of what is done in this PR

* Remove manual call to `load_plugin_textdomain()` in favor of leveraging just-in-time translation loading.

## Test instructions
This PR can be tested by following these steps:

* Ensure translations are loaded as expected, especially when the user's locale differs from the site's locale.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #27199
