### PR TITLE
Tweak: Improve Cloud Library quota [ED-19474]

### DIFF
--- a/modules/cloud-library/connect/cloud-library.php
+++ b/modules/cloud-library/connect/cloud-library.php
@@ -336,6 +336,10 @@ class Cloud_Library extends Library {
 	 * @return array|\WP_Error
 	 */
 	public function get_quota() {
+		if ( ! $this->is_connected() ) {
+			return new \WP_Error( 'not_connected', esc_html__( 'Not connected', 'elementor' ) );
+		}
+
 		return $this->http_request( 'GET', 'quota', [], [
 			'return_type' => static::HTTP_RETURN_TYPE_ARRAY,
 		] );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add connection check in Cloud Library quota retrieval to prevent errors when fetching quota in disconnected state.
Main changes:
- Added is_connected() validation in get_quota() method to return WP_Error when library is not connected

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
