### PR TITLE
Tweak: Keep the placeholder unit on size control [ED-20062]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/__tests__/size-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/size-control.test.tsx
@@ -634,5 +634,34 @@ describe( 'SizeControl', () => {
 			expect( sizeInput ).not.toHaveAttribute( 'placeholder' );
 			expect( unitButton ).toHaveTextContent( 'px' );
 		} );
+
+		it( 'should keep the placeholder unit when value got changed', () => {
+			// Arrange.
+			const setValue = jest.fn();
+			const props = {
+				setValue,
+				bind: 'select',
+				disabled: true,
+				propType,
+				placeholder: {
+					$$type: 'size',
+					value: {
+						size: 200,
+						unit: '%',
+					},
+				},
+			};
+
+			// Act.
+			renderControl( <SizeControl />, props );
+
+			const sizeInput = screen.getByRole( 'spinbutton' );
+			fireEvent.change( sizeInput, { target: { value: '123' } } );
+			const unitButton = screen.getByRole( 'button' );
+
+			// Assert.
+			expect( sizeInput ).toHaveDisplayValue( '123' );
+			expect( unitButton ).toHaveTextContent( '%' );
+		} );
 	} );
 } );

--- a/packages/packages/libs/editor-controls/src/controls/size-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/size-control.tsx
@@ -87,11 +87,16 @@ export const SizeControl = createControl(
 		extendedOptions,
 		disableCustom,
 	}: Omit< SizeControlProps, 'variant' > & { variant?: SizeVariant } ) => {
-		const { value: sizeValue, setValue: setSizeValue, disabled, restoreValue, placeholder: externalPlaceholder } = useBoundProp( sizePropTypeUtil );
+		const {
+			value: sizeValue,
+			setValue: setSizeValue,
+			disabled,
+			restoreValue,
+			placeholder: externalPlaceholder,
+		} = useBoundProp( sizePropTypeUtil );
 		const actualDefaultUnit = defaultUnit ?? externalPlaceholder?.unit ?? defaultSelectedUnit[ variant ];
-		const actualDefaultSize = externalPlaceholder?.size ?? DEFAULT_SIZE;
 		const actualUnits = units ?? [ ...defaultUnits[ variant ] ];
-		const [ internalState, setInternalState ] = useState( createStateFromSizeProp( sizeValue, actualDefaultUnit, actualDefaultSize ) );
+		const [ internalState, setInternalState ] = useState( createStateFromSizeProp( sizeValue, actualDefaultUnit ) );
 		const activeBreakpoint = useActiveBreakpoint();
 
 		const actualExtendedOptions = useSizeExtendedOptions( extendedOptions || [], disableCustom ?? false );
@@ -113,12 +118,12 @@ export const SizeControl = createControl(
 			},
 			fallback: ( newState ) => ( {
 				unit: newState?.unit ?? actualDefaultUnit,
-				numeric: newState?.numeric ?? Number( actualDefaultSize ) ?? DEFAULT_SIZE,
+				numeric: newState?.numeric ?? DEFAULT_SIZE,
 				custom: newState?.custom ?? '',
 			} ),
 		} );
 
-		const { size: controlSize = actualDefaultSize, unit: controlUnit = actualDefaultUnit } =
+		const { size: controlSize = DEFAULT_SIZE, unit: controlUnit = actualDefaultUnit } =
 			extractValueFromState( state ) || {};
 
 		const handleUnitChange = ( newUnit: Unit | ExtendedOption ) => {
@@ -230,7 +235,11 @@ function formatSize< TSize extends string | number >( size: TSize, unit: Unit | 
 	return size || size === 0 ? ( Number( size ) as TSize ) : ( NaN as TSize );
 }
 
-function createStateFromSizeProp( sizeValue: SizeValue | null, defaultUnit: Unit | ExtendedOption, defaultSize: string | number = '' ): State {
+function createStateFromSizeProp(
+	sizeValue: SizeValue | null,
+	defaultUnit: Unit | ExtendedOption,
+	defaultSize: string | number = ''
+): State {
 	const unit = sizeValue?.unit ?? defaultUnit;
 	const size = sizeValue?.size ?? defaultSize;
 

--- a/packages/packages/libs/editor-controls/src/controls/size-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/size-control.tsx
@@ -87,10 +87,11 @@ export const SizeControl = createControl(
 		extendedOptions,
 		disableCustom,
 	}: Omit< SizeControlProps, 'variant' > & { variant?: SizeVariant } ) => {
-		const actualDefaultUnit = defaultUnit ?? defaultSelectedUnit[ variant ];
+		const { value: sizeValue, setValue: setSizeValue, disabled, restoreValue, placeholder: externalPlaceholder } = useBoundProp( sizePropTypeUtil );
+		const actualDefaultUnit = defaultUnit ?? externalPlaceholder?.unit ?? defaultSelectedUnit[ variant ];
+		const actualDefaultSize = externalPlaceholder?.size ?? DEFAULT_SIZE;
 		const actualUnits = units ?? [ ...defaultUnits[ variant ] ];
-		const { value: sizeValue, setValue: setSizeValue, disabled, restoreValue } = useBoundProp( sizePropTypeUtil );
-		const [ internalState, setInternalState ] = useState( createStateFromSizeProp( sizeValue, actualDefaultUnit ) );
+		const [ internalState, setInternalState ] = useState( createStateFromSizeProp( sizeValue, actualDefaultUnit, actualDefaultSize ) );
 		const activeBreakpoint = useActiveBreakpoint();
 
 		const actualExtendedOptions = useSizeExtendedOptions( extendedOptions || [], disableCustom ?? false );
@@ -112,12 +113,12 @@ export const SizeControl = createControl(
 			},
 			fallback: ( newState ) => ( {
 				unit: newState?.unit ?? actualDefaultUnit,
-				numeric: newState?.numeric ?? DEFAULT_SIZE,
+				numeric: newState?.numeric ?? Number( actualDefaultSize ) ?? DEFAULT_SIZE,
 				custom: newState?.custom ?? '',
 			} ),
 		} );
 
-		const { size: controlSize = DEFAULT_SIZE, unit: controlUnit = actualDefaultUnit } =
+		const { size: controlSize = actualDefaultSize, unit: controlUnit = actualDefaultUnit } =
 			extractValueFromState( state ) || {};
 
 		const handleUnitChange = ( newUnit: Unit | ExtendedOption ) => {
@@ -229,9 +230,9 @@ function formatSize< TSize extends string | number >( size: TSize, unit: Unit | 
 	return size || size === 0 ? ( Number( size ) as TSize ) : ( NaN as TSize );
 }
 
-function createStateFromSizeProp( sizeValue: SizeValue | null, defaultUnit: Unit | ExtendedOption ): State {
+function createStateFromSizeProp( sizeValue: SizeValue | null, defaultUnit: Unit | ExtendedOption, defaultSize: string | number = '' ): State {
 	const unit = sizeValue?.unit ?? defaultUnit;
-	const size = sizeValue?.size ?? '';
+	const size = sizeValue?.size ?? defaultSize;
 
 	return {
 		numeric:


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update size control component to maintain placeholder unit when value changes, improving UX consistency.

Main changes:
- Modified createStateFromSizeProp to handle placeholder units with defaultSize parameter
- Added access to external placeholder via useBoundProp for unit persistence
- Implemented test case to verify placeholder unit persistence during value changes

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
