### PR TITLE
Internal: Remove deprecated accent color [ED-20462]

### DIFF
--- a/modules/atomic-opt-in/assets/js/panel-chip/components/popover-card.js
+++ b/modules/atomic-opt-in/assets/js/panel-chip/components/popover-card.js
@@ -62,7 +62,7 @@ const PopoverCard = ( { doClose } ) => {
 					<Button
 						variant="contained"
 						size="small"
-						color="accent"
+						color="promotion"
 						onClick={ redirectHandler }
 						sx={ { ml: 'auto' } }
 					>{ ctaText }</Button>

--- a/modules/atomic-opt-in/assets/js/welcome-screen/welcome-dialog.js
+++ b/modules/atomic-opt-in/assets/js/welcome-screen/welcome-dialog.js
@@ -74,7 +74,7 @@ export const WelcomeDialog = ( { doClose } ) => {
 			<Stack py={ 2 } px={ 3 }>
 				<Button
 					variant="contained"
-					color="accent"
+					color="promotion"
 					onClick={ doClose }
 					sx={ { ml: 'auto' } }
 				>{ i18n.closeButton }</Button>

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-selector.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-selector.tsx
@@ -53,7 +53,7 @@ const EMPTY_OPTION = {
 	label: __( 'local', 'elementor' ),
 	value: null,
 	fixed: true,
-	color: getTempStylesProviderColorName( 'accent' ),
+	color: getTempStylesProviderColorName( 'promotion' ),
 	icon: <MapPinIcon />,
 	provider: null,
 } satisfies StyleDefOption;
@@ -230,7 +230,7 @@ function useOptions() {
 }
 
 function getTempStylesProviderColorName( color: ChipOwnProps[ 'color' ] ): ChipOwnProps[ 'color' ] {
-	if ( color === 'accent' ) {
+	if ( color === 'promotion' ) {
 		return 'primary';
 	}
 

--- a/packages/packages/core/editor-editing-panel/src/utils/get-styles-provider-color.ts
+++ b/packages/packages/core/editor-editing-panel/src/utils/get-styles-provider-color.ts
@@ -9,7 +9,7 @@ export const getStylesProviderColorName = ( provider: string ): ChipProps[ 'colo
 	}
 
 	if ( isElementsStylesProvider( provider ) ) {
-		return 'accent';
+		return 'promotion';
 	}
 
 	return getStyleProviderColors( provider ).name;
@@ -21,7 +21,7 @@ export const getStylesProviderThemeColor = ( provider: string ): ( ( theme: Them
 	}
 
 	if ( isElementsStylesProvider( provider ) ) {
-		return ( theme: Theme ) => theme.palette.accent.main;
+		return ( theme: Theme ) => theme.palette.promotion.main;
 	}
 
 	return getStyleProviderColors( provider ).getThemeColor;


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace deprecated 'accent' color with 'promotion' color across UI components to maintain consistent styling and follow design system updates.

Main changes:
- Updated Button color property from 'accent' to 'promotion' in popover and welcome dialog components
- Modified color reference in CSS class selector from 'accent' to 'promotion'
- Updated styles provider color functions to use 'promotion' palette instead of 'accent'

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
