### PR TITLE
Internal: Register nested elements under experiment

### DIFF
--- a/modules/atomic-widgets/assets/js/editor/module.js
+++ b/modules/atomic-widgets/assets/js/editor/module.js
@@ -25,13 +25,18 @@ class Module extends elementorModules.editor.utils.Module {
 	}
 
 	registerAtomicElements() {
+		const nestedElementsExperiment = 'e_nested_elements';
+
 		elementor.elementsManager.registerElementType( createDivBlockType() );
 		elementor.elementsManager.registerElementType( createFlexboxType() );
-		elementor.elementsManager.registerElementType( createAtomicTabsType() );
-		elementor.elementsManager.registerElementType( createAtomicTabPanelType() );
-		elementor.elementsManager.registerElementType( createAtomicTabType() );
-		elementor.elementsManager.registerElementType( createAtomicTabsListType() );
-		elementor.elementsManager.registerElementType( createAtomicTabsContentType() );
+
+		if ( elementorCommon.config.experimentalFeatures[ nestedElementsExperiment ] ) {
+			elementor.elementsManager.registerElementType( createAtomicTabsType() );
+			elementor.elementsManager.registerElementType( createAtomicTabPanelType() );
+			elementor.elementsManager.registerElementType( createAtomicTabType() );
+			elementor.elementsManager.registerElementType( createAtomicTabsListType() );
+			elementor.elementsManager.registerElementType( createAtomicTabsContentType() );
+		}
 	}
 }
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Register nested tab elements conditionally based on the experimental feature flag for improved feature control.
Main changes:
- Added conditional registration of atomic tabs elements behind 'e_nested_elements' experiment flag
- Moved tab-related element types under experimental feature control
- Created constant for experiment name to improve maintainability

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
