### PR TITLE
Internal: Disabled send app plg notice [ED-21551]

### DIFF
--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -467,6 +467,10 @@ class Admin_Notices extends Module {
 	}
 
 	private function notice_send_app_promotion() {
+
+		// not deleting it just exiting early for backwards compatibility with elementor pro older versions
+		return false;
+
 		$notice_id = 'send_app_promotion';
 
 		if ( ! $this->is_elementor_page() && ! $this->is_elementor_admin_screen() ) {

--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -469,8 +469,7 @@ class Admin_Notices extends Module {
 	}
 
 	private function notice_send_app_promotion() {
-
-        return EXIT_EARLY_FOR_BACKWARD_COMPATIBILITY;
+		return self::EXIT_EARLY_FOR_BACKWARD_COMPATIBILITY;
 
 		$notice_id = 'send_app_promotion';
 

--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -21,6 +21,8 @@ class Admin_Notices extends Module {
 	const DEFAULT_EXCLUDED_PAGES = [ 'plugins.php', 'plugin-install.php', 'plugin-editor.php' ];
 	const LOCAL_GOOGLE_FONTS_DISABLED_NOTICE_ID = 'local_google_fonts_disabled';
 
+	const EXIT_EARLY_FOR_BACKWARD_COMPATIBILITY = false;
+
 	private $plain_notices = [
 		'api_notice',
 		'api_upgrade_plugin',
@@ -468,8 +470,7 @@ class Admin_Notices extends Module {
 
 	private function notice_send_app_promotion() {
 
-		// not deleting it just exiting early for backwards compatibility with elementor pro older versions
-		return false;
+        return EXIT_EARLY_FOR_BACKWARD_COMPATIBILITY;
 
 		$notice_id = 'send_app_promotion';
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Disable send app promotion notification by adding early return mechanism for backward compatibility.
Main changes:
- Added EXIT_EARLY_FOR_BACKWARD_COMPATIBILITY constant defaulted to false
- Modified notice_send_app_promotion() to return early using the new constant

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
