### PR TITLE
Internal: Use the revert kit via API request [ED-21206]

### DIFF
--- a/.grunt-config/webpack.js
+++ b/.grunt-config/webpack.js
@@ -178,6 +178,7 @@ const externals = [
 		'@wordpress/core-data': 'wp.coreData',
 		'@wordpress/data': 'wp.data',
 		'@wordpress/plugins': 'wp.plugins',
+		'@wordpress/api-fetch': 'wp.apiFetch',
 		'@woocommerce/admin-layout': 'wc.adminLayout',
 	},
 	// Handle tree-shaking imports for ui and icons packages (@elementor/ui/xxx) to be pointed to the external object (elementorV2.ui.xxx).

--- a/app/modules/import-export-customization/assets/js/admin.js
+++ b/app/modules/import-export-customization/assets/js/admin.js
@@ -1,4 +1,5 @@
 import { AppsEventTracking } from '../../../../assets/js/event-track/apps-event-tracking';
+import { RevertKitHandler } from './shared/revert-kit-handler';
 
 class Admin {
 	constructor() {
@@ -21,6 +22,21 @@ class Admin {
 		this.importButton = document.getElementById( 'elementor-import-export__import' );
 		this.exportButton = document.getElementById( 'elementor-import-export__export' );
 
+		this.initializeRevertHandler();
+		this.bindEventListeners();
+	}
+
+	initializeRevertHandler() {
+		if ( this.revertButton ) {
+			this.revertHandler = new RevertKitHandler( {
+				revertButton: this.revertButton,
+			} );
+
+			this.revertHandler.maybeShowReferrerKitDialog();
+		}
+	}
+
+	bindEventListeners() {
 		if ( this.revertButton ) {
 			this.revertButton.addEventListener( 'click', this.onRevertButtonClick.bind( this ) );
 		}
@@ -48,8 +64,12 @@ class Admin {
 		}
 	}
 
-	onRevertButtonClick() {
+	onRevertButtonClick( event ) {
+		event.preventDefault();
+
 		AppsEventTracking.sendImportExportAdminAction( 'Revert' );
+
+		this.revertHandler?.revertKit();
 	}
 
 	onExportButtonClick() {

--- a/app/modules/import-export-customization/assets/js/shared/revert-kit-handler.js
+++ b/app/modules/import-export-customization/assets/js/shared/revert-kit-handler.js
@@ -1,0 +1,246 @@
+import { apiRequest } from './utils/api-request';
+
+export class RevertKitHandler {
+	static API_PATH = 'revert';
+	static DIALOG_ID = 'e-revert-kit-deleted-dialog';
+	static URL_PARAM_REFERRER_KIT = 'referrer_kit';
+	static KIT_DATA_KEY = 'elementor-kit-data';
+	static NAME_SEPARATOR_PATTERN = /[-_]+/;
+
+	constructor( { revertButton, onError } = {} ) {
+		this.revertButton = revertButton;
+		this.onError = onError || this.defaultErrorHandler.bind( this );
+	}
+
+	async revertKit() {
+		const activeKitName = this.getActiveKitName();
+		const confirmed = await this.showConfirmationDialog( activeKitName );
+
+		if ( ! confirmed ) {
+			return;
+		}
+
+		try {
+			const referrerKitId = this.getReferrerKitId();
+			this.saveToCache( referrerKitId, activeKitName );
+
+			const { data } = await this.callRevertAPI();
+			this.handleRevertResponse( data );
+		} catch ( error ) {
+			this.onError( error );
+		}
+	}
+
+	async callRevertAPI() {
+		const result = await apiRequest( {
+			path: RevertKitHandler.API_PATH,
+		} );
+
+		return result;
+	}
+
+	handleRevertResponse( data ) {
+		if ( ! data.revert_completed ) {
+			this.handleRevertNoSessions( data );
+			return;
+		}
+
+		this.showRevertCompletedDialog( data );
+	}
+
+	showRevertCompletedDialog() {
+		const referrerKitId = this.getReferrerKitId();
+
+		if ( referrerKitId ) {
+			this.showReferrerKitDialog( referrerKitId );
+			return;
+		}
+
+		this.showRevertSuccessDialog();
+	}
+
+	handleRevertNoSessions( responseData ) {
+		elementorCommon.dialogsManager
+			.createWidget( 'alert', {
+				message:
+					responseData.message ||
+					__( 'No import sessions available to revert.', 'elementor' ),
+			} )
+			.show();
+	}
+
+	async showConfirmationDialog( activeKitName ) {
+		return new Promise( ( resolve ) => {
+			elementorCommon.dialogsManager
+				.createWidget( 'confirm', {
+					headerMessage: __( 'Are you sure?', 'elementor' ),
+					/* Translators: %s: Kit name */
+					message: __(
+						"Removing %s will permanently delete changes made to the Website Template's content and site settings",
+						'elementor',
+					).replace( '%s', activeKitName ),
+					strings: {
+						confirm: __( 'Delete', 'elementor' ),
+						cancel: __( 'Cancel', 'elementor' ),
+					},
+					onConfirm: () => resolve( true ),
+					onCancel: () => resolve( false ),
+				} )
+				.show();
+		} );
+	}
+
+	createSuccessHeaderMessage() {
+		const { activeKitName } = this.getDataFromCache();
+
+		/* Translators: %s: Kit name */
+		return __( '%s was successfully deleted', 'elementor' ).replace(
+			'%s',
+			activeKitName,
+		);
+	}
+
+	showRevertSuccessDialog() {
+		elementorCommon.dialogsManager
+			.createWidget( 'confirm', {
+				id: RevertKitHandler.DIALOG_ID,
+				headerMessage: this.createSuccessHeaderMessage(),
+				message: __(
+					'Try a different Website Template or build your site from scratch.',
+					'elementor',
+				),
+				strings: {
+					confirm: __( 'OK', 'elementor' ),
+					cancel: __( 'Library', 'elementor' ),
+				},
+				onConfirm: () => {
+					location.reload();
+				},
+				onCancel: () => {
+					location.href = elementorImportExport.appUrl;
+				},
+			} )
+			.show();
+
+		this.clearCache();
+	}
+
+	showReferrerKitDialog( referrerKitId ) {
+		elementorCommon.dialogsManager
+			.createWidget( 'confirm', {
+				id: RevertKitHandler.DIALOG_ID,
+				headerMessage: this.createSuccessHeaderMessage(),
+				message: __( "You're ready to apply a new Kit!", 'elementor' ),
+				strings: {
+					confirm: __( 'Continue to new Kit', 'elementor' ),
+					cancel: __( 'Close', 'elementor' ),
+				},
+				onConfirm: () => {
+					location.href =
+						elementorImportExport.appUrl + '/preview/' + referrerKitId;
+				},
+				onCancel: () => {
+					location.reload();
+				},
+			} )
+			.show();
+
+		this.clearCache();
+	}
+
+	maybeShowReferrerKitDialog() {
+		const { referrerKitId } = this.getDataFromCache();
+
+		if ( undefined === referrerKitId ) {
+			return;
+		}
+
+		if ( 0 === referrerKitId.length ) {
+			this.showRevertSuccessDialog();
+			return;
+		}
+
+		this.showReferrerKitDialog( referrerKitId );
+	}
+
+	getActiveKitName() {
+		const lastKit = elementorImportExport.lastImportedSession;
+
+		if ( lastKit.kit_title ) {
+			return lastKit.kit_title;
+		}
+
+		if ( lastKit.kit_name ) {
+			return this.convertNameToTitle( lastKit.kit_name );
+		}
+
+		return __( 'Your Kit', 'elementor' );
+	}
+
+	convertNameToTitle( name ) {
+		const words = name
+			.split( RevertKitHandler.NAME_SEPARATOR_PATTERN )
+			.filter( ( word ) => word.length > 0 );
+
+		if ( 0 === words.length ) {
+			return __( 'Your Kit', 'elementor' );
+		}
+
+		return words
+			.map( ( word ) => word[ 0 ].toUpperCase() + word.substring( 1 ) )
+			.join( ' ' );
+	}
+
+	getReferrerKitId() {
+		const urlParams = new URLSearchParams( window.location.search );
+		const pageReferrerKit = urlParams.get( RevertKitHandler.URL_PARAM_REFERRER_KIT );
+		if ( pageReferrerKit ) {
+			return pageReferrerKit;
+		}
+
+		if ( ! this.revertButton ) {
+			return '';
+		}
+
+		return (
+			new URL( this.revertButton.href ).searchParams.get(
+				RevertKitHandler.URL_PARAM_REFERRER_KIT,
+			) || ''
+		);
+	}
+
+	saveToCache( referrerKitId, activeKitName ) {
+		sessionStorage.setItem(
+			RevertKitHandler.KIT_DATA_KEY,
+			JSON.stringify( {
+				referrerKitId: referrerKitId || '',
+				activeKitName: activeKitName || '',
+			} ),
+		);
+	}
+
+	getDataFromCache() {
+		try {
+			return (
+				JSON.parse( sessionStorage.getItem( RevertKitHandler.KIT_DATA_KEY ) ) || {}
+			);
+		} catch ( e ) {
+			return {};
+		}
+	}
+
+	clearCache() {
+		sessionStorage.removeItem( RevertKitHandler.KIT_DATA_KEY );
+	}
+
+	defaultErrorHandler() {
+		elementorCommon.dialogsManager
+			.createWidget( 'alert', {
+				message: __(
+					'An error occurred while reverting the kit. Please try again.',
+					'elementor',
+				),
+			} )
+			.show();
+	}
+}

--- a/app/modules/import-export-customization/assets/js/shared/utils/api-fetch-config.js
+++ b/app/modules/import-export-customization/assets/js/shared/utils/api-fetch-config.js
@@ -1,0 +1,30 @@
+import apiFetch from '@wordpress/api-fetch';
+import { ImportExportError } from '../error/import-export-error';
+
+let isApiConfigured = false;
+
+export function configureApiFetch() {
+	if ( isApiConfigured ) {
+		return;
+	}
+
+	const config = window.elementorAppConfig?.[ 'import-export-customization' ];
+
+	if ( ! config ) {
+		throw new ImportExportError( 'Configuration not found. Please refresh the page.', 'config_missing' );
+	}
+
+	if ( config.restNonce ) {
+		apiFetch.use( apiFetch.createNonceMiddleware( config.restNonce ) );
+	}
+
+	if ( config.restUrl ) {
+		apiFetch.use( apiFetch.createRootURLMiddleware( config.restUrl ) );
+	}
+
+	isApiConfigured = true;
+}
+
+export function resetApiFetchConfig() {
+	isApiConfigured = false;
+}

--- a/app/modules/import-export-customization/assets/js/shared/utils/api-request.js
+++ b/app/modules/import-export-customization/assets/js/shared/utils/api-request.js
@@ -1,0 +1,43 @@
+import apiFetch from '@wordpress/api-fetch';
+import { ImportExportError } from '../error/import-export-error';
+import { configureApiFetch } from './api-fetch-config';
+
+const HTTP_STATUS = {
+	REQUEST_TIMEOUT: 408,
+};
+
+const HTTP_METHODS = {
+	CREATABLE: 'POST',
+};
+
+export async function apiRequest( { data = null, path, method = HTTP_METHODS.CREATABLE } ) {
+	configureApiFetch();
+
+	try {
+		const requestOptions = {
+			path: `/elementor/v1/import-export-customization/${ path }`,
+			method,
+		};
+
+		if ( data && HTTP_METHODS.CREATABLE === method ) {
+			requestOptions.data = data;
+		}
+
+		return await apiFetch( requestOptions );
+	} catch ( error ) {
+		handleApiFetchError( error );
+	}
+}
+
+function handleApiFetchError( error ) {
+	const errorMessage = error?.message || 'An unknown error occurred';
+	let errorCode = 'general';
+
+	if ( error?.code ) {
+		errorCode = error.code;
+	} else if ( error?.status ) {
+		errorCode = HTTP_STATUS.REQUEST_TIMEOUT === error.status ? 'timeout' : error.status;
+	}
+
+	throw new ImportExportError( errorMessage, errorCode );
+}

--- a/app/modules/import-export-customization/data/controller.php
+++ b/app/modules/import-export-customization/data/controller.php
@@ -7,6 +7,7 @@ use Elementor\App\Modules\ImportExportCustomization\Data\Routes\Upload;
 use Elementor\App\Modules\ImportExportCustomization\Data\Routes\Import;
 use Elementor\App\Modules\ImportExportCustomization\Data\Routes\Import_Runner;
 use Elementor\App\Modules\ImportExportCustomization\Data\Routes\Process_Media;
+use Elementor\App\Modules\ImportExportCustomization\Data\Routes\Revert;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -30,5 +31,6 @@ class Controller {
 		( new Import() )->register_route( self::API_NAMESPACE, self::API_BASE );
 		( new Import_Runner() )->register_route( self::API_NAMESPACE, self::API_BASE );
 		( new Process_Media() )->register_route( self::API_NAMESPACE, self::API_BASE );
+		( new Revert() )->register_route( self::API_NAMESPACE, self::API_BASE );
 	}
 }

--- a/app/modules/import-export-customization/data/routes/revert.php
+++ b/app/modules/import-export-customization/data/routes/revert.php
@@ -1,0 +1,55 @@
+<?php
+namespace Elementor\App\Modules\ImportExportCustomization\Data\Routes;
+
+use Elementor\App\Modules\ImportExportCustomization\Module as ImportExportCustomizationModule;
+use Elementor\Plugin;
+use Elementor\App\Modules\ImportExportCustomization\Data\Response;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Revert extends Base_Route {
+
+	protected function get_route(): string {
+		return 'revert';
+	}
+
+	protected function get_method(): string {
+		return \WP_REST_Server::CREATABLE;
+	}
+
+	protected function callback( $request ): \WP_REST_Response {
+		/**
+		 * @var $module ImportExportCustomizationModule
+		 */
+		$module = Plugin::$instance->app->get_component( 'import-export-customization' );
+
+		try {
+			$revert_result = $module->revert_last_imported_kit();
+
+			Plugin::$instance->logger->get_logger()->info( 'Kit revert completed via REST API' );
+
+			return Response::success( $revert_result );
+
+		} catch ( \Error | \Exception $e ) {
+			Plugin::$instance->logger->get_logger()->error( $e->getMessage(), [
+				'meta' => [
+					'trace' => $e->getTraceAsString(),
+				],
+			] );
+
+			$frame = $e->getTrace()[0] ?? [];
+			$class = $frame['class'] ?? '';
+			if ( $module->is_third_party_class( $class ) ) {
+				return Response::error( ImportExportCustomizationModule::THIRD_PARTY_ERROR, $e->getMessage() );
+			}
+
+			return Response::error( 'revert_error', $e->getMessage() );
+		}
+	}
+
+	protected function get_args(): array {
+		return [];
+	}
+}

--- a/app/modules/import-export-customization/processes/import.php
+++ b/app/modules/import-export-customization/processes/import.php
@@ -212,6 +212,7 @@ class Import {
 		$this->manifest = $instance_data['manifest'];
 		$this->site_settings = $instance_data['site_settings'];
 
+		$this->kit_id = $instance_data['kit_id'] ?? '';
 		$this->settings_include = $instance_data['settings_include'];
 		$this->settings_referrer = $instance_data['settings_referrer'];
 		$this->settings_conflicts = $instance_data['settings_conflicts'];
@@ -417,15 +418,16 @@ class Import {
 	 */
 	public function init_import_session( $save_instance_data = false ) {
 		$import_sessions = Utils::get_import_sessions( true );
+		$existing_session = $import_sessions[ $this->session_id ] ?? [];
 
 		$import_sessions[ $this->session_id ] = [
 			'session_id' => $this->session_id,
 			'kit_title' => $this->manifest['title'] ?? '',
 			'kit_name' => $this->manifest['name'] ?? '',
-			'kit_thumbnail' => $this->get_kit_thumbnail(),
-			'kit_source' => $this->settings_referrer,
+			'kit_thumbnail' => $existing_session['kit_thumbnail'] ?? $this->get_kit_thumbnail(),
+			'kit_source' => $existing_session['kit_source'] ?? $this->settings_referrer,
 			'user_id' => get_current_user_id(),
-			'start_timestamp' => current_time( 'timestamp' ),
+			'start_timestamp' => $existing_session['start_timestamp'] ?? current_time( 'timestamp' ),
 		];
 
 		if ( $save_instance_data ) {
@@ -437,6 +439,7 @@ class Import {
 				'manifest' => $this->manifest,
 				'site_settings' => $this->site_settings,
 
+				'kit_id' => $this->kit_id,
 				'settings_include' => $this->settings_include,
 				'settings_referrer' => $this->settings_referrer,
 				'settings_conflicts' => $this->settings_conflicts,

--- a/tests/phpunit/elementor/app/import-export-customization/data/routes/test-revert.php
+++ b/tests/phpunit/elementor/app/import-export-customization/data/routes/test-revert.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Elementor\App\ImportExportCustomization\Data\Routes;
+
+use Elementor\App\Modules\ImportExportCustomization\Module as ImportExportCustomizationModule;
+use Elementor\Plugin;
+use Elementor\App\Modules\ImportExportCustomization\Data\Controller;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+class Test_Revert extends Elementor_Test_Base {
+
+	private $original_component;
+
+	private $rest_api_initialized = false;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_component = Plugin::$instance->app->get_component( 'import-export-customization' );
+
+		Plugin::$instance->app->add_component( 'import-export-customization', new ImportExportCustomizationModule() );
+	}
+
+	public function tearDown(): void {
+		if ( $this->original_component ) {
+			Plugin::$instance->app->add_component( 'import-export-customization', $this->original_component );
+		}
+
+		if ( $this->rest_api_initialized ) {
+			remove_all_filters( 'rest_api_init' );
+			$this->rest_api_initialized = false;
+		}
+
+		delete_option( ImportExportCustomizationModule::OPTION_KEY_ELEMENTOR_IMPORT_SESSIONS );
+
+		parent::tearDown();
+	}
+
+	private function init_rest_api() {
+		if ( ! $this->rest_api_initialized ) {
+			do_action( 'rest_api_init' );
+			$this->rest_api_initialized = true;
+		}
+	}
+
+	public function test_permission_requires_admin() {
+		$this->init_rest_api();
+
+		$this->act_as_subscriber();
+
+		$response = $this->send_revert_request();
+
+		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	public function test_permission_allows_admin() {
+		$this->init_rest_api();
+
+		$this->create_mock_import_session();
+
+		$this->act_as_admin();
+
+		$response = $this->send_revert_request();
+
+		$this->assertNotEquals( 403, $response->get_status() );
+	}
+
+	public function test_successful_revert_with_import_sessions() {
+		$this->init_rest_api();
+		$this->act_as_admin();
+
+		$this->create_mock_import_session();
+
+		$response = $this->send_revert_request();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'data', $data );
+		$this->assertArrayHasKey( 'revert_completed', $data['data'] );
+		$this->assertTrue( $data['data']['revert_completed'] );
+		$this->assertArrayHasKey( 'referrer_kit_id', $data['data'] );
+		$this->assertArrayHasKey( 'show_referrer_dialog', $data['data'] );
+	}
+
+	public function test_revert_without_import_sessions() {
+		$this->init_rest_api();
+		$this->act_as_admin();
+
+		$response = $this->send_revert_request();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'data', $data );
+		$this->assertArrayHasKey( 'revert_completed', $data['data'] );
+		$this->assertFalse( $data['data']['revert_completed'] );
+		$this->assertArrayHasKey( 'message', $data['data'] );
+		$this->assertEquals( 'No import sessions available to revert.', $data['data']['message'] );
+	}
+
+	public function test_revert_with_referrer_kit_id() {
+		$this->init_rest_api();
+		$this->act_as_admin();
+
+		$this->create_mock_import_session();
+
+		$_GET['referrer_kit'] = 'test-kit-123';
+
+		$response = $this->send_revert_request();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertTrue( $data['data']['revert_completed'] );
+		$this->assertEquals( 'test-kit-123', $data['data']['referrer_kit_id'] );
+		$this->assertTrue( $data['data']['show_referrer_dialog'] );
+
+		unset( $_GET['referrer_kit'] );
+	}
+
+	public function test_revert_without_referrer_kit_id() {
+		$this->init_rest_api();
+		$this->act_as_admin();
+
+		$this->create_mock_import_session();
+
+		$response = $this->send_revert_request();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertTrue( $data['data']['revert_completed'] );
+		$this->assertEquals( '', $data['data']['referrer_kit_id'] );
+		$this->assertFalse( $data['data']['show_referrer_dialog'] );
+	}
+
+	public function test_revert_error_handling() {
+		$this->init_rest_api();
+		$this->act_as_admin();
+
+		$mock_module = $this->getMockBuilder( ImportExportCustomizationModule::class )
+			->onlyMethods( ['revert_last_imported_kit'] )
+			->getMock();
+
+		$mock_module->expects( $this->once() )
+			->method( 'revert_last_imported_kit' )
+			->willThrowException( new \Exception( 'revert_error' ) );
+
+		Plugin::$instance->app->add_component( 'import-export-customization', $mock_module );
+
+		$response = $this->send_revert_request();
+
+		$this->assertEquals( 500, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertEquals( 'revert_error', $data['data']['code'] );
+		$this->assertEquals( 'revert_error', $data['data']['message'] );
+	}
+
+	private function send_revert_request() {
+		$request = new \WP_REST_Request(
+			'POST',
+			'/' . Controller::API_NAMESPACE . '/' . Controller::API_BASE . '/revert'
+		);
+
+		return rest_do_request( $request );
+	}
+
+	private function create_mock_import_session() {
+		$session_data = [
+			[
+				'session_id' => 'test-session-' . time(),
+				'kit_title' => 'Test Kit',
+				'kit_name' => 'test-kit',
+				'kit_thumbnail' => '',
+				'kit_source' => 'local',
+				'start_timestamp' => time(),
+				'source' => 'local',
+			],
+		];
+
+		update_option( ImportExportCustomizationModule::OPTION_KEY_ELEMENTOR_IMPORT_SESSIONS, $session_data, false );
+	}
+}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Update kit reversion functionality to use REST API instead of admin-post for improved client-server communication and error handling.

Main changes:
- Added new REST API endpoint for kit reversion with proper authentication and error handling
- Implemented client-side JavaScript handler for API communication with confirmation dialogs
- Added support for referrer kit ID tracking to improve kit replacement workflow
- Created PHPUnit tests to verify API endpoint functionality and permissions
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
