### PR TITLE
Fix: AI Planner displays a compatibility notice when php >= 8.1 [ED-17682]

### DIFF
--- a/modules/ai/site-planner-connect/module.php
+++ b/modules/ai/site-planner-connect/module.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Module {
 	const NOT_TRANSLATED_APP_NAME = 'Site Planner';
 	const PLANNER_ORIGIN = 'https://planner.elementor.com';
-	const HIDDEN_PAGE_SLUG = null;
+	const HIDDEN_PAGE_SLUG = '';
 
 	public function __construct() {
 		add_action( 'rest_api_init', [ $this, 'on_rest_init' ] );


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/52648dd2-96cf-418b-8e34-e5c73b53926a)
