### PR TITLE
Temporarily restore `core/schemes/color.php`

### DIFF
--- a/core/schemes/color.php
+++ b/core/schemes/color.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Elementor\Core\schemes;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Elementor color scheme.
+ *
+ * Elementor color scheme class is responsible for initializing a scheme for
+ * colors.
+ *
+ * @since 1.0.0
+ * @deprecated 3.0.0 Use `Global_Colors` instead.
+ */
+class Color {
+
+	/**
+	 * 1st color scheme.
+	 * @deprecated 3.0.0 Use `Global_Colors::COLOR_PRIMARY` instead.
+	 */
+	const COLOR_1 = '1';
+
+	/**
+	 * 2nd color scheme.
+	 * @deprecated 3.0.0 Use `Global_Colors::COLOR_SECONDARY` instead.
+	 */
+	const COLOR_2 = '2';
+
+	/**
+	 * 3rd color scheme.
+	 * @deprecated 3.0.0 Use `Global_Colors::COLOR_TEXT` instead.
+	 */
+	const COLOR_3 = '3';
+
+	/**
+	 * 4th color scheme.
+	 * @deprecated 3.0.0 Use `Global_Colors::COLOR_ACCENT` instead.
+	 */
+	const COLOR_4 = '4';
+
+	/**
+	 * Get color scheme type.
+	 *
+	 * Retrieve the color scheme type.
+	 *
+	 * @return string Color scheme type.
+	 * @deprecated 3.0.0
+	 *
+	 * @since 1.0.0
+	 * @access public
+	 * @static
+	 */
+	public static function get_type() {
+		return 'color';
+	}
+
+	/**
+	 * Get color scheme title.
+	 *
+	 * Retrieve the color scheme title.
+	 *
+	 * @return string Color scheme title.
+	 * @deprecated 3.0.0
+	 *
+	 * @since 1.0.0
+	 * @access public
+	 */
+	public function get_title() {
+		return '';
+	}
+
+	/**
+	 * Get color scheme disabled title.
+	 *
+	 * Retrieve the color scheme disabled title.
+	 *
+	 * @return string Color scheme disabled title.
+	 * @deprecated 3.0.0
+	 *
+	 * @since 1.0.0
+	 * @access public
+	 */
+	public function get_disabled_title() {
+		return '';
+	}
+
+	/**
+	 * Get color scheme titles.
+	 *
+	 * Retrieve the color scheme titles.
+	 *
+	 * @return array Color scheme titles.
+	 * @deprecated 3.0.0
+	 *
+	 * @since 1.0.0
+	 * @access public
+	 */
+	public function get_scheme_titles() {
+		return [];
+	}
+
+	/**
+	 * Get default color scheme.
+	 *
+	 * Retrieve the default color scheme.
+	 *
+	 * @return array Default color scheme.
+	 * @deprecated 3.0.0
+	 *
+	 * @since 1.0.0
+	 * @access public
+	 */
+	public function get_default_scheme() {
+		return [];
+	}
+
+	/**
+	 * Print color scheme content template.
+	 *
+	 * Used to generate the HTML in the editor using Underscore JS template. The
+	 * variables for the class are available using `data` JS object.
+	 *
+	 * @since 1.0.0
+	 * @access public
+	 * @deprecated 3.0.0
+	 */
+	public function print_template_content() {
+	}
+}


### PR DESCRIPTION
https://github.com/elementor/elementor/issues/29520

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Backward compatibility with 3rd party components.

## Summary

This PR can be summarized in the following changelog entry:

I don't think it requires a changelog entry since it's not released yet.

## Description

I propose to temporarily restore the class which will allow some time for 3rd party plugins to adapt their custom widgets.
The [notification of removal of this class was just last week.](https://github.com/elementor/elementor/issues/29436).

## Test instructions
- Install, activate and setup Elementor 3.26.0-beta3
- Install, activate and setup WPML Core + WPML String Translation (latest versions)
- Create a new page and edit it with the Elementor editor

=> The Elementor editor should still be usable.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
https://github.com/elementor/elementor/issues/29520