### PR TITLE
Fix: Show empty state when all interactions are deleted [ED-21753]

### DIFF
--- a/packages/packages/core/editor-interactions/src/components/interactions-tab.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interactions-tab.tsx
@@ -20,16 +20,10 @@ export const InteractionsTab = ( { elementId }: { elementId: string } ) => {
 function InteractionsTabContent( { elementId }: { elementId: string } ) {
 	const existingInteractions = useElementInteractions( elementId );
 	const [ firstInteraction, setFirstInteraction ] = useState< boolean >( false );
-	const [ showInteractions, setShowInteractions ] = useState( () => {
-		if ( existingInteractions?.items?.length > 0 ) {
-			return true;
-		}
-		return false;
-	} );
 
 	return (
 		<SessionStorageProvider prefix={ elementId }>
-			{ showInteractions ? (
+			{ firstInteraction || existingInteractions ? (
 				<InteractionsProvider elementId={ elementId }>
 					<InteractionsContent firstInteraction={ firstInteraction } />
 				</InteractionsProvider>
@@ -37,7 +31,6 @@ function InteractionsTabContent( { elementId }: { elementId: string } ) {
 				<EmptyState
 					onCreateInteraction={ () => {
 						setFirstInteraction( true );
-						setShowInteractions( true );
 					} }
 				/>
 			) }

--- a/packages/packages/core/editor-interactions/src/components/interactions-tab.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interactions-tab.tsx
@@ -20,10 +20,11 @@ export const InteractionsTab = ( { elementId }: { elementId: string } ) => {
 function InteractionsTabContent( { elementId }: { elementId: string } ) {
 	const existingInteractions = useElementInteractions( elementId );
 	const [ firstInteraction, setFirstInteraction ] = useState< boolean >( false );
+	const hasInteractions = existingInteractions?.items?.length || firstInteraction;
 
 	return (
 		<SessionStorageProvider prefix={ elementId }>
-			{ firstInteraction || existingInteractions ? (
+			{ hasInteractions ? (
 				<InteractionsProvider elementId={ elementId }>
 					<InteractionsContent firstInteraction={ firstInteraction } />
 				</InteractionsProvider>


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix empty state visibility in the Interactions tab to properly display when all interactions are deleted.
Main changes:
- Replaced showInteractions state with direct hasInteractions check based on existingInteractions length
- Simplified conditional rendering logic to always show empty state when no interactions exist
- Removed redundant state update in onCreateInteraction handler

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
