### PR TITLE
Fix: Fix Key value control prop type and attributes control preparation [ED-19252]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -1,13 +1,6 @@
 {% if settings.title is not empty %}
-	{% set id_attribute = settings.cssid is not empty ? 'id=' ~ settings.cssid | e('html_attr') : '' %}
-	{% set attributes %}
-		{% for item in settings.attributes %}
-			{% if item.key is not empty and item.value is not empty %}
-				{{- item.key | e('html_attr') }}="{{ item.value | e('html_attr') }}"{% if not loop.last %} {% endif %}
-			{% endif %}
-		{% endfor %}
-	{% endset %}
-	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }} {{ attributes | raw }}>
+	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
+	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }}>
 	{% if settings.icon %}
 		<span class="{{ base_styles['icon-base'] }}">
 			{{ settings.icon | icon }}

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -1,13 +1,6 @@
 {% if settings.title is not empty %}
 	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
-	{% set attributes %}
-		{% for item in settings.attributes %}
-			{% if item.key is not empty and item.value is not empty %}
-				{{- item.key | e('html_attr') }}="{{ item.value | e('html_attr') }}"{% if not loop.last %} {% endif %}
-			{% endif %}
-		{% endfor %}
-	{% endset %}
-	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }} {{ attributes }}>
+	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }}>
 	{% if settings.link.href %}
 		<a href="{{ settings.link.href }}" target="{{ settings.link.target }}" class="{{ base_styles['link-base'] }}">
 			{{ settings.title }}

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -1,11 +1,13 @@
 {% if settings.title is not empty %}
 	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
-	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }}>
-	{% if settings.icon %}
-		<span class="{{ base_styles['icon-base'] }}">
-			{{ settings.icon | icon }}
-		</span>
-	{% endif %}
+	{% set attributes %}
+		{% for item in settings.attributes %}
+			{% if item.key is not empty and item.value is not empty %}
+				{{- item.key | e('html_attr') }}="{{ item.value | e('html_attr') }}"{% if not loop.last %} {% endif %}
+			{% endif %}
+		{% endfor %}
+	{% endset %}
+	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }} {{ attributes }}>
 	{% if settings.link.href %}
 		<a href="{{ settings.link.href }}" target="{{ settings.link.target }}" class="{{ base_styles['link-base'] }}">
 			{{ settings.title }}

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -1,7 +1,7 @@
 {% if settings.title is not empty %}
 	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
 	{% set attributes %}
-		{% for item in settings.repeater %}
+		{% for item in settings.attributes %}
 			{% if item.key is not empty and item.value is not empty %}
 				{{- item.key | e('html_attr') }}="{{ item.value | e('html_attr') }}"{% if not loop.last %} {% endif %}
 			{% endif %}

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -1,20 +1,22 @@
 {% if settings.title is not empty %}
-	{% set id_attribute = (settings._cssid is defined and settings._cssid is not empty) ? 'id=' ~ settings._cssid|e('html_attr') : '' %}
+	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
 	{% set attributes = '' %}
 	{% if settings.attributes is defined and settings.attributes is iterable %}
-		{% for item in settings.attributes %}
-			{% if item.key is not empty and item.value is not empty %}
-				{% set attributes = attributes ~ (item.key|e('html_attr')) ~ '="' ~ (item.value|e('html_attr')) ~ '"' ~ (not loop.last ? ' ' : '') %}
-			{% endif %}
-		{% endfor %}
+		{% set attributes %}
+			{% for item in settings.attributes %}
+				{% if item.key is not empty and item.value is not empty %}
+					{{- item.key | e('html_attr') }}="{{ item.value | e('html_attr') }}"{% if not loop.last %} {% endif %}
+				{% endif %}
+			{% endfor %}
+		{% endset %}
 	{% endif %}
-	<{{ settings.tag|default('div')|e('html_tag') }} class="{{ settings.classes|merge([base_styles.base])|join(' ') }}"{{ id_attribute ? ' ' ~ id_attribute : '' }}{{ attributes ? ' ' ~ attributes : '' }}>
-	{% if settings.link is defined and settings.link.href %}
-		<a href="{{ settings.link.href }}" target="{{ settings.link.target|default('_self') }}" class="{{ base_styles['link-base'] }}">
+	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }} {{ attributes }}>
+	{% if settings.link.href %}
+		<a href="{{ settings.link.href }}" target="{{ settings.link.target }}" class="{{ base_styles['link-base'] }}">
 			{{ settings.title }}
 		</a>
 	{% else %}
 		{{ settings.title }}
 	{% endif %}
-	</{{ settings.tag|default('div')|e('html_tag') }}>
+	</{{ settings.tag | e('html_tag') }}>
 {% endif %}

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -7,7 +7,12 @@
 			{% endif %}
 		{% endfor %}
 	{% endset %}
-	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }}>
+	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }} {{ attributes | raw }}>
+	{% if settings.icon %}
+		<span class="{{ base_styles['icon-base'] }}">
+			{{ settings.icon | icon }}
+		</span>
+	{% endif %}
 	{% if settings.link.href %}
 		<a href="{{ settings.link.href }}" target="{{ settings.link.target }}" class="{{ base_styles['link-base'] }}">
 			{{ settings.title }}

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -1,19 +1,20 @@
 {% if settings.title is not empty %}
-	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
-	{% set attributes %}
+	{% set id_attribute = (settings._cssid is defined and settings._cssid is not empty) ? 'id=' ~ settings._cssid|e('html_attr') : '' %}
+	{% set attributes = '' %}
+	{% if settings.attributes is defined and settings.attributes is iterable %}
 		{% for item in settings.attributes %}
 			{% if item.key is not empty and item.value is not empty %}
-				{{- item.key | e('html_attr') }}="{{ item.value | e('html_attr') }}"{% if not loop.last %} {% endif %}
+				{% set attributes = attributes ~ (item.key|e('html_attr')) ~ '="' ~ (item.value|e('html_attr')) ~ '"' ~ (not loop.last ? ' ' : '') %}
 			{% endif %}
 		{% endfor %}
-	{% endset %}
-	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }} {{ attributes }}>
-	{% if settings.link.href %}
-		<a href="{{ settings.link.href }}" target="{{ settings.link.target }}" class="{{ base_styles['link-base'] }}">
+	{% endif %}
+	<{{ settings.tag|default('div')|e('html_tag') }} class="{{ settings.classes|merge([base_styles.base])|join(' ') }}"{{ id_attribute ? ' ' ~ id_attribute : '' }}{{ attributes ? ' ' ~ attributes : '' }}>
+	{% if settings.link is defined and settings.link.href %}
+		<a href="{{ settings.link.href }}" target="{{ settings.link.target|default('_self') }}" class="{{ base_styles['link-base'] }}">
 			{{ settings.title }}
 		</a>
 	{% else %}
 		{{ settings.title }}
 	{% endif %}
-	</{{ settings.tag | e('html_tag') }}>
+	</{{ settings.tag|default('div')|e('html_tag') }}>
 {% endif %}

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -1,5 +1,12 @@
 {% if settings.title is not empty %}
-	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
+	{% set id_attribute = settings.cssid is not empty ? 'id=' ~ settings.cssid | e('html_attr') : '' %}
+	{% set attributes %}
+		{% for item in settings.attributes %}
+			{% if item.key is not empty and item.value is not empty %}
+				{{- item.key | e('html_attr') }}="{{ item.value | e('html_attr') }}"{% if not loop.last %} {% endif %}
+			{% endif %}
+		{% endfor %}
+	{% endset %}
 	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }}>
 	{% if settings.link.href %}
 		<a href="{{ settings.link.href }}" target="{{ settings.link.target }}" class="{{ base_styles['link-base'] }}">

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -110,7 +110,7 @@ class Atomic_Heading extends Atomic_Widget_Base {
 			] ),
 			Repeatable_Control::bind_to( 'attributes' )
 				->set_meta( [ 'topDivider' => true ] )
-				->set_repeaterLabel( __( 'Attributes', 'elementor-pro' ) )
+				->set_repeaterLabel( __( 'Attributes', 'elementor' ) )
 				->set_initialValues(
 					[
 						'key'   => [
@@ -128,12 +128,12 @@ class Atomic_Heading extends Atomic_Widget_Base {
 				->set_child_control_type( 'key-value' )
 				->set_child_control_props(
 					[
-						'regexKey'=> '^[a-zA-Z0-9_-]+$',
+						'regexKey' => '^[a-zA-Z0-9_-]+$',
 						'validationErrorMessage' => 'Names can only use letters, numbers, dashes (-) and underscores (_).',
 					]
 				)
 				->hide_duplicate()
-				->hide_toggle()
+				->hide_toggle(),
 		];
 	}
 

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -54,7 +54,7 @@ class Atomic_Heading extends Atomic_Widget_Base {
 
 			'link' => Link_Prop_Type::make(),
 
-			'repeater' => Key_Value_Array_Prop_Type::make(),
+			'attributes' => Key_Value_Array_Prop_Type::make(),
 		];
 
 		return $props;

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -15,6 +15,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
 
+if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -9,6 +9,7 @@ use Elementor\Modules\AtomicWidgets\Elements\Atomic_Widget_Base;
 use Elementor\Modules\AtomicWidgets\Elements\Has_Template;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Key_Value_Array_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Repeatable_Control;
 use Elementor\Modules\AtomicWidgets\PropTypes\Link_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
@@ -107,6 +108,32 @@ class Atomic_Heading extends Atomic_Widget_Base {
 			Link_Control::bind_to( 'link' )->set_meta( [
 				'topDivider' => true,
 			] ),
+			Repeatable_Control::bind_to( 'attributes' )
+				->set_meta( [ 'topDivider' => true ] )
+				->set_repeaterLabel( __( 'Attributes', 'elementor-pro' ) )
+				->set_initialValues(
+					[
+						'key'   => [
+							'$$type' => 'string',
+							'value'  => '',
+						],
+						'value' => [
+							'$$type' => 'string',
+							'value'  => '',
+						],
+					]
+				)
+				->set_patternLabel( '${key.value}="${value.value}"' )
+				->set_placeholder( 'Empty attribute' )
+				->set_child_control_type( 'key-value' )
+				->set_child_control_props(
+					[
+						'regexKey'=> '^[a-zA-Z0-9_-]+$',
+						'validationErrorMessage' => 'Names can only use letters, numbers, dashes (-) and underscores (_).',
+					]
+				)
+				->hide_duplicate()
+				->hide_toggle()
 		];
 	}
 

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -15,7 +15,6 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
 
-if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -9,7 +9,6 @@ use Elementor\Modules\AtomicWidgets\Elements\Atomic_Widget_Base;
 use Elementor\Modules\AtomicWidgets\Elements\Has_Template;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Key_Value_Array_Prop_Type;
-use Elementor\Modules\AtomicWidgets\Controls\Types\Repeatable_Control;
 use Elementor\Modules\AtomicWidgets\PropTypes\Link_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -108,32 +108,6 @@ class Atomic_Heading extends Atomic_Widget_Base {
 			Link_Control::bind_to( 'link' )->set_meta( [
 				'topDivider' => true,
 			] ),
-			Repeatable_Control::bind_to( 'attributes' )
-				->set_meta( [ 'topDivider' => true ] )
-				->set_repeaterLabel( __( 'Attributes', 'elementor' ) )
-				->set_initialValues(
-					[
-						'key'   => [
-							'$$type' => 'string',
-							'value'  => '',
-						],
-						'value' => [
-							'$$type' => 'string',
-							'value'  => '',
-						],
-					]
-				)
-				->set_patternLabel( '${key.value}="${value.value}"' )
-				->set_placeholder( 'Empty attribute' )
-				->set_child_control_type( 'key-value' )
-				->set_child_control_props(
-					[
-						'regexKey' => '^[a-zA-Z0-9_-]+$',
-						'validationErrorMessage' => 'Names can only use letters, numbers, dashes (-) and underscores (_).',
-					]
-				)
-				->hide_duplicate()
-				->hide_toggle(),
 		];
 	}
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactors atomic-heading element to use 'attributes' property name instead of 'repeater' for consistency in attribute handling.

Main changes:
- Renamed 'repeater' property to 'attributes' in atomic-heading.php
- Added null check with conditional rendering for attributes in template
- Initialized attributes variable to empty string by default

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
