### PR TITLE
Tweak: Change Generative Fill AI image feature to use Clipdrop text-inpainting [ED-14707]

### DIFF
--- a/modules/ai/assets/js/editor/pages/form-media/views/in-painting/in-painting-content.js
+++ b/modules/ai/assets/js/editor/pages/form-media/views/in-painting/in-painting-content.js
@@ -21,7 +21,8 @@ import RedoIcon from '../../../../icons/redo-icon';
 
 const STROKE_SELECT_WIDTH = 120;
 
-const BRUSH_COLOR = 'rgba(0, 0, 0, 0.75)';
+const BRUSH_COLOR = 'rgba(255, 255, 255)';
+const CANVAS_COLOR = 'rgba(0, 0, 0)';
 
 const StyledUndoIcon = withDirection( UndoIcon );
 const StyledRedoIcon = withDirection( RedoIcon );
@@ -153,6 +154,7 @@ const InPaintingContent = ( { editImage, setMask, width: canvasWidth, height: ca
 					width={ canvasWidth + 'px' }
 					strokeWidth={ stroke }
 					strokeColor={ BRUSH_COLOR }
+					canvasColor={ CANVAS_COLOR }
 					backgroundImage={ editImage.url }
 					onChange={ async () => {
 						const svg = await sketchRef.current.exportSvg();

--- a/modules/ai/connect/ai.php
+++ b/modules/ai/connect/ai.php
@@ -498,12 +498,11 @@ class Ai extends Library {
 			'image/image-to-image/inpainting',
 			[
 				self::PROMPT => $image_data[ self::PROMPT ],
-				self::IMAGE_TYPE => $image_data['promptSettings'][ self::IMAGE_TYPE ] . '/' . $image_data['promptSettings'][ self::STYLE_PRESET ],
-				self::IMAGE_STRENGTH => $image_data['promptSettings'][ self::IMAGE_STRENGTH ],
 				'context' => wp_json_encode( $context ),
 				'ids' => $request_ids,
 				'api_version' => ELEMENTOR_VERSION,
 				'site_lang' => get_bloginfo( 'language' ),
+				'image_url' => $image_data['image_url'],
 			],
 			[
 				[

--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -664,9 +664,9 @@ class Module extends BaseModule {
 
 		$result = $app->get_image_to_image_mask( [
 			'prompt' => $data['payload']['prompt'],
-			'promptSettings' => $data['payload']['settings'],
 			'attachment_id' => $data['payload']['image']['id'],
 			'mask' => $data['payload']['mask'],
+			'image_url' => $data['payload']['image']['url'],
 		], $context, $request_ids );
 
 		$this->throw_on_error( $result );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

Tweak: Change Generative Fill AI image feature to use Clipdrop text-inpainting

## Description
- replace canvas colors to output a black background and white on the painting area according to clipdrop's API 
![image](https://github.com/elementor/elementor/assets/58907447/74bc0cde-2a08-42d6-a607-087aebd79413)
- add image URL to extract the original image
- remove redundant params


## Test instructions
This PR can be tested by following these steps:

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
