### PR TITLE
wptexturize before do_shortcode, like wp does it

### DIFF
--- a/includes/base/widget-base.php
+++ b/includes/base/widget-base.php
@@ -451,8 +451,8 @@ abstract class Widget_Base extends Element_Base {
 		$content = apply_filters( 'widget_text', $content, $this->get_settings() );
 
 		$content = shortcode_unautop( $content );
-		$content = do_shortcode( $content );
 		$content = wptexturize( $content );
+		$content = do_shortcode( $content );
 
 		if ( $GLOBALS['wp_embed'] instanceof \WP_Embed ) {
 			$content = $GLOBALS['wp_embed']->autoembed( $content );


### PR DESCRIPTION
Resubmitting #9341 because it was closed with no reason given and this issue was not fixed.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* moved wptexturize before do_shortcode to avoid garbling shortcode output (some shortcode include inline scripts or styles an wp_texturize messes up with it)

## Description
An explanation of what is done in this PR

* moved wptexturize before do_shortcode

## Test instructions
This PR can be tested by following these steps:

* Add a simple shortcode that outputs '\n' in a text editor and ensure no `<p></p>` are added in the output

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #9340, which has been open for years now and affects shortcodes of plugins like bookly

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Reorders the text processing operations in parse_text_editor method to ensure do_shortcode executes after wptexturize.

Main changes:
- Swapped wptexturize and do_shortcode function calls in parse_text_editor method
- Ensures proper text formatting sequence where texturizing happens before shortcode execution
- Maintains backward compatibility with WordPress text processing pipeline

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
