### PR TITLE
Tweak: Activated "Element Caching" experiment for all sites [ED-19733]

### DIFF
--- a/modules/element-cache/module.php
+++ b/modules/element-cache/module.php
@@ -47,11 +47,7 @@ class Module extends BaseModule {
 			'tag' => esc_html__( 'Performance', 'elementor' ),
 			'description' => esc_html__( 'Elements caching reduces loading times by serving up a copy of an element instead of rendering it fresh every time the page is loaded. When active, Elementor will determine which elements can benefit from static loading - but you can override this.', 'elementor' ),
 			'release_status' => ExperimentsManager::RELEASE_STATUS_STABLE,
-			'default' => ExperimentsManager::STATE_INACTIVE,
-			'new_site' => [
-				'default_active' => true,
-				'minimum_installation_version' => '3.23.0',
-			],
+			'default' => ExperimentsManager::STATE_ACTIVE,
 			'generator_tag' => true,
 		];
 	}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enables Element Caching by default in Elementor by changing the experiment's default state from inactive to active.

Main changes:
- Changed default experiment state from STATE_INACTIVE to STATE_ACTIVE
- Removed the new_site configuration array with default_active and minimum_installation_version settings

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
