### PR TITLE
Internal: Use release command properly from packages directory [ED-20698]

### DIFF
--- a/.github/workflows/one-click-release.yml
+++ b/.github/workflows/one-click-release.yml
@@ -210,7 +210,7 @@ jobs:
         run: |
           if [ "${{ env.CHANNEL }}" == "ga" ]; then
             # Assuming the version is already bumped in the creation of the release branch
-            npm run packages:release ${{ github.event.inputs.dry_run && '-- --dry-run' || '' }}
+            npm run release ${{ github.event.inputs.dry_run && '-- --dry-run' || '' }}
           else
             if [ ${{ github.event.inputs.dry_run }} == 'false' ]; then
               LATEST_BETA_NUM=$(git tag -l "v${{ env.PACKAGE_VERSION }}-*" | sed 's/.*-//' | sort -nr | head -n1 || echo "0")
@@ -221,7 +221,7 @@ jobs:
               git tag -a "v${{ env.PACKAGE_VERSION }}-${NEXT_BETA_NUM}" -m "Release ${{ env.PACKAGE_VERSION }}-${NEXT_BETA_NUM}"
               git push origin "v${{ env.PACKAGE_VERSION }}-${NEXT_BETA_NUM}"
             fi
-            npm run packages:release ${{ github.event.inputs.dry_run && '-- --dry-run' || '' }}
+            npm run release ${{ github.event.inputs.dry_run && '-- --dry-run' || '' }}
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.MAINTAIN_TOKEN }}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update GitHub workflow to use the correct release command when publishing packages from the packages directory.
Main changes:
- Changed npm run command from `packages:release` to `release` in the one-click-release workflow

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
