### PR TITLE
Fix: Add default units to transformers [ED-19691]

### DIFF
--- a/modules/atomic-widgets/prop-types/selection-size-prop-type.php
+++ b/modules/atomic-widgets/prop-types/selection-size-prop-type.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\AtomicWidgets\PropTypes;
 
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Size_Constants;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -16,7 +17,10 @@ class Selection_Size_Prop_Type extends Object_Prop_Type {
 	protected function define_shape(): array {
 		return [
 			'selection' => Key_Value_Prop_Type::make()->required(),
-			'size' => Size_Prop_Type::make()->required(),
+			'size' => Size_Prop_Type::make()
+				->units( Size_Constants::transition() )
+				->default_unit( Size_Constants::UNIT_MILLI_SECOND )
+				->required(),
 		];
 	}
 }

--- a/modules/atomic-widgets/prop-types/transform/transform-move-prop-type.php
+++ b/modules/atomic-widgets/prop-types/transform/transform-move-prop-type.php
@@ -20,6 +20,8 @@ class Transform_Move_Prop_Type extends Object_Prop_Type {
 	}
 
 	protected function get_prop_type(): Prop_Type {
-		return Size_Prop_Type::make()->units( Size_Constants::transform() );
+		return Size_Prop_Type::make()
+			->units( Size_Constants::transform() )
+			->default_unit( Size_Constants::UNIT_ANGLE_DEG );
 	}
 }

--- a/modules/atomic-widgets/prop-types/transform/transform-rotate-prop-type.php
+++ b/modules/atomic-widgets/prop-types/transform/transform-rotate-prop-type.php
@@ -27,6 +27,8 @@ class Transform_Rotate_Prop_Type extends Object_Prop_Type {
 	}
 
 	public function get_prop_type(): Prop_Type {
-		return Size_Prop_Type::make()->units( Size_Constants::transform() );
+		return Size_Prop_Type::make()
+			->units( Size_Constants::transform() )
+			->default_unit( Size_Constants::UNIT_ANGLE_DEG );
 	}
 }

--- a/modules/atomic-widgets/prop-types/transform/transform-skew-prop-type.php
+++ b/modules/atomic-widgets/prop-types/transform/transform-skew-prop-type.php
@@ -27,6 +27,8 @@ class Transform_Skew_Prop_Type extends Object_Prop_Type {
 	}
 
 	protected function get_prop_type(): Prop_Type {
-		return Size_Prop_Type::make()->units( Size_Constants::transform() );
+		return Size_Prop_Type::make()
+			->units( Size_Constants::transform() )
+			->default_unit( Size_Constants::UNIT_ANGLE_DEG );
 	}
 }

--- a/modules/atomic-widgets/styles/size-constants.php
+++ b/modules/atomic-widgets/styles/size-constants.php
@@ -15,6 +15,9 @@ class Size_Constants {
 	const UNIT_VH = 'vh';
 	const UNIT_AUTO = 'auto';
 	const UNIT_CUSTOM = 'custom';
+	const UNIT_SECOND = 's';
+	const UNIT_MILLI_SECOND = 'ms';
+	const UNIT_ANGLE_DEG = 'deg';
 
 	const COMMON_UNITS = [
 		self::UNIT_PX,
@@ -25,10 +28,10 @@ class Size_Constants {
 		self::UNIT_CUSTOM,
 	];
 
-	const TIME_UNITS = [ 's', 'ms' ];
-	const EXTENDED_UNITS = [ 'auto', 'custom' ];
+	const TIME_UNITS = [ self::UNIT_SECOND, self::UNIT_MILLI_SECOND ];
+	const EXTENDED_UNITS = [ self::UNIT_AUTO, self::UNIT_CUSTOM ];
 	const VIEWPORT_MIN_MAX_UNITS = [ 'vmin', 'vmax' ];
-	const ANGLE_UNITS = [ 'deg', 'rad', 'grad', 'turn' ];
+	const ANGLE_UNITS = [ self::UNIT_ANGLE_DEG, 'rad', 'grad', 'turn' ];
 
 	public static function all_supported_units(): array {
 		return array_merge(
@@ -79,6 +82,10 @@ class Size_Constants {
 			self::UNIT_REM,
 			self::UNIT_CUSTOM,
 		];
+	}
+
+	public static function transition() {
+		return [ ...self::TIME_UNITS, self::UNIT_CUSTOM ];
 	}
 
 	public static function border(): array {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add default units to transformation properties to ensure consistent behavior across atomic widgets.
Main changes:
- Added default_unit(Size_Constants::UNIT_ANGLE_DEG) to transform property types
- Defined Size_Constants::UNIT_SECOND, UNIT_MILLI_SECOND and UNIT_ANGLE_DEG as constants
- Added transition() method to Size_Constants for time-based units
- Set default millisecond unit for selection-size property

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
