### PR TITLE
Revert "Fix: Provide z-index as base to button [ED-20301]"

### DIFF
--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.php
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.php
@@ -13,7 +13,6 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Link_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Dimensions_Prop_Type;
-use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
@@ -117,7 +116,6 @@ class Atomic_Button extends Atomic_Widget_Base {
 			'unit' => 'px',
 		] );
 		$align_text_value = String_Prop_Type::generate( 'center' );
-		$z_index_value = Number_Prop_Type::generate( 1 );
 
 		return [
 			'base' => Style_Definition::make()
@@ -129,7 +127,6 @@ class Atomic_Button extends Atomic_Widget_Base {
 						->add_prop( 'border-radius', $border_radius_value )
 						->add_prop( 'border-width', $border_width_value )
 						->add_prop( 'text-align', $align_text_value )
-						->add_prop( 'z-index', $z_index_value )
 				),
 		];
 	}


### PR DESCRIPTION
Reverts elementor/elementor#32560
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert z-index property addition to atomic-button component that was previously implemented in PR #32560.
Main changes:
- Removed Number_Prop_Type import from atomic-button.php
- Removed z-index value definition and its application to the button's base style variant

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
