### PR TITLE
Internal: Update php coding standard - NoReservedKeywordParameterNames [ED-20666]

### DIFF
--- a/app/modules/import-export-customization/data/routes/base-route.php
+++ b/app/modules/import-export-customization/data/routes/base-route.php
@@ -5,8 +5,8 @@ namespace Elementor\App\Modules\ImportExportCustomization\Data\Routes;
 abstract class Base_Route {
 	public function __construct() {}
 
-	public function register_route( $namespace, $base_route ): void {
-		register_rest_route( $namespace, '/' . $base_route . '/' . $this->get_route(), [
+	public function register_route( $name_space, $base_route ): void {
+		register_rest_route( $name_space, '/' . $base_route . '/' . $this->get_route(), [
 			[
 				'methods' => $this->get_method(),
 				'callback' => fn( $request ) => $this->callback( $request ),

--- a/app/modules/import-export-customization/module.php
+++ b/app/modules/import-export-customization/module.php
@@ -755,11 +755,11 @@ class Module extends BaseModule {
 	}
 
 	/**
-	 * @param string $class
+	 * @param string $class_name
 	 *
 	 * @return bool
 	 */
-	public function is_third_party_class( $class ) {
+	public function is_third_party_class( $class_name ) {
 		$allowed_classes = [
 			'Elementor\\',
 			'ElementorPro\\',
@@ -768,7 +768,7 @@ class Module extends BaseModule {
 		];
 
 		foreach ( $allowed_classes as $allowed_class ) {
-			if ( str_starts_with( $class, $allowed_class ) ) {
+			if ( str_starts_with( $class_name, $allowed_class ) ) {
 				return false;
 			}
 		}

--- a/app/modules/import-export-customization/processes/export.php
+++ b/app/modules/import-export-customization/processes/export.php
@@ -167,8 +167,8 @@ class Export {
 		}
 	}
 
-	public function settings_include( $include ) {
-		$this->settings_include = $include;
+	public function settings_include( $settings_include ) {
+		$this->settings_include = $settings_include;
 	}
 
 	public function get_settings_include() {

--- a/app/modules/import-export-customization/runners/import/wp-content.php
+++ b/app/modules/import-export-customization/runners/import/wp-content.php
@@ -122,18 +122,18 @@ class Wp_Content extends Import_Runner_Base {
 	}
 
 	/**
-	 * @param $array array The array we want to relocate his element.
-	 * @param $element mixed The value of the element in the array we want to shift to end of the array.
+	 * @param array $base_array The array we want to relocate his element.
+	 * @param mixed $element    The value of the element in the array we want to shift to end of the array.
 	 * @return mixed
 	 */
-	private function force_element_to_be_last_by_value( array $array, $element ) {
-		$index = array_search( $element, $array, true );
+	private function force_element_to_be_last_by_value( array $base_array, $element ) {
+		$index = array_search( $element, $base_array, true );
 
 		if ( false !== $index ) {
-			unset( $array[ $index ] );
-			$array[] = $element;
+			unset( $base_array[ $index ] );
+			$base_array[] = $element;
 		}
 
-		return $array;
+		return $base_array;
 	}
 }

--- a/app/modules/import-export/module.php
+++ b/app/modules/import-export/module.php
@@ -974,11 +974,11 @@ class Module extends BaseModule {
 	}
 
 	/**
-	 * @param string $class
+	 * @param string $class_name
 	 *
 	 * @return bool
 	 */
-	public function is_third_party_class( $class ) {
+	public function is_third_party_class( $class_name ) {
 		$allowed_classes = [
 			'Elementor\\',
 			'ElementorPro\\',
@@ -987,7 +987,7 @@ class Module extends BaseModule {
 		];
 
 		foreach ( $allowed_classes as $allowed_class ) {
-			if ( str_starts_with( $class, $allowed_class ) ) {
+			if ( str_starts_with( $class_name, $allowed_class ) ) {
 				return false;
 			}
 		}

--- a/app/modules/import-export/processes/export.php
+++ b/app/modules/import-export/processes/export.php
@@ -154,8 +154,8 @@ class Export {
 		}
 	}
 
-	public function settings_include( $include ) {
-		$this->settings_include = $include;
+	public function settings_include( $included_settings ) {
+		$this->settings_include = $included_settings;
 	}
 
 	public function get_settings_include() {

--- a/app/modules/import-export/runners/import/wp-content.php
+++ b/app/modules/import-export/runners/import/wp-content.php
@@ -107,18 +107,18 @@ class Wp_Content extends Import_Runner_Base {
 	}
 
 	/**
-	 * @param $array array The array we want to relocate his element.
-	 * @param $element mixed The value of the element in the array we want to shift to end of the array.
+	 * @param array $base_array The array we want to relocate his element.
+	 * @param mixed $element    The value of the element in the array we want to shift to end of the array.
 	 * @return mixed
 	 */
-	private function force_element_to_be_last_by_value( array $array, $element ) {
-		$index = array_search( $element, $array, true );
+	private function force_element_to_be_last_by_value( array $base_array, $element ) {
+		$index = array_search( $element, $base_array, true );
 
 		if ( false !== $index ) {
-			unset( $array[ $index ] );
-			$array[] = $element;
+			unset( $base_array[ $index ] );
+			$base_array[] = $element;
 		}
 
-		return $array;
+		return $base_array;
 	}
 }

--- a/core/base/traits/shared-widget-controls-trait.php
+++ b/core/base/traits/shared-widget-controls-trait.php
@@ -16,9 +16,9 @@ trait Shared_Widget_Controls_Trait {
 		'step' => 1,
 	];
 
-	protected function add_html_tag_control( string $name, string $default = 'h2' ): void {
+	protected function add_html_tag_control( string $control_name, string $default_tag = 'h2' ): void {
 		$this->add_control(
-			$name,
+			$control_name,
 			[
 				'label' => esc_html__( 'HTML Tag', 'elementor' ),
 				'type' => Controls_Manager::SELECT,
@@ -33,7 +33,7 @@ trait Shared_Widget_Controls_Trait {
 					'span' => 'span',
 					'p' => 'p',
 				],
-				'default' => $default,
+				'default' => $default_tag,
 			]
 		);
 	}
@@ -99,7 +99,7 @@ trait Shared_Widget_Controls_Trait {
 			'2' => '2',
 			'3' => '3',
 		],
-		string $default = '3',
+		string $default_value = '3',
 		$label = '',
 		$selector_custom_property = '--e-link-in-bio-icon-columns'
 	): void {
@@ -112,7 +112,7 @@ trait Shared_Widget_Controls_Trait {
 				'label' => $label,
 				'type' => Controls_Manager::SELECT,
 				'options' => $options,
-				'default' => $default,
+				'default' => $default_value,
 				'render_type' => 'template',
 				'selectors' => [
 					'{{WRAPPER}} .e-link-in-bio' => $selector_custom_property . ': {{VALUE}};',

--- a/core/common/modules/connect/apps/base-app.php
+++ b/core/common/modules/connect/apps/base-app.php
@@ -288,10 +288,10 @@ abstract class Base_App {
 	 * @since 2.3.0
 	 * @access public
 	 */
-	public function get( $key, $default = null ) {
+	public function get( $key, $default_value = null ) {
 		$this->init_data();
 
-		return isset( $this->data[ $key ] ) ? $this->data[ $key ] : $default;
+		return isset( $this->data[ $key ] ) ? $this->data[ $key ] : $default_value;
 	}
 
 	/**
@@ -330,8 +330,8 @@ abstract class Base_App {
 	 * @since 2.3.0
 	 * @access protected
 	 */
-	protected function add( $key, $value, $default = '' ) {
-		$new_value = $this->get( $key, $default );
+	protected function add( $key, $value, $default_value = '' ) {
+		$new_value = $this->get( $key, $default_value );
 
 		if ( is_array( $new_value ) ) {
 			$new_value[] = $value;

--- a/core/common/modules/connect/module.php
+++ b/core/common/modules/connect/module.php
@@ -130,13 +130,13 @@ class Module extends BaseModule {
 	 * @since 2.3.0
 	 * @access public
 	 *
-	 * @param string $slug App slug.
-	 * @param string $class App full class name.
+	 * @param string $slug       App slug.
+	 * @param string $class_name App full class name.
 	 *
 	 * @return self The updated apps manager instance.
 	 */
-	public function register_app( $slug, $class ) {
-		$this->registered_apps[ $slug ] = $class;
+	public function register_app( $slug, $class_name ) {
+		$this->registered_apps[ $slug ] = $class_name;
 
 		return $this;
 	}

--- a/core/documents-manager.php
+++ b/core/documents-manager.php
@@ -137,16 +137,16 @@ class Documents_Manager {
 	 * @since 2.0.0
 	 * @access public
 	 *
-	 * @param string $type  Document type name.
-	 * @param string $class The name of the class that registers the document type.
-	 *                      Full name with the namespace.
+	 * @param string $type       Document type name.
+	 * @param string $class_name The name of the class that registers the document type.
+	 *                           Full name with the namespace.
 	 *
 	 * @return Documents_Manager The updated document manager instance.
 	 */
-	public function register_document_type( $type, $class ) {
-		$this->types[ $type ] = $class;
+	public function register_document_type( $type, $class_name ) {
+		$this->types[ $type ] = $class_name;
 
-		$cpt = $class::get_property( 'cpt' );
+		$cpt = $class_name::get_property( 'cpt' );
 
 		if ( $cpt ) {
 			foreach ( $cpt as $post_type ) {
@@ -154,7 +154,7 @@ class Documents_Manager {
 			}
 		}
 
-		if ( $class::get_property( 'register_type' ) ) {
+		if ( $class_name::get_property( 'register_type' ) ) {
 			Source_Local::add_template_type( $type );
 		}
 

--- a/core/dynamic-tags/manager.php
+++ b/core/dynamic-tags/manager.php
@@ -270,9 +270,9 @@ class Manager {
 	 * @access public
 	 * @deprecated 3.5.0 Use `register()` method instead.
 	 *
-	 * @param string $class
+	 * @param string $class_name
 	 */
-	public function register_tag( $class ) {
+	public function register_tag( $class_name ) {
 		Plugin::$instance->modules_manager->get_modules( 'dev-tools' )->deprecation->deprecated_function(
 			__METHOD__,
 			'3.5.0',
@@ -280,7 +280,7 @@ class Manager {
 		);
 
 		/** @var Base_Tag $tag */
-		$instance = new $class();
+		$instance = new $class_name();
 
 		$this->register( $instance );
 	}

--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -81,9 +81,9 @@ class Editor {
 	 * @since 1.0.0
 	 * @access public
 	 *
-	 * @param bool $die Optional. Whether to die at the end. Default is `true`.
+	 * @param bool $to_die Optional. Whether to die at the end. Default is `true`.
 	 */
-	public function init( $die = true ) {
+	public function init( $to_die = true ) {
 		if ( empty( $_REQUEST['post'] ) ) {
 			return;
 		}
@@ -160,7 +160,7 @@ class Editor {
 		$this->get_loader()->print_root_template();
 
 		// From the action it's an empty string, from tests its `false`
-		if ( false !== $die ) {
+		if ( false !== $to_die ) {
 			die;
 		}
 	}

--- a/core/editor/loader/common/editor-common-scripts-settings.php
+++ b/core/editor/loader/common/editor-common-scripts-settings.php
@@ -223,8 +223,8 @@ class Editor_Common_Scripts_Settings {
 		return $client_env;
 	}
 
-	private static function ensure_numeric_keys( array $array ) {
-		return array_values( $array );
+	private static function ensure_numeric_keys( array $base_array ) {
+		return array_values( $base_array );
 	}
 
 	private static function bc_move_document_filters() {

--- a/core/files/manager.php
+++ b/core/files/manager.php
@@ -37,12 +37,12 @@ class Manager {
 		$this->register_actions();
 	}
 
-	public function get( $class, $args ) {
-		$id = $class . '-' . wp_json_encode( $args );
+	public function get( $class_name, $args ) {
+		$id = $class_name . '-' . wp_json_encode( $args );
 
 		if ( ! isset( $this->files[ $id ] ) ) {
 			// Create an instance from dynamic args length.
-			$reflection_class = new \ReflectionClass( $class );
+			$reflection_class = new \ReflectionClass( $class_name );
 			$this->files[ $id ] = $reflection_class->newInstanceArgs( $args );
 		}
 

--- a/core/logger/manager.php
+++ b/core/logger/manager.php
@@ -154,8 +154,8 @@ class Manager extends BaseModule {
 		wp_send_json_success();
 	}
 
-	public function register_logger( $name, $class ) {
-		$this->loggers[ $name ] = $class;
+	public function register_logger( $name, $class_name ) {
+		$this->loggers[ $name ] = $class_name;
 	}
 
 	public function set_default_logger( $name ) {

--- a/core/utils/hints.php
+++ b/core/utils/hints.php
@@ -110,11 +110,11 @@ class Hints {
 	 * Print or Retrieve the notice template.
 	 *
 	 * @param array $notice
-	 * @param bool  $return
+	 * @param bool  $should_return
 	 *
 	 * @return string|void
 	 */
-	public static function get_notice_template( array $notice, bool $return = false ) {
+	public static function get_notice_template( array $notice, bool $should_return = false ) {
 		$default_settings = [
 			'type' => 'info',
 			'icon' => false,
@@ -187,7 +187,7 @@ class Hints {
 			$notice_settings['display']
 		);
 
-		if ( $return ) {
+		if ( $should_return ) {
 			return $notice_template;
 		}
 		echo wp_kses( $notice_template, self::get_notice_allowed_html() );

--- a/core/utils/import-export/parsers/wxr-parser-regex.php
+++ b/core/utils/import-export/parsers/wxr-parser-regex.php
@@ -209,10 +209,10 @@ class WXR_Parser_Regex {
 		return $term_data;
 	}
 
-	private function process_meta( $string, $tag ) {
+	private function process_meta( $meta_string, $tag ) {
 		$parsed_meta = [];
 
-		preg_match_all( "|<$tag>(.+?)</$tag>|is", $string, $meta );
+		preg_match_all( "|<$tag>(.+?)</$tag>|is", $meta_string, $meta );
 
 		if ( ! isset( $meta[1] ) ) {
 			return $parsed_meta;
@@ -322,8 +322,8 @@ class WXR_Parser_Regex {
 		return $postdata;
 	}
 
-	private function get_tag( $string, $tag ) {
-		preg_match( "|<$tag.*?>(.*?)</$tag>|is", $string, $return );
+	private function get_tag( $text_string, $tag ) {
+		preg_match( "|<$tag.*?>(.*?)</$tag>|is", $text_string, $return );
 		if ( isset( $return[1] ) ) {
 			if ( substr( $return[1], 0, 9 ) == '<![CDATA[' ) {
 				if ( strpos( $return[1], ']]]]><![CDATA[>' ) !== false ) {

--- a/core/utils/svg/svg-sanitizer.php
+++ b/core/utils/svg/svg-sanitizer.php
@@ -758,19 +758,19 @@ class Svg_Sanitizer {
 	 * @since 3.16.0
 	 * @access private
 	 *
-	 * @param $string
+	 * @param string $content
 	 * @return string
 	 */
-	private function strip_php_tags( $string ) {
-		$string = preg_replace( '/<\?(=|php)(.+?)\?>/i', '', $string );
+	private function strip_php_tags( $content ) {
+		$content = preg_replace( '/<\?(=|php)(.+?)\?>/i', '', $content );
 		// Remove XML, ASP, etc.
-		$string = preg_replace( '/<\?(.*)\?>/Us', '', $string );
-		$string = preg_replace( '/<\%(.*)\%>/Us', '', $string );
+		$content = preg_replace( '/<\?(.*)\?>/Us', '', $content );
+		$content = preg_replace( '/<\%(.*)\%>/Us', '', $content );
 
-		if ( ( false !== strpos( $string, '<?' ) ) || ( false !== strpos( $string, '<%' ) ) ) {
+		if ( ( false !== strpos( $content, '<?' ) ) || ( false !== strpos( $content, '<%' ) ) ) {
 			return '';
 		}
-		return $string;
+		return $content;
 	}
 
 	/**
@@ -779,17 +779,17 @@ class Svg_Sanitizer {
 	 * @since 3.16.0
 	 * @access private
 	 *
-	 * @param $string
+	 * @param string $content
 	 * @return string
 	 */
-	private function strip_comments( $string ) {
+	private function strip_comments( $content ) {
 		// Remove comments.
-		$string = preg_replace( '/<!--(.*)-->/Us', '', $string );
-		$string = preg_replace( '/\/\*(.*)\*\//Us', '', $string );
-		if ( ( false !== strpos( $string, '<!--' ) ) || ( false !== strpos( $string, '/*' ) ) ) {
+		$content = preg_replace( '/<!--(.*)-->/Us', '', $content );
+		$content = preg_replace( '/\/\*(.*)\*\//Us', '', $content );
+		if ( ( false !== strpos( $content, '<!--' ) ) || ( false !== strpos( $content, '/*' ) ) ) {
 			return '';
 		}
-		return $string;
+		return $content;
 	}
 
 	/**
@@ -798,11 +798,11 @@ class Svg_Sanitizer {
 	 * @since 3.16.0
 	 * @access private
 	 *
-	 * @param $string
+	 * @param string $content
 	 * @return string
 	 */
-	private function strip_line_breaks( $string ) {
+	private function strip_line_breaks( $content ) {
 		// Remove line breaks.
-		return preg_replace( '/\r|\n/', '', $string );
+		return preg_replace( '/\r|\n/', '', $content );
 	}
 }

--- a/data/v2/base/endpoint.php
+++ b/data/v2/base/endpoint.php
@@ -137,16 +137,16 @@ abstract class Endpoint extends Base_Route {
 	/**
 	 * Endpoint constructor.
 	 *
-	 * @param \Elementor\Data\V2\Base\Controller|\Elementor\Data\V2\Base\Endpoint $parent
+	 * @param \Elementor\Data\V2\Base\Controller|\Elementor\Data\V2\Base\Endpoint $parent_endpoint
 	 * @param string                                                              $route
 	 */
-	public function __construct( $parent, $route = '/' ) {
-		$controller = $parent;
-		$this->parent = $parent;
+	public function __construct( $parent_endpoint, $route = '/' ) {
+		$controller = $parent_endpoint;
+		$this->parent = $parent_endpoint;
 
 		// In case, its behave like sub-endpoint.
-		if ( ! ( $parent instanceof Controller ) ) {
-			$controller = $parent->get_controller();
+		if ( ! ( $parent_endpoint instanceof Controller ) ) {
+			$controller = $parent_endpoint->get_controller();
 		}
 
 		parent::__construct( $controller, $route );

--- a/data/v2/manager.php
+++ b/data/v2/manager.php
@@ -295,15 +295,15 @@ class Manager extends BaseModule {
 	 * @param string $endpoint
 	 * @param array  $args
 	 * @param string $method
-	 * @param string $namespace Optional.
-	 * @param string $version Optional.
+	 * @param string $name_space Optional.
+	 * @param string $version    Optional.
 	 *
 	 * @return \WP_REST_Response
 	 */
-	public function run_request( $endpoint, $args = [], $method = \WP_REST_Server::READABLE, $namespace = self::ROOT_NAMESPACE, $version = self::VERSION ) {
+	public function run_request( $endpoint, $args = [], $method = \WP_REST_Server::READABLE, $name_space = self::ROOT_NAMESPACE, $version = self::VERSION ) {
 		$this->run_server();
 
-		$endpoint = '/' . $namespace . '/v' . $version . '/' . trim( $endpoint, '/' );
+		$endpoint = '/' . $name_space . '/v' . $version . '/' . trim( $endpoint, '/' );
 
 		// Run reset api.
 		$request = new \WP_REST_Request( $method, $endpoint );

--- a/includes/autoloader.php
+++ b/includes/autoloader.php
@@ -189,13 +189,13 @@ class Autoloader {
 	 *
 	 * Used to convert control names to class names.
 	 *
-	 * @param string $string
+	 * @param string $class_name
 	 * @param string $delimiter
 	 *
 	 * @return mixed
 	 */
-	private static function normalize_class_name( $string, $delimiter = ' ' ) {
-		return ucwords( str_replace( '-', '_', $string ), $delimiter );
+	private static function normalize_class_name( $class_name, $delimiter = ' ' ) {
+		return ucwords( str_replace( '-', '_', $class_name ), $delimiter );
 	}
 
 	/**
@@ -308,14 +308,14 @@ class Autoloader {
 	 * @access private
 	 * @static
 	 *
-	 * @param string $class Class name.
+	 * @param string $class_name Class name.
 	 */
-	private static function autoload( $class ) {
-		if ( 0 !== strpos( $class, self::$default_namespace . '\\' ) ) {
+	private static function autoload( $class_name ) {
+		if ( 0 !== strpos( $class_name, self::$default_namespace . '\\' ) ) {
 			return;
 		}
 
-		$relative_class_name = preg_replace( '/^' . self::$default_namespace . '\\\/', '', $class );
+		$relative_class_name = preg_replace( '/^' . self::$default_namespace . '\\\/', '', $class_name );
 
 		$classes_aliases = self::get_classes_aliases();
 
@@ -335,9 +335,9 @@ class Autoloader {
 		}
 
 		if ( $has_class_alias ) {
-			class_alias( $final_class_name, $class );
+			class_alias( $final_class_name, $class_name );
 
-			Utils::handle_deprecation( $class, $alias_data['version'], $final_class_name );
+			Utils::handle_deprecation( $class_name, $alias_data['version'], $final_class_name );
 		}
 	}
 }

--- a/includes/controls/media.php
+++ b/includes/controls/media.php
@@ -470,7 +470,7 @@ class Control_Media extends Control_Base_Multiple {
 		return wp_get_attachment_image_url( $control_value['id'], $control_value['size'] );
 	}
 
-	public static function sanitise_text( $string ) {
-		return esc_attr( strip_tags( $string ) );
+	public static function sanitise_text( $text ) {
+		return esc_attr( strip_tags( $text ) );
 	}
 }

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -242,13 +242,13 @@ class Frontend extends App {
 	/**
 	 * @since 2.0.12
 	 * @access public
-	 * @param string|array $class
+	 * @param string|array $class_name
 	 */
-	public function add_body_class( $class ) {
-		if ( is_array( $class ) ) {
-			$this->body_classes = array_merge( $this->body_classes, $class );
+	public function add_body_class( $class_name ) {
+		if ( is_array( $class_name ) ) {
+			$this->body_classes = array_merge( $this->body_classes, $class_name );
 		} else {
-			$this->body_classes[] = $class;
+			$this->body_classes[] = $class_name;
 		}
 	}
 

--- a/includes/maintenance-mode.php
+++ b/includes/maintenance-mode.php
@@ -41,14 +41,14 @@ class Maintenance_Mode {
 	 * @access public
 	 * @static
 	 *
-	 * @param string $option  Option name. Expected to not be SQL-escaped.
-	 * @param mixed  $default Optional. Default value to return if the option
-	 *                        does not exist. Default is false.
+	 * @param string $option        Option name. Expected to not be SQL-escaped.
+	 * @param mixed  $default_value Optional. Default value to return if the option
+	 *                              does not exist. Default is false.
 	 *
 	 * @return bool False if value was not updated and true if value was updated.
 	 */
-	public static function get( $option, $default = false ) {
-		return get_option( self::OPTION_PREFIX . $option, $default );
+	public static function get( $option, $default_value = false ) {
+		return get_option( self::OPTION_PREFIX . $option, $default_value );
 	}
 
 	/**

--- a/includes/template-library/sources/local.php
+++ b/includes/template-library/sources/local.php
@@ -1705,7 +1705,7 @@ class Source_Local extends Source_Base {
 		return $posts_columns;
 	}
 
-	public function get_current_tab_group( $default = '' ) {
+	public function get_current_tab_group() {
 		//phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verification is not required here.
 		$current_tabs_group = Utils::get_super_global_value( $_REQUEST, 'tabs_group' ) ?? '';
 		//phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verification is not required here.

--- a/includes/user.php
+++ b/includes/user.php
@@ -363,18 +363,18 @@ class User {
 	}
 
 	/**
-	 * Get a user option with default value as fallback.
+	 * Get a user option with a fallback value.
 	 *
-	 * @param string $option  - Option key.
-	 * @param int    $user_id - User ID.
-	 * @param mixed  $default - Default fallback value.
+	 * @param string $option   Option key.
+	 * @param int    $user_id  User ID.
+	 * @param mixed  $fallback Default fallback value.
 	 *
 	 * @return mixed
 	 */
-	public static function get_user_option_with_default( $option, $user_id, $default ) {
+	public static function get_user_option_with_default( $option, $user_id, $fallback ) {
 		$value = get_user_option( $option, $user_id );
 
-		return ( false === $value ) ? $default : $value;
+		return ( false === $value ) ? $fallback : $value;
 	}
 
 	/**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -513,12 +513,12 @@ class Utils {
 	 * @access public
 	 * @static
 	 */
-	public static function array_inject( $array, $key, $insert ) {
-		$length = array_search( $key, array_keys( $array ), true ) + 1;
+	public static function array_inject( $base_array, $key, $insert ) {
+		$length = array_search( $key, array_keys( $base_array ), true ) + 1;
 
-		return array_slice( $array, 0, $length, true ) +
+		return array_slice( $base_array, 0, $length, true ) +
 			$insert +
-			array_slice( $array, $length, null, true );
+			array_slice( $base_array, $length, null, true );
 	}
 
 	/**
@@ -640,10 +640,10 @@ class Utils {
 	/**
 	 * Convert HTMLEntities to UTF-8 characters
 	 *
-	 * @param string $string
+	 * @param string $html_string
 	 * @return string
 	 */
-	public static function urlencode_html_entities( $string ) {
+	public static function urlencode_html_entities( $html_string ) {
 		$entities_dictionary = [
 			'&#145;' => "'", // Opening single quote
 			'&#146;' => "'", // Closing single quote
@@ -658,9 +658,9 @@ class Utils {
 		];
 
 		// Decode decimal entities
-		$string = str_replace( array_keys( $entities_dictionary ), array_values( $entities_dictionary ), $string );
+		$html_string = str_replace( array_keys( $entities_dictionary ), array_values( $entities_dictionary ), $html_string );
 
-		return rawurlencode( html_entity_decode( $string, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) );
+		return rawurlencode( html_entity_decode( $html_string, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) );
 	}
 
 	/**
@@ -773,8 +773,8 @@ class Utils {
 	/**
 	 * Print internal content (not user input) without escaping.
 	 */
-	public static function print_unescaped_internal_string( $string ) {
-		echo $string; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	public static function print_unescaped_internal_string( $internal_string ) {
+		echo $internal_string; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -801,7 +801,7 @@ class Utils {
 		return new \WP_Query( $args );
 	}
 
-	public static function print_wp_kses_extended( $string, array $tags ) {
+	public static function print_wp_kses_extended( $text, array $tags ) {
 		$allowed_html = wp_kses_allowed_html( 'post' );
 
 		foreach ( $tags as $tag ) {
@@ -811,7 +811,7 @@ class Utils {
 			}
 		}
 
-		echo wp_kses( $string, $allowed_html );
+		echo wp_kses( $text, $allowed_html );
 	}
 
 	public static function is_elementor_path( $path ) {
@@ -877,19 +877,19 @@ class Utils {
 	/**
 	 * Return specific object property value if exist from array of keys.
 	 *
-	 * @param array $array
+	 * @param array $base_array
 	 * @param array $keys
 	 * @return mixed|null
 	 */
-	public static function get_array_value_by_keys( $array, $keys ) {
+	public static function get_array_value_by_keys( $base_array, $keys ) {
 		$keys = (array) $keys;
 		foreach ( $keys as $key ) {
-			if ( ! isset( $array[ $key ] ) ) {
+			if ( ! isset( $base_array[ $key ] ) ) {
 				return null;
 			}
-			$array = $array[ $key ];
+			$base_array = $base_array[ $key ];
 		}
-		return $array;
+		return $base_array;
 	}
 
 	public static function get_cached_callback( $callback, $cache_key, $cache_time = 24 * HOUR_IN_SECONDS ) {
@@ -946,15 +946,15 @@ class Utils {
 		return (bool) Plugin::$instance->kits_manager->get_previous_id();
 	}
 
-	public static function decode_string( string $string, ?string $fallback = '' ) {
+	public static function decode_string( string $encoded_string, ?string $fallback = '' ) {
 		try {
-			return base64_decode( $string, true ) ?? $fallback;
+			return base64_decode( $encoded_string, true ) ?? $fallback;
 		} catch ( \Exception $e ) {
 			return $fallback;
 		}
 	}
 
-	public static function encode_string( string $string ): string {
-		return base64_encode( $string );
+	public static function encode_string( string $decoded_string ): string {
+		return base64_encode( $decoded_string );
 	}
 }

--- a/includes/widgets/divider.php
+++ b/includes/widgets/divider.php
@@ -328,8 +328,8 @@ class Widget_Divider extends Widget_Base {
 		);
 	}
 
-	private function filter_styles_by( $array, $key, $value ) {
-		return array_filter( $array, function( $style ) use ( $key, $value ) {
+	private function filter_styles_by( $styles_array, $key, $value ) {
+		return array_filter( $styles_array, function( $style ) use ( $key, $value ) {
 			return $value === $style[ $key ];
 		} );
 	}

--- a/modules/atomic-widgets/prop-types/concerns/has-meta.php
+++ b/modules/atomic-widgets/prop-types/concerns/has-meta.php
@@ -33,7 +33,7 @@ trait Has_Meta {
 		return $this->meta;
 	}
 
-	public function get_meta_item( $key, $default = null ) {
-		return array_key_exists( $key, $this->meta ) ? $this->meta[ $key ] : $default;
+	public function get_meta_item( $key, $default_value = null ) {
+		return array_key_exists( $key, $this->meta ) ? $this->meta[ $key ] : $default_value;
 	}
 }

--- a/modules/atomic-widgets/prop-types/concerns/has-required-setting.php
+++ b/modules/atomic-widgets/prop-types/concerns/has-required-setting.php
@@ -31,7 +31,7 @@ trait Has_Required_Setting {
 		return $this;
 	}
 
-	abstract public function get_setting( string $key, $default = null );
+	abstract public function get_setting( string $key, $default_value = null );
 
 	abstract public function setting( $key, $value );
 }

--- a/modules/atomic-widgets/prop-types/concerns/has-settings.php
+++ b/modules/atomic-widgets/prop-types/concerns/has-settings.php
@@ -27,7 +27,7 @@ trait Has_Settings {
 		return $this->settings;
 	}
 
-	public function get_setting( string $key, $default = null ) {
-		return array_key_exists( $key, $this->settings ) ? $this->settings[ $key ] : $default;
+	public function get_setting( string $key, $default_value = null ) {
+		return array_key_exists( $key, $this->settings ) ? $this->settings[ $key ] : $default_value;
 	}
 }

--- a/modules/atomic-widgets/prop-types/contracts/prop-type.php
+++ b/modules/atomic-widgets/prop-types/contracts/prop-type.php
@@ -15,9 +15,9 @@ interface Prop_Type extends \JsonSerializable {
 	public function validate( $value ): bool;
 	public function sanitize( $value );
 	public function get_meta(): array;
-	public function get_meta_item( string $key, $default = null );
+	public function get_meta_item( string $key, $default_value = null );
 	public function get_settings(): array;
-	public function get_setting( string $key, $default = null );
+	public function get_setting( string $key, $default_value = null );
 	public function set_dependencies( ?array $dependencies ): self;
 	public function get_dependencies(): ?array;
 }

--- a/modules/dev-tools/deprecation.php
+++ b/modules/dev-tools/deprecation.php
@@ -227,18 +227,18 @@ class Deprecation {
 	 *
 	 * @since 3.1.0
 	 *
-	 * @param string $function
+	 * @param string $function_name
 	 * @param string $version
-	 * @param string $replacement Optional. Default is ''
-	 * @param string $base_version Optional. Default is `null`
+	 * @param string $replacement   Optional. Default is ''
+	 * @param string $base_version  Optional. Default is `null`
 	 * @throws \Exception Deprecation error.
 	 */
-	public function deprecated_function( $function, $version, $replacement = '', $base_version = null ) {
-		$print_deprecated = $this->check_deprecation( $function, $version, $replacement, $base_version );
+	public function deprecated_function( $function_name, $version, $replacement = '', $base_version = null ) {
+		$print_deprecated = $this->check_deprecation( $function_name, $version, $replacement, $base_version );
 
 		if ( $print_deprecated ) {
 			// PHPCS - We need to echo special characters because they can exist in function calls.
-			_deprecated_function( $function, esc_html( $version ), $replacement );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			_deprecated_function( $function_name, esc_html( $version ), $replacement );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 

--- a/modules/favorites/module.php
+++ b/modules/favorites/module.php
@@ -167,10 +167,10 @@ class Module extends BaseModule {
 	/**
 	 * Register a new type class.
 	 *
-	 * @param string $class
+	 * @param string $class_name
 	 */
-	public function register( $class ) {
-		$type_instance = new $class();
+	public function register( $class_name ) {
+		$type_instance = new $class_name();
 
 		$this->types[ $type_instance->get_name() ] = $type_instance;
 	}

--- a/modules/global-classes/global-classes-cleanup.php
+++ b/modules/global-classes/global-classes-cleanup.php
@@ -72,7 +72,7 @@ class Global_Classes_Cleanup {
 			}
 
 			$element_data['settings'][ $prop->get_key() ]['value'] = Collection::make( $current_classes['value'] )
-				->filter( fn( $class ) => ! in_array( $class, $deleted_classes_ids, true ) )
+				->filter( fn( $class_name ) => ! in_array( $class_name, $deleted_classes_ids, true ) )
 				->values();
 		}
 

--- a/modules/gutenberg/module.php
+++ b/modules/gutenberg/module.php
@@ -39,12 +39,12 @@ class Module extends BaseModule {
 	public function register_elementor_rest_field() {
 		register_rest_field( get_post_types( '', 'names' ),
 			'gutenberg_elementor_mode', [
-				'update_callback' => function( $request_value, $object ) {
-					if ( ! User::is_current_user_can_edit( $object->ID ) ) {
+				'update_callback' => function( $request_value, $obj ) {
+					if ( ! User::is_current_user_can_edit( $obj->ID ) ) {
 						return false;
 					}
 
-					$document = Plugin::$instance->documents->get( $object->ID );
+					$document = Plugin::$instance->documents->get( $obj->ID );
 
 					if ( ! $document ) {
 						return false;

--- a/modules/library/user-favorites.php
+++ b/modules/library/user-favorites.php
@@ -29,12 +29,12 @@ class User_Favorites {
 
 	/**
 	 * @param null  $vendor
-	 * @param null  $resource
+	 * @param null  $resource_name
 	 * @param false $ignore_cache
 	 *
 	 * @return array
 	 */
-	public function get( $vendor = null, $resource = null, $ignore_cache = false ) {
+	public function get( $vendor = null, $resource_name = null, $ignore_cache = false ) {
 		if ( $ignore_cache || empty( $this->cache ) ) {
 			$this->cache = get_user_meta( $this->user_id, self::USER_META_KEY, true );
 		}
@@ -43,8 +43,8 @@ class User_Favorites {
 			return [];
 		}
 
-		if ( $vendor && $resource ) {
-			$key = $this->get_key( $vendor, $resource );
+		if ( $vendor && $resource_name ) {
+			$key = $this->get_key( $vendor, $resource_name );
 
 			return isset( $this->cache[ $key ] ) ? $this->cache[ $key ] : [];
 		}
@@ -54,27 +54,27 @@ class User_Favorites {
 
 	/**
 	 * @param $vendor
-	 * @param $resource
+	 * @param $resource_name
 	 * @param $id
 	 *
 	 * @return bool
 	 */
-	public function exists( $vendor, $resource, $id ) {
-		return in_array( $id, $this->get( $vendor, $resource ), true );
+	public function exists( $vendor, $resource_name, $id ) {
+		return in_array( $id, $this->get( $vendor, $resource_name ), true );
 	}
 
 	/**
 	 * @param       $vendor
-	 * @param       $resource
+	 * @param       $resource_name
 	 * @param array $value
 	 *
 	 * @return $this
 	 * @throws \Exception If the favorites cannot be saved.
 	 */
-	public function save( $vendor, $resource, $value = [] ) {
+	public function save( $vendor, $resource_name, $value = [] ) {
 		$all_favorites = $this->get();
 
-		$all_favorites[ $this->get_key( $vendor, $resource ) ] = $value;
+		$all_favorites[ $this->get_key( $vendor, $resource_name ) ] = $value;
 
 		$result = update_user_meta( $this->user_id, self::USER_META_KEY, $all_favorites );
 
@@ -89,14 +89,14 @@ class User_Favorites {
 
 	/**
 	 * @param $vendor
-	 * @param $resource
+	 * @param $resource_name
 	 * @param $id
 	 *
 	 * @return $this
 	 * @throws \Exception If the favorites cannot be added.
 	 */
-	public function add( $vendor, $resource, $id ) {
-		$favorites = $this->get( $vendor, $resource );
+	public function add( $vendor, $resource_name, $id ) {
+		$favorites = $this->get( $vendor, $resource_name );
 
 		if ( in_array( $id, $favorites, true ) ) {
 			return $this;
@@ -104,21 +104,21 @@ class User_Favorites {
 
 		$favorites[] = $id;
 
-		$this->save( $vendor, $resource, $favorites );
+		$this->save( $vendor, $resource_name, $favorites );
 
 		return $this;
 	}
 
 	/**
 	 * @param $vendor
-	 * @param $resource
+	 * @param $resource_name
 	 * @param $id
 	 *
 	 * @return $this
 	 * @throws \Exception If the favorites cannot be removed.
 	 */
-	public function remove( $vendor, $resource, $id ) {
-		$favorites = $this->get( $vendor, $resource );
+	public function remove( $vendor, $resource_name, $id ) {
+		$favorites = $this->get( $vendor, $resource_name );
 
 		if ( ! in_array( $id, $favorites, true ) ) {
 			return $this;
@@ -128,18 +128,18 @@ class User_Favorites {
 			return $item !== $id;
 		} );
 
-		$this->save( $vendor, $resource, $favorites );
+		$this->save( $vendor, $resource_name, $favorites );
 
 		return $this;
 	}
 
 	/**
 	 * @param $vendor
-	 * @param $resource
+	 * @param $resource_name
 	 *
 	 * @return string
 	 */
-	private function get_key( $vendor, $resource ) {
-		return "{$vendor}/{$resource}";
+	private function get_key( $vendor, $resource_name ) {
+		return "{$vendor}/{$resource_name}";
 	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Update PHP parameter names to avoid PHP reserved keywords across the codebase for improved code quality and maintainability.
Main changes:
- Renamed parameters using PHP reserved keywords (class, string, default, array, etc.) to more descriptive alternatives
- Updated function signatures in various modules while maintaining backward compatibility 
- Improved parameter naming consistency across the codebase for better code readability
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
