### PR TITLE
Fix: Fatal error when no promotion widgets are set [ED-20905]

### DIFF
--- a/core/editor/loader/common/editor-common-scripts-settings.php
+++ b/core/editor/loader/common/editor-common-scripts-settings.php
@@ -208,7 +208,9 @@ class Editor_Common_Scripts_Settings {
 			$client_env = self::ensure_pro_widgets( $client_env );
 		}
 
-		$client_env['promotionWidgets'] = self::ensure_numeric_keys( $client_env['promotionWidgets'] );
+		if ( ! empty( $client_env['promotionWidgets'] && is_array( $client_env['promotionWidgets'] ) ) ) {
+			$client_env['promotionWidgets'] = self::ensure_numeric_keys( $client_env['promotionWidgets'] );
+		}
 
 		return $client_env;
 	}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix fatal error when the promotionWidgets array is unset by adding a null check before processing.
Main changes:
- Added conditional check to verify promotionWidgets exists and is an array before calling ensure_numeric_keys()

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
