### PR TITLE
Fix: Woocommerce hint shown when not installed CP [APP-1416][ED-19620]

### DIFF
--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -379,7 +379,7 @@ class Admin_Notices extends Module {
 	}
 
 	private function site_has_forms_plugins() {
-		return defined( 'WPFORMS_VERSION' ) || defined( 'WPCF7_VERSION' ) || defined( 'FLUENTFORM_VERSION' ) || class_exists( '\GFCommon' ) || class_exists( '\Ninja_Forms' ) || function_exists( 'load_formidable_forms' );
+		return defined( 'WPFORMS_VERSION' ) || defined( 'WPCF7_VERSION' ) || defined( 'FLUENTFORM_VERSION' ) || class_exists( '\GFCommon' ) || class_exists( '\Ninja_Forms' ) || function_exists( 'load_formidable_forms' ) || did_action( 'metform/after_load' ) || defined( 'FORMINATOR_PLUGIN_BASENAME' );
 	}
 
 	private function site_has_woocommerce() {
@@ -501,6 +501,10 @@ class Admin_Notices extends Module {
 
 		if ( $has_forms && $has_woocommerce && Utils::has_pro() ) {
 			return true;
+		}
+
+		if ( ! $has_woocommerce ) {
+			return false;
 		}
 
 		return (bool) wp_rand( 0, 1 );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add support for detecting MetForm and Forminator plugins in site forms detection for admin notice display.

Main changes:
- Enhanced `site_has_forms_plugins()` to detect MetForm and Forminator plugins
- Added early return in `should_render_woocommerce_hint()` when WooCommerce not detected
- Fixed logic flow in WooCommerce hint display decision-making

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
