### PR TITLE
Internal: Initialize editor settings on elements [ED-20703]

### DIFF
--- a/modules/atomic-widgets/assets/js/editor/atomic-element-model.js
+++ b/modules/atomic-widgets/assets/js/editor/atomic-element-model.js
@@ -35,6 +35,7 @@ export default class AtomicContainer extends elementor.modules.elements.models.E
 				settings: element.settings || {},
 				elements: element.elements || [],
 				isLocked: element.isLocked || false,
+				editor_settings: element.editor_settings || {},
 			};
 		} );
 	}

--- a/modules/atomic-widgets/elements/element-builder.php
+++ b/modules/atomic-widgets/elements/element-builder.php
@@ -7,6 +7,7 @@ class Element_Builder {
 	protected $settings = [];
 	protected $is_locked = false;
 	protected $children = [];
+	protected $editor_settings = [];
 
 	public static function make( string $element_type ) {
 		return new self( $element_type );
@@ -26,11 +27,19 @@ class Element_Builder {
 		return $this;
 	}
 
+	public function editor_settings( array $editor_settings ) {
+		$this->editor_settings = $editor_settings;
+		return $this;
+	}
+
 	public function build() {
-		return [
+		$element_data = [
 			'elType' => $this->element_type,
 			'settings' => $this->settings,
 			'isLocked' => $this->is_locked,
+			'editor_settings' => $this->editor_settings,
 		];
+
+		return $element_data;
 	}
 }

--- a/modules/atomic-widgets/elements/widget-builder.php
+++ b/modules/atomic-widgets/elements/widget-builder.php
@@ -6,6 +6,7 @@ class Widget_Builder {
 	protected $widget_type;
 	protected $settings = [];
 	protected $is_locked = false;
+	protected $editor_settings = [];
 
 	public static function make( string $widget_type ) {
 		return new self( $widget_type );
@@ -25,12 +26,20 @@ class Widget_Builder {
 		return $this;
 	}
 
+	public function editor_settings( array $editor_settings ) {
+		$this->editor_settings = $editor_settings;
+		return $this;
+	}
+
 	public function build() {
-		return [
+		$widget_data = [
 			'elType' => 'widget',
 			'widgetType' => $this->widget_type,
 			'settings' => $this->settings,
 			'isLocked' => $this->is_locked,
+			'editor_settings' => $this->editor_settings,
 		];
+
+		return $widget_data;
 	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add editor settings support to element and widget builders for enhanced editor customization capabilities.

Main changes:
- Added editor_settings property to Element_Builder and Widget_Builder classes
- Created editor_settings() method in both builder classes to set custom editor settings
- Updated build() method to include editor_settings in returned element data
- Modified AtomicContainer model to handle editor_settings property from elements

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
