### PR TITLE
Internal: Events fixes [ED-21501]

### DIFF
--- a/assets/dev/js/editor/components/template-library/views/parts/save-template.js
+++ b/assets/dev/js/editor/components/template-library/views/parts/save-template.js
@@ -209,8 +209,6 @@ const TemplateLibrarySaveTemplateView = Marionette.ItemView.extend( {
 	onFormSubmit( event ) {
 		event.preventDefault();
 
-		elementor.templates.eventManager.sendNewSaveTemplateClickedEvent();
-
 		var formData = this.ui.form.elementorSerializeObject(),
 			JSONParams = { remove: [ 'default' ] };
 

--- a/assets/dev/js/editor/elements/views/base.js
+++ b/assets/dev/js/editor/elements/views/base.js
@@ -946,6 +946,8 @@ BaseElementView = BaseContainer.extend( {
 	},
 
 	save() {
+		elementor.templates.eventManager.sendNewSaveTemplateClickedEvent();
+
 		$e.route( 'library/save-template', {
 			model: this.model,
 		} );

--- a/assets/dev/js/editor/elements/views/container.js
+++ b/assets/dev/js/editor/elements/views/container.js
@@ -270,6 +270,8 @@ const ContainerView = BaseElementView.extend( {
 	 * @return {void}
 	 */
 	saveAsTemplate() {
+		elementor.templates.eventManager.sendNewSaveTemplateClickedEvent();
+
 		$e.route( 'library/save-template', {
 			model: this.model,
 		} );

--- a/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.js
+++ b/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.js
@@ -278,6 +278,8 @@ export default function createAtomicElementBaseView( type ) {
 		},
 
 		saveAsTemplate() {
+			elementor.templates.eventManager.sendNewSaveTemplateClickedEvent();
+
 			$e.route( 'library/save-template', {
 				model: this.model,
 			} );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Move "Save as Template" analytics event from form submission to the method calls that trigger the form to ensure proper event tracking.

Main changes:
- Removed event tracking code from template library form submission handler
- Added event tracking to save() method in BaseElementView
- Added event tracking to saveAsTemplate() method in ContainerView and AtomicElementBaseView

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
