### PR TITLE
CI: Trigger send slack only when actual failure occurs [ED-20556]

### DIFF
--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Send Slack notification
         uses: slackapi/slack-github-action@v2.0.0
-        if: failure()
+        if: failure() && ${{ steps.run-performance-check.outputs.v3-performance-median-score }} > 0 && ${{ steps.run-performance-check.outputs.mixed-performance-median-score }} > 0
         env:
           RUN_ID: ${{ github.run_id }}
           ARTIFACT_ID: ${{ steps.upload-reports.outputs.artifact-id }}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update Slack notification trigger in CI workflow to only send messages for actual performance failures with valid score data.
Main changes:
- Modified GitHub Action conditional to check for failure() and positive performance scores before sending Slack notifications

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
