### PR TITLE
Tweak: Change expand image AI feature to use Clipdrop uncrop [ED-14685]

### DIFF
--- a/modules/ai/assets/js/editor/pages/form-media/views/out-painting/index.js
+++ b/modules/ai/assets/js/editor/pages/form-media/views/out-painting/index.js
@@ -6,8 +6,6 @@ import ImageForm from '../../components/image-form';
 import ImageRatioSelect from '../../components/image-ratio-select';
 import GenerateSubmit from '../../components/generate-submit';
 import GenerateAgainSubmit from '../../components/generate-again-submit';
-import NewPromptButton from '../../components/new-prompt-button';
-import PromptField from '../../components/prompt-field';
 import OutPaintingContent from './out-painting-content';
 import ImagesDisplay from '../../components/images-display';
 import { useEditImage } from '../../context/edit-image-context';
@@ -17,31 +15,23 @@ import useOutPainting from './hooks/use-out-painting';
 import { useRequestIds } from '../../../../context/requests-ids';
 
 const OutPainting = () => {
-	const [ prompt, setPrompt ] = useState( '' );
-	const { setGenerate } = useRequestIds();
-	const { editImage, aspectRatio: initialAspectRatio } = useEditImage();
-
+	const [ imageSize, setImageSize ] = useState( { width: 0, height: 0 } );
+	const [ position, setPosition ] = useState( { x: 0.5, y: 0.5 } );
 	const [ mask, setMask ] = useState( '' );
 
-	const { settings, updateSettings, resetSettings } = usePromptSettings( { aspectRatio: initialAspectRatio } );
-
+	const { setGenerate } = useRequestIds();
+	const { editImage, aspectRatio: initialAspectRatio } = useEditImage();
+	const { settings, updateSettings } = usePromptSettings( { aspectRatio: initialAspectRatio } );
 	const { use, edit, isLoading: isUploading } = useImageActions();
-
-	const { data, send, isLoading: isGenerating, error, reset } = useOutPainting();
-
+	const { data, send, isLoading: isGenerating, error } = useOutPainting();
 	const isLoading = isGenerating || isUploading;
-
 	const generatedAspectRatio = useMemo( () => settings[ IMAGE_RATIO ], [ data?.result ] );
-
 	const hasGeneratedResult = !! data?.result;
 
 	const handleSubmit = ( event ) => {
 		event.preventDefault();
-
-		// The fallback instruction should be hidden for the user.
-		const finalPrompt = prompt || 'Fill based on the surroundings';
 		setGenerate();
-		send( { prompt: finalPrompt, settings, image: editImage, mask } );
+		send( { settings, image: editImage, mask, size: imageSize, position } );
 	};
 
 	return (
@@ -68,7 +58,7 @@ const OutPainting = () => {
 							marks
 							id="zoom"
 							name="zoom"
-							max={ 2 }
+							max={ 1 }
 							min={ 0.1 }
 							step={ 0.1 }
 							color="secondary"
@@ -85,23 +75,10 @@ const OutPainting = () => {
 						</Typography>
 					</FormControl>
 
-					<PromptField
-						value={ prompt }
-						disabled={ isLoading }
-						onChange={ setPrompt }
-						placeholder={ __( 'Describe what you want to generate in the expended area (English only)', 'elementor' ) }
-					/>
-
 					{
 						data?.result ? (
 							<Stack gap={ 2 } sx={ { my: 2.5 } }>
 								<GenerateAgainSubmit disabled={ isLoading } />
-
-								<NewPromptButton disabled={ isLoading } onClick={ () => {
-									resetSettings();
-									setPrompt( '' );
-									reset();
-								} } />
 							</Stack>
 						) : (
 							<GenerateSubmit disabled={ isLoading } />
@@ -125,6 +102,8 @@ const OutPainting = () => {
 							editImage={ editImage }
 							scale={ settings[ IMAGE_ZOOM ] }
 							aspectRatio={ settings[ IMAGE_RATIO ] }
+							setImageSize={ setImageSize }
+							setPosition={ setPosition }
 						/>
 					)
 				}

--- a/modules/ai/assets/js/editor/pages/form-media/views/out-painting/index.js
+++ b/modules/ai/assets/js/editor/pages/form-media/views/out-painting/index.js
@@ -18,7 +18,6 @@ const OutPainting = () => {
 	const [ imageSize, setImageSize ] = useState( { width: 0, height: 0 } );
 	const [ position, setPosition ] = useState( { x: 0.5, y: 0.5 } );
 	const [ mask, setMask ] = useState( '' );
-
 	const { setGenerate } = useRequestIds();
 	const { editImage, aspectRatio: initialAspectRatio } = useEditImage();
 	const { settings, updateSettings } = usePromptSettings( { aspectRatio: initialAspectRatio } );

--- a/modules/ai/assets/js/editor/pages/form-media/views/out-painting/out-painting-content.js
+++ b/modules/ai/assets/js/editor/pages/form-media/views/out-painting/out-painting-content.js
@@ -9,16 +9,30 @@ const OutPaintingContent = ( {
 	setMask,
 	editImage,
 	aspectRatio,
+	setImageSize,
+	setPosition,
 } ) => {
 	const cropperRef = useRef();
-
+	const position = useRef( { x: 0.5, y: 0.5 } );
 	const { width, height } = useImageSize( aspectRatio );
+	let imageSize = { width, height };
 
 	const updateMask = async () => {
 		const imageDataURL = await cropperRef.current.getImageScaledToCanvas().toDataURL();
 		setMask( imageDataURL );
 	};
 
+	const onPositionChange = async ( args ) => {
+		position.current = { x: args.x, y: args.y };
+		await updateMask();
+		setPosition( position.current );
+	};
+
+	const onImageChange = async () => {
+		imageSize = { width: imageSize.width * scale, height: imageSize.height * scale };
+		await updateMask();
+		setImageSize( imageSize );
+	};
 	return (
 		<Stack alignItems={ 'center' } spacing={ 0.5 } flexGrow={ 1 }>
 			<AvatarEditor
@@ -37,8 +51,8 @@ const OutPaintingContent = ( {
 				allowZoomOut={ true }
 				backgroundColor={ 'transparent' }
 				showGrid={ true }
-				onImageChange={ () => updateMask() }
-				onPositionChange={ () => updateMask() }
+				onImageChange={ onImageChange }
+				onPositionChange={ ( args ) => onPositionChange( args ) }
 				{ ... {
 					width,
 					height,
@@ -54,6 +68,8 @@ OutPaintingContent.propTypes = {
 	setMask: PropTypes.func.isRequired,
 	editImage: PropTypes.object.isRequired,
 	aspectRatio: PropTypes.string.isRequired,
+	setImageSize: PropTypes.func.isRequired,
+	setPosition: PropTypes.func.isRequired,
 };
 
 export default OutPaintingContent;

--- a/modules/ai/connect/ai.php
+++ b/modules/ai/connect/ai.php
@@ -453,12 +453,14 @@ class Ai extends Library {
 			'POST',
 			'image/image-to-image/outpainting',
 			[
-				self::PROMPT => $image_data[ self::PROMPT ],
-				self::IMAGE_TYPE => '',
 				'context' => wp_json_encode( $context ),
 				'ids' => $request_ids,
 				'api_version' => ELEMENTOR_VERSION,
 				'site_lang' => get_bloginfo( 'language' ),
+				'size' => wp_json_encode( $image_data['size'] ),
+				'position' => wp_json_encode( $image_data['position'] ),
+				'image_url' => $image_data['image_url'],
+				$image_data['image'],
 			],
 			[
 				[

--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -682,10 +682,6 @@ class Module extends BaseModule {
 
 		$app = $this->get_ai_app();
 
-		if ( empty( $data['payload']['prompt'] ) ) {
-			throw new \Exception( 'Missing prompt' );
-		}
-
 		if ( ! $app->is_connected() ) {
 			throw new \Exception( 'not_connected' );
 		}
@@ -697,8 +693,10 @@ class Module extends BaseModule {
 		$context = $this->get_request_context( $data );
 		$request_ids = $this->get_request_ids( $data['payload'] );
 		$result = $app->get_image_to_image_out_painting( [
-			'prompt' => $data['payload']['prompt'],
+			'size' => $data['payload']['size'],
+			'position' => $data['payload']['position'],
 			'mask' => $data['payload']['mask'],
+			'image_url' => $data['payload']['image']['url'],
 		], $context, $request_ids );
 
 		$this->throw_on_error( $result );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Update expand image AI feature to use Clipdrop uncrop API

## Description

* remove the prompt field from the expand image view as it's not needed
* decrease the max scale to 1 to only allow expanding the image
* add two callbacks from the `OutPaintingContent` to get the image size and position
* pass position, size and image_url to the ai-api

![image](https://github.com/elementor/elementor/assets/58907447/d875406f-c708-48be-8b36-83cc67259053)

https://github.com/elementor/elementor-ai-api/pull/750

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
