### PR TITLE
Tweak: Prevent closing export/import customization modals when clicking outside [ED-20920]

### DIFF
--- a/app/modules/import-export-customization/assets/js/shared/components/kit-customization-dialog.js
+++ b/app/modules/import-export-customization/assets/js/shared/components/kit-customization-dialog.js
@@ -17,10 +17,16 @@ export function KitCustomizationDialog( {
 	children,
 	saveDisabled = false,
 } ) {
+	const handleDialogClose = ( _event, reason ) => {
+		if ( 'escapeKeyDown' === reason ) {
+			handleClose();
+		}
+	};
+
 	return (
 		<Dialog
 			open={ open }
-			onClose={ handleClose }
+			onClose={ handleDialogClose }
 			maxWidth="md"
 			fullWidth
 		>


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Modify dialog behavior to prevent automatic closing when clicking outside while maintaining escape key functionality.

Main changes:
- Added custom handleDialogClose handler that only closes the dialog on escape keypress
- Removed automatic close behavior when clicking outside the dialog boundaries

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
