### PR TITLE
Fix: Fix breaking change [ED-21265]

### DIFF
--- a/app/assets/js/event-track/apps-event-tracking.js
+++ b/app/assets/js/event-track/apps-event-tracking.js
@@ -88,7 +88,7 @@ export class AppsEventTracking {
 		const isError = !! error;
 		if ( isError ) {
 			this.dispatchEvent( EVENTS_MAP.KITDEMO_APPLY_FAILED, {
-				error_title: error?.message || 'Unknown error'
+				error_title: error?.message || 'Unknown error',
 				kit_id: id,
 				kit_title: title,
 			} );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix missing comma in error tracking payload causing kit import failure event tracking to break.
Main changes:
- Added missing comma after error_title property in KITDEMO_APPLY_FAILED event payload

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
