### PR TITLE
Internal: Update consent handling for existing site data usage [ED-21470] (#33336)

### DIFF
--- a/includes/tracker.php
+++ b/includes/tracker.php
@@ -595,6 +595,11 @@ class Tracker {
 			$params['site_key'] = $site_key;
 		}
 
+		$allowed_usage_time = self::get_last_update_time();
+		if ( ! empty( $allowed_usage_time ) ) {
+			$params['allowed_usage_time'] = $allowed_usage_time;
+		}
+
 		/**
 		 * Tracker send tracking data params.
 		 *

--- a/tests/phpunit/schemas/usage.json
+++ b/tests/phpunit/schemas/usage.json
@@ -1336,6 +1336,11 @@
 			"type": "number",
 			"title": "Install timestamp"
 		},
+		"allowed_usage_time": {
+			"$id": "#/allowed_usage_time",
+			"type": "number",
+			"title": "Allowed usage time"
+		},
 		"site_key": {
 			"$id": "#/site_key",
 			"type": "string",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add support for tracking allowed usage time in the consent data collection system.
Main changes:
- Added allowed_usage_time parameter to tracking data using self::get_last_update_time() method
- Updated usage.json schema to include allowed_usage_time field with number type

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
