### PR TITLE
Internal: Skip youtube test [ED-21688]

### DIFF
--- a/tests/playwright/sanity/modules/v4-tests/atomic-widgets.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-widgets.test.ts
@@ -17,7 +17,7 @@ test.describe( 'Atomic Widgets @v4-tests', () => {
 		{ name: 'e-svg', title: 'SVG' },
 		{ name: 'e-button', title: 'Button' },
 		{ name: 'e-divider', title: 'Divider' },
-		//{ name: 'e-youtube', title: 'YouTube' },
+		// { name: 'e-youtube', title: 'YouTube' },
 		// Notice: there is a bug: [ED-21689] Youtube widget is not visible on frontend
 	];
 

--- a/tests/playwright/sanity/modules/v4-tests/atomic-widgets.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-widgets.test.ts
@@ -17,7 +17,8 @@ test.describe( 'Atomic Widgets @v4-tests', () => {
 		{ name: 'e-svg', title: 'SVG' },
 		{ name: 'e-button', title: 'Button' },
 		{ name: 'e-divider', title: 'Divider' },
-		{ name: 'e-youtube', title: 'YouTube' },
+		//{ name: 'e-youtube', title: 'YouTube' },
+		// Notice: there is a bug: [ED-21689] Youtube widget is not visible on frontend
 	];
 
 	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Temporarily disable YouTube atomic widget test due to widget visibility bug in frontend

Main changes:
- Commented out YouTube widget test entry in atomic widget test configuration
- Added explanatory comment referencing bug ticket ED-21689 for context

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
