### PR TITLE
Internal: Preserve custom value for custom units between breakpoints [ED-20291]

### DIFF
--- a/packages/packages/libs/editor-controls/src/components/size-control/size-input.tsx
+++ b/packages/packages/libs/editor-controls/src/components/size-control/size-input.tsx
@@ -72,6 +72,7 @@ export const SizeInput = ( {
 
 	const inputProps = {
 		...popupAttributes,
+		readOnly: isUnitExtendedOption( unit ),
 		autoComplete: 'off',
 		onClick,
 		onFocus,
@@ -116,8 +117,8 @@ export const SizeInput = ( {
 					} }
 					onKeyUp={ handleKeyUp }
 					onBlur={ onBlur }
-					shouldBlockInput={ isUnitExtendedOption( unit ) }
 					inputProps={ inputProps }
+					isPopoverOpen={ popupState.isOpen }
 				/>
 			</Box>
 		</ControlActions>

--- a/packages/packages/libs/editor-controls/src/components/size-control/size-input.tsx
+++ b/packages/packages/libs/editor-controls/src/components/size-control/size-input.tsx
@@ -118,7 +118,6 @@ export const SizeInput = ( {
 					onKeyUp={ handleKeyUp }
 					onBlur={ onBlur }
 					inputProps={ inputProps }
-					isPopoverOpen={ popupState.isOpen }
 				/>
 			</Box>
 		</ControlActions>

--- a/packages/packages/libs/editor-controls/src/components/size-control/text-field-inner-selection.tsx
+++ b/packages/packages/libs/editor-controls/src/components/size-control/text-field-inner-selection.tsx
@@ -30,7 +30,6 @@ type TextFieldInnerSelectionProps = {
 		endAdornment: React.JSX.Element;
 	};
 	disabled?: boolean;
-	isPopoverOpen?: boolean;
 };
 
 export const TextFieldInnerSelection = forwardRef(
@@ -46,7 +45,6 @@ export const TextFieldInnerSelection = forwardRef(
 			shouldBlockInput = false,
 			inputProps,
 			disabled,
-			isPopoverOpen,
 		}: TextFieldInnerSelectionProps,
 		ref
 	) => {
@@ -69,7 +67,6 @@ export const TextFieldInnerSelection = forwardRef(
 				onKeyUp={ shouldBlockInput ? undefined : onKeyUp }
 				disabled={ disabled }
 				onBlur={ onBlur }
-				focused={ isPopoverOpen ? true : undefined }
 				placeholder={ placeholder ?? ( String( boundPropPlaceholder?.size ?? '' ) || undefined ) }
 				InputProps={ inputProps }
 			/>

--- a/packages/packages/libs/editor-controls/src/components/size-control/text-field-inner-selection.tsx
+++ b/packages/packages/libs/editor-controls/src/components/size-control/text-field-inner-selection.tsx
@@ -53,8 +53,8 @@ export const TextFieldInnerSelection = forwardRef(
 		const { placeholder: boundPropPlaceholder } = useBoundProp( sizePropTypeUtil );
 
 		const getCursorStyle = () => ( {
-		input: { cursor: inputProps.readOnly ? 'default !important' : undefined },
-	} );
+			input: { cursor: inputProps.readOnly ? 'default !important' : undefined },
+		} );
 
 		return (
 			<TextField

--- a/packages/packages/libs/editor-controls/src/components/size-control/text-field-inner-selection.tsx
+++ b/packages/packages/libs/editor-controls/src/components/size-control/text-field-inner-selection.tsx
@@ -30,6 +30,7 @@ type TextFieldInnerSelectionProps = {
 		endAdornment: React.JSX.Element;
 	};
 	disabled?: boolean;
+	isPopoverOpen?: boolean;
 };
 
 export const TextFieldInnerSelection = forwardRef(
@@ -45,15 +46,20 @@ export const TextFieldInnerSelection = forwardRef(
 			shouldBlockInput = false,
 			inputProps,
 			disabled,
+			isPopoverOpen,
 		}: TextFieldInnerSelectionProps,
 		ref
 	) => {
 		const { placeholder: boundPropPlaceholder } = useBoundProp( sizePropTypeUtil );
 
+		const getCursorStyle = () => ( {
+		input: { cursor: inputProps.readOnly ? 'default !important' : undefined },
+	} );
+
 		return (
 			<TextField
 				ref={ ref }
-				sx={ { input: { cursor: shouldBlockInput ? 'default !important' : undefined } } }
+				sx={ getCursorStyle() }
 				size="tiny"
 				fullWidth
 				type={ shouldBlockInput ? undefined : type }
@@ -63,6 +69,7 @@ export const TextFieldInnerSelection = forwardRef(
 				onKeyUp={ shouldBlockInput ? undefined : onKeyUp }
 				disabled={ disabled }
 				onBlur={ onBlur }
+				focused={ isPopoverOpen ? true : undefined }
 				placeholder={ placeholder ?? ( String( boundPropPlaceholder?.size ?? '' ) || undefined ) }
 				InputProps={ inputProps }
 			/>


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix custom unit values preservation between breakpoints in size control component to maintain user customizations.

Main changes:
- Added readOnly prop instead of shouldBlockInput for custom unit fields to prevent accidental editing
- Modified createStateFromSizeProp to preserve custom values during breakpoint changes
- Updated cursor styling for readOnly inputs to maintain consistent UX
- Removed onInputFocus handler in favor of declarative readOnly property

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
