### PR TITLE
Fix: When the attribute value is longer than one word, it breaks [ED -20187]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.html.twig
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.html.twig
@@ -6,12 +6,12 @@
             href="{{ settings.link.href }}"
             target="{{ settings.link.target }}"
             class="{{ classes }}"
-            {{ id_attribute }} {{ settings.attributes }}
+            {{ id_attribute }} {{ settings.attributes | raw }}
         >
             {{ settings.text }}
         </a>
     {% else %}
-        <button class="{{ classes }}" {{ id_attribute }} {{ settings.attributes }}>
+        <button class="{{ classes }}" {{ id_attribute }} {{ settings.attributes | raw }}>
             {{ settings.text }}
         </button>
     {% endif %}

--- a/modules/atomic-widgets/elements/atomic-divider/atomic-divider.html.twig
+++ b/modules/atomic-widgets/elements/atomic-divider/atomic-divider.html.twig
@@ -1,4 +1,4 @@
 {% set classes = settings.classes | merge( [ base_styles.base ] ) | join(' ') %}
 {% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
 
-<hr class="{{ classes }}" {{ id_attribute }} {{ settings.attributes }} />
+<hr class="{{ classes }}" {{ id_attribute }} {{ settings.attributes | raw }} />

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -1,6 +1,6 @@
 {% if settings.title is not empty %}
 	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
-	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }} {{ settings.attributes }}>
+	<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }} {{ settings.attributes | raw }}>
 	{% if settings.link.href %}
 		<a href="{{ settings.link.href }}" target="{{ settings.link.target }}" class="{{ base_styles['link-base'] }}">
 			{{ settings.title }}

--- a/modules/atomic-widgets/elements/atomic-image/atomic-image.html.twig
+++ b/modules/atomic-widgets/elements/atomic-image/atomic-image.html.twig
@@ -3,7 +3,7 @@
 	{% if settings.link.href %}
 		<a href="{{ settings.link.href }}" class="{{ base_styles['link-base'] }}" target="{{ settings.link.target }}">
 	{% endif %}
-	<img class="{{ base_styles['base'] }} {{ settings.classes | join(' ') }}" {{ id_attribute }} {{ settings.attributes }}
+	<img class="{{ base_styles['base'] }} {{ settings.classes | join(' ') }}" {{ id_attribute }} {{ settings.attributes | raw }}
 		{% for attr, value in settings.image %}
 			{% if attr == 'src' %}
 				src="{{ value | e('full_url') }}"

--- a/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.html.twig
+++ b/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.html.twig
@@ -1,6 +1,6 @@
 {% if settings.paragraph is not empty %}
 	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
-		<p class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }} {{ settings.attributes }}>
+		<p class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" {{ id_attribute }} {{ settings.attributes | raw }}>
 				{% if settings.link.href %}
 						<a href="{{ settings.link.href }}" target="{{ settings.link.target }}" class="{{ base_styles['link-base'] }}">
 								{{ settings.paragraph }}

--- a/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.html.twig
+++ b/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.html.twig
@@ -14,5 +14,5 @@
 		'privacy': settings.privacy_mode,
 		'lazyload': settings.lazyload,
 	} %}
-	<div data-id="{{ id }}" data-e-type="{{ type }}" {{ id_attribute }} class="{{ classes }}" {{ settings.attributes }} data-settings="{{ data_settings|json_encode|e('html_attr') }}"></div>
+	<div data-id="{{ id }}" data-e-type="{{ type }}" {{ id_attribute }} class="{{ classes }}" {{ settings.attributes | raw }} data-settings="{{ data_settings|json_encode|e('html_attr') }}"></div>
 {% endif %}

--- a/modules/atomic-widgets/elements/div-block/div-block.php
+++ b/modules/atomic-widgets/elements/div-block/div-block.php
@@ -149,7 +149,7 @@ class Div_Block extends Atomic_Element_Base {
 		$settings = $this->get_atomic_settings();
 		$attributes = $settings['attributes'];
 		if ( ! empty( $attributes ) && is_string( $attributes ) ) {
-			echo ' ' . esc_attr( $attributes );
+			echo ' ' . $attributes;
 		}
 	}
 

--- a/modules/atomic-widgets/elements/div-block/div-block.php
+++ b/modules/atomic-widgets/elements/div-block/div-block.php
@@ -149,6 +149,7 @@ class Div_Block extends Atomic_Element_Base {
 		$settings = $this->get_atomic_settings();
 		$attributes = $settings['attributes'];
 		if ( ! empty( $attributes ) && is_string( $attributes ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo ' ' . $attributes;
 		}
 	}

--- a/modules/atomic-widgets/props-resolver/transformers/settings/attributes-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/settings/attributes-transformer.php
@@ -20,7 +20,7 @@ class Attributes_Transformer extends Transformer_Base {
 				return '';
 			}
 			$escaped_value = esc_attr( $item['value'] );
-			return $item['key'] . '=' . $escaped_value;
+			return $item['key'] . '="' . $escaped_value . '"';
 		}, $value ) );
 
 		return $result;


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix attributes rendering in atomic widgets by properly formatting HTML attributes and ensuring safe output with raw filter

Main changes:
- Fixed attribute value formatting in Attributes_Transformer by adding quotes around values
- Added raw filter to all Twig templates when outputting custom attributes to prevent HTML escaping
- Updated all atomic widget templates for consistent attribute handling (button, divider, heading, image, paragraph, youtube)

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
