### PR TITLE
Internal: Prevent repeater item remount on update settings [ED-20644]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.34.0",
       "dependencies": {
         "@elementor/icons": "1.54.0",
-        "@elementor/ui": "1.36.14",
+        "@elementor/ui": "1.36.15",
         "@reach/router": "1.3.4",
         "@reduxjs/toolkit": "^1.8.3",
         "@woocommerce/admin-layout": "^1.1.0",
@@ -3546,9 +3546,9 @@
       }
     },
     "node_modules/@elementor/ui": {
-      "version": "1.36.14",
-      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.14.tgz",
-      "integrity": "sha512-oC6wcme3O7ybmD3WeQizwTA5aPBqR86LeHJcfE8XJKOaaKU/jxpn+iT6H+ogR5KSgqyD7QveSUTHiwcmTpNXIA==",
+      "version": "1.36.15",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.15.tgz",
+      "integrity": "sha512-JpZFndzKKzjPQlftggfK0GWgRsiwvnr8f5g8DNtUi+F0zQWI6PWD9Rsdr6hpOazh1OqUFDyRakNlBBLRFr1zRw==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
   },
   "dependencies": {
     "@elementor/icons": "1.54.0",
-    "@elementor/ui": "1.36.14",
+    "@elementor/ui": "1.36.15",
     "@reach/router": "1.3.4",
     "@reduxjs/toolkit": "^1.8.3",
     "@woocommerce/admin-layout": "^1.1.0",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -3009,6 +3009,7 @@
       "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.14.tgz",
       "integrity": "sha512-oC6wcme3O7ybmD3WeQizwTA5aPBqR86LeHJcfE8XJKOaaKU/jxpn+iT6H+ogR5KSgqyD7QveSUTHiwcmTpNXIA==",
       "license": "GPL-3.0-or-later",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/modifiers": "9.0.0",
@@ -20084,7 +20085,7 @@
         "@elementor/locations": "3.33.0",
         "@elementor/query": "3.33.0",
         "@elementor/store": "3.33.0",
-        "@elementor/ui": "1.36.14"
+        "@elementor/ui": "1.36.15"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -20106,7 +20107,7 @@
         "@elementor/icons": "1.54.0",
         "@elementor/locations": "3.33.0",
         "@elementor/menus": "3.33.0",
-        "@elementor/ui": "1.36.14",
+        "@elementor/ui": "1.36.15",
         "@wordpress/i18n": "^5.13.0"
       },
       "devDependencies": {
@@ -20125,6 +20126,37 @@
       "peerDependencies": {
         "@elementor/ui": "^1.34.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "packages/core/editor-app-bar/node_modules/@elementor/ui": {
+      "version": "1.36.15",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.15.tgz",
+      "integrity": "sha512-JpZFndzKKzjPQlftggfK0GWgRsiwvnr8f5g8DNtUi+F0zQWI6PWD9Rsdr6hpOazh1OqUFDyRakNlBBLRFr1zRw==",
+      "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
+        "@elementor/design-tokens": "1.1.4",
+        "@emotion/cache": "11.13.0",
+        "@emotion/react": "11.13.0",
+        "@emotion/styled": "11.13.0",
+        "@mui/material": "5.15.17",
+        "@mui/system": "5.17.1",
+        "@mui/utils": "5.16.14",
+        "@mui/x-date-pickers": "6.18.1",
+        "clsx": "2.1.0",
+        "colord": "2.9.3",
+        "dayjs": "1.11.10",
+        "material-ui-popup-state": "5.0.11",
+        "react-colorful": "5.6.1",
+        "react-transition-group": "4.4.5",
+        "stylis": "4.1.3",
+        "stylis-plugin-rtl": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "packages/core/editor-canvas": {
@@ -20205,7 +20237,7 @@
         "@elementor/query": "3.33.0",
         "@elementor/schema": "3.33.0",
         "@elementor/store": "3.33.0",
-        "@elementor/ui": "1.36.14",
+        "@elementor/ui": "1.36.15",
         "@elementor/utils": "3.33.0",
         "@wordpress/i18n": "^5.13.0"
       },
@@ -20215,6 +20247,37 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "packages/core/editor-components/node_modules/@elementor/ui": {
+      "version": "1.36.15",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.15.tgz",
+      "integrity": "sha512-JpZFndzKKzjPQlftggfK0GWgRsiwvnr8f5g8DNtUi+F0zQWI6PWD9Rsdr6hpOazh1OqUFDyRakNlBBLRFr1zRw==",
+      "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
+        "@elementor/design-tokens": "1.1.4",
+        "@emotion/cache": "11.13.0",
+        "@emotion/react": "11.13.0",
+        "@emotion/styled": "11.13.0",
+        "@mui/material": "5.15.17",
+        "@mui/system": "5.17.1",
+        "@mui/utils": "5.16.14",
+        "@mui/x-date-pickers": "6.18.1",
+        "clsx": "2.1.0",
+        "colord": "2.9.3",
+        "dayjs": "1.11.10",
+        "material-ui-popup-state": "5.0.11",
+        "react-colorful": "5.6.1",
+        "react-transition-group": "4.4.5",
+        "stylis": "4.1.3",
+        "stylis-plugin-rtl": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "packages/core/editor-documents": {
@@ -20257,7 +20320,7 @@
         "@elementor/menus": "3.33.0",
         "@elementor/schema": "3.33.0",
         "@elementor/session": "3.33.0",
-        "@elementor/ui": "1.36.14",
+        "@elementor/ui": "1.36.15",
         "@elementor/utils": "3.33.0",
         "@elementor/wp-media": "3.33.0",
         "@wordpress/i18n": "^5.13.0"
@@ -20268,6 +20331,37 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "packages/core/editor-editing-panel/node_modules/@elementor/ui": {
+      "version": "1.36.15",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.15.tgz",
+      "integrity": "sha512-JpZFndzKKzjPQlftggfK0GWgRsiwvnr8f5g8DNtUi+F0zQWI6PWD9Rsdr6hpOazh1OqUFDyRakNlBBLRFr1zRw==",
+      "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
+        "@elementor/design-tokens": "1.1.4",
+        "@emotion/cache": "11.13.0",
+        "@emotion/react": "11.13.0",
+        "@emotion/styled": "11.13.0",
+        "@mui/material": "5.15.17",
+        "@mui/system": "5.17.1",
+        "@mui/utils": "5.16.14",
+        "@mui/x-date-pickers": "6.18.1",
+        "clsx": "2.1.0",
+        "colord": "2.9.3",
+        "dayjs": "1.11.10",
+        "material-ui-popup-state": "5.0.11",
+        "react-colorful": "5.6.1",
+        "react-transition-group": "4.4.5",
+        "stylis": "4.1.3",
+        "stylis-plugin-rtl": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "packages/core/editor-elements-panel": {
@@ -20339,7 +20433,7 @@
         "@elementor/query": "3.33.0",
         "@elementor/schema": "3.33.0",
         "@elementor/store": "3.33.0",
-        "@elementor/ui": "1.36.14",
+        "@elementor/ui": "1.36.15",
         "@elementor/utils": "3.33.0",
         "@wordpress/i18n": "^5.13.0"
       },
@@ -20349,6 +20443,37 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "packages/core/editor-global-classes/node_modules/@elementor/ui": {
+      "version": "1.36.15",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.15.tgz",
+      "integrity": "sha512-JpZFndzKKzjPQlftggfK0GWgRsiwvnr8f5g8DNtUi+F0zQWI6PWD9Rsdr6hpOazh1OqUFDyRakNlBBLRFr1zRw==",
+      "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
+        "@elementor/design-tokens": "1.1.4",
+        "@emotion/cache": "11.13.0",
+        "@emotion/react": "11.13.0",
+        "@emotion/styled": "11.13.0",
+        "@mui/material": "5.15.17",
+        "@mui/system": "5.17.1",
+        "@mui/utils": "5.16.14",
+        "@mui/x-date-pickers": "6.18.1",
+        "clsx": "2.1.0",
+        "colord": "2.9.3",
+        "dayjs": "1.11.10",
+        "material-ui-popup-state": "5.0.11",
+        "react-colorful": "5.6.1",
+        "react-transition-group": "4.4.5",
+        "stylis": "4.1.3",
+        "stylis-plugin-rtl": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "packages/core/editor-mcp": {
@@ -20373,7 +20498,7 @@
       "dependencies": {
         "@elementor/editor": "3.33.0",
         "@elementor/store": "3.33.0",
-        "@elementor/ui": "1.36.14",
+        "@elementor/ui": "1.36.15",
         "notistack": "^3.0.2"
       },
       "devDependencies": {
@@ -20382,6 +20507,37 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "packages/core/editor-notifications/node_modules/@elementor/ui": {
+      "version": "1.36.15",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.15.tgz",
+      "integrity": "sha512-JpZFndzKKzjPQlftggfK0GWgRsiwvnr8f5g8DNtUi+F0zQWI6PWD9Rsdr6hpOazh1OqUFDyRakNlBBLRFr1zRw==",
+      "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
+        "@elementor/design-tokens": "1.1.4",
+        "@emotion/cache": "11.13.0",
+        "@emotion/react": "11.13.0",
+        "@emotion/styled": "11.13.0",
+        "@mui/material": "5.15.17",
+        "@mui/system": "5.17.1",
+        "@mui/utils": "5.16.14",
+        "@mui/x-date-pickers": "6.18.1",
+        "clsx": "2.1.0",
+        "colord": "2.9.3",
+        "dayjs": "1.11.10",
+        "material-ui-popup-state": "5.0.11",
+        "react-colorful": "5.6.1",
+        "react-transition-group": "4.4.5",
+        "stylis": "4.1.3",
+        "stylis-plugin-rtl": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "packages/core/editor-panels": {
@@ -20393,7 +20549,7 @@
         "@elementor/editor-v1-adapters": "3.33.0",
         "@elementor/locations": "3.33.0",
         "@elementor/store": "3.33.0",
-        "@elementor/ui": "1.36.14"
+        "@elementor/ui": "1.36.15"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -20401,6 +20557,37 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "packages/core/editor-panels/node_modules/@elementor/ui": {
+      "version": "1.36.15",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.15.tgz",
+      "integrity": "sha512-JpZFndzKKzjPQlftggfK0GWgRsiwvnr8f5g8DNtUi+F0zQWI6PWD9Rsdr6hpOazh1OqUFDyRakNlBBLRFr1zRw==",
+      "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
+        "@elementor/design-tokens": "1.1.4",
+        "@emotion/cache": "11.13.0",
+        "@emotion/react": "11.13.0",
+        "@emotion/styled": "11.13.0",
+        "@mui/material": "5.15.17",
+        "@mui/system": "5.17.1",
+        "@mui/utils": "5.16.14",
+        "@mui/x-date-pickers": "6.18.1",
+        "clsx": "2.1.0",
+        "colord": "2.9.3",
+        "dayjs": "1.11.10",
+        "material-ui-popup-state": "5.0.11",
+        "react-colorful": "5.6.1",
+        "react-transition-group": "4.4.5",
+        "stylis": "4.1.3",
+        "stylis-plugin-rtl": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "packages/core/editor-site-navigation": {
@@ -20415,7 +20602,7 @@
         "@elementor/env": "3.33.0",
         "@elementor/icons": "1.53.0",
         "@elementor/query": "3.33.0",
-        "@elementor/ui": "1.36.14",
+        "@elementor/ui": "1.36.15",
         "@wordpress/api-fetch": "^6.42.0",
         "@wordpress/i18n": "^5.13.0"
       },
@@ -20425,6 +20612,37 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "packages/core/editor-site-navigation/node_modules/@elementor/ui": {
+      "version": "1.36.15",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.15.tgz",
+      "integrity": "sha512-JpZFndzKKzjPQlftggfK0GWgRsiwvnr8f5g8DNtUi+F0zQWI6PWD9Rsdr6hpOazh1OqUFDyRakNlBBLRFr1zRw==",
+      "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
+        "@elementor/design-tokens": "1.1.4",
+        "@emotion/cache": "11.13.0",
+        "@emotion/react": "11.13.0",
+        "@emotion/styled": "11.13.0",
+        "@mui/material": "5.15.17",
+        "@mui/system": "5.17.1",
+        "@mui/utils": "5.16.14",
+        "@mui/x-date-pickers": "6.18.1",
+        "clsx": "2.1.0",
+        "colord": "2.9.3",
+        "dayjs": "1.11.10",
+        "material-ui-popup-state": "5.0.11",
+        "react-colorful": "5.6.1",
+        "react-transition-group": "4.4.5",
+        "stylis": "4.1.3",
+        "stylis-plugin-rtl": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "packages/core/editor-styles-repository": {
@@ -20467,7 +20685,7 @@
         "@elementor/icons": "1.53.0",
         "@elementor/mixpanel": "3.33.0",
         "@elementor/schema": "3.33.0",
-        "@elementor/ui": "1.36.14",
+        "@elementor/ui": "1.36.15",
         "@wordpress/i18n": "^5.13.0"
       },
       "devDependencies": {
@@ -20476,6 +20694,68 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "packages/core/editor-variables/node_modules/@elementor/ui": {
+      "version": "1.36.15",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.15.tgz",
+      "integrity": "sha512-JpZFndzKKzjPQlftggfK0GWgRsiwvnr8f5g8DNtUi+F0zQWI6PWD9Rsdr6hpOazh1OqUFDyRakNlBBLRFr1zRw==",
+      "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
+        "@elementor/design-tokens": "1.1.4",
+        "@emotion/cache": "11.13.0",
+        "@emotion/react": "11.13.0",
+        "@emotion/styled": "11.13.0",
+        "@mui/material": "5.15.17",
+        "@mui/system": "5.17.1",
+        "@mui/utils": "5.16.14",
+        "@mui/x-date-pickers": "6.18.1",
+        "clsx": "2.1.0",
+        "colord": "2.9.3",
+        "dayjs": "1.11.10",
+        "material-ui-popup-state": "5.0.11",
+        "react-colorful": "5.6.1",
+        "react-transition-group": "4.4.5",
+        "stylis": "4.1.3",
+        "stylis-plugin-rtl": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "packages/core/editor/node_modules/@elementor/ui": {
+      "version": "1.36.15",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.15.tgz",
+      "integrity": "sha512-JpZFndzKKzjPQlftggfK0GWgRsiwvnr8f5g8DNtUi+F0zQWI6PWD9Rsdr6hpOazh1OqUFDyRakNlBBLRFr1zRw==",
+      "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
+        "@elementor/design-tokens": "1.1.4",
+        "@emotion/cache": "11.13.0",
+        "@emotion/react": "11.13.0",
+        "@emotion/styled": "11.13.0",
+        "@mui/material": "5.15.17",
+        "@mui/system": "5.17.1",
+        "@mui/utils": "5.16.14",
+        "@mui/x-date-pickers": "6.18.1",
+        "clsx": "2.1.0",
+        "colord": "2.9.3",
+        "dayjs": "1.11.10",
+        "material-ui-popup-state": "5.0.11",
+        "react-colorful": "5.6.1",
+        "react-transition-group": "4.4.5",
+        "stylis": "4.1.3",
+        "stylis-plugin-rtl": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "packages/core/frontend-handlers": {
@@ -20504,7 +20784,7 @@
         "@elementor/mixpanel": "3.33.0",
         "@elementor/query": "3.33.0",
         "@elementor/session": "3.33.0",
-        "@elementor/ui": "1.36.14",
+        "@elementor/ui": "1.36.15",
         "@elementor/utils": "3.33.0",
         "@elementor/wp-media": "3.33.0",
         "@monaco-editor/react": "^4.7.0",
@@ -20517,6 +20797,37 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "packages/libs/editor-controls/node_modules/@elementor/ui": {
+      "version": "1.36.15",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.15.tgz",
+      "integrity": "sha512-JpZFndzKKzjPQlftggfK0GWgRsiwvnr8f5g8DNtUi+F0zQWI6PWD9Rsdr6hpOazh1OqUFDyRakNlBBLRFr1zRw==",
+      "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
+        "@elementor/design-tokens": "1.1.4",
+        "@emotion/cache": "11.13.0",
+        "@emotion/react": "11.13.0",
+        "@emotion/styled": "11.13.0",
+        "@mui/material": "5.15.17",
+        "@mui/system": "5.17.1",
+        "@mui/utils": "5.16.14",
+        "@mui/x-date-pickers": "6.18.1",
+        "clsx": "2.1.0",
+        "colord": "2.9.3",
+        "dayjs": "1.11.10",
+        "material-ui-popup-state": "5.0.11",
+        "react-colorful": "5.6.1",
+        "react-transition-group": "4.4.5",
+        "stylis": "4.1.3",
+        "stylis-plugin-rtl": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "packages/libs/editor-current-user": {
@@ -20629,7 +20940,7 @@
       "dependencies": {
         "@elementor/editor-v1-adapters": "3.33.0",
         "@elementor/icons": "1.53.0",
-        "@elementor/ui": "1.36.14",
+        "@elementor/ui": "1.36.15",
         "@tanstack/react-virtual": "^3.13.3",
         "@wordpress/i18n": "^5.13.0"
       },
@@ -20639,6 +20950,37 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "packages/libs/editor-ui/node_modules/@elementor/ui": {
+      "version": "1.36.15",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.36.15.tgz",
+      "integrity": "sha512-JpZFndzKKzjPQlftggfK0GWgRsiwvnr8f5g8DNtUi+F0zQWI6PWD9Rsdr6hpOazh1OqUFDyRakNlBBLRFr1zRw==",
+      "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
+        "@elementor/design-tokens": "1.1.4",
+        "@emotion/cache": "11.13.0",
+        "@emotion/react": "11.13.0",
+        "@emotion/styled": "11.13.0",
+        "@mui/material": "5.15.17",
+        "@mui/system": "5.17.1",
+        "@mui/utils": "5.16.14",
+        "@mui/x-date-pickers": "6.18.1",
+        "clsx": "2.1.0",
+        "colord": "2.9.3",
+        "dayjs": "1.11.10",
+        "material-ui-popup-state": "5.0.11",
+        "react-colorful": "5.6.1",
+        "react-transition-group": "4.4.5",
+        "stylis": "4.1.3",
+        "stylis-plugin-rtl": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "packages/libs/editor-v1-adapters": {

--- a/packages/packages/core/editor-app-bar/package.json
+++ b/packages/packages/core/editor-app-bar/package.json
@@ -47,7 +47,7 @@
     "@elementor/icons": "1.54.0",
     "@elementor/locations": "3.33.0",
     "@elementor/menus": "3.33.0",
-    "@elementor/ui": "1.36.14",
+    "@elementor/ui": "1.36.15",
     "@wordpress/i18n": "^5.13.0"
   },
   "devDependencies": {

--- a/packages/packages/core/editor-components/package.json
+++ b/packages/packages/core/editor-components/package.json
@@ -54,7 +54,7 @@
     "@elementor/query": "3.33.0",
     "@elementor/schema": "3.33.0",
     "@elementor/store": "3.33.0",
-    "@elementor/ui": "1.36.14",
+    "@elementor/ui": "1.36.15",
     "@elementor/utils": "3.33.0",
     "@wordpress/i18n": "^5.13.0"
   },

--- a/packages/packages/core/editor-editing-panel/package.json
+++ b/packages/packages/core/editor-editing-panel/package.json
@@ -56,7 +56,7 @@
     "@elementor/menus": "3.33.0",
     "@elementor/schema": "3.33.0",
     "@elementor/session": "3.33.0",
-    "@elementor/ui": "1.36.14",
+    "@elementor/ui": "1.36.15",
     "@elementor/utils": "3.33.0",
     "@elementor/wp-media": "3.33.0",
     "@wordpress/i18n": "^5.13.0"

--- a/packages/packages/core/editor-global-classes/package.json
+++ b/packages/packages/core/editor-global-classes/package.json
@@ -55,7 +55,7 @@
     "@elementor/icons": "1.53.0",
     "@elementor/query": "3.33.0",
     "@elementor/store": "3.33.0",
-    "@elementor/ui": "1.36.14",
+    "@elementor/ui": "1.36.15",
     "@elementor/utils": "3.33.0",
     "@wordpress/i18n": "^5.13.0"
   },

--- a/packages/packages/core/editor-notifications/package.json
+++ b/packages/packages/core/editor-notifications/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@elementor/editor": "3.33.0",
     "@elementor/store": "3.33.0",
-    "@elementor/ui": "1.36.14",
+    "@elementor/ui": "1.36.15",
     "notistack": "^3.0.2"
   },
   "peerDependencies": {

--- a/packages/packages/core/editor-panels/package.json
+++ b/packages/packages/core/editor-panels/package.json
@@ -43,7 +43,7 @@
     "@elementor/editor-v1-adapters": "3.33.0",
     "@elementor/locations": "3.33.0",
     "@elementor/store": "3.33.0",
-    "@elementor/ui": "1.36.14"
+    "@elementor/ui": "1.36.15"
   },
   "peerDependencies": {
     "react": "^18.3.1",

--- a/packages/packages/core/editor-site-navigation/package.json
+++ b/packages/packages/core/editor-site-navigation/package.json
@@ -46,7 +46,7 @@
     "@elementor/env": "3.33.0",
     "@elementor/icons": "1.53.0",
     "@elementor/query": "3.33.0",
-    "@elementor/ui": "1.36.14",
+    "@elementor/ui": "1.36.15",
     "@wordpress/api-fetch": "^6.42.0",
     "@wordpress/i18n": "^5.13.0"
   },

--- a/packages/packages/core/editor-variables/package.json
+++ b/packages/packages/core/editor-variables/package.json
@@ -53,7 +53,7 @@
     "@elementor/icons": "1.53.0",
     "@elementor/mixpanel": "3.33.0",
     "@elementor/schema": "3.33.0",
-    "@elementor/ui": "1.36.14",
+    "@elementor/ui": "1.36.15",
     "@wordpress/i18n": "^5.13.0"
   },
   "peerDependencies": {

--- a/packages/packages/core/editor/package.json
+++ b/packages/packages/core/editor/package.json
@@ -45,7 +45,7 @@
     "@elementor/locations": "3.33.0",
     "@elementor/query": "3.33.0",
     "@elementor/store": "3.33.0",
-    "@elementor/ui": "1.36.14",
+    "@elementor/ui": "1.36.15",
     "@elementor/editor-ui": "3.33.0"
   },
   "peerDependencies": {

--- a/packages/packages/libs/editor-controls/package.json
+++ b/packages/packages/libs/editor-controls/package.json
@@ -53,7 +53,7 @@
     "@elementor/mixpanel": "3.33.0",
     "@elementor/query": "3.33.0",
     "@elementor/session": "3.33.0",
-    "@elementor/ui": "1.36.14",
+    "@elementor/ui": "1.36.15",
     "@elementor/utils": "3.33.0",
     "@elementor/wp-media": "3.33.0",
     "@wordpress/i18n": "^5.13.0",

--- a/packages/packages/libs/editor-controls/src/components/control-repeater/context/repeater-context.tsx
+++ b/packages/packages/libs/editor-controls/src/components/control-repeater/context/repeater-context.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createContext, useState } from 'react';
+import { createContext, useMemo, useState } from 'react';
 import { type PropTypeUtil } from '@elementor/editor-props';
 import { type PopupState, usePopupState } from '@elementor/ui';
 
@@ -63,21 +63,20 @@ export const RepeaterContextProvider = < T extends RepeatablePropValue = Repeata
 		persistWhen: () => true,
 	} );
 
-	const [ itemsWithKeys, setItemsWithKeys ] = useState< ItemWithKey< T >[] >( () => {
-		return items?.map( ( item ) => ( { key: generateUniqueKey(), item } ) ) ?? [];
+	const [ uniqueKeys, setUniqueKeys ] = useState( () => {
+		return items?.map( ( _, index ) => index ) ?? [];
 	} );
 
-	React.useEffect( () => {
-		setItemsWithKeys( ( prevItemsWithKeys ) => {
-			const newItemsWithKeys =
-				items?.map( ( item ) => {
-					const existingItem = prevItemsWithKeys.find( ( i ) => i.item === item );
-					return existingItem || { key: generateUniqueKey(), item };
-				} ) ?? [];
-
-			return newItemsWithKeys;
-		} );
-	}, [ items ] );
+	const itemsWithKeys = useMemo(
+		() =>
+			uniqueKeys
+				.map( ( key, index ) => ( {
+					key,
+					item: items[ index ],
+				} ) )
+				.filter( ( { item } ) => item !== undefined ),
+		[ uniqueKeys, items ]
+	);
 
 	const handleSetItems = ( newItemsWithKeys: ItemWithKey< T >[] ) => {
 		setItems( newItemsWithKeys.map( ( { item } ) => item ) );
@@ -92,10 +91,13 @@ export const RepeaterContextProvider = < T extends RepeatablePropValue = Repeata
 	const addItem = ( ev: React.MouseEvent, config?: AddItem< T > ) => {
 		const item = config?.item ?? { ...initial };
 		const newIndex = config?.index ?? items.length;
+		const newKey = generateUniqueKey();
 		const newItems = [ ...items ];
 
 		newItems.splice( newIndex, 0, item );
 		setItems( newItems );
+
+		setUniqueKeys( [ ...uniqueKeys.slice( 0, newIndex ), newKey, ...uniqueKeys.slice( newIndex ) ] );
 
 		setOpenItemIndex( newIndex );
 		popoverState.open( rowRef ?? ev );
@@ -109,6 +111,7 @@ export const RepeaterContextProvider = < T extends RepeatablePropValue = Repeata
 		const itemToRemove = items[ index ];
 
 		setItems( items.filter( ( _, pos ) => pos !== index ) );
+		setUniqueKeys( uniqueKeys.filter( ( _, pos ) => pos !== index ) );
 
 		eventBus.emit( `${ propTypeUtil.key }-item-removed`, {
 			itemValue: itemToRemove?.value,

--- a/packages/packages/libs/editor-ui/package.json
+++ b/packages/packages/libs/editor-ui/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@elementor/editor-v1-adapters": "3.33.0",
     "@elementor/icons": "1.53.0",
-    "@elementor/ui": "1.36.14",
+    "@elementor/ui": "1.36.15",
     "@tanstack/react-virtual": "^3.13.3",
     "@wordpress/i18n": "^5.13.0"
   },


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor repeater item management to prevent component remounting when settings are updated for improved performance and state preservation.
Main changes:
- Replaced state-based item key management with immutable unique keys array to maintain stable component identities
- Implemented useMemo for derived itemsWithKeys array to optimize rendering performance
- Updated @elementor/ui dependency from 1.36.14 to 1.36.15 across multiple packages

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
