### PR TITLE
Revert "Internal: Rename _cssid control to _element_id atomic widget [ED-19415]"

### DIFF
--- a/modules/atomic-widgets/assets/js/editor/div-block-view.js
+++ b/modules/atomic-widgets/assets/js/editor/div-block-view.js
@@ -39,7 +39,7 @@ const DivBlockView = BaseElementView.extend( {
 	attributes() {
 		const attr = BaseElementView.prototype.attributes.apply( this );
 		const local = {};
-		const cssId = this.model.getSetting( '_element_id' );
+		const cssId = this.model.getSetting( '_cssid' );
 
 		if ( cssId ) {
 			local.id = cssId.value;

--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.html.twig
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.html.twig
@@ -1,6 +1,6 @@
 {% if settings.text is not empty %}
     {% set classes = settings.classes | merge( [ base_styles.base ] ) | join(' ') %}
-	{% set id_attribute = settings._element_id is not empty ? 'id=' ~ settings._element_id | e('html_attr') : '' %}
+	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
     {% if settings.link.href %}
         <a
                 href="{{ settings.link.href }}"

--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.php
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.php
@@ -54,7 +54,7 @@ class Atomic_Button extends Atomic_Widget_Base {
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$props['_element_id'] = String_Prop_Type::make();
+			$props['_cssid'] = String_Prop_Type::make();
 		}
 
 		return $props;
@@ -66,7 +66,7 @@ class Atomic_Button extends Atomic_Widget_Base {
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$settings_section_items[] = Text_Control::bind_to( '_element_id' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
+			$settings_section_items[] = Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
 				'layout' => 'two-columns',
 				'topDivider' => true,
 			] );

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -1,5 +1,5 @@
 {% if settings.title is not empty %}
-	{% set id_attribute = settings._element_id is not empty ? 'id=' ~ settings._element_id | e('html_attr') : '' %}
+	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
 	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }}>
 	{% if settings.link.href %}
 		<a href="{{ settings.link.href }}" target="{{ settings.link.target }}" class="{{ base_styles['link-base'] }}">

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -58,7 +58,7 @@ class Atomic_Heading extends Atomic_Widget_Base {
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$props['_element_id'] = String_Prop_Type::make();
+			$props['_cssid'] = String_Prop_Type::make();
 		}
 
 		return $props;
@@ -106,7 +106,7 @@ class Atomic_Heading extends Atomic_Widget_Base {
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$settings_section_items[] = Text_Control::bind_to( '_element_id' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
+			$settings_section_items[] = Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
 				'layout' => 'two-columns',
 				'topDivider' => true,
 			] );

--- a/modules/atomic-widgets/elements/atomic-image/atomic-image.html.twig
+++ b/modules/atomic-widgets/elements/atomic-image/atomic-image.html.twig
@@ -1,5 +1,5 @@
 {% if settings.image.src is not empty %}
-	{% set id_attribute = settings._element_id is not empty ? 'id=' ~ settings._element_id | e('html_attr') : '' %}
+	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
 	{% if settings.link.href %}
 		<a href="{{ settings.link.href }}" class="{{ base_styles['link-base'] }}" target="{{ settings.link.target }}">
 	{% endif %}

--- a/modules/atomic-widgets/elements/atomic-image/atomic-image.php
+++ b/modules/atomic-widgets/elements/atomic-image/atomic-image.php
@@ -56,7 +56,7 @@ class Atomic_Image extends Atomic_Widget_Base {
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$props['_element_id'] = String_Prop_Type::make();
+			$props['_cssid'] = String_Prop_Type::make();
 		}
 
 		return $props;
@@ -77,7 +77,7 @@ class Atomic_Image extends Atomic_Widget_Base {
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$settings_section_items[] = Text_Control::bind_to( '_element_id' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
+			$settings_section_items[] = Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
 				'layout' => 'two-columns',
 				'topDivider' => true,
 			] );

--- a/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.html.twig
+++ b/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.html.twig
@@ -1,5 +1,5 @@
 {% if settings.paragraph is not empty %}
-		{% set id_attribute = settings._element_id is not empty ? 'id=' ~ settings._element_id | e('html_attr') : '' %}
+		{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
         <p class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }}>
             {% if settings.link.href %}
                 <a href="{{ settings.link.href }}" target="{{ settings.link.target }}" class="{{ base_styles['link-base'] }}">

--- a/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.php
+++ b/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.php
@@ -54,7 +54,7 @@ class Atomic_Paragraph extends Atomic_Widget_Base {
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$props['_element_id'] = String_Prop_Type::make();
+			$props['_cssid'] = String_Prop_Type::make();
 		}
 
 		return $props;
@@ -66,7 +66,7 @@ class Atomic_Paragraph extends Atomic_Widget_Base {
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$settings_section_items[] = Text_Control::bind_to( '_element_id' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
+			$settings_section_items[] = Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
 				'layout' => 'two-columns',
 				'topDivider' => true,
 			] );

--- a/modules/atomic-widgets/elements/atomic-svg/atomic-svg.php
+++ b/modules/atomic-widgets/elements/atomic-svg/atomic-svg.php
@@ -52,7 +52,7 @@ class Atomic_Svg extends Atomic_Widget_Base {
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$props['_element_id'] = String_Prop_Type::make();
+			$props['_cssid'] = String_Prop_Type::make();
 		}
 		return $props;
 	}
@@ -63,7 +63,7 @@ class Atomic_Svg extends Atomic_Widget_Base {
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$settings_section_items[] = Text_Control::bind_to( '_element_id' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
+			$settings_section_items[] = Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
 				'layout' => 'two-columns',
 				'topDivider' => true,
 			] );
@@ -127,7 +127,7 @@ class Atomic_Svg extends Atomic_Widget_Base {
 
 		$classes_string = implode( ' ', $classes );
 
-		$cssid_attribute = ! empty( $settings['_element_id'] ) ? 'id="' . esc_attr( $settings['_element_id'] ) . '"' : '';
+		$cssid_attribute = ! empty( $settings['_cssid'] ) ? 'id="' . esc_attr( $settings['_cssid'] ) . '"' : '';
 		if ( isset( $settings['link'] ) && ! empty( $settings['link']['href'] ) ) {
 			$svg_html = sprintf(
 				'<a href="%s" target="%s" class="%s" %s>%s</a>',

--- a/modules/atomic-widgets/elements/div-block/div-block.php
+++ b/modules/atomic-widgets/elements/div-block/div-block.php
@@ -58,7 +58,7 @@ class Div_Block extends Atomic_Element_Base {
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$props['_element_id'] = String_Prop_Type::make();
+			$props['_cssid'] = String_Prop_Type::make();
 		}
 
 		return $props;
@@ -99,7 +99,7 @@ class Div_Block extends Atomic_Element_Base {
 		];
 
 		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$settings_section_items[] = Text_Control::bind_to( '_element_id' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
+			$settings_section_items[] = Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
 				'layout' => 'two-columns',
 				'topDivider' => true,
 			] );
@@ -196,8 +196,8 @@ class Div_Block extends Atomic_Element_Base {
 			],
 		];
 
-		if ( ! empty( $settings['_element_id'] ) ) {
-			$attributes['id'] = esc_attr( $settings['_element_id'] );
+		if ( ! empty( $settings['_cssid'] ) ) {
+			$attributes['id'] = esc_attr( $settings['_cssid'] );
 		}
 
 		if ( ! empty( $settings['link']['href'] ) ) {

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Flexbox__test__render_with_css_id__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Flexbox__test__render_with_css_id__1.txt
@@ -1,3 +1,3 @@
-		<div class="elementor-element elementor-element-e8e55a1 e-con e-flexbox-base" data-id="e8e55a1" data-element_type="e-flexbox">
+		<div class="elementor-element elementor-element-e8e55a1 e-con e-flexbox-base" data-id="e8e55a1" data-element_type="e-flexbox" id="test-css-id">
 				</div>
 		


### PR DESCRIPTION


This reverts commit e19f5e308ccdb735faee03ab058ced5c11e9bd6c.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
