### PR TITLE
Internal: Prevent adding into non editable component [ED-22194]

### DIFF
--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -34,16 +34,16 @@ import { InstanceEditingPanel } from './components/instance-editing-panel/instan
 import { OverridablePropControl } from './components/overridable-props/overridable-prop-control';
 import { OverridablePropIndicator } from './components/overridable-props/overridable-prop-indicator';
 import { COMPONENT_WIDGET_TYPE, createComponentType } from './create-component-type';
-import { initRegenerateOverrideKeys } from './hooks/regenerate-override-keys';
 import { initMcp } from './mcp';
 import { PopulateStore } from './populate-store';
-import { initCircularNestingPrevention } from './prevent-circular-nesting';
 import { componentOverridablePropTypeUtil } from './prop-types/component-overridable-prop-type';
 import { loadComponentsAssets } from './store/actions/load-components-assets';
 import { removeComponentStyles } from './store/actions/remove-component-styles';
 import { componentsStylesProvider } from './store/components-styles-provider';
 import { slice } from './store/store';
 import { beforeSave } from './sync/before-save';
+import { initBlockCommands } from './sync/commands/block-commands';
+import { initRegenerateOverrideKeys } from './sync/commands/regenerate-override-keys';
 import { type ExtendedWindow } from './types';
 import { onElementDrop } from './utils/tracking';
 
@@ -131,5 +131,5 @@ export function init() {
 
 	initMcp();
 
-	initCircularNestingPrevention();
+	initBlockCommands();
 }

--- a/packages/packages/core/editor-components/src/sync/__tests__/prevent-circular-nesting.test.ts
+++ b/packages/packages/core/editor-components/src/sync/__tests__/prevent-circular-nesting.test.ts
@@ -1,11 +1,11 @@
 import { __getState as getState } from '@elementor/store';
 
+import { type ComponentsPathItem, SLICE_NAME } from '../../store/store';
 import {
 	type ClipboardElement,
 	extractComponentIdsFromElements,
 	wouldCreateCircularNesting,
-} from '../prevent-circular-nesting';
-import { type ComponentsPathItem, SLICE_NAME } from '../store/store';
+} from '../commands/prevent-circular-nesting';
 
 jest.mock( '@elementor/store', () => ( {
 	...jest.requireActual( '@elementor/store' ),

--- a/packages/packages/core/editor-components/src/sync/__tests__/prevent-non-editable-component.test.ts
+++ b/packages/packages/core/editor-components/src/sync/__tests__/prevent-non-editable-component.test.ts
@@ -1,0 +1,162 @@
+import { getCurrentDocumentId, type V1Element } from '@elementor/editor-elements';
+
+import { isTargetInNonEditableComponent } from '../commands/prevent-non-editable-component';
+
+jest.mock( '@elementor/editor-elements', () => ( {
+	...jest.requireActual( '@elementor/editor-elements' ),
+	getCurrentDocumentId: jest.fn(),
+} ) );
+
+const mockGetCurrentDocumentId = getCurrentDocumentId as jest.Mock;
+
+const MOCK_CURRENT_DOCUMENT_ID = 500;
+const MOCK_COMPONENT_DOCUMENT_ID = 600;
+
+describe( 'isTargetInNonEditableComponent', () => {
+	beforeEach( () => {
+		mockGetCurrentDocumentId.mockReturnValue( MOCK_CURRENT_DOCUMENT_ID );
+	} );
+
+	it( 'should return false when targetContainer is undefined', () => {
+		// Act
+		const result = isTargetInNonEditableComponent( undefined );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return false when target has no component ancestor', () => {
+		// Arrange
+		const container = createMockContainer( { widgetType: 'container' } );
+
+		// Act
+		const result = isTargetInNonEditableComponent( container );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return false when target is inside a component that is the current document', () => {
+		// Arrange
+		const componentContainer = createMockContainer( {
+			widgetType: 'e-component',
+			componentId: MOCK_CURRENT_DOCUMENT_ID,
+		} );
+		const targetContainer = createMockContainer( {
+			widgetType: 'container',
+			parent: componentContainer,
+		} );
+
+		// Act
+		const result = isTargetInNonEditableComponent( targetContainer );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return true when target is inside a component that is not the current document', () => {
+		// Arrange
+		const componentContainer = createMockContainer( {
+			widgetType: 'e-component',
+			componentId: MOCK_COMPONENT_DOCUMENT_ID,
+		} );
+		const targetContainer = createMockContainer( {
+			widgetType: 'container',
+			parent: componentContainer,
+		} );
+
+		// Act
+		const result = isTargetInNonEditableComponent( targetContainer );
+
+		// Assert
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should check ancestors recursively to find component', () => {
+		// Arrange
+		const componentContainer = createMockContainer( {
+			widgetType: 'e-component',
+			componentId: MOCK_COMPONENT_DOCUMENT_ID,
+		} );
+		const intermediateContainer = createMockContainer( {
+			widgetType: 'container',
+			parent: componentContainer,
+		} );
+		const targetContainer = createMockContainer( {
+			widgetType: 'container',
+			parent: intermediateContainer,
+		} );
+
+		// Act
+		const result = isTargetInNonEditableComponent( targetContainer );
+
+		// Assert
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should return false when component ancestor has no component_instance settings', () => {
+		// Arrange
+		const componentContainer = createMockContainer( {
+			widgetType: 'e-component',
+		} );
+		const targetContainer = createMockContainer( {
+			widgetType: 'container',
+			parent: componentContainer,
+		} );
+
+		// Act
+		const result = isTargetInNonEditableComponent( targetContainer );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return true when target itself is a non-editable component', () => {
+		// Arrange
+		const componentContainer = createMockContainer( {
+			widgetType: 'e-component',
+			componentId: MOCK_COMPONENT_DOCUMENT_ID,
+		} );
+
+		// Act
+		const result = isTargetInNonEditableComponent( componentContainer );
+
+		// Assert
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should return false when target itself is a component being edited', () => {
+		// Arrange
+		const componentContainer = createMockContainer( {
+			widgetType: 'e-component',
+			componentId: MOCK_CURRENT_DOCUMENT_ID,
+		} );
+
+		// Act
+		const result = isTargetInNonEditableComponent( componentContainer );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+} );
+
+function createMockContainer( options: { widgetType?: string; componentId?: number; parent?: V1Element } ): V1Element {
+	return {
+		id: 'mock-container-id',
+		parent: options.parent,
+		model: {
+			toJSON: jest.fn().mockReturnValue( { widgetType: options.widgetType } ),
+		},
+		settings: {
+			get: () => ( {
+				$$type: 'component-instance',
+				value: {
+					component_id: {
+						$$type: 'number',
+						value: options.componentId,
+					},
+				},
+			} ),
+		},
+	} as unknown as V1Element;
+}

--- a/packages/packages/core/editor-components/src/sync/__tests__/regenerate-override-keys.test.ts
+++ b/packages/packages/core/editor-components/src/sync/__tests__/regenerate-override-keys.test.ts
@@ -6,7 +6,7 @@ import { generateUniqueId } from '@elementor/utils';
 import { componentInstanceOverridePropTypeUtil } from '../../prop-types/component-instance-override-prop-type';
 import { componentInstanceOverridesPropTypeUtil } from '../../prop-types/component-instance-overrides-prop-type';
 import { componentInstancePropTypeUtil } from '../../prop-types/component-instance-prop-type';
-import { regenerateOverrideKeysForContainers } from '../regenerate-override-keys';
+import { regenerateOverrideKeysForContainers } from '../../sync/commands/regenerate-override-keys';
 
 jest.mock( '@elementor/editor-elements', () => ( {
 	...jest.requireActual( '@elementor/editor-elements' ),

--- a/packages/packages/core/editor-components/src/sync/commands/block-commands.ts
+++ b/packages/packages/core/editor-components/src/sync/commands/block-commands.ts
@@ -1,0 +1,27 @@
+import { blockCommand } from '@elementor/editor-v1-adapters';
+
+import { blockCircularCreate, blockCircularMove, blockCircularPaste } from './prevent-circular-nesting';
+import {
+	blockCreateInNonEditableComponent,
+	blockMoveToNonEditableComponent,
+	blockPasteToNonEditableComponent,
+} from './prevent-non-editable-component';
+import { type CreateArgs, type MoveArgs, type PasteArgs } from './types';
+
+function blockCreate( args: CreateArgs ): boolean {
+	return [ blockCreateInNonEditableComponent, blockCircularCreate ].some( ( condition ) => condition( args ) );
+}
+
+function blockMove( args: MoveArgs ): boolean {
+	return [ blockMoveToNonEditableComponent, blockCircularMove ].some( ( condition ) => condition( args ) );
+}
+
+function blockPaste( args: PasteArgs ): boolean {
+	return [ blockPasteToNonEditableComponent, blockCircularPaste ].some( ( condition ) => condition( args ) );
+}
+
+export function initBlockCommands() {
+	blockCommand( { command: 'document/elements/create', condition: blockCreate } );
+	blockCommand( { command: 'document/elements/move', condition: blockMove } );
+	blockCommand( { command: 'document/elements/paste', condition: blockPaste } );
+}

--- a/packages/packages/core/editor-components/src/sync/commands/prevent-circular-nesting.ts
+++ b/packages/packages/core/editor-components/src/sync/commands/prevent-circular-nesting.ts
@@ -1,37 +1,14 @@
 import { getAllDescendants, type V1Element } from '@elementor/editor-elements';
 import { type NotificationData, notify } from '@elementor/editor-notifications';
-import { blockCommand } from '@elementor/editor-v1-adapters';
 import { __getState as getState } from '@elementor/store';
 import { __ } from '@wordpress/i18n';
 
-import { type ComponentInstanceProp } from './prop-types/component-instance-prop-type';
-import { type ComponentsSlice, selectCurrentComponentId, selectPath } from './store/store';
-import { type ExtendedWindow } from './types';
+import { type ComponentInstanceProp } from '../../prop-types/component-instance-prop-type';
+import { type ComponentsSlice, selectCurrentComponentId, selectPath } from '../../store/store';
+import { type ExtendedWindow } from '../../types';
+import { type CreateArgs, type MoveArgs, type PasteArgs } from './types';
 
 const COMPONENT_TYPE = 'e-component';
-
-type CreateArgs = {
-	container?: V1Element;
-	model?: {
-		elType?: string;
-		widgetType?: string;
-		settings?: {
-			component_instance?: ComponentInstanceProp;
-		};
-	};
-};
-
-type MoveArgs = {
-	containers?: V1Element[];
-	container?: V1Element;
-	target?: V1Element;
-};
-
-type PasteArgs = {
-	containers?: V1Element[];
-	container?: V1Element;
-	storageType?: string;
-};
 
 export type ClipboardElement = {
 	widgetType?: string;
@@ -52,23 +29,6 @@ const COMPONENT_CIRCULAR_NESTING_ALERT: NotificationData = {
 	message: __( 'Cannot add this component here - it would create a circular reference.', 'elementor' ),
 	id: 'circular-component-nesting-blocked',
 };
-
-export function initCircularNestingPrevention() {
-	blockCommand( {
-		command: 'document/elements/create',
-		condition: blockCircularCreate,
-	} );
-
-	blockCommand( {
-		command: 'document/elements/move',
-		condition: blockCircularMove,
-	} );
-
-	blockCommand( {
-		command: 'document/elements/paste',
-		condition: blockCircularPaste,
-	} );
-}
 
 // Note that this function only checks for direct circular nesting, not indirect nesting
 export function wouldCreateCircularNesting( componentIdToAdd: number | string | undefined ): boolean {
@@ -144,7 +104,7 @@ function extractComponentIdFromContainer( container: V1Element ): number | strin
 	return componentInstance?.value?.component_id?.value ?? null;
 }
 
-function blockCircularCreate( args: CreateArgs ): boolean {
+export function blockCircularCreate( args: CreateArgs ): boolean {
 	const componentId = extractComponentIdFromModel( args.model );
 
 	if ( componentId === null ) {
@@ -160,7 +120,7 @@ function blockCircularCreate( args: CreateArgs ): boolean {
 	return isBlocked;
 }
 
-function blockCircularMove( args: MoveArgs ): boolean {
+export function blockCircularMove( args: MoveArgs ): boolean {
 	const { containers = [ args.container ] } = args;
 
 	const hasCircularComponent = containers.some( ( container ) => {
@@ -188,7 +148,7 @@ function blockCircularMove( args: MoveArgs ): boolean {
 	return hasCircularComponent;
 }
 
-function blockCircularPaste( args: PasteArgs ): boolean {
+export function blockCircularPaste( args: PasteArgs ): boolean {
 	const { storageType } = args;
 
 	if ( storageType !== 'localstorage' ) {

--- a/packages/packages/core/editor-components/src/sync/commands/prevent-non-editable-component.ts
+++ b/packages/packages/core/editor-components/src/sync/commands/prevent-non-editable-component.ts
@@ -1,0 +1,86 @@
+import { getCurrentDocumentId, type V1Element } from '@elementor/editor-elements';
+import { type NotificationData, notify } from '@elementor/editor-notifications';
+import { __ } from '@wordpress/i18n';
+
+import { type ComponentInstanceProp } from '../../prop-types/component-instance-prop-type';
+import { isComponentInstance } from '../../utils/is-component-instance';
+import { type CreateArgs, type MoveArgs, type PasteArgs } from './types';
+
+const COMPONENT_NOT_IN_EDIT_MODE_ALERT: NotificationData = {
+	type: 'default',
+	message: __( 'Cannot add elements to a component that is not being edited.', 'elementor' ),
+	id: 'component-not-in-edit-mode-blocked',
+};
+
+export function isTargetInNonEditableComponent( targetContainer: V1Element | undefined ): boolean {
+	if ( ! targetContainer ) {
+		return false;
+	}
+
+	const componentAncestor = getComponentAncestor( targetContainer );
+
+	if ( ! componentAncestor ) {
+		return false;
+	}
+
+	const componentIdFromSettings = extractComponentIdFromAncestor( componentAncestor );
+
+	if ( componentIdFromSettings === null ) {
+		return false;
+	}
+
+	const currentDocumentId = getCurrentDocumentId();
+
+	return componentIdFromSettings !== currentDocumentId;
+}
+
+export function blockCreateInNonEditableComponent( args: CreateArgs ): boolean {
+	const isBlocked = isTargetInNonEditableComponent( args.container );
+
+	if ( isBlocked ) {
+		notify( COMPONENT_NOT_IN_EDIT_MODE_ALERT );
+	}
+
+	return isBlocked;
+}
+
+export function blockMoveToNonEditableComponent( args: MoveArgs ): boolean {
+	const isBlocked = isTargetInNonEditableComponent( args.target );
+
+	if ( isBlocked ) {
+		notify( COMPONENT_NOT_IN_EDIT_MODE_ALERT );
+	}
+
+	return isBlocked;
+}
+
+export function blockPasteToNonEditableComponent( args: PasteArgs ): boolean {
+	const { containers = [ args.container ] } = args;
+
+	const isBlocked = containers.some( isTargetInNonEditableComponent );
+
+	if ( isBlocked ) {
+		notify( COMPONENT_NOT_IN_EDIT_MODE_ALERT );
+	}
+
+	return isBlocked;
+}
+
+function getComponentAncestor( container: V1Element ): V1Element | null {
+	let current: V1Element | undefined = container;
+
+	while ( current ) {
+		if ( isComponentInstance( current.model.toJSON() ) ) {
+			return current;
+		}
+		current = current.parent;
+	}
+
+	return null;
+}
+
+function extractComponentIdFromAncestor( componentAncestor: V1Element ): number | string | null {
+	const componentInstance = componentAncestor.settings?.get?.( 'component_instance' ) as ComponentInstanceProp;
+
+	return componentInstance?.value?.component_id?.value ?? null;
+}

--- a/packages/packages/core/editor-components/src/sync/commands/regenerate-override-keys.ts
+++ b/packages/packages/core/editor-components/src/sync/commands/regenerate-override-keys.ts
@@ -2,16 +2,16 @@ import { getAllDescendants, getContainer, updateElementSettings, type V1Element 
 import { registerDataHook } from '@elementor/editor-v1-adapters';
 import { generateUniqueId } from '@elementor/utils';
 
-import { componentInstanceOverridePropTypeUtil } from '../prop-types/component-instance-override-prop-type';
+import { componentInstanceOverridePropTypeUtil } from '../../prop-types/component-instance-override-prop-type';
 import {
 	componentInstanceOverridesPropTypeUtil,
 	type ComponentInstanceOverridesPropValue,
-} from '../prop-types/component-instance-overrides-prop-type';
+} from '../../prop-types/component-instance-overrides-prop-type';
 import {
 	componentInstancePropTypeUtil,
 	type ComponentInstancePropValue,
-} from '../prop-types/component-instance-prop-type';
-import { isComponentInstance } from '../utils/is-component-instance';
+} from '../../prop-types/component-instance-prop-type';
+import { isComponentInstance } from '../../utils/is-component-instance';
 
 export function initRegenerateOverrideKeys() {
 	registerDataHook( 'after', 'document/elements/duplicate', ( _args, result: V1Element | V1Element[] ) => {

--- a/packages/packages/core/editor-components/src/sync/commands/types.ts
+++ b/packages/packages/core/editor-components/src/sync/commands/types.ts
@@ -1,0 +1,26 @@
+import { type V1Element } from '@elementor/editor-elements';
+
+import { type ComponentInstanceProp } from '../../prop-types/component-instance-prop-type';
+
+export type CreateArgs = {
+	container?: V1Element;
+	model?: {
+		elType?: string;
+		widgetType?: string;
+		settings?: {
+			component_instance?: ComponentInstanceProp;
+		};
+	};
+};
+
+export type MoveArgs = {
+	containers?: V1Element[];
+	container?: V1Element;
+	target?: V1Element;
+};
+
+export type PasteArgs = {
+	containers?: V1Element[];
+	container?: V1Element;
+	storageType?: string;
+};


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Prevent adding, moving, and pasting elements into non-editable components by implementing validation checks and consolidating command blocking logic into a centralized module.

Main changes:
- Created new prevent-non-editable-component module with blockCreate/Move/Paste functions that validate target containers are in currently edited documents
- Consolidated command blocking logic into initBlockCommands function that combines circular nesting and non-editable component checks for create/move/paste operations
- Reorganized command handlers by extracting types into separate types.ts file and moving prevent-circular-nesting functions to exports for reuse in unified command registration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
