### PR TITLE
Internal: Update local google fonts notice [ED-21604]

### DIFF
--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -4,6 +4,7 @@ namespace Elementor\Core\Admin;
 use Elementor\Api;
 use Elementor\Core\Admin\UI\Components\Button;
 use Elementor\Core\Base\Module;
+use Elementor\Core\Upgrade\Manager;
 use Elementor\Core\Utils\Promotions\Filtered_Promotions_Manager;
 use Elementor\Plugin;
 use Elementor\Settings;
@@ -20,6 +21,7 @@ class Admin_Notices extends Module {
 
 	const DEFAULT_EXCLUDED_PAGES = [ 'plugins.php', 'plugin-install.php', 'plugin-editor.php' ];
 	const LOCAL_GOOGLE_FONTS_DISABLED_NOTICE_ID = 'local_google_fonts_disabled';
+	const LOCAL_GOOGLE_FONTS_NOTICE_MIN_VERSION = '3.33.3';
 
 	const EXIT_EARLY_FOR_BACKWARD_COMPATIBILITY = false;
 
@@ -521,6 +523,10 @@ class Admin_Notices extends Module {
 	private function notice_local_google_fonts_disabled() {
 
 		if ( ! $this->is_elementor_page() && ! $this->is_elementor_admin_screen() ) {
+			return false;
+		}
+
+		if ( ! Manager::had_install_prior_to( self::LOCAL_GOOGLE_FONTS_NOTICE_MIN_VERSION ) ) {
 			return false;
 		}
 

--- a/core/upgrade/manager.php
+++ b/core/upgrade/manager.php
@@ -103,4 +103,26 @@ class Manager extends DB_Upgrades_Manager {
 
 		return empty( $installs_history ) || static::install_compare( ELEMENTOR_VERSION, '>=' );
 	}
+
+	public static function had_install_prior_to( string $version ): bool {
+		if ( ! $version ) {
+			return false;
+		}
+
+		$installs_history = self::get_installs_history();
+
+		if ( empty( $installs_history ) ) {
+			return false;
+		}
+
+		uksort( $installs_history, 'version_compare' );
+
+		$first_version = array_key_first( $installs_history );
+
+		if ( ! $first_version ) {
+			return false;
+		}
+
+		return version_compare( $first_version, $version, '<' );
+	}
 }

--- a/tests/phpunit/elementor/core/admin/test-admin-notices.php
+++ b/tests/phpunit/elementor/core/admin/test-admin-notices.php
@@ -3,8 +3,10 @@ namespace Elementor\Tests\Phpunit\Elementor\Core\Admin;
 
 use Elementor\Core\Admin\Admin_Notices;
 use Elementor\Core\Admin\Notices\Base_Notice;
+use Elementor\Core\Upgrade\Manager;
 use Elementor\User;
 use ElementorEditorTesting\Elementor_Test_Base;
+use ReflectionClass;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -16,6 +18,13 @@ class Test_Admin_Notices extends Elementor_Test_Base {
 		parent::setUp();
 
 		remove_all_actions('admin_notices');
+	}
+
+	public function tearDown(): void {
+		delete_option( Manager::get_install_history_meta() );
+		delete_option( 'elementor_local_google_fonts' );
+
+		parent::tearDown();
 	}
 
 	public function test_admin_notices() {
@@ -75,5 +84,75 @@ class Test_Admin_Notices extends Elementor_Test_Base {
 
 		// Assert
 		$this->assertEmpty( $result );
+	}
+
+	public function test_local_google_fonts_notice_prints_for_legacy_installs() {
+		$admin_notices = $this->create_testable_admin_notices();
+		$this->set_admin_environment( $admin_notices );
+
+		update_option( Manager::get_install_history_meta(), [
+			'3.30.0' => time(),
+		] );
+		update_option( 'elementor_local_google_fonts', '0' );
+		delete_user_meta( get_current_user_id(), User::ADMIN_NOTICES_KEY );
+
+		$result = $this->invoke_local_google_fonts_notice( $admin_notices );
+
+		$this->assertTrue( $result );
+		$this->assertNotEmpty( $admin_notices->printed_notices );
+		$this->assertSame(
+			Admin_Notices::LOCAL_GOOGLE_FONTS_DISABLED_NOTICE_ID,
+			$admin_notices->printed_notices[0]['id']
+		);
+	}
+
+	public function test_local_google_fonts_notice_skipped_for_recent_installs() {
+		$admin_notices = $this->create_testable_admin_notices();
+		$this->set_admin_environment( $admin_notices );
+
+		update_option( Manager::get_install_history_meta(), [
+			Admin_Notices::LOCAL_GOOGLE_FONTS_NOTICE_MIN_VERSION => time(),
+		] );
+		update_option( 'elementor_local_google_fonts', '0' );
+		delete_user_meta( get_current_user_id(), User::ADMIN_NOTICES_KEY );
+
+		$result = $this->invoke_local_google_fonts_notice( $admin_notices );
+
+		$this->assertFalse( $result );
+		$this->assertEmpty( $admin_notices->printed_notices );
+	}
+
+	private function create_testable_admin_notices(): Admin_Notices_Testable {
+		return new Admin_Notices_Testable();
+	}
+
+	private function invoke_local_google_fonts_notice( Admin_Notices_Testable $admin_notices ): bool {
+		$reflection = new ReflectionClass( Admin_Notices::class );
+		$method = $reflection->getMethod( 'notice_local_google_fonts_disabled' );
+		$method->setAccessible( true );
+
+		return (bool) $method->invoke( $admin_notices );
+	}
+
+	private function set_admin_environment( Admin_Notices_Testable $admin_notices ): void {
+		$user_id = self::factory()->user->create( [
+			'role' => 'administrator',
+		] );
+
+		wp_set_current_user( $user_id );
+		set_current_screen( 'toplevel_page_elementor' );
+
+		$reflection = new ReflectionClass( Admin_Notices::class );
+		$property = $reflection->getProperty( 'current_screen_id' );
+		$property->setAccessible( true );
+		$property->setValue( $admin_notices, 'toplevel_page_elementor' );
+	}
+}
+
+class Admin_Notices_Testable extends Admin_Notices {
+	public array $printed_notices = [];
+
+	public function print_admin_notice( array $options, $exclude_pages = self::DEFAULT_EXCLUDED_PAGES ) {
+		$this->printed_notices[] = $options;
 	}
 }

--- a/tests/phpunit/elementor/core/upgrade/test-manager.php
+++ b/tests/phpunit/elementor/core/upgrade/test-manager.php
@@ -1,10 +1,17 @@
 <?php
 namespace Elementor\Tests\Phpunit\Elementor\Core\Upgrade;
 
+use Elementor\Core\Upgrade\Manager as CoreUpgradeManager;
 use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
 
 class Test_Manager extends Elementor_Test_Base {
+
+	public function tearDown(): void {
+		delete_option( CoreUpgradeManager::get_install_history_meta() );
+
+		parent::tearDown();
+	}
 
 	public function test_start_run() {
 		$manager = new Manager();
@@ -27,5 +34,23 @@ class Test_Manager extends Elementor_Test_Base {
 		$this->assertContains( 'Elementor/Upgrades - upgrade_callback Start ', $messages );
 		$this->assertContains( 'Elementor/Upgrades - upgrade_callback Finished', $messages );
 		$this->assertContains( 'Elementor data updater process has been completed.', $messages );
+	}
+
+	public function test_had_install_prior_to_returns_true_for_legacy_installs() {
+		update_option( CoreUpgradeManager::get_install_history_meta(), [
+			'3.30.0' => strtotime( '-2 days' ),
+			'3.35.0' => strtotime( '-1 day' ),
+		] );
+
+		$this->assertTrue( CoreUpgradeManager::had_install_prior_to( '3.33.3' ) );
+	}
+
+	public function test_had_install_prior_to_returns_false_for_recent_installs() {
+		update_option( CoreUpgradeManager::get_install_history_meta(), [
+			'3.33.3' => strtotime( '-1 day' ),
+			'3.34.0' => time(),
+		] );
+
+		$this->assertFalse( CoreUpgradeManager::had_install_prior_to( '3.33.3' ) );
 	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update local Google Fonts notice to only display for users who installed Elementor prior to version 3.33.3.
Main changes:
- Added version check using new had_install_prior_to() method to skip notice for recent installations
- Implemented had_install_prior_to() utility method in Manager class to check installation history
- Added comprehensive unit tests for both the notice display condition and version checking logic

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
