### PR TITLE
Fix: BC Issue with uninitialized parameter [ED-20690]

### DIFF
--- a/modules/atomic-widgets/controls/types/repeatable-control.php
+++ b/modules/atomic-widgets/controls/types/repeatable-control.php
@@ -17,7 +17,7 @@ class Repeatable_Control extends Atomic_Control_Base {
 	private ?object $initial_values;
 	private ?string $pattern_label;
 	private ?string $placeholder;
-	private ?string $prop_key;
+	private ?string $prop_key = '';
 
 	public function get_type(): string {
 		return 'repeatable';


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix backward compatibility issue by initializing the private prop_key property with empty string default value.
Main changes:
- Changed uninitialized nullable property $prop_key to have empty string default value

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
