### PR TITLE
Tweak: Change variations AI image feature to use clipdrop reimagine api [ED-14568]

### DIFF
--- a/modules/ai/assets/js/editor/pages/form-media/views/variations/index.js
+++ b/modules/ai/assets/js/editor/pages/form-media/views/variations/index.js
@@ -3,11 +3,6 @@ import { Stack, Box } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 import View from '../../components/view';
 import ImageForm from '../../components/image-form';
-import ImageStrengthSlider from '../../components/image-strength-slider';
-import PromptField from '../../components/prompt-field';
-import ImageTypeSelect from '../../components/image-type-select';
-import ImageStyleSelect from '../../components/image-style-select';
-import ImageRatioSelect from '../../components/image-ratio-select';
 import GenerateAgainSubmit from '../../components/generate-again-submit';
 import GenerateImagesSubmit from '../../components/generate-images-submit';
 import ImagesDisplay from '../../components/images-display';
@@ -15,17 +10,17 @@ import VariationsPlaceholder from './components/variations-placeholder';
 import useImageToImage from './hooks/use-image-to-image';
 import useImageActions from '../../hooks/use-image-actions';
 import { useEditImage } from '../../context/edit-image-context';
-import usePromptSettings, { IMAGE_STRENGTH, IMAGE_TYPE, IMAGE_STYLE, IMAGE_RATIO } from '../../hooks/use-prompt-settings';
+import usePromptSettings, { IMAGE_RATIO } from '../../hooks/use-prompt-settings';
 import { useRequestIds } from '../../../../context/requests-ids';
 
 const IMAGE_WEIGHT_DEFAULT = 45;
 
 const Variations = () => {
-	const [ prompt, setPrompt ] = useState( '' );
+	const [ prompt ] = useState( '' );
 	const { setGenerate } = useRequestIds();
 	const { editImage, aspectRatio: initialAspectRatio } = useEditImage();
 
-	const { settings, updateSettings } = usePromptSettings( {
+	const { settings } = usePromptSettings( {
 		aspectRatio: initialAspectRatio,
 		imageWeight: IMAGE_WEIGHT_DEFAULT,
 	} );
@@ -72,43 +67,11 @@ const Variations = () => {
 						} } />
 					</Box>
 
-					<ImageStrengthSlider
-						disabled={ isLoading }
-						defaultValue={ IMAGE_WEIGHT_DEFAULT }
-						onChange={ ( event ) => updateSettings( { [ IMAGE_STRENGTH ]: event.target.value } ) }
-					/>
-
-					<PromptField
-						value={ prompt }
-						disabled={ isLoading }
-						placeholder={ __( 'describe your image', 'elementor' ) }
-						onChange={ setPrompt }
-					/>
-
-					<ImageTypeSelect
-						disabled={ isLoading }
-						value={ settings[ IMAGE_TYPE ] }
-						onChange={ ( event ) => updateSettings( { [ IMAGE_TYPE ]: event.target.value } ) }
-					/>
-
-					<ImageStyleSelect
-						type={ settings[ IMAGE_TYPE ] }
-						value={ settings[ IMAGE_STYLE ] }
-						disabled={ isLoading || ( ! settings[ IMAGE_TYPE ] || false ) }
-						onChange={ ( event ) => updateSettings( { [ IMAGE_STYLE ]: event.target.value } ) }
-					/>
-
-					<ImageRatioSelect
-						disabled={ isLoading }
-						value={ settings[ IMAGE_RATIO ] }
-						onChange={ ( event ) => updateSettings( { [ IMAGE_RATIO ]: event.target.value } ) }
-					/>
-
 					<Stack gap={ 2 } sx={ { my: 2.5 } }>
 						{
 							data?.result?.length > 0
-								? <GenerateAgainSubmit disabled={ isLoading || '' === prompt } />
-								: <GenerateImagesSubmit disabled={ isLoading || '' === prompt } />
+								? <GenerateAgainSubmit disabled={ isLoading } />
+								: <GenerateImagesSubmit disabled={ isLoading } />
 						}
 					</Stack>
 				</ImageForm>

--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -508,10 +508,6 @@ class Module extends BaseModule {
 
 		$app = $this->get_ai_app();
 
-		if ( empty( $data['payload']['prompt'] ) ) {
-			throw new \Exception( 'Missing prompt' );
-		}
-
 		if ( empty( $data['payload']['image'] ) || empty( $data['payload']['image']['id'] ) ) {
 			throw new \Exception( 'Missing Image' );
 		}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Change variations AI image feature to use clipdrop reimagine api

## Description
- remove all the form fields that aren't used in the new clipdrop api
- delete prompt field validation
- related pr - https://github.com/elementor/elementor-ai-api/pull/722
![image](https://github.com/elementor/elementor/assets/58907447/53d10cc2-957e-4972-9922-aea37ad726a8)

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
