### PR TITLE
Internal: Add Mixpanel event `add_element` for editor_panel location [ED-20328]

### DIFF
--- a/assets/dev/js/editor/regions/panel/pages/elements/views/element.js
+++ b/assets/dev/js/editor/regions/panel/pages/elements/views/element.js
@@ -181,6 +181,20 @@ module.exports = Marionette.ItemView.extend( {
 			},
 			model: this.model.toJSON(),
 		} );
+
+		if ( elementorCommon.eventsManager ) {
+			const modelData = this.model.toJSON();
+			const elementName = 'widget' === elType ? widgetType : elType;
+
+			const eventData = {
+				location: 'editor_panel',
+				element_name: elementName,
+				element_type: modelData.elType,
+				widget_type: modelData.widgetType,
+			};
+
+			elementorCommon.eventsManager.dispatchEvent( 'add_element', eventData );
+		}
 	},
 
 	getSelectedElements() {

--- a/assets/dev/js/editor/views/base-container.js
+++ b/assets/dev/js/editor/views/base-container.js
@@ -196,6 +196,19 @@ module.exports = Marionette.CompositeView.extend( {
 		args.options = options;
 
 		$e.run( 'preview/drop', args );
+
+		if ( elementorCommon.eventsManager && args.model ) {
+			const elementName = 'widget' === elType ? widgetType : elType;
+
+			const eventData = {
+				location: 'editor_panel',
+				element_name: elementName,
+				element_type: args.model.elType,
+				widget_type: args.model.widgetType,
+			};
+
+			elementorCommon.eventsManager.dispatchEvent( 'add_element', eventData );
+		}
 	},
 
 	getHistoryType( event ) {

--- a/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.js
+++ b/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.js
@@ -360,6 +360,23 @@ export default function createAtomicElementBaseView( type ) {
 
 						this.onDrop( event, { at: targetIndex } );
 
+						if ( elementorCommon.eventsManager ) {
+							const selectedElement = elementor.channels.panelElements.request( 'element:selected' );
+
+							if ( selectedElement ) {
+								const elementName = 'widget' === elType ? widgetType : elType;
+
+								const eventData = {
+									location: 'editor_panel',
+									element_name: elementName,
+									element_type: selectedElement.model.get( 'elType' ),
+									widget_type: wselectedElement.model.get( 'widgetType' ),
+								};
+
+								elementorCommon.eventsManager.dispatchEvent( 'add_element', eventData );
+							}
+						}
+
 						return;
 					}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add Mixpanel analytics event tracking for element additions in the editor panel to monitor user interactions.
Main changes:
- Implemented event tracking when elements are added from the panel using `eventsManager.dispatchEvent('add_element')`
- Added consistent event data structure with location, element_name, element_type, and widget_type properties
- Applied tracking across different element addition flows in editor panel, container, and atomic widgets

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
