### PR TITLE
Internal: Temporarily disable plugin upgrade test yml workflow [ED-20671]

### DIFF
--- a/.github/workflows/plugin-upgrade-test.yml
+++ b/.github/workflows/plugin-upgrade-test.yml
@@ -2,16 +2,16 @@ name: Upgrade Elementor test
 
 on:
   push:
-    branches:
-      - 'main'
-      - '3.[0-9][0-9]'
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - '.github/config.json'
-      - 'bin/**'
-      - '.gitignore'
-      - 'docs/**'
+    # branches:
+    #   - 'main'
+    #   - '3.[0-9][0-9]'
+    # paths-ignore:
+    #   - '**.md'
+    #   - '**.txt'
+    #   - '.github/config.json'
+    #   - 'bin/**'
+    #   - '.gitignore'
+    #   - 'docs/**'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/plugin-upgrade-test.yml
+++ b/.github/workflows/plugin-upgrade-test.yml
@@ -1,7 +1,7 @@
 name: Upgrade Elementor test
 
 on:
-  push:
+  #push:
     # branches:
     #   - 'main'
     #   - '3.[0-9][0-9]'


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Disable automatic plugin upgrade testing workflow by commenting out push trigger while preserving manual workflow dispatch capability.
Main changes:
- Commented out push event trigger and branch configuration in plugin-upgrade-test.yml workflow
- Retained workflow_dispatch functionality for manual test execution

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
