### PR TITLE
Fix: Can't save a page in Gutenberg with ACF and active Elementor post settings [ED-18151]

### DIFF
--- a/modules/wp-rest/classes/elementor-post-meta.php
+++ b/modules/wp-rest/classes/elementor-post-meta.php
@@ -85,6 +85,7 @@ class Elementor_Post_Meta {
 		register_meta( 'post', '_elementor_page_settings', [
 			'single' => true,
 			'object_subtype' => $post_type,
+			'type' => 'object',
 			'show_in_rest' => [
 				'schema' => [
 					'title' => 'Elementor page settings',

--- a/tests/phpunit/elementor/modules/wp-rest/test-elementor-post-meta.php
+++ b/tests/phpunit/elementor/modules/wp-rest/test-elementor-post-meta.php
@@ -106,12 +106,68 @@ class Test_Elementor_Post_Meta extends Elementor_Test_Base {
 		$request = new \WP_REST_Request( 'OPTIONS', '/wp/v2/non_elementor' );
 		$response = rest_get_server()->dispatch( $request );
 		$data = $response->get_data();
-		
+
 		// Assert
 		$meta_schema = $data['schema']['properties']['meta']['properties'];
 		$this->assertArrayNotHasKey( '_elementor_edit_mode', $meta_schema );
 		$this->assertArrayNotHasKey( '_elementor_template_type', $meta_schema );
 		$this->assertArrayNotHasKey( '_elementor_data', $meta_schema );
 		$this->assertArrayNotHasKey( '_elementor_page_settings', $meta_schema );
+	}
+
+	public function test_page_settings_json_object_should_be_saved_as_an_array() {
+		// Arrange
+		$this->act_as_admin();
+
+		$page_settings = [
+			'hide_title' => 'yes',
+			'custom_setting' => 'value',
+		];
+
+		$object_settings = (object) [
+			'meta' => (object) [
+				'_elementor_page_settings' => (object) $page_settings,
+			],
+		];
+
+		$json_string = wp_json_encode( $object_settings );
+
+		// Act
+		$request = new \WP_REST_Request( 'POST', '/wp/v2/posts/' . $this->post_id );
+		$request->set_body( $json_string );
+		$request->set_header( 'content-type', 'application/json' );
+		rest_get_server()->dispatch( $request );
+
+		// Assert
+		$saved_value = get_post_meta( $this->post_id, '_elementor_page_settings', true );
+		$this->assertEquals( $page_settings, $saved_value, 'Saved value should be an array' );
+	}
+
+	/**
+	 * @see https://github.com/elementor/elementor/issues/30160
+	 * Issue caused by WP_REST_Meta_Fields::is_meta_value_same_as_stored_value() function that attempted to
+	 * sanitize the meta value as a string by using a default type of 'string' in the schema.
+	 */
+	public function test_page_settings_should_be_saved_when_meta_value_is_same_as_stored_value() {
+		// Arrange
+		$this->act_as_admin();
+
+		$page_settings = [
+			'hide_title' => 'yes',
+			'custom_setting' => 'value',
+		];
+
+		update_post_meta( $this->post_id, '_elementor_page_settings', $page_settings );
+
+		// Act
+		$request = new \WP_REST_Request( 'POST', '/wp/v2/posts/' . $this->post_id );
+		$request->set_param( 'meta', [
+			'_elementor_page_settings' => $page_settings,
+		] );
+		$request->set_header( 'content-type', 'application/json' );
+		$data = rest_get_server()->dispatch( $request );
+
+		// Assert
+		$this->assertEquals( 200, $data->get_status(), 'Status should be 200' );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/elementor/elementor/issues/29970, https://github.com/elementor/elementor/issues/30160

This issue was caused by the WP_REST_Meta_Fields::is_meta_value_same_as_stored_value() function, which attempted to sanitize the meta value as a string by using a default string type in the schema.
