### PR TITLE
Revert "Internal: Update popup logic for seasonal promotions [ED-21270]"

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -907,8 +907,8 @@ class Utils {
 	}
 
 	public static function is_sale_time(): bool {
-		$sale_start_time = gmmktime( 12, 0, 0, 11, 25, 2025 );
-		$sale_end_time = gmmktime( 3, 59, 0, 12, 3, 2025 );
+		$sale_start_time = gmmktime( 12, 0, 0, 6, 10, 2025 );
+		$sale_end_time = gmmktime( 3, 59, 0, 6, 17, 2025 );
 
 		$now_time = gmdate( 'U' );
 


### PR DESCRIPTION
Reverts elementor/elementor#33148
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert date changes in seasonal promotion logic by restoring sale period to June 2025 instead of November-December 2025.
Main changes:
- Modified sale start date from November 25 to June 10, 2025
- Changed sale end date from December 3 to June 17, 2025

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
