### PR TITLE
Internal: Hide Z axis for move and scale transform effects [ED-19968]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/transform-control/__tests__/transform-repeater-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/__tests__/transform-repeater-control.test.tsx
@@ -140,7 +140,8 @@ describe( 'TransformRepeaterControl', () => {
 		// Assert.
 		expect( screen.getByText( 'Scale X' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Scale Y' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Scale Z' ) ).toBeInTheDocument();
+		// Scale Z is hidden in 1st phase since transform 'base' settings are not implemented
+		expect( screen.queryByText( 'Scale Z' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should switch to Rotate tab when clicked', () => {

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/functions/__tests__/scale.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/functions/__tests__/scale.test.tsx
@@ -32,7 +32,7 @@ describe( 'Scale Transform', () => {
 		},
 	} );
 
-	it( 'should render scale controls with proper labels', () => {
+	it( 'should render scale controls with proper labels (Z-axis hidden in 1st phase)', () => {
 		// Arrange.
 		const mockValue = {
 			x: { $$type: 'number', value: 1 },
@@ -46,6 +46,7 @@ describe( 'Scale Transform', () => {
 		// Assert.
 		expect( screen.getByText( 'Scale X' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Scale Y' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Scale Z' ) ).toBeInTheDocument();
+		// Scale Z is hidden in 1st phase since transform 'base' settings are not implemented
+		expect( screen.queryByText( 'Scale Z' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/functions/move.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/functions/move.tsx
@@ -31,11 +31,14 @@ export const Move = () => {
 	const context = useBoundProp( moveTransformPropTypeUtil );
 	const rowRef = useRef< HTMLDivElement >( null );
 
+	// Filter out Z axis control for the 1st phase since transform 'base' settings are not implemented
+	const visibleAxisControls = moveAxisControls.filter( ( control ) => control.bindValue !== 'z' );
+
 	return (
 		<Grid container spacing={ 1.5 }>
 			<PropProvider { ...context }>
 				<PropKeyProvider bind={ TransformFunctionKeys.move }>
-					{ moveAxisControls.map( ( control ) => (
+					{ visibleAxisControls.map( ( control ) => (
 						<AxisRow key={ control.bindValue } { ...control } anchorRef={ rowRef } />
 					) ) }
 				</PropKeyProvider>

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/functions/scale.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/functions/scale.tsx
@@ -31,11 +31,14 @@ export const Scale = () => {
 	const context = useBoundProp( scaleTransformPropTypeUtil );
 	const rowRef = useRef< HTMLDivElement >( null );
 
+	// Filter out Z axis control for the 1st phase since transform 'base' settings are not implemented
+	const visibleAxisControls = scaleAxisControls.filter( ( control ) => control.bindValue !== 'z' );
+
 	return (
 		<Grid container spacing={ 1.5 }>
 			<PropProvider { ...context }>
 				<PropKeyProvider bind={ TransformFunctionKeys.scale }>
-					{ scaleAxisControls.map( ( control ) => (
+					{ visibleAxisControls.map( ( control ) => (
 						<ScaleAxisRow key={ control.bindValue } { ...control } anchorRef={ rowRef } />
 					) ) }
 				</PropKeyProvider>


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Hide Z axis controls in Move and Scale transform effects as part of a phased implementation approach.
Main changes:
- Filtered Z axis from Move and Scale transform controls with clear code comments
- Updated tests to verify Z axis absence instead of presence
- Added explanatory comments about Z axis hiding being temporary for first phase

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
