### PR TITLE
Fix: Autocomplete results should not show categories if there is only one. [ED-21046]

### DIFF
--- a/packages/packages/libs/editor-controls/src/components/__tests__/autocomplete.test.tsx
+++ b/packages/packages/libs/editor-controls/src/components/__tests__/autocomplete.test.tsx
@@ -19,6 +19,11 @@ const categorizedOptions: CategorizedOption[] = [
 	{ id: '4', label: 'Four', groupLabel: 'Group 2' },
 ];
 
+const singleCategoryOptions: CategorizedOption[] = [
+	{ id: '5', label: 'Five', groupLabel: 'Group 1' },
+	{ id: '6', label: 'Six', groupLabel: 'Group 1' },
+];
+
 const basicProps: AutocompleteProps = {
 	options: flatOptions,
 	onOptionChange: jest.fn(),
@@ -99,15 +104,41 @@ describe( 'Autocomplete', () => {
 
 		const input = screen.getByPlaceholderText( 'test' );
 		fireEvent.input( input, { target: { value: 'T' } } );
+		let group1 = screen.queryByText( 'Group 1' );
+		let group2 = screen.queryByText( 'Group 2' );
 
 		// Assert.
 		expect( categorizedOptions.filter( ( { label } ) => screen.queryByText( label ) ).length ).toBe( 1 );
+		expect( group1 ).toBeVisible();
+		expect( group2 ).not.toBeInTheDocument();
 
 		// Act.
 		fireEvent.input( input, { target: { value: 'F' } } );
 
+		group1 = screen.queryByText( 'Group 1' );
+		group2 = screen.queryByText( 'Group 2' );
 		// Assert.
 		expect( categorizedOptions.filter( ( { label } ) => screen.queryByText( label ) ).length ).toBe( 1 );
+	} );
+
+	it( 'should NOT group options when only one groupLabel is present', () => {
+		// Act.
+		renderWithTheme(
+			<Autocomplete
+				{ ...customValueProps }
+				options={ singleCategoryOptions }
+				placeholder={ 'test' }
+				minInputLength={ 0 }
+				value={ '' }
+			/>
+		);
+
+		const input = screen.getByPlaceholderText( 'test' );
+		fireEvent.input( input, { target: { value: 'F' } } );
+
+		// Assert.
+		const group1 = screen.queryByText( 'Group 1' );
+		expect( group1 ).not.toBeInTheDocument();
 	} );
 
 	it( 'should clear input when clicking on clear input button, allowCustomValues is off', () => {

--- a/packages/packages/libs/editor-controls/src/components/autocomplete.tsx
+++ b/packages/packages/libs/editor-controls/src/components/autocomplete.tsx
@@ -173,7 +173,13 @@ export function findMatchingOption(
 }
 
 export function isCategorizedOptionPool( options: FlatOption[] | CategorizedOption[] ): options is CategorizedOption[] {
-	return options.every( ( option ) => 'groupLabel' in option );
+	if ( options.length <= 1 ) {
+		return false;
+	}
+
+	const uniqueGroupLabels = new Set( options.map( ( option ) => option.groupLabel ) );
+
+	return uniqueGroupLabels.size > 1; // should not categorize options if there is only one group
 }
 
 function factoryFilter< T extends FlatOption[] | CategorizedOption[] >(


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix autocomplete dropdown to hide category labels when all items belong to a single category.

Main changes:
- Updated isCategorizedOptionPool to only group options when multiple categories exist
- Added test case to verify single category options are not grouped
- Added test for category visibility when filtering autocomplete results

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
