### PR TITLE
Revert "Internal: Revert free-to-Pro promotions - clean up [ED-20036]"

### DIFF
--- a/.grunt-config/webpack.js
+++ b/.grunt-config/webpack.js
@@ -142,6 +142,7 @@ const entry = {
 	'editor-v4-opt-in': path.resolve( __dirname, '../modules/atomic-opt-in/assets/js/opt-in-page/app.js'),
 	'editor-v4-welcome-opt-in': path.resolve( __dirname, '../modules/atomic-opt-in/assets/js/welcome-screen/app.js'),
 	'editor-v4-opt-in-alphachip': path.resolve( __dirname, '../modules/atomic-opt-in/assets/js/panel-chip/panel-chip.js' ),
+	'e-react-promotions': path.resolve( __dirname, '../modules/promotions/assets/js/react/index.js' ),
 	'e-wc-product-editor': path.resolve( __dirname, '../modules/wc-product-editor/assets/js/e-wc-product-editor.js' ),
 	'floating-elements-modal': path.resolve( __dirname, '../assets/dev/js/admin/floating-elements/new-floating-elements.js' ),
 	'cloud-library-screenshot': path.resolve( __dirname, '../modules/cloud-library/assets/js/preview/screenshot.js' ),

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -91,6 +91,19 @@ class Utils {
 		],
 	];
 
+	/**
+	 * Variables for free to pro upsale modal promotions
+	 */
+
+	const ANIMATED_HEADLINE = 'animated_headline';
+
+	const CTA = 'cta';
+
+	const VIDEO_PLAYLIST = 'video_playlist';
+
+	const TESTIMONIAL_WIDGET = 'testimonial_widget';
+
+	const IMAGE_CAROUSEL = 'image_carousel';
 
 	/**
 	 * Whether WordPress CLI mode is enabled or not.

--- a/includes/widgets/button.php
+++ b/includes/widgets/button.php
@@ -2,6 +2,7 @@
 namespace Elementor;
 
 use Elementor\Includes\Widgets\Traits\Button_Trait;
+use Elementor\Modules\Promotions\Controls\Promotion_Control;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.

--- a/includes/widgets/heading.php
+++ b/includes/widgets/heading.php
@@ -8,6 +8,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Modules\ContentSanitizer\Interfaces\Sanitizable;
+use Elementor\Modules\Promotions\Controls\Promotion_Control;
+
 /**
  * Elementor heading widget.
  *

--- a/includes/widgets/image-carousel.php
+++ b/includes/widgets/image-carousel.php
@@ -6,6 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Modules\Promotions\Controls\Promotion_Control;
 
 /**
  * Elementor image carousel widget.

--- a/includes/widgets/testimonial.php
+++ b/includes/widgets/testimonial.php
@@ -7,6 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Modules\Promotions\Controls\Promotion_Control;
 
 /**
  * Elementor testimonial widget.

--- a/includes/widgets/video.php
+++ b/includes/widgets/video.php
@@ -2,6 +2,7 @@
 namespace Elementor;
 
 use Elementor\Modules\DynamicTags\Module as TagsModule;
+use Elementor\Modules\Promotions\Controls\Promotion_Control;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.

--- a/modules/promotions/assets/js/react/app-manager.js
+++ b/modules/promotions/assets/js/react/app-manager.js
@@ -1,0 +1,67 @@
+import App from './app';
+import { createRoot } from 'react-dom/client';
+
+export class AppManager {
+	constructor() {
+		this.promotionInfoTip = null;
+		this.onRoute = () => {};
+	}
+
+	getPromotionData( promotionType ) {
+		return elementorPromotionsData[ promotionType ] || {};
+	}
+
+	mount( targetNode, selectors ) {
+		if ( this.promotionInfoTip ) {
+			return;
+		}
+
+		const wrapperElement = targetNode?.closest( selectors.wrapperElement );
+		const rootElement = wrapperElement?.querySelector( selectors.reactAnchor );
+
+		if ( ! rootElement ) {
+			return;
+		}
+
+		this.attachEditorEventListeners();
+
+		this.promotionInfoTip = createRoot( rootElement );
+
+		const colorScheme = elementor?.getPreferences?.( 'ui_theme' ) || 'auto';
+		const isRTL = elementorCommon.config.isRTL;
+		const promotionType = rootElement.getAttribute( 'data-promotion' )?.replace( '_promotion', '' );
+
+		this.promotionInfoTip.render(
+			<App
+				colorScheme={ colorScheme }
+				isRTL={ isRTL }
+				promotionsData={ this.getPromotionData( promotionType ) }
+				onClose={ () => this.unmount() }
+			/>,
+		);
+	}
+
+	unmount() {
+		if ( this.promotionInfoTip ) {
+			this.detachEditorEventListeners();
+			this.promotionInfoTip.unmount();
+		}
+
+		this.promotionInfoTip = null;
+	}
+
+	attachEditorEventListeners() {
+		this.onRoute = ( component, route ) => {
+			if ( route !== 'panel/elements/categories' && route !== 'panel/editor/content' ) {
+				return;
+			}
+			this.unmount();
+		};
+
+		$e.routes.on( 'run:after', this.onRoute );
+	}
+
+	detachEditorEventListeners() {
+		$e.routes.off( 'run:after', this.onRoute );
+	}
+}

--- a/modules/promotions/assets/js/react/app.js
+++ b/modules/promotions/assets/js/react/app.js
@@ -1,0 +1,43 @@
+import {
+	DirectionProvider,
+	Infotip,
+	LocalizationProvider,
+	ThemeProvider,
+} from '@elementor/ui';
+import PromotionCard from './components/promotion-card';
+
+const App = ( props ) => {
+	return (
+		<DirectionProvider rtl={ props.isRTL }>
+			<LocalizationProvider>
+				<ThemeProvider colorScheme={ props.colorScheme }>
+					<Infotip
+						content={ <PromotionCard doClose={ props.onClose } promotionsData={ props.promotionsData } /> }
+						placement="right"
+						arrow={ true }
+						open={ true }
+						disableHoverListener={ true }
+						PopperProps={ {
+							modifiers: [
+								{
+									name: 'offset',
+									options:
+										{ offset: [ -24, 8 ] },
+								},
+							],
+						} }
+					><span /></Infotip>
+				</ThemeProvider>
+			</LocalizationProvider>
+		</DirectionProvider>
+	);
+};
+
+App.propTypes = {
+	colorScheme: PropTypes.oneOf( [ 'auto', 'light', 'dark' ] ),
+	isRTL: PropTypes.bool,
+	promotionsData: PropTypes.object,
+	onClose: PropTypes.func.isRequired,
+};
+
+export default App;

--- a/modules/promotions/assets/js/react/components/promotion-card.js
+++ b/modules/promotions/assets/js/react/components/promotion-card.js
@@ -1,0 +1,72 @@
+import { __ } from '@wordpress/i18n';
+import {
+	ClickAwayListener,
+	Image,
+	Box,
+	Chip,
+	Typography,
+	Button,
+	CloseButton,
+	Stack,
+	List,
+	ListItem,
+} from '@elementor/ui';
+
+const PromotionCard = ( { doClose, promotionsData } ) => {
+	const title = promotionsData?.title,
+		description = promotionsData?.description,
+		imgSrc = promotionsData?.image,
+		imgAlt = promotionsData?.image_alt,
+		ctaText = promotionsData?.upgrade_text,
+		ctaUrl = promotionsData?.upgrade_url;
+
+	const redirectHandler = () => {
+		window.open( ctaUrl, '_blank' );
+		return doClose();
+	};
+
+	return (
+		<ClickAwayListener disableReactTree={ true } mouseEvent="onMouseDown" touchEvent="onTouchStart" onClickAway={ doClose }>
+			<Box sx={ { width: 296 } } data-testid="e-promotion-card">
+				<Stack direction="row" alignItems="center" py={ 1 } px={ 2 }>
+					<Typography variant="subtitle2">{ title }</Typography>
+					<Chip label={ __( 'PRO', 'elementor' ) } size="small" variant="outlined" color="promotion" sx={ { ml: 1 } } />
+					<CloseButton edge="end" sx={ { ml: 'auto' } } slotProps={ {
+						icon: {
+							fontSize: 'small',
+						},
+					} } onClick={ doClose } />
+				</Stack>
+				<Image src={ imgSrc } alt={ imgAlt } sx={ { height: 150, width: '100%' } } />
+				<Stack px={ 2 }>
+					{ 1 === description.length ? <Typography variant="body2" color="secondary" sx={ { pt: 1.5, pb: 1 } }>{ description[ 0 ] }</Typography> : <List sx={ { pl: 2 } }>
+						{ description.map( ( text, index ) => {
+							return (
+								<ListItem key={ index } sx={ { listStyle: 'disc', display: 'list-item', color: 'text.secondary', p: 0 } }>
+									<Typography variant="body2" color="secondary">{ text }</Typography>
+								</ListItem>
+							);
+						} ) }
+					</List> }
+
+				</Stack>
+				<Stack pt={ 1 } pb={ 1.5 } px={ 2 }>
+					<Button
+						variant="contained"
+						size="small"
+						color="promotion"
+						onClick={ redirectHandler }
+						sx={ { ml: 'auto' } }
+					>{ ctaText }</Button>
+				</Stack>
+			</Box>
+		</ClickAwayListener>
+	);
+};
+
+PromotionCard.propTypes = {
+	doClose: PropTypes.func,
+	promotionsData: PropTypes.object,
+};
+
+export default PromotionCard;

--- a/modules/promotions/assets/js/react/controls/promotion.js
+++ b/modules/promotions/assets/js/react/controls/promotion.js
@@ -1,0 +1,34 @@
+import { default as ControlBaseDataView } from 'elementor-controls/base-data';
+import { AppManager } from '../app-manager';
+export default class extends ControlBaseDataView {
+	promotionInfoTip = null;
+
+	constructor( options ) {
+		super( options );
+
+		this.AppManager = new AppManager();
+	}
+	selectors = {
+		wrapperElement: '.elementor-control-type-switcher',
+		reactAnchor: '.e-promotion-react-wrapper',
+	};
+
+	ui() {
+		return {
+			switcher: '[data-promotion].elementor-control-type-switcher',
+		};
+	}
+	events() {
+		return {
+			'click @ui.switcher': 'onClickControlSwitcher',
+		};
+	}
+	promotionData( promotionType ) {
+		return elementorPromotionsData[ promotionType ] || {};
+	}
+
+	onClickControlSwitcher( event ) {
+		event.stopPropagation();
+		this.AppManager.mount( event.target, this.selectors );
+	}
+}

--- a/modules/promotions/assets/js/react/index.js
+++ b/modules/promotions/assets/js/react/index.js
@@ -1,0 +1,3 @@
+import Module from './module.js';
+
+new Module();

--- a/modules/promotions/assets/js/react/module.js
+++ b/modules/promotions/assets/js/react/module.js
@@ -1,0 +1,7 @@
+import PromotionControl from './controls/promotion';
+
+export default class Module extends elementorModules.editor.utils.Module {
+	onElementorInit() {
+		elementor.addControlView( 'promotion_control', PromotionControl );
+	}
+}

--- a/modules/promotions/controls/promotion-control.php
+++ b/modules/promotions/controls/promotion-control.php
@@ -1,0 +1,38 @@
+<?php
+namespace Elementor\Modules\Promotions\Controls;
+
+use Elementor\Base_Data_Control;
+
+class Promotion_Control extends Base_Data_Control {
+
+	const TYPE = 'promotion_control';
+
+	public function get_type() {
+		return static::TYPE;
+	}
+
+	public function content_template() {
+		?>
+		<div data-promotion="{{{ data.name }}}" class="elementor-control-type-switcher elementor-label-inline e-control-promotion__wrapper">
+			<div class="elementor-control-content">
+				<div class="elementor-control-field">
+					<# if ( data.label ) {#>
+						<label for="<?php $this->print_control_uid(); ?>" class="elementor-control-title">{{{ data.label }}}</label>
+					<# } #>
+					<span class="e-control-promotion__lock-wrapper">
+						<i class="eicon-lock"></i>
+					</span>
+					<div class="elementor-control-input-wrapper">
+						<label class="elementor-switch elementor-control-unit-2 e-control-promotion-switch">
+							<input type="checkbox" class="elementor-switch-input" disabled>
+							<span class="elementor-switch-label" data-off="Off"></span>
+							<span class="elementor-switch-handle"></span>
+						</label>
+					</div>
+					<div class="e-promotion-react-wrapper" data-promotion="{{{ data.name }}}"></div>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
+}

--- a/modules/promotions/promotion-data.php
+++ b/modules/promotions/promotion-data.php
@@ -1,0 +1,126 @@
+<?php
+namespace Elementor\Modules\Promotions;
+
+use Elementor\Core\Utils\Promotions\Filtered_Promotions_Manager;
+use Elementor\Includes\EditorAssetsAPI;
+use Elementor\Utils;
+
+class PromotionData {
+	protected EditorAssetsAPI $editor_assets_api;
+
+	public function __construct( EditorAssetsAPI $editor_assets_api ) {
+		$this->editor_assets_api = $editor_assets_api;
+	}
+
+	public function get_promotion_data( $force_request = false ): array {
+		$assets_data = $this->transform_assets_data( $force_request );
+
+		return [
+			Utils::ANIMATED_HEADLINE => $this->get_animated_headline_data( $assets_data ),
+			Utils::VIDEO_PLAYLIST => $this->get_video_playlist_data( $assets_data ),
+			Utils::CTA => $this->get_cta_button_data( $assets_data ),
+			Utils::IMAGE_CAROUSEL => $this->get_image_carousel_data( $assets_data ),
+			Utils::TESTIMONIAL_WIDGET => $this->get_testimonial_widget_data( $assets_data ),
+		];
+	}
+
+	private function transform_assets_data( $force_request = false ) {
+		$assets_data = $this->editor_assets_api->get_assets_data( $force_request );
+		$transformed_data = [];
+
+		foreach ( $assets_data as $asset ) {
+			$transformed_data[ $asset['id'] ] = $asset['imageSrc'];
+		}
+
+		return $transformed_data;
+	}
+
+	private function get_animated_headline_data( $assets_data ) {
+		$data = [
+			'image' => esc_url( $assets_data[ Utils::ANIMATED_HEADLINE ] ?? '' ),
+			'image_alt' => esc_attr__( 'Upgrade', 'elementor' ),
+			'title' => esc_html__( 'Bring Headlines to Life', 'elementor' ),
+			'description' => [
+				esc_html__( 'Highlight key messages dynamically.', 'elementor' ),
+				esc_html__( 'Apply rotating effects to text.', 'elementor' ),
+				esc_html__( 'Fully customize your headlines.', 'elementor' ),
+			],
+			'upgrade_text' => esc_html__( 'Upgrade Now', 'elementor' ),
+			'upgrade_url' => 'https://go.elementor.com/go-pro-heading-widget-control/',
+		];
+
+		return $this->filter_data( Utils::ANIMATED_HEADLINE, $data );
+	}
+
+	private function get_video_playlist_data( $assets_data ) {
+		$data = [
+			'image' => esc_url( $assets_data[ Utils::VIDEO_PLAYLIST ] ?? '' ),
+			'image_alt' => esc_attr__( 'Upgrade', 'elementor' ),
+			'title' => esc_html__( 'Showcase Video Playlists', 'elementor' ),
+			'description' => [
+				esc_html__( 'Embed videos with full control.', 'elementor' ),
+				esc_html__( 'Adjust layout and playback settings.', 'elementor' ),
+				esc_html__( 'Seamlessly customize video appearance.', 'elementor' ),
+			],
+			'upgrade_text' => esc_html__( 'Upgrade Now', 'elementor' ),
+			'upgrade_url' => 'https://go.elementor.com/go-pro-video-widget-control/',
+		];
+
+		return $this->filter_data( Utils::VIDEO_PLAYLIST, $data );
+	}
+
+	private function get_cta_button_data( $assets_data ) {
+		$data = [
+			'image' => esc_url( $assets_data[ Utils::CTA ] ?? '' ),
+			'image_alt' => esc_attr__( 'Upgrade', 'elementor' ),
+			'title' => esc_html__( 'Boost Conversions with CTAs', 'elementor' ),
+			'description' => [
+				esc_html__( 'Combine text, buttons, and images.', 'elementor' ),
+				esc_html__( 'Add hover animations and CSS effects.', 'elementor' ),
+				esc_html__( 'Create unique, interactive designs.', 'elementor' ),
+			],
+			'upgrade_text' => esc_html__( 'Upgrade Now', 'elementor' ),
+			'upgrade_url' => 'https://go.elementor.com/go-pro-button-widget-control/',
+		];
+
+		return $this->filter_data( Utils::CTA, $data );
+	}
+
+	private function get_image_carousel_data( $assets_data ) {
+		$data = [
+			'image' => esc_url( $assets_data[ Utils::IMAGE_CAROUSEL ] ?? '' ),
+			'image_alt' => esc_attr__( 'Upgrade', 'elementor' ),
+			'title' => esc_html__( 'Design Custom Carousels', 'elementor' ),
+			'description' => [
+				esc_html__( 'Create flexible custom carousels.', 'elementor' ),
+				esc_html__( 'Adjust transitions and animations.', 'elementor' ),
+				esc_html__( 'Showcase multiple items with style.', 'elementor' ),
+			],
+			'upgrade_text' => esc_html__( 'Upgrade Now', 'elementor' ),
+			'upgrade_url' => 'https://go.elementor.com/go-pro-image-carousel-widget-control/',
+		];
+
+		return $this->filter_data( Utils::IMAGE_CAROUSEL, $data );
+	}
+
+	private function get_testimonial_widget_data( $assets_data ) {
+		$data = [
+			'image' => esc_url( $assets_data[ Utils::TESTIMONIAL_WIDGET ] ?? '' ),
+			'image_alt' => esc_attr__( 'Upgrade', 'elementor' ),
+			'title' => esc_html__( 'Upgrade Your Testimonials', 'elementor' ),
+			'description' => [
+				esc_html__( 'Display reviews in a rotating carousel.', 'elementor' ),
+				esc_html__( 'Boost credibility with dynamic testimonials.', 'elementor' ),
+				esc_html__( 'Customize layouts for visual appeal.', 'elementor' ),
+			],
+			'upgrade_text' => esc_html__( 'Upgrade Now', 'elementor' ),
+			'upgrade_url' => 'https://go.elementor.com/go-pro-testimonial-widget-control/',
+		];
+
+		return $this->filter_data( Utils::TESTIMONIAL_WIDGET, $data );
+	}
+
+	private function filter_data( $widget_name, $asset_data ): array {
+		return Filtered_Promotions_Manager::get_filtered_promotion_data( $asset_data, "elementor/widgets/{$widget_name}/custom_promotion", 'upgrade_url' );
+	}
+}

--- a/tests/playwright/pages/promotions/helper.ts
+++ b/tests/playwright/pages/promotions/helper.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 import Content from '../elementor-panel-tabs/content';
+import EditorSelectors from '../../selectors/editor-selectors';
 
 export default class promotionsHelper extends Content {
 	/**
@@ -14,5 +15,21 @@ export default class promotionsHelper extends Content {
 		const modalContainer = this.page.locator( '#elementor-element--promotion__dialog' );
 		await expect.soft( modalContainer ).toHaveScreenshot( `${ element }-modal.png` );
 		await this.page.locator( '.dialog-header .eicon-close' ).click();
+	}
+
+	/**
+	 * Test promotion modal visibility.
+	 *
+	 * @param {string} element - Element name.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async modalPromotionModalVisibilityTest( element: string ): Promise<void> {
+		await this.page.locator( `.elementor-control-${ element }` ).click( { force: true } );
+		const modalContainer = this.page.locator( EditorSelectors.panels.promotionCard );
+		await expect.soft( modalContainer ).toBeVisible();
+		await expect( modalContainer.getByText( 'PRO' ) ).toBeVisible();
+		await modalContainer.getByRole( 'button', { name: 'close' } ).click();
+		await expect.soft( modalContainer ).toBeHidden();
 	}
 }

--- a/tests/playwright/sanity/modules/promotions/promotions.test.ts
+++ b/tests/playwright/sanity/modules/promotions/promotions.test.ts
@@ -56,6 +56,44 @@ test.describe( 'Promotion tests @promotions', () => {
 		} );
 	} );
 
+	// TODO : Clean up task : https://elementor.atlassian.net/browse/ED-20036
+	test.skip( 'Widgets React Modal Promotions', async ( { page, apiRequests }, testInfo ) => {
+		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests ),
+			editor = await wpAdmin.openNewPage(),
+			promotionsHelper = new PromotionsHelper( page, testInfo ),
+			container = await editor.addElement( { elType: 'container' }, 'document' );
+
+		await test.step( 'Free to Pro - react animated headline modal visible', async () => {
+			await editor.addWidget( { widgetType: 'heading', container } );
+			await editor.openPanelTab( 'content' );
+			await promotionsHelper.modalPromotionModalVisibilityTest( 'animated_headline_promotion' );
+		} );
+
+		await test.step( 'Free to Pro - react video playlist modal visible', async () => {
+			await editor.addWidget( { widgetType: 'video', container } );
+			await editor.openPanelTab( 'content' );
+			await promotionsHelper.modalPromotionModalVisibilityTest( 'video_playlist_promotion' );
+		} );
+
+		await test.step( 'Free to Pro - react cta button modal visible', async () => {
+			await editor.addWidget( { widgetType: 'button', container } );
+			await editor.openPanelTab( 'content' );
+			await promotionsHelper.modalPromotionModalVisibilityTest( 'cta_promotion' );
+		} );
+
+		await test.step( 'Free to Pro - react image carousel modal visible', async () => {
+			await editor.addWidget( { widgetType: 'image-carousel', container } );
+			await editor.openPanelTab( 'content' );
+			await promotionsHelper.modalPromotionModalVisibilityTest( 'image_carousel_promotion' );
+		} );
+
+		await test.step( 'Free to Pro - react testimonial modal visible', async () => {
+			await editor.addWidget( { widgetType: 'testimonial', container } );
+			await editor.openPanelTab( 'content' );
+			await promotionsHelper.modalPromotionModalVisibilityTest( 'testimonial_widget_promotion' );
+		} );
+	} );
+
 	test( 'Context Menu Promotions - Free to Pro', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests ),


### PR DESCRIPTION
Reverts elementor/elementor#32020
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Restore free-to-Pro promotional features that display upgrade options for premium widgets in the Elementor editor.

Main changes:
- Added Promotion_Control class for displaying React-based promotional UI components
- Implemented React components for rendering promotional tooltips with upgrade CTAs
- Added promotion data infrastructure with widget-specific promotional content and tracking
- Restored import statements and widget integrations for free-to-Pro promotions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
