### PR TITLE
Internal: Add user data endpoint [ED-20296]

### DIFF
--- a/includes/autoloader.php
+++ b/includes/autoloader.php
@@ -155,6 +155,7 @@ class Autoloader {
 			'Container\Container' => 'includes/container/container.php',
 			'Tracker' => 'includes/tracker.php',
 			'User' => 'includes/user.php',
+			'User_Data' => 'includes/user-data.php',
 			'Utils' => 'includes/utils.php',
 			'Widget_WordPress' => 'includes/widgets/wordpress.php',
 			'Widgets_Manager' => 'includes/managers/widgets.php',

--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -753,6 +753,7 @@ class Plugin {
 		$this->admin_menu_manager->register_actions();
 
 		User::init();
+		User_Data::init();
 		Api::init();
 		Tracker::init();
 

--- a/includes/user-data.php
+++ b/includes/user-data.php
@@ -1,0 +1,127 @@
+<?php
+namespace Elementor;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class User_Data {
+	const API_NAMESPACE = 'elementor/v1';
+	const API_BASE = '/user-data/current-user';
+
+	public static function init() {
+		add_action( 'rest_api_init', fn() => self::register_routes() );
+	}
+
+	private static function register_routes() {
+		register_rest_route( self::API_NAMESPACE, self::API_BASE, [
+			[
+				'methods' => 'GET',
+				'callback' => fn( $request ) => self::route_wrapper( fn() => self::get_current_user( $request ) ),
+				'permission_callback' => fn() => is_user_logged_in(),
+			],
+			[
+				'methods' => 'PATCH',
+				'callback' => fn( $request ) => self::route_wrapper( fn() => self::update_current_user( $request ) ),
+				'permission_callback' => fn() => is_user_logged_in(),
+				'args' => [
+					'suppressedMessages' => [
+						'required' => false,
+						'type' => 'array',
+						'description' => 'Array of suppressed message keys',
+						'items' => [
+							'type' => 'string',
+						],
+						'validate_callback' => function( $param, $request, $key ) {
+							return is_array( $param );
+						},
+						'sanitize_callback' => fn( $param, $request, $key ) => self::sanitize_suppressed_messages( $param, $request, $key ),
+					],
+				],
+			],
+		] );
+	}
+
+	/**
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response|\WP_Error Response object or error.
+	 */
+	public static function get_current_user( $request ) {
+		$current_user = wp_get_current_user();
+		$introduction_meta = User::get_introduction_meta();
+
+		$suppressed_messages = [];
+		if ( is_array( $introduction_meta ) ) {
+			foreach ( $introduction_meta as $key => $value ) {
+				if ( $value ) {
+					$suppressed_messages[] = $key;
+				}
+			}
+		}
+
+		$capabilities = array_keys( $current_user->allcaps );
+
+		$data = [
+			'suppressedMessages' => $suppressed_messages,
+			'capabilities' => $capabilities,
+		];
+
+		return new \WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response|\WP_Error Response object or error.
+	 */
+	public static function update_current_user( $request ) {
+		$user_id = get_current_user_id();
+
+		$suppressed_messages = $request->get_param( 'suppressedMessages' );
+
+		if ( $request->has_param( 'suppressedMessages' ) && is_array( $suppressed_messages ) ) {
+			$introduction_meta = [];
+			foreach ( $suppressed_messages as $message ) {
+				$introduction_meta[ $message ] = true;
+			}
+
+			update_user_meta( $user_id, User::INTRODUCTION_KEY, $introduction_meta );
+		}
+
+		return self::get_current_user( $request );
+	}
+
+	/**
+	 * @param array $param The parameter value.
+	 * @param \WP_REST_Request $request The request object.
+	 * @param string $key The parameter key.
+	 * @return array|null The sanitized array or null.
+	 */
+	public static function sanitize_suppressed_messages( $param, $request, $key ) {
+		if ( ! is_array( $param ) ) {
+			return null;
+		}
+
+		$sanitized_messages = [];
+		foreach ( $param as $message ) {
+			if ( is_string( $message ) ) {
+				$sanitized_message = sanitize_text_field( $message );
+
+				if ( ! empty( $sanitized_message ) ) {
+					$sanitized_messages[] = $sanitized_message;
+				}
+			}
+		}
+
+		return $sanitized_messages;
+	}
+
+	private static function route_wrapper( callable $cb ) {
+		try {
+			$response = $cb();
+		} catch ( \Exception $e ) {
+			return new \WP_Error( 'unexpected_error', 'Something went wrong', [ 'status' => 500 ] );
+		}
+
+		return $response;
+	}
+}

--- a/packages/packages/libs/editor-current-user/src/api.ts
+++ b/packages/packages/libs/editor-current-user/src/api.ts
@@ -2,15 +2,15 @@ import { httpService } from '@elementor/http-client';
 
 import { type User } from './types';
 
-const RESOURCE_URL = '/users/me';
+const RESOURCE_URL = 'elementor/v1/user-data/current-user';
 
 type GetUserPayload = {
-	params: { context?: 'edit' };
+	params?: { context?: 'edit' };
 };
 
 type UserModel = {
-	elementor_introduction: Record< string, boolean >;
-	capabilities: Partial< Record< string, true > >;
+	suppressedMessages: string[];
+	capabilities: string[];
 };
 
 const getUserPayload: GetUserPayload = { params: { context: 'edit' } };
@@ -18,32 +18,14 @@ const getUserPayload: GetUserPayload = { params: { context: 'edit' } };
 export const apiClient = {
 	get: () =>
 		httpService()
-			.get< UserModel >( 'wp/v2' + RESOURCE_URL, getUserPayload )
+			.get< UserModel >( RESOURCE_URL, getUserPayload )
 			.then( ( res ) => {
-				return responseToUser( res.data );
+				const { capabilities = [], suppressedMessages = [] } = res.data;
+
+				return { capabilities, suppressedMessages };
 			} ),
 	update: ( data: Partial< User > ) =>
-		httpService().patch< Partial< UserModel > >( 'wp/v2' + RESOURCE_URL, userToRequest( data ) ),
-};
-
-const responseToUser = ( response: UserModel ): User => {
-	return {
-		suppressedMessages: Object.entries( response.elementor_introduction )
-			.filter( ( [ , value ] ) => value )
-			.map( ( [ message ] ) => message ),
-		capabilities: Object.keys( response.capabilities ),
-	};
-};
-
-const userToRequest = ( user: Partial< User > ): Partial< UserModel > => {
-	return {
-		elementor_introduction: user.suppressedMessages?.reduce(
-			( acc, message ) => {
-				acc[ message ] = true;
-
-				return acc;
-			},
-			{} as Record< string, boolean >
-		),
-	};
+		httpService().patch< Partial< UserModel > >( RESOURCE_URL, {
+			suppressedMessages: data.suppressedMessages,
+		} ),
 };

--- a/tests/phpunit/elementor/includes/test-user-data.php
+++ b/tests/phpunit/elementor/includes/test-user-data.php
@@ -1,0 +1,268 @@
+<?php
+namespace Elementor\Testing\Includes;
+
+use Elementor\User;
+use Elementor\User_Data;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_User_Data extends Elementor_Test_Base {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+
+		do_action( 'rest_api_init' );
+	}
+
+	public function test_get_current_user__returns_user_data_when_logged_in() {
+		// Arrange
+		$this->act_as_admin();
+		$suppressed_messages = [ 'welcome_message', 'tutorial_tip' ];
+		$this->setup_user_with_suppressed_messages( $suppressed_messages );
+
+		// Act
+		$response = $this->make_get_request();
+
+		// Assert
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		
+		$this->assertArrayHasKey( 'suppressedMessages', $data );
+		$this->assertArrayHasKey( 'capabilities', $data );
+		$this->assertSame( $suppressed_messages, $data['suppressedMessages'] );
+		$this->assertIsArray( $data['capabilities'] );
+		$this->assertContains( 'manage_options', $data['capabilities'] );
+	}
+
+	public function test_get_current_user__returns_empty_suppressed_messages_when_none_set() {
+		// Arrange
+		$this->act_as_admin();
+
+		// Act
+		$response = $this->make_get_request();
+
+		// Assert
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		
+		$this->assertSame( [], $data['suppressedMessages'] );
+		$this->assertIsArray( $data['capabilities'] );
+	}
+
+	public function test_get_current_user__fails_when_not_logged_in() {
+		// Arrange
+		wp_set_current_user( 0 );
+
+		// Act
+		$response = $this->make_get_request();
+
+		// Assert
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	public function test_update_current_user__updates_suppressed_messages() {
+		// Arrange
+		$this->act_as_admin();
+		$initial_messages = [ 'old_message' ];
+		$this->setup_user_with_suppressed_messages( $initial_messages );
+
+		// Act
+		$new_messages = [ 'new_message', 'another_message' ];
+		$response = $this->make_patch_request( [ 'suppressedMessages' => $new_messages ] );
+
+		// Assert
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		
+		$this->assertSame( $new_messages, $data['suppressedMessages'] );
+		
+		// Verify the meta was actually updated
+		$updated_meta = User::get_introduction_meta();
+		$this->assertTrue( $updated_meta['new_message'] );
+		$this->assertTrue( $updated_meta['another_message'] );
+		$this->assertArrayNotHasKey( 'old_message', $updated_meta );
+	}
+
+	public function test_update_current_user__handles_empty_suppressed_messages() {
+		// Arrange
+		$this->act_as_admin();
+		$this->setup_user_with_suppressed_messages( [ 'some_message' ] );
+
+		// Act
+		$response = $this->make_patch_request( [ 'suppressedMessages' => [] ] );
+
+		// Assert
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		
+		$this->assertSame( [], $data['suppressedMessages'] );
+		
+		// Verify the meta was cleared
+		$updated_meta = User::get_introduction_meta();
+		$this->assertEmpty( $updated_meta );
+	}
+
+	public function test_update_current_user__fails_with_invalid_suppressed_messages_param() {
+		// Arrange
+		$this->act_as_admin();
+		$initial_messages = [ 'existing_message' ];
+		$this->setup_user_with_suppressed_messages( $initial_messages );
+
+		// Act
+		$response = $this->make_patch_request( [ 'suppressedMessages' => 'not-an-array' ] );
+
+		// Assert
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] );
+		
+		// Verify the meta was not changed
+		$updated_meta = User::get_introduction_meta();
+		$this->assertTrue( $updated_meta['existing_message'] );
+	}
+
+	public function test_update_current_user__fails_when_not_logged_in() {
+		// Arrange
+		wp_set_current_user( 0 );
+
+		// Act
+		$response = $this->make_patch_request( [ 'suppressedMessages' => [ 'test_message' ] ] );
+
+		// Assert
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	public function test_register_routes__endpoint_exists() {
+		// Arrange
+		global $wp_rest_server;
+		$routes = $wp_rest_server->get_routes();
+
+		// Assert
+		$this->assertArrayHasKey( '/elementor/v1/user-data/current-user', $routes );
+		
+		$route = $routes['/elementor/v1/user-data/current-user'];
+		$this->assertCount( 2, $route ); // GET and PATCH methods
+		
+		// Check GET method
+		$get_method = $route[0];
+		$this->assertTrue( isset( $get_method['methods']['GET'] ) );
+		$this->assertInstanceOf( \Closure::class, $get_method['callback'] );
+		$this->assertInstanceOf( \Closure::class, $get_method['permission_callback'] );
+		
+		// Check PATCH method
+		$patch_method = $route[1];
+		$this->assertTrue( isset( $patch_method['methods']['PATCH'] ) );
+		$this->assertInstanceOf( \Closure::class, $patch_method['callback'] );
+		$this->assertInstanceOf( \Closure::class, $patch_method['permission_callback'] );
+		
+		// Check PATCH method args
+		$this->assertArrayHasKey( 'suppressedMessages', $patch_method['args'] );
+		$this->assertSame( 'array', $patch_method['args']['suppressedMessages']['type'] );
+		$this->assertFalse( $patch_method['args']['suppressedMessages']['required'] );
+	}
+
+	public function test_constants_are_defined() {
+		// Assert
+		$this->assertSame( 'elementor/v1', User_Data::API_NAMESPACE );
+		$this->assertSame( '/user-data/current-user', User_Data::API_BASE );
+	}
+
+	public function test_integration__full_workflow() {
+		// Arrange
+		$this->act_as_admin();
+
+		// Act & Assert - Initial GET (empty data)
+		$get_response = $this->make_get_request();
+		
+		$this->assertSame( 200, $get_response->get_status() );
+		$initial_data = $get_response->get_data();
+		$this->assertSame( [], $initial_data['suppressedMessages'] );
+
+		// Act & Assert - UPDATE with new messages
+		$messages = [ 'intro_dismissed', 'tooltip_hidden', 'banner_closed' ];
+		$update_response = $this->make_patch_request( [ 'suppressedMessages' => $messages ] );
+		
+		$this->assertSame( 200, $update_response->get_status() );
+		$updated_data = $update_response->get_data();
+		$this->assertSame( $messages, $updated_data['suppressedMessages'] );
+
+		// Act & Assert - GET again to verify persistence
+		$final_get_response = $this->make_get_request();
+		$this->assertSame( 200, $final_get_response->get_status() );
+		$final_data = $final_get_response->get_data();
+		$this->assertSame( $messages, $final_data['suppressedMessages'] );
+	}
+
+	private function setup_user_with_suppressed_messages( array $messages ) {
+		$user_id = get_current_user_id();
+		$introduction_meta = [];
+		foreach ( $messages as $message ) {
+			$introduction_meta[ $message ] = true;
+		}
+		update_user_meta( $user_id, User::INTRODUCTION_KEY, $introduction_meta );
+	}
+
+	private function make_get_request() {
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/user-data/current-user' );
+		return rest_do_request( $request );
+	}
+
+	private function make_patch_request( array $params ) {
+		$request = new \WP_REST_Request( 'PATCH', '/elementor/v1/user-data/current-user' );
+		$request->set_body_params( $params );
+		return rest_do_request( $request );
+	}
+
+	public function test_sanitize_suppressed_messages__sanitizes_array_properly() {
+		// Arrange
+		$input_array = [
+			'clean_message',
+			'<script>alert("xss")</script>',
+			'message with spaces  ',
+			123, // Non-string should be filtered out
+			null, // Non-string should be filtered out
+			'normal_message',
+		];
+
+		// Act
+		$result = User_Data::sanitize_suppressed_messages( $input_array, new \WP_REST_Request(), 'suppressedMessages' );
+
+		// Assert
+		$expected = [
+			'clean_message',
+			// Script tags get completely removed by sanitize_text_field, resulting in empty string which is filtered out
+			'message with spaces', // Trailing spaces should be trimmed
+			'normal_message',
+		];
+		
+		$this->assertSame( $expected, $result );
+		$this->assertCount( 3, $result ); // Non-string items and empty strings after sanitization are filtered out
+	}
+
+	public function test_sanitize_suppressed_messages__returns_null_for_non_array() {
+		// Arrange & Act
+		$result1 = User_Data::sanitize_suppressed_messages( 'not-an-array', new \WP_REST_Request(), 'suppressedMessages' );
+		$result2 = User_Data::sanitize_suppressed_messages( 123, new \WP_REST_Request(), 'suppressedMessages' );
+		$result3 = User_Data::sanitize_suppressed_messages( null, new \WP_REST_Request(), 'suppressedMessages' );
+
+		// Assert
+		$this->assertNull( $result1 );
+		$this->assertNull( $result2 );
+		$this->assertNull( $result3 );
+	}
+
+	public function test_sanitize_suppressed_messages__handles_empty_array() {
+		// Arrange & Act
+		$result = User_Data::sanitize_suppressed_messages( [], new \WP_REST_Request(), 'suppressedMessages' );
+
+		// Assert
+		$this->assertSame( [], $result );
+	}
+} 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add user data REST API endpoint for accessing current user information, including suppressed messages and capabilities.
Main changes:
- Created User_Data class with REST API endpoints for getting and updating user data
- Updated autoloader and plugin initialization to register the new user data API
- Refactored editor-current-user API client to use the new custom endpoint instead of WordPress core endpoint

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
