### PR TITLE
Internal: Move Isolate object to a standalone endpoint [AI-2909]

### DIFF
--- a/modules/ai/assets/js/editor/pages/form-media/constants/index.js
+++ b/modules/ai/assets/js/editor/pages/form-media/constants/index.js
@@ -24,6 +24,10 @@ export const IMAGE_PROMPT_SETTINGS = {
 	IMAGE_BACKGROUND_COLOR: 'background_color',
 };
 
+export const FEATURE_IDENTIFIER = {
+	ISOLATE_OBJECT: 'isolate-object',
+};
+
 export const IMAGE_PROMPT_CATEGORIES = {
 	'': {
 		label: __( 'None', 'elementor' ),

--- a/modules/ai/assets/js/editor/pages/form-media/views/isolate-objects/index.js
+++ b/modules/ai/assets/js/editor/pages/form-media/views/isolate-objects/index.js
@@ -13,6 +13,7 @@ import { useRequestIds } from '../../../../context/requests-ids';
 import usePromptSettings, { IMAGE_BACKGROUND_COLOR, IMAGE_RATIO } from '../../hooks/use-prompt-settings';
 import ColorInput from '../../components/color-picker';
 import { useMemo } from 'react';
+import { FEATURE_IDENTIFIER } from '../../constants';
 
 const IsolateObject = () => {
 	const { editImage } = useEditImage();
@@ -39,6 +40,7 @@ const IsolateObject = () => {
 				[ IMAGE_RATIO ]: generatedAspectRatio,
 				[ IMAGE_BACKGROUND_COLOR ]: generatedBgColor,
 			},
+			featureIdentifier: FEATURE_IDENTIFIER.ISOLATE_OBJECT,
 		} );
 	};
 

--- a/modules/ai/connect/ai.php
+++ b/modules/ai/connect/ai.php
@@ -471,6 +471,7 @@ class Ai extends Library {
 			[
 				'aspectRatio' => $image_data['promptSettings'][ self::ASPECT_RATIO ],
 				'backgroundColor' => $image_data['promptSettings'][ self::IMAGE_BACKGROUND_COLOR ],
+				'featureIdentifier' => $image_data['featureIdentifier'],
 				'context' => wp_json_encode( $context ),
 				'ids' => $request_ids,
 				'api_version' => ELEMENTOR_VERSION,

--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -1433,6 +1433,7 @@ class Module extends BaseModule {
 		$result = $app->get_unify_product_images( [
 			'promptSettings' => $data['payload']['settings'],
 			'attachment_id' => $data['payload']['image']['id'],
+			'featureIdentifier' => $data['payload']['featureIdentifier'] ?? '',
 		], $context, $request_ids );
 
 		$this->throw_on_error( $result );

--- a/tests/jest/unit/modules/ai/assets/js/editor/pages/form-media/views/isolate-objects/index.test.js
+++ b/tests/jest/unit/modules/ai/assets/js/editor/pages/form-media/views/isolate-objects/index.test.js
@@ -52,6 +52,7 @@ const { useLocation } = require( 'elementor/modules/ai/assets/js/editor/pages/fo
 const usePromptSettings = require( 'elementor/modules/ai/assets/js/editor/pages/form-media/hooks/use-prompt-settings' ).default;
 const { IMAGE_RATIO, IMAGE_BACKGROUND_COLOR } = require( 'elementor/modules/ai/assets/js/editor/pages/form-media/hooks/use-prompt-settings' );
 const IsolateObject = require( 'elementor/modules/ai/assets/js/editor/pages/form-media/views/isolate-objects/index' ).default;
+const { FEATURE_IDENTIFIER } = require( 'elementor/modules/ai/assets/js/editor/pages/form-media/constants' );
 
 describe( 'IsolateObject Component - Functional Tests', () => {
 	const mockSubmitFn = jest.fn();
@@ -131,6 +132,7 @@ describe( 'IsolateObject Component - Functional Tests', () => {
 				[ IMAGE_RATIO ]: '1:1',
 				[ IMAGE_BACKGROUND_COLOR ]: '#ffffff',
 			},
+			featureIdentifier: FEATURE_IDENTIFIER.ISOLATE_OBJECT,
 		} );
 	} );
 


### PR DESCRIPTION
## PR Type
- [x] Bugfix

## Summary

We want to identify which feature triggered the API call. To achieve this, we added a new parameter to the API request: featureIdentifier.
Currently, this is explicitly added to the "Isolate Object" feature, as it’s the first scenario where we need to distinguish the triggering feature. This is necessary because it shares the same call function with the "Unify Images" feature.


## Quality assurance

- [x] I have tested this code to the best of my abilities
