### PR TITLE
Internal: Refactor create component flow [ED-21031]

### DIFF
--- a/assets/dev/js/editor/document/save/commands/internal/save.js
+++ b/assets/dev/js/editor/document/save/commands/internal/save.js
@@ -1,5 +1,5 @@
 export class Save extends $e.modules.CommandInternalBase {
-	apply( args ) {
+	async apply( args ) {
 		const { status = 'draft', force = false, onSuccess = null, document = elementor.documents.getCurrent() } = args;
 
 		if ( ! force && document.editor.isSaving ) {
@@ -20,6 +20,10 @@ export class Save extends $e.modules.CommandInternalBase {
 		document.editor.isChangedDuringSave = false;
 
 		settings.post_status = status;
+
+		if ( elementorCommon.config.experimentalFeatures?.e_components ) {
+			await elementor.__beforeSave?.( { container, status } );
+		}
 
 		let elements = [];
 

--- a/assets/dev/js/editor/document/save/commands/internal/save.js
+++ b/assets/dev/js/editor/document/save/commands/internal/save.js
@@ -22,7 +22,7 @@ export class Save extends $e.modules.CommandInternalBase {
 		settings.post_status = status;
 
 		if ( elementorCommon.config.experimentalFeatures?.e_components ) {
-			await elementor.__beforeSave?.( { container, status } );
+			await elementorCommon.__beforeSave?.( { container, status } );
 		}
 
 		let elements = [];

--- a/modules/components/components-repository.php
+++ b/modules/components/components-repository.php
@@ -43,12 +43,12 @@ class Components_Repository {
 		return Components::make( $components );
 	}
 
-	public function create( string $name, array $content ) {
+	public function create( string $name, array $content, string $status ) {
 		$document = Plugin::$instance->documents->create(
 			Component_Document::get_type(),
 			[
 				'post_title' => $name,
-				'post_status' => 'publish',
+				'post_status' => $status,
 			]
 		);
 

--- a/modules/components/components-repository.php
+++ b/modules/components/components-repository.php
@@ -20,7 +20,7 @@ class Components_Repository {
 		// Components count is limited to 50, if we increase this number, we need to iterate the posts in batches.
 		$posts = get_posts( [
 			'post_type' => Component_Document::TYPE,
-			'post_status' => 'publish',
+			'post_status' => 'any',
 			'posts_per_page' => Components_REST_API::MAX_COMPONENTS,
 		] );
 

--- a/modules/components/components-rest-api.php
+++ b/modules/components/components-rest-api.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Components;
 
+use Elementor\Core\Base\Document;
 use Elementor\Core\Utils\Api\Error_Builder;
 use Elementor\Core\Utils\Api\Response_Builder;
 
@@ -63,6 +64,10 @@ class Components_REST_API {
 							'type' => 'object',
 						],
 					],
+					'status' => [
+									'type' => 'string',
+									'enum' => [ Document::STATUS_PUBLISH, Document::STATUS_DRAFT, Document::STATUS_AUTOSAVE ],
+								],
 				],
 			],
 		] );
@@ -118,9 +123,10 @@ class Components_REST_API {
 		$name = $name_result->unwrap();
 		// The content is validated & sanitized in the document save process.
 		$content = $request->get_param( 'content' );
+		$status = $request->get_param( 'status' );
 
 		try {
-			$component_id = $this->get_repository()->create( $name, $content );
+			$component_id = $this->get_repository()->create( $name, $content, $status );
 
 			return Response_Builder::make( [ 'component_id' => $component_id ] )->set_status( 201 )->build();
 		} catch ( \Exception $e ) {

--- a/modules/components/components-rest-api.php
+++ b/modules/components/components-rest-api.php
@@ -65,9 +65,9 @@ class Components_REST_API {
 						],
 					],
 					'status' => [
-									'type' => 'string',
-									'enum' => [ Document::STATUS_PUBLISH, Document::STATUS_DRAFT, Document::STATUS_AUTOSAVE ],
-								],
+						'type' => 'string',
+						'enum' => [ Document::STATUS_PUBLISH, Document::STATUS_DRAFT, Document::STATUS_AUTOSAVE ],
+					],
 				],
 			],
 		] );

--- a/modules/components/components-rest-api.php
+++ b/modules/components/components-rest-api.php
@@ -67,6 +67,7 @@ class Components_REST_API {
 					'status' => [
 						'type' => 'string',
 						'enum' => [ Document::STATUS_PUBLISH, Document::STATUS_DRAFT, Document::STATUS_AUTOSAVE ],
+						'required' => true,
 					],
 				],
 			],

--- a/packages/packages/core/editor-components/src/api.ts
+++ b/packages/packages/core/editor-components/src/api.ts
@@ -2,13 +2,14 @@ import { type V1ElementData, type V1ElementModelProps } from '@elementor/editor-
 import { ajax } from '@elementor/editor-v1-adapters';
 import { type HttpResponse, httpService } from '@elementor/http-client';
 
-import { type Component } from './types';
+import { DocumentStatus, type Component } from './types';
 
 const BASE_URL = 'elementor/v1/components';
 
 export type CreateComponentPayload = {
 	name: string;
-	content: V1ElementModelProps[];
+	content: V1ElementData[];
+	status: DocumentStatus;
 };
 
 type GetComponentResponse = Array< Component >;
@@ -31,10 +32,6 @@ export const apiClient = {
 	create: ( payload: CreateComponentPayload ) =>
 		httpService()
 			.post< HttpResponse< CreateComponentResponse > >( `${ BASE_URL }`, payload )
-			.then( ( res ) => res.data.data ),
-	update: ( payload: any ) =>
-		httpService()
-			.post< HttpResponse< Map< number, number > > >( `${ BASE_URL }`, payload )
 			.then( ( res ) => res.data.data ),
 	getComponentConfig: ( id: number ) => ajax.load< { id: number }, V1ElementData >( getParams( id ) ),
 	invalidateComponentConfigCache: ( id: number ) => ajax.invalidateCache< { id: number } >( getParams( id ) ),

--- a/packages/packages/core/editor-components/src/api.ts
+++ b/packages/packages/core/editor-components/src/api.ts
@@ -1,8 +1,8 @@
-import { type V1ElementData, type V1ElementModelProps } from '@elementor/editor-elements';
+import { type V1ElementData } from '@elementor/editor-elements';
 import { ajax } from '@elementor/editor-v1-adapters';
 import { type HttpResponse, httpService } from '@elementor/http-client';
 
-import { DocumentStatus, type Component } from './types';
+import { type Component, type DocumentStatus } from './types';
 
 const BASE_URL = 'elementor/v1/components';
 

--- a/packages/packages/core/editor-components/src/api.ts
+++ b/packages/packages/core/editor-components/src/api.ts
@@ -32,6 +32,10 @@ export const apiClient = {
 		httpService()
 			.post< HttpResponse< CreateComponentResponse > >( `${ BASE_URL }`, payload )
 			.then( ( res ) => res.data.data ),
+	update: ( payload: any ) =>
+		httpService()
+			.post< HttpResponse< Map< number, number > > >( `${ BASE_URL }`, payload )
+			.then( ( res ) => res.data.data ),
 	getComponentConfig: ( id: number ) => ajax.load< { id: number }, V1ElementData >( getParams( id ) ),
 	invalidateComponentConfigCache: ( id: number ) => ajax.invalidateCache< { id: number } >( getParams( id ) ),
 };

--- a/packages/packages/core/editor-components/src/component-id-transformer.ts
+++ b/packages/packages/core/editor-components/src/component-id-transformer.ts
@@ -1,14 +1,24 @@
 import { createTransformer } from '@elementor/editor-canvas';
+import { __getState as getState } from '@elementor/store';
+
+import { selectUnpublishedComponents } from './store/store';
 
 type ComponentIdTransformerWindow = Window & {
 	elementor?: {
 		documents?: {
-			request: ( id: string ) => Promise< { elements?: unknown[] } >;
+			request: ( id: number ) => Promise< { elements?: unknown[] } >;
 		};
 	};
 };
 
-export const componentIdTransformer = createTransformer( async ( id: string ) => {
+export const componentIdTransformer = createTransformer( async ( id: number ) => {
+	const unpublishedComponents = selectUnpublishedComponents( getState() );
+
+	const unpublishedComponent = unpublishedComponents.find( ( component ) => component.id === id );
+	if ( unpublishedComponent ) {
+		return structuredClone( unpublishedComponent.content );
+	}
+
 	const extendedWindow = window as unknown as ComponentIdTransformerWindow;
 
 	const documentManager = extendedWindow.elementor?.documents;

--- a/packages/packages/core/editor-components/src/components/__tests__/create-component-form.test.tsx
+++ b/packages/packages/core/editor-components/src/components/__tests__/create-component-form.test.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { createMockElement, renderWithStore } from 'test-utils';
 import { getElementLabel, replaceElement, type V1Element } from '@elementor/editor-elements';
 import { __createStore, __dispatch, __registerSlice, type SliceState, type Store } from '@elementor/store';
+import { __getState as getState } from '@elementor/store';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 
 import { apiClient } from '../../api';
-import { slice } from '../../store/store';
+import { selectComponents, slice } from '../../store/store';
 import { CreateComponentForm } from '../create-component-form/create-component-form';
 
 jest.mock( '@elementor/editor-elements' );
@@ -14,13 +15,11 @@ jest.mock( '../../api' );
 
 const mockGetElementLabel = jest.mocked( getElementLabel );
 
-const mockCreateComponent = jest.mocked( apiClient.create );
 const mockGetComponents = jest.mocked( apiClient.get );
 
 const mockReplaceElement = jest.mocked( replaceElement );
 
 const mockElement: V1Element = createMockElement( { model: { id: 'test-element' } } );
-const mockComponentId = 123245;
 
 describe( 'CreateComponentForm', () => {
 	let store: Store< SliceState< typeof slice > >;
@@ -73,17 +72,6 @@ describe( 'CreateComponentForm', () => {
 		};
 	};
 
-	const setupSuccessfulSave = () => {
-		mockCreateComponent.mockImplementation( async () => {
-			await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
-			return Promise.resolve( { component_id: mockComponentId } );
-		} );
-	};
-
-	const setupFailedSave = () => {
-		mockCreateComponent.mockRejectedValue( new Error( 'Creation failed' ) );
-	};
-
 	describe( 'Form Opening & Initial State', () => {
 		it( 'should not show form initially', () => {
 			// Arrange.
@@ -130,7 +118,6 @@ describe( 'CreateComponentForm', () => {
 			// Assert.
 			expect( screen.getByText( 'Component name is required.' ) ).toBeInTheDocument();
 			expect( getCreateButton() ).toBeDisabled();
-			expect( mockCreateComponent ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should disable submit when component name is only whitespace', () => {
@@ -145,7 +132,6 @@ describe( 'CreateComponentForm', () => {
 			// Assert.
 			expect( screen.getByText( 'Component name is required.' ) ).toBeInTheDocument();
 			expect( getCreateButton() ).toBeDisabled();
-			expect( mockCreateComponent ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should disable submit when component name is too short (< 2 chars)', () => {
@@ -162,7 +148,6 @@ describe( 'CreateComponentForm', () => {
 			expect(
 				screen.getByText( 'Component name is too short. Please enter at least 2 characters.' )
 			).toBeInTheDocument();
-			expect( mockCreateComponent ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should disable submit when component name is too long (> 50 chars)', () => {
@@ -219,11 +204,32 @@ describe( 'CreateComponentForm', () => {
 	} );
 
 	describe( 'Component Creation - Success Flow', () => {
-		beforeEach( () => {
-			setupSuccessfulSave();
+		it( 'should add component to local store', () => {
+			// Arrange.
+			const { openForm, fillComponentName, getCreateButton } = setupForm();
+			const spyAddUnpublished = jest.spyOn( slice.actions, 'addUnpublished' );
+			openForm();
+
+			// Act.
+			fillComponentName( 'My Test Component' );
+			fireEvent.click( getCreateButton() );
+
+			// Assert.
+			expect( spyAddUnpublished ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					id: expect.any( Number ),
+					name: 'My Test Component',
+					content: [ mockElement.model.toJSON( { remove: [ 'default' ] } ) ],
+				} )
+			);
+
+			expect( selectComponents( getState() ) ).toEqual( [
+				{ id: expect.any( Number ), name: 'My Test Component' },
+				{ id: 123, name: 'Existing Component' },
+			] );
 		} );
 
-		xit( 'should call create component with correct parameters', async () => {
+		it( 'should replace original element with component instance', async () => {
 			// Arrange.
 			const { openForm, fillComponentName, getCreateButton } = setupForm();
 			openForm();
@@ -233,91 +239,22 @@ describe( 'CreateComponentForm', () => {
 			fireEvent.click( getCreateButton() );
 
 			// Assert.
-			await waitFor( () => {
-				expect( mockCreateComponent ).toHaveBeenCalledWith(
-					expect.objectContaining( {
-						name: 'My Test Component',
-						content: [ mockElement.model.toJSON( { remove: [ 'default' ] } ) ],
-					} )
-				);
-			} );
-		} );
-
-		it( 'should show loading state during component creation', async () => {
-			// Arrange.
-			const { openForm, fillComponentName, getCreateButton } = setupForm();
-			openForm();
-
-			// Act.
-			fillComponentName( 'My Test Component' );
-			fireEvent.click( getCreateButton() );
-
-			// Assert.
-			await waitFor( () => {
-				expect( screen.getByText( 'Creating…' ) ).toBeInTheDocument();
-			} );
-		} );
-
-		it( 'should disable buttons during loading', async () => {
-			// Arrange.
-			const { openForm, fillComponentName, getCreateButton, getCancelButton } = setupForm();
-			openForm();
-
-			// Act.
-			fillComponentName( 'My Test Component' );
-			fireEvent.click( getCreateButton() );
-
-			// Assert.
-			await waitFor(
-				() => {
-					expect( screen.queryByText( 'Create' ) ).not.toBeInTheDocument();
-				},
-				{ timeout: 1000 }
-			);
-
-			await waitFor(
-				() => {
-					expect( screen.getByText( 'Creating…' ) ).toBeDisabled();
-				},
-				{ timeout: 1000 }
-			);
-
-			await waitFor(
-				() => {
-					expect( getCancelButton() ).toBeDisabled();
-				},
-				{ timeout: 1000 }
-			);
-		} );
-
-		it( 'should call replace element with correct parameters after successful creation', async () => {
-			// Arrange.
-			const { openForm, fillComponentName, getCreateButton } = setupForm();
-			openForm();
-
-			// Act.
-			fillComponentName( 'My Test Component' );
-			fireEvent.click( getCreateButton() );
-
-			// Assert.
-			await waitFor( () => {
-				expect( mockReplaceElement ).toHaveBeenCalledWith( {
-					currentElement: mockElement,
-					newElement: {
-						elType: 'widget',
-						widgetType: 'e-component',
-						settings: {
-							component: {
-								$$type: 'component-id',
-								value: mockComponentId,
-							},
-						},
-						editor_settings: {
-							title: 'My Test Component',
+			expect( mockReplaceElement ).toHaveBeenCalledWith( {
+				currentElement: mockElement,
+				newElement: {
+					elType: 'widget',
+					widgetType: 'e-component',
+					settings: {
+						component: {
+							$$type: 'component-id',
+							value: expect.any( Number ),
 						},
 					},
-					withHistory: false,
-				} );
+					editor_settings: {
+						title: 'My Test Component',
+					},
+				},
+				withHistory: false,
 			} );
 		} );
 
@@ -353,12 +290,12 @@ describe( 'CreateComponentForm', () => {
 	} );
 
 	describe( 'Error Handling', () => {
-		beforeEach( () => {
-			setupFailedSave();
-		} );
-
-		it( 'should show error notification when creation fails', async () => {
+		it( 'should show error notification when replacing element fails', async () => {
 			// Arrange.
+			mockReplaceElement.mockImplementation( () => {
+				throw new Error( 'Failed to replace element' );
+			} );
+
 			const { openForm, fillComponentName, getCreateButton } = setupForm();
 			openForm();
 
@@ -370,24 +307,6 @@ describe( 'CreateComponentForm', () => {
 			await waitFor( () => {
 				expect( screen.getByText( 'Failed to save component. Please try again.' ) ).toBeInTheDocument();
 			} );
-		} );
-
-		it( 'should reset loading state after error', async () => {
-			// Arrange.
-			const { openForm, fillComponentName, getCreateButton } = setupForm();
-			openForm();
-
-			// Act.
-			fillComponentName( 'My Test Component' );
-			fireEvent.click( getCreateButton() );
-
-			// Assert.
-			await waitFor( () => {
-				expect( screen.queryByText( 'Creating…' ) ).not.toBeInTheDocument();
-			} );
-
-			// Assert.
-			expect( getCreateButton() ).toBeEnabled();
 		} );
 	} );
 

--- a/packages/packages/core/editor-components/src/components/create-component-form/create-component-form.tsx
+++ b/packages/packages/core/editor-components/src/components/create-component-form/create-component-form.tsx
@@ -3,11 +3,12 @@ import { useEffect, useMemo, useState } from 'react';
 import { getElementLabel, type V1Element } from '@elementor/editor-elements';
 import { ThemeProvider } from '@elementor/editor-ui';
 import { StarIcon } from '@elementor/icons';
+import { __useDispatch as useDispatch } from '@elementor/store';
 import { Alert, Button, FormLabel, Grid, Popover, Snackbar, Stack, TextField, Typography } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { useComponents } from '../../hooks/use-components';
-import { useCreateComponent } from '../../hooks/use-create-component';
+import { slice } from '../../store/store';
 import { type ComponentFormValues } from '../../types';
 import { useForm } from './hooks/use-form';
 import { createBaseComponentSchema, createSubmitComponentSchema } from './utils/component-form-schema';
@@ -34,7 +35,8 @@ export function CreateComponentForm() {
 
 	const [ resultNotification, setResultNotification ] = useState< ResultNotification | null >( null );
 
-	const { createComponent, isPending } = useCreateComponent();
+	const dispatch = useDispatch();
+
 	useEffect( () => {
 		const OPEN_SAVE_AS_COMPONENT_FORM_EVENT = 'elementor/editor/open-save-as-component-form';
 
@@ -51,31 +53,32 @@ export function CreateComponentForm() {
 	}, [] );
 
 	const handleSave = async ( values: ComponentFormValues ) => {
-		if ( ! element ) {
-			throw new Error( `Can't save element as component: element not found` );
-		}
-
 		try {
-			const result = await createComponent( {
-				name: values.componentName,
-				content: [ element.element.model.toJSON( { remove: [ 'default' ] } ) ],
-			} );
-
 			if ( ! element ) {
-				throw new Error( `Can't replace element with component: element not found` );
+				throw new Error( `Can't save element as component: element not found` );
 			}
 
+			const tempId = generateTempId();
+
+			dispatch(
+				slice.actions.addUnpublished( {
+					id: tempId,
+					name: values.componentName,
+					content: [ element.element.model.toJSON( { remove: [ 'default' ] } ) ],
+				} )
+			);
+
 			replaceElementWithComponent( element.element, {
-				id: result.component_id,
+				id: tempId,
 				name: values.componentName,
 			} );
 
 			setResultNotification( {
 				show: true,
-				// Translators: %1$s: Component name, %2$s: Component ID
-				message: __( 'Component saved successfully as: %1$s (ID: %2$s)', 'elementor' )
+				// Translators: %1$s: Component name, %2$s: Component temp ID
+				message: __( 'Component saved successfully as: %1$s (temp ID: %2$s)', 'elementor' )
 					.replace( '%1$s', values.componentName )
-					.replace( '%2$s', result.component_id.toString() ),
+					.replace( '%2$s', tempId.toString() ),
 				type: 'success',
 			} );
 
@@ -107,7 +110,6 @@ export function CreateComponentForm() {
 					<Form
 						initialValues={ { componentName: element.elementLabel } }
 						handleSave={ handleSave }
-						isSubmitting={ isPending }
 						closePopup={ resetAndClosePopup }
 					/>
 				) }
@@ -130,12 +132,10 @@ const FONT_SIZE = 'tiny';
 const Form = ( {
 	initialValues,
 	handleSave,
-	isSubmitting,
 	closePopup,
 }: {
 	initialValues: ComponentFormValues;
 	handleSave: ( values: ComponentFormValues ) => void;
-	isSubmitting: boolean;
 	closePopup: () => void;
 } ) => {
 	const { values, errors, isValid, handleChange, validateForm } = useForm< ComponentFormValues >( initialValues );
@@ -199,19 +199,23 @@ const Form = ( {
 				</Grid>
 			</Grid>
 			<Stack direction="row" justifyContent="flex-end" alignSelf="end" py={ 1 } px={ 1.5 }>
-				<Button onClick={ closePopup } disabled={ isSubmitting } color="secondary" variant="text" size="small">
+				<Button onClick={ closePopup } color="secondary" variant="text" size="small">
 					{ __( 'Cancel', 'elementor' ) }
 				</Button>
 				<Button
 					onClick={ handleSubmit }
-					disabled={ isSubmitting || ! isValid }
+					disabled={ ! isValid }
 					variant="contained"
 					color="primary"
 					size="small"
 				>
-					{ isSubmitting ? __( 'Creating…', 'elementor' ) : __( 'Create', 'elementor' ) }
+					{ __( 'Create', 'elementor' ) }
 				</Button>
 			</Stack>
 		</Stack>
 	);
+};
+
+export const generateTempId = () => {
+	return Date.now() + Math.floor( Math.random() * 1000000 );
 };

--- a/packages/packages/core/editor-components/src/components/create-component-form/utils/replace-element-with-component.ts
+++ b/packages/packages/core/editor-components/src/components/create-component-form/utils/replace-element-with-component.ts
@@ -2,7 +2,7 @@ import { replaceElement, type V1Element } from '@elementor/editor-elements';
 
 import { type Component } from '../../../types';
 
-export const replaceElementWithComponent = async ( element: V1Element, component: Component ) => {
+export const replaceElementWithComponent = ( element: V1Element, component: Component ) => {
 	replaceElement( {
 		currentElement: element,
 		newElement: createComponentModel( component ),

--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -33,7 +33,7 @@ export function init() {
 		return true;
 	} );
 
-	( window as unknown as ExtendedWindow ).elementor.__beforeSave = beforeSave;
+	( window as unknown as ExtendedWindow ).elementorCommon.__beforeSave = beforeSave;
 
 	injectTab( {
 		id: 'components',

--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -16,7 +16,8 @@ import { componentsStylesProvider } from './store/components-styles-provider';
 import { loadComponentsStyles } from './store/load-components-styles';
 import { removeComponentStyles } from './store/remove-component-styles';
 import { slice } from './store/store';
-import { type Element } from './types';
+import { type Element, type ExtendedWindow } from './types';
+import { beforeSave } from './utils/before-save';
 
 const COMPONENT_DOCUMENT_TYPE = 'elementor_component';
 
@@ -31,6 +32,8 @@ export function init() {
 		}
 		return true;
 	} );
+
+	( window as unknown as ExtendedWindow ).elementor.__beforeSave = beforeSave;
 
 	injectTab( {
 		id: 'components',

--- a/packages/packages/core/editor-components/src/store/store.ts
+++ b/packages/packages/core/editor-components/src/store/store.ts
@@ -1,3 +1,4 @@
+import { type V1ElementData } from '@elementor/editor-elements';
 import {
 	__createSelector as createSelector,
 	__createSlice as createSlice,
@@ -7,7 +8,6 @@ import {
 
 import { type Component, type ComponentId, type StylesDefinition } from '../types';
 import { createComponent, loadComponents } from './thunks';
-import { V1ElementData } from '@elementor/editor-elements';
 
 type GetComponentResponse = Component[];
 

--- a/packages/packages/core/editor-components/src/store/store.ts
+++ b/packages/packages/core/editor-components/src/store/store.ts
@@ -7,11 +7,12 @@ import {
 
 import { type Component, type ComponentId, type StylesDefinition } from '../types';
 import { createComponent, loadComponents } from './thunks';
+import { V1ElementData } from '@elementor/editor-elements';
 
 type GetComponentResponse = Component[];
 
-type UnpublishedComponent = Component & {
-	content: Element[];
+export type UnpublishedComponent = Component & {
+	content: V1ElementData[];
 };
 
 type Status = 'idle' | 'pending' | 'error';

--- a/packages/packages/core/editor-components/src/store/store.ts
+++ b/packages/packages/core/editor-components/src/store/store.ts
@@ -10,10 +10,15 @@ import { createComponent, loadComponents } from './thunks';
 
 type GetComponentResponse = Component[];
 
+type UnpublishedComponent = Component & {
+	content: Element[];
+};
+
 type Status = 'idle' | 'pending' | 'error';
 
 type ComponentsState = {
 	data: Component[];
+	unpublishedData: UnpublishedComponent[];
 	loadStatus: Status;
 	createStatus: Status;
 	styles: StylesDefinition;
@@ -23,6 +28,7 @@ type ComponentsSlice = SliceState< typeof slice >;
 
 export const initialState: ComponentsState = {
 	data: [],
+	unpublishedData: [],
 	loadStatus: 'idle',
 	createStatus: 'idle',
 	styles: {},
@@ -33,11 +39,21 @@ export const slice = createSlice( {
 	name: SLICE_NAME,
 	initialState,
 	reducers: {
-		add: ( state, { payload } ) => {
-			state.data = { ...payload };
+		add: ( state, { payload }: PayloadAction< Component | Component[] > ) => {
+			if ( Array.isArray( payload ) ) {
+				state.data = [ ...state.data, ...payload ];
+			} else {
+				state.data.unshift( payload );
+			}
 		},
-		load: ( state, { payload } ) => {
+		load: ( state, { payload }: PayloadAction< Component[] > ) => {
 			state.data = payload;
+		},
+		addUnpublished: ( state, { payload } ) => {
+			state.unpublishedData.unshift( payload );
+		},
+		resetUnpublished: ( state ) => {
+			state.unpublishedData = [];
 		},
 		removeStyles( state, { payload }: PayloadAction< { id: ComponentId } > ) {
 			const { [ payload.id ]: _, ...rest } = state.styles;
@@ -79,8 +95,20 @@ const selectData = ( state: ComponentsSlice ) => state[ SLICE_NAME ].data;
 const selectLoadStatus = ( state: ComponentsSlice ) => state[ SLICE_NAME ].loadStatus;
 const selectCreateStatus = ( state: ComponentsSlice ) => state[ SLICE_NAME ].createStatus;
 const selectStylesDefinitions = ( state: ComponentsSlice ) => state[ SLICE_NAME ].styles ?? {};
+const selectUnpublishedData = ( state: ComponentsSlice ) => state[ SLICE_NAME ].unpublishedData;
 
-export const selectComponents = createSelector( selectData, ( data: Component[] ) => data );
+export const selectComponents = createSelector(
+	selectData,
+	selectUnpublishedData,
+	( data: Component[], unpublishedData: UnpublishedComponent[] ) => [
+		...unpublishedData.map( ( item ) => ( { id: item.id, name: item.name } ) ),
+		...data,
+	]
+);
+export const selectUnpublishedComponents = createSelector(
+	selectUnpublishedData,
+	( unpublishedData: UnpublishedComponent[] ) => unpublishedData
+);
 export const selectLoadIsPending = createSelector( selectLoadStatus, ( status ) => status === 'pending' );
 export const selectLoadIsError = createSelector( selectLoadStatus, ( status ) => status === 'error' );
 export const selectCreateIsPending = createSelector( selectCreateStatus, ( status ) => status === 'pending' );

--- a/packages/packages/core/editor-components/src/types.ts
+++ b/packages/packages/core/editor-components/src/types.ts
@@ -1,5 +1,4 @@
 import { type V1ElementModelProps, type V1ElementSettingsProps } from '@elementor/editor-elements';
-import { type NumberPropValue } from '@elementor/editor-props';
 import type { StyleDefinition } from '@elementor/editor-styles';
 
 export type ComponentFormValues = {
@@ -20,7 +19,10 @@ export type DocumentStatus = 'publish' | 'draft' | 'autosave';
 export type Element = V1ElementModelProps & {
 	elements?: Element[];
 	settings?: V1ElementSettingsProps & {
-		component_id?: NumberPropValue;
+		component?: {
+			$$type: 'component-id';
+			value: number;
+		};
 	};
 };
 

--- a/packages/packages/core/editor-components/src/types.ts
+++ b/packages/packages/core/editor-components/src/types.ts
@@ -15,6 +15,8 @@ export type Component = {
 	name: string;
 };
 
+export type DocumentStatus = 'publish' | 'draft' | 'autosave';
+
 export type Element = V1ElementModelProps & {
 	elements?: Element[];
 	settings?: V1ElementSettingsProps & {
@@ -23,5 +25,5 @@ export type Element = V1ElementModelProps & {
 };
 
 export type ExtendedWindow = Window & {
-	elementor: Record< string, unknown >;
+	elementorCommon: Record< string, unknown >;
 };

--- a/packages/packages/core/editor-components/src/types.ts
+++ b/packages/packages/core/editor-components/src/types.ts
@@ -21,3 +21,7 @@ export type Element = V1ElementModelProps & {
 		component_id?: NumberPropValue;
 	};
 };
+
+export type ExtendedWindow = Window & {
+	elementor: Record< string, unknown >;
+};

--- a/packages/packages/core/editor-components/src/utils/__tests__/before-save.test.ts
+++ b/packages/packages/core/editor-components/src/utils/__tests__/before-save.test.ts
@@ -9,9 +9,247 @@ jest.mock( '@elementor/editor-elements' );
 jest.mock( '../../api' );
 
 const mockUpdateElementSettings = jest.mocked( updateElementSettings );
-const mockUpdateComponents = jest.mocked( apiClient.update );
+const mockCreateComponents = jest.mocked( apiClient.create );
 
-const mockElements: V1ElementData[] = [
+describe( 'beforeSave', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		__registerSlice( slice );
+		__createStore();
+	} );
+
+	const createMockContainer = ( elements: V1ElementData[] = [] ) => ( {
+		model: {
+			get: () => ( {
+				toJSON: () => elements,
+			} ),
+		},
+	} );
+
+	const setupUnpublishedComponents = () => {
+		__dispatch(
+			slice.actions.addUnpublished( {
+				id: 1000,
+				name: 'Test Component 1',
+				content: mockComponent1Content,
+			} )
+		);
+		__dispatch(
+			slice.actions.addUnpublished( {
+				id: 3000,
+				name: 'Test Component 2',
+				content: mockComponent2Content,
+			} )
+		);
+
+		mockCreateComponents.mockImplementation( (payload) => {
+			switch (payload.name) {
+				case 'Test Component 1':
+					return Promise.resolve( { component_id: 1111 } );
+				case 'Test Component 2':
+					return Promise.resolve( { component_id: 3333 } );
+
+				default:
+					return Promise.resolve( { component_id: 0 } );
+			}
+		} );
+	};
+
+	describe( 'No Unpublished Components', () => {
+		it( 'should not update any element settings or make API calls', async () => {
+			// Arrange
+			const container = createMockContainer();
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			  expect(mockCreateComponents).not.toHaveBeenCalled();
+			expect( mockUpdateElementSettings ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Component Publishing', () => {
+		beforeEach( () => {
+			setupUnpublishedComponents();
+		} );
+
+		it( 'should send create requests for unpublished components', async () => {
+			// Act
+			await beforeSave( { container: createMockContainer(), status: 'publish' } );
+
+			// Assert
+			expect( mockCreateComponents ).toHaveBeenCalledTimes( 2 );
+			expect( mockCreateComponents ).toHaveBeenCalledWith( {
+				name: 'Test Component 1',
+				content: mockComponent1Content,
+				status: 'publish',
+			} );
+			expect( mockCreateComponents ).toHaveBeenCalledWith( {
+				name: 'Test Component 2',
+				content: mockComponent2Content,
+				status: 'publish',
+			} );
+		} );
+
+		it( 'should throw error when component update fails', async () => {
+			// Arrange
+			const container = createMockContainer();
+			mockCreateComponents.mockRejectedValue( new Error( 'API Error' ) );
+
+			// Act & Assert
+			await expect( beforeSave( { container, status: 'draft' } ) ).rejects.toThrow(
+				'Failed to publish components and update component instances'
+			);
+		} );
+	} );
+
+	describe( 'Component Instance Updates - Replacing temporary IDs with actual IDs', () => {
+		beforeEach( () => {
+			setupUnpublishedComponents();
+		} );
+
+		it( 'should replace temporary component IDs with actual IDs from server response', async () => {
+			// Arrange
+			const container = createMockContainer( mockPageElements );
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			expect( mockUpdateElementSettings ).toHaveBeenCalledTimes( 2 );
+			expect( mockUpdateElementSettings ).toHaveBeenCalledWith( {
+				id: 'element-1_component-with-temp-id',
+				props: {
+					component_id: expect.objectContaining( {
+						value: 1111,
+					} ),
+				},
+				withHistory: false,
+			} );
+			expect( mockUpdateElementSettings ).toHaveBeenCalledWith( {
+				id: 'element-3_component-with-temp-id',
+				props: {
+					component_id: expect.objectContaining( {
+						value: 3333,
+					} ),
+				},
+				withHistory: false,
+			} );
+		} );
+
+		it( 'should not change component instances that already have actual IDs', async () => {
+			// Arrange
+			const container = createMockContainer( mockPageElements );
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			expect( mockUpdateElementSettings ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { id: 'element-5_component-with-actual-id' } )
+			);
+		} );
+
+		it( 'should skip non-component elements', async () => {
+			// Arrange
+			const container = createMockContainer( mockPageElements );
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			expect( mockUpdateElementSettings ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { id: 'element-2_not-a-component' } )
+			);
+			expect( mockUpdateElementSettings ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { id: 'element-4_not-a-component' } )
+			);
+		} );
+
+		it( 'should handle empty elements array', async () => {
+			// Arrange
+			const container = createMockContainer( [] );
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			expect( mockUpdateElementSettings ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Handle store state', () => {
+		beforeEach( () => {
+			setupUnpublishedComponents();
+		} );
+
+		it( 'should add newly published components to the main component store', async () => {
+			// Arrange
+			__dispatch(
+				slice.actions.add( {
+					id: 4444,
+					name: 'Published Component',
+				} )
+			);
+			const container = createMockContainer( [] );
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			expect( getState().components.data ).toEqual( [
+				{ id: 4444, name: 'Published Component' },
+				{ id: 3333, name: 'Test Component 2' },
+				{ id: 1111, name: 'Test Component 1' },
+			] );
+		} );
+
+		it( 'should clear all unpublished components from store after successful save', async () => {
+			// Assert
+			expect( selectUnpublishedComponents( getState() ) ).toEqual( [
+				{ id: 3000, name: 'Test Component 2', content: mockComponent2Content },
+				{ id: 1000, name: 'Test Component 1', content: mockComponent1Content },
+			] );
+
+			// Act
+			await beforeSave( { container: createMockContainer(), status: 'draft' } );
+
+			// Assert
+			expect( selectUnpublishedComponents( getState() ) ).toEqual( [] );
+		} );
+	} );
+} );
+
+const mockComponent1Content: V1ElementData[] = [
+	{
+		id: 'element-1_component-1',
+		elType: 'widget',
+		widgetType: 'button',
+		settings: {
+			text: {
+				$$type: 'string',
+				value: 'Click Me!',
+			},
+		},
+	}
+];
+
+const mockComponent2Content: V1ElementData[] = [
+	{
+		id: 'element-2_component-2',
+		elType: 'widget',
+		widgetType: 'heading',
+		settings: {
+			title: {
+				$$type: 'string',
+				value: 'This is a heading',
+			},
+		},
+	}
+];
+
+const mockPageElements: V1ElementData[] = [
 	{
 		id: 'element-1_component-with-temp-id',
 		elType: 'widget',
@@ -63,221 +301,3 @@ const mockElements: V1ElementData[] = [
 		},
 	},
 ];
-
-describe( 'beforeSave', () => {
-	beforeEach( () => {
-		jest.clearAllMocks();
-		__registerSlice( slice );
-		__createStore();
-	} );
-
-	const createMockContainer = ( elements: V1ElementData[] = [] ) => ( {
-		model: {
-			get: () => ( {
-				toJSON: () => elements,
-			} ),
-		},
-	} );
-
-	describe( 'No Unpublished Components', () => {
-		it( 'should not update any element settings or make API calls', async () => {
-			// Arrange
-			const container = createMockContainer();
-
-			// Act
-			await beforeSave( { container, status: 'draft' } );
-
-			// Assert
-			  expect(mockUpdateComponents).not.toHaveBeenCalled();
-			expect( mockUpdateElementSettings ).not.toHaveBeenCalled();
-		} );
-	} );
-
-	describe( 'Component Publishing', () => {
-		beforeEach( () => {
-			// Add unpublished components to store
-			__dispatch(
-				slice.actions.addUnpublished( {
-					id: 1001,
-					name: 'Test Component',
-					content: [],
-				} )
-			);
-		} );
-
-		it.skip( 'should send components changes to server', async () => {
-			// Arrange
-			const container = createMockContainer();
-			const status = 'publish';
-			mockUpdateComponents.mockResolvedValue( new Map( [ [ 1001, 2001 ] ] ) );
-
-			// Act
-			await beforeSave( { container, status } );
-
-			// Assert
-			expect( mockUpdateComponents ).toHaveBeenCalledWith(
-				expect.arrayContaining( [ expect.objectContaining( { id: 1001 } ) ] ),
-				status
-			);
-		} );
-
-		it( 'should throw error when component update fails', async () => {
-			// Arrange
-			const container = createMockContainer();
-			mockUpdateComponents.mockRejectedValue( new Error( 'API Error' ) );
-
-			// Act & Assert
-			await expect( beforeSave( { container, status: 'draft' } ) ).rejects.toThrow(
-				'Failed to publish components and update component instances'
-			);
-		} );
-	} );
-
-	describe( 'Component Instance Updates - Replacing temporary IDs with actual IDs', () => {
-		beforeEach( () => {
-			__dispatch(
-				slice.actions.addUnpublished( {
-					id: 1000,
-					name: 'Test Component 1',
-					content: [],
-				} )
-			);
-			__dispatch(
-				slice.actions.addUnpublished( {
-					id: 3000,
-					name: 'Test Component 2',
-					content: [],
-				} )
-			);
-			mockUpdateComponents.mockResolvedValue(
-				new Map( [
-					[ 1000, 1111 ],
-					[ 3000, 3333 ],
-				] )
-			);
-		} );
-
-		it( 'should replace temporary component IDs with actual IDs from server response', async () => {
-			// Arrange
-			const container = createMockContainer( mockElements );
-
-			// Act
-			await beforeSave( { container, status: 'draft' } );
-
-			// Assert
-			expect( mockUpdateElementSettings ).toHaveBeenCalledTimes( 2 );
-			expect( mockUpdateElementSettings ).toHaveBeenCalledWith( {
-				id: 'element-1_component-with-temp-id',
-				props: {
-					component_id: expect.objectContaining( {
-						value: 1111,
-					} ),
-				},
-				withHistory: false,
-			} );
-			expect( mockUpdateElementSettings ).toHaveBeenCalledWith( {
-				id: 'element-3_component-with-temp-id',
-				props: {
-					component_id: expect.objectContaining( {
-						value: 3333,
-					} ),
-				},
-				withHistory: false,
-			} );
-		} );
-
-		it( 'should not change component instances that already have actual IDs', async () => {
-			// Arrange
-			const container = createMockContainer( mockElements );
-
-			// Act
-			await beforeSave( { container, status: 'draft' } );
-
-			// Assert
-			expect( mockUpdateElementSettings ).not.toHaveBeenCalledWith(
-				expect.objectContaining( { id: 'element-5_component-with-actual-id' } )
-			);
-		} );
-
-		it( 'should skip non-component elements', async () => {
-			// Arrange
-			const container = createMockContainer( mockElements );
-
-			// Act
-			await beforeSave( { container, status: 'draft' } );
-
-			// Assert
-			expect( mockUpdateElementSettings ).not.toHaveBeenCalledWith(
-				expect.objectContaining( { id: 'element-2_not-a-component' } )
-			);
-			expect( mockUpdateElementSettings ).not.toHaveBeenCalledWith(
-				expect.objectContaining( { id: 'element-4_not-a-component' } )
-			);
-		} );
-
-		it( 'should handle empty elements array', async () => {
-			// Arrange
-			const container = createMockContainer( [] );
-
-			// Act
-			await beforeSave( { container, status: 'draft' } );
-
-			// Assert
-			expect( mockUpdateElementSettings ).not.toHaveBeenCalled();
-		} );
-	} );
-
-	describe( 'Handle store state', () => {
-		it( 'should add newly published components to the main component store', async () => {
-			// Arrange
-			__dispatch(
-				slice.actions.add( {
-					id: 4444,
-					name: 'Published Component',
-				} )
-			);
-			__dispatch(
-				slice.actions.addUnpublished( {
-					id: 3000,
-					name: 'Unpublished Component',
-					content: [],
-				} )
-			);
-			const container = createMockContainer( [] );
-
-			// Act
-			await beforeSave( { container, status: 'draft' } );
-
-			// Assert
-			expect( getState().components.data ).toEqual( [
-				{ id: 4444, name: 'Published Component' },
-				{ id: 3333, name: 'Unpublished Component' },
-			] );
-		} );
-
-		it( 'should clear all unpublished components from store after successful save', async () => {
-			// Arrange
-			__dispatch(
-				slice.actions.addUnpublished( {
-					id: 1000,
-					name: 'Test Component 1',
-					content: [],
-				} )
-			);
-			__dispatch(
-				slice.actions.addUnpublished( {
-					id: 3000,
-					name: 'Test Component 2',
-					content: [],
-				} )
-			);
-			const container = createMockContainer( [] );
-
-			// Act
-			await beforeSave( { container, status: 'draft' } );
-
-			// Assert
-			expect( selectUnpublishedComponents( getState() ) ).toEqual( [] );
-		} );
-	} );
-} );

--- a/packages/packages/core/editor-components/src/utils/__tests__/before-save.test.ts
+++ b/packages/packages/core/editor-components/src/utils/__tests__/before-save.test.ts
@@ -1,8 +1,8 @@
 import { updateElementSettings, type V1ElementData } from '@elementor/editor-elements';
-import { __createStore, __dispatch, __registerSlice, __getState as getState } from '@elementor/store';
+import { __createStore, __dispatch, __getState as getState, __registerSlice } from '@elementor/store';
 
 import { apiClient } from '../../api';
-import { selectComponents, selectUnpublishedComponents, slice } from '../../store/store';
+import { selectUnpublishedComponents, slice } from '../../store/store';
 import { beforeSave } from '../before-save';
 
 jest.mock( '@elementor/editor-elements' );
@@ -42,8 +42,8 @@ describe( 'beforeSave', () => {
 			} )
 		);
 
-		mockCreateComponents.mockImplementation( (payload) => {
-			switch (payload.name) {
+		mockCreateComponents.mockImplementation( ( payload ) => {
+			switch ( payload.name ) {
 				case 'Test Component 1':
 					return Promise.resolve( { component_id: 1111 } );
 				case 'Test Component 2':
@@ -64,7 +64,7 @@ describe( 'beforeSave', () => {
 			await beforeSave( { container, status: 'draft' } );
 
 			// Assert
-			  expect(mockCreateComponents).not.toHaveBeenCalled();
+			expect( mockCreateComponents ).not.toHaveBeenCalled();
 			expect( mockUpdateElementSettings ).not.toHaveBeenCalled();
 		} );
 	} );
@@ -121,18 +121,20 @@ describe( 'beforeSave', () => {
 			expect( mockUpdateElementSettings ).toHaveBeenCalledWith( {
 				id: 'element-1_component-with-temp-id',
 				props: {
-					component_id: expect.objectContaining( {
+					component: {
+						$$type: 'component-id',
 						value: 1111,
-					} ),
+					},
 				},
 				withHistory: false,
 			} );
 			expect( mockUpdateElementSettings ).toHaveBeenCalledWith( {
 				id: 'element-3_component-with-temp-id',
 				props: {
-					component_id: expect.objectContaining( {
+					component: {
+						$$type: 'component-id',
 						value: 3333,
-					} ),
+					},
 				},
 				withHistory: false,
 			} );
@@ -232,7 +234,7 @@ const mockComponent1Content: V1ElementData[] = [
 				value: 'Click Me!',
 			},
 		},
-	}
+	},
 ];
 
 const mockComponent2Content: V1ElementData[] = [
@@ -246,7 +248,7 @@ const mockComponent2Content: V1ElementData[] = [
 				value: 'This is a heading',
 			},
 		},
-	}
+	},
 ];
 
 const mockPageElements: V1ElementData[] = [
@@ -255,8 +257,8 @@ const mockPageElements: V1ElementData[] = [
 		elType: 'widget',
 		widgetType: 'e-component',
 		settings: {
-			component_id: {
-				$$type: 'number',
+			component: {
+				$$type: 'component-id',
 				value: 1000,
 			},
 		},
@@ -270,8 +272,8 @@ const mockPageElements: V1ElementData[] = [
 				elType: 'widget',
 				widgetType: 'e-component',
 				settings: {
-					component_id: {
-						$$type: 'number',
+					component: {
+						$$type: 'component-id',
 						value: 3000,
 					},
 				},
@@ -294,8 +296,8 @@ const mockPageElements: V1ElementData[] = [
 		elType: 'widget',
 		widgetType: 'e-component',
 		settings: {
-			component_id: {
-				$$type: 'number',
+			component: {
+				$$type: 'component-id',
 				value: 4444,
 			},
 		},

--- a/packages/packages/core/editor-components/src/utils/__tests__/before-save.test.ts
+++ b/packages/packages/core/editor-components/src/utils/__tests__/before-save.test.ts
@@ -1,0 +1,283 @@
+import { updateElementSettings, type V1ElementData } from '@elementor/editor-elements';
+import { __createStore, __dispatch, __registerSlice, __getState as getState } from '@elementor/store';
+
+import { apiClient } from '../../api';
+import { selectComponents, selectUnpublishedComponents, slice } from '../../store/store';
+import { beforeSave } from '../before-save';
+
+jest.mock( '@elementor/editor-elements' );
+jest.mock( '../../api' );
+
+const mockUpdateElementSettings = jest.mocked( updateElementSettings );
+const mockUpdateComponents = jest.mocked( apiClient.update );
+
+const mockElements: V1ElementData[] = [
+	{
+		id: 'element-1_component-with-temp-id',
+		elType: 'widget',
+		widgetType: 'e-component',
+		settings: {
+			component_id: {
+				$$type: 'number',
+				value: 1000,
+			},
+		},
+	},
+	{
+		id: 'element-2_not-a-component',
+		elType: 'container',
+		elements: [
+			{
+				id: 'element-3_component-with-temp-id',
+				elType: 'widget',
+				widgetType: 'e-component',
+				settings: {
+					component_id: {
+						$$type: 'number',
+						value: 3000,
+					},
+				},
+			},
+			{
+				id: 'element-4_not-a-component',
+				elType: 'widget',
+				widgetType: 'e-button',
+				settings: {
+					text: {
+						$$type: 'string',
+						value: 'Click Me!',
+					},
+				},
+			},
+		],
+	},
+	{
+		id: 'element-5_component-with-actual-id',
+		elType: 'widget',
+		widgetType: 'e-component',
+		settings: {
+			component_id: {
+				$$type: 'number',
+				value: 4444,
+			},
+		},
+	},
+];
+
+describe( 'beforeSave', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		__registerSlice( slice );
+		__createStore();
+	} );
+
+	const createMockContainer = ( elements: V1ElementData[] = [] ) => ( {
+		model: {
+			get: () => ( {
+				toJSON: () => elements,
+			} ),
+		},
+	} );
+
+	describe( 'No Unpublished Components', () => {
+		it( 'should not update any element settings or make API calls', async () => {
+			// Arrange
+			const container = createMockContainer();
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			  expect(mockUpdateComponents).not.toHaveBeenCalled();
+			expect( mockUpdateElementSettings ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Component Publishing', () => {
+		beforeEach( () => {
+			// Add unpublished components to store
+			__dispatch(
+				slice.actions.addUnpublished( {
+					id: 1001,
+					name: 'Test Component',
+					content: [],
+				} )
+			);
+		} );
+
+		it.skip( 'should send components changes to server', async () => {
+			// Arrange
+			const container = createMockContainer();
+			const status = 'publish';
+			mockUpdateComponents.mockResolvedValue( new Map( [ [ 1001, 2001 ] ] ) );
+
+			// Act
+			await beforeSave( { container, status } );
+
+			// Assert
+			expect( mockUpdateComponents ).toHaveBeenCalledWith(
+				expect.arrayContaining( [ expect.objectContaining( { id: 1001 } ) ] ),
+				status
+			);
+		} );
+
+		it( 'should throw error when component update fails', async () => {
+			// Arrange
+			const container = createMockContainer();
+			mockUpdateComponents.mockRejectedValue( new Error( 'API Error' ) );
+
+			// Act & Assert
+			await expect( beforeSave( { container, status: 'draft' } ) ).rejects.toThrow(
+				'Failed to publish components and update component instances'
+			);
+		} );
+	} );
+
+	describe( 'Component Instance Updates - Replacing temporary IDs with actual IDs', () => {
+		beforeEach( () => {
+			__dispatch(
+				slice.actions.addUnpublished( {
+					id: 1000,
+					name: 'Test Component 1',
+					content: [],
+				} )
+			);
+			__dispatch(
+				slice.actions.addUnpublished( {
+					id: 3000,
+					name: 'Test Component 2',
+					content: [],
+				} )
+			);
+			mockUpdateComponents.mockResolvedValue(
+				new Map( [
+					[ 1000, 1111 ],
+					[ 3000, 3333 ],
+				] )
+			);
+		} );
+
+		it( 'should replace temporary component IDs with actual IDs from server response', async () => {
+			// Arrange
+			const container = createMockContainer( mockElements );
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			expect( mockUpdateElementSettings ).toHaveBeenCalledTimes( 2 );
+			expect( mockUpdateElementSettings ).toHaveBeenCalledWith( {
+				id: 'element-1_component-with-temp-id',
+				props: {
+					component_id: expect.objectContaining( {
+						value: 1111,
+					} ),
+				},
+				withHistory: false,
+			} );
+			expect( mockUpdateElementSettings ).toHaveBeenCalledWith( {
+				id: 'element-3_component-with-temp-id',
+				props: {
+					component_id: expect.objectContaining( {
+						value: 3333,
+					} ),
+				},
+				withHistory: false,
+			} );
+		} );
+
+		it( 'should not change component instances that already have actual IDs', async () => {
+			// Arrange
+			const container = createMockContainer( mockElements );
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			expect( mockUpdateElementSettings ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { id: 'element-5_component-with-actual-id' } )
+			);
+		} );
+
+		it( 'should skip non-component elements', async () => {
+			// Arrange
+			const container = createMockContainer( mockElements );
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			expect( mockUpdateElementSettings ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { id: 'element-2_not-a-component' } )
+			);
+			expect( mockUpdateElementSettings ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { id: 'element-4_not-a-component' } )
+			);
+		} );
+
+		it( 'should handle empty elements array', async () => {
+			// Arrange
+			const container = createMockContainer( [] );
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			expect( mockUpdateElementSettings ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Handle store state', () => {
+		it( 'should add newly published components to the main component store', async () => {
+			// Arrange
+			__dispatch(
+				slice.actions.add( {
+					id: 4444,
+					name: 'Published Component',
+				} )
+			);
+			__dispatch(
+				slice.actions.addUnpublished( {
+					id: 3000,
+					name: 'Unpublished Component',
+					content: [],
+				} )
+			);
+			const container = createMockContainer( [] );
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			expect( getState().components.data ).toEqual( [
+				{ id: 4444, name: 'Published Component' },
+				{ id: 3333, name: 'Unpublished Component' },
+			] );
+		} );
+
+		it( 'should clear all unpublished components from store after successful save', async () => {
+			// Arrange
+			__dispatch(
+				slice.actions.addUnpublished( {
+					id: 1000,
+					name: 'Test Component 1',
+					content: [],
+				} )
+			);
+			__dispatch(
+				slice.actions.addUnpublished( {
+					id: 3000,
+					name: 'Test Component 2',
+					content: [],
+				} )
+			);
+			const container = createMockContainer( [] );
+
+			// Act
+			await beforeSave( { container, status: 'draft' } );
+
+			// Assert
+			expect( selectUnpublishedComponents( getState() ) ).toEqual( [] );
+		} );
+	} );
+} );

--- a/packages/packages/core/editor-components/src/utils/before-save.ts
+++ b/packages/packages/core/editor-components/src/utils/before-save.ts
@@ -1,0 +1,76 @@
+import { updateElementSettings, type V1ElementData } from '@elementor/editor-elements';
+import { numberPropTypeUtil, type TransformablePropValue } from '@elementor/editor-props';
+import { __getState as getState, __dispatch as dispatch } from '@elementor/store';
+
+import { apiClient } from '../api';
+import { selectUnpublishedComponents, slice } from '../store/store';
+
+type Container = {
+	model: {
+		get: ( key: 'elements' ) => {
+			toJSON: () => V1ElementData[];
+		};
+	};
+};
+
+type Status = 'draft' | 'autosave' | 'publish';
+
+export const beforeSave = async ( { container, status }: { container: Container; status: Status } ) => {
+	const unpublishedComponents = selectUnpublishedComponents( getState() );
+
+	if ( ! unpublishedComponents.length ) {
+		return;
+	}
+
+	try {
+		const tempIdToComponentId = await apiClient.update( { unpublishedComponents, status } );
+
+		const elements = container.model.get( 'elements' ).toJSON();
+		updateComponentInstances( elements, tempIdToComponentId );
+
+		dispatch( slice.actions.add( unpublishedComponents.map( ( component ) => ( {
+			id: tempIdToComponentId.get( component.id ) as number,
+			name: component.name,
+		} ) ) ) );
+		dispatch( slice.actions.resetUnpublished() );
+	} catch ( error ) {
+		throw new Error( `Failed to publish components and update component instances: ${ error }` );
+	}
+};
+
+function updateComponentInstances( elements: V1ElementData[], tempIdToComponentId: Map< number, number > ): void {
+	elements.forEach( ( element ) => {
+		const { shouldUpdate, newComponentId } = shouldUpdateElement( element, tempIdToComponentId );
+		if ( shouldUpdate ) {
+			updateElementComponentId( element.id, newComponentId );
+		}
+
+		if ( element.elements ) {
+			updateComponentInstances( element.elements, tempIdToComponentId );
+		}
+	} );
+}
+
+function shouldUpdateElement(
+	element: V1ElementData,
+	tempIdToComponentId: Map< number, number >
+): { shouldUpdate: true; newComponentId: number } | { shouldUpdate: false; newComponentId: null } {
+	if ( element.widgetType === 'e-component' ) {
+		const currentComponentId = ( element.settings?.component_id as TransformablePropValue< 'number', number > )
+			?.value;
+		if ( currentComponentId && tempIdToComponentId.has( currentComponentId ) ) {
+			return { shouldUpdate: true, newComponentId: tempIdToComponentId.get( currentComponentId ) as number };
+		}
+	}
+	return { shouldUpdate: false, newComponentId: null };
+}
+
+function updateElementComponentId( elementId: string, componentId: number ): void {
+	updateElementSettings( {
+		id: elementId,
+		props: {
+			component_id: numberPropTypeUtil.create( componentId ),
+		},
+		withHistory: false,
+	} );
+}

--- a/packages/packages/core/editor-components/src/utils/before-save.ts
+++ b/packages/packages/core/editor-components/src/utils/before-save.ts
@@ -76,7 +76,8 @@ function shouldUpdateElement(
 	tempIdToComponentId: Map< number, number >
 ): { shouldUpdate: true; newComponentId: number } | { shouldUpdate: false; newComponentId: null } {
 	if ( element.widgetType === 'e-component' ) {
-		const currentComponentId = ( element.settings?.component as TransformablePropValue< 'component-id', number > )?.value;
+		const currentComponentId = ( element.settings?.component as TransformablePropValue< 'component-id', number > )
+			?.value;
 		if ( currentComponentId && tempIdToComponentId.has( currentComponentId ) ) {
 			return { shouldUpdate: true, newComponentId: tempIdToComponentId.get( currentComponentId ) as number };
 		}

--- a/packages/packages/core/editor-components/src/utils/before-save.ts
+++ b/packages/packages/core/editor-components/src/utils/before-save.ts
@@ -1,10 +1,10 @@
 import { updateElementSettings, type V1ElementData } from '@elementor/editor-elements';
-import { numberPropTypeUtil, type TransformablePropValue } from '@elementor/editor-props';
-import { __getState as getState, __dispatch as dispatch } from '@elementor/store';
+import { type TransformablePropValue } from '@elementor/editor-props';
+import { __dispatch as dispatch, __getState as getState } from '@elementor/store';
 
 import { apiClient } from '../api';
-import { selectUnpublishedComponents, slice, UnpublishedComponent } from '../store/store';
-import { DocumentStatus } from '../types';
+import { selectUnpublishedComponents, slice, type UnpublishedComponent } from '../store/store';
+import { type DocumentStatus } from '../types';
 
 type Container = {
 	model: {
@@ -22,32 +22,37 @@ export const beforeSave = async ( { container, status }: { container: Container;
 	}
 
 	try {
-		const tempIdToComponentId = await createComponents( unpublishedComponents, status  );
+		const tempIdToComponentId = await createComponents( unpublishedComponents, status );
 
 		const elements = container.model.get( 'elements' ).toJSON();
 		updateComponentInstances( elements, tempIdToComponentId );
 
-		dispatch( slice.actions.add( unpublishedComponents.map( ( component ) => ( {
-			id: tempIdToComponentId.get( component.id ) as number,
-			name: component.name,
-		} ) ) ) );
+		dispatch(
+			slice.actions.add(
+				unpublishedComponents.map( ( component ) => ( {
+					id: tempIdToComponentId.get( component.id ) as number,
+					name: component.name,
+				} ) )
+			)
+		);
 		dispatch( slice.actions.resetUnpublished() );
 	} catch ( error ) {
 		throw new Error( `Failed to publish components and update component instances: ${ error }` );
 	}
 };
 
-async function createComponents( components: UnpublishedComponent[], status: DocumentStatus ): Promise< Map< number, number > > {
+async function createComponents(
+	components: UnpublishedComponent[],
+	status: DocumentStatus
+): Promise< Map< number, number > > {
 	const tempIdToComponentId = new Map< number, number >();
 
 	const promises = components.map( ( component ) => {
-		return apiClient.create( { name: component.name, content: component.content, status } ).then(
-			( response ) => {
-				tempIdToComponentId.set( component.id, response.component_id );
-			}
-		);
+		return apiClient.create( { name: component.name, content: component.content, status } ).then( ( response ) => {
+			tempIdToComponentId.set( component.id, response.component_id );
+		} );
 	} );
-	
+
 	await Promise.all( promises );
 
 	return tempIdToComponentId;
@@ -71,8 +76,7 @@ function shouldUpdateElement(
 	tempIdToComponentId: Map< number, number >
 ): { shouldUpdate: true; newComponentId: number } | { shouldUpdate: false; newComponentId: null } {
 	if ( element.widgetType === 'e-component' ) {
-		const currentComponentId = ( element.settings?.component_id as TransformablePropValue< 'number', number > )
-			?.value;
+		const currentComponentId = ( element.settings?.component as TransformablePropValue< 'number', number > )?.value;
 		if ( currentComponentId && tempIdToComponentId.has( currentComponentId ) ) {
 			return { shouldUpdate: true, newComponentId: tempIdToComponentId.get( currentComponentId ) as number };
 		}
@@ -84,7 +88,10 @@ function updateElementComponentId( elementId: string, componentId: number ): voi
 	updateElementSettings( {
 		id: elementId,
 		props: {
-			component_id: numberPropTypeUtil.create( componentId ),
+			component: {
+				$$type: 'component-id',
+				value: componentId,
+			},
 		},
 		withHistory: false,
 	} );

--- a/packages/packages/core/editor-components/src/utils/before-save.ts
+++ b/packages/packages/core/editor-components/src/utils/before-save.ts
@@ -76,7 +76,7 @@ function shouldUpdateElement(
 	tempIdToComponentId: Map< number, number >
 ): { shouldUpdate: true; newComponentId: number } | { shouldUpdate: false; newComponentId: null } {
 	if ( element.widgetType === 'e-component' ) {
-		const currentComponentId = ( element.settings?.component as TransformablePropValue< 'number', number > )?.value;
+		const currentComponentId = ( element.settings?.component as TransformablePropValue< 'component-id', number > )?.value;
 		if ( currentComponentId && tempIdToComponentId.has( currentComponentId ) ) {
 			return { shouldUpdate: true, newComponentId: tempIdToComponentId.get( currentComponentId ) as number };
 		}

--- a/tests/phpunit/elementor/modules/components/test-components-rest-api.php
+++ b/tests/phpunit/elementor/modules/components/test-components-rest-api.php
@@ -199,6 +199,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request->set_body_params( [
 			'name' => 'New Test Component',
 			'content' => $this->mock_component_1_content,
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );
@@ -235,6 +236,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request->set_body_params( [
 			'name' => '  <script>alert("xss")</script>Sanitized Component  ',
 			'content' => $this->mock_component_1_content,
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );
@@ -256,6 +258,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request->set_body_params( [
 			'name' => 'Test Component',
 			'content' => [ $this->mock_component_1_content ],
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );
@@ -272,6 +275,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/components' );
 		$request->set_body_params( [
 			'content' => [ $this->mock_component_2_content ],
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );
@@ -290,6 +294,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/components' );
 		$request->set_body_params( [
 			'name' => 'Test Component',
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );
@@ -313,6 +318,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request->set_body_params( [
 			'name' => 'Test Component 50',
 			'content' => $this->mock_component_1_content,
+			'status' => 'publish',
 		] );
 
 		// Act - create the 50th component
@@ -330,6 +336,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request->set_body_params( [
 			'name' => 'Test Component 51',
 			'content' => $this->mock_component_1_content,
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );
@@ -349,6 +356,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request->set_body_params( [
 			'name' => 'a  ',
 			'content' => [ $this->mock_component_1_content ],
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );
@@ -368,6 +376,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request->set_body_params( [
 			'name' => 'a'.str_repeat('a', 51),
 			'content' => [ $this->mock_component_1_content ],
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );
@@ -388,6 +397,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request->set_body_params( [
 			'name' => 'Test Component',
 			'content' => [ $this->mock_component_1_content ],
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );
@@ -407,6 +417,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request->set_body_params( [
 			'name' => 123,
 			'content' => [ $this->mock_component_2_content ],
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );
@@ -426,6 +437,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request->set_body_params( [
 			'name' => 'Test Component',
 			'content' => 'not-an-array',
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );
@@ -445,6 +457,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request->set_body_params( [
 			'name' => 'Invalid Test Component',
 			'content' => $this->mock_invalid_component_content,
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );
@@ -469,6 +482,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$request->set_body_params( [
 			'name' => 'Test Component',
 			'content' => [ $this->mock_component_1_content ],
+			'status' => 'publish',
 		] );
 
 		$response = rest_do_request( $request );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Refactor component creation flow to support draft status and implement local components management before publishing

Main changes:
- Added component status parameter to allow creating draft/published components
- Implemented unpublished components store for local tracking before publishing
- Created beforeSave hook to persist temporary components during document save
- Updated components repository to fetch components of any status
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
