### PR TITLE
Fix: Present correct history promotion for AI Power and above [ED-16722]

### DIFF
--- a/modules/ai/assets/js/editor/components/prompt-history/history-modal.js
+++ b/modules/ai/assets/js/editor/components/prompt-history/history-modal.js
@@ -13,10 +13,11 @@ import InfiniteScroll from 'react-infinite-scroller';
 import PromptHistoryUpgrade from './parts/modal-upgrade';
 import { usePromptHistoryContext } from './context/prompt-history-context';
 import ModalContainer from './parts/modal-container';
+import useUserInfo from '../../hooks/use-user-info';
 
 const ITEMS_LIMIT = 10;
 const FREE_PLAN_ERRORS = [ 'invalid_connect_data', 'no_subscription' ];
-
+const QUOTA_UPGRADE_THRESHOLD = 50000;
 const PromptHistoryModal = ( props ) => {
 	const lastRun = useRef( () => {} );
 	const scrollContainer = useRef( null );
@@ -38,10 +39,12 @@ const PromptHistoryModal = ( props ) => {
 		deleteItem,
 	} = useDeletePromptHistoryItem();
 
+	const { quota } = useUserInfo();
+
 	const error = historyFetchingError || historyDeletingError;
 	const isLoading = isHistoryFetchingInProgress || isDeletingInProgress;
 	const isLastPage = meta && meta?.currentPage === meta?.totalPages;
-	const showUpgrade = items?.length > 0 && meta?.allowedDays < 90 && isLastPage;
+	const showUpgrade = quota < QUOTA_UPGRADE_THRESHOLD && items?.length > 0 && meta?.allowedDays < 90 && isLastPage;
 
 	useEffect( () => {
 		lastRun.current = async () => fetchData( { page: 1, limit: ITEMS_LIMIT } );

--- a/modules/ai/assets/js/editor/hooks/use-user-info.js
+++ b/modules/ai/assets/js/editor/hooks/use-user-info.js
@@ -43,6 +43,7 @@ const useUserInfo = ( immediately = false ) => {
 		connectUrl: userInfo.connect_url,
 		builderUrl: userInfo.usage.builderUrl,
 		hasSubscription: userInfo.usage.hasAiSubscription,
+		quota: userInfo.usage.quota,
 		credits: credits < 0 ? 0 : credits,
 		usagePercentage: Math.round( usagePercentage ),
 		fetchData,


### PR DESCRIPTION
Don't show upgrade promotion to users with Power or Visinorary subscriptions (above 5000 credits)
<img width="622" alt="Screenshot 2024-12-30 at 14 32 27" src="https://github.com/user-attachments/assets/15317065-f511-424b-a709-dc44a37a2b77" />
![78bb77c7-bd46-4de9-8a7a-a398e6b79e84](https://github.com/user-attachments/assets/360f3f54-0c72-4913-b06a-c44d44258eda)
