### PR TITLE
Feature: Minimize LLM using custom css to zero [ED-22140]

### DIFF
--- a/packages/packages/core/editor-canvas/src/mcp/mcp-description.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/mcp-description.ts
@@ -39,8 +39,6 @@ The tool accepts both the structure, the styling and the configuration of each e
 - Second step: decide which elements to create, and their configuration and styles.
   Retrieve the used elements configuration schema from the resource [${ ELEMENT_SCHEMA_URI }]
 - Third step: define the styles for each element, using the common styles schema from the resource [${ STYLE_SCHEMA_URI }]. List the resource to see all available style properties.
-  For background and complicated layered styles, you can use "custom_css" property, which is supported only for ELEMENTOR PRO users ONLY.
-  The custom css is intented to deal with yet unsupported CSS features that ARE NOT PART OF THE STYLE SCHEMA, to enable PRO users to support new CSS features.
 
 ## Workflow for build-compositions tool
 1. **Parse user requirements** - Undestand what needs to be built (structure, content, styling).
@@ -62,10 +60,7 @@ The tool accepts both the structure, the styling and the configuration of each e
 
 6. **Create stylesConfig** - For each configuration-id:
    - Use style schema PropValues from [${ STYLE_SCHEMA_URI }]
-   - **Priority**: Use style schema PropValues over custom_css
    - **Use global variables** for colors, sizes, fonts where applicable
-   - **custom_css (PRO Users Only)**: The property appears only for PRO user. The purpose of custom_css is to support new CSS features not yet available in the style schema.
-     The schema supports multiple layers of background, gradients, filters. Prefer NOT USING custom_css.
    - **Important**: Global classes are applied AFTER building the composition. Once built, apply classes using the "apply-global-class" tool - after completion of building the composition.
 
 7. **Validate** - Ensure:

--- a/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/prompt.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/prompt.ts
@@ -58,9 +58,6 @@ Prefer this tool over any other tool for building HTML structure, unless you are
    Layout properties, such as margin, padding, align, etc. must be applied using the [${ STYLE_SCHEMA_URI }] PropValues.
 7. Some elements allow nesting of other elements, and most of the DO NOT. The allowed elements that can have nested children are "e-tabs", "e-div-block", and "e-flexbox".
 8. Make sure that non-container elements do NOT have any nested elements.
-9. **CRITICAL - CUSTOM CSS USAGE**: ALWAYS Prefer using style schema. Custom CSS is ONLY FOR UNSUPPRTED schema styles.
-   ALWAYS PRIORITIZE using the style schema PropValues for styling elements as they provide better user experience in the editor, and UI features for the end-users.
-   Use custom_css only for style attributes that ARE NOT SUPPORTED via the style schema AFTER YOU CHECK THE [${ STYLE_SCHEMA_URI }].
 
 # DESIGN VECTORS - Concrete Implementation Guidance
 
@@ -195,9 +192,6 @@ background:
           "unit": { "$$type": "string", "value": "px" }
         }
       },
-    },
-    "button1": {
-      "custom_css": "background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 12px 24px;"
     }
   }
 }
@@ -217,16 +211,23 @@ background:
   },
   "stylesConfig": {
     "hero-section": {
-      "custom_css": "display: flex; flex-direction: column; align-items: flex-start; gap: 3rem; background: radial-gradient(circle at 30% 20%, rgba(216, 67, 21, 0.1) 0%, transparent 60%), linear-gradient(135deg, #faf8f6 0%, #f0ebe6 100%); padding: 10rem 3rem;"
+      "display": { "$$type": "string", "value": "flex" },
+      "flex-direction": { "$$type": "string", "value": "column" },
+      "align-items": { "$$type": "string", "value": "flex-start" },
+      "background": {
+        "$$type": "color",
+        "value": "#f0ebe6",
+        "$intention": "background: #f0ebe6",
+      }
     },
     "hero-title": {
-      "custom_css": "font-size: 4.5rem; font-weight: 900; line-height: 1.05; letter-spacing: -0.04em; color: #2d2622; max-width: 700px;"
-    },
-    "hero-subtitle": {
-      "custom_css": "font-size: 1.25rem; font-weight: 200; line-height: 1.7; letter-spacing: 0.01em; color: #5a534d; max-width: 600px;"
-    },
-    "hero-cta": {
-      "custom_css": "background: #d84315; color: #ffffff; padding: 1.25rem 3rem; font-size: 1rem; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; border-radius: 2px; box-shadow: 0 4px 16px rgba(216, 67, 21, 0.25); transition: transform 0.15s ease-out, box-shadow 0.15s ease-out;"
+      "font-size": {
+          "$$type": "size",
+          "value": {
+            "size": { "$$type": "number", "value": 72 },
+            "unit": { "$$type": "string", "value": "px" }
+          }
+        },
     }
   }
 }
@@ -298,9 +299,6 @@ A Heading and a button inside a flexbox
       },
   },
   stylesConfig: {
-    "flex1": {
-      "custom_css": "background: radial-gradient(circle at 20% 30%, rgba(216, 67, 21, 0.08) 0%, transparent 50%), radial-gradient(circle at 80% 70%, rgba(0, 191, 165, 0.06) 0%, transparent 50%), linear-gradient(135deg, #faf8f6 0%, #f0ebe6 100%); display: flex; flex-direction: column; align-items: center; padding: 80px 32px; gap: 48px;"
-    },
     "heading1": {
       "font-size": {
         "$$type": "size",

--- a/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/schema.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/schema.ts
@@ -17,7 +17,7 @@ export const inputSchema = {
 		.record(
 			z.string().describe( 'The configuration id' ),
 			z.record(
-				z.string().describe( 'StyleSchema property name. Last priority is custom_css!' ),
+				z.string().describe( 'StyleSchema property name' ),
 				z.any().describe( `The PropValue for the style property. MANDATORY, refer to [${ STYLE_SCHEMA_URI }]` )
 			)
 		)

--- a/packages/packages/core/editor-canvas/src/mcp/utils/validate-input.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/utils/validate-input.ts
@@ -66,7 +66,7 @@ export const validateInput = {
 	validateStyles( values: Record< string, unknown > ): ValidationResult {
 		const styleSchema = getStylesSchema();
 		const customCssValue = values.custom_css;
-		const result = this.validateProps( styleSchema, values, [ 'custom_css' ] );
+		const result = this.validateProps( styleSchema, values, [ 'custom_css', '$intention' ] );
 		const appendInvalidCustomCssErr = () => {
 			result.valid = false;
 			result.errors = result.errors || [];

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/design-system/design-system-tool.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/design-system/design-system-tool.ts
@@ -4,7 +4,7 @@ import { GLOBAL_VARIABLES_URI, service } from '@elementor/editor-variables';
 import { z } from '@elementor/schema';
 
 import { GLOBAL_CLASSES_URI } from '../classes-resource';
-import { inputSchema as globalClassInputSchema, handler } from '../mcp-create-global-class';
+import { handler, inputSchema as globalClassInputSchema } from '../mcp-create-global-class';
 
 export const initDesignSystemTool = ( reg: MCPRegistryEntry ) => {
 	const { addTool } = reg;

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/design-system/design-system-tool.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/design-system/design-system-tool.ts
@@ -4,7 +4,7 @@ import { GLOBAL_VARIABLES_URI, service } from '@elementor/editor-variables';
 import { z } from '@elementor/schema';
 
 import { GLOBAL_CLASSES_URI } from '../classes-resource';
-import { handler, inputSchema as globalClassInputSchema } from '../mcp-create-global-class';
+import { inputSchema as globalClassInputSchema, handler } from '../mcp-create-global-class';
 
 export const initDesignSystemTool = ( reg: MCPRegistryEntry ) => {
 	const { addTool } = reg;
@@ -70,7 +70,7 @@ Most sites would need classes for:
 - Hero sections (main site intro, etc).
 
 Global Classes SHOULD HAVE meaningful names that reflect their purpose and usage.
-Global Classes SHOULD HAVE PROPERTIES / custom CSS that support their intended design and functionality.
+Global Classes SHOULD HAVE PROPERTIES.
 
 DO NOT PROVIDE EMPTY OBJECTS
 

--- a/packages/packages/libs/editor-props/src/index.ts
+++ b/packages/packages/libs/editor-props/src/index.ts
@@ -2,9 +2,11 @@ import { adjustLlmPropValueSchema } from './utils/adjust-llm-prop-value-schema';
 import { jsonSchemaToPropType } from './utils/llm-schema-to-props';
 import {
 	configurableKeys,
+	enrichWithIntention,
 	isPropKeyConfigurable,
 	nonConfigurablePropKeys,
 	propTypeToJsonSchema,
+	removeIntention,
 } from './utils/props-to-llm-schema';
 import { validatePropValue } from './utils/validate-prop-value';
 
@@ -35,4 +37,6 @@ export const Schema = {
 	nonConfigurablePropKeys,
 	configurableKeys,
 	validatePropValue,
+	enrichWithIntention,
+	removeIntention,
 };

--- a/packages/packages/libs/editor-props/src/utils/adjust-llm-prop-value-schema.ts
+++ b/packages/packages/libs/editor-props/src/utils/adjust-llm-prop-value-schema.ts
@@ -27,6 +27,9 @@ export const adjustLlmPropValueSchema = (
 		return clone.map( ( item ) => adjustLlmPropValueSchema( item, { forceKey, transformers } ) ) as PropValue;
 	}
 	const transformablePropValue = clone as TransformablePropValue< string >;
+	if ( '$intention' in transformablePropValue ) {
+		delete ( transformablePropValue as Record< string, unknown > ).$intention;
+	}
 	if ( forceKey ) {
 		transformablePropValue.$$type = forceKey;
 	}

--- a/packages/packages/libs/editor-props/src/utils/props-to-llm-schema.ts
+++ b/packages/packages/libs/editor-props/src/utils/props-to-llm-schema.ts
@@ -219,3 +219,31 @@ export function isPropKeyConfigurable( propKey: string ): boolean {
 export function configurableKeys( schema: PropsSchema ): string[] {
 	return Object.keys( schema ).filter( isPropKeyConfigurable );
 }
+
+export function enrichWithIntention(
+	jsonSchema: JsonSchema7,
+	text: string = 'Describe the desired outcome'
+): JsonSchema7 {
+	const result = structuredClone( jsonSchema );
+	if ( ! result.properties ) {
+		return jsonSchema;
+	}
+	result.properties.$intention = {
+		type: 'string',
+		description: text,
+	};
+	result.required = [ ...( result.required || [] ), '$intention' ];
+	return result;
+}
+
+export function removeIntention( jsonSchema: JsonSchema7 ): JsonSchema7 {
+	const result = structuredClone( jsonSchema );
+	if ( ! result.properties ) {
+		return jsonSchema;
+	}
+	delete result.properties.$intention;
+	if ( result.required ) {
+		result.required = result.required.filter( ( req ) => req !== '$intention' );
+	}
+	return result;
+}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

Reducing the use of custom css to zero.
It seems that when forcing it to write the rule in separate, inside the schema, it builds correct schema.

Tried to make the LLM (sonnet) fail with complex layers of semi-transparent gradients, zero failures.

*

## Description
An explanation of what is done in this PR

- Removed the custom css option from the schema
- Removed the custom css from the prompts
- LLM should be unaware of custom css

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove custom CSS functionality from LLM composition builder and replace with schema-based intention system to standardize styling approach across all user tiers.

Main changes:
- Removed custom_css property support and PRO user detection logic from MCP resources and styling workflow
- Added $intention field to style schema for LLM to describe desired CSS outcomes in natural language
- Updated validation to exclude $intention from prop validation while maintaining custom_css error handling for backward compatibility

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
