### PR TITLE
Internal: Remove run-tests label from the PR after first run [ED-20330]

### DIFF
--- a/.github/workflows/create-revert-pr/action.yml
+++ b/.github/workflows/create-revert-pr/action.yml
@@ -124,9 +124,7 @@ runs:
         ${COMMIT_MESSAGE}
         \`\`\`
 
-        This revert commit was created automatically using \`git revert\` because the ${WORKFLOW_NAME} tests failed after the original commit was pushed to ${BRANCH_NAME}.
-        
-        The 'run-tests' label has been added to trigger tests on this revert PR."
+        This revert commit was created automatically using \`git revert\` because the ${WORKFLOW_NAME} tests failed after the original commit was pushed to ${BRANCH_NAME}."
         
         # Create the PR
         PR_URL=$(gh pr create \
@@ -140,10 +138,6 @@ runs:
         
         echo "Created revert PR #${PR_NUMBER}"
         
-        # Add the 'run-tests' label
-        gh pr edit "${PR_NUMBER}" --add-label "run-tests"
-        
-        echo "Added 'run-tests' label to PR #${PR_NUMBER}"
         echo "::notice::Created revert PR #${PR_NUMBER} for commit ${COMMIT_SHA}"
         
         # Set outputs

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -187,9 +187,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Remove run-tests label
-        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests') }}
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests') && (needs.Playwright.result == 'success' || needs.Playwright.result == 'failure') }}
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "run-tests"
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "run-tests" --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create revert PR on push failure

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -186,6 +186,12 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove run-tests label
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests') }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "run-tests"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create revert PR on push failure
         id: create_revert_pr
         if: ${{ needs.Playwright.result == 'failure' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')) }}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove automatic run-tests label from PRs after the first test execution to prevent redundant test runs.

Main changes:
- Added logic to playwright.yml to remove run-tests label after tests complete
- Removed automatic run-tests label addition from create-revert-PR action
- Updated PR description template to reflect the change in label behavior

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
