### PR TITLE
Internal: Allow filtering of close modal behavior [ED-19530]

### DIFF
--- a/modules/floating-buttons/assets/js/floating-buttons/editor/module.js
+++ b/modules/floating-buttons/assets/js/floating-buttons/editor/module.js
@@ -31,6 +31,17 @@ class FloatingButtonsLibraryModule extends elementorModules.editor.utils.Module 
 			return behaviors;
 		}, 1000 );
 
+		elementor.hooks.addFilter( 'component/modal/close', ( close, component ) => {
+			if (
+				'library' === component.getNamespace() &&
+				'library/templates/floating-buttons' === component.defaultRoute
+			) {
+				return () => {};
+			}
+
+			return close;
+		}, 1000 );
+
 		elementor.hooks.addFilter(
 			'elementor/editor/template-library/template/promotion-link-search-params',
 			( queryString, templateData ) => {

--- a/modules/web-cli/assets/js/modules/component-modal-base.js
+++ b/modules/web-cli/assets/js/modules/component-modal-base.js
@@ -40,11 +40,11 @@ export default class ComponentModalBase extends ComponentBase {
 			return false;
 		}
 
-		const close = elementor.hooks.applyFilters( 
-            'component/modal/close', 
-            this.layout.getModal().hide.bind( this.layout.getModal() ), 
-            this 
-        );
+		const close = elementor.hooks.applyFilters(
+			'component/modal/close',
+			this.layout.getModal().hide.bind( this.layout.getModal() ),
+			this,
+		);
 
 		close();
 

--- a/modules/web-cli/assets/js/modules/component-modal-base.js
+++ b/modules/web-cli/assets/js/modules/component-modal-base.js
@@ -40,7 +40,13 @@ export default class ComponentModalBase extends ComponentBase {
 			return false;
 		}
 
-		this.layout.getModal().hide();
+		const close = elementor.hooks.applyFilters( 
+            'component/modal/close', 
+            this.layout.getModal().hide.bind( this.layout.getModal() ), 
+            this 
+        );
+
+		close();
 
 		return true;
 	}

--- a/tests/playwright/sanity/modules/floating-buttons/floating-elements-admin.test.ts
+++ b/tests/playwright/sanity/modules/floating-buttons/floating-elements-admin.test.ts
@@ -76,6 +76,9 @@ test.describe( 'Verify floating buttons editor, admin page and front page behavi
 				await deleteContainer.click();
 				const libraryModal = page.locator( '#elementor-template-library-modal' );
 				await expect( libraryModal ).toBeVisible();
+				await libraryModal.focus();
+				await page.keyboard.press( 'Escape' );
+				await expect( libraryModal ).toBeVisible();
 			} );
 
 		let floatingElement, context, newPage;


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Allow components to overrride the default behavior of the modal of closing on press of ESC button

## Description
An explanation of what is done in this PR

* I have added the ability to override with a filter the standard behavior of closing the modal on esc. The changes are done on closing as when the component is created elementor.hooks is not defined. This also allows more control of what happens on close, as there are cases when we need to redirect on modal close.  

## Test instructions
This PR can be tested by following these steps:

* Go to Floating Elements
* Add a new Floating Element, button or bar is the same
* Wait for the Template Library Modal to appear
* Press Esc -> Verify modal doesn't close.

## Quality assurance

-  [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
