### PR TITLE
Revert "Internal: Cherry-pick PR 33011 to 3.32 Update core onboarding flow data [ED-21100]"

### DIFF
--- a/app/modules/onboarding/assets/js/utils/modules/event-dispatcher.js
+++ b/app/modules/onboarding/assets/js/utils/modules/event-dispatcher.js
@@ -104,11 +104,11 @@ export function createStepEventPayload( stepNumber, stepName, additionalData = {
 		...additionalData,
 	};
 
-	if ( stepNumber >= 2 && elementorAppConfig?.onboarding?.themeSelectionExperimentEnabled ) {
+	if ( 2 === stepNumber && elementorAppConfig?.onboarding?.themeSelectionExperimentEnabled ) {
 		basePayload.theme_selection_variant = getThemeSelectionVariant();
 	}
 
-	if ( stepNumber >= 4 && elementorAppConfig?.onboarding?.goodToGoExperimentEnabled ) {
+	if ( 4 === stepNumber && elementorAppConfig?.onboarding?.goodToGoExperimentEnabled ) {
 		basePayload.good_to_go_variant = getGoodToGoVariant();
 	}
 
@@ -116,27 +116,11 @@ export function createStepEventPayload( stepNumber, stepName, additionalData = {
 }
 
 export function createEditorEventPayload( additionalData = {} ) {
-	const basePayload = {
+	return {
 		location: 'editor',
 		trigger: 'elementor_loaded',
 		...additionalData,
 	};
-
-	if ( elementorAppConfig?.onboarding?.themeSelectionExperimentEnabled ) {
-		const themeVariant = getThemeSelectionVariant();
-		if ( themeVariant ) {
-			basePayload.theme_selection_variant = themeVariant;
-		}
-	}
-
-	if ( elementorAppConfig?.onboarding?.goodToGoExperimentEnabled ) {
-		const goodToGoVariant = getGoodToGoVariant();
-		if ( goodToGoVariant ) {
-			basePayload.good_to_go_variant = goodToGoVariant;
-		}
-	}
-
-	return basePayload;
 }
 
 export function dispatchStepEvent( eventName, stepNumber, stepName, additionalData = {} ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert changes to onboarding flow event tracking that modified theme selection and good-to-go variant payload handling.

Main changes:
- Reverted theme selection logic to only apply at step 2 instead of step >= 2
- Reverted good-to-go variant logic to only apply at step 4 instead of step >= 4
- Restored simpler createEditorEventPayload implementation without theme and good-to-go variant data

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
