### PR TITLE
Internal: Angie creates Pro elements to non connected pro users [AI-3856]

### DIFF
--- a/modules/promotions/widgets/pro-widget-promotion.php
+++ b/modules/promotions/widgets/pro-widget-promotion.php
@@ -28,6 +28,10 @@ class Pro_Widget_Promotion extends Widget_Base {
 		return $this->widget_data['widget_title'];
 	}
 
+	public function get_categories() {
+		return [ 'general', 'pro-elements' ];
+	}
+
 	public function on_import( $element ) {
 		$element['settings']['__should_import'] = true;
 


### PR DESCRIPTION
Pro elements should be tagged in the correct category, like in the Pro plugin, for correct filtering when needed
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add Pro Elements category to non-connected pro user widgets to improve discoverability and organization in the Elementor editor.
Main changes:
- Implemented get_categories() method in Pro_Widget_Promotion class to include 'pro-elements' category

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
