### PR TITLE
Fix: Floatign Buttons - when library is empty, redirect to admin on close

### DIFF
--- a/core/common/assets/js/views/modal/header.js
+++ b/core/common/assets/js/views/modal/header.js
@@ -49,9 +49,12 @@ export default class extends Marionette.LayoutView {
 				this.$el
 					.closest( '.dialog-lightbox-widget-content' )
 					.find( '.elementor-template-library-template-floating_button' ).length ||
-				this.$el.
-					closest( '.dialog-lightbox-widget-content' )
-					.find( '#elementor-template-library-preview' ).length
+				this.$el
+					.closest( '.dialog-lightbox-widget-content' )
+					.find( '#elementor-template-library-preview' ).length ||
+				this.$el
+					.closest( '.dialog-lightbox-widget-content' )
+					.find( '#elementor-template-library-templates-empty' ).length
 			);
 	}
 }

--- a/modules/floating-buttons/module.php
+++ b/modules/floating-buttons/module.php
@@ -26,16 +26,11 @@ class Module extends BaseModule {
 
 	const EXPERIMENT_NAME = 'floating-buttons';
 	const FLOATING_BARS_EXPERIMENT_NAME = 'floating-bars';
-
 	const FLOATING_ELEMENTS_TYPE_META_KEY = '_elementor_floating_elements_type';
-
 	const ROUTER_VERSION = '1.0.0';
 	const ROUTER_OPTION_KEY = 'elementor_floating_buttons_router_version';
-
 	const META_CLICK_TRACKING = '_elementor_click_tracking';
-
 	const CLICK_TRACKING_NONCE = 'elementor-conversion-center-click';
-
 	const FLOATING_BUTTONS_DOCUMENT_TYPE = 'floating-buttons';
 	const CPT_FLOATING_BUTTONS = 'e-floating-buttons';
 	const ADMIN_PAGE_SLUG_CONTACT = 'edit.php?post_type=e-floating-buttons';


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* when library is empty, redirect to admin on close.

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
