### PR TITLE
Add filter for should_optimize_controls return value

### DIFF
--- a/core/frontend/performance.php
+++ b/core/frontend/performance.php
@@ -25,6 +25,6 @@ class Performance {
 			);
 		}
 
-		return static::$is_frontend;
+		return apply_filters( 'elementor/core/frontend/performance/should_optimize_controls', static::$is_frontend );
 	}
 }


### PR DESCRIPTION


## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

 - Add filter to the return value from `should_optimize_controls`

## Description

 - Some third party plugins break when the controls are optimised. Allowing the 3rd party plugin to temporarily disable control optimization will allow better compatibility.

## Test instructions

```
function custom_elementor_optimize_controls_callback( $optimize_controls ) {
    return false; // or true
}
add_filter( 'elementor/core/frontend/performance/should_optimize_controls', 'custom_elementor_optimize_controls_callback' );
```

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
