### PR TITLE
Internal: Link/unlink handling for gap-control and variables [ED-21968]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/__tests__/gap-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/gap-control.test.tsx
@@ -68,6 +68,36 @@ describe( 'GapControl', () => {
 		} );
 	} );
 
+	it( 'when linking: should apply row value if column is missing', () => {
+		// Arrange.
+		const setValue = jest.fn();
+		const bind = 'gap';
+		const label = 'Gaps';
+
+		const mockValue = {
+			$$type: 'layout-direction',
+			value: {
+				column: null,
+				row: { $$type: 'size', value: { unit: 'px', size: 10 } },
+			},
+		};
+
+		const props = { setValue, value: mockValue, bind, propType };
+
+		renderControl( <GapControl label={ label } />, props );
+
+		const toggleButton = screen.getByRole( 'button', { name: 'Link gaps' } );
+
+		// Act.
+		fireEvent.click( toggleButton );
+
+		// Assert.
+		expect( setValue ).toHaveBeenCalledWith( {
+			$$type: 'size',
+			value: { unit: 'px', size: 10 },
+		} );
+	} );
+
 	it( 'should call the setValue function with the correct value when unlinking', () => {
 		// Arrange.
 		const setValue = jest.fn();
@@ -196,38 +226,5 @@ describe( 'GapControl', () => {
 
 		// Assert.
 		expect( setValue ).toHaveBeenCalledWith( null );
-	} );
-
-	it( 'should return null layout direction props when clicking toggle link button with undefined size props', () => {
-		// Arrange.
-		const setValue = jest.fn();
-		const bind = 'gap';
-		const label = 'Gaps';
-
-		const props = {
-			setValue,
-			value: {
-				$$type: 'size',
-				value: undefined,
-			},
-			bind,
-			propType,
-		};
-
-		renderControl( <GapControl label={ label } />, props );
-
-		const toggleButton = screen.getByRole( 'button', { name: 'Unlink gaps' } );
-
-		// Act.
-		fireEvent.click( toggleButton );
-
-		// Assert.
-		expect( setValue ).toHaveBeenCalledWith( {
-			$$type: 'layout-direction',
-			value: {
-				row: null,
-				column: null,
-			},
-		} );
 	} );
 } );

--- a/packages/packages/libs/editor-controls/src/controls/gap-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/gap-control.tsx
@@ -1,41 +1,76 @@
 import * as React from 'react';
-import { type RefObject, useRef } from 'react';
+import { type RefObject, useLayoutEffect, useRef, useState } from 'react';
 import { layoutDirectionPropTypeUtil, type PropKey, sizePropTypeUtil } from '@elementor/editor-props';
+import { useActiveBreakpoint } from '@elementor/editor-responsive';
 import { DetachIcon, LinkIcon } from '@elementor/icons';
-import { Grid, Stack, ToggleButton, Tooltip } from '@elementor/ui';
+import { Grid, Stack, Tooltip } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { PropKeyProvider, PropProvider, useBoundProp } from '../bound-prop-context';
 import { ControlFormLabel } from '../components/control-form-label';
 import { ControlLabel } from '../components/control-label';
+import { StyledToggleButton } from '../components/control-toggle-button-group';
 import { SizeControl } from './size-control';
 
 export const GapControl = ( { label }: { label: string } ) => {
+	const stackRef = useRef< HTMLDivElement >( null );
+
+	const { disabled: sizeDisabled } = useBoundProp( sizePropTypeUtil );
+
 	const {
 		value: directionValue,
 		setValue: setDirectionValue,
 		propType,
+		placeholder: directionPlaceholder,
 		disabled: directionDisabled,
 	} = useBoundProp( layoutDirectionPropTypeUtil );
 
-	const stackRef = useRef< HTMLDivElement >( null );
+	const { value: masterValue, setValue: setMasterValue, placeholder: masterPlaceholder } = useBoundProp();
 
-	const { value: sizeValue, setValue: setSizeValue, disabled: sizeDisabled } = useBoundProp( sizePropTypeUtil );
+	const inferIsLinked = () => {
+		if ( layoutDirectionPropTypeUtil.isValid( masterValue ) ) {
+			return false;
+		}
 
-	const isLinked = ! directionValue && ! sizeValue ? true : !! sizeValue;
+		if ( ! masterValue && layoutDirectionPropTypeUtil.isValid( masterPlaceholder ) ) {
+			return false;
+		}
+
+		return true;
+	};
+
+	const [ isLinked, setIsLinked ] = useState( () => inferIsLinked() );
+
+	const activeBreakpoint = useActiveBreakpoint();
+	useLayoutEffect( () => {
+		setIsLinked( inferIsLinked() );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ activeBreakpoint ] );
 
 	const onLinkToggle = () => {
-		if ( ! isLinked ) {
-			setSizeValue( directionValue?.column?.value ?? null );
+		setIsLinked( ( prev ) => ! prev );
+
+		if ( ! layoutDirectionPropTypeUtil.isValid( masterValue ) ) {
+			const currentValue = masterValue ? masterValue : null;
+
+			if ( ! currentValue ) {
+				setMasterValue( null );
+				return;
+			}
+
+			setMasterValue(
+				layoutDirectionPropTypeUtil.create( {
+					row: currentValue,
+					column: currentValue,
+				} )
+			);
+
 			return;
 		}
 
-		const value = sizeValue ? sizePropTypeUtil.create( sizeValue ) : null;
+		const currentValue = directionValue?.column ?? directionValue?.row ?? null;
 
-		setDirectionValue( {
-			row: value,
-			column: value,
-		} );
+		setMasterValue( currentValue );
 	};
 
 	const tooltipLabel = label.toLowerCase();
@@ -48,12 +83,21 @@ export const GapControl = ( { label }: { label: string } ) => {
 
 	const disabled = sizeDisabled || directionDisabled;
 
+	const propProviderProps = {
+		propType,
+		value: directionValue,
+		setValue: setDirectionValue,
+		placeholder: directionPlaceholder,
+	};
+
+	const hasPlaceholders = ! masterValue && ( directionPlaceholder || masterPlaceholder );
+
 	return (
-		<PropProvider propType={ propType } value={ directionValue } setValue={ setDirectionValue }>
+		<PropProvider { ...propProviderProps }>
 			<Stack direction="row" gap={ 2 } flexWrap="nowrap">
 				<ControlLabel>{ label }</ControlLabel>
 				<Tooltip title={ isLinked ? unlinkedLabel : linkedLabel } placement="top">
-					<ToggleButton
+					<StyledToggleButton
 						aria-label={ isLinked ? unlinkedLabel : linkedLabel }
 						size={ 'tiny' }
 						value={ 'check' }
@@ -61,9 +105,10 @@ export const GapControl = ( { label }: { label: string } ) => {
 						sx={ { marginLeft: 'auto' } }
 						onChange={ onLinkToggle }
 						disabled={ disabled }
+						isPlaceholder={ hasPlaceholders }
 					>
 						<LinkedIcon fontSize={ 'tiny' } />
-					</ToggleButton>
+					</StyledToggleButton>
 				</Tooltip>
 			</Stack>
 			<Stack direction="row" gap={ 2 } flexWrap="nowrap" ref={ stackRef }>

--- a/packages/packages/libs/editor-controls/src/controls/linked-dimensions-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/linked-dimensions-control.tsx
@@ -42,7 +42,7 @@ export const LinkedDimensionsControl = ( { label, isSiteRtl = false, extendedOpt
 			return false;
 		}
 
-		if ( dimensionsPropTypeUtil.isValid( masterPlaceholder ) ) {
+		if ( ! masterValue && dimensionsPropTypeUtil.isValid( masterPlaceholder ) ) {
 			return false;
 		}
 

--- a/packages/packages/libs/editor-controls/src/controls/linked-dimensions-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/linked-dimensions-control.tsx
@@ -35,8 +35,6 @@ export const LinkedDimensionsControl = ( { label, isSiteRtl = false, extendedOpt
 
 	const { value: masterValue, placeholder: masterPlaceholder, setValue: setMasterValue } = useBoundProp();
 
-	const hasPlaceholders = !! ( sizePlaceholder || dimensionsPlaceholder );
-
 	const inferIsLinked = () => {
 		if ( dimensionsPropTypeUtil.isValid( masterValue ) ) {
 			return false;
@@ -113,6 +111,8 @@ export const LinkedDimensionsControl = ( { label, isSiteRtl = false, extendedOpt
 		setValue: setDimensionsValue,
 		isDisabled: () => dimensionsDisabled,
 	};
+
+	const hasPlaceholders = ! masterValue && ( dimensionsPlaceholder || masterPlaceholder );
 
 	return (
 		<PropProvider { ...propProviderProps }>

--- a/packages/packages/libs/editor-controls/src/controls/linked-dimensions-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/linked-dimensions-control.tsx
@@ -23,7 +23,7 @@ type Props = {
 export const LinkedDimensionsControl = ( { label, isSiteRtl = false, extendedOptions, min }: Props ) => {
 	const gridRowRefs: RefObject< HTMLDivElement >[] = [ useRef( null ), useRef( null ) ];
 
-	const { disabled: sizeDisabled, placeholder: sizePlaceholder } = useBoundProp( sizePropTypeUtil );
+	const { disabled: sizeDisabled } = useBoundProp( sizePropTypeUtil );
 
 	const {
 		value: dimensionsValue,


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor gap-control and linked-dimensions-control to fix link/unlink state management and placeholder handling for responsive breakpoints.

Main changes:
- Implemented inferIsLinked() logic using masterValue and placeholder validation instead of sizeValue checks
- Added useLayoutEffect to reset link state on breakpoint changes with activeBreakpoint dependency
- Fixed onLinkToggle to properly handle row/column value propagation when linking with missing values
- Replaced ToggleButton with StyledToggleButton component and added isPlaceholder prop for visual feedback
- Updated hasPlaceholders calculation to check masterValue absence alongside placeholder values

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
