### PR TITLE
Fix: Color for repeatable control labels [ED-20090]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/__tests__/repeatable-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/repeatable-control.test.tsx
@@ -13,6 +13,8 @@ jest.mock( '../../bound-prop-context', () => ( {
 
 import { useBoundProp } from '../../bound-prop-context';
 const mockUseBoundProp = useBoundProp as jest.MockedFunction< typeof useBoundProp >;
+const TEXT_PRIMARY_COLOR = 'rgb(12, 13, 14)';
+const TEXT_TERTIARY_COLOR = 'rgb(105, 114, 125)';
 
 const stringPropType = createMockPropType( { kind: 'object' } );
 
@@ -207,7 +209,9 @@ describe( '<RepeatableControl />', () => {
 			);
 
 			// Assert.
-			expect( screen.getByText( 'Empty item' ) ).toBeInTheDocument();
+			const placeholderElement = screen.getByText( 'Empty item' );
+			expect( placeholderElement ).toBeInTheDocument();
+			expect( placeholderElement ).toHaveStyle( { color: TEXT_TERTIARY_COLOR } );
 		} );
 
 		it( 'should show placeholder when pattern has placeholders but data has empty string', () => {
@@ -240,7 +244,9 @@ describe( '<RepeatableControl />', () => {
 			);
 
 			// Assert.
-			expect( screen.getByText( 'Empty item' ) ).toBeInTheDocument();
+			const placeholderElement = screen.getByText( 'Empty item' );
+			expect( placeholderElement ).toBeInTheDocument();
+			expect( placeholderElement ).toHaveStyle( { color: TEXT_TERTIARY_COLOR } );
 		} );
 
 		it( 'should show placeholder when pattern has placeholders but data has whitespace-only string', () => {
@@ -273,7 +279,9 @@ describe( '<RepeatableControl />', () => {
 			);
 
 			// Assert.
-			expect( screen.getByText( 'Empty item' ) ).toBeInTheDocument();
+			const placeholderElement = screen.getByText( 'Empty item' );
+			expect( placeholderElement ).toBeInTheDocument();
+			expect( placeholderElement ).toHaveStyle( { color: TEXT_TERTIARY_COLOR } );
 		} );
 
 		it( 'should show interpolated pattern when data has valid values', () => {
@@ -306,7 +314,9 @@ describe( '<RepeatableControl />', () => {
 			);
 
 			// Assert.
-			expect( screen.getByText( 'Item: Hello World' ) ).toBeInTheDocument();
+			const labelElement = screen.getByText( 'Item: Hello World' );
+			expect( labelElement ).toBeInTheDocument();
+			expect( labelElement ).toHaveStyle( { color: TEXT_PRIMARY_COLOR } );
 		} );
 
 		it( 'should show interpolated pattern when no placeholders are present', () => {
@@ -339,7 +349,9 @@ describe( '<RepeatableControl />', () => {
 			);
 
 			// Assert.
-			expect( screen.getByText( 'Static Label' ) ).toBeInTheDocument();
+			const labelElement = screen.getByText( 'Static Label' );
+			expect( labelElement ).toBeInTheDocument();
+			expect( labelElement ).toHaveStyle( { color: TEXT_PRIMARY_COLOR } );
 		} );
 
 		it( 'should show interpolated pattern when nested object properties exist', () => {
@@ -373,7 +385,9 @@ describe( '<RepeatableControl />', () => {
 			);
 
 			// Assert.
-			expect( screen.getByText( 'User: John Doe - john@example.com' ) ).toBeInTheDocument();
+			const labelElement = screen.getByText( 'User: John Doe - john@example.com' );
+			expect( labelElement ).toBeInTheDocument();
+			expect( labelElement ).toHaveStyle( { color: TEXT_PRIMARY_COLOR } );
 		} );
 
 		it( 'should show placeholder when nested object properties are missing', () => {
@@ -407,7 +421,9 @@ describe( '<RepeatableControl />', () => {
 			);
 
 			// Assert.
-			expect( screen.getByText( 'No user data' ) ).toBeInTheDocument();
+			const placeholderElement = screen.getByText( 'No user data' );
+			expect( placeholderElement ).toBeInTheDocument();
+			expect( placeholderElement ).toHaveStyle( { color: TEXT_TERTIARY_COLOR } );
 		} );
 
 		it( 'should show interpolated pattern when some values are considered empty but others are not', () => {
@@ -441,7 +457,9 @@ describe( '<RepeatableControl />', () => {
 			);
 
 			// Assert.
-			expect( screen.getByText( 'Title: My Title - Description:' ) ).toBeInTheDocument();
+			const labelElement = screen.getByText( 'Title: My Title - Description:' );
+			expect( labelElement ).toBeInTheDocument();
+			expect( labelElement ).toHaveStyle( { color: TEXT_PRIMARY_COLOR } );
 		} );
 
 		it( 'should show placeholder when all pattern values are empty', () => {
@@ -475,7 +493,9 @@ describe( '<RepeatableControl />', () => {
 			);
 
 			// Assert.
-			expect( screen.getByText( 'All empty' ) ).toBeInTheDocument();
+			const placeholderElement = screen.getByText( 'All empty' );
+			expect( placeholderElement ).toBeInTheDocument();
+			expect( placeholderElement ).toHaveStyle( { color: TEXT_TERTIARY_COLOR } );
 		} );
 	} );
 } );

--- a/packages/packages/libs/editor-controls/src/controls/repeatable-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/repeatable-control.tsx
@@ -183,11 +183,12 @@ const shouldShowPlaceholder = ( pattern: string, data: Record< string, unknown >
 
 const ItemLabel = ( { value }: { value: Record< string, unknown > } ) => {
 	const { placeholder, patternLabel } = useRepeatableControlContext();
-
-	const label = shouldShowPlaceholder( patternLabel, value ) ? placeholder : interpolate( patternLabel, value );
+	const showPlaceholder = shouldShowPlaceholder( patternLabel, value );
+	const label = showPlaceholder ? placeholder : interpolate( patternLabel, value );
+	const color = showPlaceholder ? 'text.tertiary' : 'text.primary';
 
 	return (
-		<Box component="span" color="text.tertiary">
+		<Box component="span" color={ color }>
 			{ label }
 		</Box>
 	);


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix color styling in repeatable control labels to visually differentiate between placeholders and actual content.
Main changes:
- Updated ItemLabel component to dynamically set text color based on content type (placeholder vs actual data)
- Added consistent styling with TEXT_TERTIARY_COLOR for placeholders and TEXT_PRIMARY_COLOR for populated content
- Extended tests to verify proper color application for both placeholder and populated label scenarios

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
