### PR TITLE
Internal: REST API for Elementor post meta - fixed version [ED-17971]

### DIFF
--- a/modules/wp-rest/classes/elementor-post-meta.php
+++ b/modules/wp-rest/classes/elementor-post-meta.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Elementor\Modules\WpRest\Classes;
+
+use Elementor\Plugin;
+use Elementor\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Elementor_Post_Meta {
+
+	public function register(): void {
+		$post_types = get_post_types_by_support( 'elementor' );
+
+		foreach ( $post_types as $post_type ) {
+			register_meta( $post_type, '_elementor_edit_mode', [
+				'single' => true,
+				'show_in_rest' => [
+					'schema' => [
+						'title' => 'Elementor edit mode',
+						'description' => 'Elementor edit mode, `builder` is required for Elementor editing',
+						'type' => 'string',
+						'enum' => [ '', 'builder' ],
+						'default' => '',
+						'context' => [ 'edit' ],
+					],
+				],
+				'auth_callback' => [ $this, 'check_edit_permission' ],
+			]);
+
+			$document_types = Plugin::$instance->documents->get_document_types();
+
+			register_meta( $post_type, '_elementor_template_type', [
+				'single' => true,
+				'show_in_rest' => [
+					'schema' => [
+						'title' => 'Elementor template type',
+						'description' => 'Elementor document type',
+						'type' => 'string',
+						'enum' => array_merge( array_keys( $document_types ), [ '' ] ),
+						'default' => '',
+						'context' => [ 'edit' ],
+					],
+				],
+				'auth_callback' => [ $this, 'check_edit_permission' ],
+			]);
+
+			register_meta( $post_type, '_elementor_data', [
+				'single' => true,
+				'show_in_rest' => [
+					'schema' => [
+						'title' => 'Elementor data',
+						'description' => 'Elementor JSON as a string',
+						'type' => 'string',
+						'default' => '',
+						'context' => [ 'edit' ],
+					],
+				],
+				'auth_callback' => [ $this, 'check_edit_permission' ],
+			]);
+
+			register_meta( $post_type, '_elementor_page_settings', [
+				'single' => true,
+				'show_in_rest' => [
+					'schema' => [
+						'title' => 'Elementor page settings',
+						'description' => 'Elementor page level settings',
+						'type' => 'object',
+						'properties' => [
+							'hide_title' => [
+								'type' => 'string',
+								'enum' => [ 'yes', 'no' ],
+								'default' => '',
+							],
+						],
+						'default' => '{}',
+						'additionalProperties' => true,
+						'context' => [ 'edit' ],
+					],
+				],
+				'auth_callback' => [ $this, 'check_edit_permission' ],
+			]);
+
+			if ( Utils::has_pro() ) {
+				register_meta( $post_type, '_elementor_conditions', [
+					'type' => 'object',
+					'title' => 'Elementor conditions',
+					'description' => 'Elementor conditions',
+					'single' => true,
+					'show_in_rest' => [
+						'schema' => [
+							'description' => 'Elementor conditions',
+							'type' => 'array',
+							'additionalProperties' => true,
+							'default' => [],
+							'context' => [ 'edit' ],
+						],
+					],
+					'auth_callback' => [ $this, 'check_edit_permission' ],
+				]);
+			}
+		}
+	}
+
+	/**
+	 * Check if current user has permission to edit the specific post with elementor
+	 *
+	 * @param bool   $allowed Whether the user can add the post meta. Default false.
+	 * @param string $meta_key The meta key.
+	 * @param int    $post_id Post ID.
+	 * @return bool
+	 * @since 3.27.0
+	 */
+	public function check_edit_permission( bool $allowed, string $meta_key, int $post_id ): bool {
+		$document = Plugin::$instance->documents->get( $post_id );
+
+		return $document && $document->is_editable_by_current_user();
+	}
+}

--- a/modules/wp-rest/classes/elementor-post-meta.php
+++ b/modules/wp-rest/classes/elementor-post-meta.php
@@ -15,8 +15,9 @@ class Elementor_Post_Meta {
 		$post_types = get_post_types_by_support( 'elementor' );
 
 		foreach ( $post_types as $post_type ) {
-			register_meta( $post_type, '_elementor_edit_mode', [
+			register_meta( 'post', '_elementor_edit_mode', [
 				'single' => true,
+				'object_subtype' => $post_type,
 				'show_in_rest' => [
 					'schema' => [
 						'title' => 'Elementor edit mode',
@@ -32,8 +33,9 @@ class Elementor_Post_Meta {
 
 			$document_types = Plugin::$instance->documents->get_document_types();
 
-			register_meta( $post_type, '_elementor_template_type', [
+			register_meta( 'post', '_elementor_template_type', [
 				'single' => true,
+				'object_subtype' => $post_type,
 				'show_in_rest' => [
 					'schema' => [
 						'title' => 'Elementor template type',
@@ -47,8 +49,9 @@ class Elementor_Post_Meta {
 				'auth_callback' => [ $this, 'check_edit_permission' ],
 			]);
 
-			register_meta( $post_type, '_elementor_data', [
+			register_meta( 'post', '_elementor_data', [
 				'single' => true,
+				'object_subtype' => $post_type,
 				'show_in_rest' => [
 					'schema' => [
 						'title' => 'Elementor data',
@@ -61,8 +64,9 @@ class Elementor_Post_Meta {
 				'auth_callback' => [ $this, 'check_edit_permission' ],
 			]);
 
-			register_meta( $post_type, '_elementor_page_settings', [
+			register_meta( 'post', '_elementor_page_settings', [
 				'single' => true,
+				'object_subtype' => $post_type,
 				'show_in_rest' => [
 					'schema' => [
 						'title' => 'Elementor page settings',
@@ -84,7 +88,8 @@ class Elementor_Post_Meta {
 			]);
 
 			if ( Utils::has_pro() ) {
-				register_meta( $post_type, '_elementor_conditions', [
+				register_meta( 'post', '_elementor_conditions', [
+					'object_subtype' => $post_type,
 					'type' => 'object',
 					'title' => 'Elementor conditions',
 					'description' => 'Elementor conditions',

--- a/modules/wp-rest/classes/elementor-post-meta.php
+++ b/modules/wp-rest/classes/elementor-post-meta.php
@@ -15,18 +15,18 @@ class Elementor_Post_Meta {
 		$post_types = get_post_types_by_support( 'elementor' );
 
 		foreach ( $post_types as $post_type ) {
-			$this->register_edit_mode_meta($post_type);
-			$this->register_template_type_meta($post_type);
-			$this->register_elementor_data_meta($post_type);
-			$this->register_page_settings_meta($post_type);
+			$this->register_edit_mode_meta( $post_type );
+			$this->register_template_type_meta( $post_type );
+			$this->register_elementor_data_meta( $post_type );
+			$this->register_page_settings_meta( $post_type );
 
 			if ( Utils::has_pro() ) {
-				$this->register_conditions_meta($post_type);
+				$this->register_conditions_meta( $post_type );
 			}
 		}
 	}
 
-	private function register_edit_mode_meta(string $post_type): void {
+	private function register_edit_mode_meta( string $post_type ): void {
 		register_meta( 'post', '_elementor_edit_mode', [
 			'single' => true,
 			'object_subtype' => $post_type,
@@ -44,7 +44,7 @@ class Elementor_Post_Meta {
 		]);
 	}
 
-	private function register_template_type_meta(string $post_type): void {
+	private function register_template_type_meta( string $post_type ): void {
 		$document_types = Plugin::$instance->documents->get_document_types();
 
 		register_meta( 'post', '_elementor_template_type', [
@@ -64,7 +64,7 @@ class Elementor_Post_Meta {
 		]);
 	}
 
-	private function register_elementor_data_meta(string $post_type): void {
+	private function register_elementor_data_meta( string $post_type ): void {
 		register_meta( 'post', '_elementor_data', [
 			'single' => true,
 			'object_subtype' => $post_type,
@@ -81,7 +81,7 @@ class Elementor_Post_Meta {
 		]);
 	}
 
-	private function register_page_settings_meta(string $post_type): void {
+	private function register_page_settings_meta( string $post_type ): void {
 		register_meta( 'post', '_elementor_page_settings', [
 			'single' => true,
 			'object_subtype' => $post_type,
@@ -106,7 +106,7 @@ class Elementor_Post_Meta {
 		]);
 	}
 
-	private function register_conditions_meta(string $post_type): void {
+	private function register_conditions_meta( string $post_type ): void {
 		register_meta( 'post', '_elementor_conditions', [
 			'object_subtype' => $post_type,
 			'type' => 'object',

--- a/modules/wp-rest/classes/elementor-post-meta.php
+++ b/modules/wp-rest/classes/elementor-post-meta.php
@@ -15,98 +15,115 @@ class Elementor_Post_Meta {
 		$post_types = get_post_types_by_support( 'elementor' );
 
 		foreach ( $post_types as $post_type ) {
-			register_meta( 'post', '_elementor_edit_mode', [
-				'single' => true,
-				'object_subtype' => $post_type,
-				'show_in_rest' => [
-					'schema' => [
-						'title' => 'Elementor edit mode',
-						'description' => 'Elementor edit mode, `builder` is required for Elementor editing',
-						'type' => 'string',
-						'enum' => [ '', 'builder' ],
-						'default' => '',
-						'context' => [ 'edit' ],
-					],
-				],
-				'auth_callback' => [ $this, 'check_edit_permission' ],
-			]);
-
-			$document_types = Plugin::$instance->documents->get_document_types();
-
-			register_meta( 'post', '_elementor_template_type', [
-				'single' => true,
-				'object_subtype' => $post_type,
-				'show_in_rest' => [
-					'schema' => [
-						'title' => 'Elementor template type',
-						'description' => 'Elementor document type',
-						'type' => 'string',
-						'enum' => array_merge( array_keys( $document_types ), [ '' ] ),
-						'default' => '',
-						'context' => [ 'edit' ],
-					],
-				],
-				'auth_callback' => [ $this, 'check_edit_permission' ],
-			]);
-
-			register_meta( 'post', '_elementor_data', [
-				'single' => true,
-				'object_subtype' => $post_type,
-				'show_in_rest' => [
-					'schema' => [
-						'title' => 'Elementor data',
-						'description' => 'Elementor JSON as a string',
-						'type' => 'string',
-						'default' => '',
-						'context' => [ 'edit' ],
-					],
-				],
-				'auth_callback' => [ $this, 'check_edit_permission' ],
-			]);
-
-			register_meta( 'post', '_elementor_page_settings', [
-				'single' => true,
-				'object_subtype' => $post_type,
-				'show_in_rest' => [
-					'schema' => [
-						'title' => 'Elementor page settings',
-						'description' => 'Elementor page level settings',
-						'type' => 'object',
-						'properties' => [
-							'hide_title' => [
-								'type' => 'string',
-								'enum' => [ 'yes', 'no' ],
-								'default' => '',
-							],
-						],
-						'default' => '{}',
-						'additionalProperties' => true,
-						'context' => [ 'edit' ],
-					],
-				],
-				'auth_callback' => [ $this, 'check_edit_permission' ],
-			]);
+			$this->register_edit_mode_meta($post_type);
+			$this->register_template_type_meta($post_type);
+			$this->register_elementor_data_meta($post_type);
+			$this->register_page_settings_meta($post_type);
 
 			if ( Utils::has_pro() ) {
-				register_meta( 'post', '_elementor_conditions', [
-					'object_subtype' => $post_type,
-					'type' => 'object',
-					'title' => 'Elementor conditions',
-					'description' => 'Elementor conditions',
-					'single' => true,
-					'show_in_rest' => [
-						'schema' => [
-							'description' => 'Elementor conditions',
-							'type' => 'array',
-							'additionalProperties' => true,
-							'default' => [],
-							'context' => [ 'edit' ],
-						],
-					],
-					'auth_callback' => [ $this, 'check_edit_permission' ],
-				]);
+				$this->register_conditions_meta($post_type);
 			}
 		}
+	}
+
+	private function register_edit_mode_meta(string $post_type): void {
+		register_meta( 'post', '_elementor_edit_mode', [
+			'single' => true,
+			'object_subtype' => $post_type,
+			'show_in_rest' => [
+				'schema' => [
+					'title' => 'Elementor edit mode',
+					'description' => 'Elementor edit mode, `builder` is required for Elementor editing',
+					'type' => 'string',
+					'enum' => [ '', 'builder' ],
+					'default' => '',
+					'context' => [ 'edit' ],
+				],
+			],
+			'auth_callback' => [ $this, 'check_edit_permission' ],
+		]);
+	}
+
+	private function register_template_type_meta(string $post_type): void {
+		$document_types = Plugin::$instance->documents->get_document_types();
+
+		register_meta( 'post', '_elementor_template_type', [
+			'single' => true,
+			'object_subtype' => $post_type,
+			'show_in_rest' => [
+				'schema' => [
+					'title' => 'Elementor template type',
+					'description' => 'Elementor document type',
+					'type' => 'string',
+					'enum' => array_merge( array_keys( $document_types ), [ '' ] ),
+					'default' => '',
+					'context' => [ 'edit' ],
+				],
+			],
+			'auth_callback' => [ $this, 'check_edit_permission' ],
+		]);
+	}
+
+	private function register_elementor_data_meta(string $post_type): void {
+		register_meta( 'post', '_elementor_data', [
+			'single' => true,
+			'object_subtype' => $post_type,
+			'show_in_rest' => [
+				'schema' => [
+					'title' => 'Elementor data',
+					'description' => 'Elementor JSON as a string',
+					'type' => 'string',
+					'default' => '',
+					'context' => [ 'edit' ],
+				],
+			],
+			'auth_callback' => [ $this, 'check_edit_permission' ],
+		]);
+	}
+
+	private function register_page_settings_meta(string $post_type): void {
+		register_meta( 'post', '_elementor_page_settings', [
+			'single' => true,
+			'object_subtype' => $post_type,
+			'show_in_rest' => [
+				'schema' => [
+					'title' => 'Elementor page settings',
+					'description' => 'Elementor page level settings',
+					'type' => 'object',
+					'properties' => [
+						'hide_title' => [
+							'type' => 'string',
+							'enum' => [ 'yes', 'no' ],
+							'default' => '',
+						],
+					],
+					'default' => '{}',
+					'additionalProperties' => true,
+					'context' => [ 'edit' ],
+				],
+			],
+			'auth_callback' => [ $this, 'check_edit_permission' ],
+		]);
+	}
+
+	private function register_conditions_meta(string $post_type): void {
+		register_meta( 'post', '_elementor_conditions', [
+			'object_subtype' => $post_type,
+			'type' => 'object',
+			'title' => 'Elementor conditions',
+			'description' => 'Elementor conditions',
+			'single' => true,
+			'show_in_rest' => [
+				'schema' => [
+					'description' => 'Elementor conditions',
+					'type' => 'array',
+					'additionalProperties' => true,
+					'default' => [],
+					'context' => [ 'edit' ],
+				],
+			],
+			'auth_callback' => [ $this, 'check_edit_permission' ],
+		]);
 	}
 
 	/**

--- a/modules/wp-rest/module.php
+++ b/modules/wp-rest/module.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\WpRest;
 
 use Elementor\Core\Base\Module as BaseModule;
+use Elementor\Modules\WpRest\Classes\Elementor_Post_Meta;
 use Elementor\Modules\WpRest\Classes\Elementor_Settings;
 use Elementor\Modules\WpRest\Classes\Elementor_User_Meta;
 
@@ -19,6 +20,7 @@ class Module extends BaseModule {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', function () {
+			( new Elementor_Post_Meta() )->register();
 			( new Elementor_Settings() )->register();
 			( new Elementor_User_Meta() )->register();
 		} );

--- a/tests/phpunit/elementor/includes/template-library/test-manager-local.php
+++ b/tests/phpunit/elementor/includes/template-library/test-manager-local.php
@@ -256,6 +256,44 @@ class Elementor_Test_Manager_Local extends Elementor_Test_Base {
 		$this->assertIsArray( $response->get_data() );
 	}
 
+	public function test_admin_can_save_template_via_wp_rest() {
+		// Arrange
+		do_action( 'rest_api_init' );
+		wp_set_current_user( $this->factory()->get_administrator_user()->ID );
+
+		$template_data = [
+			'title' => 'Test Template',
+			'status' => 'publish',
+			'meta' => [
+				'_elementor_template_type' => 'container',
+				'_elementor_edit_mode' => 'builder',
+				'_elementor_data' => wp_json_encode([
+					[
+						'id' => 'test-section',
+						'elType' => 'section',
+						'settings' => [],
+						'elements' => [],
+						'isInner' => false
+					]
+				])
+			]
+		];
+
+		$request = new \WP_REST_Request( 'POST', '/wp/v2/elementor_library' );
+		$request->set_body_params( $template_data );
+
+		// Act
+		$response = rest_do_request( $request );
+		$result = $response->get_data();
+
+		// Assert
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertEquals( 'Test Template', $result['title']['rendered'] );
+		$this->assertEquals( 'container', get_post_meta( $result['id'], '_elementor_template_type', true ) );
+		$this->assertNotEmpty( get_post_meta( $result['id'], '_elementor_data', true ) );
+	}
+
 	/**
 	 * The data managers are killing the rest server (@see `kill_server`), and removing the post type rest routes.
 	 * This is a workaround to re-register the post type rest routes.

--- a/tests/phpunit/elementor/modules/wp-rest/test-elementor-post-meta.php
+++ b/tests/phpunit/elementor/modules/wp-rest/test-elementor-post-meta.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Elementor\Testing\Modules\WpRest;
+
+use Elementor\Modules\WpRest\Classes\Elementor_Post_Meta;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Elementor_Post_Meta extends Elementor_Test_Base {
+	protected Elementor_Post_Meta $post_meta;
+
+	protected int $post_id;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->post_meta = new Elementor_Post_Meta();
+		$this->post_id = $this->factory()->create_and_get_default_post()->ID;
+
+		$document = Plugin::$instance->documents->get( $this->post_id );
+		$document->set_is_built_with_elementor( true );
+
+		do_action( 'rest_api_init' );
+	}
+
+	public function test_register() {
+		// Arrange
+		$this->post_meta->register();
+
+		// Act
+		$request = new \WP_REST_Request( 'OPTIONS', '/wp/v2/posts' );
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data();
+		$meta_schema = $data['schema']['properties']['meta']['properties'];
+
+		// Assert
+		$this->assertArrayHasKey( '_elementor_edit_mode', $meta_schema );
+		$this->assertArrayHasKey( '_elementor_template_type', $meta_schema );
+		$this->assertArrayHasKey( '_elementor_data', $meta_schema );
+		$this->assertArrayHasKey( '_elementor_page_settings', $meta_schema );
+	}
+
+	public function test_check_edit_permission_with_valid_user() {
+		// Arrange
+		$this->act_as_admin();
+
+		// Act
+		$has_permission = $this->post_meta->check_edit_permission( true, '_elementor_edit_mode', $this->post_id );
+
+		// Assert
+		$this->assertTrue( $has_permission );
+	}
+
+	public function test_check_edit_permission_with_invalid_user() {
+		// Arrange
+		$this->act_as_subscriber();
+
+		// Act
+		$has_permission = $this->post_meta->check_edit_permission( true, '_elementor_edit_mode', $this->post_id );
+
+		// Assert
+		$this->assertFalse( $has_permission );
+	}
+
+	public function test_check_edit_permission_with_non_elementor_post() {
+		// Arrange
+		$this->act_as_admin();
+		$non_elementor_post_id = $this->factory()->post->create();
+
+		// Act
+		$has_permission = $this->post_meta->check_edit_permission( true, '_elementor_edit_mode', $non_elementor_post_id );
+
+		// Assert
+		$this->assertTrue( $has_permission );
+	}
+
+	public function test_check_edit_permission_with_elementor_post_and_excluded_user_roles() {
+		// Arrange
+		$this->act_as_admin();
+		update_option( 'elementor_exclude_user_roles', [ 'administrator' ] );
+
+		// Act
+		$has_permission = $this->post_meta->check_edit_permission( true, '_elementor_edit_mode', $this->post_id );
+
+		// Assert
+		$this->assertFalse( $has_permission );
+	}
+}

--- a/tests/phpunit/elementor/modules/wp-rest/test-elementor-post-meta.php
+++ b/tests/phpunit/elementor/modules/wp-rest/test-elementor-post-meta.php
@@ -89,4 +89,29 @@ class Test_Elementor_Post_Meta extends Elementor_Test_Base {
 		// Assert
 		$this->assertFalse( $has_permission );
 	}
+
+	public function test_meta_should_not_be_registered_for_non_elementor_post_types() {
+		// Arrange
+		$this->act_as_admin();
+
+		register_post_type( 'non_elementor', [
+			'public' => true,
+			'show_in_rest' => true,
+			'supports' => [ 'title', 'editor', 'custom-fields' ],
+		] );
+
+		do_action( 'rest_api_init' );
+
+		// Act
+		$request = new \WP_REST_Request( 'OPTIONS', '/wp/v2/non_elementor' );
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data();
+		
+		// Assert
+		$meta_schema = $data['schema']['properties']['meta']['properties'];
+		$this->assertArrayNotHasKey( '_elementor_edit_mode', $meta_schema );
+		$this->assertArrayNotHasKey( '_elementor_template_type', $meta_schema );
+		$this->assertArrayNotHasKey( '_elementor_data', $meta_schema );
+		$this->assertArrayNotHasKey( '_elementor_page_settings', $meta_schema );
+	}
 }


### PR DESCRIPTION
Reverts #30005 to re-add elementor post meta to WP REST API.
Fixed to register only for elementor-supported post types. 

The meta had to be registered with the `object_subtype` argument: 
```
register_meta( 'post', '_elementor_edit_mode', [
	'object_subtype' => $post_type,
``` 

And not as:

```
register_meta( $post_type, '_elementor_edit_mode', [
```