### PR TITLE
Internal: Add common settings controls [ED-19386]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.php
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.php
@@ -7,7 +7,6 @@ use Elementor\Modules\AtomicWidgets\Elements\Atomic_Widget_Base;
 use Elementor\Modules\AtomicWidgets\Controls\Section;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Link_Control;
 use Elementor\Modules\AtomicWidgets\Elements\Has_Template;
-use Elementor\Modules\AtomicWidgets\Module;
 use Elementor\Modules\AtomicWidgets\PropTypes\Background_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
@@ -17,7 +16,6 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
-use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -53,25 +51,10 @@ class Atomic_Button extends Atomic_Widget_Base {
 			'link' => Link_Prop_Type::make(),
 		];
 
-		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$props['_cssid'] = String_Prop_Type::make();
-		}
-
 		return $props;
 	}
 
 	protected function define_atomic_controls(): array {
-		$settings_section_items = [
-			Link_Control::bind_to( 'link' ),
-		];
-
-		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$settings_section_items[] = Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
-				'layout' => 'two-columns',
-				'topDivider' => true,
-			] );
-		}
-
 		return [
 			Section::make()
 				->set_label( __( 'Content', 'elementor' ) )
@@ -80,9 +63,12 @@ class Atomic_Button extends Atomic_Widget_Base {
 						->set_label( __( 'Button text', 'elementor' ) )
 						->set_placeholder( __( 'Type your button text here', 'elementor' ) ),
 				] ),
-			Section::make()
-				->set_label( __( 'Settings', 'elementor' ) )
-				->set_items( $settings_section_items ),
+		];
+	}
+
+	protected function get_settings_controls(): array {
+		return [
+			Link_Control::bind_to( 'link' ),
 		];
 	}
 

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -4,18 +4,15 @@ namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Heading;
 use Elementor\Modules\AtomicWidgets\Controls\Section;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Link_Control;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Select_Control;
-use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Textarea_Control;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Widget_Base;
 use Elementor\Modules\AtomicWidgets\Elements\Has_Template;
-use Elementor\Modules\AtomicWidgets\Module;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Link_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
-use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -57,10 +54,6 @@ class Atomic_Heading extends Atomic_Widget_Base {
 			'link' => Link_Prop_Type::make(),
 		];
 
-		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$props['_cssid'] = String_Prop_Type::make();
-		}
-
 		return $props;
 	}
 
@@ -73,10 +66,16 @@ class Atomic_Heading extends Atomic_Widget_Base {
 					->set_placeholder( __( 'Type your title here', 'elementor' ) ),
 			] );
 
-		$settings_section_items = [
+		return [
+			$content_section,
+		];
+	}
+
+	protected function get_settings_controls(): array {
+		return [
 			Select_Control::bind_to( 'tag' )
 				->set_label( esc_html__( 'Tag', 'elementor' ) )
-				->set_options( [
+				->set_options([
 					[
 						'value' => 'h1',
 						'label' => 'H1',
@@ -105,22 +104,6 @@ class Atomic_Heading extends Atomic_Widget_Base {
 			Link_Control::bind_to( 'link' )->set_meta( [
 				'topDivider' => true,
 			] ),
-		];
-
-		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$settings_section_items[] = Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
-				'layout' => 'two-columns',
-				'topDivider' => true,
-			] );
-		}
-
-		$settings_section = Section::make()
-			->set_label( __( 'Settings', 'elementor' ) )
-			->set_items( $settings_section_items );
-
-		return [
-			$content_section,
-			$settings_section,
 		];
 	}
 

--- a/modules/atomic-widgets/elements/atomic-image/atomic-image.php
+++ b/modules/atomic-widgets/elements/atomic-image/atomic-image.php
@@ -2,9 +2,7 @@
 namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Image;
 
 use Elementor\Modules\AtomicWidgets\Controls\Types\Link_Control;
-use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
 use Elementor\Modules\AtomicWidgets\Elements\Has_Template;
-use Elementor\Modules\AtomicWidgets\Module;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Image_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Link_Prop_Type;
@@ -12,10 +10,8 @@ use Elementor\Modules\AtomicWidgets\Controls\Section;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Widget_Base;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Image_Control;
 use Elementor\Modules\AtomicWidgets\Image\Placeholder_Image;
-use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
-use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -55,41 +51,27 @@ class Atomic_Image extends Atomic_Widget_Base {
 			'link' => Link_Prop_Type::make(),
 		];
 
-		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$props['_cssid'] = String_Prop_Type::make();
-		}
-
 		return $props;
 	}
 
 	protected function define_atomic_controls(): array {
-		$content_section = Section::make()
-			->set_label( esc_html__( 'Content', 'elementor' ) )
-			->set_items( [
-				Image_Control::bind_to( 'image' )
-					->set_show_mode( 'media' ),
-			] );
+		return [
+			Section::make()
+				->set_label( esc_html__( 'Content', 'elementor' ) )
+				->set_items( [
+					Image_Control::bind_to( 'image' )
+						->set_show_mode( 'media' ),
+				] ),
+		];
+	}
 
-		$settings_section_items = [
+	protected function get_settings_controls(): array {
+		return [
 			Image_Control::bind_to( 'image' )
 				->set_show_mode( 'sizes' ),
 			Link_Control::bind_to( 'link' )->set_meta( [
 				'topDivider' => true,
 			] ),
-		];
-
-		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$settings_section_items[] = Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
-				'layout' => 'two-columns',
-				'topDivider' => true,
-			] );
-		}
-
-		return [
-			$content_section,
-			Section::make()
-				->set_label( esc_html__( 'Settings', 'elementor' ) )
-				->set_items( $settings_section_items ),
 		];
 	}
 

--- a/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.php
+++ b/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.php
@@ -2,20 +2,17 @@
 
 namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Paragraph;
 
-use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Widget_Base;
 use Elementor\Modules\AtomicWidgets\Controls\Section;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Link_Control;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Textarea_Control;
 use Elementor\Modules\AtomicWidgets\Elements\Has_Template;
-use Elementor\Modules\AtomicWidgets\Module;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Link_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
-use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -53,25 +50,10 @@ class Atomic_Paragraph extends Atomic_Widget_Base {
 			'link' => Link_Prop_Type::make(),
 		];
 
-		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$props['_cssid'] = String_Prop_Type::make();
-		}
-
 		return $props;
 	}
 
 	protected function define_atomic_controls(): array {
-		$settings_section_items = [
-			Link_Control::bind_to( 'link' ),
-		];
-
-		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$settings_section_items[] = Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
-				'layout' => 'two-columns',
-				'topDivider' => true,
-			] );
-		}
-
 		return [
 			Section::make()
 				->set_label( __( 'Content', 'elementor' ) )
@@ -80,9 +62,12 @@ class Atomic_Paragraph extends Atomic_Widget_Base {
 						->set_label( __( 'Paragraph', 'elementor' ) )
 						->set_placeholder( __( 'Type your paragraph here', 'elementor' ) ),
 				] ),
-			Section::make()
-				->set_label( __( 'Settings', 'elementor' ) )
-				->set_items( $settings_section_items ),
+		];
+	}
+
+	protected function get_settings_controls(): array {
+		return [
+			Link_Control::bind_to( 'link' ),
 		];
 	}
 

--- a/modules/atomic-widgets/elements/atomic-svg/atomic-svg.php
+++ b/modules/atomic-widgets/elements/atomic-svg/atomic-svg.php
@@ -3,8 +3,6 @@ namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Svg;
 
 use Elementor\Modules\AtomicWidgets\Controls\Section;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Link_Control;
-use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
-use Elementor\Modules\AtomicWidgets\Module;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Widget_Base;
 use Elementor\Core\Utils\Svg\Svg_Sanitizer;
@@ -15,7 +13,6 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
-use Elementor\Plugin;
 use Elementor\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -45,39 +42,26 @@ class Atomic_Svg extends Atomic_Widget_Base {
 	}
 
 	protected static function define_props_schema(): array {
-		$props = [
+		return [
 			'classes' => Classes_Prop_Type::make()->default( [] ),
 			'svg' => Image_Src_Prop_Type::make()->default_url( static::DEFAULT_SVG_URL ),
 			'link' => Link_Prop_Type::make(),
 		];
-
-		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$props['_cssid'] = String_Prop_Type::make();
-		}
-		return $props;
 	}
 
 	protected function define_atomic_controls(): array {
-		$settings_section_items = [
-			Link_Control::bind_to( 'link' ),
-		];
-
-		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$settings_section_items[] = Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
-				'layout' => 'two-columns',
-				'topDivider' => true,
-			] );
-		}
-
 		return [
 			Section::make()
 				->set_label( esc_html__( 'Content', 'elementor' ) )
 				->set_items( [
 					Svg_Control::bind_to( 'svg' ),
 				] ),
-			Section::make()
-				->set_label( esc_html__( 'Settings', 'elementor' ) )
-				->set_items( $settings_section_items ),
+		];
+	}
+
+	protected function get_settings_controls(): array {
+		return [
+			Link_Control::bind_to( 'link' ),
 		];
 	}
 

--- a/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.php
+++ b/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.php
@@ -9,7 +9,6 @@ use Elementor\Modules\AtomicWidgets\Elements\Has_Template;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Boolean_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
-use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
 
@@ -78,6 +77,10 @@ class Atomic_Youtube extends Atomic_Widget_Base {
 					Switch_Control::bind_to( 'rel' )->set_label( esc_html__( 'Related videos', 'elementor' ) ),
 				] ),
 		];
+	}
+
+	protected function get_settings_controls(): array {
+		return [];
 	}
 
 	protected function define_base_styles(): array {

--- a/modules/atomic-widgets/elements/div-block/div-block.php
+++ b/modules/atomic-widgets/elements/div-block/div-block.php
@@ -2,14 +2,9 @@
 namespace Elementor\Modules\AtomicWidgets\Elements\Div_Block;
 
 use Elementor\Modules\AtomicWidgets\Controls\Types\Link_Control;
-use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Element_Base;
-use Elementor\Modules\AtomicWidgets\Controls\Section;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Select_Control;
-use Elementor\Modules\AtomicWidgets\Module;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
-use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
-use Elementor\Modules\AtomicWidgets\PropTypes\Dimensions_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Link_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
@@ -49,23 +44,20 @@ class Div_Block extends Atomic_Element_Base {
 		$props = [
 			'classes' => Classes_Prop_Type::make()
 				->default( [] ),
-
 			'tag' => String_Prop_Type::make()
 				->enum( [ 'div', 'header', 'section', 'article', 'aside', 'footer' ] )
 				->default( 'div' ),
-
 			'link' => Link_Prop_Type::make(),
 		];
-
-		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$props['_cssid'] = String_Prop_Type::make();
-		}
-
 		return $props;
 	}
 
 	protected function define_atomic_controls(): array {
-		$settings_section_items = [
+		return [];
+	}
+
+	protected function get_settings_controls(): array {
+		return [
 			Select_Control::bind_to( 'tag' )
 				->set_label( esc_html__( 'HTML Tag', 'elementor' ) )
 				->set_options( [
@@ -94,23 +86,9 @@ class Div_Block extends Atomic_Element_Base {
 						'label' => 'Footer',
 					],
 				]),
-
 			Link_Control::bind_to( 'link' )->set_meta( [
 				'topDivider' => true,
 			] ),
-		];
-
-		if ( Plugin::$instance->experiments->is_feature_active( Module::EXPERIMENT_VERSION_3_30 ) ) {
-			$settings_section_items[] = Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
-				'layout' => 'two-columns',
-				'topDivider' => true,
-			] );
-		}
-
-		return [
-			Section::make()
-				->set_label( __( 'Settings', 'elementor' ) )
-				->set_items( $settings_section_items ),
 		];
 	}
 

--- a/modules/atomic-widgets/elements/has-atomic-base.php
+++ b/modules/atomic-widgets/elements/has-atomic-base.php
@@ -10,6 +10,10 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 use Elementor\Modules\AtomicWidgets\Parsers\Props_Parser;
 use Elementor\Modules\AtomicWidgets\Parsers\Style_Parser;
+use Elementor\Modules\AtomicWidgets\Module;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Plugin;
 use Elementor\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -112,7 +116,7 @@ trait Has_Atomic_Base {
 	public function get_atomic_controls() {
 		$controls = apply_filters(
 			'elementor/atomic-widgets/controls',
-			$this->define_atomic_controls(),
+			$this->combine_controls(),
 			$this
 		);
 
@@ -122,6 +126,28 @@ trait Has_Atomic_Base {
 		static::validate_schema( $schema );
 
 		return $this->get_valid_controls( $schema, $controls );
+	}
+
+	protected function combine_controls(): array {
+		$common_settings_controls = [
+			Text_Control::bind_to( '_cssid' )->set_label( __( 'ID', 'elementor' ) )->set_meta( [
+				'layout' => 'two-columns',
+				'topDivider' => true,
+			] ),
+		];
+
+		return array_merge(
+			$this->define_atomic_controls(),
+			[
+				Section::make()
+					->set_label( __( 'Settings', 'elementor' ) )
+					->set_items( array_merge( $this->get_settings_controls(), $common_settings_controls ) ),
+			],
+		);
+	}
+
+	protected function get_settings_controls(): array {
+		return [];
 	}
 
 	final public function get_controls( $control_id = null ) {
@@ -177,9 +203,12 @@ trait Has_Atomic_Base {
 	}
 
 	public static function get_props_schema(): array {
+		$schema = static::define_props_schema();
+		$schema['_cssid'] = String_Prop_Type::make();
+
 		return apply_filters(
 			'elementor/atomic-widgets/props-schema',
-			static::define_props_schema()
+			$schema
 		);
 	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-widget-base.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-widget-base.php
@@ -37,6 +37,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Act.
 		$settings = $widget->get_atomic_settings();
+		array_pop( $settings ); // remove common settings
 
 		// Assert.
 		$this->assertSame( $args['result'], $settings );
@@ -294,6 +295,8 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 		remove_all_filters( 'elementor/atomic-widgets/props-schema' );
 
 		$schema = [
+			'_cssid' => String_Prop_Type::make(),
+	
 			'string_prop' => String_Prop_Type::make()
 				->enum( [ 'value-a', 'value-b' ] )
 				->default( 'value-a' ),
@@ -321,6 +324,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Assert.
 		$keys = [
+			'_cssid', // will automatically be added as a common prop
 			'string_prop',
 			'number_prop',
 			'boolean_prop',
@@ -348,8 +352,10 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		$widget = $this->make_mock_widget( [ 'props_schema' => $schema ] );
 
+		$test_schema = $widget::get_props_schema();
+		unset( $test_schema['_cssid'] );
 		// Act & Assert.
-		$this->assertSame( $schema, $widget::get_props_schema() );
+		$this->assertSame( $schema, $test_schema );
 	}
 
 	public function test_get_atomic_controls__throws_when_control_is_invalid() {
@@ -450,6 +456,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Act.
 		$controls = $widget->get_atomic_controls();
+		array_pop( $controls ); //remove settings section
 
 		// Assert.
 		$this->assertEquals( $controls_definitions, $controls );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

Adds common settings controls to all atomic widgets, currently only css id.

*

## Description
Changed trait of has-atomic-base to allow for use of common controls and props for atomic widgets while allowing the adding of more controls by each specific widget.

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
