### PR TITLE
Internal: Replace the 'Scale' icon [ED-20593]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "elementor",
       "version": "3.34.0",
       "dependencies": {
-        "@elementor/icons": "1.54.0",
+        "@elementor/icons": "1.55.0",
         "@elementor/ui": "1.36.15",
         "@reach/router": "1.3.4",
         "@reduxjs/toolkit": "^1.8.3",
@@ -3536,10 +3536,9 @@
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@elementor/icons": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@elementor/icons/-/icons-1.54.0.tgz",
-      "integrity": "sha512-MyskEtHg2MRFnFKvtq1X1qSB4aA6e1DxY/s4IbkuNwAAREUbz1JvMfcyHNvLaHvPmlnTwJIP9P/4G+WVHXbpuA==",
-      "license": "GPL-3.0-or-later",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@elementor/icons/-/icons-1.55.0.tgz",
+      "integrity": "sha512-MH4yFikoYJZ9rRaXN0Yowfx9So+pswJNyDVgDSkXoDtEnxM+twyMr2bSmu8NWNQKZ4IbbMbqPmWQCfgQyf0/KQ==",
       "peerDependencies": {
         "@elementor/ui": "^1.34.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "write": "^2.0.0"
   },
   "dependencies": {
-    "@elementor/icons": "1.54.0",
+    "@elementor/icons": "1.55.0",
     "@elementor/ui": "1.36.15",
     "@reach/router": "1.3.4",
     "@reduxjs/toolkit": "^1.8.3",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -20779,7 +20779,7 @@
         "@elementor/editor-v1-adapters": "3.33.0",
         "@elementor/env": "3.33.0",
         "@elementor/http-client": "3.33.0",
-        "@elementor/icons": "1.53.0",
+        "@elementor/icons": "1.55.0",
         "@elementor/locations": "3.33.0",
         "@elementor/mixpanel": "3.33.0",
         "@elementor/query": "3.33.0",
@@ -20797,6 +20797,15 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "packages/libs/editor-controls/node_modules/@elementor/icons": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@elementor/icons/-/icons-1.55.0.tgz",
+      "integrity": "sha512-MH4yFikoYJZ9rRaXN0Yowfx9So+pswJNyDVgDSkXoDtEnxM+twyMr2bSmu8NWNQKZ4IbbMbqPmWQCfgQyf0/KQ==",
+      "peerDependencies": {
+        "@elementor/ui": "^1.34.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "packages/libs/editor-controls/node_modules/@elementor/ui": {

--- a/packages/packages/libs/editor-controls/package.json
+++ b/packages/packages/libs/editor-controls/package.json
@@ -48,7 +48,7 @@
     "@elementor/editor-v1-adapters": "3.33.0",
     "@elementor/env": "3.33.0",
     "@elementor/http-client": "3.33.0",
-    "@elementor/icons": "1.53.0",
+    "@elementor/icons": "1.55.0",
     "@elementor/locations": "3.33.0",
     "@elementor/mixpanel": "3.33.0",
     "@elementor/query": "3.33.0",

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/transform-icon.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/transform-icon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { type TransformFunctionsItemPropValue } from '@elementor/editor-props';
-import { ArrowsMaximizeIcon, ArrowAutofitHeightIcon, RotateClockwise2Icon, SkewXIcon } from '@elementor/icons';
+import { ArrowAutofitHeightIcon, ArrowsMaximizeIcon, RotateClockwise2Icon, SkewXIcon } from '@elementor/icons';
 
 import { TransformFunctionKeys } from './initial-values';
 

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/transform-icon.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/transform-icon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { type TransformFunctionsItemPropValue } from '@elementor/editor-props';
-import { ArrowsMaximizeIcon, ExpandIcon, RotateClockwise2Icon, SkewXIcon } from '@elementor/icons';
+import { ArrowsMaximizeIcon, ArrowAutofitHeightIcon, RotateClockwise2Icon, SkewXIcon } from '@elementor/icons';
 
 import { TransformFunctionKeys } from './initial-values';
 
@@ -9,7 +9,7 @@ export const TransformIcon = ( { value }: { value: TransformFunctionsItemPropVal
 		case TransformFunctionKeys.move:
 			return <ArrowsMaximizeIcon fontSize="tiny" />;
 		case TransformFunctionKeys.scale:
-			return <ExpandIcon fontSize="tiny" />;
+			return <ArrowAutofitHeightIcon fontSize="tiny" />;
 		case TransformFunctionKeys.rotate:
 			return <RotateClockwise2Icon fontSize="tiny" />;
 		case TransformFunctionKeys.skew:


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace the Scale transform icon with ArrowAutofitHeightIcon to provide a more appropriate visual representation for scaling functionality.

Main changes:
- Replaced ExpandIcon with ArrowAutofitHeightIcon in the transform control component
- Updated @elementor/icons dependency from 1.54.0 to 1.55.0 in the root package.json
- Updated @elementor/icons dependency from 1.53.0 to 1.55.0 in editor-controls package

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
