### PR TITLE
Tweak: Change export_terms method to public [ED-20465]

### DIFF
--- a/app/modules/import-export-customization/runners/export/taxonomies.php
+++ b/app/modules/import-export-customization/runners/export/taxonomies.php
@@ -101,7 +101,7 @@ class Taxonomies extends Export_Runner_Base {
 		];
 	}
 
-	private function export_terms( $taxonomy ) {
+	public function export_terms( $taxonomy ) {
 		$terms = get_terms( [
 			'taxonomy' => (array) $taxonomy,
 			'hide_empty' => true,


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Change visibility of export_terms method from private to public in taxonomy export runner to allow external access.
Main changes:
- Modified export_terms method visibility from private to public in Taxonomies export runner class

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
