### PR TITLE
Fix: New template dialog not closing in Elementor core [ED-20976]

### DIFF
--- a/assets/dev/js/admin/new-template/layout.js
+++ b/assets/dev/js/admin/new-template/layout.js
@@ -18,9 +18,6 @@ module.exports = elementorModules.common.views.modal.Layout.extend( {
 	initialize() {
 		elementorModules.common.views.modal.Layout.prototype.initialize.apply( this, arguments );
 
-		const lookupControlIdPrefix = 'elementor-new-template__form__';
-		const templateTypeSelectId = `${ lookupControlIdPrefix }template-type`;
-
 		this.showLogo();
 
 		this.showContentView();
@@ -30,8 +27,23 @@ module.exports = elementorModules.common.views.modal.Layout.extend( {
 		this.lockProBehavior = new LockPro( this.elements );
 		this.lockProBehavior.bindEvents();
 
+		this.setupDynamicControlsVisibility();
+	},
+
+	setupDynamicControlsVisibility() {
+		// eslint-disable-next-line camelcase
+		const isFormControlsDefined = 'undefined' !== typeof elementor_new_template_form_controls;
+
+		if ( ! isFormControlsDefined ) {
+			return;
+		}
+
+		const CONTROL_ID_PREFIX = 'elementor-new-template__form__';
+		const templateTypeSelectId = `${ CONTROL_ID_PREFIX }template-type`;
+
 		const dynamicControlsVisibilityListener = () => {
-			elementorAdmin.templateControls.setDynamicControlsVisibility( lookupControlIdPrefix, elementor_new_template_form_controls );
+			// eslint-disable-next-line camelcase
+			elementorAdmin.templateControls.setDynamicControlsVisibility( CONTROL_ID_PREFIX, elementor_new_template_form_controls );
 		};
 
 		this.getModal().onShow = () => {

--- a/assets/dev/js/admin/new-template/new-template.js
+++ b/assets/dev/js/admin/new-template/new-template.js
@@ -26,7 +26,7 @@ var NewTemplateModule = elementorModules.ViewModule.extend( {
 
 	showModalByHash() {
 		if ( '#add_new' === location.hash ) {
-			this.layout.showModal();
+			this.layout?.showModal();
 
 			location.hash = '';
 		}
@@ -43,7 +43,7 @@ var NewTemplateModule = elementorModules.ViewModule.extend( {
 	onAddButtonClick( event ) {
 		event.preventDefault();
 
-		this.layout.showModal();
+		this.layout?.showModal();
 	},
 } );
 

--- a/core/common/assets/js/views/modal/header.js
+++ b/core/common/assets/js/views/modal/header.js
@@ -36,9 +36,9 @@ export default class extends Marionette.LayoutView {
 	onCloseModalClick() {
 		this._parent._parent._parent.hideModal();
 
-		const type = elementor.config?.document?.type ?? 'default';
+		const documentType = this.getDocumentType();
 
-		const customEvent = new CustomEvent( `core/modal/close/${ type }` );
+		const customEvent = new CustomEvent( `core/modal/close/${ documentType }` );
 
 		window.dispatchEvent( customEvent );
 
@@ -46,6 +46,16 @@ export default class extends Marionette.LayoutView {
 			$e.internal( 'document/save/set-is-modified', { status: false } );
 			window.location.href = elementor.config.admin_floating_button_admin_url;
 		}
+	}
+
+	getDocumentType() {
+		const DEFAULT_TYPE = 'default';
+
+		if ( 'undefined' !== typeof elementor ) {
+			return DEFAULT_TYPE;
+		}
+
+		return elementor?.config?.document?.type ?? DEFAULT_TYPE;
 	}
 
 	isFloatingButtonLibraryClose() {

--- a/core/common/assets/js/views/modal/header.js
+++ b/core/common/assets/js/views/modal/header.js
@@ -27,6 +27,26 @@ export default class extends Marionette.LayoutView {
 		};
 	}
 
+	onRender() {
+		this.bindEscapeKey();
+	}
+
+	bindEscapeKey() {
+		this.onDocumentKeyDown = ( event ) => {
+			if ( 'Escape' === event.key ) {
+				this.onCloseModalClick();
+			}
+		};
+		
+		document.addEventListener( 'keydown', this.onDocumentKeyDown );
+	}
+
+	onDestroy() {
+		if ( this.onDocumentKeyDown ) {
+			document.removeEventListener( 'keydown', this.onDocumentKeyDown );
+		}
+	}
+
 	templateHelpers() {
 		return {
 			closeType: this.getOption( 'closeType' ),
@@ -51,7 +71,7 @@ export default class extends Marionette.LayoutView {
 	getDocumentType() {
 		const DEFAULT_TYPE = 'default';
 
-		if ( 'undefined' !== typeof elementor ) {
+		if ( 'undefined' === typeof window.elementor ) {
 			return DEFAULT_TYPE;
 		}
 

--- a/core/common/assets/js/views/modal/header.js
+++ b/core/common/assets/js/views/modal/header.js
@@ -37,7 +37,7 @@ export default class extends Marionette.LayoutView {
 				this.onCloseModalClick();
 			}
 		};
-		
+
 		document.addEventListener( 'keydown', this.onDocumentKeyDown );
 	}
 

--- a/tests/playwright/sanity/admin/new-templates/new-template.test.ts
+++ b/tests/playwright/sanity/admin/new-templates/new-template.test.ts
@@ -26,16 +26,16 @@ test.describe( 'New Template Modal', () => {
 		// Assert - Modal is closed
 		await expect( modal ).not.toBeVisible();
 
-                // Act - Click Add New Template button
-                await page.click( ADD_NEW_TEMPLATE_SELECTOR );
+        // Act - Click Add New Template button
+        await page.click( ADD_NEW_TEMPLATE_SELECTOR );
 
-                // Assert - Modal is visible
-                await expect( modal ).toBeVisible();
+        // Assert - Modal is visible
+        await expect( modal ).toBeVisible();
 
-                // Act - Press Escape key
-                await page.keyboard.press( 'Escape' );
+        // Act - Press Escape key
+        await page.keyboard.press( 'Escape' );
 
-                // Assert - Modal is closed
-                await expect( modal ).not.toBeVisible();
+        // Assert - Modal is closed
+        await expect( modal ).not.toBeVisible();
 	} );
 } );

--- a/tests/playwright/sanity/admin/new-templates/new-template.test.ts
+++ b/tests/playwright/sanity/admin/new-templates/new-template.test.ts
@@ -1,0 +1,29 @@
+import { parallelTest as test } from '../../../parallelTest';
+import { expect } from '@playwright/test';
+import WpAdminPage from '../../../pages/wp-admin-page';
+
+const TEMPLATE_LIBRARY_URL = '/wp-admin/edit.php?post_type=elementor_library&tabs_group=library';
+const ADD_NEW_TEMPLATE_SELECTOR = 'a.page-title-action[href*="post-new.php?post_type=elementor_library"]';
+const MODAL_SELECTOR = '#elementor-new-template-modal';
+const MODAL_CLOSE_SELECTOR = '.elementor-templates-modal__header__close';
+
+test.describe( 'New Template Modal', () => {
+	test( 'Opens modal when clicking Add New Template and closes when clicking close button', async ( { page, apiRequests }, testInfo ) => {
+		// Arrange
+		new WpAdminPage( page, testInfo, apiRequests );
+		await page.goto( TEMPLATE_LIBRARY_URL );
+
+		// Act - Click Add New Template button
+		await page.click( ADD_NEW_TEMPLATE_SELECTOR );
+
+		// Assert - Modal is visible
+		const modal = page.locator( MODAL_SELECTOR );
+		await expect( modal ).toBeVisible();
+
+		// Act - Click close button
+		await page.click( MODAL_CLOSE_SELECTOR );
+
+		// Assert - Modal is closed
+		await expect( modal ).not.toBeVisible();
+	} );
+} );

--- a/tests/playwright/sanity/admin/new-templates/new-template.test.ts
+++ b/tests/playwright/sanity/admin/new-templates/new-template.test.ts
@@ -25,5 +25,17 @@ test.describe( 'New Template Modal', () => {
 
 		// Assert - Modal is closed
 		await expect( modal ).not.toBeVisible();
+
+                // Act - Click Add New Template button
+                await page.click( ADD_NEW_TEMPLATE_SELECTOR );
+
+                // Assert - Modal is visible
+                await expect( modal ).toBeVisible();
+
+                // Act - Press Escape key
+                await page.keyboard.press( 'Escape' );
+
+                // Assert - Modal is closed
+                await expect( modal ).not.toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix template dialog not closing when using Escape key or X button in Elementor's new template modal.
Main changes:
- Added Escape key event listener with document-level binding in modal header
- Fixed optional chaining for layout.showModal() calls to prevent errors
- Implemented proper dynamic controls visibility setup in a separate method
- Added Playwright tests to verify modal closing functionality

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
