### PR TITLE
Fix: Published global classes doesn't work in preview [ED-20272]

### DIFF
--- a/modules/global-classes/atomic-global-styles.php
+++ b/modules/global-classes/atomic-global-styles.php
@@ -62,7 +62,7 @@ class Atomic_Global_Styles {
 	private function invalidate_cache( ?string $context = null ) {
 		$cache_validity = new Cache_Validity();
 
-		if ( empty( $context ) || $context === Global_Classes_Repository::CONTEXT_FRONTEND ) {
+		if ( empty( $context ) || Global_Classes_Repository::CONTEXT_FRONTEND === $context ) {
 			$cache_validity->invalidate( [ self::STYLES_KEY ] );
 
 			return;

--- a/modules/global-classes/atomic-global-styles.php
+++ b/modules/global-classes/atomic-global-styles.php
@@ -62,7 +62,7 @@ class Atomic_Global_Styles {
 	private function invalidate_cache( ?string $context = null ) {
 		$cache_validity = new Cache_Validity();
 
-		if ( empty( $context ) ) {
+		if ( empty( $context ) || $context === Global_Classes_Repository::CONTEXT_FRONTEND ) {
 			$cache_validity->invalidate( [ self::STYLES_KEY ] );
 
 			return;

--- a/tests/phpunit/elementor/modules/global-classes/test-atomic-global-styles.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-atomic-global-styles.php
@@ -160,7 +160,7 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 		$this->assertEquals( [ 'g-only-frontend', 'both', 'preview' ], $result );
 	}
 
-	public function test_cache_invalidation_on_update() {
+	public function test_cache_invalidation_on_frontend_update() {
 		// Arrange.
 		$global_classes = new Atomic_Global_Styles();
 		$global_classes->register_hooks();
@@ -191,7 +191,45 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 		$this->assertFalse( $cache_validity->is_valid(
 			[ Atomic_Global_Styles::STYLES_KEY, Global_Classes_Repository::CONTEXT_FRONTEND ]
 		) );
+
+		$this->assertFalse( $cache_validity->is_valid(
+			[ Atomic_Global_Styles::STYLES_KEY, Global_Classes_Repository::CONTEXT_PREVIEW ]
+		) );
+	}
+
+	public function test_cache_invalidation_on_preview_update() {
+		// Arrange.
+		$global_classes = new Atomic_Global_Styles();
+		$global_classes->register_hooks();
+		$cache_validity = new Cache_Validity();
+
+		// Act.
+		$cache_validity->validate( [ Atomic_Global_Styles::STYLES_KEY, Global_Classes_Repository::CONTEXT_FRONTEND ] );
+		$cache_validity->validate( [ Atomic_Global_Styles::STYLES_KEY, Global_Classes_Repository::CONTEXT_PREVIEW ] );
+
+		// Assert.
 		$this->assertTrue( $cache_validity->is_valid(
+			[ Atomic_Global_Styles::STYLES_KEY, Global_Classes_Repository::CONTEXT_FRONTEND ]
+		) );
+		$this->assertTrue( $cache_validity->is_valid(
+			[ Atomic_Global_Styles::STYLES_KEY, Global_Classes_Repository::CONTEXT_PREVIEW ]
+		) );
+
+		// Act.
+		do_action( 'elementor/global_classes/update', Global_Classes_Repository::CONTEXT_PREVIEW, [
+			'items' => [],
+			'order' => [],
+		], [
+			'items' => [],
+			'order' => [],
+		] );
+
+		// Assert.
+		$this->assertTrue( $cache_validity->is_valid(
+			[ Atomic_Global_Styles::STYLES_KEY, Global_Classes_Repository::CONTEXT_FRONTEND ]
+		) );
+
+		$this->assertFalse( $cache_validity->is_valid(
 			[ Atomic_Global_Styles::STYLES_KEY, Global_Classes_Repository::CONTEXT_PREVIEW ]
 		) );
 	}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix global classes cache invalidation to properly handle preview context, ensuring published global classes work correctly in preview mode.

Main changes:
- Modified invalidate_cache() to only invalidate frontend cache when context is explicitly frontend
- Added test_cache_invalidation_on_preview_update() to verify preview-only cache invalidation
- Renamed test_cache_invalidation_on_update() to test_cache_invalidation_on_frontend_update() for clarity

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
