### PR TITLE
Internal: Change icon widget template [ED-20374]

### DIFF
--- a/includes/widgets/icon.php
+++ b/includes/widgets/icon.php
@@ -491,13 +491,15 @@ class Widget_Icon extends Widget_Base {
 			return;
 		}
 
+		let iconTag = 'div';
+
 		if ( settings.link?.url ) {
 			view.addRenderAttribute( 'link_url', 'href', elementor.helpers.sanitizeUrl( settings.link?.url ) );
+			iconTag = 'a';
 		}
 
 		const iconHTML = elementor.helpers.renderIcon( view, settings.selected_icon, { 'aria-hidden': true }, 'i' , 'object' ),
-			migrated = elementor.helpers.isIconMigrated( settings, 'selected_icon' ),
-			iconTag = elementor.helpers.validateHTMLTag( settings.link?.url ? 'a' : 'div' );
+			migrated = elementor.helpers.isIconMigrated( settings, 'selected_icon' );
 
 		view.addRenderAttribute( 'icon', 'class', 'elementor-icon' );
 

--- a/includes/widgets/icon.php
+++ b/includes/widgets/icon.php
@@ -465,13 +465,13 @@ class Widget_Icon extends Widget_Base {
 
 		?>
 		<div <?php $this->print_render_attribute_string( 'wrapper' ); ?>>
-			<<?php Utils::print_unescaped_internal_string( $icon_tag . ' ' . $this->get_render_attribute_string( 'icon-wrapper' ) ); ?>>
+			<<?php Utils::print_validated_html_tag( $icon_tag ); ?> <?php $this->print_render_attribute_string( 'icon-wrapper' ); ?>>
 			<?php if ( $is_new || $migrated ) :
 				Icons_Manager::render_icon( $settings['selected_icon'], [ 'aria-hidden' => 'true' ] );
 			else : ?>
 				<i <?php $this->print_render_attribute_string( 'icon' ); ?>></i>
 			<?php endif; ?>
-			</<?php Utils::print_unescaped_internal_string( $icon_tag ); ?>>
+			</<?php Utils::print_validated_html_tag( $icon_tag ); ?>>
 		</div>
 		<?php
 	}
@@ -497,7 +497,7 @@ class Widget_Icon extends Widget_Base {
 
 		const iconHTML = elementor.helpers.renderIcon( view, settings.selected_icon, { 'aria-hidden': true }, 'i' , 'object' ),
 			migrated = elementor.helpers.isIconMigrated( settings, 'selected_icon' ),
-			iconTag = settings.link?.url ? 'a' : 'div';
+			iconTag = elementor.helpers.validateHTMLTag( settings.link?.url ? 'a' : 'div' );
 
 		view.addRenderAttribute( 'icon', 'class', 'elementor-icon' );
 

--- a/tests/playwright/sanity/includes/widgets/icon-2.test.ts
+++ b/tests/playwright/sanity/includes/widgets/icon-2.test.ts
@@ -55,6 +55,7 @@ test.describe( 'Icon widget tests', () => {
 
 		// Act 2 - Add link
 		await editor.setTextControlValue( 'link', testUrl );
+		await page.waitForTimeout( 100 );
 
 		// Assert 2 - With link the tag becomes anchor tag
 		await test.step( 'Link anchor tag in the Editor', async () => {

--- a/tests/playwright/sanity/includes/widgets/icon-2.test.ts
+++ b/tests/playwright/sanity/includes/widgets/icon-2.test.ts
@@ -55,7 +55,7 @@ test.describe( 'Icon widget tests', () => {
 
 		// Act 2 - Add link
 		await editor.setTextControlValue( 'link', testUrl );
-		await editor.getPreviewFrame().locator( '.elementor-icon[href]' ).waitFor( { timeout: 10000 } );
+		await editor.getPreviewFrame().locator( '.elementor-icon[href]' ).waitFor();
 
 		// Assert 2 - With link the tag becomes anchor tag
 		await test.step( 'Link anchor tag in the Editor', async () => {

--- a/tests/playwright/sanity/includes/widgets/icon-2.test.ts
+++ b/tests/playwright/sanity/includes/widgets/icon-2.test.ts
@@ -55,7 +55,7 @@ test.describe( 'Icon widget tests', () => {
 
 		// Act 2 - Add link
 		await editor.setTextControlValue( 'link', testUrl );
-		await page.waitForTimeout( 100 );
+		await editor.getPreviewFrame().locator( '[data-widget_type="icon.default"] a' ).waitFor();
 
 		// Assert 2 - With link the tag becomes anchor tag
 		await test.step( 'Link anchor tag in the Editor', async () => {

--- a/tests/playwright/sanity/includes/widgets/icon-2.test.ts
+++ b/tests/playwright/sanity/includes/widgets/icon-2.test.ts
@@ -55,7 +55,7 @@ test.describe( 'Icon widget tests', () => {
 
 		// Act 2 - Add link
 		await editor.setTextControlValue( 'link', testUrl );
-		await editor.getPreviewFrame().locator( '[data-widget_type="icon.default"] a' ).waitFor();
+		await editor.getPreviewFrame().locator( '.elementor-icon[href]' ).waitFor( { timeout: 10000 } );
 
 		// Assert 2 - With link the tag becomes anchor tag
 		await test.step( 'Link anchor tag in the Editor', async () => {

--- a/tests/playwright/sanity/includes/widgets/icon-2.test.ts
+++ b/tests/playwright/sanity/includes/widgets/icon-2.test.ts
@@ -55,7 +55,7 @@ test.describe( 'Icon widget tests', () => {
 
 		// Act 2 - Add link
 		await editor.setTextControlValue( 'link', testUrl );
-		await editor.getPreviewFrame().locator( '.elementor-icon[href]' ).waitFor();
+		await editor.getPreviewFrame().locator( `a.elementor-icon[href="${ testUrl }"]` ).waitFor();
 
 		// Assert 2 - With link the tag becomes anchor tag
 		await test.step( 'Link anchor tag in the Editor', async () => {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor Icon widget template to improve HTML rendering with validated tags and clearer link handling logic.

Main changes:
- Replaced print_unescaped_internal_string with print_validated_html_tag for better HTML tag validation
- Refactored icon tag handling in editor JavaScript template for improved maintainability
- Added waitFor assertion in tests to ensure proper link rendering before validation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
