### PR TITLE
Internal: [V4] prop dependencies terms error

### DIFF
--- a/modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php
@@ -85,7 +85,7 @@ class Dynamic_Prop_Types_Mapping {
 
 		if ( $prop_type instanceof Transformable_Prop_Type ) {
 			$dependencies = $prop_type->get_dependencies();
-			$prop_type->set_dependencies( [] );
+			$prop_type->set_dependencies( null );
 			$union_prop_type = Union_Prop_Type::create_from( $prop_type )->set_dependencies( $dependencies );
 		}
 

--- a/modules/atomic-widgets/prop-types/base/array-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/array-prop-type.php
@@ -23,7 +23,7 @@ abstract class Array_Prop_Type implements Transformable_Prop_Type {
 
 	protected Prop_Type $item_type;
 
-	private array $dependencies = [];
+	private ?array $dependencies = null;
 
 	public function __construct() {
 		$this->item_type = $this->define_item_type();


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix prop dependencies terms error by updating null handling in Array_Prop_Type and Dynamic_Prop_Types_Mapping classes.
Main changes:
- Changed default dependencies value from empty array to null in Array_Prop_Type class
- Updated set_dependencies() call to use null instead of empty array in Dynamic_Prop_Types_Mapping

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
