### PR TITLE
Tweak: Add Site Planner to Elementor Home screen

### DIFF
--- a/assets/images/app/ai/ai-site-creator-homepage-bg.svg
+++ b/assets/images/app/ai/ai-site-creator-homepage-bg.svg
@@ -1,0 +1,72 @@
+<svg width="402" height="177" viewBox="0 0 402 177" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_14738_2317" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="402" height="177">
+<path d="M0 0H402V177H0V0Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_14738_2317)">
+<g style="mix-blend-mode:multiply" opacity="0.16" clip-path="url(#clip0_14738_2317)">
+<rect width="534.395" height="529.346" transform="translate(-23.498 -169.771)" fill="white"/>
+<g filter="url(#filter0_f_14738_2317)">
+<circle cx="239.062" cy="10.0051" r="120.921" fill="black"/>
+<circle cx="315.487" cy="95.0776" r="142.84" transform="rotate(-165 315.487 95.0776)" fill="black"/>
+<circle cx="157.343" cy="157.343" r="157.343" transform="matrix(0.998118 0.0613208 0.0613208 -0.998118 -3.75 296.006)" fill="black"/>
+<circle cx="111.789" cy="111.789" r="111.789" transform="matrix(0.976166 0.217027 0.217027 -0.976166 185.396 238.602)" fill="black"/>
+<circle cx="295.196" cy="103.485" r="131.612" fill="black"/>
+</g>
+<g style="mix-blend-mode:color-dodge">
+<rect x="-51.2617" y="-169.184" width="582.461" height="547.055" fill="#878787"/>
+</g>
+<g style="mix-blend-mode:color-burn">
+<rect x="-51.2617" y="-169.184" width="582.461" height="547.055" fill="white"/>
+</g>
+<g style="mix-blend-mode:screen">
+<rect width="771.761" height="724.848" transform="translate(-145.91 -258.08)" fill="url(#paint0_linear_14738_2317)"/>
+</g>
+</g>
+<g style="mix-blend-mode:multiply" opacity="0.16" clip-path="url(#clip1_14738_2317)">
+<rect width="582.366" height="576.865" transform="translate(150.463 -161.477)" fill="white"/>
+<g filter="url(#filter1_f_14738_2317)">
+<circle cx="445.473" cy="34.4419" r="131.776" fill="black"/>
+<circle cx="528.759" cy="127.147" r="155.662" transform="rotate(-165 528.759 127.147)" fill="black"/>
+<circle cx="171.467" cy="171.467" r="171.467" transform="matrix(0.998118 0.0613208 0.0613208 -0.998118 180.861 346.111)" fill="black"/>
+<circle cx="121.824" cy="121.824" r="121.824" transform="matrix(0.976166 0.217027 0.217027 -0.976166 386.988 283.553)" fill="black"/>
+<circle cx="506.645" cy="136.309" r="143.427" fill="black"/>
+</g>
+<g style="mix-blend-mode:color-dodge">
+<rect x="129.084" y="-160.836" width="634.747" height="596.163" fill="#878787"/>
+</g>
+<g style="mix-blend-mode:color-burn">
+<rect x="129.084" y="-160.836" width="634.747" height="596.163" fill="white"/>
+</g>
+<g style="mix-blend-mode:screen">
+<rect width="841.04" height="789.916" transform="translate(58.2656 -152.107)" fill="url(#paint1_linear_14738_2317)"/>
+</g>
+</g>
+</g>
+<defs>
+<filter id="filter0_f_14738_2317" x="-156.981" y="-322.617" width="812.578" height="835.558" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="76.4229" result="effect1_foregroundBlur_14738_2317"/>
+</filter>
+<filter id="filter1_f_14738_2317" x="13.8788" y="-328.043" width="885.522" height="910.564" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="83.2832" result="effect1_foregroundBlur_14738_2317"/>
+</filter>
+<linearGradient id="paint0_linear_14738_2317" x1="290.8" y1="199.757" x2="387.404" y2="454.729" gradientUnits="userSpaceOnUse">
+<stop stop-color="#F0FDFA"/>
+<stop offset="1" stop-color="#87FEE3"/>
+</linearGradient>
+<linearGradient id="paint1_linear_14738_2317" x1="316.905" y1="217.689" x2="456.784" y2="638.657" gradientUnits="userSpaceOnUse">
+<stop stop-color="#EA58F8"/>
+<stop offset="0.35" stop-color="#B28DF2"/>
+<stop offset="1" stop-color="#A0F7FC"/>
+</linearGradient>
+<clipPath id="clip0_14738_2317">
+<rect width="534.395" height="529.346" fill="white" transform="translate(-23.498 -169.771)"/>
+</clipPath>
+<clipPath id="clip1_14738_2317">
+<rect width="582.366" height="576.865" fill="white" transform="translate(150.463 -161.477)"/>
+</clipPath>
+</defs>
+</svg>

--- a/assets/images/app/ai/ai-site-creator-homepage-bg.svg
+++ b/assets/images/app/ai/ai-site-creator-homepage-bg.svg
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 <svg width="402" height="177" viewBox="0 0 402 177" fill="none" xmlns="http://www.w3.org/2000/svg">
 <mask id="mask0_14738_2317" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="402" height="177">
 <path d="M0 0H402V177H0V0Z" fill="white"/>
@@ -39,16 +40,67 @@
 </g>
 <g style="mix-blend-mode:screen">
 <rect width="841.04" height="789.916" transform="translate(58.2656 -152.107)" fill="url(#paint1_linear_14738_2317)"/>
+=======
+<svg width="403" height="178" viewBox="0 0 403 178" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_14738_2317" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="403" height="178">
+<path d="M0.5 8.24218C0.5 3.82391 4.08172 0.242188 8.5 0.242188H394.541C398.959 0.242188 402.541 3.82391 402.541 8.24219V169.242C402.541 173.66 398.959 177.242 394.541 177.242H8.5C4.08172 177.242 0.5 173.66 0.5 169.242V8.24218Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_14738_2317)">
+<g style="mix-blend-mode:multiply" opacity="0.16" clip-path="url(#clip0_14738_2317)">
+<rect width="534.45" height="529.346" transform="translate(-23 -169.529)" fill="white"/>
+<g filter="url(#filter0_f_14738_2317)">
+<circle cx="239.56" cy="10.2473" r="120.921" fill="black"/>
+<circle cx="315.985" cy="95.3197" r="142.84" transform="rotate(-165 315.985 95.3197)" fill="black"/>
+<circle cx="157.343" cy="157.343" r="157.343" transform="matrix(0.998118 0.0613208 0.0613208 -0.998118 -3.25195 296.248)" fill="black"/>
+<circle cx="111.789" cy="111.789" r="111.789" transform="matrix(0.976166 0.217027 0.217027 -0.976166 185.895 238.844)" fill="black"/>
+<circle cx="295.694" cy="103.727" r="131.612" fill="black"/>
+</g>
+<g style="mix-blend-mode:color-dodge">
+<rect x="-50.7637" y="-168.941" width="582.461" height="547.055" fill="#878787"/>
+</g>
+<g style="mix-blend-mode:color-burn">
+<rect x="-50.7637" y="-168.941" width="582.461" height="547.055" fill="white"/>
+</g>
+<g style="mix-blend-mode:screen">
+<rect width="771.761" height="724.848" transform="translate(-145.412 -257.838)" fill="url(#paint0_linear_14738_2317)"/>
+</g>
+</g>
+<g style="mix-blend-mode:multiply" opacity="0.16" clip-path="url(#clip1_14738_2317)">
+<rect width="582.426" height="576.865" transform="translate(150.979 -161.234)" fill="white"/>
+<g filter="url(#filter1_f_14738_2317)">
+<circle cx="445.989" cy="34.6841" r="131.776" fill="black"/>
+<circle cx="529.274" cy="127.389" r="155.662" transform="rotate(-165 529.274 127.389)" fill="black"/>
+<circle cx="171.467" cy="171.467" r="171.467" transform="matrix(0.998118 0.0613208 0.0613208 -0.998118 181.377 346.354)" fill="black"/>
+<circle cx="121.824" cy="121.824" r="121.824" transform="matrix(0.976166 0.217027 0.217027 -0.976166 387.504 283.795)" fill="black"/>
+<circle cx="507.161" cy="136.552" r="143.427" fill="black"/>
+</g>
+<g style="mix-blend-mode:color-dodge">
+<rect x="129.6" y="-160.594" width="634.747" height="596.163" fill="#878787"/>
+</g>
+<g style="mix-blend-mode:color-burn">
+<rect x="129.6" y="-160.594" width="634.747" height="596.163" fill="white"/>
+</g>
+<g style="mix-blend-mode:screen">
+<rect width="841.04" height="789.916" transform="translate(58.7812 -151.865)" fill="url(#paint1_linear_14738_2317)"/>
+>>>>>>> f6f6bbbe2a (Tweak: Add Site Planner to Elementor Home screen (#31040))
 </g>
 </g>
 </g>
 <defs>
+<<<<<<< HEAD
 <filter id="filter0_f_14738_2317" x="-156.981" y="-322.617" width="812.578" height="835.558" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+=======
+<filter id="filter0_f_14738_2317" x="-156.483" y="-322.375" width="812.578" height="835.557" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+>>>>>>> f6f6bbbe2a (Tweak: Add Site Planner to Elementor Home screen (#31040))
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feGaussianBlur stdDeviation="76.4229" result="effect1_foregroundBlur_14738_2317"/>
 </filter>
+<<<<<<< HEAD
 <filter id="filter1_f_14738_2317" x="13.8788" y="-328.043" width="885.522" height="910.564" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+=======
+<filter id="filter1_f_14738_2317" x="14.3944" y="-327.801" width="885.522" height="910.563" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+>>>>>>> f6f6bbbe2a (Tweak: Add Site Planner to Elementor Home screen (#31040))
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feGaussianBlur stdDeviation="83.2832" result="effect1_foregroundBlur_14738_2317"/>
@@ -63,10 +115,17 @@
 <stop offset="1" stop-color="#A0F7FC"/>
 </linearGradient>
 <clipPath id="clip0_14738_2317">
+<<<<<<< HEAD
 <rect width="534.395" height="529.346" fill="white" transform="translate(-23.498 -169.771)"/>
 </clipPath>
 <clipPath id="clip1_14738_2317">
 <rect width="582.366" height="576.865" fill="white" transform="translate(150.463 -161.477)"/>
+=======
+<rect width="534.45" height="529.346" fill="white" transform="translate(-23 -169.529)"/>
+</clipPath>
+<clipPath id="clip1_14738_2317">
+<rect width="582.426" height="576.865" fill="white" transform="translate(150.979 -161.234)"/>
+>>>>>>> f6f6bbbe2a (Tweak: Add Site Planner to Elementor Home screen (#31040))
 </clipPath>
 </defs>
 </svg>

--- a/assets/images/app/ai/ai-site-creator-homepage-bg.svg
+++ b/assets/images/app/ai/ai-site-creator-homepage-bg.svg
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 <svg width="402" height="177" viewBox="0 0 402 177" fill="none" xmlns="http://www.w3.org/2000/svg">
 <mask id="mask0_14738_2317" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="402" height="177">
 <path d="M0 0H402V177H0V0Z" fill="white"/>
@@ -40,67 +39,16 @@
 </g>
 <g style="mix-blend-mode:screen">
 <rect width="841.04" height="789.916" transform="translate(58.2656 -152.107)" fill="url(#paint1_linear_14738_2317)"/>
-=======
-<svg width="403" height="178" viewBox="0 0 403 178" fill="none" xmlns="http://www.w3.org/2000/svg">
-<mask id="mask0_14738_2317" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="403" height="178">
-<path d="M0.5 8.24218C0.5 3.82391 4.08172 0.242188 8.5 0.242188H394.541C398.959 0.242188 402.541 3.82391 402.541 8.24219V169.242C402.541 173.66 398.959 177.242 394.541 177.242H8.5C4.08172 177.242 0.5 173.66 0.5 169.242V8.24218Z" fill="white"/>
-</mask>
-<g mask="url(#mask0_14738_2317)">
-<g style="mix-blend-mode:multiply" opacity="0.16" clip-path="url(#clip0_14738_2317)">
-<rect width="534.45" height="529.346" transform="translate(-23 -169.529)" fill="white"/>
-<g filter="url(#filter0_f_14738_2317)">
-<circle cx="239.56" cy="10.2473" r="120.921" fill="black"/>
-<circle cx="315.985" cy="95.3197" r="142.84" transform="rotate(-165 315.985 95.3197)" fill="black"/>
-<circle cx="157.343" cy="157.343" r="157.343" transform="matrix(0.998118 0.0613208 0.0613208 -0.998118 -3.25195 296.248)" fill="black"/>
-<circle cx="111.789" cy="111.789" r="111.789" transform="matrix(0.976166 0.217027 0.217027 -0.976166 185.895 238.844)" fill="black"/>
-<circle cx="295.694" cy="103.727" r="131.612" fill="black"/>
-</g>
-<g style="mix-blend-mode:color-dodge">
-<rect x="-50.7637" y="-168.941" width="582.461" height="547.055" fill="#878787"/>
-</g>
-<g style="mix-blend-mode:color-burn">
-<rect x="-50.7637" y="-168.941" width="582.461" height="547.055" fill="white"/>
-</g>
-<g style="mix-blend-mode:screen">
-<rect width="771.761" height="724.848" transform="translate(-145.412 -257.838)" fill="url(#paint0_linear_14738_2317)"/>
-</g>
-</g>
-<g style="mix-blend-mode:multiply" opacity="0.16" clip-path="url(#clip1_14738_2317)">
-<rect width="582.426" height="576.865" transform="translate(150.979 -161.234)" fill="white"/>
-<g filter="url(#filter1_f_14738_2317)">
-<circle cx="445.989" cy="34.6841" r="131.776" fill="black"/>
-<circle cx="529.274" cy="127.389" r="155.662" transform="rotate(-165 529.274 127.389)" fill="black"/>
-<circle cx="171.467" cy="171.467" r="171.467" transform="matrix(0.998118 0.0613208 0.0613208 -0.998118 181.377 346.354)" fill="black"/>
-<circle cx="121.824" cy="121.824" r="121.824" transform="matrix(0.976166 0.217027 0.217027 -0.976166 387.504 283.795)" fill="black"/>
-<circle cx="507.161" cy="136.552" r="143.427" fill="black"/>
-</g>
-<g style="mix-blend-mode:color-dodge">
-<rect x="129.6" y="-160.594" width="634.747" height="596.163" fill="#878787"/>
-</g>
-<g style="mix-blend-mode:color-burn">
-<rect x="129.6" y="-160.594" width="634.747" height="596.163" fill="white"/>
-</g>
-<g style="mix-blend-mode:screen">
-<rect width="841.04" height="789.916" transform="translate(58.7812 -151.865)" fill="url(#paint1_linear_14738_2317)"/>
->>>>>>> f6f6bbbe2a (Tweak: Add Site Planner to Elementor Home screen (#31040))
 </g>
 </g>
 </g>
 <defs>
-<<<<<<< HEAD
 <filter id="filter0_f_14738_2317" x="-156.981" y="-322.617" width="812.578" height="835.558" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-=======
-<filter id="filter0_f_14738_2317" x="-156.483" y="-322.375" width="812.578" height="835.557" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
->>>>>>> f6f6bbbe2a (Tweak: Add Site Planner to Elementor Home screen (#31040))
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feGaussianBlur stdDeviation="76.4229" result="effect1_foregroundBlur_14738_2317"/>
 </filter>
-<<<<<<< HEAD
 <filter id="filter1_f_14738_2317" x="13.8788" y="-328.043" width="885.522" height="910.564" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-=======
-<filter id="filter1_f_14738_2317" x="14.3944" y="-327.801" width="885.522" height="910.563" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
->>>>>>> f6f6bbbe2a (Tweak: Add Site Planner to Elementor Home screen (#31040))
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feGaussianBlur stdDeviation="83.2832" result="effect1_foregroundBlur_14738_2317"/>
@@ -115,17 +63,10 @@
 <stop offset="1" stop-color="#A0F7FC"/>
 </linearGradient>
 <clipPath id="clip0_14738_2317">
-<<<<<<< HEAD
 <rect width="534.395" height="529.346" fill="white" transform="translate(-23.498 -169.771)"/>
 </clipPath>
 <clipPath id="clip1_14738_2317">
 <rect width="582.366" height="576.865" fill="white" transform="translate(150.463 -161.477)"/>
-=======
-<rect width="534.45" height="529.346" fill="white" transform="translate(-23 -169.529)"/>
-</clipPath>
-<clipPath id="clip1_14738_2317">
-<rect width="582.426" height="576.865" fill="white" transform="translate(150.979 -161.234)"/>
->>>>>>> f6f6bbbe2a (Tweak: Add Site Planner to Elementor Home screen (#31040))
 </clipPath>
 </defs>
 </svg>

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -941,4 +941,8 @@ class Utils {
 
 		return $is_private || $not_allowed || $password_required;
 	}
+
+	public static function is_custom_kit_applied() {
+		return (bool) Plugin::$instance->kits_manager->get_previous_id();
+	}
 }

--- a/modules/home/assets/js/components/create-with-ai-banner.js
+++ b/modules/home/assets/js/components/create-with-ai-banner.js
@@ -1,0 +1,106 @@
+import { Box, Paper, Stack, TextField } from '@elementor/ui';
+import Typography from '@elementor/ui/Typography';
+import Button from '@elementor/ui/Button';
+import { useState } from 'react';
+
+const CreateWithAIBanner = ( { ...props } ) => {
+	const { createWithAIData } = props;
+	const [ inputValue, setInputValue ] = useState( '' );
+
+	if ( ! createWithAIData ) {
+		return null;
+	}
+
+	const {
+		title,
+		description,
+		input_placeholder: inputPlaceholder,
+		button_title: buttonTitle,
+		button_cta_url: buttonCtaUrl,
+		background_image: backgroundImage,
+		utm_source: utmSource,
+		utm_medium: utmMedium,
+		utm_campaign: utmCampaign,
+	} = createWithAIData;
+
+	const handleInputChange = ( event ) => {
+		setInputValue( event.target.value );
+	};
+
+	const getButtonHref = () => {
+		if ( ! inputValue ) {
+			return buttonCtaUrl;
+		}
+		const url = new URL( buttonCtaUrl );
+		url.searchParams.append( 'prompt', inputValue );
+		url.searchParams.append( 'utm_source', utmSource );
+		url.searchParams.append( 'utm_medium', utmMedium );
+		url.searchParams.append( 'utm_campaign', utmCampaign );
+		return url.toString();
+	};
+
+	const handleNavigation = () => {
+		if ( ! inputValue ) {
+			return;
+		}
+		window.open( getButtonHref(), '_blank' );
+		setInputValue( '' );
+	};
+
+	const handleKeyDown = ( event ) => {
+		if ( 'Enter' === event.key ) {
+			event.preventDefault();
+			handleNavigation();
+		}
+	};
+
+	return (
+		<Paper
+			elevation={ 0 }
+			sx={ {
+				display: 'flex',
+				flexDirection: 'column',
+				py: 3,
+				px: 4,
+				gap: 2,
+				backgroundImage: `url(${ backgroundImage })`,
+				backgroundSize: 'cover',
+				backgroundPosition: 'right center',
+				backgroundRepeat: 'no-repeat',
+			} }
+		>
+			<Stack gap={ 1 } justifyContent="center">
+				<Typography variant="h6">{ title }</Typography>
+				<Typography variant="body2" color="secondary">{ description }</Typography>
+			</Stack>
+			<Box sx={ { display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: 2, mt: 1 } }>
+				<TextField
+					fullWidth
+					placeholder={ inputPlaceholder }
+					variant="outlined"
+					color="secondary"
+					size="small"
+					sx={ { flex: 1 } }
+					value={ inputValue }
+					onChange={ handleInputChange }
+					onKeyDown={ handleKeyDown }
+				/>
+				<Button
+					variant="outlined"
+					size="small"
+					color="secondary"
+					startIcon={ <span className="eicon-ai"></span> }
+					onClick={ handleNavigation }
+				>
+					{ buttonTitle }
+				</Button>
+			</Box>
+		</Paper>
+	);
+};
+
+CreateWithAIBanner.propTypes = {
+	createWithAIData: PropTypes.object,
+};
+
+export default CreateWithAIBanner;

--- a/modules/home/assets/js/components/create-with-ai-banner.js
+++ b/modules/home/assets/js/components/create-with-ai-banner.js
@@ -63,16 +63,8 @@ const CreateWithAIBanner = ( { ...props } ) => {
 				py: 3,
 				px: 4,
 				gap: 2,
-<<<<<<< HEAD
 				backgroundImage: `url(${ backgroundImage })`,
 				backgroundSize: 'cover',
-=======
-				border: '1px solid var(--e-a-border-color)',
-				borderRadius: 1,
-				boxShadow: 'none',
-				backgroundImage: `url(${ backgroundImage })`,
-				backgroundSize: 'contain',
->>>>>>> f6f6bbbe2a (Tweak: Add Site Planner to Elementor Home screen (#31040))
 				backgroundPosition: 'right center',
 				backgroundRepeat: 'no-repeat',
 			} }

--- a/modules/home/assets/js/components/create-with-ai-banner.js
+++ b/modules/home/assets/js/components/create-with-ai-banner.js
@@ -63,8 +63,16 @@ const CreateWithAIBanner = ( { ...props } ) => {
 				py: 3,
 				px: 4,
 				gap: 2,
+<<<<<<< HEAD
 				backgroundImage: `url(${ backgroundImage })`,
 				backgroundSize: 'cover',
+=======
+				border: '1px solid var(--e-a-border-color)',
+				borderRadius: 1,
+				boxShadow: 'none',
+				backgroundImage: `url(${ backgroundImage })`,
+				backgroundSize: 'contain',
+>>>>>>> f6f6bbbe2a (Tweak: Add Site Planner to Elementor Home screen (#31040))
 				backgroundPosition: 'right center',
 				backgroundRepeat: 'no-repeat',
 			} }

--- a/modules/home/assets/js/components/home-screen.js
+++ b/modules/home/assets/js/components/home-screen.js
@@ -5,6 +5,7 @@ import SideBarPromotion from './sidebar-promotion';
 import Addons from './addons-section';
 import ExternalLinksSection from './external-links-section';
 import GetStarted from './get-started-section';
+import CreateWithAIBanner from './create-with-ai-banner';
 
 const HomeScreen = ( props ) => {
 	const hasSidebarPromotion = props.homeScreenData.hasOwnProperty( 'sidebar_promotion_variants' );
@@ -16,6 +17,7 @@ const HomeScreen = ( props ) => {
 				{ props.homeScreenData.top_with_licences && <TopSection topData={ props.homeScreenData.top_with_licences } buttonCtaUrl={ props.homeScreenData.button_cta_url } /> }
 				<Box sx={ { display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, justifyContent: 'space-between', gap: 3 } }>
 					<Stack sx={ { flex: 1, gap: 3 } }>
+						{ props.homeScreenData.create_with_ai && <CreateWithAIBanner createWithAIData={ props.homeScreenData.create_with_ai } /> }
 						<GetStarted
 							getStartedData={ props.homeScreenData.get_started }
 							adminUrl={ props.adminUrl }

--- a/tests/phpunit/elementor/modules/home/Test_Filter_Hosting.php
+++ b/tests/phpunit/elementor/modules/home/Test_Filter_Hosting.php
@@ -55,6 +55,14 @@ class Test_Filter_Hosting extends PHPUnit_TestCase {
 					"youtube_embed_id" => "QdkDGrS8ZZs?si=s_VjZCQR6Fh1jgB5",
 				],
 			],
+			"create_with_ai" => [
+				"title" => "Create and launch your site faster with AI",
+				"description" => "Share your vision with our AI Chat and watch as it becomes a brief, sitemap, and wireframes in minutes:",
+				"input_placeholder" => "Start describing the site you want to create...",
+				"button_title" => "Create with AI",
+				"button_cta_url" => "http://planner.elementor.com/chat.html",
+				"background_image" => ELEMENTOR_ASSETS_URL . 'images/app/ai/ai-site-creator-homepage-bg.svg',
+			],
 			"get_started" => [
 				[
 					"license" => [ "free" ],


### PR DESCRIPTION
## PR Type
- [x] Feature

## Summary
This PR adds an AI Site Planner promotion box to the Elementor homepage for new users with fewer than 10 Elementor pages and no custom kit applied.

## Description
- Added a new promotional section for the AI Site Planner on the Elementor admin homepage
- Added logic to only display the promotion for sites with fewer than 10 Elementor pages
- Added conditions to hide the promotion if a custom kit is applied
- Added UTM parameters to track conversions from the homepage promotion
- Implemented proper background styling for the promotional box

## Test instructions
1. Install Elementor on a fresh site
2. Navigate to the Elementor homepage
3. Verify the AI Site Planner promotion is displayed
4. Create more than 10 pages with Elementor and verify the promotion disappears
5. Apply a custom kit and verify the promotion disappears

## Quality assurance
- [x] I have tested this code to the best of my abilities

## Screenshot
<img width="1495" alt="image" src="https://github.com/user-attachments/assets/994dfee9-f7bc-4842-9b3b-283eb6e9af5e" />

## Solves
https://elementor.atlassian.net/browse/ED-18686