### PR TITLE
Fix: [V4] Fatal error when setting a background image overlay to be hidden - 3.29 [ED-19303]

### DIFF
--- a/modules/atomic-widgets/props-resolver/transformers/styles/background-overlay-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/styles/background-overlay-transformer.php
@@ -24,7 +24,7 @@ class Background_Overlay_Transformer extends Transformer_Base {
 	}
 
 	private function normalize_overlay_values( $overlays ): array {
-		return array_map( function( $value ) {
+		$mapped_values = array_map( function( $value ) {
 			if ( is_string( $value ) ) {
 				return [
 					'src' => $value,
@@ -37,6 +37,10 @@ class Background_Overlay_Transformer extends Transformer_Base {
 
 			return $value;
 		}, $overlays );
+
+		return array_filter( $mapped_values, function( $value ) {
+			return is_array( $value ) && ! empty( $value['src'] );
+		} );
 	}
 
 	private function get_values_string( $value, string $prop, string $default_value, bool $prevent_unification = false ) {

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/test-styles-renderer.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/test-styles-renderer.php
@@ -368,6 +368,13 @@ class Test_Styles_Renderer extends Elementor_Test_Base {
 												'value' => [
 													'color' => 'blue',
 												],
+												'disabled' => true,
+											], // this should not be rendered due to `disabled` => true
+											[
+												'$$type' => 'background-color-overlay',
+												'value' => [
+													'color' => 'blue',
+												],
 											],
 											[
 												'$$type' => 'background-image-overlay',


### PR DESCRIPTION
Same as https://github.com/elementor/elementor/pull/31270, but for 3.29