### PR TITLE
Fix: Kits cannot be imported if Container feature is disabled [ED-18043]

### DIFF
--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -44,10 +44,6 @@ class Module extends BaseModule {
 			add_action( 'elementor/import-export/import-kit/runner/after-run', [ $this, 'handle_kit_install' ] );
 		}
 
-		if ( ! Plugin::$instance->experiments->is_feature_active( 'container' ) ) {
-			return;
-		}
-
 		if ( ! $this->is_ai_enabled() ) {
 			return;
 		}
@@ -171,6 +167,10 @@ class Module extends BaseModule {
 	}
 
 	public function is_ai_enabled() {
+		if ( ! Plugin::$instance->experiments->is_feature_active( 'container' ) ) {
+			return false;
+		}
+
 		return Preferences::is_ai_enabled( get_current_user_id() );
 	}
 

--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -187,13 +187,13 @@ class Module extends BaseModule {
 			return;
 		}
 
-		$is_connected = $this->get_ai_app()->is_connected() && User::get_introduction_meta( 'ai_get_started' );
-
-		if ( ! $is_connected ) {
+		if ( ! isset( $imported_data['configData']['lastImportedSession']['instance_data']['site_settings']['settings']['ai'] ) ) {
 			return;
 		}
 
-		if ( ! isset( $imported_data['configData']['lastImportedSession']['instance_data']['site_settings']['settings']['ai'] ) ) {
+		$is_connected = $this->get_ai_app()->is_connected() && User::get_introduction_meta( 'ai_get_started' );
+
+		if ( ! $is_connected ) {
 			return;
 		}
 

--- a/tests/phpunit/elementor/modules/ai/test-module.php
+++ b/tests/phpunit/elementor/modules/ai/test-module.php
@@ -177,4 +177,20 @@ class Elementor_Test_Module extends Elementor_Test_Base {
 
 		do_action( 'elementor/import-export/import-kit/runner/after-run', $imported_data );
 	}
+
+	public function test_is_ai_enabled_should_return_true_if_container_experiment_active() {
+		Plugin::$instance->experiments->set_feature_default_state( 'container', 'active' );
+
+		$module = new Module();
+
+		$this->assertTrue( $module->is_ai_enabled() );
+	}
+
+	public function test_is_ai_enabled_should_return_false_if_container_experiment_inactive() {
+		Plugin::$instance->experiments->set_feature_default_state( 'container', 'inactive' );
+		
+		$module = new Module();
+
+		$this->assertFalse( $module->is_ai_enabled() );
+	}
 }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Kits cannot be imported when the Container feature is disabled [ED-18043]

## Description
An explanation of what is done in this PR

* Avoid running the AI hook on the import kit when the Container feature is disabled
* Avoid running the AI hook on the import kit when it's not an AI-generated kit
* Added proper test coverage for the Container feature dependency

## Test instructions
This PR can be tested by following these steps:

* Disable the Container experiment in Elementor
* Try to import a Kit
* Verify that the Kit imports successfully
* Verify that AI features are properly disabled when Container is inactive
* Enable Container experiment and verify AI features become available

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unit tests to verify the code works as intended

Fixes #ED-18043

[ED-18043]: https://elementor.atlassian.net/browse/ED-18043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ