### PR TITLE
Internal: Allow to reset via floating actions menu in popovers - Filters [ED-20020]

### DIFF
--- a/modules/atomic-widgets/prop-types/filters/css-filter-func-prop-type.php
+++ b/modules/atomic-widgets/prop-types/filters/css-filter-func-prop-type.php
@@ -42,7 +42,7 @@ class Css_Filter_Func_Prop_Type extends Object_Prop_Type {
 					'size' => 0,
 					'unit' => 'px',
 				] )
-				->required()
+				->required(),
 		];
 	}
 }

--- a/modules/atomic-widgets/prop-types/filters/css-filter-func-prop-type.php
+++ b/modules/atomic-widgets/prop-types/filters/css-filter-func-prop-type.php
@@ -30,6 +30,7 @@ class Css_Filter_Func_Prop_Type extends Object_Prop_Type {
 			'func' => String_Prop_Type::make()
 				->enum( [ 'blur', 'brightness', 'contrast', 'grayscale', 'invert', 'saturate', 'sepia', 'hue-rotate', 'drop-shadow' ] )
 				->default( 'blur' )
+				->initial_value( 'blur' )
 				->required(),
 			'args' => Union_Prop_Type::make()
 				->add_prop_type( Blur_Prop_Type::make() )
@@ -37,7 +38,11 @@ class Css_Filter_Func_Prop_Type extends Object_Prop_Type {
 				->add_prop_type( Hue_Rotate_Prop_Type::make() )
 				->add_prop_type( Color_Tone_Prop_Type::make() )
 				->add_prop_type( Drop_Shadow_Filter_Prop_Type::make() )
-				->required(),
+				->initial_value( [
+					'size' => 0,
+					'unit' => 'px',
+				] )
+				->required()
 		];
 	}
 }

--- a/modules/atomic-widgets/prop-types/filters/functions/drop-shadow-filter-prop-type.php
+++ b/modules/atomic-widgets/prop-types/filters/functions/drop-shadow-filter-prop-type.php
@@ -19,8 +19,14 @@ class Drop_Shadow_Filter_Prop_Type extends Object_Prop_Type {
 
 	protected function define_shape(): array {
 		$units = Size_Constants::drop_shadow();
-		$axis_size = [ 'size' => 0, 'unit' => 'px' ];
-		$blur = [ 'size' => 10, 'unit' => 'px' ];
+		$axis_size = [
+			'size' => 0,
+			'unit' => 'px',
+		];
+		$blur = [
+			'size' => 10,
+			'unit' => 'px',
+		];
 		$color = 'rgba(0, 0, 0, 1)';
 
 		return [
@@ -30,17 +36,17 @@ class Drop_Shadow_Filter_Prop_Type extends Object_Prop_Type {
 				->required()
 				->units( $units ),
 			'yAxis' => Size_Prop_Type::make()
-			    ->default( $axis_size )
+				->default( $axis_size )
 				->initial_value( $axis_size )
 				->required()
 				->units( $units ),
 			'blur' => Size_Prop_Type::make()
-			    ->default( $blur )
+				->default( $blur )
 				->initial_value( $blur )
 				->required()
 				->units( $units ),
 			'color' => Color_Prop_Type::make()
-			    ->default( $color )
+				->default( $color )
 				->initial_value( $color )
 				->required(),
 		];

--- a/modules/atomic-widgets/prop-types/filters/functions/drop-shadow-filter-prop-type.php
+++ b/modules/atomic-widgets/prop-types/filters/functions/drop-shadow-filter-prop-type.php
@@ -19,21 +19,30 @@ class Drop_Shadow_Filter_Prop_Type extends Object_Prop_Type {
 
 	protected function define_shape(): array {
 		$units = Size_Constants::drop_shadow();
+		$axis_size = [ 'size' => 0, 'unit' => 'px' ];
+		$blur = [ 'size' => 10, 'unit' => 'px' ];
+		$color = 'rgba(0, 0, 0, 1)';
 
 		return [
-			'xAxis' => Size_Prop_Type::make()->default( [
-				'size' => 0,
-				'unit' => 'px',
-			] )->required()->units( $units ),
-			'yAxis' => Size_Prop_Type::make()->default( [
-				'size' => 0,
-				'unit' => 'px',
-			] )->required()->units( $units ),
-			'blur'  => Size_Prop_Type::make()->default( [
-				'size' => 10,
-				'unit' => 'px',
-			] )->required()->units( $units ),
-			'color' => Color_Prop_Type::make()->default( 'rgba(0, 0, 0, 1)' )->required(),
+			'xAxis' => Size_Prop_Type::make()
+			    ->default( $axis_size )
+			    ->initial_value( $axis_size )
+				->required()
+				->units( $units ),
+			'yAxis' => Size_Prop_Type::make()
+			    ->default( $axis_size )
+				->initial_value( $axis_size )
+				->required()
+				->units( $units ),
+			'blur' => Size_Prop_Type::make()
+			    ->default( $blur )
+				->initial_value( $blur )
+				->required()
+				->units( $units ),
+			'color' => Color_Prop_Type::make()
+			    ->default( $color )
+				->initial_value( $color )
+				->required(),
 		];
 	}
 }

--- a/modules/atomic-widgets/prop-types/filters/functions/drop-shadow-filter-prop-type.php
+++ b/modules/atomic-widgets/prop-types/filters/functions/drop-shadow-filter-prop-type.php
@@ -31,8 +31,8 @@ class Drop_Shadow_Filter_Prop_Type extends Object_Prop_Type {
 
 		return [
 			'xAxis' => Size_Prop_Type::make()
-			    ->default( $axis_size )
-			    ->initial_value( $axis_size )
+				->default( $axis_size )
+				->initial_value( $axis_size )
 				->required()
 				->units( $units ),
 			'yAxis' => Size_Prop_Type::make()

--- a/packages/packages/core/editor-editing-panel/src/reset-style-props.tsx
+++ b/packages/packages/core/editor-editing-panel/src/reset-style-props.tsx
@@ -9,7 +9,7 @@ import { isEqual } from './utils/is-equal';
 const { registerAction } = controlActionsMenu;
 
 // TODO: BC: Only background repeater supports reset; remove this constant once all repeaters support it.
-const REPEATERS_SUPPORTED_FOR_RESET = [ 'background', 'transform' ];
+const REPEATERS_SUPPORTED_FOR_RESET = [ 'background', 'transform', 'filter', 'backdrop-filter' ];
 
 export function initResetStyleProps() {
 	registerAction( {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add reset functionality via floating actions menu in filter popovers by implementing initial value properties for CSS filters.

Main changes:
- Added initial_value properties to CSS filter function properties to support reset actions
- Extended drop-shadow filter with initial value configurations for all parameters
- Updated REPEATERS_SUPPORTED_FOR_RESET to include 'filter' and 'backdrop-filter'

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
