### PR TITLE
Internal: If experiments are active by default, do not activate them in Playwright tests [ED-20104]

### DIFF
--- a/tests/playwright/sanity/includes/widgets/icons/icons-brands.test.ts
+++ b/tests/playwright/sanity/includes/widgets/icons/icons-brands.test.ts
@@ -5,14 +5,6 @@ import EditorPage from '../../../../pages/editor-page';
 import _path from 'path';
 
 test.describe( 'Icons (FA Brands)', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await wpAdmin.setExperiments( { container: 'active' } );
-		await page.close();
-	} );
-
 	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
 		const context = await browser.newContext();
 		const page = await context.newPage();

--- a/tests/playwright/sanity/includes/widgets/image-carousel.test.ts
+++ b/tests/playwright/sanity/includes/widgets/image-carousel.test.ts
@@ -76,7 +76,6 @@ test.describe( 'Image carousel tests', () => {
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
 		const editor = new EditorPage( page, testInfo );
 
-		await wpAdmin.setExperiments( { additional_custom_breakpoints: true } );
 		await wpAdmin.openNewPage();
 		await editor.closeNavigatorIfOpen();
 
@@ -112,8 +111,6 @@ test.describe( 'Image carousel tests', () => {
 		await editor.setSliderControlValue( 'image_spacing_custom_tablet', '10' );
 		await editor.togglePreviewMode();
 		await expect( editor.getPreviewFrame().locator( '.swiper-slide-active' ).first() ).toHaveCSS( 'margin-right', '10px' );
-
-		await wpAdmin.resetExperiments();
 	} );
 
 	test( 'Accessibility test', async ( { page, apiRequests }, testInfo ) => {

--- a/tests/playwright/sanity/includes/widgets/rating/style-panel.test.ts
+++ b/tests/playwright/sanity/includes/widgets/rating/style-panel.test.ts
@@ -11,7 +11,7 @@ iconExperimentStates.forEach( ( iconExperimentState ) => {
 			const context = await browser.newContext();
 			const page = await context.newPage();
 			const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-			await wpAdmin.setExperiments( { container: 'active', e_font_icon_svg: 'active' === iconExperimentState } );
+			await wpAdmin.setExperiments( { e_font_icon_svg: 'active' === iconExperimentState } );
 			await page.close();
 		} );
 

--- a/tests/playwright/sanity/includes/widgets/tabs.test.ts
+++ b/tests/playwright/sanity/includes/widgets/tabs.test.ts
@@ -8,7 +8,6 @@ test.describe( 'Tabs widget tests', () => {
 	test( 'Ensure the old tabs widget is telling deprecation warning message', async ( { page, apiRequests }, testInfo ) => {
 	// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active' } );
 		const editor = await wpAdmin.openNewPage();
 
 		// Act.
@@ -17,8 +16,6 @@ test.describe( 'Tabs widget tests', () => {
 		// Assert.
 		await expect( editor.page.locator( '.elementor-control-alert.elementor-panel-alert.elementor-panel-alert-info' ) )
 			.toContainText( 'You are currently editing a Tabs Widget in its old version.' );
-
-		await wpAdmin.resetExperiments();
 	} );
 
 	test( 'Tabs widget sanity test', async ( { page, apiRequests }, testInfo ) => {

--- a/tests/playwright/sanity/modules/container/container-1.test.ts
+++ b/tests/playwright/sanity/modules/container/container-1.test.ts
@@ -5,22 +5,6 @@ import WpAdminPage from '../../../pages/wp-admin-page';
 import widgets from '../../../enums/widgets';
 
 test.describe( 'Container tests #1 @container', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: true, 'nested-elements': true } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Background slideshow', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/modules/container/container-2.test.ts
+++ b/tests/playwright/sanity/modules/container/container-2.test.ts
@@ -7,22 +7,6 @@ import Breakpoints from '../../../assets/breakpoints';
 import EditorPage from '../../../pages/editor-page';
 
 test.describe( 'Container tests #2 @container', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: true, 'nested-elements': true } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Justify icons are displayed correctly', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/modules/container/container-3.test.ts
+++ b/tests/playwright/sanity/modules/container/container-3.test.ts
@@ -5,22 +5,6 @@ import EditorPage from '../../../pages/editor-page';
 import ContextMenu from '../../../pages/widgets/context-menu';
 
 test.describe( 'Container tests #3 @container', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: true, 'nested-elements': true } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Widget display inside container flex wrap', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/modules/container/container-4.test.ts
+++ b/tests/playwright/sanity/modules/container/container-4.test.ts
@@ -8,22 +8,6 @@ import _path from 'path';
 const templateFilePath = _path.resolve( __dirname, `../../templates/container-dimensions-ltr-rtl.json` );
 
 test.describe( 'Container tests #4 @container', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: true, 'nested-elements': true } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Container no horizontal scroll', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/modules/container/container-grid.test.ts
+++ b/tests/playwright/sanity/modules/container/container-grid.test.ts
@@ -4,22 +4,6 @@ import WpAdminPage from '../../../pages/wp-admin-page';
 import EditorPage from '../../../pages/editor-page';
 
 test.describe( 'Container Grid tests @container', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: true } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Test grid container', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/modules/nested-accordion/nested-accordion-atomic-repeaters.test.ts
+++ b/tests/playwright/sanity/modules/nested-accordion/nested-accordion-atomic-repeaters.test.ts
@@ -5,21 +5,6 @@ import { addItemFromRepeater, cloneItemFromRepeater, deleteItemFromRepeater } fr
 import _path from 'path';
 
 test.describe( 'Nested Accordion tests @nested-atomic-repeaters', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active' } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Atomic repeaters functionality', async ( { page, apiRequests }, testInfo ) => {
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests ),
 			editor = await wpAdmin.openNewPage(),

--- a/tests/playwright/sanity/modules/nested-accordion/nested-accordion-content.test.ts
+++ b/tests/playwright/sanity/modules/nested-accordion/nested-accordion-content.test.ts
@@ -4,21 +4,6 @@ import WpAdminPage from '../../../pages/wp-admin-page';
 import { expectScreenshotToMatchLocator, setTitleTextTag, setTitleIconPosition, setTitleHorizontalAlignment } from './helper';
 
 test.describe( 'Nested Accordion Content Tests @nested-accordion', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active' } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Nested Accordion Title Icon and Text Vertical Alignment', async ( { browser, apiRequests }, testInfo ) => {
 		const page = await browser.newPage(),
 			wpAdmin = new WpAdminPage( page, testInfo, apiRequests ),

--- a/tests/playwright/sanity/modules/nested-accordion/nested-accordion-icon.test.ts
+++ b/tests/playwright/sanity/modules/nested-accordion/nested-accordion-icon.test.ts
@@ -4,14 +4,6 @@ import { expectScreenshotToMatchLocator, addIcon, setIconSize } from './helper';
 import { expect } from '@playwright/test';
 
 test.describe( 'Nested Accordion Title Icon and Text No Overlap @nested-accordion', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active' } );
-		await page.close();
-	} );
-
 	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
 		const context = await browser.newContext();
 		const page = await context.newPage();

--- a/tests/playwright/sanity/modules/nested-accordion/nested-accordion-style.test.ts
+++ b/tests/playwright/sanity/modules/nested-accordion/nested-accordion-style.test.ts
@@ -7,13 +7,6 @@ import { displayState } from '../../../enums/display-states';
 import { expectScreenshotToMatchLocator, setBorderAndBackground, setIconColor } from './helper';
 
 test.describe( 'Nested Accordion Style Tests @nested-accordion', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active' } );
-		await page.close();
-	} );
-
 	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
 		const context = await browser.newContext();
 		const page = await context.newPage();

--- a/tests/playwright/sanity/modules/nested-accordion/nested-accordion.test.ts
+++ b/tests/playwright/sanity/modules/nested-accordion/nested-accordion.test.ts
@@ -43,21 +43,6 @@ test.describe( 'Nested Accordion tests @nested-accordion', () => {
 } );
 
 test.describe( 'Nested Accordion tests @nested-accordion', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active' } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'General Test', async ( { page, apiRequests }, testInfo ) => {
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests ),
 			editor = await wpAdmin.openNewPage(),

--- a/tests/playwright/sanity/modules/nested-tabs/nested-tabs-1.test.ts
+++ b/tests/playwright/sanity/modules/nested-tabs/nested-tabs-1.test.ts
@@ -7,21 +7,6 @@ import { clickTabByPosition, setTabItemColor, selectDropdownContainer, locators,
 import EditorPage from '../../../pages/editor-page';
 
 test.describe( 'Nested Tabs tests @nested-tabs', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active' } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'General test', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/modules/nested-tabs/nested-tabs-2.test.ts
+++ b/tests/playwright/sanity/modules/nested-tabs/nested-tabs-2.test.ts
@@ -4,21 +4,6 @@ import WpAdminPage from '../../../pages/wp-admin-page';
 import _path from 'path';
 
 test.describe( 'Nested Tabs tests @nested-tabs', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active' } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Accessibility inside the Editor', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/modules/nested-tabs/nested-tabs-3.test.ts
+++ b/tests/playwright/sanity/modules/nested-tabs/nested-tabs-3.test.ts
@@ -5,21 +5,6 @@ import { viewportSize } from '../../../enums/viewport-sizes';
 import { editTab, clickTabByPosition, selectDropdownContainer, locators, templatePath } from './helper';
 
 test.describe( 'Nested Tabs tests @nested-tabs', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active' } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Verify that the tab sizes don\'t shrink when adding a widget in the content section.', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/modules/nested-tabs/nested-tabs-4.test.ts
+++ b/tests/playwright/sanity/modules/nested-tabs/nested-tabs-4.test.ts
@@ -6,21 +6,6 @@ import { clickTabByPosition, setBackgroundVideoUrl, isTabTitleVisible } from './
 import _path from 'path';
 
 test.describe( 'Nested Tabs tests @nested-tabs', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active' } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Check none breakpoint', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/modules/nested-tabs/nested-tabs-5.test.ts
+++ b/tests/playwright/sanity/modules/nested-tabs/nested-tabs-5.test.ts
@@ -4,21 +4,6 @@ import WpAdminPage from '../../../pages/wp-admin-page';
 import { setTabItemColor, setTabBorderColor, templatePath } from './helper';
 
 test.describe( 'Nested Tabs tests @nested-tabs', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active' } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Verify the correct working of the title alignment', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/modules/nested-tabs/nested-tabs-6.test.ts
+++ b/tests/playwright/sanity/modules/nested-tabs/nested-tabs-6.test.ts
@@ -8,7 +8,7 @@ test.describe( 'Nested Tabs tests (e_font_icon_svg: active) @nested-tabs', () =>
 	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
 		const page = await browser.newPage();
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active', e_font_icon_svg: 'active' } );
+		await wpAdmin.setExperiments( { e_font_icon_svg: 'active' } );
 		await page.close();
 	} );
 

--- a/tests/playwright/sanity/modules/nested-tabs/nested-tabs-atomic-repeaters.test.ts
+++ b/tests/playwright/sanity/modules/nested-tabs/nested-tabs-atomic-repeaters.test.ts
@@ -5,21 +5,6 @@ import { addItemFromRepeater, cloneItemFromRepeater, deleteItemFromRepeater } fr
 import _path from 'path';
 
 test.describe( 'Nested Tabs @nested-atomic-repeaters', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'active', 'nested-elements': 'active' } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Repeaters functionality Test', async ( { page, apiRequests }, testInfo ) => {
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests ),
 			editor = await wpAdmin.openNewPage(),

--- a/tests/playwright/sanity/plugin-tester-container.test.ts
+++ b/tests/playwright/sanity/plugin-tester-container.test.ts
@@ -1,25 +1,8 @@
 import { parallelTest as test } from '../parallelTest';
 import { generatePluginTests } from './plugin-tester-generator';
-import WpAdminPage from '../pages/wp-admin-page';
 
 test.describe.configure( { mode: 'parallel' } );
 
 test.describe( `Plugin tester tests: containers @plugin_tester_container`, () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await wpAdmin.setExperiments( { e_optimized_markup: 'active' } );
-		await page.close();
-	} );
-
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	generatePluginTests( 'containers' );
 } );

--- a/tests/playwright/sanity/plugin-tester-section.test.ts
+++ b/tests/playwright/sanity/plugin-tester-section.test.ts
@@ -9,7 +9,7 @@ test.describe( `Plugin tester tests: sections @plugin_tester_section`, () => {
 		const page = await browser.newPage();
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
 		await wpAdmin.resetExperiments();
-		await wpAdmin.setExperiments( { container: 'inactive', e_optimized_markup: 'active' } );
+		await wpAdmin.setExperiments( { container: 'inactive' } );
 		await page.close();
 	} );
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove redundant experiment activation in Playwright tests since experiments are now active by default.
Main changes:
- Removed wpAdmin.setExperiments() calls for container and nested-elements features across multiple test files
- Preserved only critical experiment state changes that override default behavior
- Removed unnecessary resetExperiments() calls within test methods

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
