### PR TITLE
Fix: Overriden post types [ED-16367]

### DIFF
--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -311,13 +311,6 @@ class Module extends BaseModule {
 			];
 		}
 
-//		$supported_post_types = get_option( 'elementor_cpt_support', [] );
-//		$new_post_type = 'product';
-//		if ( ! in_array( $new_post_type, $supported_post_types, true ) ) {
-//			$supported_post_types[] = $new_post_type;
-//			update_option( 'elementor_cpt_support', $supported_post_types );
-//		}
-
 		wp_send_json_success( [ 'product_images' => array_slice( $image_ids, 0, 10 ) ] );
 
 		wp_die();

--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -311,12 +311,12 @@ class Module extends BaseModule {
 			];
 		}
 
-		$supported_post_types = get_option( 'elementor_cpt_support', [] );
-		$new_post_type = 'product';
-		if ( ! in_array( $new_post_type, $supported_post_types, true ) ) {
-			$supported_post_types[] = $new_post_type;
-			update_option( 'elementor_cpt_support', $supported_post_types );
-		}
+//		$supported_post_types = get_option( 'elementor_cpt_support', [] );
+//		$new_post_type = 'product';
+//		if ( ! in_array( $new_post_type, $supported_post_types, true ) ) {
+//			$supported_post_types[] = $new_post_type;
+//			update_option( 'elementor_cpt_support', $supported_post_types );
+//		}
 
 		wp_send_json_success( [ 'product_images' => array_slice( $image_ids, 0, 10 ) ] );
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Elementor supported post types are being overridden after a WooCommerce product is created

## Description
An explanation of what is done in this PR

* Elementor supported post types are being overridden after a WooCommerce product is created

## Test instructions
This PR can be tested by following these steps:

1. Install WooCommerce
2. Install Elementor v3.26
3. Go to Elementor > Settings > supported post types and see that posts and pages are marked as supported but products are not.
4. Go to WooCommerce > Products and create a new one (title + featured image) > Publish
5. Go to Elementor > Settings > supported post types and see that the mark has been changed to support products only.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
