### PR TITLE
Fix: Icon Box widget - Icon can no longer be aligned left/right [ED-20352]

### DIFF
--- a/assets/dev/scss/frontend/widgets/icon-box.scss
+++ b/assets/dev/scss/frontend/widgets/icon-box.scss
@@ -29,7 +29,7 @@
 				text-align: center;
 				flex-direction: column;
 				gap: var(--icon-box-icon-margin, 15px);
-				align-items: unset !important; // Fix mobile icon alignment bug.
+				align-items: unset !important; // Specificity override to fix mobile icon alignment issue.
 			}
 		}
 	}
@@ -47,6 +47,7 @@
 	.elementor-icon-box-icon {
 		display: inline-block;
 		flex: 0 0 auto; // Hack for Safari
+		line-height: 0;
 	}
 
 	.elementor-icon-box-content {

--- a/assets/dev/scss/frontend/widgets/icon-box.scss
+++ b/assets/dev/scss/frontend/widgets/icon-box.scss
@@ -32,7 +32,8 @@
 			}
 
 			.elementor-icon-box-icon {
-				justify-content: center;
+				align-items: unset;
+				text-align: center;
 			}
 		}
 	}
@@ -48,7 +49,7 @@
 	}
 
 	.elementor-icon-box-icon {
-		display: inline-flex;
+		display: inline-block;
 		flex: 0 0 auto; // Hack for Safari
 	}
 

--- a/assets/dev/scss/frontend/widgets/icon-box.scss
+++ b/assets/dev/scss/frontend/widgets/icon-box.scss
@@ -32,7 +32,7 @@
 			}
 
 			.elementor-icon-box-icon {
-				margin-inline: auto;
+				justify-content: center;
 			}
 		}
 	}

--- a/assets/dev/scss/frontend/widgets/icon-box.scss
+++ b/assets/dev/scss/frontend/widgets/icon-box.scss
@@ -29,11 +29,7 @@
 				text-align: center;
 				flex-direction: column;
 				gap: var(--icon-box-icon-margin, 15px);
-			}
-
-			.elementor-icon-box-icon {
-				align-items: unset;
-				text-align: center;
+				align-items: unset !important; // Fix mobile icon alignment bug.
 			}
 		}
 	}

--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -278,7 +278,8 @@ class Widget_Icon_Box extends Widget_Base {
 						'icon' => 'eicon-v-align-bottom',
 					],
 				],
-				'default' => 'top',
+				'default' => 'start',
+				'mobile_default' => 'center',
 				'selectors_dictionary' => [
 					'top' => 'start',
 					'middle' => 'center',

--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -279,7 +279,7 @@ class Widget_Icon_Box extends Widget_Base {
 					],
 				],
 				'default' => 'start',
-				'mobile_default' => 'center',
+				'mobile_default' => 'middle',
 				'selectors_dictionary' => [
 					'top' => 'start',
 					'middle' => 'center',
@@ -320,7 +320,6 @@ class Widget_Icon_Box extends Widget_Base {
 				],
 				'selectors' => [
 					'{{WRAPPER}} .elementor-icon-box-wrapper' => 'text-align: {{VALUE}};',
-					'{{WRAPPER}} .elementor-icon-box-icon' => 'justify-content: {{VALUE}};',
 				],
 				'separator' => 'after',
 			]

--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -278,6 +278,7 @@ class Widget_Icon_Box extends Widget_Base {
 						'icon' => 'eicon-v-align-bottom',
 					],
 				],
+				'default' => 'top',
 				'selectors_dictionary' => [
 					'top' => 'start',
 					'middle' => 'center',

--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -278,8 +278,6 @@ class Widget_Icon_Box extends Widget_Base {
 						'icon' => 'eicon-v-align-bottom',
 					],
 				],
-				'default' => 'start',
-				'mobile_default' => 'middle',
 				'selectors_dictionary' => [
 					'top' => 'start',
 					'middle' => 'center',

--- a/includes/widgets/icon-box.php
+++ b/includes/widgets/icon-box.php
@@ -319,6 +319,7 @@ class Widget_Icon_Box extends Widget_Base {
 				],
 				'selectors' => [
 					'{{WRAPPER}} .elementor-icon-box-wrapper' => 'text-align: {{VALUE}};',
+					'{{WRAPPER}} .elementor-icon-box-icon' => 'justify-content: {{VALUE}};',
 				],
 				'separator' => 'after',
 			]


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Icon Box widget alignment issues when icons are positioned left/right by removing conflicting styling that forced center alignment.

Main changes:
- Added align-items: unset !important to override mobile icon alignment issues
- Changed icon-box-icon from inline-flex to inline-block with line-height: 0
- Removed unnecessary margin-inline: auto that was forcing center alignment

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
