### PR TITLE
Revert "Fix: Update the elementor-icons for fix the rotate issue [ED-19770] "

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "elementor",
 			"version": "3.31.0",
 			"dependencies": {
-				"@elementor/icons": "1.47.0",
+				"@elementor/icons": "1.46.0",
 				"@elementor/ui": "1.36.0",
 				"@reach/router": "1.3.4",
 				"@reduxjs/toolkit": "^1.8.3",
@@ -3532,9 +3532,10 @@
 			"license": "GPL-3.0-or-later"
 		},
 		"node_modules/@elementor/icons": {
-			"version": "1.47.0",
-			"resolved": "https://registry.npmjs.org/@elementor/icons/-/icons-1.47.0.tgz",
-			"integrity": "sha512-jeZhgxwHnrfpvG7qeBtPsNAQBipF5sIqdgg4eG8RKKDDpjZd578h2vQw/sWKJtHirEhJ+WbgDIN8RxG82QhdCw==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/@elementor/icons/-/icons-1.46.0.tgz",
+			"integrity": "sha512-X41zzh/okGWUjbHi3+BbT3hGQnlXRMfT/agzbvlQ4vBisKE3t7E7V3LDKdP9uGeml53nSnYm9mXbuUMy9nP1zw==",
+			"license": "GPL-3.0-or-later",
 			"peerDependencies": {
 				"@elementor/ui": "^1.34.0",
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 		"write": "^2.0.0"
 	},
 	"dependencies": {
-		"@elementor/icons": "1.47.0",
+		"@elementor/icons": "1.46.0",
 		"@elementor/ui": "1.36.0",
 		"@reach/router": "1.3.4",
 		"@reduxjs/toolkit": "^1.8.3",


### PR DESCRIPTION
Reverts elementor/elementor#31846
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert @elementor/icons package from v1.47.0 to v1.46.0 to address rotation functionality issue.

Main changes:
- Downgraded @elementor/icons dependency from v1.47.0 to v1.46.0 in package.json

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
