### PR TITLE
Internal: Create Admin notice informing users about changes in our T&C [ED-18748] (#30974)

### DIFF
--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -24,6 +24,7 @@ class Admin_Notices extends Module {
 		'api_notice',
 		'api_upgrade_plugin',
 		'tracker',
+		'tracker_last_update',
 		'rate_us_feedback',
 		'role_manager_promote',
 		'experiment_promotion',
@@ -241,6 +242,47 @@ class Admin_Notices extends Module {
 				'text' => esc_html__( 'No thanks', 'elementor' ),
 				'url' => $optout_url,
 				'variant' => 'outline',
+				'type' => 'cta',
+			],
+		];
+
+		$this->print_admin_notice( $options );
+
+		return true;
+	}
+
+	private function notice_tracker_last_update() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+
+		if ( ! Tracker::has_terms_changed() ) {
+			return false;
+		}
+
+		$notice_id = 'tracker_last_update_' . Tracker::LAST_TERMS_UPDATED;
+
+		if ( User::is_user_notice_viewed( $notice_id ) ) {
+			return false;
+		}
+
+		$optin_url = wp_nonce_url( add_query_arg( 'elementor_tracker', 'opt_into' ), 'opt_into' );
+
+		$message = esc_html__( 'We\'re updating our Terms and Conditions to include the collection of usage and behavioral data. This information helps us understand how you use Elementor so we can make informed improvements to the product.', 'elementor' );
+
+		$options = [
+			'id' => $notice_id,
+			'title' => esc_html__( 'Update regarding usage data collection', 'elementor' ),
+			'description' => $message,
+			'button' => [
+				'text' => esc_html__( 'Opt in', 'elementor' ),
+				'url' => $optin_url,
+				'type' => 'cta',
+			],
+			'button_secondary' => [
+				'text' => esc_html__( 'Learn more', 'elementor' ),
+				'url' => 'https://go.elementor.com/wp-dash-update-usage-notice/',
+				'new_tab' => true,
 				'type' => 'cta',
 			],
 		];

--- a/includes/tracker.php
+++ b/includes/tracker.php
@@ -33,6 +33,8 @@ class Tracker {
 
 	private static $notice_shown = false;
 
+	const LAST_TERMS_UPDATED = '2025-07-01';
+
 	/**
 	 * Init.
 	 *
@@ -45,6 +47,8 @@ class Tracker {
 	public static function init() {
 		add_action( 'elementor/tracker/send_event', [ __CLASS__, 'send_tracking_data' ] );
 		add_action( 'admin_init', [ __CLASS__, 'handle_tracker_actions' ] );
+
+		add_action( 'update_option_elementor_allow_tracking', [ __CLASS__, 'set_last_update_time' ] );
 	}
 
 	/**
@@ -68,6 +72,8 @@ class Tracker {
 				'opt_in_send_tracking_data',
 			] );
 		}
+
+		self::set_last_update_time();
 
 		if ( empty( $new_value ) ) {
 			$new_value = 'no';
@@ -171,6 +177,29 @@ class Tracker {
 		return 'yes' === get_option( 'elementor_allow_tracking', 'no' );
 	}
 
+	public static function get_last_update_time() {
+		return get_option( 'elementor_allow_tracking_last_update', false );
+	}
+
+	public static function set_last_update_time(): void {
+		update_option( 'elementor_allow_tracking_last_update', gmdate( 'U' ) );
+	}
+
+	public static function has_terms_changed( $terms_updated = self::LAST_TERMS_UPDATED ): bool {
+		if ( ! self::is_allow_track() ) {
+			return false;
+		}
+
+		$last_update_time = self::get_last_update_time();
+		if ( $last_update_time ) {
+			$terms_updated_timestamp = strtotime( $terms_updated . ' UTC' );
+
+			return $last_update_time < $terms_updated_timestamp;
+		}
+
+		return true;
+	}
+
 	/**
 	 * Handle tracker actions.
 	 *
@@ -215,6 +244,8 @@ class Tracker {
 	public static function set_opt_in( $value ) {
 		if ( $value ) {
 			update_option( 'elementor_allow_tracking', 'yes' );
+			self::set_last_update_time();
+
 			self::send_tracking_data( true );
 		} else {
 			update_option( 'elementor_allow_tracking', 'no' );

--- a/includes/tracker.php
+++ b/includes/tracker.php
@@ -33,7 +33,7 @@ class Tracker {
 
 	private static $notice_shown = false;
 
-	const LAST_TERMS_UPDATED = '2025-07-01';
+	const LAST_TERMS_UPDATED = '2025-07-07';
 
 	/**
 	 * Init.

--- a/modules/editor-events/module.php
+++ b/modules/editor-events/module.php
@@ -24,7 +24,7 @@ class Module extends BaseModule {
 	public static function get_editor_events_config() {
 		$can_send_events = defined( 'ELEMENTOR_EDITOR_EVENTS_MIXPANEL_TOKEN' ) &&
 			Tracker::is_allow_track() &&
-			! Tracker::has_terms_changed( '2025-07-01' ) &&
+			! Tracker::has_terms_changed( '2025-07-07' ) &&
 			Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME );
 
 		$settings = [

--- a/modules/editor-events/module.php
+++ b/modules/editor-events/module.php
@@ -24,6 +24,7 @@ class Module extends BaseModule {
 	public static function get_editor_events_config() {
 		$can_send_events = defined( 'ELEMENTOR_EDITOR_EVENTS_MIXPANEL_TOKEN' ) &&
 			Tracker::is_allow_track() &&
+			! Tracker::has_terms_changed( '2025-07-01' ) &&
 			Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME );
 
 		$settings = [

--- a/tests/phpunit/elementor/includes/test-tracker.php
+++ b/tests/phpunit/elementor/includes/test-tracker.php
@@ -155,4 +155,55 @@ class Test_Tracker extends Elementor_Test_Base {
 			}
 		}
 	}
+
+	public function test_has_terms_changed_when_tracking_not_allowed() {
+		// Arrange
+		update_option( 'elementor_allow_tracking', 'no' );
+
+		// Act
+		$result = Tracker::has_terms_changed();
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function test_has_terms_changed_when_last_update_time_not_set() {
+		// Arrange
+		update_option( 'elementor_allow_tracking', 'yes' );
+		delete_option( 'elementor_allow_tracking_last_update' );
+
+		// Act
+		$result = Tracker::has_terms_changed();
+
+		// Assert
+		$this->assertTrue( $result );
+	}
+
+	public function test_has_terms_changed_when_last_update_time_before_terms_update() {
+		// Arrange
+		update_option( 'elementor_allow_tracking', 'yes' );
+		$terms_updated = '2024-01-01';
+		$last_update_time = strtotime( '2023-12-31 UTC' );
+		update_option( 'elementor_allow_tracking_last_update', $last_update_time );
+
+		// Act
+		$result = Tracker::has_terms_changed( $terms_updated );
+
+		// Assert
+		$this->assertTrue( $result );
+	}
+
+	public function test_has_terms_changed_when_last_update_time_after_terms_update() {
+		// Arrange
+		update_option( 'elementor_allow_tracking', 'yes' );
+		$terms_updated = '2024-01-01';
+		$last_update_time = strtotime( '2024-01-02 UTC' );
+		update_option( 'elementor_allow_tracking_last_update', $last_update_time );
+
+		// Act
+		$result = Tracker::has_terms_changed( $terms_updated );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add tracking terms update notification to inform users about usage data collection changes in Elementor.

Main changes:
- Added `tracker_last_update` notice to show users updated data collection terms
- Implemented `has_terms_changed()` and timestamp tracking methods to detect when terms were updated
- Added `LAST_TERMS_UPDATED` constant to track when terms were last modified
- Modified editor events to check for terms acceptance before sending usage data

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
