### PR TITLE
Fix: Template Widget & Shortcode Styles Not Loading (conflict with WP 6.9) [ED-21920]

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -224,6 +224,7 @@ class Frontend extends App {
 				$src = add_query_arg( 'ver', $registered_style->ver, $src );
 			}
 
+			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 			$missing_styles .= sprintf(
 				"<link rel='stylesheet' id='%s-css' href='%s' media='all' />\n",
 				esc_attr( $handle ),
@@ -252,9 +253,9 @@ class Frontend extends App {
 		$style_id = $handle . '-css';
 
 		return false !== strpos( $html, "id='{$style_id}'" ) ||
-		       false !== strpos( $html, "id=\"{$style_id}\"" );
+			false !== strpos( $html, "id=\"{$style_id}\"" );
 	}
- 
+
 	/**
 	 * Insert styles at the end of the <head> or <body> section.
 	 *

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -224,9 +224,8 @@ class Frontend extends App {
 				$src = add_query_arg( 'ver', $registered_style->ver, $src );
 			}
 
-			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 			$missing_styles .= sprintf(
-				"<link rel='stylesheet' id='%s-css' href='%s' media='all' />\n",
+				"<link rel='stylesheet' id='%s-css' href='%s' media='all' />\n", // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet -- Styles already enqueued but not hoisted by WP 6.9.
 				esc_attr( $handle ),
 				esc_url( $src )
 			);


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix template widget and shortcode styles not loading in WordPress 6.9 by implementing compatibility adjustments for the new template enhancement output buffer.

Main changes:
- Added filter hook for WordPress 6.9's template enhancement output buffer to ensure Elementor post CSS is properly included
- Implemented style detection mechanism to identify missing Elementor styles in the hoisted output
- Created fallback method to inject missing styles into the HTML output when WP's hoisting mechanism fails

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
