### PR TITLE
Fix: Regression in loop elements - overlay is broken [ED-20537]

### DIFF
--- a/core/base/document.php
+++ b/core/base/document.php
@@ -733,6 +733,7 @@ abstract class Document extends Controls_Stack {
 				->all();
 
 			$config['elements'] = $this->get_elements_raw_data( null, true );
+			// `get_elements_raw_data` has to be called before `get_widget_types_config`, because it affects it.
 			$config['widgets'] = array_merge( $elements_config, Plugin::$instance->widgets_manager->get_widget_types_config() );
 		}
 

--- a/core/base/document.php
+++ b/core/base/document.php
@@ -727,15 +727,13 @@ abstract class Document extends Controls_Stack {
 		do_action( 'elementor/document/before_get_config', $this );
 
 		if ( static::get_property( 'has_elements' ) ) {
-			$widgets_config = Plugin::$instance->widgets_manager->get_widget_types_config();
-
 			$elements_config = Collection::make( Plugin::$instance->elements_manager->get_element_types() )
 				->filter( fn( $element ) => ( ! empty( $element->get_config()['include_in_widgets_config'] ) ) )
 				->map( fn( $element ) => $element->get_config() )
 				->all();
 
-			$config['widgets'] = array_merge( $elements_config, $widgets_config );
 			$config['elements'] = $this->get_elements_raw_data( null, true );
+			$config['widgets'] = array_merge( $elements_config, Plugin::$instance->widgets_manager->get_widget_types_config() );
 		}
 
 		$additional_config = [];


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix regression in document configuration where elements overlay was broken due to incorrect order of operations.

Main changes:
- Moved widget configuration generation after elements raw data retrieval to maintain proper overlay functionality
- Added clarifying comment about execution order dependency between the two operations

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
