### PR TITLE
Fix: Clean up variables TODO [ED-16053] 

### DIFF
--- a/modules/variables/classes/rest-api.php
+++ b/modules/variables/classes/rest-api.php
@@ -308,6 +308,13 @@ class Rest_Api {
 	private function list_of_variables() {
 		$db_record = $this->variables_repository->load();
 
+		$db_record['data'][] = [
+			'id' => 'test',
+			'type' => Font_Variable_Prop_Type::get_key(),
+			'label' => 'Test',
+			'value' => 'Robott',
+		];
+
 		return $this->success_response( [
 			'variables' => $db_record['data'],
 			'total' => count( $db_record['data'] ),

--- a/modules/variables/classes/rest-api.php
+++ b/modules/variables/classes/rest-api.php
@@ -308,13 +308,6 @@ class Rest_Api {
 	private function list_of_variables() {
 		$db_record = $this->variables_repository->load();
 
-		$db_record['data'][] = [
-			'id' => 'test',
-			'type' => Font_Variable_Prop_Type::get_key(),
-			'label' => 'Test',
-			'value' => 'Robott',
-		];
-
 		return $this->success_response( [
 			'variables' => $db_record['data'],
 			'total' => count( $db_record['data'] ),

--- a/modules/variables/classes/style-transformers.php
+++ b/modules/variables/classes/style-transformers.php
@@ -13,8 +13,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Style_Transformers {
 	public function append_to( Transformers_Registry $transformers_registry ): self {
-		$transformers_registry->register( Color_Variable_Prop_Type::get_key(), new Global_Variable_Transformer() );
-		$transformers_registry->register( Font_Variable_Prop_Type::get_key(), new Global_Variable_Transformer() );
+		$transformer = new Global_Variable_Transformer();
+
+		$transformers_registry->register( Color_Variable_Prop_Type::get_key(), $transformer );
+		$transformers_registry->register( Font_Variable_Prop_Type::get_key(), $transformer );
 
 		return $this;
 	}

--- a/modules/variables/storage/repository.php
+++ b/modules/variables/storage/repository.php
@@ -216,11 +216,8 @@ class Repository {
 	}
 
 	private function get_default_meta(): array {
-		// TODO: Replace with an empty array, when we have the full flow for the variables
-		$predefined_variables = ( new Variables() )->get_all();
-
 		return [
-			'data' => $predefined_variables,
+			'data' => [],
 			'watermark' => 0,
 			'version' => self::FORMAT_VERSION_V1,
 		];

--- a/tests/phpunit/elementor/modules/variables/classes/test-variable-repository.php
+++ b/tests/phpunit/elementor/modules/variables/classes/test-variable-repository.php
@@ -30,29 +30,7 @@ class Test_Variables_Repository extends TestCase {
 		$this->repository = new Variables_Repository( $this->kit );
 	}
 
-	/**
-	 * TODO: Remove this, when we have the full flow for the variables
-	 */
-	public function test_list_of_variables__returns_predefined_variables() {
-		// Arrange.
-		$this->kit->method( 'get_json_meta' )->willReturn( null );
-
-		// Act.
-		$result = $this->repository->load();
-
-		$expected = [
-			'data' => ( new Variables() )->get_all(),
-			'watermark' => 0,
-			'version' => 1,
-		];
-
-		// Assert.
-		$this->assertEquals( $expected, $result );
-	}
-
 	public function test_list_of_variables__returns_default_when_empty() {
-		return $this->markTestSkipped( 'TODO: Unskip, when we have the full flow for the variables' );
-
 		// Arrange.
 		$this->kit->method( 'get_json_meta' )->willReturn( null );
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Removes predefined variables from Elementor's Variables Repository, reusing a single Global_Variable_Transformer instance for multiple types.

Main changes:
- Reuses single Global_Variable_Transformer instance for both color and font variable types
- Removes predefined variables in Repository->get_default_meta() to start with empty array
- Updates unit tests to remove tests for predefined variables and validate empty state

GitHub Copilot: Purpose: Removes predefined variables from Elementor's Variables Repository, reusing a single Global_Variable_Transformer instance for multiple types.

Main changes:
- Reuses single Global_Variable_Transformer instance for both color and font variable types
- Removes predefined variables in Repository->get_default_meta() to start with empty array
- Updates unit tests to remove tests for predefined variables and validate empty state

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
