### PR TITLE
Internal: Remove usage of unsecure `print_unescaped_setting()` function [ED-19758]

### DIFF
--- a/includes/widgets/alert.php
+++ b/includes/widgets/alert.php
@@ -495,11 +495,11 @@ class Widget_Alert extends Widget_Base {
 		<div <?php $this->print_render_attribute_string( 'alert_wrapper' ); ?>>
 
 			<?php if ( ! Utils::is_empty( $settings['alert_title'] ) ) : ?>
-			<span <?php $this->print_render_attribute_string( 'alert_title' ); ?>><?php $this->print_unescaped_setting( 'alert_title' ); ?></span>
+			<span <?php $this->print_render_attribute_string( 'alert_title' ); ?>><?php echo wp_kses_post( $settings['alert_title'] ); ?></span>
 			<?php endif; ?>
 
 			<?php if ( ! Utils::is_empty( $settings['alert_description'] ) ) : ?>
-			<span <?php $this->print_render_attribute_string( 'alert_description' ); ?>><?php $this->print_unescaped_setting( 'alert_description' ); ?></span>
+			<span <?php $this->print_render_attribute_string( 'alert_description' ); ?>><?php echo wp_kses_post( $settings['alert_description'] ); ?></span>
 			<?php endif; ?>
 
 			<?php if ( 'show' === $settings['show_dismiss'] ) : ?>
@@ -550,11 +550,11 @@ class Widget_Alert extends Widget_Base {
 		<div {{{ view.getRenderAttributeString( 'alert_wrapper' ) }}}>
 
 			<# if ( settings.alert_title ) { #>
-			<span {{{ view.getRenderAttributeString( 'alert_title' ) }}}>{{{ settings.alert_title }}}</span>
+			<span {{{ view.getRenderAttributeString( 'alert_title' ) }}}>{{ settings.alert_title }}</span>
 			<# } #>
 
 			<# if ( settings.alert_description ) { #>
-			<span {{{ view.getRenderAttributeString( 'alert_description' ) }}}>{{{ settings.alert_description }}}</span>
+			<span {{{ view.getRenderAttributeString( 'alert_description' ) }}}>{{ settings.alert_description }}</span>
 			<# } #>
 
 			<# if ( 'show' === settings.show_dismiss ) { #>

--- a/includes/widgets/counter.php
+++ b/includes/widgets/counter.php
@@ -648,9 +648,9 @@ class Widget_Counter extends Widget_Base {
 				#><{{ titleTag }} {{{ view.getRenderAttributeString( 'counter-title' ) }}}>{{{ elementor.helpers.sanitize( settings.title, { ALLOW_DATA_ATTR: false } ) }}}</{{ titleTag }}><#
 			} #>
 			<div {{{ view.getRenderAttributeString( 'counter-number' ) }}}>
-				<span {{{ view.getRenderAttributeString( 'prefix' ) }}}>{{{ settings.prefix }}}</span>
-				<span {{{ view.getRenderAttributeString( 'counter' ) }}}>{{{ settings.starting_number }}}</span>
-				<span {{{ view.getRenderAttributeString( 'suffix' ) }}}>{{{ settings.suffix }}}</span>
+				<span {{{ view.getRenderAttributeString( 'prefix' ) }}}>{{ settings.prefix }}</span>
+				<span {{{ view.getRenderAttributeString( 'counter' ) }}}>{{ settings.starting_number }}</span>
+				<span {{{ view.getRenderAttributeString( 'suffix' ) }}}>{{ settings.suffix }}</span>
 			</div>
 		</div>
 		<?php
@@ -703,9 +703,9 @@ class Widget_Counter extends Widget_Base {
 			endif;
 			?>
 			<div <?php $this->print_render_attribute_string( 'counter-number' ); ?>>
-				<span <?php $this->print_render_attribute_string( 'prefix' ); ?>><?php $this->print_unescaped_setting( 'prefix' ); ?></span>
-				<span <?php $this->print_render_attribute_string( 'counter' ); ?>><?php $this->print_unescaped_setting( 'starting_number' ); ?></span>
-				<span <?php $this->print_render_attribute_string( 'suffix' ); ?>><?php $this->print_unescaped_setting( 'suffix' ); ?></span>
+				<span <?php $this->print_render_attribute_string( 'prefix' ); ?>><?php echo wp_kses_post( $settings['prefix'] ); ?></span>
+				<span <?php $this->print_render_attribute_string( 'counter' ); ?>><?php echo wp_kses_post( $settings['starting_number'] ); ?></span>
+				<span <?php $this->print_render_attribute_string( 'suffix' ); ?>><?php echo wp_kses_post( $settings['suffix'] ); ?></span>
 			</div>
 		</div>
 		<?php

--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -843,14 +843,14 @@ class Widget_Icon_Box extends Widget_Base {
 				<?php if ( ! Utils::is_empty( $settings['title_text'] ) ) : ?>
 					<<?php Utils::print_validated_html_tag( $settings['title_size'] ); ?> class="elementor-icon-box-title">
 						<<?php Utils::print_validated_html_tag( $html_tag ); ?> <?php $this->print_render_attribute_string( 'link' ); ?> <?php $this->print_render_attribute_string( 'title_text' ); ?>>
-							<?php $this->print_unescaped_setting( 'title_text' ); ?>
+							<?php echo wp_kses_post( $settings['title_text'] ); ?>
 						</<?php Utils::print_validated_html_tag( $html_tag ); ?>>
 					</<?php Utils::print_validated_html_tag( $settings['title_size'] ); ?>>
 				<?php endif; ?>
 
 				<?php if ( ! Utils::is_empty( $settings['description_text'] ) ) : ?>
 					<p <?php $this->print_render_attribute_string( 'description_text' ); ?>>
-						<?php $this->print_unescaped_setting( 'description_text' ); ?>
+						<?php echo wp_kses_post( $settings['description_text'] ); ?>
 					</p>
 				<?php endif; ?>
 

--- a/includes/widgets/testimonial.php
+++ b/includes/widgets/testimonial.php
@@ -485,7 +485,7 @@ class Widget_Testimonial extends Widget_Base {
 				$this->add_render_attribute( 'testimonial_content', 'class', 'elementor-testimonial-content' );
 				$this->add_inline_editing_attributes( 'testimonial_content' );
 				?>
-				<div <?php $this->print_render_attribute_string( 'testimonial_content' ); ?>><?php $this->print_unescaped_setting( 'testimonial_content' ); ?></div>
+				<div <?php $this->print_render_attribute_string( 'testimonial_content' ); ?>><?php echo wp_kses_post( $settings['testimonial_content'] ); ?></div>
 			<?php endif; ?>
 
 			<?php if ( $has_image || $has_name || $has_job ) : ?>
@@ -512,11 +512,11 @@ class Widget_Testimonial extends Widget_Base {
 
 							if ( ! empty( $settings['link']['url'] ) ) :
 								?>
-								<a <?php $this->print_render_attribute_string( 'testimonial_name' ); ?> <?php $this->print_render_attribute_string( 'link' ); ?>><?php $this->print_unescaped_setting( 'testimonial_name' ); ?></a>
+								<a <?php $this->print_render_attribute_string( 'testimonial_name' ); ?> <?php $this->print_render_attribute_string( 'link' ); ?>><?php echo wp_kses_post( $settings['testimonial_name'] ); ?></a>
 								<?php
 							else :
 								?>
-								<div <?php $this->print_render_attribute_string( 'testimonial_name' ); ?>><?php $this->print_unescaped_setting( 'testimonial_name' ); ?></div>
+								<div <?php $this->print_render_attribute_string( 'testimonial_name' ); ?>><?php echo wp_kses_post( $settings['testimonial_name'] ); ?></div>
 								<?php
 							endif;
 						endif; ?>
@@ -528,11 +528,11 @@ class Widget_Testimonial extends Widget_Base {
 
 							if ( ! empty( $settings['link']['url'] ) ) :
 								?>
-								<a <?php $this->print_render_attribute_string( 'testimonial_job' ); ?> <?php $this->print_render_attribute_string( 'link' ); ?>><?php $this->print_unescaped_setting( 'testimonial_job' ); ?></a>
+								<a <?php $this->print_render_attribute_string( 'testimonial_job' ); ?> <?php $this->print_render_attribute_string( 'link' ); ?>><?php echo wp_kses_post( $settings['testimonial_job'] ); ?></a>
 								<?php
 							else :
 								?>
-								<div <?php $this->print_render_attribute_string( 'testimonial_job' ); ?>><?php $this->print_unescaped_setting( 'testimonial_job' ); ?></div>
+								<div <?php $this->print_render_attribute_string( 'testimonial_job' ); ?>><?php echo wp_kses_post( $settings['testimonial_job'] ); ?></div>
 								<?php
 							endif;
 						endif; ?>
@@ -596,7 +596,7 @@ class Widget_Testimonial extends Widget_Base {
 
 				view.addInlineEditingAttributes( 'testimonial_content' );
 				#>
-				<div {{{ view.getRenderAttributeString( 'testimonial_content' ) }}}>{{{ settings.testimonial_content }}}</div>
+				<div {{{ view.getRenderAttributeString( 'testimonial_content' ) }}}>{{ settings.testimonial_content }}</div>
 			<# } #>
 			<div class="elementor-testimonial-meta{{ hasImage }}{{ testimonial_image_position }}">
 				<div class="elementor-testimonial-meta-inner">
@@ -622,11 +622,11 @@ class Widget_Testimonial extends Widget_Base {
 
 			if ( settings.link.url ) {
 				#>
-				<a href="{{  elementor.helpers.sanitizeUrl( settings.link.url ) }}" {{{ view.getRenderAttributeString( 'testimonial_name' ) }}}>{{{ settings.testimonial_name }}}</a>
+				<a href="{{  elementor.helpers.sanitizeUrl( settings.link.url ) }}" {{{ view.getRenderAttributeString( 'testimonial_name' ) }}}>{{ settings.testimonial_name }}</a>
 				<#
 			} else {
 				#>
-				<div {{{ view.getRenderAttributeString( 'testimonial_name' ) }}}>{{{ settings.testimonial_name }}}</div>
+				<div {{{ view.getRenderAttributeString( 'testimonial_name' ) }}}>{{ settings.testimonial_name }}</div>
 				<#
 			}
 		}
@@ -638,11 +638,11 @@ class Widget_Testimonial extends Widget_Base {
 
 			if ( settings.link.url ) {
 				#>
-				<a href="{{  elementor.helpers.sanitizeUrl( settings.link.url ) }}" {{{ view.getRenderAttributeString( 'testimonial_job' ) }}}>{{{ settings.testimonial_job }}}</a>
+				<a href="{{  elementor.helpers.sanitizeUrl( settings.link.url ) }}" {{{ view.getRenderAttributeString( 'testimonial_job' ) }}}>{{ settings.testimonial_job }}</a>
 				<#
 			} else {
 				#>
-				<div {{{ view.getRenderAttributeString( 'testimonial_job' ) }}}>{{{ settings.testimonial_job }}}</div>
+				<div {{{ view.getRenderAttributeString( 'testimonial_job' ) }}}>{{ settings.testimonial_job }}</div>
 				<#
 			}
 		}

--- a/includes/widgets/traits/button-trait.php
+++ b/includes/widgets/traits/button-trait.php
@@ -631,7 +631,7 @@ trait Button_Trait {
 					</span>
 					<# } #>
 					<# if ( settings.text ) { #>
-					<span {{{ view.getRenderAttributeString( 'text' ) }}}>{{{ settings.text }}}</span>
+					<span {{{ view.getRenderAttributeString( 'text' ) }}}>{{ settings.text }}</span>
 					<# } #>
 				</span>
 			</a>
@@ -688,7 +688,7 @@ trait Button_Trait {
 			</span>
 			<?php endif; ?>
 			<?php if ( ! empty( $settings['text'] ) ) : ?>
-			<span <?php $instance->print_render_attribute_string( 'text' ); ?>><?php $this->print_unescaped_setting( 'text' ); ?></span>
+			<span <?php $instance->print_render_attribute_string( 'text' ); ?>><?php echo wp_kses_post( $settings['text'] ); ?></span>
 			<?php endif; ?>
 		</span>
 		<?php


### PR DESCRIPTION
Ref: https://github.com/elementor/elementor/pull/29529/files

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove usage of unsafe `print_unescaped_setting()` function and replace with WordPress' `wp_kses_post()` to improve security by properly escaping output.
Main changes:
- Replaced `print_unescaped_setting()` with `wp_kses_post()` in Alert, Counter, Icon Box, and Testimonial widgets
- Changed triple curly braces output `{{{ settings.text }}}` to double curly braces `{{ settings.text }}` in JavaScript templates
- Implemented proper HTML sanitization for button text, testimonial content, and alert descriptions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
