### PR TITLE
Internal: Show dynamic tab title [ED-21523]

### DIFF
--- a/modules/atomic-widgets/assets/js/editor/atomic-element-base-model.js
+++ b/modules/atomic-widgets/assets/js/editor/atomic-element-base-model.js
@@ -27,20 +27,19 @@ export default class AtomicElementBaseModel extends elementor.modules.elements.m
 	getDefaultChildren() {
 		const { default_children: defaultChildren } = this.config;
 
-		return defaultChildren;
+		return this.modifyDefaultChildren( defaultChildren );
 	}
 
 	onElementCreate() {
 		this.set( 'elements', this.getDefaultChildren().map( ( element ) => this.buildElement( element ) ) );
 	}
 
-	modifyDefaultChildren( elements ) {
-		return elements.settings ?? {};
+	modifyDefaultChildren( element ) {
+		return element;
 	}
 
 	buildElement( element ) {
 		const id = elementorCommon.helpers.getUniqueId();
-		const elementSettings = this.modifyDefaultChildren( element );
 
 		const elements = ( element.elements || [] ).map( ( el ) => this.buildElement( el ) );
 
@@ -48,7 +47,7 @@ export default class AtomicElementBaseModel extends elementor.modules.elements.m
 			elType: element.elType,
 			widgetType: element.widgetType,
 			id,
-			settings: elementSettings,
+			settings: element.settings ?? {},
 			elements,
 			isLocked: element.isLocked || false,
 			editor_settings: element.editor_settings || {},

--- a/modules/atomic-widgets/assets/js/editor/atomic-element-base-model.js
+++ b/modules/atomic-widgets/assets/js/editor/atomic-element-base-model.js
@@ -31,18 +31,16 @@ export default class AtomicElementBaseModel extends elementor.modules.elements.m
 	}
 
 	onElementCreate() {
-		const elements = this.getDefaultChildren();
-
-		this.set( 'elements', elements.map( ( element ) => this.buildElement( element ) ) );
+		this.set( 'elements', this.getDefaultChildren().map( ( element ) => this.buildElement( element ) ) );
 	}
 
-	updateSettings( elements ) {
+	modifyDefaultChildren( elements ) {
 		return elements.settings ?? {};
 	}
 
 	buildElement( element ) {
 		const id = elementorCommon.helpers.getUniqueId();
-		const elementSettings = this.updateSettings( element );
+		const elementSettings = this.modifyDefaultChildren( element );
 
 		const elements = ( element.elements || [] ).map( ( el ) => this.buildElement( el ) );
 

--- a/modules/atomic-widgets/assets/js/editor/atomic-element-base-model.js
+++ b/modules/atomic-widgets/assets/js/editor/atomic-element-base-model.js
@@ -1,52 +1,59 @@
 export default class AtomicElementBaseModel extends elementor.modules.elements.models.Element {
-    /**
-     * Do not allow section, column or container be placed in the Atomic container.
-     *
-     * @param {*} childModel
-     */
-    isValidChild( childModel ) {
-        const elType = childModel.get( 'elType' );
+	/**
+	 * Do not allow section, column or container be placed in the Atomic container.
+	 *
+	 * @param {*} childModel
+	 */
+	isValidChild( childModel ) {
+		const elType = childModel.get( 'elType' );
 
-        return 'section' !== elType && 'column' !== elType;
-    }
+		return 'section' !== elType && 'column' !== elType;
+	}
 
-    initialize( attributes, options ) {
-        const elementType = this.get( 'elType' );
-        this.config = elementor.config.elements[ elementType ];
+	initialize( attributes, options ) {
+		const elementType = this.get( 'elType' );
+		this.config = elementor.config.elements[ elementType ];
 
-        const isNewElementCreate = 0 === this.get( 'elements' ).length &&
+		const isNewElementCreate = 0 === this.get( 'elements' ).length &&
             $e.commands.currentTrace.includes( 'document/elements/create' );
 
-        if ( isNewElementCreate ) {
-            this.onElementCreate();
-        }
+		if ( isNewElementCreate ) {
+			this.onElementCreate();
+		}
 
-        super.initialize( attributes, options );
-    }
+		super.initialize( attributes, options );
+	}
 
-    getDefaultChildren() {
-        const { default_children: defaultChildren } = this.config;
+	getDefaultChildren() {
+		const { default_children: defaultChildren } = this.config;
 
-        return defaultChildren;
-    }
+		return defaultChildren;
+	}
 
-    onElementCreate() {
-        this.set( 'elements', this.getDefaultChildren().map( ( element ) => this.buildElement( element ) ) );
-    }
+	onElementCreate() {
+		const elements = this.getDefaultChildren();
 
-    buildElement( element ) {
-        const id = elementorCommon.helpers.getUniqueId();
+		this.set( 'elements', elements.map( ( element ) => this.buildElement( element ) ) );
+	}
 
-        const elements = ( element.elements || [] ).map( ( el ) => this.buildElement( el ) );
+	updateSettings( elements ) {
+		return elements.settings ?? {};
+	}
 
-        return {
-            elType: element.elType,
-            widgetType: element.widgetType,
-            id,
-            settings: element.settings || {},
-            elements,
-            isLocked: element.isLocked || false,
-            editor_settings: element.editor_settings || {},
-        };
-    }
+	buildElement( element ) {
+		const id = elementorCommon.helpers.getUniqueId();
+		const elementSettings = this.updateSettings( element );
+
+		const elements = ( element.elements || [] ).map( ( el ) => this.buildElement( el ) );
+
+		return {
+			elType: element.elType,
+			widgetType: element.widgetType,
+			id,
+			settings: elementSettings,
+			elements,
+			isLocked: element.isLocked || false,
+			editor_settings: element.editor_settings || {},
+		};
+	}
 }

--- a/modules/atomic-widgets/assets/js/editor/atomic-element-types/atomic-tab/create-atomic-tab-model.js
+++ b/modules/atomic-widgets/assets/js/editor/atomic-element-types/atomic-tab/create-atomic-tab-model.js
@@ -2,16 +2,16 @@ const createAtomicTabModel = () => {
 	const AtomicElementBaseModel = elementor.modules.elements.models.AtomicElementBase;
 
 	return class AtomicTabModel extends AtomicElementBaseModel {
-		modifyDefaultChildren( element ) {
+		modifyDefaultChildren( elements ) {
+			const [ paragraph ] = elements;
 			const position = this.attributes.editor_settings?.initial_position;
 
-			return {
-				...element.settings,
-				paragraph: {
-					$$type: 'string',
-					value: `Tab ${ position }`,
-				},
+			paragraph.settings.paragraph = {
+				$$type: 'string',
+				value: `Tab ${ position }`,
 			};
+
+			return elements;
 		}
 	};
 };

--- a/modules/atomic-widgets/assets/js/editor/atomic-element-types/atomic-tab/create-atomic-tab-model.js
+++ b/modules/atomic-widgets/assets/js/editor/atomic-element-types/atomic-tab/create-atomic-tab-model.js
@@ -2,8 +2,8 @@ const createAtomicTabModel = () => {
 	const AtomicElementBaseModel = elementor.modules.elements.models.AtomicElementBase;
 
 	return class AtomicTabModel extends AtomicElementBaseModel {
-		updateSettings( element ) {
-			const position = this.attributes.editor_settings?.position;
+		modifyDefaultChildren( element ) {
+			const position = this.attributes.editor_settings?.initial_position;
 
 			return {
 				...element.settings,

--- a/modules/atomic-widgets/assets/js/editor/atomic-element-types/atomic-tab/create-atomic-tab-model.js
+++ b/modules/atomic-widgets/assets/js/editor/atomic-element-types/atomic-tab/create-atomic-tab-model.js
@@ -1,0 +1,19 @@
+const createAtomicTabModel = () => {
+	const AtomicElementBaseModel = elementor.modules.elements.models.AtomicElementBase;
+
+	return class AtomicTabModel extends AtomicElementBaseModel {
+		updateSettings( element ) {
+			const position = this.attributes.editor_settings?.position;
+
+			return {
+				...element.settings,
+				paragraph: {
+					$$type: 'string',
+					value: `Tab ${ position }`,
+				},
+			};
+		}
+	};
+};
+
+export default createAtomicTabModel;

--- a/modules/atomic-widgets/assets/js/editor/atomic-element-types/atomic-tab/create-atomic-tab-type.js
+++ b/modules/atomic-widgets/assets/js/editor/atomic-element-types/atomic-tab/create-atomic-tab-type.js
@@ -1,7 +1,8 @@
 import createAtomicTabView from './create-atomic-tab-view';
+import createAtomicTabModel from './create-atomic-tab-model';
 
 const createAtomicTabType = () => {
-	return new elementor.modules.elements.types.AtomicElementBase( 'e-tab', createAtomicTabView() );
+	return new elementor.modules.elements.types.AtomicElementBase( 'e-tab', createAtomicTabView(), createAtomicTabModel() );
 };
 
 export default createAtomicTabType;

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs.php
@@ -119,7 +119,7 @@ class Atomic_Tabs extends Atomic_Element_Base {
 			$tab_elements[] = Atomic_Tab::generate()
 				->editor_settings( [
 					'title' => "Tab {$i} trigger",
-					'position' => $i,
+					'initial_position' => $i,
 				] )
 				->is_locked( true )
 				->build();
@@ -128,7 +128,7 @@ class Atomic_Tabs extends Atomic_Element_Base {
 				->is_locked( true )
 				->editor_settings( [
 					'title' => "Tab {$i} content",
-					'position' => $i,
+					'initial_position' => $i,
 				] )
 				->build();
 		}

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs.php
@@ -119,6 +119,7 @@ class Atomic_Tabs extends Atomic_Element_Base {
 			$tab_elements[] = Atomic_Tab::generate()
 				->editor_settings( [
 					'title' => "Tab {$i} trigger",
+					'position' => $i,
 				] )
 				->is_locked( true )
 				->build();
@@ -127,6 +128,7 @@ class Atomic_Tabs extends Atomic_Element_Base {
 				->is_locked( true )
 				->editor_settings( [
 					'title' => "Tab {$i} content",
+					'position' => $i,
 				] )
 				->build();
 		}

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/use-actions.ts
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/use-actions.ts
@@ -145,6 +145,8 @@ export const useActions = () => {
 		items: ItemsActionPayload< TabItem >;
 	} ) => {
 		items.forEach( ( { index } ) => {
+			const position = index + 1;
+
 			createElements( {
 				title: __( 'Tabs', 'elementor' ),
 				elements: [
@@ -152,14 +154,14 @@ export const useActions = () => {
 						containerId: tabContentAreaId,
 						model: {
 							elType: TAB_CONTENT_ELEMENT_TYPE,
-							editor_settings: { title: `Tab ${ index + 1 } content` },
+							editor_settings: { title: `Tab ${ position } content`, position },
 						},
 					},
 					{
 						containerId: tabsMenuId,
 						model: {
 							elType: TAB_ELEMENT_TYPE,
-							editor_settings: { title: `Tab ${ index + 1 } trigger` },
+							editor_settings: { title: `Tab ${ position } trigger`, position },
 						},
 					},
 				],

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/use-actions.ts
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/use-actions.ts
@@ -154,14 +154,14 @@ export const useActions = () => {
 						containerId: tabContentAreaId,
 						model: {
 							elType: TAB_CONTENT_ELEMENT_TYPE,
-							editor_settings: { title: `Tab ${ position } content`, position },
+							editor_settings: { title: `Tab ${ position } content`, initial_position: position },
 						},
 					},
 					{
 						containerId: tabsMenuId,
 						model: {
 							elType: TAB_ELEMENT_TYPE,
-							editor_settings: { title: `Tab ${ position } trigger`, position },
+							editor_settings: { title: `Tab ${ position } trigger`, initial_position: position },
 						},
 					},
 				],

--- a/packages/packages/libs/editor-elements/src/sync/types.ts
+++ b/packages/packages/libs/editor-elements/src/sync/types.ts
@@ -73,7 +73,7 @@ export type V1ElementData = Omit< V1ElementModelProps, 'elements' > & {
 
 export type V1ElementEditorSettingsProps = {
 	title?: string;
-	position?: number;
+	initial_position?: number;
 	component_uid?: string;
 };
 

--- a/packages/packages/libs/editor-elements/src/sync/types.ts
+++ b/packages/packages/libs/editor-elements/src/sync/types.ts
@@ -73,6 +73,7 @@ export type V1ElementData = Omit< V1ElementModelProps, 'elements' > & {
 
 export type V1ElementEditorSettingsProps = {
 	title?: string;
+	position?: number;
 	component_uid?: string;
 };
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add dynamic tab title functionality by implementing initial position tracking for tab elements in the editor.

Main changes:
- Added initial_position parameter to tab elements' editor settings for position tracking
- Created AtomicTabModel class to customize tab title content based on position
- Modified modifyDefaultChildren method to enable customization of default children elements
- Updated element creation logic to preserve position information during tab operations

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
