### PR TITLE
Internal: Update create kit route to use signed URL [ED-19641]

### DIFF
--- a/app/modules/kit-library/connect/cloud-kits.php
+++ b/app/modules/kit-library/connect/cloud-kits.php
@@ -82,11 +82,6 @@ class Cloud_Kits extends Library {
 				'includes' => wp_json_encode( $includes ),
 			],
 			[
-				'file' => [
-					'filename' => 'content.zip',
-					'content' => $content_file_data,
-					'content_type' => 'application/zip',
-				],
 				'previewFile' => [
 					'filename' => 'preview.png',
 					'content' => $preview_file_data,
@@ -111,7 +106,41 @@ class Cloud_Kits extends Library {
 			throw new \Exception( $error_message, Exceptions::INTERNAL_SERVER_ERROR ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		}
 
+		if ( empty( $response['uploadUrl'] ) ) {
+			$this->delete_kit( $response['id'] );
+			$error_message = esc_html__( 'Failed to create kit: No upload URL provided', 'elementor' );
+			throw new \Exception( $error_message, Exceptions::INTERNAL_SERVER_ERROR ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		$upload_success = $this->upload_content_file( $response['uploadUrl'], $content_file_data );
+
+		if ( ! $upload_success ) {
+			$this->delete_kit( $response['id'] );
+			$error_message = esc_html__( 'Failed to create kit: Content upload failed', 'elementor' );
+			throw new \Exception( $error_message, Exceptions::INTERNAL_SERVER_ERROR ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
 		return $response;
+	}
+
+	private function upload_content_file( $upload_url, $content_file_data ) {
+		$upload_response = wp_remote_request( $upload_url, [
+			'method' => 'PUT',
+			'body' => $content_file_data,
+			'headers' => [
+				'Content-Type' => 'application/zip',
+				'Content-Length' => strlen( $content_file_data ),
+			],
+			'timeout' => 120,
+		] );
+
+		if ( is_wp_error( $upload_response ) ) {
+			return false;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $upload_response );
+
+		return $response_code >= 200 && $response_code < 300;
 	}
 
 	public function get_kit( array $args ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Modifies Cloud_Kits class to handle content file uploads using a separate API endpoint for improved efficiency.

Main changes:
- Removes content.zip from initial multipart upload request
- Adds upload_content_file() method for separate PUT request to upload URL
- Adds validation and error handling for upload URL and content file upload

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
