### PR TITLE
Internal: Update `@elementor/ui` version back to 1.36.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.32.0",
       "dependencies": {
         "@elementor/icons": "1.51.0",
-        "@elementor/ui": "1.36.0",
+        "@elementor/ui": "1.36.2",
         "@reach/router": "1.3.4",
         "@reduxjs/toolkit": "^1.8.3",
         "@woocommerce/admin-layout": "^1.1.0",
@@ -3541,9 +3541,10 @@
       }
     },
     "node_modules/@elementor/ui": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.0.tgz",
-      "integrity": "sha512-/+SuvYceHRYazC+dLht0bgwlZQ1Qha8SZ92qbOZKJIU6vH/BeiwRZwd7OqWxPtP17XRohudhtNb6i0EmNNR7+Q==",
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.2.tgz",
+      "integrity": "sha512-TpdT6Q5IJEnn5Bn+8167LJe57377FT+uQx6O8fY+wmQ3VCSmqwqxdmEigaqG6UpB4QYHDD3igQFjQu7imdX97A==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/modifiers": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   },
   "dependencies": {
     "@elementor/icons": "1.51.0",
-    "@elementor/ui": "1.36.0",
+    "@elementor/ui": "1.36.2",
     "@reach/router": "1.3.4",
     "@reduxjs/toolkit": "^1.8.3",
     "@woocommerce/admin-layout": "^1.1.0",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update @elementor/ui dependency from version 1.36.0 to 1.36.2 to maintain compatibility with dependent components.
Main changes:
- Bumped @elementor/ui package version from 1.36.0 to 1.36.2 in package.json dependencies

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
