### PR TITLE
Internal: Revert "Optimized Markup" activation for all websites [ED-20115]

### DIFF
--- a/core/experiments/manager.php
+++ b/core/experiments/manager.php
@@ -370,7 +370,11 @@ class Manager extends Base_Object {
 			'tag' => esc_html__( 'Performance', 'elementor' ),
 			'description' => esc_html__( 'Reduce the DOM size by eliminating HTML tags in various elements and widgets. This experiment includes markup changes so it might require updating custom CSS/JS code and cause compatibility issues with third party plugins.', 'elementor' ),
 			'release_status' => self::RELEASE_STATUS_STABLE,
-			'default' => self::STATE_ACTIVE,
+			'default' => self::STATE_INACTIVE,
+			'new_site' => [
+				'default_active' => true,
+				'minimum_installation_version' => '3.30.0',
+			],
 		] );
 	}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert automatic activation of the "Optimized Markup" feature for existing websites while preserving activation for new installations.

Main changes:
- Changed default state from ACTIVE to INACTIVE for existing sites
- Added conditional activation only for new sites installed after version 3.30.0

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
