### PR TITLE
Tweak: Fixed indicators for style effects

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/effects-section/effects-section.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/effects-section/effects-section.tsx
@@ -7,7 +7,7 @@ import { StylesField } from '../../../controls-registry/styles-field';
 import { EXPERIMENTAL_FEATURES } from '../../../sync/experiments-flags';
 import { PanelDivider } from '../../panel-divider';
 import { SectionContent } from '../../section-content';
-import { OpacityControlField } from '../layout-section/opacity-control-field';
+import { OpacityControlField } from './opacity-control-field';
 
 const BOX_SHADOW_LABEL = __( 'Box shadow', 'elementor' );
 const FILTER_LABEL = __( 'Filters', 'elementor' );

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/effects-section/opacity-control-field.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/effects-section/opacity-control-field.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 
 import { StylesField } from '../../../controls-registry/styles-field';
 import { StylesFieldLayout } from '../../styles-field-layout';
+// import { StylesFieldLayout } from '../../styles-field-layout';
 
 const OPACITY_LABEL = __( 'Opacity', 'elementor' );
 

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/effects-section/opacity-control-field.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/effects-section/opacity-control-field.tsx
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 
 import { StylesField } from '../../../controls-registry/styles-field';
 import { StylesFieldLayout } from '../../styles-field-layout';
-// import { StylesFieldLayout } from '../../styles-field-layout';
 
 const OPACITY_LABEL = __( 'Opacity', 'elementor' );
 

--- a/packages/packages/core/editor-editing-panel/src/components/style-tab.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-tab.tsx
@@ -155,7 +155,7 @@ export const StyleTab = () => {
 									name: 'Effects',
 									title: __( 'Effects', 'elementor' ),
 								} }
-								fields={ [ 'box-shadow' ] }
+								fields={ [ 'box-shadow', 'opacity', 'transform', 'filter', 'backdrop-filter' ] }
 							/>
 						</SectionsList>
 					</StyleInheritanceProvider>


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix style effect indicators by properly relocating the opacity control field and updating fields list for the Effects section.

Main changes:
- Moved OpacityControlField import from layout-section to effects-section directory for proper organization
- Added missing style effect indicators in fields list including opacity, transform, filter, and backdrop-filter

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
