### PR TITLE
Internal: Delayed timing [ED-21531] cp 3.33

### DIFF
--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -566,6 +566,11 @@ class Admin_Notices extends Module {
 			return false;
 		}
 
+		$image_opt_first_time = get_user_meta( get_current_user_id(), 'plugin_image_optimization_first_time', true );
+		if ( ! $image_opt_first_time || strtotime( $image_opt_first_time ) > ( time() - 7 * DAY_IN_SECONDS ) ) {
+			return false;
+		}
+
 		$plugin_file_path = 'pojo-accessibility/pojo-accessibility.php';
 		$plugin_slug = 'pojo-accessibility';
 
@@ -725,6 +730,10 @@ class Admin_Notices extends Module {
 
 		if ( ! current_user_can( 'manage_options' ) || User::is_user_notice_viewed( $notice_id ) ) {
 			return false;
+		}
+
+		if ( ! get_user_meta( get_current_user_id(), 'plugin_image_optimization_first_time', true ) ) {
+			update_user_meta( get_current_user_id(), 'plugin_image_optimization_first_time', current_time( 'mysql' ) );
 		}
 
 		$attachments = new \WP_Query( [

--- a/includes/widgets/heading.php
+++ b/includes/widgets/heading.php
@@ -461,6 +461,11 @@ class Widget_Heading extends Widget_Base implements Sanitizable {
 		if ( ! Hints::should_display_hint( $notice_id ) ) {
 			return;
 		}
+
+		$image_opt_first_time = get_user_meta( get_current_user_id(), 'plugin_image_optimization_first_time', true );
+		if ( ! $image_opt_first_time || strtotime( $image_opt_first_time ) > ( time() - 7 * DAY_IN_SECONDS ) ) {
+			return;
+		}
 		$notice_content = esc_html__( 'Make sure your page is structured with accessibility in mind. Ally helps detect and fix common issues across your site.', 'elementor' );
 
 		$campaign_data = [


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add delay condition for Ally plugin notices to ensure they display only after users have engaged with Image Optimization for at least 7 days.

Main changes:
- Added 7-day delay condition to prevent displaying Ally plugin notices too early
- Implemented tracking of first Image Optimization usage via user metadata
- Applied timing delay to both admin notices and editor widget heading hints

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
