### PR TITLE
Internal: Update WordPress versions in php unit tests [ED-20444]

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        wordpress_versions: ['nightly', 'latest', '6.6', '6.5']
+        wordpress_versions: ['nightly', 'latest', '6.7', '6.6']
         php_versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
     name: PHPUnit - WordPress ${{ matrix.wordpress_versions }} - PHP version ${{ matrix.php_versions }}
     env:


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update WordPress version targets in PHP unit test configuration to include newer WordPress 6.7 and remove testing against 6.5.
Main changes:
- Modified WordPress test matrix to use versions 'nightly', 'latest', '6.7', and '6.6' instead of 'nightly', 'latest', '6.6', and '6.5'

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
