### PR TITLE
Internal: Handle multi-level override parsing [ED-22151]

### DIFF
--- a/modules/components/documents/component-overridable-prop.php
+++ b/modules/components/documents/component-overridable-prop.php
@@ -30,6 +30,9 @@ class Component_Overridable_Prop {
 	/** @var string */
 	public $group_id;
 
+	/** @var ?array{ $el_type: string, $widget_type: string, $prop_key: string } */
+	public $origin_prop_fields = null;
+
 	public function __construct( array $overridable_prop ) {
 		$this->override_key = $overridable_prop['overrideKey'];
 		$this->element_id = $overridable_prop['elementId'];
@@ -39,6 +42,14 @@ class Component_Overridable_Prop {
 		$this->label = $overridable_prop['label'];
 		$this->origin_value = $overridable_prop['originValue'];
 		$this->group_id = $overridable_prop['groupId'] ?? null;
+
+		if ( isset( $overridable_prop['originPropFields'] ) ) {
+			$this->origin_prop_fields = [
+				'el_type' => $overridable_prop['originPropFields']['elType'],
+				'widget_type' => $overridable_prop['originPropFields']['widgetType'],
+				'prop_key' => $overridable_prop['originPropFields']['propKey']
+			];
+		}
 	}
 
 	public static function make( array $overridable_prop ): self {

--- a/modules/components/documents/component-overridable-prop.php
+++ b/modules/components/documents/component-overridable-prop.php
@@ -47,7 +47,7 @@ class Component_Overridable_Prop {
 			$this->origin_prop_fields = [
 				'el_type' => $overridable_prop['originPropFields']['elType'],
 				'widget_type' => $overridable_prop['originPropFields']['widgetType'],
-				'prop_key' => $overridable_prop['originPropFields']['propKey']
+				'prop_key' => $overridable_prop['originPropFields']['propKey'],
 			];
 		}
 	}

--- a/modules/components/overridable-props/overridable-prop-parser.php
+++ b/modules/components/overridable-props/overridable-prop-parser.php
@@ -49,7 +49,12 @@ class Overridable_Prop_Parser {
 			return $result;
 		}
 
-		$this->origin_value_prop_type = Parsing_Utils::get_prop_type( $prop['elType'], $prop['widgetType'], $prop['propKey'] );
+		if ( isset( $prop['originPropFields'] ) ) {
+			['elType' => $el_type, 'widgetType' => $widget_type, 'propKey' => $prop_key] = $prop['originPropFields'];
+		} else {
+			['elType' => $el_type, 'widgetType' => $widget_type, 'propKey' => $prop_key] = $prop;
+		}		
+		$this->origin_value_prop_type = Parsing_Utils::get_prop_type( $el_type, $widget_type, $prop_key );
 
 		if ( ! empty( $prop['originValue'] ) && ! $this->origin_value_prop_type->validate( $prop['originValue'] ) ) {
 			$result->errors()->add( 'originValue', 'invalid' );

--- a/modules/components/overridable-props/overridable-prop-parser.php
+++ b/modules/components/overridable-props/overridable-prop-parser.php
@@ -53,7 +53,7 @@ class Overridable_Prop_Parser {
 			['elType' => $el_type, 'widgetType' => $widget_type, 'propKey' => $prop_key] = $prop['originPropFields'];
 		} else {
 			['elType' => $el_type, 'widgetType' => $widget_type, 'propKey' => $prop_key] = $prop;
-		}		
+		}
 		$this->origin_value_prop_type = Parsing_Utils::get_prop_type( $el_type, $widget_type, $prop_key );
 
 		if ( ! empty( $prop['originValue'] ) && ! $this->origin_value_prop_type->validate( $prop['originValue'] ) ) {

--- a/modules/components/prop-types/component-override-parser.php
+++ b/modules/components/prop-types/component-override-parser.php
@@ -93,11 +93,12 @@ class Component_Override_Parser extends Override_Parser {
 	}
 
 	private function get_overridable_prop_type( Component_Overridable_Prop $overridable ): ?Prop_Type {
-		$el_type = $overridable->el_type;
-		$widget_type = $overridable->widget_type;
-		$prop_key = $overridable->prop_key;
+		if ( $overridable->origin_prop_fields ) {
+			['el_type' => $el_type, 'widget_type' => $widget_type, 'prop_key' => $prop_key] = $overridable->origin_prop_fields;
+			return Parsing_Utils::get_prop_type( $el_type, $widget_type, $prop_key );
+		}
 
-		return Parsing_Utils::get_prop_type( $el_type, $widget_type, $prop_key );
+		return Parsing_Utils::get_prop_type( $overridable->el_type, $overridable->widget_type, $overridable->prop_key );
 	}
 
 	private function get_component_overridable_props( int $component_id ) {

--- a/tests/phpunit/elementor/modules/components/mocks/component-overrides-mocks.php
+++ b/tests/phpunit/elementor/modules/components/mocks/component-overrides-mocks.php
@@ -84,6 +84,24 @@ class Component_Overrides_Mocks {
 					],
 					'groupId' => 'group-2',
 				],
+				'prop-uuid-5' => [
+					'overrideKey' => 'prop-uuid-5',
+					'label' => 'Exposed further button text',
+					'elementId' => 'button-123',
+					'elType' => 'widget',
+					'widgetType' => 'e-component',
+					'propKey' => 'override',
+					'originValue' => [
+						'$$type' => 'string',
+						'value' => 'Click here',
+					],
+					'originPropFields' => [
+						'elType' => 'widget',
+						'widgetType' => 'e-button',
+						'propKey' => 'text',
+					],
+					'groupId' => 'group-2',
+				],
 			],
 			'groups' => [
 				'items' => [
@@ -95,7 +113,7 @@ class Component_Overrides_Mocks {
 					'group-2' => [
 						'id' => 'group-2-uuid',
 						'label' => 'Image',
-						'props' => [ 'prop-uuid-3', 'prop-uuid-4' ],
+						'props' => [ 'prop-uuid-3', 'prop-uuid-4', 'prop-uuid-5' ],
 					],
 				],
 				'order' => [ 'group-1-uuid', 'group-2-uuid' ],

--- a/tests/phpunit/elementor/modules/components/overridable-props-parsers/test-overridable-props-parser.php
+++ b/tests/phpunit/elementor/modules/components/overridable-props-parsers/test-overridable-props-parser.php
@@ -121,8 +121,6 @@ class Test_Overridable_Props_Parser extends Elementor_Test_Base {
 		$result = $this->parser->parse( $data_to_sanitize );
 
 		// Assert.
-		$this->assertTrue( $result->is_valid() );
-
 		$sanitized = $result->unwrap();
 		$this->assertEquals( [ '$$type' => 'string', 'value' => 'Click here' ], $sanitized['prop-uuid-1']['originValue'] );
 	}

--- a/tests/phpunit/elementor/modules/components/overridable-props-parsers/test-overridable-props-parser.php
+++ b/tests/phpunit/elementor/modules/components/overridable-props-parsers/test-overridable-props-parser.php
@@ -41,7 +41,7 @@ class Test_Overridable_Props_Parser extends Elementor_Test_Base {
 		$this->assertTrue( $result->is_valid() );
 	}
 
-	public function test_parse__with_valid_data_and_origin_prop_fields__succeeds() {
+	public function test_parse__with_origin_prop_fields__succeeds() {
 		// Arrange.
 		$valid_data = [
 			'prop-uuid-1' => [
@@ -95,6 +95,36 @@ class Test_Overridable_Props_Parser extends Elementor_Test_Base {
 		$sanitized = $result->unwrap();
 		$this->assertEquals( 'User Name', $sanitized['prop-uuid-1']['label'] );
 		$this->assertEquals( '<strong>Original text</strong>alert("xss")', $sanitized['prop-uuid-1']['originValue']['value'] );
+	}
+
+	public function test_parser__sanitizes_origin_value_by_origin_prop_fields() {
+		// Arrange.
+		$data_to_sanitize = [
+			'prop-uuid-1' => [
+				'overrideKey' => 'prop-uuid-1',
+				'label' => 'User Name',
+				'elementId' => 'element-123',
+				'propKey' => 'override',
+				'widgetType' => 'e-component',
+				'elType' => 'widget',
+				'originValue' => [ '$$type' => 'string', 'value' => '<script>alert("xss")</script>Click here' ],
+				'originPropFields' => [
+					'elType' => 'widget',
+					'widgetType' => 'e-button',
+					'propKey' => 'text',
+				],
+				'groupId' => 'group-uuid-1',
+			],
+		];
+
+		// Act.
+		$result = $this->parser->parse( $data_to_sanitize );
+
+		// Assert.
+		$this->assertTrue( $result->is_valid() );
+
+		$sanitized = $result->unwrap();
+		$this->assertEquals( [ '$$type' => 'string', 'value' => 'Click here' ], $sanitized['prop-uuid-1']['originValue'] );
 	}
 
 	/**

--- a/tests/phpunit/elementor/modules/components/overridable-props-parsers/test-overridable-props-parser.php
+++ b/tests/phpunit/elementor/modules/components/overridable-props-parsers/test-overridable-props-parser.php
@@ -41,6 +41,33 @@ class Test_Overridable_Props_Parser extends Elementor_Test_Base {
 		$this->assertTrue( $result->is_valid() );
 	}
 
+	public function test_parse__with_valid_data_and_origin_prop_fields__succeeds() {
+		// Arrange.
+		$valid_data = [
+			'prop-uuid-1' => [
+				'overrideKey' => 'prop-uuid-1',
+				'label' => 'User Name',
+				'elementId' => 'element-123',
+				'propKey' => 'override',
+				'widgetType' => 'e-component',
+				'elType' => 'widget',
+				'originValue' => [ '$$type' => 'html', 'value' => 'Original text' ],
+				'groupId' => 'group-uuid-1',
+				'originPropFields' => [
+					'elType' => 'widget',
+					'widgetType' => 'e-heading',
+					'propKey' => 'title',
+				],
+			]
+		];
+
+		// Act.
+		$result = $this->parser->parse( $valid_data );
+
+		// Assert.
+		$this->assertTrue( $result->is_valid() );
+	}
+
 	public function test_parser__sanitizes_strings() {
 		// Arrange.
 		$data_to_sanitize = [

--- a/tests/phpunit/elementor/modules/components/prop-types/component-prop-types-test-base.php
+++ b/tests/phpunit/elementor/modules/components/prop-types/component-prop-types-test-base.php
@@ -8,6 +8,7 @@ use Elementor\Core\Documents_Manager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Heading\Atomic_Heading;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Image\Atomic_Image;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Button\Atomic_Button;
 use Elementor\Testing\Modules\Components\Mocks\Component_Overrides_Mocks;
 use Elementor\Modules\Components\Documents\Component;
 use Elementor\Modules\Components\Documents\Component_Overridable_Props;
@@ -58,6 +59,8 @@ abstract class Component_Prop_Type_Test_Base extends Elementor_Test_Base {
                         return new Atomic_Heading();
 					case 'e-image':
 						return new Atomic_Image();
+					case 'e-button':
+						return new Atomic_Button();
                     default:
                         return null;
                 }

--- a/tests/phpunit/elementor/modules/components/prop-types/test-component-override.php
+++ b/tests/phpunit/elementor/modules/components/prop-types/test-component-override.php
@@ -196,6 +196,31 @@ class Test_Component_Override extends Component_Prop_Type_Test_Base {
 		], $result );
 	}
 
+	public function test_sanitize__sanitizes_valid_second_level_override() {
+		// Arrange
+		$component_override = Override_Prop_Type::make();
+
+		// Act
+		$result = $component_override->sanitize( [
+			'$$type' => 'override',
+			'value' => [
+				'override_key' => 'prop-uuid-5',
+				'override_value' => [ '$$type' => 'string', 'value' => 'New button text <script>alert(1)</script>' ],
+				'schema_source' => ['type' => 'component', 'id' => $this::VALID_COMPONENT_ID ],
+			],
+		] );
+
+		// Assert
+		$this->assertEquals( [
+			'$$type' => 'override',
+			'value' => [
+				'override_key' => 'prop-uuid-5',
+				'override_value' => [ '$$type' => 'string', 'value' => 'New button text' ],
+				'schema_source' => ['type' => 'component', 'id' => $this::VALID_COMPONENT_ID ],
+			],
+		], $result );
+	}
+
 	public function test_sanitize__returns_null_when_override_key_not_in_component_props() {
 		// Arrange
 		$component_override = Override_Prop_Type::make();

--- a/tests/phpunit/elementor/modules/components/prop-types/test-component-override.php
+++ b/tests/phpunit/elementor/modules/components/prop-types/test-component-override.php
@@ -31,6 +31,24 @@ class Test_Component_Override extends Component_Prop_Type_Test_Base {
 		$this->assertTrue( $result );
 	}
 
+	public function test_validate__passes_with_valid_second_level_override() {
+		// Arrange
+		$component_override = Override_Prop_Type::make();
+
+		// Act
+		$result = $component_override->validate( [
+			'$$type' => 'override',
+			'value' => [
+				'override_key' => 'prop-uuid-5',
+				'override_value' => [ '$$type' => 'string', 'value' => 'New button text' ],
+				'schema_source' => ['type' => 'component', 'id' => $this::VALID_COMPONENT_ID ],
+			]
+		] );
+
+		// Assert
+		$this->assertTrue( $result );
+	}
+
 	public function test_validate__passes_when_override_key_not_in_component_props() {
 		// Arrange
 		$component_override = Override_Prop_Type::make();


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add support for multi-level override parsing by tracking origin property fields in component overridable props to enable nested component overrides [ED-22151]

Main changes:
- Added origin_prop_fields property to Component_Overridable_Prop class to store original element type, widget type, and prop key
- Updated Overridable_Prop_Parser to use originPropFields when determining prop type for validation and sanitization
- Modified Component_Override_Parser.get_overridable_prop_type() to prioritize origin_prop_fields over direct element properties for accurate type resolution
- Added comprehensive test coverage for second-level override validation and sanitization with button widget mock

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-22151]: https://elementor.atlassian.net/browse/ED-22151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ