### PR TITLE
Fix: Classes are not applied to elements after rename [ED-20634]

### DIFF
--- a/packages/packages/core/editor-canvas/src/__tests__/settings-props-resolver.test.ts
+++ b/packages/packages/core/editor-canvas/src/__tests__/settings-props-resolver.test.ts
@@ -1,7 +1,5 @@
-import { createMockStyleDefinition, createMockStylesProvider } from 'test-utils';
 import {
 	booleanPropTypeUtil,
-	classesPropTypeUtil,
 	imageAttachmentIdPropType,
 	imagePropTypeUtil,
 	imageSrcPropTypeUtil,
@@ -12,7 +10,6 @@ import {
 	stringPropTypeUtil,
 	urlPropTypeUtil,
 } from '@elementor/editor-props';
-import { stylesRepository } from '@elementor/editor-styles-repository';
 import { getMediaAttachment } from '@elementor/wp-media';
 
 import { initSettingsTransformers } from '../init-settings-transformers';
@@ -21,7 +18,6 @@ import { settingsTransformersRegistry } from '../settings-transformers-registry'
 import { mockAttachmentData } from './mock-attachment-data';
 import {
 	booleanPropType,
-	classesPropType,
 	imagePropType,
 	linkPropType,
 	numberPropType,
@@ -67,42 +63,6 @@ describe( 'settings props resolver', () => {
 				url: 'url',
 				number: 123,
 				boolean: true,
-			},
-		},
-		{
-			name: 'classes',
-			props: {
-				classes: classesPropTypeUtil.create( [
-					'test-1',
-					'test-2-suffix',
-					'without-provider',
-					'',
-					null as unknown as string,
-					undefined as unknown as string,
-				] ),
-			},
-			prepare: () => {
-				jest.mocked( stylesRepository.getProviders ).mockReturnValue( [
-					createMockStylesProvider( {
-						key: 'test-1-provider',
-						actions: {
-							all: () => [ createMockStyleDefinition( { id: 'test-1' } ) ],
-						},
-					} ),
-					createMockStylesProvider( {
-						key: 'test-2-provider',
-						actions: {
-							resolveCssName: ( id ) => `${ id }-suffix`,
-							all: () => [ createMockStyleDefinition( { id: 'test-2' } ) ],
-						},
-					} ),
-				] );
-			},
-			schema: {
-				classes: classesPropType(),
-			},
-			expected: {
-				classes: [ 'test-1', 'test-2-suffix', 'without-provider' ],
 			},
 		},
 		{

--- a/packages/packages/core/editor-canvas/src/transformers/settings/__tests__/classes-transformer.test.ts
+++ b/packages/packages/core/editor-canvas/src/transformers/settings/__tests__/classes-transformer.test.ts
@@ -1,0 +1,83 @@
+import { createClassesTransformer } from '../classes-transformer';
+
+jest.mock( '@elementor/editor-styles-repository', () => ( {
+	stylesRepository: {
+		getProviders: jest.fn(),
+		getProviderByKey: jest.fn(),
+	},
+} ) );
+
+const mockStylesRepository = require( '@elementor/editor-styles-repository' ).stylesRepository;
+
+describe( 'createClassesTransformer', () => {
+	const createMockProvider = ( key: string, styles: Array< { id: string } > = [] ) => ( {
+		getKey: () => key,
+		actions: {
+			all: () => styles,
+			resolveCssName: jest.fn( ( id: string ): string | null => `resolved-${ id }` ),
+		},
+	} );
+
+	const createMockStyle = ( id: string ) => ( { id } );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should transform class IDs using provider CSS names', () => {
+		const provider = createMockProvider( 'test-provider', [ createMockStyle( 'class-1' ) ] );
+		const provider2 = createMockProvider( 'test-provider-2', [ createMockStyle( 'class-2' ) ] );
+		mockStylesRepository.getProviders.mockReturnValue( [ provider, provider2 ] );
+		mockStylesRepository.getProviderByKey.mockReturnValueOnce( provider ).mockReturnValueOnce( provider2 );
+		const transformer = createClassesTransformer();
+
+		const result = transformer( [ 'class-1', 'class-2' ], { key: 'test-key' } );
+
+		expect( result ).toEqual( [ 'resolved-class-1', 'resolved-class-2' ] );
+		expect( provider.actions.resolveCssName ).toHaveBeenCalledWith( 'class-1' );
+	} );
+
+	it( 'should return original ID when no provider is found', () => {
+		mockStylesRepository.getProviders.mockReturnValue( [] );
+		const transformer = createClassesTransformer();
+
+		const result = transformer( [ 'unknown-class' ], { key: 'test-key' } );
+
+		expect( result ).toEqual( [ 'unknown-class' ] );
+	} );
+
+	it( 'should return original ID when provider has no matching style', () => {
+		const provider = createMockProvider( 'test-provider', [ createMockStyle( 'other-class' ) ] );
+		mockStylesRepository.getProviders.mockReturnValue( [ provider ] );
+		const transformer = createClassesTransformer();
+
+		const result = transformer( [ 'unknown-class' ], { key: 'test-key' } );
+
+		expect( result ).toEqual( [ 'unknown-class' ] );
+	} );
+
+	it( 'should cache provider keys to avoid repeated lookups', () => {
+		const provider = createMockProvider( 'test-provider', [ createMockStyle( 'class-1' ) ] );
+		mockStylesRepository.getProviders.mockReturnValue( [ provider ] );
+		mockStylesRepository.getProviderByKey.mockReturnValue( provider );
+		const transformer = createClassesTransformer();
+
+		transformer( [ 'class-1' ], { key: 'test-key' } );
+		transformer( [ 'class-1' ], { key: 'test-key' } );
+
+		expect( mockStylesRepository.getProviders ).toHaveBeenCalledTimes( 1 );
+		expect( provider.actions.resolveCssName ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'should handle multiple class IDs', () => {
+		const provider1 = createMockProvider( 'provider-1', [ createMockStyle( 'class-1' ) ] );
+		const provider2 = createMockProvider( 'provider-2', [ createMockStyle( 'class-2' ) ] );
+		mockStylesRepository.getProviders.mockReturnValue( [ provider1, provider2 ] );
+		mockStylesRepository.getProviderByKey.mockReturnValueOnce( provider1 ).mockReturnValueOnce( provider2 );
+		const transformer = createClassesTransformer();
+
+		const result = transformer( [ 'class-1', 'class-2' ], { key: 'test-key' } );
+
+		expect( result ).toEqual( [ 'resolved-class-1', 'resolved-class-2' ] );
+	} );
+} );

--- a/packages/packages/core/editor-canvas/src/transformers/settings/classes-transformer.ts
+++ b/packages/packages/core/editor-canvas/src/transformers/settings/classes-transformer.ts
@@ -2,30 +2,30 @@ import { stylesRepository } from '@elementor/editor-styles-repository';
 
 import { createTransformer } from '../create-transformer';
 
+function transformClassId( id: string, cache: Map< string, string > ): string {
+	if ( ! cache.has( id ) ) {
+		const provider = stylesRepository.getProviders().find( ( p ) => {
+			return p.actions.all().find( ( style ) => style.id === id );
+		} );
+
+		if ( ! provider ) {
+			return id;
+		}
+
+		cache.set( id, provider.getKey() );
+	}
+
+	const providerKey = cache.get( id ) as string;
+
+	const provider = stylesRepository.getProviderByKey( providerKey );
+
+	return provider?.actions.resolveCssName( id ) ?? id;
+}
+
 export function createClassesTransformer() {
 	const cache = new Map< string, string >();
 
 	return createTransformer( ( value: string[] ) => {
-		return value
-			.map( ( id ) => {
-				if ( ! cache.has( id ) ) {
-					cache.set( id, getCssName( id ) );
-				}
-
-				return cache.get( id );
-			} )
-			.filter( Boolean );
+		return value.map( ( id ) => transformClassId( id, cache ) ).filter( Boolean );
 	} );
-}
-
-function getCssName( id: string ) {
-	const provider = stylesRepository.getProviders().find( ( p ) => {
-		return p.actions.all().find( ( style ) => style.id === id );
-	} );
-
-	if ( ! provider ) {
-		return id;
-	}
-
-	return provider.actions.resolveCssName( id );
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix CSS class resolution by properly handling provider cache and transforming class IDs for renamed elements.

Main changes:
- Refactored class ID transformation logic into separate function to improve organization
- Added provider key caching to avoid repeated lookups and improve performance
- Created comprehensive test suite for classes transformer to ensure proper resolution behavior

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
