### PR TITLE
Internal: Add components module, package, and experiment [ED-20385]

### DIFF
--- a/core/modules-manager.php
+++ b/core/modules-manager.php
@@ -130,6 +130,7 @@ class Modules_Manager {
 			'cloud-library',
 			'cloud-kit-library',
 			'atomic-opt-in',
+			'components',
 		];
 	}
 

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -100,7 +100,6 @@ class Module extends BaseModule {
 	const ENFORCE_CAPABILITIES_EXPERIMENT = 'atomic_widgets_should_enforce_capabilities';
 	const EXPERIMENT_CUSTOM_CSS = 'atomic_custom_css';
 	const TRANSITION_EXPERIMENT = 'atomic_widgets_should_use_transition';
-	const EXPERIMENT_COMPONENTS = 'e_atomic_components';
 	const EXPERIMENT_NESTED = 'e_nested_elements';
 
 	const PACKAGES = [
@@ -127,9 +126,6 @@ class Module extends BaseModule {
 		if ( Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME ) ) {
 			Dynamic_Tags_Module::instance()->register_hooks();
 
-			if ( Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_COMPONENTS ) ) {
-				( new Atomic_Component_Styles() )->register_hooks();
-			}
 			( new Atomic_Widget_Styles() )->register_hooks();
 			( new Atomic_Widget_Base_Styles() )->register_hooks();
 
@@ -196,15 +192,6 @@ class Module extends BaseModule {
 			'name' => self::TRANSITION_EXPERIMENT,
 			'title' => esc_html__( 'Use transition', 'elementor' ),
 			'description' => esc_html__( 'Use transition.', 'elementor' ),
-			'hidden' => true,
-			'default' => Experiments_Manager::STATE_INACTIVE,
-			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,
-		] );
-
-		Plugin::$instance->experiments->add_feature([
-			'name' => self::EXPERIMENT_COMPONENTS,
-			'title' => esc_html__( 'Atomic Components', 'elementor' ),
-			'description' => esc_html__( 'Unstable Atomic Component widget.', 'elementor' ),
 			'hidden' => true,
 			'default' => Experiments_Manager::STATE_INACTIVE,
 			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,

--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -3,7 +3,6 @@ namespace Elementor\Modules\Components;
 
 use Elementor\Core\Base\Module as BaseModule;
 use Elementor\Core\Experiments\Manager as Experiments_Manager;
-use Elementor\Plugin;
 use Elementor\Modules\Components\Styles\Component_Styles;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -21,10 +20,6 @@ class Module extends BaseModule {
 	public function __construct() {
 		parent::__construct();
 
-		if ( ! self::is_active() ) {
-			return;
-		}
-
 		$this->register_hooks();
 	}
 
@@ -37,10 +32,6 @@ class Module extends BaseModule {
 			'default' => Experiments_Manager::STATE_INACTIVE,
 			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,
 		];
-	}
-
-	public static function is_active(): bool {
-		return Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME );
 	}
 
 	private function register_hooks() {

--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -6,29 +6,29 @@ use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\Plugin;
 use Elementor\Modules\Components\Styles\Component_Styles;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
 class Module extends BaseModule {
-    const EXPERIMENT_NAME = 'e_components';
-    const PACKAGES = [ 'editor-components' ];
+	const EXPERIMENT_NAME = 'e_components';
+	const PACKAGES = [ 'editor-components' ];
 
-    public function get_name() {
-        return 'components';
-    }
+	public function get_name() {
+		return 'components';
+	}
 
-    public function __construct() {
+	public function __construct() {
 		parent::__construct();
 
 		if ( ! self::is_active() ) {
 			return;
 		}
 
-        $this->register_hooks();
-    }
+		$this->register_hooks();
+	}
 
-    public static function get_experimental_data() {
+	public static function get_experimental_data() {
 		return [
 			'name' => self::EXPERIMENT_NAME,
 			'title' => esc_html__( 'Components', 'elementor' ),
@@ -39,17 +39,17 @@ class Module extends BaseModule {
 		];
 	}
 
-    public static function is_active(): bool {
+	public static function is_active(): bool {
 		return Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME );
 	}
 
-    private function register_hooks() {
-        add_filter( 'elementor/editor/v2/packages', fn ( $packages ) => $this->add_packages( $packages ) );
+	private function register_hooks() {
+		add_filter( 'elementor/editor/v2/packages', fn ( $packages ) => $this->add_packages( $packages ) );
 
-        ( new Component_Styles() )->register_hooks();
-    }
+		( new Component_Styles() )->register_hooks();
+	}
 
-    private function add_packages( $packages ) {
+	private function add_packages( $packages ) {
 		return array_merge( $packages, self::PACKAGES );
 	}
 }

--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -1,0 +1,55 @@
+<?php
+namespace Elementor\Modules\Components;
+
+use Elementor\Core\Base\Module as BaseModule;
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Plugin;
+use Elementor\Modules\Components\Styles\Component_Styles;
+
+if (!defined('ABSPATH')) {
+	exit; // Exit if accessed directly.
+}
+
+class Module extends BaseModule {
+    const EXPERIMENT_NAME = 'e_components';
+    const PACKAGES = [ 'editor-components' ];
+
+    public function get_name() {
+        return 'components';
+    }
+
+    public function __construct() {
+		parent::__construct();
+
+		if ( ! self::is_active() ) {
+			return;
+		}
+
+        $this->register_hooks();
+    }
+
+    public static function get_experimental_data() {
+		return [
+			'name' => self::EXPERIMENT_NAME,
+			'title' => esc_html__( 'Components', 'elementor' ),
+			'description' => esc_html__( 'Enable components.', 'elementor' ),
+			'hidden' => true,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,
+		];
+	}
+
+    public static function is_active(): bool {
+		return Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME );
+	}
+
+    private function register_hooks() {
+        add_filter( 'elementor/editor/v2/packages', fn ( $packages ) => $this->add_packages( $packages ) );
+
+        ( new Component_Styles() )->register_hooks();
+    }
+
+    private function add_packages( $packages ) {
+		return array_merge( $packages, self::PACKAGES );
+	}
+}

--- a/modules/components/styles/component-styles.php
+++ b/modules/components/styles/component-styles.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Elementor\Modules\AtomicWidgets\Styles;
+namespace Elementor\Modules\Components\Styles;
 
 use Elementor\Core\Base\Document;
 use Elementor\Core\Utils\Collection;
@@ -8,10 +8,10 @@ use Elementor\Modules\AtomicWidgets\Cache_Validity;
 use Elementor\Modules\AtomicWidgets\Utils;
 
 /**
- * Atomic Component styles fetching for render
+ * Component styles fetching for render
  */
-class Atomic_Component_Styles {
-	const CACHE_ROOT_KEY = 'atomic-component-styles-related-posts';
+class Component_Styles {
+	const CACHE_ROOT_KEY = 'component-styles-related-posts';
 
 	public function register_hooks() {
 		add_action( 'elementor/post/render', fn( $post_id ) => $this->render_post( $post_id ) );

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -2844,6 +2844,10 @@
       "resolved": "packages/core/editor-canvas",
       "link": true
     },
+    "node_modules/@elementor/editor-components": {
+      "resolved": "packages/core/editor-components",
+      "link": true
+    },
     "node_modules/@elementor/editor-controls": {
       "resolved": "packages/libs/editor-controls",
       "link": true
@@ -19465,6 +19469,21 @@
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "packages/core/editor-components": {
+      "name": "@elementor/editor-components",
+      "version": "0.0.1",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@elementor/editor-v1-adapters": "3.32.0"
+      },
+      "devDependencies": {
+        "tsup": "^8.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       }
     },
     "packages/core/editor-documents": {

--- a/packages/packages/core/editor-components/README.md
+++ b/packages/packages/core/editor-components/README.md
@@ -1,0 +1,4 @@
+# Editor Components
+
+> [!WARNING]
+> This package is under development and not ready for production use.

--- a/packages/packages/core/editor-components/package.json
+++ b/packages/packages/core/editor-components/package.json
@@ -1,0 +1,52 @@
+{
+    "name": "@elementor/editor-components",
+    "description": "Elementor editor components",
+    "version": "0.0.1",
+    "private": false,
+    "author": "Elementor Team",
+    "homepage": "https://elementor.com/",
+    "license": "GPL-3.0-or-later",
+    "main": "dist/index.js",
+    "module": "dist/index.mjs",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/elementor/elementor.git",
+        "directory": "packages/core/editor-components"
+    },
+    "bugs": {
+        "url": "https://github.com/elementor/elementor/issues"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "files": [
+        "README.md",
+        "CHANGELOG.md",
+        "/dist",
+        "/src",
+        "!**/__tests__"
+    ],
+    "scripts": {
+        "build": "tsup --config=../../tsup.build.ts",
+        "dev": "tsup --config=../../tsup.dev.ts"
+    },
+    "dependencies": {
+        "@elementor/editor-v1-adapters": "3.32.0"
+    },
+    "peerDependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+    },
+    "devDependencies": {
+        "tsup": "^8.5.0"
+    }
+}

--- a/packages/packages/core/editor-components/package.json
+++ b/packages/packages/core/editor-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@elementor/editor-components",
     "description": "Elementor editor components",
-    "version": "0.0.1",
+    "version": "0.0.0",
     "private": false,
     "author": "Elementor Team",
     "homepage": "https://elementor.com/",
@@ -39,9 +39,7 @@
         "build": "tsup --config=../../tsup.build.ts",
         "dev": "tsup --config=../../tsup.dev.ts"
     },
-    "dependencies": {
-        "@elementor/editor-v1-adapters": "3.32.0"
-    },
+    "dependencies": {},
     "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/packages/packages/core/editor-components/src/index.ts
+++ b/packages/packages/core/editor-components/src/index.ts
@@ -1,0 +1,1 @@
+export { init } from './init';

--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -1,0 +1,9 @@
+import { EXPERIMENTAL_FEATURES, isExperimentActive } from '@elementor/editor-v1-adapters';
+
+export function init() {
+	if ( ! isExperimentActive( EXPERIMENTAL_FEATURES.COMPONENTS ) ) {
+		// TODO: Remove this ESLint disable once package implementation is added.
+		// eslint-disable-next-line no-useless-return
+		return;
+	}
+}

--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -1,9 +1,1 @@
-import { EXPERIMENTAL_FEATURES, isExperimentActive } from '@elementor/editor-v1-adapters';
-
-export function init() {
-	if ( ! isExperimentActive( EXPERIMENTAL_FEATURES.COMPONENTS ) ) {
-		// TODO: Remove this ESLint disable once package implementation is added.
-		// eslint-disable-next-line no-useless-return
-		return;
-	}
-}
+export function init() {}

--- a/packages/packages/libs/editor-v1-adapters/src/readers/index.ts
+++ b/packages/packages/libs/editor-v1-adapters/src/readers/index.ts
@@ -3,6 +3,7 @@ import { type ExtendedWindow } from './types';
 export const EXPERIMENTAL_FEATURES = {
 	CUSTOM_CSS: 'atomic_custom_css',
 	TRANSITIONS: 'atomic_widgets_should_use_transition',
+	COMPONENTS: 'e_components',
 };
 
 export function isRouteActive( route: string ) {

--- a/packages/packages/libs/editor-v1-adapters/src/readers/index.ts
+++ b/packages/packages/libs/editor-v1-adapters/src/readers/index.ts
@@ -3,7 +3,6 @@ import { type ExtendedWindow } from './types';
 export const EXPERIMENTAL_FEATURES = {
 	CUSTOM_CSS: 'atomic_custom_css',
 	TRANSITIONS: 'atomic_widgets_should_use_transition',
-	COMPONENTS: 'e_components',
 };
 
 export function isRouteActive( route: string ) {

--- a/tests/phpunit/elementor/modules/components/styles/test-component-styles.php
+++ b/tests/phpunit/elementor/modules/components/styles/test-component-styles.php
@@ -1,15 +1,15 @@
 <?php
-namespace Elementor\Testing\Modules\AtomicWidgets\Styles;
+namespace Elementor\Testing\Modules\Components\Styles;
 
 use ElementorEditorTesting\Elementor_Test_Base;
 use Elementor\Modules\AtomicWidgets\Cache_Validity;
-use Elementor\Modules\AtomicWidgets\Styles\Atomic_Component_Styles;
+use Elementor\Modules\Components\Styles\Component_Styles;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-class Test_Atomic_Component_Styles extends Elementor_Test_Base {
+class Test_Component_Styles extends Elementor_Test_Base {
 	private $hook_call_count = 0;
 	private $rendered_post_ids = [];
 
@@ -55,12 +55,12 @@ class Test_Atomic_Component_Styles extends Elementor_Test_Base {
 	}
 
 	/**
-	 * Test that Atomic_Component_Styles extracts component IDs and triggers hooks
+	 * Test that Component_Styles extracts component IDs and triggers hooks
 	 */
-	public function test_atomic_component_styles_triggers_hooks_for_unique_component_ids() {
+	public function test_component_styles_triggers_hooks_for_unique_component_ids() {
 		// Arrange
-		$atomic_component_styles = new Atomic_Component_Styles();
-		$atomic_component_styles->register_hooks();
+		$component_styles = new Component_Styles();
+		$component_styles->register_hooks();
 
 		$post_id = $this->make_mock_post_with_elements([
 			// Not an e-component widget
@@ -126,10 +126,10 @@ class Test_Atomic_Component_Styles extends Elementor_Test_Base {
 	/**
 	 * Test that component ID deduplication works correctly
 	 */
-	public function test_invalid_atomic_components_in_post() {
+	public function test_invalid_components_in_post() {
 		// Arrange
-		$atomic_component_styles = new Atomic_Component_Styles();
-		$atomic_component_styles->register_hooks();
+		$component_styles = new Component_Styles();
+		$component_styles->register_hooks();
 
 		$post_id = $this->make_mock_post_with_elements([
 			[
@@ -157,8 +157,8 @@ class Test_Atomic_Component_Styles extends Elementor_Test_Base {
 
 	public function test_cache_validity_upon_post_update() {
 		// Arrange
-		$atomic_component_styles = new Atomic_Component_Styles();
-		$atomic_component_styles->register_hooks();
+		$component_styles = new Component_Styles();
+		$component_styles->register_hooks();
 
 		$post = $this->make_mock_post_with_elements([
 			[
@@ -185,11 +185,11 @@ class Test_Atomic_Component_Styles extends Elementor_Test_Base {
 
 		// Assert
 		$this->assertTrue(
-			$cache_validity->is_valid( [ Atomic_Component_Styles::CACHE_ROOT_KEY, $post_id ] ),
+			$cache_validity->is_valid( [ Component_Styles::CACHE_ROOT_KEY, $post_id ] ),
 			'Post-level cache should be valid'
 		);
 		$this->assertTrue(
-			$cache_validity->is_valid( [ Atomic_Component_Styles::CACHE_ROOT_KEY, $component_id ],
+			$cache_validity->is_valid( [ Component_Styles::CACHE_ROOT_KEY, $component_id ],
 			'Component-level cache should be valid' )
 		);
 
@@ -200,12 +200,12 @@ class Test_Atomic_Component_Styles extends Elementor_Test_Base {
 		);
 		$this->assertEquals(
 			[ $component_id ],
-			$cache_validity->get_meta( [ Atomic_Component_Styles::CACHE_ROOT_KEY, $post_id ] ),
+			$cache_validity->get_meta( [ Component_Styles::CACHE_ROOT_KEY, $post_id ] ),
 			'Post-level cache meta should contain the included component ID (1st level only)'
 		);
 		$this->assertEquals(
 			[],
-			$cache_validity->get_meta( [ Atomic_Component_Styles::CACHE_ROOT_KEY, $component_id ] ),
+			$cache_validity->get_meta( [ Component_Styles::CACHE_ROOT_KEY, $component_id ] ),
 			'Component-level cache meta should be empty'
 		);
 
@@ -214,11 +214,11 @@ class Test_Atomic_Component_Styles extends Elementor_Test_Base {
 
 		// Assert
 		$this->assertFalse(
-			$cache_validity->is_valid( [ Atomic_Component_Styles::CACHE_ROOT_KEY, $post_id ] ),
+			$cache_validity->is_valid( [ Component_Styles::CACHE_ROOT_KEY, $post_id ] ),
 			'After saving changes cache should be invalidated'
 		);
 		$this->assertTrue(
-			$cache_validity->is_valid( [ Atomic_Component_Styles::CACHE_ROOT_KEY, $component_id ] ),
+			$cache_validity->is_valid( [ Component_Styles::CACHE_ROOT_KEY, $component_id ] ),
 			'Component-level cache should remain valid, as no change occurred'
 		);
 	}


### PR DESCRIPTION
<img width="436" height="123" alt="image" src="https://github.com/user-attachments/assets/740102ae-a488-4c9e-8137-547fc1ff9058" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add new Components module, package, and experiment infrastructure for enabling component functionality in Elementor.
Main changes:
- Created dedicated Components module with experiment settings and Component_Styles class
- Migrated component functionality from AtomicWidgets to independent Components module
- Added editor-components package infrastructure with basic setup files
- Registered new components module in the core modules manager

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
