### PR TITLE
Fix: Allow negative values in letter and word spacing [ED-21093]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/typography-section/letter-spacing-field.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/typography-section/letter-spacing-field.tsx
@@ -14,7 +14,7 @@ export const LetterSpacingField = () => {
 	return (
 		<StylesField bind="letter-spacing" propDisplayName={ LETTER_SPACING_LABEL }>
 			<StylesFieldLayout label={ LETTER_SPACING_LABEL } ref={ rowRef }>
-				<SizeControl anchorRef={ rowRef } />
+				<SizeControl anchorRef={ rowRef } min={ -Number.MAX_SAFE_INTEGER } />
 			</StylesFieldLayout>
 		</StylesField>
 	);

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/typography-section/word-spacing-field.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/typography-section/word-spacing-field.tsx
@@ -14,7 +14,7 @@ export const WordSpacingField = () => {
 	return (
 		<StylesField bind="word-spacing" propDisplayName={ WORD_SPACING_LABEL }>
 			<StylesFieldLayout label={ WORD_SPACING_LABEL } ref={ rowRef }>
-				<SizeControl anchorRef={ rowRef } />
+				<SizeControl anchorRef={ rowRef } min={ -Number.MAX_SAFE_INTEGER } />
 			</StylesFieldLayout>
 		</StylesField>
 	);


### PR DESCRIPTION
<img width="1597" height="568" alt="image" src="https://github.com/user-attachments/assets/a78e74a7-406b-4877-a50e-ac12be5e4dca" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix letter spacing and word spacing controls to allow negative values by removing default minimum value restriction.
Main changes:
- Added min prop with -Number.MAX_SAFE_INTEGER to SizeControl components in both letter and word spacing fields

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
