### PR TITLE
Tweak: Move ‘Load Google Fonts locally’ to Settings > Performance [ED-20964] (CP)

### DIFF
--- a/core/files/fonts/google-font.php
+++ b/core/files/fonts/google-font.php
@@ -33,6 +33,11 @@ class Google_Font {
 			return true;
 		}
 
+		$is_local_gf_enabled = (bool) get_option( 'elementor_lazy_load_background_images', '0' );
+		if ( ! $is_local_gf_enabled ) {
+			$force_enqueue_from_cdn = true;
+		}
+
 		if ( $force_enqueue_from_cdn || ! static::fetch_font_data( $font_name, $font_type ) ) {
 			static::enqueue_from_cdn( $font_name, $font_type );
 			return false;

--- a/includes/settings/settings.php
+++ b/includes/settings/settings.php
@@ -467,6 +467,18 @@ class Settings extends Settings_Page {
 									'desc' => esc_html__( 'Improve initial page load performance by lazy loading all background images except the first one.', 'elementor' ),
 								],
 							],
+							'local_google_fonts' => [
+								'label' => esc_html__( 'Load Google Fonts Locally', 'elementor' ),
+								'field_args' => [
+									'type' => 'select',
+									'std' => '0',
+									'options' => [
+										'1' => esc_html__( 'Enable', 'elementor' ),
+										'0' => esc_html__( 'Disable', 'elementor' ),
+									],
+									'desc' => esc_html__( 'Load Google fonts locally to benefit from faster performance and ensure GDPR compliance. Fonts will be served from your own server instead of Google’s. Only the very first load (in the editor and on the front end) may take slightly longer.', 'elementor' ),
+								],
+							],
 						],
 					],
 				],

--- a/tests/phpunit/elementor/includes/test-tracker.php
+++ b/tests/phpunit/elementor/includes/test-tracker.php
@@ -62,6 +62,8 @@ class Test_Tracker extends Elementor_Test_Base {
 		update_option( 'elementor_optimized_image_loading', '1' );
 		update_option( 'elementor_optimized_gutenberg_loading', '1' );
 		update_option( 'elementor_lazy_load_background_images', '1' );
+		update_option( 'elementor_local_google_fonts', '1' );
+
 
 		// Act.
 		$actual = Tracker::get_settings_performance_usage();
@@ -72,6 +74,7 @@ class Test_Tracker extends Elementor_Test_Base {
 			'optimized_image_loading' => '1',
 			'optimized_gutenberg_loading' => '1',
 			'lazy_load_background_images' => '1',
+			'local_google_fonts' => '1',
 		], $actual );
 	}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Move Google Fonts local loading functionality to Settings > Performance section for better user configuration and GDPR compliance.
Main changes:
- Added new 'Load Google Fonts Locally' setting option in Performance settings panel
- Implemented conditional Google Fonts loading based on user setting preference
- Updated tracker to monitor local Google Fonts usage data

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
