### PR TITLE
Internal: Remove divider from tabs menu control [ED-21589]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-content-area.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-content-area.php
@@ -60,7 +60,9 @@ class Atomic_Tabs_Content_Area extends Atomic_Element_Base {
 				->set_items( [
 					Text_Control::bind_to( '_cssid' )
 						->set_label( __( 'ID', 'elementor' ) )
-						->set_meta( $this->get_css_id_control_meta() ),
+						->set_meta( [
+							'layout' => 'two-columns',
+						] ),
 				] ),
 		];
 	}

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-menu.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-menu.php
@@ -57,7 +57,10 @@ class Atomic_Tabs_Menu extends Atomic_Element_Base {
 				->set_items( [
 					Text_Control::bind_to( '_cssid' )
 						->set_label( __( 'ID', 'elementor' ) )
-						->set_meta( $this->get_css_id_control_meta() ),
+						->set_meta( [
+							'layout' => 'two-columns',
+							'topDivider' => false,
+						] ),
 				] ),
 		];
 	}

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-menu.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-menu.php
@@ -59,7 +59,6 @@ class Atomic_Tabs_Menu extends Atomic_Element_Base {
 						->set_label( __( 'ID', 'elementor' ) )
 						->set_meta( [
 							'layout' => 'two-columns',
-							'topDivider' => false,
 						] ),
 				] ),
 		];


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove divider functionality from tabs menu control by replacing dynamic meta configuration with static layout configuration.
Main changes:
- Replaced get_css_id_control_meta() method with explicit two-columns layout configuration in Text_Control
- Applied consistent configuration in both atomic-tabs-menu.php and atomic-tabs-content-area.php files

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
