### PR TITLE
Internal: Fix publish flow

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -62,5 +62,5 @@ jobs:
         run: |
           git config --global user.email "github-actions@github.com"
           git config --global user.name "GitHub Actions"
-          git tag -a "v${{ env.VERSION_WITH_TAG }}" -m "Release ${{ env.VERSION_WITH_TAG }}"
-          git push origin "v${{ env.VERSION_WITH_TAG }}"
+          git tag -a "v${{ steps.build-tag.outputs.VERSION_WITH_TAG }}" -m "Release ${{ steps.build-tag.outputs.VERSION_WITH_TAG }}"
+          git push origin "v${{ steps.build-tag.outputs.VERSION_WITH_TAG }}"


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix publish workflow by correcting Git tag variable reference to ensure proper version tagging during package publishing.
Main changes:
- Updated Git tag commands to use steps.build-tag.outputs.VERSION_WITH_TAG instead of env.VERSION_WITH_TAG

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
