### PR TITLE
Internal: Finalize Mixpanel events for Cloud Templates [ED-20048]

### DIFF
--- a/app/modules/kit-library/assets/js/components/item-header.js
+++ b/app/modules/kit-library/assets/js/components/item-header.js
@@ -101,6 +101,7 @@ export default function ItemHeader( props ) {
 					elementorCommon.config.library_connect.is_connected = false;
 					elementorCommon.config.library_connect.current_access_level = 0;
 					elementorCommon.config.library_connect.current_access_tier = TIERS.free;
+					elementorCommon.config.library_connect.plan_type = data.plan_type;
 
 					updateSettings( {
 						is_library_connected: false,
@@ -175,6 +176,7 @@ export default function ItemHeader( props ) {
 						elementorCommon.config.library_connect.is_connected = true;
 						elementorCommon.config.library_connect.current_access_level = accessLevel;
 						elementorCommon.config.library_connect.current_access_tier = accessTier;
+						elementorCommon.config.library_connect.plan_type = data.plan_type;
 
 						updateSettings( {
 							is_library_connected: true,

--- a/app/modules/kit-library/assets/js/components/item-header.js
+++ b/app/modules/kit-library/assets/js/components/item-header.js
@@ -101,7 +101,7 @@ export default function ItemHeader( props ) {
 					elementorCommon.config.library_connect.is_connected = false;
 					elementorCommon.config.library_connect.current_access_level = 0;
 					elementorCommon.config.library_connect.current_access_tier = TIERS.free;
-					elementorCommon.config.library_connect.plan_type = data.plan_type;
+					elementorCommon.config.library_connect.plan_type = TIERS.free;
 
 					updateSettings( {
 						is_library_connected: false,

--- a/app/modules/kit-library/assets/js/pages/cloud/connect-screen.js
+++ b/app/modules/kit-library/assets/js/pages/cloud/connect-screen.js
@@ -26,10 +26,11 @@ export default function ConnectScreen( {
 				width: 600,
 				height: 700,
 			},
-			success: ( data ) => {
+			success: ( _event, data ) => {
 				elementorCommon.config.library_connect.is_connected = true;
 				elementorCommon.config.library_connect.current_access_level = data.kits_access_level || data.access_level || 0;
 				elementorCommon.config.library_connect.current_access_tier = data.access_tier;
+				elementorCommon.config.library_connect.plan_type = data.plan_type;
 
 				onConnectSuccess?.();
 			},
@@ -37,6 +38,7 @@ export default function ConnectScreen( {
 				elementorCommon.config.library_connect.is_connected = false;
 				elementorCommon.config.library_connect.current_access_level = 0;
 				elementorCommon.config.library_connect.current_access_tier = '';
+				elementorCommon.config.library_connect.plan_type = 'free';
 
 				onConnectError?.();
 			},

--- a/app/modules/kit-library/assets/js/pages/cloud/connect-screen.js
+++ b/app/modules/kit-library/assets/js/pages/cloud/connect-screen.js
@@ -6,6 +6,7 @@ import IndexHeader from '../index/index-header';
 import IndexSidebar from '../index/index-sidebar';
 import Layout from '../../components/layout';
 import { AppsEventTracking } from 'elementor-app/event-track/apps-event-tracking';
+import { TIERS } from 'elementor-utils/tiers';
 
 export default function ConnectScreen( {
 	onConnectSuccess,
@@ -38,7 +39,7 @@ export default function ConnectScreen( {
 				elementorCommon.config.library_connect.is_connected = false;
 				elementorCommon.config.library_connect.current_access_level = 0;
 				elementorCommon.config.library_connect.current_access_tier = '';
-				elementorCommon.config.library_connect.plan_type = 'free';
+				elementorCommon.config.library_connect.plan_type = TIERS.free;
 
 				onConnectError?.();
 			},

--- a/app/modules/kit-library/module.php
+++ b/app/modules/kit-library/module.php
@@ -73,6 +73,7 @@ class Module extends BaseModule {
 			] ),
 			'access_level' => ConnectModule::ACCESS_LEVEL_CORE,
 			'access_tier' => ConnectModule::ACCESS_TIER_FREE,
+			'plan_type' => ConnectModule::ACCESS_TIER_FREE,
 			'app_url' => Plugin::$instance->app->get_base_url() . '#/' . $this->get_name(),
 		] );
 	}

--- a/app/modules/onboarding/assets/js/pages/account.js
+++ b/app/modules/onboarding/assets/js/pages/account.js
@@ -104,6 +104,7 @@ export default function Account() {
 		elementorCommon.config.library_connect.is_connected = true;
 		elementorCommon.config.library_connect.current_access_level = data.kits_access_level || data.access_level || 0;
 		elementorCommon.config.library_connect.current_access_tier = data.access_tier;
+		elementorCommon.config.library_connect.plan_type = data.plan_type;
 
 		updateState( stateToUpdate );
 

--- a/app/modules/onboarding/assets/js/utils/connect.js
+++ b/app/modules/onboarding/assets/js/utils/connect.js
@@ -10,6 +10,7 @@ export default function Connect( props ) {
 		elementorCommon.config.library_connect.is_connected = true;
 		elementorCommon.config.library_connect.current_access_level = data.kits_access_level || data.access_level || 0;
 		elementorCommon.config.library_connect.current_access_tier = data.access_tier;
+		elementorCommon.config.library_connect.plan_type = data.plan_type;
 
 		stateToUpdate.isLibraryConnected = true;
 

--- a/core/common/modules/connect/apps/library.php
+++ b/core/common/modules/connect/apps/library.php
@@ -76,6 +76,7 @@ class Library extends Common_App {
 				'base_access_tier' => ConnectModule::ACCESS_TIER_FREE,
 				'current_access_level' => ConnectModule::ACCESS_LEVEL_CORE,
 				'current_access_tier' => ConnectModule::ACCESS_TIER_FREE,
+				'plan_type' => ConnectModule::ACCESS_TIER_FREE,
 			],
 		] );
 	}
@@ -154,6 +155,7 @@ class Library extends Common_App {
 		return [
 			'access_level' => ConnectModule::ACCESS_LEVEL_CORE,
 			'access_tier' => ConnectModule::ACCESS_TIER_FREE,
+			'plan_type' => ConnectModule::ACCESS_TIER_FREE,
 		];
 	}
 

--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -20,6 +20,7 @@ export default class extends elementorModules.Module {
 				mixpanel.people.set_once( {
 					$user_id: userId,
 					$last_login: new Date().toISOString(),
+					$plan_type: elementorCommon.config.library_connect?.plan_type || null,
 				} );
 			}
 		}

--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -1,5 +1,6 @@
 import eventsConfig from './events-config';
 import mixpanel from 'mixpanel-browser';
+import { TIERS } from 'elementor-utils/tiers';
 
 export default class extends elementorModules.Module {
 	onInit() {
@@ -20,7 +21,7 @@ export default class extends elementorModules.Module {
 				mixpanel.people.set_once( {
 					$user_id: userId,
 					$last_login: new Date().toISOString(),
-					$plan_type: elementorCommon.config.library_connect?.plan_type || null,
+					$plan_type: elementorCommon.config.library_connect?.plan_type || TIERS.free,
 				} );
 			}
 		}

--- a/modules/ai/assets/js/editor/utils/editor-integration.js
+++ b/modules/ai/assets/js/editor/utils/editor-integration.js
@@ -21,6 +21,7 @@ export const onConnect = ( data ) => {
 	elementorCommon.config.library_connect.is_connected = true;
 	elementorCommon.config.library_connect.current_access_level = data.kits_access_level || data.access_level || 0;
 	elementorCommon.config.library_connect.current_access_tier = data.access_tier;
+	elementorCommon.config.library_connect.plan_type = data.plan_type;
 };
 
 export const getUiConfig = () => {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Add Mixpanel tracking plan_type property to the Connect module for accurate subscription tracking in Cloud Templates.
Main changes:
- Added plan_type property to library_connect configuration object in multiple components
- Set plan_type data in Connect module success callbacks and user profile
- Imported TIERS utility for consistent free tier fallback values
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
