### PR TITLE
Fix: Invalid context when converting local class to global class on first time [ED-20269]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
@@ -30,7 +30,7 @@ export const CssClassConvert = ( props: OwnProps ) => {
 	const elementId = element.id;
 	const currentClassesProp = useClassesProp();
 	const { setId: setActiveId } = useStyle();
-	const [ , saveValue ] = useSessionStorage( `last-converted-class-generated-name`, `app` );
+	const [ , saveValue ] = useSessionStorage( 'last-converted-class-generated-name', 'app' );
 
 	const successCallback = ( newId: string ) => {
 		if ( ! props.styleDef ) {

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
@@ -30,7 +30,7 @@ export const CssClassConvert = ( props: OwnProps ) => {
 	const elementId = element.id;
 	const currentClassesProp = useClassesProp();
 	const { setId: setActiveId } = useStyle();
-	const [ , saveValue ] = useSessionStorage( `last-converted-class-generated-name`, `global` );
+	const [ , saveValue ] = useSessionStorage( `last-converted-class-generated-name`, `app` );
 
 	const successCallback = ( newId: string ) => {
 		if ( ! props.styleDef ) {

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
 import { deleteElementStyle, getElementSetting, updateElementSettings } from '@elementor/editor-elements';
 import { classesPropTypeUtil, type ClassesPropValue } from '@elementor/editor-props';
 import { type StyleDefinition } from '@elementor/editor-styles';
 import { createLocation } from '@elementor/locations';
 import { useSessionStorage } from '@elementor/session';
+import * as React from 'react';
 
 import { useClassesProp } from '../../contexts/classes-prop-context';
 import { useElement } from '../../contexts/element-context';
@@ -30,7 +30,7 @@ export const CssClassConvert = ( props: OwnProps ) => {
 	const elementId = element.id;
 	const currentClassesProp = useClassesProp();
 	const { setId: setActiveId } = useStyle();
-	const [ , saveValue ] = useSessionStorage( `last-converted-class-generated-name` );
+	const [ , saveValue ] = useSessionStorage( `last-converted-class-generated-name`, `global` );
 
 	const successCallback = ( newId: string ) => {
 		if ( ! props.styleDef ) {

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-convert-local.tsx
@@ -1,9 +1,9 @@
+import * as React from 'react';
 import { deleteElementStyle, getElementSetting, updateElementSettings } from '@elementor/editor-elements';
 import { classesPropTypeUtil, type ClassesPropValue } from '@elementor/editor-props';
 import { type StyleDefinition } from '@elementor/editor-styles';
 import { createLocation } from '@elementor/locations';
 import { useSessionStorage } from '@elementor/session';
-import * as React from 'react';
 
 import { useClassesProp } from '../../contexts/classes-prop-context';
 import { useElement } from '../../contexts/element-context';

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-item.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-item.tsx
@@ -51,7 +51,7 @@ export function CssClassItem( props: CssClassItemProps ) {
 	const { userCan } = useUserStylesCapability();
 
 	const [ convertedFromLocalId, , clearConvertedFromLocalId ] = useSessionStorage(
-		`last-converted-class-generated-name`, `app`
+		'last-converted-class-generated-name', 'app'
 	);
 
 	const {

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-item.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-item.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { type ReactElement, useEffect, useState } from 'react';
 import { stylesRepository, useUserStylesCapability, validateStyleLabel } from '@elementor/editor-styles-repository';
 import { EditableField, EllipsisWithTooltip, useEditable } from '@elementor/editor-ui';
 import { DotsVerticalIcon } from '@elementor/icons';
@@ -15,8 +17,6 @@ import {
 	usePopupState,
 } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
-import * as React from 'react';
-import { type ReactElement, useEffect, useState } from 'react';
 
 import { useStyle } from '../../contexts/style-context';
 import { CssClassProvider } from './css-class-context';
@@ -51,7 +51,8 @@ export function CssClassItem( props: CssClassItemProps ) {
 	const { userCan } = useUserStylesCapability();
 
 	const [ convertedFromLocalId, , clearConvertedFromLocalId ] = useSessionStorage(
-		'last-converted-class-generated-name', 'app'
+		'last-converted-class-generated-name',
+		'app'
 	);
 
 	const {

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-item.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-item.tsx
@@ -51,7 +51,7 @@ export function CssClassItem( props: CssClassItemProps ) {
 	const { userCan } = useUserStylesCapability();
 
 	const [ convertedFromLocalId, , clearConvertedFromLocalId ] = useSessionStorage(
-		`last-converted-class-generated-name`, `global`
+		`last-converted-class-generated-name`, `app`
 	);
 
 	const {
@@ -79,6 +79,8 @@ export function CssClassItem( props: CssClassItemProps ) {
 			clearConvertedFromLocalId();
 			openEditMode();
 		}
+		// eslint-disable-next-line react-compiler/react-compiler
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ id, convertedFromLocalId ] );
 
 	return (

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-item.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-item.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import { type ReactElement, useEffect, useState } from 'react';
 import { stylesRepository, useUserStylesCapability, validateStyleLabel } from '@elementor/editor-styles-repository';
 import { EditableField, EllipsisWithTooltip, useEditable } from '@elementor/editor-ui';
 import { DotsVerticalIcon } from '@elementor/icons';
@@ -17,6 +15,8 @@ import {
 	usePopupState,
 } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
+import * as React from 'react';
+import { type ReactElement, useEffect, useState } from 'react';
 
 import { useStyle } from '../../contexts/style-context';
 import { CssClassProvider } from './css-class-context';
@@ -51,7 +51,7 @@ export function CssClassItem( props: CssClassItemProps ) {
 	const { userCan } = useUserStylesCapability();
 
 	const [ convertedFromLocalId, , clearConvertedFromLocalId ] = useSessionStorage(
-		`last-converted-class-generated-name`
+		`last-converted-class-generated-name`, `global`
 	);
 
 	const {
@@ -79,9 +79,7 @@ export function CssClassItem( props: CssClassItemProps ) {
 			clearConvertedFromLocalId();
 			openEditMode();
 		}
-		// eslint-disable-next-line react-compiler/react-compiler
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ id ] );
+	}, [ id, convertedFromLocalId ] );
 
 	return (
 		<ThemeProvider palette="default">

--- a/packages/packages/libs/session/src/use-session-storage.ts
+++ b/packages/packages/libs/session/src/use-session-storage.ts
@@ -4,7 +4,8 @@ import { getSessionStorageItem, removeSessionStorageItem, setSessionStorageItem 
 import { Context } from './session-storage-context';
 
 export const useSessionStorage = < T >( key: string, customPrefix?: string ) => {
-	const prefix = customPrefix ? customPrefix : useContext( Context )?.prefix ?? '';
+	const contextPrefix = useContext( Context )?.prefix ?? '';
+	const prefix = customPrefix ? customPrefix : contextPrefix;
 	const prefixedKey = `${ prefix }/${ key }`;
 
 	const [ value, setValue ] = useState< T | null >();

--- a/packages/packages/libs/session/src/use-session-storage.ts
+++ b/packages/packages/libs/session/src/use-session-storage.ts
@@ -3,8 +3,8 @@ import { useContext, useEffect, useState } from 'react';
 import { getSessionStorageItem, removeSessionStorageItem, setSessionStorageItem } from './session-storage';
 import { Context } from './session-storage-context';
 
-export const useSessionStorage = < T >( key: string ) => {
-	const prefix = useContext( Context )?.prefix ?? '';
+export const useSessionStorage = < T >( key: string, customPrefix?: string ) => {
+	const prefix = customPrefix ? customPrefix : useContext( Context )?.prefix ?? '';
 	const prefixedKey = `${ prefix }/${ key }`;
 
 	const [ value, setValue ] = useState< T | null >();


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix invalid context when converting local CSS class to global class by adding custom prefix fallback in useSessionStorage hook.

Main changes:
- Added customPrefix parameter to useSessionStorage hook with fallback mechanism
- Set default value 'app' for the last-converted-class-generated-name storage key
- Updated dependency array in useEffect to properly track convertedFromLocalId changes

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
