### PR TITLE
Tweak: Remove all non numeric keys element from array added by 3rd party plugins

### DIFF
--- a/core/editor/loader/common/editor-common-scripts-settings.php
+++ b/core/editor/loader/common/editor-common-scripts-settings.php
@@ -161,6 +161,16 @@ class Editor_Common_Scripts_Settings {
 
 		static::bc_move_document_filters();
 
+		// Remove all non numeric keys element from array added by 3rd party plugins
+		add_filter( 'elementor/editor/localize_settings', function ( $config ) {
+			if ( ! isset( $config['promotionWidgets'] ) ) {
+				$config['promotionWidgets'] = [];
+			}
+
+			$config['promotionWidgets'] = array_values( $config['promotionWidgets'] );
+			return $config;
+		}, 999 );
+
 		/**
 		 * Localize editor settings.
 		 *


### PR DESCRIPTION
…gins

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add filter to normalize promotionWidgets array data structure by removing non-numeric keys introduced by third-party plugins.

Main changes:
- Added a late-priority filter to ensure promotionWidgets always uses sequential numeric keys via array_values()
- Set default empty array for promotionWidgets if not set by other plugins

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
