### PR TITLE
Internal: Make on move elements run before command

### DIFF
--- a/packages/packages/libs/editor-elements/src/sync/move-elements.ts
+++ b/packages/packages/libs/editor-elements/src/sync/move-elements.ts
@@ -43,7 +43,8 @@ export const moveElements = ( {
 		{
 			do: ( { moves }: { moves: MoveElementParams[] } ): MovedElementsResult => {
 				const movedElements: MovedElement[] = [];
-
+				// Call onMoveElements before moving element to avoid conflicts between commands
+				onMoveElements?.();
 				moves.forEach( ( move ) => {
 					const { elementId } = move;
 					const sourceContainer = getContainer( elementId );
@@ -66,9 +67,6 @@ export const moveElements = ( {
 						options: { ...move.options, useHistory: false },
 					} );
 
-					// Call onMoveElements before moving element to avoid conflicts between commands
-					onMoveElements?.();
-
 					movedElements.push( {
 						elementId,
 						originalPosition,
@@ -80,10 +78,10 @@ export const moveElements = ( {
 				return { movedElements };
 			},
 			undo: ( _: { moves: MoveElementParams[] }, { movedElements }: MovedElementsResult ) => {
+				onRestoreElements?.();
+
 				[ ...movedElements ].reverse().forEach( ( { originalPosition } ) => {
 					const { elementId, originalContainerId, originalIndex } = originalPosition;
-
-					onRestoreElements?.();
 
 					moveElement( {
 						elementId,
@@ -100,14 +98,13 @@ export const moveElements = ( {
 				{ movedElements }: MovedElementsResult
 			): MovedElementsResult => {
 				const newMovedElements: MovedElement[] = [];
+				onMoveElements?.();
 
 				movedElements.forEach( ( { move, originalPosition } ) => {
 					const element = moveElement( {
 						...move,
 						options: { ...move.options, useHistory: false },
 					} );
-
-					onMoveElements?.();
 
 					newMovedElements.push( {
 						elementId: move.elementId,


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor editor element movement mechanism to call onMoveElements callback before command execution to prevent conflicts.

Main changes:
- Moved onMoveElements callback to execute before element movement operations
- Added onRestoreElements call in undo operation at the function start
- Repositioned onMoveElements call in redo operation to occur before individual element moves

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
