### PR TITLE
Internal: `seems_utf8` is deprecated using `wp_is_valid_utf8` [ED-20422]

### DIFF
--- a/core/utils/import-export/wp-exporter.php
+++ b/core/utils/import-export/wp-exporter.php
@@ -173,7 +173,8 @@ class WP_Exporter {
 	private function wxr_cdata( $str ) {
 		$str = (string) $str;
 
-		if ( ! wp_is_valid_utf8( $str ) ) {
+		$is_valid_utf8 = wp_check_invalid_utf8( $str, true ) === $str;
+		if ( ! $is_valid_utf8 ) {
 			$str = utf8_encode( $str );
 		}
 

--- a/core/utils/import-export/wp-exporter.php
+++ b/core/utils/import-export/wp-exporter.php
@@ -173,7 +173,7 @@ class WP_Exporter {
 	private function wxr_cdata( $str ) {
 		$str = (string) $str;
 
-		if ( ! seems_utf8( $str ) ) {
+		if ( ! wp_is_valid_utf8( $str ) ) {
 			$str = utf8_encode( $str );
 		}
 

--- a/tests/phpunit/elementor/core/utils/import-export/test-wp-exporter.php
+++ b/tests/phpunit/elementor/core/utils/import-export/test-wp-exporter.php
@@ -182,7 +182,8 @@ class Test_WP_Exporter extends Elementor_Test_Base {
 	private function wxr_cdata( $str ) {
 		$str = (string) $str;
 
-		if ( ! wp_is_valid_utf8( $str ) ) {
+		$is_valid_utf8 = wp_check_invalid_utf8( $str, true ) === $str;
+		if ( ! $is_valid_utf8 ) {
 			$str = utf8_encode( $str );
 		}
 

--- a/tests/phpunit/elementor/core/utils/import-export/test-wp-exporter.php
+++ b/tests/phpunit/elementor/core/utils/import-export/test-wp-exporter.php
@@ -182,7 +182,7 @@ class Test_WP_Exporter extends Elementor_Test_Base {
 	private function wxr_cdata( $str ) {
 		$str = (string) $str;
 
-		if ( ! seems_utf8( $str ) ) {
+		if ( ! wp_is_valid_utf8( $str ) ) {
 			$str = utf8_encode( $str );
 		}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace deprecated seems_utf8() function with wp_is_valid_utf8() in the WP_Exporter class for UTF-8 validation.
Main changes:
- Updated wxr_cdata() method in core/utils/import-export/wp-exporter.php to use wp_is_valid_utf8()
- Applied same function replacement in the corresponding test file for consistency

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
