### PR TITLE
Fix: Links to Elementor settings are broken [ED-14577]

### DIFF
--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -6,6 +6,7 @@ use Elementor\Core\Admin\UI\Components\Button;
 use Elementor\Core\Base\Module;
 use Elementor\Core\Utils\Promotions\Filtered_Promotions_Manager;
 use Elementor\Plugin;
+use Elementor\Settings;
 use Elementor\Tracker;
 use Elementor\User;
 use Elementor\Utils;
@@ -363,7 +364,7 @@ class Admin_Notices extends Module {
 			'id' => $notice_id,
 			'button' => [
 				'text' => esc_html__( 'Try it out', 'elementor' ),
-				'url' => admin_url( 'admin.php?page=elementor#tab-experiments' ),
+				'url' => Settings::get_settings_tab_url( 'experiments' ),
 				'type' => 'cta',
 			],
 			'button_secondary' => [

--- a/core/common/modules/finder/categories/settings.php
+++ b/core/common/modules/finder/categories/settings.php
@@ -44,27 +44,25 @@ class Settings extends Base_Category {
 	 * @return array
 	 */
 	public function get_category_items( array $options = [] ) {
-		$settings_url = ElementorSettings::get_url();
-
 		return [
 			'general-settings' => [
 				'title' => esc_html__( 'General Settings', 'elementor' ),
-				'url' => $settings_url,
+				'url' => ElementorSettings::get_settings_tab_url( 'general' ),
 				'keywords' => [ 'general', 'settings', 'elementor' ],
 			],
 			'advanced' => [
 				'title' => esc_html__( 'Advanced', 'elementor' ),
-				'url' => $settings_url . '#tab-advanced',
+				'url' => ElementorSettings::get_settings_tab_url( 'advanced' ),
 				'keywords' => [ 'advanced', 'settings', 'elementor' ],
 			],
 			'experiments' => [
 				'title' => esc_html__( 'Experiments', 'elementor' ),
-				'url' => $settings_url . '#tab-experiments',
+				'url' => ElementorSettings::get_settings_tab_url( 'experiments' ),
 				'keywords' => [ 'settings', 'elementor', 'experiments' ],
 			],
 			'features' => [
 				'title' => esc_html__( 'Features', 'elementor' ),
-				'url' => $settings_url . '#tab-experiments',
+				'url' => ElementorSettings::get_settings_tab_url( 'experiments' ),
 				'keywords' => [ 'settings', 'elementor', 'features' ],
 			],
 			'element-manager' => [

--- a/core/experiments/manager.php
+++ b/core/experiments/manager.php
@@ -138,7 +138,7 @@ class Manager extends Base_Object {
 					$message = sprintf(
 						'<p>%s</p><p><a href="#" onclick="location.href=\'%s\'">%s</a></p>',
 						esc_html( $e->getMessage() ),
-						site_url( 'wp-admin/admin.php?page=elementor#tab-experiments' ),
+						Settings::get_settings_tab_url( 'experiments' ),
 						esc_html__( 'Back', 'elementor' )
 					);
 

--- a/includes/settings/settings-page.php
+++ b/includes/settings/settings-page.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elementor;
 
+use Elementor\Plugin;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -67,6 +69,27 @@ abstract class Settings_Page {
 	 */
 	final public static function get_url() {
 		return admin_url( 'admin.php?page=' . static::PAGE_ID );
+	}
+
+	/**
+	 * Get settings tab URL.
+	 *
+	 * Retrieve the URL of a specific tab in the settings page.
+	 *
+	 * @since 3.23.0
+	 * @access public
+	 * @static
+	 *
+	 * @param string $tab_id The ID of the settings tab.
+	 *
+	 * @return string Settings tab URL.
+	 */
+	final public static function get_settings_tab_url( $tab_id ): string {
+		$settings_page_id = Plugin::$instance->experiments->is_feature_active( 'home_screen' )
+			? 'elementor-settings'
+			: 'elementor';
+
+		return admin_url( "admin.php?page=$settings_page_id#tab-$tab_id" );
 	}
 
 	/**

--- a/includes/widgets/google-maps.php
+++ b/includes/widgets/google-maps.php
@@ -120,7 +120,7 @@ class Widget_Google_Maps extends Widget_Base {
 						'content' => sprintf(
 							/* translators: 1: Integration settings link open tag, 2: Create API key link open tag, 3: Link close tag. */
 							esc_html__( 'Set your Google Maps API Key in Elementor\'s %1$sIntegrations Settings%3$s page. Create your key %2$shere.%3$s', 'elementor' ),
-							'<a href="' . Settings::get_url() . '#tab-integrations" target="_blank">',
+							'<a href="' . Settings::get_settings_tab_url( 'integrations' ) . '" target="_blank">',
 							'<a href="https://developers.google.com/maps/documentation/embed/get-api-key" target="_blank">',
 							'</a>'
 						),

--- a/tests/phpunit/elementor/core/experiments/test-manager.php
+++ b/tests/phpunit/elementor/core/experiments/test-manager.php
@@ -551,7 +551,7 @@ class Test_Manager extends Elementor_Test_Base {
 
 		// Assert.
 		$this->expectException( \WPDieException::class );
-		$this->expectExceptionMessage( '<p>The feature `module-a` has a dependency `module-b` that is not available.</p><p><a href="#" onclick="location.href=\'http://example.org/wp-admin/admin.php?page=elementor#tab-experiments\'">Back</a></p>' );
+		$this->expectExceptionMessage( '<p>The feature `module-a` has a dependency `module-b` that is not available.</p><p><a href="#" onclick="location.href=\'http://example.org/wp-admin/admin.php?page=elementor-settings#tab-experiments\'">Back</a></p>' );
 
 		// Act.
 		update_option(
@@ -581,7 +581,7 @@ class Test_Manager extends Elementor_Test_Base {
 
 		// Assert.
 		$this->expectException( \WPDieException::class );
-		$this->expectExceptionMessage( '<p>To turn on `module-a`, Experiment: `module-b` activity is required!</p><p><a href="#" onclick="location.href=\'http://example.org/wp-admin/admin.php?page=elementor#tab-experiments\'">Back</a></p>' );
+		$this->expectExceptionMessage( '<p>To turn on `module-a`, Experiment: `module-b` activity is required!</p><p><a href="#" onclick="location.href=\'http://example.org/wp-admin/admin.php?page=elementor-settings#tab-experiments\'">Back</a></p>' );
 
 		// Act.
 		update_option(

--- a/tests/qunit/mock/elments/form.json
+++ b/tests/qunit/mock/elments/form.json
@@ -1442,7 +1442,7 @@
 				"mailchimp_api_key_source": "default"
 			},
 			"section": "section_mailchimp",
-			"raw": "Set your MailChimp API Key in the <a href=\"http://localhost/elementor/wp-admin/admin.php?page=elementor#tab-integrations\" target=\"_blank\">Integrations Settings</a>. You can also set a different MailChimp API Key by choosing \"Custom\".",
+			"raw": "Set your MailChimp API Key in the <a href=\"http://localhost/elementor/wp-admin/admin.php?page=elementor-settings#tab-integrations\" target=\"_blank\">Integrations Settings</a>. You can also set a different MailChimp API Key by choosing \"Custom\".",
 			"content_classes": "elementor-panel-alert elementor-panel-alert-danger",
 			"name": "mailchimp_api_key_msg"
 		},
@@ -1571,7 +1571,7 @@
 				"drip_api_token_source": "default"
 			},
 			"section": "section_drip",
-			"raw": "Set your Drip API Token in the <a href=\"http://localhost/elementor/wp-admin/admin.php?page=elementor#tab-integrations\" target=\"_blank\">Integrations Settings</a>. You can also set a different Drip API Token by choosing \"Custom\".",
+			"raw": "Set your Drip API Token in the <a href=\"http://localhost/elementor/wp-admin/admin.php?page=elementor-settings#tab-integrations\" target=\"_blank\">Integrations Settings</a>. You can also set a different Drip API Token by choosing \"Custom\".",
 			"content_classes": "elementor-panel-alert elementor-panel-alert-danger",
 			"name": "drip_api_key_msg"
 		},
@@ -1709,7 +1709,7 @@
 				"activecampaign_api_credentials_source": "default"
 			},
 			"section": "section_activecampaign",
-			"raw": "Set your ActiveCampaign API credentials in the <a href=\"http://localhost/elementor/wp-admin/admin.php?page=elementor#tab-integrations\" target=\"_blank\">Integrations Settings</a>. You can also set a different ActiveCampaign API credentials by choosing \"Custom\".",
+			"raw": "Set your ActiveCampaign API credentials in the <a href=\"http://localhost/elementor/wp-admin/admin.php?page=elementor-settings#tab-integrations\" target=\"_blank\">Integrations Settings</a>. You can also set a different ActiveCampaign API credentials by choosing \"Custom\".",
 			"content_classes": "elementor-panel-alert elementor-panel-alert-danger",
 			"name": "activecampaign_api_key_msg"
 		},
@@ -1846,7 +1846,7 @@
 				"getresponse_api_key_source": "default"
 			},
 			"section": "section_getresponse",
-			"raw": "Set your GetResponse API key in the <a href=\"http://localhost/elementor/wp-admin/admin.php?page=elementor#tab-integrations\" target=\"_blank\">Integrations Settings</a>. You can also set a different GetResponse API key by choosing \"Custom\".",
+			"raw": "Set your GetResponse API key in the <a href=\"http://localhost/elementor/wp-admin/admin.php?page=elementor-settings#tab-integrations\" target=\"_blank\">Integrations Settings</a>. You can also set a different GetResponse API key by choosing \"Custom\".",
 			"content_classes": "elementor-panel-alert elementor-panel-alert-danger",
 			"name": "getresponse_api_key_msg"
 		},
@@ -1960,7 +1960,7 @@
 				"convertkit_api_key_source": "default"
 			},
 			"section": "section_convertkit",
-			"raw": "Set your ConvertKit API key in the <a href=\"http://localhost/elementor/wp-admin/admin.php?page=elementor#tab-integrations\" target=\"_blank\">Integrations Settings</a>. You can also set a different ConvertKit API key by choosing \"Custom\".",
+			"raw": "Set your ConvertKit API key in the <a href=\"http://localhost/elementor/wp-admin/admin.php?page=elementor-settings#tab-integrations\" target=\"_blank\">Integrations Settings</a>. You can also set a different ConvertKit API key by choosing \"Custom\".",
 			"content_classes": "elementor-panel-alert elementor-panel-alert-danger",
 			"name": "convertkit_api_key_msg"
 		},
@@ -2077,7 +2077,7 @@
 				"mailerlite_api_key_source": "default"
 			},
 			"section": "section_mailerlite",
-			"raw": "Set your MailerLite API Key in the <a href=\"http://localhost/elementor/wp-admin/admin.php?page=elementor#tab-integrations\" target=\"_blank\">Integrations Settings</a>. You can also set a different MailerLite API Key by choosing \"Custom\".",
+			"raw": "Set your MailerLite API Key in the <a href=\"http://localhost/elementor/wp-admin/admin.php?page=elementor-settings#tab-integrations\" target=\"_blank\">Integrations Settings</a>. You can also set a different MailerLite API Key by choosing \"Custom\".",
 			"content_classes": "elementor-panel-alert elementor-panel-alert-danger",
 			"name": "mailerlite_api_key_msg"
 		},


### PR DESCRIPTION
Elementor should not use hardcoded links to settings pages as the URL is based on the experiment.

Therefor, all the links should use generic function that returns the correct URL for the specific settings page tab.