### PR TITLE
Internal: Revert Cherry-pick PR 32730 to 3.32 Help group in top bar [ED-20977] 

### DIFF
--- a/packages/packages/core/editor-app-bar/src/components/locations/main-menu-location.tsx
+++ b/packages/packages/core/editor-app-bar/src/components/locations/main-menu-location.tsx
@@ -41,10 +41,6 @@ export default function MainMenuLocation() {
 				{ menuItems.default.map( ( { MenuItem, id } ) => (
 					<MenuItem key={ id } />
 				) ) }
-				{ menuItems.help.length > 0 && <Divider /> }
-				{ menuItems.help.map( ( { MenuItem, id } ) => (
-					<MenuItem key={ id } />
-				) ) }
 				{ menuItems.exits.length > 0 && <Divider /> }
 				{ menuItems.exits.map( ( { MenuItem, id } ) => (
 					<MenuItem key={ id } />

--- a/packages/packages/core/editor-app-bar/src/locations.ts
+++ b/packages/packages/core/editor-app-bar/src/locations.ts
@@ -18,7 +18,7 @@ const components = {
 };
 
 export const mainMenu = createMenu( {
-	groups: [ 'help', 'exits' ],
+	groups: [ 'exits' ],
 	components,
 } );
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert "Help" group from main menu in editor app bar to match 3.32 implementation.
Main changes:
- Removed 'help' group from mainMenu groups array in locations.ts
- Removed corresponding UI rendering code for help menu items and divider from main-menu-location.tsx

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
