### PR TITLE
Internal: Update skip button in core onboarding [ED-21359]

### DIFF
--- a/app/modules/onboarding/assets/js/components/good-to-go-content-experiment402-b.js
+++ b/app/modules/onboarding/assets/js/components/good-to-go-content-experiment402-b.js
@@ -10,6 +10,8 @@ export default function GoodToGoContentExperiment402B( { skipButton } ) {
 
 	const handleBlankCanvasClick = ( event ) => {
 		OnboardingEventTracking.handleSiteStarterChoice( 'blank_canvas' );
+		OnboardingEventTracking.trackStepAction( 4, 'skipped' );
+		OnboardingEventTracking.sendEventOrStore( 'SKIP', { currentStep: 4 } );
 
 		if ( skipButton.href ) {
 			event.preventDefault();

--- a/app/modules/onboarding/assets/js/components/good-to-go-content-experiment402-b.js
+++ b/app/modules/onboarding/assets/js/components/good-to-go-content-experiment402-b.js
@@ -10,6 +10,7 @@ export default function GoodToGoContentExperiment402B( { skipButton } ) {
 
 	const handleBlankCanvasClick = ( event ) => {
 		OnboardingEventTracking.trackStepAction( 4, 'skipped' );
+		OnboardingEventTracking.sendStepEndState( 4 );
 		OnboardingEventTracking.sendEventOrStore( 'SKIP', { currentStep: 4 } );
 		OnboardingEventTracking.sendEventOrStore( 'EXIT', {
 			currentStep: 4,

--- a/app/modules/onboarding/assets/js/components/good-to-go-content-experiment402-b.js
+++ b/app/modules/onboarding/assets/js/components/good-to-go-content-experiment402-b.js
@@ -9,9 +9,12 @@ export default function GoodToGoContentExperiment402B( { skipButton } ) {
 	const kitLibraryLink = elementorAppConfig.onboarding.urls.kitLibrary + '&referrer=onboarding';
 
 	const handleBlankCanvasClick = ( event ) => {
-		OnboardingEventTracking.handleSiteStarterChoice( 'blank_canvas' );
 		OnboardingEventTracking.trackStepAction( 4, 'skipped' );
 		OnboardingEventTracking.sendEventOrStore( 'SKIP', { currentStep: 4 } );
+		OnboardingEventTracking.sendEventOrStore( 'EXIT', {
+			currentStep: 4,
+			exitType: 'skip_button',
+		} );
 
 		if ( skipButton.href ) {
 			event.preventDefault();


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update event tracking in core onboarding to properly track when users skip step 4 using the blank canvas option.
Main changes:
- Replaced generic handleSiteStarterChoice tracking with specific step completion and skip event tracking
- Added EXIT event tracking with skip_button exit type for analytics

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
