### PR TITLE
Internal: Use short array syntax in all PHP files [ED-15130]

### DIFF
--- a/core/admin/admin.php
+++ b/core/admin/admin.php
@@ -725,14 +725,14 @@ class Admin extends App {
 	}
 
 	private function get_allowed_fields_for_role() {
-		$allowed_fields = array(
+		$allowed_fields = [
 			'post_title',
 			'post_content',
 			'post_excerpt',
 			'post_category',
 			'post_type',
 			'tags_input',
-		);
+		];
 
 		if ( current_user_can( 'publish_posts' ) ) {
 			$allowed_fields[] = 'post_status';

--- a/core/base/background-process/wp-async-request.php
+++ b/core/base/background-process/wp-async-request.php
@@ -51,12 +51,12 @@ abstract class WP_Async_Request {
 	/**
 	 * Data
 	 *
-	 * (default value: array())
+	 * (default value: [])
 	 *
 	 * @var array
 	 * @access protected
 	 */
-	protected $data = array();
+	protected $data = [];
 
 	/**
 	 * Initiate new async request
@@ -64,8 +64,8 @@ abstract class WP_Async_Request {
 	public function __construct() {
 		$this->identifier = $this->prefix . '_' . $this->action;
 
-		add_action( 'wp_ajax_' . $this->identifier, array( $this, 'maybe_handle' ) );
-		add_action( 'wp_ajax_nopriv_' . $this->identifier, array( $this, 'maybe_handle' ) );
+		add_action( 'wp_ajax_' . $this->identifier, [ $this, 'maybe_handle' ] );
+		add_action( 'wp_ajax_nopriv_' . $this->identifier, [ $this, 'maybe_handle' ] );
 	}
 
 	/**
@@ -103,10 +103,10 @@ abstract class WP_Async_Request {
 			return $this->query_args;
 		}
 
-		return array(
+		return [
 			'action' => $this->identifier,
 			'nonce'  => wp_create_nonce( $this->identifier ),
-		);
+		];
 	}
 
 	/**
@@ -132,14 +132,14 @@ abstract class WP_Async_Request {
 			return $this->post_args;
 		}
 
-		return array(
+		return [
 			'timeout'   => 0.01,
 			'blocking'  => false,
 			'body'      => $this->data,
 			'cookies'   => $_COOKIE,
 			/** This filter is documented in wp-includes/class-wp-http-streams.php */
 			'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
-		);
+		];
 	}
 
 	/**

--- a/core/base/background-process/wp-background-process.php
+++ b/core/base/background-process/wp-background-process.php
@@ -66,8 +66,8 @@ abstract class WP_Background_Process extends WP_Async_Request {
 		$this->cron_hook_identifier     = $this->identifier . '_cron';
 		$this->cron_interval_identifier = $this->identifier . '_cron_interval';
 
-		add_action( $this->cron_hook_identifier, array( $this, 'handle_cron_healthcheck' ) );
-		add_filter( 'cron_schedules', array( $this, 'schedule_cron_healthcheck' ) );
+		add_action( $this->cron_hook_identifier, [ $this, 'handle_cron_healthcheck' ] );
+		add_filter( 'cron_schedules', [ $this, 'schedule_cron_healthcheck' ] );
 	}
 
 	/**
@@ -432,14 +432,14 @@ abstract class WP_Background_Process extends WP_Async_Request {
 		}
 
 		// Adds every 5 minutes to the existing schedules.
-		$schedules[ $this->identifier . '_cron_interval' ] = array(
+		$schedules[ $this->identifier . '_cron_interval' ] = [
 			'interval' => MINUTE_IN_SECONDS * $interval,
 			'display' => sprintf(
 				/* translators: %d: Interval in minutes. */
 				esc_html__( 'Every %d minutes', 'elementor' ),
 				$interval,
 			),
-		);
+		];
 
 		return $schedules;
 	}

--- a/core/base/background-task.php
+++ b/core/base/background-task.php
@@ -305,14 +305,14 @@ abstract class Background_Task extends WP_Background_Process {
 		$interval = apply_filters( $this->identifier . '_cron_interval', 5 );
 
 		// Adds every 5 minutes to the existing schedules.
-		$schedules[ $this->identifier . '_cron_interval' ] = array(
+		$schedules[ $this->identifier . '_cron_interval' ] = [
 			'interval' => MINUTE_IN_SECONDS * $interval,
 			'display' => sprintf(
 				/* translators: %d: Interval in minutes. */
 				esc_html__( 'Every %d minutes', 'elementor' ),
 				$interval
 			),
-		);
+		];
 
 		return $schedules;
 	}

--- a/core/utils/import-export/parsers/wxr-parser-xml.php
+++ b/core/utils/import-export/parsers/wxr-parser-xml.php
@@ -190,7 +190,7 @@ class WXR_Parser_XML {
 			return new WP_Error( 'WXR_parse_error', esc_html__( 'This does not appear to be a WXR file, missing/invalid WXR version number', 'elementor' ) );
 		}
 
-		return array(
+		return [
 			'authors' => $this->authors,
 			'posts' => $this->posts,
 			'categories' => $this->category,
@@ -199,7 +199,7 @@ class WXR_Parser_XML {
 			'base_url' => $this->base_url,
 			'base_blog_url' => $this->base_blog_url,
 			'version' => $this->wxr_version,
-		);
+		];
 	}
 
 	private function tag_open( $tag, $attr ) {

--- a/core/utils/plugins-manager.php
+++ b/core/utils/plugins-manager.php
@@ -57,7 +57,7 @@ class Plugins_Manager {
 			$api = Plugin::$instance->wp->plugins_api('plugin_information',
 				[
 					'slug' => $slug,
-					'fields' => array(
+					'fields' => [
 						'short_description' => false,
 						'sections' => false,
 						'requires' => false,
@@ -70,7 +70,7 @@ class Plugins_Manager {
 						'compatibility' => false,
 						'homepage' => false,
 						'donate_link' => false,
-					),
+					],
 				]
 			);
 

--- a/data/base/controller.php
+++ b/data/base/controller.php
@@ -190,7 +190,7 @@ abstract class Controller extends WP_REST_Controller {
 		register_rest_route( $this->get_namespace(), '/' . $this->get_rest_base(), [
 			[
 				'methods' => WP_REST_Server::READABLE,
-				'callback' => array( $this, 'get_items' ),
+				'callback' => [ $this, 'get_items' ],
 				'args' => [],
 				'permission_callback' => function ( $request ) {
 					return $this->get_permission_callback( $request );

--- a/includes/managers/wordpress-widgets.php
+++ b/includes/managers/wordpress-widgets.php
@@ -50,13 +50,13 @@ class WordPress_Widgets_Manager {
 		$suffix = Utils::is_script_debug() ? '' : '.min';
 
 		// TODO: after WP >= 4.9 - it's no needed, Keep for Backward compatibility.
-		$wp_scripts->add( 'media-widgets', "/wp-admin/js/widgets/media-widgets$suffix.js", array( 'jquery', 'media-models', 'media-views' ) );
+		$wp_scripts->add( 'media-widgets', "/wp-admin/js/widgets/media-widgets$suffix.js", [ 'jquery', 'media-models', 'media-views' ] );
 		$wp_scripts->add_inline_script( 'media-widgets', 'wp.mediaWidgets.init();', 'after' );
 
-		$wp_scripts->add( 'media-audio-widget', "/wp-admin/js/widgets/media-audio-widget$suffix.js", array( 'media-widgets', 'media-audiovideo' ) );
-		$wp_scripts->add( 'media-image-widget', "/wp-admin/js/widgets/media-image-widget$suffix.js", array( 'media-widgets' ) );
-		$wp_scripts->add( 'media-video-widget', "/wp-admin/js/widgets/media-video-widget$suffix.js", array( 'media-widgets', 'media-audiovideo' ) );
-		$wp_scripts->add( 'text-widgets', "/wp-admin/js/widgets/text-widgets$suffix.js", array( 'jquery', 'editor', 'wp-util' ) );
+		$wp_scripts->add( 'media-audio-widget', "/wp-admin/js/widgets/media-audio-widget$suffix.js", [ 'media-widgets', 'media-audiovideo' ] );
+		$wp_scripts->add( 'media-image-widget', "/wp-admin/js/widgets/media-image-widget$suffix.js", [ 'media-widgets' ] );
+		$wp_scripts->add( 'media-video-widget', "/wp-admin/js/widgets/media-video-widget$suffix.js", [ 'media-widgets', 'media-audiovideo' ] );
+		$wp_scripts->add( 'text-widgets', "/wp-admin/js/widgets/text-widgets$suffix.js", [ 'jquery', 'editor', 'wp-util' ] );
 		$wp_scripts->add_inline_script( 'text-widgets', 'wp.textWidgets.init();', 'after' );
 
 		wp_enqueue_style( 'widgets' );

--- a/includes/template-library/sources/local.php
+++ b/includes/template-library/sources/local.php
@@ -1395,7 +1395,7 @@ class Source_Local extends Source_Base {
 		}
 
 		$all_items = get_taxonomy( self::TAXONOMY_CATEGORY_SLUG )->labels->all_items;
-		$dropdown_options = array(
+		$dropdown_options = [
 			'show_option_all' => $all_items,
 			'show_option_none' => $all_items,
 			'hide_empty' => 0,
@@ -1407,7 +1407,7 @@ class Source_Local extends Source_Base {
 			'name' => self::TAXONOMY_CATEGORY_SLUG,
 			//phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is not required to retrieve the value.
 			'selected' => Utils::get_super_global_value( $_GET, self::TAXONOMY_CATEGORY_SLUG ) ?? '',
-		);
+		];
 
 		printf(
 			'<label class="screen-reader-text" for="%1$s">%2$s</label>',

--- a/modules/element-cache/module.php
+++ b/modules/element-cache/module.php
@@ -74,9 +74,9 @@ class Module extends BaseModule {
 	}
 
 	private function add_advanced_tab_actions() {
-		$hooks = array(
+		$hooks = [
 			'elementor/element/common/_section_style/after_section_end' => '_css_classes', // Widgets
-		);
+		];
 
 		foreach ( $hooks as $hook => $injection_position ) {
 			add_action(

--- a/modules/usage/module.php
+++ b/modules/usage/module.php
@@ -275,7 +275,7 @@ class Module extends BaseModule {
 			delete_option( self::OPTION_NAME );
 		}
 
-		$post_types = get_post_types( array( 'public' => true ) );
+		$post_types = get_post_types( [ 'public' => true ] );
 
 		$query = new \WP_Query( [
 			'no_found_rows' => true,

--- a/tests/phpunit/elementor/core/experiments/test-wp-cli.php
+++ b/tests/phpunit/elementor/core/experiments/test-wp-cli.php
@@ -24,7 +24,7 @@ class Test_Wp_Cli extends Elementor_Test_Base {
 		$experiments_manager->add_feature( $test_experiment );
 
 		// Act
-		$wp_cli->activate( array( $experiment ), array() );
+		$wp_cli->activate( [ $experiment ], [] );
 		$is_option_active = $experiments_manager->is_feature_active( $experiment );
 
 		// Assert
@@ -49,7 +49,7 @@ class Test_Wp_Cli extends Elementor_Test_Base {
 		$experiments_manager->add_feature( $test_experiment2 );
 
 		// Act
-		$wp_cli->activate( array( $experiment1 . ',' . $experiment2 ), array() );
+		$wp_cli->activate( [ $experiment1 . ',' . $experiment2 ], [] );
 		$is_option1_active = $experiments_manager->is_feature_active( $experiment1 );
 		$is_option2_active = $experiments_manager->is_feature_active( $experiment2 );
 
@@ -70,7 +70,7 @@ class Test_Wp_Cli extends Elementor_Test_Base {
 		$experiments_manager->add_feature( $test_experiment );
 
 		// Act
-		$wp_cli->deactivate( array( $experiment ), array() );
+		$wp_cli->deactivate( [ $experiment ], [] );
 		$is_option_active = $experiments_manager->is_feature_active( $experiment );
 
 		// Assert
@@ -95,7 +95,7 @@ class Test_Wp_Cli extends Elementor_Test_Base {
 		$experiments_manager->add_feature( $test_experiment2 );
 
 		// Act
-		$wp_cli->deactivate( array( $experiment1 . ',' . $experiment2 ), array() );
+		$wp_cli->deactivate( [ $experiment1 . ',' . $experiment2 ], [] );
 		$is_option1_active = $experiments_manager->is_feature_active( $experiment1 );
 		$is_option2_active = $experiments_manager->is_feature_active( $experiment2 );
 

--- a/tests/phpunit/elementor/core/utils/test-plugins-manager.php
+++ b/tests/phpunit/elementor/core/utils/test-plugins-manager.php
@@ -261,7 +261,7 @@ class Test_Plugins_Manager extends Elementor_Test_Base {
 			'plugin_information',
 			[
 				'slug' => $slug,
-				'fields' => array(
+				'fields' => [
 					'short_description' => false,
 					'sections' => false,
 					'requires' => false,
@@ -274,7 +274,7 @@ class Test_Plugins_Manager extends Elementor_Test_Base {
 					'compatibility' => false,
 					'homepage' => false,
 					'donate_link' => false,
-				),
+				],
 			]
 		];
 	}

--- a/tests/phpunit/elementor/includes/sources/test-local.php
+++ b/tests/phpunit/elementor/includes/sources/test-local.php
@@ -30,7 +30,7 @@ class Test_Local extends Elementor_Test_Base {
 		// Arrange - fake globals.
 		global $post_type, $wp_list_table;
 
-		$wp_list_table = _get_list_table( 'WP_Posts_List_Table' , array( 'screen' => 'edit-page' ) );
+		$wp_list_table = _get_list_table( 'WP_Posts_List_Table' , [ 'screen' => 'edit-page' ] );
 		$post_type = 'post';
 
 		// Act.

--- a/tests/phpunit/elementor/modules/image-loading-optimization/test-module.php
+++ b/tests/phpunit/elementor/modules/image-loading-optimization/test-module.php
@@ -68,8 +68,10 @@ class Elementor_Image_Loading_Optimization_Test_Module extends Elementor_Test_Ba
 		$content = '<img width="800" height="530" src="featured_image.jpg" /><img width="640" height="471" src="image_1.jpg" /><img width="800" height="800" src="image_2.jpg" /><img width="566" height="541" src="image_3.jpg" /><img width="691" height="1024" src="image_4.jpg" />';
 
 		// Update the post content.
-		$updated_post = array( 'ID' => $document->get_main_id(), 'post_content' => $content );
-		wp_update_post( $updated_post );
+		wp_update_post( [
+			'ID' => $document->get_main_id(),
+			'post_content' => $content,
+		] );
 		$page_templates_module = Plugin::$instance->modules_manager->get_modules( 'page-templates' );
 		$document->update_main_meta( '_wp_page_template', $page_template );
 


### PR DESCRIPTION
Short array syntax was added in PHP 5.4, replacing long `array()` with short `[]`.

Elementor dropped PHP 5.x support a while ago, but not fully migrated to short array syntax.