### PR TITLE
Internal: Fix sending a message on failure [ED-21191]

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
     types: [ labeled, synchronize, opened, reopened ]
   push:
-    #branches:
-    #  - 'main'
-    #  - '3.[0-9][0-9]'
+    branches:
+      - 'main'
+      - '3.[0-9][0-9]'
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -203,24 +203,19 @@ jobs:
         if: ${{ needs.Playwright.result == 'failure' && github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request' }}
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            BASE_MESSAGE="Elementor Core: Scheduled Playwright tests failed - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          BASE_MESSAGE="Elementor Core: Scheduled Playwright tests failed - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           else
             BASE_MESSAGE="Elementor Core: Playwright - ${{ github.event_name }} failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
 
           if [[ "${{ steps.create_revert_pr.outputs.status }}" == "created" ]]; then
-            REVERT_MESSAGE="\n\nYou can review revert of this commit here: [PR #${{ steps.create_revert_pr.outputs.pr_number }}](${{ steps.create_revert_pr.outputs.pr_url }})"
-            {
-              echo "message<<EOF"
-              echo "${BASE_MESSAGE}${REVERT_MESSAGE}"
-              echo "EOF"
-            } >> $GITHUB_OUTPUT
+            REVERT_MESSAGE="
+
+          You can review revert of this commit here: [PR #${{ steps.create_revert_pr.outputs.pr_number }}](${{ steps.create_revert_pr.outputs.pr_url }})"
+            echo "message=${BASE_MESSAGE}${REVERT_MESSAGE}" >> $GITHUB_OUTPUT
           else
-            {
-              echo "message<<EOF"
-              echo "${BASE_MESSAGE}"
-              echo "EOF"
-            } >> $GITHUB_OUTPUT
+            echo "message=${BASE_MESSAGE}" >> $GITHUB_OUTPUT
           fi
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -203,20 +203,26 @@ jobs:
         if: ${{ needs.Playwright.result == 'failure' && github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request' }}
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-
-          BASE_MESSAGE="Elementor Core: Scheduled Playwright tests failed - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            BASE_MESSAGE="Elementor Core: Scheduled Playwright tests failed - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           else
             BASE_MESSAGE="Elementor Core: Playwright - ${{ github.event_name }} failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
 
           if [[ "${{ steps.create_revert_pr.outputs.status }}" == "created" ]]; then
-            REVERT_MESSAGE="
-
-          You can review revert of this commit here: [PR #${{ steps.create_revert_pr.outputs.pr_number }}](${{ steps.create_revert_pr.outputs.pr_url }})"
-            echo "message=${BASE_MESSAGE}${REVERT_MESSAGE}" >> $GITHUB_OUTPUT
+            REVERT_MESSAGE="\n\nYou can review revert of this commit here: [PR #${{ steps.create_revert_pr.outputs.pr_number }}](${{ steps.create_revert_pr.outputs.pr_url }})"
+            {
+              echo "message<<EOF"
+              echo "${BASE_MESSAGE}${REVERT_MESSAGE}"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
           else
-            echo "message=${BASE_MESSAGE}" >> $GITHUB_OUTPUT
+            {
+              echo "message<<EOF"
+              echo "${BASE_MESSAGE}"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
           fi
+
       - name: Generate a token
         id: generate-token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
     types: [ labeled, synchronize, opened, reopened ]
   push:
-    branches:
-      - 'main'
-      - '3.[0-9][0-9]'
+    #branches:
+    #  - 'main'
+    #  - '3.[0-9][0-9]'
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -203,19 +203,24 @@ jobs:
         if: ${{ needs.Playwright.result == 'failure' && github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request' }}
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-
-          BASE_MESSAGE="Elementor Core: Scheduled Playwright tests failed - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            BASE_MESSAGE="Elementor Core: Scheduled Playwright tests failed - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           else
             BASE_MESSAGE="Elementor Core: Playwright - ${{ github.event_name }} failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
 
           if [[ "${{ steps.create_revert_pr.outputs.status }}" == "created" ]]; then
-            REVERT_MESSAGE="
-
-          You can review revert of this commit here: [PR #${{ steps.create_revert_pr.outputs.pr_number }}](${{ steps.create_revert_pr.outputs.pr_url }})"
-            echo "message=${BASE_MESSAGE}${REVERT_MESSAGE}" >> $GITHUB_OUTPUT
+            REVERT_MESSAGE="\n\nYou can review revert of this commit here: [PR #${{ steps.create_revert_pr.outputs.pr_number }}](${{ steps.create_revert_pr.outputs.pr_url }})"
+            {
+              echo "message<<EOF"
+              echo "${BASE_MESSAGE}${REVERT_MESSAGE}"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
           else
-            echo "message=${BASE_MESSAGE}" >> $GITHUB_OUTPUT
+            {
+              echo "message<<EOF"
+              echo "${BASE_MESSAGE}"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
           fi
       - name: Generate a token
         id: generate-token

--- a/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-word-spacing.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-word-spacing.test.ts
@@ -52,18 +52,6 @@ test.describe( 'V4 Typography Word Spacing Tests @v4-tests', () => {
 		} );
 	} );
 
-	test( 'Word spacing for button', async () => {
-		await test.step( 'Test word spacing across different widget types', async () => {
-			const widget = WIDGET_CONFIGS.BUTTON;
-			await addWidgetWithOpenTypographySection( driver, widget.type );
-
-			const testValue = 2.5;
-			const testUnit = 'px';
-			await driver.editor.v4Panel.style.setSpacingValue( 'Word spacing', testValue, testUnit );
-			await verifySpacingEditor( { driver, selector: widget.selector, expectedValue: testValue, expectedUnit: testUnit, cssProperty: 'wordSpacing' } );
-		} );
-	} );
-
 	test( 'Word spacing for paragraph on published page', async () => {
 		await test.step( 'Test word spacing on published page with paragraph widget', async () => {
 			const widget = WIDGET_CONFIGS.PARAGRAPH;

--- a/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-word-spacing.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-word-spacing.test.ts
@@ -52,6 +52,18 @@ test.describe( 'V4 Typography Word Spacing Tests @v4-tests', () => {
 		} );
 	} );
 
+	test( 'Word spacing for button', async () => {
+		await test.step( 'Test word spacing across different widget types', async () => {
+			const widget = WIDGET_CONFIGS.BUTTON;
+			await addWidgetWithOpenTypographySection( driver, widget.type );
+
+			const testValue = 2.5;
+			const testUnit = 'px';
+			await driver.editor.v4Panel.style.setSpacingValue( 'Word spacing', testValue, testUnit );
+			await verifySpacingEditor( { driver, selector: widget.selector, expectedValue: testValue, expectedUnit: testUnit, cssProperty: 'wordSpacing' } );
+		} );
+	} );
+
 	test( 'Word spacing for paragraph on published page', async () => {
 		await test.step( 'Test word spacing on published page with paragraph widget', async () => {
 			const widget = WIDGET_CONFIGS.PARAGRAPH;


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix message formatting in GitHub workflow when Playwright tests fail by properly handling multiline output and scheduled test cases.
Main changes:
- Added missing BASE_MESSAGE initialization for scheduled test cases
- Fixed multiline output handling with EOF delimiter pattern
- Improved message formatting with proper newline characters

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
