### PR TITLE
Fix: Slow first load due to local Google Fonts [ED-19938] (#31878)

### DIFF
--- a/assets/dev/js/editor/utils/helpers.js
+++ b/assets/dev/js/editor/utils/helpers.js
@@ -299,7 +299,7 @@ module.exports = {
 					elementorCommon.ajax.addRequest( 'enqueue_google_fonts', {
 						data: { font_name: font },
 						unique_id: 'enqueue_google_fonts_' + font,
-					} );
+					}, true );
 				}
 
 				break;

--- a/core/files/fonts/google-font.php
+++ b/core/files/fonts/google-font.php
@@ -28,12 +28,12 @@ class Google_Font {
 
 	private static array $folders = [];
 
-	public static function enqueue( string $font_name, string $font_type = self::TYPE_DEFAULT ): bool {
+	public static function enqueue( string $font_name, string $font_type = self::TYPE_DEFAULT, $force_enqueue_from_cdn = false ): bool {
 		if ( static::enqueue_style( $font_name ) ) {
 			return true;
 		}
 
-		if ( ! static::fetch_font_data( $font_name, $font_type ) ) {
+		if ( $force_enqueue_from_cdn || ! static::fetch_font_data( $font_name, $font_type ) ) {
 			static::enqueue_from_cdn( $font_name, $font_type );
 			return false;
 		}

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -1004,16 +1004,17 @@ class Frontend extends App {
 			return;
 		}
 
-		// Print used fonts
+		$force_enqueue_from_cdn = Plugin::$instance->preview->is_preview_mode();
+
 		if ( ! empty( $google_fonts['google'] ) ) {
 			foreach ( $google_fonts['google'] as $current_font ) {
-				Google_Font::enqueue( $current_font );
+				Google_Font::enqueue( $current_font, Google_Font::TYPE_DEFAULT, $force_enqueue_from_cdn );
 			}
 		}
 
 		if ( ! empty( $google_fonts['early'] ) ) {
 			foreach ( $google_fonts['early'] as $current_font ) {
-				Google_Font::enqueue( $current_font, Google_Font::TYPE_EARLYACCESS );
+				Google_Font::enqueue( $current_font, Google_Font::TYPE_EARLYACCESS, $force_enqueue_from_cdn );
 			}
 		}
 	}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix slow initial page load by optimizing Google Fonts loading strategy with forced CDN usage during preview mode.

Main changes:
- Added force_enqueue_from_cdn parameter to Google_Font::enqueue method
- Modified AJAX request to use non-blocking mode with true parameter
- Added preview mode detection to determine when to force CDN loading

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
