### PR TITLE
Internal: Fix interactions live preview [ED-21484]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.html.twig
+++ b/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.html.twig
@@ -14,5 +14,5 @@
 		'privacy': settings.privacy_mode,
 		'lazyload': settings.lazyload,
 	} %}
-	<div data-id="{{ id }}" data-interaction-id="{{ id }}" data-e-type="{{ type }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" {{ id_attribute }} class="{{ classes }}" {{ settings.attributes | raw }} data-settings="{{ data_settings|json_encode|e('html_attr') }}"></div>
+	<div data-interaction-id="{{ id }}" data-e-type="{{ type }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" {{ id_attribute }} class="{{ classes }}" {{ settings.attributes | raw }} data-settings="{{ data_settings|json_encode|e('html_attr') }}"></div>
 {% endif %}

--- a/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.html.twig
+++ b/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.html.twig
@@ -14,5 +14,5 @@
 		'privacy': settings.privacy_mode,
 		'lazyload': settings.lazyload,
 	} %}
-	<div data-interaction-id="{{ id }}" data-e-type="{{ type }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" {{ id_attribute }} class="{{ classes }}" {{ settings.attributes | raw }} data-settings="{{ data_settings|json_encode|e('html_attr') }}"></div>
+	<div data-id="{{ id }}" data-interaction-id="{{ id }}" data-e-type="{{ type }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" {{ id_attribute }} class="{{ classes }}" {{ settings.attributes | raw }} data-settings="{{ data_settings|json_encode|e('html_attr') }}"></div>
 {% endif %}

--- a/modules/interactions/assets/js/editor-interactions.js
+++ b/modules/interactions/assets/js/editor-interactions.js
@@ -58,10 +58,14 @@ function applyInteractionsToElement( element, interactionsData ) {
 	}
 
 	let parsedData;
-	try {
-		parsedData = JSON.parse( interactionsData );
-	} catch ( error ) {
-		return;
+	if ( 'string' === typeof interactionsData ) {
+		try {
+			parsedData = JSON.parse( interactionsData );
+		} catch ( error ) {
+			return;
+		}
+	} else {
+		parsedData = interactionsData;
 	}
 
 	const interactions = Object.values( parsedData?.items );
@@ -95,8 +99,13 @@ function handleInteractionsUpdate() {
 
 	changedItems.forEach( ( item ) => {
 		const element = findElementByInteractionId( item.dataId );
-		if ( element ) {
-			applyInteractionsToElement( element, item.interactions );
+		const prevInteractions = previousInteractionsData.find( ( prev ) => prev.dataId === item.dataId )?.interactions;
+		if ( element && item.interactions?.items?.length > 0 && item.interactions?.items?.length === prevInteractions?.items?.length ) {
+			const interactionsToApply = {
+				...item.interactions,
+				items: [ ...item.interactions.items ].filter( ( interaction, index ) => prevInteractions?.items[ index ]?.animation?.animation_id !== interaction.animation.animation_id ),
+			};
+			applyInteractionsToElement( element, interactionsToApply );
 		}
 	} );
 
@@ -166,7 +175,10 @@ function handlePlayInteractions( event ) {
 	}
 	const element = findElementByInteractionId( elementId );
 	if ( element ) {
-		const interactionsCopy = item.interactions;
+		const interactionsCopy = {
+			...item.interactions,
+			items: [ ...item.interactions.items ],
+		};
 		interactionsCopy.items = interactionsCopy.items.filter( ( interactionItem ) => interactionItem.animation.animation_id === animationId );
 		applyInteractionsToElement( element, JSON.stringify( interactionsCopy ) );
 	}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix interactions live preview functionality to handle different data types and prevent unintended interactions re-application.

Main changes:
- Modified applyInteractionsToElement to accept both string and object inputs for interactionsData
- Fixed duplicate interactions application by filtering unchanged interactions based on animation ID
- Implemented proper deep copying of interaction objects to prevent mutation of original data

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
