### PR TITLE
Fix: Interactions repeater not working

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/tabs-control.tsx
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/tabs-control.tsx
@@ -101,7 +101,6 @@ export const TabsControl = ( { label }: { label: string } ) => {
 			setValues={ setValue }
 			showRemove={ repeaterValues.length > 1 }
 			label={ label }
-			isSortable={ true }
 			itemSettings={ {
 				getId: ( { item } ) => item.id,
 				initialValues: { id: '', title: 'Tab' },

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/tabs-control.tsx
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/tabs-control.tsx
@@ -101,6 +101,7 @@ export const TabsControl = ( { label }: { label: string } ) => {
 			setValues={ setValue }
 			showRemove={ repeaterValues.length > 1 }
 			label={ label }
+			isSortable={ true }
 			itemSettings={ {
 				getId: ( { item } ) => item.id,
 				initialValues: { id: '', title: 'Tab' },

--- a/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
@@ -43,7 +43,6 @@ export function InteractionsList( props: InteractionListProps ) {
 
 	return (
 		<Repeater
-			addToBottom
 			openOnAdd
 			openItem={ triggerCreateOnShowEmpty ? 0 : undefined }
 			label={ __( 'Interactions', 'elementor' ) }
@@ -56,6 +55,7 @@ export function InteractionsList( props: InteractionListProps ) {
 			isSortable={ false }
 			disableAddItemButton={ !! interactionId }
 			itemSettings={ {
+				getId: ( { item, index } ) => item,
 				initialValues: DEFAULT_INTERACTION,
 				Label: ( { value } ) => displayLabel( value ),
 				Icon: () => null,

--- a/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
@@ -55,7 +55,6 @@ export function InteractionsList( props: InteractionListProps ) {
 			isSortable={ false }
 			disableAddItemButton={ !! interactionId }
 			itemSettings={ {
-				getId: ( { item, index } ) => item,
 				initialValues: DEFAULT_INTERACTION,
 				Label: ( { value } ) => displayLabel( value ),
 				Icon: () => null,

--- a/packages/packages/libs/editor-controls/src/components/repeater/repeater.tsx
+++ b/packages/packages/libs/editor-controls/src/components/repeater/repeater.tsx
@@ -133,9 +133,7 @@ export const Repeater = < T, >( {
 	const [ openItem, setOpenItem ] = useState( initialOpenItem );
 
 	const uniqueKeys = items.map( ( item, index ) =>
-		isSortable && 'getId' in itemSettings
-			? itemSettings.getId( { item, index } )
-			: String( index )
+		isSortable && 'getId' in itemSettings ? itemSettings.getId( { item, index } ) : String( index )
 	);
 
 	const addRepeaterItem = () => {
@@ -222,7 +220,7 @@ export const Repeater = < T, >( {
 				</IconButton>
 			</RepeaterHeader>
 			{ 0 < uniqueKeys.length && (
-				<SortableProvider value={ uniqueKeys } onChange={ onChangeOrder } >
+				<SortableProvider value={ uniqueKeys } onChange={ onChangeOrder }>
 					{ uniqueKeys.map( ( key ) => {
 						const index = uniqueKeys.indexOf( key );
 						const value = items[ index ];

--- a/packages/packages/libs/editor-controls/src/components/repeater/repeater.tsx
+++ b/packages/packages/libs/editor-controls/src/components/repeater/repeater.tsx
@@ -96,7 +96,7 @@ type RepeaterProps< T > =
 			showToggle?: boolean;
 			showRemove?: boolean;
 			openItem?: number;
-			isSortable?: false;
+			isSortable: false;
 			itemSettings: BaseItemSettings< T >;
 	  }
 	| {
@@ -110,7 +110,7 @@ type RepeaterProps< T > =
 			showToggle?: boolean;
 			showRemove?: boolean;
 			openItem?: number;
-			isSortable: true;
+			isSortable?: true;
 			itemSettings: SortableItemSettings< T >;
 	  };
 
@@ -128,7 +128,7 @@ export const Repeater = < T, >( {
 	showRemove = true,
 	disableAddItemButton = false,
 	openItem: initialOpenItem = EMPTY_OPEN_ITEM,
-	isSortable = false,
+	isSortable = true,
 }: RepeaterProps< RepeaterItem< T > > ) => {
 	const [ openItem, setOpenItem ] = useState( initialOpenItem );
 

--- a/packages/packages/libs/editor-controls/src/components/repeater/repeater.tsx
+++ b/packages/packages/libs/editor-controls/src/components/repeater/repeater.tsx
@@ -75,7 +75,6 @@ export type SetRepeaterValuesMeta< T > =
 type RepeaterProps< T > = {
 	label: string;
 	values?: T[];
-	addToBottom?: boolean;
 	openOnAdd?: boolean;
 	setValues: ( newValue: T[], _: CreateOptions, meta?: SetRepeaterValuesMeta< T > ) => void;
 	disabled?: boolean;

--- a/packages/packages/libs/editor-controls/src/components/repeater/repeater.tsx
+++ b/packages/packages/libs/editor-controls/src/components/repeater/repeater.tsx
@@ -72,27 +72,47 @@ export type SetRepeaterValuesMeta< T > =
 	| SetValueMeta< ReorderItemMeta >
 	| SetValueMeta< ToggleDisableItemMeta >;
 
-type RepeaterProps< T > = {
-	label: string;
-	values?: T[];
-	openOnAdd?: boolean;
-	setValues: ( newValue: T[], _: CreateOptions, meta?: SetRepeaterValuesMeta< T > ) => void;
-	disabled?: boolean;
-	disableAddItemButton?: boolean;
-	itemSettings: {
-		getId: ( { item, index }: { item: T; index: number } ) => string;
-		initialValues: T;
-		Label: React.ComponentType< { value: T; index: number } >;
-		Icon: React.ComponentType< { value: T } >;
-		Content: RepeaterItemContent< T >;
-		actions?: React.ReactNode;
-	};
-	showDuplicate?: boolean;
-	showToggle?: boolean;
-	showRemove?: boolean;
-	openItem?: number;
-	isSortable?: boolean;
+type BaseItemSettings< T > = {
+	initialValues: T;
+	Label: React.ComponentType< { value: T; index: number } >;
+	Icon: React.ComponentType< { value: T } >;
+	Content: RepeaterItemContent< T >;
+	actions?: React.ReactNode;
 };
+
+type SortableItemSettings< T > = BaseItemSettings< T > & {
+	getId: ( { item, index }: { item: T; index: number } ) => string;
+};
+
+type RepeaterProps< T > =
+	| {
+			label: string;
+			values?: T[];
+			openOnAdd?: boolean;
+			setValues: ( newValue: T[], _: CreateOptions, meta?: SetRepeaterValuesMeta< T > ) => void;
+			disabled?: boolean;
+			disableAddItemButton?: boolean;
+			showDuplicate?: boolean;
+			showToggle?: boolean;
+			showRemove?: boolean;
+			openItem?: number;
+			isSortable?: false;
+			itemSettings: BaseItemSettings< T >;
+	  }
+	| {
+			label: string;
+			values?: T[];
+			openOnAdd?: boolean;
+			setValues: ( newValue: T[], _: CreateOptions, meta?: SetRepeaterValuesMeta< T > ) => void;
+			disabled?: boolean;
+			disableAddItemButton?: boolean;
+			showDuplicate?: boolean;
+			showToggle?: boolean;
+			showRemove?: boolean;
+			openItem?: number;
+			isSortable: true;
+			itemSettings: SortableItemSettings< T >;
+	  };
 
 const EMPTY_OPEN_ITEM = -1;
 
@@ -108,11 +128,15 @@ export const Repeater = < T, >( {
 	showRemove = true,
 	disableAddItemButton = false,
 	openItem: initialOpenItem = EMPTY_OPEN_ITEM,
-	isSortable = true,
+	isSortable = false,
 }: RepeaterProps< RepeaterItem< T > > ) => {
 	const [ openItem, setOpenItem ] = useState( initialOpenItem );
 
-	const uniqueKeys = items.map( ( item, index ) => itemSettings.getId( { item, index } ) );
+	const uniqueKeys = items.map( ( item, index ) =>
+		isSortable && 'getId' in itemSettings
+			? itemSettings.getId( { item, index } )
+			: String( index )
+	);
 
 	const addRepeaterItem = () => {
 		const newItem = structuredClone( itemSettings.initialValues );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix interactions repeater functionality by refactoring the Repeater component to properly handle sortable and non-sortable item configurations.

Main changes:
- Removed deprecated 'addToBottom' prop from InteractionsList component
- Refactored Repeater component with discriminated union types for sortable/non-sortable configurations
- Fixed item ID generation to properly handle both sortable and non-sortable repeater items
- Added proper type checking for getId method to ensure compatibility with configuration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
