### PR TITLE
Internal: Animation e2e test [ED-21882]

### DIFF
--- a/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
@@ -118,7 +118,7 @@ export function InteractionsList( props: InteractionListProps ) {
 				),
 				actions: ( value ) => (
 					<>
-						<IconButton size="tiny" onClick={ () => onPlayInteraction( value.animation.animation_id ) }>
+						<IconButton aria-label={ __( 'Play interaction', 'elementor' ) } size="tiny" onClick={ () => onPlayInteraction( value.animation.animation_id ) }>
 							<PlayerPlayIcon fontSize="tiny" />
 						</IconButton>
 					</>

--- a/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
@@ -118,7 +118,11 @@ export function InteractionsList( props: InteractionListProps ) {
 				),
 				actions: ( value ) => (
 					<>
-						<IconButton aria-label={ __( 'Play interaction', 'elementor' ) } size="tiny" onClick={ () => onPlayInteraction( value.animation.animation_id ) }>
+						<IconButton
+							aria-label={ __( 'Play interaction', 'elementor' ) }
+							size="tiny"
+							onClick={ () => onPlayInteraction( value.animation.animation_id ) }
+						>
 							<PlayerPlayIcon fontSize="tiny" />
 						</IconButton>
 					</>

--- a/tests/playwright/sanity/modules/v4-tests/interactions-tab.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/interactions-tab.test.ts
@@ -123,5 +123,81 @@ test.describe( 'Interactions Tab @v4-tests', () => {
 			expect( interactionsData ).toBeTruthy();
 		} );
 	} );
+
+	test( 'Verify animation plays correctly via play button, publish, and frontend view', async ( { page, apiRequests }, testInfo ) => {
+		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+		const editor = await wpAdmin.openNewPage();
+
+		await test.step( 'Add heading widget and navigate to interactions tab', async () => {
+			const container = await editor.addElement( { elType: 'container' }, 'document' );
+			await editor.addWidget( { widgetType: 'e-heading', container } );
+
+			const interactionsTab = page.getByRole( 'tab', { name: 'Interactions' } );
+			await interactionsTab.click();
+			await expect( interactionsTab ).toHaveAttribute( 'aria-selected', 'true' );
+		} );
+
+		await test.step( 'Create a simple Fade In animation on Page load', async () => {
+			const addInteractionButton = page.getByRole( 'button', { name: 'Create an interaction' } );
+			await expect( addInteractionButton ).toBeVisible();
+			await addInteractionButton.click();
+
+			await page.waitForSelector( '.MuiPopover-root' );
+
+			// Keep default "Page load" and "Fade" settings, just close the popover
+			await page.locator( 'body' ).click();
+
+			const interactionTag = page.locator( '.MuiTag-root' ).first();
+			await expect( interactionTag ).toBeVisible();
+		} );
+
+		await test.step( 'Test play button in editor', async () => {
+			// Set up event listener before clicking play button
+			const eventPromise = page.evaluate( () => {
+				return new Promise( ( resolve ) => {
+					const handler = ( e: CustomEvent ) => {
+						resolve( e.detail );
+					};
+					window.top.addEventListener( 'atomic/play_interactions', handler, { once: true } );
+				} );
+			} );
+
+			// Click the play button
+			const interactionTag = page.locator( '.MuiTag-root' ).first();
+			const { x, y, width, height } = await interactionTag.boundingBox();
+			await page.mouse.move( x + ( width / 2 ), y + ( height / 2 ) );
+			await interactionTag.locator( 'button[aria-label*="Play interaction"]' ).click();
+
+			// Verify the custom event was fired with correct data
+			const eventDetail = await eventPromise;
+			expect( eventDetail ).toHaveProperty( 'animationId' );
+			expect( eventDetail ).toHaveProperty( 'elementId' );
+		} );
+
+		await test.step( 'Publish and view the page', async () => {
+			await editor.publishAndViewPage();
+		} );
+
+		await test.step( 'Verify animation runs on published page', async () => {
+			const headingElement = page.locator( '.e-heading-base' ).first();
+
+			await expect( headingElement ).toBeVisible();
+			await expect( headingElement ).toHaveAttribute( 'data-interactions' );
+
+			// Verify motion.dev library is loaded
+			const isMotionLoaded = await page.evaluate( () => {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				return typeof ( window as any ).Motion !== 'undefined' || typeof ( window as any ).animate !== 'undefined';
+			} );
+			expect( isMotionLoaded ).toBe( true );
+
+			// Wait for the animation to complete (default 300ms duration + buffer)
+			await page.waitForTimeout( 500 );
+
+			// For "Fade In" on "Page load", the element should be fully visible (opacity: 1)
+			const opacity = await headingElement.evaluate( ( el ) => window.getComputedStyle( el ).opacity );
+			expect( parseFloat( opacity ) ).toBeGreaterThan( 0.9 );
+		} );
+	} );
 } );
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add aria-label to animation play button and implement end-to-end test for animation functionality in the Elementor editor.
Main changes:
- Added accessibility improvements to play interaction button with proper aria-label
- Implemented comprehensive e2e test verifying animation functionality in editor and published pages
- Added test assertions for proper animation event firing and rendering completion

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
