### PR TITLE
Fix: Plugins checkbox should be disabled in import [ED-20655]

### DIFF
--- a/app/modules/import-export-customization/assets/js/shared/components/kit-parts-selection.js
+++ b/app/modules/import-export-customization/assets/js/shared/components/kit-parts-selection.js
@@ -45,7 +45,7 @@ export default function KitPartsSelection( { data, onCheckboxChange, testId, han
 		}
 
 		if ( isImport ) {
-			return ! isExported( item );
+			return ! isExported( item ) || item.required;
 		}
 
 		return item.required && contextData?.data?.includes?.includes( item.type );

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-parts-selection.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-parts-selection.test.js
@@ -363,7 +363,7 @@ describe( 'KitPartsSelection Component', () => {
 
 			expect( templatesCheckbox.disabled ).toBe( false );
 			expect( settingsCheckbox.disabled ).toBe( false );
-			expect( contentCheckbox.disabled ).toBe( false );
+			expect( contentCheckbox.disabled ).toBe( true );
 		} );
 
 		it( 'should map settings type to site-settings in manifest', () => {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix plugins checkbox being incorrectly enabled during import when required plugins are not properly considered.
Main changes:
- Updated checkbox disabled logic to consider both export status and required flag
- Fixed test case to verify content checkbox is correctly disabled during import

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
