### PR TITLE
Internal: Remove duplicate escaping functions [ED-21436]

### DIFF
--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -135,11 +135,11 @@ class Admin_Notices extends Module {
 			/* translators: 1: Details URL, 2: Accessibility text, 3: Version number, 4: Update URL, 5: Accessibility text. */
 			__( 'There is a new version of Elementor Page Builder available. <a href="%1$s" class="thickbox open-plugin-details-modal" aria-label="%2$s">View version %3$s details</a> or <a href="%4$s" class="update-link" aria-label="%5$s">update now</a>.', 'elementor' ),
 			esc_url( $details_url ),
-			esc_attr( sprintf(
+			sprintf(
 				/* translators: %s: Elementor version. */
-				__( 'View Elementor version %s details', 'elementor' ),
+				esc_attr__( 'View Elementor version %s details', 'elementor' ),
 				$new_version
-			) ),
+			),
 			$new_version,
 			esc_url( $upgrade_url ),
 			esc_attr__( 'Update Now', 'elementor' )

--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -142,7 +142,7 @@ class Admin_Notices extends Module {
 			) ),
 			$new_version,
 			esc_url( $upgrade_url ),
-			esc_attr( esc_html__( 'Update Now', 'elementor' ) )
+			esc_attr__( 'Update Now', 'elementor' )
 		);
 
 		$options = [

--- a/core/admin/admin.php
+++ b/core/admin/admin.php
@@ -372,8 +372,8 @@ class Admin extends App {
 	public function plugin_row_meta( $plugin_meta, $plugin_file ) {
 		if ( ELEMENTOR_PLUGIN_BASE === $plugin_file ) {
 			$row_meta = [
-				'docs' => '<a href="https://go.elementor.com/docs-admin-plugins/" aria-label="' . esc_attr( esc_html__( 'View Elementor Documentation', 'elementor' ) ) . '" target="_blank">' . esc_html__( 'Docs & FAQs', 'elementor' ) . '</a>',
-				'ideo' => '<a href="https://go.elementor.com/yt-admin-plugins/" aria-label="' . esc_attr( esc_html__( 'View Elementor Video Tutorials', 'elementor' ) ) . '" target="_blank">' . esc_html__( 'Video Tutorials', 'elementor' ) . '</a>',
+				'docs' => '<a href="https://go.elementor.com/docs-admin-plugins/" aria-label="' . esc_attr__( 'View Elementor Documentation', 'elementor' ) . '" target="_blank">' . esc_html__( 'Docs & FAQs', 'elementor' ) . '</a>',
+				'ideo' => '<a href="https://go.elementor.com/yt-admin-plugins/" aria-label="' . esc_attr__( 'View Elementor Video Tutorials', 'elementor' ) . '" target="_blank">' . esc_html__( 'Video Tutorials', 'elementor' ) . '</a>',
 			];
 
 			$plugin_meta = array_merge( $plugin_meta, $row_meta );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove duplicate escaping functions in translation strings to improve code consistency and maintainability.
Main changes:
- Replaced `esc_attr(esc_html__())` with direct `esc_attr__()` for translation strings
- Refactored sprintf formatting for accessibility labels to eliminate unnecessary nesting
- Streamlined escaping approach in plugin row meta links for documentation and video tutorials

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
