### PR TITLE
Internal: Hide empty groups in component editing panel [ED-22202]

### DIFF
--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/__tests__/instance-editing-panel.test.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/__tests__/instance-editing-panel.test.tsx
@@ -127,6 +127,28 @@ const MOCK_OVERRIDABLE_PROPS = {
 	},
 };
 
+const MOCK_OVERRIDABLE_PROPS_WITH_EMPTY_GROUP = {
+	props: {
+		'prop-1': {
+			overrideKey: 'prop-1',
+			label: 'Title',
+			elementId: 'element-1',
+			propKey: 'title',
+			widgetType: 'e-heading',
+			elType: 'widget',
+			groupId: 'content',
+			originValue: { $$type: 'string', value: 'Hello' },
+		},
+	},
+	groups: {
+		items: {
+			content: { id: 'content', label: 'Content', props: [ 'prop-1' ] },
+			empty: { id: 'empty', label: 'Empty Group', props: [] },
+		},
+		order: [ 'content', 'empty' ],
+	},
+};
+
 const MOCK_OVERRIDABLE_PROPS_WITH_NESTED = {
 	props: {
 		'prop-1': {
@@ -351,12 +373,40 @@ describe( '<InstanceEditingPanel />', () => {
 		expect( screen.getByText( 'Title' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Nested Component Title' ) ).toBeInTheDocument();
 	} );
+
+	it( 'should not display groups that have no props', () => {
+		// Arrange.
+		setupComponent( { isWithOverridableProps: true, isWithEmptyGroup: true } );
+
+		// Act.
+		renderEditInstancePanel( store );
+
+		// Assert.
+		expect( screen.getByText( 'Content' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Empty Group' ) ).not.toBeInTheDocument();
+	} );
 } );
 
-function setupComponent( options: { isWithOverridableProps?: boolean; isWithNestedOverridableProps?: boolean } = {} ) {
-	const { isWithOverridableProps = true, isWithNestedOverridableProps = false } = options;
+type SetupComponentOptions = {
+	isWithOverridableProps?: boolean;
+	isWithNestedOverridableProps?: boolean;
+	isWithEmptyGroup?: boolean;
+};
 
-	const overridableProps = isWithNestedOverridableProps ? MOCK_OVERRIDABLE_PROPS_WITH_NESTED : MOCK_OVERRIDABLE_PROPS;
+function setupComponent( options: SetupComponentOptions = {} ) {
+	const { isWithOverridableProps = true, isWithNestedOverridableProps = false, isWithEmptyGroup = false } = options;
+
+	const getOverridableProps = () => {
+		if ( isWithNestedOverridableProps ) {
+			return MOCK_OVERRIDABLE_PROPS_WITH_NESTED;
+		}
+		if ( isWithEmptyGroup ) {
+			return MOCK_OVERRIDABLE_PROPS_WITH_EMPTY_GROUP;
+		}
+		return MOCK_OVERRIDABLE_PROPS;
+	};
+
+	const overridableProps = getOverridableProps();
 
 	const componentData = {
 		id: MOCK_COMPONENT_ID,

--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/instance-editing-panel.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/instance-editing-panel.tsx
@@ -34,8 +34,7 @@ export function InstanceEditingPanel() {
 
 	const handleEditComponent = () => switchToComponent( componentId, componentInstanceId );
 
-	const isNonEmptyGroup = ( group: OverridablePropsGroup | null ): group is OverridablePropsGroup =>
-		group !== null && group.props.length > 0;
+	const isNonEmptyGroup = ( group: OverridablePropsGroup | null ) => group !== null && group.props.length > 0;
 
 	const groups = overridableProps.groups.order
 		.map( ( groupId ) => overridableProps.groups.items[ groupId ] ?? null )

--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/instance-editing-panel.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/instance-editing-panel.tsx
@@ -34,11 +34,12 @@ export function InstanceEditingPanel() {
 
 	const handleEditComponent = () => switchToComponent( componentId, componentInstanceId );
 
+	const isNonEmptyGroup = ( group: OverridablePropsGroup | null ): group is OverridablePropsGroup =>
+		group !== null && group.props.length > 0;
+
 	const groups = overridableProps.groups.order
-		.map( ( groupId ) =>
-			overridableProps.groups.items[ groupId ] ? overridableProps.groups.items[ groupId ] : null
-		)
-		.filter( Boolean ) as OverridablePropsGroup[];
+		.map( ( groupId ) => overridableProps.groups.items[ groupId ] ?? null )
+		.filter( isNonEmptyGroup );
 
 	const isEmpty = groups.length === 0 || Object.keys( overridableProps.props ).length === 0;
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor instance editing panel to filter out empty property groups and improve UI cleanliness by hiding groups with no editable properties.

Main changes:
- Added isNonEmptyGroup filter function to exclude groups with zero props from rendering
- Simplified groups filtering logic by replacing verbose ternary with nullish coalescing operator
- Added test coverage for empty group filtering with MOCK_OVERRIDABLE_PROPS_WITH_EMPTY_GROUP fixture

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
