### PR TITLE
Fix: Export and import all without customization missing the CPT [ED-20595]

### DIFF
--- a/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
+++ b/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
@@ -30,13 +30,13 @@ export function useKitCustomizationCustomPostTypes( { data } ) {
 
 		return customPostTypesTitles.filter( ( postType ) => {
 			const postTypeValue = postType.value;
-			
+
 			const wpContentArray = wpContent[ postTypeValue ];
 			const isInWpContent = wpContentArray && Array.isArray( wpContentArray ) && wpContentArray.length > 0;
-			
+
 			const contentObject = content[ postTypeValue ];
 			const isInElementorContent = contentObject && 'object' === typeof contentObject && Object.keys( contentObject ).length > 0;
-			
+
 			return isInWpContent || isInElementorContent;
 		} );
 	}, [ isImport, data?.uploadedData, builtInCustomPostTypes ] );

--- a/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
+++ b/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
@@ -11,31 +11,34 @@ export function useKitCustomizationCustomPostTypes( { data } ) {
 			return builtInCustomPostTypes;
 		}
 
-		const customPostTypesFromTitle = Object.values( data?.uploadedData?.manifest?.[ 'custom-post-type-title' ] || {} ).map( ( postType ) => {
+		const customPostTypesTitles = Object.values( data?.uploadedData?.manifest?.[ 'custom-post-type-title' ] || {} ).map( ( postType ) => {
 			return {
 				value: postType.name,
 				label: postType.label,
 			};
 		} );
 
+		if ( ! customPostTypesTitles.some( ( postType ) => 'post' === postType.value ) ) {
+			customPostTypesTitles.push( {
+				value: 'post',
+				label: 'Post',
+			} );
+		}
+
 		const wpContent = data?.uploadedData?.manifest?.[ 'wp-content' ] || {};
 		const content = data?.uploadedData?.manifest?.content || {};
 
-		const postWpContent = wpContent?.post;
-		const postContent = content?.post;
-		const hasPostWpContent = postWpContent && Array.isArray( postWpContent ) && postWpContent.length > 0;
-		const hasPostContent = postContent && 'object' === typeof postContent && Object.keys( postContent ).length > 0;
-
-		if ( hasPostWpContent || hasPostContent ) {
-			if ( ! customPostTypesFromTitle.some( ( postType ) => 'post' === postType.value ) ) {
-				customPostTypesFromTitle.push( {
-					value: 'post',
-					label: 'Post',
-				} );
-			}
-		}
-
-		return customPostTypesFromTitle;
+		return customPostTypesTitles.filter( ( postType ) => {
+			const postTypeValue = postType.value;
+			
+			const wpContentArray = wpContent[ postTypeValue ];
+			const isInWpContent = wpContentArray && Array.isArray( wpContentArray ) && wpContentArray.length > 0;
+			
+			const contentObject = content[ postTypeValue ];
+			const isInElementorContent = contentObject && 'object' === typeof contentObject && Object.keys( contentObject ).length > 0;
+			
+			return isInWpContent || isInElementorContent;
+		} );
 	}, [ isImport, data?.uploadedData, builtInCustomPostTypes ] );
 
 	return {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix bug in kit customization where posts were missing when exporting/importing without customization.

Main changes:
- Renamed customPostTypesFromTitle to customPostTypesTitles for clarity
- Added post type earlier in the process rather than conditionally
- Implemented filter to include all post types with content instead of checking only posts

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
