### PR TITLE
Fix: Export and import all without customization missing the CPT [ED-20595]

### DIFF
--- a/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
+++ b/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types.js
@@ -11,11 +11,33 @@ export function useKitCustomizationCustomPostTypes( { data } ) {
 			return builtInCustomPostTypes;
 		}
 
-		const wpContent = data?.uploadedData?.manifest?.[ 'wp-content' ] || {};
+		const customPostTypesTitles = Object.values( data?.uploadedData?.manifest?.[ 'custom-post-type-title' ] || {} ).map( ( postType ) => {
+			return {
+				value: postType.name,
+				label: postType.label,
+			};
+		} );
 
-		return builtInCustomPostTypes.filter( ( postType ) => {
-			const contentArray = wpContent[ postType.value ];
-			return contentArray && Array.isArray( contentArray ) && contentArray.length > 0;
+		if ( ! customPostTypesTitles.some( ( postType ) => 'post' === postType.value ) ) {
+			customPostTypesTitles.push( {
+				value: 'post',
+				label: 'Post',
+			} );
+		}
+
+		const wpContent = data?.uploadedData?.manifest?.[ 'wp-content' ] || {};
+		const content = data?.uploadedData?.manifest?.content || {};
+
+		return customPostTypesTitles.filter( ( postType ) => {
+			const postTypeValue = postType.value;
+
+			const wpContentArray = wpContent[ postTypeValue ];
+			const isInWpContent = wpContentArray && Array.isArray( wpContentArray ) && wpContentArray.length > 0;
+
+			const contentObject = content[ postTypeValue ];
+			const isInElementorContent = contentObject && 'object' === typeof contentObject && Object.keys( contentObject ).length > 0;
+
+			return isInWpContent || isInElementorContent;
 		} );
 	}, [ isImport, data?.uploadedData, builtInCustomPostTypes ] );
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix import/export functionality to properly detect custom post types in uploaded kit data when customization is missing.

Main changes:
- Added custom post type extraction from manifest data with proper label/value mapping
- Ensured 'post' type is included even if not found in the manifest
- Enhanced filtering to check both wp-content and Elementor content areas for post types

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
