### PR TITLE
Internal: Allow empty values in plain props type if they are not required [ED-20592]

### DIFF
--- a/modules/atomic-widgets/dynamic-tags/dynamic-tags-schemas.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-tags-schemas.php
@@ -70,6 +70,7 @@ class Dynamic_Tags_Schemas {
 
 			case 'number':
 				return Number_Prop_Type::make()
+					->set_required( $control['required'] ?? false )
 					->default( $control['default'] ?? null );
 
 			case 'switcher':

--- a/modules/atomic-widgets/prop-types/base/plain-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/plain-prop-type.php
@@ -34,7 +34,7 @@ abstract class Plain_Prop_Type implements Transformable_Prop_Type {
 	}
 
 	public function validate( $value ): bool {
-		if ( is_null( $value ) ) {
+		if ( is_null( $value ) || ( $this->is_transformable( $value ) && empty( $value['value'] ) ) ) {
 			return ! $this->is_required();
 		}
 

--- a/modules/atomic-widgets/prop-types/concerns/has-required-setting.php
+++ b/modules/atomic-widgets/prop-types/concerns/has-required-setting.php
@@ -25,6 +25,12 @@ trait Has_Required_Setting {
 		return $this;
 	}
 
+	public function set_required( bool $required ) {
+		$this->setting( 'required', $required );
+
+		return $this;
+	}
+
 	abstract public function get_setting( string $key, $default = null );
 
 	abstract public function setting( $key, $value );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add support for empty values in plain props when they are not required, while enhancing prop type validation and control configuration.
Main changes:
- Updated Plain_Prop_Type to accept empty values when not required
- Added set_required method to Has_Required_Setting trait for cleaner prop configuration
- Extended Number_Prop_Type to respect required attribute from control configuration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
