### PR TITLE
Fix: Can’t read properties of undefined reading url [ED-20504]

### DIFF
--- a/core/base/document.php
+++ b/core/base/document.php
@@ -729,9 +729,8 @@ abstract class Document extends Controls_Stack {
 		if ( static::get_property( 'has_elements' ) ) {
 			$widgets_config = Plugin::$instance->widgets_manager->get_widget_types_config();
 
-			$excluded_elements = [ 'column', 'section' ];
 			$elements_config = Collection::make( Plugin::$instance->elements_manager->get_element_types() )
-				->filter( fn( $element ) => ( ! in_array( $element->get_type(), $excluded_elements ) ) )
+				->filter( fn( $element ) => ( ! empty( $element->get_config()['include_in_widgets_config'] ) ) )
 				->map( fn( $element ) => $element->get_config() )
 				->all();
 

--- a/core/base/document.php
+++ b/core/base/document.php
@@ -729,9 +729,9 @@ abstract class Document extends Controls_Stack {
 		if ( static::get_property( 'has_elements' ) ) {
 			$widgets_config = Plugin::$instance->widgets_manager->get_widget_types_config();
 
-			// defines the elements that will be shown in the panel
+			$excluded_elements = [ 'column', 'section' ];
 			$elements_config = Collection::make( Plugin::$instance->elements_manager->get_element_types() )
-				->filter( fn( $element ) => ( ! empty( $element->get_config()['show_in_panel'] ) ) )
+				->filter( fn( $element ) => ( ! in_array( $element->get_type(), $excluded_elements ) ) )
 				->map( fn( $element ) => $element->get_config() )
 				->all();
 

--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -140,6 +140,7 @@ class Container extends Element_Base {
 		$config['tabs_controls'] = $this->get_tabs_controls();
 		$config['show_in_panel'] = true;
 		$config['categories'] = [ 'layout' ];
+		$config['include_in_widgets_config'] = true;
 
 		return $config;
 	}

--- a/modules/atomic-widgets/assets/js/editor/atomic-element-view.js
+++ b/modules/atomic-widgets/assets/js/editor/atomic-element-view.js
@@ -38,7 +38,7 @@ export default function createAtomicElementView( type ) {
 		},
 
 		className() {
-			return `${ BaseElementView.prototype.className.apply( this ) } e-con ${ this.getClassString() }`;
+			return `${ BaseElementView.prototype.className.apply( this ) } e-con e-atomic-element ${ this.getClassString() }`;
 		},
 
 		// TODO: Copied from `views/column.js`.

--- a/modules/atomic-widgets/elements/atomic-element-base.php
+++ b/modules/atomic-widgets/elements/atomic-element-base.php
@@ -48,6 +48,7 @@ abstract class Atomic_Element_Base extends Element_Base {
 		$config['hide_on_search'] = false;
 		$config['controls'] = [];
 		$config['keywords'] = $this->get_keywords();
+		$config['include_in_widgets_config'] = true;
 
 		return $config;
 	}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix element configuration filtering in widgets panel to prevent JavaScript error when accessing undefined URL property.
Main changes:
- Added 'include_in_widgets_config' flag to Container and Atomic_Element_Base elements
- Changed element filtering criterion from 'show_in_panel' to 'include_in_widgets_config'
- Updated atomic element class to include 'e-atomic-element' for proper styling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
