### PR TITLE
Internal: Validate dry run really a dry run [ED-20017]

### DIFF
--- a/.github/workflows/one-click-release.yml
+++ b/.github/workflows/one-click-release.yml
@@ -141,7 +141,7 @@ jobs:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          PRE_RELEASE: ${{ github.event.inputs.dry_run }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
           PACKAGE_VERSION : ${{ env.PACKAGE_VERSION }}
       - name: Post To Slack Created Release
         if: github.event.inputs.dry_run == 'false'

--- a/.github/workflows/one-click-release.yml
+++ b/.github/workflows/one-click-release.yml
@@ -6,19 +6,19 @@ on:
       channel:
         required: true
         type: choice
-        description: Select a channel. For cloud, use main branch only!
+        description: Select a channel.
         options:
-          - ga
           - beta
-          - cloud
+          - ga
       custom_core_executed:
         type: boolean
         description: 'Was the Custom Core process executed and completed successful?'
         required: true
-      pre_release:
+      dry_run:
         type: boolean
-        description: 'Pre-release?'
+        description: 'Run in dry-run mode (no actual release will be created)'
         required: false
+        default: true
 
 env:
   CHANNEL: ${{inputs.channel}}
@@ -73,7 +73,6 @@ jobs:
           POSTFIX: ''
           OVERRIDE_PACKAGE_VERSION: true
       - name: Update Readme.txt
-        if: env.CHANNEL != 'cloud'
         uses: ./.github/workflows/update-readme-txt
         with:
           README_TXT_PATH: $GITHUB_WORKSPACE/readme.txt
@@ -112,10 +111,19 @@ jobs:
           files: |
             elementor-*.zip
             ${{ env.CHANGELOG_FILE }}
-          prerelease: ${{ github.event.inputs.pre_release }}
+          prerelease: ${{ github.event.inputs.dry_run }}
+          draft: ${{ github.event.inputs.dry_run }}
           body_path: ${{ env.CHANGELOG_FILE }}
+      - name: Validate Build Files
+        if: github.repository_owner == 'elementor'
+        env:
+          PLUGIN_VERSION: ${{ env.RELEASE_NAME }}
+          CHANNEL: ${{ env.CHANNEL }}
+          PACKAGE_VERSION : ${{ env.PACKAGE_VERSION }}
+        run: |
+            bash "${GITHUB_WORKSPACE}/.github/scripts/validate-build-files.sh"
       - name: Publish to WordPress.org SVN
-        if: env.CHANNEL != 'cloud' && github.repository_owner == 'elementor' && github.event.inputs.pre_release == 'false' # We don't publish cloud to WordPress.org, ga, beta, dev are published.
+        if: github.repository_owner == 'elementor' && github.event.inputs.dry_run == 'false'
         env:
           PLUGIN_VERSION: ${{ env.RELEASE_NAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
@@ -123,10 +131,9 @@ jobs:
           CHANNEL: ${{ env.CHANNEL }}
           PACKAGE_VERSION : ${{ env.PACKAGE_VERSION }}
         run: |
-          bash "${GITHUB_WORKSPACE}/.github/scripts/validate-build-files.sh"
           bash "${GITHUB_WORKSPACE}/.github/scripts/publish-to-wordpress-org.sh"
       - name: Release Dev From Beta
-        if: env.CHANNEL == 'beta' # Only for beta releases
+        if: env.CHANNEL == 'beta' && github.event.inputs.dry_run == 'false'
         uses: ./.github/workflows/release-dev-from-beta
         with:
           BUILD_ZIP_FILE_PATH: ${{ github.event.repository.name }}-${{ env.RELEASE_FILENAME }}.zip
@@ -134,10 +141,10 @@ jobs:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          PRE_RELEASE: ${{ github.event.inputs.pre_release }}
+          PRE_RELEASE: ${{ github.event.inputs.dry_run }}
           PACKAGE_VERSION : ${{ env.PACKAGE_VERSION }}
       - name: Post To Slack Created Release
-        if: github.event.inputs.pre_release == 'false'
+        if: github.event.inputs.dry_run == 'false'
         uses : ./.github/workflows/post-to-slack
         with:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/release-dev-from-beta/action.yml
+++ b/.github/workflows/release-dev-from-beta/action.yml
@@ -17,8 +17,8 @@ inputs:
   SVN_USERNAME:
     description: 'The username for the SVN.'
     required: true
-  PRE_RELEASE:
-    description: 'flag to indicate if the release is pre-release.'
+  DRY_RUN:
+    description: 'flag to indicate if the release is dry-run (pre-release).'
     required: true
   PACKAGE_VERSION:
     description: 'The version of the package.'
@@ -73,20 +73,15 @@ runs:
         tag_name: ${{ env.DEV_RELEASE_NAME }}
         files: ${{ env.DEV_BUILD_ZIP_FILE_PATH }}
         body_path: ${{ env.CHANGELOG_FILE }}
-        prerelease: ${{ inputs.PRE_RELEASE }}
+        prerelease: ${{ inputs.DRY_RUN }}
+        draft: ${{ inputs.DRY_RUN }}
     - name: Publish to WordPress.org SVN
-      if: inputs.PRE_RELEASE == 'false'
+      if: inputs.DRY_RUN == 'false' && inputs.REPOSITORY_OWNER == 'elementor'
       shell: bash
       env:
         PLUGIN_VERSION: ${{ env.DEV_RELEASE_NAME }}
         SVN_PASSWORD: ${{ inputs.SVN_PASSWORD }}
         SVN_USERNAME: ${{ inputs.SVN_USERNAME }}
       run: |
-            if [[ ${{ inputs.PRE_RELEASE }} == "true" ]]; then
-              exit 1
-            fi
-
-            if [[ ${{ inputs.REPOSITORY_OWNER }} == "elementor" ]]; then
-              bash "${GITHUB_WORKSPACE}/.github/scripts/publish-to-wordpress-org.sh"
-            fi
+          bash "${GITHUB_WORKSPACE}/.github/scripts/publish-to-wordpress-org.sh"
 


### PR DESCRIPTION
Clone of https://github.com/elementor/elementor-pro/pull/5638

Validates one-click-release dry-run runs properly
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update release workflow to support proper dry-run functionality for testing releases without actual publishing.
Main changes:
- Replace pre_release flag with dry_run parameter defaulting to true for safer testing
- Add validation step for build files before attempting release
- Conditionally skip WordPress.org SVN publishing and Slack notifications during dry runs
- Update dev release process to respect dry-run flag

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
