### PR TITLE
Internal: Update button ID notice on Button widget [ED-19853]

### DIFF
--- a/includes/widgets/traits/button-trait.php
+++ b/includes/widgets/traits/button-trait.php
@@ -214,7 +214,7 @@ trait Button_Trait {
 				'title' => esc_html__( 'Add your custom id WITHOUT the Pound key. e.g: my-id', 'elementor' ),
 				'description' => sprintf(
 					/* translators: 1: `<code>` opening tag, 2: `</code>` closing tag. */
-					esc_html__( 'Please make sure the ID is unique and not used elsewhere on the page this form is displayed. This field allows %1$sA-z 0-9%2$s & underscore chars without spaces.', 'elementor' ),
+					esc_html__( 'Please make sure the ID is unique and not used elsewhere on the page. This field allows %1$sA-z 0-9%2$s & underscore chars without spaces.', 'elementor' ),
 					'<code>',
 					'</code>'
 				),

--- a/tests/qunit/mock/elments/button.json
+++ b/tests/qunit/mock/elments/button.json
@@ -254,7 +254,7 @@
 			"default": "",
 			"title": "Add your custom id WITHOUT the Pound key. e.g: my-id",
 			"label_block": false,
-			"description": "Please make sure the ID is unique and not used elsewhere on the page this form is displayed. This field allows <code>A-z 0-9</code> & underscore chars without spaces.",
+			"description": "Please make sure the ID is unique and not used elsewhere on the page. This field allows <code>A-z 0-9</code> & underscore chars without spaces.",
 			"separator": "before",
 			"name": "button_css_id"
 		},

--- a/tests/qunit/mock/elments/form.json
+++ b/tests/qunit/mock/elments/form.json
@@ -994,7 +994,7 @@
 			"default": "",
 			"title": "Add your custom id WITHOUT the Pound key. e.g: my-id",
 			"label_block": false,
-			"description": "Please make sure the ID is unique and not used elsewhere on the page this form is displayed. This field allows <code>A-z 0-9</code> & underscore chars without spaces.",
+			"description": "Please make sure the ID is unique and not used elsewhere on the page. This field allows <code>A-z 0-9</code> & underscore chars without spaces.",
 			"separator": "before",
 			"name": "button_css_id"
 		},
@@ -2452,7 +2452,7 @@
 			"section": "section_form_options",
 			"label": "Form ID",
 			"placeholder": "new_form_id",
-			"description": "Please make sure the ID is unique and not used elsewhere on the page this form is displayed. This field allows <code>A-z 0-9</code> & underscore chars without spaces.",
+			"description": "Please make sure the ID is unique and not used elsewhere on the page. This field allows <code>A-z 0-9</code> & underscore chars without spaces.",
 			"separator": "after",
 			"name": "form_id",
 			"default": ""


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove "this form is displayed" phrase from button ID field description to improve clarity in the Elementor Button_Trait.

Main changes:
- Modified help text to simply read "elsewhere on the page" instead of "elsewhere on the page this form is displayed"
- Maintains the existing technical guidance for valid ID characters and uniqueness requirements
- No changes to the functionality or validation of button ID field

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
