### PR TITLE
Internal: Remove unneeded `resetExperiments()` from Playwright tests [ED-21249]

### DIFF
--- a/tests/playwright/sanity/assets/js/editor/editor.test.ts
+++ b/tests/playwright/sanity/assets/js/editor/editor.test.ts
@@ -4,13 +4,6 @@ import EditorSelectors from '../../../../selectors/editor-selectors';
 import WpAdminPage from '../../../../pages/wp-admin-page';
 
 test.describe( 'Editor tests', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Check that app-bar exists', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/device-mode.test.ts
+++ b/tests/playwright/sanity/device-mode.test.ts
@@ -3,13 +3,6 @@ import { parallelTest as test } from '../parallelTest';
 import WpAdminPage from '../pages/wp-admin-page';
 
 test.describe( 'Device mode', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Correct device mode is returned on Desktop', async ( { page, apiRequests }, testInfo ) => {
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests ),
 			editor = await wpAdmin.openNewPage(),

--- a/tests/playwright/sanity/includes/widgets/rating/accessibility-structured-data.test.ts
+++ b/tests/playwright/sanity/includes/widgets/rating/accessibility-structured-data.test.ts
@@ -2,15 +2,7 @@ import { expect } from '@playwright/test';
 import { parallelTest as test } from '../../../../parallelTest';
 import WpAdminPage from '../../../../pages/wp-admin-page';
 
-test.describe( 'Accessibility & Structured data @rating', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
+test.describe( 'Rating accessibility & structured data @rating', () => {
 	test( 'Accessibility & Structured data', async ( { page, apiRequests }, testInfo ) => {
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests ),
 			editor = await wpAdmin.openNewPage(),

--- a/tests/playwright/sanity/modules/nested-accordion/nested-accordion-style.test.ts
+++ b/tests/playwright/sanity/modules/nested-accordion/nested-accordion-style.test.ts
@@ -7,14 +7,6 @@ import { displayState } from '../../../enums/display-states';
 import { expectScreenshotToMatchLocator, setBorderAndBackground, setIconColor } from './helper';
 
 test.describe( 'Nested Accordion Style Tests @nested-accordion', () => {
-	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Accordion style tests', async ( { page, apiRequests }, testInfo ) => {
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests ),
 			editor = await wpAdmin.openNewPage(),

--- a/tests/playwright/sanity/modules/styleguide/styleguide-1.test.ts
+++ b/tests/playwright/sanity/modules/styleguide/styleguide-1.test.ts
@@ -4,13 +4,6 @@ import WpAdminPage from '../../../pages/wp-admin-page';
 import { getInSettingsTab } from './styleguide.helper';
 
 test.describe( 'Styleguide Preview tests @styleguide_image_link', () => {
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
-
 	test( 'Enabling Styleguide Preview user preference enabled Styleguide Preview at Global Colors and Global Typography', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/modules/styleguide/styleguide-2.test.ts
+++ b/tests/playwright/sanity/modules/styleguide/styleguide-2.test.ts
@@ -1,17 +1,9 @@
 import { expect } from '@playwright/test';
 import { parallelTest as test } from '../../../parallelTest';
-import WpAdminPage from '../../../pages/wp-admin-page';
 import { getInSettingsTab } from './styleguide.helper';
 
 test.describe( 'Styleguide Preview tests @styleguide_image_link', () => {
 	const fontsContentText = 'The five boxing wizards jump quickly.';
-
-	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		const page = await browser.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
-	} );
 
 	test( 'Change font title', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.

--- a/tests/playwright/sanity/plugin-tester-section.test.ts
+++ b/tests/playwright/sanity/plugin-tester-section.test.ts
@@ -8,7 +8,6 @@ test.describe( `Plugin tester tests: sections @plugin_tester_section`, () => {
 	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
 		const page = await browser.newPage();
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
 		await wpAdmin.setExperiments( { container: 'inactive' } );
 		await page.close();
 	} );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove unnecessary `resetExperiments()` calls from Playwright test setup hooks to streamline test initialization.

Main changes:
- Removed `beforeAll` and `afterAll` hooks that called `resetExperiments()` from multiple test files
- Updated `plugin-tester-section.test.ts` to maintain `setExperiments()` call without the reset
- Fixed test description in `accessibility-structured-data.test.ts` to maintain proper tagging

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
