### PR TITLE
Fix: Remove unnecessary meta settings in multiple atomic widget classes [ED-19358]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.php
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.php
@@ -62,7 +62,7 @@ class Atomic_Button extends Atomic_Widget_Base {
 
 	protected function define_atomic_controls(): array {
 		$settings_section_items = [
-			Link_Control::bind_to( 'link' )
+			Link_Control::bind_to( 'link' ),
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {

--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.php
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.php
@@ -62,9 +62,7 @@ class Atomic_Button extends Atomic_Widget_Base {
 
 	protected function define_atomic_controls(): array {
 		$settings_section_items = [
-			Link_Control::bind_to( 'link' )->set_meta( [
-				'topDivider' => true,
-			] ),
+			Link_Control::bind_to( 'link' )
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -102,9 +102,7 @@ class Atomic_Heading extends Atomic_Widget_Base {
 						'label' => 'H6',
 					],
 				]),
-			Link_Control::bind_to( 'link' )->set_meta( [
-				'topDivider' => true,
-			] ),
+			Link_Control::bind_to( 'link' )
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -102,7 +102,7 @@ class Atomic_Heading extends Atomic_Widget_Base {
 						'label' => 'H6',
 					],
 				]),
-			Link_Control::bind_to( 'link' )
+			Link_Control::bind_to( 'link' ),
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {

--- a/modules/atomic-widgets/elements/atomic-image/atomic-image.php
+++ b/modules/atomic-widgets/elements/atomic-image/atomic-image.php
@@ -73,7 +73,7 @@ class Atomic_Image extends Atomic_Widget_Base {
 		$settings_section_items = [
 			Image_Control::bind_to( 'image' )
 				->set_show_mode( 'sizes' ),
-			Link_Control::bind_to( 'link' )
+			Link_Control::bind_to( 'link' ),
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {

--- a/modules/atomic-widgets/elements/atomic-image/atomic-image.php
+++ b/modules/atomic-widgets/elements/atomic-image/atomic-image.php
@@ -73,9 +73,7 @@ class Atomic_Image extends Atomic_Widget_Base {
 		$settings_section_items = [
 			Image_Control::bind_to( 'image' )
 				->set_show_mode( 'sizes' ),
-			Link_Control::bind_to( 'link' )->set_meta( [
-				'topDivider' => true,
-			] ),
+			Link_Control::bind_to( 'link' )
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {

--- a/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.php
+++ b/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.php
@@ -62,9 +62,7 @@ class Atomic_Paragraph extends Atomic_Widget_Base {
 
 	protected function define_atomic_controls(): array {
 		$settings_section_items = [
-			Link_Control::bind_to( 'link' )->set_meta( [
-				'topDivider' => true,
-			] ),
+			Link_Control::bind_to( 'link' )
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {

--- a/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.php
+++ b/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.php
@@ -62,7 +62,7 @@ class Atomic_Paragraph extends Atomic_Widget_Base {
 
 	protected function define_atomic_controls(): array {
 		$settings_section_items = [
-			Link_Control::bind_to( 'link' )
+			Link_Control::bind_to( 'link' ),
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {

--- a/modules/atomic-widgets/elements/atomic-svg/atomic-svg.php
+++ b/modules/atomic-widgets/elements/atomic-svg/atomic-svg.php
@@ -59,9 +59,7 @@ class Atomic_Svg extends Atomic_Widget_Base {
 
 	protected function define_atomic_controls(): array {
 		$settings_section_items = [
-			Link_Control::bind_to( 'link' )->set_meta( [
-				'topDivider' => true,
-			] ),
+			Link_Control::bind_to( 'link' )
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {

--- a/modules/atomic-widgets/elements/atomic-svg/atomic-svg.php
+++ b/modules/atomic-widgets/elements/atomic-svg/atomic-svg.php
@@ -59,7 +59,7 @@ class Atomic_Svg extends Atomic_Widget_Base {
 
 	protected function define_atomic_controls(): array {
 		$settings_section_items = [
-			Link_Control::bind_to( 'link' )
+			Link_Control::bind_to( 'link' ),
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {

--- a/modules/atomic-widgets/elements/div-block/div-block.php
+++ b/modules/atomic-widgets/elements/div-block/div-block.php
@@ -95,7 +95,7 @@ class Div_Block extends Atomic_Element_Base {
 					],
 				]),
 
-			Link_Control::bind_to( 'link' )
+			Link_Control::bind_to( 'link' ),
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {

--- a/modules/atomic-widgets/elements/div-block/div-block.php
+++ b/modules/atomic-widgets/elements/div-block/div-block.php
@@ -95,9 +95,7 @@ class Div_Block extends Atomic_Element_Base {
 					],
 				]),
 
-			Link_Control::bind_to( 'link' )->set_meta( [
-				'topDivider' => true,
-			] ),
+			Link_Control::bind_to( 'link' )
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Removed unnecessary meta settings for Link_Control in multiple atomic widget classes

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
