### PR TITLE
Revert "Internal: Cherry-pick PR 32348 to 3.31 Add min WP and PHP version to elementor header [ED-2047]"

### DIFF
--- a/elementor.php
+++ b/elementor.php
@@ -7,8 +7,6 @@
  * Author: Elementor.com
  * Author URI: https://elementor.com/?utm_source=wp-plugins&utm_campaign=author-uri&utm_medium=wp-dash
  * Text Domain: elementor
- * Requires at least: 6.5
- * Requires PHP: 7.4
  *
  * @package Elementor
  * @category Core


### PR DESCRIPTION
Reverts elementor/elementor#32354
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert the addition of WordPress and PHP minimum version requirements in the Elementor plugin header.
Main changes:
- Removed the "Requires at least: 6.5" WordPress version requirement from plugin header
- Removed the "Requires PHP: 7.4" PHP version requirement from plugin header

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
