### PR TITLE
Tweak: Load Text Editor widget styles on control level rather than widget level [ED-17735, ED-17819]

### DIFF
--- a/includes/widgets/text-editor.php
+++ b/includes/widgets/text-editor.php
@@ -99,13 +99,15 @@ class Widget_Text_Editor extends Widget_Base {
 	 * Therefor, style should not be loaded on the widget level, rather only on
 	 * control level when the drop cap is active.
 	 *
+	 * Only in the Editor, these style should be loaded on the widget level.
+	 *
 	 * @since 3.24.0
 	 * @access public
 	 *
 	 * @return array Widget style dependencies.
 	 */
 	public function get_style_depends(): array {
-		return [];
+		return Plugin::$instance->preview->is_preview_mode() ? [ 'widget-text-editor' ] : [];
 	}
 
 	public function has_widget_inner_wrapper(): bool {

--- a/tests/elements-regression/tests/elements-regression.test.ts
+++ b/tests/elements-regression/tests/elements-regression.test.ts
@@ -27,7 +27,7 @@ test.describe( 'Elementor regression tests with templates for CORE', () => {
 		'container_grid',
 		'divider',
 		'heading',
-		// 'text_editor',
+		'text_editor',
 		'button',
 		'image',
 		'icon',


### PR DESCRIPTION
Fix failing test introduced in https://github.com/elementor/elementor/pull/29853/