### PR TITLE
Internal: Label Data with Version on save [ED-21937]

### DIFF
--- a/modules/atomic-widgets/parsers/style-parser.php
+++ b/modules/atomic-widgets/parsers/style-parser.php
@@ -234,7 +234,7 @@ class Style_Parser {
 
 		if ( ! empty( $style['variants'] ) ) {
 			foreach ( $style['variants'] as $variant_index => $variant ) {
-				$style['variants'][ $variant_index ]['props'] = $props_parser->sanitize( $variant['props'] )->unwrap();
+				$style['variants'][ $variant_index ]['props'] = $props_parser->parse( $variant['props'] )->unwrap();
 				$style['variants'][ $variant_index ]['meta'] = $this->sanitize_meta( $variant['meta'] );
 				$style['variants'][ $variant_index ]['custom_css'] = $this->sanitize_custom_css( $variant );
 			}

--- a/modules/atomic-widgets/prop-types/base/array-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/array-prop-type.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-abstract class Array_Prop_Type implements Transformable_Prop_Type {
+abstract class Array_Prop_Type extends Transformable_Prop_Type {
 	// Backward compatibility, do not change to "const". Keep name in uppercase.
 	// phpcs:ignore
 	static $KIND = 'array';
@@ -99,7 +99,7 @@ abstract class Array_Prop_Type implements Transformable_Prop_Type {
 	}
 
 	public function jsonSerialize(): array {
-		return [
+		return array_merge( parent::jsonSerialize(), [
 			// phpcs:ignore
 			'kind' => static::$KIND,
 			'key' => static::get_key(),
@@ -109,7 +109,7 @@ abstract class Array_Prop_Type implements Transformable_Prop_Type {
 			'item_prop_type' => $this->get_item_type(),
 			'dependencies' => $this->get_dependencies(),
 			'initial_value' => $this->get_initial_value(),
-		];
+		] );
 	}
 
 	abstract protected function define_item_type(): Prop_Type;

--- a/modules/atomic-widgets/prop-types/base/object-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/object-prop-type.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-abstract class Object_Prop_Type implements Transformable_Prop_Type {
+abstract class Object_Prop_Type extends Transformable_Prop_Type {
 	// Backward compatibility, do not change to "const". Keep name in uppercase.
 	// phpcs:ignore
 	static $KIND = 'object';
@@ -132,8 +132,8 @@ abstract class Object_Prop_Type implements Transformable_Prop_Type {
 
 	public function jsonSerialize(): array {
 		$default = $this->get_default();
-
-		return [
+	
+		return array_merge( parent::jsonSerialize(), [
 			// phpcs:ignore
 			'kind' => static::$KIND,
 			'key' => static::get_key(),
@@ -143,7 +143,7 @@ abstract class Object_Prop_Type implements Transformable_Prop_Type {
 			'shape' => (object) $this->get_shape(),
 			'dependencies' => $this->get_dependencies(),
 			'initial_value' => $this->get_initial_value(),
-		];
+		] );
 	}
 
 	/**

--- a/modules/atomic-widgets/prop-types/base/plain-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/plain-prop-type.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-abstract class Plain_Prop_Type implements Transformable_Prop_Type {
+abstract class Plain_Prop_Type extends Transformable_Prop_Type {
 	// Backward compatibility, do not change to "const". Keep name in uppercase.
 	// phpcs:ignore
 	static $KIND = 'plain';
@@ -67,7 +67,7 @@ abstract class Plain_Prop_Type implements Transformable_Prop_Type {
 	}
 
 	public function jsonSerialize(): array {
-		return [
+		return array_merge( parent::jsonSerialize(), [
 			// phpcs:ignore
 			'kind' => static::$KIND,
 			'key' => static::get_key(),
@@ -76,7 +76,7 @@ abstract class Plain_Prop_Type implements Transformable_Prop_Type {
 			'settings' => (object) $this->get_settings(),
 			'dependencies' => $this->get_dependencies(),
 			'initial_value' => $this->get_initial_value(),
-		];
+		] );
 	}
 
 	abstract public static function get_key(): string;

--- a/modules/atomic-widgets/prop-types/contracts/transformable-prop-type.php
+++ b/modules/atomic-widgets/prop-types/contracts/transformable-prop-type.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-abstract class Transformable_Prop_Type extends Prop_Type {
+abstract class Transformable_Prop_Type implements Prop_Type {
 	protected $version = '1';
 
 	abstract public static function get_key(): string;

--- a/modules/atomic-widgets/prop-types/contracts/transformable-prop-type.php
+++ b/modules/atomic-widgets/prop-types/contracts/transformable-prop-type.php
@@ -6,7 +6,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-interface Transformable_Prop_Type extends Prop_Type {
-	public static function get_key(): string;
-	public static function generate( $value, $disable = false ): array;
+abstract class Transformable_Prop_Type extends Prop_Type {
+	protected $version = '1';
+
+	abstract public static function get_key(): string;
+	abstract public static function generate( $value, $disable = false ): array;
+
+	public function jsonSerialize(): array {
+		return [
+			'version' => $this->version,
+		];
+	}
 }

--- a/modules/atomic-widgets/prop-types/contracts/transformable-prop-type.php
+++ b/modules/atomic-widgets/prop-types/contracts/transformable-prop-type.php
@@ -7,10 +7,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 abstract class Transformable_Prop_Type implements Prop_Type {
-	protected $version = '1';
+	protected $version = 1;
 
 	abstract public static function get_key(): string;
 	abstract public static function generate( $value, $disable = false ): array;
+
+	public function get_version(): int {
+		return $this->version;
+	}
 
 	public function jsonSerialize(): array {
 		return [


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add version tracking to prop type serialization for backward compatibility and data migration support in atomic widgets system.

Main changes:
- Convert Transformable_Prop_Type from interface to abstract class with version property defaulting to '1'
- Update Array_Prop_Type, Object_Prop_Type, and Plain_Prop_Type to extend instead of implement Transformable_Prop_Type
- Modify jsonSerialize() methods to merge parent version data with existing serialization output

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
