### PR TITLE
Internal: Variables - show only size variables related to the control [ED-20226]

### DIFF
--- a/modules/atomic-widgets/prop-types/css-filter-func-prop-type.php
+++ b/modules/atomic-widgets/prop-types/css-filter-func-prop-type.php
@@ -6,6 +6,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Drop_Shadow_Filter_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Size_Constants;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -28,7 +29,7 @@ class Css_Filter_Func_Prop_Type extends Object_Prop_Type {
 				->default( 'blur' )
 				->required(),
 			'args' => Union_Prop_Type::make()
-				->add_prop_type( Size_Prop_Type::make()
+				->add_prop_type( Size_Prop_Type::make()->units( Size_Constants::filters() )
 					->default( [
 						'value' => [
 							'unit' => 'px',

--- a/modules/atomic-widgets/prop-types/position-prop-type.php
+++ b/modules/atomic-widgets/prop-types/position-prop-type.php
@@ -4,6 +4,7 @@ namespace Elementor\Modules\AtomicWidgets\PropTypes;
 
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Size_Constants;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -16,8 +17,8 @@ class Position_Prop_Type extends Object_Prop_Type {
 
 	protected function define_shape(): array {
 		return [
-			'x' => Size_Prop_Type::make(),
-			'y' => Size_Prop_Type::make(),
+			'x' => Size_Prop_Type::make()->units( Size_Constants::position() ),
+			'y' => Size_Prop_Type::make()->units( Size_Constants::position() ),
 		];
 	}
 

--- a/modules/atomic-widgets/prop-types/size-prop-type.php
+++ b/modules/atomic-widgets/prop-types/size-prop-type.php
@@ -5,7 +5,6 @@ namespace Elementor\Modules\AtomicWidgets\PropTypes;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
-use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Size_Constants;
 use Elementor\Utils;
 
@@ -19,9 +18,9 @@ class Size_Prop_Type extends Object_Prop_Type {
 		return Size_Constants::all_supported_units();
 	}
 
-	public function units( $units = 'all' ) {
+	public function units( $units = 'all' ): static {
 		if ( 'all' === $units ) {
-			$units = Size_Constants::all_units();
+			$units = Size_Constants::all();
 		}
 
 		if ( is_array( $units ) ) {

--- a/modules/atomic-widgets/prop-types/size-prop-type.php
+++ b/modules/atomic-widgets/prop-types/size-prop-type.php
@@ -24,7 +24,7 @@ class Size_Prop_Type extends Object_Prop_Type {
 			$units = Size_Constants::all_units();
 		}
 
-		if( is_array( $units ) ) {
+		if ( is_array( $units ) ) {
 			$supported_units = static::get_supported_units();
 
 			foreach ( $units as $unit ) {

--- a/modules/atomic-widgets/prop-types/stroke-prop-type.php
+++ b/modules/atomic-widgets/prop-types/stroke-prop-type.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\AtomicWidgets\PropTypes;
 
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Size_Constants;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -16,7 +17,7 @@ class Stroke_Prop_Type extends Object_Prop_Type {
 	protected function define_shape(): array {
 		return [
 			'color' => Color_Prop_Type::make(),
-			'width' => Size_Prop_Type::make(),
+			'width' => Size_Prop_Type::make()->units( Size_Constants::stroke_width() ),
 		];
 	}
 }

--- a/modules/atomic-widgets/prop-types/transform/transform-move-prop-type.php
+++ b/modules/atomic-widgets/prop-types/transform/transform-move-prop-type.php
@@ -4,6 +4,7 @@ namespace Elementor\Modules\AtomicWidgets\PropTypes\Transform;
 
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Size_Constants;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -17,18 +18,21 @@ class Transform_Move_Prop_Type extends Object_Prop_Type {
 
 	protected function define_shape(): array {
 		return [
-			'x' => Size_Prop_Type::make()->default( [
-				'size' => 0,
-				'unit' => 'px',
-			] ),
-			'y' => Size_Prop_Type::make()->default( [
-				'size' => 0,
-				'unit' => 'px',
-			] ),
-			'z' => Size_Prop_Type::make()->default( [
-				'size' => 0,
-				'unit' => 'px',
-			] ),
+			'x' => Size_Prop_Type::make()->units( Size_Constants::transform() )
+				->default( [
+					'size' => 0,
+					'unit' => 'px',
+				] ),
+			'y' => Size_Prop_Type::make()->units( Size_Constants::transform() )
+				->default( [
+					'size' => 0,
+					'unit' => 'px',
+				] ),
+			'z' => Size_Prop_Type::make()->units( Size_Constants::transform() )
+				->default( [
+					'size' => 0,
+					'unit' => 'px',
+				] ),
 		];
 	}
 }

--- a/modules/atomic-widgets/styles/size-constants.php
+++ b/modules/atomic-widgets/styles/size-constants.php
@@ -8,11 +8,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Size_Constants {
 	const UNIT_PX = 'px';
+	const UNIT_PERCENT = '%';
 	const UNIT_EM = 'em';
 	const UNIT_REM = 'rem';
 	const UNIT_VW = 'vw';
 	const UNIT_VH = 'vh';
-	const UNIT_PERCENT = '%';
 	const UNIT_AUTO = 'auto';
 	const UNIT_CUSTOM = 'custom';
 
@@ -21,7 +21,8 @@ class Size_Constants {
 		self::UNIT_EM,
 		self::UNIT_REM,
 		self::UNIT_VW,
-		self::UNIT_VH
+		self::UNIT_VH,
+		self::UNIT_CUSTOM,
 	];
 
 	const TIME_UNITS = [ 's', 'ms' ];
@@ -31,7 +32,7 @@ class Size_Constants {
 
 	public static function all_supported_units(): array {
 		return array_merge(
-			self::all_units(),
+			self::all(),
 			self::ANGLE_UNITS,
 			self::TIME_UNITS,
 			self::EXTENDED_UNITS,
@@ -39,48 +40,65 @@ class Size_Constants {
 		);
 	}
 
-	public static function all_units(): array {
+	public static function all(): array {
 		return [
 			...self::COMMON_UNITS,
 			self::UNIT_PERCENT,
 			self::UNIT_AUTO,
-			self::UNIT_CUSTOM
 		];
 	}
 
-	public static function typography_units(): array {
+	private static function units_without_auto(): array {
+		return [ ...self::COMMON_UNITS, self::UNIT_PERCENT ];
+	}
+
+	public static function layout() {
+		return self::units_without_auto();
+	}
+
+	public static function spacing(): array {
+		return self::units_without_auto();
+	}
+
+	public static function position(): array {
+		return self::units_without_auto();
+	}
+
+	public static function anchor_offset() {
+		return self::COMMON_UNITS;
+	}
+
+	public static function typography(): array {
+		return self::units_without_auto();
+	}
+
+	public static function stroke_width() {
 		return [
-			...self::COMMON_UNITS,
-			self::UNIT_PERCENT,
-			self::UNIT_CUSTOM
+			self::UNIT_PX,
+			self::UNIT_EM,
+			self::UNIT_REM,
+			self::UNIT_CUSTOM,
 		];
 	}
 
-	public static function spacing_units(): array {
-		return [
-			...self::COMMON_UNITS,
-			self::UNIT_PERCENT,
-			self::UNIT_CUSTOM
-		];
+	public static function border(): array {
+		return self::units_without_auto();
 	}
 
-	public static function border_units(): array {
-		return [
-			...self::COMMON_UNITS,
-			self::UNIT_PERCENT,
-			self::UNIT_CUSTOM
-		];
-	}
 
-	public static function get_position_units(): array {
-		return [ ...self::COMMON_UNITS, self::UNIT_CUSTOM ];
-	}
-
-	public static function effect_units(): array {
+	public static function opacity(): array {
 		return [ self::UNIT_PERCENT, self::UNIT_CUSTOM ];
 	}
 
-	public static function opacity_units(): array {
-		return [ self::UNIT_PERCENT, self::UNIT_CUSTOM ];
+	public static function box_shadow(): array {
+		return self::units_without_auto();
+	}
+
+	public static function transform(): array {
+		return [ ...self::ANGLE_UNITS, self::COMMON_UNITS ];
+	}
+
+	public static function filters() {
+		return self::COMMON_UNITS;
 	}
 }

--- a/modules/atomic-widgets/styles/size-constants.php
+++ b/modules/atomic-widgets/styles/size-constants.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\Styles;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Size_Constants {
+	const UNIT_PX = 'px';
+	const UNIT_EM = 'em';
+	const UNIT_REM = 'rem';
+	const UNIT_VW = 'vw';
+	const UNIT_VH = 'vh';
+	const UNIT_PERCENT = '%';
+	const UNIT_AUTO = 'auto';
+	const UNIT_CUSTOM = 'custom';
+
+	const COMMON_UNITS = [
+		self::UNIT_PX,
+		self::UNIT_EM,
+		self::UNIT_REM,
+		self::UNIT_VW,
+		self::UNIT_VH
+	];
+
+	const TIME_UNITS = [ 's', 'ms' ];
+	const EXTENDED_UNITS = [ 'auto', 'custom' ];
+	const VIEWPORT_MIN_MAX_UNITS = [ 'vmin', 'vmax' ];
+	const ANGLE_UNITS = [ 'deg', 'rad', 'grad', 'turn' ];
+
+	public static function all_supported_units(): array {
+		return array_merge(
+			self::all_units(),
+			self::ANGLE_UNITS,
+			self::TIME_UNITS,
+			self::EXTENDED_UNITS,
+			self::VIEWPORT_MIN_MAX_UNITS,
+		);
+	}
+
+	public static function all_units(): array {
+		return [
+			...self::COMMON_UNITS,
+			self::UNIT_PERCENT,
+			self::UNIT_AUTO,
+			self::UNIT_CUSTOM
+		];
+	}
+
+	public static function typography_units(): array {
+		return [
+			...self::COMMON_UNITS,
+			self::UNIT_PERCENT,
+			self::UNIT_CUSTOM
+		];
+	}
+
+	public static function spacing_units(): array {
+		return [
+			...self::COMMON_UNITS,
+			self::UNIT_PERCENT,
+			self::UNIT_CUSTOM
+		];
+	}
+
+	public static function border_units(): array {
+		return [
+			...self::COMMON_UNITS,
+			self::UNIT_PERCENT,
+			self::UNIT_CUSTOM
+		];
+	}
+
+	public static function get_position_units(): array {
+		return [ ...self::COMMON_UNITS, self::UNIT_CUSTOM ];
+	}
+
+	public static function effect_units(): array {
+		return [ self::UNIT_PERCENT, self::UNIT_CUSTOM ];
+	}
+
+	public static function opacity_units(): array {
+		return [ self::UNIT_PERCENT, self::UNIT_CUSTOM ];
+	}
+}

--- a/modules/atomic-widgets/styles/style-schema.php
+++ b/modules/atomic-widgets/styles/style-schema.php
@@ -97,12 +97,12 @@ class Style_Schema {
 				'fixed',
 				'sticky',
 			] ),
-			'inset-block-start' => Size_Prop_Type::make(),
-			'inset-inline-end' => Size_Prop_Type::make(),
-			'inset-block-end' => Size_Prop_Type::make(),
-			'inset-inline-start' => Size_Prop_Type::make(),
+			'inset-block-start' => Size_Prop_Type::make() ,
+			'inset-inline-end' => Size_Prop_Type::make() ,
+			'inset-block-end' => Size_Prop_Type::make() ,
+			'inset-inline-start' => Size_Prop_Type::make() ,
 			'z-index' => Number_Prop_Type::make(),
-			'scroll-margin-top' => Size_Prop_Type::make(),
+			'scroll-margin-top' => Size_Prop_Type::make() ,
 		];
 	}
 
@@ -124,10 +124,10 @@ class Style_Schema {
 				'bolder',
 				'lighter',
 			] ),
-			'font-size' => Size_Prop_Type::make(),
+			'font-size' => Size_Prop_Type::make()->units( Size_Constants::typography_units() ),
 			'color' => Color_Prop_Type::make(),
-			'letter-spacing' => Size_Prop_Type::make(),
-			'word-spacing' => Size_Prop_Type::make(),
+			'letter-spacing' => Size_Prop_Type::make()->units( Size_Constants::typography_units() ),
+			'word-spacing' => Size_Prop_Type::make()->units( Size_Constants::typography_units() ),
 			'column-count' => Number_Prop_Type::make(),
 			'column-gap' => Size_Prop_Type::make()
 				->set_dependencies(
@@ -138,8 +138,8 @@ class Style_Schema {
 						'value' => 1,
 					] )
 					->get()
-				),
-			'line-height' => Size_Prop_Type::make(),
+				) ,
+			'line-height' => Size_Prop_Type::make()->units( Size_Constants::typography_units() ), // Check
 			'text-align' => String_Prop_Type::make()->enum( [
 				'start',
 				'center',
@@ -181,7 +181,7 @@ class Style_Schema {
 		return [
 			'padding' => Union_Prop_Type::make()
 				->add_prop_type( Dimensions_Prop_Type::make() )
-				->add_prop_type( Size_Prop_Type::make() ),
+				->add_prop_type( Size_Prop_Type::make()->units( Size_Constants::spacing_units() ) ),
 			'margin' => Union_Prop_Type::make()
 				->add_prop_type( Dimensions_Prop_Type::make() )
 				->add_prop_type( Size_Prop_Type::make() ),
@@ -191,10 +191,10 @@ class Style_Schema {
 	private static function get_border_props() {
 		return [
 			'border-radius' => Union_Prop_Type::make()
-				->add_prop_type( Size_Prop_Type::make() )
+				->add_prop_type( Size_Prop_Type::make()->units( Size_Constants::border_units() ) )
 				->add_prop_type( Border_Radius_Prop_Type::make() ),
 			'border-width' => Union_Prop_Type::make()
-				->add_prop_type( Size_Prop_Type::make() )
+				->add_prop_type( Size_Prop_Type::make()->units( Size_Constants::border_units() ) )
 				->add_prop_type( Border_Width_Prop_Type::make() ),
 			'border-color' => Color_Prop_Type::make(),
 			'border-style' => String_Prop_Type::make()->enum( [
@@ -226,7 +226,7 @@ class Style_Schema {
 	private static function get_effects_props() {
 		return [
 			'box-shadow' => Box_Shadow_Prop_Type::make(),
-			'opacity' => Size_Prop_Type::make(),
+			'opacity' => Size_Prop_Type::make()->units( Size_Constants::opacity_units() ),
 			'filter' => Filter_Prop_Type::make(),
 			'backdrop-filter' => Backdrop_Filter_Prop_Type::make(),
 			'transform' => Transform_Prop_Type::make(),

--- a/modules/atomic-widgets/styles/style-schema.php
+++ b/modules/atomic-widgets/styles/style-schema.php
@@ -97,12 +97,12 @@ class Style_Schema {
 				'fixed',
 				'sticky',
 			] ),
-			'inset-block-start' => Size_Prop_Type::make() ,
-			'inset-inline-end' => Size_Prop_Type::make() ,
-			'inset-block-end' => Size_Prop_Type::make() ,
-			'inset-inline-start' => Size_Prop_Type::make() ,
+			'inset-block-start' => Size_Prop_Type::make(),
+			'inset-inline-end' => Size_Prop_Type::make(),
+			'inset-block-end' => Size_Prop_Type::make(),
+			'inset-inline-start' => Size_Prop_Type::make(),
 			'z-index' => Number_Prop_Type::make(),
-			'scroll-margin-top' => Size_Prop_Type::make() ,
+			'scroll-margin-top' => Size_Prop_Type::make()->units( Size_Constants::anchor_offset() ),
 		];
 	}
 
@@ -124,10 +124,10 @@ class Style_Schema {
 				'bolder',
 				'lighter',
 			] ),
-			'font-size' => Size_Prop_Type::make()->units( Size_Constants::typography_units() ),
+			'font-size' => Size_Prop_Type::make()->units( Size_Constants::typography() ),
 			'color' => Color_Prop_Type::make(),
-			'letter-spacing' => Size_Prop_Type::make()->units( Size_Constants::typography_units() ),
-			'word-spacing' => Size_Prop_Type::make()->units( Size_Constants::typography_units() ),
+			'letter-spacing' => Size_Prop_Type::make()->units( Size_Constants::typography() ),
+			'word-spacing' => Size_Prop_Type::make()->units( Size_Constants::typography() ),
 			'column-count' => Number_Prop_Type::make(),
 			'column-gap' => Size_Prop_Type::make()
 				->set_dependencies(
@@ -138,8 +138,8 @@ class Style_Schema {
 						'value' => 1,
 					] )
 					->get()
-				) ,
-			'line-height' => Size_Prop_Type::make()->units( Size_Constants::typography_units() ), // Check
+				),
+			'line-height' => Size_Prop_Type::make()->units( Size_Constants::typography() ), // Check
 			'text-align' => String_Prop_Type::make()->enum( [
 				'start',
 				'center',
@@ -181,7 +181,7 @@ class Style_Schema {
 		return [
 			'padding' => Union_Prop_Type::make()
 				->add_prop_type( Dimensions_Prop_Type::make() )
-				->add_prop_type( Size_Prop_Type::make()->units( Size_Constants::spacing_units() ) ),
+				->add_prop_type( Size_Prop_Type::make()->units( Size_Constants::spacing() ) ),
 			'margin' => Union_Prop_Type::make()
 				->add_prop_type( Dimensions_Prop_Type::make() )
 				->add_prop_type( Size_Prop_Type::make() ),
@@ -191,10 +191,10 @@ class Style_Schema {
 	private static function get_border_props() {
 		return [
 			'border-radius' => Union_Prop_Type::make()
-				->add_prop_type( Size_Prop_Type::make()->units( Size_Constants::border_units() ) )
+				->add_prop_type( Size_Prop_Type::make()->units( Size_Constants::border() ) )
 				->add_prop_type( Border_Radius_Prop_Type::make() ),
 			'border-width' => Union_Prop_Type::make()
-				->add_prop_type( Size_Prop_Type::make()->units( Size_Constants::border_units() ) )
+				->add_prop_type( Size_Prop_Type::make()->units( Size_Constants::border() ) )
 				->add_prop_type( Border_Width_Prop_Type::make() ),
 			'border-color' => Color_Prop_Type::make(),
 			'border-style' => String_Prop_Type::make()->enum( [
@@ -226,7 +226,7 @@ class Style_Schema {
 	private static function get_effects_props() {
 		return [
 			'box-shadow' => Box_Shadow_Prop_Type::make(),
-			'opacity' => Size_Prop_Type::make()->units( Size_Constants::opacity_units() ),
+			'opacity' => Size_Prop_Type::make()->units( Size_Constants::opacity() ),
 			'filter' => Filter_Prop_Type::make(),
 			'backdrop-filter' => Backdrop_Filter_Prop_Type::make(),
 			'transform' => Transform_Prop_Type::make(),
@@ -256,7 +256,7 @@ class Style_Schema {
 			] ),
 			'gap' => Union_Prop_Type::make()
 				->add_prop_type( Layout_Direction_Prop_Type::make() )
-				->add_prop_type( Size_Prop_Type::make() ),
+				->add_prop_type( Size_Prop_Type::make()->units( Size_Constants::layout() ) ),
 			'flex-wrap' => String_Prop_Type::make()->enum( [
 				'wrap',
 				'nowrap',

--- a/packages/packages/core/editor-variables/src/hooks/use-prop-variables.ts
+++ b/packages/packages/core/editor-variables/src/hooks/use-prop-variables.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
+import { useBoundProp } from '@elementor/editor-controls';
 import { type PropKey } from '@elementor/editor-props';
 
+import { useVariableType } from '../context/variable-type-context';
 import { service } from '../service';
 import { type Variable } from '../types';
 
@@ -18,7 +20,13 @@ export const useVariable = ( key: string ) => {
 };
 
 export const useFilteredVariables = ( searchValue: string, propTypeKey: string ) => {
-	const variables = usePropVariables( propTypeKey );
+	let variables = usePropVariables( propTypeKey );
+	const { propType } = useBoundProp();
+	const { listFilter } = useVariableType();
+
+	if ( listFilter ) {
+		variables = listFilter( variables, propType );
+	}
 
 	const filteredVariables = variables.filter( ( { label } ) => {
 		return label.toLowerCase().includes( searchValue.toLowerCase() );

--- a/packages/packages/core/editor-variables/src/variables-registry/create-variable-type-registry.ts
+++ b/packages/packages/core/editor-variables/src/variables-registry/create-variable-type-registry.ts
@@ -38,6 +38,7 @@ export function createVariableTypeRegistry() {
 	const registerVariableType = ( {
 		icon,
 		startIcon,
+		listFilter,
 		valueField,
 		propTypeUtil,
 		variableType,
@@ -50,6 +51,7 @@ export function createVariableTypeRegistry() {
 		variableTypes[ propTypeUtil.key ] = {
 			icon,
 			startIcon,
+			listFilter,
 			valueField,
 			propTypeUtil,
 			variableType,

--- a/packages/packages/core/editor-variables/src/variables-registry/create-variable-type-registry.ts
+++ b/packages/packages/core/editor-variables/src/variables-registry/create-variable-type-registry.ts
@@ -1,7 +1,7 @@
 import { type ForwardRefExoticComponent, type JSX, type RefAttributes } from 'react';
 import { styleTransformersRegistry } from '@elementor/editor-canvas';
 import { stylesInheritanceTransformersRegistry } from '@elementor/editor-editing-panel';
-import { type createPropUtils, type PropTypeKey, type PropTypeUtil } from '@elementor/editor-props';
+import { type createPropUtils, type PropType, type PropTypeKey, type PropTypeUtil } from '@elementor/editor-props';
 import { type SvgIconProps } from '@elementor/ui';
 
 import { inheritanceTransformer } from '../transformers/inheritance-transformer';
@@ -10,6 +10,12 @@ import { variableTransformer } from '../transformers/variable-transformer';
 type ValueFieldProps = {
 	value: string;
 	onChange: ( value: string ) => void;
+};
+
+type Variable = {
+	key: string;
+	label: string;
+	value: string;
 };
 
 type FallbackPropTypeUtil = ReturnType< typeof createPropUtils >;
@@ -21,6 +27,7 @@ type VariableTypeOptions = {
 	variableType: string;
 	fallbackPropTypeUtil: FallbackPropTypeUtil;
 	propTypeUtil: PropTypeUtil< string, string >;
+	listFilter?: ( variables: Variable[], propType: PropType ) => Variable[];
 };
 
 export type VariableTypesMap = Record< string, VariableTypeOptions >;


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add filtering mechanism for size variables to show only relevant unit types based on their context.
Main changes:
- Created Size_Constants class to centralize and organize unit types for various contexts
- Implemented units() method in Size_Prop_Type to restrict available units based on context
- Added listFilter capability to variable type registry to filter variables by property type

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
