### PR TITLE
Internal: Remove enforcing linter

### DIFF
--- a/packages/.eslintrc.js
+++ b/packages/.eslintrc.js
@@ -57,7 +57,6 @@ module.exports = {
 		// This is set to `warn` by WordPress, but we want to enforce it.
 		'react-hooks/exhaustive-deps': 'error',
 
-		'react-compiler/react-compiler': 'error',
 
 		// Styling rules:
 		'@typescript-eslint/consistent-type-imports': [


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove the react-compiler/react-compiler linter rule from ESLint configuration to stop enforcing React compiler checks.
Main changes:
- Removed 'react-compiler/react-compiler': 'error' rule from .eslintrc.js configuration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
