### PR TITLE
Internal: Update Size Control to Use Backend-Defined Units from Prop Type [ED-20524]

### DIFF
--- a/modules/atomic-widgets/styles/size-constants.php
+++ b/modules/atomic-widgets/styles/size-constants.php
@@ -25,7 +25,6 @@ class Size_Constants {
 		self::UNIT_REM,
 		self::UNIT_VW,
 		self::UNIT_VH,
-		self::UNIT_CUSTOM,
 	];
 
 	const TIME_UNITS = [ self::UNIT_SECOND, self::UNIT_MILLI_SECOND ];
@@ -80,12 +79,11 @@ class Size_Constants {
 			self::UNIT_PX,
 			self::UNIT_EM,
 			self::UNIT_REM,
-			self::UNIT_CUSTOM,
 		];
 	}
 
 	public static function transition() {
-		return [ ...self::TIME_UNITS, self::UNIT_CUSTOM ];
+		return self::TIME_UNITS;
 	}
 
 	public static function border(): array {
@@ -94,7 +92,7 @@ class Size_Constants {
 
 
 	public static function opacity(): array {
-		return [ self::UNIT_PERCENT, self::UNIT_CUSTOM ];
+		return [ self::UNIT_PERCENT ];
 	}
 
 	public static function box_shadow(): array {

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/size-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/size-control.test.tsx
@@ -383,6 +383,146 @@ describe( 'SizeControl', () => {
 		expect( options.slice( -1 )[ 0 ] ).toContainHTML( customOptionElement );
 	} );
 
+	describe( 'Units', () => {
+		it( 'should use external units when enablePropTypeUnits is false', () => {
+			// Arrange.
+			const setValue = jest.fn();
+			const externalUnits: LengthUnit[] = [ 'px', 'em', 'rem' ];
+			const propTypeWithAvailableUnits = createMockPropType( {
+				key: 'size',
+				kind: 'plain',
+				settings: {
+					available_units: [ 'vw', 'vh', '%' ],
+				},
+			} );
+
+			const props = {
+				setValue,
+				value: mockSizeProp( { size: 10, unit: 'px' } ),
+				bind: 'select',
+				propType: propTypeWithAvailableUnits,
+			};
+
+			// Act.
+			renderControl( <SizeControl units={ externalUnits } disableCustom />, props );
+
+			const select = screen.getByRole( 'button' );
+
+			fireEvent.click( select );
+
+			const options = screen.getAllByRole( 'menuitem' );
+
+			// Assert.
+			expect( options ).toHaveLength( 3 );
+			expect( options[ 0 ] ).toHaveTextContent( 'PX' );
+			expect( options[ 1 ] ).toHaveTextContent( 'EM' );
+			expect( options[ 2 ] ).toHaveTextContent( 'REM' );
+		} );
+
+		it( 'should use default fallback units when enablePropTypeUnits is false and no external units provided', () => {
+			// Arrange.
+			const propTypeWithAvailableUnits = createMockPropType( {
+				key: 'size',
+				kind: 'plain',
+				settings: {
+					available_units: [ 'deg', 'rad' ],
+				},
+			} );
+
+			const props = {
+				setValue: jest.fn(),
+				value: mockSizeProp( { size: 10, unit: 'px' } ),
+				bind: 'select',
+				propType: propTypeWithAvailableUnits,
+			};
+
+			// Act.
+			renderControl( <SizeControl disableCustom />, props );
+
+			const select = screen.getByRole( 'button' );
+
+			fireEvent.click( select );
+
+			const expected = [ 'px', '%', 'em', 'rem', 'vw', 'vh' ];
+
+			// Assert.
+			screen.getAllByRole( 'menuitem' ).forEach( ( option, index ) => {
+				expect( option ).toHaveTextContent( expected[ index ].toUpperCase() );
+			} );
+		} );
+
+		it( 'should use propType available_units when enablePropTypeUnits is true', () => {
+			// Arrange.
+			const setValue = jest.fn();
+			const externalUnits: LengthUnit[] = [ 'px', 'em', 'rem' ];
+			const propTypeWithAvailableUnits = createMockPropType( {
+				key: 'size',
+				kind: 'plain',
+				settings: {
+					available_units: [ 'vw', 'vh', '%' ],
+				},
+			} );
+
+			const props = {
+				setValue,
+				value: mockSizeProp( { size: 10, unit: 'vw' } ),
+				bind: 'select',
+				propType: propTypeWithAvailableUnits,
+			};
+
+			// Act.
+			renderControl( <SizeControl units={ externalUnits } enablePropTypeUnits={ true } disableCustom />, props );
+
+			const select = screen.getByRole( 'button' );
+
+			// Act.
+			fireEvent.click( select );
+
+			const options = screen.getAllByRole( 'menuitem' );
+
+			// Assert.
+			expect( options ).toHaveLength( 3 );
+			expect( options[ 0 ] ).toHaveTextContent( 'VW' );
+			expect( options[ 1 ] ).toHaveTextContent( 'VH' );
+			expect( options[ 2 ] ).toHaveTextContent( '%' );
+		} );
+
+		it( 'should fallback to default variant units when enablePropTypeUnits is true but no available_units in propType', () => {
+			// Arrange.
+			const setValue = jest.fn();
+			const externalUnits: LengthUnit[] = [ 'px', 'em' ];
+			const propTypeWithoutAvailableUnits = createMockPropType( {
+				key: 'size',
+				kind: 'plain',
+				settings: {}, // No available_units
+			} );
+
+			const props = {
+				setValue,
+				value: mockSizeProp( { size: 10, unit: 'px' } ),
+				bind: 'select',
+				propType: propTypeWithoutAvailableUnits,
+			};
+
+			// Act.
+			renderControl(
+				<SizeControl units={ externalUnits } variant="angle" enablePropTypeUnits={ true } disableCustom />,
+				props
+			);
+
+			const select = screen.getByRole( 'button' );
+
+			// Act.
+			fireEvent.click( select );
+
+			const expected = [ 'deg', 'rad', 'grad', 'turn' ];
+
+			screen.getAllByRole( 'menuitem' ).forEach( ( option, index ) => {
+				expect( option ).toHaveTextContent( expected[ index ].toUpperCase() );
+			} );
+		} );
+	} );
+
 	describe( 'Keyboard Unit Selection', () => {
 		it.each( [
 			{ input: '%', expected: '%', description: 'exact match' },

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-size-prop-type.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-size-prop-type.php
@@ -61,7 +61,7 @@ class Test_Size_Prop_Type extends Elementor_Test_Base {
 		// Act.
 		$settings = $prop_type->get_settings();
 
-		$expected = ['px', 'em', 'rem', 'vw', 'vh', 'custom', '%', 'auto'];
+		$expected = ['px', 'em', 'rem', 'vw', 'vh', '%', 'auto'];
 
 		// Assert.
 		$this->assertEqualsCanonicalizing( $expected, $settings['available_units'] );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update SizeControl component to use backend-defined units from PropType instead of hardcoded units.

Main changes:
- Removed UNIT_CUSTOM from Size_Constants class and updated related methods
- Added enablePropTypeUnits prop to SizeControl with unit resolution logic
- Implemented resolveUnits function to determine which units to use based on PropType settings
- Added comprehensive unit tests for different unit resolution scenarios

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
