### PR TITLE
Internal: Revert delayed timing on Ally PLG [ED-21885]

### DIFF
--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -570,10 +570,6 @@ class Admin_Notices extends Module {
 			return false;
 		}
 
-		if ( ! User::has_plugin_notice_been_displayed_for_required_time( 'image_optimization', WEEK_IN_SECONDS ) ) {
-			return false;
-		}
-
 		$plugin_file_path = 'pojo-accessibility/pojo-accessibility.php';
 		$plugin_slug = 'pojo-accessibility';
 
@@ -734,8 +730,6 @@ class Admin_Notices extends Module {
 		if ( ! current_user_can( 'manage_options' ) || User::is_user_notice_viewed( $notice_id ) ) {
 			return false;
 		}
-
-		User::set_user_notice_first_time( 'image_optimization' );
 
 		$attachments = new \WP_Query( [
 			'post_type' => 'attachment',

--- a/includes/user.php
+++ b/includes/user.php
@@ -276,49 +276,6 @@ class User {
 	}
 
 	/**
-	 * @param string $plugin_name
-	 *
-	 * @return void
-	 */
-	public static function set_user_notice_first_time( $plugin_name ) {
-		if ( ! $plugin_name ) {
-			return;
-		}
-		if ( ! self::get_user_notice_first_time( $plugin_name ) ) {
-			update_user_meta( get_current_user_id(), 'plugin_' . $plugin_name . '_first_time', current_time( 'mysql' ) );
-		}
-	}
-
-	/**
-	 * Check if a plugin notice has been displayed for a required time.
-	 *
-	 * @param mixed $plugin_name
-	 * @param mixed $required_seconds
-	 * @return bool
-	 */
-	public static function has_plugin_notice_been_displayed_for_required_time( $plugin_name, $required_seconds ) {
-		$first_time = self::get_user_notice_first_time( $plugin_name );
-		if ( ! $first_time ) {
-			return false;
-		}
-
-		return strtotime( $first_time ) <= ( time() - $required_seconds );
-	}
-
-	/**
-	 * @param string $plugin_name
-	 *
-	 * @return string|false
-	 */
-	public static function get_user_notice_first_time( $plugin_name = '' ) {
-		if ( ! $plugin_name ) {
-			return false;
-		}
-
-		return get_user_meta( get_current_user_id(), 'plugin_' . $plugin_name . '_first_time', true );
-	}
-
-	/**
 	 * @param string $notice_id
 	 * @param bool   $is_viewed
 	 * @param array  $meta

--- a/includes/widgets/heading.php
+++ b/includes/widgets/heading.php
@@ -11,7 +11,6 @@ use Elementor\Modules\ContentSanitizer\Interfaces\Sanitizable;
 use Elementor\Core\Utils\Hints;
 use Elementor\Core\Admin\Admin_Notices;
 use Elementor\Modules\Promotions\Controls\Promotion_Control;
-use Elementor\User;
 
 /**
  * Elementor heading widget.
@@ -460,10 +459,6 @@ class Widget_Heading extends Widget_Base implements Sanitizable {
 		$notice_id = 'ally_heading_notice';
 		$plugin_slug = 'pojo-accessibility';
 		if ( ! Hints::should_display_hint( $notice_id ) ) {
-			return;
-		}
-
-		if ( ! User::has_plugin_notice_been_displayed_for_required_time( 'image_optimization', WEEK_IN_SECONDS ) ) {
 			return;
 		}
 		$notice_content = esc_html__( 'Make sure your page is structured with accessibility in mind. Ally helps detect and fix common issues across your site.', 'elementor' );


### PR DESCRIPTION
This reverts commit 4e3140425ae1e96528323f67776d3f19e9641f72 PR https://github.com/elementor/elementor/pull/33410

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove delayed timing mechanism for displaying Ally plugin notices to users, reverting to immediate display.

Main changes:
- Removed week-long delay requirement for accessibility plugin notice display
- Deleted User class methods for tracking first-time notice display timestamps
- Removed unnecessary User class import in heading widget

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
