### PR TITLE
Internal: Youtube widget - remove dynamic tags from Start/End time [ED-21324]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.php
+++ b/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.php
@@ -4,6 +4,7 @@ namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Youtube;
 use Elementor\Modules\AtomicWidgets\Controls\Section;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Switch_Control;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
+use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Widget_Base;
 use Elementor\Modules\AtomicWidgets\Elements\Has_Template;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
@@ -53,8 +54,8 @@ class Atomic_Youtube extends Atomic_Widget_Base {
 			'source' => String_Prop_Type::make()
 				->default( 'https://www.youtube.com/watch?v=XHOmBV4js_E' ),
 
-			'start' => String_Prop_Type::make(),
-			'end' => String_Prop_Type::make(),
+			'start' => String_Prop_Type::make()->meta( Dynamic_Prop_Type::ignore() ),
+			'end' => String_Prop_Type::make()->meta( Dynamic_Prop_Type::ignore() ),
 			'autoplay' => Boolean_Prop_Type::make()->default( false ),
 			'mute' => Boolean_Prop_Type::make()->default( false ),
 			'loop' => Boolean_Prop_Type::make()->default( false ),


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove dynamic tag support from YouTube widget's Start and End time properties to prevent unexpected behavior.

Main changes:
- Imported Dynamic_Prop_Type class to support dynamic tag configuration
- Modified start and end properties to explicitly ignore dynamic tags using Dynamic_Prop_Type::ignore()

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
