### PR TITLE
Fix: Site settings can't be changed [ED-22081]

### DIFF
--- a/packages/packages/core/editor-components/src/sync/before-save.ts
+++ b/packages/packages/core/editor-components/src/sync/before-save.ts
@@ -20,7 +20,7 @@ type Options = {
 };
 
 export const beforeSave = ( { container, status }: Options ) => {
-	const elements = container?.model?.get?.( 'elements' )?.toJSON() ?? [];
+	const elements = container?.model.get( 'elements' ).toJSON?.() ?? [];
 
 	return Promise.all( [
 		updateArchivedComponentBeforeSave(),

--- a/packages/packages/core/editor-components/src/sync/before-save.ts
+++ b/packages/packages/core/editor-components/src/sync/before-save.ts
@@ -20,7 +20,7 @@ type Options = {
 };
 
 export const beforeSave = ( { container, status }: Options ) => {
-	const elements = container.model.get( 'elements' )?.toJSON() ?? [];
+	const elements = container?.model?.get?.( 'elements' )?.toJSON() ?? [];
 
 	return Promise.all( [
 		updateArchivedComponentBeforeSave(),


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix null reference error in site settings save flow by adding null-safe property access to container model elements retrieval.

Main changes:
- Added optional chaining to container?.model.get() to prevent TypeError when container is undefined
- Added optional chaining to toJSON?.() method call to handle cases where elements may not have toJSON method
- Prevents site settings save failures caused by attempting to access properties on undefined container object

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
