### PR TITLE
Internal: Fix sending the message on scheduled PHP unit test failure failure [ED-21286]

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -66,6 +66,9 @@ jobs:
     runs-on: ubuntu-22.04
     name: PHPUnit - Test Results
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Check stable test status
         run: echo "Stable Test status is - ${{ needs.test_pr_group.result }}"
       - name: Check nightly test status

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -68,7 +68,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Check stable test status
         run: echo "Stable Test status is - ${{ needs.test_pr_group.result }}"
       - name: Check nightly test status


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix GitHub Actions workflow to properly send Slack notifications on scheduled PHP unit test failures.
Main changes:
- Added checkout step to ensure repository content is available before sending failure notifications
- Added missing 'run' command for Final Test Status Check step to properly exit with error code

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
