### PR TITLE
Internal: Fix order of dynamic tags groups in selection popup [ED-20348]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/dynamics/hooks/__tests__/use-prop-dynamic-tags.test.ts
+++ b/packages/packages/core/editor-editing-panel/src/dynamics/hooks/__tests__/use-prop-dynamic-tags.test.ts
@@ -140,6 +140,98 @@ describe( 'usePropDynamicTags', () => {
 		// Assert.
 		expect( result.current ).toEqual( [] );
 	} );
+
+	it( 'should sort tags by group key order first, then by tag insertion order within each group', () => {
+		// Arrange
+		const tags = mockAtomicDynamicTags( [
+			{ categories: [ 'string' ], name: 'group3-tag2', group: 'group3' },
+			{ categories: [ 'string' ], name: 'group1-tag1', group: 'group1' },
+			{ categories: [ 'string' ], name: 'group2-tag1', group: 'group2' },
+			{ categories: [ 'string' ], name: 'group1-tag2', group: 'group1' },
+			{ categories: [ 'string' ], name: 'group3-tag1', group: 'group3' },
+			{ categories: [ 'string' ], name: 'group2-tag2', group: 'group2' },
+		] );
+
+		mockPropType( {
+			kind: 'union',
+			prop_types: {
+				string: createMockPropType( { kind: 'plain', key: 'string' } ),
+				dynamic: createMockPropType( {
+					kind: 'plain',
+					key: 'dynamic',
+					settings: { categories: [ 'string' ] },
+				} ),
+			},
+		} );
+
+		jest.mocked( getAtomicDynamicTags ).mockReturnValue( {
+			tags,
+			groups: {
+				group1: { title: 'Group 1' },
+				group2: { title: 'Group 2' },
+				group3: { title: 'Group 3' },
+			},
+		} );
+
+		// Act.
+		const { result } = renderHook( usePropDynamicTags );
+
+		// Assert.
+		expect( result.current ).toEqual( [
+			tags[ 'group1-tag1' ],
+			tags[ 'group1-tag2' ],
+			tags[ 'group2-tag1' ],
+			tags[ 'group2-tag2' ],
+			tags[ 'group3-tag2' ],
+			tags[ 'group3-tag1' ],
+		] );
+	} );
+
+	it( 'should not break sort order when data is already sorted', () => {
+		// Arrange
+		const tags = mockAtomicDynamicTags( [
+			{ categories: [ 'string' ], name: 'group1-tag1', group: 'group1' },
+			{ categories: [ 'string' ], name: 'group1-tag2', group: 'group1' },
+			{ categories: [ 'string' ], name: 'group2-tag1', group: 'group2' },
+			{ categories: [ 'string' ], name: 'group2-tag2', group: 'group2' },
+			{ categories: [ 'string' ], name: 'group3-tag1', group: 'group3' },
+			{ categories: [ 'string' ], name: 'group3-tag2', group: 'group3' },
+		] );
+
+		mockPropType( {
+			kind: 'union',
+			prop_types: {
+				string: createMockPropType( { kind: 'plain', key: 'string' } ),
+				dynamic: createMockPropType( {
+					kind: 'plain',
+					key: 'dynamic',
+					settings: { categories: [ 'string' ] },
+				} ),
+			},
+		} );
+
+		jest.mocked( getAtomicDynamicTags ).mockReturnValue( {
+			tags,
+			groups: {
+				group1: { title: 'Group 1' },
+				group2: { title: 'Group 2' },
+				group3: { title: 'Group 3' },
+			},
+		} );
+
+		// Act.
+		const { result } = renderHook( usePropDynamicTags );
+
+		// Assert.
+		expect( result.current ).toEqual( [
+			tags[ 'group1-tag1' ],
+			tags[ 'group1-tag2' ],
+			tags[ 'group2-tag1' ],
+			tags[ 'group2-tag2' ],
+			tags[ 'group3-tag1' ],
+			tags[ 'group3-tag2' ],
+		] );
+	} );
 } );
 
 const mockPropType = ( params: Partial< PropType > ) => {

--- a/packages/packages/core/editor-editing-panel/src/dynamics/hooks/__tests__/use-prop-dynamic-tags.test.ts
+++ b/packages/packages/core/editor-editing-panel/src/dynamics/hooks/__tests__/use-prop-dynamic-tags.test.ts
@@ -34,8 +34,8 @@ describe( 'usePropDynamicTags', () => {
 		mockPropType( null );
 
 		jest.mocked( getAtomicDynamicTags ).mockReturnValue( {
-			tags: mockAtomicDynamicTags( [ { categories: [ 'string' ], name: 'only-string' } ] ),
-			groups: {},
+			tags: mockAtomicDynamicTags( [ { categories: [ 'string' ], name: 'only-string', group: 'group1' } ] ),
+			groups: { group1: { title: 'Group 1' } },
 		} );
 
 		// Act.
@@ -48,8 +48,8 @@ describe( 'usePropDynamicTags', () => {
 	it( 'should return an empty array when the additional_types list is empty', () => {
 		// Arrange
 		jest.mocked( getAtomicDynamicTags ).mockReturnValue( {
-			tags: mockAtomicDynamicTags( [ { categories: [ 'string' ], name: 'only-string' } ] ),
-			groups: {},
+			tags: mockAtomicDynamicTags( [ { categories: [ 'string' ], name: 'only-string', group: 'group1' } ] ),
+			groups: { group1: { title: 'Group 1' } },
 		} );
 
 		mockPropType( { kind: 'plain', key: 'string' } );
@@ -64,10 +64,10 @@ describe( 'usePropDynamicTags', () => {
 	it( 'should return an array of dynamic tags that match the tag categories', () => {
 		// Arrange
 		const tags = mockAtomicDynamicTags( [
-			{ categories: [ 'url' ], name: 'only-url' },
-			{ categories: [ 'string' ], name: 'only-string' },
-			{ categories: [ 'url', 'string' ], name: 'url-and-string' },
-			{ categories: [ 'number' ], name: 'only-number' },
+			{ categories: [ 'url' ], name: 'only-url', group: 'group1' },
+			{ categories: [ 'string' ], name: 'only-string', group: 'group1' },
+			{ categories: [ 'url', 'string' ], name: 'url-and-string', group: 'group1' },
+			{ categories: [ 'number' ], name: 'only-number', group: 'group2' },
 		] );
 
 		mockPropType( {
@@ -82,7 +82,10 @@ describe( 'usePropDynamicTags', () => {
 			},
 		} );
 
-		jest.mocked( getAtomicDynamicTags ).mockReturnValue( { tags, groups: {} } );
+		jest.mocked( getAtomicDynamicTags ).mockReturnValue( {
+			tags,
+			groups: { group1: { title: 'Group 1' }, group2: { title: 'Group 2' } },
+		} );
 
 		// Act.
 		const { result, rerender } = renderHook( usePropDynamicTags );
@@ -91,7 +94,10 @@ describe( 'usePropDynamicTags', () => {
 		expect( result.current ).toEqual( [ tags[ 'only-url' ], tags[ 'only-string' ], tags[ 'url-and-string' ] ] );
 
 		// Arrange.
-		jest.mocked( getAtomicDynamicTags ).mockReturnValue( { tags, groups: {} } );
+		jest.mocked( getAtomicDynamicTags ).mockReturnValue( {
+			tags,
+			groups: { group1: { title: 'Group 1' }, group2: { title: 'Group 2' } },
+		} );
 
 		mockPropType( {
 			kind: 'union',
@@ -124,8 +130,8 @@ describe( 'usePropDynamicTags', () => {
 		} );
 
 		jest.mocked( getAtomicDynamicTags ).mockReturnValue( {
-			tags: mockAtomicDynamicTags( [ { categories: [ 'string' ], name: 'only-string' } ] ),
-			groups: {},
+			tags: mockAtomicDynamicTags( [ { categories: [ 'string' ], name: 'only-string', group: 'group1' } ] ),
+			groups: { group1: { title: 'Group 1' } },
 		} );
 
 		// Act.
@@ -149,13 +155,13 @@ const mockPropType = ( params: Partial< PropType > ) => {
 	} );
 };
 
-const mockAtomicDynamicTags = ( tags: Pick< DynamicTag, 'name' | 'categories' >[] ) => {
+const mockAtomicDynamicTags = ( tags: Pick< DynamicTag, 'name' | 'categories' | 'group' >[] ) => {
 	return tags.reduce< DynamicTags >(
-		( acc, { name, categories } ) => ( {
+		( acc, { name, categories, group } ) => ( {
 			...acc,
 			[ name ]: {
 				name,
-				group: '',
+				group,
 				categories,
 				label: '',
 				atomic_controls: [],

--- a/packages/packages/core/editor-editing-panel/src/dynamics/hooks/use-prop-dynamic-tags.ts
+++ b/packages/packages/core/editor-editing-panel/src/dynamics/hooks/use-prop-dynamic-tags.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useBoundProp } from '@elementor/editor-controls';
 
 import { getAtomicDynamicTags } from '../sync/get-atomic-dynamic-tags';
+import { type DynamicTag } from '../types';
 import { getDynamicPropType } from '../utils';
 
 export const usePropDynamicTags = () => {
@@ -21,15 +22,33 @@ export const usePropDynamicTags = () => {
 };
 
 const getDynamicTagsByCategories = ( categories: string[] ) => {
-	const dynamicTags = getAtomicDynamicTags();
+	const { tags, groups } = getAtomicDynamicTags() || {};
 
-	if ( ! categories.length || ! dynamicTags?.tags ) {
+	if ( ! categories.length || ! tags || ! groups ) {
 		return [];
 	}
 
 	const _categories = new Set( categories );
 
-	return Object.values( dynamicTags.tags ).filter( ( dynamicTag ) =>
-		dynamicTag.categories.some( ( category ) => _categories.has( category ) )
-	);
+	const dynamicTags: DynamicTag[] = [];
+	const groupedFilteredTags: Record< string, DynamicTag[] > = {};
+
+	for ( const tag of Object.values( tags ) ) {
+		if ( ! tag.categories.some( ( category ) => _categories.has( category ) ) ) {
+			continue;
+		}
+
+		if ( ! groupedFilteredTags[ tag.group ] ) {
+			groupedFilteredTags[ tag.group ] = [];
+		}
+		groupedFilteredTags[ tag.group ].push( tag );
+	}
+
+	for ( const group in groups ) {
+		if ( groupedFilteredTags[ group ] ) {
+			dynamicTags.push( ...groupedFilteredTags[ group ] );
+		}
+	}
+
+	return dynamicTags;
 };


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix ordering of dynamic tags groups in selection popup to ensure consistent and predictable display across the application.
Main changes:
- Added group property to dynamic tags and implemented group-based sorting logic
- Refactored tag filtering to group tags by their associated group before display
- Added comprehensive tests for tag sorting and grouping behavior

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
