### PR TITLE
Internal: Use duplicate command for nested elements duplication [ED-21982]

### DIFF
--- a/packages/packages/libs/editor-elements/src/sync/duplicate-element.ts
+++ b/packages/packages/libs/editor-elements/src/sync/duplicate-element.ts
@@ -1,4 +1,5 @@
-import { createElement } from './create-element';
+import { __privateRunCommandSync as runCommandSync } from '@elementor/editor-v1-adapters';
+
 import { getContainer } from './get-container';
 import { type V1Element } from './types';
 
@@ -20,23 +21,12 @@ export function duplicateElement( { elementId, options = {} }: DuplicateElementP
 		throw new Error( `Element with ID "${ elementId }" not found` );
 	}
 
-	if ( ! elementToDuplicate.parent ) {
-		throw new Error( `Element with ID "${ elementId }" has no parent container` );
-	}
-
-	const parentContainer = elementToDuplicate.parent;
-	const elementModel = elementToDuplicate.model.toJSON();
-
 	// Get the position after the original element (only when cloning)
 	const currentIndex = elementToDuplicate.view?._index ?? 0;
 	const insertPosition = options.clone !== false ? currentIndex + 1 : undefined;
 
-	return createElement( {
-		containerId: parentContainer.id,
-		model: elementModel,
-		options: {
-			at: insertPosition,
-			...options,
-		},
+	return runCommandSync< V1Element >( 'document/elements/duplicate', {
+		container: elementToDuplicate,
+		options: { at: insertPosition, edit: false, ...options },
 	} );
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Refactor element duplication to use standardized command system instead of manual model manipulation for improved consistency and maintainability.
Main changes:
- Replaced manual createElement with runCommandSync('document/elements/duplicate') for standardized element duplication
- Removed redundant parent container validation and manual model serialization logic
- Added edit: false option to command to prevent automatic editing after duplication
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
