### PR TITLE
Fix: Theme Builder: template Display Conditions third dropdown doesn't work (#30729, #30732) [ED-18741]

### DIFF
--- a/assets/dev/scss/global/_dialog-lightbox.scss
+++ b/assets/dev/scss/global/_dialog-lightbox.scss
@@ -9,7 +9,7 @@
 	bottom: 0;
 	left: 0;
 	background-color: rgba(0, 0, 0, 0.8);
-	z-index: $lightbox-layer;
+	z-index: 9999;
 	user-select: none;
 }
 

--- a/assets/dev/scss/helpers/variables.scss
+++ b/assets/dev/scss/helpers/variables.scss
@@ -193,7 +193,6 @@ $fourth-layer: 4;
 $element-overlay: 9998;
 $editor-layer: 9999;
 $super-layer: 10000;
-$lightbox-layer: 190000;
 
 // Info Alert
 $info:			#5bc0de;

--- a/modules/ai/assets/js/editor/pages/form-media/hooks/use-image-actions.js
+++ b/modules/ai/assets/js/editor/pages/form-media/hooks/use-image-actions.js
@@ -30,8 +30,11 @@ const useImageActions = () => {
 		) || elementorCommon.config.filesUpload.unfilteredFiles;
 
 		if ( ! isUploadAllowed ) {
-			FilesUploadHandler.getUnfilteredFilesNotEnabledDialog( () => {} ).show();
+			const dialog = FilesUploadHandler.getUnfilteredFilesNotEnabledDialog( () => {} );
+			dialog.getElements( 'widget' ).css( 'z-index', '170001' );
+			dialog.show();
 		}
+
 		return isUploadAllowed;
 	};
 

--- a/tests/jest/unit/modules/ai/assets/js/editor/pages/form-media/hooks/use-image-actions.test.js
+++ b/tests/jest/unit/modules/ai/assets/js/editor/pages/form-media/hooks/use-image-actions.test.js
@@ -6,11 +6,16 @@ const { useGlobalActions } = require( 'elementor/modules/ai/assets/js/editor/pag
 jest.mock( 'elementor/modules/ai/assets/js/editor/pages/form-media/context/edit-image-context' );
 jest.mock( 'elementor/modules/ai/assets/js/editor/pages/form-media/hooks/use-image-upload' );
 jest.mock( 'elementor/modules/ai/assets/js/editor/pages/form-media/context/global-actions-context' );
-jest.mock( 'elementor-editor/utils/files-upload-handler', () => ( {
-	getUnfilteredFilesNotEnabledDialog: jest.fn().mockReturnValue( {
-		show: jest.fn(),
-	} ),
-} ) );
+jest.mock( 'elementor-editor/utils/files-upload-handler', () => {
+	return {
+		getUnfilteredFilesNotEnabledDialog: jest.fn().mockReturnValue( {
+			getElements: jest.fn().mockReturnValue( {
+				css: jest.fn(),
+			} ),
+			show: jest.fn(),
+		} ),
+	};
+} );
 
 describe( 'useImageActions', () => {
 	beforeEach( () => {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] Bugfix

## Summary

* Fix: Theme Builder: template Display Conditions third dropdown doesn't work (#30729, #30732) [AI-2905]


## Description

* Removed z-index used via css and make functional css addition on dialog show

Fixes for [AI-2905] [ED-18741] 


## Quality assurance

- [x] I have tested this code to the best of my abilities


[AI-2905]: https://elementor.atlassian.net/browse/AI-2905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ED-18741]: https://elementor.atlassian.net/browse/ED-18741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ