### PR TITLE
Internal: Update the TNC date [ED-18748]

### DIFF
--- a/includes/tracker.php
+++ b/includes/tracker.php
@@ -33,7 +33,7 @@ class Tracker {
 
 	private static $notice_shown = false;
 
-	const LAST_TERMS_UPDATED = '2025-07-01';
+	const LAST_TERMS_UPDATED = '2025-07-07';
 
 	/**
 	 * Init.

--- a/modules/editor-events/module.php
+++ b/modules/editor-events/module.php
@@ -24,7 +24,7 @@ class Module extends BaseModule {
 	public static function get_editor_events_config() {
 		$can_send_events = defined( 'ELEMENTOR_EDITOR_EVENTS_MIXPANEL_TOKEN' ) &&
 			Tracker::is_allow_track() &&
-			! Tracker::has_terms_changed( '2025-07-01' ) &&
+			! Tracker::has_terms_changed( '2025-07-07' ) &&
 			Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME );
 
 		$settings = [


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update terms agreement date in Elementor Tracker from 2025-07-01 to 2025-07-07 affecting tracking functionality.

Main changes:
- Changed LAST_TERMS_UPDATED constant from '2025-07-01' to '2025-07-07' in tracker.php
- Updated reference to terms date in modules/editor-events/module.php
- Maintained compatibility with editor events tracking system

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
