### PR TITLE
Revert "Internal: Issues write permissions in the build"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,6 @@ jobs:
       changelog_diff: ${{ steps.changelog_diff_files.outputs.diff }}
     permissions:
       pull-requests: write
-      issues: write
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4


### PR DESCRIPTION
Reverts elementor/elementor#31920
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert unnecessary 'issues: write' permissions in GitHub workflow file that were added in a previous commit.

Main changes:
- Removed 'issues: write' permission from build.yml workflow permissions section while retaining 'pull-requests: write'

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
