### PR TITLE
Internal: Replace SASS direction-based styling with native CSS solution [ED-19656]

### DIFF
--- a/assets/dev/scss/editor/panel/_controls.scss
+++ b/assets/dev/scss/editor/panel/_controls.scss
@@ -172,11 +172,8 @@
 
 		.elementor-panel-heading-toggle {
 
-			.eicon {
-
-				&:before {
-					content: '\e92a';
-				}
+			i {
+				transform: rotate(90deg);
 			}
 		}
 	}
@@ -185,12 +182,8 @@
 
 		.elementor-panel-heading-toggle {
 
-			.eicon {
-
-				&:before {
-					content: '\e90a';
-					scale: calc(1 * var(--direction-multiplier)) 1; // Flip in RTL
-				}
+			i {
+				scale: calc(1 * var(--direction-multiplier)) 1; // Flip in RTL
 			}
 		}
 	}

--- a/includes/controls/section.php
+++ b/includes/controls/section.php
@@ -46,7 +46,7 @@ class Control_Section extends Base_UI_Control {
 		?>
 		<button class="elementor-panel-heading">
 			<div class="elementor-panel-heading-toggle elementor-section-toggle" data-collapse_id="{{ data.name }}">
-				<i class="eicon" aria-hidden="true"></i>
+				<i class="eicon-caret-right" aria-hidden="true"></i>
 			</div>
 			<div class="elementor-panel-heading-title elementor-section-title">{{{ data.label }}}</div>
 		</button>

--- a/includes/editor-templates/panel-elements.php
+++ b/includes/editor-templates/panel-elements.php
@@ -55,7 +55,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <script type="text/template" id="tmpl-elementor-panel-elements-category">
 	<button class="elementor-panel-heading elementor-panel-category-title">
 		<span class="elementor-panel-heading-toggle">
-			<i class="eicon" aria-hidden="true"></i>
+			<i class="eicon-caret-right" aria-hidden="true"></i>
 		</span>
 		<span class="elementor-panel-heading-title">{{{ title }}}</span>
 		<?php do_action( 'elementor/editor/templates/panel/category' ); ?>

--- a/includes/editor-templates/panel.php
+++ b/includes/editor-templates/panel.php
@@ -214,7 +214,7 @@ $document = Plugin::$instance->documents->get( Plugin::$instance->editor->get_po
 <script type="text/template" id="tmpl-elementor-panel-scheme-typography-item">
 	<div class="elementor-panel-heading">
 		<div class="elementor-panel-heading-toggle">
-			<i class="eicon" aria-hidden="true"></i>
+			<i class="eicon-caret-right" aria-hidden="true"></i>
 		</div>
 		<div class="elementor-panel-heading-title">{{{ title }}}</div>
 	</div>


### PR DESCRIPTION
Related to: https://github.com/elementor/elementor/pull/31568
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace hardcoded toggle icon implementation with a named icon and rotation transform in Elementor's panel controls.

Main changes:
- Replaced generic .eicon elements with specific eicon-caret-right class in panel components
- Implemented CSS transform:rotate(90deg) for open state toggle icons
- Maintained RTL support with scale transformation for closed state icons

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
