### PR TITLE
Fix: AI User consent modal is being loaded after the request has been…

### DIFF
--- a/modules/ai/assets/js/editor/ai-excerpt.js
+++ b/modules/ai/assets/js/editor/ai-excerpt.js
@@ -17,12 +17,12 @@ const AIExcerpt = ( { onClose, currExcerpt, updateExcerpt, postTextualContent } 
 		credits,
 		usagePercentage,
 	} = useUserInfo( true );
-	const { data: newExcerpt, isLoading: isLoadingExcerpt, error, send } = useExcerptPrompt( {
+	const { data: newExcerpt, error, send } = useExcerptPrompt( {
 		result: currExcerpt,
 		credits,
 	} );
 	const generateExcerptOnce = useRef( false );
-	const [isLoadingCombined, setIsLoadingCombined] = useState( true );
+	const [isLoadingCombined, setIsLoadingCombined ] = useState( true );
 	const initHook = () => ( {
 		isLoading: isLoadingCombined,
 		isConnected,

--- a/modules/ai/assets/js/editor/ai-excerpt.js
+++ b/modules/ai/assets/js/editor/ai-excerpt.js
@@ -33,7 +33,7 @@ const AIExcerpt = ( { onClose, currExcerpt, updateExcerpt, postTextualContent } 
 	}, [ initialUsagePercentage, isInitUsageDone, updateUsagePercentage ] );
 
 	const generateExcerptOnce = useRef( false );
-  const [isLoadingCombined, setIsLoadingCombined ] = useState( true );
+	const [ isLoadingCombined, setIsLoadingCombined ] = useState( true );
 	const initHook = () => ( {
 		isLoading: isLoadingCombined,
 		isConnected,


### PR DESCRIPTION
… made in Text feature [ED-15016]

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

There is a bug where the request to preform ai action is made before the consent modal is opened.
*

## Description

Added validator value that checks if the user agreed to the consent message before sending the request to the ai service.
Additionally, a combined loader value was added to fix a glitch caused by the gap between user data fetching and the start of Excerpt data fetching.
*

## Test instructions

Tested using debugger to verify that no extra network request beed made before user agreed to the terms.
*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #


[ED-15016]: https://elementor.atlassian.net/browse/ED-15016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ