### PR TITLE
Fix: Visual Choice control is hard to see in Dark Mode [ED-19640]

### DIFF
--- a/assets/dev/scss/editor/panel/controls/_visual-choice.scss
+++ b/assets/dev/scss/editor/panel/controls/_visual-choice.scss
@@ -48,6 +48,7 @@
 				}
 
 				&:not(:checked) + label {
+					background-color: var(--e-a-color-white);
 					opacity: 0.5;
 				}
 			}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Adds white background to unselected items in visual choice control to prevent transparency issues.

Main changes:
- Adds background-color CSS property to unselected visual choice labels

AI: 

Purpose: Sets white background color on unchecked visual choice labels to prevent transparency issues.

Main changes:
- Adds background-color CSS property with value var(--e-a-color-white) to unchecked labels

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
