### PR TITLE
Revert "Fix: Cloud kits placeholder when screenshot failed [ED-21471]"

### DIFF
--- a/app/assets/js/ui/card/card-image.js
+++ b/app/assets/js/ui/card/card-image.js
@@ -1,7 +1,7 @@
 import './card.scss';
 
 export default function CardImage( props ) {
-	const image = <img src={ props.src } alt={ props.alt } className="eps-card__image" loading="lazy" onError={ props.onError } />;
+	const image = <img src={ props.src } alt={ props.alt } className="eps-card__image" loading="lazy" />;
 
 	return (
 		<figure className={ `eps-card__figure ${ props.className }` }>
@@ -16,10 +16,8 @@ CardImage.propTypes = {
 	src: PropTypes.string.isRequired,
 	alt: PropTypes.string.isRequired,
 	children: PropTypes.any,
-	onError: PropTypes.func,
 };
 
 CardImage.defaultProps = {
 	className: '',
-	onError: () => {},
 };

--- a/app/modules/kit-library/assets/js/components/kit-list-cloud-item.js
+++ b/app/modules/kit-library/assets/js/components/kit-list-cloud-item.js
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@reach/router';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import Kit from '../models/kit';
@@ -20,8 +20,6 @@ import { KIT_SOURCE_MAP } from '../../../../import-export/assets/js/hooks/use-ki
 import Tooltip from 'elementor-app/molecules/tooltip';
 
 import './kit-list-item.scss';
-
-const PLACEHOLDER_IMAGE_SRC = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzQ1IiBoZWlnaHQ9IjMzMCIgdmlld0JveD0iMCAwIDM0NSAzMzAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIzNDUiIGhlaWdodD0iMzMwIiBmaWxsPSIjRjNGOUZBIi8+CjxnIG9wYWNpdHk9IjAuMyI+CjxwYXRoIGQ9Ik0xODIuNDM3IDE0OS41NTVDMTg0LjAwOCAxNDkuNTU1IDE4NS41MTQgMTUwLjE3OSAxODYuNjI1IDE1MS4yOUMxODcuNzM2IDE1Mi40MDEgMTg4LjM2IDE1My45MDcgMTg4LjM2IDE1NS40NzlWMTc0LjQzN0MxODguMzYgMTc2LjAwOCAxODcuNzM2IDE3Ny41MTQgMTg2LjYyNSAxNzguNjI1QzE4NS41MTQgMTc5LjczNiAxODQuMDA4IDE4MC4zNiAxODIuNDM3IDE4MC4zNkgxNjMuNDc5QzE2MS45MDcgMTgwLjM2IDE2MC40MDEgMTc5LjczNiAxNTkuMjkgMTc4LjYyNUMxNTguMTc5IDE3Ny41MTQgMTU3LjU1NSAxNzYuMDA4IDE1Ny41NTUgMTc0LjQzN1YxNTUuNDc5QzE1Ny41NTUgMTUzLjkwNyAxNTguMTc5IDE1Mi40MDEgMTU5LjI5IDE1MS4yOUMxNjAuNDAxIDE1MC4xNzkgMTYxLjkwNyAxNDkuNTU1IDE2My40NzkgMTQ5LjU1NUgxODIuNDM3Wk0xNjMuNDc5IDE1MS45MjRDMTYyLjUzNiAxNTEuOTI0IDE2MS42MzIgMTUyLjI5OSAxNjAuOTY2IDE1Mi45NjZDMTYwLjI5OSAxNTMuNjMyIDE1OS45MjQgMTU0LjUzNiAxNTkuOTI0IDE1NS40NzlWMTY4LjQxNkwxNjUuODAxIDE2Mi41NEwxNjUuODE2IDE2Mi41MjRDMTY2LjcyNyAxNjEuNjQ4IDE2Ny44MjkgMTYxLjEzNSAxNjkuMDA4IDE2MS4xMzVDMTcwLjE4NyAxNjEuMTM1IDE3MS4yODggMTYxLjY0OCAxNzIuMTk5IDE2Mi41MjRMMTcyLjIxNiAxNjIuNTRMMTc2LjExNyAxNjYuNDQxTDE3Ni44NzUgMTY1LjY4NEMxNzcuNzg2IDE2NC44MDcgMTc4Ljg4NyAxNjQuMjk1IDE4MC4wNjYgMTY0LjI5NUMxODEuMjQ2IDE2NC4yOTUgMTgyLjM0NyAxNjQuODA3IDE4My4yNTggMTY1LjY4NEwxODMuMjc0IDE2NS42OTlMMTg1Ljk5MSAxNjguNDE2VjE1NS40NzlDMTg1Ljk5MSAxNTQuNTM2IDE4NS42MTYgMTUzLjYzMiAxODQuOTUgMTUyLjk2NkMxODQuMjg0IDE1Mi4yOTkgMTgzLjM3OSAxNTEuOTI0IDE4Mi40MzcgMTUxLjkyNEgxNjMuNDc5Wk0xNzcuOTAzIDE1NS44OTFDMTc5LjI2OSAxNTUuODkxIDE4MC4zNzYgMTU2Ljk5OCAxODAuMzc2IDE1OC4zNjNDMTgwLjM3NiAxNTkuNzI5IDE3OS4yNjkgMTYwLjgzNiAxNzcuOTAzIDE2MC44MzZDMTc2LjUzOCAxNjAuODM2IDE3NS40MzEgMTU5LjcyOSAxNzUuNDMxIDE1OC4zNjNDMTc1LjQzMSAxNTYuOTk4IDE3Ni41MzggMTU1Ljg5MSAxNzcuOTAzIDE1NS44OTFaIiBmaWxsPSIjNjk3MjdEIi8+CjwvZz4KPC9zdmc+Cg==';
 
 const PopoverItem = ( { className = '', icon, title, onClick } ) => {
 	const handleClick = () => {
@@ -93,20 +91,8 @@ const KitListCloudItem = ( props ) => {
 	const navigate = useNavigate();
 
 	const [ isPopoverOpen, setIsPopoverOpen ] = useState( false );
-	const [ imageError, setImageError ] = useState( false );
 
 	const isLocked = 'locked' === props.model?.status;
-	const imageSrc = ( ! props.model.thumbnailUrl || imageError ) ? PLACEHOLDER_IMAGE_SRC : props.model.thumbnailUrl;
-
-	useEffect( () => {
-		setImageError( false );
-	}, [ props.model.thumbnailUrl ] );
-
-	const handleImageError = () => {
-		if ( props.model.thumbnailUrl && ! imageError ) {
-			setImageError( true );
-		}
-	};
 
 	const handleDelete = () => {
 		setIsPopoverOpen( false );
@@ -156,11 +142,7 @@ const KitListCloudItem = ( props ) => {
 				/>
 			</CardHeader>
 			<CardBody>
-				<CardImage
-					alt={ props.model.title }
-					src={ imageSrc }
-					onError={ handleImageError }
-				>
+				<CardImage alt={ props.model.title } src={ props.model.thumbnailUrl || '' }>
 					<CardOverlay>
 						<Grid container direction="column" className="e-kit-library__kit-item-cloud-overlay">
 							{ isLocked ? (


### PR DESCRIPTION
Reverts elementor/elementor#33286
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert changes to image error handling in cloud kits by removing placeholder functionality when screenshots fail to load.

Main changes:
- Removed onError handler and placeholder image for failed kit thumbnails in CardImage component
- Removed imageError state management and placeholder image constant from KitListCloudItem component
- Simplified CardImage implementation by removing error handling capability

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
