### PR TITLE
Internal: Update import export customization handling [ED-21120]

### DIFF
--- a/app/modules/import-export-customization/assets/js/export/pages/export-complete.js
+++ b/app/modules/import-export-customization/assets/js/export/pages/export-complete.js
@@ -50,38 +50,19 @@ export default function ExportComplete() {
 
 	useEffect( () => {
 		if ( exportedData.manifest ) {
-			let pages = '';
-
-			if ( includes.includes( 'pages' ) ) {
-				pages = analytics?.customization?.content?.includes( 'pages' ) ? 'partial' : 'all';
-			}
-
-			let postTypes = '';
-
-			if ( includes.includes( 'postTypes' ) ) {
-				postTypes = analytics?.customization?.content?.includes( 'customPostTypes' ) ? 'partial' : 'all';
-			}
-
-			let plugins = '';
-
-			if ( includes.includes( 'plugins' ) ) {
-				plugins = analytics?.customization?.plugins?.length ? 'partial' : 'all';
-			}
+			const contentCounts = getContentCounts();
 
 			AppsEventTracking.sendExportKitCustomization( {
 				kit_export_content: includes.includes( 'content' ),
 				kit_export_templates: includes.includes( 'templates' ),
 				kit_export_settings: includes.includes( 'settings' ),
 				kit_export_plugins: includes.includes( 'plugins' ),
-				kit_export_deselected: analytics?.customization,
+				kit_export_customization_modals: analytics?.customization,
 				kit_description: Boolean( kitInfo.description ),
-				kit_page_count: exportedData?.manifest?.content?.page ? Object.values( exportedData?.manifest?.content?.page ).length : 0,
-				kit_post_type_count: exportedData?.manifest?.content ? Object.keys( exportedData?.manifest?.content )
-					.filter( ( key ) => ! elementorAppConfig?.builtinWpPostTypes?.includes( key ) ).length : 0,
-				kit_post_count: exportedData?.manifest?.content?.post ? Object.values( exportedData?.manifest?.content?.post ).length : 0,
-				pages,
-				postTypes,
-				plugins,
+				kit_page_count: contentCounts.page || 0,
+				kit_post_count: contentCounts.post || 0,
+				kit_post_type_count: exportedData.manifest?.[ 'custom-post-type-title' ] ? Object.keys( exportedData.manifest?.[ 'custom-post-type-title' ] ).length : 0,
+				kit_source: kitInfo.source,
 			} );
 		}
 	}, [ includes, exportedData?.manifest, analytics?.customization, kitInfo.description ] );
@@ -159,6 +140,25 @@ export default function ExportComplete() {
 		return summaryParts.length > 0 ? summaryParts.join( ' | ' ) : __( 'No templates exported', 'elementor' );
 	};
 
+	const getContentCounts = () => {
+		const content = exportedData?.manifest?.content;
+		const wpContent = exportedData?.manifest?.[ 'wp-content' ];
+
+		const counts = {};
+
+		const countItems = ( [ docType, docs ] ) => {
+			const count = Object.keys( docs ).length;
+			if ( count > 0 ) {
+				counts[ docType ] = ( counts[ docType ] || 0 ) + count;
+			}
+		};
+
+		Object.entries( content || {} ).forEach( countItems );
+		Object.entries( wpContent || {} ).forEach( countItems );
+
+		return counts;
+	};
+
 	const getContentSummary = () => {
 		const content = exportedData?.manifest?.content;
 		const wpContent = exportedData?.manifest?.[ 'wp-content' ];
@@ -169,24 +169,14 @@ export default function ExportComplete() {
 		}
 
 		const summaryTitles = elementorAppConfig[ 'import-export-customization' ]?.summaryTitles?.content || {};
+		const counts = getContentCounts();
 
 		const summaryPartsMap = {};
 
-		const getSummaryParts = ( [ docType, docs ] ) => {
+		Object.entries( counts ).forEach( ( [ docType, count ] ) => {
 			const label = summaryTitles[ docType ];
 			if ( ! label ) {
 				return;
-			}
-
-			let count = Object.keys( docs ).length;
-			if ( 0 === count ) {
-				return;
-			}
-
-			const existingPart = summaryPartsMap[ docType ];
-
-			if ( existingPart ) {
-				count += existingPart.count;
 			}
 
 			const title = count > 1 ? label.plural : label.single;
@@ -194,10 +184,7 @@ export default function ExportComplete() {
 				count,
 				title,
 			};
-		};
-
-		Object.entries( content || {} ).forEach( getSummaryParts );
-		Object.entries( wpContent || {} ).forEach( getSummaryParts );
+		} );
 
 		if ( Object.keys( taxonomies || {} ).length ) {
 			const allTaxonomiesSet = new Set();

--- a/app/modules/import-export-customization/assets/js/import/pages/import-complete.js
+++ b/app/modules/import-export-customization/assets/js/import/pages/import-complete.js
@@ -194,7 +194,7 @@ export default function ImportComplete() {
 	}, [] );
 
 	useEffect( () => {
-		AppsEventTracking.sendExportKitCustomization( {
+		AppsEventTracking.sendImportKitCustomization( {
 			kit_source: data?.kitUploadParams?.source || 'file',
 			kit_import_content: includes.includes( 'content' ),
 			kit_import_templates: includes.includes( 'templates' ),

--- a/app/modules/import-export-customization/assets/js/shared/components/kit-content-customization-dialog.js
+++ b/app/modules/import-export-customization/assets/js/shared/components/kit-content-customization-dialog.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Stack } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
@@ -24,24 +24,6 @@ const transformAnalyticsData = ( payload, customPostTypes ) => {
 	return transformed;
 };
 
-const MEDIA_FORMAT_OPTIONS = {
-	LINK: 'link',
-	CLOUD: 'cloud',
-};
-
-const MEDIA_FORMAT_CONFIG = [
-	{
-		value: MEDIA_FORMAT_OPTIONS.LINK,
-		title: __( 'Link to media', 'elementor' ),
-		description: __( 'Stores only the URLs. The export stays light, but files load only while the original site is online.', 'elementor' ),
-	},
-	{
-		value: MEDIA_FORMAT_OPTIONS.CLOUD,
-		title: __( 'Save media to the cloud', 'elementor' ),
-		description: __( 'All images and files are stored with the template. Keeps everything intact, but the file is larger.', 'elementor' ),
-	},
-];
-
 export function KitContentCustomizationDialog( {
 	open,
 	handleClose,
@@ -51,10 +33,6 @@ export function KitContentCustomizationDialog( {
 	isOldElementorVersion,
 } ) {
 	const { customPostTypes } = useKitCustomizationCustomPostTypes( { data } );
-
-	const unselectedValues = useRef( data.analytics?.customization?.content || [] );
-	const alertRef = useRef( null );
-	const mediaFormatSectionRef = useRef( null );
 
 	const [ settings, setSettings ] = useState( () => {
 		if ( data.customization.content ) {

--- a/app/modules/import-export-customization/assets/js/shared/components/kit-settings-customization-dialog.js
+++ b/app/modules/import-export-customization/assets/js/shared/components/kit-settings-customization-dialog.js
@@ -1,12 +1,23 @@
 import { Stack } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { SettingSection } from './customization-setting-section';
 import { KitCustomizationDialog } from './kit-customization-dialog';
 import { AppsEventTracking } from 'elementor-app/event-track/apps-event-tracking';
 import useContextDetection from '../hooks/use-context-detection';
 import { UpgradeVersionBanner } from './upgrade-version-banner';
+import { transformValueForAnalytics } from '../utils/analytics-transformer';
+
+const transformAnalyticsData = ( payload ) => {
+	const transformed = {};
+
+	for ( const [ key, value ] of Object.entries( payload ) ) {
+		transformed[ key ] = transformValueForAnalytics( key, value, [] );
+	}
+
+	return transformed;
+};
 
 function getInitialState( contextData, isImport ) {
 	const data = contextData.data;
@@ -31,7 +42,6 @@ export function KitSettingsCustomizationDialog( { open, handleClose, handleSaveC
 	const { isImport, contextData } = useContextDetection();
 
 	const initialState = getInitialState( contextData, isImport );
-	const unselectedValues = useRef( data.analytics?.customization?.settings || [] );
 
 	const [ settings, setSettings ] = useState( () => {
 		if ( data.customization.settings ) {
@@ -65,11 +75,7 @@ export function KitSettingsCustomizationDialog( { open, handleClose, handleSaveC
 		}
 	}, [ open ] );
 
-	const handleToggleChange = ( settingKey, isChecked ) => {
-		unselectedValues.current = isChecked
-			? unselectedValues.current.filter( ( val ) => settingKey !== val )
-			: [ ...unselectedValues.current, settingKey ];
-
+	const handleToggleChange = ( settingKey ) => {
 		setSettings( ( prev ) => ( {
 			...prev,
 			[ settingKey ]: ! prev[ settingKey ],
@@ -81,7 +87,10 @@ export function KitSettingsCustomizationDialog( { open, handleClose, handleSaveC
 			open={ open }
 			title={ __( 'Edit settings & configurations', 'elementor' ) }
 			handleClose={ handleClose }
-			handleSaveChanges={ () => handleSaveChanges( 'settings', settings, true, unselectedValues.current ) }
+			handleSaveChanges={ () => {
+				const transformedAnalytics = transformAnalyticsData( settings );
+				handleSaveChanges( 'settings', settings, true, transformedAnalytics );
+			} }
 		>
 			<Stack gap={ 2 }>
 				{ contextData?.isOldElementorVersion && (

--- a/app/modules/import-export-customization/assets/js/shared/utils/analytics-transformer.js
+++ b/app/modules/import-export-customization/assets/js/shared/utils/analytics-transformer.js
@@ -1,0 +1,41 @@
+export const ANALYTICS_TRANSFORM_RULES = {
+	STRING: ( value ) => value,
+	BOOLEAN: ( value ) => value,
+	EMPTY_ARRAY: () => 'None',
+	FULL_ARRAY: () => 'All',
+	PARTIAL_ARRAY: () => 'Partial',
+};
+
+export const getTotalAvailableCount = ( key, optionsArray ) => {
+	const optionsMap = optionsArray.reduce( ( map, { key: optionKey, options } ) => {
+		map[ optionKey ] = options.length;
+		return map;
+	}, {} );
+
+	return optionsMap[ key ] || 0;
+};
+
+export const transformValueForAnalytics = ( key, value, optionsArray ) => {
+	if ( 'string' === typeof value || 'boolean' === typeof value ) {
+		return ANALYTICS_TRANSFORM_RULES[ ( typeof value ).toUpperCase() ]( value );
+	}
+
+	if ( 'object' === typeof value && value !== null && ! Array.isArray( value ) && 'enabled' in value ) {
+		return value.enabled;
+	}
+
+	if ( Array.isArray( value ) ) {
+		if ( 0 === value.length ) {
+			return ANALYTICS_TRANSFORM_RULES.EMPTY_ARRAY();
+		}
+
+		const totalAvailable = getTotalAvailableCount( key, optionsArray );
+		const isFullSelection = value.length === totalAvailable;
+
+		return isFullSelection
+			? ANALYTICS_TRANSFORM_RULES.FULL_ARRAY()
+			: ANALYTICS_TRANSFORM_RULES.PARTIAL_ARRAY();
+	}
+
+	return value;
+};

--- a/app/modules/import-export-customization/module.php
+++ b/app/modules/import-export-customization/module.php
@@ -249,7 +249,7 @@ class Module extends BaseModule {
 			<?php endif; ?>
 			<div class="tab-import-export-kit__box action-buttons">
 				<?php if ( ! empty( $data['button_secondary'] ) ) : ?>
-					<a href="<?php ElementorUtils::print_unescaped_internal_string( $data['button_secondary']['url'] ); ?>" class="elementor-button e-btn-txt e-btn-txt-border">
+					<a id="<?php ElementorUtils::print_unescaped_internal_string( $data['button_secondary']['id'] ); ?>" href="<?php ElementorUtils::print_unescaped_internal_string( $data['button_secondary']['url'] ); ?>" class="elementor-button e-btn-txt e-btn-txt-border">
 						<?php ElementorUtils::print_unescaped_internal_string( $data['button_secondary']['text'] ); ?>
 					</a>
 				<?php endif; ?>

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/export/pages/export-complete.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/export/pages/export-complete.test.js
@@ -178,4 +178,364 @@ describe( 'ExportComplete Component', () => {
 			} );
 		} );
 	} );
+
+	describe( 'Analytics Tracking', () => {
+		it( 'should track kit_post_type_count with custom post types', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				content: { page: {}, post: {} },
+				'custom-post-type-title': {
+					product: {
+						name: 'product',
+						label: 'Products',
+					},
+					event: {
+						name: 'event',
+						label: 'Events',
+					},
+				},
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_post_type_count: 2,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_post_type_count with all post types', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				content: { page: {}, post: {} },
+				'custom-post-type-title': {
+					product: {
+						name: 'product',
+						label: 'Products',
+					},
+					post: {
+						name: 'post',
+						label: 'Posts',
+					},
+					page: {
+						name: 'page',
+						label: 'Pages',
+					},
+				},
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_post_type_count: 3,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_post_type_count as 0 when custom-post-type-title is empty', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				content: { page: {}, post: {} },
+				'custom-post-type-title': {},
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_post_type_count: 0,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_post_type_count as 0 when custom-post-type-title is missing', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				content: { page: {}, post: {} },
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_post_type_count: 0,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_post_type_count with multiple post types', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				content: { page: {}, post: {} },
+				'custom-post-type-title': {
+					product: {
+						name: 'product',
+						label: 'Products',
+					},
+					post: {
+						name: 'post',
+						label: 'Posts',
+					},
+					nav_menu_item: {
+						name: 'nav_menu_item',
+						label: 'Navigation Menu Items',
+					},
+					event: {
+						name: 'event',
+						label: 'Events',
+					},
+				},
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_post_type_count: 4,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_export_customization_modals from analytics data', async () => {
+			const mockCustomization = {
+				settings: 'Customized',
+				templates: 'Not Customized',
+				content: 'Customized',
+				plugins: 'Not Customized',
+			};
+
+			mockExportContext.data.analytics = {
+				customization: mockCustomization,
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_export_customization_modals: mockCustomization,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_export_customization_modals as undefined when analytics is missing', async () => {
+			mockExportContext.data.analytics = undefined;
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_export_customization_modals: undefined,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_page_count from content manifest', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				content: {
+					page: {
+						1: { title: 'Home Page' },
+						2: { title: 'About Page' },
+						3: { title: 'Contact Page' },
+					},
+					post: {
+						4: { title: 'Blog Post 1' },
+					},
+				},
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_page_count: 3,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_page_count from wp-content manifest', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				'wp-content': {
+					page: {
+						1: { title: 'Home Page' },
+						2: { title: 'About Page' },
+					},
+				},
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_page_count: 2,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_page_count combining content and wp-content', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				content: {
+					page: {
+						1: { title: 'Home Page' },
+						2: { title: 'About Page' },
+					},
+				},
+				'wp-content': {
+					page: {
+						3: { title: 'Contact Page' },
+					},
+				},
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_page_count: 3,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_page_count as 0 when no pages exist', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				content: {
+					post: {
+						1: { title: 'Blog Post' },
+					},
+				},
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_page_count: 0,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_post_count from content manifest', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				content: {
+					post: {
+						1: { title: 'Blog Post 1' },
+						2: { title: 'Blog Post 2' },
+						3: { title: 'Blog Post 3' },
+					},
+					page: {
+						4: { title: 'Home Page' },
+					},
+				},
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_post_count: 3,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_post_count from wp-content manifest', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				'wp-content': {
+					post: {
+						1: { title: 'Blog Post 1' },
+						2: { title: 'Blog Post 2' },
+					},
+				},
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_post_count: 2,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_post_count combining content and wp-content', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				content: {
+					post: {
+						1: { title: 'Blog Post 1' },
+						2: { title: 'Blog Post 2' },
+					},
+				},
+				'wp-content': {
+					post: {
+						3: { title: 'Blog Post 3' },
+						4: { title: 'Blog Post 4' },
+					},
+				},
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_post_count: 4,
+					} ),
+				);
+			} );
+		} );
+
+		it( 'should track kit_post_count as 0 when no posts exist', async () => {
+			mockExportContext.data.exportedData.manifest = {
+				version: '1.0',
+				content: {
+					page: {
+						1: { title: 'Home Page' },
+					},
+				},
+			};
+
+			render( <ExportComplete /> );
+
+			await waitFor( () => {
+				expect( mockSendExportKitCustomization ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						kit_post_count: 0,
+					} ),
+				);
+			} );
+		} );
+	} );
 } );

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/import/pages/import-complete.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/import/pages/import-complete.test.js
@@ -18,11 +18,11 @@ jest.mock( '@reach/router', () => ( {
 } ) );
 
 const mockSendPageViewsWebsiteTemplates = jest.fn();
-const mockSendExportKitCustomization = jest.fn();
+const mockSendImportKitCustomization = jest.fn();
 jest.mock( 'elementor/app/assets/js/event-track/apps-event-tracking', () => ( {
 	AppsEventTracking: {
 		sendPageViewsWebsiteTemplates: ( ...args ) => mockSendPageViewsWebsiteTemplates( ...args ),
-		sendExportKitCustomization: ( ...args ) => mockSendExportKitCustomization( ...args ),
+		sendImportKitCustomization: ( ...args ) => mockSendImportKitCustomization( ...args ),
 	},
 } ) );
 describe( 'ImportComplete Page', () => {
@@ -94,7 +94,7 @@ describe( 'ImportComplete Page', () => {
 		render( <ImportComplete /> );
 		// Assert
 		expect( mockNavigate ).toHaveBeenCalledWith( '/import-customization', { replace: true } );
-		expect( mockSendExportKitCustomization ).toHaveBeenCalledWith( expect.objectContaining( {
+		expect( mockSendImportKitCustomization ).toHaveBeenCalledWith( expect.objectContaining( {
 			kit_description: false,
 			kit_import_content: true,
 			kit_import_plugins: true,

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-content-customization-dialog.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-content-customization-dialog.test.js
@@ -1,0 +1,633 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock( 'elementor/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types', () => ( {
+	useKitCustomizationCustomPostTypes: jest.fn(),
+} ) );
+
+jest.mock( 'elementor-app/event-track/apps-event-tracking', () => ( {
+	AppsEventTracking: {
+		sendPageViewsWebsiteTemplates: jest.fn(),
+	},
+} ) );
+
+import { useKitCustomizationCustomPostTypes } from 'elementor/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types';
+import { AppsEventTracking } from 'elementor-app/event-track/apps-event-tracking';
+
+import { KitContentCustomizationDialog } from 'elementor/app/modules/import-export-customization/assets/js/shared/components/kit-content-customization-dialog';
+
+global.__ = jest.fn( ( text ) => text );
+
+describe( 'KitContentCustomizationDialog Component', () => {
+	const mockHandleClose = jest.fn();
+	const mockHandleSaveChanges = jest.fn();
+	const mockData = {
+		includes: [ 'content' ],
+		customization: {
+			content: null,
+		},
+		analytics: {
+			customization: {
+				content: [],
+			},
+		},
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		global.elementorCommon = {
+			eventsManager: {
+				config: {
+					secondaryLocations: {
+						kitLibrary: {
+							kitExportCustomizationEdit: 'test-location',
+						},
+					},
+				},
+			},
+		};
+
+		useKitCustomizationCustomPostTypes.mockReturnValue( {
+			customPostTypes: [
+				{ value: 'post', label: 'Post' },
+				{ value: 'test_cpt', label: 'Test CPT' },
+			],
+		} );
+	} );
+
+	describe( 'Dialog Rendering', () => {
+		it( 'should render dialog when open is true', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			expect( screen.getByText( 'Edit content' ) ).toBeTruthy();
+			expect( screen.getByText( 'Save changes' ) ).toBeTruthy();
+			expect( screen.getByText( 'Cancel' ) ).toBeTruthy();
+		} );
+
+		it( 'should not render dialog content when open is false', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: false,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			expect( screen.queryByText( 'Edit content' ) ).toBeFalsy();
+		} );
+
+		it( 'should render custom post types section', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			expect( screen.getByText( 'Custom post types' ) ).toBeTruthy();
+		} );
+
+		it( 'should render custom post type options', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			expect( screen.getByText( 'Post' ) ).toBeTruthy();
+			expect( screen.getByText( 'Test CPT' ) ).toBeTruthy();
+		} );
+	} );
+
+	describe( 'Initial State', () => {
+		it( 'should initialize with content enabled when content is in includes', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			const checkboxes = screen.getAllByRole( 'checkbox' );
+			checkboxes.forEach( ( checkbox ) => {
+				expect( checkbox.checked ).toBe( true );
+			} );
+		} );
+
+		it( 'should initialize with content disabled when content is not in includes', () => {
+			// Arrange
+			const data = {
+				includes: [],
+				customization: {
+					content: null,
+				},
+				analytics: {
+					customization: {
+						content: [],
+					},
+				},
+			};
+			const props = {
+				data,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			const checkboxes = screen.getAllByRole( 'checkbox' );
+			checkboxes.forEach( ( checkbox ) => {
+				expect( checkbox.checked ).toBe( false );
+			} );
+		} );
+
+		it( 'should use existing customization settings when available', () => {
+			// Arrange
+			const data = {
+				includes: [ 'content' ],
+				customization: {
+					content: {
+						customPostTypes: [ 'post' ],
+					},
+				},
+				analytics: {
+					customization: {
+						content: [],
+					},
+				},
+			};
+			const props = {
+				data,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			const postCheckbox = screen.getByLabelText( 'Post' );
+			expect( postCheckbox.checked ).toBe( true );
+		} );
+	} );
+
+	describe( 'Import Mode Functionality', () => {
+		it( 'should detect import mode when uploadedData is present', () => {
+			// Arrange
+			const importData = {
+				includes: [ 'content' ],
+				customization: {
+					content: null,
+				},
+				analytics: {
+					customization: {
+						content: [],
+					},
+				},
+				uploadedData: {
+					manifest: {
+						content: {
+							post: [ 'post-1', 'post-2' ],
+						},
+						'wp-content': {
+							post: [ 'post-1' ],
+						},
+						'custom-post-type-title': [ 'test_cpt' ],
+					},
+				},
+			};
+			const props = {
+				data: importData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			expect( screen.getByText( 'Edit content' ) ).toBeTruthy();
+		} );
+
+		it( 'should show "not exported" message when no custom post types in import mode', () => {
+			// Arrange
+			useKitCustomizationCustomPostTypes.mockReturnValue( {
+				customPostTypes: [],
+			} );
+
+			const importData = {
+				includes: [ 'content' ],
+				customization: {
+					content: null,
+				},
+				analytics: {
+					customization: {
+						content: [],
+					},
+				},
+				uploadedData: {
+					manifest: {},
+				},
+			};
+			const props = {
+				data: importData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+				isImport: true,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			expect( screen.getByText( 'Custom post types' ) ).toBeTruthy();
+		} );
+
+		it( 'should handle missing manifest gracefully', () => {
+			// Arrange
+			const importData = {
+				includes: [ 'content' ],
+				customization: {
+					content: null,
+				},
+				analytics: {
+					customization: {
+						content: [],
+					},
+				},
+				uploadedData: {
+					manifest: {},
+				},
+			};
+			const props = {
+				data: importData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			expect( screen.getByText( 'Edit content' ) ).toBeTruthy();
+		} );
+	} );
+
+	describe( 'Toggle Functionality', () => {
+		it( 'should toggle custom post type selection when clicked', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+			render( <KitContentCustomizationDialog { ...props } /> );
+			const testCptCheckbox = screen.getByLabelText( 'Test CPT' );
+			const initialState = testCptCheckbox.checked;
+
+			// Act
+			fireEvent.click( testCptCheckbox );
+
+			// Assert
+			expect( testCptCheckbox.checked ).toBe( ! initialState );
+		} );
+
+		it( 'should handle toggle interactions in import mode', () => {
+			// Arrange
+			const importData = {
+				includes: [ 'content' ],
+				customization: {
+					content: null,
+				},
+				analytics: {
+					customization: {
+						content: [],
+					},
+				},
+				uploadedData: {
+					manifest: {
+						content: {
+							post: [ 'post-1', 'post-2' ],
+						},
+						'wp-content': {
+							post: [ 'post-1' ],
+						},
+						'custom-post-type-title': [ 'test_cpt' ],
+					},
+				},
+			};
+			const props = {
+				data: importData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+			render( <KitContentCustomizationDialog { ...props } /> );
+			const testCptCheckbox = screen.getByLabelText( 'Test CPT' );
+			const initialState = testCptCheckbox.checked;
+
+			// Act
+			fireEvent.click( testCptCheckbox );
+
+			// Assert
+			expect( testCptCheckbox.checked ).toBe( ! initialState );
+		} );
+	} );
+
+	describe( 'Dialog Actions', () => {
+		it( 'should call handleClose when Cancel button is clicked', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+			render( <KitContentCustomizationDialog { ...props } /> );
+			const cancelButton = screen.getByText( 'Cancel' );
+
+			// Act
+			fireEvent.click( cancelButton );
+
+			// Assert
+			expect( mockHandleClose ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should call handleClose when close button is clicked', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+			render( <KitContentCustomizationDialog { ...props } /> );
+			const closeButtons = screen.getAllByRole( 'button' );
+			const closeButton = closeButtons.find( ( button ) => 'close' === button.getAttribute( 'aria-label' ) );
+
+			// Act
+			if ( closeButton ) {
+				fireEvent.click( closeButton );
+			}
+
+			// Assert
+			if ( closeButton ) {
+				expect( mockHandleClose ).toHaveBeenCalledTimes( 1 );
+			}
+		} );
+
+		it( 'should dispatch customization and close dialog when Save changes is clicked', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+			render( <KitContentCustomizationDialog { ...props } /> );
+			const saveButton = screen.getByText( 'Save changes' );
+
+			// Act
+			fireEvent.click( saveButton );
+
+			// Assert
+			expect( mockHandleSaveChanges ).toHaveBeenCalledWith(
+				'content',
+				{
+					customPostTypes: [ 'post', 'test_cpt' ],
+				},
+				true,
+				{
+					customPostTypes: 'All',
+				},
+			);
+			expect( mockHandleClose ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'Upgrade Version Banner', () => {
+		it( 'should render upgrade version banner when isOldElementorVersion is true', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+				isOldElementorVersion: true,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			// The banner component should be rendered, but we can't test its content without mocking the component
+			expect( screen.getByText( 'Custom post types' ) ).toBeTruthy();
+		} );
+
+		it( 'should not render upgrade version banner when isOldElementorVersion is false', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+				isOldElementorVersion: false,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			expect( screen.getByText( 'Custom post types' ) ).toBeTruthy();
+		} );
+	} );
+
+	describe( 'Event Tracking', () => {
+		it( 'should call AppsEventTracking.sendPageViewsWebsiteTemplates when dialog opens', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			expect( AppsEventTracking.sendPageViewsWebsiteTemplates ).toHaveBeenCalledWith( 'test-location' );
+		} );
+
+		it( 'should not call tracking when dialog is closed', () => {
+			// Arrange
+			const props = {
+				data: mockData,
+				open: false,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			expect( AppsEventTracking.sendPageViewsWebsiteTemplates ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Import Mode Data Validation', () => {
+		it( 'should render dialog with malformed manifest data', () => {
+			// Arrange
+			const malformedData = {
+				...mockData,
+				uploadedData: {
+					manifest: {
+						content: null,
+						'wp-content': undefined,
+						'custom-post-type-title': 'invalid-string',
+					},
+				},
+			};
+
+			const props = {
+				data: malformedData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+				isImport: true,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert - should still render basic dialog
+			expect( screen.getByText( 'Edit content' ) ).toBeTruthy();
+			expect( screen.getByText( 'Custom post types' ) ).toBeTruthy();
+		} );
+
+		it( 'should render dialog with missing manifest sections', () => {
+			// Arrange
+			const incompleteData = {
+				...mockData,
+				uploadedData: {
+					manifest: {
+						// Missing content and wp-content sections
+					},
+				},
+			};
+
+			const props = {
+				data: incompleteData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+				isImport: true,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert - should render with default values
+			expect( screen.getByText( 'Edit content' ) ).toBeTruthy();
+			expect( screen.getByText( 'Custom post types' ) ).toBeTruthy();
+		} );
+
+		it( 'should render dialog with empty manifest data', () => {
+			// Arrange
+			const emptyData = {
+				...mockData,
+				uploadedData: {
+					manifest: {},
+				},
+			};
+
+			const props = {
+				data: emptyData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+				isImport: true,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			expect( screen.getByText( 'Edit content' ) ).toBeTruthy();
+			expect( screen.getByText( 'Custom post types' ) ).toBeTruthy();
+		} );
+
+		it( 'should render dialog with valid manifest data', () => {
+			// Arrange
+			const validData = {
+				...mockData,
+				uploadedData: {
+					manifest: {
+						content: {
+							post: [ 'post-1', 'post-2' ],
+						},
+						'wp-content': {
+							post: [ 'post-1' ],
+						},
+						'custom-post-type-title': [ 'test_cpt' ],
+					},
+				},
+			};
+
+			const props = {
+				data: validData,
+				open: true,
+				handleClose: mockHandleClose,
+				handleSaveChanges: mockHandleSaveChanges,
+				isImport: true,
+			};
+
+			// Act
+			render( <KitContentCustomizationDialog { ...props } /> );
+
+			// Assert
+			expect( screen.getByText( 'Edit content' ) ).toBeTruthy();
+			expect( screen.getByText( 'Custom post types' ) ).toBeTruthy();
+		} );
+	} );
+} );

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-plugins-customization-dialog.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-plugins-customization-dialog.test.js
@@ -446,7 +446,11 @@ describe( 'KitPluginsCustomizationDialog Component', () => {
 					'contact-form-7/wp-contact-form-7': true,
 				},
 				true,
-				[],
+				{
+					'advanced-custom-fields/acf': true,
+					'contact-form-7/wp-contact-form-7': true,
+					'elementor/elementor': true,
+				},
 			);
 			expect( mockHandleClose ).toHaveBeenCalledTimes( 1 );
 		} );
@@ -475,7 +479,11 @@ describe( 'KitPluginsCustomizationDialog Component', () => {
 					'contact-form-7/wp-contact-form-7': true,
 				},
 				true,
-				[ 'advanced-custom-fields/acf' ],
+				{
+					'advanced-custom-fields/acf': false,
+					'contact-form-7/wp-contact-form-7': true,
+					'elementor/elementor': true,
+				},
 			);
 		} );
 	} );

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/utils/analytics-transformer.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/utils/analytics-transformer.test.js
@@ -1,0 +1,171 @@
+import {
+	ANALYTICS_TRANSFORM_RULES,
+	getTotalAvailableCount,
+	transformValueForAnalytics,
+} from 'elementor/app/modules/import-export-customization/assets/js/shared/utils/analytics-transformer';
+
+describe( 'Analytics Transformer', () => {
+	describe( 'ANALYTICS_TRANSFORM_RULES', () => {
+		test( 'should transform string values correctly', () => {
+			expect( ANALYTICS_TRANSFORM_RULES.STRING( 'test' ) ).toBe( 'test' );
+			expect( ANALYTICS_TRANSFORM_RULES.STRING( '' ) ).toBe( '' );
+		} );
+
+		test( 'should transform boolean values correctly', () => {
+			expect( ANALYTICS_TRANSFORM_RULES.BOOLEAN( true ) ).toBe( true );
+			expect( ANALYTICS_TRANSFORM_RULES.BOOLEAN( false ) ).toBe( false );
+		} );
+
+		test( 'should return "None" for empty array', () => {
+			expect( ANALYTICS_TRANSFORM_RULES.EMPTY_ARRAY() ).toBe( 'None' );
+		} );
+
+		test( 'should return "All" for full array', () => {
+			expect( ANALYTICS_TRANSFORM_RULES.FULL_ARRAY() ).toBe( 'All' );
+		} );
+
+		test( 'should return "Partial" for partial array', () => {
+			expect( ANALYTICS_TRANSFORM_RULES.PARTIAL_ARRAY() ).toBe( 'Partial' );
+		} );
+	} );
+
+	describe( 'getTotalAvailableCount', () => {
+		test( 'should return correct count for existing key', () => {
+			// Arrange
+			const optionsArray = [
+				{ key: 'pages', options: [ 'page1', 'page2', 'page3' ] },
+				{ key: 'posts', options: [ 'post1', 'post2' ] },
+			];
+
+			// Act
+			const result = getTotalAvailableCount( 'pages', optionsArray );
+
+			// Assert
+			expect( result ).toBe( 3 );
+		} );
+
+		test( 'should return 0 for non-existing key', () => {
+			// Arrange
+			const optionsArray = [
+				{ key: 'pages', options: [ 'page1', 'page2' ] },
+			];
+
+			// Act
+			const result = getTotalAvailableCount( 'nonExisting', optionsArray );
+
+			// Assert
+			expect( result ).toBe( 0 );
+		} );
+
+		test( 'should handle empty options array', () => {
+			// Arrange
+			const optionsArray = [];
+
+			// Act
+			const result = getTotalAvailableCount( 'anyKey', optionsArray );
+
+			// Assert
+			expect( result ).toBe( 0 );
+		} );
+
+		test( 'should handle empty options within array', () => {
+			// Arrange
+			const optionsArray = [
+				{ key: 'pages', options: [] },
+				{ key: 'posts', options: [ 'post1' ] },
+			];
+
+			// Act
+			const result = getTotalAvailableCount( 'pages', optionsArray );
+
+			// Assert
+			expect( result ).toBe( 0 );
+		} );
+	} );
+
+	describe( 'transformValueForAnalytics', () => {
+		const mockOptionsArray = [
+			{ key: 'pages', options: [ 'page1', 'page2', 'page3' ] },
+			{ key: 'posts', options: [ 'post1', 'post2' ] },
+		];
+
+		test( 'should transform string values', () => {
+			// Act & Assert
+			expect( transformValueForAnalytics( 'test', 'hello', mockOptionsArray ) ).toBe( 'hello' );
+			expect( transformValueForAnalytics( 'test', '', mockOptionsArray ) ).toBe( '' );
+		} );
+
+		test( 'should transform boolean values', () => {
+			// Act & Assert
+			expect( transformValueForAnalytics( 'test', true, mockOptionsArray ) ).toBe( true );
+			expect( transformValueForAnalytics( 'test', false, mockOptionsArray ) ).toBe( false );
+		} );
+
+		test( 'should transform objects with enabled property', () => {
+			// Arrange
+			const objectWithEnabled = { enabled: true, other: 'value' };
+			const objectWithDisabled = { enabled: false, other: 'value' };
+
+			// Act & Assert
+			expect( transformValueForAnalytics( 'test', objectWithEnabled, mockOptionsArray ) ).toBe( true );
+			expect( transformValueForAnalytics( 'test', objectWithDisabled, mockOptionsArray ) ).toBe( false );
+		} );
+
+		test( 'should transform empty arrays to "None"', () => {
+			// Act & Assert
+			expect( transformValueForAnalytics( 'pages', [], mockOptionsArray ) ).toBe( 'None' );
+		} );
+
+		test( 'should transform full arrays to "All"', () => {
+			// Arrange
+			const fullPagesArray = [ 'page1', 'page2', 'page3' ];
+			const fullPostsArray = [ 'post1', 'post2' ];
+
+			// Act & Assert
+			expect( transformValueForAnalytics( 'pages', fullPagesArray, mockOptionsArray ) ).toBe( 'All' );
+			expect( transformValueForAnalytics( 'posts', fullPostsArray, mockOptionsArray ) ).toBe( 'All' );
+		} );
+
+		test( 'should transform partial arrays to "Partial"', () => {
+			// Arrange
+			const partialPagesArray = [ 'page1', 'page2' ];
+			const partialPostsArray = [ 'post1' ];
+
+			// Act & Assert
+			expect( transformValueForAnalytics( 'pages', partialPagesArray, mockOptionsArray ) ).toBe( 'Partial' );
+			expect( transformValueForAnalytics( 'posts', partialPostsArray, mockOptionsArray ) ).toBe( 'Partial' );
+		} );
+
+		test( 'should handle null values', () => {
+			// Act & Assert
+			expect( transformValueForAnalytics( 'test', null, mockOptionsArray ) ).toBe( null );
+		} );
+
+		test( 'should handle undefined values', () => {
+			// Act & Assert
+			expect( transformValueForAnalytics( 'test', undefined, mockOptionsArray ) ).toBe( undefined );
+		} );
+
+		test( 'should handle objects without enabled property', () => {
+			// Arrange
+			const objectWithoutEnabled = { other: 'value', nested: { data: 'test' } };
+
+			// Act & Assert
+			expect( transformValueForAnalytics( 'test', objectWithoutEnabled, mockOptionsArray ) ).toBe( objectWithoutEnabled );
+		} );
+
+		test( 'should handle arrays with unknown key', () => {
+			// Arrange
+			const unknownKeyArray = [ 'item1', 'item2' ];
+
+			// Act & Assert
+			expect( transformValueForAnalytics( 'unknownKey', unknownKeyArray, mockOptionsArray ) ).toBe( 'Partial' );
+		} );
+
+		test( 'should handle numeric values', () => {
+			// Act & Assert
+			expect( transformValueForAnalytics( 'test', 42, mockOptionsArray ) ).toBe( 42 );
+			expect( transformValueForAnalytics( 'test', 0, mockOptionsArray ) ).toBe( 0 );
+		} );
+	} );
+} );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Refactor import-export customization analytics to improve data consistency and add new tracking capabilities for content metrics.

Main changes:
- Added analytics transformer utility to standardize customization data formatting
- Updated export tracking to include detailed content metrics (page/post counts, post types)
- Fixed incorrect event tracking in import complete component (sendExportKit → sendImportKit)
- Added ID attribute to secondary button in customization dialog for tracking
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
