### PR TITLE
Internal: Fix repeater interaction details to set default properly [ED-21595]

### DIFF
--- a/packages/packages/core/editor-interactions/src/components/interaction-details.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interaction-details.tsx
@@ -15,7 +15,7 @@ type InteractionDetailsProps = {
 	interaction: string;
 	onChange: ( interaction: string ) => void;
 };
-export const DEFAULT_INTERACTION = 'load-fade-in-left-300-0';
+export const DEFAULT_INTERACTION = 'load-fade-in--300-0';
 
 const getDefaultInteractionDetails = () => {
 	const [ trigger, effect, type, direction, duration, delay ] = DEFAULT_INTERACTION.split( DELIMITER );

--- a/packages/packages/core/editor-interactions/src/components/interaction-details.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interaction-details.tsx
@@ -15,31 +15,49 @@ type InteractionDetailsProps = {
 	interaction: string;
 	onChange: ( interaction: string ) => void;
 };
+export const DEFAULT_INTERACTION = 'load-fade-in-left-300-0';
+
+const getDefaultInteractionDetails = () => {
+	const [ trigger, effect, type, direction, duration, delay ] = DEFAULT_INTERACTION.split( DELIMITER );
+
+	return {
+		trigger,
+		effect,
+		type,
+		direction,
+		duration,
+		delay,
+	};
+};
+
+const buildInteractionDetails = ( interaction: string ) => {
+	const [ trigger, effect, type, direction, duration, delay ] = interaction.split( DELIMITER );
+	const defaultInteractionDetails = getDefaultInteractionDetails();
+
+	return {
+		trigger: trigger || defaultInteractionDetails.trigger,
+		effect: effect || defaultInteractionDetails.effect,
+		type: type || defaultInteractionDetails.type,
+		direction: direction || defaultInteractionDetails.direction,
+		duration: duration || defaultInteractionDetails.duration,
+		delay: delay || defaultInteractionDetails.delay,
+	};
+};
 
 export const InteractionDetails = ( { interaction, onChange }: InteractionDetailsProps ) => {
-	const [ interactionDetails, setInteractionDetails ] = useState( () => {
-		const [ trigger, effect, type, direction, duration, delay ] = interaction.split( DELIMITER );
-
-		return {
-			trigger: trigger || 'load',
-			effect: effect || 'fade',
-			type: type || 'in',
-			direction: direction || '',
-			duration: duration || '300',
-			delay: delay || '0',
-		};
-	} );
-
-	useEffect( () => {
-		const newValue = Object.values( interactionDetails ).join( DELIMITER );
-		onChange( newValue );
-	}, [ interactionDetails, onChange ] );
+	const interactionDetails = React.useMemo( () => {
+		return buildInteractionDetails( interaction );
+	}, [ interaction ] );
 
 	const handleChange = < K extends keyof typeof interactionDetails >(
 		key: K,
 		value: ( typeof interactionDetails )[ K ]
 	) => {
-		setInteractionDetails( ( prev ) => ( { ...prev, [ key ]: value } ) );
+		if ( value === null ) {
+			value = getDefaultInteractionDetails()[ key ];
+		}
+		const newInteractionDetails = { ...interactionDetails, [ key ]: value };
+		onChange( Object.values( newInteractionDetails ).join( DELIMITER ) );
 	};
 
 	return (
@@ -52,7 +70,7 @@ export const InteractionDetails = ( { interaction, onChange }: InteractionDetail
 				<Effect value={ interactionDetails.effect } onChange={ ( v ) => handleChange( 'effect', v ) } />
 				<EffectType value={ interactionDetails.type } onChange={ ( v ) => handleChange( 'type', v ) } />
 				<Direction
-					value={ interactionDetails.direction ?? '' }
+					value={ interactionDetails.direction }
 					onChange={ ( v ) => handleChange( 'direction', v ) }
 				/>
 				<TimeFrameIndicator

--- a/packages/packages/core/editor-interactions/src/components/interaction-details.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interaction-details.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useEffect, useState } from 'react';
 import { Divider, Grid } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 

--- a/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
@@ -6,7 +6,7 @@ import { IconButton } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { getInteractionsConfig } from '../utils/get-interactions-config';
-import { InteractionDetails } from './interaction-details';
+import { DEFAULT_INTERACTION, InteractionDetails } from './interaction-details';
 
 export type InteractionListProps = {
 	onSelectInteraction: ( interaction: string | null ) => void;
@@ -21,7 +21,7 @@ export function InteractionsList( props: InteractionListProps ) {
 	const [ interactionId, setInteractionId ] = useState< string | null >( selectedInteraction );
 
 	if ( triggerCreateOnShowEmpty && ! interactionId ) {
-		setInteractionId( 'load-fade-in-left-100-0' );
+		setInteractionId( DEFAULT_INTERACTION );
 	}
 
 	useEffect( () => {
@@ -56,7 +56,7 @@ export function InteractionsList( props: InteractionListProps ) {
 			isSortable={ false }
 			disableAddItemButton={ !! interactionId }
 			itemSettings={ {
-				initialValues: interactionId ?? 'load-fade-in-left-100-0',
+				initialValues: DEFAULT_INTERACTION,
 				Label: ( { value } ) => displayLabel( value ),
 				Icon: () => null,
 				Content: ( { value } ) => (


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix interaction details component to properly set default values for repeater elements in editor interactions.

Main changes:
- Centralized default interaction value as exportable constant with value 'load-fade-in--300-0'
- Refactored to build interaction details using immutable pattern instead of useState/useEffect
- Added fallback logic to set default values when interaction properties are missing or null

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
