### PR TITLE
Internal: Update class conversion behavior [ED-20221]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/__tests__/css-class-selector.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/__tests__/css-class-selector.test.tsx
@@ -49,7 +49,7 @@ jest.mock( '@elementor/editor-documents', () => ( {
 
 jest.mock( '../use-can-convert-local-class-to-global', () => ( {
 	useCanConvertLocalClassToGlobal: jest.fn( () => ( {
-		canPromote: false,
+		canConvert: false,
 		styleDef: null,
 	} ) ),
 } ) );

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
@@ -10,13 +10,15 @@ import { useElement } from '../../contexts/element-context';
 import { useStyle } from '../../contexts/style-context';
 
 export const { Slot: CssClassConvertSlot, inject: injectIntoCssClassConvert } = createLocation< {
-	styleDef: StyleDefinition;
+	styleDef: StyleDefinition | null;
 	successCallback: ( newId: string ) => void;
+	canConvert?: boolean;
 } >();
 
 type OwnProps = {
-	styleDef: StyleDefinition;
+	styleDef: StyleDefinition | null;
 	closeMenu: () => void;
+	canConvert: boolean;
 };
 
 /**
@@ -35,14 +37,22 @@ export const CssClassConvert = ( props: OwnProps ) => {
 			newId,
 			elementId,
 			classesProp: currentClassesProp,
-			styleDef: props.styleDef,
+			// at this point styleDef is always set, otherwise the menu would not appear
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			styleDef: props.styleDef!,
 		} );
 		saveValue( newId );
 		setActiveId( newId );
 		props.closeMenu();
 	};
 
-	return <CssClassConvertSlot styleDef={ props.styleDef } successCallback={ successCallback } />;
+	return (
+		<CssClassConvertSlot
+			canConvert={ !! props.canConvert }
+			styleDef={ props.styleDef }
+			successCallback={ successCallback }
+		/>
+	);
 };
 
 type OnPromoteSuccessOpts = {

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
@@ -12,7 +12,7 @@ import { useStyle } from '../../contexts/style-context';
 export const { Slot: CssClassConvertSlot, inject: injectIntoCssClassConvert } = createLocation< {
 	styleDef: StyleDefinition | null;
 	successCallback: ( newId: string ) => void;
-	canConvert?: boolean;
+	canConvert: boolean;
 } >();
 
 type OwnProps = {

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
@@ -43,7 +43,7 @@ export const CssClassConvert = ( props: OwnProps ) => {
 			classesProp: currentClassesProp,
 			styleDef: props.styleDef,
 		} );
-		
+
 		saveValue( newId );
 		setActiveId( newId );
 		props.closeMenu();

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
@@ -33,14 +33,17 @@ export const CssClassConvert = ( props: OwnProps ) => {
 	const [ , saveValue ] = useSessionStorage( `last-converted-class-generated-name` );
 
 	const successCallback = ( newId: string ) => {
+		if ( ! props.styleDef ) {
+			throw new Error( 'Style definition is required for converting local class to global class.' );
+		}
+
 		onPromoteSuccess( {
 			newId,
 			elementId,
 			classesProp: currentClassesProp,
-			// at this point styleDef is always set, otherwise the menu would not appear
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			styleDef: props.styleDef!,
+			styleDef: props.styleDef,
 		} );
+		
 		saveValue( newId );
 		setActiveId( newId );
 		props.closeMenu();

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
@@ -22,7 +22,7 @@ type OwnProps = {
 };
 
 /**
- * Promote a local class to a global class injection point
+ * Convert a local class to a global class injection point
  * @param props
  */
 export const CssClassConvert = ( props: OwnProps ) => {
@@ -37,7 +37,7 @@ export const CssClassConvert = ( props: OwnProps ) => {
 			throw new Error( 'Style definition is required for converting local class to global class.' );
 		}
 
-		onPromoteSuccess( {
+		onConvert( {
 			newId,
 			elementId,
 			classesProp: currentClassesProp,
@@ -58,13 +58,14 @@ export const CssClassConvert = ( props: OwnProps ) => {
 	);
 };
 
-type OnPromoteSuccessOpts = {
+type OnConvertOptions = {
 	newId: string;
 	elementId: string;
 	classesProp: string;
 	styleDef: StyleDefinition;
 };
-const onPromoteSuccess = ( opts: OnPromoteSuccessOpts ) => {
+
+const onConvert = ( opts: OnConvertOptions ) => {
 	const { newId, elementId, classesProp } = opts;
 	deleteElementStyle( elementId, opts.styleDef.id );
 	const currentUsedClasses = getElementSetting< ClassesPropValue >( elementId, classesProp ) || { value: [] };

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { type StyleDefinitionState } from '@elementor/editor-styles';
-import { isElementsStylesProvider, stylesRepository, useUserStylesCapability } from '@elementor/editor-styles-repository';
+import {
+	isElementsStylesProvider,
+	stylesRepository,
+	useUserStylesCapability,
+} from '@elementor/editor-styles-repository';
 import { MenuItemInfotip, MenuListItem } from '@elementor/editor-ui';
 import { bindMenu, Divider, Menu, MenuSubheader, type PopupState, Stack } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
@@ -33,7 +37,7 @@ type CssClassMenuProps = {
 
 export function CssClassMenu( { popupState, anchorEl, fixed }: CssClassMenuProps ) {
 	const { provider } = useCssClass();
-	const isLocalStyle = provider ? isElementsStylesProvider( provider ) : true
+	const isLocalStyle = provider ? isElementsStylesProvider( provider ) : true;
 
 	const handleKeyDown = ( e: React.KeyboardEvent< HTMLElement > ) => {
 		e.stopPropagation();

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
@@ -10,9 +10,8 @@ import { type StyleDefinitionStateWithNormal } from '../../styles-inheritance/ty
 import { getTempStylesProviderThemeColor } from '../../utils/get-styles-provider-color';
 import { StyleIndicator } from '../style-indicator';
 import { useCssClass } from './css-class-context';
-import { CssClassConvert } from './css-class-convert-local';
+import { LocalClassSubMenu } from './local-class-sub-menu';
 import { useUnapplyClass } from './use-apply-and-unapply-class';
-import { useCanConvertLocalClassToGlobal } from './use-can-convert-local-class-to-global';
 
 type State = {
 	key: StyleDefinitionStateWithNormal;
@@ -33,8 +32,8 @@ type CssClassMenuProps = {
 };
 
 export function CssClassMenu( { popupState, anchorEl, fixed }: CssClassMenuProps ) {
-	const { provider } = useCssClass();
-	const { canPromote, styleDef } = useCanConvertLocalClassToGlobal();
+	const { provider, label } = useCssClass();
+	const isLocalStyle = label.toLowerCase() === 'local';
 
 	const handleKeyDown = ( e: React.KeyboardEvent< HTMLElement > ) => {
 		e.stopPropagation();
@@ -57,14 +56,7 @@ export function CssClassMenu( { popupState, anchorEl, fixed }: CssClassMenuProps
 			// Workaround for focus-visible issue.
 			disableAutoFocusItem
 		>
-			{ canPromote && styleDef && (
-				<>
-					<MenuSubheader sx={ { typography: 'caption', color: 'text.secondary', pb: 0.5, pt: 1 } }>
-						{ __( 'Actions', 'elementor' ) }
-					</MenuSubheader>
-					<CssClassConvert styleDef={ styleDef } closeMenu={ popupState.close } />
-				</>
-			) }
+			{ isLocalStyle && <LocalClassSubMenu popupState={ popupState } /> }
 			{ /* It has to be an array since MUI menu doesn't accept a Fragment as a child, and wrapping the items with an HTML element disrupts keyboard navigation */ }
 			{ getMenuItemsByProvider( { provider, closeMenu: popupState.close, fixed } ) }
 			<MenuSubheader sx={ { typography: 'caption', color: 'text.secondary', pb: 0.5, pt: 1 } }>

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { type StyleDefinitionState } from '@elementor/editor-styles';
-import { stylesRepository, useUserStylesCapability } from '@elementor/editor-styles-repository';
+import { isElementsStylesProvider, stylesRepository, useUserStylesCapability } from '@elementor/editor-styles-repository';
 import { MenuItemInfotip, MenuListItem } from '@elementor/editor-ui';
 import { bindMenu, Divider, Menu, MenuSubheader, type PopupState, Stack } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
@@ -32,8 +32,8 @@ type CssClassMenuProps = {
 };
 
 export function CssClassMenu( { popupState, anchorEl, fixed }: CssClassMenuProps ) {
-	const { provider, label } = useCssClass();
-	const isLocalStyle = label.toLowerCase() === 'local';
+	const { provider } = useCssClass();
+	const isLocalStyle = provider ? isElementsStylesProvider( provider ) : true
 
 	const handleKeyDown = ( e: React.KeyboardEvent< HTMLElement > ) => {
 		e.stopPropagation();

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/local-class-sub-menu.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/local-class-sub-menu.tsx
@@ -10,13 +10,14 @@ type OwnProps = {
 };
 
 export const LocalClassSubMenu = ( props: OwnProps ) => {
-	const { canPromote, styleDef } = useCanConvertLocalClassToGlobal();
+	const { canConvert, styleDef } = useCanConvertLocalClassToGlobal();
+
 	return (
 		<>
 			<MenuSubheader sx={ { typography: 'caption', color: 'text.secondary', pb: 0.5, pt: 1 } }>
 				{ __( 'Local Class', 'elementor' ) }
 			</MenuSubheader>
-			<CssClassConvert canConvert={ canPromote } styleDef={ styleDef } closeMenu={ props.popupState.close } />
+			<CssClassConvert canConvert={ canConvert } styleDef={ styleDef } closeMenu={ props.popupState.close } />
 		</>
 	);
 };

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/local-class-sub-menu.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/local-class-sub-menu.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { MenuSubheader, type PopupState } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import { CssClassConvert } from './css-class-convert-local';
+import { useCanConvertLocalClassToGlobal } from './use-can-convert-local-class-to-global';
+
+type OwnProps = {
+	popupState: PopupState;
+};
+
+export const LocalClassSubMenu = ( props: OwnProps ) => {
+	const { canPromote, styleDef } = useCanConvertLocalClassToGlobal();
+	return (
+		<>
+			<MenuSubheader sx={ { typography: 'caption', color: 'text.secondary', pb: 0.5, pt: 1 } }>
+				{ __( 'Local Class', 'elementor' ) }
+			</MenuSubheader>
+			<CssClassConvert canConvert={ canPromote } styleDef={ styleDef } closeMenu={ props.popupState.close } />
+		</>
+	);
+};

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/use-can-convert-local-class-to-global.ts
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/use-can-convert-local-class-to-global.ts
@@ -15,6 +15,8 @@ export const useCanConvertLocalClassToGlobal = () => {
 
 	return {
 		canPromote,
+		isLocalStylesProvider,
+		id,
 		styleDef: styleDef || null,
 	};
 };

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/use-can-convert-local-class-to-global.ts
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/use-can-convert-local-class-to-global.ts
@@ -11,10 +11,10 @@ export const useCanConvertLocalClassToGlobal = () => {
 	const isLocalStylesProvider = provider && isElementsStylesProvider( provider?.getKey() );
 	const variants = styleDef?.variants || [];
 
-	const canPromote = !! ( isLocalStylesProvider && variants.length );
+	const canConvert = !! ( isLocalStylesProvider && variants.length );
 
 	return {
-		canPromote,
+		canConvert,
 		isLocalStylesProvider,
 		id,
 		styleDef: styleDef || null,

--- a/packages/packages/core/editor-global-classes/src/components/convert-local-class-to-global-class.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/convert-local-class-to-global-class.tsx
@@ -9,7 +9,7 @@ import { globalClassesStylesProvider } from '../global-classes-styles-provider';
 
 type OwnProps = {
 	successCallback: ( _: string ) => void;
-	styleDef: StyleDefinition;
+	styleDef: StyleDefinition | null;
 	canConvert: boolean;
 };
 
@@ -18,6 +18,10 @@ export const ConvertLocalClassToGlobalClass = ( props: OwnProps ) => {
 
 	const handleConversion = () => {
 		const newClassName = createClassName( `converted-class-` );
+
+		if ( ! localStyleData ) {
+			throw new Error( 'Style definition is required for converting local class to global class.' );
+		}
 
 		const newId = globalClassesStylesProvider.actions.create?.( newClassName, localStyleData.variants );
 		if ( newId ) {

--- a/packages/packages/core/editor-global-classes/src/components/convert-local-class-to-global-class.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/convert-local-class-to-global-class.tsx
@@ -17,16 +17,8 @@ export const ConvertLocalClassToGlobalClass = ( props: OwnProps ) => {
 	const localStyleData = props.styleDef;
 
 	const handlePromote = () => {
-		const classNamePrefix = `converted-class-`;
-		let i = 1;
-		let isValid = false;
-		let newClassName = ``;
-		while ( ! isValid ) {
-			newClassName = `${ classNamePrefix }${ i }`;
-			const validation = validateStyleLabel( newClassName, 'create' );
-			isValid = validation.isValid;
-			i++;
-		}
+		const newClassName = createClassName( `converted-class-` );
+
 		const newId = globalClassesStylesProvider.actions.create?.( newClassName, localStyleData.variants );
 		if ( newId ) {
 			props.successCallback( newId );
@@ -53,3 +45,14 @@ export const ConvertLocalClassToGlobalClass = ( props: OwnProps ) => {
 		</>
 	);
 };
+
+function createClassName( prefix: string ): string {
+	let i = 1;
+	let newClassName = `${ prefix }${ i }`;
+
+	while ( ! validateStyleLabel( newClassName, 'create' ).isValid ) {
+		newClassName = `${ prefix }${ ++i }`;
+	}
+
+	return newClassName;
+}

--- a/packages/packages/core/editor-global-classes/src/components/convert-local-class-to-global-class.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/convert-local-class-to-global-class.tsx
@@ -16,7 +16,7 @@ type OwnProps = {
 export const ConvertLocalClassToGlobalClass = ( props: OwnProps ) => {
 	const localStyleData = props.styleDef;
 
-	const handlePromote = () => {
+	const handleConversion = () => {
 		const newClassName = createClassName( `converted-class-` );
 
 		const newId = globalClassesStylesProvider.actions.create?.( newClassName, localStyleData.variants );
@@ -29,7 +29,7 @@ export const ConvertLocalClassToGlobalClass = ( props: OwnProps ) => {
 		<>
 			<MenuListItem
 				disabled={ ! props.canConvert }
-				onClick={ handlePromote }
+				onClick={ handleConversion }
 				dense
 				sx={ {
 					'&.Mui-focusVisible': {

--- a/packages/packages/core/editor-global-classes/src/components/convert-local-class-to-global-class.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/convert-local-class-to-global-class.tsx
@@ -10,13 +10,14 @@ import { globalClassesStylesProvider } from '../global-classes-styles-provider';
 type OwnProps = {
 	successCallback: ( _: string ) => void;
 	styleDef: StyleDefinition;
+	canConvert: boolean;
 };
 
 export const ConvertLocalClassToGlobalClass = ( props: OwnProps ) => {
 	const localStyleData = props.styleDef;
 
 	const handlePromote = () => {
-		const classNamePrefix = `local-copy-`;
+		const classNamePrefix = `converted-class-`;
 		let i = 1;
 		let isValid = false;
 		let newClassName = ``;
@@ -35,6 +36,7 @@ export const ConvertLocalClassToGlobalClass = ( props: OwnProps ) => {
 	return (
 		<>
 			<MenuListItem
+				disabled={ ! props.canConvert }
 				onClick={ handlePromote }
 				dense
 				sx={ {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update local-to-global class conversion terminology and improve code structure for CSS class operations

Main changes:
- Renamed "canPromote" to "canConvert" with consistent terminology throughout the codebase
- Extracted conversion functionality to a dedicated LocalClassSubMenu component
- Added explicit error handling for missing style definitions during class conversion
- Refactored class name generation into a separate reusable function

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
