### PR TITLE
Internal: Update WP min version on main [ED-20509]

### DIFF
--- a/elementor.php
+++ b/elementor.php
@@ -7,7 +7,7 @@
  * Author: Elementor.com
  * Author URI: https://elementor.com/?utm_source=wp-plugins&utm_campaign=author-uri&utm_medium=wp-dash
  * Text Domain: elementor
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP: 7.4
  *
  * @package Elementor

--- a/elementor.php
+++ b/elementor.php
@@ -6,9 +6,9 @@
  * Version: 3.32.0
  * Author: Elementor.com
  * Author URI: https://elementor.com/?utm_source=wp-plugins&utm_campaign=author-uri&utm_medium=wp-dash
- * Text Domain: elementor
- * Requires at least: 6.6
  * Requires PHP: 7.4
+ * Requires at least: 6.6
+ * Text Domain: elementor
  *
  * @package Elementor
  * @category Core


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update WordPress minimum version requirement from 6.5 to 6.6 for Elementor plugin compatibility.
Main changes:
- Increased minimum required WordPress version from 6.5 to 6.6
- Reordered plugin header metadata to place Text Domain after version requirements

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
