### PR TITLE
Fix: On import conflicts in the templates customization part is not working well [ED-20620]

### DIFF
--- a/app/modules/import-export-customization/processes/import.php
+++ b/app/modules/import-export-customization/processes/import.php
@@ -177,7 +177,7 @@ class Import {
 			$this->settings_include = ! empty( $settings['include'] ) ? $settings['include'] : null;
 
 			// Using isset and not empty is important since empty array is valid option.
-			$this->settings_selected_override_conditions = $settings['overrideConditions'] ?? null;
+			$this->settings_selected_override_conditions = $settings['customization']['templates']['themeBuilder']['overrideConditions'] ?? null;
 			$this->settings_selected_custom_post_types = $settings['customization']['content']['customPostTypes'] ?? null;
 			$this->settings_selected_plugins = $settings['plugins'] ?? null;
 			$this->settings_customization = $settings['customization'] ?? null;


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix import process to correctly handle template customization override conditions during conflict resolution.

Main changes:
- Updated settings_selected_override_conditions path to use proper nested structure from settings['customization']['templates']['themeBuilder']['overrideConditions']

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
