### PR TITLE
Internal: Add overridable prop indicator in setting fields [ED-21251]

### DIFF
--- a/packages/packages/core/editor-components/package.json
+++ b/packages/packages/core/editor-components/package.json
@@ -42,7 +42,9 @@
   "dependencies": {
     "@elementor/editor": "3.33.0",
     "@elementor/editor-canvas": "3.33.0",
+    "@elementor/editor-controls": "3.33.0",
     "@elementor/editor-documents": "^3.33.0",
+    "@elementor/editor-editing-panel": "3.33.0",
     "@elementor/editor-elements": "3.33.0",
     "@elementor/editor-elements-panel": "3.33.0",
     "@elementor/editor-props": "3.33.0",

--- a/packages/packages/core/editor-components/src/components/overridable-props/__tests__/overridable-prop-indicator.test.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/__tests__/overridable-prop-indicator.test.tsx
@@ -1,0 +1,157 @@
+import * as React from 'react';
+import { createMockDocumentData, createMockPropType } from 'test-utils';
+import { useBoundProp } from '@elementor/editor-controls';
+import { getV1CurrentDocument } from '@elementor/editor-documents';
+import { useElement } from '@elementor/editor-editing-panel';
+import { type PropValue } from '@elementor/editor-props';
+import { __createStore, __registerSlice } from '@elementor/store';
+import { ThemeProvider } from '@elementor/ui';
+import { generateUniqueId } from '@elementor/utils';
+import { render, screen } from '@testing-library/react';
+
+import { componentOverridablePropTypeUtil } from '../../../prop-types/component-overridable-prop-type';
+import { selectOverridableProps, slice } from '../../../store/store';
+import { COMPONENT_DOCUMENT_TYPE } from '../../consts';
+import { FORBIDDEN_KEYS, OverridablePropIndicator } from '../overridable-prop-indicator';
+
+jest.mock( '@elementor/editor-controls', () => ( {
+	...jest.requireActual( '@elementor/editor-controls' ),
+	useBoundProp: jest.fn(),
+} ) );
+jest.mock( '@elementor/editor-documents' );
+jest.mock( '@elementor/editor-editing-panel', () => ( {
+	...jest.requireActual( '@elementor/editor-editing-panel' ),
+	useElement: jest.fn(),
+} ) );
+jest.mock( '../../../store/store', () => ( {
+	...jest.requireActual( '../../../store/store' ),
+	selectOverridableProps: jest.fn(),
+} ) );
+
+const MOCK_ELEMENT_ID = 'test-element-123';
+const MOCK_COMPONENT_ID = 456;
+const MOCK_WIDGET_TYPE = 'e-heading';
+
+describe( 'OverridablePropIndicator', () => {
+	beforeEach( () => {
+		__registerSlice( slice );
+		__createStore();
+
+		jest.mocked( useElement ).mockReturnValue( {
+			element: { id: MOCK_ELEMENT_ID, type: MOCK_WIDGET_TYPE },
+			elementType: { key: MOCK_WIDGET_TYPE, propsSchema: {}, controls: [], title: 'Test Element' },
+		} );
+
+		jest.mocked( selectOverridableProps ).mockReturnValue( {
+			props: {},
+			groups: {
+				items: {},
+				order: [],
+			},
+		} );
+	} );
+
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	it.each( [
+		{
+			should: 'not show indicator on fields when not editing a component',
+			bind: 'title',
+			isOverridable: false,
+			isComponent: false,
+		},
+		{
+			should: 'be a plus icon if prop is not overridable',
+			bind: 'title',
+			isOverridable: false,
+			isComponent: true,
+		},
+		{
+			should: 'be a check icon if prop is overridable',
+			bind: 'title',
+			isOverridable: true,
+			isComponent: true,
+		},
+		{
+			should: 'not show indicator on fields bound to forbidden keys',
+			bind: '_cssid',
+			isOverridable: true,
+			isComponent: true,
+		},
+	] )( 'should $should', ( { bind, isOverridable, isComponent } ) => {
+		// Arrange
+		const mockDocument = createMockDocumentData( {
+			id: MOCK_COMPONENT_ID,
+			type: isComponent ? COMPONENT_DOCUMENT_TYPE : 'wp-page',
+		} );
+
+		jest.mocked( getV1CurrentDocument ).mockReturnValue( mockDocument );
+		jest.mocked( useBoundProp ).mockReturnValue(
+			mockPropType(
+				{
+					bind,
+					value: { $$type: 'string', value: 'Test' },
+				},
+				isOverridable
+			)
+		);
+
+		// Act
+		renderFieldWithIndicator();
+
+		// Assert
+		if ( ! isComponent ) {
+			expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+
+			return;
+		}
+
+		if ( FORBIDDEN_KEYS.includes( bind ) ) {
+			expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+
+			return;
+		}
+
+		const indicator = screen.getByLabelText( isOverridable ? 'Overridable property' : 'Make prop overridable' );
+		expect( indicator ).toBeInTheDocument();
+	} );
+} );
+
+function mockPropType(
+	{ bind, value }: { bind: string; value: PropValue },
+	isOverridableType: boolean
+): ReturnType< typeof useBoundProp > {
+	const params = {
+		value,
+		setValue: jest.fn(),
+		restoreValue: jest.fn(),
+		resetValue: jest.fn(),
+		bind,
+		propType: createMockPropType( { kind: 'plain' } ),
+		path: [ bind ],
+	};
+
+	if ( ! isOverridableType ) {
+		return params;
+	}
+
+	const overridablePropValue = componentOverridablePropTypeUtil.create( {
+		override_key: generateUniqueId(),
+		default_value: value,
+	} );
+
+	return {
+		...params,
+		value: overridablePropValue,
+	};
+}
+
+function renderFieldWithIndicator() {
+	return render(
+		<ThemeProvider>
+			<OverridablePropIndicator />
+		</ThemeProvider>
+	);
+}

--- a/packages/packages/core/editor-components/src/components/overridable-props/indicator.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/indicator.tsx
@@ -1,11 +1,30 @@
 import * as React from 'react';
+import { forwardRef } from 'react';
 import { CheckIcon, PlusIcon } from '@elementor/icons';
 import { type bindTrigger, Box, styled } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 const SIZE = 'tiny';
 
-const IconWrapper = styled( Box )`
+const IconContainer = styled( Box )`
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 0.2s ease-in-out;
+
+	& > svg {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
+		width: 10px;
+		height: 10px;
+		fill: ${ ( { theme } ) => theme.palette.primary.contrastText };
+		stroke: ${ ( { theme } ) => theme.palette.primary.contrastText };
+		stroke-width: 2px;
+	}
+`;
+
+const Content = styled( Box )`
 	position: relative;
 	display: flex;
 	align-items: center;
@@ -43,29 +62,13 @@ const IconWrapper = styled( Box )`
 	}
 `;
 
-const IconContainer = styled( Box )`
-	pointer-events: none;
-	opacity: 0;
-	transition: opacity 0.2s ease-in-out;
-
-	& > svg {
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		transform: translate( -50%, -50% );
-		width: 10px;
-		height: 10px;
-		fill: ${ ( { theme } ) => theme.palette.primary.contrastText };
-	}
-`;
-
 type Props = {
 	isOverridable: boolean;
 	triggerProps: ReturnType< typeof bindTrigger >;
 	isOpen: boolean;
 };
-export const Indicator = ( { triggerProps, isOpen, isOverridable }: Props ) => (
-	<IconWrapper { ...triggerProps } className={ isOpen || isOverridable ? 'enlarged' : '' }>
+export const Indicator = forwardRef< HTMLDivElement, Props >( ( { triggerProps, isOpen, isOverridable }, ref ) => (
+	<Content ref={ ref } { ...triggerProps } className={ isOpen || isOverridable ? 'enlarged' : '' }>
 		<IconContainer
 			className="icon"
 			aria-label={
@@ -74,5 +77,5 @@ export const Indicator = ( { triggerProps, isOpen, isOverridable }: Props ) => (
 		>
 			{ isOverridable ? <CheckIcon fontSize={ SIZE } /> : <PlusIcon fontSize={ SIZE } /> }
 		</IconContainer>
-	</IconWrapper>
-);
+	</Content>
+) );

--- a/packages/packages/core/editor-components/src/components/overridable-props/indicator.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/indicator.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { CheckIcon, PlusIcon } from '@elementor/icons';
+import { type bindTrigger, Box, styled } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+const SIZE = 'tiny';
+
+const IconWrapper = styled( Box )`
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	width: 16px;
+	height: 16px;
+	margin-inline: ${ ( { theme } ) => theme.spacing( 0.5 ) };
+
+	&:before {
+		content: '';
+		display: block;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% ) rotate( 45deg );
+		width: 5px;
+		height: 5px;
+		border-radius: 1px;
+		background-color: ${ ( { theme } ) => theme.palette.primary.main };
+		transition: all 0.1s ease-in-out;
+	}
+
+	&:hover,
+	&.enlarged {
+		&:before {
+			width: 12px;
+			height: 12px;
+			border-radius: 2px;
+		}
+
+		.icon {
+			opacity: 1;
+		}
+	}
+`;
+
+const IconContainer = styled( Box )`
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 0.2s ease-in-out;
+
+	& > svg {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
+		width: 10px;
+		height: 10px;
+		fill: ${ ( { theme } ) => theme.palette.primary.contrastText };
+	}
+`;
+
+type Props = {
+	isOverridable: boolean;
+	triggerProps: ReturnType< typeof bindTrigger >;
+	isOpen: boolean;
+};
+export const Indicator = ( { triggerProps, isOpen, isOverridable }: Props ) => (
+	<IconWrapper { ...triggerProps } className={ isOpen || isOverridable ? 'enlarged' : '' }>
+		<IconContainer
+			className="icon"
+			aria-label={
+				isOverridable ? __( 'Overridable property', 'elementor' ) : __( 'Make prop overridable', 'elementor' )
+			}
+		>
+			{ isOverridable ? <CheckIcon fontSize={ SIZE } /> : <PlusIcon fontSize={ SIZE } /> }
+		</IconContainer>
+	</IconWrapper>
+);

--- a/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-indicator.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-indicator.tsx
@@ -84,7 +84,7 @@ export function Content( { componentId, isOverridable, overridables }: Props ) {
 				} }
 				{ ...popoverProps }
 			>
-				{ JSON.stringify( currentValue ) /** TODO: replace with actual form */}
+				{ JSON.stringify( currentValue ) /** TODO: replace with actual form */ }
 			</Popover>
 		</>
 	);

--- a/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-indicator.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-indicator.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { useBoundProp } from '@elementor/editor-controls';
+import { getV1CurrentDocument } from '@elementor/editor-documents';
+import { useElement } from '@elementor/editor-editing-panel';
+import { __getState as getState } from '@elementor/store';
+import { bindPopover, bindTrigger, Popover, Tooltip, usePopupState } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import { componentOverridablePropTypeUtil } from '../../prop-types/component-overridable-prop-type';
+import { selectOverridableProps } from '../../store/store';
+import { type OverridableProps } from '../../types';
+import { COMPONENT_DOCUMENT_TYPE } from '../consts';
+import { Indicator } from './indicator';
+
+export const FORBIDDEN_KEYS = [ '_cssid', 'attributes' ];
+
+export function OverridablePropIndicator() {
+	const { bind, value } = useBoundProp();
+	const currentDocument = getV1CurrentDocument();
+	const componentOverrides = selectOverridableProps( getState(), currentDocument.id );
+
+	if ( currentDocument.config.type !== COMPONENT_DOCUMENT_TYPE || ! currentDocument.id ) {
+		return null;
+	}
+
+	if ( ! isPropAllowed( bind ) ) {
+		return null;
+	}
+
+	const isOverridable = componentOverridablePropTypeUtil.isValid( value );
+	return (
+		<Content
+			componentId={ currentDocument.id }
+			isOverridable={ isOverridable }
+			overridables={ componentOverrides }
+		/>
+	);
+}
+
+type Props = {
+	componentId: number;
+	isOverridable: boolean;
+	overridables?: OverridableProps;
+};
+export function Content( { componentId, isOverridable, overridables }: Props ) {
+	const {
+		element: { id: elementId },
+		elementType,
+	} = useElement();
+	const { bind } = useBoundProp();
+
+	const popupState = usePopupState( {
+		variant: 'popover',
+	} );
+
+	const triggerProps = bindTrigger( popupState );
+	const popoverProps = bindPopover( popupState );
+
+	const currentValue = Object.values( overridables?.props ?? {} ).find(
+		( prop ) => prop.elementId === elementId && prop.propKey === bind
+	);
+
+	return (
+		<>
+			<Tooltip placement="top" title={ __( 'Override Property', 'elementor' ) }>
+				<Indicator
+					triggerProps={ triggerProps }
+					isOpen={ !! popoverProps.open }
+					isOverridable={ isOverridable }
+				/>
+			</Tooltip>
+			<Popover
+				disableScrollLock
+				anchorOrigin={ {
+					vertical: 'bottom',
+					horizontal: 'right',
+				} }
+				transformOrigin={ {
+					vertical: 'top',
+					horizontal: 'right',
+				} }
+				PaperProps={ {
+					sx: { my: 2.5 },
+				} }
+				{ ...popoverProps }
+			>
+				{ JSON.stringify( currentValue ) /** TODO: replace with actual form */}
+			</Popover>
+		</>
+	);
+}
+
+function isPropAllowed( bind: string ) {
+	return ! FORBIDDEN_KEYS.includes( bind );
+}

--- a/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-indicator.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-indicator.tsx
@@ -42,10 +42,9 @@ type Props = {
 	isOverridable: boolean;
 	overridables?: OverridableProps;
 };
-export function Content( { componentId, isOverridable, overridables }: Props ) {
+export function Content( { isOverridable, overridables }: Props ) {
 	const {
 		element: { id: elementId },
-		elementType,
 	} = useElement();
 	const { bind } = useBoundProp();
 

--- a/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-indicator.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-indicator.tsx
@@ -12,12 +12,11 @@ import { type OverridableProps } from '../../types';
 import { COMPONENT_DOCUMENT_TYPE } from '../consts';
 import { Indicator } from './indicator';
 
-export const FORBIDDEN_KEYS = [ '_cssid', 'attributes' ];
+const FORBIDDEN_KEYS = [ '_cssid', 'attributes' ];
 
 export function OverridablePropIndicator() {
 	const { bind, value } = useBoundProp();
 	const currentDocument = getV1CurrentDocument();
-	const componentOverrides = selectOverridableProps( getState(), currentDocument.id );
 
 	if ( currentDocument.config.type !== COMPONENT_DOCUMENT_TYPE || ! currentDocument.id ) {
 		return null;
@@ -27,12 +26,14 @@ export function OverridablePropIndicator() {
 		return null;
 	}
 
+	const overridableProps = selectOverridableProps( getState(), currentDocument.id );
 	const isOverridable = componentOverridablePropTypeUtil.isValid( value );
+
 	return (
 		<Content
 			componentId={ currentDocument.id }
 			isOverridable={ isOverridable }
-			overridables={ componentOverrides }
+			overridableProps={ overridableProps }
 		/>
 	);
 }
@@ -40,9 +41,9 @@ export function OverridablePropIndicator() {
 type Props = {
 	componentId: number;
 	isOverridable: boolean;
-	overridables?: OverridableProps;
+	overridableProps?: OverridableProps;
 };
-export function Content( { isOverridable, overridables }: Props ) {
+export function Content( { isOverridable, overridableProps }: Props ) {
 	const {
 		element: { id: elementId },
 	} = useElement();
@@ -55,7 +56,7 @@ export function Content( { isOverridable, overridables }: Props ) {
 	const triggerProps = bindTrigger( popupState );
 	const popoverProps = bindPopover( popupState );
 
-	const currentValue = Object.values( overridables?.props ?? {} ).find(
+	const overridableConfig = Object.values( overridableProps?.props ?? {} ).find(
 		( prop ) => prop.elementId === elementId && prop.propKey === bind
 	);
 
@@ -83,7 +84,7 @@ export function Content( { isOverridable, overridables }: Props ) {
 				} }
 				{ ...popoverProps }
 			>
-				{ JSON.stringify( currentValue ) /** TODO: replace with actual form */ }
+				{ JSON.stringify( overridableConfig ) /** TODO: replace with actual form */ }
 			</Popover>
 		</>
 	);

--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -5,6 +5,7 @@ import {
 	settingsTransformersRegistry,
 } from '@elementor/editor-canvas';
 import { getV1CurrentDocument } from '@elementor/editor-documents';
+import { FIELD_TYPE, registerFieldIndicator } from '@elementor/editor-editing-panel';
 import { type V1ElementData } from '@elementor/editor-elements';
 import { injectTab } from '@elementor/editor-elements-panel';
 import { stylesRepository } from '@elementor/editor-styles-repository';
@@ -17,6 +18,7 @@ import { Components } from './components/components-tab/components';
 import { CreateComponentForm } from './components/create-component-form/create-component-form';
 import { EditComponent } from './components/edit-component/edit-component';
 import { openEditModeDialog } from './components/in-edit-mode';
+import { OverridablePropIndicator } from './components/overridable-props/overridable-prop-indicator';
 import { createComponentType, TYPE } from './create-component-type';
 import { PopulateStore } from './populate-store';
 import { componentsStylesProvider } from './store/components-styles-provider';
@@ -79,6 +81,13 @@ export function init() {
 		}
 
 		loadComponentsStyles( ( config?.elements as V1ElementData[] ) ?? [] );
+	} );
+
+	registerFieldIndicator( {
+		fieldType: FIELD_TYPE.SETTINGS,
+		id: 'component-overridable-prop',
+		priority: 1,
+		indicator: OverridablePropIndicator,
 	} );
 
 	settingsTransformersRegistry.register( 'component-instance', componentInstanceTransformer );

--- a/packages/packages/core/editor-components/src/prop-types/component-overridable-prop-type.ts
+++ b/packages/packages/core/editor-components/src/prop-types/component-overridable-prop-type.ts
@@ -1,0 +1,10 @@
+import { createPropUtils } from '@elementor/editor-props';
+import { z } from '@elementor/schema';
+
+export const componentOverridablePropTypeUtil = createPropUtils(
+	'component-overridable',
+	z.object( {
+		override_key: z.string(),
+		default_value: z.any().nullable(),
+	} )
+);

--- a/packages/packages/core/editor-components/src/prop-types/component-overridable-prop-type.ts
+++ b/packages/packages/core/editor-components/src/prop-types/component-overridable-prop-type.ts
@@ -2,7 +2,7 @@ import { createPropUtils } from '@elementor/editor-props';
 import { z } from '@elementor/schema';
 
 export const componentOverridablePropTypeUtil = createPropUtils(
-	'component-overridable',
+	'overridable',
 	z.object( {
 		override_key: z.string(),
 		default_value: z

--- a/packages/packages/core/editor-components/src/prop-types/component-overridable-prop-type.ts
+++ b/packages/packages/core/editor-components/src/prop-types/component-overridable-prop-type.ts
@@ -5,6 +5,11 @@ export const componentOverridablePropTypeUtil = createPropUtils(
 	'component-overridable',
 	z.object( {
 		override_key: z.string(),
-		default_value: z.any().nullable(),
+		default_value: z
+			.object( {
+				$$type: z.string(),
+				value: z.unknown(),
+			} )
+			.nullable(),
 	} )
 );

--- a/packages/packages/core/editor-components/src/store/store.ts
+++ b/packages/packages/core/editor-components/src/store/store.ts
@@ -113,5 +113,5 @@ export const selectCreatedThisSession = createSelector(
 );
 export const selectOverridableProps = createSelector(
 	selectComponent,
-	( component: PublishedComponent | undefined ) => component?.overrides
+	( component: PublishedComponent | undefined ) => component?.overridableProps
 );

--- a/packages/packages/core/editor-components/src/store/store.ts
+++ b/packages/packages/core/editor-components/src/store/store.ts
@@ -88,6 +88,8 @@ const selectLoadStatus = ( state: ComponentsSlice ) => state[ SLICE_NAME ].loadS
 const selectStylesDefinitions = ( state: ComponentsSlice ) => state[ SLICE_NAME ].styles ?? {};
 const selectUnpublishedData = ( state: ComponentsSlice ) => state[ SLICE_NAME ].unpublishedData;
 const getCreatedThisSession = ( state: ComponentsSlice ) => state[ SLICE_NAME ].createdThisSession;
+const selectComponent = ( state: ComponentsSlice, componentId: ComponentId ) =>
+	state[ SLICE_NAME ].data.find( ( component ) => component.id === componentId );
 
 export const selectComponents = createSelector(
 	selectData,
@@ -108,4 +110,8 @@ export const selectFlatStyles = createSelector( selectStylesDefinitions, ( data 
 export const selectCreatedThisSession = createSelector(
 	getCreatedThisSession,
 	( createdThisSession ) => createdThisSession
+);
+export const selectOverridableProps = createSelector(
+	selectComponent,
+	( component: PublishedComponent | undefined ) => component?.overrides
 );

--- a/packages/packages/core/editor-components/src/types.ts
+++ b/packages/packages/core/editor-components/src/types.ts
@@ -21,10 +21,11 @@ export type UnpublishedComponent = BaseComponent & {
 };
 
 export type OverridableProp = {
-	'override-key': string;
+	overrideKey: string;
 	label: string;
 	elementId: string;
 	propKey: string;
+	elType: string;
 	widgetType: string;
 	defaultValue: PropValue;
 	groupId: string;
@@ -47,7 +48,7 @@ export type OverridableProps = {
 type BaseComponent = {
 	uid: string;
 	name: string;
-	overrides?: OverridableProps;
+	overridableProps?: OverridableProps;
 };
 
 export type DocumentStatus = 'publish' | 'draft';

--- a/packages/packages/core/editor-components/src/types.ts
+++ b/packages/packages/core/editor-components/src/types.ts
@@ -1,6 +1,5 @@
 import { type V1ElementData } from '@elementor/editor-elements';
-import { type PropValue } from '@elementor/editor-props';
-import { type TransformablePropValue } from '@elementor/editor-props';
+import { type PropValue, type TransformablePropValue } from '@elementor/editor-props';
 import type { StyleDefinition } from '@elementor/editor-styles';
 
 export type ComponentFormValues = {

--- a/packages/packages/core/editor-components/src/types.ts
+++ b/packages/packages/core/editor-components/src/types.ts
@@ -1,4 +1,5 @@
 import { type V1ElementData } from '@elementor/editor-elements';
+import { type PropValue } from '@elementor/editor-props';
 import { type TransformablePropValue } from '@elementor/editor-props';
 import type { StyleDefinition } from '@elementor/editor-styles';
 
@@ -20,9 +21,34 @@ export type UnpublishedComponent = BaseComponent & {
 	elements: V1ElementData[];
 };
 
+export type OverridableProp = {
+	'override-key': string;
+	label: string;
+	elementId: string;
+	propKey: string;
+	widgetType: string;
+	defaultValue: PropValue;
+	groupId: string;
+};
+
+export type OverridablePropGroup = {
+	id: string;
+	label: string;
+	props: string[];
+};
+
+export type OverridableProps = {
+	props: Record< string, OverridableProp >;
+	groups: {
+		items: Record< string, OverridablePropGroup >;
+		order: string[];
+	};
+};
+
 type BaseComponent = {
 	uid: string;
 	name: string;
+	overrides?: OverridableProps;
 };
 
 export type DocumentStatus = 'publish' | 'draft';

--- a/packages/packages/core/editor-editing-panel/src/components/settings-control.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/settings-control.tsx
@@ -14,11 +14,7 @@ const Wrapper = styled( 'span' )`
 	display: contents;
 `;
 
-export const SettingsControl = ( {
-	control: { value, type },
-}: {
-	control: Control | ElementControl;
-} ) => {
+export const SettingsControl = ( { control: { value, type } }: { control: Control | ElementControl } ) => {
 	if ( ! controlsRegistry.get( value.type as ControlType ) ) {
 		return null;
 	}
@@ -31,22 +27,12 @@ export const SettingsControl = ( {
 	}
 
 	if ( type === 'element-control' ) {
-		return (
-			<ControlLayout
-				control={ value }
-				layout={ layout }
-				controlProps={ controlProps }
-			/>
-		);
+		return <ControlLayout control={ value } layout={ layout } controlProps={ controlProps } />;
 	}
 
 	return (
 		<SettingsField bind={ value.bind } propDisplayName={ value.label || value.bind }>
-			<ControlLayout
-				control={ value }
-				layout={ layout }
-				controlProps={ controlProps }
-			/>
+			<ControlLayout control={ value } layout={ layout } controlProps={ controlProps } />
 		</SettingsField>
 	);
 };

--- a/packages/packages/core/editor-editing-panel/src/components/settings-control.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/settings-control.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { ControlAdornmentsProvider } from '@elementor/editor-controls';
+import { type Control, type ControlLayout, type ElementControl } from '@elementor/editor-elements';
+import { Divider, styled } from '@elementor/ui';
+
+import { Control as BaseControl } from '../controls-registry/control';
+import { ControlTypeContainer } from '../controls-registry/control-type-container';
+import { controlsRegistry, type ControlType } from '../controls-registry/controls-registry';
+import { SettingsField } from '../controls-registry/settings-field';
+import { getFieldIndicators } from '../field-indicators-registry';
+import { ControlLabel } from './control-label';
+
+const Wrapper = styled( 'span' )`
+	display: contents;
+`;
+
+export const SettingsControl = ( {
+	control: { value, type },
+}: {
+	control: Control | ElementControl;
+} ) => {
+	if ( ! controlsRegistry.get( value.type as ControlType ) ) {
+		return null;
+	}
+
+	const layout = value.meta?.layout || controlsRegistry.getLayout( value.type as ControlType );
+	const controlProps = populateChildControlProps( value.props );
+
+	if ( layout === 'custom' ) {
+		controlProps.label = value.label;
+	}
+
+	if ( type === 'element-control' ) {
+		return (
+			<ControlLayout
+				control={ value }
+				layout={ layout }
+				controlProps={ controlProps }
+			/>
+		);
+	}
+
+	return (
+		<SettingsField bind={ value.bind } propDisplayName={ value.label || value.bind }>
+			<ControlLayout
+				control={ value }
+				layout={ layout }
+				controlProps={ controlProps }
+			/>
+		</SettingsField>
+	);
+};
+
+const ControlLayout = ( {
+	control,
+	layout,
+	controlProps,
+}: {
+	control: Control[ 'value' ] | ElementControl[ 'value' ];
+	layout: ControlLayout;
+	controlProps: Record< string, unknown >;
+} ) => {
+	const controlType = control.type as ControlType;
+
+	return (
+		<ControlAdornmentsProvider items={ getFieldIndicators( 'settings' ) }>
+			{ control.meta?.topDivider && <Divider /> }
+			<Wrapper data-type="settings-field">
+				<ControlTypeContainer layout={ layout }>
+					{ control.label && layout !== 'custom' ? <ControlLabel>{ control.label }</ControlLabel> : null }
+					<BaseControl type={ controlType } props={ controlProps } />
+				</ControlTypeContainer>
+			</Wrapper>
+		</ControlAdornmentsProvider>
+	);
+};
+
+function populateChildControlProps( props: Record< string, unknown > ) {
+	if ( props.childControlType ) {
+		const childComponent = controlsRegistry.get( props.childControlType as ControlType );
+		const childPropType = controlsRegistry.getPropTypeUtil( props.childControlType as ControlType );
+		props = {
+			...props,
+			childControlConfig: {
+				component: childComponent,
+				props: props.childControlProps || {},
+				propTypeUtil: childPropType,
+			},
+		};
+	}
+
+	return props;
+}

--- a/packages/packages/core/editor-editing-panel/src/components/settings-tab.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/settings-tab.tsx
@@ -1,24 +1,12 @@
 import * as React from 'react';
-import { ControlAdornmentsProvider, ControlFormLabel } from '@elementor/editor-controls';
-import {
-	type Control,
-	type ControlItem,
-	type ControlLayout,
-	type Element,
-	type ElementControl,
-} from '@elementor/editor-elements';
+import { type Control, type ControlItem, type Element, type ElementControl } from '@elementor/editor-elements';
 import { SessionStorageProvider } from '@elementor/session';
-import { Divider } from '@elementor/ui';
 
 import { useElement } from '../contexts/element-context';
-import { Control as BaseControl } from '../controls-registry/control';
-import { ControlTypeContainer } from '../controls-registry/control-type-container';
-import { controlsRegistry, type ControlType } from '../controls-registry/controls-registry';
-import { SettingsField } from '../controls-registry/settings-field';
-import { getFieldIndicators } from '../field-indicators-registry';
 import { useDefaultPanelSettings } from '../hooks/use-default-panel-settings';
 import { Section } from './section';
 import { SectionsList } from './sections-list';
+import { SettingsControl } from './settings-control';
 
 export const SettingsTab = () => {
 	const { elementType, element } = useElement();
@@ -32,7 +20,7 @@ export const SettingsTab = () => {
 			<SectionsList>
 				{ elementType.controls.map( ( control, index ) => {
 					if ( isControl( control ) ) {
-						return <Control key={ getKey( control, element ) } control={ control } />;
+						return <SettingsControl key={ getKey( control, element ) } control={ control } />;
 					}
 
 					const { type, value } = control;
@@ -46,7 +34,7 @@ export const SettingsTab = () => {
 							>
 								{ value.items?.map( ( item ) => {
 									if ( isControl( item ) ) {
-										return <Control key={ getKey( item, element ) } control={ item } />;
+										return <SettingsControl key={ getKey( item, element ) } control={ item } />;
 									}
 
 									// TODO: Handle 2nd level sections
@@ -62,64 +50,6 @@ export const SettingsTab = () => {
 		</SessionStorageProvider>
 	);
 };
-
-const Control = ( { control: { value, type } }: { control: Control | ElementControl } ) => {
-	if ( ! controlsRegistry.get( value.type as ControlType ) ) {
-		return null;
-	}
-
-	const layout = value.meta?.layout || controlsRegistry.getLayout( value.type as ControlType );
-	const controlProps = populateChildControlProps( value.props );
-
-	if ( layout === 'custom' ) {
-		controlProps.label = value.label;
-	}
-
-	if ( type === 'element-control' ) {
-		return <ControlLayout control={ value } layout={ layout } controlProps={ controlProps } />;
-	}
-
-	return (
-		<SettingsField bind={ value.bind } propDisplayName={ value.label || value.bind }>
-			<ControlLayout control={ value } layout={ layout } controlProps={ controlProps } />
-		</SettingsField>
-	);
-};
-
-const ControlLayout = ( {
-	control,
-	layout,
-	controlProps,
-}: {
-	control: Control[ 'value' ] | ElementControl[ 'value' ];
-	layout: ControlLayout;
-	controlProps: Record< string, unknown >;
-} ) => (
-	<ControlAdornmentsProvider items={ getFieldIndicators( 'settings' ) }>
-		{ control.meta?.topDivider && <Divider /> }
-		<ControlTypeContainer layout={ layout }>
-			{ control.label && layout !== 'custom' ? <ControlFormLabel>{ control.label }</ControlFormLabel> : null }
-			<BaseControl type={ control.type as ControlType } props={ controlProps } />
-		</ControlTypeContainer>
-	</ControlAdornmentsProvider>
-);
-
-function populateChildControlProps( props: Record< string, unknown > ) {
-	if ( props.childControlType ) {
-		const childComponent = controlsRegistry.get( props.childControlType as ControlType );
-		const childPropType = controlsRegistry.getPropTypeUtil( props.childControlType as ControlType );
-		props = {
-			...props,
-			childControlConfig: {
-				component: childComponent,
-				props: props.childControlProps || {},
-				propTypeUtil: childPropType,
-			},
-		};
-	}
-
-	return props;
-}
 
 function getKey( control: Control | ElementControl, element: Element ) {
 	if ( control.type === 'control' ) {

--- a/packages/packages/core/editor-editing-panel/src/index.ts
+++ b/packages/packages/core/editor-editing-panel/src/index.ts
@@ -5,6 +5,7 @@ export { injectIntoClassSelectorActions } from './components/css-classes/css-cla
 export { CustomCssIndicator } from './components/custom-css-indicator';
 export { PopoverBody } from './components/popover-body';
 export { SectionContent } from './components/section-content';
+export { SettingsControl } from './components/settings-control';
 export { StyleIndicator } from './components/style-indicator';
 export { useFontFamilies } from './components/style-sections/typography-section/hooks/use-font-families';
 export { injectIntoStyleTab } from './components/style-tab';
@@ -25,5 +26,6 @@ export { usePanelActions, usePanelStatus } from './panel';
 export type { PopoverActionProps } from './popover-action';
 export { registerStyleProviderToColors } from './provider-colors-registry';
 export { stylesInheritanceTransformersRegistry } from './styles-inheritance/styles-inheritance-transformers-registry';
+export { registerFieldIndicator, FIELD_TYPE } from './field-indicators-registry';
 
 export { doApplyClasses, doGetAppliedClasses, doUnapplyClass } from './apply-unapply-actions';

--- a/packages/packages/libs/editor-controls/src/controls/link-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/link-control.tsx
@@ -14,6 +14,7 @@ import { createControl } from '../create-control';
 import { type ControlProps } from '../utils/types';
 import { QueryControl } from './query-control';
 import { SwitchControl } from './switch-control';
+import { ControlLabel } from '../components/control-label';
 
 type Props = ControlProps< {
 	queryOptions: {
@@ -102,7 +103,7 @@ export const LinkControl = createControl( ( props: Props ) => {
 						marginInlineEnd: -0.75,
 					} }
 				>
-					<ControlFormLabel>{ label }</ControlFormLabel>
+					<ControlLabel>{ label }</ControlLabel>
 					<RestrictedLinkInfotip isVisible={ ! isActive } linkInLinkRestriction={ linkInLinkRestriction }>
 						<ToggleIconControl
 							disabled={ shouldDisableAddingLink }

--- a/packages/packages/libs/editor-controls/src/controls/link-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/link-control.tsx
@@ -9,12 +9,12 @@ import { __ } from '@wordpress/i18n';
 
 import { PropKeyProvider, PropProvider, useBoundProp } from '../bound-prop-context';
 import { ControlFormLabel } from '../components/control-form-label';
+import { ControlLabel } from '../components/control-label';
 import { RestrictedLinkInfotip } from '../components/restricted-link-infotip';
 import { createControl } from '../create-control';
 import { type ControlProps } from '../utils/types';
 import { QueryControl } from './query-control';
 import { SwitchControl } from './switch-control';
-import { ControlLabel } from '../components/control-label';
 
 type Props = ControlProps< {
 	queryOptions: {

--- a/tests/playwright/sanity/modules/atomic-widgets/helper.ts
+++ b/tests/playwright/sanity/modules/atomic-widgets/helper.ts
@@ -59,7 +59,7 @@ export class AtomicHelper {
 	}
 
 	public getHtmlTagControl( deeperSelector: string = '' ) {
-		const field = this.getSettingsField( 'Tag' );
+		const field = this.getSettingsField( 'HTML Tag' );
 
 		return deeperSelector
 			? field.locator( deeperSelector )

--- a/tests/playwright/sanity/modules/atomic-widgets/helper.ts
+++ b/tests/playwright/sanity/modules/atomic-widgets/helper.ts
@@ -59,11 +59,16 @@ export class AtomicHelper {
 	}
 
 	public getHtmlTagControl( deeperSelector: string = '' ) {
-		const control = this.page.locator( `.MuiStack-root >.MuiBox-root>label`, { hasText: /Tag/ig } ).locator( '..' );
+		const field = this.getSettingsField( 'Tag' );
 
 		return deeperSelector
-			? control.locator( deeperSelector )
-			: control;
+			? field.locator( deeperSelector )
+			: field;
+	}
+
+	public getSettingsField( label: string ) {
+		return this.page.locator( `[data-type="settings-field"]` )
+			.filter( { has: this.page.getByText( label, { exact: true } ) } );
 	}
 
 	public async isHtmlTagControlDisabled() {


### PR DESCRIPTION
<img width="124" height="362" alt="Screenshot 2025-11-25 at 8 20 09" src="https://github.com/user-attachments/assets/f753a8ca-9b03-4dff-9657-125a2d3bf5a5" />


Adding a new indicator to expose properties of component's nested widgets to be overridable on the instance level,

In this PR I'm adding 
- the indicator itself, with all states as described in the [figma](https://www.figma.com/design/c9toOa40958fiqatsEXnIY/Components?node-id=6519-115611&t=SH7511XmJpz8btri-0) - non-overridable, hover and overridable
- a simple block list of some common fields we do not wish to allow making overridable - _cssid (labeled as "ID"), and attributes
- a corresponding `propType` for validation purposes - `componentOverridablePropTypeUtil`
<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Add visual indicator in component setting fields to show and manage overridable properties in the Elementor editor.
Main changes:
- Implemented indicator icon component that toggles between plus/check states for overridable properties
- Created OverridablePropIndicator component with popover UI for property override management
- Registered field indicator in editor panel to display on setting fields when editing components
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
