### PR TITLE
Internal: Handle initial user fetch error [ED-19935]

### DIFF
--- a/packages/packages/libs/editor-current-user/src/__tests__/ensure-current-user.test.tsx
+++ b/packages/packages/libs/editor-current-user/src/__tests__/ensure-current-user.test.tsx
@@ -1,0 +1,36 @@
+import { registerDataHook } from '@elementor/editor-v1-adapters';
+import { type QueryClient } from '@elementor/query';
+
+import { ensureCurrentUser } from '../ensure-current-user';
+
+jest.mock( '@elementor/editor-v1-adapters', () => ( {
+	...jest.requireActual( '@elementor/editor-v1-adapters' ),
+	registerDataHook: jest.fn(),
+} ) );
+
+describe( 'ensureCurrentUser', () => {
+	it( 'should not fail the attach preview command is user fetch failed', async () => {
+		// Arrange.
+		const queryClient = {
+			ensureQueryData: jest.fn().mockRejectedValue( new Error( 'Failed to fetch current user' ) ),
+			setQueryData: jest.fn(),
+			getQueryData: jest.fn().mockReturnValue( null ),
+		} as unknown as QueryClient;
+
+		jest.mocked( registerDataHook ).mockImplementation( ( _hook, _command, callback ) => {
+			return callback( {} ) as never;
+		} );
+
+		// Act.
+		const result = await ensureCurrentUser( { queryClient } );
+
+		// Assert.
+		expect( queryClient.ensureQueryData ).toHaveBeenCalledWith( {
+			queryKey: [ 'editor-current-user' ],
+			queryFn: expect.any( Function ),
+			retry: false,
+		} );
+
+		expect( result ).toBeNull();
+	} );
+} );

--- a/packages/packages/libs/editor-current-user/src/ensure-current-user.ts
+++ b/packages/packages/libs/editor-current-user/src/ensure-current-user.ts
@@ -1,15 +1,20 @@
 import { registerDataHook } from '@elementor/editor-v1-adapters';
 import { type QueryClient } from '@elementor/query';
 
-import { apiClient } from './api';
+import { getCurrentUser } from './get-current-user';
 import { EDITOR_CURRENT_USER_QUERY_KEY } from './use-current-user';
 
 export function ensureCurrentUser( { queryClient }: { queryClient: QueryClient } ) {
 	registerDataHook( 'after', 'editor/documents/attach-preview', async () => {
-		await queryClient.ensureQueryData( {
-			queryKey: [ EDITOR_CURRENT_USER_QUERY_KEY ],
-			queryFn: apiClient.get,
-		} );
+		try {
+			await queryClient.ensureQueryData( {
+				queryKey: [ EDITOR_CURRENT_USER_QUERY_KEY ],
+				queryFn: getCurrentUser,
+				retry: false,
+			} );
+		} catch {
+			queryClient.setQueryData( [ EDITOR_CURRENT_USER_QUERY_KEY ], null );
+		}
 	} );
 
 	return queryClient.getQueryData( [ EDITOR_CURRENT_USER_QUERY_KEY ] );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix error handling for initial user fetch to prevent failure of the attach-preview command when user data can't be retrieved.

Main changes:
- Added try-catch block in ensureCurrentUser to handle API errors gracefully
- Set current user data to null when fetch fails instead of propagating the error
- Added unit test to verify attach-preview command completes despite user fetch failures

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
