### PR TITLE
Fix: The "What s New" string in the Editor is not translatable [ED-14985]

### DIFF
--- a/modules/notifications/module.php
+++ b/modules/notifications/module.php
@@ -39,6 +39,8 @@ class Module extends BaseModule {
 				'elementorNotifications',
 				$this->get_app_js_config()
 			);
+
+			wp_set_script_translations( 'e-editor-notifications', 'elementor' );
 		}, 5 /* Before Elementor's admin enqueue scripts */ );
 
 		add_action( 'elementor/editor/v2/scripts/enqueue', [ $this, 'enqueue_editor_scripts' ] );
@@ -75,6 +77,8 @@ class Module extends BaseModule {
 			'elementorNotifications',
 			$this->get_app_js_config()
 		);
+
+		wp_set_script_translations( 'e-editor-notifications', 'elementor' );
 	}
 
 	private function get_app_js_config() : array {


### PR DESCRIPTION
Hello @rami-elementor 

Fix: The "What s New" string in the Editor is not translatable [ED-14985] for 3.22

[ED-14985]: https://elementor.atlassian.net/browse/ED-14985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ