### PR TITLE
Tweak: Add FE validation when exporting kit name [ED-20918]

### DIFF
--- a/app/modules/import-export-customization/assets/js/export/components/export-kit-footer.js
+++ b/app/modules/import-export-customization/assets/js/export/components/export-kit-footer.js
@@ -11,7 +11,7 @@ export default function ExportKitFooter() {
 	const connectButtonRef = useRef();
 	const navigate = useNavigate();
 	const { isConnected, isConnecting, setConnecting, handleConnectSuccess, handleConnectError } = useConnectState();
-	const { data, dispatch, isTemplateNameValid, hasValidationErrors, isExporting } = useExportContext();
+	const { data, dispatch, hasValidationErrors, isExporting } = useExportContext();
 
 	const { data: cloudKitsData, isLoading: isCheckingEligibility, refetch: refetchEligibility } = useCloudKitsEligibility( {
 		enabled: isConnected,
@@ -104,7 +104,7 @@ export default function ExportKitFooter() {
 					variant="outlined"
 					color="secondary"
 					size="small"
-					disabled={ ! isTemplateNameValid || hasValidationErrors }
+					disabled={ hasValidationErrors }
 					href={ elementorAppConfig?.[ 'cloud-library' ]?.library_connect_url?.replace( /&#038;/g, '&' ) || '#' }
 					data-testid="export-kit-footer-save-to-library-button"
 				>
@@ -134,7 +134,7 @@ export default function ExportKitFooter() {
 					variant="outlined"
 					color="secondary"
 					size="small"
-					disabled={ ! isTemplateNameValid || hasValidationErrors }
+					disabled={ hasValidationErrors }
 					onClick={ handleUpgradeClick }
 					data-testid="export-kit-footer-save-to-library-button"
 				>
@@ -148,7 +148,7 @@ export default function ExportKitFooter() {
 				variant="outlined"
 				color="secondary"
 				size="small"
-				disabled={ ! isTemplateNameValid }
+				disabled={ hasValidationErrors }
 				onClick={ handleUploadClick }
 				data-testid="export-kit-footer-save-to-library-button"
 			>
@@ -164,7 +164,7 @@ export default function ExportKitFooter() {
 				variant="contained"
 				color="primary"
 				size="small"
-				disabled={ ! isTemplateNameValid }
+				disabled={ hasValidationErrors }
 				onClick={ handleExportAsZip }
 				data-testid="export-kit-footer-export-zip-button"
 			>

--- a/app/modules/import-export-customization/assets/js/export/components/export-kit-footer.js
+++ b/app/modules/import-export-customization/assets/js/export/components/export-kit-footer.js
@@ -11,7 +11,7 @@ export default function ExportKitFooter() {
 	const connectButtonRef = useRef();
 	const navigate = useNavigate();
 	const { isConnected, isConnecting, setConnecting, handleConnectSuccess, handleConnectError } = useConnectState();
-	const { data, dispatch, isTemplateNameValid, isExporting } = useExportContext();
+	const { data, dispatch, isTemplateNameValid, hasValidationErrors, isExporting } = useExportContext();
 
 	const { data: cloudKitsData, isLoading: isCheckingEligibility, refetch: refetchEligibility } = useCloudKitsEligibility( {
 		enabled: isConnected,
@@ -72,11 +72,19 @@ export default function ExportKitFooter() {
 	};
 
 	const handleUploadClick = () => {
+		if ( hasValidationErrors ) {
+			return;
+		}
+
 		dispatch( { type: 'SET_KIT_SAVE_SOURCE', payload: 'cloud' } );
 		dispatch( { type: 'SET_EXPORT_STATUS', payload: EXPORT_STATUS.EXPORTING } );
 	};
 
 	const handleExportAsZip = () => {
+		if ( hasValidationErrors ) {
+			return;
+		}
+
 		const hasCloudMediaFormat = 'cloud' === data.customization?.content?.mediaFormat;
 
 		if ( hasCloudMediaFormat ) {
@@ -96,7 +104,7 @@ export default function ExportKitFooter() {
 					variant="outlined"
 					color="secondary"
 					size="small"
-					disabled={ ! isTemplateNameValid }
+					disabled={ ! isTemplateNameValid || hasValidationErrors }
 					href={ elementorAppConfig?.[ 'cloud-library' ]?.library_connect_url?.replace( /&#038;/g, '&' ) || '#' }
 					data-testid="export-kit-footer-save-to-library-button"
 				>
@@ -126,7 +134,7 @@ export default function ExportKitFooter() {
 					variant="outlined"
 					color="secondary"
 					size="small"
-					disabled={ ! isTemplateNameValid }
+					disabled={ ! isTemplateNameValid || hasValidationErrors }
 					onClick={ handleUpgradeClick }
 					data-testid="export-kit-footer-save-to-library-button"
 				>

--- a/app/modules/import-export-customization/assets/js/export/components/kit-info.js
+++ b/app/modules/import-export-customization/assets/js/export/components/kit-info.js
@@ -1,14 +1,16 @@
 import { Typography, Input, Box } from '@elementor/ui';
 
-import { useExportContext } from '../context/export-context';
+import { useKitValidation } from '../hooks/use-kit-validation';
 
 export default function KitInfo() {
-	const { data, dispatch } = useExportContext();
-
-	const { templateName, description } = {
-		templateName: data.kitInfo.title || '',
-		description: data.kitInfo.description || '',
-	};
+	const {
+		templateName,
+		description,
+		nameError,
+		handleNameChange,
+		handleDescriptionChange,
+		DESCRIPTION_MAX_LENGTH,
+	} = useKitValidation();
 
 	return (
 		<Box sx={ { mb: 3, border: 1, borderRadius: 1, borderColor: 'action.focus', p: 3.5 } }>
@@ -19,11 +21,17 @@ export default function KitInfo() {
 				fullWidth
 				required
 				value={ templateName }
-				onChange={ ( e ) => dispatch( { type: 'SET_KIT_TITLE', payload: e.target.value || '' } ) }
+				onChange={ handleNameChange }
 				placeholder={ __( 'Type name here...', 'elementor' ) }
 				inputProps={ { maxLength: 75 } }
-				sx={ { mb: 2 } }
+				error={ !! nameError }
+				sx={ { mb: nameError ? 1 : 2 } }
 			/>
+			{ nameError && (
+				<Typography color="error.main" variant="caption" sx={ { mb: 2, display: 'block' } }>
+					{ nameError }
+				</Typography>
+			) }
 
 			<Typography variant="caption" component="label" color="text.secondary">
 				{ __( 'Description (Optional)', 'elementor' ) }
@@ -32,9 +40,18 @@ export default function KitInfo() {
 				fullWidth
 				multiline
 				value={ description }
-				onChange={ ( e ) => dispatch( { type: 'SET_KIT_DESCRIPTION', payload: e.target.value || '' } ) }
+				onChange={ handleDescriptionChange }
 				placeholder={ __( 'Type description here...', 'elementor' ) }
+				inputProps={ { maxLength: DESCRIPTION_MAX_LENGTH } }
+				error={ description.length > DESCRIPTION_MAX_LENGTH }
 			/>
+			<Typography
+				variant="caption"
+				color={ description.length > DESCRIPTION_MAX_LENGTH ? 'error' : 'text.secondary' }
+				sx={ { mt: 0.5, display: 'block' } }
+			>
+				{ description.length } / { DESCRIPTION_MAX_LENGTH } { __( 'characters', 'elementor' ) }
+			</Typography>
 		</Box>
 	);
 }

--- a/app/modules/import-export-customization/assets/js/export/components/kit-info.js
+++ b/app/modules/import-export-customization/assets/js/export/components/kit-info.js
@@ -7,6 +7,8 @@ export default function KitInfo() {
 		templateName,
 		description,
 		nameError,
+		hasDescriptionError,
+		descriptionCounterColor,
 		handleNameChange,
 		handleDescriptionChange,
 		DESCRIPTION_MAX_LENGTH,
@@ -43,11 +45,11 @@ export default function KitInfo() {
 				onChange={ handleDescriptionChange }
 				placeholder={ __( 'Type description here...', 'elementor' ) }
 				inputProps={ { maxLength: DESCRIPTION_MAX_LENGTH } }
-				error={ description.length > DESCRIPTION_MAX_LENGTH }
+				error={ hasDescriptionError }
 			/>
 			<Typography
 				variant="caption"
-				color={ description.length > DESCRIPTION_MAX_LENGTH ? 'error' : 'text.secondary' }
+				color={ descriptionCounterColor }
 				sx={ { mt: 0.5, display: 'block' } }
 			>
 				{ description.length } / { DESCRIPTION_MAX_LENGTH } { __( 'characters', 'elementor' ) }

--- a/app/modules/import-export-customization/assets/js/export/context/export-context.js
+++ b/app/modules/import-export-customization/assets/js/export/context/export-context.js
@@ -35,6 +35,10 @@ const initialState = {
 		},
 	},
 	showMediaFormatValidation: false,
+	validationErrors: {
+		name: null,
+		description: null,
+	},
 };
 
 function exportReducer( state, { type, payload } ) {
@@ -90,6 +94,8 @@ function exportReducer( state, { type, payload } ) {
 			};
 		case 'SET_MEDIA_FORMAT_VALIDATION':
 			return { ...state, showMediaFormatValidation: payload };
+		case 'SET_VALIDATION_ERRORS':
+			return { ...state, validationErrors: { ...state.validationErrors, ...payload } };
 		case 'RESET_STATE':
 			return { ...initialState };
 		default:
@@ -103,7 +109,8 @@ export function ExportContextProvider( { children } ) {
 	const value = {
 		data,
 		dispatch,
-		isTemplateNameValid: ( data.kitInfo.title?.trim() || '' ).length > 0,
+		isTemplateNameValid: ( data.kitInfo.title?.trim() || '' ).length > 0 && ! data.validationErrors.name,
+		hasValidationErrors: !! ( data.validationErrors.name || data.validationErrors.description ),
 		isExporting: data.exportStatus === EXPORT_STATUS.EXPORTING,
 		isCompleted: data.exportStatus === EXPORT_STATUS.COMPLETED,
 		isPending: data.exportStatus === EXPORT_STATUS.PENDING,

--- a/app/modules/import-export-customization/assets/js/export/context/export-context.js
+++ b/app/modules/import-export-customization/assets/js/export/context/export-context.js
@@ -106,11 +106,14 @@ function exportReducer( state, { type, payload } ) {
 export function ExportContextProvider( { children } ) {
 	const [ data, dispatch ] = useReducer( exportReducer, initialState );
 
+	const isNameEmpty = ! ( data.kitInfo.title?.trim() || '' ).length;
+	const hasNameError = data.validationErrors.name || isNameEmpty;
+	const hasDescriptionError = data.validationErrors.description;
+
 	const value = {
 		data,
 		dispatch,
-		isTemplateNameValid: ( data.kitInfo.title?.trim() || '' ).length > 0 && ! data.validationErrors.name,
-		hasValidationErrors: !! ( data.validationErrors.name || data.validationErrors.description ),
+		hasValidationErrors: !! ( hasNameError || hasDescriptionError ),
 		isExporting: data.exportStatus === EXPORT_STATUS.EXPORTING,
 		isCompleted: data.exportStatus === EXPORT_STATUS.COMPLETED,
 		isPending: data.exportStatus === EXPORT_STATUS.PENDING,

--- a/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation.js
+++ b/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation.js
@@ -1,0 +1,76 @@
+import { useState, useEffect } from 'react';
+import { useExportContext } from '../context/export-context';
+
+export function useKitValidation() {
+	const { data, dispatch } = useExportContext();
+	const [ nameError, setNameError ] = useState( null );
+
+	const DESCRIPTION_MAX_LENGTH = 300;
+
+	const validateKitName = ( value ) => {
+		if ( ! value || 0 === value.trim().length ) {
+			return __( 'Website template name is required', 'elementor' );
+		}
+
+		const specialCharsRegex = /[<>:"/\\|?*]/g;
+		const problematicCharsRegex = /[^\w\s\-_.()]/g;
+
+		if ( specialCharsRegex.test( value ) ) {
+			return __( 'Special characters < > : " / \\ | ? * are not allowed', 'elementor' );
+		}
+
+		if ( problematicCharsRegex.test( value ) ) {
+			return __( 'Only letters, numbers, spaces, and basic punctuation (- _ . ( )) are allowed', 'elementor' );
+		}
+
+		return null;
+	};
+
+	const validateDescription = ( value ) => {
+		if ( value.length > DESCRIPTION_MAX_LENGTH ) {
+			return __( 'Description exceeds 300 characters', 'elementor' );
+		}
+		return null;
+	};
+
+	const templateName = data.kitInfo.title || '';
+	const description = data.kitInfo.description || '';
+
+	useEffect( () => {
+		const nameValidationError = validateKitName( templateName );
+		const descriptionValidationError = validateDescription( description );
+
+		setNameError( nameValidationError );
+
+		dispatch( {
+			type: 'SET_VALIDATION_ERRORS',
+			payload: {
+				name: nameValidationError,
+				description: descriptionValidationError,
+			},
+		} );
+	}, [ templateName, description, dispatch ] );
+
+	const handleNameChange = ( e ) => {
+		const value = e.target.value || '';
+		dispatch( { type: 'SET_KIT_TITLE', payload: value } );
+	};
+
+	const handleDescriptionChange = ( e ) => {
+		const value = e.target.value || '';
+		if ( value.length <= DESCRIPTION_MAX_LENGTH ) {
+			dispatch( { type: 'SET_KIT_DESCRIPTION', payload: value } );
+		}
+	};
+
+	return {
+		templateName,
+		description,
+		nameError,
+		handleNameChange,
+		handleDescriptionChange,
+		DESCRIPTION_MAX_LENGTH,
+		validateKitName,
+		validateDescription,
+	};
+}

--- a/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation.js
+++ b/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation.js
@@ -32,6 +32,9 @@ export function useKitValidation() {
 	const templateName = data.kitInfo.title || '';
 	const description = data.kitInfo.description || '';
 
+	const hasDescriptionError = description.length > DESCRIPTION_MAX_LENGTH;
+	const descriptionCounterColor = hasDescriptionError ? 'error' : 'text.secondary';
+
 	useEffect( () => {
 		const nameValidationError = validateKitName( templateName );
 		const descriptionValidationError = validateDescription( description );
@@ -63,6 +66,8 @@ export function useKitValidation() {
 		templateName,
 		description,
 		nameError,
+		hasDescriptionError,
+		descriptionCounterColor,
 		handleNameChange,
 		handleDescriptionChange,
 		DESCRIPTION_MAX_LENGTH,

--- a/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation.js
+++ b/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation.js
@@ -9,13 +9,13 @@ export function useKitValidation() {
 
 	const validateKitName = ( value ) => {
 		if ( ! value || 0 === value.trim().length ) {
-			return __( 'Website template name is required', 'elementor' );
+			return __( 'Must add a website template name', 'elementor' );
 		}
 
 		const problematicCharsRegex = /[^\w\s\-_.()]/g;
 
 		if ( problematicCharsRegex.test( value ) ) {
-			return __( 'Only letters, numbers, spaces, and basic punctuation (- _ . ( )) are allowed', 'elementor' );
+			return __( 'Use characters only', 'elementor' );
 		}
 
 		return null;

--- a/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation.js
+++ b/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation.js
@@ -12,10 +12,9 @@ export function useKitValidation() {
 			return __( 'Website template name is required', 'elementor' );
 		}
 
-		const specialCharsRegex = /[<>:"/\\|?*]/g;
 		const problematicCharsRegex = /[^\w\s\-_.()]/g;
 
-		if ( problematicCharsRegex.test( value ) || specialCharsRegex.test( value ) ) {
+		if ( problematicCharsRegex.test( value ) ) {
 			return __( 'Only letters, numbers, spaces, and basic punctuation (- _ . ( )) are allowed', 'elementor' );
 		}
 

--- a/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation.js
+++ b/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation.js
@@ -15,11 +15,7 @@ export function useKitValidation() {
 		const specialCharsRegex = /[<>:"/\\|?*]/g;
 		const problematicCharsRegex = /[^\w\s\-_.()]/g;
 
-		if ( specialCharsRegex.test( value ) ) {
-			return __( 'Special characters < > : " / \\ | ? * are not allowed', 'elementor' );
-		}
-
-		if ( problematicCharsRegex.test( value ) ) {
+		if ( problematicCharsRegex.test( value ) || specialCharsRegex.test( value ) ) {
 			return __( 'Only letters, numbers, spaces, and basic punctuation (- _ . ( )) are allowed', 'elementor' );
 		}
 
@@ -30,6 +26,7 @@ export function useKitValidation() {
 		if ( value.length > DESCRIPTION_MAX_LENGTH ) {
 			return __( 'Description exceeds 300 characters', 'elementor' );
 		}
+
 		return null;
 	};
 

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/export/components/export-kit-footer.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/export/components/export-kit-footer.test.js
@@ -55,7 +55,7 @@ describe( 'ExportKitFooter Component', () => {
 
 		useExportContext.mockReturnValue( {
 			dispatch: mockDispatch,
-			isTemplateNameValid: true,
+			hasValidationErrors: false,
 			data: {
 				customization: {
 					content: {
@@ -109,10 +109,10 @@ describe( 'ExportKitFooter Component', () => {
 			expect( saveToLibraryButton.getAttribute( 'href' ) ).toBe( 'https://example.com/connect' );
 		} );
 
-		it( 'should render Save to Library button disabled when template name is invalid', () => {
+		it( 'should render Save to Library button disabled when there are validation errors', () => {
 			useExportContext.mockReturnValue( {
 				dispatch: mockDispatch,
-				isTemplateNameValid: false,
+				hasValidationErrors: true,
 			} );
 
 			render( <ExportKitFooter /> );
@@ -129,10 +129,10 @@ describe( 'ExportKitFooter Component', () => {
 			expect( exportButton ).toBeTruthy();
 		} );
 
-		it( 'should render Export as .zip button disabled when template name is invalid', () => {
+		it( 'should render Export as .zip button disabled when there are validation errors', () => {
 			useExportContext.mockReturnValue( {
 				dispatch: mockDispatch,
-				isTemplateNameValid: false,
+				hasValidationErrors: true,
 			} );
 
 			render( <ExportKitFooter /> );
@@ -216,7 +216,7 @@ describe( 'ExportKitFooter Component', () => {
 		it( 'should not trigger export when button is disabled', () => {
 			useExportContext.mockReturnValue( {
 				dispatch: mockDispatch,
-				isTemplateNameValid: false,
+				hasValidationErrors: true,
 			} );
 
 			render( <ExportKitFooter /> );

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/export/context/export-context.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/export/context/export-context.test.js
@@ -40,18 +40,18 @@ describe( 'Export Context', () => {
 			} );
 		} );
 
-		it( 'should correctly calculate template name validity', async () => {
+		it( 'should correctly calculate validation errors', async () => {
 			const { result } = renderHook( () => useExportContext(), {
 				wrapper: createWrapper(),
 			} );
 
-			expect( result.current.isTemplateNameValid ).toBe( false );
+			expect( result.current.hasValidationErrors ).toBe( true );
 
 			await waitFor( () => {
 				result.current.dispatch( { type: 'SET_KIT_TITLE', payload: 'My Kit' } );
 			} );
 
-			expect( result.current.isTemplateNameValid ).toBe( true );
+			expect( result.current.hasValidationErrors ).toBe( false );
 		} );
 
 		it( 'should correctly calculate export status flags', () => {
@@ -296,7 +296,7 @@ describe( 'Export Context', () => {
 				result.current.dispatch( { type: 'SET_KIT_TITLE', payload: '' } );
 			} );
 
-			expect( result.current.isTemplateNameValid ).toBe( false );
+			expect( result.current.hasValidationErrors ).toBe( true );
 		} );
 
 		it( 'should validate whitespace-only title as invalid', async () => {
@@ -308,7 +308,7 @@ describe( 'Export Context', () => {
 				result.current.dispatch( { type: 'SET_KIT_TITLE', payload: '   ' } );
 			} );
 
-			expect( result.current.isTemplateNameValid ).toBe( false );
+			expect( result.current.hasValidationErrors ).toBe( true );
 		} );
 
 		it( 'should validate proper title as valid', async () => {
@@ -320,7 +320,7 @@ describe( 'Export Context', () => {
 				result.current.dispatch( { type: 'SET_KIT_TITLE', payload: 'My Kit' } );
 			} );
 
-			expect( result.current.isTemplateNameValid ).toBe( true );
+			expect( result.current.hasValidationErrors ).toBe( false );
 		} );
 	} );
 } );

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/export/context/export-context.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/export/context/export-context.test.js
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import PropTypes from 'prop-types';
 import { ExportContextProvider, useExportContext, EXPORT_STATUS } from 'elementor/app/modules/import-export-customization/assets/js/export/context/export-context';
+import { useKitValidation } from 'elementor/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation';
 
 const createWrapper = () => {
 	const Wrapper = ( { children } ) => (
@@ -40,18 +41,29 @@ describe( 'Export Context', () => {
 			} );
 		} );
 
-		it( 'should correctly calculate validation errors', async () => {
-			const { result } = renderHook( () => useExportContext(), {
+		it( 'should correctly calculate validation errors using validation hook', async () => {
+			const { result } = renderHook( () => {
+				const exportContext = useExportContext();
+				const validationHook = useKitValidation();
+				return { exportContext, validationHook };
+			}, {
 				wrapper: createWrapper(),
 			} );
 
-			expect( result.current.hasValidationErrors ).toBe( true );
+			expect( result.current.exportContext.hasValidationErrors ).toBe( true );
+			expect( result.current.validationHook.nameError ).toBeTruthy();
+
+			expect( result.current.validationHook.validateKitName( '' ) ).toBeTruthy();
+			expect( result.current.validationHook.validateKitName( 'Valid Name' ) ).toBeNull();
 
 			await waitFor( () => {
-				result.current.dispatch( { type: 'SET_KIT_TITLE', payload: 'My Kit' } );
+				result.current.exportContext.dispatch( { type: 'SET_KIT_TITLE', payload: 'My Kit' } );
 			} );
 
-			expect( result.current.hasValidationErrors ).toBe( false );
+			await waitFor( () => {
+				expect( result.current.exportContext.hasValidationErrors ).toBe( false );
+				expect( result.current.validationHook.nameError ).toBeNull();
+			} );
 		} );
 
 		it( 'should correctly calculate export status flags', () => {
@@ -321,6 +333,84 @@ describe( 'Export Context', () => {
 			} );
 
 			expect( result.current.hasValidationErrors ).toBe( false );
+		} );
+	} );
+
+	describe( 'Kit Validation Hook', () => {
+		it( 'should validate special characters in kit name', () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const validateKitName = result.current.validateKitName;
+
+			// Test special characters that should be rejected
+			expect( validateKitName( 'Kit<Name>' ) ).toBeTruthy();
+			expect( validateKitName( 'Kit"Name"' ) ).toBeTruthy();
+			expect( validateKitName( 'Kit|Name' ) ).toBeTruthy();
+			expect( validateKitName( 'Kit?Name' ) ).toBeTruthy();
+			expect( validateKitName( 'Kit*Name' ) ).toBeTruthy();
+
+			// Test valid characters that should be accepted
+			expect( validateKitName( 'My Kit Name' ) ).toBeNull();
+			expect( validateKitName( 'Kit-Name_123' ) ).toBeNull();
+			expect( validateKitName( 'Kit.Name(1)' ) ).toBeNull();
+		} );
+
+		it( 'should validate description length', async () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const validateDescription = result.current.validateDescription;
+			const DESCRIPTION_MAX_LENGTH = result.current.DESCRIPTION_MAX_LENGTH;
+
+			// Test valid description
+			expect( validateDescription( 'Short description' ) ).toBeNull();
+
+			// Test description at exactly max length
+			const exactLengthDescription = 'a'.repeat( DESCRIPTION_MAX_LENGTH );
+			expect( validateDescription( exactLengthDescription ) ).toBeNull();
+
+			// Test description exceeding max length
+			const tooLongDescription = 'a'.repeat( DESCRIPTION_MAX_LENGTH + 1 );
+			expect( validateDescription( tooLongDescription ) ).toBeTruthy();
+		} );
+
+		it( 'should handle description change validation', async () => {
+			const { result } = renderHook( () => {
+				const exportContext = useExportContext();
+				const validationHook = useKitValidation();
+				return { exportContext, validationHook };
+			}, {
+				wrapper: createWrapper(),
+			} );
+
+			// Set initial valid description
+			await waitFor( () => {
+				result.current.exportContext.dispatch( {
+					type: 'SET_KIT_DESCRIPTION',
+					payload: 'Valid description',
+				} );
+			} );
+
+			expect( result.current.validationHook.hasDescriptionError ).toBe( false );
+			expect( result.current.validationHook.descriptionCounterColor ).toBe( 'text.secondary' );
+
+			// Set description that exceeds limit
+			const longDescription = 'a'.repeat( 301 );
+			await waitFor( () => {
+				result.current.exportContext.dispatch( {
+					type: 'SET_KIT_DESCRIPTION',
+					payload: longDescription,
+				} );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.validationHook.hasDescriptionError ).toBe( true );
+				expect( result.current.validationHook.descriptionCounterColor ).toBe( 'error' );
+				expect( result.current.exportContext.hasValidationErrors ).toBe( true );
+			} );
 		} );
 	} );
 } );

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation.test.js
@@ -1,0 +1,373 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import PropTypes from 'prop-types';
+import { ExportContextProvider } from 'elementor/app/modules/import-export-customization/assets/js/export/context/export-context';
+import { useKitValidation } from 'elementor/app/modules/import-export-customization/assets/js/export/hooks/use-kit-validation';
+
+const createWrapper = () => {
+	const Wrapper = ( { children } ) => (
+		<ExportContextProvider>
+			{ children }
+		</ExportContextProvider>
+	);
+
+	Wrapper.propTypes = {
+		children: PropTypes.node.isRequired,
+	};
+
+	return Wrapper;
+};
+
+describe( 'useKitValidation Hook', () => {
+	describe( 'Initial State', () => {
+		it( 'should initialize with correct default values', async () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			expect( result.current.templateName ).toBe( '' );
+			expect( result.current.description ).toBe( '' );
+			expect( result.current.hasDescriptionError ).toBe( false );
+			expect( result.current.descriptionCounterColor ).toBe( 'text.secondary' );
+			expect( result.current.DESCRIPTION_MAX_LENGTH ).toBe( 300 );
+			expect( typeof result.current.handleNameChange ).toBe( 'function' );
+			expect( typeof result.current.handleDescriptionChange ).toBe( 'function' );
+			expect( typeof result.current.validateKitName ).toBe( 'function' );
+			expect( typeof result.current.validateDescription ).toBe( 'function' );
+
+			// Name should have validation error since it starts empty
+			await waitFor( () => {
+				expect( result.current.nameError ).toBe( 'Must add a website template name' );
+			} );
+		} );
+	} );
+
+	describe( 'Name Validation', () => {
+		it( 'should validate empty name as invalid', () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const validateKitName = result.current.validateKitName;
+
+			expect( validateKitName( '' ) ).toBe( 'Must add a website template name' );
+			expect( validateKitName( null ) ).toBe( 'Must add a website template name' );
+			expect( validateKitName( undefined ) ).toBe( 'Must add a website template name' );
+		} );
+
+		it( 'should validate whitespace-only name as invalid', () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const validateKitName = result.current.validateKitName;
+
+			expect( validateKitName( '   ' ) ).toBe( 'Must add a website template name' );
+			expect( validateKitName( '\t\n' ) ).toBe( 'Must add a website template name' );
+			expect( validateKitName( '    \r\n   ' ) ).toBe( 'Must add a website template name' );
+		} );
+
+		it( 'should reject special characters', () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const validateKitName = result.current.validateKitName;
+
+			expect( validateKitName( 'Kit<Name' ) ).toBe( 'Use characters only' );
+			expect( validateKitName( 'Kit>Name' ) ).toBe( 'Use characters only' );
+			expect( validateKitName( 'Kit:Name' ) ).toBe( 'Use characters only' );
+			expect( validateKitName( 'Kit"Name' ) ).toBe( 'Use characters only' );
+			expect( validateKitName( 'Kit/Name' ) ).toBe( 'Use characters only' );
+			expect( validateKitName( 'Kit\\Name' ) ).toBe( 'Use characters only' );
+			expect( validateKitName( 'Kit|Name' ) ).toBe( 'Use characters only' );
+			expect( validateKitName( 'Kit?Name' ) ).toBe( 'Use characters only' );
+			expect( validateKitName( 'Kit*Name' ) ).toBe( 'Use characters only' );
+
+			expect( validateKitName( 'Kit<>Name' ) ).toBe( 'Use characters only' );
+			expect( validateKitName( 'Kit"Name"|Test' ) ).toBe( 'Use characters only' );
+
+			expect( validateKitName( '<KitName' ) ).toBe( 'Use characters only' );
+			expect( validateKitName( 'KitName>' ) ).toBe( 'Use characters only' );
+			expect( validateKitName( 'Kit<Na>me' ) ).toBe( 'Use characters only' );
+		} );
+
+		it( 'should accept valid characters', () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const validateKitName = result.current.validateKitName;
+
+			expect( validateKitName( 'My Kit' ) ).toBeNull();
+			expect( validateKitName( 'Kit Name' ) ).toBeNull();
+			expect( validateKitName( 'Simple Kit' ) ).toBeNull();
+
+			expect( validateKitName( 'Kit 123' ) ).toBeNull();
+			expect( validateKitName( '2023 Kit' ) ).toBeNull();
+			expect( validateKitName( 'Kit2023' ) ).toBeNull();
+
+			expect( validateKitName( 'Kit-Name' ) ).toBeNull();
+			expect( validateKitName( 'Kit_Name' ) ).toBeNull();
+			expect( validateKitName( 'Kit.Name' ) ).toBeNull();
+			expect( validateKitName( 'Kit(Name)' ) ).toBeNull();
+
+			expect( validateKitName( 'My-Kit_2023.v1' ) ).toBeNull();
+			expect( validateKitName( 'Corporate Kit (Version 2)' ) ).toBeNull();
+			expect( validateKitName( 'Kit_Name-123.final' ) ).toBeNull();
+		} );
+
+		it( 'should handle edge cases', () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const validateKitName = result.current.validateKitName;
+
+			expect( validateKitName( 'A' ) ).toBeNull();
+			expect( validateKitName( '1' ) ).toBeNull();
+
+			const longValidName = 'A'.repeat( 75 );
+			expect( validateKitName( longValidName ) ).toBeNull();
+
+			expect( validateKitName( 'MyKitName' ) ).toBeNull();
+			expect( validateKitName( 'KITNAME' ) ).toBeNull();
+			expect( validateKitName( 'kitname' ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'Description Validation', () => {
+		it( 'should validate description length correctly', () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const validateDescription = result.current.validateDescription;
+			const DESCRIPTION_MAX_LENGTH = result.current.DESCRIPTION_MAX_LENGTH;
+
+			expect( validateDescription( '' ) ).toBeNull();
+
+			expect( validateDescription( 'Short description' ) ).toBeNull();
+
+			const exactLengthDescription = 'a'.repeat( DESCRIPTION_MAX_LENGTH );
+			expect( validateDescription( exactLengthDescription ) ).toBeNull();
+
+			const tooLongDescription = 'a'.repeat( DESCRIPTION_MAX_LENGTH + 1 );
+			expect( validateDescription( tooLongDescription ) ).toBe( 'Description exceeds 300 characters' );
+
+			const muchTooLongDescription = 'a'.repeat( DESCRIPTION_MAX_LENGTH + 100 );
+			expect( validateDescription( muchTooLongDescription ) ).toBe( 'Description exceeds 300 characters' );
+		} );
+
+		it( 'should handle special characters in description', () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const validateDescription = result.current.validateDescription;
+
+			expect( validateDescription( 'Description with <special> characters' ) ).toBeNull();
+			expect( validateDescription( 'Description with "quotes" and | pipes' ) ).toBeNull();
+			expect( validateDescription( 'Description with ? and * wildcards' ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'Computed Properties', () => {
+		it( 'should compute hasDescriptionError correctly', async () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			expect( result.current.hasDescriptionError ).toBe( false );
+
+			const mockEvent = {
+				target: { value: 'a'.repeat( 301 ) },
+			};
+
+			await waitFor( () => {
+				result.current.handleDescriptionChange( mockEvent );
+			} );
+
+			expect( result.current.hasDescriptionError ).toBe( false );
+		} );
+
+		it( 'should compute descriptionCounterColor correctly', () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			expect( result.current.descriptionCounterColor ).toBe( 'text.secondary' );
+
+			// Should change to error when hasDescriptionError is true
+		} );
+	} );
+
+	describe( 'Change Handlers', () => {
+		it( 'should handle name changes correctly', async () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const mockEvent = {
+				target: { value: 'New Kit Name' },
+			};
+
+			await waitFor( () => {
+				result.current.handleNameChange( mockEvent );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.templateName ).toBe( 'New Kit Name' );
+			} );
+		} );
+
+		it( 'should handle empty name changes', async () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const mockEvent = {
+				target: { value: '' },
+			};
+
+			await waitFor( () => {
+				result.current.handleNameChange( mockEvent );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.templateName ).toBe( '' );
+			} );
+		} );
+
+		it( 'should handle description changes within limit', async () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const validDescription = 'This is a valid description';
+			const mockEvent = {
+				target: { value: validDescription },
+			};
+
+			await waitFor( () => {
+				result.current.handleDescriptionChange( mockEvent );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.description ).toBe( validDescription );
+			} );
+		} );
+
+		it( 'should prevent description changes exceeding limit', async () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const tooLongDescription = 'a'.repeat( 301 );
+			const mockEvent = {
+				target: { value: tooLongDescription },
+			};
+
+			const initialDescription = result.current.description;
+
+			await waitFor( () => {
+				result.current.handleDescriptionChange( mockEvent );
+			} );
+
+			expect( result.current.description ).toBe( initialDescription );
+		} );
+
+		it( 'should handle description at exact limit', async () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const exactLimitDescription = 'a'.repeat( 300 );
+			const mockEvent = {
+				target: { value: exactLimitDescription },
+			};
+
+			await waitFor( () => {
+				result.current.handleDescriptionChange( mockEvent );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.description ).toBe( exactLimitDescription );
+			} );
+		} );
+
+		it( 'should handle null/undefined event values', async () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			const mockEventNull = {
+				target: { value: null },
+			};
+
+			await waitFor( () => {
+				result.current.handleNameChange( mockEventNull );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.templateName ).toBe( '' );
+			} );
+
+			const mockEventUndefined = {
+				target: { value: undefined },
+			};
+
+			await waitFor( () => {
+				result.current.handleDescriptionChange( mockEventUndefined );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.description ).toBe( '' );
+			} );
+		} );
+	} );
+
+	describe( 'Integration with Export Context', () => {
+		it( 'should update validation errors in context', async () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			await waitFor( () => {
+				expect( result.current.nameError ).toBe( 'Must add a website template name' );
+			} );
+
+			const validNameEvent = {
+				target: { value: 'Valid Kit Name' },
+			};
+
+			await waitFor( () => {
+				result.current.handleNameChange( validNameEvent );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.nameError ).toBeNull();
+			} );
+		} );
+
+		it( 'should validate on initial render with existing data', async () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			await waitFor( () => {
+				expect( result.current.nameError ).toBe( 'Must add a website template name' ); // Empty name is invalid
+			} );
+		} );
+	} );
+
+	describe( 'Constants', () => {
+		it( 'should expose correct constants', () => {
+			const { result } = renderHook( () => useKitValidation(), {
+				wrapper: createWrapper(),
+			} );
+
+			expect( result.current.DESCRIPTION_MAX_LENGTH ).toBe( 300 );
+			expect( typeof result.current.DESCRIPTION_MAX_LENGTH ).toBe( 'number' );
+		} );
+	} );
+} );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Add max length counter to description
* Validate name on the FE following the same rules as on the BE ( Sanitize title )
* Prevent submission if something is invalid

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

* Go to Kit export and try to use special chars in the name.
* type into the description

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description

Purpose: Add form validation for kit name and description fields in the export customization module to prevent invalid submissions.

Main changes:
- Implemented character validation for kit names, rejecting special characters
- Added description field length validation with 300 character limit and visual counter
- Replaced isTemplateNameValid with comprehensive hasValidationErrors state to control button enabling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
