### PR TITLE
Fix: Background UI fix for the Site Planner banner on Elementor Home screen

### DIFF
--- a/assets/images/app/ai/ai-site-creator-homepage-bg.svg
+++ b/assets/images/app/ai/ai-site-creator-homepage-bg.svg
@@ -1,54 +1,54 @@
-<svg width="403" height="178" viewBox="0 0 403 178" fill="none" xmlns="http://www.w3.org/2000/svg">
-<mask id="mask0_14738_2317" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="403" height="178">
-<path d="M0.5 8.24218C0.5 3.82391 4.08172 0.242188 8.5 0.242188H394.541C398.959 0.242188 402.541 3.82391 402.541 8.24219V169.242C402.541 173.66 398.959 177.242 394.541 177.242H8.5C4.08172 177.242 0.5 173.66 0.5 169.242V8.24218Z" fill="white"/>
+<svg width="402" height="177" viewBox="0 0 402 177" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_14738_2317" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="402" height="177">
+<path d="M0 0H402V177H0V0Z" fill="white"/>
 </mask>
 <g mask="url(#mask0_14738_2317)">
 <g style="mix-blend-mode:multiply" opacity="0.16" clip-path="url(#clip0_14738_2317)">
-<rect width="534.45" height="529.346" transform="translate(-23 -169.529)" fill="white"/>
+<rect width="534.395" height="529.346" transform="translate(-23.498 -169.771)" fill="white"/>
 <g filter="url(#filter0_f_14738_2317)">
-<circle cx="239.56" cy="10.2473" r="120.921" fill="black"/>
-<circle cx="315.985" cy="95.3197" r="142.84" transform="rotate(-165 315.985 95.3197)" fill="black"/>
-<circle cx="157.343" cy="157.343" r="157.343" transform="matrix(0.998118 0.0613208 0.0613208 -0.998118 -3.25195 296.248)" fill="black"/>
-<circle cx="111.789" cy="111.789" r="111.789" transform="matrix(0.976166 0.217027 0.217027 -0.976166 185.895 238.844)" fill="black"/>
-<circle cx="295.694" cy="103.727" r="131.612" fill="black"/>
+<circle cx="239.062" cy="10.0051" r="120.921" fill="black"/>
+<circle cx="315.487" cy="95.0776" r="142.84" transform="rotate(-165 315.487 95.0776)" fill="black"/>
+<circle cx="157.343" cy="157.343" r="157.343" transform="matrix(0.998118 0.0613208 0.0613208 -0.998118 -3.75 296.006)" fill="black"/>
+<circle cx="111.789" cy="111.789" r="111.789" transform="matrix(0.976166 0.217027 0.217027 -0.976166 185.396 238.602)" fill="black"/>
+<circle cx="295.196" cy="103.485" r="131.612" fill="black"/>
 </g>
 <g style="mix-blend-mode:color-dodge">
-<rect x="-50.7637" y="-168.941" width="582.461" height="547.055" fill="#878787"/>
+<rect x="-51.2617" y="-169.184" width="582.461" height="547.055" fill="#878787"/>
 </g>
 <g style="mix-blend-mode:color-burn">
-<rect x="-50.7637" y="-168.941" width="582.461" height="547.055" fill="white"/>
+<rect x="-51.2617" y="-169.184" width="582.461" height="547.055" fill="white"/>
 </g>
 <g style="mix-blend-mode:screen">
-<rect width="771.761" height="724.848" transform="translate(-145.412 -257.838)" fill="url(#paint0_linear_14738_2317)"/>
+<rect width="771.761" height="724.848" transform="translate(-145.91 -258.08)" fill="url(#paint0_linear_14738_2317)"/>
 </g>
 </g>
 <g style="mix-blend-mode:multiply" opacity="0.16" clip-path="url(#clip1_14738_2317)">
-<rect width="582.426" height="576.865" transform="translate(150.979 -161.234)" fill="white"/>
+<rect width="582.366" height="576.865" transform="translate(150.463 -161.477)" fill="white"/>
 <g filter="url(#filter1_f_14738_2317)">
-<circle cx="445.989" cy="34.6841" r="131.776" fill="black"/>
-<circle cx="529.274" cy="127.389" r="155.662" transform="rotate(-165 529.274 127.389)" fill="black"/>
-<circle cx="171.467" cy="171.467" r="171.467" transform="matrix(0.998118 0.0613208 0.0613208 -0.998118 181.377 346.354)" fill="black"/>
-<circle cx="121.824" cy="121.824" r="121.824" transform="matrix(0.976166 0.217027 0.217027 -0.976166 387.504 283.795)" fill="black"/>
-<circle cx="507.161" cy="136.552" r="143.427" fill="black"/>
+<circle cx="445.473" cy="34.4419" r="131.776" fill="black"/>
+<circle cx="528.759" cy="127.147" r="155.662" transform="rotate(-165 528.759 127.147)" fill="black"/>
+<circle cx="171.467" cy="171.467" r="171.467" transform="matrix(0.998118 0.0613208 0.0613208 -0.998118 180.861 346.111)" fill="black"/>
+<circle cx="121.824" cy="121.824" r="121.824" transform="matrix(0.976166 0.217027 0.217027 -0.976166 386.988 283.553)" fill="black"/>
+<circle cx="506.645" cy="136.309" r="143.427" fill="black"/>
 </g>
 <g style="mix-blend-mode:color-dodge">
-<rect x="129.6" y="-160.594" width="634.747" height="596.163" fill="#878787"/>
+<rect x="129.084" y="-160.836" width="634.747" height="596.163" fill="#878787"/>
 </g>
 <g style="mix-blend-mode:color-burn">
-<rect x="129.6" y="-160.594" width="634.747" height="596.163" fill="white"/>
+<rect x="129.084" y="-160.836" width="634.747" height="596.163" fill="white"/>
 </g>
 <g style="mix-blend-mode:screen">
-<rect width="841.04" height="789.916" transform="translate(58.7812 -151.865)" fill="url(#paint1_linear_14738_2317)"/>
+<rect width="841.04" height="789.916" transform="translate(58.2656 -152.107)" fill="url(#paint1_linear_14738_2317)"/>
 </g>
 </g>
 </g>
 <defs>
-<filter id="filter0_f_14738_2317" x="-156.483" y="-322.375" width="812.578" height="835.557" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_f_14738_2317" x="-156.981" y="-322.617" width="812.578" height="835.558" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feGaussianBlur stdDeviation="76.4229" result="effect1_foregroundBlur_14738_2317"/>
 </filter>
-<filter id="filter1_f_14738_2317" x="14.3944" y="-327.801" width="885.522" height="910.563" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_f_14738_2317" x="13.8788" y="-328.043" width="885.522" height="910.564" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feGaussianBlur stdDeviation="83.2832" result="effect1_foregroundBlur_14738_2317"/>
@@ -63,10 +63,10 @@
 <stop offset="1" stop-color="#A0F7FC"/>
 </linearGradient>
 <clipPath id="clip0_14738_2317">
-<rect width="534.45" height="529.346" fill="white" transform="translate(-23 -169.529)"/>
+<rect width="534.395" height="529.346" fill="white" transform="translate(-23.498 -169.771)"/>
 </clipPath>
 <clipPath id="clip1_14738_2317">
-<rect width="582.426" height="576.865" fill="white" transform="translate(150.979 -161.234)"/>
+<rect width="582.366" height="576.865" fill="white" transform="translate(150.463 -161.477)"/>
 </clipPath>
 </defs>
 </svg>

--- a/modules/home/assets/js/components/create-with-ai-banner.js
+++ b/modules/home/assets/js/components/create-with-ai-banner.js
@@ -67,7 +67,7 @@ const CreateWithAIBanner = ( { ...props } ) => {
 				boxShadow: 'none',
 				backgroundImage: `url(${ backgroundImage })`,
 				backgroundSize: 'cover',
-				backgroundPosition: '1px',
+				backgroundPosition: 'right center',
 				backgroundRepeat: 'no-repeat',
 			} }
 		>

--- a/modules/home/assets/js/components/create-with-ai-banner.js
+++ b/modules/home/assets/js/components/create-with-ai-banner.js
@@ -63,12 +63,11 @@ const CreateWithAIBanner = ( { ...props } ) => {
 				py: 3,
 				px: 4,
 				gap: 2,
-				border: '1px solid var(--e-a-border-color)',
-				borderRadius: 1,
+				borderRadius: '8px',
 				boxShadow: 'none',
 				backgroundImage: `url(${ backgroundImage })`,
-				backgroundSize: 'contain',
-				backgroundPosition: 'right center',
+				backgroundSize: 'cover',
+				backgroundPosition: '1px',
 				backgroundRepeat: 'no-repeat',
 			} }
 		>

--- a/modules/home/assets/js/components/create-with-ai-banner.js
+++ b/modules/home/assets/js/components/create-with-ai-banner.js
@@ -63,8 +63,6 @@ const CreateWithAIBanner = ( { ...props } ) => {
 				py: 3,
 				px: 4,
 				gap: 2,
-				borderRadius: '8px',
-				boxShadow: 'none',
 				backgroundImage: `url(${ backgroundImage })`,
 				backgroundSize: 'cover',
 				backgroundPosition: 'right center',


### PR DESCRIPTION
## PR Type
- [x] Fix

## Summary
This PR fixed the background glitch of the added AI Site Planner promotion box to the Elementor homepage for new users with fewer than 10 Elementor pages and no custom kit applied.

## Description
- Fixed the background styling for the promotional box

## Test instructions
1. Install Elementor on a fresh site
2. Navigate to the Elementor homepage (make sure you have less than 10 pages and default kit)
3. Verify the AI Site Planner promotion is displayed

## Quality assurance
- [x] I have tested this code to the best of my abilities

## Screenshot
<img width="1492" alt="image" src="https://github.com/user-attachments/assets/8d0c6191-f88d-4547-b375-bd14d0b82305" />
