### PR TITLE
Tweak: Clear Cache after Enabling/Disabling Load Google Fonts Locally (#32795) [ED-21060]

### DIFF
--- a/core/files/fonts/google-font.php
+++ b/core/files/fonts/google-font.php
@@ -33,7 +33,7 @@ class Google_Font {
 			return true;
 		}
 
-		$is_local_gf_enabled = (bool) get_option( 'elementor_lazy_load_background_images', '0' );
+		$is_local_gf_enabled = (bool) get_option( 'elementor_local_google_fonts', '0' );
 		if ( ! $is_local_gf_enabled ) {
 			$force_enqueue_from_cdn = true;
 		}

--- a/includes/settings/settings.php
+++ b/includes/settings/settings.php
@@ -571,6 +571,7 @@ class Settings extends Settings_Page {
 			'elementor_disable_color_schemes',
 			'elementor_disable_typography_schemes',
 			'elementor_css_print_method',
+			'elementor_local_google_fonts',
 		];
 
 		foreach ( $css_settings as $option_name ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Google Fonts local loading feature by correcting option name and ensuring cache clears when the setting changes.
Main changes:
- Fixed incorrect option name from 'elementor_lazy_load_background_images' to 'elementor_local_google_fonts'
- Added 'elementor_local_google_fonts' to CSS settings that trigger cache clearing when updated

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
