### PR TITLE
Internal: Update core onboarding flow [ED-21359]

### DIFF
--- a/app/modules/onboarding/assets/js/utils/modules/onboarding-tracker.js
+++ b/app/modules/onboarding/assets/js/utils/modules/onboarding-tracker.js
@@ -750,21 +750,14 @@ class OnboardingTracker {
 
 	sendAppropriateStatusEvent( status, data = null ) {
 		const hasCreateAccountAction = StorageManager.exists( ONBOARDING_STORAGE_KEYS.PENDING_CREATE_MY_ACCOUNT );
-		const hasConnectAction = StorageManager.exists( ONBOARDING_STORAGE_KEYS.PENDING_STEP1_CLICKED_CONNECT );
 
 		if ( hasCreateAccountAction ) {
 			this.sendEventDirect( 'CREATE_ACCOUNT_STATUS', { status, currentStep: 1 } );
-		} else if ( hasConnectAction ) {
-			if ( data ) {
-				this.sendEventDirect( 'CONNECT_STATUS', { status, trackingOptedIn: data.tracking_opted_in, userTier: data.access_tier } );
-			} else {
-				this.sendEventDirect( 'CONNECT_STATUS', { status, trackingOptedIn: false, userTier: null } );
-			}
-		} else if ( data ) {
-			this.sendEventDirect( 'CONNECT_STATUS', { status, trackingOptedIn: data.tracking_opted_in, userTier: data.access_tier } );
-		} else {
-			this.sendEventDirect( 'CONNECT_STATUS', { status, trackingOptedIn: false, userTier: null } );
 		}
+
+		const trackingOptedIn = data?.tracking_opted_in || false;
+		const userTier = data?.access_tier || null;
+		this.sendEventDirect( 'CONNECT_STATUS', { status, trackingOptedIn, userTier } );
 	}
 
 	sendAllStoredEvents() {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor onboarding tracking flow to always send CONNECT_STATUS events regardless of pending connection state.
Main changes:
- Simplified conditional logic by removing hasConnectAction checks in sendAppropriateStatusEvent
- Standardized handling of tracking opt-in and user tier data parameters
- Always emit CONNECT_STATUS events alongside CREATE_ACCOUNT_STATUS when applicable

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
