### PR TITLE
Fix: [V4] Custom CSS field breaks from certain characters [ED-21876]

### DIFF
--- a/packages/packages/libs/utils/src/__tests__/encoding.test.ts
+++ b/packages/packages/libs/utils/src/__tests__/encoding.test.ts
@@ -1,21 +1,19 @@
 import { decodeString, encodeString } from '../encoding';
 
 describe( 'encoding', () => {
-	describe( 'encodeString and decodeString', () => {
-		it( 'should encode and decode mixed Unicode characters', () => {
-			const original = 'Hello שלום مرحبا 你好 🎉 /*...*/';
-			const encoded = encodeString( original );
-			const decoded = decodeString( encoded );
+	it( 'should encode and decode mixed Unicode characters', () => {
+		const original = 'Hello שלום مرحبا 你好 🎉 /*...*/';
+		const encoded = encodeString( original );
+		const decoded = decodeString( encoded );
 
-			expect( decoded ).toBe( original );
-		} );
+		expect( decoded ).toBe( original );
+	} );
 
-		it( 'should return fallback on decode error', () => {
-			const invalid = 'not-valid-base64!!!';
-			const fallback = 'fallback value';
-			const decoded = decodeString( invalid, fallback );
+	it( 'should return fallback on decode error', () => {
+		const invalid = 'not-valid-base64!!!';
+		const fallback = 'fallback value';
+		const decoded = decodeString( invalid, fallback );
 
-			expect( decoded ).toBe( fallback );
-		} );
+		expect( decoded ).toBe( fallback );
 	} );
 } );

--- a/packages/packages/libs/utils/src/__tests__/encoding.test.ts
+++ b/packages/packages/libs/utils/src/__tests__/encoding.test.ts
@@ -3,7 +3,7 @@ import { decodeString, encodeString } from '../encoding';
 describe( 'encoding', () => {
 	describe( 'encodeString and decodeString', () => {
 		it( 'should encode and decode mixed Unicode characters', () => {
-			const original = 'Hello שלום مرحبا 你好 🎉';
+			const original = 'Hello שלום مرحبا 你好 🎉 /*...*/';
 			const encoded = encodeString( original );
 			const decoded = decodeString( encoded );
 

--- a/packages/packages/libs/utils/src/__tests__/encoding.test.ts
+++ b/packages/packages/libs/utils/src/__tests__/encoding.test.ts
@@ -1,0 +1,21 @@
+import { decodeString, encodeString } from '../encoding';
+
+describe( 'encoding', () => {
+	describe( 'encodeString and decodeString', () => {
+		it( 'should encode and decode mixed Unicode characters', () => {
+			const original = 'Hello שלום مرحبا 你好 🎉';
+			const encoded = encodeString( original );
+			const decoded = decodeString( encoded );
+
+			expect( decoded ).toBe( original );
+		} );
+
+		it( 'should return fallback on decode error', () => {
+			const invalid = 'not-valid-base64!!!';
+			const fallback = 'fallback value';
+			const decoded = decodeString( invalid, fallback );
+
+			expect( decoded ).toBe( fallback );
+		} );
+	} );
+} );

--- a/packages/packages/libs/utils/src/encoding.ts
+++ b/packages/packages/libs/utils/src/encoding.ts
@@ -1,22 +1,14 @@
 export const encodeString = ( value: string ): string => {
-	const encoder = new TextEncoder();
-	const bytes = encoder.encode( value );
-	let binary = '';
-
-	for ( const b of bytes ) {
-		binary += String.fromCharCode( b );
-	}
-
+	const binary = Array.from( new TextEncoder().encode( value ), ( b ) => String.fromCharCode( b ) ).join( '' );
 	return btoa( binary );
 };
 
 export const decodeString = < T = string >( value: string, fallback?: T ): string | T => {
 	try {
 		const binary = atob( value );
-		const bytes = new Uint8Array( [ ...binary ].map( ( char ) => char.charCodeAt( 0 ) ) );
-		const decoder = new TextDecoder();
-		return decoder.decode( bytes );
+		const bytes = new Uint8Array( Array.from( binary, ( char ) => char.charCodeAt( 0 ) ) );
+		return new TextDecoder().decode( bytes );
 	} catch {
-		return fallback ?? '';
+		return fallback !== undefined ? fallback : '';
 	}
 };

--- a/packages/packages/libs/utils/src/encoding.ts
+++ b/packages/packages/libs/utils/src/encoding.ts
@@ -1,17 +1,21 @@
 export const encodeString = ( value: string ): string => {
-	const utf8Bytes = encodeURIComponent( value ).replace( /%([0-9A-F]{2})/g, ( _, hex ) =>
-		String.fromCharCode( parseInt( hex, 16 ) )
-	);
-	return btoa( utf8Bytes );
+	const encoder = new TextEncoder();
+	const bytes = encoder.encode( value );
+	let binary = '';
+
+	for ( const b of bytes ) {
+		binary += String.fromCharCode( b );
+	}
+
+	return btoa( binary );
 };
 
 export const decodeString = < T = string >( value: string, fallback?: T ): string | T => {
 	try {
-		const utf8Bytes = atob( value );
-		const percentEncoded = Array.from( utf8Bytes )
-			.map( ( char ) => '%' + ( '00' + char.charCodeAt( 0 ).toString( 16 ) ).slice( -2 ) )
-			.join( '' );
-		return decodeURIComponent( percentEncoded );
+		const binary = atob( value );
+		const bytes = new Uint8Array( [ ...binary ].map( ( char ) => char.charCodeAt( 0 ) ) );
+		const decoder = new TextDecoder();
+		return decoder.decode( bytes );
 	} catch {
 		return fallback ?? '';
 	}

--- a/packages/packages/libs/utils/src/encoding.ts
+++ b/packages/packages/libs/utils/src/encoding.ts
@@ -1,21 +1,17 @@
 export const encodeString = ( value: string ): string => {
-	const encoder = new TextEncoder();
-	const bytes = encoder.encode( value );
-	let binary = '';
-
-	for ( const b of bytes ) {
-		binary += String.fromCharCode( b );
-	}
-
-	return btoa( binary );
+	const utf8Bytes = encodeURIComponent( value ).replace( /%([0-9A-F]{2})/g, ( _, hex ) =>
+		String.fromCharCode( parseInt( hex, 16 ) )
+	);
+	return btoa( utf8Bytes );
 };
 
 export const decodeString = < T = string >( value: string, fallback?: T ): string | T => {
 	try {
-		const binary = atob( value );
-		const bytes = new Uint8Array( [ ...binary ].map( ( char ) => char.charCodeAt( 0 ) ) );
-		const decoder = new TextDecoder();
-		return decoder.decode( bytes );
+		const utf8Bytes = atob( value );
+		const percentEncoded = Array.from( utf8Bytes )
+			.map( ( char ) => '%' + ( '00' + char.charCodeAt( 0 ).toString( 16 ) ).slice( -2 ) )
+			.join( '' );
+		return decodeURIComponent( percentEncoded );
 	} catch {
 		return fallback ?? '';
 	}

--- a/packages/packages/libs/utils/src/encoding.ts
+++ b/packages/packages/libs/utils/src/encoding.ts
@@ -1,21 +1,21 @@
-export const encodeString = (value: string): string => {
+export const encodeString = ( value: string ): string => {
 	const encoder = new TextEncoder();
-	const bytes = encoder.encode(value);
+	const bytes = encoder.encode( value );
 	let binary = '';
 
-	for (const b of bytes) {
-		binary += String.fromCharCode(b);
+	for ( const b of bytes ) {
+		binary += String.fromCharCode( b );
 	}
 
-	return btoa(binary);
+	return btoa( binary );
 };
 
-export const decodeString = <T = string>(value: string, fallback?: T): string | T => {
+export const decodeString = < T = string >( value: string, fallback?: T ): string | T => {
 	try {
-		const binary = atob(value);
-		const bytes = new Uint8Array([...binary].map((char) => char.charCodeAt(0)));
+		const binary = atob( value );
+		const bytes = new Uint8Array( [ ...binary ].map( ( char ) => char.charCodeAt( 0 ) ) );
 		const decoder = new TextDecoder();
-		return decoder.decode(bytes);
+		return decoder.decode( bytes );
 	} catch {
 		return fallback ?? '';
 	}

--- a/packages/packages/libs/utils/src/encoding.ts
+++ b/packages/packages/libs/utils/src/encoding.ts
@@ -1,10 +1,17 @@
 export const encodeString = ( value: string ): string => {
-	return btoa( value );
+	const utf8Bytes = encodeURIComponent( value ).replace( /%([0-9A-F]{2})/g, ( _, hex ) => 
+		String.fromCharCode( parseInt( hex, 16 ) )
+	);
+	return btoa( utf8Bytes );
 };
 
 export const decodeString = < T = string >( value: string, fallback?: T ): T | string => {
 	try {
-		return atob( value );
+		const utf8Bytes = atob( value );
+		const percentEncoded = Array.from( utf8Bytes )
+			.map( ( char ) => '%' + ( '00' + char.charCodeAt( 0 ).toString( 16 ) ).slice( -2 ) )
+			.join( '' );
+		return decodeURIComponent( percentEncoded );
 	} catch {
 		return fallback || '';
 	}

--- a/packages/packages/libs/utils/src/encoding.ts
+++ b/packages/packages/libs/utils/src/encoding.ts
@@ -1,18 +1,22 @@
-export const encodeString = ( value: string ): string => {
-	const utf8Bytes = encodeURIComponent( value ).replace( /%([0-9A-F]{2})/g, ( _, hex ) => 
-		String.fromCharCode( parseInt( hex, 16 ) )
-	);
-	return btoa( utf8Bytes );
+export const encodeString = (value: string): string => {
+	const encoder = new TextEncoder();
+	const bytes = encoder.encode(value);
+	let binary = '';
+
+	for (const b of bytes) {
+		binary += String.fromCharCode(b);
+	}
+
+	return btoa(binary);
 };
 
-export const decodeString = < T = string >( value: string, fallback?: T ): T | string => {
+export const decodeString = <T = string>(value: string, fallback?: T): string | T => {
 	try {
-		const utf8Bytes = atob( value );
-		const percentEncoded = Array.from( utf8Bytes )
-			.map( ( char ) => '%' + ( '00' + char.charCodeAt( 0 ).toString( 16 ) ).slice( -2 ) )
-			.join( '' );
-		return decodeURIComponent( percentEncoded );
+		const binary = atob(value);
+		const bytes = new Uint8Array([...binary].map((char) => char.charCodeAt(0)));
+		const decoder = new TextDecoder();
+		return decoder.decode(bytes);
 	} catch {
-		return fallback || '';
+		return fallback ?? '';
 	}
 };

--- a/packages/tests/setup.ts
+++ b/packages/tests/setup.ts
@@ -9,10 +9,13 @@ import {
 import { __resetEnv } from '@elementor/env';
 import { __flushAllInjections } from '@elementor/locations';
 import { __deleteStore } from '@elementor/store';
+import { TextEncoder, TextDecoder } from 'util';
 
 jest.mock( '@elementor/http-client' );
 jest.mock( '@elementor/editor-mcp', () => ( {} ) );
 globalThis.structuredClone = ( value ) => JSON.parse( JSON.stringify( value ) );
+globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
+globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;
 
 globalThis.ResizeObserver = class ResizeObserver {
 	observe() {}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix encoding/decoding of custom CSS fields to properly handle Unicode characters and special symbols.
Main changes:
- Updated encodeString to use TextEncoder for proper Unicode handling before base64 conversion
- Improved decodeString to use TextDecoder for reliable Unicode character reconstruction
- Added tests to verify correct handling of mixed Unicode characters and invalid inputs

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
