### PR TITLE
Fix: Image Generation & Edit triggering from WP media library [ED-15079]

### DIFF
--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -103,7 +103,9 @@ class Module extends BaseModule {
 			}
 		} );
 
-		add_action( 'wp_enqueue_media', [ $this, 'enqueue_ai_media_library' ] );
+		if ( is_admin() ) {
+			add_action( 'wp_enqueue_media', [ $this, 'enqueue_ai_media_library' ] );
+		}
 
 		add_action( 'enqueue_block_editor_assets', function() {
 			wp_enqueue_script( 'elementor-ai-gutenberg',


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

Ensure that Elementor AI will work on the Media Library only in the Admin Dashboard

## Description
Some plugins seem to be doing something wrong, and they are running the WP media library popup on the visitors side (the website, instead of the admin dashboard).
It caused Elementor AI to run too, but Elementor AI was not designed to work on the visitors side.
So, we added a condition to ensure that Elementor AI will work on the Media Library only in the Admin Dashboard, even when a plugin runs it on the visitors side.

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
