### PR TITLE
Tweak: Change some style tab control titles and tooltip for transform settings button. [ED-20718]

### DIFF
--- a/packages/packages/core/editor-variables/src/components/fields/font-field.tsx
+++ b/packages/packages/core/editor-variables/src/components/fields/font-field.tsx
@@ -74,7 +74,7 @@ export const FontField = ( { value, onChange, onValidationChange }: FontFieldPro
 					onItemChange={ handleFontFamilyChange }
 					onClose={ fontPopoverState.close }
 					sectionWidth={ sectionWidth }
-					title={ __( 'Font Family', 'elementor' ) }
+					title={ __( 'Font family', 'elementor' ) }
 					itemStyle={ ( item ) => ( { fontFamily: item.value } ) }
 					onDebounce={ enqueueFont }
 					icon={ TextIcon as React.ElementType< { fontSize: string } > }

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/filter-repeater-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/filter-repeater-control.test.tsx
@@ -106,7 +106,7 @@ describe( 'FilterRepeaterControl', () => {
 
 		// Assert.
 		const btn = screen.getAllByRole( 'button' )[ 0 ];
-		expect( screen.getByText( 'Backdrop Filters' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Backdrop filters' ) ).toBeInTheDocument();
 		expect( btn ).toHaveAttribute( 'aria-label', 'Add backdrop filter item' );
 	} );
 

--- a/packages/packages/libs/editor-controls/src/controls/filter-control/filter-repeater-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/filter-control/filter-repeater-control.tsx
@@ -36,7 +36,7 @@ const FILTER_CONFIG: Record< string, Config > = {
 	},
 	'backdrop-filter': {
 		propTypeUtil: backdropFilterPropTypeUtil,
-		label: __( 'Backdrop Filters', 'elementor' ),
+		label: __( 'Backdrop filters', 'elementor' ),
 	},
 } as const;
 

--- a/packages/packages/libs/editor-controls/src/controls/font-family-control/font-family-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/font-family-control/font-family-control.tsx
@@ -81,7 +81,7 @@ export const FontFamilyControl = createControl(
 						onItemChange={ setFontFamily }
 						onClose={ popoverState.close }
 						sectionWidth={ sectionWidth }
-						title={ __( 'Font Family', 'elementor' ) }
+						title={ __( 'Font family', 'elementor' ) }
 						itemStyle={ ( item ) => ( { fontFamily: item.value } ) }
 						onDebounce={ enqueueFont }
 						icon={ TextIcon as React.ElementType< { fontSize: string } > }

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/__tests__/transform-repeater-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/__tests__/transform-repeater-control.test.tsx
@@ -21,6 +21,8 @@ type DimensionPropValue< T extends string[] > = {
 	};
 };
 
+const TRANSFORM_SETTINGS_BUTTON_NAME = 'Transform settings';
+
 describe( 'TransformRepeaterControl', () => {
 	const sizePropType = createMockPropType( {
 		kind: 'object',
@@ -293,7 +295,7 @@ describe( 'TransformRepeaterControl', () => {
 		// Act.
 		renderControl( <TransformRepeaterControl />, { value: mockTransformValue, propType } );
 
-		const transformBaseTriggerButton = screen.getByRole( 'button', { name: 'Base Transform' } );
+		const transformBaseTriggerButton = screen.getByRole( 'button', { name: TRANSFORM_SETTINGS_BUTTON_NAME } );
 
 		// Assert.
 		expect( transformBaseTriggerButton ).toBeInTheDocument();
@@ -316,7 +318,7 @@ describe( 'TransformRepeaterControl', () => {
 
 		// Act.
 		renderControl( <TransformRepeaterControl />, { value: mockTransformValue, propType } );
-		fireEvent.click( screen.getByRole( 'button', { name: 'Base Transform' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: TRANSFORM_SETTINGS_BUTTON_NAME } ) );
 
 		const inputs = screen.getAllByDisplayValue( /\d*/ );
 
@@ -351,7 +353,7 @@ describe( 'TransformRepeaterControl', () => {
 
 				// Act.
 				renderControl( <TransformRepeaterControl />, { value: mockTransformValue, propType, setValue } );
-				fireEvent.click( screen.getByRole( 'button', { name: 'Base Transform' } ) );
+				fireEvent.click( screen.getByRole( 'button', { name: TRANSFORM_SETTINGS_BUTTON_NAME } ) );
 
 				const inputs = screen.getAllByDisplayValue( /\d*/ );
 

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/transform-repeater-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/transform-repeater-control.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useRef } from 'react';
 import { type PropType, transformFunctionsPropTypeUtil, transformPropTypeUtil } from '@elementor/editor-props';
 import { AdjustmentsIcon, InfoCircleFilledIcon } from '@elementor/icons';
-import { bindTrigger, Box, IconButton, type PopupState, Typography, usePopupState } from '@elementor/ui';
+import { bindTrigger, Box, IconButton, type PopupState, Tooltip, Typography, usePopupState } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { PropKeyProvider, PropProvider, useBoundProp } from '../../bound-prop-context';
@@ -13,10 +13,10 @@ import { EditItemPopover } from '../../components/control-repeater/items/edit-it
 import { ControlAdornments } from '../../control-adornments/control-adornments';
 import { createControl } from '../../create-control';
 import { initialRotateValue, initialScaleValue, initialSkewValue, initialTransformValue } from './initial-values';
-import { TransformBaseControl } from './transform-base-control';
 import { TransformContent } from './transform-content';
 import { TransformIcon } from './transform-icon';
 import { TransformLabel } from './transform-label';
+import { TransformSettingsControl } from './transform-settings-control';
 
 const SIZE = 'tiny';
 
@@ -27,7 +27,7 @@ export const TransformRepeaterControl = createControl( () => {
 
 	return (
 		<PropProvider { ...context }>
-			<TransformBaseControl popupState={ popupState } anchorRef={ headerRef } />
+			<TransformSettingsControl popupState={ popupState } anchorRef={ headerRef } />
 			<PropKeyProvider bind={ 'transform-functions' }>
 				<Repeater headerRef={ headerRef } propType={ context.propType } popupState={ popupState } />
 			</PropKeyProvider>
@@ -114,10 +114,13 @@ const TransformBasePopoverTrigger = ( {
 	repeaterBindKey: string;
 } ) => {
 	const { bind } = useBoundProp();
+	const titleLabel = __( 'Transform settings', 'elementor' );
 
 	return bind !== repeaterBindKey ? null : (
-		<IconButton size={ SIZE } aria-label={ __( 'Base Transform', 'elementor' ) } { ...bindTrigger( popupState ) }>
-			<AdjustmentsIcon fontSize={ SIZE } />
-		</IconButton>
+		<Tooltip title={ titleLabel } placement="top">
+			<IconButton size={ SIZE } aria-label={ titleLabel } { ...bindTrigger( popupState ) }>
+				<AdjustmentsIcon fontSize={ SIZE } />
+			</IconButton>
+		</Tooltip>
 	);
 };

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/transform-settings-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/transform-settings-control.tsx
@@ -11,7 +11,7 @@ import { TransformOriginControl } from './transform-base-controls/transform-orig
 
 const SIZE = 'tiny';
 
-export const TransformBaseControl = ( {
+export const TransformSettingsControl = ( {
 	popupState,
 	anchorRef,
 }: {
@@ -38,7 +38,7 @@ export const TransformBaseControl = ( {
 			{ ...popupProps }
 		>
 			<PopoverHeader
-				title={ __( 'Base Transform', 'elementor' ) }
+				title={ __( 'Transform settings', 'elementor' ) }
 				onClose={ popupState.close }
 				icon={ <AdjustmentsIcon fontSize={ SIZE } /> }
 			/>

--- a/packages/packages/libs/editor-controls/src/index.ts
+++ b/packages/packages/libs/editor-controls/src/index.ts
@@ -28,7 +28,7 @@ export { RepeatableControl } from './controls/repeatable-control';
 export { KeyValueControl } from './controls/key-value-control';
 export { PositionControl } from './controls/position-control';
 export { TransformRepeaterControl } from './controls/transform-control/transform-repeater-control';
-export { TransformBaseControl } from './controls/transform-control/transform-base-control';
+export { TransformSettingsControl } from './controls/transform-control/transform-settings-control';
 export { TransitionRepeaterControl } from './controls/transition-control/transition-repeater-control';
 export { PopoverContent } from './components/popover-content';
 export { enqueueFont } from './controls/font-family-control/enqueue-font';


### PR DESCRIPTION
Change some style control titles and add tooltip for transform settings button

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update style control titles and tooltips to improve consistency and clarity in the Elementor editor interface.
Main changes:
- Changed "Font Family" to lowercase "Font family" in multiple components for consistent capitalization
- Changed "Backdrop Filters" to "Backdrop filters" for consistent capitalization style
- Renamed "Base Transform" to "Transform settings" and added tooltip functionality
- Renamed TransformBaseControl to TransformSettingsControl for better semantics

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
