### PR TITLE
Internal: Wire flyout [ED-21899]

### DIFF
--- a/modules/editor-one/assets/js/admin-menu/app.js
+++ b/modules/editor-one/assets/js/admin-menu/app.js
@@ -4,13 +4,12 @@ import { FlyoutInteractionHandler } from './classes/flyout-interaction-handler';
 
 class EditorOneMenu {
 	constructor() {
-		// eslint-disable-next-line no-undef
-		this.config = editorOneMenuConfig || {};
+		this.config = window?.editorOneMenuConfig || {};
 	}
 
 	init() {
 		if ( this.isSidebarNavigationActive() ) {
-			new SidebarMenuHandler().handle();
+			new SidebarMenuHandler();
 			return;
 		}
 

--- a/modules/editor-one/assets/js/admin-menu/classes/flyout-menu-renderer.js
+++ b/modules/editor-one/assets/js/admin-menu/classes/flyout-menu-renderer.js
@@ -10,7 +10,7 @@ export class FlyoutMenuRenderer {
 			return false;
 		}
 
-		const editorLi = this.findEditorMenuItem();
+		const editorLi = this.findEditorInMenu( `#toplevel_page_elementor-home` );
 
 		if ( ! editorLi ) {
 			return false;
@@ -39,18 +39,8 @@ export class FlyoutMenuRenderer {
 		return true;
 	}
 
-	findEditorMenuItem() {
-		let elementorMenu = document.querySelector( '#adminmenu a[href="admin.php?page=elementor"]' );
-
-		if ( ! elementorMenu ) {
-			elementorMenu = document.querySelector( '#adminmenu .toplevel_page_elementor' );
-		}
-
-		if ( ! elementorMenu ) {
-			return null;
-		}
-
-		const menuItem = elementorMenu.closest( 'li.menu-top' );
+	findEditorInMenu( menuSelector ) {
+		const menuItem = document.querySelector( menuSelector );
 
 		if ( ! menuItem ) {
 			return null;

--- a/modules/editor-one/assets/js/admin-menu/classes/sidebar-menu-handler.js
+++ b/modules/editor-one/assets/js/admin-menu/classes/sidebar-menu-handler.js
@@ -1,9 +1,8 @@
 export class SidebarMenuHandler {
 	constructor() {
-		const elementorHomeMenu = this.findElementorHomeMenu();
+		this.elementorHomeMenu = this.findElementorHomeMenu();
 
-		if ( elementorHomeMenu ) {
-			this.elementorHomeMenu = elementorHomeMenu;
+		if ( this.elementorHomeMenu ) {
 			this.deactivateOtherMenus();
 			this.activateElementorMenu();
 			this.highlightSubmenu();

--- a/modules/editor-one/assets/js/admin-menu/classes/sidebar-menu-handler.js
+++ b/modules/editor-one/assets/js/admin-menu/classes/sidebar-menu-handler.js
@@ -1,21 +1,23 @@
 export class SidebarMenuHandler {
 	constructor() {
-		this.elementorMenu = document.querySelector( '#toplevel_page_elementor' );
+		console.log( 'SidebarMenuHandler' );
+		const elementorHomeMenu = this.findElementorHomeMenu();
+		console.log( 'elementorHomeMenu', elementorHomeMenu );
+		if ( elementorHomeMenu ) {
+			this.activeMenu = elementorHomeMenu;
+			this.deactivateOtherMenus();
+			this.activateElementorMenu();
+			this.highlightSubmenu();
+		}
 	}
 
-	handle() {
-		if ( ! this.elementorMenu ) {
-			return;
-		}
-
-		this.deactivateOtherMenus();
-		this.activateElementorMenu();
-		this.highlightSubmenu();
+	findElementorHomeMenu() {
+		return document.querySelector( '#toplevel_page_elementor-home' );
 	}
 
 	deactivateOtherMenus() {
 		document.querySelectorAll( '#adminmenu li.wp-has-current-submenu' ).forEach( ( item ) => {
-			if ( item !== this.elementorMenu ) {
+			if ( item !== this.activeMenu ) {
 				item.classList.remove( 'wp-has-current-submenu', 'wp-menu-open', 'selected' );
 				item.classList.add( 'wp-not-current-submenu' );
 
@@ -28,10 +30,10 @@ export class SidebarMenuHandler {
 	}
 
 	activateElementorMenu() {
-		this.elementorMenu.classList.remove( 'wp-not-current-submenu' );
-		this.elementorMenu.classList.add( 'wp-has-current-submenu', 'wp-menu-open', 'selected' );
+		this.activeMenu.classList.remove( 'wp-not-current-submenu' );
+		this.activeMenu.classList.add( 'wp-has-current-submenu', 'wp-menu-open', 'selected' );
 
-		const elementorLink = this.elementorMenu.querySelector( ':scope > a.menu-top' );
+		const elementorLink = this.activeMenu.querySelector( ':scope > a.menu-top' );
 		if ( elementorLink ) {
 			elementorLink.classList.add( 'wp-has-current-submenu', 'wp-menu-open' );
 		}
@@ -44,7 +46,7 @@ export class SidebarMenuHandler {
 
 		let targetSlug = 'elementor-editor';
 
-		if ( 'elementor' === page ) {
+		if ( 'elementor' === page || 'elementor-home' === page ) {
 			targetSlug = 'elementor-editor';
 		} else if ( 'e-form-submissions' === page ) {
 			targetSlug = 'e-form-submissions';
@@ -52,7 +54,7 @@ export class SidebarMenuHandler {
 			targetSlug = 'elementor-theme-builder';
 		}
 
-		const submenuItems = this.elementorMenu.querySelectorAll( '.wp-submenu li' );
+		const submenuItems = this.activeMenu.querySelectorAll( '.wp-submenu li' );
 
 		submenuItems.forEach( ( item ) => {
 			const link = item.querySelector( 'a' );

--- a/modules/editor-one/assets/js/admin-menu/classes/sidebar-menu-handler.js
+++ b/modules/editor-one/assets/js/admin-menu/classes/sidebar-menu-handler.js
@@ -1,10 +1,9 @@
 export class SidebarMenuHandler {
 	constructor() {
-		console.log( 'SidebarMenuHandler' );
 		const elementorHomeMenu = this.findElementorHomeMenu();
-		console.log( 'elementorHomeMenu', elementorHomeMenu );
+
 		if ( elementorHomeMenu ) {
-			this.activeMenu = elementorHomeMenu;
+			this.elementorHomeMenu = elementorHomeMenu;
 			this.deactivateOtherMenus();
 			this.activateElementorMenu();
 			this.highlightSubmenu();
@@ -17,7 +16,7 @@ export class SidebarMenuHandler {
 
 	deactivateOtherMenus() {
 		document.querySelectorAll( '#adminmenu li.wp-has-current-submenu' ).forEach( ( item ) => {
-			if ( item !== this.activeMenu ) {
+			if ( item !== this.elementorHomeMenu ) {
 				item.classList.remove( 'wp-has-current-submenu', 'wp-menu-open', 'selected' );
 				item.classList.add( 'wp-not-current-submenu' );
 
@@ -30,10 +29,10 @@ export class SidebarMenuHandler {
 	}
 
 	activateElementorMenu() {
-		this.activeMenu.classList.remove( 'wp-not-current-submenu' );
-		this.activeMenu.classList.add( 'wp-has-current-submenu', 'wp-menu-open', 'selected' );
+		this.elementorHomeMenu.classList.remove( 'wp-not-current-submenu' );
+		this.elementorHomeMenu.classList.add( 'wp-has-current-submenu', 'wp-menu-open', 'selected' );
 
-		const elementorLink = this.activeMenu.querySelector( ':scope > a.menu-top' );
+		const elementorLink = this.elementorHomeMenu.querySelector( ':scope > a.menu-top' );
 		if ( elementorLink ) {
 			elementorLink.classList.add( 'wp-has-current-submenu', 'wp-menu-open' );
 		}
@@ -54,7 +53,7 @@ export class SidebarMenuHandler {
 			targetSlug = 'elementor-theme-builder';
 		}
 
-		const submenuItems = this.activeMenu.querySelectorAll( '.wp-submenu li' );
+		const submenuItems = this.elementorHomeMenu.querySelectorAll( '.wp-submenu li' );
 
 		submenuItems.forEach( ( item ) => {
 			const link = item.querySelector( 'a' );

--- a/modules/editor-one/classes/menu-config.php
+++ b/modules/editor-one/classes/menu-config.php
@@ -8,6 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Menu_Config {
 	const ELEMENTOR_MENU_SLUG = 'elementor';
+	const ELEMENTOR_HOME_MENU_SLUG = 'elementor-home';
 	const EDITOR_MENU_SLUG = 'elementor-editor';
 	const TEMPLATES_GROUP_ID = 'elementor-editor-templates';
 	const SETTINGS_GROUP_ID = 'elementor-editor-settings';
@@ -38,9 +39,14 @@ class Menu_Config {
 		$default_mapping = [
 			self::LEGACY_TEMPLATES_SLUG => self::TEMPLATES_GROUP_ID,
 			self::ELEMENTOR_MENU_SLUG => self::EDITOR_GROUP_ID,
+			self::ELEMENTOR_HOME_MENU_SLUG => self::EDITOR_GROUP_ID,
 		];
 
 		return apply_filters( 'elementor/editor-one/menu/legacy_slug_mapping', $default_mapping );
+	}
+
+	public static function is_elementor_home_menu_available(): bool {
+		return class_exists( '\ElementorOne\Loader' );
 	}
 	public static function get_legacy_pro_mapping(): array {
 		$default_mapping = [

--- a/modules/editor-one/classes/menu-config.php
+++ b/modules/editor-one/classes/menu-config.php
@@ -48,6 +48,7 @@ class Menu_Config {
 	public static function is_elementor_home_menu_available(): bool {
 		return class_exists( '\ElementorOne\Loader' );
 	}
+
 	public static function get_legacy_pro_mapping(): array {
 		$default_mapping = [
 			'elementor-license' => [ 'group' => self::SYSTEM_GROUP_ID ],

--- a/modules/editor-one/classes/menu-data-provider.php
+++ b/modules/editor-one/classes/menu-data-provider.php
@@ -139,6 +139,7 @@ class Menu_Data_Provider {
 	public function get_all_sidebar_page_slugs(): array {
 		$base_slugs = [
 			Menu_Config::ELEMENTOR_MENU_SLUG,
+			Menu_Config::ELEMENTOR_HOME_MENU_SLUG,
 			Menu_Config::EDITOR_MENU_SLUG,
 		];
 

--- a/modules/editor-one/components/elementor-one-menu-manager.php
+++ b/modules/editor-one/components/elementor-one-menu-manager.php
@@ -185,9 +185,7 @@ class Elementor_One_Menu_Manager {
 	}
 
 	private function resolve_hidden_submenu_parent( ?string $parent_slug ): string {
-		$default_parent = Menu_Config::is_elementor_home_menu_available()
-			? Menu_Config::ELEMENTOR_HOME_MENU_SLUG
-			: Menu_Config::ELEMENTOR_MENU_SLUG;
+		$default_parent = Menu_Config::ELEMENTOR_HOME_MENU_SLUG;
 
 		if ( empty( $parent_slug ) ) {
 			return $default_parent;

--- a/modules/editor-one/components/elementor-one-menu-manager.php
+++ b/modules/editor-one/components/elementor-one-menu-manager.php
@@ -185,9 +185,9 @@ class Elementor_One_Menu_Manager {
 	}
 
 	private function resolve_hidden_submenu_parent( ?string $parent_slug ): string {
-		$default_parent = Menu_Config::ELEMENTOR_HOME_MENU_SLUG;
+		$default_parent_slug = Menu_Config::ELEMENTOR_HOME_MENU_SLUG;
 		if ( empty( $parent_slug ) ) {
-			return $default_parent;
+			return $default_parent_slug;
 		}
 
 		$elementor_parent_slugs = [
@@ -201,7 +201,7 @@ class Elementor_One_Menu_Manager {
 		];
 
 		if ( isset( $elementor_parent_slugs[ $parent_slug ] ) ) {
-			return $default_parent;
+			return $default_parent_slug;
 		}
 
 		return $parent_slug;

--- a/modules/editor-one/components/elementor-one-menu-manager.php
+++ b/modules/editor-one/components/elementor-one-menu-manager.php
@@ -44,7 +44,6 @@ class Elementor_One_Menu_Manager {
 
 		add_action( 'admin_menu', [ $this, 'intercept_legacy_submenus' ], 999 );
 		add_action( 'admin_menu', [ $this, 'register_flyout_items_as_hidden_submenus' ], 1001 );
-		add_action( 'admin_menu', [ $this, 'reorder_elementor_submenu' ], 1002 );
 		add_filter( 'add_menu_classes', [ $this, 'fix_theme_builder_submenu_url' ] );
 		add_action( 'admin_head', [ $this, 'hide_flyout_items_from_wp_menu' ] );
 		add_action( 'admin_head', [ $this, 'hide_legacy_templates_menu' ] );
@@ -90,7 +89,7 @@ class Elementor_One_Menu_Manager {
 			''
 		);
 
-		do_action( 'elementor/editor-one/menu/register_submenus', Menu_Config::ELEMENTOR_MENU_SLUG );
+		do_action( 'elementor/editor-one/menu/register_submenus' );
 	}
 
 	public function render_editor_page(): void {
@@ -108,11 +107,7 @@ class Elementor_One_Menu_Manager {
 	public function fix_theme_builder_submenu_url( $menu ) {
 		global $submenu;
 
-		$menu_slugs = [ Menu_Config::ELEMENTOR_MENU_SLUG ];
-
-		if ( Menu_Config::is_elementor_home_menu_available() ) {
-			$menu_slugs[] = Menu_Config::ELEMENTOR_HOME_MENU_SLUG;
-		}
+		$menu_slugs = [ Menu_Config::ELEMENTOR_HOME_MENU_SLUG ];
 
 		foreach ( $menu_slugs as $menu_slug ) {
 			if ( empty( $submenu[ $menu_slug ] ) ) {

--- a/modules/editor-one/components/elementor-one-menu-manager.php
+++ b/modules/editor-one/components/elementor-one-menu-manager.php
@@ -193,7 +193,8 @@ class Elementor_One_Menu_Manager {
 		$elementor_parent_slugs = [
 			Menu_Config::EDITOR_GROUP_ID => true,
 			Menu_Config::EDITOR_MENU_SLUG => true,
-			Menu_Config::TEMPLATES_GROUP_ID => true, Menu_Config::LEGACY_TEMPLATES_SLUG => true,
+			Menu_Config::TEMPLATES_GROUP_ID => true,
+			Menu_Config::LEGACY_TEMPLATES_SLUG => true,
 			Menu_Config::SETTINGS_GROUP_ID => true,
 			Menu_Config::CUSTOM_ELEMENTS_GROUP_ID => true,
 			Menu_Config::SYSTEM_GROUP_ID => true,

--- a/modules/editor-one/components/elementor-one-menu-manager.php
+++ b/modules/editor-one/components/elementor-one-menu-manager.php
@@ -186,7 +186,6 @@ class Elementor_One_Menu_Manager {
 
 	private function resolve_hidden_submenu_parent( ?string $parent_slug ): string {
 		$default_parent = Menu_Config::ELEMENTOR_HOME_MENU_SLUG;
-
 		if ( empty( $parent_slug ) ) {
 			return $default_parent;
 		}
@@ -194,8 +193,7 @@ class Elementor_One_Menu_Manager {
 		$elementor_parent_slugs = [
 			Menu_Config::EDITOR_GROUP_ID => true,
 			Menu_Config::EDITOR_MENU_SLUG => true,
-			Menu_Config::TEMPLATES_GROUP_ID => true,
-			Menu_Config::LEGACY_TEMPLATES_SLUG => true,
+			Menu_Config::TEMPLATES_GROUP_ID => true, Menu_Config::LEGACY_TEMPLATES_SLUG => true,
 			Menu_Config::SETTINGS_GROUP_ID => true,
 			Menu_Config::CUSTOM_ELEMENTS_GROUP_ID => true,
 			Menu_Config::SYSTEM_GROUP_ID => true,

--- a/modules/editor-one/components/elementor-one-menu-manager.php
+++ b/modules/editor-one/components/elementor-one-menu-manager.php
@@ -266,8 +266,6 @@ class Elementor_One_Menu_Manager {
 
 		$config = [
 			'editorFlyout' => $this->get_editor_flyout_data(),
-			'useElementorHomeMenu' => Menu_Config::is_elementor_home_menu_available(),
-			'elementorHomeMenuSlug' => Menu_Config::ELEMENTOR_HOME_MENU_SLUG,
 		];
 
 		wp_enqueue_script(

--- a/modules/editor-one/components/sidebar-navigation-handler.php
+++ b/modules/editor-one/components/sidebar-navigation-handler.php
@@ -4,6 +4,7 @@ namespace Elementor\Modules\EditorOne\Components;
 
 use Elementor\Core\Utils\Promotions\Filtered_Promotions_Manager;
 use Elementor\Modules\EditorOne\Classes\Active_Menu_Resolver;
+use Elementor\Modules\EditorOne\Classes\Menu_Config;
 use Elementor\Modules\EditorOne\Classes\Menu_Data_Provider;
 use Elementor\Modules\EditorOne\Classes\Url_Matcher;
 use Elementor\Utils;
@@ -37,7 +38,13 @@ class Sidebar_Navigation_Handler {
 			return $classes;
 		}
 
-		return $classes . ' e-has-sidebar-navigation';
+		$classes .= ' e-has-sidebar-navigation';
+
+		if ( Menu_Config::is_elementor_home_menu_available() ) {
+			$classes .= ' e-has-elementor-home-menu';
+		}
+
+		return $classes;
 	}
 
 	public function enqueue_sidebar_assets(): void {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor Elementor admin menu structure to introduce new elementor-home parent menu and wire flyout navigation to new menu system

Main changes:
- Added ELEMENTOR_HOME_MENU_SLUG constant and registered new elementor-home parent menu with submenus for Editor, Theme Builder, and Submissions
- Removed menu reordering and repositioning logic (reorder_elementor_submenu, reposition_elementor_menu) in favor of simpler submenu registration
- Updated flyout menu renderer to target #toplevel_page_elementor-home selector instead of dynamic elementor menu detection
- Added hide_old_elementor_menu method to hide legacy elementor menu when new home menu is available
- Modified SidebarMenuHandler to reference elementorHomeMenu and support both 'elementor' and 'elementor-home' page parameters

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
