### PR TITLE
Fix: Issues with rendering in Text Editor widget [ED-22104]

### DIFF
--- a/includes/widgets/text-editor.php
+++ b/includes/widgets/text-editor.php
@@ -606,7 +606,9 @@ class Widget_Text_Editor extends Widget_Base {
 		<?php if ( $should_render_inline_editing ) { ?>
 			<div <?php $this->print_render_attribute_string( 'editor' ); ?>>
 		<?php } ?>
-		<?php echo wp_kses_post( $editor_content ); ?>
+		<?php // PHPCS - DO NOT REMOVE THIS ECHO - THE MAIN TEXT OF A WIDGET SHOULD NOT BE ESCAPED!
+			echo $editor_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		?>
 		<?php if ( $should_render_inline_editing ) { ?>
 			</div>
 		<?php } ?>


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Revert text editor output sanitization to allow unescaped HTML content rendering in Elementor text editor widget.
Main changes:
- Replaced wp_kses_post() sanitization with raw echo to output unescaped editor content
- Added phpcs:ignore directive to suppress WordPress.Security.EscapeOutput.OutputNotEscaped warning
- Included explicit comment documenting intentional unescaped output for widget main text content
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
