### PR TITLE
Internal: Component overridable prop type [ED-21778] 

### DIFF
--- a/modules/atomic-widgets/dynamic-tags/dynamic-prop-type.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-prop-type.php
@@ -15,7 +15,7 @@ class Dynamic_Prop_Type extends Plain_Prop_Type {
 
 	/**
 	 * Return a tuple that lets the developer ignore the dynamic prop type in the props schema
-	 * using `Prop_Type::add_meta()`, e.g. `String_Prop_Type::make()->add_meta( Dynamic_Prop_Type::ignore() )`.
+	 * using `Prop_Type::meta()`, e.g. `String_Prop_Type::make()->meta( Dynamic_Prop_Type::ignore() )`.
 	 */
 	public static function ignore(): array {
 		return [ static::META_KEY, false ];

--- a/modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php
@@ -2,14 +2,12 @@
 
 namespace Elementor\Modules\AtomicWidgets\DynamicTags;
 
-use Elementor\Modules\AtomicWidgets\PropTypes\Base\Array_Prop_Type;
-use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Utils\Prop_Types_Schema_Extender;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Transformable_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Image_Src_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
-use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Url_Prop_Type;
 use Elementor\Modules\DynamicTags\Module as V1_Dynamic_Tags_Module;
 
@@ -17,79 +15,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-class Dynamic_Prop_Types_Mapping {
+class Dynamic_Prop_Types_Mapping extends Prop_Types_Schema_Extender {
 
 	public static function make(): self {
 		return new static();
 	}
 
-	/**
-	 * @param array<string, Prop_Type> $schema
-	 *
-	 * @return array<string, Prop_Type>
-	 */
-	public function get_modified_prop_types( array $schema ): array {
-		$result = [];
-
-		foreach ( $schema as $key => $prop_type ) {
-			if ( ! ( $prop_type instanceof Prop_Type ) ) {
-				$result[ $key ] = $prop_type;
-
-				continue;
-			}
-
-			$result[ $key ] = $this->get_modified_prop_type( $prop_type );
-		}
-
-		return $result;
-	}
-
-	/**
-	 * Change prop type into a union prop type if the original prop type supports dynamic tags.
-	 *
-	 * @param Prop_Type $prop_type
-	 *
-	 * @return Prop_Type|Union_Prop_Type
-	 */
-	private function get_modified_prop_type( Prop_Type $prop_type ) {
-		$transformable_prop_types = $prop_type instanceof Union_Prop_Type ?
-			$prop_type->get_prop_types() :
-			[ $prop_type ];
-
+	protected function get_prop_types_to_add( Prop_Type $prop_type, array $nested_prop_types ): array {
 		$categories = [];
 
-		foreach ( $transformable_prop_types as $transformable_prop_type ) {
-			if ( $transformable_prop_type instanceof Object_Prop_Type ) {
-				$transformable_prop_type->set_shape(
-					$this->get_modified_prop_types( $transformable_prop_type->get_shape() )
-				);
+		foreach ( $nested_prop_types as $nested_prop_type ) {
+			if ( $nested_prop_type instanceof Transformable_Prop_Type ) {
+				$categories = array_merge( $categories, $this->get_related_categories( $nested_prop_type ) );
 			}
-
-			if ( $transformable_prop_type instanceof Array_Prop_Type ) {
-				$transformable_prop_type->set_item_type(
-					$this->get_modified_prop_type( $transformable_prop_type->get_item_type() )
-				);
-			}
-
-			// When the prop type is originally a union, we need to merge all the categories
-			// of each prop type in the union and create one dynamic prop type with all the categories.
-			$categories = array_merge( $categories, $this->get_related_categories( $transformable_prop_type ) );
 		}
 
 		if ( empty( $categories ) ) {
-			return $prop_type;
+			return [];
 		}
 
-		$dynamic_prop_type = Dynamic_Prop_Type::make()->categories( $categories );
-		$union_prop_type = $prop_type;
-
-		if ( $prop_type instanceof Transformable_Prop_Type ) {
-			$union_prop_type = Union_Prop_Type::create_from( $prop_type );
-		}
-
-		$union_prop_type->add_prop_type( $dynamic_prop_type );
-
-		return $union_prop_type;
+		return [ Dynamic_Prop_Type::make()->categories( $categories ) ];
 	}
 
 	private function get_related_categories( Transformable_Prop_Type $prop_type ): array {

--- a/modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php
@@ -10,6 +10,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Url_Prop_Type;
 use Elementor\Modules\DynamicTags\Module as V1_Dynamic_Tags_Module;
+use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -21,12 +22,23 @@ class Dynamic_Prop_Types_Mapping extends Prop_Types_Schema_Extender {
 		return new static();
 	}
 
-	protected function get_prop_types_to_add( Prop_Type $prop_type, array $nested_prop_types ): array {
+	/**
+	 * Get the dynamic prop type to add to the prop type
+	 *
+	 * @param Prop_Type $prop_type
+	 */
+	protected function get_prop_types_to_add( Prop_Type $prop_type ): array {
 		$categories = [];
 
-		foreach ( $nested_prop_types as $nested_prop_type ) {
-			if ( $nested_prop_type instanceof Transformable_Prop_Type ) {
-				$categories = array_merge( $categories, $this->get_related_categories( $nested_prop_type ) );
+		$transformable_prop_types = $prop_type instanceof Union_Prop_Type ?
+			$prop_type->get_prop_types() :
+			[ $prop_type ];
+
+		foreach ( $transformable_prop_types as $transformable_prop_type ) {
+			if ( $transformable_prop_type instanceof Transformable_Prop_Type ) {
+				// When the prop type is originally a union, we need to merge all the categories
+				// of each prop type in the union and create one dynamic prop type with all the categories.
+				$categories = array_merge( $categories, $this->get_related_categories( $transformable_prop_type ) );
 			}
 		}
 

--- a/modules/atomic-widgets/dynamic-tags/dynamic-tags-module.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-tags-module.php
@@ -43,7 +43,7 @@ class Dynamic_Tags_Module {
 
 		add_filter(
 			'elementor/atomic-widgets/props-schema',
-			fn( array $schema ) => Dynamic_Prop_Types_Mapping::make()->get_modified_prop_types( $schema )
+			fn( array $schema ) => Dynamic_Prop_Types_Mapping::make()->get_extended_schema( $schema )
 		);
 
 		add_action(

--- a/modules/atomic-widgets/elements/has-atomic-base.php
+++ b/modules/atomic-widgets/elements/has-atomic-base.php
@@ -13,6 +13,7 @@ use Elementor\Modules\AtomicWidgets\Parsers\Props_Parser;
 use Elementor\Modules\AtomicWidgets\Parsers\Style_Parser;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Utils;
+use Elementor\Modules\Components\PropTypes\Component_Overridable_Prop_Type;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -224,7 +225,7 @@ trait Has_Atomic_Base {
 
 	public static function get_props_schema(): array {
 		$schema = static::define_props_schema();
-		$schema['_cssid'] = String_Prop_Type::make();
+		$schema['_cssid'] = String_Prop_Type::make()->meta( Component_Overridable_Prop_Type::ignore() );
 
 		return apply_filters(
 			'elementor/atomic-widgets/props-schema',

--- a/modules/atomic-widgets/prop-types/utils/prop-types-schema-extender.php
+++ b/modules/atomic-widgets/prop-types/utils/prop-types-schema-extender.php
@@ -38,8 +38,6 @@ abstract class Prop_Types_Schema_Extender {
 			$prop_type->get_prop_types() :
 			[ $prop_type ];
 
-		$nested_prop_types = [];
-
 		foreach ( $transformable_prop_types as $transformable_prop_type ) {
 			if ( $transformable_prop_type instanceof Object_Prop_Type ) {
 				$transformable_prop_type->set_shape(
@@ -52,11 +50,9 @@ abstract class Prop_Types_Schema_Extender {
 					$this->get_extended_prop_type( $transformable_prop_type->get_item_type() )
 				);
 			}
-
-			$nested_prop_types = array_merge( $nested_prop_types, [ $transformable_prop_type ] );
 		}
 
-		$prop_types_to_add = $this->get_prop_types_to_add( $prop_type, $nested_prop_types );
+		$prop_types_to_add = $this->get_prop_types_to_add( $prop_type );
 
 		if ( empty( $prop_types_to_add ) ) {
 			return $prop_type;
@@ -77,5 +73,10 @@ abstract class Prop_Types_Schema_Extender {
 		return $union_prop_type;
 	}
 
-	abstract protected function get_prop_types_to_add( Prop_Type $prop_type, array $nested_prop_types ): array;
+	/**
+	 * Get the prop types to add to the prop type we extend
+	 *
+	 * @param Prop_Type $prop_type the prop type we extend
+	 */
+	abstract protected function get_prop_types_to_add( Prop_Type $prop_type ): array;
 }

--- a/modules/atomic-widgets/prop-types/utils/prop-types-schema-extender.php
+++ b/modules/atomic-widgets/prop-types/utils/prop-types-schema-extender.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\PropTypes\Utils;
+
+use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Base\Array_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Transformable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+abstract class Prop_Types_Schema_Extender {
+	public function get_extended_schema( array $schema ): array {
+		$result = [];
+
+		foreach ( $schema as $key => $prop_type ) {
+			if ( ! ( $prop_type instanceof Prop_Type ) ) {
+				$result[ $key ] = $prop_type;
+
+				continue;
+			}
+
+			$result[ $key ] = $this->get_extended_prop_type( $prop_type );
+		}
+
+		return $result;
+	}
+
+	protected function get_extended_prop_type( Prop_Type $prop_type ): Prop_Type {
+		if ( ! ( $prop_type instanceof Transformable_Prop_Type || $prop_type instanceof Union_Prop_Type ) ) {
+			return $prop_type;
+		}
+
+		$transformable_prop_types = $prop_type instanceof Union_Prop_Type ?
+			$prop_type->get_prop_types() :
+			[ $prop_type ];
+
+		$nested_prop_types = [];
+
+		foreach ( $transformable_prop_types as $transformable_prop_type ) {
+			if ( $transformable_prop_type instanceof Object_Prop_Type ) {
+				$transformable_prop_type->set_shape(
+					$this->get_extended_schema( $transformable_prop_type->get_shape() )
+				);
+			}
+
+			if ( $transformable_prop_type instanceof Array_Prop_Type ) {
+				$transformable_prop_type->set_item_type(
+					$this->get_extended_prop_type( $transformable_prop_type->get_item_type() )
+				);
+			}
+
+			$nested_prop_types = array_merge( $nested_prop_types, [ $transformable_prop_type ] );
+		}
+
+		$prop_types_to_add = $this->get_prop_types_to_add( $prop_type, $nested_prop_types );
+
+		if ( empty( $prop_types_to_add ) ) {
+			return $prop_type;
+		}
+
+		$union_prop_type = $prop_type;
+
+		if ( $prop_type instanceof Union_Prop_Type ) {
+			$union_prop_type = clone $prop_type;
+		} elseif ( $prop_type instanceof Transformable_Prop_Type ) {
+			$union_prop_type = Union_Prop_Type::create_from( $prop_type );
+		}
+
+		foreach ( $prop_types_to_add as $added_prop_type ) {
+			$union_prop_type->add_prop_type( $added_prop_type );
+		}
+
+		return $union_prop_type;
+	}
+
+	abstract protected function get_prop_types_to_add( Prop_Type $prop_type, array $nested_prop_types ): array;
+}

--- a/modules/atomic-widgets/props-resolver/props-resolver-context.php
+++ b/modules/atomic-widgets/props-resolver/props-resolver-context.php
@@ -15,6 +15,8 @@ class Props_Resolver_Context {
 
 	private bool $disabled = false;
 
+	private ?Transformers_Registry $transformers_registry = null;
+
 	public static function make(): self {
 		return new static();
 	}
@@ -47,5 +49,19 @@ class Props_Resolver_Context {
 
 	public function get_prop_type(): ?Transformable_Prop_Type {
 		return $this->prop_type;
+	}
+
+	public function set_transformers_registry( Transformers_Registry $transformers_registry ): self {
+		$this->transformers_registry = $transformers_registry;
+
+		return $this;
+	}
+
+	public function get_transformer( string $prop_type_key ): ?Transformer_Base {
+		if ( ! isset( $this->transformers_registry ) ) {
+			return null;
+		}
+
+		return $this->transformers_registry->get( $prop_type_key );
 	}
 }

--- a/modules/atomic-widgets/props-resolver/props-resolver.php
+++ b/modules/atomic-widgets/props-resolver/props-resolver.php
@@ -90,7 +90,8 @@ abstract class Props_Resolver {
 			$context = Props_Resolver_Context::make()
 				->set_key( $key )
 				->set_disabled( (bool) ( $value['disabled'] ?? false ) )
-				->set_prop_type( $prop_type );
+				->set_prop_type( $prop_type )
+				->set_transformers_registry( $this->transformers_registry );
 
 			return $transformer->transform( $value['value'], $context );
 		} catch ( Exception $e ) {

--- a/modules/atomic-widgets/styles/style-schema.php
+++ b/modules/atomic-widgets/styles/style-schema.php
@@ -224,7 +224,7 @@ class Style_Schema {
 				'inset',
 				'outset',
 			] )
-			  ->description( 'The border style in CSS values' ),
+				->description( 'The border style in CSS values' ),
 			'outline-width' => Size_Prop_Type::make()
 				->units( Size_Constants::border() )
 				->description( 'The width of the outline in Size PropType format' ),

--- a/modules/atomic-widgets/styles/style-schema.php
+++ b/modules/atomic-widgets/styles/style-schema.php
@@ -236,7 +236,7 @@ class Style_Schema {
 		$background_prop_type = Background_Prop_Type::make();
 		$bg_overlay_prop_type = $background_prop_type->get_shape_field( Background_Overlay_Prop_Type::get_key() );
 		$bg_image_overlay_prop_type = $bg_overlay_prop_type->get_item_type()->get_prop_type( Background_Image_Overlay_Prop_Type::get_key() );
-		Dynamic_Prop_Types_Mapping::make()->get_modified_prop_types( $bg_image_overlay_prop_type->get_shape() );
+		Dynamic_Prop_Types_Mapping::make()->get_extended_schema( $bg_image_overlay_prop_type->get_shape() );
 		return [
 			'background' => $background_prop_type,
 		];

--- a/modules/components/component-overridable-schema-extender.php
+++ b/modules/components/component-overridable-schema-extender.php
@@ -11,7 +11,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Component_Overridable_Schema_Extender extends Prop_Types_Schema_Extender {
+	public static function make(): self {
+		return new static();
+	}
+	
 	protected function get_prop_types_to_add( Prop_Type $prop_type, array $nested_prop_types ): array {
+		if ( ! $prop_type->get_meta_item( Component_Overridable_Prop_Type::META_KEY, true ) ) {
+			return [];
+		}
+
 		return [ Component_Overridable_Prop_Type::make()->set_origin_prop_type( $prop_type ) ];
 	}
 }

--- a/modules/components/component-overridable-schema-extender.php
+++ b/modules/components/component-overridable-schema-extender.php
@@ -16,7 +16,7 @@ class Component_Overridable_Schema_Extender extends Prop_Types_Schema_Extender {
 		return new static();
 	}
 
-	protected function get_prop_types_to_add( Prop_Type $prop_type, array $nested_prop_types ): array {
+	protected function get_prop_types_to_add( Prop_Type $prop_type ): array {
 		$is_ignore_overridable_applied = ! $prop_type->get_meta_item( Component_Overridable_Prop_Type::META_KEY, true );
 		$is_classes_prop = Atomic_Elements_Utils::is_classes_prop( $prop_type );
 

--- a/modules/components/component-overridable-schema-extender.php
+++ b/modules/components/component-overridable-schema-extender.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Elementor\Modules\Components;
+
+use Elementor\Modules\AtomicWidgets\PropTypes\Utils\Prop_Types_Schema_Extender;
+use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
+use Elementor\Modules\Components\PropTypes\Component_Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Component_Overridable_Schema_Extender extends Prop_Types_Schema_Extender {
+	protected function get_prop_types_to_add( Prop_Type $prop_type, array $nested_prop_types ): array {
+		return [ Component_Overridable_Prop_Type::make()->set_origin_prop_type( $prop_type ) ];
+	}
+}

--- a/modules/components/component-overridable-schema-extender.php
+++ b/modules/components/component-overridable-schema-extender.php
@@ -5,6 +5,7 @@ namespace Elementor\Modules\Components;
 use Elementor\Modules\AtomicWidgets\PropTypes\Utils\Prop_Types_Schema_Extender;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\Components\PropTypes\Component_Overridable_Prop_Type;
+use Elementor\Modules\GlobalClasses\Utils\Atomic_Elements_Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -16,10 +17,12 @@ class Component_Overridable_Schema_Extender extends Prop_Types_Schema_Extender {
 	}
 
 	protected function get_prop_types_to_add( Prop_Type $prop_type, array $nested_prop_types ): array {
-		if ( ! $prop_type->get_meta_item( Component_Overridable_Prop_Type::META_KEY, true ) ) {
+		$is_ignore_overridable_applied = ! $prop_type->get_meta_item( Component_Overridable_Prop_Type::META_KEY, true );
+		$is_classes_prop = Atomic_Elements_Utils::is_classes_prop( $prop_type );
+
+		if ( $is_ignore_overridable_applied || $is_classes_prop ) {
 			return [];
 		}
-
 		return [ Component_Overridable_Prop_Type::make()->set_origin_prop_type( $prop_type ) ];
 	}
 }

--- a/modules/components/component-overridable-schema-extender.php
+++ b/modules/components/component-overridable-schema-extender.php
@@ -14,7 +14,7 @@ class Component_Overridable_Schema_Extender extends Prop_Types_Schema_Extender {
 	public static function make(): self {
 		return new static();
 	}
-	
+
 	protected function get_prop_types_to_add( Prop_Type $prop_type, array $nested_prop_types ): array {
 		if ( ! $prop_type->get_meta_item( Component_Overridable_Prop_Type::META_KEY, true ) ) {
 			return [];

--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -9,6 +9,8 @@ use Elementor\Modules\Components\Documents\Component as Component_Document;
 use Elementor\Modules\Components\Component_Lock_Manager;
 use Elementor\Modules\Components\PropTypes\Component_Instance_Prop_Type;
 use Elementor\Modules\Components\Transformers\Component_Instance_Transformer;
+use Elementor\Modules\Components\PropTypes\Component_Overridable_Prop_Type;
+use Elementor\Modules\Components\Transformers\Component_Overridable_Transformer;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -28,6 +30,8 @@ class Module extends BaseModule {
 		$this->register_component_post_type();
 
 		add_filter( 'elementor/editor/v2/packages', fn ( $packages ) => $this->add_packages( $packages ) );
+		add_filter( 'elementor/atomic-widgets/props-schema', fn ( $schema ) => $this->modify_props_schema( $schema ) );
+
 		add_action( 'elementor/documents/register', fn ( $documents_manager ) => $this->register_document_type( $documents_manager ) );
 		add_action( 'elementor/atomic-widgets/settings/transformers/register', fn ( $transformers ) => $this->register_settings_transformers( $transformers ) );
 
@@ -57,6 +61,10 @@ class Module extends BaseModule {
 		return array_merge( $packages, self::PACKAGES );
 	}
 
+	private function modify_props_schema( array $schema ) {
+		return ( new Component_Overridable_Schema_Extender() )->get_extended_schema( $schema );
+	}
+
 	private function register_component_post_type() {
 		register_post_type( Component_Document::TYPE, [
 			'label'    => Component_Document::get_title(),
@@ -75,5 +83,6 @@ class Module extends BaseModule {
 
 	private function register_settings_transformers( Transformers_Registry $transformers ) {
 		$transformers->register( Component_Instance_Prop_Type::get_key(), new Component_Instance_Transformer() );
+		$transformers->register( Component_Overridable_Prop_Type::get_key(), new Component_Overridable_Transformer() );
 	}
 }

--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -62,7 +62,7 @@ class Module extends BaseModule {
 	}
 
 	private function modify_props_schema( array $schema ) {
-		return ( new Component_Overridable_Schema_Extender() )->get_extended_schema( $schema );
+		return Component_Overridable_Schema_Extender::make()->get_extended_schema( $schema );
 	}
 
 	private function register_component_post_type() {

--- a/modules/components/prop-types/component-overridable-prop-type.php
+++ b/modules/components/prop-types/component-overridable-prop-type.php
@@ -10,6 +10,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Component_Overridable_Prop_Type extends Plain_Prop_Type {
+	const META_KEY = 'component-overridable';
+
+	/**
+	 * Return a tuple that lets the developer ignore the component overridable prop type in the props schema
+	 * using `Prop_Type::meta()`, e.g. `String_Prop_Type::make()->meta( Component_Overridable_Prop_Type::ignore() )`.
+	 */
+
+	public static function ignore(): array {
+		return [ static::META_KEY, false ];
+	}
+
 	public static function get_key(): string {
 		return 'component-overridable';
 	}

--- a/modules/components/prop-types/component-overridable-prop-type.php
+++ b/modules/components/prop-types/component-overridable-prop-type.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Component_Overridable_Prop_Type extends Plain_Prop_Type {
-	const META_KEY = 'component-overridable';
+	const META_KEY = 'overridable';
 
 	/**
 	 * Return a tuple that lets the developer ignore the component overridable prop type in the props schema

--- a/modules/components/prop-types/component-overridable-prop-type.php
+++ b/modules/components/prop-types/component-overridable-prop-type.php
@@ -21,7 +21,7 @@ class Component_Overridable_Prop_Type extends Plain_Prop_Type {
 	}
 
 	public static function get_key(): string {
-		return 'component-overridable';
+		return 'overridable';
 	}
 
 	protected function validate_value( $value ): bool {
@@ -47,10 +47,14 @@ class Component_Overridable_Prop_Type extends Plain_Prop_Type {
 		return $origin_prop_type->validate( $origin_value );
 	}
 
-	protected function sanitize_value( $value ): array {
+	protected function sanitize_value( $value ): ?array {
 		['override_key' => $override_key, 'origin_value' => $origin_value] = $value;
 
 		$origin_prop_type = $this->get_origin_prop_type();
+
+		if ( ! $origin_prop_type ) {
+			return null;
+		}
 
 		$sanitized_override_key = sanitize_text_field( $override_key );
 		$sanitized_origin_value = $origin_prop_type->sanitize( $origin_value );

--- a/modules/components/prop-types/component-overridable-prop-type.php
+++ b/modules/components/prop-types/component-overridable-prop-type.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Elementor\Modules\Components\PropTypes;
+
+use Elementor\Modules\AtomicWidgets\PropTypes\Base\Plain_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Component_Overridable_Prop_Type extends Plain_Prop_Type {
+	public static function get_key(): string {
+		return 'component-overridable';
+	}
+
+	protected function validate_value( $value ): bool {
+		if ( ! is_array( $value ) ) {
+			return false;
+		}
+
+		$is_valid_structure = (
+			isset( $value['override_key'] ) &&
+			is_string( $value['override_key'] ) &&
+			isset( $value['origin_value'] ) &&
+			is_array( $value['origin_value'] )
+		);
+
+		$origin_prop_type = $this->get_origin_prop_type();
+
+		if ( ! $is_valid_structure || ! $origin_prop_type ) {
+			return false;
+		}
+
+		['origin_value' => $origin_value] = $value;
+
+		return $origin_prop_type->validate( $origin_value );
+	}
+
+	protected function sanitize_value( $value ): array {
+		['override_key' => $override_key, 'origin_value' => $origin_value] = $value;
+
+		$origin_prop_type = $this->get_origin_prop_type();
+
+		$sanitized_override_key = sanitize_text_field( $override_key );
+		$sanitized_origin_value = $origin_prop_type->sanitize( $origin_value );
+
+		return [
+			'override_key' => $sanitized_override_key,
+			'origin_value' => $sanitized_origin_value,
+		];
+	}
+
+	public function set_origin_prop_type( Prop_Type $origin_prop_type ) {
+		$this->settings['origin_prop_type'] = $origin_prop_type;
+
+		return $this;
+	}
+
+	private function get_origin_prop_type() {
+		return $this->settings['origin_prop_type'] ?? null;
+	}
+}

--- a/modules/components/prop-types/component-overridable-prop-type.php
+++ b/modules/components/prop-types/component-overridable-prop-type.php
@@ -16,7 +16,6 @@ class Component_Overridable_Prop_Type extends Plain_Prop_Type {
 	 * Return a tuple that lets the developer ignore the component overridable prop type in the props schema
 	 * using `Prop_Type::meta()`, e.g. `String_Prop_Type::make()->meta( Component_Overridable_Prop_Type::ignore() )`.
 	 */
-
 	public static function ignore(): array {
 		return [ static::META_KEY, false ];
 	}

--- a/modules/components/prop-types/component-overridable-prop-type.php
+++ b/modules/components/prop-types/component-overridable-prop-type.php
@@ -68,7 +68,7 @@ class Component_Overridable_Prop_Type extends Plain_Prop_Type {
 		return $this;
 	}
 
-	private function get_origin_prop_type() {
+	public function get_origin_prop_type() {
 		return $this->settings['origin_prop_type'] ?? null;
 	}
 }

--- a/modules/components/transformers/component-overridable-transformer.php
+++ b/modules/components/transformers/component-overridable-transformer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Elementor\Modules\Components\Transformers;
+
+use Elementor\Modules\AtomicWidgets\PropsResolver\Props_Resolver_Context;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Transformer_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Component_Overridable_Transformer extends Transformer_Base {
+	public function transform( $value, Props_Resolver_Context $context ) {
+		// todo: render component overrides
+		return $value['origin_value'];
+	}
+}

--- a/modules/components/transformers/component-overridable-transformer.php
+++ b/modules/components/transformers/component-overridable-transformer.php
@@ -4,6 +4,7 @@ namespace Elementor\Modules\Components\Transformers;
 
 use Elementor\Modules\AtomicWidgets\PropsResolver\Props_Resolver_Context;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformer_Base;
+use Exception;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -12,6 +13,30 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Component_Overridable_Transformer extends Transformer_Base {
 	public function transform( $value, Props_Resolver_Context $context ) {
 		// todo: render component overrides
-		return $value['origin_value'];
+		return $this->transform_origin_value( $value, $context );
+	}
+
+	private function transform_origin_value( array $value, Props_Resolver_Context $context ): ?array {
+		if ( ! isset( $value['origin_value'] ) || ! is_array( $value['origin_value'] ) ) {
+			return null;
+		}
+
+		$origin_value = $value['origin_value'];
+
+		if ( ! isset( $origin_value['$$type'] ) || ! isset( $origin_value['value'] ) ) {
+			return null;
+		}
+
+		$transformer = $context->get_transformer( $origin_value['$$type'] );
+
+		if ( ! ( $transformer instanceof Transformer_Base ) ) {
+			return null;
+		}
+
+		try {
+			return $transformer->transform( $origin_value['value'], $context );
+		} catch ( Exception $e ) {
+			return null;
+		}
 	}
 }

--- a/packages/packages/core/editor-components/src/component-overridable-transformer.ts
+++ b/packages/packages/core/editor-components/src/component-overridable-transformer.ts
@@ -1,0 +1,10 @@
+import { createTransformer } from '@elementor/editor-canvas';
+
+import { type ComponentOverridable } from './types';
+
+export const componentOverridableTransformer = createTransformer(
+	async ( value: ComponentOverridable ) => {
+		// todo: render component overrides
+		return value.origin_value;
+	}
+);

--- a/packages/packages/core/editor-components/src/component-overridable-transformer.ts
+++ b/packages/packages/core/editor-components/src/component-overridable-transformer.ts
@@ -1,8 +1,28 @@
-import { createTransformer } from '@elementor/editor-canvas';
+import { createTransformer, settingsTransformersRegistry } from '@elementor/editor-canvas';
 
 import { type ComponentOverridable } from './types';
 
-export const componentOverridableTransformer = createTransformer( async ( value: ComponentOverridable ) => {
-	// todo: render component overrides
-	return value.origin_value;
-} );
+export const componentOverridableTransformer = createTransformer(
+	async ( value: ComponentOverridable, options: { key: string; signal?: AbortSignal } ) => {
+		// todo: render component overrides
+		return await transformOriginValue( value, options );
+	}
+);
+
+async function transformOriginValue( value: ComponentOverridable, options: { key: string; signal?: AbortSignal } ) {
+	if ( ! value.origin_value || ! value.origin_value.value || ! value.origin_value.$$type ) {
+		return null;
+	}
+
+	const transformer = settingsTransformersRegistry.get( value.origin_value.$$type );
+
+	if ( ! transformer ) {
+		return null;
+	}
+
+	try {
+		return await transformer( value.origin_value.value, options );
+	} catch {
+		return null;
+	}
+}

--- a/packages/packages/core/editor-components/src/component-overridable-transformer.ts
+++ b/packages/packages/core/editor-components/src/component-overridable-transformer.ts
@@ -2,9 +2,7 @@ import { createTransformer } from '@elementor/editor-canvas';
 
 import { type ComponentOverridable } from './types';
 
-export const componentOverridableTransformer = createTransformer(
-	async ( value: ComponentOverridable ) => {
-		// todo: render component overrides
-		return value.origin_value;
-	}
-);
+export const componentOverridableTransformer = createTransformer( async ( value: ComponentOverridable ) => {
+	// todo: render component overrides
+	return value.origin_value;
+} );

--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -13,6 +13,7 @@ import { __registerSlice as registerSlice } from '@elementor/store';
 import { __ } from '@wordpress/i18n';
 
 import { componentInstanceTransformer } from './component-instance-transformer';
+import { componentOverridableTransformer } from './component-overridable-transformer';
 import { Components } from './components/components-tab/components';
 import { CreateComponentForm } from './components/create-component-form/create-component-form';
 import { EditComponent } from './components/edit-component/edit-component';
@@ -82,4 +83,5 @@ export function init() {
 	} );
 
 	settingsTransformersRegistry.register( 'component-instance', componentInstanceTransformer );
+	settingsTransformersRegistry.register( 'component-overridable', componentOverridableTransformer );
 }

--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -13,7 +13,7 @@ import { __registerSlice as registerSlice } from '@elementor/store';
 import { __ } from '@wordpress/i18n';
 
 import { componentInstanceTransformer } from './component-instance-transformer';
-import { componentOverridableTransformer } from './component-overridable-transformer';
+import { componentOverridableTransformer } from './overridable-transformer';
 import { Components } from './components/components-tab/components';
 import { CreateComponentForm } from './components/create-component-form/create-component-form';
 import { EditComponent } from './components/edit-component/edit-component';
@@ -83,5 +83,5 @@ export function init() {
 	} );
 
 	settingsTransformersRegistry.register( 'component-instance', componentInstanceTransformer );
-	settingsTransformersRegistry.register( 'component-overridable', componentOverridableTransformer );
+	settingsTransformersRegistry.register( 'overridable', componentOverridableTransformer );
 }

--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -13,7 +13,7 @@ import { __registerSlice as registerSlice } from '@elementor/store';
 import { __ } from '@wordpress/i18n';
 
 import { componentInstanceTransformer } from './component-instance-transformer';
-import { componentOverridableTransformer } from './overridable-transformer';
+import { componentOverridableTransformer } from './component-overridable-transformer';
 import { Components } from './components/components-tab/components';
 import { CreateComponentForm } from './components/create-component-form/create-component-form';
 import { EditComponent } from './components/edit-component/edit-component';

--- a/packages/packages/core/editor-components/src/types.ts
+++ b/packages/packages/core/editor-components/src/types.ts
@@ -61,3 +61,8 @@ type ComponentOverride = {
 	override_key: string;
 	value: TransformablePropValue< string >;
 };
+
+export type ComponentOverridable = {
+	override_key: string;
+	origin_value: TransformablePropValue< string >;
+}

--- a/packages/packages/core/editor-components/src/types.ts
+++ b/packages/packages/core/editor-components/src/types.ts
@@ -65,4 +65,4 @@ type ComponentOverride = {
 export type ComponentOverridable = {
 	override_key: string;
 	origin_value: TransformablePropValue< string >;
-}
+};

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-plain-prop-type-inheritance.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-plain-prop-type-inheritance.php
@@ -15,6 +15,7 @@ class Test_Plain_Prop_Type_Inheritance extends TestCase
 		'Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type',
 		'Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Prop_Type',
 		'Elementor\Modules\Components\PropTypes\Component_Instance_Prop_Type',
+		'Elementor\Modules\Components\PropTypes\Component_Overridable_Prop_Type'
 	];
 
 	const ALLOWED_PROP_KINDS = [

--- a/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-widget-base.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-widget-base.php
@@ -16,6 +16,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
+use Elementor\Modules\Components\PropTypes\Component_Overridable_Prop_Type;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -349,7 +350,8 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 		$schema = [
 			'string_prop' => String_Prop_Type::make()
 				->enum( [ 'value-a', 'value-b' ] )
-				->default( 'value-a' ),
+				->default( 'value-a' )
+				->meta( Component_Overridable_Prop_Type::ignore() ),
 		];
 
 		$widget = $this->make_mock_widget( [ 'props_schema' => $schema ] );

--- a/tests/phpunit/elementor/modules/components/prop-types/test-component-overridable-prop-type.php
+++ b/tests/phpunit/elementor/modules/components/prop-types/test-component-overridable-prop-type.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Elementor\Testing\Modules\Components\PropTypes;
+
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Component_Overridable_Prop_Type;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Component_Overridable_Prop_Type extends Elementor_Test_Base {
+
+	public function test_validate__passes_with_origin_value_matching_origin_prop_type() {
+		// Arrange
+		$prop_type = Component_Overridable_Prop_Type::make()
+			->set_origin_prop_type( String_Prop_Type::make() );
+
+		// Act
+		$result = $prop_type->validate( [
+			'$$type' => 'component-overridable',
+			'value' => [
+				'override_key' => 'my-override-key',
+				'origin_value' => [ '$$type' => 'string', 'value' => 'Default Text' ],
+			],
+		] );
+
+		// Assert
+		$this->assertTrue( $result );
+	}
+
+	public function invalid_structure_data_provider() {
+		return [
+			'non-array value' => [ 'not-an-array' ],
+			'missing_override_key' => [ [
+				'origin_value' => [ '$$type' => 'string', 'value' => 'Default Text' ],
+			] ],
+			'non-string override_key' => [ [
+				'override_key' => 123,
+				'origin_value' => [ '$$type' => 'string', 'value' => 'Default Text' ],
+			] ],
+			'missing_origin_value' => [ [
+				'override_key' => 'my-override-key',
+			] ],
+			'non-array origin_value' => [ [
+				'override_key' => 'my-override-key',
+				'origin_value' => 'not-an-array',
+			] ],
+		];
+	}
+
+	/**
+	 * @dataProvider invalid_structure_data_provider
+	 */
+	public function test_validate__fail_for_invalid_structure( $value ) {
+		// Arrange
+		$prop_type = Component_Overridable_Prop_Type::make()
+			->set_origin_prop_type( String_Prop_Type::make() );
+
+		// Act.
+		$result = $prop_type->validate( $value );
+
+		// Assert.
+		$this->assertFalse( $result );
+	}
+
+	public function test_validate__fails_when_origin_value_invalid_against_origin_prop_type() {
+		// Arrange
+		$prop_type = Component_Overridable_Prop_Type::make()
+			->set_origin_prop_type( 
+				String_Prop_Type::make()
+					->enum( [ 'p', 'span' ] )
+					->default( 'p' ) 
+			);
+
+		// Act
+		$result = $prop_type->validate( [
+			'$$type' => 'component-overridable',
+			'value' => [
+				'override_key' => 'my-key',
+				'origin_value' => [ '$$type' => 'string', 'value' => 'not-in-enum' ],
+			],
+		] );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function test_validate__fails_when_origin_prop_type_not_set() {
+		// Arrange
+		$prop_type = Component_Overridable_Prop_Type::make();
+
+		// Act
+		$result = $prop_type->validate( [
+			'$$type' => 'component-overridable',
+			'value' => [
+				'override_key' => 'my-key',
+				'origin_value' => [ '$$type' => 'string', 'value' => 'Default Text' ],
+			],
+		] );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function test_sanitize__sanitizes_override_key_and_origin_value() {
+		// Arrange
+		$prop_type = Component_Overridable_Prop_Type::make()
+			->set_origin_prop_type( String_Prop_Type::make() );
+
+		// Act
+		$result = $prop_type->sanitize( [
+			'$$type' => 'component-overridable',
+			'value' => [
+				'override_key' => ' <script>alert(1)</script>my-key ',
+				'origin_value' => [ '$$type' => 'string', 'value' => '<script>alert(2)</script>Text' ],
+			],
+		] );
+
+		// Assert
+		$this->assertEquals( [
+			'$$type' => 'component-overridable',
+			'value' => [
+				'override_key' => 'my-key',
+				'origin_value' => [ '$$type' => 'string', 'value' => 'Text' ],
+			],
+		], $result );
+	}
+}

--- a/tests/phpunit/elementor/modules/components/prop-types/test-component-overridable-prop-type.php
+++ b/tests/phpunit/elementor/modules/components/prop-types/test-component-overridable-prop-type.php
@@ -20,7 +20,7 @@ class Test_Component_Overridable_Prop_Type extends Elementor_Test_Base {
 
 		// Act
 		$result = $prop_type->validate( [
-			'$$type' => 'component-overridable',
+			'$$type' => 'overridable',
 			'value' => [
 				'override_key' => 'my-override-key',
 				'origin_value' => [ '$$type' => 'string', 'value' => 'Default Text' ],
@@ -77,7 +77,7 @@ class Test_Component_Overridable_Prop_Type extends Elementor_Test_Base {
 
 		// Act
 		$result = $prop_type->validate( [
-			'$$type' => 'component-overridable',
+			'$$type' => 'overridable',
 			'value' => [
 				'override_key' => 'my-key',
 				'origin_value' => [ '$$type' => 'string', 'value' => 'not-in-enum' ],
@@ -94,7 +94,7 @@ class Test_Component_Overridable_Prop_Type extends Elementor_Test_Base {
 
 		// Act
 		$result = $prop_type->validate( [
-			'$$type' => 'component-overridable',
+			'$$type' => 'overridable',
 			'value' => [
 				'override_key' => 'my-key',
 				'origin_value' => [ '$$type' => 'string', 'value' => 'Default Text' ],
@@ -112,7 +112,7 @@ class Test_Component_Overridable_Prop_Type extends Elementor_Test_Base {
 
 		// Act
 		$result = $prop_type->sanitize( [
-			'$$type' => 'component-overridable',
+			'$$type' => 'overridable',
 			'value' => [
 				'override_key' => ' <script>alert(1)</script>my-key ',
 				'origin_value' => [ '$$type' => 'string', 'value' => '<script>alert(2)</script>Text' ],
@@ -121,7 +121,7 @@ class Test_Component_Overridable_Prop_Type extends Elementor_Test_Base {
 
 		// Assert
 		$this->assertEquals( [
-			'$$type' => 'component-overridable',
+			'$$type' => 'overridable',
 			'value' => [
 				'override_key' => 'my-key',
 				'origin_value' => [ '$$type' => 'string', 'value' => 'Text' ],

--- a/tests/phpunit/elementor/modules/components/test-component-overridable-schema-extender.php
+++ b/tests/phpunit/elementor/modules/components/test-component-overridable-schema-extender.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Elementor\Testing\Modules\Components;
+
+use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Image_Src_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Url_Prop_Type;
+use Elementor\Modules\Components\Component_Overridable_Schema_Extender;
+use Elementor\Modules\Components\PropTypes\Component_Overridable_Prop_Type;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Component_Overridable_Schema_Extender extends Elementor_Test_Base {
+
+	public function set_up() {
+		parent::set_up();
+	}
+
+	/**
+	 * @dataProvider add_component_overridable_prop_type_data_provider
+	 */
+	public function test_get_extended_schema__adds_component_overridable_to_props( Prop_Type $prop ) {
+		// Arrange
+		$extender = Component_Overridable_Schema_Extender::make();
+
+		// Act
+		$schema = $extender->get_extended_schema( [
+			'prop' => $prop
+		] );
+
+		// Assert
+		$this->assertInstanceof( Union_Prop_Type::class, $schema['prop'] );
+		$this->assertEquals( $prop->get_default(), $schema['prop']->get_default() );
+		$this->assertEquals( [ $prop->get_key(),'component-overridable'], array_keys($schema['prop']->get_prop_types() ));
+
+        $union = $schema['prop'];
+            
+        $this->assertEquals( $prop, $union->get_prop_type( $prop->get_key() ) );
+        $this->assertEquals( $prop, $union->get_prop_type( 'component-overridable' )->get_origin_prop_type() );
+	}
+
+	public function test_get_extended_schema__adds_recursively_to_object_types() {
+		// Arrange
+		$extender = Component_Overridable_Schema_Extender::make();
+
+		$prop = new class extends Object_Prop_Type {
+			public static function get_key(): string {
+				return 'test-prop';
+			}
+
+			protected function define_shape(): array {
+				return [
+					'internal' => String_Prop_Type::make()->default( 'test' ),
+				];
+			}
+		};
+
+		// Act
+		$schema = $extender->get_extended_schema( [
+			'prop' => $prop
+		] );
+
+		// Assert
+        // 'prop' is a union prop type, and it has two prop types: the original 'test-prop' and 'component-overridable'
+		$this->assertInstanceof( Union_Prop_Type::class, $schema['prop'] );
+		$this->assertEquals( ['test-prop','component-overridable'], array_keys($schema['prop']->get_prop_types() ));
+
+        // 'component-overridable' has the original 'test-prop' prop type as its origin prop type
+        $override_component_overridable_prop_type = $schema['prop']->get_prop_type( 'component-overridable' );
+        $this->assertEquals( $prop, $override_component_overridable_prop_type->get_origin_prop_type() );
+
+        $test_prop_prop_type = $schema['prop']->get_prop_type( 'test-prop' );
+        $internal = $test_prop_prop_type->get_shape_field( 'internal' );
+
+        // 'internal' is a union prop type, and it has two prop types: the original 'string' and 'component-overridable'
+		$this->assertInstanceof( Union_Prop_Type::class, $internal );
+        $this->assertEquals( ['string','component-overridable'], array_keys($internal->get_prop_types() ));
+
+        // 'string' is the original string prop type, and it has the default value 'test'
+        $internal_string_prop_type = $internal->get_prop_type( 'string' );
+        $this->assertEquals( 'test', $internal_string_prop_type->get_default()['value'] );
+
+        // 'component-overridable' has the original 'string' with default value 'test' prop type as its origin prop type
+        $internal_component_overridable_prop_type = $internal->get_prop_type( 'component-overridable' );
+        $this->assertEquals( String_Prop_Type::make()->default( 'test' ), $internal_component_overridable_prop_type->get_origin_prop_type() );
+	}
+
+	public function test_get_extended_schema__adds_to_existing_union_prop_type() {
+		// Arrange
+		$extender = Component_Overridable_Schema_Extender::make();
+
+		$union_prop = Union_Prop_Type::make()
+			->add_prop_type( String_Prop_Type::make() )
+			->add_prop_type( Number_Prop_Type::make() )
+			->default( String_Prop_Type::generate( 'test' ) );
+
+		// Act
+		$schema = $extender->get_extended_schema( [
+			'prop' => $union_prop
+		] );
+
+		// Assert
+		$this->assertInstanceof( Union_Prop_Type::class, $schema['prop'] );
+		$this->assertInstanceof( 
+			Component_Overridable_Prop_Type::class, 
+			$schema['prop']->get_prop_type( Component_Overridable_Prop_Type::get_key() ) 
+		);
+		$this->assertInstanceof( 
+			String_Prop_Type::class, 
+			$schema['prop']->get_prop_type( String_Prop_Type::get_key() ) 
+		);
+		$this->assertInstanceof( 
+			Number_Prop_Type::class, 
+			$schema['prop']->get_prop_type( Number_Prop_Type::get_key() ) 
+		);
+        $this->assertEquals( String_Prop_Type::generate( 'test' ), $schema['prop']->get_default() );
+	}
+
+    public function test_get_extended_schema__skips_prop_types_that_ignore_component_overridable() {
+		// Arrange
+		$extender = Component_Overridable_Schema_Extender::make();
+
+		$prop1 = String_Prop_Type::make()
+			->meta( Component_Overridable_Prop_Type::ignore() )
+			->default( 'default-value' );
+
+		$prop2 = String_Prop_Type::make()
+			->meta( Component_Overridable_Prop_Type::META_KEY, false )
+			->default( 'default-value' );
+
+		// Act
+		$schema = $extender->get_extended_schema( [
+			'prop1' => $prop1,
+			'prop2' => $prop2,
+		] );
+
+		// Assert
+		$this->assertSame( [ 'prop1' => $prop1, 'prop2' => $prop2 ], $schema );
+	}
+
+	public function add_component_overridable_prop_type_data_provider() {
+		return [
+			'string' => [
+				String_Prop_Type::make()->default( 'test' ),
+			],
+
+			'number' => [
+				Number_Prop_Type::make()->default( 0 ),
+			],
+
+			'image-src' => [
+				Image_Src_Prop_Type::make(),
+			],
+
+			'url' => [
+				Url_Prop_Type::make()->default( 'http://example.com' ),
+			],
+		];
+	}
+}
+

--- a/tests/phpunit/elementor/modules/components/test-component-overridable-schema-extender.php
+++ b/tests/phpunit/elementor/modules/components/test-component-overridable-schema-extender.php
@@ -38,7 +38,7 @@ class Test_Component_Overridable_Schema_Extender extends Elementor_Test_Base {
 		// Assert
 		$this->assertInstanceof( Union_Prop_Type::class, $schema['prop'] );
 		$this->assertEquals( $prop->get_default(), $schema['prop']->get_default() );
-		$this->assertEquals( [ $prop->get_key(),'component-overridable'], array_keys($schema['prop']->get_prop_types() ));
+		$this->assertEquals( [ $prop->get_key(), 'component-overridable' ], array_keys( $schema[ 'prop' ]->get_prop_types() ) );
 
         $union = $schema['prop'];
             
@@ -70,7 +70,7 @@ class Test_Component_Overridable_Schema_Extender extends Elementor_Test_Base {
 		// Assert
         // 'prop' is a union prop type, and it has two prop types: the original 'test-prop' and 'component-overridable'
 		$this->assertInstanceof( Union_Prop_Type::class, $schema['prop'] );
-		$this->assertEquals( ['test-prop','component-overridable'], array_keys($schema['prop']->get_prop_types() ));
+		$this->assertEquals( [ 'test-prop', 'component-overridable' ], array_keys( $schema['prop']->get_prop_types() ));
 
         // 'component-overridable' has the original 'test-prop' prop type as its origin prop type
         $override_component_overridable_prop_type = $schema['prop']->get_prop_type( 'component-overridable' );
@@ -81,11 +81,11 @@ class Test_Component_Overridable_Schema_Extender extends Elementor_Test_Base {
 
         // 'internal' is a union prop type, and it has two prop types: the original 'string' and 'component-overridable'
 		$this->assertInstanceof( Union_Prop_Type::class, $internal );
-        $this->assertEquals( ['string','component-overridable'], array_keys($internal->get_prop_types() ));
+        $this->assertEquals( [ 'string', 'component-overridable' ], array_keys( $internal->get_prop_types() ));
 
         // 'string' is the original string prop type, and it has the default value 'test'
         $internal_string_prop_type = $internal->get_prop_type( 'string' );
-        $this->assertEquals( 'test', $internal_string_prop_type->get_default()['value'] );
+        $this->assertEquals( 'test', $internal_string_prop_type->get_default()[ 'value' ] );
 
         // 'component-overridable' has the original 'string' with default value 'test' prop type as its origin prop type
         $internal_component_overridable_prop_type = $internal->get_prop_type( 'component-overridable' );

--- a/tests/phpunit/elementor/modules/components/test-component-overridable-schema-extender.php
+++ b/tests/phpunit/elementor/modules/components/test-component-overridable-schema-extender.php
@@ -38,12 +38,12 @@ class Test_Component_Overridable_Schema_Extender extends Elementor_Test_Base {
 		// Assert
 		$this->assertInstanceof( Union_Prop_Type::class, $schema['prop'] );
 		$this->assertEquals( $prop->get_default(), $schema['prop']->get_default() );
-		$this->assertEquals( [ $prop->get_key(), 'component-overridable' ], array_keys( $schema[ 'prop' ]->get_prop_types() ) );
+		$this->assertEquals( [ $prop->get_key(), 'overridable' ], array_keys( $schema[ 'prop' ]->get_prop_types() ) );
 
         $union = $schema['prop'];
             
         $this->assertEquals( $prop, $union->get_prop_type( $prop->get_key() ) );
-        $this->assertEquals( $prop, $union->get_prop_type( 'component-overridable' )->get_origin_prop_type() );
+        $this->assertEquals( $prop, $union->get_prop_type( 'overridable' )->get_origin_prop_type() );
 	}
 
 	public function test_get_extended_schema__adds_recursively_to_object_types() {
@@ -68,27 +68,27 @@ class Test_Component_Overridable_Schema_Extender extends Elementor_Test_Base {
 		] );
 
 		// Assert
-        // 'prop' is a union prop type, and it has two prop types: the original 'test-prop' and 'component-overridable'
+        // 'prop' is a union prop type, and it has two prop types: the original 'test-prop' and 'overridable'
 		$this->assertInstanceof( Union_Prop_Type::class, $schema['prop'] );
-		$this->assertEquals( [ 'test-prop', 'component-overridable' ], array_keys( $schema['prop']->get_prop_types() ));
+		$this->assertEquals( [ 'test-prop', 'overridable' ], array_keys( $schema['prop']->get_prop_types() ));
 
-        // 'component-overridable' has the original 'test-prop' prop type as its origin prop type
-        $override_component_overridable_prop_type = $schema['prop']->get_prop_type( 'component-overridable' );
+        // 'overridable' has the original 'test-prop' prop type as its origin prop type
+        $override_component_overridable_prop_type = $schema['prop']->get_prop_type( 'overridable' );
         $this->assertEquals( $prop, $override_component_overridable_prop_type->get_origin_prop_type() );
 
         $test_prop_prop_type = $schema['prop']->get_prop_type( 'test-prop' );
         $internal = $test_prop_prop_type->get_shape_field( 'internal' );
 
-        // 'internal' is a union prop type, and it has two prop types: the original 'string' and 'component-overridable'
+        // 'internal' is a union prop type, and it has two prop types: the original 'string' and 'overridable'
 		$this->assertInstanceof( Union_Prop_Type::class, $internal );
-        $this->assertEquals( [ 'string', 'component-overridable' ], array_keys( $internal->get_prop_types() ));
+        $this->assertEquals( [ 'string', 'overridable' ], array_keys( $internal->get_prop_types() ));
 
         // 'string' is the original string prop type, and it has the default value 'test'
         $internal_string_prop_type = $internal->get_prop_type( 'string' );
         $this->assertEquals( 'test', $internal_string_prop_type->get_default()[ 'value' ] );
 
-        // 'component-overridable' has the original 'string' with default value 'test' prop type as its origin prop type
-        $internal_component_overridable_prop_type = $internal->get_prop_type( 'component-overridable' );
+        // 'overridable' has the original 'string' with default value 'test' prop type as its origin prop type
+        $internal_component_overridable_prop_type = $internal->get_prop_type( 'overridable' );
         $this->assertEquals( String_Prop_Type::make()->default( 'test' ), $internal_component_overridable_prop_type->get_origin_prop_type() );
 	}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add Component Overridable prop type to enable overriding component properties with custom values while maintaining component schema integrity.
Main changes:
- Created Component_Overridable_Prop_Type class with validation, sanitization, and origin prop type reference
- Implemented Component_Overridable_Schema_Extender for automatically extending prop schemas
- Added transformers for processing component overridable values at runtime
- Fixed Dynamic_Prop_Types_Mapping to use new schema extension pattern

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-21778]: https://elementor.atlassian.net/browse/ED-21778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ