### PR TITLE
Fix: Validate prompt and canvas changes to allow generation in image edit generative fill [ED-15270]

### DIFF
--- a/modules/ai/assets/js/editor/pages/form-media/views/in-painting/in-painting-content.js
+++ b/modules/ai/assets/js/editor/pages/form-media/views/in-painting/in-painting-content.js
@@ -45,11 +45,9 @@ const BrishSizeIcon = styled( Box, { shouldForwardProp: ( prop ) => 'size' === p
 	backgroundColor: theme.palette.secondary.main,
 } ) );
 
-const InPaintingContent = ( { editImage, setMask, width: canvasWidth, height: canvasHeight } ) => {
+const InPaintingContent = ( { editImage, setMask, setIsCanvasChanged, width: canvasWidth, height: canvasHeight } ) => {
 	const sketchRef = useRef();
-
 	const [ stroke, setStroke ] = useState( 30 );
-
 	const brushCursorRef = useRef();
 
 	useEffect( () => {
@@ -156,6 +154,7 @@ const InPaintingContent = ( { editImage, setMask, width: canvasWidth, height: ca
 					strokeColor={ BRUSH_COLOR }
 					canvasColor={ CANVAS_COLOR }
 					backgroundImage={ editImage.url }
+					onStroke={ () => setIsCanvasChanged( true ) }
 					onChange={ async () => {
 						const svg = await sketchRef.current.exportSvg();
 						setMask( svg );
@@ -168,6 +167,7 @@ const InPaintingContent = ( { editImage, setMask, width: canvasWidth, height: ca
 
 InPaintingContent.propTypes = {
 	setMask: PropTypes.func.isRequired,
+	setIsCanvasChanged: PropTypes.func.isRequired,
 	width: PropTypes.number.isRequired,
 	height: PropTypes.number.isRequired,
 	editImage: PropTypes.object.isRequired,

--- a/modules/ai/assets/js/editor/pages/form-media/views/in-painting/index.js
+++ b/modules/ai/assets/js/editor/pages/form-media/views/in-painting/index.js
@@ -19,15 +19,11 @@ const InPainting = () => {
 	const [ prompt, setPrompt ] = useState( '' );
 	const { setGenerate } = useRequestIds();
 	const [ mask, setMask ] = useState( '' );
-
+	const [ isCanvasChanged, setIsCanvasChanged ] = useState( false );
 	const { settings, resetSettings } = usePromptSettings();
-
 	const { editImage, width, height } = useEditImage();
-
 	const { use, edit, isLoading: isUploading } = useImageActions();
-
 	const { data, send, isLoading: isGenerating, error, reset } = useInPainting();
-
 	const isLoading = isGenerating || isUploading;
 
 	const handleSubmit = async ( event ) => {
@@ -71,7 +67,7 @@ const InPainting = () => {
 								} } />
 							</Stack>
 						) : (
-							<GenerateSubmit disabled={ isLoading } />
+							<GenerateSubmit disabled={ isLoading || ! prompt || ! isCanvasChanged } />
 						)
 					}
 				</ImageForm>
@@ -87,7 +83,13 @@ const InPainting = () => {
 							onEditImage={ edit }
 						/>
 					) : (
-						<InPaintingContent editImage={ editImage } width={ width } height={ height } setMask={ setMask } />
+						<InPaintingContent
+							editImage={ editImage }
+							width={ width }
+							height={ height }
+							setMask={ setMask }
+							setIsCanvasChanged={ setIsCanvasChanged }
+						/>
 					)
 				}
 			</View.Content>


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Validate prompt and canvas changes to allow generation in image edit generative fill
* 
## Description
An explanation of what is done in this PR

* Validate if the mask image changed and the prompt exists
* Add as a condition to the generate button


## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
