### PR TITLE
Internal: Close revert PRs if not merged [ED-20106]

### DIFF
--- a/.github/workflows/cleanup-revert-prs.yml
+++ b/.github/workflows/cleanup-revert-prs.yml
@@ -44,7 +44,7 @@ jobs:
             AGE_HOURS=$(( (NOW - CREATED_TS) / 3600 ))
 
             if [ "$AGE_HOURS" -ge 72 ]; then
-              echo "🗑 Closing PR #$NUMBER: '$TITLE' (age: ${AGE_HOURS}h) and deleting branch '$BRANCH'"
+              echo "Closing PR #$NUMBER: '$TITLE' (age: ${AGE_HOURS}h) and deleting branch '$BRANCH'"
               gh pr close "$NUMBER" --delete-branch --comment "Automatically closed after ${AGE_HOURS} hours of inactivity"
             else
               echo "⏭ PR #$NUMBER is only ${AGE_HOURS}h old — skipping"

--- a/.github/workflows/cleanup-revert-prs.yml
+++ b/.github/workflows/cleanup-revert-prs.yml
@@ -34,7 +34,7 @@ jobs:
             exit 0
           fi
 
-          cat prs.json | jq -c '.' | while read -r pr; do
+          while read -r pr; do
             NUMBER=$(echo "$pr" | jq -r '.number')
             CREATED_AT=$(echo "$pr" | jq -r '.createdAt')
             BRANCH=$(echo "$pr" | jq -r '.headRefName')
@@ -52,4 +52,4 @@ jobs:
             else
               echo "⏭ PR #$NUMBER is only ${AGE_HOURS}h old — skipping"
             fi
-          done
+          done < <(jq -c '.' prs.json)

--- a/.github/workflows/cleanup-revert-prs.yml
+++ b/.github/workflows/cleanup-revert-prs.yml
@@ -45,7 +45,10 @@ jobs:
 
             if [ "$AGE_HOURS" -ge 72 ]; then
               echo "Closing PR #$NUMBER: '$TITLE' (age: ${AGE_HOURS}h) and deleting branch '$BRANCH'"
-              gh pr close "$NUMBER" --delete-branch --comment "Automatically closed after ${AGE_HOURS} hours of inactivity"
+              if ! gh pr close "$NUMBER" --delete-branch --comment "Automatically closed after ${AGE_HOURS} hours of inactivity"; then
+                echo "Failed to close PR #$NUMBER"
+                continue
+              fi
             else
               echo "⏭ PR #$NUMBER is only ${AGE_HOURS}h old — skipping"
             fi

--- a/.github/workflows/cleanup-revert-prs.yml
+++ b/.github/workflows/cleanup-revert-prs.yml
@@ -1,0 +1,52 @@
+name: Cleanup Revert PRs
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Close old revert PRs (older than 72h)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+
+          NOW=$(date +%s)
+
+          echo "Fetching open PRs with title starting with 'Revert'"
+          gh pr list --state open --limit 100 --json number,title,createdAt,headRefName \
+            --jq '.[] | select(.title | startswith("Revert")) | {number, title, createdAt, headRefName}' > prs.json
+
+          if [ ! -s prs.json ]; then
+            echo "No revert PRs found to clean up"
+            exit 0
+          fi
+
+          cat prs.json | jq -c '.' | while read -r pr; do
+            NUMBER=$(echo "$pr" | jq -r '.number')
+            CREATED_AT=$(echo "$pr" | jq -r '.createdAt')
+            BRANCH=$(echo "$pr" | jq -r '.headRefName')
+            TITLE=$(echo "$pr" | jq -r '.title')
+
+            CREATED_TS=$(date --date="$CREATED_AT" +%s)
+            AGE_HOURS=$(( (NOW - CREATED_TS) / 3600 ))
+
+            if [ "$AGE_HOURS" -ge 72 ]; then
+              echo "🗑 Closing PR #$NUMBER: '$TITLE' (age: ${AGE_HOURS}h) and deleting branch '$BRANCH'"
+              gh pr close "$NUMBER" --delete-branch --comment "Automatically closed after ${AGE_HOURS} hours of inactivity"
+            else
+              echo "⏭ PR #$NUMBER is only ${AGE_HOURS}h old — skipping"
+            fi
+          done


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add a GitHub workflow to automatically close stale revert PRs that remain open beyond 72 hours.

Main changes:
- Created new workflow that runs daily at 3:00 UTC or can be manually triggered
- Implemented logic to identify and close PRs with titles starting with "Revert" that are older than 72 hours
- Added branch deletion capability when closing outdated revert PRs

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
