### PR TITLE
Fix: New Prompt button not working in AI Generate module when not in editor context

### DIFF
--- a/modules/ai/assets/js/editor/pages/form-code/index.js
+++ b/modules/ai/assets/js/editor/pages/form-code/index.js
@@ -103,7 +103,14 @@ const FormCode = ( { onClose, getControlValue, setControlValue, additionalOption
 			.replace( /selector/g, selector ); // Replace `selector` with the actual selector
 	};
 
+	const isElementorEditor = () => {
+		return window.elementorFrontend;
+	};
+
 	const insertStyleTag = ( cssCode ) => {
+		if ( ! isElementorEditor() ) {
+			return;
+		}
 		const style = document.createElement( 'style' );
 		style.id = styleTagId.current;
 		style.appendChild( document.createTextNode( cssCode ) );
@@ -111,6 +118,9 @@ const FormCode = ( { onClose, getControlValue, setControlValue, additionalOption
 	};
 
 	const removeStyleTag = () => {
+		if ( ! isElementorEditor() ) {
+			return;
+		}
 		const styleTag = elementorFrontend.elements.$body[ 0 ].querySelector( `#${ styleTagId.current }` );
 		if ( styleTag ) {
 			styleTag.remove();


### PR DESCRIPTION
Fixed an issue where the "New Prompt" button in the AI Generate module failed to work properly when not in the Elementor editor context.

The bug occurred because the code was attempting to insert and remove style tags even when the Elementor frontend was not initialized. This PR adds environment checks before manipulating style tags, ensuring proper functionality in all contexts.

## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

*Fixed the "New Prompt" button not working in AI Generate module when not in Elementor editor context.*

## Description

*Added editor check to prevent style tag manipulation when not in the Elementor editor context. The code was attempting to insert and remove style tags even when the Elementor frontend was not initialized, causing the "New Prompt" button to fail due to undefined exception.*

## Test instructions
This PR can be tested by following these steps:

*1. Navigate in wordpress admin to Elementor -> Custom code
2. Verify the "New Prompt" button works properly
3. Test both in editor and non-editor contexts to ensure proper functionality*

## Quality assurance

- [x] I have tested this code to the best of my abilities

Fixes #ED-18974