### PR TITLE
Internal: Remove createControl from gap and linked controls [ED-20270]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/gap-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/gap-control.tsx
@@ -11,7 +11,7 @@ import { ControlLabel } from '../components/control-label';
 import { createControl } from '../create-control';
 import { SizeControl } from './size-control';
 
-export const GapControl = createControl( ( { label }: { label: string } ) => {
+export const GapControl = ( { label }: { label: string } ) => {
 	const {
 		value: directionValue,
 		setValue: setDirectionValue,
@@ -87,7 +87,7 @@ export const GapControl = createControl( ( { label }: { label: string } ) => {
 			</Stack>
 		</PropProvider>
 	);
-} );
+};
 
 const Control = ( {
 	bind,

--- a/packages/packages/libs/editor-controls/src/controls/gap-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/gap-control.tsx
@@ -8,7 +8,6 @@ import { __ } from '@wordpress/i18n';
 import { PropKeyProvider, PropProvider, useBoundProp } from '../bound-prop-context';
 import { ControlFormLabel } from '../components/control-form-label';
 import { ControlLabel } from '../components/control-label';
-import { createControl } from '../create-control';
 import { SizeControl } from './size-control';
 
 export const GapControl = ( { label }: { label: string } ) => {

--- a/packages/packages/libs/editor-controls/src/controls/linked-dimensions-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/linked-dimensions-control.tsx
@@ -9,118 +9,117 @@ import { PropKeyProvider, PropProvider, useBoundProp } from '../bound-prop-conte
 import { ControlFormLabel } from '../components/control-form-label';
 import { ControlLabel } from '../components/control-label';
 import { StyledToggleButton } from '../components/control-toggle-button-group';
-import { createControl } from '../create-control';
 import { type ExtendedOption } from '../utils/size-control';
 import { SizeControl } from './size-control';
 
 export const LinkedDimensionsControl = ( {
-		label,
-		isSiteRtl = false,
-		extendedOptions,
-		min,
-	}: {
-		label: string;
-		isSiteRtl?: boolean;
-		extendedOptions?: ExtendedOption[];
-		min?: number;
-	} ) => {
-		const {
-			value: sizeValue,
-			setValue: setSizeValue,
-			disabled: sizeDisabled,
-			placeholder: sizePlaceholder,
-		} = useBoundProp( sizePropTypeUtil );
-		const gridRowRefs: RefObject< HTMLDivElement >[] = [ useRef( null ), useRef( null ) ];
+	label,
+	isSiteRtl = false,
+	extendedOptions,
+	min,
+}: {
+	label: string;
+	isSiteRtl?: boolean;
+	extendedOptions?: ExtendedOption[];
+	min?: number;
+} ) => {
+	const {
+		value: sizeValue,
+		setValue: setSizeValue,
+		disabled: sizeDisabled,
+		placeholder: sizePlaceholder,
+	} = useBoundProp( sizePropTypeUtil );
+	const gridRowRefs: RefObject< HTMLDivElement >[] = [ useRef( null ), useRef( null ) ];
 
-		const {
-			value: dimensionsValue,
-			setValue: setDimensionsValue,
-			propType,
-			placeholder: dimensionsPlaceholder,
-			disabled: dimensionsDisabled,
-		} = useBoundProp( dimensionsPropTypeUtil );
+	const {
+		value: dimensionsValue,
+		setValue: setDimensionsValue,
+		propType,
+		placeholder: dimensionsPlaceholder,
+		disabled: dimensionsDisabled,
+	} = useBoundProp( dimensionsPropTypeUtil );
 
-		const hasUserValues = !! ( dimensionsValue || sizeValue );
-		const hasPlaceholders = !! ( sizePlaceholder || dimensionsPlaceholder );
+	const hasUserValues = !! ( dimensionsValue || sizeValue );
+	const hasPlaceholders = !! ( sizePlaceholder || dimensionsPlaceholder );
 
-		const isLinked =
-			( ! hasUserValues && ! hasPlaceholders ) || ( hasPlaceholders ? !! sizePlaceholder : !! sizeValue );
-		const onLinkToggle = () => {
-			if ( ! isLinked ) {
-				setSizeValue( dimensionsValue[ 'block-start' ]?.value ?? null );
-				return;
-			}
+	const isLinked =
+		( ! hasUserValues && ! hasPlaceholders ) || ( hasPlaceholders ? !! sizePlaceholder : !! sizeValue );
+	const onLinkToggle = () => {
+		if ( ! isLinked ) {
+			setSizeValue( dimensionsValue[ 'block-start' ]?.value ?? null );
+			return;
+		}
 
-			const value = sizeValue ? sizePropTypeUtil.create( sizeValue ) : null;
+		const value = sizeValue ? sizePropTypeUtil.create( sizeValue ) : null;
 
-			setDimensionsValue( {
-				'block-start': value,
-				'block-end': value,
-				'inline-start': value,
-				'inline-end': value,
-			} );
-		};
-
-		const tooltipLabel = label.toLowerCase();
-
-		const LinkedIcon = isLinked ? LinkIcon : DetachIcon;
-		// translators: %s: Tooltip title.
-		const linkedLabel = __( 'Link %s', 'elementor' ).replace( '%s', tooltipLabel );
-		// translators: %s: Tooltip title.
-		const unlinkedLabel = __( 'Unlink %s', 'elementor' ).replace( '%s', tooltipLabel );
-
-		const disabled = sizeDisabled || dimensionsDisabled;
-
-		return (
-			<PropProvider
-				propType={ propType }
-				value={ dimensionsValue }
-				setValue={ setDimensionsValue }
-				placeholder={ dimensionsPlaceholder }
-				isDisabled={ () => disabled }
-			>
-				<Stack direction="row" gap={ 2 } flexWrap="nowrap">
-					<ControlFormLabel>{ label }</ControlFormLabel>
-					<Tooltip title={ isLinked ? unlinkedLabel : linkedLabel } placement="top">
-						<StyledToggleButton
-							aria-label={ isLinked ? unlinkedLabel : linkedLabel }
-							size={ 'tiny' }
-							value={ 'check' }
-							selected={ isLinked }
-							sx={ { marginLeft: 'auto' } }
-							onChange={ onLinkToggle }
-							disabled={ disabled }
-							isPlaceholder={ hasPlaceholders }
-						>
-							<LinkedIcon fontSize={ 'tiny' } />
-						</StyledToggleButton>
-					</Tooltip>
-				</Stack>
-
-				{ getCssDimensionProps( isSiteRtl ).map( ( row, index ) => (
-					<Stack direction="row" gap={ 2 } flexWrap="nowrap" key={ index } ref={ gridRowRefs[ index ] }>
-						{ row.map( ( { icon, ...props } ) => (
-							<Grid container gap={ 0.75 } alignItems="center" key={ props.bind }>
-								<Grid item xs={ 12 }>
-									<Label { ...props } />
-								</Grid>
-								<Grid item xs={ 12 }>
-									<Control
-										bind={ props.bind }
-										startIcon={ icon }
-										isLinked={ isLinked }
-										extendedOptions={ extendedOptions }
-										anchorRef={ gridRowRefs[ index ] }
-										min={ min }
-									/>
-								</Grid>
-							</Grid>
-						) ) }
-					</Stack>
-				) ) }
-			</PropProvider>
-		);
+		setDimensionsValue( {
+			'block-start': value,
+			'block-end': value,
+			'inline-start': value,
+			'inline-end': value,
+		} );
 	};
+
+	const tooltipLabel = label.toLowerCase();
+
+	const LinkedIcon = isLinked ? LinkIcon : DetachIcon;
+	// translators: %s: Tooltip title.
+	const linkedLabel = __( 'Link %s', 'elementor' ).replace( '%s', tooltipLabel );
+	// translators: %s: Tooltip title.
+	const unlinkedLabel = __( 'Unlink %s', 'elementor' ).replace( '%s', tooltipLabel );
+
+	const disabled = sizeDisabled || dimensionsDisabled;
+
+	return (
+		<PropProvider
+			propType={ propType }
+			value={ dimensionsValue }
+			setValue={ setDimensionsValue }
+			placeholder={ dimensionsPlaceholder }
+			isDisabled={ () => disabled }
+		>
+			<Stack direction="row" gap={ 2 } flexWrap="nowrap">
+				<ControlFormLabel>{ label }</ControlFormLabel>
+				<Tooltip title={ isLinked ? unlinkedLabel : linkedLabel } placement="top">
+					<StyledToggleButton
+						aria-label={ isLinked ? unlinkedLabel : linkedLabel }
+						size={ 'tiny' }
+						value={ 'check' }
+						selected={ isLinked }
+						sx={ { marginLeft: 'auto' } }
+						onChange={ onLinkToggle }
+						disabled={ disabled }
+						isPlaceholder={ hasPlaceholders }
+					>
+						<LinkedIcon fontSize={ 'tiny' } />
+					</StyledToggleButton>
+				</Tooltip>
+			</Stack>
+
+			{ getCssDimensionProps( isSiteRtl ).map( ( row, index ) => (
+				<Stack direction="row" gap={ 2 } flexWrap="nowrap" key={ index } ref={ gridRowRefs[ index ] }>
+					{ row.map( ( { icon, ...props } ) => (
+						<Grid container gap={ 0.75 } alignItems="center" key={ props.bind }>
+							<Grid item xs={ 12 }>
+								<Label { ...props } />
+							</Grid>
+							<Grid item xs={ 12 }>
+								<Control
+									bind={ props.bind }
+									startIcon={ icon }
+									isLinked={ isLinked }
+									extendedOptions={ extendedOptions }
+									anchorRef={ gridRowRefs[ index ] }
+									min={ min }
+								/>
+							</Grid>
+						</Grid>
+					) ) }
+				</Stack>
+			) ) }
+		</PropProvider>
+	);
+};
 
 const Control = ( {
 	bind,

--- a/packages/packages/libs/editor-controls/src/controls/linked-dimensions-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/linked-dimensions-control.tsx
@@ -13,8 +13,7 @@ import { createControl } from '../create-control';
 import { type ExtendedOption } from '../utils/size-control';
 import { SizeControl } from './size-control';
 
-export const LinkedDimensionsControl = createControl(
-	( {
+export const LinkedDimensionsControl = ( {
 		label,
 		isSiteRtl = false,
 		extendedOptions,
@@ -121,8 +120,7 @@ export const LinkedDimensionsControl = createControl(
 				) ) }
 			</PropProvider>
 		);
-	}
-);
+	};
 
 const Control = ( {
 	bind,


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove createControl HOC from gap and linked controls to simplify component architecture and reduce abstraction layers.
Main changes:
- Converted GapControl from HOC-wrapped component to direct function component
- Converted LinkedDimensionsControl from HOC-wrapped component to direct function component
- Removed import of createControl module from affected components

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
