### PR TITLE
Internal: Show notice for changing menu location [ED-21967]

### DIFF
--- a/modules/editor-one/classes/editor-one-pointer.php
+++ b/modules/editor-one/classes/editor-one-pointer.php
@@ -50,7 +50,6 @@ class Editor_One_Pointer {
 							edge: <?php echo is_rtl() ? "'right'" : "'left'"; ?>,
 							align: 'center'
 						},
-						pointerWidth: 360,
 						close: function () {
 							elementorCommon.ajax.addRequest( 'introduction_viewed', {
 								data: {

--- a/modules/editor-one/classes/editor-one-pointer.php
+++ b/modules/editor-one/classes/editor-one-pointer.php
@@ -1,0 +1,86 @@
+<?php
+namespace Elementor\Modules\EditorOne;
+
+use Elementor\Core\Admin\Admin;
+use Elementor\Core\Upgrade\Manager as Upgrade_Manager;
+use Elementor\User;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Editor_One_Pointer {
+
+	const RELEASE_VERSION = '3.26.0';
+
+	const CURRENT_POINTER_SLUG = 'e-editor-one-new-home';
+
+	public static function add_hooks() {
+		add_action( 'admin_print_footer_scripts', [ __CLASS__, 'admin_print_script' ] );
+	}
+
+	public static function admin_print_script() {
+		if ( static::is_dismissed() || static::is_new_installation() || ! static::should_show() ) {
+			return;
+		}
+
+		wp_enqueue_script( 'wp-pointer' );
+		wp_enqueue_style( 'wp-pointer' );
+
+		$pointer_content = '<h3>' . esc_html__( 'The Editor has a new home', 'elementor' ) . '</h3>';
+		$pointer_content .= '<p>' . esc_html__( 'Editor tools are now grouped together for quick access. Build and grow your site with everything you need in one place.', 'elementor' ) . '</p>';
+
+		$got_it_url = admin_url( 'admin.php?page=elementor' );
+		$pointer_content .= sprintf(
+			'<p><a class="button button-primary" href="%s" onclick="jQuery(this).closest(\'.wp-pointer\').pointer(\'close\'); setTimeout(function(){window.location.href=\'%s\';}, 100); return false;">%s</a> <button class="button" onclick="jQuery(this).closest(\'.wp-pointer\').pointer(\'close\');">%s</button></p>',
+			esc_url( $got_it_url ),
+			esc_js( $got_it_url ),
+			esc_html__( 'Got it', 'elementor' ),
+			esc_html__( 'Dismiss', 'elementor' )
+		);
+
+		?>
+		<script>
+			jQuery( document ).ready( function( $ ) {
+				setTimeout( function () {
+					$( '#toplevel_page_elementor' ).pointer( {
+						content: '<?php echo $pointer_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>',
+						position: {
+							edge: <?php echo is_rtl() ? "'right'" : "'left'"; ?>,
+							align: 'center'
+						},
+						pointerWidth: 360,
+						close: function () {
+							elementorCommon.ajax.addRequest( 'introduction_viewed', {
+								data: {
+									introductionKey: '<?php echo esc_attr( static::CURRENT_POINTER_SLUG ); ?>',
+								},
+							} );
+						}
+					} ).pointer( 'open' );
+				}, 10 );
+			} );
+		</script>
+		<?php
+	}
+
+	private static function is_dismissed() {
+		return User::get_introduction_meta( static::CURRENT_POINTER_SLUG );
+	}
+
+	private static function is_new_installation() {
+		return Upgrade_Manager::install_compare( static::RELEASE_VERSION, '>=' );
+	}
+
+	private static function should_show() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+
+		if ( ! Admin::is_elementor_admin_page() ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/modules/editor-one/classes/editor-one-pointer.php
+++ b/modules/editor-one/classes/editor-one-pointer.php
@@ -10,30 +10,35 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Editor_One_Pointer {
 
-	const CURRENT_POINTER_SLUG = 'e-editor-one-new-home';
+	const CURRENT_POINTER_SLUG = 'e-editor-one-notice-pointer';
 
 	public function __construct() {
 		add_action( 'admin_print_footer_scripts-index.php', [ $this, 'admin_print_script' ] );
 	}
 
 	public function admin_print_script() {
-		if ( ! $this->is_admin_user() || $this->is_dismissed() || $this->is_new_installation() ) {
+		if ( ! $this->is_admin_user() || $this->is_new_installation() || $this->is_dismissed() ) {
 			return;
 		}
 
 		wp_enqueue_script( 'wp-pointer' );
 		wp_enqueue_style( 'wp-pointer' );
 
+		$learn_more_url = 'https://go.elementor.com/wp-dash-editor-one-learn-more/';
 		$pointer_content = '<h3>' . esc_html__( 'The Editor has a new home', 'elementor' ) . '</h3>';
-		$pointer_content .= '<p>' . esc_html__( 'Editor tools are now grouped together for quick access. Build and grow your site with everything you need in one place.', 'elementor' ) . '</p>';
+		$pointer_content .= sprintf(
+			'<p>%s <a href="%s" target="_blank">%s</a></p>',
+			esc_html__( 'Editor tools are now grouped together for quick access. Build and grow your site with everything you need in one place.', 'elementor' ),
+			esc_url( $learn_more_url ),
+			esc_html__( 'Learn more', 'elementor' )
+		);
 
 		$got_it_url = admin_url( 'admin.php?page=elementor' );
 		$pointer_content .= sprintf(
-			'<p><a class="button button-primary" href="%s" onclick="jQuery(this).closest(\'.wp-pointer\').pointer(\'close\'); setTimeout(function(){window.location.href=\'%s\';}, 100); return false;">%s</a> <button class="button" onclick="jQuery(this).closest(\'.wp-pointer\').pointer(\'close\');">%s</button></p>',
+			'<p><a class="button button-primary" href="%s" onclick="jQuery(this).closest(\'.wp-pointer\').pointer(\'close\'); setTimeout(function(){window.location.href=\'%s\';}, 100); return false;">%s</a></p>',
 			esc_url( $got_it_url ),
 			esc_js( $got_it_url ),
-			esc_html__( 'Got it', 'elementor' ),
-			esc_html__( 'Dismiss', 'elementor' )
+			esc_html__( 'Got it', 'elementor' )
 		);
 
 		?>
@@ -41,7 +46,7 @@ class Editor_One_Pointer {
 			jQuery( document ).ready( function( $ ) {
 				setTimeout( function () {
 					$( '#toplevel_page_elementor' ).pointer( {
-						content: '<?php echo $pointer_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>',
+						content: <?php echo wp_json_encode( $pointer_content ); ?>,
 						position: {
 							edge: <?php echo is_rtl() ? "'right'" : "'left'"; ?>,
 							align: 'center'

--- a/modules/editor-one/classes/editor-one-pointer.php
+++ b/modules/editor-one/classes/editor-one-pointer.php
@@ -17,9 +17,9 @@ class Editor_One_Pointer {
 	}
 
 	public function admin_print_script() {
-		if ( ! $this->is_admin_user() || $this->is_new_installation() || $this->is_dismissed() ) {
-			return;
-		}
+		// if ( ! $this->is_admin_user() || $this->is_new_installation() || $this->is_dismissed() ) {
+		// 	return;
+		// }
 
 		wp_enqueue_script( 'wp-pointer' );
 		wp_enqueue_style( 'wp-pointer' );
@@ -35,9 +35,8 @@ class Editor_One_Pointer {
 
 		$got_it_url = admin_url( 'admin.php?page=elementor' );
 		$pointer_content .= sprintf(
-			'<p><a class="button button-primary" href="%s" onclick="jQuery(this).closest(\'.wp-pointer\').pointer(\'close\'); setTimeout(function(){window.location.href=\'%s\';}, 100); return false;">%s</a></p>',
+			'<p><a class="button button-primary" href="%s">%s</a></p>',
 			esc_url( $got_it_url ),
-			esc_js( $got_it_url ),
 			esc_html__( 'Got it', 'elementor' )
 		);
 

--- a/modules/editor-one/classes/editor-one-pointer.php
+++ b/modules/editor-one/classes/editor-one-pointer.php
@@ -1,7 +1,6 @@
 <?php
-namespace Elementor\Modules\EditorOne;
+namespace Elementor\Modules\EditorOne\Classes;
 
-use Elementor\Core\Admin\Admin;
 use Elementor\Core\Upgrade\Manager as Upgrade_Manager;
 use Elementor\User;
 
@@ -11,16 +10,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Editor_One_Pointer {
 
-	const RELEASE_VERSION = '3.26.0';
-
 	const CURRENT_POINTER_SLUG = 'e-editor-one-new-home';
 
-	public static function add_hooks() {
-		add_action( 'admin_print_footer_scripts', [ __CLASS__, 'admin_print_script' ] );
+	public function __construct() {
+		add_action( 'admin_print_footer_scripts-index.php', [ $this, 'admin_print_script' ] );
 	}
 
-	public static function admin_print_script() {
-		if ( static::is_dismissed() || static::is_new_installation() || ! static::should_show() ) {
+	public function admin_print_script() {
+		if ( ! $this->is_admin_user() || $this->is_dismissed() || $this->is_new_installation() ) {
 			return;
 		}
 
@@ -53,7 +50,7 @@ class Editor_One_Pointer {
 						close: function () {
 							elementorCommon.ajax.addRequest( 'introduction_viewed', {
 								data: {
-									introductionKey: '<?php echo esc_attr( static::CURRENT_POINTER_SLUG ); ?>',
+									introductionKey: '<?php echo esc_attr( self::CURRENT_POINTER_SLUG ); ?>',
 								},
 							} );
 						}
@@ -64,23 +61,15 @@ class Editor_One_Pointer {
 		<?php
 	}
 
-	private static function is_dismissed() {
-		return User::get_introduction_meta( static::CURRENT_POINTER_SLUG );
+	private function is_dismissed() {
+		return User::get_introduction_meta( self::CURRENT_POINTER_SLUG );
 	}
 
-	private static function is_new_installation() {
-		return Upgrade_Manager::install_compare( static::RELEASE_VERSION, '>=' );
+	private function is_new_installation() {
+		return Upgrade_Manager::is_new_installation();
 	}
 
-	private static function should_show() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return false;
-		}
-
-		if ( ! Admin::is_elementor_admin_page() ) {
-			return false;
-		}
-
-		return true;
+	private function is_admin_user() {
+		return current_user_can( 'manage_options' );
 	}
 }

--- a/modules/editor-one/classes/editor-one-pointer.php
+++ b/modules/editor-one/classes/editor-one-pointer.php
@@ -14,7 +14,7 @@ class Editor_One_Pointer {
 	const MINIMUM_VERSION = '3.34.0';
 
 	public function __construct() {
-		add_action( 'admin_print_footer_scripts-index.php', [ $this, 'admin_print_script' ] );
+		add_action( 'admin_print_footer_scripts', [ $this, 'admin_print_script' ] );
 	}
 
 	public function admin_print_script() {

--- a/modules/editor-one/classes/editor-one-pointer.php
+++ b/modules/editor-one/classes/editor-one-pointer.php
@@ -11,13 +11,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Editor_One_Pointer {
 
 	const CURRENT_POINTER_SLUG = 'e-editor-one-notice-pointer';
+	const MINIMUM_VERSION = '3.34.0';
 
 	public function __construct() {
 		add_action( 'admin_print_footer_scripts-index.php', [ $this, 'admin_print_script' ] );
 	}
 
 	public function admin_print_script() {
-		if ( ! $this->is_admin_user() || $this->is_new_installation() || $this->is_dismissed() ) {
+		if ( ! $this->is_admin_user() || $this->is_new_installation() || $this->is_dismissed() || ! $this->is_version_3_34_or_larger() ) {
 			return;
 		}
 
@@ -74,5 +75,9 @@ class Editor_One_Pointer {
 
 	private function is_admin_user() {
 		return current_user_can( 'manage_options' );
+	}
+
+	private function is_version_3_34_or_larger() {
+		return version_compare( ELEMENTOR_VERSION, self::MINIMUM_VERSION, '>=' );
 	}
 }

--- a/modules/editor-one/classes/editor-one-pointer.php
+++ b/modules/editor-one/classes/editor-one-pointer.php
@@ -17,9 +17,9 @@ class Editor_One_Pointer {
 	}
 
 	public function admin_print_script() {
-		// if ( ! $this->is_admin_user() || $this->is_new_installation() || $this->is_dismissed() ) {
-		// 	return;
-		// }
+		if ( ! $this->is_admin_user() || $this->is_new_installation() || $this->is_dismissed() ) {
+			return;
+		}
 
 		wp_enqueue_script( 'wp-pointer' );
 		wp_enqueue_style( 'wp-pointer' );

--- a/modules/editor-one/classes/editor-one-pointer.php
+++ b/modules/editor-one/classes/editor-one-pointer.php
@@ -18,7 +18,7 @@ class Editor_One_Pointer {
 	}
 
 	public function admin_print_script() {
-		if ( ! $this->is_admin_user() || $this->is_new_installation() || $this->is_dismissed() || ! $this->is_version_3_34_or_larger() ) {
+		if ( ! $this->is_admin_user() || $this->is_new_installation() || $this->is_dismissed() || ! $this->is_minimum_required_version() ) {
 			return;
 		}
 
@@ -77,7 +77,7 @@ class Editor_One_Pointer {
 		return current_user_can( 'manage_options' );
 	}
 
-	private function is_version_3_34_or_larger() {
+	private function is_minimum_required_version() {
 		return version_compare( ELEMENTOR_VERSION, self::MINIMUM_VERSION, '>=' );
 	}
 }

--- a/modules/editor-one/module.php
+++ b/modules/editor-one/module.php
@@ -5,6 +5,7 @@ namespace Elementor\Modules\EditorOne;
 use Elementor\Core\Admin\Admin;
 use Elementor\Core\Base\Module as BaseModule;
 use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\EditorOne\Classes\Editor_One_Pointer;
 use Elementor\Modules\EditorOne\Components\Elementor_One_Menu_Manager;
 use Elementor\Modules\EditorOne\Components\Sidebar_Navigation_Handler;
 use Elementor\Plugin;
@@ -42,6 +43,7 @@ class Module extends BaseModule {
 		if ( is_admin() ) {
 			$this->add_component( 'editor-one-menu-manager', new Elementor_One_Menu_Manager() );
 			$this->add_component( 'sidebar-navigation-handler', new Sidebar_Navigation_Handler() );
+			Editor_One_Pointer::add_hooks();
 		}
 
 		add_action( 'current_screen', function () {

--- a/modules/editor-one/module.php
+++ b/modules/editor-one/module.php
@@ -43,7 +43,7 @@ class Module extends BaseModule {
 		if ( is_admin() ) {
 			$this->add_component( 'editor-one-menu-manager', new Elementor_One_Menu_Manager() );
 			$this->add_component( 'sidebar-navigation-handler', new Sidebar_Navigation_Handler() );
-			Editor_One_Pointer::add_hooks();
+			$this->add_component( 'editor-one-pointer', new Editor_One_Pointer() );
 		}
 
 		add_action( 'current_screen', function () {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add user notification pointer to inform administrators about the relocated Elementor editor menu in WordPress admin dashboard.

Main changes:
- Created Editor_One_Pointer class with WordPress pointer implementation for menu relocation notice
- Implemented dismissal mechanism using user meta to prevent repeated display of notification
- Added version and permission checks to show pointer only for eligible admin users

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
