### PR TITLE
Tweak: Using REST for import export customization is not loadg some includes [ED-20618]

### DIFF
--- a/app/modules/import-export-customization/runners/import/elementor-content.php
+++ b/app/modules/import-export-customization/runners/import/elementor-content.php
@@ -34,6 +34,10 @@ class Elementor_Content extends Import_Runner_Base {
 	}
 
 	public function import( array $data, array $imported_data ) {
+		if ( ! function_exists( 'wp_set_post_terms' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/taxonomy.php';
+		}
+
 		$result['content'] = [];
 		$this->import_session_id = $data['session_id'];
 

--- a/app/modules/import-export-customization/runners/import/plugins.php
+++ b/app/modules/import-export-customization/runners/import/plugins.php
@@ -63,6 +63,12 @@ class Plugins extends Import_Runner_Base {
 			} )
 			->all();
 
+		if ( ! function_exists( 'request_filesystem_credentials' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		}
+
 		$installed = $this->plugins_manager->install( $slugs );
 		$activated = $this->plugins_manager->activate( $installed['succeeded'] );
 

--- a/app/modules/import-export-customization/runners/import/site-settings.php
+++ b/app/modules/import-export-customization/runners/import/site-settings.php
@@ -275,6 +275,10 @@ class Site_Settings extends Import_Runner_Base {
 			return null;
 		}
 
+		if ( ! function_exists( 'wp_get_theme' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/theme.php';
+		}
+
 		$theme = $data['site_settings']['theme'];
 		$theme_slug = $theme['slug'];
 		$theme_name = $theme['name'];

--- a/app/modules/import-export-customization/runners/import/taxonomies.php
+++ b/app/modules/import-export-customization/runners/import/taxonomies.php
@@ -22,6 +22,10 @@ class Taxonomies extends Import_Runner_Base {
 	}
 
 	public function import( array $data, array $imported_data ) {
+		if ( ! function_exists( 'wp_insert_term' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/taxonomy.php';
+		}
+
 		$customization = $data['customization']['content'] ?? null;
 
 		if ( $customization ) {

--- a/core/utils/import-export/wp-import.php
+++ b/core/utils/import-export/wp-import.php
@@ -1352,6 +1352,34 @@ class WP_Import extends \WP_Importer {
 	 * @param $args
 	 */
 	public function __construct( $file, $args = [] ) {
+		if ( ! function_exists( 'wp_tempnam' ) || ! function_exists( 'wp_upload_dir' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( ! function_exists( 'wp_insert_term' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/taxonomy.php';
+		}
+
+		if ( ! function_exists( 'wp_insert_attachment' ) || ! function_exists( 'wp_update_attachment_metadata' ) || ! function_exists( 'wp_generate_attachment_metadata' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+		}
+
+		if ( ! function_exists( 'wp_update_nav_menu_item' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/nav-menu.php';
+		}
+
+		if ( ! function_exists( 'wp_create_user' ) || ! function_exists( 'wp_insert_user' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/user.php';
+		}
+
+		if ( ! function_exists( 'wp_import_cleanup' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/import.php';
+		}
+
+		if ( ! function_exists( 'stick_post' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/post.php';
+		}
+
 		$this->requested_file_path = $file;
 		$this->args = $args;
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix missing WordPress includes when import/export customization is accessed via REST API by adding required include files.

Main changes:
- Added taxonomy.php include for term functions in elementor-content.php and taxonomies.php
- Added file.php, plugin-install.php and upgrader class includes for plugin installation
- Added theme.php include for wp_get_theme() function in site-settings.php
- Added comprehensive includes in wp-import.php for file, taxonomy, image, user and post functions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
