### PR TITLE
Internal: Replace SASS `getValueByDirection()` mixin with native CSS [ED-21502]

### DIFF
--- a/assets/dev/scss/frontend/_forms.scss
+++ b/assets/dev/scss/frontend/_forms.scss
@@ -217,14 +217,22 @@
 	&start {
 		.elementor-field-type-submit,
 		.e-form__buttons {
-			justify-content: getValueByDirection(flex-start, flex-end);
+			justify-content: flex-start;
+
+			[dir="rtl"] & { // BC for RTL direction.
+				justify-content: flex-end;
+			}
 		}
 	}
 
 	&end {
 		.elementor-field-type-submit,
 		.e-form__buttons {
-			justify-content: getValueByDirection(flex-end, flex-start);
+			justify-content: flex-end;
+
+			[dir="rtl"] & { // BC for RTL direction.
+				justify-content: flex-start;
+			}
 		}
 	}
 

--- a/assets/dev/scss/frontend/widgets/icon-box.scss
+++ b/assets/dev/scss/frontend/widgets/icon-box.scss
@@ -9,8 +9,12 @@
 
 			.elementor-icon-box-wrapper {
 				text-align: end;
-				flex-direction: getValueByDirection(row-reverse, row);
+				flex-direction: row-reverse;
 				gap: var(--icon-box-icon-margin, 15px);
+
+				[dir="rtl"] & { // BC for RTL direction.
+					flex-direction: row;
+				}
 			}
 		}
 
@@ -18,8 +22,12 @@
 
 			.elementor-icon-box-wrapper {
 				text-align: start;
-				flex-direction: getValueByDirection(row, row-reverse);
+				flex-direction: row;
 				gap: var(--icon-box-icon-margin, 15px);
+
+				[dir="rtl"] & { // BC for RTL direction.
+					flex-direction: row-reverse;
+				}
 			}
 		}
 

--- a/assets/dev/scss/frontend/widgets/image-box.scss
+++ b/assets/dev/scss/frontend/widgets/image-box.scss
@@ -22,7 +22,11 @@
 
 				.elementor-image-box-wrapper {
 					text-align: end;
-					flex-direction: getValueByDirection(row-reverse, row);
+					flex-direction: row-reverse;
+
+					[dir="rtl"] & { // BC for RTL direction.
+						flex-direction: row;
+					}
 				}
 			}
 
@@ -30,7 +34,11 @@
 
 				.elementor-image-box-wrapper {
 					text-align: start;
-					flex-direction: getValueByDirection(row, row-reverse);
+					flex-direction: row;
+
+					[dir="rtl"] & { // BC for RTL direction.
+						flex-direction: row-reverse;
+					}
 				}
 			}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace SASS `getValueByDirection()` mixin with native CSS directional properties to improve maintainability and leverage CSS logical properties.
Main changes:
- Replaced `getValueByDirection()` usage with explicit flex-direction values and added RTL overrides
- Updated form button alignment to use direct CSS properties instead of SASS mixins
- Added RTL-specific rules with [dir="rtl"] selectors to maintain bidirectional layout support

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
