### PR TITLE
Internal: Fix tabs sorting default active tab

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/__tests__/use-actions.test.ts
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/__tests__/use-actions.test.ts
@@ -75,27 +75,6 @@ describe( 'tabs-control actions', () => {
 				expect( mockSetValue ).toHaveBeenCalledWith( 0 );
 			} );
 
-			it( 'should swap active to old position (from 0 to 2)', () => {
-				// Arrange
-				setupBoundProp( 2 );
-				const { result } = renderHook( () => useActions() );
-
-				// Act
-				result.current.moveItem( {
-					toIndex: 2,
-					tabsMenuId: TABS_MENU_ID,
-					tabContentAreaId: TAB_CONTENT_AREA_ID,
-					movedElementId: MOVED_ELEMENT_ID,
-					movedElementIndex: 0,
-				} );
-
-				const onMoveElements = jest.mocked( moveElements ).mock.calls[ 0 ][ 0 ].onMoveElements;
-				onMoveElements?.();
-
-				// Assert
-				expect( mockSetValue ).toHaveBeenCalledWith( 0 );
-			} );
-
 			it( 'should decrement active tab (from 0 to 3, active at 2)', () => {
 				// Arrange
 				setupBoundProp( 2 );
@@ -157,6 +136,48 @@ describe( 'tabs-control actions', () => {
 
 				// Assert
 				expect( mockSetValue ).not.toHaveBeenCalled();
+			} );
+
+			it( 'should decrement active tab when moving from top to active position (from 0 to 2, active at 2)', () => {
+				// Arrange
+				setupBoundProp( 2 );
+				const { result } = renderHook( () => useActions() );
+
+				// Act
+				result.current.moveItem( {
+					toIndex: 2,
+					tabsMenuId: TABS_MENU_ID,
+					tabContentAreaId: TAB_CONTENT_AREA_ID,
+					movedElementId: MOVED_ELEMENT_ID,
+					movedElementIndex: 0,
+				} );
+
+				const onMoveElements = jest.mocked( moveElements ).mock.calls[ 0 ][ 0 ].onMoveElements;
+				onMoveElements?.();
+
+				// Assert
+				expect( mockSetValue ).toHaveBeenCalledWith( 1 );
+			} );
+
+			it( 'should increment active tab when moving from bottom to active position (from 4 to 2, active at 2)', () => {
+				// Arrange
+				setupBoundProp( 2 );
+				const { result } = renderHook( () => useActions() );
+
+				// Act
+				result.current.moveItem( {
+					toIndex: 2,
+					tabsMenuId: TABS_MENU_ID,
+					tabContentAreaId: TAB_CONTENT_AREA_ID,
+					movedElementId: MOVED_ELEMENT_ID,
+					movedElementIndex: 4,
+				} );
+
+				const onMoveElements = jest.mocked( moveElements ).mock.calls[ 0 ][ 0 ].onMoveElements;
+				onMoveElements?.();
+
+				// Assert
+				expect( mockSetValue ).toHaveBeenCalledWith( 3 );
 			} );
 
 			it( 'should restore original value on undo', () => {

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/use-actions.ts
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/use-actions.ts
@@ -190,15 +190,19 @@ const calculateDefaultOnMove = ( {
 		return to;
 	}
 
-	if ( to === defaultActiveTab ) {
-		return from;
-	}
-
 	if ( from < defaultActiveTab && to > defaultActiveTab ) {
 		return defaultActiveTab - 1;
 	}
 
 	if ( from > defaultActiveTab && to < defaultActiveTab ) {
+		return defaultActiveTab + 1;
+	}
+
+	if ( to === defaultActiveTab && to > from ) {
+		return defaultActiveTab - 1;
+	}
+
+	if ( to === defaultActiveTab && to < from ) {
 		return defaultActiveTab + 1;
 	}
 

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/use-actions.ts
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/tabs-control/use-actions.ts
@@ -190,19 +190,11 @@ const calculateDefaultOnMove = ( {
 		return to;
 	}
 
-	if ( from < defaultActiveTab && to > defaultActiveTab ) {
+	if ( from < defaultActiveTab && to >= defaultActiveTab ) {
 		return defaultActiveTab - 1;
 	}
 
-	if ( from > defaultActiveTab && to < defaultActiveTab ) {
-		return defaultActiveTab + 1;
-	}
-
-	if ( to === defaultActiveTab && to > from ) {
-		return defaultActiveTab - 1;
-	}
-
-	if ( to === defaultActiveTab && to < from ) {
+	if ( from > defaultActiveTab && to <= defaultActiveTab ) {
 		return defaultActiveTab + 1;
 	}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix tabs control component to properly maintain the correct active tab when reordering tabs in the editor interface.
Main changes:
- Corrected active tab calculation logic in calculateDefaultOnMove function
- Updated test cases to validate proper tab index behavior when moving tabs
- Added new test cases for when tabs are moved to the active position

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
