### PR TITLE
Internal: Set specific stroke css for empty view and handles [ED-19259]

### DIFF
--- a/assets/dev/scss/editor/preview/_container.scss
+++ b/assets/dev/scss/editor/preview/_container.scss
@@ -71,6 +71,9 @@
 		width: 100%;
 		height: 100%;
 		min-height: 100px;
+		stroke: transparent;
+		stroke-width: 0;
+		-webkit-text-stroke: 0 transparent;
 
 		.elementor-first-add {
 			width: auto;

--- a/assets/dev/scss/editor/preview/_section.scss
+++ b/assets/dev/scss/editor/preview/_section.scss
@@ -16,6 +16,9 @@
 	border-start-end-radius: 5px;
 	border-end-start-radius: 0;
 	border-end-end-radius: 0;
+	stroke: transparent;
+	stroke-width: 0;
+	-webkit-text-stroke: 0 transparent;
 
 	i.eicon-handle {
 		font-size: 16px;

--- a/tests/playwright/sanity/modules/div-block/div-block.test.ts
+++ b/tests/playwright/sanity/modules/div-block/div-block.test.ts
@@ -122,4 +122,31 @@ test.describe( 'Div Block tests @div-block', () => {
 			await expect( secondContainerHandles ).toHaveScreenshot( 'normal-handles.png' );
 		} );
 	} );
+	test( 'Verify that text stroke style do not apply to empty view and frame handle elements', async ( { page, apiRequests }, testInfo ) => {
+		// Arrange.
+		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+		const editor = await wpAdmin.openNewPage();
+		const divBlockId = await editor.addElement( { elType: 'e-div-block' }, 'document' );
+
+		const divBlock = editor.getPreviewFrame().locator( `[data-id="${ divBlockId }"]` );
+		await divBlock.waitFor();
+		const divBlockHandles = divBlock.locator( '.elementor-editor-element-settings' );
+		const divBlockEmptyView = divBlock.locator( '.elementor-empty-view' );
+
+		// Apply text stroke style to div block, no need to go through entire UI, just need to check styles are not passed to empty view and frame handle elements.
+		await divBlock.evaluate( ( el ) => {
+			el.style.stroke = 'red';
+			el.style.strokeWidth = '10px';
+		} );
+
+		await divBlockEmptyView.waitFor();
+
+		await divBlock.hover();
+
+		// Assert.
+		expect( divBlockEmptyView ).toHaveCSS( 'stroke', 'rgba(0, 0, 0, 0)' );
+		expect( divBlockEmptyView ).toHaveCSS( 'strokeWidth', '0px' );
+		expect( divBlockHandles ).toHaveCSS( 'stroke', 'rgba(0, 0, 0, 0)' );
+		expect( divBlockHandles ).toHaveCSS( 'strokeWidth', '0px' );
+	} );
 } );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
Stroke snd stroke width should no longer apply to empty view and widget frame handles.