### PR TITLE
Fix: Inline editing multiple repeaters in the controls [ED-18719]

### DIFF
--- a/assets/dev/js/editor/elements/views/behaviors/inline-editing.js
+++ b/assets/dev/js/editor/elements/views/behaviors/inline-editing.js
@@ -201,10 +201,17 @@ InlineEditingBehavior = Marionette.Behavior.extend( {
 
 		const parts = key.split( '.' );
 
-		// Is it repeater?
-		if ( 3 === parts.length ) {
-			container = container.children[ parts[ 1 ] ];
-			key = parts[ 2 ];
+		const isRepeaterKey = 3 === parts.length;
+
+		if ( isRepeaterKey ) {
+			const repeaterId = parts[ 0 ];
+			const repeater = container.repeaters[ repeaterId ];
+
+			const repeaterChildIndex = parts[ 1 ];
+			container = repeater.children[ repeaterChildIndex ];
+
+			const fieldToUpdate = parts[ 2 ];
+			key = fieldToUpdate;
 		}
 
 		$e.run( 'document/elements/settings', {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Widgets with multiple repeaters can now implement inline editing

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
