### PR TITLE
Fix: Visual Choice control is hard to see in Dark Mode [ED-19640]

### DIFF
--- a/assets/dev/scss/editor/panel/controls/_visual-choice.scss
+++ b/assets/dev/scss/editor/panel/controls/_visual-choice.scss
@@ -48,6 +48,7 @@
 				}
 
 				&:not(:checked) + label {
+					background-color: var(--e-a-color-white);
 					opacity: 0.5;
 				}
 			}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add white background color to unchecked visual choice labels in the Elementor panel controls.

Main changes:
- Added background-color: var(--e-a-color-white) to unchecked label elements in visual choice control

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
