### PR TITLE
Internal: Disable addons-for-elementor from plugin tester

### DIFF
--- a/tests/playwright/sanity/plugin-tester-generator.ts
+++ b/tests/playwright/sanity/plugin-tester-generator.ts
@@ -13,7 +13,9 @@ const pluginList: { pluginName: string, installByAPI: boolean }[] = [
 	{ pluginName: 'bdthemes-prime-slider-lite', installByAPI: true },
 	{ pluginName: 'wunderwp', installByAPI: true },
 	{ pluginName: 'addon-elements-for-elementor-page-builder', installByAPI: true },
-	{ pluginName: 'addons-for-elementor', installByAPI: true },
+	// Addons for elementor is closed as of July 2, 2024 and is not available for download. This closure is temporary, pending a full review.
+	// see: https://wordpress.org/plugins/addons-for-elementor/
+	// { pluginName: 'addons-for-elementor', installByAPI: true },
 	{ pluginName: 'anywhere-elementor', installByAPI: true },
 	{ pluginName: 'astra-sites', installByAPI: true },
 	{ pluginName: 'connect-polylang-elementor', installByAPI: true },


### PR DESCRIPTION
See: https://wordpress.org/plugins/addons-for-elementor/
<img width="766" alt="image" src="https://github.com/elementor/elementor-pro/assets/83912471/b66defb5-744e-454c-8931-520932a616be">
