### PR TITLE
Internal: Simplify prop structure inside Home screen [ED-21841] (#33834)

### DIFF
--- a/modules/home/assets/js/app.js
+++ b/modules/home/assets/js/app.js
@@ -4,7 +4,7 @@ import HomeScreen from './components/home-screen/home-screen';
 import EditorScreen from './components/editor-screen/home-screen';
 
 const App = ( props ) => {
-	const ScreenComponent = props.isEditorOneActive ? EditorScreen : HomeScreen;
+	const ScreenComponent = !! props.homeScreenData?.isEditorOneActive ? EditorScreen : HomeScreen;
 
 	return (
 		<DirectionProvider rtl={ props.isRTL }>
@@ -28,7 +28,6 @@ App.propTypes = {
 	isRTL: PropTypes.bool,
 	adminUrl: PropTypes.string,
 	homeScreenData: PropTypes.object,
-	isEditorOneActive: PropTypes.bool,
 };
 
 ReactUtils.render( (
@@ -36,6 +35,5 @@ ReactUtils.render( (
 		isRTL={ isRTL }
 		homeScreenData={ elementorHomeScreenData }
 		adminUrl={ adminUrl }
-		isEditorOneActive={ elementorHomeScreenData?.isEditorOneActive }
 	/>
 ), rootElement );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor prop structure to access isEditorOneActive flag directly from homeScreenData object instead of passing it as a separate prop.

Main changes:
- Updated ScreenComponent conditional to use nullish coalescing operator when accessing props.homeScreenData?.isEditorOneActive
- Removed redundant isEditorOneActive prop from App component PropTypes definition
- Removed isEditorOneActive prop passing in ReactUtils.render to simplify component interface

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
