### PR TITLE
Internal: Deprecated- change upload-artifact to v4

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload Lighthouse reports on failure
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lighthouseci-reports
           path: ${{ github.workspace }}/.lighthouseci/reports/**/*
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload Lighthouse HTML dumps on failure
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lighthouseci-htmls
           path: ${{ github.workspace }}/.lighthouseci/dumps/**/*

--- a/.github/workflows/plugin-upgrade-test.yml
+++ b/.github/workflows/plugin-upgrade-test.yml
@@ -56,7 +56,7 @@ jobs:
         run: npx playwright install chromium
       - name: Run Playwright tests
         run: npm run test:playwright:elements-regression -- --grep="Test heading template"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-test-results-elements-regression

--- a/.github/workflows/release-dev-from-beta/action.yml
+++ b/.github/workflows/release-dev-from-beta/action.yml
@@ -62,7 +62,7 @@ runs:
       run: |
             bash "${GITHUB_WORKSPACE}/.github/scripts/validate-build-files.sh"
     - name: Upload Dev Build To GitHub Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: dev-svn-preview
         path: elementor


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:
Change actions/upload-artifact from v3 to v4.

*

## Description
An explanation of what is done in this PR
* According to github documentation, actions/download-artifact@v3 is scheduled for deprecation on November 30, 2024.  The same about actions/upload-artifact@v3 [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). This pr make the relevant changes.


## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
