### PR TITLE
Internal: Pass action payload from repeater [ED-20675]

### DIFF
--- a/packages/packages/libs/editor-controls/src/bound-prop-context/prop-context.tsx
+++ b/packages/packages/libs/editor-controls/src/bound-prop-context/prop-context.tsx
@@ -7,6 +7,10 @@ import { HookOutsideProviderError } from './errors';
 export type SetValueMeta = {
 	bind?: PropKey;
 	validation?: ( value: PropValue ) => boolean;
+	action?: {
+		type: string;
+		payload?: Record< string, unknown >;
+	};
 };
 
 export type SetValue< T > = ( value: T, options?: CreateOptions, meta?: SetValueMeta ) => void;

--- a/packages/packages/libs/editor-controls/src/components/__tests__/repeater.test.tsx
+++ b/packages/packages/libs/editor-controls/src/components/__tests__/repeater.test.tsx
@@ -4,12 +4,6 @@ import { fireEvent, screen } from '@testing-library/react';
 
 import { Repeater } from '../repeater';
 
-const setValuesWrapper = ( setValues: ( value: unknown ) => void ) => {
-	return ( value: unknown ) => {
-		setValues( value );
-	};
-};
-
 describe( 'Repeater', () => {
 	it( 'should render the repeater with no items', () => {
 		// Arrange.
@@ -84,7 +78,7 @@ describe( 'Repeater', () => {
 			<Repeater
 				label={ 'Repeater' }
 				itemSettings={ itemSettings }
-				setValues={ setValuesWrapper( setValues ) }
+				setValues={ setValues }
 				values={ [
 					{
 						$$type: 'example',
@@ -100,13 +94,17 @@ describe( 'Repeater', () => {
 
 		// Assert.
 		expect( setValues ).toHaveBeenCalledTimes( 1 );
-		expect( setValues ).toHaveBeenCalledWith( [
-			itemSettings.initialValues,
-			{
-				$$type: 'example',
-				value: 'Initial item',
-			},
-		] );
+		expect( setValues ).toHaveBeenCalledWith(
+			[
+				itemSettings.initialValues,
+				{
+					$$type: 'example',
+					value: 'Initial item',
+				},
+			],
+			undefined,
+			{ action: { type: 'add' } }
+		);
 	} );
 
 	it( 'should add a new item to the bottom', () => {
@@ -129,7 +127,7 @@ describe( 'Repeater', () => {
 				addToBottom
 				label={ 'Repeater' }
 				itemSettings={ itemSettings }
-				setValues={ setValuesWrapper( setValues ) }
+				setValues={ setValues }
 				values={ [
 					{
 						$$type: 'example',
@@ -145,13 +143,17 @@ describe( 'Repeater', () => {
 
 		// Assert.
 		expect( setValues ).toHaveBeenCalledTimes( 1 );
-		expect( setValues ).toHaveBeenCalledWith( [
-			{
-				$$type: 'example',
-				value: 'Initial item',
-			},
-			itemSettings.initialValues,
-		] );
+		expect( setValues ).toHaveBeenCalledWith(
+			[
+				{
+					$$type: 'example',
+					value: 'Initial item',
+				},
+				itemSettings.initialValues,
+			],
+			undefined,
+			{ action: { type: 'add' } }
+		);
 	} );
 
 	it( 'should duplicate an item when the duplicate button is clicked, and add it right after the clicked item', () => {
@@ -177,12 +179,7 @@ describe( 'Repeater', () => {
 
 		// Act.
 		renderWithTheme(
-			<Repeater
-				label={ 'Repeater' }
-				itemSettings={ itemSettings }
-				values={ values }
-				setValues={ setValuesWrapper( setValues ) }
-			/>
+			<Repeater label={ 'Repeater' } itemSettings={ itemSettings } values={ values } setValues={ setValues } />
 		);
 		// eslint-disable-next-line testing-library/no-node-access
 		const duplicateButton = document.querySelector( 'button[aria-label="Duplicate"]' );
@@ -190,20 +187,24 @@ describe( 'Repeater', () => {
 		fireEvent.click( duplicateButton as Element );
 
 		// Assert.
-		expect( setValues ).toHaveBeenCalledWith( [
-			{
-				$$type: 'example',
-				value: 'First item',
-			},
-			{
-				$$type: 'example',
-				value: 'First item',
-			},
-			{
-				$$type: 'example',
-				value: 'Second item',
-			},
-		] );
+		expect( setValues ).toHaveBeenCalledWith(
+			[
+				{
+					$$type: 'example',
+					value: 'First item',
+				},
+				{
+					$$type: 'example',
+					value: 'First item',
+				},
+				{
+					$$type: 'example',
+					value: 'Second item',
+				},
+			],
+			undefined,
+			{ action: { type: 'duplicate' } }
+		);
 	} );
 
 	it( 'should remove the item when the remove button is clicked', () => {
@@ -229,12 +230,7 @@ describe( 'Repeater', () => {
 
 		// Act.
 		renderWithTheme(
-			<Repeater
-				label={ 'Repeater' }
-				itemSettings={ itemSettings }
-				values={ values }
-				setValues={ setValuesWrapper( setValues ) }
-			/>
+			<Repeater label={ 'Repeater' } itemSettings={ itemSettings } values={ values } setValues={ setValues } />
 		);
 		// eslint-disable-next-line testing-library/no-node-access
 		const removeButton = document.querySelector( 'button[aria-label="Remove"]' );
@@ -242,12 +238,16 @@ describe( 'Repeater', () => {
 		fireEvent.click( removeButton as Element );
 
 		// Assert.
-		expect( setValues ).toHaveBeenCalledWith( [
-			{
-				$$type: 'example',
-				value: 'Second item',
-			},
-		] );
+		expect( setValues ).toHaveBeenCalledWith(
+			[
+				{
+					$$type: 'example',
+					value: 'Second item',
+				},
+			],
+			undefined,
+			{ action: { type: 'remove' } }
+		);
 	} );
 
 	it( 'should render the item content and pass the index as bind prop', () => {
@@ -267,12 +267,7 @@ describe( 'Repeater', () => {
 
 		// Act.
 		renderWithTheme(
-			<Repeater
-				label={ 'Repeater' }
-				itemSettings={ itemSettings }
-				values={ values }
-				setValues={ setValuesWrapper( setValues ) }
-			/>
+			<Repeater label={ 'Repeater' } itemSettings={ itemSettings } values={ values } setValues={ setValues } />
 		);
 
 		const [ , secondItem ] = screen.getAllByRole( 'button', { name: 'Open item' } );
@@ -305,12 +300,7 @@ describe( 'Repeater', () => {
 
 		// Act.
 		renderWithTheme(
-			<Repeater
-				label={ 'Repeater' }
-				itemSettings={ itemSettings }
-				values={ values }
-				setValues={ setValuesWrapper( setValues ) }
-			/>
+			<Repeater label={ 'Repeater' } itemSettings={ itemSettings } values={ values } setValues={ setValues } />
 		);
 		// eslint-disable-next-line testing-library/no-node-access
 		const disableButton = document.querySelector( 'button[aria-label="Hide"]' );
@@ -318,13 +308,17 @@ describe( 'Repeater', () => {
 		fireEvent.click( disableButton as Element );
 
 		// Assert.
-		expect( setValues ).toHaveBeenCalledWith( [
-			{
-				$$type: 'example',
-				value: 'First item',
-				disabled: true,
-			},
-		] );
+		expect( setValues ).toHaveBeenCalledWith(
+			[
+				{
+					$$type: 'example',
+					value: 'First item',
+					disabled: true,
+				},
+			],
+			undefined,
+			{ action: { type: 'toggle-disable' } }
+		);
 	} );
 
 	it( 'should remove the disabled property when the enable button is clicked', () => {
@@ -345,12 +339,7 @@ describe( 'Repeater', () => {
 
 		// Act.
 		renderWithTheme(
-			<Repeater
-				label={ 'Repeater' }
-				itemSettings={ itemSettings }
-				values={ values }
-				setValues={ setValuesWrapper( setValues ) }
-			/>
+			<Repeater label={ 'Repeater' } itemSettings={ itemSettings } values={ values } setValues={ setValues } />
 		);
 		// eslint-disable-next-line testing-library/no-node-access
 		const enableButton = document.querySelector( 'button[aria-label="Show"]' );
@@ -358,12 +347,16 @@ describe( 'Repeater', () => {
 		fireEvent.click( enableButton as Element );
 
 		// Assert.
-		expect( setValues ).toHaveBeenCalledWith( [
-			{
-				$$type: 'example',
-				value: 'First item',
-			},
-		] );
+		expect( setValues ).toHaveBeenCalledWith(
+			[
+				{
+					$$type: 'example',
+					value: 'First item',
+				},
+			],
+			undefined,
+			{ action: { type: 'toggle-disable' } }
+		);
 	} );
 
 	it( 'should open the first repeater item popover, if the newly added item was added to top and "openOnAdd" is true', () => {

--- a/packages/packages/libs/editor-controls/src/components/repeater.tsx
+++ b/packages/packages/libs/editor-controls/src/components/repeater.tsx
@@ -95,10 +95,10 @@ export const Repeater = < T, >( {
 		const newKey = generateNextKey( uniqueKeys );
 
 		if ( addToBottom ) {
-			setItems( [ ...items, newItem ] );
+			setItems( [ ...items, newItem ], undefined, { action: { type: 'add' } } );
 			setUniqueKeys( [ ...uniqueKeys, newKey ] );
 		} else {
-			setItems( [ newItem, ...items ] );
+			setItems( [ newItem, ...items ], undefined, { action: { type: 'add' } } );
 			setUniqueKeys( [ newKey, ...uniqueKeys ] );
 		}
 
@@ -114,7 +114,9 @@ export const Repeater = < T, >( {
 		// Insert the new (cloned item) at the next spot (after the current index)
 		const atPosition = 1 + index;
 
-		setItems( [ ...items.slice( 0, atPosition ), newItem, ...items.slice( atPosition ) ] );
+		setItems( [ ...items.slice( 0, atPosition ), newItem, ...items.slice( atPosition ) ], undefined, {
+			action: { type: 'duplicate' },
+		} );
 		setUniqueKeys( [ ...uniqueKeys.slice( 0, atPosition ), newKey, ...uniqueKeys.slice( atPosition ) ] );
 	};
 
@@ -128,7 +130,9 @@ export const Repeater = < T, >( {
 		setItems(
 			items.filter( ( _, pos ) => {
 				return pos !== index;
-			} )
+			} ),
+			undefined,
+			{ action: { type: 'remove' } }
 		);
 	};
 
@@ -143,18 +147,24 @@ export const Repeater = < T, >( {
 				}
 
 				return value;
-			} )
+			} ),
+			undefined,
+			{ action: { type: 'toggle-disable' } }
 		);
 	};
 
-	const onChangeOrder = ( reorderedKeys: number[] ) => {
+	const onChangeOrder = ( reorderedKeys: number[], meta: { from: number; to: number } ) => {
 		setUniqueKeys( reorderedKeys );
-		setItems( ( prevItems ) => {
-			return reorderedKeys.map( ( keyValue ) => {
-				const index = uniqueKeys.indexOf( keyValue );
-				return prevItems[ index ];
-			} );
-		} );
+		setItems(
+			( prevItems ) => {
+				return reorderedKeys.map( ( keyValue ) => {
+					const index = uniqueKeys.indexOf( keyValue );
+					return prevItems[ index ];
+				} );
+			},
+			undefined,
+			{ action: { type: 'reorder', payload: { ...meta } } }
+		);
 	};
 
 	return (

--- a/packages/packages/libs/editor-controls/src/index.ts
+++ b/packages/packages/libs/editor-controls/src/index.ts
@@ -35,6 +35,7 @@ export { transitionProperties, transitionsItemsList } from './controls/transitio
 export { ControlFormLabel } from './components/control-form-label';
 export { ControlToggleButtonGroup } from './components/control-toggle-button-group';
 export { CssEditor } from './components/css-code-editor/css-editor';
+export { Repeater } from './components/repeater';
 
 // types
 export type { ControlComponent } from './create-control';


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add action type and payload to repeater component for better action tracking and data management.
Main changes:
- Extended SetValueMeta type to include action type and payload information
- Added action metadata to repeater operations (add, remove, duplicate, toggle-disable, reorder)
- Removed setValuesWrapper in favor of direct setValues calls with action metadata
- Exported Repeater component from main package index

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
