### PR TITLE
Tweak: Added new `lh` and `rlh` CSS units to Typography Line Height control [ED-19604]

### DIFF
--- a/includes/controls/groups/typography.php
+++ b/includes/controls/groups/typography.php
@@ -212,7 +212,7 @@ class Group_Control_Typography extends Group_Control_Base {
 				],
 			],
 			'responsive' => true,
-			'size_units' => [ 'px', 'em', 'rem', 'custom' ],
+			'size_units' => [ 'px', 'em', 'rem', 'lh', 'rlh', 'custom' ],
 			'selector_value' => 'line-height: {{SIZE}}{{UNIT}}',
 		];
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Added 'lh' and 'rlh' units to typography line-height control in Elementor for enhanced text styling capabilities.

Main changes:
- Added 'lh' and 'rlh' CSS length units to line-height size_units array
- Maintains backward compatibility with existing units (px, em, rem, custom)
- Enables line-height values to be set using logical height units

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
