### PR TITLE
Internal: Remove the container padding from floating buttons widget - [ED-15203]

### DIFF
--- a/modules/floating-buttons/assets/scss/widgets/contact-buttons.scss
+++ b/modules/floating-buttons/assets/scss/widgets/contact-buttons.scss
@@ -677,6 +677,13 @@
 	}
 }
 
+.elementor-location-floating_buttons {
+
+	& .e-con-inner {
+		padding: 0;
+	}
+}
+
 @keyframes e-contact-buttons-typing-jump {
 	0% {
 		bottom: 0px;


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Remove default container padding on floating buttons widget

## Description
An explanation of what is done in this PR

* Add CSS rule to remove default container padding on floating buttons widget

## Test instructions
This PR can be tested by following these steps:

* Add Floating Buttons template and display it on a page
* The Floating Button template should not produce 20px empty space below the footer.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
