### PR TITLE
Added additional filter to element-base.php to prevent elements from …

### DIFF
--- a/includes/base/element-base.php
+++ b/includes/base/element-base.php
@@ -473,7 +473,11 @@ abstract class Element_Base extends Controls_Stack {
 		 */
 		do_action( "elementor/frontend/{$element_type}/before_render", $this );
 
+
+        if(apply_filters("elementor/frontend/{$element_type}/should_process",true, $this)){
+
 		ob_start();
+
 
 		if ( $this->has_own_method( '_print_content', self::class ) ) {
 			Plugin::$instance->modules_manager->get_modules( 'dev-tools' )->deprecation->deprecated_function( '_print_content', '3.1.0', __CLASS__ . '::print_content()' );
@@ -518,6 +522,8 @@ abstract class Element_Base extends Controls_Stack {
 			$this->enqueue_scripts();
 			$this->enqueue_styles();
 		}
+
+        }
 
 		/**
 		 * After frontend element render.
@@ -825,7 +831,7 @@ abstract class Element_Base extends Controls_Stack {
 	 * @access protected
 	 * @return void
 	 */
-	protected function register_transform_section( $element_selector = '', $transform_selector_class = ' > .elementor-widget-container' ) {
+	protected function register_transform_section( $element_selector = '' ) {
 		$default_unit_values_deg = [];
 		$default_unit_values_ms = [];
 
@@ -856,6 +862,7 @@ abstract class Element_Base extends Controls_Stack {
 
 		$transform_prefix_class = 'e-';
 		$transform_return_value = 'transform';
+		$transform_selector_class = ' > .elementor-widget-container';
 		$transform_css_modifier = '';
 
 		if ( 'con' === $element_selector ) {
@@ -920,7 +927,6 @@ abstract class Element_Base extends Controls_Stack {
 					'condition' => [
 						"_transform_rotate_popover{$tab}!" => '',
 					],
-					'frontend_available' => true,
 				]
 			);
 
@@ -1546,10 +1552,6 @@ abstract class Element_Base extends Controls_Stack {
 
 			$this->add_child( $child_data );
 		}
-	}
-
-	public function has_widget_inner_wrapper(): bool {
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
Added additional filter to element-base.php to prevent elements from beeing processed to reduce overhead when features like timed or conditional content are used.

## PR Type

- [X] Feature

## Summary

This PR can be summarized in the following changelog entry:

* We have implemented some functionality to show or hide elementor elements
This method uses the element or/frontend/section/should_render hook. We expected that whenever this filter returns false the element would not be processed at all. However the Element is processed beforehand which can lead to a high loading time on some pages - even though half of the content does not need to be processed and rendered. 

## Description
An explanation of what is done in this PR

* Modified element-base.php
* Added additional filter "elementor/frontend/{$element_type}/should_render" to prevent execution of Element Code

## Test instructions
This PR can be tested by following these steps:

* Create a filter in your theme or plugin, eg. "elementor/frontend/section/should_render"
* Return false
* See if elements are rendered or not

## Quality assurance

- [x] I have tested this code to the best of my abilities
