### PR TITLE
Fix: Merge props don't work in store [ED-22002]

### DIFF
--- a/packages/packages/core/editor-global-classes/src/store.ts
+++ b/packages/packages/core/editor-global-classes/src/store.ts
@@ -1,4 +1,4 @@
-import { mergeProps, type Props } from '@elementor/editor-props';
+import { type Props } from '@elementor/editor-props';
 import {
 	type CustomCss,
 	getVariantByMeta,
@@ -200,6 +200,22 @@ export const slice = createSlice( {
 		},
 	},
 } );
+
+const mergeProps = ( current: Props, updates: Props ): Props => {
+	// edge case, the server returns an array instead of an object when empty props because of PHP array / object conversion
+	const props = Array.isArray( current ) ? {} : current;
+
+	Object.entries( updates ).forEach( ( [ key, value ] ) => {
+		if ( value === null || value === undefined ) {
+			// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+			delete props[ key ];
+		} else {
+			props[ key ] = value;
+		}
+	} );
+
+	return props;
+};
 
 const getNonEmptyVariants = ( style: StyleDefinition ) => {
 	return style.variants.filter(


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix props merging functionality in global classes store by implementing custom merge logic to handle PHP empty array edge case.

Main changes:
- Removed mergeProps import from @elementor/editor-props package and implemented local version
- Added edge case handling for PHP array/object conversion when server returns empty props
- Implemented null/undefined property deletion logic in custom mergeProps function

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
