### PR TITLE
Fix: Duplicated Tab Prevents Selecting the Next Tab in Editor [ED-22016]

### DIFF
--- a/packages/packages/core/frontend-handlers/src/lifecycle-events.ts
+++ b/packages/packages/core/frontend-handlers/src/lifecycle-events.ts
@@ -17,16 +17,27 @@ export const onElementRender = ( {
 	const controller = new AbortController();
 	const manualUnmount: ( () => void )[] = [];
 
-	element.dispatchEvent(
-		new CustomEvent( ELEMENT_RENDERED_EVENT_NAME, {
-			bubbles: true,
-			detail: {
-				element,
-				elementType,
-				elementId,
-			},
-		} )
-	);
+	const dispatchRenderedEvent = () => {
+		element.dispatchEvent(
+			new CustomEvent( ELEMENT_RENDERED_EVENT_NAME, {
+				bubbles: true,
+				detail: {
+					element,
+					elementType,
+					elementId,
+				},
+			} )
+		);
+	};
+
+	// When the rendered event is dispatched, the element is not yet connected to the DOM (marrionet view case)
+	if ( ! element.isConnected ) {
+		requestAnimationFrame( () => {
+			dispatchRenderedEvent();
+		} );
+	} else {
+		dispatchRenderedEvent();
+	}
 
 	if ( ! elementTypeHandlers.has( elementType ) ) {
 		return;
@@ -47,8 +58,6 @@ export const onElementRender = ( {
 						}
 
 						callback();
-
-						event.stopPropagation();
 					},
 					{ signal: controller.signal }
 				);


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix race condition in element rendering lifecycle that prevented tab selection when duplicate tabs triggered premature event propagation in the editor.

Main changes:
- Deferred ELEMENT_RENDERED_EVENT dispatch using requestAnimationFrame when element is not yet connected to DOM
- Removed event.stopPropagation() call to allow proper event bubbling through element hierarchy
- Extracted event dispatch logic into reusable dispatchRenderedEvent function for improved code organization

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
