### PR TITLE
Fix: Fatal error when V4 experiment is deactivated [ED-21039]

### DIFF
--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -342,7 +342,7 @@ class Container extends Element_Base {
 			return Plugin::$instance->elements_manager->get_element_types( $element_data['elType'] );
 		}
 
-		if ( empty( $element_data['widgetType'] ) ) {
+		if ( !isset( $element_data['widgetType'] ) ) {
 			return null;
 		}
 

--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -342,6 +342,10 @@ class Container extends Element_Base {
 			return Plugin::$instance->elements_manager->get_element_types( $element_data['elType'] );
 		}
 
+		if ( empty( $element_data['widgetType'] ) ) {
+			return null;
+		}
+
 		return Plugin::$instance->widgets_manager->get_widget_types( $element_data['widgetType'] );
 	}
 

--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -342,7 +342,7 @@ class Container extends Element_Base {
 			return Plugin::$instance->elements_manager->get_element_types( $element_data['elType'] );
 		}
 
-		if ( !isset( $element_data['widgetType'] ) ) {
+		if ( ! isset( $element_data['widgetType'] ) ) {
 			return null;
 		}
 

--- a/modules/atomic-widgets/elements/atomic-element-base.php
+++ b/modules/atomic-widgets/elements/atomic-element-base.php
@@ -206,6 +206,10 @@ abstract class Atomic_Element_Base extends Element_Base {
 			return Plugin::$instance->elements_manager->get_element_types( $element_data['elType'] );
 		}
 
+		if ( ! isset( $element_data['widgetType'] ) ) {
+			return null;
+		}
+
 		return Plugin::$instance->widgets_manager->get_widget_types( $element_data['widgetType'] );
 	}
 

--- a/tests/phpunit/elementor/modules/atomic-widgets/test-div-block.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/test-div-block.php
@@ -114,4 +114,20 @@ class Test_Div_Block extends Elementor_Test_Base {
 		// Assert.
 		$this->assertMatchesSnapshot( $rendered_output );
 	}
+
+	public function test__add_child_with_non_existent_widget_type(): void {
+		// Arrange.
+		$non_existent_widget_data = [
+			'id' => 'test-child',
+			'elType' => 'widget',
+			'widgetType' => 'non_existent_widget_type',
+		];
+
+		// Act.
+		$result = $this->instance->add_child( $non_existent_widget_data );
+
+		// Assert.
+		$this->assertFalse( $result );
+		$this->assertEmpty( $this->instance->get_children() );
+	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/test-flexbox.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/test-flexbox.php
@@ -157,4 +157,19 @@ class Test_Flexbox extends Elementor_Test_Base {
 		// Assert.
 		$this->assertMatchesSnapshot( $rendered_output );
 	}
+
+	public function test__add_child_with_non_existent_element_type(): void {
+		// Arrange.
+		$non_existent_child_data = [
+			'id' => 'test-child',
+			'elType' => 'unregistered_element_type',
+		];
+
+		// Act.
+		$result = $this->instance->add_child( $non_existent_child_data );
+
+		// Assert.
+		$this->assertFalse( $result );
+		$this->assertEmpty( $this->instance->get_children() );
+	}
 }

--- a/tests/phpunit/elementor/test-elements.php
+++ b/tests/phpunit/elementor/test-elements.php
@@ -106,4 +106,26 @@ class Elementor_Test_Elements extends Elementor_Test_Base {
 			}
 		}
 	}
+
+	public function test_addChildWithNonExistentElementType() {
+		// Arrange
+		$container_data = [
+			'id' => 'test-container',
+			'elType' => 'container',
+		];
+
+		$container = $this->elementor()->elements_manager->create_element_instance( $container_data );
+
+		$non_existent_child_data = [
+			'id' => 'test-child',
+			'elType' => 'unregistered_element_type',
+		];
+
+		// Act
+		$result = $container->add_child( $non_existent_child_data );
+
+		// Assert
+		$this->assertFalse( $result );
+		$this->assertEmpty( $container->get_children() );
+	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix fatal error when deactivating V4 experiment by adding null checks for undefined widget types in element creation methods.

Main changes:
- Added null check for undefined widgetType in Container and Atomic_Element_Base classes
- Added unit tests for handling non-existent widget types and element types
- Prevented fatal error when adding child elements with invalid element types

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
