### PR TITLE
Internal: Run playwright tests as pre-merge check [ED-21554]

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,11 +2,7 @@ name: Playwright
 
 on:
   pull_request:
-    types: [ labeled, synchronize, opened, reopened ]
-  push:
-    branches:
-      - 'main'
-      - '3.[0-9][0-9]'
+    types: [ labeled, synchronize, opened, reopened, ready_for_review ]
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -42,7 +38,9 @@ jobs:
     uses: ./.github/workflows/calculate_php_version.yml
 
   build-plugin:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-tests')
+    if: |
+      !github.event.pull_request.draft && 
+      (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-tests') || github.event.action == 'ready_for_review')
     name: Build plugin
     uses: ./.github/workflows/build.yml
   
@@ -50,7 +48,10 @@ jobs:
     name: Playwright test - ${{ matrix.shardIndex }} on PHP (${{ needs.get-php-version.outputs.php_version }})
     runs-on: ubuntu-22.04
     needs: [build-plugin, get-php-version]
-    if: github.event.inputs.tag == '' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-tests'))
+    if: |
+      github.event.inputs.tag == '' && 
+      !github.event.pull_request.draft && 
+      (contains(github.event.pull_request.labels.*.name, 'run-tests') || github.event.action == 'ready_for_review' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     strategy:
       fail-fast: ${{ inputs.fail_fast || false }}
       matrix:


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update GitHub workflow to run Playwright tests as a pre-merge check on non-draft PRs that are ready for review.
Main changes:
- Added 'ready_for_review' trigger to PR event types for Playwright workflow
- Implemented conditional logic to skip tests on draft PRs
- Removed automatic testing on branch pushes to main and version branches

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
