### PR TITLE
Internal: Add the ability to set Elementor advanced/performance settings in Playwright [ED-20621]

### DIFF
--- a/tests/playwright/pages/wp-admin-page.ts
+++ b/tests/playwright/pages/wp-admin-page.ts
@@ -46,13 +46,32 @@ export default class WpAdminPage extends BasePage {
 	/**
 	 * Go to the WordPress Settings pages.
 	 *
-	 * @param {('tab-general' | 'tab-integrations' | 'tab-advanced' | 'tab-experiments')} tab - The Elementor settings tab to open.
+	 * @param {('tab-general' | 'tab-integrations' | 'tab-advanced' | 'tab-performance' | 'tab-experiments')} tab - The Elementor settings tab to open.
 	 *
 	 * @return {Promise<void>}
 	 */
-	async openElementorSettings( tab: 'tab-general' | 'tab-integrations' | 'tab-advanced' | 'tab-experiments' ): Promise<void> {
+	async openElementorSettings( tab: 'tab-general' | 'tab-integrations' | 'tab-advanced' | 'tab-performance' | 'tab-experiments' ): Promise<void> {
 		await this.page.goto( `/wp-admin/admin.php?page=elementor-settings#${ tab }` );
 		await this.page.locator( `#elementor-settings-${ tab }` ).waitFor();
+	}
+
+	/**
+	 * Set settings in Elementor advanced/performance tab, as they both have only select-based options.
+	 *
+	 * @param {('tab-advanced' | 'tab-performance')} tab      - Either Elementor advanced or performance tab.
+	 * @param {Object}                               settings - Settings to set ( `{ setting_id: setting_value }` );
+	 *
+	 * @return {Promise<void>}
+	 */
+	async setElementorSettings( tab: 'tab-advanced' | 'tab-performance', settings: { [ n: string ]: string } ): Promise<void> {
+		await this.openElementorSettings( tab );
+
+		for ( const [ selector, state ] of Object.entries( settings ) ) {
+			await this.page.locator( `select[name="${ selector }"]` ).waitFor();
+			await this.page.selectOption( `[name="${ selector }"]`, state.toString() );
+		}
+
+		await this.page.click( '#submit' );
 	}
 
 	/**
@@ -354,9 +373,7 @@ export default class WpAdminPage extends BasePage {
 	 * @return {Promise<void>}
 	 */
 	async enableAdvancedUploads(): Promise<void> {
-		await this.openElementorSettings( 'tab-advanced' );
-		await this.page.locator( 'select[name="elementor_unfiltered_files_upload"]' ).selectOption( '1' );
-		await this.page.getByRole( 'button', { name: 'Save Changes' } ).click();
+		await this.setElementorSettings( 'tab-advanced', { elementor_unfiltered_files_upload: '1' } );
 	}
 
 	/**
@@ -365,9 +382,7 @@ export default class WpAdminPage extends BasePage {
 	 * @return {Promise<void>}
 	 */
 	async disableAdvancedUploads(): Promise<void> {
-		await this.openElementorSettings( 'tab-advanced' );
-		await this.page.locator( 'select[name="elementor_unfiltered_files_upload"]' ).selectOption( '' );
-		await this.page.getByRole( 'button', { name: 'Save Changes' } ).click();
+		await this.setElementorSettings( 'tab-advanced', { elementor_unfiltered_files_upload: '' } );
 	}
 
 	/**


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add support for configuring Elementor advanced and performance settings in Playwright tests via a reusable utility method.

Main changes:
- Added 'tab-performance' to the valid tabs in openElementorSettings method
- Created new setElementorSettings utility method for managing select-based settings
- Refactored enableAdvancedUploads and disableAdvancedUploads methods to use the new utility

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
