### PR TITLE
Internal: Variables - unify submit availability [ED-19971]

### DIFF
--- a/packages/packages/core/editor-variables/src/components/color-variable-creation.tsx
+++ b/packages/packages/core/editor-variables/src/components/color-variable-creation.tsx
@@ -56,7 +56,11 @@ export const ColorVariableCreation = ( { onGoBack, onClose }: Props ) => {
 		return '' === color.trim() || '' === label.trim();
 	};
 
-	const isSubmitDisabled = hasEmptyValue();
+	const hasErrors = () => {
+		return !! errorMessage;
+	};
+
+	const isSubmitDisabled = hasEmptyValue() || hasErrors();
 
 	return (
 		<PopoverBody height="auto">

--- a/packages/packages/core/editor-variables/src/components/color-variable-edit.tsx
+++ b/packages/packages/core/editor-variables/src/components/color-variable-edit.tsx
@@ -91,7 +91,11 @@ export const ColorVariableEdit = ( { onClose, onGoBack, onSubmit, editId }: Prop
 		return color === variable.value && label === variable.label;
 	};
 
-	const isSubmitDisabled = noValueChanged() || hasEmptyValues();
+	const hasErrors = () => {
+		return !! errorMessage;
+	};
+
+	const isSubmitDisabled = noValueChanged() || hasEmptyValues() || hasErrors();
 
 	return (
 		<>

--- a/packages/packages/core/editor-variables/src/components/color-variable-restore.tsx
+++ b/packages/packages/core/editor-variables/src/components/color-variable-restore.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { PopoverContent, useBoundProp } from '@elementor/editor-controls';
 import { PopoverBody } from '@elementor/editor-editing-panel';
 import { PopoverHeader } from '@elementor/editor-ui';
-import { ArrowLeftIcon, BrushIcon } from '@elementor/icons';
-import { Button, CardActions, Divider, FormHelperText, IconButton } from '@elementor/ui';
+import { BrushIcon } from '@elementor/icons';
+import { Button, CardActions, Divider, FormHelperText } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { restoreVariable, useVariable } from '../hooks/use-prop-variables';
@@ -19,11 +19,10 @@ const SIZE = 'tiny';
 type Props = {
 	variableId: string;
 	onClose: () => void;
-	onGoBack?: () => void;
 	onSubmit?: () => void;
 };
 
-export const ColorVariableRestore = ( { variableId, onClose, onGoBack, onSubmit }: Props ) => {
+export const ColorVariableRestore = ( { variableId, onClose, onSubmit }: Props ) => {
 	const { setValue: notifyBoundPropChange } = useBoundProp( colorVariablePropTypeUtil );
 
 	const variable = useVariable( variableId );
@@ -64,22 +63,9 @@ export const ColorVariableRestore = ( { variableId, onClose, onGoBack, onSubmit 
 		<PopoverContentRefContextProvider>
 			<PopoverBody height="auto">
 				<PopoverHeader
+					icon={ <BrushIcon fontSize={ SIZE } /> }
 					title={ __( 'Restore variable', 'elementor' ) }
 					onClose={ onClose }
-					icon={
-						<>
-							{ onGoBack && (
-								<IconButton
-									size={ SIZE }
-									aria-label={ __( 'Go Back', 'elementor' ) }
-									onClick={ onGoBack }
-								>
-									<ArrowLeftIcon fontSize={ SIZE } />
-								</IconButton>
-							) }
-							<BrushIcon fontSize={ SIZE } />
-						</>
-					}
 				/>
 
 				<Divider />

--- a/packages/packages/core/editor-variables/src/components/font-variable-creation.tsx
+++ b/packages/packages/core/editor-variables/src/components/font-variable-creation.tsx
@@ -56,7 +56,11 @@ export const FontVariableCreation = ( { onClose, onGoBack }: Props ) => {
 		return '' === fontFamily.trim() || '' === label.trim();
 	};
 
-	const isSubmitDisabled = hasEmptyValue();
+	const hasErrors = () => {
+		return !! errorMessage;
+	};
+
+	const isSubmitDisabled = hasEmptyValue() || hasErrors();
 
 	return (
 		<PopoverBody height="auto">

--- a/packages/packages/core/editor-variables/src/components/font-variable-edit.tsx
+++ b/packages/packages/core/editor-variables/src/components/font-variable-edit.tsx
@@ -78,7 +78,11 @@ export const FontVariableEdit = ( { onClose, onGoBack, onSubmit, editId }: Props
 		return fontFamily === variable.value && label === variable.label;
 	};
 
-	const isSubmitDisabled = noValueChanged() || hasEmptyValue();
+	const hasErrors = () => {
+		return !! errorMessage;
+	};
+
+	const isSubmitDisabled = noValueChanged() || hasEmptyValue() || hasErrors();
 
 	const actions = [];
 

--- a/packages/packages/core/editor-variables/src/components/font-variable-restore.tsx
+++ b/packages/packages/core/editor-variables/src/components/font-variable-restore.tsx
@@ -19,7 +19,6 @@ const SIZE = 'tiny';
 type Props = {
 	variableId: string;
 	onClose: () => void;
-	onGoBack?: () => void;
 	onSubmit?: () => void;
 };
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Unify submit button availability logic across variable components by standardizing error handling and validation criteria.

Main changes:
- Added hasErrors() function to check for error messages in all variable components
- Standardized isSubmitDisabled logic to include error message validation
- Removed onGoBack parameter from ColorVariableRestore and FontVariableRestore components
- Simplified icon rendering in ColorVariableRestore component header

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
