### PR TITLE
Internal: Get nested children by parent [ED-21742]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/tabs-control.tsx
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/tabs-control.tsx
@@ -20,7 +20,7 @@ import { __ } from '@wordpress/i18n';
 import { useElement } from '../../../contexts/element-context';
 import { SettingsField } from '../../settings-field';
 import { getElementByType } from '../get-element-by-type';
-import { TAB_CONTENT_ELEMENT_TYPE, TAB_ELEMENT_TYPE, type TabItem, useActions } from './use-actions';
+import { TAB_ELEMENT_TYPE, type TabItem, useActions } from './use-actions';
 
 const TAB_MENU_ELEMENT_TYPE = 'e-tabs-menu';
 const TAB_CONTENT_AREA_ELEMENT_TYPE = 'e-tabs-content-area';
@@ -36,10 +36,9 @@ export const TabsControlContent = ( { label }: { label: string } ) => {
 	const { element } = useElement();
 	const { addItem, duplicateItem, moveItem, removeItem } = useActions();
 
-	const { [ TAB_ELEMENT_TYPE ]: tabLinks } = useElementChildren( element.id, [
-		TAB_ELEMENT_TYPE,
-		TAB_CONTENT_ELEMENT_TYPE,
-	] );
+	const { [ TAB_ELEMENT_TYPE ]: tabLinks } = useElementChildren( element.id, {
+		[ TAB_MENU_ELEMENT_TYPE ]: TAB_ELEMENT_TYPE,
+	} );
 
 	const tabList = getElementByType( element.id, TAB_MENU_ELEMENT_TYPE );
 	const tabContentArea = getElementByType( element.id, TAB_CONTENT_AREA_ELEMENT_TYPE );

--- a/packages/packages/libs/editor-elements/src/hooks/__tests__/use-element-children.test.ts
+++ b/packages/packages/libs/editor-elements/src/hooks/__tests__/use-element-children.test.ts
@@ -18,7 +18,9 @@ describe( 'useElementChildren', () => {
 		mockGetContainer.mockReturnValue( null );
 
 		// Act.
-		const { result } = renderHook( () => useElementChildren( 'element-1', [ 'tab', 'accordion' ] ) );
+		const { result } = renderHook( () =>
+			useElementChildren( 'element-1', { tabs: 'tab', accordions: 'accordion' } )
+		);
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
@@ -33,7 +35,9 @@ describe( 'useElementChildren', () => {
 		mockGetContainer.mockReturnValue( mockContainer );
 
 		// Act.
-		const { result } = renderHook( () => useElementChildren( 'element-1', [ 'tab', 'accordion' ] ) );
+		const { result } = renderHook( () =>
+			useElementChildren( 'element-1', { tabs: 'tab', accordions: 'accordion' } )
+		);
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
@@ -44,16 +48,24 @@ describe( 'useElementChildren', () => {
 
 	it( 'should return children grouped by element type', () => {
 		// Arrange.
-		const mockChildren = [
+		const tabs = [
 			createMockChild( { id: 'child-1', elType: 'tab' } ),
-			createMockChild( { id: 'child-2', elType: 'accordion' } ),
 			createMockChild( { id: 'child-3', elType: 'tab' } ),
 		];
-		const mockContainer = createMockContainer( 'element-1', mockChildren );
+
+		const tabsParent = createMockContainer( 'tabs-parent', tabs, 'tabs' );
+
+		const accordions = [ createMockChild( { id: 'child-2', elType: 'accordion' } ) ];
+
+		const accordionsParent = createMockContainer( 'accordions-parent', accordions, 'accordions' );
+
+		const mockContainer = createMockContainer( 'element-1', [ tabsParent, accordionsParent ] );
 		mockGetContainer.mockReturnValue( mockContainer );
 
 		// Act.
-		const { result } = renderHook( () => useElementChildren( 'element-1', [ 'tab', 'accordion' ] ) );
+		const { result } = renderHook( () =>
+			useElementChildren( 'element-1', { tabs: 'tab', accordions: 'accordion' } )
+		);
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
@@ -69,11 +81,14 @@ describe( 'useElementChildren', () => {
 			createMockChild( { id: 'child-2', elType: 'accordion' } ),
 			createMockChild( { id: 'child-3', elType: 'button' } ),
 		];
-		const mockContainer = createMockContainer( 'element-1', mockChildren );
+
+		const tabsParent = createMockContainer( 'tabs-parent', mockChildren, 'tabs' );
+
+		const mockContainer = createMockContainer( 'element-1', [ tabsParent ] );
 		mockGetContainer.mockReturnValue( mockContainer );
 
 		// Act.
-		const { result } = renderHook( () => useElementChildren( 'element-1', [ 'tab' ] ) );
+		const { result } = renderHook( () => useElementChildren( 'element-1', { tabs: 'tab' } ) );
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
@@ -83,12 +98,18 @@ describe( 'useElementChildren', () => {
 
 	it( 'should include empty arrays for types with no matching children', () => {
 		// Arrange.
-		const mockChildren = [ createMockChild( { id: 'child-1', elType: 'tab' } ) ];
-		const mockContainer = createMockContainer( 'element-1', mockChildren );
+		const tabs = [ createMockChild( { id: 'child-1', elType: 'tab' } ) ];
+		const tabsParent = createMockContainer( 'tabs-parent', tabs, 'tabs' );
+
+		const accordionsParent = createMockContainer( 'accordions-parent', [], 'accordions' );
+
+		const mockContainer = createMockContainer( 'element-1', [ tabsParent, accordionsParent ] );
 		mockGetContainer.mockReturnValue( mockContainer );
 
 		// Act.
-		const { result } = renderHook( () => useElementChildren( 'element-1', [ 'tab', 'accordion' ] ) );
+		const { result } = renderHook( () =>
+			useElementChildren( 'element-1', { tabs: 'tab', accordions: 'accordion' } )
+		);
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
@@ -99,12 +120,14 @@ describe( 'useElementChildren', () => {
 
 	it( 'should update when V1 ready event is dispatched', () => {
 		// Arrange.
-		const mockChildren = [ createMockChild( { id: 'child-1', elType: 'tab' } ) ];
-		const mockContainer = createMockContainer( 'element-1', mockChildren );
+		const tabs = [ createMockChild( { id: 'child-1', elType: 'tab' } ) ];
+		const tabsParent = createMockContainer( 'tabs-parent', tabs, 'tabs' );
+
+		const mockContainer = createMockContainer( 'element-1', [ tabsParent ] );
 		mockGetContainer.mockReturnValue( mockContainer );
 
 		// Act.
-		const { result } = renderHook( () => useElementChildren( 'element-1', [ 'tab' ] ) );
+		const { result } = renderHook( () => useElementChildren( 'element-1', { tabs: 'tab' } ) );
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
@@ -112,11 +135,14 @@ describe( 'useElementChildren', () => {
 		} );
 
 		// Arrange.
-		const newMockChildren = [
+		const newTabs = [
 			createMockChild( { id: 'child-1', elType: 'tab' } ),
 			createMockChild( { id: 'child-2', elType: 'tab' } ),
 		];
-		const newMockContainer = createMockContainer( 'element-1', newMockChildren );
+
+		const newTabsParent = createMockContainer( 'tabs-parent', newTabs, 'tabs' );
+
+		const newMockContainer = createMockContainer( 'element-1', [ newTabsParent ] );
 		mockGetContainer.mockReturnValue( newMockContainer );
 
 		// Act.
@@ -137,12 +163,14 @@ describe( 'useElementChildren', () => {
 		'document/elements/set-settings',
 	] )( 'should update when %s command ends', ( command ) => {
 		// Arrange.
-		const mockChildren = [ createMockChild( { id: 'child-1', elType: 'tab' } ) ];
-		const mockContainer = createMockContainer( 'element-1', mockChildren );
+		const tabs = [ createMockChild( { id: 'child-1', elType: 'tab' } ) ];
+		const tabsParent = createMockContainer( 'tabs-parent', tabs, 'tabs' );
+
+		const mockContainer = createMockContainer( 'element-1', [ tabsParent ] );
 		mockGetContainer.mockReturnValue( mockContainer );
 
 		// Act.
-		const { result } = renderHook( () => useElementChildren( 'element-1', [ 'tab' ] ) );
+		const { result } = renderHook( () => useElementChildren( 'element-1', { tabs: 'tab' } ) );
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
@@ -150,11 +178,13 @@ describe( 'useElementChildren', () => {
 		} );
 
 		// Arrange.
-		const newMockChildren = [
+		const newTabs = [
 			createMockChild( { id: 'child-1', elType: 'tab' } ),
 			createMockChild( { id: 'child-2', elType: 'tab' } ),
 		];
-		const newMockContainer = createMockContainer( 'element-1', newMockChildren );
+		const newTabsParent = createMockContainer( 'tabs-parent', newTabs, 'tabs' );
+
+		const newMockContainer = createMockContainer( 'element-1', [ newTabsParent ] );
 		mockGetContainer.mockReturnValue( newMockContainer );
 
 		// Act.
@@ -170,13 +200,16 @@ describe( 'useElementChildren', () => {
 
 	it( 'should re-compute when elementId dependency changes', () => {
 		// Arrange.
-		const mockContainer1 = createMockContainer( 'element-1', [
-			createMockChild( { id: 'child-1', elType: 'tab' } ),
-		] );
-		const mockContainer2 = createMockContainer( 'element-2', [
+		const tabs1 = [ createMockChild( { id: 'child-1', elType: 'tab' } ) ];
+		const tabsParent1 = createMockContainer( 'tabs-parent-1', tabs1, 'tabs' );
+		const mockContainer1 = createMockContainer( 'element-1', [ tabsParent1 ] );
+
+		const tabs2 = [
 			createMockChild( { id: 'child-2', elType: 'tab' } ),
 			createMockChild( { id: 'child-3', elType: 'tab' } ),
-		] );
+		];
+		const tabsParent2 = createMockContainer( 'tabs-parent-2', tabs2, 'tabs' );
+		const mockContainer2 = createMockContainer( 'element-2', [ tabsParent2 ] );
 
 		mockGetContainer.mockImplementation( ( id ) => {
 			if ( id === 'element-1' ) {
@@ -189,9 +222,12 @@ describe( 'useElementChildren', () => {
 		} );
 
 		// Act.
-		const { result, rerender } = renderHook( ( { elementId } ) => useElementChildren( elementId, [ 'tab' ] ), {
-			initialProps: { elementId: 'element-1' },
-		} );
+		const { result, rerender } = renderHook(
+			( { elementId } ) => useElementChildren( elementId, { tabs: 'tab' } ),
+			{
+				initialProps: { elementId: 'element-1' },
+			}
+		);
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
@@ -209,15 +245,17 @@ describe( 'useElementChildren', () => {
 
 	it( 'should handle children without elType', () => {
 		// Arrange.
-		const mockChildren = [
+		const tabs = [
 			createMockChild( { id: 'child-1', elType: 'tab' } ),
 			createMockChild( { id: 'child-2', elType: '' } ),
 		];
-		const mockContainer = createMockContainer( 'element-1', mockChildren );
+		const tabsParent = createMockContainer( 'tabs-parent', tabs, 'tabs' );
+
+		const mockContainer = createMockContainer( 'element-1', [ tabsParent ] );
 		mockGetContainer.mockReturnValue( mockContainer );
 
 		// Act.
-		const { result } = renderHook( () => useElementChildren( 'element-1', [ 'tab' ] ) );
+		const { result } = renderHook( () => useElementChildren( 'element-1', { tabs: 'tab' } ) );
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
@@ -232,11 +270,13 @@ describe( 'useElementChildren', () => {
 		mockGetContainer.mockReturnValue( mockContainer );
 
 		// Act.
-		const { result } = renderHook( () => useElementChildren( 'element-1', [ 'tab', 'accordion' ] ) );
+		const { result } = renderHook( () =>
+			useElementChildren( 'element-1', { container: 'tab', section: 'accordion' } )
+		);
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
-			tab: [ { id: 'grandchild-1' }, { id: 'child-2' } ],
+			tab: [ { id: 'grandchild-1' } ],
 			accordion: [ { id: 'grandchild-2' } ],
 		} );
 	} );
@@ -244,14 +284,15 @@ describe( 'useElementChildren', () => {
 	it( 'should handle deeply nested children correctly', () => {
 		// Arrange.
 		const deeplyNestedChild = createMockChild( { id: 'deep-child', elType: 'tab' } );
-		const levelThreeContainer = createMockContainer( 'level-3', [ deeplyNestedChild ] );
+		const levelThreeContainer = createMockContainer( 'level-3', [ deeplyNestedChild ], 'tabs' );
+
 		const levelTwoContainer = createMockContainer( 'level-2', [ levelThreeContainer ] );
 		const levelOneContainer = createMockContainer( 'level-1', [ levelTwoContainer ] );
 		const mockContainer = createMockContainer( 'element-1', [ levelOneContainer ] );
 		mockGetContainer.mockReturnValue( mockContainer );
 
 		// Act.
-		const { result } = renderHook( () => useElementChildren( 'element-1', [ 'tab' ] ) );
+		const { result } = renderHook( () => useElementChildren( 'element-1', { tabs: 'tab' } ) );
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
@@ -261,7 +302,6 @@ describe( 'useElementChildren', () => {
 
 	it( 'should handle case when container children is undefined', () => {
 		// Arrange.
-
 		const mockContainer = {
 			id: 'element-1',
 			model: { get: jest.fn(), set: jest.fn(), toJSON: jest.fn() },
@@ -272,7 +312,7 @@ describe( 'useElementChildren', () => {
 		mockGetContainer.mockReturnValue( mockContainer );
 
 		// Act.
-		const { result } = renderHook( () => useElementChildren( 'element-1', [ 'tab' ] ) );
+		const { result } = renderHook( () => useElementChildren( 'element-1', { tabs: 'tab' } ) );
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
@@ -286,21 +326,45 @@ describe( 'useElementChildren', () => {
 		const nestedAccordionChild = createMockChild( { id: 'nested-accordion', elType: 'accordion' } );
 		const nestedButtonChild = createMockChild( { id: 'nested-button', elType: 'button' } );
 
-		const container1 = createMockContainer( 'container-1', [ nestedTabChild, nestedButtonChild ] );
-		const container2 = createMockContainer( 'container-2', [ nestedAccordionChild ] );
+		const container1 = createMockContainer( 'container-1', [ nestedTabChild, nestedButtonChild ], 'tabs' );
 
-		const directTabChild = createMockChild( { id: 'direct-tab', elType: 'tab' } );
+		const container2 = createMockContainer( 'container-2', [ nestedAccordionChild ], 'accordions' );
 
-		const mockContainer = createMockContainer( 'element-1', [ container1, directTabChild, container2 ] );
+		const mockContainer = createMockContainer( 'element-1', [ container1, container2 ] );
 		mockGetContainer.mockReturnValue( mockContainer );
 
 		// Act.
-		const { result } = renderHook( () => useElementChildren( 'element-1', [ 'tab', 'accordion' ] ) );
+		const { result } = renderHook( () =>
+			useElementChildren( 'element-1', { tabs: 'tab', accordions: 'accordion' } )
+		);
 
 		// Assert.
 		expect( result.current ).toEqual< ElementChildren >( {
-			tab: [ { id: 'nested-tab' }, { id: 'direct-tab' } ],
+			tab: [ { id: 'nested-tab' } ],
 			accordion: [ { id: 'nested-accordion' } ],
+		} );
+	} );
+
+	it( 'should only return direct children from the first level where parent is found, not nested descendants', () => {
+		// Arrange.
+		const deeplyNestedTab = createMockChild( { id: 'deeply-nested-tab', elType: 'tab' } );
+		const nestedTabContainer = createMockContainer( 'nested-tab-container', [ deeplyNestedTab ] );
+
+		const directTab1 = createMockChild( { id: 'direct-tab-1', elType: 'tab' } );
+		const directTab2 = createMockContainer( 'direct-tab-2', [ nestedTabContainer ], 'tab' );
+
+		const tabsParent = createMockContainer( 'tabs-parent', [ directTab1, directTab2 ], 'tabs' );
+
+		const outerContainer = createMockContainer( 'outer-container', [ tabsParent ] );
+		const mockContainer = createMockContainer( 'element-1', [ outerContainer ] );
+		mockGetContainer.mockReturnValue( mockContainer );
+
+		// Act.
+		const { result } = renderHook( () => useElementChildren( 'element-1', { tabs: 'tab' } ) );
+
+		// Assert.
+		expect( result.current ).toEqual< ElementChildren >( {
+			tab: [ { id: 'direct-tab-1' }, { id: 'direct-tab-2' } ],
 		} );
 	} );
 } );
@@ -310,11 +374,9 @@ function createNestedMockElements() {
 	const grandChild2 = createMockChild( { id: 'grandchild-2', elType: 'accordion' } );
 
 	const child1 = createMockContainer( 'child-1', [ grandChild1 ] );
-	child1.model.set( 'elType', 'container' );
 
 	const child2 = createMockChild( { id: 'child-2', elType: 'tab' } );
-	const child3 = createMockContainer( 'child-3', [ grandChild2 ] );
-	child3.model.set( 'elType', 'section' );
+	const child3 = createMockContainer( 'child-3', [ grandChild2 ], 'section' );
 
 	return [ child1, child2, child3 ];
 }

--- a/packages/packages/libs/editor-elements/src/hooks/use-element-children.ts
+++ b/packages/packages/libs/editor-elements/src/hooks/use-element-children.ts
@@ -29,11 +29,11 @@ export function useElementChildren< T extends ElementChildren >(
 					( { model } ) => model.get( 'elType' ) === parentType
 				);
 
-				if ( parent?.children ) {
-					acc[ childType ] = parent.children
-						.filter( ( { model } ) => model.get( 'elType' ) === childType )
-						.map( ( { id } ) => ( { id } ) );
-				}
+				const children = parent?.children ?? [];
+
+				acc[ childType ] = children
+					.filter( ( { model } ) => model.get( 'elType' ) === childType )
+					.map( ( { id } ) => ( { id } ) );
 
 				return acc;
 			}, {} as ElementChildren );

--- a/packages/packages/libs/editor-elements/src/hooks/use-element-children.ts
+++ b/packages/packages/libs/editor-elements/src/hooks/use-element-children.ts
@@ -11,7 +11,7 @@ export type ElementChildren = Record< string, ElementModel[] >;
 
 export function useElementChildren< T extends ElementChildren >(
 	elementId: ElementID,
-	childrenTypes: ( keyof T & string )[]
+	childrenTypes: Record< string, string >
 ): T {
 	return useListenTo(
 		[
@@ -24,19 +24,19 @@ export function useElementChildren< T extends ElementChildren >(
 		() => {
 			const container = getContainer( elementId );
 
-			const elementChildren = childrenTypes.reduce( ( acc, type ) => {
-				acc[ type ] = [];
+			const elementChildren = Object.entries( childrenTypes ).reduce( ( acc, [ parentType, childType ] ) => {
+				const parent = container?.children?.findRecursive?.(
+					( { model } ) => model.get( 'elType' ) === parentType
+				);
+
+				if ( parent?.children ) {
+					acc[ childType ] = parent.children
+						.filter( ( { model } ) => model.get( 'elType' ) === childType )
+						.map( ( { id } ) => ( { id } ) );
+				}
 
 				return acc;
 			}, {} as ElementChildren );
-
-			container?.children?.forEachRecursive?.( ( { model, id } ) => {
-				const elType = model.get( 'elType' );
-
-				if ( elType && elType in elementChildren ) {
-					elementChildren[ elType ].push( { id } );
-				}
-			} );
 
 			return elementChildren;
 		},

--- a/packages/tests/test-utils/create-mock-element-with-children.ts
+++ b/packages/tests/test-utils/create-mock-element-with-children.ts
@@ -57,9 +57,9 @@ function createMockChildren( children: V1Element[] ): V1Element[ 'children' ] {
 	return mockChildren;
 }
 
-export function createMockContainer( id: string, children: V1Element[] ): V1Element {
+export function createMockContainer( id: string, children: V1Element[], elType = 'container' ): V1Element {
 	const modelData: V1ElementModelProps = {
-		elType: 'container',
+		elType,
 		id,
 	};
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Refactor element children retrieval to support nested parent-child relationships in the editor by filtering elements based on parent type.

Main changes:
- Changed useElementChildren API to accept a Record<parentType, childType> map instead of a string array
- Implemented hierarchical element filtering based on parent container types
- Fixed tabs control to use the new element children retrieval pattern
- Added test cases for nested element hierarchy navigation
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
