### PR TITLE
Fix: Register `swiper.js` script [ED-16665]

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -383,6 +383,14 @@ class Frontend extends App {
 		);
 
 		wp_register_script(
+			'swiper',
+			$this->get_js_assets_url( 'swiper', 'assets/lib/swiper/v8/' ),
+			[],
+			'8.4.5',
+			true
+		);
+
+		wp_register_script(
 			'flatpickr',
 			$this->get_js_assets_url( 'flatpickr', 'assets/lib/flatpickr/' ),
 			[


### PR DESCRIPTION
Register `swiper.js` script to allow widget developers declare that they need to load swiper:

```php
class Elementor_Test_Widget extends \Elementor\Widget_Base {

	public function get_style_depends(): array {
		return [ 'swiper', 'my-swiper-styles' ];
	}

	public function get_script_depends(): array {
		return [ 'swiper', 'my-swiper-scripts' ];
	}

}
```

This should help Elementor migrate all carousel widgets to use `get_script_depends()`.