### PR TITLE
Internal: Add playwright tests to the icon widget [ED-20374]

### DIFF
--- a/tests/playwright/sanity/includes/widgets/icon-2.test.ts
+++ b/tests/playwright/sanity/includes/widgets/icon-2.test.ts
@@ -1,34 +1,75 @@
 import { expect } from '@playwright/test';
 import { parallelTest as test } from '../../../parallelTest';
 import WpAdminPage from '../../../pages/wp-admin-page';
+import EditorPage from '../../../pages/editor-page';
 
-test( 'Icon widget sanity test', async ( { page, apiRequests }, testInfo ) => {
-	const getComputedStyle = async ( element, pseudo: string ) => page.evaluate( ( [ e, p ] ) => getComputedStyle( e, p ), [ element, pseudo ] );
+test.describe( 'Icon widget tests', () => {
+	test( 'Icon widget sanity test', async ( { page, apiRequests }, testInfo ) => {
+		const getComputedStyle = async ( element, pseudo: string ) => page.evaluate( ( [ e, p ] ) => getComputedStyle( e, p ), [ element, pseudo ] );
 
-	const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-	const editor = await wpAdmin.openNewPage();
+		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+		const editor = await wpAdmin.openNewPage();
 
-	await editor.addWidget( { widgetType: 'icon' } );
-	let icon = await editor.getPreviewFrame().waitForSelector( 'i.fa-star' );
-	let style = await getComputedStyle( icon, 'before' );
-	expect( style.content.charCodeAt() ).toBe( 34 );
+		await editor.addWidget( { widgetType: 'icon' } );
+		let icon = await editor.getPreviewFrame().waitForSelector( 'i.fa-star' );
+		let style = await getComputedStyle( icon, 'before' );
+		expect( style.content.charCodeAt() ).toBe( 34 );
 
-	await page.click( '.elementor-control-media__preview' );
-	await page.click( '.elementor-icons-manager__tab__item__icon.fas.fa-surprise' );
-	await page.click( 'button:has-text("Insert")' );
+		await page.click( '.elementor-control-media__preview' );
+		await page.click( '.elementor-icons-manager__tab__item__icon.fas.fa-surprise' );
+		await page.click( 'button:has-text("Insert")' );
 
-	icon = await editor.getPreviewFrame().waitForSelector( 'i.fa-surprise' );
-	await editor.setSelectControlValue( 'view', 'stacked' );
-	await editor.setSelectControlValue( 'shape', 'square' );
+		icon = await editor.getPreviewFrame().waitForSelector( 'i.fa-surprise' );
+		await editor.setSelectControlValue( 'view', 'stacked' );
+		await editor.setSelectControlValue( 'shape', 'square' );
 
-	// Style
-	const width = '90';
-	await editor.setWidgetTab( 'style' );
-	await editor.setSliderControlValue( 'size', width );
+		// Style
+		const width = '90';
+		await editor.setWidgetTab( 'style' );
+		await editor.setSliderControlValue( 'size', width );
 
-	await expect.poll( async () => {
-		icon = await editor.getPreviewFrame().waitForSelector( '.elementor-icon:first-child' );
-		style = await getComputedStyle( icon, '' );
-		return style.fontSize;
-	} ).toBe( `${ width }px` );
+		await expect.poll( async () => {
+			icon = await editor.getPreviewFrame().waitForSelector( '.elementor-icon:first-child' );
+			style = await getComputedStyle( icon, '' );
+			return style.fontSize;
+		} ).toBe( `${ width }px` );
+	} );
+
+	test( 'Icon widget wrapping HTML tag', async ( { page, apiRequests }, testInfo ) => {
+		// Arrange.
+		const testUrl = 'https://elementor.com/';
+		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+		const editor = new EditorPage( page, testInfo );
+
+		// Act.
+		await wpAdmin.openNewPage();
+		await editor.addWidget( { widgetType: 'icon' } );
+
+		// Assert 1 - Default behavior (no link)
+		await test.step( 'No link - DIV tag in Editor', async () => {
+			const iconElement = editor.getPreviewFrame().locator( '.elementor-icon' );
+			await expect( iconElement ).not.toHaveAttribute( 'href' );
+			const tagName = await iconElement.evaluate( ( el ) => el.tagName );
+			expect( tagName ).toBe( 'DIV' );
+		} );
+
+		// Act 2 - Add link
+		await editor.setTextControlValue( 'link', testUrl );
+
+		// Assert 2 - With link the tag becomes anchor tag
+		await test.step( 'Link anchor tag in the Editor', async () => {
+			const iconElement = editor.getPreviewFrame().locator( '.elementor-icon' );
+			await expect( iconElement ).toHaveAttribute( 'href', testUrl );
+			const tagName = await iconElement.evaluate( ( el ) => el.tagName );
+			expect( tagName ).toBe( 'A' );
+		} );
+
+		await test.step( 'Link anchor tag in the published page', async () => {
+			await editor.publishAndViewPage();
+			const iconElement = page.locator( '.elementor-icon' );
+			await expect( iconElement ).toHaveAttribute( 'href', testUrl );
+			const tagName = await iconElement.evaluate( ( el ) => el.tagName );
+			expect( tagName ).toBe( 'A' );
+		} );
+	} );
 } );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add Playwright tests for icon widget to verify functionality and HTML tag behavior when links are added.

Main changes:
- Restructured existing test inside a test.describe block for better organization
- Added new test case to verify icon widget changes from DIV to anchor tag when links are added
- Imported EditorPage class to support additional testing functionality

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
