### PR TITLE
Revert "Internal: Editor Core Stability [ED-21965]"

### DIFF
--- a/tests/elements-regression/tests/atomic-elements-regression.test.ts
+++ b/tests/elements-regression/tests/atomic-elements-regression.test.ts
@@ -3,11 +3,14 @@ import _path from 'path';
 import WpAdminPage from '../../playwright/pages/wp-admin-page';
 import EditorPage from '../../playwright/pages/editor-page';
 import ElementRegressionHelper from '../helper';
-import { DriverFactory } from '../../playwright/drivers/driver-factory';
 
 test.describe( 'Elementor regression tests with templates for CORE - V4', () => {
-	test.beforeAll( async ( {} ) => {
-		await DriverFactory.activateExperimentsCli( [ 'e_atomic_elements' ] );
+	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
+		const page = await browser.newPage();
+		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+		await wpAdmin.resetExperiments();
+		await wpAdmin.setExperiments( { e_atomic_elements: 'active' } );
+		await page.close();
 	} );
 
 	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {

--- a/tests/playwright/drivers/driver-factory.ts
+++ b/tests/playwright/drivers/driver-factory.ts
@@ -2,7 +2,6 @@ import { Browser, BrowserContext, Page, TestInfo } from '@playwright/test';
 import { EditorDriver, DriverContext } from './editor-driver';
 import WpAdminPage from '../pages/wp-admin-page';
 import ApiRequests from '../assets/api-requests';
-import { wpCli } from '../assets/wp-cli';
 
 export class DriverFactory {
 	private static async createTemporaryContext(
@@ -21,16 +20,7 @@ export class DriverFactory {
 		return { context, page, wpAdmin };
 	}
 
-	static async createEditorDriver(
-		browser: Browser,
-		testInfo?: TestInfo,
-		apiRequests?: ApiRequests,
-		options?: { experiments?: string[] },
-	): Promise<EditorDriver> {
-		if ( options?.experiments?.length ) {
-			await this.activateExperimentsCli( options.experiments );
-		}
-
+	static async createEditorDriver( browser: Browser, testInfo?: TestInfo, apiRequests?: ApiRequests ): Promise<EditorDriver> {
 		const { context, wpAdmin } = await this.createTemporaryContext( browser, testInfo, apiRequests );
 		const editor = await wpAdmin.openNewPage();
 
@@ -57,17 +47,5 @@ export class DriverFactory {
 
 		await wpAdmin.resetExperiments();
 		await context.close();
-	}
-
-	static async activateExperimentsCli( experiments: string[] ): Promise<void> {
-		for ( const experiment of experiments ) {
-			await wpCli( `wp elementor experiments activate ${ experiment }` );
-		}
-	}
-
-	static async deactivateExperimentsCli( experiments: string[] ): Promise<void> {
-		for ( const experiment of experiments ) {
-			await wpCli( `wp elementor experiments deactivate ${ experiment }` );
-		}
 	}
 }

--- a/tests/playwright/pages/editor-assertions.ts
+++ b/tests/playwright/pages/editor-assertions.ts
@@ -20,9 +20,8 @@ export class EditorAssertions {
 		buttonExpectations: Array<{ buttonName: string; isPressed: boolean }>,
 		timeout = timeouts.expect,
 	): Promise<void> {
-		const stylePanel = driver.page.getByRole( 'tabpanel', { name: 'Style' } );
 		for ( const { buttonName, isPressed } of buttonExpectations ) {
-			const button = stylePanel.getByRole( 'button', { name: buttonName } );
+			const button = driver.page.getByRole( 'button', { name: buttonName } );
 			await expect( button ).toHaveAttribute( 'aria-pressed', String( isPressed ), { timeout } );
 		}
 	}

--- a/tests/playwright/pages/editor-page.ts
+++ b/tests/playwright/pages/editor-page.ts
@@ -832,25 +832,11 @@ export default class EditorPage extends BasePage {
 	}
 
 	/**
-	 * Close any visible MUI dialog that might be blocking interactions.
-	 *
-	 * @return {Promise<void>}
-	 */
-	async closeMuiDialogIfVisible(): Promise<void> {
-		const dialogCloseButton = this.page.locator( '.MuiDialog-container button[aria-label="close"]' );
-		if ( await dialogCloseButton.isVisible( { timeout: 500 } ).catch( () => false ) ) {
-			await dialogCloseButton.click();
-			await this.page.locator( '.MuiDialog-root' ).waitFor( { state: 'hidden', timeout: 2000 } ).catch( () => {} );
-		}
-	}
-
-	/**
 	 * Open the elements/widgets panel.
 	 *
 	 * @return {Promise<void>}
 	 */
 	async openElementsPanel(): Promise<void> {
-		await this.closeMuiDialogIfVisible();
 		await this.clickTopBarItem( TopBarSelectors.elementsPanel );
 		await this.page.locator( EditorSelectors.panels.elements.wrapper ).waitFor();
 	}

--- a/tests/playwright/sanity/modules/v4-tests/atomic-widgets-wrapper.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-widgets-wrapper.test.ts
@@ -3,7 +3,6 @@ import { parallelTest as test } from '../../../parallelTest';
 import { expect } from '@playwright/test';
 import ContextMenu from '../../../pages/widgets/context-menu';
 import EditorSelectors from '../../../selectors/editor-selectors';
-import { DriverFactory } from '../../../drivers/driver-factory';
 
 test.describe( 'Atomic Widgets Wrapper @v4-tests', () => {
 	const atomicWidgets = [
@@ -12,8 +11,14 @@ test.describe( 'Atomic Widgets Wrapper @v4-tests', () => {
 		{ name: 'e-paragraph', title: 'Paragraph' },
 	];
 
-	test.beforeAll( async () => {
-		await DriverFactory.activateExperimentsCli( [ 'e_atomic_elements' ] );
+	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+		await wpAdmin.setExperiments( {
+			e_atomic_elements: 'active',
+		} );
+		await page.close();
 	} );
 
 	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {

--- a/tests/playwright/sanity/modules/v4-tests/editing-panel-tabs.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/editing-panel-tabs.test.ts
@@ -3,7 +3,6 @@ import { parallelTest as test } from '../../../parallelTest';
 import { BrowserContext, expect } from '@playwright/test';
 import EditorPage from '../../../pages/editor-page';
 import { timeouts } from '../../../config/timeouts';
-import { DriverFactory } from '../../../drivers/driver-factory';
 
 test.describe( 'Editing panel tabs @v4-tests', () => {
 	let editor: EditorPage;
@@ -25,15 +24,13 @@ test.describe( 'Editing panel tabs @v4-tests', () => {
 		'border',
 	];
 
-	test.beforeAll( async () => {
-		await DriverFactory.activateExperimentsCli( [ 'e_atomic_elements' ] );
-	} );
-
 	test.beforeEach( async ( { browser, apiRequests }, testInfo ) => {
 		context = await browser.newContext();
 		const page = await context.newPage();
 
 		wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+		await wpAdmin.setExperiments( { e_atomic_elements: 'active' } );
+
 		editor = await wpAdmin.openNewPage();
 	} );
 

--- a/tests/playwright/sanity/modules/v4-tests/editor-variables/utils.ts
+++ b/tests/playwright/sanity/modules/v4-tests/editor-variables/utils.ts
@@ -1,11 +1,11 @@
 import { TestInfo, type Page } from '@playwright/test';
 import WpAdminPage from '../../../../pages/wp-admin-page';
 import ApiRequests from '../../../../assets/api-requests';
-import { DriverFactory } from '../../../../drivers/driver-factory';
 
 export const initTemplate = async ( page: Page, testInfo: TestInfo, apiRequests: ApiRequests ) => {
 	const wpAdminPage = new WpAdminPage( page, testInfo, apiRequests );
-	await DriverFactory.activateExperimentsCli( [ 'e_atomic_elements', 'e_variables', 'e_variables_manager' ] );
+	await wpAdminPage.setExperiments( { e_variables: 'active', e_atomic_elements: 'active' } );
+	await wpAdminPage.setExperiments( { e_variables_manager: 'active' } );
 	const editorPage = await wpAdminPage.openNewPage();
 	await editorPage.loadTemplate( 'tests/playwright/sanity/modules/v4-tests/editor-variables/variables-manager-template.json' );
 	return wpAdminPage;

--- a/tests/playwright/sanity/modules/v4-tests/editor-variables/variables-manager-page.ts
+++ b/tests/playwright/sanity/modules/v4-tests/editor-variables/variables-manager-page.ts
@@ -96,16 +96,9 @@ export default class VariablesManagerPage {
 	}
 
 	private async saveVariablesManager( shouldSave: boolean ) {
-		const saveButton = this.page.locator( '#elementor-panel' ).getByRole( 'button', { name: /Save/ } );
-		const isSaveVisible = await saveButton.isVisible( { timeout: 1000 } ).catch( () => false );
-
-		if ( ! isSaveVisible ) {
-			return;
-		}
-
-		const isSaveEnabled = await saveButton.isEnabled();
+		const isSaveEnabled = await this.page.locator( '#elementor-panel' ).getByRole( 'button', { name: /Save/ } ).isEnabled();
 		if ( shouldSave || isSaveEnabled ) {
-			await saveButton.click();
+			await this.page.locator( '#elementor-panel' ).getByRole( 'button', { name: /Save/ } ).click();
 			await this.page.waitForRequest( ( response ) => response.url().includes( 'list' ) && null === response.failure() );
 		}
 	}

--- a/tests/playwright/sanity/modules/v4-tests/inline-text-editing/canvas-editing.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/inline-text-editing/canvas-editing.test.ts
@@ -3,7 +3,6 @@ import { parallelTest as test } from '../../../../parallelTest';
 import WpAdminPage from '../../../../pages/wp-admin-page';
 import EditorPage from '../../../../pages/editor-page';
 import { INLINE_EDITING_SELECTORS } from './selectors/selectors';
-import { DriverFactory } from '../../../../drivers/driver-factory';
 
 test.describe( 'Inline Editing Canvas @v4-tests', () => {
 	let wpAdminPage: WpAdminPage;
@@ -16,10 +15,9 @@ test.describe( 'Inline Editing Canvas @v4-tests', () => {
 		page = await context.newPage();
 		wpAdminPage = new WpAdminPage( page, testInfo, apiRequests );
 
-		await DriverFactory.activateExperimentsCli( [ 'e_atomic_elements', 'v4-inline-text-editing' ] );
-	} );
+		await wpAdminPage.setExperiments( { e_atomic_elements: 'active' } );
+		await wpAdminPage.setExperiments( { 'v4-inline-text-editing': 'active' } );
 
-	test.beforeEach( async () => {
 		editor = await wpAdminPage.openNewPage();
 	} );
 

--- a/tests/playwright/sanity/modules/v4-tests/inline-text-editing/functionality.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/inline-text-editing/functionality.test.ts
@@ -3,7 +3,6 @@ import { parallelTest as test } from '../../../../parallelTest';
 import WpAdminPage from '../../../../pages/wp-admin-page';
 import EditorPage from '../../../../pages/editor-page';
 import { INLINE_EDITING_SELECTORS } from './selectors/selectors';
-import { DriverFactory } from '../../../../drivers/driver-factory';
 
 test.describe( 'Inline Editing Control @v4-tests', () => {
 	let wpAdminPage: WpAdminPage;
@@ -16,7 +15,8 @@ test.describe( 'Inline Editing Control @v4-tests', () => {
 		page = await context.newPage();
 		wpAdminPage = new WpAdminPage( page, testInfo, apiRequests );
 
-		await DriverFactory.activateExperimentsCli( [ 'e_atomic_elements', 'v4-inline-text-editing' ] );
+		await wpAdminPage.setExperiments( { e_atomic_elements: 'active' } );
+		await wpAdminPage.setExperiments( { 'v4-inline-text-editing': 'active' } );
 
 		editor = await wpAdminPage.openNewPage();
 	} );

--- a/tests/playwright/sanity/modules/v4-tests/interactions-tab.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/interactions-tab.test.ts
@@ -1,11 +1,17 @@
 import { parallelTest as test } from '../../../parallelTest';
-import { expect } from '@playwright/test';
-import { DriverFactory } from '../../../drivers/driver-factory';
 import WpAdminPage from '../../../pages/wp-admin-page';
+import { expect } from '@playwright/test';
 
 test.describe( 'Interactions Tab @v4-tests', () => {
-	test.beforeAll( async () => {
-		await DriverFactory.activateExperimentsCli( [ 'e_atomic_elements', 'e_interactions' ] );
+	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+		await wpAdmin.setExperiments( {
+			e_interactions: 'active',
+			e_atomic_elements: 'active',
+		} );
+		await page.close();
 	} );
 
 	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {

--- a/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-decorations.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-decorations.test.ts
@@ -6,14 +6,14 @@ import { WIDGET_CONFIGS, TYPOGRAPHY_DECORATIONS } from './typography-constants';
 import { EditorAssertions } from '../../../../pages/editor-assertions';
 import { DriverFactory } from '../../../../drivers/driver-factory';
 import type { EditorDriver } from '../../../../drivers/editor-driver';
+import { wpCli } from '../../../../assets/wp-cli';
 
 test.describe( 'Atomic Widgets - Text Decoration @v4-tests', () => {
 	let driver: EditorDriver;
 
 	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		driver = await DriverFactory.createEditorDriver( browser, testInfo, apiRequests, {
-			experiments: [ 'e_atomic_elements' ],
-		} );
+		await wpCli( 'wp elementor experiments activate e_atomic_elements' );
+		driver = await DriverFactory.createEditorDriver( browser, testInfo, apiRequests );
 	} );
 
 	test.afterAll( async () => {
@@ -29,8 +29,7 @@ test.describe( 'Atomic Widgets - Text Decoration @v4-tests', () => {
 		const decoration = TYPOGRAPHY_DECORATIONS.UNDERLINE;
 		await addWidgetWithOpenTypographySection( driver, widget.type );
 
-		const stylePanel = driver.page.getByRole( 'tabpanel', { name: 'Style' } );
-		await stylePanel.getByRole( 'button', { name: decoration.buttonName } ).click();
+		await driver.editor.clickButton( decoration.buttonName );
 
 		await EditorAssertions.verifyCSSProperties( driver, widget.selector, [
 			{ property: decoration.cssProperty, value: decoration.activeValue },
@@ -42,8 +41,7 @@ test.describe( 'Atomic Widgets - Text Decoration @v4-tests', () => {
 		const decoration = TYPOGRAPHY_DECORATIONS.UPPERCASE;
 		await addWidgetWithOpenTypographySection( driver, widget.type );
 
-		const stylePanel = driver.page.getByRole( 'tabpanel', { name: 'Style' } );
-		await stylePanel.getByRole( 'button', { name: decoration.buttonName } ).click();
+		await driver.editor.clickButton( decoration.buttonName );
 
 		await EditorAssertions.verifyCSSProperties( driver, widget.selector, [
 			{ property: decoration.cssProperty, value: decoration.activeValue },
@@ -55,8 +53,7 @@ test.describe( 'Atomic Widgets - Text Decoration @v4-tests', () => {
 		const decoration = TYPOGRAPHY_DECORATIONS.RTL;
 		await addWidgetWithOpenTypographySection( driver, widget.type );
 
-		const stylePanel = driver.page.getByRole( 'tabpanel', { name: 'Style' } );
-		await stylePanel.getByRole( 'button', { name: decoration.buttonName } ).click();
+		await driver.editor.clickButton( decoration.buttonName );
 
 		await EditorAssertions.verifyCSSProperties( driver, widget.selector, [
 			{ property: decoration.cssProperty, value: decoration.activeValue },
@@ -68,8 +65,7 @@ test.describe( 'Atomic Widgets - Text Decoration @v4-tests', () => {
 		const decoration = TYPOGRAPHY_DECORATIONS.ITALIC;
 		await addWidgetWithOpenTypographySection( driver, widget.type );
 
-		const stylePanel = driver.page.getByRole( 'tabpanel', { name: 'Style' } );
-		await stylePanel.getByRole( 'button', { name: decoration.buttonName } ).click();
+		await driver.editor.clickButton( decoration.buttonName );
 
 		await EditorAssertions.verifyCSSProperties( driver, widget.selector, [
 			{ property: decoration.cssProperty, value: decoration.activeValue },
@@ -81,8 +77,7 @@ test.describe( 'Atomic Widgets - Text Decoration @v4-tests', () => {
 		const decoration = TYPOGRAPHY_DECORATIONS.TEXT_STROKE;
 		await addWidgetWithOpenTypographySection( driver, widget.type );
 
-		const stylePanel = driver.page.getByRole( 'tabpanel', { name: 'Style' } );
-		await stylePanel.getByRole( 'button', { name: decoration.addButtonName, exact: true } ).click();
+		await driver.editor.clickButton( decoration.addButtonName, true );
 
 		await EditorAssertions.verifyCSSProperties( driver, widget.selector, [
 			{ property: decoration.cssProperty, value: decoration.defaultValue },
@@ -96,12 +91,11 @@ test.describe( 'Atomic Widgets - Text Decoration @v4-tests', () => {
 		await test.step( 'Apply multiple typography features', async () => {
 			await addWidgetWithOpenTypographySection( driver, widget.type );
 
-			const stylePanel = driver.page.getByRole( 'tabpanel', { name: 'Style' } );
-			await stylePanel.getByRole( 'button', { name: UNDERLINE.buttonName } ).click();
-			await stylePanel.getByRole( 'button', { name: ITALIC.buttonName } ).click();
-			await stylePanel.getByRole( 'button', { name: UPPERCASE.buttonName } ).click();
-			await stylePanel.getByRole( 'button', { name: RTL.buttonName } ).click();
-			await stylePanel.getByRole( 'button', { name: TEXT_STROKE.addButtonName, exact: true } ).click();
+			await driver.editor.clickButton( UNDERLINE.buttonName );
+			await driver.editor.clickButton( ITALIC.buttonName );
+			await driver.editor.clickButton( UPPERCASE.buttonName );
+			await driver.editor.clickButton( RTL.buttonName );
+			await driver.editor.clickButton( TEXT_STROKE.addButtonName, true );
 		} );
 
 		await test.step( 'Verify all features applied correctly', async () => {
@@ -125,8 +119,7 @@ test.describe( 'Atomic Widgets - Text Decoration @v4-tests', () => {
 		} );
 
 		await test.step( 'Toggle features off', async () => {
-			const stylePanel = driver.page.getByRole( 'tabpanel', { name: 'Style' } );
-			await stylePanel.getByRole( 'button', { name: UNDERLINE.buttonName } ).click();
+			await driver.editor.clickButton( UNDERLINE.buttonName );
 			await EditorAssertions.verifyCSSProperties( driver, widget.selector, [
 				{ property: UNDERLINE.cssProperty, value: UNDERLINE.inactiveValue },
 			] );
@@ -134,7 +127,7 @@ test.describe( 'Atomic Widgets - Text Decoration @v4-tests', () => {
 				{ buttonName: UNDERLINE.buttonName, isPressed: false },
 			] );
 
-			await stylePanel.getByRole( 'button', { name: TEXT_STROKE.removeButtonName } ).click();
+			await driver.editor.clickButton( TEXT_STROKE.removeButtonName );
 			await EditorAssertions.verifyCSSProperties( driver, widget.selector, [
 				{ property: TEXT_STROKE.cssProperty, value: TEXT_STROKE.removedValue },
 			] );

--- a/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-font-family.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-font-family.test.ts
@@ -18,9 +18,8 @@ test.describe( 'V4 Typography Font Family Tests @v4-tests', () => {
 	let driver: EditorDriver;
 
 	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		driver = await DriverFactory.createEditorDriver( browser, testInfo, apiRequests, {
-			experiments: [ 'e_atomic_elements' ],
-		} );
+		driver = await DriverFactory.createEditorDriver( browser, testInfo, apiRequests );
+		await driver.wpAdmin.setExperiments( { e_atomic_elements: 'active' } );
 	} );
 
 	test.afterAll( async () => {

--- a/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-font-size.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-font-size.test.ts
@@ -18,9 +18,8 @@ test.describe( 'V4 Typography Font Size Tests @v4-tests', () => {
 	let driver: EditorDriver;
 
 	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		driver = await DriverFactory.createEditorDriver( browser, testInfo, apiRequests, {
-			experiments: [ 'e_atomic_elements' ],
-		} );
+		driver = await DriverFactory.createEditorDriver( browser, testInfo, apiRequests );
+		await driver.wpAdmin.setExperiments( { e_atomic_elements: 'active' } );
 	} );
 
 	test.afterAll( async () => {

--- a/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-letter-spacing.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-letter-spacing.test.ts
@@ -8,6 +8,7 @@ import { WIDGET_CONFIGS, SPACING_VALUES, UNITS } from './typography-constants';
 import { DriverFactory } from '../../../../drivers/driver-factory';
 import type { EditorDriver } from '../../../../drivers/editor-driver';
 import { timeouts } from '../../../../config/timeouts';
+import { wpCli } from '../../../../assets/wp-cli';
 
 const LETTER_SPACING_VALUES = {
 	POSITIVE: SPACING_VALUES.POSITIVE,
@@ -19,9 +20,8 @@ test.describe( 'V4 Typography Letter Spacing Tests @v4-tests', () => {
 	let driver: EditorDriver;
 
 	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		driver = await DriverFactory.createEditorDriver( browser, testInfo, apiRequests, {
-			experiments: [ 'e_atomic_elements' ],
-		} );
+		await wpCli( 'wp elementor experiments activate e_atomic_elements' );
+		driver = await DriverFactory.createEditorDriver( browser, testInfo, apiRequests );
 	} );
 
 	test.afterAll( async () => {

--- a/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-word-spacing.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/typography/v4-typography-word-spacing.test.ts
@@ -8,6 +8,7 @@ import { WIDGET_CONFIGS, SPACING_VALUES, UNITS } from './typography-constants';
 import { DriverFactory } from '../../../../drivers/driver-factory';
 import type { EditorDriver } from '../../../../drivers/editor-driver';
 import { timeouts } from '../../../../config/timeouts';
+import { wpCli } from '../../../../assets/wp-cli';
 
 const WORD_SPACING_VALUES = {
 	POSITIVE: SPACING_VALUES.POSITIVE,
@@ -19,9 +20,8 @@ test.describe( 'V4 Typography Word Spacing Tests @v4-tests', () => {
 	let driver: EditorDriver;
 
 	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
-		driver = await DriverFactory.createEditorDriver( browser, testInfo, apiRequests, {
-			experiments: [ 'e_atomic_elements' ],
-		} );
+		await wpCli( 'wp elementor experiments activate e_atomic_elements' );
+		driver = await DriverFactory.createEditorDriver( browser, testInfo, apiRequests );
 	} );
 
 	test.afterAll( async () => {


### PR DESCRIPTION
Reverts elementor/elementor#33767

This breaks local wp-playground runs
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert editor core stability changes from ED-21965 by removing CLI-based experiment activation and dialog handling utilities from test infrastructure.

Main changes:
- Removed DriverFactory.activateExperimentsCli() and deactivateExperimentsCli() methods and wpCli import from driver factory
- Replaced CLI-based experiment activation with WpAdminPage.setExperiments() API calls across all test files
- Deleted closeMuiDialogIfVisible() helper method from EditorPage and removed stylePanel scoping in test assertions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
