### PR TITLE
Internal: Update Core release owners list on GA [ED-21631]

### DIFF
--- a/.github/workflows/config.json
+++ b/.github/workflows/config.json
@@ -2,6 +2,7 @@
   "deployment" : {
     "repository_owner" : "elementor",
     "environment" : "prod",
-    "permitted" : "Batsirai-muchareva,TzviRabinovitch,davseve,louiswol94,mykytamurzin,ronenelementor,hein-obox,MichaelLiamin,elchugreeva,asafdl,mugurelLupu,baghdasarovelementor,mike-elementor,Svitlana-Dykun,IshayMaya,MiryamOren,eyalmrejen-elementor,marcin-elementor,nami-p,Nevoss,Omerisra6,ronros-elementor,YaelAvitan,ntnelbaba"
+    "permitted" : "Batsirai-muchareva,davseve,louiswol94,mykytamurzin,ronenelementor,hein-obox,MichaelLiamin,elchugreeva,asafdl,baghdasarovelementor,mike-elementor,Svitlana-Dykun,IshayMaya,MiryamOren,eyalmrejen-elementor,marcin-elementor,nami-p,Omerisra6,ronros-elementor,YaelAvitan,ntnelbaba,max-zu,ManorHazaz,nicoladj77,dima-belkin,annab1"
+
   }
 }

--- a/.github/workflows/config.json
+++ b/.github/workflows/config.json
@@ -2,7 +2,7 @@
   "deployment" : {
     "repository_owner" : "elementor",
     "environment" : "prod",
-    "permitted" : "Batsirai-muchareva,davseve,louiswol94,mykytamurzin,ronenelementor,hein-obox,MichaelLiamin,elchugreeva,asafdl,baghdasarovelementor,mike-elementor,Svitlana-Dykun,IshayMaya,MiryamOren,eyalmrejen-elementor,marcin-elementor,nami-p,Omerisra6,ronros-elementor,YaelAvitan,ntnelbaba,max-zu,ManorHazaz,nicoladj77,dima-belkin,annab1"
+    "permitted" : "Batsirai-muchareva,davseve,louiswol94,mykytamurzin,ronenelementor,hein-obox,MichaelLiamin,elchugreeva,asafdl,mike-elementor,Svitlana-Dykun,IshayMaya,MiryamOren,eyalmrejen-elementor,marcin-elementor,nami-p,Omerisra6,ronros-elementor,YaelAvitan,ntnelbaba,max-zu,ManorHazaz,nicoladj77,dima-belkin,annab1"
 
   }
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update permitted users list for deployment configuration in the Core release owners workflow.
Main changes:
- Removed users TzviRabinovitch, mugurelLupu, baghdasarovelementor, and Nevoss from permitted list
- Added users max-zu, ManorHazaz, nicoladj77, and dima-belkin to permitted list

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
