### PR TITLE
Fix: Ensure the wp request action suffix is sent [ED-15505]

### DIFF
--- a/modules/ai/assets/js/gutenberg/index.js
+++ b/modules/ai/assets/js/gutenberg/index.js
@@ -4,10 +4,11 @@ import GenerateFeaturedImageWithAI from './featured-image';
 import { GenerateTextWithAi } from './text-with-ai';
 import React from 'react';
 import { EditTextWithAi } from './edit-text-with-ai';
+import { getUniqueId } from '../editor/context/requests-ids';
 
 ( function() {
 	'use strict';
-
+	window.EDITOR_SESSION_ID = getUniqueId( 'wp-gutenberg-session' );
 	// Wait for the Gutenberg editor to initialize
 	wp.domReady( () => {
 		// Define a function to add the custom link to the excerpt panel

--- a/modules/ai/assets/js/media-library/index.js
+++ b/modules/ai/assets/js/media-library/index.js
@@ -3,6 +3,7 @@ import AIMediaGenerateAppWrapper from './generate';
 import { createRoot } from '@wordpress/element';
 import AIMediaEditAppButtonWrapper from './edit-button';
 import AIMediaEditAppLinkWrapper from './edit-link';
+import { getUniqueId } from '../editor/context/requests-ids';
 
 const isMediaLibrary = () => window.location.href.includes( '/upload.php' );
 
@@ -41,6 +42,7 @@ const addEventListener = ( eventName, containerId, Component ) => {
 
 ( function() {
 	if ( isMediaLibrary() ) {
+		window.EDITOR_SESSION_ID = getUniqueId( 'wp-media-lib-session' );
 		const mediaLibrary = document.querySelector( '.page-title-action' );
 
 		if ( mediaLibrary ) {

--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -124,29 +124,17 @@ class Module extends BaseModule {
 					'wp-compose',
 					'wp-i18n',
 					'wp-hooks',
+					'elementor-ai-media-library',
 				],
 			ELEMENTOR_VERSION, true );
-
-			$session_id = 'wp-gutenberg-session-' . Utils::generate_random_string();
-
-			$config = [
-				'is_get_started' => User::get_introduction_meta( 'ai_get_started' ),
-				'connect_url' => $this->get_ai_connect_url(),
-				'client_session_id' => $session_id,
-			];
-
-			if ( $this->get_ai_app()->is_connected() ) {
-				$usage = $this->get_ai_app()->get_usage( 'gutenberg-loader', $session_id );
-
-				if ( ! is_wp_error( $usage ) ) {
-					$config['usage'] = $usage;
-				}
-			}
 
 			wp_localize_script(
 				'elementor-ai-gutenberg',
 				'ElementorAiConfig',
-				$config
+				[
+					'is_get_started' => User::get_introduction_meta( 'ai_get_started' ),
+					'connect_url' => $this->get_ai_connect_url(),
+				]
 			);
 
 			wp_set_script_translations( 'elementor-ai-gutenberg', 'elementor' );
@@ -187,24 +175,13 @@ class Module extends BaseModule {
 			true
 		);
 
-		if ( function_exists( 'get_current_screen' ) ) {
-			if ( get_current_screen()->is_block_editor ) {
-				return;
-			}
-		}
-
-		$session_id = 'wp-media-lib-session-' . Utils::generate_random_string();
-
-		$config = [
-			'is_get_started' => User::get_introduction_meta( 'ai_get_started' ),
-			'connect_url' => $this->get_ai_connect_url(),
-			'client_session_id' => $session_id,
-		];
-
 		wp_localize_script(
 			'elementor-ai-media-library',
 			'ElementorAiConfig',
-			$config
+			[
+				'is_get_started' => User::get_introduction_meta( 'ai_get_started' ),
+				'connect_url' => $this->get_ai_connect_url(),
+			]
 		);
 
 		wp_set_script_translations( 'elementor-ai-media-library', 'elementor' );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Ensure AI modules have the correct session id

## Description
An explanation of what is done in this PR

* Each module sets its session id (media library and gutenberg)
* Make sure the ai-gutenberg script is being loaded after the media-library one
* Remove session id redundant code from the module.php
* Remove get_usage from the ai-gutenberg as it's not needed

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
