### PR TITLE
Fix: Style controls are not affecting the video iframe in YouTube element [ED-19555]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.php
+++ b/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.php
@@ -86,6 +86,7 @@ class Atomic_Youtube extends Atomic_Widget_Base {
 				->add_variant(
 					Style_Variant::make()
 						->add_prop( 'aspect-ratio', String_Prop_Type::generate( '16/9' ) )
+						->add_prop( 'overflow', String_Prop_Type::generate( 'hidden' ) )
 				),
 		];
 	}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add overflow:hidden property to the YouTube atomic widget to prevent content from flowing outside its container.

Main changes:
- Added 'overflow' property with value 'hidden' to the YouTube widget's base style variant.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
