### PR TITLE
Fix: Refresh the media library after inserting an edited image [ED-15035]

### DIFF
--- a/modules/ai/assets/js/media-library/edit-button.js
+++ b/modules/ai/assets/js/media-library/edit-button.js
@@ -40,7 +40,7 @@ const AIMediaEditAppButtonWrapper = () => {
 	};
 
 	const handleClose = () => {
-		wp.media.frame?.content?.get().collection?._requery( true ); // Refresh the media library
+		wp.media.frame?.controller?.content?.get( 'gallery' )?.collection?._requery( true ); // Refresh the media library
 		setIsOpen( false );
 	};
 

--- a/modules/ai/assets/js/media-library/edit-button.js
+++ b/modules/ai/assets/js/media-library/edit-button.js
@@ -40,7 +40,7 @@ const AIMediaEditAppButtonWrapper = () => {
 	};
 
 	const handleClose = () => {
-		wp.media.frame?.controller?.content?.get( 'gallery' )?.collection?._requery( true ); // Refresh the media library
+		wp.media.frame?.controller?.content?.get().collection?._requery( true ); // Refresh the media library
 		setIsOpen( false );
 	};
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

Fix: Refresh the media library after inserting an edited image

## Description
The gallery view in WordPress media library sometimes switches modes unexpectedly, causing the collection of images to become undefined, using this command in the attachment details view we can query and refresh the media library items.

https://github.com/elementor/elementor/assets/58907447/2161ec01-0452-462a-ba6b-d9d52e18674e


## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #


[ED-15035]: https://elementor.atlassian.net/browse/ED-15035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ