### PR TITLE
Internal: Merge `frontend-rtl.min.css` file with `frontend.min.css` file [ED-21510]

### DIFF
--- a/assets/dev/scss/direction/frontend-rtl.scss
+++ b/assets/dev/scss/direction/frontend-rtl.scss
@@ -1,3 +1,0 @@
-$direction: rtl;
-
-@import "../frontend/frontend";

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -550,7 +550,7 @@ class Frontend extends App {
 
 		wp_register_style(
 			'elementor-frontend',
-			$this->get_frontend_file_url( "frontend{$direction_suffix}{$min_suffix}.css", $has_custom_breakpoints ),
+			$this->get_frontend_file_url( "frontend{$min_suffix}.css", $has_custom_breakpoints ),
 			[],
 			$has_custom_breakpoints ? null : ELEMENTOR_VERSION
 		);


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Merge frontend-rtl.min.css into frontend.min.css to simplify stylesheet management and reduce HTTP requests.
Main changes:
- Removed direction-specific suffix from CSS file URL in wp_register_style
- Eliminated separate RTL stylesheet by removing its source file

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
