### PR TITLE
Internal: Refactor IE app to use useContextDetection() hook [ED-20523]

### DIFF
--- a/app/modules/import-export-customization/assets/js/export/components/export-kit-parts-selection.js
+++ b/app/modules/import-export-customization/assets/js/export/components/export-kit-parts-selection.js
@@ -50,7 +50,6 @@ export default function ExportKitPartsSelection() {
 
 	return (
 		<KitPartsSelection
-			data={ data }
 			onCheckboxChange={ handleCheckboxChange }
 			handleSaveCustomization={ handleSaveCustomization }
 			isCloudKitsEligible={ isCloudKitsEligible }

--- a/app/modules/import-export-customization/assets/js/import/components/import-kit-parts-selection.js
+++ b/app/modules/import-export-customization/assets/js/import/components/import-kit-parts-selection.js
@@ -56,7 +56,6 @@ export default function ImportKitPartsSelection() {
 
 	return (
 		<KitPartsSelection
-			data={ data }
 			onCheckboxChange={ handleCheckboxChange }
 			handleSaveCustomization={ handleSaveCustomization }
 			testId="import-kit-parts-content"

--- a/app/modules/import-export-customization/assets/js/shared/components/kit-content-customization-dialog.js
+++ b/app/modules/import-export-customization/assets/js/shared/components/kit-content-customization-dialog.js
@@ -7,6 +7,7 @@ import { ListSettingSection } from './customization-list-setting-section';
 import { SettingSection } from './customization-setting-section';
 import { AppsEventTracking } from 'elementor-app/event-track/apps-event-tracking';
 import { useKitCustomizationCustomPostTypes } from '../hooks/use-kit-customization-custom-post-types';
+import useContextDetection from '../hooks/use-context-detection';
 import { UpgradeVersionBanner } from './upgrade-version-banner';
 import { transformValueForAnalytics } from '../utils/analytics-transformer';
 
@@ -46,12 +47,12 @@ export function KitContentCustomizationDialog( {
 	open,
 	handleClose,
 	handleSaveChanges,
-	data,
-	isImport,
-	isOldElementorVersion,
 	isCloudKitsEligible = false,
 	showMediaFormatValidation = false,
 } ) {
+	const { isImport = false, contextData = {} } = useContextDetection() ?? {};
+	const { data = null, isOldElementorVersion = false } = contextData;
+
 	const { customPostTypes } = useKitCustomizationCustomPostTypes( { data } );
 
 	const alertRef = useRef( null );
@@ -265,11 +266,8 @@ export function KitContentCustomizationDialog( {
 
 KitContentCustomizationDialog.propTypes = {
 	open: PropTypes.bool.isRequired,
-	isImport: PropTypes.bool,
-	isOldElementorVersion: PropTypes.bool,
 	handleClose: PropTypes.func.isRequired,
 	handleSaveChanges: PropTypes.func.isRequired,
-	data: PropTypes.object.isRequired,
 	isCloudKitsEligible: PropTypes.bool,
 	showMediaFormatValidation: PropTypes.bool,
 };

--- a/app/modules/import-export-customization/assets/js/shared/components/kit-parts-selection.js
+++ b/app/modules/import-export-customization/assets/js/shared/components/kit-parts-selection.js
@@ -7,9 +7,10 @@ import useContextDetection from '../hooks/use-context-detection';
 import { ReExportBanner } from './re-export-banner';
 import { UpgradeVersionBanner } from './upgrade-version-banner';
 
-export default function KitPartsSelection( { data, onCheckboxChange, testId, handleSaveCustomization, isCloudKitsEligible = false, showMediaFormatValidation = false } ) {
+export default function KitPartsSelection( { onCheckboxChange, testId, handleSaveCustomization, isCloudKitsEligible = false, showMediaFormatValidation = false } ) {
 	const [ activeDialog, setActiveDialog ] = useState( null );
-	const { isImport, contextData } = useContextDetection();
+	const { isImport = false, contextData = {} } = useContextDetection() ?? {};
+	const { data = null } = contextData;
 
 	useEffect( () => {
 		if ( showMediaFormatValidation && ! isImport ) {
@@ -226,7 +227,6 @@ export default function KitPartsSelection( { data, onCheckboxChange, testId, han
 }
 
 KitPartsSelection.propTypes = {
-	data: PropTypes.object.isRequired,
 	onCheckboxChange: PropTypes.func.isRequired,
 	testId: PropTypes.string,
 	handleSaveCustomization: PropTypes.func.isRequired,

--- a/app/modules/import-export-customization/assets/js/shared/components/kit-plugins-customization-dialog.js
+++ b/app/modules/import-export-customization/assets/js/shared/components/kit-plugins-customization-dialog.js
@@ -17,6 +17,7 @@ import { ExternalLinkIcon } from './icons';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import useKitPlugins from '../hooks/use-kit-plugins';
+import useContextDetection from '../hooks/use-context-detection';
 import { AppsEventTracking } from 'elementor-app/event-track/apps-event-tracking';
 import { UpgradeVersionBanner } from './upgrade-version-banner';
 import { transformValueForAnalytics } from '../utils/analytics-transformer';
@@ -35,7 +36,10 @@ const REQUIRED_PLUGINS = [
 	'elementor/elementor',
 ];
 
-export function KitPluginsCustomizationDialog( { open, handleClose, handleSaveChanges, data, isImport, isOldElementorVersion } ) {
+export function KitPluginsCustomizationDialog( { open, handleClose, handleSaveChanges } ) {
+	const { isImport = false, contextData = {} } = useContextDetection() ?? {};
+	const { data = null, isOldElementorVersion = false } = contextData;
+
 	const { pluginsList: fetchedPluginsList, isLoading: fetchIsLoading } = useKitPlugins( { open: open && ! isImport } );
 
 	const pluginsList = useMemo( () => {
@@ -314,7 +318,4 @@ KitPluginsCustomizationDialog.propTypes = {
 	open: PropTypes.bool.isRequired,
 	handleClose: PropTypes.func.isRequired,
 	handleSaveChanges: PropTypes.func.isRequired,
-	data: PropTypes.object.isRequired,
-	isImport: PropTypes.bool,
-	isOldElementorVersion: PropTypes.bool,
 };

--- a/app/modules/import-export-customization/assets/js/shared/components/kit-settings-customization-dialog.js
+++ b/app/modules/import-export-customization/assets/js/shared/components/kit-settings-customization-dialog.js
@@ -38,8 +38,9 @@ function isExported( contextData ) {
 	return contextData?.data?.uploadedData?.manifest?.[ 'site-settings' ]?.theme;
 }
 
-export function KitSettingsCustomizationDialog( { open, handleClose, handleSaveChanges, data } ) {
-	const { isImport, contextData } = useContextDetection();
+export function KitSettingsCustomizationDialog( { open, handleClose, handleSaveChanges } ) {
+	const { isImport = false, contextData = {} } = useContextDetection() ?? {};
+	const { data = null } = contextData;
 
 	const initialState = getInitialState( contextData, isImport );
 
@@ -122,5 +123,4 @@ KitSettingsCustomizationDialog.propTypes = {
 	open: PropTypes.bool.isRequired,
 	handleClose: PropTypes.func.isRequired,
 	handleSaveChanges: PropTypes.func.isRequired,
-	data: PropTypes.object.isRequired,
 };

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/export/components/kit-parts-customization.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/export/components/kit-parts-customization.test.js
@@ -226,11 +226,20 @@ describe( 'ExportKitPartsSelection Component', () => {
 		} );
 
 		it( 'should show unchecked state for items not in includes array', () => {
+			const data = {
+				includes: [ 'content' ],
+			};
+
 			useExportContext.mockReturnValue( {
-				data: {
-					includes: [ 'content' ],
-				},
+				data,
 				dispatch: mockDispatch,
+			} );
+
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data,
+				},
 			} );
 
 			const { container } = render( <ExportKitPartsSelection />, { wrapper: createQueryWrapper() } );
@@ -247,11 +256,20 @@ describe( 'ExportKitPartsSelection Component', () => {
 		} );
 
 		it( 'should handle empty includes array', () => {
+			const data = {
+				includes: [],
+			};
+
 			useExportContext.mockReturnValue( {
-				data: {
-					includes: [],
-				},
+				data,
 				dispatch: mockDispatch,
+			} );
+
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data,
+				},
 			} );
 
 			const { container } = render( <ExportKitPartsSelection />, { wrapper: createQueryWrapper() } );
@@ -269,11 +287,20 @@ describe( 'ExportKitPartsSelection Component', () => {
 		} );
 
 		it( 'should handle all items included', () => {
+			const data = {
+				includes: [ 'content', 'templates', 'settings', 'plugins' ],
+			};
+
 			useExportContext.mockReturnValue( {
-				data: {
-					includes: [ 'content', 'templates', 'settings', 'plugins' ],
-				},
+				data,
 				dispatch: mockDispatch,
+			} );
+
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data,
+				},
 			} );
 
 			const { container } = render( <ExportKitPartsSelection />, { wrapper: createQueryWrapper() } );
@@ -412,6 +439,13 @@ describe( 'ExportKitPartsSelection Component', () => {
 				dispatch: mockDispatch,
 			} );
 
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data: mockData,
+				},
+			} );
+
 			const { container } = render( <ExportKitPartsSelection />, { wrapper: createQueryWrapper() } );
 
 			// Use data-type attributes instead of array indexes
@@ -428,11 +462,20 @@ describe( 'ExportKitPartsSelection Component', () => {
 			expect( getCheckboxByType( container, 'content' ).checked ).toBe( true );
 
 			// Update context data
+			const newData = {
+				includes: [ 'templates', 'plugins' ],
+			};
+
 			useExportContext.mockReturnValue( {
-				data: {
-					includes: [ 'templates', 'plugins' ],
-				},
+				data: newData,
 				dispatch: mockDispatch,
+			} );
+
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data: newData,
+				},
 			} );
 
 			rerender( <ExportKitPartsSelection />, { wrapper: createQueryWrapper() } );

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-content-customization-dialog.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-content-customization-dialog.test.js
@@ -5,6 +5,11 @@ jest.mock( 'elementor/app/modules/import-export-customization/assets/js/shared/h
 	useKitCustomizationCustomPostTypes: jest.fn(),
 } ) );
 
+jest.mock( 'elementor/app/modules/import-export-customization/assets/js/shared/hooks/use-context-detection', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
 jest.mock( 'elementor-app/event-track/apps-event-tracking', () => ( {
 	AppsEventTracking: {
 		sendPageViewsWebsiteTemplates: jest.fn(),
@@ -12,6 +17,7 @@ jest.mock( 'elementor-app/event-track/apps-event-tracking', () => ( {
 } ) );
 
 import { useKitCustomizationCustomPostTypes } from 'elementor/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-customization-custom-post-types';
+import useContextDetection from 'elementor/app/modules/import-export-customization/assets/js/shared/hooks/use-context-detection';
 import { AppsEventTracking } from 'elementor-app/event-track/apps-event-tracking';
 
 import { KitContentCustomizationDialog } from 'elementor/app/modules/import-export-customization/assets/js/shared/components/kit-content-customization-dialog';
@@ -47,6 +53,14 @@ describe( 'KitContentCustomizationDialog Component', () => {
 				},
 			},
 		};
+
+		useContextDetection.mockReturnValue( {
+			isImport: false,
+			contextData: {
+				data: mockData,
+				isOldElementorVersion: false,
+			},
+		} );
 
 		useKitCustomizationCustomPostTypes.mockReturnValue( {
 			customPostTypes: [
@@ -158,8 +172,16 @@ describe( 'KitContentCustomizationDialog Component', () => {
 					},
 				},
 			};
+
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data,
+					isOldElementorVersion: false,
+				},
+			} );
+
 			const props = {
-				data,
 				open: true,
 				handleClose: mockHandleClose,
 				handleSaveChanges: mockHandleSaveChanges,
@@ -266,12 +288,19 @@ describe( 'KitContentCustomizationDialog Component', () => {
 					manifest: {},
 				},
 			};
+
+			useContextDetection.mockReturnValue( {
+				isImport: true,
+				contextData: {
+					data: importData,
+					isOldElementorVersion: false,
+				},
+			} );
+
 			const props = {
-				data: importData,
 				open: true,
 				handleClose: mockHandleClose,
 				handleSaveChanges: mockHandleSaveChanges,
-				isImport: true,
 			};
 
 			// Act
@@ -488,13 +517,19 @@ describe( 'KitContentCustomizationDialog Component', () => {
 
 		it( 'should render media format banner in import mode', () => {
 			// Arrange
+			useContextDetection.mockReturnValue( {
+				isImport: true,
+				contextData: {
+					data: mockData,
+					isOldElementorVersion: false,
+				},
+			} );
+
 			const props = {
-				data: mockData,
 				open: true,
 				handleClose: mockHandleClose,
 				handleSaveChanges: mockHandleSaveChanges,
 				isCloudKitsEligible: true,
-				isImport: true,
 			};
 
 			// Act
@@ -657,12 +692,18 @@ describe( 'KitContentCustomizationDialog Component', () => {
 	describe( 'Upgrade Version Banner', () => {
 		it( 'should render upgrade version banner when isOldElementorVersion is true', () => {
 			// Arrange
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data: mockData,
+					isOldElementorVersion: true,
+				},
+			} );
+
 			const props = {
-				data: mockData,
 				open: true,
 				handleClose: mockHandleClose,
 				handleSaveChanges: mockHandleSaveChanges,
-				isOldElementorVersion: true,
 			};
 
 			// Act
@@ -739,12 +780,18 @@ describe( 'KitContentCustomizationDialog Component', () => {
 				},
 			};
 
+			useContextDetection.mockReturnValue( {
+				isImport: true,
+				contextData: {
+					data: malformedData,
+					isOldElementorVersion: false,
+				},
+			} );
+
 			const props = {
-				data: malformedData,
 				open: true,
 				handleClose: mockHandleClose,
 				handleSaveChanges: mockHandleSaveChanges,
-				isImport: true,
 			};
 
 			// Act
@@ -766,12 +813,18 @@ describe( 'KitContentCustomizationDialog Component', () => {
 				},
 			};
 
+			useContextDetection.mockReturnValue( {
+				isImport: true,
+				contextData: {
+					data: incompleteData,
+					isOldElementorVersion: false,
+				},
+			} );
+
 			const props = {
-				data: incompleteData,
 				open: true,
 				handleClose: mockHandleClose,
 				handleSaveChanges: mockHandleSaveChanges,
-				isImport: true,
 			};
 
 			// Act
@@ -791,12 +844,18 @@ describe( 'KitContentCustomizationDialog Component', () => {
 				},
 			};
 
+			useContextDetection.mockReturnValue( {
+				isImport: true,
+				contextData: {
+					data: emptyData,
+					isOldElementorVersion: false,
+				},
+			} );
+
 			const props = {
-				data: emptyData,
 				open: true,
 				handleClose: mockHandleClose,
 				handleSaveChanges: mockHandleSaveChanges,
-				isImport: true,
 			};
 
 			// Act
@@ -824,12 +883,18 @@ describe( 'KitContentCustomizationDialog Component', () => {
 				},
 			};
 
+			useContextDetection.mockReturnValue( {
+				isImport: true,
+				contextData: {
+					data: validData,
+					isOldElementorVersion: false,
+				},
+			} );
+
 			const props = {
-				data: validData,
 				open: true,
 				handleClose: mockHandleClose,
 				handleSaveChanges: mockHandleSaveChanges,
-				isImport: true,
 			};
 
 			// Act

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-parts-selection.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-parts-selection.test.js
@@ -150,8 +150,15 @@ describe( 'KitPartsSelection Component', () => {
 				includes: [ 'templates', 'settings' ],
 				customization: {},
 			};
+
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data,
+				},
+			} );
+
 			const props = {
-				data,
 				onCheckboxChange: mockOnCheckboxChange,
 				handleSaveCustomization: mockHandleSaveCustomization,
 				testId: 'test-kit-parts',
@@ -176,8 +183,15 @@ describe( 'KitPartsSelection Component', () => {
 				includes: [],
 				customization: {},
 			};
+
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data,
+				},
+			} );
+
 			const props = {
-				data,
 				onCheckboxChange: mockOnCheckboxChange,
 				handleSaveCustomization: mockHandleSaveCustomization,
 				testId: 'test-kit-parts',
@@ -460,13 +474,6 @@ describe( 'KitPartsSelection Component', () => {
 
 		it( 'should not call onCheckboxChange when disabled checkbox is clicked', () => {
 			// Arrange
-			useContextDetection.mockReturnValue( {
-				isImport: true,
-				contextData: {
-					isOldExport: false,
-				},
-			} );
-
 			const importData = {
 				includes: [ 'templates' ],
 				customization: {},
@@ -476,8 +483,16 @@ describe( 'KitPartsSelection Component', () => {
 					},
 				},
 			};
+
+			useContextDetection.mockReturnValue( {
+				isImport: true,
+				contextData: {
+					isOldExport: false,
+					data: importData,
+				},
+			} );
+
 			const props = {
-				data: importData,
 				onCheckboxChange: mockOnCheckboxChange,
 				handleSaveCustomization: mockHandleSaveCustomization,
 				testId: 'test-kit-parts',
@@ -558,8 +573,15 @@ describe( 'KitPartsSelection Component', () => {
 				includes: [],
 				customization: {},
 			};
+
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data,
+				},
+			} );
+
 			const props = {
-				data,
 				onCheckboxChange: mockOnCheckboxChange,
 				handleSaveCustomization: mockHandleSaveCustomization,
 				testId: 'test-kit-parts',
@@ -584,8 +606,15 @@ describe( 'KitPartsSelection Component', () => {
 				includes: [ 'non-existent-type' ],
 				customization: {},
 			};
+
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data,
+				},
+			} );
+
 			const props = {
-				data,
 				onCheckboxChange: mockOnCheckboxChange,
 				handleSaveCustomization: mockHandleSaveCustomization,
 				testId: 'test-kit-parts',
@@ -606,8 +635,15 @@ describe( 'KitPartsSelection Component', () => {
 				customization: {},
 				uploadedData: {},
 			};
+
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data: importData,
+				},
+			} );
+
 			const props = {
-				data: importData,
 				onCheckboxChange: mockOnCheckboxChange,
 				handleSaveCustomization: mockHandleSaveCustomization,
 				testId: 'test-kit-parts',

--- a/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-plugins-customization-dialog.test.js
+++ b/tests/jest/unit/app/modules/import-export-customization/assets/js/shared/components/kit-plugins-customization-dialog.test.js
@@ -3,7 +3,13 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { KitPluginsCustomizationDialog } from 'elementor/app/modules/import-export-customization/assets/js/shared/components/kit-plugins-customization-dialog';
 
 jest.mock( 'elementor/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-plugins' );
+jest.mock( 'elementor/app/modules/import-export-customization/assets/js/shared/hooks/use-context-detection', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
 import useKitPlugins from 'elementor/app/modules/import-export-customization/assets/js/shared/hooks/use-kit-plugins';
+import useContextDetection from 'elementor/app/modules/import-export-customization/assets/js/shared/hooks/use-context-detection';
 import eventsConfig from 'elementor/core/common/modules/events-manager/assets/js/events-config';
 
 global.__ = jest.fn( ( text ) => text );
@@ -54,6 +60,14 @@ describe( 'KitPluginsCustomizationDialog Component', () => {
 		useKitPlugins.mockReturnValue( {
 			pluginsList: mockPluginsList,
 			isLoading: false,
+		} );
+
+		useContextDetection.mockReturnValue( {
+			isImport: false,
+			contextData: {
+				data: mockData,
+				isOldElementorVersion: false,
+			},
 		} );
 
 		global.elementorCommon = {
@@ -219,12 +233,19 @@ describe( 'KitPluginsCustomizationDialog Component', () => {
 				},
 			};
 
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data: dataWithCustomization,
+					isOldElementorVersion: false,
+				},
+			} );
+
 			render(
 				<KitPluginsCustomizationDialog
 					open={ true }
 					handleClose={ mockHandleClose }
 					handleSaveChanges={ mockHandleSaveChanges }
-					data={ dataWithCustomization }
 				/>,
 			);
 
@@ -262,12 +283,19 @@ describe( 'KitPluginsCustomizationDialog Component', () => {
 				},
 			};
 
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data: dataWithoutPlugins,
+					isOldElementorVersion: false,
+				},
+			} );
+
 			render(
 				<KitPluginsCustomizationDialog
 					open={ true }
 					handleClose={ mockHandleClose }
 					handleSaveChanges={ mockHandleSaveChanges }
-					data={ dataWithoutPlugins }
 				/>,
 			);
 
@@ -317,12 +345,19 @@ describe( 'KitPluginsCustomizationDialog Component', () => {
 				},
 			};
 
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data: dataWithPartialSelection,
+					isOldElementorVersion: false,
+				},
+			} );
+
 			render(
 				<KitPluginsCustomizationDialog
 					open={ true }
 					handleClose={ mockHandleClose }
 					handleSaveChanges={ mockHandleSaveChanges }
-					data={ dataWithPartialSelection }
 				/>,
 			);
 
@@ -344,12 +379,19 @@ describe( 'KitPluginsCustomizationDialog Component', () => {
 				},
 			};
 
+			useContextDetection.mockReturnValue( {
+				isImport: false,
+				contextData: {
+					data: dataWithoutPlugins,
+					isOldElementorVersion: false,
+				},
+			} );
+
 			render(
 				<KitPluginsCustomizationDialog
 					open={ true }
 					handleClose={ mockHandleClose }
 					handleSaveChanges={ mockHandleSaveChanges }
-					data={ dataWithoutPlugins }
 				/>,
 			);
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Refactor Import/Export app to use useContextDetection() hook for accessing contextual data instead of passing props directly.
Main changes:
- Removed direct data props from components in favor of useContextDetection() hook
- Added proper null-safety with optional chaining and default values
- Updated test files to mock the hook response instead of passing props
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
