### PR TITLE
Internal: Update Home Screen UI tests [ED-21841]

### DIFF
--- a/tests/playwright/pages/wp-admin-page.ts
+++ b/tests/playwright/pages/wp-admin-page.ts
@@ -67,8 +67,10 @@ export default class WpAdminPage extends BasePage {
 		await this.openElementorSettings( tab );
 
 		for ( const [ selector, state ] of Object.entries( settings ) ) {
-			await this.page.locator( `select[name="${ selector }"]` ).waitFor();
-			await this.page.selectOption( `[name="${ selector }"]`, state.toString() );
+			const selectLocator = this.page.locator( `select[name="${ selector }"]` );
+			await selectLocator.waitFor( { state: 'attached' } );
+
+			await selectLocator.selectOption( state.toString(), { force: true } );
 		}
 
 		await this.page.click( '#submit' );

--- a/tests/playwright/sanity/modules/home/home-screen-ui.test.ts
+++ b/tests/playwright/sanity/modules/home/home-screen-ui.test.ts
@@ -2,13 +2,14 @@ import { expect, request } from '@playwright/test';
 import { parallelTest as test } from '../../../parallelTest';
 import WpAdminPage from '../../../pages/wp-admin-page';
 import { type LicenseType, mockHomeScreenData, transformMockDataByLicense } from './home-screen.helper';
+import { wpCli } from '../../../assets/wp-cli';
 
 test.describe( 'Home screen visual regression tests', () => {
 	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
+		await wpCli( 'wp elementor experiments deactivate e_editor_one' );
 		const context = await browser.newContext();
 		const page = await context.newPage();
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { e_editor_one: 'inactive' } );
 		await wpAdmin.enableAdvancedUploads();
 		await page.close();
 		await context.close();


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix flaky Home Screen UI tests by improving element selection reliability and experiment deactivation method in test setup.

Main changes:
- Replaced page-level selectOption with locator-based selection and explicit 'attached' state wait for reliability
- Changed experiment deactivation from setExperiments() method to direct wpCli command for consistency
- Added force option to selectOption call to handle potentially obscured select elements

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
