### PR TITLE
Fix: Export and import all without customization missing the CPT [ED-20595]

### DIFF
--- a/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
+++ b/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
@@ -11,21 +11,31 @@ export function useKitCustomizationCustomPostTypes( { data } ) {
 			return builtInCustomPostTypes;
 		}
 
-		const wpContent = data?.uploadedData?.manifest?.[ 'wp-content' ] || {};
-		const content = data?.uploadedData?.manifest?.[ 'content' ] || {};
-		
-		return builtInCustomPostTypes.filter( ( postType ) => {
-			const contentArray = wpContent[ postType.value ];
-			const hasWpContent = contentArray && Array.isArray( contentArray ) && contentArray.length > 0;
-			
-			if ( postType.value === 'post' ) {
-				const postContent = content[ 'post' ];
-				const hasPostContent = postContent && typeof postContent === 'object' && Object.keys( postContent ).length > 0;
-				return hasWpContent || hasPostContent;
-			}
-			
-			return hasWpContent;
+		const customPostTypesFromTitle = Object.values( data?.uploadedData?.manifest?.[ 'custom-post-type-title' ] || {} ).map( ( postType ) => {
+			return {
+				value: postType.name,
+				label: postType.label,
+			};
 		} );
+
+		const wpContent = data?.uploadedData?.manifest?.[ 'wp-content' ] || {};
+		const content = data?.uploadedData?.manifest?.content || {};
+
+		const postWpContent = wpContent?.post;
+		const postContent = content?.post;
+		const hasPostWpContent = postWpContent && Array.isArray( postWpContent ) && postWpContent.length > 0;
+		const hasPostContent = postContent && 'object' === typeof postContent && Object.keys( postContent ).length > 0;
+
+		if ( hasPostWpContent || hasPostContent ) {
+			if ( ! customPostTypesFromTitle.some( ( postType ) => 'post' ===postType.value ) ) {
+			customPostTypesFromTitle.push( {
+					value: 'post',
+					label: 'Post',
+				} );
+			}
+		}
+
+		return customPostTypesFromTitle;
 	}, [ isImport, data?.uploadedData, builtInCustomPostTypes ] );
 
 	return {

--- a/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
+++ b/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
@@ -28,7 +28,7 @@ export function useKitCustomizationCustomPostTypes( { data } ) {
 
 		if ( hasPostWpContent || hasPostContent ) {
 			if ( ! customPostTypesFromTitle.some( ( postType ) => 'post' === postType.value ) ) {
-			customPostTypesFromTitle.push( {
+				customPostTypesFromTitle.push( {
 					value: 'post',
 					label: 'Post',
 				} );

--- a/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
+++ b/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
@@ -27,7 +27,7 @@ export function useKitCustomizationCustomPostTypes( { data } ) {
 		const hasPostContent = postContent && 'object' === typeof postContent && Object.keys( postContent ).length > 0;
 
 		if ( hasPostWpContent || hasPostContent ) {
-			if ( ! customPostTypesFromTitle.some( ( postType ) => 'post' ===postType.value ) ) {
+			if ( ! customPostTypesFromTitle.some( ( postType ) => 'post' === postType.value ) ) {
 			customPostTypesFromTitle.push( {
 					value: 'post',
 					label: 'Post',

--- a/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
+++ b/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
@@ -12,10 +12,19 @@ export function useKitCustomizationCustomPostTypes( { data } ) {
 		}
 
 		const wpContent = data?.uploadedData?.manifest?.[ 'wp-content' ] || {};
-
+		const content = data?.uploadedData?.manifest?.[ 'content' ] || {};
+		
 		return builtInCustomPostTypes.filter( ( postType ) => {
 			const contentArray = wpContent[ postType.value ];
-			return contentArray && Array.isArray( contentArray ) && contentArray.length > 0;
+			const hasWpContent = contentArray && Array.isArray( contentArray ) && contentArray.length > 0;
+			
+			if ( postType.value === 'post' ) {
+				const postContent = content[ 'post' ];
+				const hasPostContent = postContent && typeof postContent === 'object' && Object.keys( postContent ).length > 0;
+				return hasWpContent || hasPostContent;
+			}
+			
+			return hasWpContent;
 		} );
 	}, [ isImport, data?.uploadedData, builtInCustomPostTypes ] );
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix missing Custom Post Types in export/import process by improving the detection logic for post types in kit data.

Main changes:
- Added extraction of post types from 'custom-post-type-title' manifest entries
- Added detection of post content from both 'wp-content' and 'content' manifest structures
- Implemented conditional logic to include standard 'post' type when content exists

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
