### PR TITLE
Revert: Remove-PLG-checks-and-text 3.31 [EMP-3512] [ED-20338]

### DIFF
--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -479,12 +479,6 @@ class Admin_Notices extends Module {
 			return false;
 		}
 
-		$form_plugin_name = $this->get_installed_form_plugin_name();
-
-		if ( ! $form_plugin_name ) {
-			return false;
-		}
-
 		$plugin_file_path = 'send/send-app.php';
 		$plugin_slug = 'send-app';
 
@@ -493,11 +487,7 @@ class Admin_Notices extends Module {
 			return false;
 		}
 
-		$title = sprintf(
-			/* translators: %s: Form plugin name */
-			esc_html__( 'Turn %s leads into loyal shoppers', 'elementor' ),
-			$form_plugin_name
-		);
+		$title = sprintf( esc_html__( 'Turn leads into loyal shoppers', 'elementor' ) );
 
 		$options = [
 			'title' => $title,
@@ -651,7 +641,7 @@ class Admin_Notices extends Module {
 	}
 
 	private function is_elementor_admin_screen(): bool {
-		return in_array( $this->current_screen_id, [ 'toplevel_page_elementor', 'edit-elementor_library', 'dashboard' ], true );
+		return in_array( $this->current_screen_id, [ 'toplevel_page_elementor', 'edit-elementor_library' ], true );
 	}
 
 	private function is_elementor_admin_screen_with_system_info(): bool {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert changes to Send notification by removing PLG (Plugin) references in admin notice title and adjusting dashboard screen detection.

Main changes:
- Removed conditional logic that checked for installed form plugins before showing Send notice
- Simplified admin notice title to remove dynamic plugin name reference
- Removed 'dashboard' from elementor_admin_screen detection criteria

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
