### PR TITLE
Internal: Update test methods [ED-17678]

### DIFF
--- a/tests/playwright/pages/editor-page.ts
+++ b/tests/playwright/pages/editor-page.ts
@@ -61,7 +61,10 @@ export default class EditorPage extends BasePage {
 	}
 
 	/**
-	 * Upload SVG in the Media Library. Expects media library to be open.
+	 * Upload SVG in the Media Library. Can be used on both Media Control and Icons Control.
+	 *
+	 * Please note that this method expects media library to be open as different controls
+	 * have different ways to open the media library.
 	 *
 	 * @param {string} svgFileName - Optional. SVG file name, without extension.
 	 *

--- a/tests/playwright/pages/elementor-panel-tabs/content.ts
+++ b/tests/playwright/pages/elementor-panel-tabs/content.ts
@@ -138,34 +138,6 @@ export default class Content {
 	}
 
 	/**
-	 * Upload SVG icon.
-	 *
-	 * @param {Object} options        - SVG options.
-	 * @param {string} options.icon   - SVG icon.
-	 * @param {string} options.widget - The widget to which to upload the SVG.
-	 *
-	 * @return {Promise<void>}
-	 */
-	async uploadSVG( options? : { icon?: string, widget?: string} ): Promise<void> {
-		const _icon = options?.icon === undefined ? 'test-svg-wide' : options.icon;
-		if ( 'text-path' === options?.widget ) {
-			await this.page.locator( EditorSelectors.plusIcon ).click();
-		} else {
-			await this.editor.openPanelTab( 'content' );
-			const mediaUploadControl = this.page.locator( EditorSelectors.media.preview ).first();
-			await mediaUploadControl.hover();
-			await mediaUploadControl.waitFor();
-			await this.page.getByText( 'Upload SVG' ).first().click();
-		}
-		const regex = new RegExp( _icon );
-		const response = this.page.waitForResponse( regex );
-		await this.page.setInputFiles( EditorSelectors.media.imageInp, path.resolve( __dirname, `../../resources/${ _icon }.svg` ) );
-		await response;
-		await this.page.getByRole( 'button', { name: 'Insert Media' } )
-			.or( this.page.getByRole( 'button', { name: 'Select' } ) ).nth( 1 ).click();
-	}
-
-	/**
 	 * Parse link (HTML `a` tag) `src` attribute and gets Query Params and their values.
 	 * The same as you copy src attribute value and put in Postman
 	 *

--- a/tests/playwright/pages/elementor-panel-tabs/content.ts
+++ b/tests/playwright/pages/elementor-panel-tabs/content.ts
@@ -1,7 +1,6 @@
 import EditorSelectors from '../../selectors/editor-selectors';
 import { expect, type Frame, Locator, type Page, type TestInfo } from '@playwright/test';
 import EditorPage from '../editor-page';
-import path from 'path';
 import { LinkOptions } from '../../types/types';
 
 export default class Content {

--- a/tests/playwright/sanity/includes/widgets/icon.test.ts
+++ b/tests/playwright/sanity/includes/widgets/icon.test.ts
@@ -2,7 +2,6 @@ import { expect } from '@playwright/test';
 import { parallelTest as test } from '../../../parallelTest';
 import WpAdminPage from '../../../pages/wp-admin-page';
 import EditorPage from '../../../pages/editor-page';
-import Content from '../../../pages/elementor-panel-tabs/content';
 import EditorSelectors from '../../../selectors/editor-selectors';
 
 test.describe( 'Icon and social icon widget tests', () => {
@@ -25,7 +24,6 @@ test.describe( 'Icon and social icon widget tests', () => {
 		const editor = await wpAdmin.openNewPage(),
 			iconWidget = await editor.addWidget( 'icon' ),
 			iconSelector = '.elementor-element-' + iconWidget + ' .elementor-icon';
-		const contentTab = new Content( page, testInfo );
 
 		await test.step( 'Fit Aspect hidden for Icons', async () => {
 			await editor.openPanelTab( 'style' );
@@ -33,7 +31,11 @@ test.describe( 'Icon and social icon widget tests', () => {
 		} );
 
 		await test.step( 'Act', async () => {
-			await contentTab.uploadSVG();
+			const mediaUploadControl = page.locator( '.elementor-control-selected_icon .elementor-control-media__preview' ).first();
+			await mediaUploadControl.hover();
+			await mediaUploadControl.waitFor();
+			await page.getByText( 'Upload SVG' ).first().click();
+			await editor.uploadSVG();
 			await editor.openPanelTab( 'style' );
 			await page.locator( '.elementor-switch-label' ).click();
 			await editor.setSliderControlValue( 'size', '300' );
@@ -62,13 +64,21 @@ test.describe( 'Icon and social icon widget tests', () => {
 	} );
 
 	test( 'Social icons: upload svg', async ( { page, apiRequests }, testInfo ) => {
+		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
 		const editor = new EditorPage( page, testInfo );
-		const contentTab = new Content( page, testInfo );
 		await wpAdmin.openNewPage();
+
+		// Act.
 		await editor.addWidget( 'social-icons' );
 		await page.locator( EditorSelectors.item ).first().click();
-		await contentTab.uploadSVG();
+		const mediaUploadControl = page.locator( '.elementor-control-social_icon .elementor-control-media__preview' ).first();
+		await mediaUploadControl.hover();
+		await mediaUploadControl.waitFor();
+		await page.getByText( 'Upload SVG' ).first().click();
+		await editor.uploadSVG();
+
+		// Assert.
 		await expect( editor.getPreviewFrame().locator( EditorSelectors.socialIcons.svgIcon ) ).toBeVisible();
 		await editor.publishAndViewPage();
 		await expect( page.locator( EditorSelectors.socialIcons.svgIcon ) ).toBeVisible();

--- a/tests/playwright/sanity/includes/widgets/icon.test.ts
+++ b/tests/playwright/sanity/includes/widgets/icon.test.ts
@@ -31,6 +31,7 @@ test.describe( 'Icon and social icon widget tests', () => {
 		} );
 
 		await test.step( 'Act', async () => {
+			await editor.openPanelTab( 'content' );
 			const mediaUploadControl = page.locator( '.elementor-control-selected_icon .elementor-control-media__preview' ).first();
 			await mediaUploadControl.hover();
 			await mediaUploadControl.waitFor();

--- a/tests/playwright/sanity/includes/widgets/text-path.test.ts
+++ b/tests/playwright/sanity/includes/widgets/text-path.test.ts
@@ -16,7 +16,7 @@ test( 'Custom path type', async ( { page, apiRequests }, testInfo ) => {
 	// Act.
 	await editor.addWidget( 'text-path' );
 	await editor.setSelectControlValue( 'path', 'custom' );
-	await page.locator( '.elementor-control-custom_path .elementor-control-media__preview' ).click();
+	await page.locator( '.elementor-control-custom_path .eicon-plus-circle' ).click();
 	await editor.uploadSVG();
 
 	// Assert.

--- a/tests/playwright/sanity/includes/widgets/text-path.test.ts
+++ b/tests/playwright/sanity/includes/widgets/text-path.test.ts
@@ -2,19 +2,24 @@ import { expect } from '@playwright/test';
 import { parallelTest as test } from '../../../parallelTest';
 import WpAdminPage from '../../../pages/wp-admin-page';
 import EditorPage from '../../../pages/editor-page';
-import Content from '../../../pages/elementor-panel-tabs/content';
 import EditorSelectors from '../../../selectors/editor-selectors';
 
 test( 'Custom path type', async ( { page, apiRequests }, testInfo ) => {
+	// Arrange.
 	const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
 	const editor = new EditorPage( page, testInfo );
-	const contentTab = new Content( page, testInfo );
+
 	await wpAdmin.enableAdvancedUploads();
 	await wpAdmin.openNewPage();
 	await editor.closeNavigatorIfOpen();
+
+	// Act.
 	await editor.addWidget( 'text-path' );
 	await editor.setSelectControlValue( 'path', 'custom' );
-	await contentTab.uploadSVG( { widget: 'text-path' } );
+	await page.locator( '.elementor-control-custom_path .elementor-control-media__preview' ).click();
+	await editor.uploadSVG();
+
+	// Assert.
 	await expect( editor.getPreviewFrame().locator( EditorSelectors.textPath.svgIcon ) ).toBeVisible();
 	await editor.publishAndViewPage();
 	await expect( page.locator( EditorSelectors.textPath.svgIcon ) ).toBeVisible();


### PR DESCRIPTION
Elementor tests have 2 very similar methods to upload SVG. One in the `Content()` class, the other in `EditorPage()`. Eventually, we will delete the `Content()`, moving the methods to helper files used by specific widgets. This PR removes the duplicate `uploadSVG()` methods.

Tests: https://github.com/elementor/elementor/actions/runs/13153619513