### PR TITLE
Tweak: Add Pro capabilities to the settings customization [ED-20223]

### DIFF
--- a/app/modules/import-export-customization/assets/js/module.js
+++ b/app/modules/import-export-customization/assets/js/module.js
@@ -2,6 +2,7 @@ import router from '@elementor/router';
 
 import Export from './export';
 import Import from './import';
+import {siteSettingsRegistry} from "./shared/registry/site-settings";
 
 export default class ImportExportCustomization {
 	routes = [
@@ -21,6 +22,7 @@ export default class ImportExportCustomization {
 		}
 
 		this.registerImportExportTemplate();
+		this.registerImportExportSiteSettings();
 	}
 
 	registerImportExportTemplate() {
@@ -34,6 +36,59 @@ export default class ImportExportCustomization {
 			title: 'Site Templates',
 			order: 0,
 			getInitialState: elementorModules?.importExport?.createGetInitialState?.( 'site-templates' ),
+		} );
+	}
+
+	registerImportExportSiteSettings() {
+		if ( ! elementorCommon?.config?.experimentalFeatures?.[ 'import-export-customization' ] ) {
+			return;
+		}
+
+		const sections = [
+			{
+				key: 'theme',
+				title: __( 'Theme', 'elementor' ),
+				description: __( 'Only public WordPress themes are supported', 'elementor' ),
+				order: 0,
+			},
+			{
+				key: 'siteSettings',
+				title: __( 'Site settings', 'elementor' ),
+				order: 1,
+				children: [
+					{
+						key: 'globalColors',
+						title: __( 'Global colors', 'elementor' ),
+						order: 0,
+					},
+					{
+						key: 'globalFonts',
+						title: __( 'Global fonts', 'elementor' ),
+						order: 1,
+					},
+					{
+						key: 'themeStyleSettings',
+						title: __( 'Theme style settingss', 'elementor' ),
+						order: 2,
+					},
+				],
+			},
+			{
+				key: 'generalSettings',
+				title: __( 'Settings', 'elementor' ),
+				description: __( 'Include site identity, background, layout, Lightbox, page transitions, and custom CSS', 'elementor' ),
+				order: 2,
+			},
+			{
+				key: 'experiments',
+				title: __( 'Experiments', 'elementor' ),
+				description: __( 'This will apply all experiments that are still active during import', 'elementor' ),
+				order: 3,
+			},
+		];
+
+		sections.forEach( ( section ) => {
+			elementorModules?.importExport?.siteSettingsRegistry.register( section );
 		} );
 	}
 }

--- a/app/modules/import-export-customization/assets/js/module.js
+++ b/app/modules/import-export-customization/assets/js/module.js
@@ -2,7 +2,6 @@ import router from '@elementor/router';
 
 import Export from './export';
 import Import from './import';
-import {siteSettingsRegistry} from "./shared/registry/site-settings";
 
 export default class ImportExportCustomization {
 	routes = [
@@ -33,7 +32,7 @@ export default class ImportExportCustomization {
 		elementorModules?.importExport?.templateRegistry.register( {
 			key: 'siteTemplates',
 			exportGroup: 'site-templates',
-			title: __( 'Site Templates', 'elementor '),
+			title: __( 'Site Templates', 'elementor ' ),
 			order: 0,
 			getInitialState: elementorModules?.importExport?.createGetInitialState?.( 'site-templates' ),
 		} );
@@ -68,7 +67,7 @@ export default class ImportExportCustomization {
 					},
 					{
 						key: 'themeStyleSettings',
-						title: __( 'Theme style settingss', 'elementor' ),
+						title: __( 'Theme style settings', 'elementor' ),
 						order: 2,
 					},
 				],

--- a/app/modules/import-export-customization/assets/js/module.js
+++ b/app/modules/import-export-customization/assets/js/module.js
@@ -33,7 +33,7 @@ export default class ImportExportCustomization {
 		elementorModules?.importExport?.templateRegistry.register( {
 			key: 'siteTemplates',
 			exportGroup: 'site-templates',
-			title: 'Site Templates',
+			title: __( 'Site Templates', 'elementor '),
 			order: 0,
 			getInitialState: elementorModules?.importExport?.createGetInitialState?.( 'site-templates' ),
 		} );

--- a/app/modules/import-export-customization/assets/js/shared/components/kit-parts-selection.js
+++ b/app/modules/import-export-customization/assets/js/shared/components/kit-parts-selection.js
@@ -53,7 +53,6 @@ export default function KitPartsSelection( { data, onCheckboxChange, testId, han
 								onClick={ () => setActiveDialog( item.type ) }
 								sx={ { alignSelf: 'center' } }
 								data-type={ item.type }
-								disabled={ isDisabled( item ) }
 							>
 								{ __( 'Edit', 'elementor' ) }
 							</Button>

--- a/app/modules/import-export-customization/assets/js/shared/components/kit-parts-selection.js
+++ b/app/modules/import-export-customization/assets/js/shared/components/kit-parts-selection.js
@@ -53,6 +53,7 @@ export default function KitPartsSelection( { data, onCheckboxChange, testId, han
 								onClick={ () => setActiveDialog( item.type ) }
 								sx={ { alignSelf: 'center' } }
 								data-type={ item.type }
+								disabled={ isDisabled( item ) }
 							>
 								{ __( 'Edit', 'elementor' ) }
 							</Button>

--- a/app/modules/import-export-customization/assets/js/shared/components/kit-settings-customization-dialog.js
+++ b/app/modules/import-export-customization/assets/js/shared/components/kit-settings-customization-dialog.js
@@ -10,6 +10,9 @@ import { AppsEventTracking } from 'elementor-app/event-track/apps-event-tracking
 export function KitSettingsCustomizationDialog( { open, handleClose, handleSaveChanges, data } ) {
 	const isImport = data.hasOwnProperty( 'uploadedData' );
 
+	const siteSettingsRegistry = elementorModules?.importExport?.siteSettingsRegistry;
+	const siteSettingsSections = siteSettingsRegistry?.getAll() || [];
+
 	const initialState = data.includes.includes( 'settings' );
 	const unselectedValues = useRef( data.analytics?.customization?.settings || [] );
 
@@ -18,34 +21,7 @@ export function KitSettingsCustomizationDialog( { open, handleClose, handleSaveC
 			return data.customization.settings;
 		}
 
-		if ( isImport ) {
-			const {
-				theme,
-				globalColors,
-				globalFonts,
-				themeStyleSettings,
-				generalSettings,
-				experiments,
-			} = data?.uploadedData?.manifest?.[ 'site-settings' ] || {};
-
-			return {
-				theme,
-				globalColors,
-				globalFonts,
-				themeStyleSettings,
-				generalSettings,
-				experiments,
-			};
-		}
-
-		return {
-			theme: initialState,
-			globalColors: initialState,
-			globalFonts: initialState,
-			themeStyleSettings: initialState,
-			generalSettings: initialState,
-			experiments: initialState,
-		};
+		return siteSettingsRegistry.getState( data, initialState );
 	} );
 
 	useEffect( () => {
@@ -53,37 +29,12 @@ export function KitSettingsCustomizationDialog( { open, handleClose, handleSaveC
 			if ( data.customization.settings ) {
 				setSettings( data.customization.settings );
 			} else {
-				const {
-					theme,
-					globalColors,
-					globalFonts,
-					themeStyleSettings,
-					generalSettings,
-					experiments,
-				} = data?.uploadedData?.manifest?.[ 'site-settings' ] || {};
-
-				const state = isImport
-					? {
-						theme,
-						globalColors,
-						globalFonts,
-						themeStyleSettings,
-						generalSettings,
-						experiments,
-					}
-					: {
-						theme: initialState,
-						globalColors: initialState,
-						globalFonts: initialState,
-						themeStyleSettings: initialState,
-						generalSettings: initialState,
-						experiments: initialState,
-					};
+				const state = siteSettingsRegistry.getState( data, initialState );
 
 				setSettings( state );
 			}
 		}
-	}, [ open, data.customization.settings, initialState, isImport, data?.uploadedData ] );
+	}, [ open, data.customization.settings, siteSettingsRegistry, data?.uploadedData, initialState ] );
 
 	useEffect( () => {
 		AppsEventTracking.sendPageViewsWebsiteTemplates( elementorCommon.eventsManager.config.secondaryLocations.kitLibrary.kitExportCustomizationEdit );
@@ -108,61 +59,46 @@ export function KitSettingsCustomizationDialog( { open, handleClose, handleSaveC
 			handleSaveChanges={ () => handleSaveChanges( 'settings', settings, unselectedValues.current ) }
 		>
 			<Stack>
-				<SettingSection
-					checked={ settings.theme }
-					title={ __( 'Theme', 'elementor' ) }
-					description={ __( 'Only public WordPress themes are supported', 'elementor' ) }
-					settingKey="theme"
-					onSettingChange={ handleToggleChange }
-					disabled={ isImport && ! data?.uploadedData?.manifest?.[ 'site-settings' ]?.theme }
-				/>
+				{ siteSettingsSections.map( ( siteSettingsSection ) => {
+					if ( siteSettingsSection.children ) {
+						return (
+							<SettingSection
+								key={ siteSettingsSection.key }
+								title={ siteSettingsSection.title }
+								description={ siteSettingsSection.description }
+								hasToggle={ false }
+							>
+								<Stack>
+									{ siteSettingsSection.children.map( ( siteSettingsChildSection ) => {
+										return (
+											<SubSetting
+												key={ siteSettingsChildSection.key }
+												label={ siteSettingsChildSection.title }
+												description={ siteSettingsChildSection.description }
+												settingKey={ siteSettingsChildSection.key }
+												onSettingChange={ handleToggleChange }
+												checked={ settings[ siteSettingsChildSection.key ] }
+												disabled={ isImport && ! data?.uploadedData?.manifest?.[ 'site-settings' ]?.[ siteSettingsChildSection.key ] }
+											/>
+										);
+									} ) }
+								</Stack>
+							</SettingSection>
+						);
+					}
 
-				<SettingSection
-					title={ __( 'Site settings', 'elementor' ) }
-					hasToggle={ false }
-				>
-					<Stack>
-						<SubSetting
-							label={ __( 'Global colors', 'elementor' ) }
-							settingKey="globalColors"
+					return (
+						<SettingSection
+							key={ siteSettingsSection.key }
+							checked={ settings[ siteSettingsSection.key ] }
+							title={ siteSettingsSection.title }
+							description={ siteSettingsSection.description }
+							settingKey={ siteSettingsSection.key }
 							onSettingChange={ handleToggleChange }
-							checked={ settings.globalColors }
-							disabled={ isImport && ! data?.uploadedData?.manifest?.[ 'site-settings' ]?.globalColors }
+							disabled={ isImport && ! data?.uploadedData?.manifest?.[ 'site-settings' ]?.[ siteSettingsSection.key ] }
 						/>
-						<SubSetting
-							label={ __( 'Global fonts', 'elementor' ) }
-							settingKey="globalFonts"
-							onSettingChange={ handleToggleChange }
-							checked={ settings.globalFonts }
-							disabled={ isImport && ! data?.uploadedData?.manifest?.[ 'site-settings' ]?.globalFonts }
-						/>
-						<SubSetting
-							label={ __( 'Theme style settings', 'elementor' ) }
-							settingKey="themeStyleSettings"
-							onSettingChange={ handleToggleChange }
-							checked={ settings.themeStyleSettings }
-							disabled={ isImport && ! data?.uploadedData?.manifest?.[ 'site-settings' ]?.themeStyleSettings }
-						/>
-					</Stack>
-				</SettingSection>
-
-				<SettingSection
-					title={ __( 'Settings', 'elementor' ) }
-					description={ __( 'Include site identity, background, layout, Lightbox, page transitions, and custom CSS', 'elementor' ) }
-					settingKey="generalSettings"
-					onSettingChange={ handleToggleChange }
-					checked={ settings.generalSettings }
-					disabled={ isImport && ! data?.uploadedData?.manifest?.[ 'site-settings' ]?.generalSettings }
-				/>
-
-				<SettingSection
-					title={ __( 'Experiments', 'elementor' ) }
-					description={ __( 'This will apply all experiments that are still active during import', 'elementor' ) }
-					settingKey="experiments"
-					onSettingChange={ handleToggleChange }
-					checked={ settings.experiments }
-					disabled={ isImport && ! data?.uploadedData?.manifest?.[ 'site-settings' ]?.experiments }
-				/>
+					);
+				} ) }
 			</Stack>
 		</KitCustomizationDialog>
 	);

--- a/app/modules/import-export-customization/assets/js/shared/registry/base.js
+++ b/app/modules/import-export-customization/assets/js/shared/registry/base.js
@@ -1,0 +1,47 @@
+export class BaseRegistry {
+	constructor() {
+		this.sections = new Map();
+	}
+
+	register( section ) {
+		if ( ! section.key || ! section.title ) {
+			throw new Error( 'Template type must have key and title' );
+		}
+
+		const formattedSection = {
+			key: section.key,
+			title: section.title,
+			description: section.description || '',
+			useParentDefault: section.useParentDefault !== false,
+			getInitialState: section.getInitialState || null,
+			component: section.component || null,
+			order: section.order || 10,
+			isAvailable: section.isAvailable || ( () => true ),
+			...section,
+		};
+
+		if ( section.children ) {
+			formattedSection.children = section.children?.map( ( childSection ) => ( {
+				key: childSection.key,
+				title: childSection.title,
+				description: childSection.description || '',
+				useParentDefault: childSection.useParentDefault !== false,
+				getInitialState: childSection.getInitialState || null,
+				component: childSection.component || null,
+				order: childSection.order || 10,
+				...childSection,
+			} ) );
+		}
+		this.sections.set( section.key, formattedSection );
+	}
+
+	getAll() {
+		return Array.from( this.sections.values() )
+			.filter( ( type ) => type.isAvailable() )
+			.sort( ( a, b ) => a.order - b.order );
+	}
+
+	get( key ) {
+		return this.sections.get( key );
+	}
+}

--- a/app/modules/import-export-customization/assets/js/shared/registry/site-settings.js
+++ b/app/modules/import-export-customization/assets/js/shared/registry/site-settings.js
@@ -1,0 +1,47 @@
+import { BaseRegistry } from './base';
+class SiteSettingsRegistry extends BaseRegistry {
+	getState( data, parentInitialState ) {
+		const state = {};
+
+		this.getAll().forEach( ( section ) => {
+			if ( section.children ) {
+				section.children?.forEach( ( childSection ) => {
+					const sectionState = this.getSectionState( childSection, data, parentInitialState );
+
+					Object.assign( state, sectionState );
+				} );
+			} else {
+				Object.assign( state, this.getSectionState( section, data, parentInitialState ) );
+			}
+		} );
+
+		return state;
+	}
+
+	getSectionState( section, data, parentInitialState ) {
+		const state = {};
+
+		const isImport = data?.hasOwnProperty( 'uploadedData' );
+
+		if ( isImport ) {
+			state[ section.key ] = data?.uploadedData?.manifest?.[ 'site-settings' ]?.[ section.key ];
+			return state;
+		}
+
+		if ( data?.customization?.settings?.[ section.key ] !== undefined ) {
+			state[ section.key ] = data.customization.settings[ section.key ];
+			return state;
+		}
+
+		if ( section.getInitialState ) {
+			state[ section.key ] = section.getInitialState( data, parentInitialState );
+			return state;
+		}
+
+		state[ section.key ] = section.useParentDefault ? parentInitialState : false;
+
+		return state;
+	}
+}
+
+export const siteSettingsRegistry = new SiteSettingsRegistry();

--- a/assets/dev/js/modules/modules.js
+++ b/assets/dev/js/modules/modules.js
@@ -5,6 +5,7 @@ import Masonry from './imports/utils/masonry';
 import Scroll from './imports/utils/scroll';
 import ForceMethodImplementation from './imports/force-method-implementation';
 import { templateRegistry } from '../../../../app/modules/import-export-customization/assets/js/shared/registry/templates';
+import { siteSettingsRegistry } from '../../../../app/modules/import-export-customization/assets/js/shared/registry/site-settings';
 import { createGetInitialState } from '../../../../app/modules/import-export-customization/assets/js/shared/utils/template-registry-helpers';
 
 export default window.elementorModules = {
@@ -21,5 +22,6 @@ export default window.elementorModules = {
 	importExport: {
 		templateRegistry,
 		createGetInitialState,
+		siteSettingsRegistry,
 	},
 };

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/import/pages/import-customization.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/import/pages/import-customization.test.js
@@ -33,6 +33,98 @@ describe( 'ImportCustomization Page', () => {
 				config: eventsConfig,
 			},
 		};
+
+		global.elementorModules = {
+			importExport: {
+				siteSettingsRegistry: {
+					getAll: jest.fn( () => [
+						{
+							key: 'theme',
+							title: __( 'Theme', 'elementor' ),
+							description: __( 'Only public WordPress themes are supported', 'elementor' ),
+							order: 0,
+						},
+						{
+							key: 'siteSettings',
+							title: __( 'Site settings', 'elementor' ),
+							order: 1,
+							children: [
+								{
+									key: 'globalColors',
+									title: __( 'Global colors', 'elementor' ),
+									order: 0,
+								},
+								{
+									key: 'globalFonts',
+									title: __( 'Global fonts', 'elementor' ),
+									order: 1,
+								},
+								{
+									key: 'themeStyleSettings',
+									title: __( 'Theme style settingss', 'elementor' ),
+									order: 2,
+								},
+							],
+						},
+						{
+							key: 'generalSettings',
+							title: __( 'Settings', 'elementor' ),
+							description: __( 'Include site identity, background, layout, Lightbox, page transitions, and custom CSS', 'elementor' ),
+							order: 2,
+						},
+						{
+							key: 'experiments',
+							title: __( 'Experiments', 'elementor' ),
+							description: __( 'This will apply all experiments that are still active during import', 'elementor' ),
+							order: 3,
+						},
+					] ),
+					getState: jest.fn( ( data, parentInitialState ) => {
+						function getSectionState( section ) {
+							const state = {};
+
+							const isImport = data?.hasOwnProperty( 'uploadedData' );
+
+							if ( isImport ) {
+								state[ section.key ] = data?.uploadedData?.manifest?.[ 'site-settings' ]?.[ section.key ];
+								return state;
+							}
+
+							if ( data?.customization?.settings?.[ section.key ] !== undefined ) {
+								state[ section.key ] = data.customization.settings[ section.key ];
+								return state;
+							}
+
+							if ( section.getInitialState ) {
+								state[ section.key ] = section.getInitialState( data, parentInitialState );
+								return state;
+							}
+
+							state[ section.key ] = section.useParentDefault ? parentInitialState : false;
+
+							return state;
+						}
+						const state = {};
+						const sections = global.elementorModules.importExport.siteSettingsRegistry.getAll();
+
+						sections.forEach( ( section ) => {
+							if ( section.children ) {
+								section.children?.forEach( ( childSection ) => {
+									const sectionState = getSectionState( childSection, data, parentInitialState );
+
+									Object.assign( state, sectionState );
+								} );
+							} else {
+								Object.assign( state, getSectionState( section, data, parentInitialState ) );
+							}
+						} );
+
+						return state;
+					} ),
+
+				},
+			},
+		};
 	} );
 
 	afterEach( () => {

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-settings-customization-dialog.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-settings-customization-dialog.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
 import { KitSettingsCustomizationDialog } from 'elementor/app/modules/import-export-customization/assets/js/shared/components/kit-settings-customization-dialog';
 import eventsConfig from 'elementor/core/common/modules/events-manager/assets/js/events-config';
 
@@ -28,6 +28,104 @@ describe( 'KitSettingsCustomizationDialog Component', () => {
 		global.elementorCommon = {
 			eventsManager: {
 				config: eventsConfig,
+			},
+		};
+
+		global.elementorModules = {
+			importExport: {
+				siteSettingsRegistry: {
+					getAll: jest.fn( () => [
+						{
+							key: 'theme',
+							title: __( 'Theme', 'elementor' ),
+							description: __( 'Only public WordPress themes are supported', 'elementor' ),
+							useParentDefault: true,
+							order: 0,
+						},
+						{
+							key: 'siteSettings',
+							title: __( 'Site settings', 'elementor' ),
+							order: 1,
+							children: [
+								{
+									key: 'globalColors',
+									title: __( 'Global colors', 'elementor' ),
+									useParentDefault: true,
+									order: 0,
+								},
+								{
+									key: 'globalFonts',
+									title: __( 'Global fonts', 'elementor' ),
+									useParentDefault: true,
+									order: 1,
+								},
+								{
+									key: 'themeStyleSettings',
+									title: __( 'Theme style settings', 'elementor' ),
+									useParentDefault: true,
+									order: 2,
+								},
+							],
+						},
+						{
+							key: 'generalSettings',
+							title: __( 'Settings', 'elementor' ),
+							description: __( 'Include site identity, background, layout, Lightbox, page transitions, and custom CSS', 'elementor' ),
+							useParentDefault: true,
+							order: 2,
+						},
+						{
+							key: 'experiments',
+							title: __( 'Experiments', 'elementor' ),
+							description: __( 'This will apply all experiments that are still active during import', 'elementor' ),
+							useParentDefault: true,
+							order: 3,
+						},
+					] ),
+					getState: jest.fn( ( data, parentInitialState ) => {
+						function getSectionState( section ) {
+							const state = {};
+
+							const isImport = data?.hasOwnProperty( 'uploadedData' );
+
+							if ( isImport ) {
+								state[ section.key ] = data?.uploadedData?.manifest?.[ 'site-settings' ]?.[ section.key ];
+								return state;
+							}
+
+							if ( data?.customization?.settings?.[ section.key ] !== undefined ) {
+								state[ section.key ] = data.customization.settings[ section.key ];
+								return state;
+							}
+
+							if ( section.getInitialState ) {
+								state[ section.key ] = section.getInitialState( data, parentInitialState );
+								return state;
+							}
+
+							state[ section.key ] = section.useParentDefault ? parentInitialState : false;
+
+							return state;
+						}
+						const state = {};
+						const sections = global.elementorModules.importExport.siteSettingsRegistry.getAll();
+
+						sections.forEach( ( section ) => {
+							if ( section.children ) {
+								section.children?.forEach( ( childSection ) => {
+									const sectionState = getSectionState( childSection, data, parentInitialState );
+
+									Object.assign( state, sectionState );
+								} );
+							} else {
+								Object.assign( state, getSectionState( section, data, parentInitialState ) );
+							}
+						} );
+
+						return state;
+					} ),
+
+				},
 			},
 		};
 	} );
@@ -124,7 +222,7 @@ describe( 'KitSettingsCustomizationDialog Component', () => {
 	} );
 
 	describe( 'Initial State', () => {
-		it( 'should initialize with settings enabled when settings is in includes', () => {
+		it( 'should initialize with settings enabled when settings is in includes', async () => {
 			// Arrange
 			const props = {
 				data: mockData,

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-settings-customization-dialog.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-settings-customization-dialog.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { KitSettingsCustomizationDialog } from 'elementor/app/modules/import-export-customization/assets/js/shared/components/kit-settings-customization-dialog';
 import eventsConfig from 'elementor/core/common/modules/events-manager/assets/js/events-config';
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add site settings registry and customization capabilities to the Import/Export module for Pro features and better settings management.
Main changes:
- Created BaseRegistry class with reusable registry functionality for templates and site settings
- Implemented SiteSettingsRegistry class to manage configuration of site settings during import/export
- Refactored KitSettingsCustomizationDialog to dynamically render settings based on registry data
- Added internationalization support for template titles and descriptions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
