### PR TITLE
Fix: Fix global classes count limit in server [ED-20505]

### DIFF
--- a/modules/global-classes/global-classes-rest-api.php
+++ b/modules/global-classes/global-classes-rest-api.php
@@ -169,7 +169,7 @@ class Global_Classes_REST_API {
 
 		$items_count = count( $items_result->unwrap() );
 
-		if ( $items_count >= static::MAX_ITEMS ) {
+		if ( $items_count > static::MAX_ITEMS ) {
 			return Error_Builder::make( 'global_classes_limit_exceeded' )
 				->set_status( 400 )
 				->set_message( sprintf(

--- a/tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php
@@ -493,15 +493,15 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 'invalid_order', $response->get_data()['code'] );
 	}
 
-	public function test_put_fails_when_max_items_limit_reached() {
+	public function test_put__fails_when_max_items_limit_reached() {
 		// Arrange.
 		$this->act_as_admin();
 
-		// Act.
+		// Act - send 50 items.
 		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
 
 		$items = [];
-		for ( $i = 0; $i < 51; $i++ ) {
+		for ( $i = 0; $i < 50; $i++ ) {
 			$items[ "g-$i" ] = $this->create_global_class( "g-$i" );
 		}
 
@@ -517,7 +517,25 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		$response = rest_do_request( $request );
 
-		// Assert.
+		// Assert - should succeed.
+		$this->assertSame( 204, $response->get_status() );
+
+		// Act - send 51 items.
+		$items["g-51"] = $this->create_global_class( "g-51" );
+
+		$request->set_body_params( [
+			'items' => $items,
+			'order' => array_keys( $items ),
+			'changes' => [
+				'added' => array_keys( $items ),
+				'deleted' => [],
+				'modified' => [],
+			]
+		] );
+
+		$response = rest_do_request( $request );
+
+		// Assert - should fail.
 		$this->assertSame( 400, $response->get_status() );
 		$this->assertSame( 'global_classes_limit_exceeded', $response->get_data()['code'] );
 	}

--- a/tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php
@@ -520,14 +520,14 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		// Assert - should succeed.
 		$this->assertSame( 204, $response->get_status() );
 
-		// Act - send 51 items.
-		$items["g-51"] = $this->create_global_class( "g-51" );
+		// Act - send the 51st item.
+		$items[ "g-50" ] = $this->create_global_class( "g-50" );
 
 		$request->set_body_params( [
 			'items' => $items,
 			'order' => array_keys( $items ),
 			'changes' => [
-				'added' => array_keys( $items ),
+				'added' => [ 'g-50' ],
 				'deleted' => [],
 				'modified' => [],
 			]


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix global classes count validation to allow exactly 50 classes before rejecting, preventing incorrect saving failures.

Main changes:
- Changed comparison operator from >= to > in the global classes limit check
- Updated test to properly validate both valid (50 items) and invalid (51 items) scenarios
- Improved test name and added more descriptive comments for test clarity

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
