### PR TITLE
Fix: Changes in the API-Info break the way several 3rd party plugin serve their templates (#32811) [ED-21059]

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -18,6 +18,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Api {
 
 	/**
+	 * Elementor library option key.
+	 */
+	const LIBRARY_OPTION_KEY = 'elementor_remote_info_library';
+
+	/**
 	 * Elementor feed option key.
 	 */
 	const FEED_OPTION_KEY = 'elementor_remote_info_feed_data';
@@ -219,7 +224,22 @@ class Api {
 
 		$library_data = json_decode( wp_remote_retrieve_body( $response ), true );
 
-		return empty( $library_data ) ? [] : $library_data;
+		/**
+		 * Filters the library data to allow 3rd party extending the response data.
+		 *
+		 * @since 3.32.2
+		 * @param-out array $library_data an array of templates data.
+		 */
+		$library_data = apply_filters( 'elementor/remote/library/data', $library_data );
+
+		if ( empty( $library_data ) || ! is_array( $library_data ) ) {
+			return [];
+		}
+
+		// the following update & get are a temporary measure, to allow 3rd party plugins inject more templates:
+		update_option( self::LIBRARY_OPTION_KEY, $library_data, 'no' );
+
+		return get_option( self::LIBRARY_OPTION_KEY, $library_data );
 	}
 
 	/**

--- a/includes/template-library/manager.php
+++ b/includes/template-library/manager.php
@@ -252,10 +252,18 @@ class Manager {
 
 		$filter_sources = ! empty( $args['filter_sources'] ) ? $args['filter_sources'] : [];
 
-		return [
+		$full_library_data = [
 			'templates' => $this->get_templates( $filter_sources, $force_update ),
 			'config' => $library_data['types_data'],
 		];
+
+		/**
+		 * Filter the full library data.
+		 *
+		 * @since 3.32.2
+		 * @param-out $full_library_data - 'templates' and 'config' data ('config' holds the list of categories).
+		 */
+		return apply_filters( 'elementor/library/full-data', $full_library_data );
 	}
 
 	/**


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not
include enough information to be reviewed in a timely manner may be
closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:
https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no
spaces eg: [x]. -->
- [ X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Changes in the API-Info break the way several 3rd party plugin
serve their templates

## Description
* Restore the `LIBRARY_OPTION_KEY` const, used by 3rd party plugins'
templates and add a filter as the official method

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix template library data handling to restore compatibility with 3rd party plugins that extend template functionality.

Main changes:
- Added LIBRARY_OPTION_KEY constant and persistent storage for template data
- Implemented filter hook 'elementor/remote/library/data' for 3rd party template injection
- Added 'elementor/library/full-data' filter to modify complete library data structure

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->

---------

Co-authored-by: Louis Wolmarans <louiswol94@gmail.com>