### PR TITLE
Fix: Top bar structure Infotip popup opens the structure nav [ED-21445]

### DIFF
--- a/packages/packages/core/editor-app-bar/src/extensions/structure/hooks/structure-icon-with-popup.tsx
+++ b/packages/packages/core/editor-app-bar/src/extensions/structure/hooks/structure-icon-with-popup.tsx
@@ -15,8 +15,12 @@ const StructurePopupContent = ( { onClose }: { onClose: () => void } ) => {
 		extendedWindow.elementorCommon?.ajax?.addRequest?.( 'structure_popup_dismiss' ).catch( () => {} );
 	};
 
+	const stopEventPropagation = ( event: React.MouseEvent ) => {
+		event.stopPropagation();
+	};
+
 	return (
-		<Card elevation={ 0 } sx={ { maxWidth: 300 } }>
+		<Card elevation={ 0 } sx={ { maxWidth: 300 } } onClick={ stopEventPropagation }>
 			<CardContent>
 				<Typography variant="subtitle2" sx={ { mb: 2 } }>
 					{ __( 'Refreshed Top Bar layout!', 'elementor' ) }


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix issue where clicking the "Got it" button in the Top Bar structure Infotip popup incorrectly opens the structure navigation panel.
Main changes:
- Added event stopPropagation to prevent clicks on the Card from bubbling up to parent elements
- Implemented onClick handler on Card component to intercept and stop click event propagation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
