### PR TITLE
Internal: Split background overlays from color on V4 widgets - 3.29 [ED-18630]

### DIFF
--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -69,8 +69,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Module extends BaseModule {
 	const EXPERIMENT_NAME = 'e_atomic_elements';
-	const CSSID_EXPERIMENT_NAME = 'e_css_id';
-
 	const PACKAGES = [
 		'editor-canvas',
 		'editor-current-user',
@@ -124,23 +122,6 @@ class Module extends BaseModule {
 			'default' => Experiments_Manager::STATE_INACTIVE,
 			'release_status' => Experiments_Manager::RELEASE_STATUS_ALPHA,
 		]);
-
-		Plugin::$instance->experiments->add_feature( [
-			'name' => self::CSSID_EXPERIMENT_NAME,
-			'title' => esc_html__( 'V4 - CSS ID', 'elementor' ),
-			'description' => esc_html__( 'Enable CSS ID control for V4.', 'elementor' ),
-			'hidden' => true,
-			'default' => Experiments_Manager::STATE_INACTIVE,
-			'release_status' => Experiments_Manager::RELEASE_STATUS_ALPHA,
-		] );
-
-		Plugin::$instance->experiments->add_feature( [
-			'name' => 'e_indications_popover',
-			'title' => esc_html__( 'V4 Indications Popover', 'elementor' ),
-			'description' => esc_html__( 'Enable V4 Indication Popovers', 'elementor' ),
-			'hidden' => true,
-			'default' => Experiments_Manager::STATE_INACTIVE,
-		] );
 	}
 
 	private function add_packages( $packages ) {

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -34,6 +34,7 @@ use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Styles\Stroke_Tra
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Styles\Background_Image_Overlay_Transformer;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Styles\Background_Image_Overlay_Size_Scale_Transformer;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Styles\Background_Image_Position_Offset_Transformer;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Styles\Background_Overlay_Transformer;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers_Registry;
 use Elementor\Modules\AtomicWidgets\PropTypes\Background_Color_Overlay_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Background_Gradient_Overlay_Prop_Type;
@@ -68,6 +69,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Module extends BaseModule {
 	const EXPERIMENT_NAME = 'e_atomic_elements';
+	const CSSID_EXPERIMENT_NAME = 'e_css_id';
 
 	const PACKAGES = [
 		'editor-canvas',
@@ -122,6 +124,23 @@ class Module extends BaseModule {
 			'default' => Experiments_Manager::STATE_INACTIVE,
 			'release_status' => Experiments_Manager::RELEASE_STATUS_ALPHA,
 		]);
+
+		Plugin::$instance->experiments->add_feature( [
+			'name' => self::CSSID_EXPERIMENT_NAME,
+			'title' => esc_html__( 'V4 - CSS ID', 'elementor' ),
+			'description' => esc_html__( 'Enable CSS ID control for V4.', 'elementor' ),
+			'hidden' => true,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+			'release_status' => Experiments_Manager::RELEASE_STATUS_ALPHA,
+		] );
+
+		Plugin::$instance->experiments->add_feature( [
+			'name' => 'e_indications_popover',
+			'title' => esc_html__( 'V4 Indications Popover', 'elementor' ),
+			'description' => esc_html__( 'Enable V4 Indication Popovers', 'elementor' ),
+			'hidden' => true,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+		] );
 	}
 
 	private function add_packages( $packages ) {
@@ -173,7 +192,7 @@ class Module extends BaseModule {
 		$transformers->register( Background_Image_Overlay_Size_Scale_Prop_Type::get_key(), new Background_Image_Overlay_Size_Scale_Transformer() );
 		$transformers->register( Background_Image_Position_Offset_Prop_Type::get_key(), new Background_Image_Position_Offset_Transformer() );
 		$transformers->register( Background_Color_Overlay_Prop_Type::get_key(), new Background_Color_Overlay_Transformer() );
-		$transformers->register( Background_Overlay_Prop_Type::get_key(), new Combine_Array_Transformer( ',' ) );
+		$transformers->register( Background_Overlay_Prop_Type::get_key(), new Background_Overlay_Transformer() );
 		$transformers->register( Background_Prop_Type::get_key(), new Background_Transformer() );
 		$transformers->register( Background_Gradient_Overlay_Prop_Type::get_key(), new Background_Gradient_Overlay_Transformer() );
 		$transformers->register( Color_Stop_Prop_Type::get_key(), new Color_Stop_Transformer() );

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -69,6 +69,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Module extends BaseModule {
 	const EXPERIMENT_NAME = 'e_atomic_elements';
+
 	const PACKAGES = [
 		'editor-canvas',
 		'editor-current-user',

--- a/modules/atomic-widgets/props-resolver/transformers/styles/background-image-overlay-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/styles/background-image-overlay-transformer.php
@@ -10,6 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Background_Image_Overlay_Transformer extends Transformer_Base {
+	const DEFAULT_IMAGE = 'none';
+	const DEFAULT_REPEAT = 'repeat';
+	const DEFAULT_ATTACHMENT = 'scroll';
+	const DEFAULT_SIZE = 'auto auto';
 	const DEFAULT_POSITION = '0% 0%';
 
 	public function transform( $value, Props_Resolver_Context $context ) {
@@ -19,36 +23,12 @@ class Background_Image_Overlay_Transformer extends Transformer_Base {
 
 		$image_url = $value['image']['src'];
 
-		$background_style = "url(\" $image_url \")";
-
-		if ( ! empty( $value['repeat'] ) ) {
-			$background_style .= ' ' . $value['repeat'];
-		}
-
-		if ( ! empty( $value['attachment'] ) ) {
-			$background_style .= ' ' . $value['attachment'];
-		}
-
-		$position_and_size_style = $this->get_position_and_size_style( $value );
-
-		if ( ! empty( $position_and_size_style ) ) {
-			$background_style .= ' ' . $position_and_size_style;
-		}
-
-		return $background_style;
-	}
-
-	private function get_position_and_size_style( array $value ): string {
-		if ( ! isset( $value['size'] ) && ! isset( $value['position'] ) ) {
-			return '';
-		}
-
-		if ( ! isset( $value['size'] ) ) {
-			return $value['position'];
-		}
-
-		$position = $value['position'] ?? self::DEFAULT_POSITION;
-
-		return $position . ' / ' . $value['size'];
+		return [
+			'src' => "url(\"$image_url\")",
+			'repeat' => $value['repeat'] ?? null,
+			'attachment' => $value['attachment'] ?? null,
+			'size' => $value['size'] ?? null,
+			'position' => $value['position'] ?? null,
+		];
 	}
 }

--- a/modules/atomic-widgets/props-resolver/transformers/styles/background-overlay-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/styles/background-overlay-transformer.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Styles;
+
+use Elementor\Modules\AtomicWidgets\PropsResolver\Multi_Props;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Props_Resolver_Context;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Transformer_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Background_Overlay_Transformer extends Transformer_Base {
+	public function transform( $value, Props_Resolver_Context $context ) {
+		$normalized_values = $this->normalize_overlay_values( $value );
+
+		return array_filter( [
+			'background-image' => $this->get_values_string( $normalized_values, 'src', Background_Image_Overlay_Transformer::DEFAULT_IMAGE, true ),
+			'background-repeat' => $this->get_values_string( $normalized_values, 'repeat', Background_Image_Overlay_Transformer::DEFAULT_REPEAT ),
+			'background-attachment' => $this->get_values_string( $normalized_values, 'attachment', Background_Image_Overlay_Transformer::DEFAULT_ATTACHMENT ),
+			'background-size' => $this->get_values_string( $normalized_values, 'size', Background_Image_Overlay_Transformer::DEFAULT_SIZE ),
+			'background-position' => $this->get_values_string( $normalized_values, 'position', Background_Image_Overlay_Transformer::DEFAULT_POSITION ),
+		] );
+	}
+
+	private function normalize_overlay_values( $overlays ): array {
+		return array_map( function( $value ) {
+			if ( is_string( $value ) ) {
+				return [
+					'src' => $value,
+					'repeat' => null,
+					'attachment' => null,
+					'size' => null,
+					'position' => null,
+				];
+			}
+
+			return $value;
+		}, $overlays );
+	}
+
+	private function get_values_string( $value, string $prop, string $default_value, bool $prevent_unification = false ) {
+		$is_empty = empty( array_filter( $value, function ( array $item ) use ( $prop ) {
+			return isset( $item[ $prop ] ) && ! is_null( $item[ $prop ] );
+		} ) );
+
+		if ( $is_empty ) {
+			return null;
+		}
+
+		$formatted_values = array_map( function ( $item ) use ( $prop, $default_value ) {
+			if ( is_string( $item ) ) {
+				return $default_value;
+			}
+
+			if ( ! is_array( $item ) ) {
+				return $default_value;
+			}
+
+			return $item[ $prop ] ?? $default_value;
+		}, $value );
+
+		if ( ! $prevent_unification ) {
+			$all_same = count( array_unique( $formatted_values ) ) === 1;
+
+			if ( $all_same ) {
+				return $formatted_values[0];
+			}
+		}
+
+		return implode( ',', $formatted_values );
+	}
+}

--- a/modules/atomic-widgets/props-resolver/transformers/styles/background-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/styles/background-transformer.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Styles;
 
+use Elementor\Modules\AtomicWidgets\PropsResolver\Multi_Props;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Props_Resolver_Context;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformer_Base;
 
@@ -11,9 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Background_Transformer extends Transformer_Base {
 	public function transform( $value, Props_Resolver_Context $context ) {
-		$overlay = $value['background-overlay'] ?? '';
-		$color = $value['color'] ?? '';
+		$overlay = $value['background-overlay'] ?? [];
+		$color = $value['color'] ?? null;
 
-		return trim( "$overlay $color" );
+		return Multi_Props::generate( array_merge( $overlay, [
+			'background-color' => $color,
+		] ) );
 	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_background_color_transformers__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_background_color_transformers__1.txt
@@ -1,1 +1,1 @@
-.test-background-color{background:red;}
+.test-background-color{background-color:red;}

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_background_gradient_transformers__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_background_gradient_transformers__1.txt
@@ -1,1 +1,1 @@
-.test-style{background:linear-gradient(45deg, red 0%,rgb(255, 0, 255, 0.3) 100%),radial-gradient(circle at bottom center, rgb(90, 143,11) 67%,rgb(0, 0, 0) 21%);}
+.test-style{background-image:linear-gradient(45deg, red 0%,rgb(255, 0, 255, 0.3) 100%),radial-gradient(circle at bottom center, rgb(90, 143,11) 67%,rgb(0, 0, 0) 21%);}

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_background_image_transformers_without_image__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_background_image_transformers_without_image__1.txt
@@ -1,1 +1,1 @@
-.test-background-overlay{background:linear-gradient(blue, blue);}
+.test-background-overlay{background-image:linear-gradient(blue, blue);}

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_background_overlay_transformers__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_background_overlay_transformers__1.txt
@@ -1,1 +1,1 @@
-.test-background-overlay{background:linear-gradient(blue, blue),url(" https://example.com/image-1024x682.jpg ") repeat-x scroll 0% 0% / 140px auto;}
+.test-background-overlay{background-image:linear-gradient(blue, blue),url("https://example.com/image-1024x682.jpg");background-repeat:repeat,repeat-x;background-size:auto auto,140px auto;}

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_background_with_fields_of_similar_valus__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_background_with_fields_of_similar_valus__1.txt
@@ -1,0 +1,1 @@
+.test-background-overlay{background-image:url("https://example.com/image-1024x682.jpg"),url("https://example.com/image-1024x682.jpg"),url("https://example.com/image-1024x682.jpg");background-attachment:scroll;background-size:140px auto,140px auto,150px auto;background-position:center left;}

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_nested_background_image_transformers__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_nested_background_image_transformers__1.txt
@@ -1,1 +1,1 @@
-.test-style{background:linear-gradient(blue, blue),url(" https://example.com/image.jpg ") repeat fixed bottom right / cover,url(" https://example.com/image.jpg ") 40px 70px red;}
+.test-style{background-image:linear-gradient(blue, blue),url("https://example.com/image.jpg"),url("https://example.com/image.jpg");background-attachment:scroll,fixed,scroll;background-size:auto auto,cover,auto auto;background-position:0% 0%,bottom right,40px 70px;background-color:red;}

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_nested_background_transformers__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render__style_with_nested_background_transformers__1.txt
@@ -1,1 +1,1 @@
-.test-style{background:linear-gradient(blue, blue),url(" https://example.com/image-300x300.jpg ") repeat-y fixed top center red;}
+.test-style{background-image:linear-gradient(blue, blue),url("https://example.com/image-300x300.jpg");background-repeat:repeat,repeat-y;background-attachment:scroll,fixed;background-position:0% 0%,top center;background-color:red;}

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/test-styles-renderer.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/test-styles-renderer.php
@@ -585,7 +585,6 @@ class Test_Styles_Renderer extends Elementor_Test_Base {
 													],
 													'size' => 'cover',
 													'position' => 'bottom right',
-													'repeat' => 'repeat',
 													'attachment' => 'fixed',
 												]
 											],
@@ -750,7 +749,6 @@ class Test_Styles_Renderer extends Elementor_Test_Base {
 															],
 														],
 													],
-													'attachment' => 'scroll',
 													'repeat' => 'repeat-x',
 												]
 											],
@@ -804,6 +802,165 @@ class Test_Styles_Renderer extends Elementor_Test_Base {
 												'value' => [
 													'color' => 'blue',
 												],
+											],
+										],
+									],
+								],
+							],
+						],
+
+						'meta' => [],
+					],
+				],
+			],
+		];
+
+		$stylesRenderer = Styles_Renderer::make( [], '' );
+
+		// Act.
+		$css = $stylesRenderer->render( $styles );
+
+		// Assert.
+		$this->assertNotEmpty( $css, 'CSS should not be empty' );
+		$this->assertMatchesSnapshot( $css );
+	}
+
+	public function test_render__style_with_background_with_fields_of_similar_valus() {
+		// Arrange.
+		add_filter( 'wp_get_attachment_image_src', function( ...$args ) {
+			$resolution = $args[2];
+			$images = $this->mock_images();
+
+			return $images[ $resolution ];
+		}, 10, 3 );
+
+		$styles = [
+			[
+				'id' => 'test-background-overlay',
+				'type' => 'class',
+				'variants' => [
+					[
+						'props' => [
+							'background' => [
+								'$$type' => 'background',
+								'value' => [
+									'background-overlay' => [
+										'$$type' => 'background-overlay',
+										'value' => [
+											[
+												'$$type' => 'background-image-overlay',
+												'value' => [
+													'image' => [
+														'$$type' => 'image',
+														'value' => [
+															'src' => [
+																'$$type' => 'image-src',
+																'value' => [
+																	'id' => [
+																		'$$type' => 'image-attachment-id',
+																		'value' => 3,
+																	],
+																	'url' => null
+																],
+															],
+															'size' => [
+																'$$type' => 'string',
+																'value' => 'large',
+															]
+														]
+													],
+													'size' => [
+														'$$type' => 'background-image-size-scale',
+														'value'  => [
+															//Missing 'height'
+															'width'  => [
+																'$$type' => 'size',
+																'value'  => [
+																	'size' => 140,
+																	'unit' => 'px'
+																]
+															],
+														],
+													],
+													'position' => 'center left',
+												]
+											],
+											[
+												'$$type' => 'background-image-overlay',
+												'value' => [
+													'image' => [
+														'$$type' => 'image',
+														'value' => [
+															'src' => [
+																'$$type' => 'image-src',
+																'value' => [
+																	'id' => [
+																		'$$type' => 'image-attachment-id',
+																		'value' => 3,
+																	],
+																	'url' => null
+																],
+															],
+															'size' => [
+																'$$type' => 'string',
+																'value' => 'large',
+															]
+														]
+													],
+													'size' => [
+														'$$type' => 'background-image-size-scale',
+														'value'  => [
+															//Missing 'height'
+															'width'  => [
+																'$$type' => 'size',
+																'value'  => [
+																	'size' => 140,
+																	'unit' => 'px'
+																]
+															],
+														],
+													],
+													'position' => 'center left',
+													'attachment' => 'scroll',
+												]
+											],
+											[
+												'$$type' => 'background-image-overlay',
+												'value' => [
+													'image' => [
+														'$$type' => 'image',
+														'value' => [
+															'src' => [
+																'$$type' => 'image-src',
+																'value' => [
+																	'id' => [
+																		'$$type' => 'image-attachment-id',
+																		'value' => 3,
+																	],
+																	'url' => null
+																],
+															],
+															'size' => [
+																'$$type' => 'string',
+																'value' => 'large',
+															]
+														]
+													],
+													'size' => [
+														'$$type' => 'background-image-size-scale',
+														'value'  => [
+															//Missing 'height'
+															'width'  => [
+																'$$type' => 'size',
+																'value'  => [
+																	'size' => 150,
+																	'unit' => 'px'
+																]
+															],
+														],
+													],
+													'position' => 'center left',
+												]
 											],
 										],
 									],


### PR DESCRIPTION
Merging the same [PR](https://github.com/elementor/elementor/pull/31083) into 3.29

** It has one line less, because originally the newly test case `test_render__style_with_background_with_fields_of_similar_valus` started as `test_render__style_with_background_with_same_position_to_all`, a snapshot was created for it, then got stuck there accidentally after the rename