### PR TITLE
Internal: Add role to tab list and remove up and down key navigation [ED-22025]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-menu.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-menu.php
@@ -41,6 +41,12 @@ class Atomic_Tabs_Menu extends Atomic_Element_Base {
 		return false;
 	}
 
+	public function define_initial_attributes(): array {
+		return [
+			'role' => 'tablist',
+		];
+	}
+
 	protected static function define_props_schema(): array {
 		return [
 			'classes' => Classes_Prop_Type::make()

--- a/modules/atomic-widgets/elements/atomic-tabs/handlers/atomic-tabs-handler.js
+++ b/modules/atomic-widgets/elements/atomic-tabs/handlers/atomic-tabs-handler.js
@@ -35,12 +35,6 @@ register( {
 				'@keydown.arrow-left.prevent'( event ) {
 					this.navigateTabs( event );
 				},
-				'@keydown.arrow-down.prevent'( event ) {
-					this.navigateTabs( event );
-				},
-				'@keydown.arrow-up.prevent'( event ) {
-					this.navigateTabs( event );
-				},
 				':class'() {
 					const id = this.$el.id;
 

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Tabs__test__render_atomic_tabs_with_active_tab__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Tabs__test__render_atomic_tabs_with_active_tab__1.txt
@@ -1,5 +1,5 @@
 		<div class="elementor-element elementor-element-tabscontainer e-con e-atomic-element e-tabs-base" data-id="tabscontainer" data-element_type="e-tabs" data-e-type="e-tabs" x-data="eTabstabscontainer" data-e-settings="{&quot;default-active-tab&quot;:&quot;tabscontainer-tab-tab1&quot;}">
-				<div class="elementor-element elementor-element-tabs-list e-con e-atomic-element e-tabs-menu-base" data-id="tabs-list" data-element_type="e-tabs-menu">
+				<div class="elementor-element elementor-element-tabs-list e-con e-atomic-element e-tabs-menu-base" data-id="tabs-list" data-element_type="e-tabs-menu" role="tablist">
 				<button class="elementor-element elementor-element-tab1 e-con e-atomic-element e-tab-base" data-id="tab1" data-element_type="e-tab" role="tab" tabindex="-1" aria-selected="false" x-bind="tab" x-ref="tab1" id="tabscontainer-tab-0" aria-controls="tabscontainer-tab-content-0">
 				</button>
 				<button class="elementor-element elementor-element-tab2 e-con e-atomic-element e-tab-base" data-id="tab2" data-element_type="e-tab" role="tab" tabindex="-1" aria-selected="false" x-bind="tab" x-ref="tab2" id="tabscontainer-tab-1" aria-controls="tabscontainer-tab-content-1">

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Tabs__test__render_atomic_tabs_with_interactions__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Tabs__test__render_atomic_tabs_with_interactions__1.txt
@@ -1,5 +1,5 @@
 		<div class="elementor-element elementor-element-tabscontainer e-con e-atomic-element e-tabs-base" data-id="tabscontainer" data-element_type="e-tabs" data-interaction-id="tabscontainer" data-interactions="[&quot;load-fade-in--300-0&quot;]" data-e-type="e-tabs" x-data="eTabstabscontainer" data-e-settings="{&quot;default-active-tab&quot;:&quot;tabscontainer-tab-0&quot;}">
-				<div class="elementor-element elementor-element-tabs-list e-con e-atomic-element e-tabs-menu-base" data-id="tabs-list" data-element_type="e-tabs-menu">
+				<div class="elementor-element elementor-element-tabs-list e-con e-atomic-element e-tabs-menu-base" data-id="tabs-list" data-element_type="e-tabs-menu" role="tablist">
 				<button class="elementor-element elementor-element-tab1 e-con e-atomic-element e-tab-base" data-id="tab1" data-element_type="e-tab" role="tab" tabindex="0" aria-selected="true" x-bind="tab" x-ref="tab1" id="tabscontainer-tab-0" aria-controls="tabscontainer-tab-content-0">
 				</button>
 				<button class="elementor-element elementor-element-tab2 e-con e-atomic-element e-tab-base" data-id="tab2" data-element_type="e-tab" role="tab" tabindex="-1" aria-selected="false" x-bind="tab" x-ref="tab2" id="tabscontainer-tab-1" aria-controls="tabscontainer-tab-content-1">

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Tabs__test__render_atomic_tabs_with_nested_context__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Tabs__test__render_atomic_tabs_with_nested_context__1.txt
@@ -1,12 +1,12 @@
 		<div class="elementor-element elementor-element-tabscontainer e-con e-atomic-element e-tabs-base" data-id="tabscontainer" data-element_type="e-tabs" data-e-type="e-tabs" x-data="eTabstabscontainer" data-e-settings="{&quot;default-active-tab&quot;:&quot;tabscontainer-tab-tab1&quot;}">
-				<div class="elementor-element elementor-element-outer-tabs-list e-con e-atomic-element e-tabs-menu-base" data-id="outer-tabs-list" data-element_type="e-tabs-menu">
+				<div class="elementor-element elementor-element-outer-tabs-list e-con e-atomic-element e-tabs-menu-base" data-id="outer-tabs-list" data-element_type="e-tabs-menu" role="tablist">
 				<button class="elementor-element elementor-element-tab1 e-con e-atomic-element e-tab-base" data-id="tab1" data-element_type="e-tab" role="tab" tabindex="-1" aria-selected="false" x-bind="tab" x-ref="tab1" id="tabscontainer-tab-0" aria-controls="tabscontainer-tab-content-0">
 				</button>
 				</div>
 				<div class="elementor-element elementor-element-outer-tabs-content e-con e-atomic-element e-tabs-content-area-base" data-id="outer-tabs-content" data-element_type="e-tabs-content-area">
 				<div class="elementor-element elementor-element-content1 e-con e-atomic-element e-tab-content-base" data-id="content1" data-element_type="e-tab-content" role="tabpanel" x-bind="tabContent" id="tabscontainer-tab-content-0" aria-labelledby="tabscontainer-tab-0" hidden="true" style="display: none;">
 				<div class="elementor-element elementor-element-nestedtabscontainer e-con e-atomic-element e-tabs-base" data-id="nestedtabscontainer" data-element_type="e-tabs" data-e-type="e-tabs" x-data="eTabsnestedtabscontainer" data-e-settings="{&quot;default-active-tab&quot;:&quot;nestedtabscontainer-tab-nestedtab2&quot;}">
-				<div class="elementor-element elementor-element-nested-tabs-list e-con e-atomic-element e-tabs-menu-base" data-id="nested-tabs-list" data-element_type="e-tabs-menu">
+				<div class="elementor-element elementor-element-nested-tabs-list e-con e-atomic-element e-tabs-menu-base" data-id="nested-tabs-list" data-element_type="e-tabs-menu" role="tablist">
 				<button class="elementor-element elementor-element-nestedtab1 e-con e-atomic-element e-tab-base" data-id="nestedtab1" data-element_type="e-tab" role="tab" tabindex="-1" aria-selected="false" x-bind="tab" x-ref="nestedtab1" id="nestedtabscontainer-tab-0" aria-controls="nestedtabscontainer-tab-content-0">
 				</button>
 				<button class="elementor-element elementor-element-nestedtab2 e-con e-atomic-element e-tab-base" data-id="nestedtab2" data-element_type="e-tab" role="tab" tabindex="-1" aria-selected="false" x-bind="tab" x-ref="nestedtab2" id="nestedtabscontainer-tab-1" aria-controls="nestedtabscontainer-tab-content-1">


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add ARIA tablist role to atomic tabs menu component and remove vertical arrow key navigation to improve accessibility compliance and keyboard interaction behavior.

Main changes:
- Added define_initial_attributes() method to set role="tablist" on tabs menu for ARIA compliance
- Removed arrow-up and arrow-down keydown event handlers from atomic-tabs-handler.js navigation logic
- Retained horizontal arrow navigation (left/right) for tab switching while removing vertical navigation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
