### PR TITLE
Internal: Class analytics properties issue in mixpanel [ED-21988]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
@@ -245,7 +245,7 @@ function StateMenuItem( { state, label, closeMenu, ...props }: StateMenuItemProp
 	);
 }
 
-function UnapplyClassMenuItem( { ...props }: { closeMenu: () => void } ) {
+function UnapplyClassMenuItem( { closeMenu, ...props }: { closeMenu: () => void } ) {
 	const { id: classId, label: classLabel, provider } = useCssClass();
 	const unapplyClass = useUnapplyClass();
 

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
@@ -219,7 +219,6 @@ function StateMenuItem( { state, label, closeMenu, ...props }: StateMenuItemProp
 					setActiveId( styleId );
 				}
 				trackStyles( provider ?? '', 'classStateClicked', {
-					location: 'from StateMenuItem',
 					classId: styleId,
 					type: label,
 					source: styleId ? 'global' : 'local',
@@ -246,7 +245,7 @@ function StateMenuItem( { state, label, closeMenu, ...props }: StateMenuItemProp
 	);
 }
 
-function UnapplyClassMenuItem( { closeMenu, ...props }: { closeMenu: () => void } ) {
+function UnapplyClassMenuItem( { ...props }: { closeMenu: () => void } ) {
 	const { id: classId, label: classLabel, provider } = useCssClass();
 	const unapplyClass = useUnapplyClass();
 
@@ -257,7 +256,6 @@ function UnapplyClassMenuItem( { closeMenu, ...props }: { closeMenu: () => void 
 				unapplyClass( { classId, classLabel } );
 				trackStyles( provider ?? '', 'classRemoved', {
 					classId,
-					location: 'from UnapplyClassMenuItem',
 					classTitle: classLabel,
 					source: 'style-tab',
 				} );

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-selector.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-selector.tsx
@@ -255,7 +255,6 @@ function useCreateAction() {
 		const { createdId } = createAction( { classLabel } );
 		trackStyles( provider.getKey() ?? '', 'classCreated', {
 			source: 'created',
-			location: 'from useCreateAction',
 			classTitle: classLabel,
 			classId: createdId,
 		} );
@@ -317,7 +316,6 @@ function useHandleSelect() {
 			case 'selectOption':
 				apply( { classId: option.value, classLabel: option.label } );
 				trackStyles( option.provider ?? '', 'classApplied', {
-					location: 'from useHandleSelect',
 					classId: option.value,
 					source: 'style-tab',
 				} );
@@ -326,7 +324,6 @@ function useHandleSelect() {
 			case 'removeOption':
 				unapply( { classId: option.value, classLabel: option.label } );
 				trackStyles( option.provider ?? '', 'classRemoved', {
-					location: 'from useHandleSelect',
 					classId: option.value,
 					source: 'style-tab',
 				} );

--- a/packages/packages/core/editor-global-classes/src/utils/tracking.ts
+++ b/packages/packages/core/editor-global-classes/src/utils/tracking.ts
@@ -157,9 +157,7 @@ const track = ( data: Record< string, unknown > ) => {
 	try {
 		dispatchEvent?.( name, {
 			event,
-			properties: {
-				...eventData,
-			},
+			...eventData,
 		} );
 	} catch ( error ) {
 		throw new GlobalClassTrackingError( { cause: error } );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Fix Mixpanel analytics tracking by correcting event property structure and removing debug location fields from class analytics events.
Main changes:
- Flattened event properties structure in tracking.ts by removing nested 'properties' wrapper object
- Removed debug 'location' property from classStateClicked, classRemoved, classCreated, and classApplied events
- Standardized analytics payload format across all CSS class tracking events
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
