### PR TITLE
Internal: Support acf-image dynamic tag in V4 [ED-20632]

### DIFF
--- a/modules/atomic-widgets/dynamic-tags/dynamic-tags-module.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-tags-module.php
@@ -52,6 +52,13 @@ class Dynamic_Tags_Module {
 			10,
 			2
 		);
+
+		add_action(
+			'elementor/atomic-widgets/styles/transformers/register',
+			fn ( $transformers, $prop_resolver ) => $this->register_transformers( $transformers, $prop_resolver ),
+			10,
+			2
+		);
 	}
 
 	private function add_atomic_dynamic_tags_to_editor_settings( $settings ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add support for ACF image dynamic tag in V4 by registering transformers for atomic widgets styles.
Main changes:
- Added action hook for registering transformers with elementor/atomic-widgets/styles/transformers/register

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
