### PR TITLE
Fix: Size variable styles still shown when Pro is deactivated [ED-22083]

### DIFF
--- a/packages/packages/core/editor-variables/src/register-variable-types.tsx
+++ b/packages/packages/core/editor-variables/src/register-variable-types.tsx
@@ -9,6 +9,7 @@ import { ColorIndicator } from './components/ui/color-indicator';
 import { colorVariablePropTypeUtil } from './prop-types/color-variable-prop-type';
 import { fontVariablePropTypeUtil } from './prop-types/font-variable-prop-type';
 import { sizeVariablePropTypeUtil } from './prop-types/size-variable-prop-type';
+import { EmptyTransformer } from './transformers/empty-transformer';
 import { registerVariableType } from './variables-registry/variable-type-registry';
 
 export function registerVariableTypes() {
@@ -33,13 +34,23 @@ export function registerVariableTypes() {
 		defaultValue: 'Roboto',
 	} );
 
-	registerVariableType( {
-		key: sizeVariablePropTypeUtil.key,
+	const sizePromotions = {
 		icon: ExpandDiagonalIcon,
 		propTypeUtil: sizeVariablePropTypeUtil,
 		fallbackPropTypeUtil: sizePropTypeUtil,
+		styleTransformer: EmptyTransformer,
 		variableType: 'size',
 		selectionFilter: () => [],
 		emptyState: <UpgradeButton size="small" href={ 'https://go.elementor.com/go-pro-panel-size-variable/' } />,
+	};
+
+	registerVariableType( {
+		...sizePromotions,
+		key: sizeVariablePropTypeUtil.key,
+	} );
+
+	registerVariableType( {
+		...sizePromotions,
+		key: 'global-custom-size-variable',
 	} );
 }

--- a/packages/packages/core/editor-variables/src/transformers/empty-transformer.tsx
+++ b/packages/packages/core/editor-variables/src/transformers/empty-transformer.tsx
@@ -1,0 +1,6 @@
+import { createTransformer } from '@elementor/editor-canvas';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const EmptyTransformer = createTransformer( ( _value: string ) => {
+	return null;
+} );

--- a/packages/packages/core/editor-variables/src/variables-registry/create-variable-type-registry.ts
+++ b/packages/packages/core/editor-variables/src/variables-registry/create-variable-type-registry.ts
@@ -1,5 +1,5 @@
 import { type ForwardRefExoticComponent, type JSX, type RefAttributes, type RefObject } from 'react';
-import { styleTransformersRegistry } from '@elementor/editor-canvas';
+import { type AnyTransformer, styleTransformersRegistry } from '@elementor/editor-canvas';
 import { stylesInheritanceTransformersRegistry } from '@elementor/editor-editing-panel';
 import {
 	type createPropUtils,
@@ -34,6 +34,7 @@ type VariableTypeOptions = {
 	variableType: string;
 	key?: string;
 	defaultValue?: string;
+	styleTransformer?: AnyTransformer;
 	fallbackPropTypeUtil: FallbackPropTypeUtil;
 	propTypeUtil: PropTypeUtil< string, string >;
 	selectionFilter?: ( variables: NormalizedVariable[], propType: PropType ) => NormalizedVariable[];
@@ -57,6 +58,7 @@ export function createVariableTypeRegistry() {
 		defaultValue,
 		selectionFilter,
 		valueTransformer,
+		styleTransformer,
 		fallbackPropTypeUtil,
 		isCompatible,
 		emptyState,
@@ -88,12 +90,12 @@ export function createVariableTypeRegistry() {
 			emptyState,
 		};
 
-		registerTransformer( propTypeUtil.key );
+		registerTransformer( propTypeUtil.key, styleTransformer );
 		registerInheritanceTransformer( propTypeUtil.key );
 	};
 
-	const registerTransformer = ( key: PropTypeKey ) => {
-		styleTransformersRegistry.register( key, variableTransformer );
+	const registerTransformer = ( key: PropTypeKey, transformer?: AnyTransformer ) => {
+		styleTransformersRegistry.register( key, transformer ?? variableTransformer );
 	};
 
 	const registerInheritanceTransformer = ( key: PropTypeKey ) => {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix size variable styles rendering in UI when Pro license is deactivated by preventing style transformation for promotional size variable types.

Main changes:
- Added EmptyTransformer that returns null to prevent style output for deactivated size variables
- Refactored size variable registration to support two types with shared promotional configuration
- Modified styleTransformer registration to accept optional custom transformer instead of always using variableTransformer

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
