### PR TITLE
Internal: Unselect removed widgets [ED-17913]

### DIFF
--- a/assets/dev/js/editor/document/elements/commands/delete.js
+++ b/assets/dev/js/editor/document/elements/commands/delete.js
@@ -50,6 +50,10 @@ export class Delete extends $e.modules.editor.document.CommandHistoryBase {
 
 			container.model.destroy();
 			container.panel.refresh();
+
+			if ( elementor.selection.has( container ) ) {
+				$e.run( 'document/elements/deselect', { container } );
+			}
 		} );
 
 		if ( 1 === containers.length ) {


### PR DESCRIPTION
Small fix to deselect widgets upon deletion, if they are in the `elementor.selection` items

Though the issue affects visually V4 elements (as the editing panel is not closed upon deletion) this fix is also relevant to V3, as the actual selection list is not emptied of deleted elements, both V3 and V4