### PR TITLE
Internal: The import/Export close button returns to the last position [ED-19560]

### DIFF
--- a/app/assets/js/layout/header.js
+++ b/app/assets/js/layout/header.js
@@ -22,7 +22,7 @@ export default function Header( props ) {
 				<i className="eps-app__logo eicon-elementor" />
 				<h1 className="eps-app__title">{ props.title }</h1>
 			</TitleTag>
-			<HeaderButtons buttons={ props.buttons } />
+			<HeaderButtons buttons={ props.buttons } onClose={ props.onClose } />
 		</Grid>
 	);
 }

--- a/app/assets/js/layout/page.js
+++ b/app/assets/js/layout/page.js
@@ -28,7 +28,7 @@ export default function Page( props ) {
 	return (
 		<div className={ `eps-app__lightbox ${ props.className }` }>
 			<div className="eps-app">
-				<Header title={ props.title } buttons={ props.headerButtons } titleRedirectRoute={ props.titleRedirectRoute } onClose={ () => props.onClose?.() } />
+				<Header title={ props.title } buttons={ props.headerButtons } titleRedirectRoute={ props.titleRedirectRoute } onClose={ props.onClose } />
 				<div className="eps-app__main">
 					{ AppSidebar() }
 					<Content>

--- a/app/modules/import-export/assets/js/pages/export/export-kit/components/kit-information/components/kit-name/kit-name.js
+++ b/app/modules/import-export/assets/js/pages/export/export-kit/components/kit-information/components/kit-name/kit-name.js
@@ -40,6 +40,8 @@ export default function KitName() {
 				className={ error ? 'e-app-export-kit-information__field--error' : '' }
 				title={ error || '' }
 				value={ exportContext.data.kitInfo?.title || '' }
+				// eslint-disable-next-line jsx-a11y/no-autofocus
+				autoFocus
 			/>
 			<div className="e-app-export-kit-information__error-container">
 				{ error && (

--- a/app/modules/import-export/assets/js/templates/layout.js
+++ b/app/modules/import-export/assets/js/templates/layout.js
@@ -67,7 +67,11 @@ export default function Layout( props ) {
 		},
 		onClose = () => {
 			eventTracking( 'kit-library/close', 'app_header', null, 'click' );
-			window.top.location = elementorAppConfig.admin_url;
+			if ( 'kit-library' === sharedContext.data.referrer || 'kit-library' === referrer ) {
+				window.top.location = elementorAppConfig.admin_url + 'admin.php?page=elementor-app#/kit-library';
+			} else {
+				window.top.location = elementorAppConfig.admin_url + 'admin.php?page=elementor-tools#tab-import-export-kit';
+			}
 		},
 		config = {
 			title: 'import' === props.type ? __( 'Import', 'elementor' ) : __( 'Export', 'elementor' ),

--- a/app/modules/kit-library/assets/js/models/taxonomy.js
+++ b/app/modules/kit-library/assets/js/models/taxonomy.js
@@ -25,7 +25,7 @@ export const TaxonomyTypes = [
 	},
 	{
 		key: SUBSCRIPTION_PLAN,
-		label: __( 'Kits by plan', 'elementor' ),
+		label: __( 'Plan', 'elementor' ),
 		data: [],
 	},
 ];


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implements back-button functionality in Import-Export module to direct users to appropriate origin pages.

Main changes:
- Passes onClose prop from Header component to HeaderButtons for proper event handling.
- Modifies navigation logic to redirect users to Kit Library or Import-Export tools based on referrer.
- Adds autoFocus attribute to Kit name input field for improved UX.
- Changes subscription plan taxonomy label from "Kits by plan" to "Plan" for conciseness.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
