### PR TITLE
Fix: Apply all when importing from library is not working [ED-20605]

### DIFF
--- a/app/modules/import-export-customization/assets/js/import/context/import-context.js
+++ b/app/modules/import-export-customization/assets/js/import/context/import-context.js
@@ -9,6 +9,10 @@ export const IMPORT_STATUS = {
 	COMPLETED: 'COMPLETED',
 };
 
+export const ACTION_TYPE = {
+	APPLY_ALL: 'apply-all',
+};
+
 const importReducer = ( state, { type, payload } ) => {
 	switch ( type ) {
 		case 'SET_IMPORT_STATUS':
@@ -21,6 +25,8 @@ const importReducer = ( state, { type, payload } ) => {
 			return { ...state, importedData: payload };
 		case 'SET_KIT_UPLOAD_PARAMS':
 			return { ...state, kitUploadParams: payload };
+		case 'SET_ACTION_TYPE':
+			return { ...state, actionType: payload };
 		case 'SET_RUNNERS_STATE':
 			return {
 				...state,
@@ -73,6 +79,7 @@ const initialState = {
 	uploadedData: null,
 	importedData: null,
 	kitUploadParams: null,
+	actionType: null,
 	plugins: [],
 	includes: [ 'plugins' ],
 	importStatus: IMPORT_STATUS.PENDING,

--- a/app/modules/import-export-customization/assets/js/import/pages/import-kit.js
+++ b/app/modules/import-export-customization/assets/js/import/pages/import-kit.js
@@ -33,7 +33,6 @@ export default function ImportKit() {
 
 	useEffect( () => {
 		if ( data.uploadedData ) {
-
 			if ( data.actionType === ACTION_TYPE.APPLY_ALL ) {
 				const includes = [];
 

--- a/app/modules/import-export-customization/assets/js/import/pages/import-kit.js
+++ b/app/modules/import-export-customization/assets/js/import/pages/import-kit.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import useQueryParams from 'elementor-app/hooks/use-query-params';
 import { BaseLayout, TopBar, PageHeader, CenteredContent } from '../../shared/components';
 import DropZone from '../components/drop-zone';
-import { IMPORT_STATUS, useImportContext } from '../context/import-context';
+import { IMPORT_STATUS, ACTION_TYPE, useImportContext } from '../context/import-context';
 import { useUploadKit } from '../hooks/use-upload-kit';
 import ImportError from '../components/import-error';
 import { AppsEventTracking } from 'elementor-app/event-track/apps-event-tracking';
@@ -14,7 +14,7 @@ export default function ImportKit() {
 	const { data, dispatch } = useImportContext();
 	const navigate = useNavigate();
 
-	const { id, referrer, file_url: fileUrl, nonce } = useQueryParams().getAll();
+	const { id, referrer, file_url: fileUrl, action_type: actionType, nonce } = useQueryParams().getAll();
 
 	const { uploading, error } = useUploadKit();
 
@@ -33,17 +33,45 @@ export default function ImportKit() {
 
 	useEffect( () => {
 		if ( data.uploadedData ) {
-			dispatch( { type: 'SET_IMPORT_STATUS', payload: IMPORT_STATUS.CUSTOMIZING } );
-			navigate( 'import-customization/content' );
+
+			if ( data.actionType === ACTION_TYPE.APPLY_ALL ) {
+				const includes = [];
+
+				if ( data.uploadedData?.manifest?.[ 'site-settings' ] ) {
+					includes.push( 'settings' );
+				}
+
+				if ( 0 < Object.keys( data.uploadedData?.manifest?.templates || {} ).length ) {
+					includes.push( 'templates' );
+				}
+
+				if ( data.uploadedData?.manifest?.content ) {
+					includes.push( 'content' );
+				}
+
+				if ( data.uploadedData?.manifest?.plugins ) {
+					includes.push( 'plugins' );
+				}
+
+				dispatch( { type: 'ADD_INCLUDES', payload: includes } );
+				dispatch( { type: 'SET_IMPORT_STATUS', payload: IMPORT_STATUS.IMPORTING } );
+				navigate( 'import-customization/process' );
+			} else {
+				dispatch( { type: 'SET_IMPORT_STATUS', payload: IMPORT_STATUS.CUSTOMIZING } );
+				navigate( 'import-customization/content' );
+			}
 		}
-	}, [ data.uploadedData, dispatch, navigate ] );
+	}, [ data.uploadedData, dispatch, navigate, data.actionType ] );
 
 	useEffect( () => {
 		if ( id || fileUrl ) {
 			dispatch( { type: 'SET_KIT_UPLOAD_PARAMS', payload: { id, source: referrer, fileUrl, nonce } } );
+			if ( actionType ) {
+				dispatch( { type: 'SET_ACTION_TYPE', payload: actionType } );
+			}
 			dispatch( { type: 'SET_IMPORT_STATUS', payload: IMPORT_STATUS.UPLOADING } );
 		}
-	}, [ id, referrer, fileUrl, nonce, dispatch ] );
+	}, [ id, referrer, fileUrl, actionType, nonce, dispatch ] );
 
 	useEffect( () => {
 		AppsEventTracking.sendPageViewsWebsiteTemplates( elementorCommon.eventsManager.config.secondaryLocations.kitLibrary.kitImportUploadBox );

--- a/app/modules/kit-library/assets/js/components/apply-kit-dialog.js
+++ b/app/modules/kit-library/assets/js/components/apply-kit-dialog.js
@@ -10,6 +10,9 @@ export default function ApplyKitDialog( props ) {
 
 		if ( elementorCommon?.config?.experimentalFeatures[ 'import-export-customization' ] ) {
 			url = `import-customization?referrer=kit-library&id=${ props.id }&file_url=${ encodeURIComponent( props.downloadLink ) }`;
+			if ( applyAll ) {
+				url += '&action_type=apply-all';
+			}
 		} else {
 			url = '/import/process' +
 				`?id=${ props.id }` +


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Apply All functionality in kit import feature by adding action type detection and automatic selection of all kit components.
Main changes:
- Added ACTION_TYPE constant and actionType state to track direct apply operations
- Implemented conditional navigation logic to bypass customization when using Apply All
- Updated URL parameter handling in ApplyKitDialog to pass action_type parameter
- Added unit tests to verify Apply All behavior

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
