### PR TITLE
Fix: "Generate with Elementor AI" button is missing in the Media Library list mode [ED-16026]

### DIFF
--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -112,6 +112,7 @@ class Module extends BaseModule {
 
 		if ( is_admin() ) {
 			add_action( 'wp_enqueue_media', [ $this, 'enqueue_ai_media_library' ] );
+			add_action( 'admin_head', [ $this, 'enqueue_ai_media_library_upload_screen' ] );
 
 			if ( current_user_can( 'edit_products' ) || current_user_can( 'publish_products' ) ) {
 				add_action( 'admin_init', [ $this, 'enqueue_ai_products_page_scripts' ] );
@@ -303,6 +304,15 @@ class Module extends BaseModule {
 			'message' => __( 'Image added successfully', 'elementor' ),
 			'refresh' => true,
 		] );
+	}
+
+	public function enqueue_ai_media_library_upload_screen() {
+		$screen = get_current_screen();
+		if ( 'upload' !== $screen->id ) {
+			return;
+		}
+
+		$this->enqueue_ai_media_library();
 	}
 
 	public function enqueue_ai_media_library() {

--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -308,7 +308,7 @@ class Module extends BaseModule {
 
 	public function enqueue_ai_media_library_upload_screen() {
 		$screen = get_current_screen();
-		if ( 'upload' !== $screen->id ) {
+		if ( ! $screen || 'upload' !== $screen->id ) {
 			return;
 		}
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Add "Generate with Elementor AI" button in the Media Library list mode

## Description
An explanation of what is done in this PR

* generate with ai button in media library is missing in list mode
![image](https://github.com/user-attachments/assets/2e03543e-987b-45fa-836b-51728442ee3e)
![image](https://github.com/user-attachments/assets/4265d403-7fb1-40fe-8091-e37e3cf45395)

- The `wp_enqueue_media` hook is not loaded in the list mode screen.
- I added a similar script with the `admin_head` hook and validated that it runs only on the upload screen.

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
