### PR TITLE
Internal: Support V4 dynamic tags in style color props [ED-21082]

### DIFF
--- a/modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php
@@ -9,6 +9,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Html_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Image_Src_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Url_Prop_Type;
 use Elementor\Modules\DynamicTags\Module as V1_Dynamic_Tags_Module;
 use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
@@ -69,6 +70,10 @@ class Dynamic_Prop_Types_Mapping extends Prop_Types_Schema_Extender {
 
 		if ( $prop_type instanceof Html_Prop_Type ) {
 			return [ V1_Dynamic_Tags_Module::TEXT_CATEGORY ];
+		}
+
+		if ( $prop_type instanceof Color_Prop_Type ) {
+			return [ V1_Dynamic_Tags_Module::COLOR_CATEGORY ];
 		}
 
 		if ( $prop_type instanceof String_Prop_Type && empty( $prop_type->get_enum() ) ) {

--- a/modules/atomic-widgets/dynamic-tags/dynamic-tags-module.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-tags-module.php
@@ -46,6 +46,13 @@ class Dynamic_Tags_Module {
 			fn( array $schema ) => Dynamic_Prop_Types_Mapping::make()->get_extended_schema( $schema )
 		);
 
+		add_filter(
+			'elementor/atomic-widgets/styles/schema',
+			fn( array $schema ) => Dynamic_Prop_Types_Mapping::make()->get_extended_style_schema( $schema ),
+			10,
+			2
+		);
+
 		add_action(
 			'elementor/atomic-widgets/settings/transformers/register',
 			fn ( $transformers, $prop_resolver ) => $this->register_transformers( $transformers, $prop_resolver ),

--- a/modules/atomic-widgets/prop-types/utils/prop-types-schema-extender.php
+++ b/modules/atomic-widgets/prop-types/utils/prop-types-schema-extender.php
@@ -7,6 +7,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Array_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Transformable_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -18,6 +19,32 @@ abstract class Prop_Types_Schema_Extender {
 
 		foreach ( $schema as $key => $prop_type ) {
 			if ( ! ( $prop_type instanceof Prop_Type ) ) {
+				$result[ $key ] = $prop_type;
+
+				continue;
+			}
+
+			$result[ $key ] = $this->get_extended_prop_type( $prop_type );
+		}
+
+		return $result;
+	}
+
+	public function get_extended_style_schema( array $schema ): array {
+		// right now, only colors support dynamic tags in styles, this list is root level keys that contain color props
+		// ED-21082
+		$allowed_keys = [
+			'backdrop-filter',
+			'background',
+			'border-color',
+			'box-shadow',
+			'color',
+			'filter',
+			'stroke',
+		];
+
+		foreach ( $schema as $key => $prop_type ) {
+			if ( ! in_array( $key, $allowed_keys ) ) {
 				$result[ $key ] = $prop_type;
 
 				continue;

--- a/modules/variables/classes/style-schema.php
+++ b/modules/variables/classes/style-schema.php
@@ -53,9 +53,19 @@ class Style_Schema {
 		return $prop_type;
 	}
 
-	private function update_font_family( String_Prop_Type $prop_type ): Union_Prop_Type {
-		return Union_Prop_Type::create_from( $prop_type )
-					->add_prop_type( Font_Variable_Prop_Type::make() );
+	private function update_font_family( $prop_type ): Union_Prop_Type {
+		$result = null;
+
+		if ( $prop_type instanceof String_Prop_Type ) {
+			$result = Union_Prop_Type::create_from( $prop_type )
+				->add_prop_type( Font_Variable_Prop_Type::make() );
+		}
+
+		if ( $prop_type instanceof Union_Prop_Type ) {
+			$result = $prop_type->add_prop_type( Font_Variable_Prop_Type::make() );
+		}
+
+		return $result;
 	}
 
 	private function update_color( Color_Prop_Type $color_prop_type ): Union_Prop_Type {

--- a/modules/variables/hooks.php
+++ b/modules/variables/hooks.php
@@ -72,7 +72,7 @@ class Hooks {
 	private function filter_for_style_schema() {
 		add_filter( 'elementor/atomic-widgets/styles/schema', function ( array $schema ) {
 			return ( new Style_Schema() )->augment( $schema );
-		} );
+		}, 11, 2 );
 
 		add_filter( 'elementor/atomic-widgets/styles/schema', function ( array $schema ) {
 			return ( new Size_Style_Schema() )->augment( $schema );


### PR DESCRIPTION
For VQA
<img width="562" height="525" alt="Screenshot 2025-12-24 at 6 34 09" src="https://github.com/user-attachments/assets/e82bd137-7531-4f85-869f-c141149a5170" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add support for V4 dynamic tags in style color properties by extending the dynamic tags mapping system to recognize and handle color prop types in style schemas.

Main changes:
- Added Color_Prop_Type recognition in Dynamic_Prop_Types_Mapping to map color properties to COLOR_CATEGORY dynamic tags
- Implemented get_extended_style_schema() method with recursive prop type inspection for nested color detection in unions and objects
- Registered dynamic tags module filter on atomic-widgets styles schema with priority 11 for proper filter chain execution
- Refactored update_font_family() to accept Union_Prop_Type in addition to String_Prop_Type for flexible property handling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
