### PR TITLE
Internal: Update consent handling for existing site data usage [ED-21470]

### DIFF
--- a/includes/tracker.php
+++ b/includes/tracker.php
@@ -588,6 +588,7 @@ class Tracker {
 			],
 			'is_first_time' => $is_first_time,
 			'install_time' => Plugin::instance()->get_install_time(),
+			'allowed_usage_time' => self::get_last_update_time(),
 		];
 
 		$site_key = Api::get_site_key();

--- a/includes/tracker.php
+++ b/includes/tracker.php
@@ -588,12 +588,16 @@ class Tracker {
 			],
 			'is_first_time' => $is_first_time,
 			'install_time' => Plugin::instance()->get_install_time(),
-			'allowed_usage_time' => self::get_last_update_time(),
 		];
 
 		$site_key = Api::get_site_key();
 		if ( ! empty( $site_key ) ) {
 			$params['site_key'] = $site_key;
+		}
+
+		$allowed_usage_time = self::get_last_update_time();
+		if ( ! empty( $allowed_usage_time ) ) {
+			$params['allowed_usage_time'] = $allowed_usage_time;
 		}
 
 		/**

--- a/tests/phpunit/schemas/usage.json
+++ b/tests/phpunit/schemas/usage.json
@@ -1336,6 +1336,11 @@
 			"type": "number",
 			"title": "Install timestamp"
 		},
+		"allowed_usage_time": {
+			"$id": "#/allowed_usage_time",
+			"type": "number",
+			"title": "Allowed usage time"
+		},
 		"site_key": {
 			"$id": "#/site_key",
 			"type": "string",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add allowed usage timestamp parameter to distinguish between old and new data usage consents in tracking system.
Main changes:
- Added allowed_usage_time parameter to tracking request data in Tracker class
- Updated usage schema to include allowed_usage_time field with type definition

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
