### PR TITLE
Internal: Reset animation preview when effect type is `out` [ED-21472]

### DIFF
--- a/modules/interactions/assets/js/editor-interactions.js
+++ b/modules/interactions/assets/js/editor-interactions.js
@@ -64,6 +64,20 @@
 		animateFunc( element, initialKeyframes, { duration: 0 } );
 
 		animateFunc( element, keyframes, options );
+
+		if ( 'out' === animConfig.type ) {
+			const totalAnimationTime = animConfig.duration + animConfig.delay;
+			const resetValues = { opacity: 1, scale: 1, x: 0, y: 0 };
+
+			setTimeout( () => {
+				const resetKeyframes = {};
+				Object.keys( keyframes ).forEach( ( key ) => {
+					resetKeyframes[ key ] = resetValues[ key ];
+				} );
+
+				animateFunc( element, resetKeyframes, { duration: 0 } );
+			}, totalAnimationTime );
+		}
 	}
 
 	function getInteractionsData() {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
