### PR TITLE
Internal: Skip 'check that app-bar exists' and regressions test [ED-17688]

### DIFF
--- a/tests/elements-regression/tests/elements-regression.test.ts
+++ b/tests/elements-regression/tests/elements-regression.test.ts
@@ -59,7 +59,7 @@ test.describe( 'Elementor regression tests with templates for CORE', () => {
 	];
 
 	for ( const widgetType of testData ) {
-		test( `Test ${ widgetType } template`, async ( { page, apiRequests }, testInfo ) => {
+		test.skip( `Test ${ widgetType } template`, async ( { page, apiRequests }, testInfo ) => {
 			const filePath = _path.resolve( __dirname, `./templates/${ widgetType }.json` );
 			const hoverSelector = {
 				button_hover: 'a',

--- a/tests/playwright/sanity/editor-v2.test.ts
+++ b/tests/playwright/sanity/editor-v2.test.ts
@@ -19,7 +19,7 @@ test.describe( 'Editor top bar', () => {
 		editor = await wpAdmin.openNewPage();
 	} );
 
-	test( 'check that app-bar exists', async () => {
+	test.skip( 'check that app-bar exists', async () => {
 		// Act
 		const wrapper = await editor.page.locator( '#elementor-editor-wrapper-v2' );
 


### PR DESCRIPTION
Co-authored-by: Tzvi Rabinovitch <tzvir@elementor.com>
