### PR TITLE
Internal: Increase global classes limit to 100 [ED-21392]

### DIFF
--- a/modules/global-classes/global-classes-rest-api.php
+++ b/modules/global-classes/global-classes-rest-api.php
@@ -15,7 +15,7 @@ class Global_Classes_REST_API {
 	const API_NAMESPACE = 'elementor/v1';
 	const API_BASE = 'global-classes';
 	const API_BASE_USAGE = self::API_BASE . '/usage';
-	const MAX_ITEMS = 50;
+	const MAX_ITEMS = 100;
 	const LABEL_PREFIX = 'DUP_';
 	const MAX_LABEL_LENGTH = 50;
 	private $repository = null;

--- a/packages/packages/core/editor-global-classes/src/global-classes-styles-provider.ts
+++ b/packages/packages/core/editor-global-classes/src/global-classes-styles-provider.ts
@@ -18,7 +18,7 @@ import {
 	type StateWithGlobalClasses,
 } from './store';
 
-const MAX_CLASSES = 50;
+const MAX_CLASSES = 100;
 
 export const GLOBAL_CLASSES_PROVIDER_KEY = 'global-classes';
 

--- a/tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php
@@ -497,11 +497,11 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		// Arrange.
 		$this->act_as_admin();
 
-		// Act - send 50 items.
+		// Act - send 100 items.
 		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
 
 		$items = [];
-		for ( $i = 0; $i < 50; $i++ ) {
+		for ( $i = 0; $i < 100; $i++ ) {
 			$items[ "g-$i" ] = $this->create_global_class( "g-$i" );
 		}
 
@@ -520,14 +520,14 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		// Assert - should succeed.
 		$this->assertSame( 204, $response->get_status() );
 
-		// Act - send the 51st item.
-		$items[ "g-50" ] = $this->create_global_class( "g-50" );
+		// Act - send the 101st item.
+		$items[ "g-101" ] = $this->create_global_class( "g-101" );
 
 		$request->set_body_params( [
 			'items' => $items,
 			'order' => array_keys( $items ),
 			'changes' => [
-				'added' => [ 'g-50' ],
+				'added' => [ 'g-101' ],
 				'deleted' => [],
 				'modified' => [],
 			]
@@ -685,7 +685,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		// Check that the duplicate label was resolved
 		$response_data = $response->get_data();
-		
+
 		// The response data is nested under 'data' key
 		$this->assertArrayHasKey( 'data', $response_data );
 		$this->assertArrayHasKey( 'code', $response_data['data'] );
@@ -1161,7 +1161,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 	public function test_all__succeeds_for_logged_in_user() {
 		// Arrange
 		$this->act_as_editor();
-		
+
 		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $this->mock_global_classes );
 
 		// Act
@@ -1176,8 +1176,8 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 	public function test_all__fails_for_non_logged_in_user() {
 		// Arrange
-		wp_set_current_user( 0 ); 
-		
+		wp_set_current_user( 0 );
+
 		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $this->mock_global_classes );
 
 		// Act


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Increase global classes limit from 50 to 100 to allow more CSS classes in Elementor.

Main changes:
- Changed MAX_ITEMS constant from 50 to 100 in Global_Classes_REST_API class
- Updated MAX_CLASSES constant from 50 to 100 in global-classes-styles-provider.ts
- Modified test cases to accommodate the new 100-class limit

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
