### PR TITLE
Fix: Scroll replay currently off [ED-21911]

### DIFF
--- a/modules/interactions/assets/js/interactions.js
+++ b/modules/interactions/assets/js/interactions.js
@@ -9,18 +9,19 @@ function scrollOutAnimation( element, animConfig, keyframes, options, animateFun
 	const stop = inViewFunc( element, () => {
 		return () => {
 			animateFunc( element, keyframes, options );
-			stop();
+			if ( false === animConfig.replay ) {
+				stop();
+			}
 		};
 	}, viewOptions );
 }
 
-function scrollInAnimation( element, keyframes, options, animateFunc, inViewFunc ) {
+function scrollInAnimation( element, animConfig, keyframes, options, animateFunc, inViewFunc ) {
 	const viewOptions = { amount: 0, root: null };
-	inViewFunc( element, () => {
+	const stop = inViewFunc( element, () => {
 		animateFunc( element, keyframes, options );
-		// This block is once the replay scroll animation should operate.
-		if ( true === animConfig.replay ) {
-			return () => scrollInAnimation( element, keyframes, options, animateFunc, inViewFunc );
+		if ( false === animConfig.replay ) {
+			stop();
 		}
 	}, viewOptions );
 }
@@ -40,7 +41,7 @@ function applyAnimation( element, animConfig, animateFunc, inViewFunc ) {
 	if ( 'scrollOut' === animConfig.trigger ) {
 		scrollOutAnimation( element, animConfig, keyframes, options, animateFunc, inViewFunc );
 	} else if ( 'scrollIn' === animConfig.trigger ) {
-		scrollInAnimation( element, keyframes, options, animateFunc, inViewFunc );
+		scrollInAnimation( element, animConfig, keyframes, options, animateFunc, inViewFunc );
 	} else {
 		defaultAnimation( element, keyframes, options, animateFunc );
 	}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix scroll replay functionality by implementing proper animation control based on replay configuration setting.
Main changes:
- Added animConfig parameter to scrollInAnimation function signature to access replay setting
- Implemented conditional stop() calls in both scroll animation functions when replay is false
- Fixed scrollInAnimation function implementation to properly use stop handler

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
