### PR TITLE
Internal: Fix 0 value for custom order field [ED-20299]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/__tests__/flex-order-field.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/__tests__/flex-order-field.test.tsx
@@ -168,4 +168,25 @@ describe( '<FlexOrderField />', () => {
 		expect( setValues ).toHaveBeenCalledWith( { order: null }, { history: { propDisplayName: 'Order' } } );
 		expect( firstButton ).not.toHaveClass( 'Mui-selected' );
 	} );
+
+	it( 'should handle order value of 0 correctly (custom mode active and field visible)', () => {
+		// Arrange.
+		const value = { $$type: 'number', value: 0 };
+
+		jest.mocked( useStylesFields ).mockReturnValue( {
+			values: { order: value },
+			setValues: jest.fn(),
+			canEdit: true,
+		} );
+
+		// Act.
+		renderFlexOrderField();
+
+		const customButton = screen.getByLabelText( 'Custom' );
+		const customControlLabel = screen.getByText( 'Custom order' );
+
+		// Assert.
+		expect( customButton ).toHaveClass( 'Mui-selected' );
+		expect( customControlLabel ).toBeVisible();
+	} );
 } );

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/flex-order-field.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/flex-order-field.tsx
@@ -58,10 +58,10 @@ export const FlexOrderField = () => {
 		history: { propDisplayName: ORDER_LABEL },
 	} );
 
-	const [ groupControlValue, setGroupControlValue ] = useState( getGroupControlValue( order?.value || null ) );
+	const [ groupControlValue, setGroupControlValue ] = useState( getGroupControlValue( order?.value ?? null ) );
 
 	useEffect( () => {
-		const newGroupControlValue = getGroupControlValue( order?.value || null );
+		const newGroupControlValue = getGroupControlValue( order?.value ?? null );
 		setGroupControlValue( newGroupControlValue );
 	}, [ order?.value ] );
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix incorrect handling of zero values in FlexOrderField component that caused custom order mode to display improperly.
Main changes:
- Replace logical OR operator with nullish coalescing to correctly handle order value of 0
- Add unit test to verify proper handling of zero values in custom order field

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
