### PR TITLE
Internal: Update php coding standard - CapitalPDangit [ED-20689]

### DIFF
--- a/core/admin/canary-deployment.php
+++ b/core/admin/canary-deployment.php
@@ -127,7 +127,7 @@ class Canary_Deployment extends Module {
 			// Reset results for each condition.
 			$result = false;
 			switch ( $condition['type'] ) {
-				case 'wordpress': // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+				case 'wordpress': // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
 					// include an unmodified $wp_version
 					include ABSPATH . WPINC . '/version.php';
 					$result = version_compare( $wp_version, $condition['version'], $condition['operator'] );

--- a/modules/element-manager/ajax.php
+++ b/modules/element-manager/ajax.php
@@ -123,7 +123,7 @@ class Ajax {
 	}
 
 	private function get_plugin_name_from_widget_instance( $widget ) {
-		if ( in_array( 'wordpress', $widget->get_categories() ) ) {
+		if ( in_array( 'wordpress', $widget->get_categories() ) ) { // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
 			return esc_html__( 'WordPress Widgets', 'elementor' );
 		}
 

--- a/modules/notifications/api.php
+++ b/modules/notifications/api.php
@@ -90,7 +90,7 @@ class API {
 			// Reset results for each condition.
 			$result = false;
 			switch ( $condition['type'] ) {
-				case 'wordpress': // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+				case 'wordpress': // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
 					// include an unmodified $wp_version
 					include ABSPATH . WPINC . '/version.php';
 					$result = version_compare( $wp_version, $condition['version'], $condition['operator'] );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update PHP code standard by fixing WordPress.WP.CapitalPDangit rule suppressions to use the correct ignore comment syntax.
Main changes:
- Changed phpcs ignore comments from 'WordPress.WP.CapitalPDangit.Misspelled' to 'WordPress.WP.CapitalPDangit.MisspelledInText'
- Added phpcs ignore comment to element-manager/ajax.php where it was missing

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
