### PR TITLE
Internal: [V4] NaN value appears in custom size in repeaters [ED-21274]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/box-shadow-repeater-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/box-shadow-repeater-control.tsx
@@ -16,7 +16,7 @@ import { PopoverGridContainer } from '../components/popover-grid-container';
 import { createControl } from '../create-control';
 import { ColorControl } from './color-control';
 import { SelectControl } from './select-control';
-import { SizeControl } from './size-control';
+import { CUSTOM_SIZE_LABEL, SizeControl } from './size-control';
 
 export const BoxShadowRepeaterControl = createControl( () => {
 	const { propType, value, setValue, disabled } = useBoundProp( boxShadowPropTypeUtil );
@@ -135,11 +135,19 @@ const ItemLabel = ( { value }: { value: ShadowPropValue } ) => {
 	const positionLabel = position?.value || 'outset';
 
 	const sizes = [
-		hOffsetSize + hOffsetUnit,
-		vOffsetSize + vOffsetUnit,
-		blurSize + blurUnit,
-		spreadSize + spreadUnit,
-	].join( ' ' );
+		[ hOffsetSize, hOffsetUnit ],
+		[ vOffsetSize, vOffsetUnit ],
+		[ blurSize, blurUnit ],
+		[ spreadSize, spreadUnit ],
+	]
+		.map( ( [ size, unit ] ) => {
+			if ( unit !== 'custom' ) {
+				return size + unit;
+			}
+
+			return ! size ? CUSTOM_SIZE_LABEL : size;
+		} )
+		.join( ' ' );
 
 	return (
 		<span style={ { textTransform: 'capitalize' } }>

--- a/packages/packages/libs/editor-controls/src/controls/filter-control/drop-shadow/drop-shadow-item-content.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/filter-control/drop-shadow/drop-shadow-item-content.tsx
@@ -53,6 +53,7 @@ export const DropShadowItemContent = ( { anchorEl }: { anchorEl?: HTMLElement | 
 									anchorRef={ rowRefs[ item.rowIndex ] }
 									enablePropTypeUnits
 									defaultUnit="px"
+									isRepeaterControl
 								/>
 							) }
 						</Grid>

--- a/packages/packages/libs/editor-controls/src/controls/filter-control/drop-shadow/drop-shadow-item-label.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/filter-control/drop-shadow/drop-shadow-item-label.tsx
@@ -5,27 +5,20 @@ import { Box } from '@elementor/ui';
 import { CUSTOM_SIZE_LABEL } from '../../size-control';
 
 export const DropShadowItemLabel = ( { value }: { value: FilterItemPropValue } ) => {
-	const { xAxis, yAxis, blur } = value.value.args.value as DropShadowFilterPropValue[ 'value' ];
-
-	const xValue =
-		xAxis?.value?.unit !== 'custom'
-			? `${ xAxis?.value?.size ?? 0 }${ xAxis?.value?.unit ?? 'px' }`
-			: xAxis?.value?.size || CUSTOM_SIZE_LABEL;
-	const yValue =
-		yAxis?.value?.unit !== 'custom'
-			? `${ yAxis?.value?.size ?? 0 }${ yAxis?.value?.unit ?? 'px' }`
-			: yAxis?.value?.size || CUSTOM_SIZE_LABEL;
-	const blurValue =
-		blur?.value?.unit !== 'custom'
-			? `${ blur?.value?.size ?? 10 }${ blur?.value?.unit ?? 'px' }`
-			: blur?.value?.size || CUSTOM_SIZE_LABEL;
+	const values = value.value.args.value as DropShadowFilterPropValue[ 'value' ];
+	const keys = [ 'xAxis', 'yAxis', 'blur' ] as Array< keyof typeof values >;
+	const labels: string[] = keys.map( ( key ) =>
+		values[ key ]?.value?.unit !== 'custom'
+			? `${ values[ key ]?.value?.size ?? 0 }${ values[ key ]?.value?.unit ?? 'px' }`
+			: values[ key ]?.value?.size || CUSTOM_SIZE_LABEL
+	);
 
 	return (
 		<Box component="span">
 			<Box component="span" style={ { textTransform: 'capitalize' } }>
 				Drop shadow:
 			</Box>
-			{ ` ${ xValue } ${ yValue } ${ blurValue }` }
+			{ ` ${ labels.join( ' ' ) }` }
 		</Box>
 	);
 };

--- a/packages/packages/libs/editor-controls/src/controls/filter-control/drop-shadow/drop-shadow-item-label.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/filter-control/drop-shadow/drop-shadow-item-label.tsx
@@ -2,19 +2,30 @@ import * as React from 'react';
 import { type DropShadowFilterPropValue, type FilterItemPropValue } from '@elementor/editor-props';
 import { Box } from '@elementor/ui';
 
+import { CUSTOM_SIZE_LABEL } from '../../size-control';
+
 export const DropShadowItemLabel = ( { value }: { value: FilterItemPropValue } ) => {
 	const { xAxis, yAxis, blur } = value.value.args.value as DropShadowFilterPropValue[ 'value' ];
 
-	const xValue = `${ xAxis?.value?.size ?? 0 }${ xAxis?.value?.unit ?? 'px' }`;
-	const yValue = `${ yAxis?.value?.size ?? 0 }${ yAxis?.value?.unit ?? 'px' }`;
-	const blurValue = `${ blur?.value?.size ?? 10 }${ blur?.value?.unit ?? 'px' }`;
+	const xValue =
+		xAxis?.value?.unit !== 'custom'
+			? `${ xAxis?.value?.size ?? 0 }${ xAxis?.value?.unit ?? 'px' }`
+			: xAxis?.value?.size || CUSTOM_SIZE_LABEL;
+	const yValue =
+		yAxis?.value?.unit !== 'custom'
+			? `${ yAxis?.value?.size ?? 0 }${ yAxis?.value?.unit ?? 'px' }`
+			: yAxis?.value?.size || CUSTOM_SIZE_LABEL;
+	const blurValue =
+		blur?.value?.unit !== 'custom'
+			? `${ blur?.value?.size ?? 10 }${ blur?.value?.unit ?? 'px' }`
+			: blur?.value?.size || CUSTOM_SIZE_LABEL;
 
 	return (
 		<Box component="span">
 			<Box component="span" style={ { textTransform: 'capitalize' } }>
 				Drop shadow:
 			</Box>
-			{ `${ xValue } ${ yValue } ${ blurValue }` }
+			{ ` ${ xValue } ${ yValue } ${ blurValue }` }
 		</Box>
 	);
 };

--- a/packages/packages/libs/editor-controls/src/controls/filter-control/single-size/single-size-item-content.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/filter-control/single-size/single-size-item-content.tsx
@@ -38,7 +38,7 @@ export const SingleSizeItemContent = ( { filterFunc }: { filterFunc: FilterFunct
 							<ControlFormLabel>{ valueName }</ControlFormLabel>
 						</Grid>
 						<Grid item xs={ 6 }>
-							<SizeControl anchorRef={ rowRef } enablePropTypeUnits />
+							<SizeControl anchorRef={ rowRef } enablePropTypeUnits isRepeaterControl />
 						</Grid>
 					</PopoverGridContainer>
 				</PropKeyProvider>

--- a/packages/packages/libs/editor-controls/src/controls/filter-control/single-size/single-size-item-label.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/filter-control/single-size/single-size-item-label.tsx
@@ -3,6 +3,7 @@ import type { FilterItemPropValue, SizePropValue } from '@elementor/editor-props
 import { Box } from '@elementor/ui';
 
 import { lengthUnits } from '../../../utils/size-control';
+import { CUSTOM_SIZE_LABEL } from '../../size-control';
 import { type FilterFunction } from '../configs';
 import { useFilterConfig } from '../context/filter-config-context';
 
@@ -24,7 +25,7 @@ export const SingleSizeItemLabel = ( { value }: { value: FilterItemPropValue } )
 	return (
 		<Box component="span">
 			{ label }
-			{ unit !== 'custom' ? ` ${ size ?? 0 }${ unit ?? defaultUnit }` : size }
+			{ ' ' + ( unit !== 'custom' ? `${ size ?? 0 }${ unit ?? defaultUnit }` : size || CUSTOM_SIZE_LABEL ) }
 		</Box>
 	);
 };

--- a/packages/packages/libs/editor-controls/src/controls/selection-size-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/selection-size-control.tsx
@@ -20,10 +20,17 @@ type SelectionSizeControlProps = {
 	sizeLabel: string;
 	selectionConfig: SelectionComponentConfig;
 	sizeConfigMap: Record< string, SizeControlConfig >;
+	avoidListeningToExternalChanges?: boolean;
 };
 
 export const SelectionSizeControl = createControl(
-	( { selectionLabel, sizeLabel, selectionConfig, sizeConfigMap }: SelectionSizeControlProps ) => {
+	( {
+		selectionLabel,
+		sizeLabel,
+		selectionConfig,
+		sizeConfigMap,
+		avoidListeningToExternalChanges = false,
+	}: SelectionSizeControlProps ) => {
 		const { value, setValue, propType } = useBoundProp( selectionSizePropTypeUtil );
 		const rowRef = useRef< HTMLDivElement >( null );
 
@@ -65,6 +72,7 @@ export const SelectionSizeControl = createControl(
 										units={ currentSizeConfig.units }
 										defaultUnit={ currentSizeConfig.defaultUnit }
 										id={ sizeFieldId }
+										isRepeaterControl={ avoidListeningToExternalChanges }
 									/>
 								</PropKeyProvider>
 							</Grid>

--- a/packages/packages/libs/editor-controls/src/controls/selection-size-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/selection-size-control.tsx
@@ -20,7 +20,7 @@ type SelectionSizeControlProps = {
 	sizeLabel: string;
 	selectionConfig: SelectionComponentConfig;
 	sizeConfigMap: Record< string, SizeControlConfig >;
-	avoidListeningToExternalChanges?: boolean;
+	isRepeaterControl?: boolean;
 };
 
 export const SelectionSizeControl = createControl(
@@ -29,7 +29,7 @@ export const SelectionSizeControl = createControl(
 		sizeLabel,
 		selectionConfig,
 		sizeConfigMap,
-		avoidListeningToExternalChanges = false,
+		isRepeaterControl = false,
 	}: SelectionSizeControlProps ) => {
 		const { value, setValue, propType } = useBoundProp( selectionSizePropTypeUtil );
 		const rowRef = useRef< HTMLDivElement >( null );
@@ -72,7 +72,7 @@ export const SelectionSizeControl = createControl(
 										units={ currentSizeConfig.units }
 										defaultUnit={ currentSizeConfig.defaultUnit }
 										id={ sizeFieldId }
-										isRepeaterControl={ avoidListeningToExternalChanges }
+										isRepeaterControl={ isRepeaterControl }
 									/>
 								</PropKeyProvider>
 							</Grid>

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/functions/axis-row.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/functions/axis-row.tsx
@@ -33,6 +33,7 @@ export const AxisRow = ( { label, bind, startIcon, anchorRef, units, variant = '
 							units={ units }
 							variant={ variant }
 							min={ -Number.MAX_SAFE_INTEGER }
+							isRepeaterControl
 							id={ safeId }
 						/>
 					</PropKeyProvider>

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/transform-label.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/transform-label.tsx
@@ -3,53 +3,36 @@ import type { TransformFunctionsItemPropValue } from '@elementor/editor-props';
 import { Box } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
+import { CUSTOM_SIZE_LABEL } from '../size-control';
 import { defaultValues, TransformFunctionKeys } from './initial-values';
 
-const transformMoveValue = ( value: TransformFunctionsItemPropValue[ 'value' ] ) =>
-	Object.values( value )
+const formatLabel = ( value: TransformFunctionsItemPropValue[ 'value' ], functionType: keyof typeof defaultValues ) => {
+	return Object.values( value )
 		.map( ( axis ) => {
-			const size = axis?.value?.size ?? defaultValues.move.size;
-			const unit = axis?.value?.unit ?? defaultValues.move.unit;
+			if ( functionType === 'scale' ) {
+				return axis?.value || defaultValues[ functionType ];
+			}
 
-			return `${ size }${ unit }`;
+			const defaults = defaultValues[ functionType ];
+			const size = axis?.value?.size ?? defaults.size;
+			const unit = axis?.value?.unit ?? defaults.unit;
+
+			return unit === 'custom' ? size || CUSTOM_SIZE_LABEL : `${ size }${ unit }`;
 		} )
 		.join( ', ' );
-
-const transformScaleValue = ( value: TransformFunctionsItemPropValue[ 'value' ] ) =>
-	Object.values( value )
-		.map( ( axis ) => axis?.value || defaultValues.scale )
-		.join( ', ' );
-
-const transformRotateValue = ( value: TransformFunctionsItemPropValue[ 'value' ] ) =>
-	Object.values( value )
-		.map( ( axis ) => {
-			const size = axis?.value?.size ?? defaultValues.rotate.size;
-			const unit = axis?.value?.unit ?? defaultValues.rotate.unit;
-
-			return `${ size }${ unit }`;
-		} )
-		.join( ', ' );
-const transformSkewValue = ( value: TransformFunctionsItemPropValue[ 'value' ] ) =>
-	Object.values( value )
-		.map( ( axis ) => {
-			const size = axis?.value?.size ?? defaultValues.skew.size;
-			const unit = axis?.value?.unit ?? defaultValues.skew.unit;
-
-			return `${ size }${ unit }`;
-		} )
-		.join( ', ' );
+};
 
 export const TransformLabel = ( props: { value: TransformFunctionsItemPropValue } ) => {
 	const { $$type, value } = props.value;
 	switch ( $$type ) {
 		case TransformFunctionKeys.move:
-			return <Label label={ __( 'Move', 'elementor' ) } value={ transformMoveValue( value ) } />;
+			return <Label label={ __( 'Move', 'elementor' ) } value={ formatLabel( value, 'move' ) } />;
 		case TransformFunctionKeys.scale:
-			return <Label label={ __( 'Scale', 'elementor' ) } value={ transformScaleValue( value ) } />;
+			return <Label label={ __( 'Scale', 'elementor' ) } value={ formatLabel( value, 'scale' ) } />;
 		case TransformFunctionKeys.rotate:
-			return <Label label={ __( 'Rotate', 'elementor' ) } value={ transformRotateValue( value ) } />;
+			return <Label label={ __( 'Rotate', 'elementor' ) } value={ formatLabel( value, 'rotate' ) } />;
 		case TransformFunctionKeys.skew:
-			return <Label label={ __( 'Skew', 'elementor' ) } value={ transformSkewValue( value ) } />;
+			return <Label label={ __( 'Skew', 'elementor' ) } value={ formatLabel( value, 'skew' ) } />;
 		default:
 			return '';
 	}

--- a/packages/packages/libs/editor-controls/src/controls/transition-control/transition-repeater-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transition-control/transition-repeater-control.tsx
@@ -33,6 +33,7 @@ const getSelectionSizeProps = ( recentlyUsedList: string[], disabledItems?: stri
 				disabledItems,
 			},
 		},
+		avoidListeningToExternalChanges: true,
 		sizeConfigMap: {
 			...transitionProperties.reduce(
 				( acc, category ) => {

--- a/packages/packages/libs/editor-controls/src/controls/transition-control/transition-repeater-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transition-control/transition-repeater-control.tsx
@@ -33,7 +33,7 @@ const getSelectionSizeProps = ( recentlyUsedList: string[], disabledItems?: stri
 				disabledItems,
 			},
 		},
-		avoidListeningToExternalChanges: true,
+		isRepeaterControl: true,
 		sizeConfigMap: {
 			...transitionProperties.reduce(
 				( acc, category ) => {

--- a/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
@@ -2,6 +2,8 @@ import { parallelTest as test } from '../../../parallelTest';
 import WpAdminPage from '../../../pages/wp-admin-page';
 import { expect } from '@playwright/test';
 
+const CUSTOM_VALUE = 'my custom value';
+
 test.describe( 'Atomic repeaters display @atomic-widgets', () => {
 	let wpAdmin: WpAdminPage;
 
@@ -52,9 +54,9 @@ test.describe( 'Atomic repeaters display @atomic-widgets', () => {
 			await controlRepeaterAdditionButton.click();
 			await inputUnitButton.click();
 			await customSizeButton.click();
-			await customSizeInput.fill( 'My milkshake brings all the boys to the yard' );
+			await customSizeInput.fill( CUSTOM_VALUE );
 
-			await expect( customSizeInput ).toHaveValue( 'My milkshake brings all the boys to the yard' );
+			await expect( customSizeInput ).toHaveValue( CUSTOM_VALUE );
 
 			while ( await editor.page.locator( '.MuiBackdrop-root' ).count() ) {
 				await editor.page.locator( '.MuiBackdrop-root' ).last().click();
@@ -62,7 +64,7 @@ test.describe( 'Atomic repeaters display @atomic-widgets', () => {
 
 			const repeaterItem = editor.page.locator( '.MuiTag-button .MuiTag-content' );
 
-			expect( await repeaterItem.textContent() ).toContain( 'My milkshake brings' );
+			expect( await repeaterItem.textContent() ).toContain( CUSTOM_VALUE );
 		} );
 	}
 } );

--- a/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
@@ -28,6 +28,23 @@ test.describe( 'Atomic repeaters display @atomic-widgets', () => {
 			await editor.openV2Section( 'effects' );
 
 			const controlRepeaterAdditionButton = editor.page.getByRole( 'button', { name: `Add ${ control } item` } );
+
+			await controlRepeaterAdditionButton.click();
+			await editor.page.locator( '.MuiBackdrop-root' ).click();
+
+			const parentDiv = controlRepeaterAdditionButton.locator( '../../..' );
+			const controlName = control.trim().toLowerCase().replace( /\s+/g, '-' );
+
+			await expect.soft( parentDiv ).toHaveScreenshot( 'transform-parent-' + controlName + '.png' );
+		} );
+
+		test( `repeater control ${ control } custom size stability`, async () => {
+			const editor = await wpAdmin.openNewPage();
+			await editor.addWidget( { widgetType: 'e-heading' } );
+			await editor.v4Panel.openTab( 'style' );
+			await editor.openV2Section( 'effects' );
+
+			const controlRepeaterAdditionButton = editor.page.getByRole( 'button', { name: `Add ${ control } item` } );
 			const inputUnitButton = editor.page.locator( 'button', { hasText: /^(px|ms)$/ } ).last();
 			const customSizeButton = editor.page.locator( '.MuiPaper-root ul li .MuiListItemText-root svg' );
 			const customSizeInput = editor.page.locator( '.MuiPaper-root .MuiPaper-root .MuiPaper-root input[type="text"]' );
@@ -38,16 +55,14 @@ test.describe( 'Atomic repeaters display @atomic-widgets', () => {
 			await customSizeInput.fill( 'My milkshake brings all the boys to the yard' );
 
 			await expect( customSizeInput ).toHaveValue( 'My milkshake brings all the boys to the yard' );
-			await customSizeInput.clear();
 
 			while ( await editor.page.locator( '.MuiBackdrop-root' ).count() ) {
 				await editor.page.locator( '.MuiBackdrop-root' ).last().click();
 			}
 
-			const parentDiv = controlRepeaterAdditionButton.locator( '../../..' );
-			const controlName = control.trim().toLowerCase().replace( /\s+/g, '-' );
+			const repeaterItem = editor.page.locator( '.MuiTag-button .MuiTag-content' );
 
-			await expect.soft( parentDiv ).toHaveScreenshot( 'transform-parent-' + controlName + '.png' );
+			expect( repeaterItem.textContent() ).toContain( 'My milkshake brings all the boys to the yard' );
 		} );
 	}
 } );

--- a/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
@@ -38,8 +38,12 @@ test.describe( 'Atomic repeaters display @atomic-widgets', () => {
 			await customSizeInput.fill( 'My milkshake brings all the boys to the yard' );
 
 			await expect( customSizeInput ).toHaveValue( 'My milkshake brings all the boys to the yard' );
-
 			await customSizeInput.clear();
+
+			const currentBackdrop = editor.page.locator( '.MuiBackdrop-root' ).last();
+
+			await currentBackdrop.click();
+			await currentBackdrop.waitFor( { state: 'detached' } );
 			await editor.page.locator( '.MuiBackdrop-root' ).last().click();
 
 			const parentDiv = controlRepeaterAdditionButton.locator( '../../..' );

--- a/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
@@ -62,7 +62,7 @@ test.describe( 'Atomic repeaters display @atomic-widgets', () => {
 				await editor.page.locator( '.MuiBackdrop-root' ).last().click();
 			}
 
-			const repeaterItem = editor.page.locator( '.MuiTag-button .MuiTag-content' );
+			const repeaterItem = editor.page.locator( '.MuiTag-content' );
 
 			expect( await repeaterItem.textContent() ).toContain( CUSTOM_VALUE );
 		} );

--- a/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
@@ -40,11 +40,9 @@ test.describe( 'Atomic repeaters display @atomic-widgets', () => {
 			await expect( customSizeInput ).toHaveValue( 'My milkshake brings all the boys to the yard' );
 			await customSizeInput.clear();
 
-			const currentBackdrop = editor.page.locator( '.MuiBackdrop-root' ).last();
-
-			await currentBackdrop.click();
-			await currentBackdrop.waitFor( { state: 'detached' } );
-			await editor.page.locator( '.MuiBackdrop-root' ).last().click();
+			while ( await editor.page.locator( '.MuiBackdrop-root' ).count() ) {
+				await editor.page.locator( '.MuiBackdrop-root' ).last().click();
+			}
 
 			const parentDiv = controlRepeaterAdditionButton.locator( '../../..' );
 			const controlName = control.trim().toLowerCase().replace( /\s+/g, '-' );

--- a/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
@@ -62,7 +62,7 @@ test.describe( 'Atomic repeaters display @atomic-widgets', () => {
 
 			const repeaterItem = editor.page.locator( '.MuiTag-button .MuiTag-content' );
 
-			expect( repeaterItem.textContent() ).toContain( 'My milkshake brings all the boys to the yard' );
+			expect( await repeaterItem.textContent() ).toContain( 'My milkshake brings' );
 		} );
 	}
 } );

--- a/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-repeaters-display.test.ts
@@ -28,9 +28,19 @@ test.describe( 'Atomic repeaters display @atomic-widgets', () => {
 			await editor.openV2Section( 'effects' );
 
 			const controlRepeaterAdditionButton = editor.page.getByRole( 'button', { name: `Add ${ control } item` } );
+			const inputUnitButton = editor.page.locator( 'button', { hasText: /^(px|ms)$/ } ).last();
+			const customSizeButton = editor.page.locator( '.MuiPaper-root ul li .MuiListItemText-root svg' );
+			const customSizeInput = editor.page.locator( '.MuiPaper-root .MuiPaper-root .MuiPaper-root input[type="text"]' );
 
 			await controlRepeaterAdditionButton.click();
-			await editor.page.locator( '.MuiBackdrop-root' ).click();
+			await inputUnitButton.click();
+			await customSizeButton.click();
+			await customSizeInput.fill( 'My milkshake brings all the boys to the yard' );
+
+			await expect( customSizeInput ).toHaveValue( 'My milkshake brings all the boys to the yard' );
+
+			await customSizeInput.clear();
+			await editor.page.locator( '.MuiBackdrop-root' ).last().click();
 
 			const parentDiv = controlRepeaterAdditionButton.locator( '../../..' );
 			const controlName = control.trim().toLowerCase().replace( /\s+/g, '-' );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix NaN value displays in custom size controls within repeater components to properly handle and display custom size values.
Main changes:
- Added CUSTOM_SIZE_LABEL constant to display "fx" for empty custom size values instead of NaN
- Implemented isRepeaterControl flag to handle size control state persistence differently in repeaters
- Fixed value extraction and display logic in transform, filter, and box-shadow components

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
