### PR TITLE
Fix: Server returns empty props as array [ED-21326]

### DIFF
--- a/packages/packages/libs/editor-props/src/utils/merge-props.ts
+++ b/packages/packages/libs/editor-props/src/utils/merge-props.ts
@@ -1,7 +1,12 @@
 import type { Props } from '../types';
 
 export function mergeProps( current: Props, updates: Props ) {
-	const props = structuredClone( current );
+	// edge case, the server returns an array instead of an object when empty props because of PHP array / object conversion
+	let props: Props = {};
+
+	if ( ! Array.isArray( current ) ) {
+		props = structuredClone( current );
+	}
 
 	Object.entries( updates ).forEach( ( [ key, value ] ) => {
 		if ( value === null || value === undefined ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix mergeProps function to handle empty props returned as arrays from PHP server endpoints.

Main changes:
- Added check to detect if current props is an array before applying structuredClone
- Initialized props as empty object to ensure consistent return type
- Added descriptive comment explaining PHP array/object conversion edge case

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
