### PR TITLE
Internal: Change new component default container [ED-22058]

### DIFF
--- a/packages/packages/libs/editor-elements/src/sync/__tests__/replace-element.test.ts
+++ b/packages/packages/libs/editor-elements/src/sync/__tests__/replace-element.test.ts
@@ -92,7 +92,7 @@ describe( 'replaceElement', () => {
 		// Assert.
 		expect( mockRunCommandSync ).toHaveBeenNthCalledWith( 1, 'document/elements/create', {
 			container: documentElement,
-			model: { elType: 'container' },
+			model: { elType: 'e-flexbox' },
 			options: { at: 1, useHistory: false, edit: false },
 		} );
 

--- a/packages/packages/libs/editor-elements/src/sync/replace-element.ts
+++ b/packages/packages/libs/editor-elements/src/sync/replace-element.ts
@@ -16,7 +16,7 @@ type ReplaceElementArgs = {
 };
 
 export const replaceElement = ( { currentElement, newElement, withHistory = true }: ReplaceElementArgs ) => {
-	const { containerId, index } = getNewElementLocation( currentElement, newElement );
+	const { containerId, index } = getNewElementContainer( currentElement, newElement );
 
 	createElement( {
 		containerId,
@@ -27,41 +27,44 @@ export const replaceElement = ( { currentElement, newElement, withHistory = true
 	deleteElement( { elementId: currentElement.id, options: { useHistory: withHistory } } );
 };
 
-function getNewElementLocation(
+function getNewElementContainer(
 	currentElement: V1ElementData,
 	newElement: Omit< V1ElementModelProps, 'id' >
 ): ElementLocation {
-	let location: ElementLocation;
-
 	const currentElementContainer = getContainer( currentElement.id );
+
 	if ( ! currentElementContainer ) {
 		throw new ElementNotFoundError( { context: { elementId: currentElement.id } } );
 	}
 
-	const parent = currentElementContainer.parent;
+	const { parent } = currentElementContainer;
+
 	if ( ! parent ) {
 		throw new ElementParentNotFoundError( { context: { elementId: currentElement.id } } );
 	}
 
 	const elementIndex = currentElementContainer.view?._index ?? 0;
-	if ( elementIndex === undefined || elementIndex === -1 ) {
+
+	if ( elementIndex === -1 ) {
 		throw new ElementIndexNotFoundError( { context: { elementId: currentElement.id } } );
 	}
 
-	location = { containerId: parent.id, index: elementIndex };
+	let container = { containerId: parent.id, index: elementIndex };
 
 	// If the element is at document top level and is a widget, wrap it with an empty container
 	if ( parent.id === 'document' && newElement.elType === 'widget' ) {
-		location = createWrapperForWidget( parent.id, elementIndex );
+		container = createWrapperForWidget( parent.id, elementIndex );
 	}
 
-	return location;
+	return container;
 }
+
+const DEFAULT_CONTAINER_TYPE = 'e-flexbox';
 
 function createWrapperForWidget( parentId: string, elementIndex: number ): ElementLocation {
 	const container = createElement( {
 		containerId: parentId,
-		model: { elType: 'container' },
+		model: { elType: DEFAULT_CONTAINER_TYPE },
 		options: { at: elementIndex, useHistory: false },
 	} );
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Change default container type from 'container' to 'e-flexbox' when wrapping widgets at document level to support new flexbox-based layout system.

Main changes:
- Updated DEFAULT_CONTAINER_TYPE constant from 'container' to 'e-flexbox' in createWrapperForWidget function
- Renamed getNewElementLocation to getNewElementContainer for improved clarity and semantic accuracy
- Refactored container location logic to use direct assignment instead of mutable variable

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
