### PR TITLE
CI: Commit lint configuration header-max-length + new enum types

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,14 +1,21 @@
 module.exports = {
 	extends: [ '@commitlint/config-conventional' ],
+	plugins: [ {
+		rules: {
+			'header-max-length-with-cherry-pick': ( { header, subject } ) => {
+				const limit = subject?.includes( 'Cherry-pick' ) ? 110 : 100;
+				return [
+					header.length <= limit,
+					`header must not be longer than ${ limit } characters, current length is ${ header.length }`,
+				];
+			},
+		},
+	} ],
 	rules: {
 		'subject-case': [ 2, 'always', 'sentence-case' ],
 		'type-case': [ 2, 'always', 'sentence-case' ],
 		'type-enum': [ 2, 'always', [ 'Feature', 'CI', 'New', 'Tweak', 'Fix', 'Experiment', 'Deprecate', 'Deprecated', 'Revert', 'Internal' ] ],
-		'header-max-length': [ 2, 'always', ( parsed ) => {
-			const { subject } = parsed;
-			// Increase limit to 150 characters for Cherry-pick PRs
-			const maxLength = subject?.includes( 'Cherry-pick' ) ? 110 : 100;
-			return parsed.header.length <= maxLength;
-		} ],
+		'header-max-length': [ 0 ], // Disable default header-max-length
+		'header-max-length-with-cherry-pick': [ 2, 'always' ],
 	},
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,6 +3,12 @@ module.exports = {
 	rules: {
 		'subject-case': [ 2, 'always', 'sentence-case' ],
 		'type-case': [ 2, 'always', 'sentence-case' ],
-		'type-enum': [ 2, 'always', [ 'New', 'Tweak', 'Fix', 'Experiment', 'Deprecate', 'Deprecated', 'Revert', 'Internal' ] ],
+		'type-enum': [ 2, 'always', [ 'Feature', 'CI', 'New', 'Tweak', 'Fix', 'Experiment', 'Deprecate', 'Deprecated', 'Revert', 'Internal' ] ],
+		'header-max-length': [ 2, 'always', ( parsed ) => {
+			const { subject } = parsed;
+			// Increase limit to 150 characters for Cherry-pick PRs
+			const maxLength = subject?.includes( 'Cherry-pick' ) ? 110 : 100;
+			return parsed.header.length <= maxLength;
+		} ],
 	},
 };


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update commit lint configuration to include header length exceptions for cherry-pick commits and expand allowed commit types.
Main changes:
- Added custom rule to allow 110 character headers for cherry-pick commits versus 100 for standard commits
- Disabled default header-max-length rule in favor of custom implementation
- Added new commit types 'Feature' and 'CI' to the allowed type enumeration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
