### PR TITLE
Fix: Verify editorControlModel exists [TMZ-615][ED-19349]

### DIFF
--- a/assets/dev/js/editor/utils/module.js
+++ b/assets/dev/js/editor/utils/module.js
@@ -19,7 +19,7 @@ const EditorModule = elementorModules.Module.extend( {
 	getEditorControlView( name ) {
 		const editor = elementor.getPanelView().getCurrentPageView();
 
-		return editor.children.findByModelCid( this.getEditorControlModel( name ).cid );
+		return editor.children.findByModelCid( this.getEditorControlModel( name )?.cid );
 	},
 
 	// TODO: Delete as soon as possible.


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [X] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Editor panel not rendering when using both Pro and Hello+ widgets

## Description
An explanation of what is done in this PR

* An unsafe attempt to access the getEditorControlModel's `cid` attribute, resulting in accessing a property of `undefined`. This is exposed only when trying to run both Pro & a widget that overrides the native "Advanced" tab, like the Hello+ widgets do.

## Test instructions
This PR can be tested by following these steps:

* 

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
