### PR TITLE
Internal: Add min WP and PHP version to elementor header [ED-2047]

### DIFF
--- a/elementor.php
+++ b/elementor.php
@@ -7,8 +7,8 @@
  * Author: Elementor.com
  * Author URI: https://elementor.com/?utm_source=wp-plugins&utm_campaign=author-uri&utm_medium=wp-dash
  * Text Domain: elementor
- * Required at least: 6.5
- * Required PHP: 7.4
+ * Requires at least: 6.5
+ * Requires PHP: 7.4
  *
  * @package Elementor
  * @category Core

--- a/elementor.php
+++ b/elementor.php
@@ -7,6 +7,8 @@
  * Author: Elementor.com
  * Author URI: https://elementor.com/?utm_source=wp-plugins&utm_campaign=author-uri&utm_medium=wp-dash
  * Text Domain: elementor
+ * Required at least: 6.5
+ * Required PHP: 7.4
  *
  * @package Elementor
  * @category Core


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add WordPress and PHP minimum version requirements to Elementor plugin header to ensure compatibility information is properly displayed.
Main changes:
- Added "Requires at least: 6.5" to specify minimum WordPress version requirement
- Added "Requires PHP: 7.4" to specify minimum PHP version requirement

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
