### PR TITLE
Internal: Tweak behavior [ED-20221]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
@@ -10,13 +10,15 @@ import { useElement } from '../../contexts/element-context';
 import { useStyle } from '../../contexts/style-context';
 
 export const { Slot: CssClassConvertSlot, inject: injectIntoCssClassConvert } = createLocation< {
-	styleDef: StyleDefinition;
+	styleDef: StyleDefinition | null;
 	successCallback: ( newId: string ) => void;
+	canConvert?: boolean;
 } >();
 
 type OwnProps = {
-	styleDef: StyleDefinition;
+	styleDef: StyleDefinition | null;
 	closeMenu: () => void;
+	canConvert: boolean;
 };
 
 /**
@@ -35,14 +37,22 @@ export const CssClassConvert = ( props: OwnProps ) => {
 			newId,
 			elementId,
 			classesProp: currentClassesProp,
-			styleDef: props.styleDef,
+			// at this point styleDef is always set, otherwise the menu would not appear
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			styleDef: props.styleDef!,
 		} );
 		saveValue( newId );
 		setActiveId( newId );
 		props.closeMenu();
 	};
 
-	return <CssClassConvertSlot styleDef={ props.styleDef } successCallback={ successCallback } />;
+	return (
+		<CssClassConvertSlot
+			canConvert={ !! props.canConvert }
+			styleDef={ props.styleDef }
+			successCallback={ successCallback }
+		/>
+	);
 };
 
 type OnPromoteSuccessOpts = {

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
@@ -10,9 +10,8 @@ import { type StyleDefinitionStateWithNormal } from '../../styles-inheritance/ty
 import { getTempStylesProviderThemeColor } from '../../utils/get-styles-provider-color';
 import { StyleIndicator } from '../style-indicator';
 import { useCssClass } from './css-class-context';
-import { CssClassConvert } from './css-class-convert-local';
+import { LocalClassSubMenu } from './local-class-sub-menu';
 import { useUnapplyClass } from './use-apply-and-unapply-class';
-import { useCanConvertLocalClassToGlobal } from './use-can-convert-local-class-to-global';
 
 type State = {
 	key: StyleDefinitionStateWithNormal;
@@ -33,8 +32,8 @@ type CssClassMenuProps = {
 };
 
 export function CssClassMenu( { popupState, anchorEl, fixed }: CssClassMenuProps ) {
-	const { provider } = useCssClass();
-	const { canPromote, styleDef } = useCanConvertLocalClassToGlobal();
+	const { provider, label } = useCssClass();
+	const isLocalStyle = label.toLowerCase() === 'local';
 
 	const handleKeyDown = ( e: React.KeyboardEvent< HTMLElement > ) => {
 		e.stopPropagation();
@@ -57,14 +56,7 @@ export function CssClassMenu( { popupState, anchorEl, fixed }: CssClassMenuProps
 			// Workaround for focus-visible issue.
 			disableAutoFocusItem
 		>
-			{ canPromote && styleDef && (
-				<>
-					<MenuSubheader sx={ { typography: 'caption', color: 'text.secondary', pb: 0.5, pt: 1 } }>
-						{ __( 'Actions', 'elementor' ) }
-					</MenuSubheader>
-					<CssClassConvert styleDef={ styleDef } closeMenu={ popupState.close } />
-				</>
-			) }
+			{ isLocalStyle && <LocalClassSubMenu popupState={ popupState } /> }
 			{ /* It has to be an array since MUI menu doesn't accept a Fragment as a child, and wrapping the items with an HTML element disrupts keyboard navigation */ }
 			{ getMenuItemsByProvider( { provider, closeMenu: popupState.close, fixed } ) }
 			<MenuSubheader sx={ { typography: 'caption', color: 'text.secondary', pb: 0.5, pt: 1 } }>

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/local-class-sub-menu.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/local-class-sub-menu.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { MenuSubheader, type PopupState } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import { CssClassConvert } from './css-class-convert-local';
+import { useCanConvertLocalClassToGlobal } from './use-can-convert-local-class-to-global';
+
+type OwnProps = {
+	popupState: PopupState;
+};
+
+export const LocalClassSubMenu = ( props: OwnProps ) => {
+	const { canPromote, styleDef } = useCanConvertLocalClassToGlobal();
+	return (
+		<>
+			<MenuSubheader sx={ { typography: 'caption', color: 'text.secondary', pb: 0.5, pt: 1 } }>
+				{ __( 'Local Class', 'elementor' ) }
+			</MenuSubheader>
+			<CssClassConvert canConvert={ canPromote } styleDef={ styleDef } closeMenu={ props.popupState.close } />
+		</>
+	);
+};

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/use-can-convert-local-class-to-global.ts
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/use-can-convert-local-class-to-global.ts
@@ -15,6 +15,8 @@ export const useCanConvertLocalClassToGlobal = () => {
 
 	return {
 		canPromote,
+		isLocalStylesProvider,
+		id,
 		styleDef: styleDef || null,
 	};
 };

--- a/packages/packages/core/editor-global-classes/src/components/convert-local-class-to-global-class.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/convert-local-class-to-global-class.tsx
@@ -10,13 +10,14 @@ import { globalClassesStylesProvider } from '../global-classes-styles-provider';
 type OwnProps = {
 	successCallback: ( _: string ) => void;
 	styleDef: StyleDefinition;
+	canConvert: boolean;
 };
 
 export const ConvertLocalClassToGlobalClass = ( props: OwnProps ) => {
 	const localStyleData = props.styleDef;
 
 	const handlePromote = () => {
-		const classNamePrefix = `local-copy-`;
+		const classNamePrefix = `converted-class-`;
 		let i = 1;
 		let isValid = false;
 		let newClassName = ``;
@@ -35,6 +36,7 @@ export const ConvertLocalClassToGlobalClass = ( props: OwnProps ) => {
 	return (
 		<>
 			<MenuListItem
+				disabled={ ! props.canConvert }
 				onClick={ handlePromote }
 				dense
 				sx={ {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Behavior Tweak

## Summary

This PR can be summarized in the following changelog entry:
See https://elementor.atlassian.net/browse/ED-20221

*

## Description
An explanation of what is done in this PR
See https://elementor.atlassian.net/browse/ED-20221

*

## Test instructions
This PR can be tested by following these steps:

* Convert is always visible, but disabled when no actual changeset is applicable for conversion.

## Quality assurance

- [X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update local-to-global class conversion in editor panel with improved component structure and visual organization.
Main changes:
- Refactored class conversion logic into a dedicated LocalClassSubMenu component
- Made styleDef parameter nullable to handle cases when style definition is not available
- Added canConvert flag to control menu item enablement
- Changed converted class prefix from "local-copy-" to "converted-class-"

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
