### PR TITLE
Fix: Show media library Edit with AI button only for supported files [ED-15590]

### DIFF
--- a/modules/ai/assets/js/media-library/edit-button.js
+++ b/modules/ai/assets/js/media-library/edit-button.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { RequestIdsProvider } from '../editor/context/requests-ids';
 import styled from 'styled-components';
 import { __ } from '@wordpress/i18n';
-import { getImageId } from './utils';
+import { getImageId, isImageFile } from './utils';
 import { AIMediaEditApp } from './components';
 
 const Icon = styled.i`
@@ -45,7 +45,7 @@ const AIMediaEditAppButtonWrapper = () => {
 	};
 
 	return (
-		<div style={ { marginLeft: '0.5em' } }>
+		isImageFile() && <div style={ { marginLeft: '0.5em' } }>
 			<RequestIdsProvider>
 				<StyledButton onClick={ handleClick }>
 					<Icon className={ 'eicon-ai' } />

--- a/modules/ai/assets/js/media-library/utils.js
+++ b/modules/ai/assets/js/media-library/utils.js
@@ -13,3 +13,10 @@ export const getImageIdByUrl = () => {
 	const image = Array.isArray( images ) && images.find( ( img ) => img.attributes.url === imageUrl );
 	return image ? image.attributes.id.toString() : null;
 };
+
+export const isImageFile = () => {
+	const filename = wp.media?.frames?.edit?.model?.attributes?.filename;
+	const imageExtensions = [ 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'tiff', 'svg', 'ico', 'heic', 'heif' ];
+	const fileExtension = filename.split( '.' ).pop()?.toLowerCase();
+	return imageExtensions.includes( fileExtension || '' );
+};


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Show media library Edit with Elementor AI button only for supported files

## Description
An explanation of what is done in this PR

* Validate the media item type based on the filename and render the edit button in case it's an image

![image](https://github.com/user-attachments/assets/86da553a-b493-4b62-814f-4bc844ee71a5)

![image](https://github.com/user-attachments/assets/4445af82-e9b7-40c4-b645-f169716af8ff)

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
