### PR TITLE
Internal: Visual fixes [ED-21260]

### DIFF
--- a/packages/packages/core/editor-components/src/components/component-properties-panel/component-properties-panel-content.tsx
+++ b/packages/packages/core/editor-components/src/components/component-properties-panel/component-properties-panel-content.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { setDocumentModifiedStatus } from '@elementor/editor-documents';
 import { PanelBody, PanelHeader, PanelHeaderTitle } from '@elementor/editor-panels';
 import { ComponentPropListIcon, FolderPlusIcon, XIcon } from '@elementor/icons';
@@ -29,6 +29,7 @@ export function ComponentPropertiesPanelContent( { onClose }: Props ) {
 	const currentComponentId = useCurrentComponentId();
 	const overridableProps = useOverridableProps( currentComponentId );
 	const [ isAddingGroup, setIsAddingGroup ] = useState( false );
+	const introductionRef = useRef< HTMLDivElement >( null );
 	const groupLabelEditable = useCurrentEditableItem();
 
 	const groups = useMemo( () => {
@@ -122,7 +123,12 @@ export function ComponentPropertiesPanelContent( { onClose }: Props ) {
 				) }
 
 				<Tooltip title={ __( 'Close panel', 'elementor' ) }>
-					<IconButton size="tiny" aria-label={ __( 'Close panel', 'elementor' ) } onClick={ onClose }>
+					<IconButton
+						ref={ introductionRef }
+						size="tiny"
+						aria-label={ __( 'Close panel', 'elementor' ) }
+						onClick={ onClose }
+					>
 						<XIcon fontSize="tiny" />
 					</IconButton>
 				</Tooltip>
@@ -132,7 +138,7 @@ export function ComponentPropertiesPanelContent( { onClose }: Props ) {
 
 			<PanelBody>
 				{ showEmptyState ? (
-					<PropertiesEmptyState />
+					<PropertiesEmptyState introductionRef={ introductionRef } />
 				) : (
 					<List sx={ { p: 2, display: 'flex', flexDirection: 'column', gap: 2 } }>
 						<SortableProvider value={ groupIds } onChange={ handleGroupsReorder }>

--- a/packages/packages/core/editor-components/src/components/component-properties-panel/component-properties-panel-content.tsx
+++ b/packages/packages/core/editor-components/src/components/component-properties-panel/component-properties-panel-content.tsx
@@ -29,7 +29,7 @@ export function ComponentPropertiesPanelContent( { onClose }: Props ) {
 	const currentComponentId = useCurrentComponentId();
 	const overridableProps = useOverridableProps( currentComponentId );
 	const [ isAddingGroup, setIsAddingGroup ] = useState( false );
-	const introductionRef = useRef< HTMLDivElement >( null );
+	const introductionRef = useRef< HTMLButtonElement >( null );
 	const groupLabelEditable = useCurrentEditableItem();
 
 	const groups = useMemo( () => {

--- a/packages/packages/core/editor-components/src/components/component-properties-panel/properties-empty-state.tsx
+++ b/packages/packages/core/editor-components/src/components/component-properties-panel/properties-empty-state.tsx
@@ -1,16 +1,13 @@
 import * as React from 'react';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { ComponentPropListIcon } from '@elementor/icons';
 import { Link, Stack, Typography } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { ComponentIntroduction } from '../components-tab/component-introduction';
 
-const LEARN_MORE_URL = 'https://go.elementor.com/tbd/';
-
-export function PropertiesEmptyState() {
+export function PropertiesEmptyState( { introductionRef }: { introductionRef: React.RefObject< HTMLButtonElement > } ) {
 	const [ isOpen, setIsOpen ] = useState( false );
-	const anchorRef = useRef< HTMLDivElement >( null );
 	return (
 		<>
 			<Stack
@@ -20,7 +17,6 @@ export function PropertiesEmptyState() {
 				color="text.secondary"
 				sx={ { px: 2.5, pt: 10, pb: 5.5 } }
 				gap={ 1 }
-				ref={ anchorRef }
 			>
 				<ComponentPropListIcon fontSize="large" />
 
@@ -46,7 +42,7 @@ export function PropertiesEmptyState() {
 				</Link>
 			</Stack>
 			<ComponentIntroduction
-				anchorRef={ anchorRef }
+				anchorRef={ introductionRef }
 				shouldShowIntroduction={ isOpen }
 				onClose={ () => setIsOpen( false ) }
 			/>

--- a/packages/packages/core/editor-components/src/components/component-properties-panel/properties-empty-state.tsx
+++ b/packages/packages/core/editor-components/src/components/component-properties-panel/properties-empty-state.tsx
@@ -1,44 +1,55 @@
 import * as React from 'react';
+import { useRef, useState } from 'react';
 import { ComponentPropListIcon } from '@elementor/icons';
 import { Link, Stack, Typography } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
+import { ComponentIntroduction } from '../components-tab/component-introduction';
+
 const LEARN_MORE_URL = 'https://go.elementor.com/tbd/';
 
 export function PropertiesEmptyState() {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const anchorRef = useRef< HTMLDivElement >( null );
 	return (
-		<Stack
-			alignItems="center"
-			justifyContent="flex-start"
-			height="100%"
-			color="text.secondary"
-			sx={ { px: 2.5, pt: 10, pb: 5.5 } }
-			gap={ 1 }
-		>
-			<ComponentPropListIcon fontSize="large" />
-
-			<Typography align="center" variant="subtitle2">
-				{ __( 'Add your first property', 'elementor' ) }
-			</Typography>
-
-			<Typography align="center" variant="caption">
-				{ __( 'Make instances flexible while keeping design synced.', 'elementor' ) }
-			</Typography>
-
-			<Typography align="center" variant="caption">
-				{ __( 'Select any element, then click + next to a setting to expose it.', 'elementor' ) }
-			</Typography>
-
-			<Link
-				variant="caption"
-				color="secondary"
-				href={ LEARN_MORE_URL }
-				target="_blank"
-				rel="noopener noreferrer"
-				sx={ { textDecorationLine: 'underline' } }
+		<>
+			<Stack
+				alignItems="center"
+				justifyContent="flex-start"
+				height="100%"
+				color="text.secondary"
+				sx={ { px: 2.5, pt: 10, pb: 5.5 } }
+				gap={ 1 }
+				ref={ anchorRef }
 			>
-				{ __( 'Learn more', 'elementor' ) }
-			</Link>
-		</Stack>
+				<ComponentPropListIcon fontSize="large" />
+
+				<Typography align="center" variant="subtitle2">
+					{ __( 'Add your first property', 'elementor' ) }
+				</Typography>
+
+				<Typography align="center" variant="caption">
+					{ __( 'Make instances flexible while keeping design synced.', 'elementor' ) }
+				</Typography>
+
+				<Typography align="center" variant="caption">
+					{ __( 'Select any element, then click + next to a setting to expose it.', 'elementor' ) }
+				</Typography>
+
+				<Link
+					variant="caption"
+					color="secondary"
+					sx={ { textDecorationLine: 'underline' } }
+					onClick={ () => setIsOpen( true ) }
+				>
+					{ __( 'Learn more', 'elementor' ) }
+				</Link>
+			</Stack>
+			<ComponentIntroduction
+				anchorRef={ anchorRef }
+				shouldShowIntroduction={ isOpen }
+				onClose={ () => setIsOpen( false ) }
+			/>
+		</>
 	);
 }

--- a/packages/packages/core/editor-components/src/components/component-properties-panel/sortable.tsx
+++ b/packages/packages/core/editor-components/src/components/component-properties-panel/sortable.tsx
@@ -78,7 +78,7 @@ export const SortableItem = ( { children, id }: SortableItemProps ) => (
 
 const StyledSortableTrigger = styled( 'div' )( ( { theme } ) => ( {
 	position: 'absolute',
-	left: 0,
+	left: '-2px',
 	top: '50%',
 	transform: `translate( -${ theme.spacing( 1.5 ) }, -50% )`,
 	color: theme.palette.action.active,

--- a/packages/packages/core/editor-components/src/components/components-tab/component-introduction.tsx
+++ b/packages/packages/core/editor-components/src/components/components-tab/component-introduction.tsx
@@ -9,7 +9,7 @@ export const ComponentIntroduction = ( {
 	shouldShowIntroduction,
 	onClose,
 }: {
-	anchorRef: React.RefObject< HTMLDivElement >;
+	anchorRef: React.RefObject< HTMLElement >;
 	shouldShowIntroduction: boolean;
 	onClose: () => void;
 } ) => {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix visual alignment and improve "Learn more" interaction in component properties panel by replacing external link with modal introduction.

Main changes:
- Replaced external "Learn more" link with modal trigger using ComponentIntroduction component and ref-based anchoring
- Fixed sortable trigger positioning by adjusting left offset from 0 to -2px for proper alignment
- Added useRef hook to manage close button reference for modal anchor positioning
- Widened ComponentIntroduction anchorRef type from HTMLDivElement to HTMLElement for flexible element support

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
