### PR TITLE
Revert "Internal: Temporary disable model preferences [ED-22127]"

### DIFF
--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -4,7 +4,7 @@ import { McpServer, type ToolCallback } from '@modelcontextprotocol/sdk/server/m
 import { type RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { type ServerNotification, type ServerRequest } from '@modelcontextprotocol/sdk/types.js';
 
-import { type AngieModelPreferences } from './angie-annotations';
+import { ANGIE_MODEL_PREFERENCES, type AngieModelPreferences } from './angie-annotations';
 import { getSDK } from './get-sdk';
 import { mockMcpRegistry } from './test-utils/mock-mcp-registry';
 
@@ -195,10 +195,9 @@ function createToolRegistrator( server: McpServer ) {
 		if ( opts.requiredResources ) {
 			annotations[ 'angie/requiredResources' ] = opts.requiredResources;
 		}
-		// TODO : Revert back once the feature is ready
-		// if ( opts.modelPreferences ) {
-		// 	annotations[ ANGIE_MODEL_PREFERENCES ] = opts.modelPreferences;
-		// }
+		if ( opts.modelPreferences ) {
+			annotations[ ANGIE_MODEL_PREFERENCES ] = opts.modelPreferences;
+		}
 		server.registerTool(
 			opts.name,
 			{


### PR DESCRIPTION
Reverts elementor/elementor#33943
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert temporary disabling of model preferences feature in MCP registry to restore Angie model preference annotations on tool registration.

Main changes:
- Re-enabled model preferences annotation assignment in createToolRegistrator when opts.modelPreferences is provided
- Restored ANGIE_MODEL_PREFERENCES constant import from angie-annotations module
- Removed temporary TODO comment that was blocking model preferences feature activation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
