### PR TITLE
Fix: Renaming a Class causes styles to break [ED-20279]

### DIFF
--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -18980,6 +18980,165 @@
         "react-dom": "^18.3.1"
       }
     },
+    "packages/core/editor-canvas/node_modules/@elementor/editor-current-user": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@elementor/editor-current-user/-/editor-current-user-0.6.1.tgz",
+      "integrity": "sha512-RhoVxd+dQ33PPAM/U67hWrGniN2TI89/UBq6NrYgvkJb6+7OyWZgl9vBFUsxtsr0s35RNOE0FbvE40bJ/9Es8A==",
+      "dependencies": {
+        "@elementor/editor-v1-adapters": "0.12.1",
+        "@elementor/http-client": "0.3.0",
+        "@elementor/query": "0.2.4"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "packages/core/editor-canvas/node_modules/@elementor/editor-current-user/node_modules/@elementor/editor-v1-adapters": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@elementor/editor-v1-adapters/-/editor-v1-adapters-0.12.1.tgz",
+      "integrity": "sha512-Bwxqdnx4hfbi+OGl/SrXv5mIkHBDhTjY/Rd/yQ6a2IauYGQTjKbT4bnd5CYBOpYLn334NdlelKwXBHOLayQn1Q==",
+      "dependencies": {
+        "@elementor/utils": "0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "packages/core/editor-canvas/node_modules/@elementor/editor-current-user/node_modules/@elementor/utils": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@elementor/utils/-/utils-0.5.0.tgz",
+      "integrity": "sha512-Qlnb+ucfJ7OpaxbNz0jZkpAHpwy04ajrS51TC67Sbs/KFw3nqz2edAiR8h8vy4oHLCvgYla0RtnVhurk+OWTWw==",
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "packages/core/editor-canvas/node_modules/@elementor/editor-documents": {
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/@elementor/editor-documents/-/editor-documents-0.13.10.tgz",
+      "integrity": "sha512-ODcTQIqLutQCIZ9/tDadhNhakTChbFHsg/fhk+iUF6E36NzTqDN390Hgrh6gclR37hL/P2bGv2baCqNt3bTbhQ==",
+      "dependencies": {
+        "@elementor/editor": "0.21.1",
+        "@elementor/editor-v1-adapters": "0.12.1",
+        "@elementor/store": "0.9.0",
+        "@elementor/utils": "0.5.0",
+        "@wordpress/i18n": "^5.13.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "packages/core/editor-canvas/node_modules/@elementor/editor-documents/node_modules/@elementor/editor": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@elementor/editor/-/editor-0.21.1.tgz",
+      "integrity": "sha512-5XkcUpNozOY9UG3COX0Z/300idnMAhOuvd6CShkKwUYk0VV49xIDLzkmiXV661gZAb/jBsAEH7vuB6Br0U7OrQ==",
+      "dependencies": {
+        "@elementor/editor-current-user": "0.6.1",
+        "@elementor/editor-v1-adapters": "0.12.1",
+        "@elementor/locations": "0.8.0",
+        "@elementor/query": "0.2.4",
+        "@elementor/store": "0.9.0",
+        "@elementor/ui": "1.36.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      }
+    },
+    "packages/core/editor-canvas/node_modules/@elementor/editor-documents/node_modules/@elementor/editor-v1-adapters": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@elementor/editor-v1-adapters/-/editor-v1-adapters-0.12.1.tgz",
+      "integrity": "sha512-Bwxqdnx4hfbi+OGl/SrXv5mIkHBDhTjY/Rd/yQ6a2IauYGQTjKbT4bnd5CYBOpYLn334NdlelKwXBHOLayQn1Q==",
+      "dependencies": {
+        "@elementor/utils": "0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "packages/core/editor-canvas/node_modules/@elementor/editor-documents/node_modules/@elementor/ui": {
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.0.tgz",
+      "integrity": "sha512-/+SuvYceHRYazC+dLht0bgwlZQ1Qha8SZ92qbOZKJIU6vH/BeiwRZwd7OqWxPtP17XRohudhtNb6i0EmNNR7+Q==",
+      "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
+        "@elementor/design-tokens": "1.1.4",
+        "@emotion/cache": "11.13.0",
+        "@emotion/react": "11.13.0",
+        "@emotion/styled": "11.13.0",
+        "@mui/material": "5.15.17",
+        "@mui/system": "5.17.1",
+        "@mui/utils": "5.16.14",
+        "@mui/x-date-pickers": "6.18.1",
+        "clsx": "2.1.0",
+        "colord": "2.9.3",
+        "dayjs": "1.11.10",
+        "material-ui-popup-state": "5.0.11",
+        "react-colorful": "5.6.1",
+        "react-transition-group": "4.4.5",
+        "stylis": "4.1.3",
+        "stylis-plugin-rtl": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "packages/core/editor-canvas/node_modules/@elementor/editor-documents/node_modules/@elementor/utils": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@elementor/utils/-/utils-0.5.0.tgz",
+      "integrity": "sha512-Qlnb+ucfJ7OpaxbNz0jZkpAHpwy04ajrS51TC67Sbs/KFw3nqz2edAiR8h8vy4oHLCvgYla0RtnVhurk+OWTWw==",
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "packages/core/editor-canvas/node_modules/@elementor/env": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@elementor/env/-/env-0.3.5.tgz",
+      "integrity": "sha512-LjXSNmncnOvc4R8wrPnS09H1Qa25HksEsEZ4zPX73fgnphCundtXL/1FCCgc+G8pxsjub5k0UJ46UYatH4N5lg=="
+    },
+    "packages/core/editor-canvas/node_modules/@elementor/http-client": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@elementor/http-client/-/http-client-0.3.0.tgz",
+      "integrity": "sha512-gBCa8uQVvHe46XOC5m84BDqLk8tiAeRLudFTh9mzomlEUW28qtc7qQfWIyc7C7noipqDaMWEWjBmfrRgeUSdOA==",
+      "dependencies": {
+        "@elementor/env": "0.3.5",
+        "axios": "^1.9.0"
+      }
+    },
+    "packages/core/editor-canvas/node_modules/@elementor/locations": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@elementor/locations/-/locations-0.8.0.tgz",
+      "integrity": "sha512-mEC+9eRNPbEuxHrdHbHBsqIk/Jp1Y/PAyV2U2LX9tlEdSvSFduGUOtQYenvkW28awjTqZF8n0GG9C27jO25GvQ==",
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "packages/core/editor-canvas/node_modules/@elementor/query": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@elementor/query/-/query-0.2.4.tgz",
+      "integrity": "sha512-dTLci2x6ZmIMGoPZCVEyKknVeZ3+N8tWtg3j+o4vrppXV00gynot+Wl3C18PtKoAvxEpCsbXKL2bUg09CqX7nA==",
+      "dependencies": {
+        "@tanstack/react-query": "^5.62.3"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "packages/core/editor-canvas/node_modules/@elementor/store": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@elementor/store/-/store-0.9.0.tgz",
+      "integrity": "sha512-UTvOZb+aRLxt0DH5vak7DlhFPgxsrsa1i3C6pRCYufMkbMqUsD7zKfKe+8wi3VXyjjUfMXOkMQkCnVrFBhh89w==",
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.7",
+        "react-redux": "^8.1.3"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "packages/core/editor-canvas/node_modules/@elementor/ui": {
       "version": "1.36.2",
       "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.2.tgz",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -18958,6 +18958,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/editor": "0.21.0",
+        "@elementor/editor-documents": "0.13.10",
         "@elementor/editor-elements": "0.9.1",
         "@elementor/editor-notifications": "1.4.0",
         "@elementor/editor-props": "0.17.0",
@@ -18984,6 +18985,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@elementor/editor-current-user/-/editor-current-user-0.6.1.tgz",
       "integrity": "sha512-RhoVxd+dQ33PPAM/U67hWrGniN2TI89/UBq6NrYgvkJb6+7OyWZgl9vBFUsxtsr0s35RNOE0FbvE40bJ/9Es8A==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/editor-v1-adapters": "0.12.1",
         "@elementor/http-client": "0.3.0",
@@ -18993,29 +18995,11 @@
         "react": "^18.3.1"
       }
     },
-    "packages/core/editor-canvas/node_modules/@elementor/editor-current-user/node_modules/@elementor/editor-v1-adapters": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@elementor/editor-v1-adapters/-/editor-v1-adapters-0.12.1.tgz",
-      "integrity": "sha512-Bwxqdnx4hfbi+OGl/SrXv5mIkHBDhTjY/Rd/yQ6a2IauYGQTjKbT4bnd5CYBOpYLn334NdlelKwXBHOLayQn1Q==",
-      "dependencies": {
-        "@elementor/utils": "0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "packages/core/editor-canvas/node_modules/@elementor/editor-current-user/node_modules/@elementor/utils": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@elementor/utils/-/utils-0.5.0.tgz",
-      "integrity": "sha512-Qlnb+ucfJ7OpaxbNz0jZkpAHpwy04ajrS51TC67Sbs/KFw3nqz2edAiR8h8vy4oHLCvgYla0RtnVhurk+OWTWw==",
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
     "packages/core/editor-canvas/node_modules/@elementor/editor-documents": {
       "version": "0.13.10",
       "resolved": "https://registry.npmjs.org/@elementor/editor-documents/-/editor-documents-0.13.10.tgz",
       "integrity": "sha512-ODcTQIqLutQCIZ9/tDadhNhakTChbFHsg/fhk+iUF6E36NzTqDN390Hgrh6gclR37hL/P2bGv2baCqNt3bTbhQ==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/editor": "0.21.1",
         "@elementor/editor-v1-adapters": "0.12.1",
@@ -19031,6 +19015,7 @@
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/@elementor/editor/-/editor-0.21.1.tgz",
       "integrity": "sha512-5XkcUpNozOY9UG3COX0Z/300idnMAhOuvd6CShkKwUYk0VV49xIDLzkmiXV661gZAb/jBsAEH7vuB6Br0U7OrQ==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/editor-current-user": "0.6.1",
         "@elementor/editor-v1-adapters": "0.12.1",
@@ -19044,21 +19029,11 @@
         "react-dom": "^18.3.1"
       }
     },
-    "packages/core/editor-canvas/node_modules/@elementor/editor-documents/node_modules/@elementor/editor-v1-adapters": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@elementor/editor-v1-adapters/-/editor-v1-adapters-0.12.1.tgz",
-      "integrity": "sha512-Bwxqdnx4hfbi+OGl/SrXv5mIkHBDhTjY/Rd/yQ6a2IauYGQTjKbT4bnd5CYBOpYLn334NdlelKwXBHOLayQn1Q==",
-      "dependencies": {
-        "@elementor/utils": "0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
     "packages/core/editor-canvas/node_modules/@elementor/editor-documents/node_modules/@elementor/ui": {
       "version": "1.36.0",
       "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.0.tgz",
       "integrity": "sha512-/+SuvYceHRYazC+dLht0bgwlZQ1Qha8SZ92qbOZKJIU6vH/BeiwRZwd7OqWxPtP17XRohudhtNb6i0EmNNR7+Q==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/modifiers": "9.0.0",
@@ -19084,59 +19059,6 @@
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "packages/core/editor-canvas/node_modules/@elementor/editor-documents/node_modules/@elementor/utils": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@elementor/utils/-/utils-0.5.0.tgz",
-      "integrity": "sha512-Qlnb+ucfJ7OpaxbNz0jZkpAHpwy04ajrS51TC67Sbs/KFw3nqz2edAiR8h8vy4oHLCvgYla0RtnVhurk+OWTWw==",
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "packages/core/editor-canvas/node_modules/@elementor/env": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@elementor/env/-/env-0.3.5.tgz",
-      "integrity": "sha512-LjXSNmncnOvc4R8wrPnS09H1Qa25HksEsEZ4zPX73fgnphCundtXL/1FCCgc+G8pxsjub5k0UJ46UYatH4N5lg=="
-    },
-    "packages/core/editor-canvas/node_modules/@elementor/http-client": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@elementor/http-client/-/http-client-0.3.0.tgz",
-      "integrity": "sha512-gBCa8uQVvHe46XOC5m84BDqLk8tiAeRLudFTh9mzomlEUW28qtc7qQfWIyc7C7noipqDaMWEWjBmfrRgeUSdOA==",
-      "dependencies": {
-        "@elementor/env": "0.3.5",
-        "axios": "^1.9.0"
-      }
-    },
-    "packages/core/editor-canvas/node_modules/@elementor/locations": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@elementor/locations/-/locations-0.8.0.tgz",
-      "integrity": "sha512-mEC+9eRNPbEuxHrdHbHBsqIk/Jp1Y/PAyV2U2LX9tlEdSvSFduGUOtQYenvkW28awjTqZF8n0GG9C27jO25GvQ==",
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "packages/core/editor-canvas/node_modules/@elementor/query": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@elementor/query/-/query-0.2.4.tgz",
-      "integrity": "sha512-dTLci2x6ZmIMGoPZCVEyKknVeZ3+N8tWtg3j+o4vrppXV00gynot+Wl3C18PtKoAvxEpCsbXKL2bUg09CqX7nA==",
-      "dependencies": {
-        "@tanstack/react-query": "^5.62.3"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "packages/core/editor-canvas/node_modules/@elementor/store": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@elementor/store/-/store-0.9.0.tgz",
-      "integrity": "sha512-UTvOZb+aRLxt0DH5vak7DlhFPgxsrsa1i3C6pRCYufMkbMqUsD7zKfKe+8wi3VXyjjUfMXOkMQkCnVrFBhh89w==",
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.7",
-        "react-redux": "^8.1.3"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
       }
     },
     "packages/core/editor-canvas/node_modules/@elementor/ui": {

--- a/packages/packages/core/editor-canvas/package.json
+++ b/packages/packages/core/editor-canvas/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@elementor/editor": "0.21.0",
     "@elementor/editor-notifications": "1.4.0",
+    "@elementor/editor-documents": "0.13.10",
     "@elementor/editor-elements": "0.9.1",
     "@elementor/editor-props": "0.17.0",
     "@elementor/editor-responsive": "0.13.6",

--- a/packages/packages/core/editor-canvas/src/components/__tests__/classes-rename.test.tsx
+++ b/packages/packages/core/editor-canvas/src/components/__tests__/classes-rename.test.tsx
@@ -1,0 +1,311 @@
+import * as React from 'react';
+import { getV1DocumentsManager } from '@elementor/editor-documents';
+import { type StyleDefinition } from '@elementor/editor-styles';
+import { render } from '@testing-library/react';
+
+import { ClassesRename } from '../classes-rename';
+
+jest.mock( '@elementor/editor-documents', () => ( {
+	getV1DocumentsManager: jest.fn(),
+} ) );
+
+jest.mock( '@elementor/editor-styles-repository', () => ( {
+	stylesRepository: {
+		subscribe: jest.fn(),
+		register: jest.fn(),
+		all: jest.fn(),
+	},
+	createStylesProvider: jest.fn(),
+} ) );
+
+const createMockDocument = () => {
+	const mockElement = {
+		classList: {
+			replace: jest.fn(),
+		},
+	};
+
+	const mockQuerySelectorAll = jest.fn().mockReturnValue( [ mockElement ] );
+
+	const mockContainer = {
+		view: {
+			el: {
+				querySelectorAll: mockQuerySelectorAll,
+			},
+		},
+	};
+
+	const mockDocument = {
+		container: mockContainer,
+	};
+
+	return { mockDocument, mockContainer, mockElement };
+};
+
+interface StylesMap {
+	[ key: string ]: StyleDefinition;
+}
+
+describe( 'ClassesRename', () => {
+	const mockGetV1DocumentsManager = jest.mocked( getV1DocumentsManager );
+	const { stylesRepository } = jest.requireMock( '@elementor/editor-styles-repository' );
+	const mockSubscribe = jest.mocked( stylesRepository.subscribe ).mockReturnValue( jest.fn() );
+
+	const triggerStylesChange = ( previousStyles: StylesMap, currentStyles: StylesMap ) => {
+		const subscriptionCallback = mockSubscribe.mock.calls[ mockSubscribe.mock.calls.length - 1 ][ 0 ];
+		subscriptionCallback( previousStyles as never, currentStyles as never );
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should not rename classes when no classes have been changed', () => {
+		// Arrange.
+		const { mockElement } = createMockDocument();
+		mockGetV1DocumentsManager.mockReturnValue( {
+			documents: {},
+		} as never );
+
+		const previousStyles: StylesMap = {
+			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
+		};
+
+		const currentStyles: StylesMap = {
+			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
+		};
+
+		// Act.
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
+
+		// Assert.
+		expect( mockElement.classList.replace ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should rename classes when label changes', () => {
+		// Arrange.
+		const { mockDocument, mockElement } = createMockDocument();
+		mockGetV1DocumentsManager.mockReturnValue( {
+			documents: {
+				1: mockDocument,
+			},
+		} as never );
+
+		const previousStyles: StylesMap = {
+			style1: {
+				id: 'style1',
+				label: 'old-class',
+				type: 'class',
+				variants: [],
+			},
+		};
+
+		const currentStyles: StylesMap = {
+			style1: { id: 'style1', label: 'new-class', type: 'class', variants: [] },
+		};
+
+		// Act.
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
+
+		// Assert.
+		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class', 'new-class' );
+	} );
+
+	it( 'should not rename classes when only non-label properties change', () => {
+		// Arrange.
+		const { mockDocument, mockElement } = createMockDocument();
+		mockGetV1DocumentsManager.mockReturnValue( {
+			documents: {
+				1: mockDocument,
+			},
+		} as never );
+
+		const previousStyles: StylesMap = {
+			style1: {
+				id: 'style1',
+				label: 'same-class',
+				type: 'class',
+				variants: [ { meta: { breakpoint: null, state: null }, props: {}, custom_css: null } ],
+			},
+		};
+
+		const currentStyles: StylesMap = {
+			style1: { id: 'style1', label: 'same-class', type: 'class', variants: [] },
+		};
+
+		// Act.
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
+
+		// Assert.
+		expect( mockElement.classList.replace ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should handle multiple style changes', () => {
+		// Arrange.
+		const { mockDocument, mockElement } = createMockDocument();
+		mockGetV1DocumentsManager.mockReturnValue( {
+			documents: {
+				1: mockDocument,
+			},
+		} as never );
+
+		const previousStyles: StylesMap = {
+			style1: { id: 'style1', label: 'old-class-1', type: 'class', variants: [] },
+			style2: { id: 'style2', label: 'old-class-2', type: 'class', variants: [] },
+			style3: { id: 'style3', label: 'unchanged-class', type: 'class', variants: [] },
+		};
+
+		const currentStyles: StylesMap = {
+			style1: { id: 'style1', label: 'new-class-1', type: 'class', variants: [] },
+			style2: { id: 'style2', label: 'new-class-2', type: 'class', variants: [] },
+			style3: { id: 'style3', label: 'unchanged-class', type: 'class', variants: [] },
+		};
+
+		// Act.
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
+
+		// Assert.
+		expect( mockElement.classList.replace ).toHaveBeenCalledTimes( 2 );
+		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class-1', 'new-class-1' );
+		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class-2', 'new-class-2' );
+	} );
+
+	it( 'should rename classes when new label is an empty string', () => {
+		// Arrange.
+		const { mockDocument, mockElement } = createMockDocument();
+		mockGetV1DocumentsManager.mockReturnValue( {
+			documents: {
+				1: mockDocument,
+			},
+		} as never );
+
+		const previousStyles: StylesMap = {
+			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
+		};
+
+		const currentStyles: StylesMap = {
+			style1: { id: 'style1', label: '', type: 'class', variants: [] },
+		};
+
+		// Act.
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
+
+		// Assert.
+		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class', '' );
+	} );
+
+	it( 'should handle new styles (not in previous)', () => {
+		// Arrange.
+		const { mockDocument, mockElement } = createMockDocument();
+		mockGetV1DocumentsManager.mockReturnValue( {
+			documents: {
+				1: mockDocument,
+			},
+		} as never );
+
+		const previousStyles: StylesMap = {
+			style1: { id: 'style1', label: 'existing-class', type: 'class', variants: [] },
+		};
+
+		const currentStyles: StylesMap = {
+			style1: { id: 'style1', label: 'existing-class', type: 'class', variants: [] },
+			style2: { id: 'style2', label: 'new-class', type: 'class', variants: [] },
+		};
+
+		// Act.
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
+
+		// Assert.
+		expect( mockElement.classList.replace ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should handle multiple documents', () => {
+		// Arrange.
+		const { mockDocument, mockElement } = createMockDocument();
+		const { mockDocument: mockDocument2, mockElement: mockElement2 } = createMockDocument();
+
+		mockGetV1DocumentsManager.mockReturnValue( {
+			documents: {
+				1: mockDocument,
+				2: mockDocument2,
+			},
+		} as never );
+
+		const previousStyles: StylesMap = {
+			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
+		};
+
+		const currentStyles: StylesMap = {
+			style1: { id: 'style1', label: 'new-class', type: 'class', variants: [] },
+		};
+
+		// Act.
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
+
+		// Assert.
+		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class', 'new-class' );
+		expect( mockElement2.classList.replace ).toHaveBeenCalledWith( 'old-class', 'new-class' );
+	} );
+
+	it( 'should handle documents without view or el', () => {
+		// Arrange.
+		const incompleteDocument = {
+			container: {
+				view: null,
+			},
+		};
+
+		mockGetV1DocumentsManager.mockReturnValue( {
+			documents: {
+				1: incompleteDocument as never,
+			},
+		} as never );
+
+		const previousStyles: StylesMap = {
+			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
+		};
+
+		const currentStyles: StylesMap = {
+			style1: { id: 'style1', label: 'new-class', type: 'class', variants: [] },
+		};
+
+		// Act & Assert - should not throw an error.
+		expect( () => {
+			render( <ClassesRename /> );
+			triggerStylesChange( previousStyles, currentStyles );
+		} ).not.toThrow();
+	} );
+
+	it( 'should use correct CSS selector format', () => {
+		// Arrange.
+		const { mockDocument, mockContainer } = createMockDocument();
+		mockGetV1DocumentsManager.mockReturnValue( {
+			documents: {
+				1: mockDocument,
+			},
+		} as never );
+
+		const previousStyles: StylesMap = {
+			style1: { id: 'style1', label: 'test-class', type: 'class', variants: [] },
+		};
+
+		const currentStyles: StylesMap = {
+			style1: { id: 'style1', label: 'new-test-class', type: 'class', variants: [] },
+		};
+
+		// Act.
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
+
+		// Assert.
+		// eslint-disable-next-line testing-library/no-node-access
+		expect( mockContainer.view.el.querySelectorAll ).toHaveBeenCalledWith( '.elementor .test-class' );
+	} );
+} );

--- a/packages/packages/core/editor-canvas/src/components/__tests__/classes-rename.test.tsx
+++ b/packages/packages/core/editor-canvas/src/components/__tests__/classes-rename.test.tsx
@@ -1,7 +1,7 @@
+import * as React from 'react';
 import { getV1DocumentsManager } from '@elementor/editor-documents';
 import { type StyleDefinition } from '@elementor/editor-styles';
 import { render } from '@testing-library/react';
-import * as React from 'react';
 
 import { ClassesRename } from '../classes-rename';
 
@@ -127,7 +127,7 @@ describe( 'ClassesRename', () => {
 				id: 'style1',
 				label: 'same-class',
 				type: 'class',
-				variants: [ { meta: { breakpoint: null, state: null }, props: {}} ],
+				variants: [ { meta: { breakpoint: null, state: null }, props: {} } ],
 			},
 		};
 

--- a/packages/packages/core/editor-canvas/src/components/__tests__/classes-rename.test.tsx
+++ b/packages/packages/core/editor-canvas/src/components/__tests__/classes-rename.test.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
 import { getV1DocumentsManager } from '@elementor/editor-documents';
 import { type StyleDefinition } from '@elementor/editor-styles';
 import { render } from '@testing-library/react';
+import * as React from 'react';
 
 import { ClassesRename } from '../classes-rename';
 
@@ -127,7 +127,7 @@ describe( 'ClassesRename', () => {
 				id: 'style1',
 				label: 'same-class',
 				type: 'class',
-				variants: [ { meta: { breakpoint: null, state: null }, props: {}, custom_css: null } ],
+				variants: [ { meta: { breakpoint: null, state: null }, props: {}} ],
 			},
 		};
 

--- a/packages/packages/core/editor-canvas/src/components/__tests__/classes-rename.test.tsx
+++ b/packages/packages/core/editor-canvas/src/components/__tests__/classes-rename.test.tsx
@@ -1,22 +1,22 @@
+import * as React from 'react';
 import { getV1DocumentsManager } from '@elementor/editor-documents';
 import { type StyleDefinition } from '@elementor/editor-styles';
 import { render } from '@testing-library/react';
-import * as React from 'react';
 
 import { ClassesRename } from '../classes-rename';
 
-jest.mock('@elementor/editor-documents', () => ({
+jest.mock( '@elementor/editor-documents', () => ( {
 	getV1DocumentsManager: jest.fn(),
-}));
+} ) );
 
-jest.mock('@elementor/editor-styles-repository', () => ({
+jest.mock( '@elementor/editor-styles-repository', () => ( {
 	stylesRepository: {
 		subscribe: jest.fn(),
 		register: jest.fn(),
 		all: jest.fn(),
 	},
 	createStylesProvider: jest.fn(),
-}));
+} ) );
 
 const createMockDocument = () => {
 	const mockElement = {
@@ -25,7 +25,7 @@ const createMockDocument = () => {
 		},
 	};
 
-	const mockQuerySelectorAll = jest.fn().mockReturnValue([mockElement]);
+	const mockQuerySelectorAll = jest.fn().mockReturnValue( [ mockElement ] );
 
 	const mockContainer = {
 		view: {
@@ -43,29 +43,29 @@ const createMockDocument = () => {
 };
 
 interface StylesMap {
-	[key: string]: StyleDefinition;
+	[ key: string ]: StyleDefinition;
 }
 
-describe('ClassesRename', () => {
-	const mockGetV1DocumentsManager = jest.mocked(getV1DocumentsManager);
-	const { stylesRepository } = jest.requireMock('@elementor/editor-styles-repository');
-	const mockSubscribe = jest.mocked(stylesRepository.subscribe).mockReturnValue(jest.fn());
+describe( 'ClassesRename', () => {
+	const mockGetV1DocumentsManager = jest.mocked( getV1DocumentsManager );
+	const { stylesRepository } = jest.requireMock( '@elementor/editor-styles-repository' );
+	const mockSubscribe = jest.mocked( stylesRepository.subscribe ).mockReturnValue( jest.fn() );
 
-	const triggerStylesChange = (previousStyles: StylesMap, currentStyles: StylesMap) => {
-		const subscriptionCallback = mockSubscribe.mock.calls[mockSubscribe.mock.calls.length - 1][0];
-		subscriptionCallback(previousStyles as never, currentStyles as never);
+	const triggerStylesChange = ( previousStyles: StylesMap, currentStyles: StylesMap ) => {
+		const subscriptionCallback = mockSubscribe.mock.calls[ mockSubscribe.mock.calls.length - 1 ][ 0 ];
+		subscriptionCallback( previousStyles as never, currentStyles as never );
 	};
 
-	beforeEach(() => {
+	beforeEach( () => {
 		jest.clearAllMocks();
-	});
+	} );
 
-	it('should not rename classes when no classes have been changed', () => {
+	it( 'should not rename classes when no classes have been changed', () => {
 		// Arrange.
 		const { mockElement } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue({
+		mockGetV1DocumentsManager.mockReturnValue( {
 			documents: {},
-		} as never);
+		} as never );
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
@@ -76,21 +76,21 @@ describe('ClassesRename', () => {
 		};
 
 		// Act.
-		render(<ClassesRename />);
-		triggerStylesChange(previousStyles, currentStyles);
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
 
 		// Assert.
-		expect(mockElement.classList.replace).not.toHaveBeenCalled();
-	});
+		expect( mockElement.classList.replace ).not.toHaveBeenCalled();
+	} );
 
-	it('should rename classes when label changes', () => {
+	it( 'should rename classes when label changes', () => {
 		// Arrange.
 		const { mockDocument, mockElement } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue({
+		mockGetV1DocumentsManager.mockReturnValue( {
 			documents: {
 				1: mockDocument,
 			},
-		} as never);
+		} as never );
 
 		const previousStyles: StylesMap = {
 			style1: {
@@ -106,28 +106,28 @@ describe('ClassesRename', () => {
 		};
 
 		// Act.
-		render(<ClassesRename />);
-		triggerStylesChange(previousStyles, currentStyles);
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
 
 		// Assert.
-		expect(mockElement.classList.replace).toHaveBeenCalledWith('old-class', 'new-class');
-	});
+		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class', 'new-class' );
+	} );
 
-	it('should not rename classes when only non-label properties change', () => {
+	it( 'should not rename classes when only non-label properties change', () => {
 		// Arrange.
 		const { mockDocument, mockElement } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue({
+		mockGetV1DocumentsManager.mockReturnValue( {
 			documents: {
 				1: mockDocument,
 			},
-		} as never);
+		} as never );
 
 		const previousStyles: StylesMap = {
 			style1: {
 				id: 'style1',
 				label: 'same-class',
 				type: 'class',
-				variants: [{ meta: { breakpoint: null, state: null }, props: {}, custom_css: null }],
+				variants: [ { meta: { breakpoint: null, state: null }, props: {}, custom_css: null } ],
 			},
 		};
 
@@ -136,21 +136,21 @@ describe('ClassesRename', () => {
 		};
 
 		// Act.
-		render(<ClassesRename />);
-		triggerStylesChange(previousStyles, currentStyles);
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
 
 		// Assert.
-		expect(mockElement.classList.replace).not.toHaveBeenCalled();
-	});
+		expect( mockElement.classList.replace ).not.toHaveBeenCalled();
+	} );
 
-	it('should handle multiple style changes', () => {
+	it( 'should handle multiple style changes', () => {
 		// Arrange.
 		const { mockDocument, mockElement } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue({
+		mockGetV1DocumentsManager.mockReturnValue( {
 			documents: {
 				1: mockDocument,
 			},
-		} as never);
+		} as never );
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'old-class-1', type: 'class', variants: [] },
@@ -165,23 +165,23 @@ describe('ClassesRename', () => {
 		};
 
 		// Act.
-		render(<ClassesRename />);
-		triggerStylesChange(previousStyles, currentStyles);
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
 
 		// Assert.
-		expect(mockElement.classList.replace).toHaveBeenCalledTimes(2);
-		expect(mockElement.classList.replace).toHaveBeenCalledWith('old-class-1', 'new-class-1');
-		expect(mockElement.classList.replace).toHaveBeenCalledWith('old-class-2', 'new-class-2');
-	});
+		expect( mockElement.classList.replace ).toHaveBeenCalledTimes( 2 );
+		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class-1', 'new-class-1' );
+		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class-2', 'new-class-2' );
+	} );
 
-	it('should rename classes when new label is an empty string', () => {
+	it( 'should rename classes when new label is an empty string', () => {
 		// Arrange.
 		const { mockDocument, mockElement } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue({
+		mockGetV1DocumentsManager.mockReturnValue( {
 			documents: {
 				1: mockDocument,
 			},
-		} as never);
+		} as never );
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
@@ -192,21 +192,21 @@ describe('ClassesRename', () => {
 		};
 
 		// Act.
-		render(<ClassesRename />);
-		triggerStylesChange(previousStyles, currentStyles);
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
 
 		// Assert.
-		expect(mockElement.classList.replace).toHaveBeenCalledWith('old-class', '');
-	});
+		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class', '' );
+	} );
 
-	it('should handle new styles (not in previous)', () => {
+	it( 'should handle new styles (not in previous)', () => {
 		// Arrange.
 		const { mockDocument, mockElement } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue({
+		mockGetV1DocumentsManager.mockReturnValue( {
 			documents: {
 				1: mockDocument,
 			},
-		} as never);
+		} as never );
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'existing-class', type: 'class', variants: [] },
@@ -218,24 +218,24 @@ describe('ClassesRename', () => {
 		};
 
 		// Act.
-		render(<ClassesRename />);
-		triggerStylesChange(previousStyles, currentStyles);
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
 
 		// Assert.
-		expect(mockElement.classList.replace).not.toHaveBeenCalled();
-	});
+		expect( mockElement.classList.replace ).not.toHaveBeenCalled();
+	} );
 
-	it('should handle multiple documents', () => {
+	it( 'should handle multiple documents', () => {
 		// Arrange.
 		const { mockDocument, mockElement } = createMockDocument();
 		const { mockDocument: mockDocument2, mockElement: mockElement2 } = createMockDocument();
 
-		mockGetV1DocumentsManager.mockReturnValue({
+		mockGetV1DocumentsManager.mockReturnValue( {
 			documents: {
 				1: mockDocument,
 				2: mockDocument2,
 			},
-		} as never);
+		} as never );
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
@@ -246,15 +246,15 @@ describe('ClassesRename', () => {
 		};
 
 		// Act.
-		render(<ClassesRename />);
-		triggerStylesChange(previousStyles, currentStyles);
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
 
 		// Assert.
-		expect(mockElement.classList.replace).toHaveBeenCalledWith('old-class', 'new-class');
-		expect(mockElement2.classList.replace).toHaveBeenCalledWith('old-class', 'new-class');
-	});
+		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class', 'new-class' );
+		expect( mockElement2.classList.replace ).toHaveBeenCalledWith( 'old-class', 'new-class' );
+	} );
 
-	it('should handle documents without view or el', () => {
+	it( 'should handle documents without view or el', () => {
 		// Arrange.
 		const incompleteDocument = {
 			container: {
@@ -262,11 +262,11 @@ describe('ClassesRename', () => {
 			},
 		};
 
-		mockGetV1DocumentsManager.mockReturnValue({
+		mockGetV1DocumentsManager.mockReturnValue( {
 			documents: {
 				1: incompleteDocument as never,
 			},
-		} as never);
+		} as never );
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
@@ -277,20 +277,20 @@ describe('ClassesRename', () => {
 		};
 
 		// Act & Assert - should not throw an error.
-		expect(() => {
-			render(<ClassesRename />);
-			triggerStylesChange(previousStyles, currentStyles);
-		}).not.toThrow();
-	});
+		expect( () => {
+			render( <ClassesRename /> );
+			triggerStylesChange( previousStyles, currentStyles );
+		} ).not.toThrow();
+	} );
 
-	it('should use correct CSS selector format', () => {
+	it( 'should use correct CSS selector format', () => {
 		// Arrange.
 		const { mockDocument, mockContainer } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue({
+		mockGetV1DocumentsManager.mockReturnValue( {
 			documents: {
 				1: mockDocument,
 			},
-		} as never);
+		} as never );
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'test-class', type: 'class', variants: [] },
@@ -301,11 +301,11 @@ describe('ClassesRename', () => {
 		};
 
 		// Act.
-		render(<ClassesRename />);
-		triggerStylesChange(previousStyles, currentStyles);
+		render( <ClassesRename /> );
+		triggerStylesChange( previousStyles, currentStyles );
 
 		// Assert.
 		// eslint-disable-next-line testing-library/no-node-access
-		expect(mockContainer.view.el.querySelectorAll).toHaveBeenCalledWith('.elementor .test-class');
-	});
-});
+		expect( mockContainer.view.el.querySelectorAll ).toHaveBeenCalledWith( '.elementor .test-class' );
+	} );
+} );

--- a/packages/packages/core/editor-canvas/src/components/__tests__/classes-rename.test.tsx
+++ b/packages/packages/core/editor-canvas/src/components/__tests__/classes-rename.test.tsx
@@ -1,22 +1,22 @@
-import * as React from 'react';
 import { getV1DocumentsManager } from '@elementor/editor-documents';
 import { type StyleDefinition } from '@elementor/editor-styles';
 import { render } from '@testing-library/react';
+import * as React from 'react';
 
 import { ClassesRename } from '../classes-rename';
 
-jest.mock( '@elementor/editor-documents', () => ( {
+jest.mock('@elementor/editor-documents', () => ({
 	getV1DocumentsManager: jest.fn(),
-} ) );
+}));
 
-jest.mock( '@elementor/editor-styles-repository', () => ( {
+jest.mock('@elementor/editor-styles-repository', () => ({
 	stylesRepository: {
 		subscribe: jest.fn(),
 		register: jest.fn(),
 		all: jest.fn(),
 	},
 	createStylesProvider: jest.fn(),
-} ) );
+}));
 
 const createMockDocument = () => {
 	const mockElement = {
@@ -25,7 +25,7 @@ const createMockDocument = () => {
 		},
 	};
 
-	const mockQuerySelectorAll = jest.fn().mockReturnValue( [ mockElement ] );
+	const mockQuerySelectorAll = jest.fn().mockReturnValue([mockElement]);
 
 	const mockContainer = {
 		view: {
@@ -43,29 +43,29 @@ const createMockDocument = () => {
 };
 
 interface StylesMap {
-	[ key: string ]: StyleDefinition;
+	[key: string]: StyleDefinition;
 }
 
-describe( 'ClassesRename', () => {
-	const mockGetV1DocumentsManager = jest.mocked( getV1DocumentsManager );
-	const { stylesRepository } = jest.requireMock( '@elementor/editor-styles-repository' );
-	const mockSubscribe = jest.mocked( stylesRepository.subscribe ).mockReturnValue( jest.fn() );
+describe('ClassesRename', () => {
+	const mockGetV1DocumentsManager = jest.mocked(getV1DocumentsManager);
+	const { stylesRepository } = jest.requireMock('@elementor/editor-styles-repository');
+	const mockSubscribe = jest.mocked(stylesRepository.subscribe).mockReturnValue(jest.fn());
 
-	const triggerStylesChange = ( previousStyles: StylesMap, currentStyles: StylesMap ) => {
-		const subscriptionCallback = mockSubscribe.mock.calls[ mockSubscribe.mock.calls.length - 1 ][ 0 ];
-		subscriptionCallback( previousStyles as never, currentStyles as never );
+	const triggerStylesChange = (previousStyles: StylesMap, currentStyles: StylesMap) => {
+		const subscriptionCallback = mockSubscribe.mock.calls[mockSubscribe.mock.calls.length - 1][0];
+		subscriptionCallback(previousStyles as never, currentStyles as never);
 	};
 
-	beforeEach( () => {
+	beforeEach(() => {
 		jest.clearAllMocks();
-	} );
+	});
 
-	it( 'should not rename classes when no classes have been changed', () => {
+	it('should not rename classes when no classes have been changed', () => {
 		// Arrange.
 		const { mockElement } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue( {
+		mockGetV1DocumentsManager.mockReturnValue({
 			documents: {},
-		} as never );
+		} as never);
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
@@ -76,21 +76,21 @@ describe( 'ClassesRename', () => {
 		};
 
 		// Act.
-		render( <ClassesRename /> );
-		triggerStylesChange( previousStyles, currentStyles );
+		render(<ClassesRename />);
+		triggerStylesChange(previousStyles, currentStyles);
 
 		// Assert.
-		expect( mockElement.classList.replace ).not.toHaveBeenCalled();
-	} );
+		expect(mockElement.classList.replace).not.toHaveBeenCalled();
+	});
 
-	it( 'should rename classes when label changes', () => {
+	it('should rename classes when label changes', () => {
 		// Arrange.
 		const { mockDocument, mockElement } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue( {
+		mockGetV1DocumentsManager.mockReturnValue({
 			documents: {
 				1: mockDocument,
 			},
-		} as never );
+		} as never);
 
 		const previousStyles: StylesMap = {
 			style1: {
@@ -106,28 +106,28 @@ describe( 'ClassesRename', () => {
 		};
 
 		// Act.
-		render( <ClassesRename /> );
-		triggerStylesChange( previousStyles, currentStyles );
+		render(<ClassesRename />);
+		triggerStylesChange(previousStyles, currentStyles);
 
 		// Assert.
-		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class', 'new-class' );
-	} );
+		expect(mockElement.classList.replace).toHaveBeenCalledWith('old-class', 'new-class');
+	});
 
-	it( 'should not rename classes when only non-label properties change', () => {
+	it('should not rename classes when only non-label properties change', () => {
 		// Arrange.
 		const { mockDocument, mockElement } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue( {
+		mockGetV1DocumentsManager.mockReturnValue({
 			documents: {
 				1: mockDocument,
 			},
-		} as never );
+		} as never);
 
 		const previousStyles: StylesMap = {
 			style1: {
 				id: 'style1',
 				label: 'same-class',
 				type: 'class',
-				variants: [ { meta: { breakpoint: null, state: null }, props: {}, custom_css: null } ],
+				variants: [{ meta: { breakpoint: null, state: null }, props: {}, custom_css: null }],
 			},
 		};
 
@@ -136,21 +136,21 @@ describe( 'ClassesRename', () => {
 		};
 
 		// Act.
-		render( <ClassesRename /> );
-		triggerStylesChange( previousStyles, currentStyles );
+		render(<ClassesRename />);
+		triggerStylesChange(previousStyles, currentStyles);
 
 		// Assert.
-		expect( mockElement.classList.replace ).not.toHaveBeenCalled();
-	} );
+		expect(mockElement.classList.replace).not.toHaveBeenCalled();
+	});
 
-	it( 'should handle multiple style changes', () => {
+	it('should handle multiple style changes', () => {
 		// Arrange.
 		const { mockDocument, mockElement } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue( {
+		mockGetV1DocumentsManager.mockReturnValue({
 			documents: {
 				1: mockDocument,
 			},
-		} as never );
+		} as never);
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'old-class-1', type: 'class', variants: [] },
@@ -165,23 +165,23 @@ describe( 'ClassesRename', () => {
 		};
 
 		// Act.
-		render( <ClassesRename /> );
-		triggerStylesChange( previousStyles, currentStyles );
+		render(<ClassesRename />);
+		triggerStylesChange(previousStyles, currentStyles);
 
 		// Assert.
-		expect( mockElement.classList.replace ).toHaveBeenCalledTimes( 2 );
-		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class-1', 'new-class-1' );
-		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class-2', 'new-class-2' );
-	} );
+		expect(mockElement.classList.replace).toHaveBeenCalledTimes(2);
+		expect(mockElement.classList.replace).toHaveBeenCalledWith('old-class-1', 'new-class-1');
+		expect(mockElement.classList.replace).toHaveBeenCalledWith('old-class-2', 'new-class-2');
+	});
 
-	it( 'should rename classes when new label is an empty string', () => {
+	it('should rename classes when new label is an empty string', () => {
 		// Arrange.
 		const { mockDocument, mockElement } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue( {
+		mockGetV1DocumentsManager.mockReturnValue({
 			documents: {
 				1: mockDocument,
 			},
-		} as never );
+		} as never);
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
@@ -192,21 +192,21 @@ describe( 'ClassesRename', () => {
 		};
 
 		// Act.
-		render( <ClassesRename /> );
-		triggerStylesChange( previousStyles, currentStyles );
+		render(<ClassesRename />);
+		triggerStylesChange(previousStyles, currentStyles);
 
 		// Assert.
-		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class', '' );
-	} );
+		expect(mockElement.classList.replace).toHaveBeenCalledWith('old-class', '');
+	});
 
-	it( 'should handle new styles (not in previous)', () => {
+	it('should handle new styles (not in previous)', () => {
 		// Arrange.
 		const { mockDocument, mockElement } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue( {
+		mockGetV1DocumentsManager.mockReturnValue({
 			documents: {
 				1: mockDocument,
 			},
-		} as never );
+		} as never);
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'existing-class', type: 'class', variants: [] },
@@ -218,24 +218,24 @@ describe( 'ClassesRename', () => {
 		};
 
 		// Act.
-		render( <ClassesRename /> );
-		triggerStylesChange( previousStyles, currentStyles );
+		render(<ClassesRename />);
+		triggerStylesChange(previousStyles, currentStyles);
 
 		// Assert.
-		expect( mockElement.classList.replace ).not.toHaveBeenCalled();
-	} );
+		expect(mockElement.classList.replace).not.toHaveBeenCalled();
+	});
 
-	it( 'should handle multiple documents', () => {
+	it('should handle multiple documents', () => {
 		// Arrange.
 		const { mockDocument, mockElement } = createMockDocument();
 		const { mockDocument: mockDocument2, mockElement: mockElement2 } = createMockDocument();
 
-		mockGetV1DocumentsManager.mockReturnValue( {
+		mockGetV1DocumentsManager.mockReturnValue({
 			documents: {
 				1: mockDocument,
 				2: mockDocument2,
 			},
-		} as never );
+		} as never);
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
@@ -246,15 +246,15 @@ describe( 'ClassesRename', () => {
 		};
 
 		// Act.
-		render( <ClassesRename /> );
-		triggerStylesChange( previousStyles, currentStyles );
+		render(<ClassesRename />);
+		triggerStylesChange(previousStyles, currentStyles);
 
 		// Assert.
-		expect( mockElement.classList.replace ).toHaveBeenCalledWith( 'old-class', 'new-class' );
-		expect( mockElement2.classList.replace ).toHaveBeenCalledWith( 'old-class', 'new-class' );
-	} );
+		expect(mockElement.classList.replace).toHaveBeenCalledWith('old-class', 'new-class');
+		expect(mockElement2.classList.replace).toHaveBeenCalledWith('old-class', 'new-class');
+	});
 
-	it( 'should handle documents without view or el', () => {
+	it('should handle documents without view or el', () => {
 		// Arrange.
 		const incompleteDocument = {
 			container: {
@@ -262,11 +262,11 @@ describe( 'ClassesRename', () => {
 			},
 		};
 
-		mockGetV1DocumentsManager.mockReturnValue( {
+		mockGetV1DocumentsManager.mockReturnValue({
 			documents: {
 				1: incompleteDocument as never,
 			},
-		} as never );
+		} as never);
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'old-class', type: 'class', variants: [] },
@@ -277,20 +277,20 @@ describe( 'ClassesRename', () => {
 		};
 
 		// Act & Assert - should not throw an error.
-		expect( () => {
-			render( <ClassesRename /> );
-			triggerStylesChange( previousStyles, currentStyles );
-		} ).not.toThrow();
-	} );
+		expect(() => {
+			render(<ClassesRename />);
+			triggerStylesChange(previousStyles, currentStyles);
+		}).not.toThrow();
+	});
 
-	it( 'should use correct CSS selector format', () => {
+	it('should use correct CSS selector format', () => {
 		// Arrange.
 		const { mockDocument, mockContainer } = createMockDocument();
-		mockGetV1DocumentsManager.mockReturnValue( {
+		mockGetV1DocumentsManager.mockReturnValue({
 			documents: {
 				1: mockDocument,
 			},
-		} as never );
+		} as never);
 
 		const previousStyles: StylesMap = {
 			style1: { id: 'style1', label: 'test-class', type: 'class', variants: [] },
@@ -301,11 +301,11 @@ describe( 'ClassesRename', () => {
 		};
 
 		// Act.
-		render( <ClassesRename /> );
-		triggerStylesChange( previousStyles, currentStyles );
+		render(<ClassesRename />);
+		triggerStylesChange(previousStyles, currentStyles);
 
 		// Assert.
 		// eslint-disable-next-line testing-library/no-node-access
-		expect( mockContainer.view.el.querySelectorAll ).toHaveBeenCalledWith( '.elementor .test-class' );
-	} );
-} );
+		expect(mockContainer.view.el.querySelectorAll).toHaveBeenCalledWith('.elementor .test-class');
+	});
+});

--- a/packages/packages/core/editor-canvas/src/components/classes-rename.tsx
+++ b/packages/packages/core/editor-canvas/src/components/classes-rename.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import { getV1DocumentsManager, type V1Document } from '@elementor/editor-documents';
+import { type V1Element } from '@elementor/editor-elements';
+import { stylesRepository } from '@elementor/editor-styles-repository';
+import { hash } from '@elementor/utils';
+
+export const ClassesRename = () => {
+	useEffect( () => {
+		const unsubscribe = subscribeToStylesRepository();
+
+		return () => {
+			unsubscribe();
+		};
+	}, [] );
+
+	return null;
+};
+
+const subscribeToStylesRepository = () => {
+	return stylesRepository.subscribe( ( previous, current ) => {
+		if ( ! previous || ! current ) {
+			return;
+		}
+		const currentIds = Object.keys( current );
+
+		currentIds.forEach( ( id ) => {
+			const isStyleChanged = previous[ id ] && hash( previous[ id ] ) !== hash( current[ id ] );
+
+			if ( ! isStyleChanged ) {
+				return;
+			}
+
+			const previousStyle = previous[ id ];
+			const currentStyle = current[ id ];
+
+			if ( previousStyle.label !== currentStyle.label ) {
+				renameClass( previousStyle.label, currentStyle.label );
+			}
+		} );
+	} );
+};
+
+const renameClass = ( oldClassName: string, newClassName: string ) => {
+	Object.values< V1Document >( getV1DocumentsManager().documents ).forEach( ( document ) => {
+		const container = document.container as V1Element;
+
+		container.view?.el?.querySelectorAll( `.elementor .${ oldClassName }` ).forEach( ( element ) => {
+			element.classList.replace( oldClassName, newClassName );
+		} );
+	} );
+};

--- a/packages/packages/core/editor-canvas/src/init.tsx
+++ b/packages/packages/core/editor-canvas/src/init.tsx
@@ -1,5 +1,6 @@
-import { injectIntoTop } from '@elementor/editor';
+import { injectIntoLogic, injectIntoTop } from '@elementor/editor';
 
+import { ClassesRename } from './components/classes-rename';
 import { ElementsOverlays } from './components/elements-overlays';
 import { StyleRenderer } from './components/style-renderer';
 import { initSettingsTransformers } from './init-settings-transformers';
@@ -26,5 +27,10 @@ export function init() {
 	injectIntoTop( {
 		id: 'canvas-style-render',
 		component: StyleRenderer,
+	} );
+
+	injectIntoLogic( {
+		id: 'classes-rename',
+		component: ClassesRename,
 	} );
 }

--- a/packages/packages/core/editor-global-classes/src/global-classes-styles-provider.ts
+++ b/packages/packages/core/editor-global-classes/src/global-classes-styles-provider.ts
@@ -1,4 +1,4 @@
-import { generateId, type StyleDefinition, type StyleDefinitionVariant } from '@elementor/editor-styles';
+import { generateId, type StyleDefinition } from '@elementor/editor-styles';
 import { createStylesProvider } from '@elementor/editor-styles-repository';
 import {
 	__dispatch as dispatch,

--- a/packages/packages/core/editor-global-classes/src/global-classes-styles-provider.ts
+++ b/packages/packages/core/editor-global-classes/src/global-classes-styles-provider.ts
@@ -1,4 +1,4 @@
-import { generateId } from '@elementor/editor-styles';
+import { generateId, type StyleDefinition, type StyleDefinitionVariant } from '@elementor/editor-styles';
 import { createStylesProvider } from '@elementor/editor-styles-repository';
 import {
 	__dispatch as dispatch,
@@ -9,7 +9,14 @@ import { __ } from '@wordpress/i18n';
 
 import { getCapabilities } from './capabilities';
 import { GlobalClassLabelAlreadyExistsError } from './errors';
-import { selectClass, selectGlobalClasses, selectOrderedClasses, slice, type StateWithGlobalClasses } from './store';
+import {
+	selectClass,
+	selectData,
+	selectGlobalClasses,
+	selectOrderedClasses,
+	slice,
+	type StateWithGlobalClasses,
+} from './store';
 
 const MAX_CLASSES = 50;
 
@@ -23,7 +30,7 @@ export const globalClassesStylesProvider = createStylesProvider( {
 		singular: __( 'class', 'elementor' ),
 		plural: __( 'classes', 'elementor' ),
 	},
-	subscribe: ( cb ) => subscribeWithSelector( ( state: StateWithGlobalClasses ) => state.globalClasses, cb ),
+	subscribe: ( cb ) => subscribeWithStates( cb ),
 	capabilities: getCapabilities(),
 	actions: {
 		all: () => selectOrderedClasses( getState() ),
@@ -75,3 +82,17 @@ export const globalClassesStylesProvider = createStylesProvider( {
 		},
 	},
 } );
+
+const subscribeWithStates = (
+	cb: ( previous: Record< string, StyleDefinition >, current: Record< string, StyleDefinition > ) => void
+) => {
+	let previousState = selectData( getState() );
+
+	return subscribeWithSelector(
+		( state: StateWithGlobalClasses ) => state.globalClasses,
+		( currentState ) => {
+			cb( previousState.items, currentState.data.items );
+			previousState = currentState.data;
+		}
+	);
+};

--- a/packages/packages/core/editor-global-classes/src/save-global-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/save-global-classes.ts
@@ -1,4 +1,5 @@
 import { __dispatch as dispatch, __getState as getState } from '@elementor/store';
+import { hash } from '@elementor/utils';
 
 import { apiClient, type ApiContext } from './api';
 import { type GlobalClasses, selectData, selectFrontendInitialData, selectPreviewInitialData, slice } from './store';
@@ -38,26 +39,4 @@ function calculateChanges( state: GlobalClasses, initialData: GlobalClasses ) {
 			return id in initialData.items && hash( state.items[ id ] ) !== hash( initialData.items[ id ] );
 		} ),
 	};
-}
-
-type UnknownObject = Record< string, unknown >;
-
-// Inspired by:
-// https://github.com/TanStack/query/blob/66ea5f2fc/packages/query-core/src/utils.ts#L212
-function hash( obj: UnknownObject ): string {
-	return JSON.stringify( obj, ( _, value ) =>
-		isPlainObject( value )
-			? Object.keys( value )
-					.sort()
-					.reduce< UnknownObject >( ( result, key ) => {
-						result[ key ] = value[ key ];
-
-						return result;
-					}, {} )
-			: value
-	);
-}
-
-function isPlainObject( value: unknown ): value is UnknownObject {
-	return !! value && typeof value === 'object' && ! Array.isArray( value );
 }

--- a/packages/packages/core/editor-styles-repository/src/providers/document-elements-styles-provider.ts
+++ b/packages/packages/core/editor-styles-repository/src/providers/document-elements-styles-provider.ts
@@ -28,7 +28,7 @@ export const documentElementsStylesProvider = createStylesProvider( {
 		return `${ ELEMENTS_STYLES_PROVIDER_KEY_PREFIX }${ documentId }`;
 	},
 	priority: 50,
-	subscribe: ( cb ) => listenTo( styleRerenderEvents, cb ),
+	subscribe: ( cb ) => listenTo( styleRerenderEvents, () => cb() ),
 	actions: {
 		all: ( meta = {} ) => {
 			let elements = getElements();

--- a/packages/packages/core/editor-styles-repository/src/types.ts
+++ b/packages/packages/core/editor-styles-repository/src/types.ts
@@ -20,12 +20,6 @@ export type UpdatePropsActionPayload = {
 	props: Props;
 };
 
-export type UpdateCustomCssActionPayload = {
-	id: StyleDefinitionID;
-	meta: StyleDefinitionVariant[ 'meta' ];
-	custom_css: CustomCss;
-};
-
 export type StylesCollection = Record< StyleDefinitionID, StyleDefinition >;
 
 export type StylesProvider = {

--- a/packages/packages/core/editor-styles-repository/src/types.ts
+++ b/packages/packages/core/editor-styles-repository/src/types.ts
@@ -20,11 +20,19 @@ export type UpdatePropsActionPayload = {
 	props: Props;
 };
 
+export type UpdateCustomCssActionPayload = {
+	id: StyleDefinitionID;
+	meta: StyleDefinitionVariant[ 'meta' ];
+	custom_css: CustomCss;
+};
+
+export type StylesCollection = Record< StyleDefinitionID, StyleDefinition >;
+
 export type StylesProvider = {
 	getKey: () => string;
 	priority: number;
 	limit: number;
-	subscribe: ( callback: () => void ) => () => void;
+	subscribe: ( callback: ( current?: StylesCollection, previous?: StylesCollection ) => void ) => () => void;
 	labels: {
 		singular: string | null;
 		plural: string | null;

--- a/packages/packages/core/editor-styles-repository/src/utils/create-styles-provider.ts
+++ b/packages/packages/core/editor-styles-repository/src/utils/create-styles-provider.ts
@@ -1,10 +1,10 @@
-import { type StylesProvider, type UserCapabilities } from '../types';
+import { type StylesCollection, type StylesProvider, type UserCapabilities } from '../types';
 
 export type CreateStylesProviderOptions = {
 	key: string | ( () => string );
 	priority?: number;
 	limit?: number;
-	subscribe?: ( callback: () => void ) => () => void;
+	subscribe?: ( callback: ( current?: StylesCollection, previous?: StylesCollection ) => void ) => () => void;
 	labels?: {
 		singular: string;
 		plural: string;

--- a/packages/packages/core/editor-styles-repository/src/utils/create-styles-repository.ts
+++ b/packages/packages/core/editor-styles-repository/src/utils/create-styles-repository.ts
@@ -1,4 +1,4 @@
-import { type Meta, type StylesProvider } from '../types';
+import { type Meta, type StylesCollection, type StylesProvider } from '../types';
 
 export const createStylesRepository = () => {
 	const providers: StylesProvider[] = [];
@@ -15,7 +15,7 @@ export const createStylesRepository = () => {
 		return getProviders().flatMap( ( provider ) => provider.actions.all( meta ) );
 	};
 
-	const subscribe = ( cb: () => void ) => {
+	const subscribe = ( cb: ( previous?: StylesCollection, current?: StylesCollection ) => void ) => {
 		const unsubscribes = providers.map( ( provider ) => {
 			return provider.subscribe( cb );
 		} );

--- a/packages/packages/libs/utils/src/hash.ts
+++ b/packages/packages/libs/utils/src/hash.ts
@@ -1,0 +1,21 @@
+type UnknownObject = Record< string, unknown >;
+
+// Inspired by:
+// https://github.com/TanStack/query/blob/66ea5f2fc/packages/query-core/src/utils.ts#L212
+export function hash( obj: UnknownObject ): string {
+	return JSON.stringify( obj, ( _, value ) =>
+		isPlainObject( value )
+			? Object.keys( value )
+					.sort()
+					.reduce< UnknownObject >( ( result, key ) => {
+						result[ key ] = value[ key ];
+
+						return result;
+					}, {} )
+			: value
+	);
+}
+
+function isPlainObject( value: unknown ): value is UnknownObject {
+	return !! value && typeof value === 'object' && ! Array.isArray( value );
+}

--- a/packages/packages/libs/utils/src/index.ts
+++ b/packages/packages/libs/utils/src/index.ts
@@ -2,3 +2,5 @@ export { ElementorError, createError, ensureError } from './errors';
 export type { ElementorErrorOptions, CreateErrorParams } from './errors';
 export { useDebounceState, type UseDebounceStateOptions, type UseDebounceStateResult } from './use-debounce-state';
 export { debounce } from './debounce';
+export { encodeString, decodeString } from './encoding';
+export { hash } from './hash';

--- a/packages/packages/libs/utils/src/index.ts
+++ b/packages/packages/libs/utils/src/index.ts
@@ -2,5 +2,4 @@ export { ElementorError, createError, ensureError } from './errors';
 export type { ElementorErrorOptions, CreateErrorParams } from './errors';
 export { useDebounceState, type UseDebounceStateOptions, type UseDebounceStateResult } from './use-debounce-state';
 export { debounce } from './debounce';
-export { encodeString, decodeString } from './encoding';
 export { hash } from './hash';


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix CSS styles breaking when class names are changed by updating the styles repository to track class rename events and apply them to DOM elements.
Main changes:
- Added ClassesRename component to update DOM elements when class names change in the styles repository
- Enhanced StylesCollection type to include previous/current style state comparison in callbacks
- Refactored hash utility function to a shared utility package for consistent object comparison

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
