### PR TITLE
Fix: Control text color should override kits text color [ED-20089]

### DIFF
--- a/modules/floating-buttons/assets/scss/floating-bars/widgets/floating-bars-base.scss
+++ b/modules/floating-buttons/assets/scss/floating-bars/widgets/floating-bars-base.scss
@@ -142,8 +142,8 @@
 		}
 	}
 
-	&__cta-button,
-	&__cta-button:not([href]):not([tabindex]) {
+	& .e-floating-bars__cta-button,
+	& .e-floating-bars__cta-button:not([href]):not([tabindex]) {
 		align-items: center;
 		color: var(--e-floating-bars-cta-button-text-color);
 		display: inline-flex;


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* The value of the control for the text color should override the global kit color

## Description
An explanation of what is done in this PR

* changed the specificity of a selector

## Test instructions
This PR can be tested by following these steps:

* Install the Vases online kit from hello commerc
* Verify that SIGN UP button in the floating bar is using the correct color ( black )

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix button text color override in floating bars by modifying CSS selector specificity to ensure control text color takes precedence over kit styles.

Main changes:
- Changed CSS selector pattern from class-based to descendant-based to increase specificity for button text color styling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
