### PR TITLE
Fix: Export and import all without customization missing the CPT [ED-20595]

### DIFF
--- a/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
+++ b/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
@@ -11,11 +11,11 @@ export function useKitCustomizationCustomPostTypes( { data } ) {
 			return builtInCustomPostTypes;
 		}
 
-		return Object.values( data?.uploadedData?.manifest?.[ 'custom-post-type-title' ] || {} ).map( ( postType ) => {
-			return {
-				value: postType.name,
-				label: postType.label,
-			};
+		const wpContent = data?.uploadedData?.manifest?.[ 'wp-content' ] || {};
+
+		return builtInCustomPostTypes.filter( ( postType ) => {
+			const contentArray = wpContent[ postType.value ];
+			return contentArray && Array.isArray( contentArray ) && contentArray.length > 0;
 		} );
 	}, [ isImport, data?.uploadedData, builtInCustomPostTypes ] );
 

--- a/app/modules/import-export-customization/runners/export/wp-content.php
+++ b/app/modules/import-export-customization/runners/export/wp-content.php
@@ -23,7 +23,7 @@ class Wp_Content extends Export_Runner_Base {
 		$customization = $data['customization']['content'] ?? null;
 		$exclude_post_types = [];
 
-		if ( isset( $data['selected_custom_post_types'] ) && ! in_array( 'post', $data['selected_custom_post_types'], true ) ) {
+		if ( isset( $customization['customPostTypes'] ) && ! in_array( 'post', $customization['customPostTypes'], true ) ) {
 			$exclude_post_types[] = 'post';
 		}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix customization selection inconsistency when exporting/importing all site content without specific customization.

Main changes:
- Updated export logic to check correct customization parameter for post type exclusion
- Refactored post type detection to filter based on actual content presence in manifest

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
