### PR TITLE
Tweak: Change IE Customization experiment [ED-20224]

### DIFF
--- a/app/app.php
+++ b/app/app.php
@@ -287,9 +287,8 @@ class App extends BaseApp {
 			'name' => 'import-export-customization',
 			'title' => esc_html__( 'Import/Export Customization', 'elementor' ),
 			'description' => esc_html__( 'Enable advanced customization options for import/export functionality.', 'elementor' ),
-			'hidden' => true,
 			'release_status' => ExperimentsManager::RELEASE_STATUS_ALPHA,
-			'default' => ExperimentsManager::STATE_INACTIVE,
+			'default' => ExperimentsManager::STATE_ACTIVE,
 		] );
 	}
 

--- a/app/modules/import-export-customization/module.php
+++ b/app/modules/import-export-customization/module.php
@@ -130,13 +130,13 @@ class Module extends BaseModule {
 	 * Render the import/export tab content.
 	 */
 	private function render_import_export_tab_content() {
-		$is_cloud_kits_available = Plugin::$instance->experiments->is_feature_active( 'cloud-library' ) && CloudKitLibrary::get_app()->is_eligible();
+		$is_cloud_kits_available = Plugin::$instance->experiments->is_feature_active( 'cloud-library' ) && CloudKitLibrary::get_app()->check_eligibility()['is_eligible'];
 
 		$content_data = [
 			'export' => [
 				'title' => esc_html__( 'Export this website', 'elementor' ),
 				'button' => [
-					'url' => Plugin::$instance->app->get_base_url() . '#/export',
+					'url' => Plugin::$instance->app->get_base_url() . '#/export-customization',
 					'text' => esc_html__( 'Export', 'elementor' ),
 					'id' => 'elementor-import-export__export',
 				],
@@ -145,7 +145,7 @@ class Module extends BaseModule {
 			'import' => [
 				'title' => esc_html__( 'Apply a Website Template', 'elementor' ),
 				'button' => [
-					'url' => Plugin::$instance->app->get_base_url() . '#/import',
+					'url' => Plugin::$instance->app->get_base_url() . '#/import-customization',
 					'text' => $is_cloud_kits_available ? esc_html__( 'Upload .zip file', 'elementor' ) : esc_html__( 'Import', 'elementor' ),
 					'id' => 'elementor-import-export__import',
 				],
@@ -156,7 +156,7 @@ class Module extends BaseModule {
 		if ( $is_cloud_kits_available ) {
 			$content_data['import']['button_secondary'] = [
 				'url' => Plugin::$instance->app->get_base_url() . '#/kit-library/cloud',
-				'text' => esc_html__( 'Open the Library', 'elementor' ),
+				'text' => esc_html__( 'Import from library', 'elementor' ),
 				'id' => 'elementor-import-export__import_from_library',
 			];
 		}

--- a/app/modules/import-export/module.php
+++ b/app/modules/import-export/module.php
@@ -483,9 +483,11 @@ class Module extends BaseModule {
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 
-		$page_id = Tools::PAGE_ID;
+		if ( ! Plugin::$instance->experiments->is_feature_active( 'import-export-customization' ) ) {
+			$page_id = Tools::PAGE_ID;
 
-		add_action( "elementor/admin/after_create_settings/{$page_id}", [ $this, 'register_settings_tab' ] );
+			add_action( "elementor/admin/after_create_settings/{$page_id}", [ $this, 'register_settings_tab' ] );
+		}
 
 		// TODO 18/04/2023 : This needs to be moved to the runner itself after https://elementor.atlassian.net/browse/HTS-434 is done.
 		if ( self::IMPORT_PLUGINS_ACTION === ElementorUtils::get_super_global_value( $_SERVER, 'HTTP_X_ELEMENTOR_ACTION' ) ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Change the Import/Export Customization experiment from inactive to active and update related UI elements and navigation paths.

Main changes:
- Changed experiment default state from STATE_INACTIVE to STATE_ACTIVE and removed hidden flag
- Updated import/export URL paths to point to new customization routes
- Modified button text from "Open the Library" to "Import from library"
- Added conditional registration of settings tab based on experiment state

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
