### PR TITLE
Tweak: Show all exported pages in Import customization [ED-20652]

### DIFF
--- a/app/modules/import-export-customization/runners/export/wp-content.php
+++ b/app/modules/import-export-customization/runners/export/wp-content.php
@@ -103,7 +103,7 @@ class Wp_Content extends Export_Runner_Base {
 				'path' => 'wp-content/' . $post_type . '/' . $post_type . '.xml',
 				'data' => $export_result['xml'],
 			],
-			'manifest_data' => $export_result['ids'],
+			'manifest_data' => $export_result['posts'],
 		];
 	}
 }

--- a/core/utils/import-export/wp-exporter.php
+++ b/core/utils/import-export/wp-exporter.php
@@ -46,6 +46,8 @@ class WP_Exporter {
 
 	private $terms;
 
+	private $exported_posts = [];
+
 	/**
 	 * Run export, by requested args.
 	 * Returns XML with exported data.
@@ -143,6 +145,7 @@ class WP_Exporter {
 		return [
 			'ids' => $post_ids,
 			'xml' => $this->get_xml_export( array_merge( $post_ids, $thumbnail_ids ) ),
+			'posts' => $this->exported_posts,
 		];
 	}
 
@@ -463,6 +466,11 @@ class WP_Exporter {
 				// Begin Loop.
 				foreach ( $posts as $post ) {
 					setup_postdata( $post );
+
+					$this->exported_posts[ $post->ID ] = [
+						'id' => $post->ID,
+						'title' => $post->post_title,
+					];
 
 					$title = apply_filters( 'the_title_rss', $post->post_title );
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add post titles to exported content in Import/Export customization to display all exported pages in the import interface.
Main changes:
- Include full post objects with titles in export manifest_data instead of just IDs
- Add exported_posts tracking property in WP_Exporter class to store post metadata
- Track post IDs and titles during export process for better reference in import UI

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
