### PR TITLE
Internal: Update Editor onboarding encourage new package [ED-21917]

### DIFF
--- a/app/modules/onboarding/assets/js/utils/modules/onboarding-tracker.js
+++ b/app/modules/onboarding/assets/js/utils/modules/onboarding-tracker.js
@@ -370,6 +370,10 @@ class OnboardingTracker {
 	extractFromObjectFormat( selectedFeatures ) {
 		const allFeatures = [];
 
+		if ( Array.isArray( selectedFeatures.one ) ) {
+			allFeatures.push( ...selectedFeatures.one );
+		}
+
 		if ( Array.isArray( selectedFeatures.essential ) ) {
 			allFeatures.push( ...selectedFeatures.essential );
 		}

--- a/app/modules/onboarding/assets/js/utils/utils.js
+++ b/app/modules/onboarding/assets/js/utils/utils.js
@@ -3,7 +3,7 @@ import { OnboardingEventTracking } from './onboarding-event-tracking';
 /**
  * Checkboxes data.
  */
-export const options = [
+const optionsWithoutOne = [
 	{
 		plan: 'essential',
 		text: __( 'Templates & Theme Builder', 'elementor' ),
@@ -37,6 +37,58 @@ export const options = [
 		text: __( 'Notes & Collaboration', 'elementor' ),
 	},
 ];
+
+/**
+ * Updated checkboxes data with ONE features (when editor_one is active).
+ * Order matches Figma design: 2 columns, 4 rows
+ * Row 1: Theme Builder | AI for code, images, & layouts
+ * Row 2: Lead Collection | Optimized images
+ * Row 3: Custom Code & CSS | AI or guided accessibility fixes
+ * Row 4: Email deliverability | WooCommerce Builder
+ */
+const optionsWithOne = [
+	{
+		plan: 'essential',
+		text: __( 'Theme Builder', 'elementor' ),
+	},
+	{
+		plan: 'one',
+		text: __( 'AI for code, images, & layouts', 'elementor' ),
+	},
+	{
+		plan: 'essential',
+		text: __( 'Lead Collection', 'elementor' ),
+	},
+	{
+		plan: 'one',
+		text: __( 'Optimized images', 'elementor' ),
+	},
+	{
+		plan: 'advanced',
+		text: __( 'Custom Code & CSS', 'elementor' ),
+	},
+	{
+		plan: 'one',
+		text: __( 'AI or guided accessibility fixes', 'elementor' ),
+	},
+	{
+		plan: 'one',
+		text: __( 'Email deliverability', 'elementor' ),
+	},
+	{
+		plan: 'advanced',
+		text: __( 'WooCommerce Builder', 'elementor' ),
+	},
+];
+
+/**
+ * Get checkboxes data based on editor_one feature status.
+ * @param {boolean} isEditorOneActive - Whether editor_one feature is active.
+ * @return {Array} Array of feature options.
+ */
+export const getOptions = ( isEditorOneActive = false ) => {
+	return isEditorOneActive ? optionsWithOne : optionsWithoutOne;
+};
 
 /**
  * Set the selected feature list.

--- a/app/modules/onboarding/module.php
+++ b/app/modules/onboarding/module.php
@@ -126,6 +126,7 @@ class Module extends BaseModule {
 			'helloOptOut' => count( $pages_and_posts->posts ) < 5,
 			'siteName' => esc_html( $site_name ),
 			'isUnfilteredFilesEnabled' => Uploads_Manager::are_unfiltered_uploads_enabled(),
+			'isEditorOneActive' => Plugin::$instance->experiments->is_feature_active( 'e_editor_one' ),
 			'urls' => [
 				'kitLibrary' => Plugin::$instance->app->get_base_url() . '&source=onboarding#/kit-library?order[direction]=desc&order[by]=featuredIndex',
 				'sitePlanner' => add_query_arg( [
@@ -144,6 +145,7 @@ class Module extends BaseModule {
 					'source' => 'generic',
 				] ),
 				'upgrade' => 'https://go.elementor.com/go-pro-onboarding-wizard-upgrade/',
+				'upgradeOne' => 'https://go.elementor.com/go-one-onboarding-wizard-upgrade/',
 				'signUp' => $library->get_admin_url( 'authorize', [
 					'utm_source' => 'onboarding-wizard',
 					'utm_campaign' => 'connect-account',


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update onboarding wizard to support Editor One package with dynamic feature selection and tier-specific upgrade flows

Main changes:
- Added 'one' tier to feature selection with conditional rendering based on e_editor_one experiment flag
- Implemented getOptions() utility to dynamically serve optionsWithOne or optionsWithoutOne feature sets
- Added tier-specific upgrade URL routing logic supporting both ONE and Pro upgrade paths

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
