### PR TITLE
Internal: Remove wunderwp plugin from plugin tester [ED-20295]

### DIFF
--- a/tests/playwright/sanity/plugin-tester-generator.ts
+++ b/tests/playwright/sanity/plugin-tester-generator.ts
@@ -12,7 +12,6 @@ const pluginList: { pluginName: string, installSource: 'api' | 'cli' | 'zip', ha
 	{ pluginName: 'the-plus-addons-for-elementor-page-builder', installSource: 'api' },
 	{ pluginName: 'stratum', installSource: 'api' },
 	{ pluginName: 'bdthemes-prime-slider-lite', installSource: 'api' },
-	{ pluginName: 'wunderwp', installSource: 'api' },
 	{ pluginName: 'addon-elements-for-elementor-page-builder', installSource: 'api' },
 	{ pluginName: 'anywhere-elementor', installSource: 'api' },
 	{ pluginName: 'astra-sites', installSource: 'api', hasInstallationPage: true },


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove wunderwp plugin from the plugin tester list in Playwright sanity tests to streamline test dependencies.
Main changes:
- Removed wunderwp entry from pluginList array in plugin-tester-generator.ts

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
