### PR TITLE
Fix: Structure Panel Indicators don't appear on RTL layouts [ED-21040]

### DIFF
--- a/assets/dev/scss/editor/navigator/navigator.scss
+++ b/assets/dev/scss/editor/navigator/navigator.scss
@@ -53,7 +53,7 @@ body {
 		#elementor-navigator__ai-titles + &__title {
 			padding-inline-end: 17.5px;
 		}
-		
+
 	}
 
 	&__ai-titles {
@@ -319,7 +319,7 @@ body {
 			z-index: 91;
 
 			&:not(:hover) {
-				transform: translateX(calc(100% * var(--direction-multiplier) - var(--e-editor-navigator-indicator-width)));
+				transform: translateX(calc(100% * var(--direction-multiplier) - (var(--e-editor-navigator-indicator-width) * var(--direction-multiplier))));
 			}
 		}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Structure Panel Indicators alignment issue in RTL layouts by correcting the transform calculation logic.
Main changes:
- Fixed transform calculation for indicator elements by multiplying indicator width with direction multiplier
- Added proper spacing in navigator SCSS to ensure consistent rendering

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
