### PR TITLE
Tweak: Move the templates customization to the Pro plugin [ED-20413]

### DIFF
--- a/app/modules/import-export-customization/assets/js/module.js
+++ b/app/modules/import-export-customization/assets/js/module.js
@@ -19,21 +19,5 @@ export default class ImportExportCustomization {
 		for ( const route of this.routes ) {
 			router.addRoute( route );
 		}
-
-		this.registerImportExportTemplate();
-	}
-
-	registerImportExportTemplate() {
-		if ( ! elementorCommon?.config?.experimentalFeatures?.[ 'import-export-customization' ] ) {
-			return;
-		}
-
-		elementorModules?.importExport?.templateRegistry.register( {
-			key: 'siteTemplates',
-			exportGroup: 'site-templates',
-			title: __( 'Site Templates', 'elementor ' ),
-			order: 0,
-			getInitialState: elementorModules?.importExport?.createGetInitialState?.( 'site-templates' ),
-		} );
 	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove import-export template customization code from core to move it to the Pro plugin as per ticket ED-20413.
Main changes:
- Removed registerImportExportTemplate method and its invocation from ImportExportCustomization class
- Eliminated site templates registration logic that will be relocated to the Pro plugin

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
