### PR TITLE
Fix: Allow inline editing when having multiple repeaters in the controls, 3.28 ver. [ED-18719] 

### DIFF
--- a/assets/dev/js/editor/elements/views/behaviors/inline-editing.js
+++ b/assets/dev/js/editor/elements/views/behaviors/inline-editing.js
@@ -201,11 +201,17 @@ InlineEditingBehavior = Marionette.Behavior.extend( {
 
 		const parts = key.split( '.' );
 
+		const isRepeaterKey = 3 === parts.length;
 		// Is it repeater?
-		if ( 3 === parts.length ) {
-			container = container.repeaters[ parts[ 0 ] ];
-			container = container.children[ parts[ 1 ] ];
-			key = parts[ 2 ];
+		if ( isRepeaterKey ) {
+			const repaterId = parts[ 0 ];
+			const repeater = container.repeaters[ repaterId ];
+
+			const repeaterChildIndex = parts[ 1 ];
+			container = repeater.children[ repeaterChildIndex ];
+
+			const fieldToUpdate = parts[ 2 ];
+			key = fieldToUpdate;
 		}
 
 		$e.run( 'document/elements/settings', {

--- a/assets/dev/js/editor/elements/views/behaviors/inline-editing.js
+++ b/assets/dev/js/editor/elements/views/behaviors/inline-editing.js
@@ -203,6 +203,7 @@ InlineEditingBehavior = Marionette.Behavior.extend( {
 
 		// Is it repeater?
 		if ( 3 === parts.length ) {
+			container = container.repeaters[ parts[ 0 ] ];
 			container = container.children[ parts[ 1 ] ];
 			key = parts[ 2 ];
 		}

--- a/assets/dev/js/editor/elements/views/behaviors/inline-editing.js
+++ b/assets/dev/js/editor/elements/views/behaviors/inline-editing.js
@@ -202,10 +202,10 @@ InlineEditingBehavior = Marionette.Behavior.extend( {
 		const parts = key.split( '.' );
 
 		const isRepeaterKey = 3 === parts.length;
-		// Is it repeater?
+
 		if ( isRepeaterKey ) {
-			const repaterId = parts[ 0 ];
-			const repeater = container.repeaters[ repaterId ];
+			const repeaterId = parts[ 0 ];
+			const repeater = container.repeaters[ repeaterId ];
 
 			const repeaterChildIndex = parts[ 1 ];
 			container = repeater.children[ repeaterChildIndex ];

--- a/includes/base/widget-base.php
+++ b/includes/base/widget-base.php
@@ -852,7 +852,7 @@ abstract class Widget_Base extends Element_Base {
 	 *
 	 * @return string The repeater setting key (e.g. `tabs.3.tab_title`).
 	 */
-	public function get_repeater_setting_key( $setting_key, $repeater_key, $repeater_item_index ) {
+	protected function get_repeater_setting_key( $setting_key, $repeater_key, $repeater_item_index ) {
 		return implode( '.', [ $repeater_key, $repeater_item_index, $setting_key ] );
 	}
 
@@ -878,7 +878,7 @@ abstract class Widget_Base extends Element_Base {
 	 * @param string $toolbar Optional. Toolbar type. Accepted values are `advanced`, `basic` or `none`. Default is
 	 *                        `basic`.
 	 */
-	public function add_inline_editing_attributes( $key, $toolbar = 'basic' ) {
+	protected function add_inline_editing_attributes( $key, $toolbar = 'basic' ) {
 		if ( ! Plugin::$instance->editor->is_edit_mode() ) {
 			return;
 		}

--- a/includes/base/widget-base.php
+++ b/includes/base/widget-base.php
@@ -852,7 +852,7 @@ abstract class Widget_Base extends Element_Base {
 	 *
 	 * @return string The repeater setting key (e.g. `tabs.3.tab_title`).
 	 */
-	protected function get_repeater_setting_key( $setting_key, $repeater_key, $repeater_item_index ) {
+	public function get_repeater_setting_key( $setting_key, $repeater_key, $repeater_item_index ) {
 		return implode( '.', [ $repeater_key, $repeater_item_index, $setting_key ] );
 	}
 
@@ -878,7 +878,7 @@ abstract class Widget_Base extends Element_Base {
 	 * @param string $toolbar Optional. Toolbar type. Accepted values are `advanced`, `basic` or `none`. Default is
 	 *                        `basic`.
 	 */
-	protected function add_inline_editing_attributes( $key, $toolbar = 'basic' ) {
+	public function add_inline_editing_attributes( $key, $toolbar = 'basic' ) {
 		if ( ! Plugin::$instance->editor->is_edit_mode() ) {
 			return;
 		}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Widgets with multiple repeaters can now  implement inline editing

## Description
An explanation of what is done in this PR
I refactored the way inline editing works with repeaters, because the way it is working now looks like related to a legacy approach in the container file https://github.com/elementor/elementor/blob/main/assets/dev/js/editor/container/container.js#L372

## Test instructions
This PR can be tested by following these steps:

* I will push a branch on hello-plus where this can be tested

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
