### PR TITLE
Internal: [V4]: Support time units in size control [ED-19762]

### DIFF
--- a/modules/atomic-widgets/prop-types/size-prop-type.php
+++ b/modules/atomic-widgets/prop-types/size-prop-type.php
@@ -9,9 +9,16 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
+const LENGTH_UNITS = [ 'px', 'em', 'rem', '%', 'vh', 'vw', 'vmin', 'vmax' ];
+const ANGLE_UNITS = [ 'deg', 'rad', 'grad', 'turn' ];
+const TIME_UNITS = [ 's', 'ms' ];
+const EXTENDED_UNITS = [ 'auto', 'custom' ];
 
 class Size_Prop_Type extends Object_Prop_Type {
-	const SUPPORTED_UNITS = [ 'px', 'em', 'rem', '%', 'vh', 'vw', 'vmin', 'vmax', 'deg', 'rad', 'grad', 'turn', 'custom', 'auto' ];
+
+	public static function get_supported_units(): array {
+		return array_merge( LENGTH_UNITS, ANGLE_UNITS, TIME_UNITS, EXTENDED_UNITS );
+	}
 
 	public static function get_key(): string {
 		return 'size';
@@ -22,7 +29,7 @@ class Size_Prop_Type extends Object_Prop_Type {
 			! array_key_exists( 'size', $value ) ||
 			! array_key_exists( 'unit', $value ) ||
 			empty( $value['unit'] ) ||
-			! in_array( $value['unit'], static::SUPPORTED_UNITS, true )
+			! in_array( $value['unit'], static::get_supported_units(), true )
 		) {
 			return false;
 		}
@@ -60,7 +67,7 @@ class Size_Prop_Type extends Object_Prop_Type {
 
 	protected function define_shape(): array {
 		return [
-			'unit' => String_Prop_Type::make()->enum( self::SUPPORTED_UNITS )
+			'unit' => String_Prop_Type::make()->enum( static::get_supported_units() )
 				->required(),
 			'size' => Union_Prop_Type::make()
 				->add_prop_type( String_Prop_Type::make() )

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/position-section/offset-field.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/position-section/offset-field.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useRef } from 'react';
-import { SizeControl, type Unit } from '@elementor/editor-controls';
+import { type LengthUnit, SizeControl } from '@elementor/editor-controls';
 import { __ } from '@wordpress/i18n';
 
 import { StylesField } from '../../../controls-registry/styles-field';
@@ -8,7 +8,7 @@ import { StylesFieldLayout } from '../../styles-field-layout';
 
 const OFFSET_LABEL = __( 'Anchor offset', 'elementor' );
 
-const UNITS: Unit[] = [ 'px', 'em', 'rem', 'vw', 'vh' ];
+const UNITS: LengthUnit[] = [ 'px', 'em', 'rem', 'vw', 'vh' ];
 
 export const OffsetField = () => {
 	const rowRef = useRef< HTMLDivElement >( null );

--- a/packages/packages/libs/editor-controls/src/components/size-control/size-input.tsx
+++ b/packages/packages/libs/editor-controls/src/components/size-control/size-input.tsx
@@ -4,19 +4,19 @@ import { PencilIcon } from '@elementor/icons';
 import { Box, InputAdornment, type PopupState } from '@elementor/ui';
 
 import ControlActions from '../../control-actions/control-actions';
-import { type DegreeUnit, type ExtendedOption, isUnitExtendedOption, type Unit } from '../../utils/size-control';
+import { type ExtendedOption, isUnitExtendedOption, type Unit } from '../../utils/size-control';
 import { SelectionEndAdornment, TextFieldInnerSelection } from '../size-control/text-field-inner-selection';
 
 type SizeInputProps = {
-	unit: Unit | DegreeUnit | ExtendedOption;
+	unit: Unit | ExtendedOption;
 	size: number | string;
 	placeholder?: string;
 	startIcon?: React.ReactNode;
-	units: ( Unit | DegreeUnit | ExtendedOption )[];
+	units: ( Unit | ExtendedOption )[];
 	onBlur?: ( event: React.FocusEvent< HTMLInputElement > ) => void;
 	onFocus?: ( event: React.FocusEvent< HTMLInputElement > ) => void;
 	onClick?: ( event: React.MouseEvent< HTMLInputElement > ) => void;
-	handleUnitChange: ( unit: Unit | DegreeUnit | ExtendedOption ) => void;
+	handleUnitChange: ( unit: Unit | ExtendedOption ) => void;
 	handleSizeChange: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
 	popupState: PopupState;
 	disabled?: boolean;

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/size-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/size-control.test.tsx
@@ -6,7 +6,7 @@ import { type SizePropValue } from '@elementor/editor-props';
 import { isExperimentActive } from '@elementor/editor-v1-adapters';
 import { fireEvent, screen } from '@testing-library/react';
 
-import { type DegreeUnit, type Unit } from '../../utils/size-control';
+import { type AngleUnit, type LengthUnit } from '../../utils/size-control';
 import { SizeControl } from '../size-control';
 
 const mockSizeProp = ( value?: SizePropValue[ 'value' ] ) => ( {
@@ -14,9 +14,8 @@ const mockSizeProp = ( value?: SizePropValue[ 'value' ] ) => ( {
 	value: { unit: '', size: 0, ...value },
 } );
 
-const mockUnits = (): Unit[] => [ 'px', 'rem', '%', 'em' ];
-const mockDegreeUnits = (): DegreeUnit[] => [ 'deg', 'rad', 'grad', 'turn' ];
-const mockAllUnits = (): ( Unit | DegreeUnit )[] => [ ...mockUnits(), ...mockDegreeUnits() ];
+const mockLengthUnits = (): LengthUnit[] => [ 'px', 'rem', '%', 'em' ];
+const mockAngleUnits = (): AngleUnit[] => [ 'deg', 'rad', 'grad', 'turn' ];
 
 jest.mock( '@elementor/editor-v1-adapters' );
 jest.mocked( isExperimentActive ).mockReturnValue( true );
@@ -39,7 +38,7 @@ describe( 'SizeControl', () => {
 	it( 'should render the size control with its props', () => {
 		// Arrange.
 		const setValue = jest.fn();
-		const units = mockUnits();
+		const units = mockLengthUnits();
 
 		const props = { setValue, value: mockSizeProp(), bind: 'select', propType };
 
@@ -68,7 +67,7 @@ describe( 'SizeControl', () => {
 		// Act.
 		renderControl(
 			<ControlActionsProvider items={ [] }>
-				<SizeControl units={ mockUnits() } />
+				<SizeControl units={ mockLengthUnits() } />
 			</ControlActionsProvider>,
 			props
 		);
@@ -95,7 +94,7 @@ describe( 'SizeControl', () => {
 		// Act.
 		renderControl(
 			<ControlActionsProvider items={ [] }>
-				<SizeControl units={ mockUnits() } />
+				<SizeControl units={ mockLengthUnits() } />
 			</ControlActionsProvider>,
 			props
 		);
@@ -121,7 +120,7 @@ describe( 'SizeControl', () => {
 		// Act.
 		renderControl(
 			<ControlActionsProvider items={ [] }>
-				<SizeControl units={ mockUnits() } />
+				<SizeControl units={ mockLengthUnits() } />
 			</ControlActionsProvider>,
 			props
 		);
@@ -144,7 +143,7 @@ describe( 'SizeControl', () => {
 		// Act.
 		renderControl(
 			<ControlActionsProvider items={ [] }>
-				<SizeControl units={ mockUnits() } />
+				<SizeControl units={ mockLengthUnits() } />
 			</ControlActionsProvider>,
 			props
 		);
@@ -169,7 +168,7 @@ describe( 'SizeControl', () => {
 		// Act.
 		renderControl(
 			<ControlActionsProvider items={ [] }>
-				<SizeControl units={ mockUnits() } />
+				<SizeControl units={ mockLengthUnits() } />
 			</ControlActionsProvider>,
 			props
 		);
@@ -237,7 +236,7 @@ describe( 'SizeControl', () => {
 		// Act.
 		renderControl(
 			<ControlActionsProvider items={ [] }>
-				<SizeControl units={ mockUnits() } />
+				<SizeControl units={ mockLengthUnits() } />
 			</ControlActionsProvider>,
 			props
 		);
@@ -279,7 +278,7 @@ describe( 'SizeControl', () => {
 		// Act.
 		renderControl(
 			<ControlActionsProvider items={ [] }>
-				<SizeControl units={ mockUnits() } />
+				<SizeControl units={ mockLengthUnits() } />
 			</ControlActionsProvider>,
 			props
 		);
@@ -316,7 +315,7 @@ describe( 'SizeControl', () => {
 		// Act.
 		renderControl(
 			<ControlActionsProvider items={ [] }>
-				<SizeControl units={ mockUnits() } />
+				<SizeControl units={ mockLengthUnits() } />
 			</ControlActionsProvider>,
 			props
 		);
@@ -359,7 +358,7 @@ describe( 'SizeControl', () => {
 
 		// Act.
 		renderControl(
-			<SizeControl units={ mockUnits() } extendedOptions={ [ 'auto' ] } anchorRef={ anchorEl } />,
+			<SizeControl units={ mockLengthUnits() } extendedOptions={ [ 'auto' ] } anchorRef={ anchorEl } />,
 			props
 		);
 
@@ -396,7 +395,7 @@ describe( 'SizeControl', () => {
 
 		// Act.
 		renderControl(
-			<SizeControl units={ mockUnits() } extendedOptions={ [ 'auto' ] } anchorRef={ anchorEl } />,
+			<SizeControl units={ mockLengthUnits() } extendedOptions={ [ 'auto' ] } anchorRef={ anchorEl } />,
 			props
 		);
 
@@ -424,7 +423,7 @@ describe( 'SizeControl', () => {
 			const props = { setValue, value: mockSizeProp( { size: 10, unit: 'px' } ), bind: 'select', propType };
 
 			// Act.
-			renderControl( <SizeControl units={ mockUnits() } disableCustom />, props );
+			renderControl( <SizeControl units={ mockLengthUnits() } disableCustom />, props );
 
 			const sizeInput = screen.getByRole( 'spinbutton' );
 
@@ -445,7 +444,7 @@ describe( 'SizeControl', () => {
 			const props = { setValue, value: mockSizeProp( { size: 10, unit: 'px' } ), bind: 'select', propType };
 
 			// Act.
-			renderControl( <SizeControl units={ mockUnits() } extendedOptions={ [ 'auto' ] } />, props );
+			renderControl( <SizeControl units={ mockLengthUnits() } extendedOptions={ [ 'auto' ] } />, props );
 
 			const sizeInput = screen.getByRole( 'spinbutton' );
 
@@ -469,7 +468,7 @@ describe( 'SizeControl', () => {
 
 			// Act.
 			renderControl(
-				<SizeControl units={ mockUnits() } extendedOptions={ [ 'auto' ] } anchorRef={ anchorEl } />,
+				<SizeControl units={ mockLengthUnits() } extendedOptions={ [ 'auto' ] } anchorRef={ anchorEl } />,
 				props
 			);
 
@@ -489,7 +488,7 @@ describe( 'SizeControl', () => {
 			const props = { setValue, value: mockSizeProp(), bind: 'select', propType };
 
 			// Act.
-			renderControl( <SizeControl units={ mockUnits() } defaultUnit="rem" />, props );
+			renderControl( <SizeControl units={ mockLengthUnits() } defaultUnit="rem" />, props );
 
 			const sizeInput = screen.getByRole( 'spinbutton' );
 
@@ -501,37 +500,14 @@ describe( 'SizeControl', () => {
 		} );
 	} );
 
-	describe( 'Degree Units Support', () => {
-		it( 'should support mixed size and degree units', () => {
-			// Arrange.
-			const setValue = jest.fn();
-			const allUnits = mockAllUnits();
-
-			const props = { setValue, value: mockSizeProp(), bind: 'select', propType };
-
-			// Act.
-			renderControl( <SizeControl units={ allUnits } disableCustom />, props );
-
-			const selectInput = screen.getByRole( 'button' );
-
-			fireEvent.click( selectInput );
-
-			// Assert.
-			const menuItems = screen.getAllByRole( 'menuitem' );
-			expect( menuItems ).toHaveLength( allUnits.length );
-
-			allUnits.forEach( ( unit, index ) => {
-				expect( menuItems[ index ] ).toHaveTextContent( unit.toUpperCase() );
-			} );
-		} );
-
-		it( 'should handle degree unit keyboard shortcuts', () => {
+	describe( 'Angle Units Support', () => {
+		it( 'should handle angle unit keyboard shortcuts', () => {
 			// Arrange.
 			const setValue = jest.fn();
 			const props = { setValue, value: mockSizeProp( { size: 45, unit: 'deg' } ), bind: 'select', propType };
 
 			// Act.
-			renderControl( <SizeControl units={ mockDegreeUnits() } disableCustom />, props );
+			renderControl( <SizeControl variant="angle" units={ mockAngleUnits() } disableCustom />, props );
 
 			const sizeInput = screen.getByRole( 'spinbutton' );
 

--- a/packages/packages/libs/editor-controls/src/controls/filter-control/drop-shadow-item-content.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/filter-control/drop-shadow-item-content.tsx
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { PropKeyProvider, PropProvider, useBoundProp } from '../../bound-prop-context';
 import { ControlFormLabel } from '../../components/control-form-label';
 import { PopoverGridContainer } from '../../components/popover-grid-container';
-import { type Unit } from '../../utils/size-control';
+import { type LengthUnit } from '../../utils/size-control';
 import { ColorControl } from '../color-control';
 import { SizeControl } from '../size-control';
 
@@ -40,7 +40,7 @@ export const DropShadowItemContent = ( {
 	anchorEl,
 }: {
 	propType: PropTypeUtil< 'drop-shadow', DropShadowFilterPropValue[ 'value' ] >;
-	units: Unit[];
+	units: LengthUnit[];
 	anchorEl?: HTMLElement | null;
 } ) => {
 	const context = useBoundProp( propType );

--- a/packages/packages/libs/editor-controls/src/controls/filter-repeater-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/filter-repeater-control.tsx
@@ -27,10 +27,10 @@ import { PopoverContent } from '../components/popover-content';
 import { PopoverGridContainer } from '../components/popover-grid-container';
 import { type CollectionPropUtil, Repeater } from '../components/repeater';
 import { createControl } from '../create-control';
-import { defaultUnits, type Unit } from '../utils/size-control';
+import { type LengthUnit, lengthUnits } from '../utils/size-control';
 import { DropShadowItemContent } from './filter-control/drop-shadow-item-content';
 import { DropShadowItemLabel } from './filter-control/drop-shadow-item-label';
-import { SizeControl } from './size-control';
+import { SizeControl, type SizeControlProps } from './size-control';
 
 type FilterType = FilterItemPropValue[ '$$type' ];
 type FilterValue = FilterItemPropValue[ 'value' ];
@@ -43,6 +43,7 @@ type FilterItemConfig = {
 	valueName: string;
 	propType: PropTypeUtil< FilterValue, FilterValue >;
 	units?: Exclude< SizePropValue[ 'value' ][ 'unit' ], 'custom' | 'auto' >[];
+	sizeVariant?: SizeControlProps[ 'variant' ];
 };
 
 const filterConfig: Record< FilterType, FilterItemConfig > = {
@@ -51,7 +52,7 @@ const filterConfig: Record< FilterType, FilterItemConfig > = {
 		name: __( 'Blur', 'elementor' ),
 		valueName: __( 'Radius', 'elementor' ),
 		propType: blurFilterPropTypeUtil,
-		units: defaultUnits.filter( ( unit ) => unit !== '%' ),
+		units: lengthUnits.filter( ( unit ) => unit !== '%' ),
 	},
 	'drop-shadow': {
 		defaultValue: {
@@ -66,7 +67,7 @@ const filterConfig: Record< FilterType, FilterItemConfig > = {
 		name: __( 'Drop shadow', 'elementor' ),
 		valueName: __( 'Drop-shadow', 'elementor' ),
 		propType: dropShadowFilterPropTypeUtil,
-		units: defaultUnits.filter( ( unit ) => unit !== '%' ),
+		units: lengthUnits.filter( ( unit ) => unit !== '%' ),
 	},
 	brightness: {
 		defaultValue: { $$type: 'brightness', brightness: { $$type: 'size', value: { size: 100, unit: '%' } } },
@@ -87,7 +88,7 @@ const filterConfig: Record< FilterType, FilterItemConfig > = {
 		name: __( 'Hue Rotate', 'elementor' ),
 		valueName: __( 'Angle', 'elementor' ),
 		propType: hueRotateFilterPropTypeUtil,
-		units: [ 'deg', 'rad', 'grad', 'turn' ],
+		sizeVariant: 'angle',
 	},
 	saturate: {
 		defaultValue: { $$type: 'saturate', saturate: { $$type: 'size', value: { size: 100, unit: '%' } } },
@@ -245,12 +246,12 @@ const Content = ( { filterType, anchorEl }: { filterType: FilterType; anchorEl?:
 	return isSingleSize( filterType ) ? (
 		<SingleSizeItemContent filterType={ filterType } />
 	) : (
-		<DropShadowItemContent propType={ propType } units={ units as Unit[] } anchorEl={ anchorEl } />
+		<DropShadowItemContent propType={ propType } units={ units as LengthUnit[] } anchorEl={ anchorEl } />
 	);
 };
 
 const SingleSizeItemContent = ( { filterType }: { filterType: FilterType } ) => {
-	const { propType, valueName, defaultValue, units } = filterConfig[ filterType ];
+	const { propType, valueName, defaultValue, units, sizeVariant } = filterConfig[ filterType ];
 	const { $$type } = defaultValue;
 	const context = useBoundProp( propType );
 	const rowRef = useRef< HTMLDivElement >( null );
@@ -264,7 +265,12 @@ const SingleSizeItemContent = ( { filterType }: { filterType: FilterType } ) => 
 						<ControlLabel>{ valueName }</ControlLabel>
 					</Grid>
 					<Grid item xs={ 6 }>
-						<SizeControl anchorRef={ rowRef } units={ units } defaultUnit={ defaultUnit } />
+						<SizeControl
+							anchorRef={ rowRef }
+							units={ units as SizeControlProps[ 'units' ] }
+							defaultUnit={ defaultUnit }
+							variant={ sizeVariant }
+						/>
 					</Grid>
 				</PopoverGridContainer>
 			</PropKeyProvider>

--- a/packages/packages/libs/editor-controls/src/controls/size-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/size-control.tsx
@@ -11,10 +11,14 @@ import { createControl } from '../create-control';
 import { useSizeExtendedOptions } from '../hooks/use-size-extended-options';
 import { useSyncExternalState } from '../hooks/use-sync-external-state';
 import {
-	defaultUnits,
-	type DegreeUnit,
+	type AngleUnit,
+	angleUnits,
 	type ExtendedOption,
 	isUnitExtendedOption,
+	type LengthUnit,
+	lengthUnits,
+	type TimeUnit,
+	timeUnits,
 	type Unit,
 } from '../utils/size-control';
 
@@ -23,153 +27,202 @@ const DEFAULT_SIZE = NaN;
 
 type SizeValue = SizePropValue[ 'value' ];
 
-type SizeControlProps = {
+type SizeVariant = 'length' | 'angle' | 'time';
+
+type UnitProps< T extends readonly Unit[] > = {
+	units?: T;
+	defaultUnit?: T[ number ];
+};
+
+type BaseSizeControlProps = {
 	placeholder?: string;
 	startIcon?: React.ReactNode;
-	units?: ( Unit | DegreeUnit )[];
 	extendedOptions?: ExtendedOption[];
 	disableCustom?: boolean;
 	anchorRef?: RefObject< HTMLDivElement | null >;
-	defaultUnit?: Unit | DegreeUnit;
 };
+
+type LengthSizeControlProps = BaseSizeControlProps &
+	UnitProps< LengthUnit[] > & {
+		variant: 'length';
+	};
+
+type AngleSizeControlProps = BaseSizeControlProps &
+	UnitProps< AngleUnit[] > & {
+		variant: 'angle';
+	};
+
+type TimeSizeControlProps = BaseSizeControlProps &
+	UnitProps< TimeUnit[] > & {
+		variant: 'time';
+	};
+
+export type SizeControlProps = LengthSizeControlProps | AngleSizeControlProps | TimeSizeControlProps;
 
 type State = {
 	numeric: number;
 	custom: string;
-	unit: Unit | DegreeUnit | ExtendedOption;
+	unit: Unit | ExtendedOption;
 };
 
-export const SizeControl = createControl( ( props: SizeControlProps ) => {
-	const defaultUnit = props.defaultUnit ?? DEFAULT_UNIT;
-	const { units = [ ...defaultUnits ], placeholder, startIcon, anchorRef } = props;
-	const { value: sizeValue, setValue: setSizeValue, disabled, restoreValue } = useBoundProp( sizePropTypeUtil );
-	const [ internalState, setInternalState ] = useState( createStateFromSizeProp( sizeValue, defaultUnit ) );
-	const activeBreakpoint = useActiveBreakpoint();
+const defaultSelectedUnit: Record< SizeControlProps[ 'variant' ], Unit > = {
+	length: 'px',
+	angle: 'deg',
+	time: 'ms',
+} as const;
 
-	const extendedOptions = useSizeExtendedOptions( props.extendedOptions || [], props.disableCustom ?? false );
-	const popupState = usePopupState( { variant: 'popover' } );
+const defaultUnits: Record< SizeControlProps[ 'variant' ], Unit[] > = {
+	length: [ ...lengthUnits ] as LengthUnit[],
+	angle: [ ...angleUnits ] as AngleUnit[],
+	time: [ ...timeUnits ] as TimeUnit[],
+} as const;
 
-	const [ state, setState ] = useSyncExternalState( {
-		external: internalState,
-		setExternal: ( newState: State | null ) => setSizeValue( extractValueFromState( newState ) ),
-		persistWhen: ( newState ) => {
-			if ( ! newState?.unit ) {
-				return false;
+export const SizeControl = createControl(
+	( {
+		variant = 'length' as SizeControlProps[ 'variant' ],
+		defaultUnit,
+		units,
+		placeholder,
+		startIcon,
+		anchorRef,
+		extendedOptions,
+		disableCustom,
+	}: Omit< SizeControlProps, 'variant' > & { variant?: SizeVariant } ) => {
+		const actualDefaultUnit = defaultUnit ?? defaultSelectedUnit[ variant ];
+		const actualUnits = units ?? [ ...defaultUnits[ variant ] ];
+		const { value: sizeValue, setValue: setSizeValue, disabled, restoreValue } = useBoundProp( sizePropTypeUtil );
+		const [ internalState, setInternalState ] = useState( createStateFromSizeProp( sizeValue, actualDefaultUnit ) );
+		const activeBreakpoint = useActiveBreakpoint();
+
+		const actualExtendedOptions = useSizeExtendedOptions( extendedOptions || [], disableCustom ?? false );
+		const popupState = usePopupState( { variant: 'popover' } );
+
+		const [ state, setState ] = useSyncExternalState( {
+			external: internalState,
+			setExternal: ( newState: State | null ) => setSizeValue( extractValueFromState( newState ) ),
+			persistWhen: ( newState ) => {
+				if ( ! newState?.unit ) {
+					return false;
+				}
+
+				if ( isUnitExtendedOption( newState.unit ) ) {
+					return newState.unit === 'auto' ? true : !! newState.custom;
+				}
+
+				return !! newState?.numeric || newState?.numeric === 0;
+			},
+			fallback: ( newState ) => ( {
+				unit: newState?.unit ?? actualDefaultUnit,
+				numeric: newState?.numeric ?? DEFAULT_SIZE,
+				custom: newState?.custom ?? '',
+			} ),
+		} );
+
+		const { size: controlSize = DEFAULT_SIZE, unit: controlUnit = actualDefaultUnit } =
+			extractValueFromState( state ) || {};
+
+		const handleUnitChange = ( newUnit: Unit | ExtendedOption ) => {
+			if ( newUnit === 'custom' ) {
+				popupState.open( anchorRef?.current );
 			}
 
-			if ( isUnitExtendedOption( newState.unit ) ) {
-				return newState.unit === 'auto' ? true : !! newState.custom;
-			}
-
-			return !! newState?.numeric || newState?.numeric === 0;
-		},
-		fallback: ( newState ) => ( {
-			unit: newState?.unit ?? defaultUnit,
-			numeric: newState?.numeric ?? DEFAULT_SIZE,
-			custom: newState?.custom ?? '',
-		} ),
-	} );
-
-	const { size: controlSize = DEFAULT_SIZE, unit: controlUnit = defaultUnit } = extractValueFromState( state ) || {};
-
-	const handleUnitChange = ( newUnit: Unit | DegreeUnit | ExtendedOption ) => {
-		if ( newUnit === 'custom' ) {
-			popupState.open( anchorRef?.current );
-		}
-
-		setState( ( prev ) => ( { ...prev, unit: newUnit } ) );
-	};
-
-	const handleSizeChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
-		const { value: size } = event.target;
-
-		if ( controlUnit === 'auto' ) {
-			setState( ( prev ) => ( { ...prev, unit: controlUnit } ) );
-
-			return;
-		}
-
-		setState( ( prev ) => ( {
-			...prev,
-			[ controlUnit === 'custom' ? 'custom' : 'numeric' ]: formatSize( size, controlUnit ),
-			unit: controlUnit,
-		} ) );
-	};
-
-	const onInputFocus = ( event: React.FocusEvent< HTMLInputElement > ) => {
-		if ( isUnitExtendedOption( state.unit ) ) {
-			( event.target as HTMLElement )?.blur();
-		}
-	};
-
-	const onInputClick = ( event: React.MouseEvent ) => {
-		if ( ( event.target as HTMLElement ).closest( 'input' ) && 'custom' === state.unit ) {
-			popupState.open( anchorRef?.current );
-		}
-	};
-
-	useEffect( () => {
-		const newState = createStateFromSizeProp( sizeValue, state.unit === 'custom' ? state.unit : defaultUnit );
-		const currentUnitType = isUnitExtendedOption( state.unit ) ? 'custom' : 'numeric';
-		const mergedStates = {
-			...state,
-			unit: newState.unit ?? state.unit,
-			[ currentUnitType ]: newState[ currentUnitType ],
+			setState( ( prev ) => ( { ...prev, unit: newUnit } ) );
 		};
 
-		if ( mergedStates.unit !== 'auto' && areStatesEqual( state, mergedStates ) ) {
-			return;
-		}
+		const handleSizeChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+			const { value: size } = event.target;
 
-		if ( state.unit === newState.unit ) {
-			setInternalState( mergedStates );
+			if ( controlUnit === 'auto' ) {
+				setState( ( prev ) => ( { ...prev, unit: controlUnit } ) );
 
-			return;
-		}
+				return;
+			}
 
-		setState( newState );
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ sizeValue ] );
+			setState( ( prev ) => ( {
+				...prev,
+				[ controlUnit === 'custom' ? 'custom' : 'numeric' ]: formatSize( size, controlUnit ),
+				unit: controlUnit,
+			} ) );
+		};
 
-	useEffect( () => {
-		const newState = createStateFromSizeProp( sizeValue, defaultUnit );
+		const onInputFocus = ( event: React.FocusEvent< HTMLInputElement > ) => {
+			if ( isUnitExtendedOption( state.unit ) ) {
+				( event.target as HTMLElement )?.blur();
+			}
+		};
 
-		if ( activeBreakpoint && ! areStatesEqual( newState, state ) ) {
+		const onInputClick = ( event: React.MouseEvent ) => {
+			if ( ( event.target as HTMLElement ).closest( 'input' ) && 'custom' === state.unit ) {
+				popupState.open( anchorRef?.current );
+			}
+		};
+
+		useEffect( () => {
+			const newState = createStateFromSizeProp(
+				sizeValue,
+				state.unit === 'custom' ? state.unit : actualDefaultUnit
+			);
+			const currentUnitType = isUnitExtendedOption( state.unit ) ? 'custom' : 'numeric';
+			const mergedStates = {
+				...state,
+				unit: newState.unit ?? state.unit,
+				[ currentUnitType ]: newState[ currentUnitType ],
+			};
+
+			if ( mergedStates.unit !== 'auto' && areStatesEqual( state, mergedStates ) ) {
+				return;
+			}
+
+			if ( state.unit === newState.unit ) {
+				setInternalState( mergedStates );
+
+				return;
+			}
+
 			setState( newState );
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ activeBreakpoint ] );
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [ sizeValue ] );
 
-	return (
-		<>
-			<SizeInput
-				disabled={ disabled }
-				size={ controlSize }
-				unit={ controlUnit }
-				units={ [ ...units, ...( extendedOptions || [] ) ] }
-				placeholder={ placeholder }
-				startIcon={ startIcon }
-				handleSizeChange={ handleSizeChange }
-				handleUnitChange={ handleUnitChange }
-				onBlur={ restoreValue }
-				onFocus={ onInputFocus }
-				onClick={ onInputClick }
-				popupState={ popupState }
-			/>
-			{ anchorRef?.current && (
-				<TextFieldPopover
+		useEffect( () => {
+			const newState = createStateFromSizeProp( sizeValue, actualDefaultUnit );
+
+			if ( activeBreakpoint && ! areStatesEqual( newState, state ) ) {
+				setState( newState );
+			}
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [ activeBreakpoint ] );
+
+		return (
+			<>
+				<SizeInput
+					disabled={ disabled }
+					size={ controlSize }
+					unit={ controlUnit }
+					units={ [ ...actualUnits, ...( actualExtendedOptions || [] ) ] }
+					placeholder={ placeholder }
+					startIcon={ startIcon }
+					handleSizeChange={ handleSizeChange }
+					handleUnitChange={ handleUnitChange }
+					onBlur={ restoreValue }
+					onFocus={ onInputFocus }
+					onClick={ onInputClick }
 					popupState={ popupState }
-					anchorRef={ anchorRef }
-					restoreValue={ restoreValue }
-					value={ controlSize as string }
-					onChange={ handleSizeChange }
 				/>
-			) }
-		</>
-	);
-} );
+				{ anchorRef?.current && (
+					<TextFieldPopover
+						popupState={ popupState }
+						anchorRef={ anchorRef }
+						restoreValue={ restoreValue }
+						value={ controlSize as string }
+						onChange={ handleSizeChange }
+					/>
+				) }
+			</>
+		);
+	}
+);
 
-function formatSize< TSize extends string | number >( size: TSize, unit: Unit | DegreeUnit | ExtendedOption ): TSize {
+function formatSize< TSize extends string | number >( size: TSize, unit: Unit | ExtendedOption ): TSize {
 	if ( isUnitExtendedOption( unit ) ) {
 		return unit === 'auto' ? ( '' as TSize ) : ( String( size ?? '' ) as TSize );
 	}
@@ -177,10 +230,7 @@ function formatSize< TSize extends string | number >( size: TSize, unit: Unit | 
 	return size || size === 0 ? ( Number( size ) as TSize ) : ( NaN as TSize );
 }
 
-function createStateFromSizeProp(
-	sizeValue: SizeValue | null,
-	defaultUnit: Unit | DegreeUnit | ExtendedOption
-): State {
+function createStateFromSizeProp( sizeValue: SizeValue | null, defaultUnit: Unit | ExtendedOption ): State {
 	const unit = sizeValue?.unit ?? defaultUnit;
 	const size = sizeValue?.size ?? '';
 

--- a/packages/packages/libs/editor-controls/src/controls/stroke-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/stroke-control.tsx
@@ -8,7 +8,7 @@ import { PropKeyProvider, PropProvider, useBoundProp } from '../bound-prop-conte
 import { ControlFormLabel } from '../components/control-form-label';
 import { SectionContent } from '../components/section-content';
 import { createControl } from '../create-control';
-import { type Unit } from '../utils/size-control';
+import { type LengthUnit } from '../utils/size-control';
 import { ColorControl } from './color-control';
 import { SizeControl } from './size-control';
 
@@ -18,7 +18,7 @@ type StrokeProps = {
 	children: React.ReactNode;
 };
 
-const units: Unit[] = [ 'px', 'em', 'rem' ];
+const units: LengthUnit[] = [ 'px', 'em', 'rem' ];
 
 export const StrokeControl = createControl( () => {
 	const propContext = useBoundProp( strokePropTypeUtil );

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/functions/axis-row.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/functions/axis-row.tsx
@@ -1,12 +1,11 @@
 import { type RefObject } from 'react';
 import * as React from 'react';
-import { type Unit } from '@elementor/editor-controls';
+import { type AngleUnit } from '@elementor/editor-controls';
 import { Grid } from '@elementor/ui';
 
 import { PropKeyProvider } from '../../../bound-prop-context';
 import { ControlLabel } from '../../../components/control-label';
 import { PopoverGridContainer } from '../../../components/popover-grid-container';
-import { type DegreeUnit } from '../../../utils/size-control';
 import { SizeControl } from '../../size-control';
 
 type TransformAxisRowProps = {
@@ -14,7 +13,7 @@ type TransformAxisRowProps = {
 	bindValue: 'x' | 'y' | 'z';
 	startIcon: React.ReactNode;
 	anchorRef?: RefObject< HTMLDivElement | null >;
-	units?: ( Unit | DegreeUnit )[];
+	units?: AngleUnit[];
 };
 
 export const AxisRow = ( { label, bindValue, startIcon, anchorRef, units }: TransformAxisRowProps ) => {
@@ -26,7 +25,7 @@ export const AxisRow = ( { label, bindValue, startIcon, anchorRef, units }: Tran
 				</Grid>
 				<Grid item xs={ 6 }>
 					<PropKeyProvider bind={ bindValue }>
-						<SizeControl anchorRef={ anchorRef } startIcon={ startIcon } units={ units } />
+						<SizeControl anchorRef={ anchorRef } startIcon={ startIcon } units={ units } variant="angle" />
 					</PropKeyProvider>
 				</Grid>
 			</PopoverGridContainer>

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/functions/rotate.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/functions/rotate.tsx
@@ -6,7 +6,7 @@ import { Grid } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { PropKeyProvider, PropProvider, useBoundProp } from '../../../bound-prop-context';
-import { type DegreeUnit } from '../../../utils/size-control';
+import { type AngleUnit } from '../../../utils/size-control';
 import { TransformFunctionKeys } from '../types';
 import { AxisRow } from './axis-row';
 
@@ -28,7 +28,7 @@ const rotateAxisControls: { label: string; bindValue: 'x' | 'y' | 'z'; startIcon
 	},
 ];
 
-const rotateUnits: DegreeUnit[] = [ 'deg', 'rad', 'grad', 'turn' ];
+const rotateUnits: AngleUnit[] = [ 'deg', 'rad', 'grad', 'turn' ];
 
 export const Rotate = () => {
 	const context = useBoundProp( rotateTransformPropTypeUtil );

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/functions/skew.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/functions/skew.tsx
@@ -6,7 +6,7 @@ import { Grid } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { PropKeyProvider, PropProvider, useBoundProp } from '../../../bound-prop-context';
-import { type DegreeUnit } from '../../../utils/size-control';
+import { type AngleUnit } from '../../../utils/size-control';
 import { TransformFunctionKeys } from '../types';
 import { AxisRow } from './axis-row';
 
@@ -23,7 +23,7 @@ const skewAxisControls: { label: string; bindValue: 'x' | 'y'; startIcon: React.
 	},
 ];
 
-const skewUnits: DegreeUnit[] = [ 'deg', 'rad', 'grad', 'turn' ];
+const skewUnits: AngleUnit[] = [ 'deg', 'rad', 'grad', 'turn' ];
 
 export const Skew = () => {
 	const context = useBoundProp( skewTransformPropTypeUtil );

--- a/packages/packages/libs/editor-controls/src/index.ts
+++ b/packages/packages/libs/editor-controls/src/index.ts
@@ -38,7 +38,7 @@ export type { EqualUnequalItems } from './controls/equal-unequal-sizes-control';
 export type { ControlActionsItems } from './control-actions/control-actions-context';
 export type { PropProviderProps } from './bound-prop-context';
 export type { SetValue } from './bound-prop-context/prop-context';
-export type { ExtendedOption, Unit } from './utils/size-control';
+export type { ExtendedOption, Unit, LengthUnit, AngleUnit, TimeUnit } from './utils/size-control';
 export type { ToggleControlProps } from './controls/toggle-control';
 export type { FontCategory } from './controls/font-family-control/font-family-control';
 

--- a/packages/packages/libs/editor-controls/src/utils/size-control.ts
+++ b/packages/packages/libs/editor-controls/src/utils/size-control.ts
@@ -1,12 +1,15 @@
-export const defaultUnits = [ 'px', '%', 'em', 'rem', 'vw', 'vh' ] as const;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const degreeUnits = [ 'deg', 'rad', 'grad', 'turn' ] as const;
+export const lengthUnits = [ 'px', '%', 'em', 'rem', 'vw', 'vh' ] as const;
+export const angleUnits = [ 'deg', 'rad', 'grad', 'turn' ] as const;
+export const timeUnits = [ 's', 'ms' ] as const;
 const defaultExtendedOptions = [ 'auto', 'custom' ] as const;
 
-export type Unit = ( typeof defaultUnits )[ number ];
-export type DegreeUnit = ( typeof degreeUnits )[ number ];
+export type LengthUnit = ( typeof lengthUnits )[ number ];
+export type AngleUnit = ( typeof angleUnits )[ number ];
+export type TimeUnit = ( typeof timeUnits )[ number ];
 export type ExtendedOption = ( typeof defaultExtendedOptions )[ number ];
 
-export function isUnitExtendedOption( unit: Unit | DegreeUnit | ExtendedOption ): unit is ExtendedOption {
+export type Unit = LengthUnit | AngleUnit | TimeUnit;
+
+export function isUnitExtendedOption( unit: Unit | ExtendedOption ): unit is ExtendedOption {
 	return defaultExtendedOptions.includes( unit as ExtendedOption );
 }

--- a/packages/packages/libs/editor-props/src/prop-types/size.ts
+++ b/packages/packages/libs/editor-props/src/prop-types/size.ts
@@ -6,9 +6,21 @@ export const sizePropTypeUtil = createPropUtils(
 	'size',
 	z
 		.strictObject( {
-			unit: z.enum( [ 'px', 'em', 'rem', '%', 'vw', 'vh', 'deg', 'rad', 'grad', 'turn' ] ),
+			unit: z.enum( [ 'px', 'em', 'rem', '%', 'vw', 'vh' ] ),
 			size: z.number(),
 		} )
+		.or(
+			z.strictObject( {
+				unit: z.enum( [ 'deg', 'rad', 'grad', 'turn' ] ),
+				size: z.number(),
+			} )
+		)
+		.or(
+			z.strictObject( {
+				unit: z.enum( [ 's', 'ms' ] ),
+				size: z.number(),
+			} )
+		)
 		.or(
 			z.strictObject( {
 				unit: z.literal( 'auto' ),


### PR DESCRIPTION
…-

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Add support for time units in the size control component while refactoring unit type definitions for better organization and maintainability.

Main changes:
- Introduced new time units ('s', 'ms') alongside existing length and angle units
- Refactored unit types into specialized categories (LengthUnit, AngleUnit, TimeUnit)
- Added variant property to SizeControl to support different unit categories
- Updated size prop type validation to accommodate the new unit types
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
