### PR TITLE
Fix: POC for site settings link fixes [ED-20965]

### DIFF
--- a/assets/dev/js/editor/components/documents/commands/switch.js
+++ b/assets/dev/js/editor/components/documents/commands/switch.js
@@ -11,12 +11,18 @@ export class Switch extends $e.modules.CommandBase {
 			jQuery( '#elementor-preview-loading' ).show();
 		}
 
-		return $e.run( 'editor/documents/close', {
-			id: elementor.documents.getCurrentId(),
-			mode,
-			onClose,
-			selector: args.selector,
-		} )
+		const currentDocument = elementor.documents.getCurrent();
+
+		const closePromise = currentDocument
+			? $e.run( 'editor/documents/close', {
+				id: currentDocument.id,
+				mode,
+				onClose,
+				selector: args.selector,
+			} )
+			: Promise.resolve();
+
+		return closePromise
 			.then( () => {
 				return $e.run( 'editor/documents/open', { id, shouldScroll, shouldNavigateToDefaultRoute, selector: args.selector, setAsInitial } );
 			} )

--- a/assets/dev/js/editor/components/documents/component.js
+++ b/assets/dev/js/editor/components/documents/component.js
@@ -109,18 +109,7 @@ export default class Component extends ComponentBase {
 	 * @return {number} document id
 	 */
 	getCurrentId() {
-		if ( this.currentDocument ) {
-			return this.currentDocument.id;
-		}
-
-		// Fallback to active-document URL parameter
-		const activeDocumentId = parseInt( getQueryParam( 'active-document' ) );
-		if ( ! isNaN( activeDocumentId ) ) {
-			return activeDocumentId;
-		}
-
-		// Final fallback to initial document
-		return this.getInitialId();
+		return this.currentDocument.id;
 	}
 
 	getInitialId() {

--- a/assets/dev/js/editor/components/documents/component.js
+++ b/assets/dev/js/editor/components/documents/component.js
@@ -3,6 +3,7 @@ import Document from './document';
 import * as commands from './commands/';
 import * as internalCommands from './commands/internal/';
 import * as hooks from './hooks';
+import { getQueryParam } from 'elementor-editor-utils/query-params';
 
 export default class Component extends ComponentBase {
 	__construct( args = {} ) {
@@ -108,7 +109,18 @@ export default class Component extends ComponentBase {
 	 * @return {number} document id
 	 */
 	getCurrentId() {
-		return this.currentDocument.id;
+		if ( this.currentDocument ) {
+			return this.currentDocument.id;
+		}
+
+		// Fallback to active-document URL parameter
+		const activeDocumentId = parseInt( getQueryParam( 'active-document' ) );
+		if ( ! isNaN( activeDocumentId ) ) {
+			return activeDocumentId;
+		}
+
+		// Final fallback to initial document
+		return this.getInitialId();
 	}
 
 	getInitialId() {
@@ -149,7 +161,8 @@ export default class Component extends ComponentBase {
 	}
 
 	isCurrent( id ) {
-		return parseInt( id ) === this.currentDocument.id;
+		const currentId = this.getCurrentId();
+		return currentId ? parseInt( id ) === currentId : false;
 	}
 
 	unsetCurrent() {

--- a/assets/dev/js/editor/components/documents/component.js
+++ b/assets/dev/js/editor/components/documents/component.js
@@ -3,7 +3,6 @@ import Document from './document';
 import * as commands from './commands/';
 import * as internalCommands from './commands/internal/';
 import * as hooks from './hooks';
-import { getQueryParam } from 'elementor-editor-utils/query-params';
 
 export default class Component extends ComponentBase {
 	__construct( args = {} ) {
@@ -150,8 +149,7 @@ export default class Component extends ComponentBase {
 	}
 
 	isCurrent( id ) {
-		const currentId = this.getCurrentId();
-		return currentId ? parseInt( id ) === currentId : false;
+		return parseInt( id ) === this.currentDocument.id;
 	}
 
 	unsetCurrent() {

--- a/assets/dev/js/editor/components/selection/manager.js
+++ b/assets/dev/js/editor/components/selection/manager.js
@@ -202,8 +202,13 @@ export default class Manager extends elementorModules.editor.utils.Module {
 			return;
 		}
 
-		elementor.navigator.getLayout()
-			.elements.currentView.recursiveChildInvoke( 'updateSelection' );
+		const navigatorLayout = elementor.navigator.getLayout();
+
+		if ( ! navigatorLayout ) {
+			return;
+		}
+
+		navigatorLayout.elements?.currentView?.recursiveChildInvoke( 'updateSelection' );
 	}
 
 	/**

--- a/assets/dev/js/editor/editor-base.js
+++ b/assets/dev/js/editor/editor-base.js
@@ -1056,7 +1056,10 @@ export default class EditorBase extends Marionette.Application {
 			.addClass( 'elementor-editor-active' );
 
 		if ( elementor.config.document.panel.has_elements ) {
-			this.documents.getCurrent().$element.addClass( 'elementor-edit-area-active' );
+			const currentDocument = this.documents.getCurrent();
+			if ( currentDocument && currentDocument.$element ) {
+				currentDocument.$element.addClass( 'elementor-edit-area-active' );
+			}
 		}
 	}
 

--- a/assets/dev/js/editor/editor-base.js
+++ b/assets/dev/js/editor/editor-base.js
@@ -1055,12 +1055,19 @@ export default class EditorBase extends Marionette.Application {
 			.removeClass( 'elementor-editor-preview' )
 			.addClass( 'elementor-editor-active' );
 
-		if ( elementor.config.document.panel.has_elements ) {
-			const currentDocument = this.documents.getCurrent();
-			if ( currentDocument && currentDocument.$element ) {
-				currentDocument.$element.addClass( 'elementor-edit-area-active' );
-			}
+		const panelHasElements = elementor.config.document.panel.has_elements;
+
+		if ( ! panelHasElements ) {
+			return;
 		}
+
+		const currentDocument = this.documents.getCurrent();
+
+		if ( ! currentDocument ) {
+			return;
+		}
+
+		currentDocument.$element?.addClass( 'elementor-edit-area-active' );
 	}
 
 	changeEditMode( newMode ) {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix error handling in documents component to prevent crashes when currentDocument is null by providing fallbacks for current document ID.
Main changes:
- Added fallbacks in getCurrentId() using URL parameters and initial ID when currentDocument is null
- Updated isCurrent() to safely handle null current document scenarios
- Imported getQueryParam utility to support fallback to active-document URL parameter

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
