### PR TITLE
Internal: Allow to reset via floating actions menu in popovers - Box Sahdow [ED-20019]

### DIFF
--- a/modules/atomic-widgets/prop-types/filters/css-filter-func-prop-type.php
+++ b/modules/atomic-widgets/prop-types/filters/css-filter-func-prop-type.php
@@ -10,6 +10,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Functions\Hue_Rotate_Prop_
 use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Functions\Intensity_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Size_Constants;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -40,7 +41,7 @@ class Css_Filter_Func_Prop_Type extends Object_Prop_Type {
 				->add_prop_type( Drop_Shadow_Filter_Prop_Type::make() )
 				->initial_value( [
 					'size' => 0,
-					'unit' => 'px',
+					'unit' => Size_Constants::UNIT_PX,
 				] )
 				->required(),
 		];

--- a/modules/atomic-widgets/prop-types/filters/functions/drop-shadow-filter-prop-type.php
+++ b/modules/atomic-widgets/prop-types/filters/functions/drop-shadow-filter-prop-type.php
@@ -21,11 +21,11 @@ class Drop_Shadow_Filter_Prop_Type extends Object_Prop_Type {
 		$units = Size_Constants::drop_shadow();
 		$axis_size = [
 			'size' => 0,
-			'unit' => 'px',
+			'unit' => Size_Constants::UNIT_PX,
 		];
 		$blur = [
 			'size' => 10,
-			'unit' => 'px',
+			'unit' => Size_Constants::UNIT_PX,
 		];
 		$color = 'rgba(0, 0, 0, 1)';
 

--- a/modules/atomic-widgets/prop-types/shadow-prop-type.php
+++ b/modules/atomic-widgets/prop-types/shadow-prop-type.php
@@ -17,13 +17,21 @@ class Shadow_Prop_Type extends Object_Prop_Type {
 
 	protected function define_shape(): array {
 		$units = Size_Constants::box_shadow();
+		$size = [
+			'size' => 0,
+			'unit' => Size_Constants::UNIT_PX,
+		];
+		$blur = [
+			'size' => 10,
+			'unit' => Size_Constants::UNIT_PX,
+		];
 
 		return [
-			'hOffset' => Size_Prop_Type::make()->required()->units( $units ),
-			'vOffset' => Size_Prop_Type::make()->required()->units( $units ),
-			'blur' => Size_Prop_Type::make()->required()->units( $units ),
-			'spread' => Size_Prop_Type::make()->required()->units( $units ),
-			'color' => Color_Prop_Type::make()->required(),
+			'hOffset' => Size_Prop_Type::make()->required()->units( $units )->initial_value( $size ),
+			'vOffset' => Size_Prop_Type::make()->required()->units( $units )->initial_value( $size ),
+			'blur' => Size_Prop_Type::make()->required()->units( $units )->initial_value( $blur ),
+			'spread' => Size_Prop_Type::make()->required()->units( $units )->initial_value( $size ),
+			'color' => Color_Prop_Type::make()->required()->initial_value( 'rgba(0, 0, 0, 1)' ),
 			'position' => String_Prop_Type::make()->enum( [ 'inset' ] ),
 		];
 	}

--- a/packages/packages/core/editor-editing-panel/src/reset-style-props.tsx
+++ b/packages/packages/core/editor-editing-panel/src/reset-style-props.tsx
@@ -9,7 +9,7 @@ import { isEqual } from './utils/is-equal';
 const { registerAction } = controlActionsMenu;
 
 // TODO: BC: Only background repeater supports reset; remove this constant once all repeaters support it.
-const REPEATERS_SUPPORTED_FOR_RESET = [ 'background', 'transform', 'filter', 'backdrop-filter' ];
+const REPEATERS_SUPPORTED_FOR_RESET = [ 'background', 'transform', 'filter', 'backdrop-filter', 'box-shadow' ];
 
 export function initResetStyleProps() {
 	registerAction( {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add box shadow reset functionality via floating actions menu in popovers and standardize unit constants.
Main changes:
- Added 'box-shadow' to REPEATERS_SUPPORTED_FOR_RESET array to enable reset functionality
- Replaced hardcoded 'px' strings with Size_Constants::UNIT_PX constant for consistency
- Added initial values for box shadow properties in Shadow_Prop_Type

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
