### PR TITLE
Fix: V4 CSS Editor recreating style variants [ED-20578]

### DIFF
--- a/packages/packages/libs/editor-controls/src/components/css-code-editor/__tests__/css-editor.test.tsx
+++ b/packages/packages/libs/editor-controls/src/components/css-code-editor/__tests__/css-editor.test.tsx
@@ -44,9 +44,6 @@ const mockEditor = {
 		onDidChangeContent: jest.fn(),
 		pushEditOperations: jest.fn(),
 	} ) ),
-	onDidChangeModelContent: jest.fn( ( callback ) => {
-		setTimeout( () => callback(), 100 );
-	} ),
 	getPosition: mockGetPosition,
 	setPosition: jest.fn(),
 	layout: jest.fn(),
@@ -72,10 +69,13 @@ const mockMonaco = {
 } as unknown as MonacoEditor;
 
 jest.mock( '@monaco-editor/react', () => ( {
-	Editor: jest.fn( ( { onMount, value } ) => {
+	Editor: jest.fn( ( { onMount, onChange, value } ) => {
 		React.useEffect( () => {
 			onMount( mockEditor, mockMonaco );
-		}, [ onMount ] );
+			if ( onChange ) {
+				setTimeout( () => onChange(), 100 );
+			}
+		}, [ onMount, onChange ] );
 
 		return (
 			<div role="textbox" aria-label="CSS Editor" data-testid="css-editor">
@@ -113,11 +113,7 @@ describe( 'CssEditor', () => {
 
 		renderWithTheme( <CssEditor value="color: green;" onChange={ onChange } /> );
 
-		// Act
-		await waitFor( () => {
-			expect( mockEditor.onDidChangeModelContent ).toHaveBeenCalled();
-		} );
-
+		// Act & Assert
 		await waitFor(
 			() => {
 				expect( onChange ).toHaveBeenCalledWith( 'color: blue;', true );
@@ -135,11 +131,7 @@ describe( 'CssEditor', () => {
 
 		renderWithTheme( <CssEditor value="color: red" onChange={ onChange } /> );
 
-		// Act
-		await waitFor( () => {
-			expect( mockEditor.onDidChangeModelContent ).toHaveBeenCalled();
-		} );
-
+		// Act & Assert
 		await waitFor(
 			() => {
 				expect( onChange ).toHaveBeenCalledWith( 'color: red', false );

--- a/packages/packages/libs/editor-controls/src/components/css-code-editor/css-editor.tsx
+++ b/packages/packages/libs/editor-controls/src/components/css-code-editor/css-editor.tsx
@@ -32,9 +32,7 @@ const getActual = ( value: string ): string => {
 
 const createEditorDidMountHandler = (
 	editorRef: React.MutableRefObject< editor.IStandaloneCodeEditor | null >,
-	monacoRef: React.MutableRefObject< MonacoEditor | null >,
-	debounceTimer: React.MutableRefObject< NodeJS.Timeout | null >,
-	onChange: ( value: string, isValid: boolean ) => void
+	monacoRef: React.MutableRefObject< MonacoEditor | null >
 ) => {
 	return ( editor: editor.IStandaloneCodeEditor, monaco: MonacoEditor ) => {
 		editorRef.current = editor;
@@ -49,30 +47,6 @@ const createEditorDidMountHandler = (
 		} );
 
 		editor.setPosition( { lineNumber: 2, column: ( editor.getModel()?.getLineContent( 2 ).length ?? 0 ) + 1 } );
-
-		editor.onDidChangeModelContent( () => {
-			const code = editor.getModel()?.getValue() ?? '';
-			const userContent = getActual( code );
-
-			setCustomSyntaxRules( editor, monaco );
-
-			const currentTimer = debounceTimer.current;
-			if ( currentTimer ) {
-				clearTimeout( currentTimer );
-			}
-
-			const newTimer = setTimeout( () => {
-				if ( ! editorRef.current || ! monacoRef.current ) {
-					return;
-				}
-
-				const hasNoErrors = validate( editorRef.current, monacoRef.current );
-
-				onChange( userContent, hasNoErrors );
-			}, 500 );
-
-			debounceTimer.current = newTimer;
-		} );
 	};
 };
 
@@ -94,7 +68,35 @@ export const CssEditor = ( { value, onChange }: CssEditorProps ) => {
 		}
 	}, [] );
 
-	const handleEditorDidMount = createEditorDidMountHandler( editorRef, monacoRef, debounceTimer, onChange );
+	const handleEditorChange = () => {
+		if ( ! editorRef.current || ! monacoRef.current ) {
+			return;
+		}
+
+		const code = editorRef.current?.getModel()?.getValue() ?? '';
+		const userContent = getActual( code );
+
+		setCustomSyntaxRules( editorRef?.current, monacoRef.current );
+
+		const currentTimer = debounceTimer.current;
+		if ( currentTimer ) {
+			clearTimeout( currentTimer );
+		}
+
+		const newTimer = setTimeout( () => {
+			if ( ! editorRef.current || ! monacoRef.current ) {
+				return;
+			}
+
+			const hasNoErrors = validate( editorRef.current, monacoRef.current );
+
+			onChange( userContent, hasNoErrors );
+		}, 500 );
+
+		debounceTimer.current = newTimer;
+	};
+
+	const handleEditorDidMount = createEditorDidMountHandler( editorRef, monacoRef );
 
 	React.useEffect( () => {
 		const timerRef = debounceTimer;
@@ -115,6 +117,7 @@ export const CssEditor = ( { value, onChange }: CssEditorProps ) => {
 				theme={ theme.palette.mode === 'dark' ? 'vs-dark' : 'vs' }
 				value={ setVisualContent( value ) }
 				onMount={ handleEditorDidMount }
+				onChange={ handleEditorChange }
 				options={ {
 					lineNumbers: 'on',
 					folding: true,


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix CSS Editor bug causing unnecessary recreation of style variants by moving change handling from editor mount to onChange callback.
Main changes:
- Moved content change handling from onDidChangeModelContent to dedicated handleEditorChange function
- Updated onChange handler to be triggered by Monaco Editor's onChange prop
- Refactored test mocks to simulate change events correctly

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
