### PR TITLE
Internal: Add space in the message text [ED-21279]

### DIFF
--- a/packages/packages/core/editor-global-classes/src/components/class-manager/duplicate-label-dialog.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/duplicate-label-dialog.tsx
@@ -137,7 +137,7 @@ export const DuplicateLabelDialog = ( {
 							<Alert severity="info" size="small" color="secondary">
 								<strong>{ __( 'Your designs and classes are safe.', 'elementor' ) }</strong>
 								{ __(
-									'Only the prefixes were added.Find them in Class Manager by searching',
+									'Only the prefixes were added. Find them in Class Manager by searching',
 									'elementor'
 								) }
 								<strong>{ DUP_PREFIX }</strong>


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix readability issue in duplicate label dialog by adding a space between sentences in the information message.
Main changes:
- Added missing space in alert text between "added." and "Find" for improved user readability

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
