### PR TITLE
Internal: Prevent saving v3 widgets inside components [ED-22203]

### DIFF
--- a/modules/components/components-rest-api.php
+++ b/modules/components/components-rest-api.php
@@ -325,6 +325,15 @@ class Components_REST_API {
 				->build();
 		}
 
+		$non_atomic_result = Non_Atomic_Widget_Validator::make()->validate_items( $items );
+
+		if ( ! $non_atomic_result['success'] ) {
+			return Error_Builder::make( Non_Atomic_Widget_Validator::ERROR_CODE )
+				->set_status( 422 )
+				->set_message( implode( ', ', $non_atomic_result['messages'] ) )
+				->build();
+		}
+
 		$validation_errors = [];
 
 		$created = $items->map_with_keys( function ( $item ) use ( $save_status, &$validation_errors ) {
@@ -525,6 +534,15 @@ class Components_REST_API {
 			return Error_Builder::make( 'circular_dependency_detected' )
 				->set_status( 422 )
 				->set_message( implode( ', ', $circular_result['messages'] ) )
+				->build();
+		}
+
+		$non_atomic_result = Non_Atomic_Widget_Validator::make()->validate_items( $items );
+
+		if ( ! $non_atomic_result['success'] ) {
+			return Error_Builder::make( Non_Atomic_Widget_Validator::ERROR_CODE )
+				->set_status( 422 )
+				->set_message( implode( ', ', $non_atomic_result['messages'] ) )
 				->build();
 		}
 

--- a/modules/components/non-atomic-widget-validator.php
+++ b/modules/components/non-atomic-widget-validator.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Elementor\Modules\Components;
+
+use Elementor\Core\Utils\Collection;
+use Elementor\Modules\AtomicWidgets\Utils\Utils;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Non_Atomic_Widget_Validator {
+	const ERROR_CODE = 'non_atomic_element_in_component';
+	const WIDGET_EL_TYPE = 'widget';
+
+	public static function make(): Non_Atomic_Widget_Validator {
+		return new self();
+	}
+
+	public function validate( array $elements ): array {
+		$non_atomic_elements = $this->find_non_atomic_elements( $elements );
+
+		if ( ! empty( $non_atomic_elements ) ) {
+			return $this->build_error_response( $non_atomic_elements );
+		}
+
+		return [
+			'success' => true,
+			'messages' => [],
+		];
+	}
+
+	public function validate_items( Collection $items ): array {
+		foreach ( $items->all() as $item ) {
+			$elements = $item['elements'] ?? [];
+			$result = $this->validate( $elements );
+
+			if ( ! $result['success'] ) {
+				return $result;
+			}
+		}
+
+		return [
+			'success' => true,
+			'messages' => [],
+		];
+	}
+
+	private function find_non_atomic_elements( array $elements ): array {
+		$non_atomic = [];
+
+		foreach ( $elements as $element ) {
+			$el_type = $element['elType'] ?? null;
+			$widget_type = $element['widgetType'] ?? null;
+			$element_type = $this->get_element_type( $el_type, $widget_type );
+
+			if ( $element_type && ! $this->is_element_atomic( $el_type, $widget_type ) ) {
+				$non_atomic[] = $element_type;
+			}
+
+			if ( ! empty( $element['elements'] ) ) {
+				$nested_non_atomic = $this->find_non_atomic_elements( $element['elements'] );
+				$non_atomic = array_merge( $non_atomic, $nested_non_atomic );
+			}
+		}
+
+		return array_unique( $non_atomic );
+	}
+
+	private function get_element_type( ?string $el_type, ?string $widget_type ): ?string {
+		return $widget_type ?? $el_type;
+	}
+
+	private function is_element_atomic( ?string $el_type, ?string $widget_type ): bool {
+		if ( ! $el_type ) {
+			return false;
+		}
+
+		$element_instance = Plugin::$instance->elements_manager->get_element( $el_type, $widget_type );
+
+		if ( ! $element_instance ) {
+			return false;
+		}
+
+		return Utils::is_atomic( $element_instance );
+	}
+
+	private function build_error_response( array $non_atomic_elements ): array {
+		$message = sprintf(
+			// translators: %s: Comma-separated list of non-atomic element types.
+			esc_html__( 'Component contains non-supported elements: %s. Only atomic elements are allowed inside components.', 'elementor' ),
+			implode( ', ', $non_atomic_elements )
+		);
+
+		return [
+			'success' => false,
+			'code' => self::ERROR_CODE,
+			'messages' => [ $message ],
+			'non_atomic_elements' => $non_atomic_elements,
+		];
+	}
+}

--- a/packages/packages/core/editor-canvas/src/index.ts
+++ b/packages/packages/core/editor-canvas/src/index.ts
@@ -2,6 +2,7 @@ export { BREAKPOINTS_SCHEMA_URI } from './mcp/resources/breakpoints-resource';
 export { STYLE_SCHEMA_URI } from './mcp/resources/widgets-schema-resource';
 
 export { init } from './init';
+export { isAtomicWidget } from './style-commands/utils';
 
 export {
 	createTemplatedElementView,

--- a/packages/packages/core/editor-components/src/__tests__/prevent-non-atomic-nesting.test.ts
+++ b/packages/packages/core/editor-components/src/__tests__/prevent-non-atomic-nesting.test.ts
@@ -27,7 +27,7 @@ jest.mock( '@elementor/editor-v1-adapters', () => ( {
 
 const mockGetElementType = getElementType as jest.Mock;
 
-function setupElementsCache( atomicElements: string[], nonAtomicElements: string[] ) {
+function setupElementsCache( atomicElements: string[] ) {
 	mockGetElementType.mockImplementation( ( type: string ) => {
 		if ( atomicElements.includes( type ) ) {
 			return { key: type, controls: [], propsSchema: {} };
@@ -44,7 +44,7 @@ describe( 'isElementAtomic', () => {
 
 	it( 'should return true for atomic widget', () => {
 		// Arrange
-		setupElementsCache( [ 'e-heading' ], [] );
+		setupElementsCache( [ 'e-heading' ] );
 
 		// Act
 		const result = isElementAtomic( 'e-heading' );
@@ -55,7 +55,7 @@ describe( 'isElementAtomic', () => {
 
 	it( 'should return true for atomic container', () => {
 		// Arrange
-		setupElementsCache( [ 'e-div-block', 'e-flexbox' ], [] );
+		setupElementsCache( [ 'e-div-block', 'e-flexbox' ] );
 
 		// Act
 		const result = isElementAtomic( 'e-div-block' );
@@ -66,7 +66,7 @@ describe( 'isElementAtomic', () => {
 
 	it( 'should return false for non-atomic widget', () => {
 		// Arrange
-		setupElementsCache( [], [ 'heading' ] );
+		setupElementsCache( [] );
 
 		// Act
 		const result = isElementAtomic( 'heading' );
@@ -77,7 +77,7 @@ describe( 'isElementAtomic', () => {
 
 	it( 'should return false for non-atomic container', () => {
 		// Arrange
-		setupElementsCache( [], [ 'container' ] );
+		setupElementsCache( [] );
 
 		// Act
 		const result = isElementAtomic( 'container' );
@@ -88,7 +88,7 @@ describe( 'isElementAtomic', () => {
 
 	it( 'should return false for unknown element', () => {
 		// Arrange
-		setupElementsCache( [], [] );
+		setupElementsCache( [] );
 
 		// Act
 		const result = isElementAtomic( 'unknown-element' );
@@ -112,7 +112,7 @@ describe( 'isElementAtomic', () => {
 describe( 'hasNonAtomicElementsInTree', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		setupElementsCache( [ 'e-heading', 'e-button', 'e-div-block' ], [ 'heading', 'button', 'image', 'container' ] );
+		setupElementsCache( [ 'e-heading', 'e-button', 'e-div-block' ] );
 	} );
 
 	it( 'should return false for empty array', () => {
@@ -235,7 +235,7 @@ describe( 'hasNonAtomicElementsInTree', () => {
 describe( 'findNonAtomicElements', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		setupElementsCache( [ 'e-heading', 'e-button', 'e-div-block' ], [ 'heading', 'button', 'image', 'container' ] );
+		setupElementsCache( [ 'e-heading', 'e-button', 'e-div-block' ] );
 	} );
 
 	it( 'should return empty array for no non-atomic elements', () => {
@@ -309,7 +309,7 @@ describe( 'findNonAtomicElements', () => {
 describe( 'findNonAtomicElementsInElement', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		setupElementsCache( [ 'e-heading', 'e-button', 'e-div-block' ], [ 'heading', 'button', 'image', 'container' ] );
+		setupElementsCache( [ 'e-heading', 'e-button', 'e-div-block' ] );
 	} );
 
 	it( 'should return non-atomic element type for single non-atomic widget', () => {

--- a/packages/packages/core/editor-components/src/__tests__/prevent-non-atomic-nesting.test.ts
+++ b/packages/packages/core/editor-components/src/__tests__/prevent-non-atomic-nesting.test.ts
@@ -1,0 +1,395 @@
+import { getElementType } from '@elementor/editor-elements';
+
+import {
+	type ClipboardElement,
+	findNonAtomicElements,
+	findNonAtomicElementsInElement,
+	hasNonAtomicElementsInTree,
+	isElementAtomic,
+} from '../prevent-non-atomic-nesting';
+
+jest.mock( '@elementor/editor-documents', () => ( {
+	getV1CurrentDocument: jest.fn(),
+} ) );
+
+jest.mock( '@elementor/editor-elements', () => ( {
+	getAllDescendants: jest.fn(),
+	getElementType: jest.fn(),
+} ) );
+
+jest.mock( '@elementor/editor-notifications', () => ( {
+	notify: jest.fn(),
+} ) );
+
+jest.mock( '@elementor/editor-v1-adapters', () => ( {
+	blockCommand: jest.fn(),
+} ) );
+
+const mockGetElementType = getElementType as jest.Mock;
+
+function setupElementsCache( atomicElements: string[], nonAtomicElements: string[] ) {
+	mockGetElementType.mockImplementation( ( type: string ) => {
+		if ( atomicElements.includes( type ) ) {
+			return { key: type, controls: [], propsSchema: {} };
+		}
+
+		return null;
+	} );
+}
+
+describe( 'isElementAtomic', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return true for atomic widget', () => {
+		// Arrange
+		setupElementsCache( [ 'e-heading' ], [] );
+
+		// Act
+		const result = isElementAtomic( 'e-heading' );
+
+		// Assert
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should return true for atomic container', () => {
+		// Arrange
+		setupElementsCache( [ 'e-div-block', 'e-flexbox' ], [] );
+
+		// Act
+		const result = isElementAtomic( 'e-div-block' );
+
+		// Assert
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should return false for non-atomic widget', () => {
+		// Arrange
+		setupElementsCache( [], [ 'heading' ] );
+
+		// Act
+		const result = isElementAtomic( 'heading' );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return false for non-atomic container', () => {
+		// Arrange
+		setupElementsCache( [], [ 'container' ] );
+
+		// Act
+		const result = isElementAtomic( 'container' );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return false for unknown element', () => {
+		// Arrange
+		setupElementsCache( [], [] );
+
+		// Act
+		const result = isElementAtomic( 'unknown-element' );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return false when getElementType returns null', () => {
+		// Arrange
+		mockGetElementType.mockReturnValue( null );
+
+		// Act
+		const result = isElementAtomic( 'e-heading' );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+} );
+
+describe( 'hasNonAtomicElementsInTree', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		setupElementsCache( [ 'e-heading', 'e-button', 'e-div-block' ], [ 'heading', 'button', 'image', 'container' ] );
+	} );
+
+	it( 'should return false for empty array', () => {
+		// Arrange
+		const elements: ClipboardElement[] = [];
+
+		// Act
+		const result = hasNonAtomicElementsInTree( elements );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return false for atomic widgets only', () => {
+		// Arrange
+		const elements: ClipboardElement[] = [
+			{ elType: 'widget', widgetType: 'e-heading' },
+			{ elType: 'widget', widgetType: 'e-button' },
+		];
+
+		// Act
+		const result = hasNonAtomicElementsInTree( elements );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return false for atomic containers only', () => {
+		// Arrange
+		const elements: ClipboardElement[] = [ { elType: 'e-div-block' } ];
+
+		// Act
+		const result = hasNonAtomicElementsInTree( elements );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return true for non-atomic widget at top level', () => {
+		// Arrange
+		const elements: ClipboardElement[] = [ { elType: 'widget', widgetType: 'heading' } ];
+
+		// Act
+		const result = hasNonAtomicElementsInTree( elements );
+
+		// Assert
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should return true for non-atomic container at top level', () => {
+		// Arrange
+		const elements: ClipboardElement[] = [ { elType: 'container' } ];
+
+		// Act
+		const result = hasNonAtomicElementsInTree( elements );
+
+		// Assert
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should return true for non-atomic widget nested in container', () => {
+		// Arrange
+		const elements: ClipboardElement[] = [
+			{
+				elType: 'e-div-block',
+				elements: [ { elType: 'widget', widgetType: 'heading' } ],
+			},
+		];
+
+		// Act
+		const result = hasNonAtomicElementsInTree( elements );
+
+		// Assert
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should return true for non-atomic widget deeply nested', () => {
+		// Arrange
+		const elements: ClipboardElement[] = [
+			{
+				elType: 'e-div-block',
+				elements: [
+					{
+						elType: 'e-div-block',
+						elements: [
+							{
+								elType: 'e-div-block',
+								elements: [ { elType: 'widget', widgetType: 'image' } ],
+							},
+						],
+					},
+				],
+			},
+		];
+
+		// Act
+		const result = hasNonAtomicElementsInTree( elements );
+
+		// Assert
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should return false for atomic containers with atomic widgets', () => {
+		// Arrange
+		const elements: ClipboardElement[] = [
+			{
+				elType: 'e-div-block',
+				elements: [ { elType: 'widget', widgetType: 'e-heading' } ],
+			},
+		];
+
+		// Act
+		const result = hasNonAtomicElementsInTree( elements );
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+} );
+
+describe( 'findNonAtomicElements', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		setupElementsCache( [ 'e-heading', 'e-button', 'e-div-block' ], [ 'heading', 'button', 'image', 'container' ] );
+	} );
+
+	it( 'should return empty array for no non-atomic elements', () => {
+		// Arrange
+		const elements: ClipboardElement[] = [ { elType: 'widget', widgetType: 'e-heading' } ];
+
+		// Act
+		const result = findNonAtomicElements( elements );
+
+		// Assert
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'should return unique element types', () => {
+		// Arrange
+		const elements: ClipboardElement[] = [
+			{ elType: 'widget', widgetType: 'heading' },
+			{ elType: 'widget', widgetType: 'heading' },
+			{ elType: 'widget', widgetType: 'heading' },
+		];
+
+		// Act
+		const result = findNonAtomicElements( elements );
+
+		// Assert
+		expect( result ).toEqual( [ 'heading' ] );
+	} );
+
+	it( 'should find all different non-atomic element types including containers', () => {
+		// Arrange
+		const elements: ClipboardElement[] = [
+			{ elType: 'widget', widgetType: 'heading' },
+			{ elType: 'widget', widgetType: 'button' },
+			{ elType: 'container' },
+		];
+
+		// Act
+		const result = findNonAtomicElements( elements );
+
+		// Assert
+		expect( result ).toContain( 'heading' );
+		expect( result ).toContain( 'button' );
+		expect( result ).toContain( 'container' );
+		expect( result ).toHaveLength( 3 );
+	} );
+
+	it( 'should find non-atomic elements in nested elements', () => {
+		// Arrange
+		const elements: ClipboardElement[] = [
+			{
+				elType: 'e-div-block',
+				elements: [
+					{ elType: 'widget', widgetType: 'heading' },
+					{
+						elType: 'e-div-block',
+						elements: [ { elType: 'widget', widgetType: 'button' } ],
+					},
+				],
+			},
+		];
+
+		// Act
+		const result = findNonAtomicElements( elements );
+
+		// Assert
+		expect( result ).toContain( 'heading' );
+		expect( result ).toContain( 'button' );
+	} );
+} );
+
+describe( 'findNonAtomicElementsInElement', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		setupElementsCache( [ 'e-heading', 'e-button', 'e-div-block' ], [ 'heading', 'button', 'image', 'container' ] );
+	} );
+
+	it( 'should return non-atomic element type for single non-atomic widget', () => {
+		// Arrange
+		const element = { elType: 'widget', widgetType: 'heading' };
+
+		// Act
+		const result = findNonAtomicElementsInElement( element );
+
+		// Assert
+		expect( result ).toEqual( [ 'heading' ] );
+	} );
+
+	it( 'should return non-atomic container type', () => {
+		// Arrange
+		const element = { elType: 'container' };
+
+		// Act
+		const result = findNonAtomicElementsInElement( element );
+
+		// Assert
+		expect( result ).toEqual( [ 'container' ] );
+	} );
+
+	it( 'should return empty array for atomic widget', () => {
+		// Arrange
+		const element = { elType: 'widget', widgetType: 'e-heading' };
+
+		// Act
+		const result = findNonAtomicElementsInElement( element );
+
+		// Assert
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'should return empty array for atomic container', () => {
+		// Arrange
+		const element = { elType: 'e-div-block' };
+
+		// Act
+		const result = findNonAtomicElementsInElement( element );
+
+		// Assert
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'should find non-atomic elements in children', () => {
+		// Arrange
+		const element = {
+			elType: 'e-div-block',
+			elements: [
+				{ elType: 'widget', widgetType: 'e-heading' },
+				{ elType: 'widget', widgetType: 'heading' },
+				{ elType: 'widget', widgetType: 'button' },
+			],
+		};
+
+		// Act
+		const result = findNonAtomicElementsInElement( element );
+
+		// Assert
+		expect( result ).toContain( 'heading' );
+		expect( result ).toContain( 'button' );
+		expect( result ).not.toContain( 'e-heading' );
+	} );
+
+	it( 'should return unique element types for duplicates', () => {
+		// Arrange
+		const element = {
+			elType: 'e-div-block',
+			elements: [
+				{ elType: 'widget', widgetType: 'heading' },
+				{ elType: 'widget', widgetType: 'heading' },
+			],
+		};
+
+		// Act
+		const result = findNonAtomicElementsInElement( element );
+
+		// Assert
+		expect( result ).toEqual( [ 'heading' ] );
+	} );
+} );

--- a/packages/packages/core/editor-components/src/components/create-component-form/create-component-form.tsx
+++ b/packages/packages/core/editor-components/src/components/create-component-form/create-component-form.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { getElementLabel, type V1ElementData } from '@elementor/editor-elements';
+import { notify } from '@elementor/editor-notifications';
 import { Form as FormElement, ThemeProvider } from '@elementor/editor-ui';
 import { StarIcon } from '@elementor/icons';
 import { Alert, Button, FormLabel, Grid, Popover, Snackbar, Stack, TextField, Typography } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { useComponents } from '../../hooks/use-components';
+import { findNonAtomicElementsInElement } from '../../prevent-non-atomic-nesting';
 import { createUnpublishedComponent } from '../../store/actions/create-unpublished-component';
 import { type ComponentFormValues } from '../../types';
 import { trackComponentEvent } from '../../utils/tracking';
@@ -46,6 +48,20 @@ export function CreateComponentForm() {
 		const OPEN_SAVE_AS_COMPONENT_FORM_EVENT = 'elementor/editor/open-save-as-component-form';
 
 		const openPopup = ( event: CustomEvent< SaveAsComponentEventData > ) => {
+			const nonAtomicElements = findNonAtomicElementsInElement( event.detail.element );
+
+			if ( nonAtomicElements.length > 0 ) {
+				notify( {
+					type: 'default',
+					message: __(
+						'Cannot save as component - contains non-supported elements. Only atomic elements are allowed inside components.',
+						'elementor'
+					),
+					id: 'non-atomic-element-save-blocked',
+				} );
+				return;
+			}
+
 			setElement( { element: event.detail.element, elementLabel: getElementLabel( event.detail.element.id ) } );
 			setAnchorPosition( event.detail.anchorPosition );
 

--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -38,6 +38,7 @@ import { initRegenerateOverrideKeys } from './hooks/regenerate-override-keys';
 import { initMcp } from './mcp';
 import { PopulateStore } from './populate-store';
 import { initCircularNestingPrevention } from './prevent-circular-nesting';
+import { initNonAtomicNestingPrevention } from './prevent-non-atomic-nesting';
 import { componentOverridablePropTypeUtil } from './prop-types/component-overridable-prop-type';
 import { loadComponentsAssets } from './store/actions/load-components-assets';
 import { removeComponentStyles } from './store/actions/remove-component-styles';
@@ -132,4 +133,6 @@ export function init() {
 	initMcp();
 
 	initCircularNestingPrevention();
+
+	initNonAtomicNestingPrevention();
 }

--- a/packages/packages/core/editor-components/src/prevent-non-atomic-nesting.ts
+++ b/packages/packages/core/editor-components/src/prevent-non-atomic-nesting.ts
@@ -1,0 +1,209 @@
+import { isAtomicWidget } from '@elementor/editor-canvas';
+import { getAllDescendants, getElementType, type V1Element } from '@elementor/editor-elements';
+import { type NotificationData, notify } from '@elementor/editor-notifications';
+import { blockCommand } from '@elementor/editor-v1-adapters';
+import { __getStore as getStore } from '@elementor/store';
+import { __ } from '@wordpress/i18n';
+
+import { type ComponentsSlice, selectCurrentComponentId } from './store/store';
+import { type ExtendedWindow } from './types';
+
+type CreateArgs = {
+	container?: V1Element;
+	model?: {
+		elType?: string;
+		widgetType?: string;
+	};
+};
+
+type MoveArgs = {
+	containers?: V1Element[];
+	container?: V1Element;
+	target?: V1Element;
+};
+
+type PasteArgs = {
+	containers?: V1Element[];
+	container?: V1Element;
+	storageType?: string;
+};
+
+export type ClipboardElement = {
+	elType?: string;
+	widgetType?: string;
+	elements?: ClipboardElement[];
+};
+
+type StorageContent = {
+	clipboard?: {
+		elements?: ClipboardElement[];
+	};
+};
+
+const NON_ATOMIC_ELEMENT_ALERT: NotificationData = {
+	type: 'default',
+	message: __( 'Cannot add this element here - only atomic elements are allowed inside components.', 'elementor' ),
+	id: 'non-atomic-element-blocked',
+};
+
+export function initNonAtomicNestingPrevention() {
+	blockCommand( {
+		command: 'document/elements/create',
+		condition: blockNonAtomicCreate,
+	} );
+
+	blockCommand( {
+		command: 'document/elements/move',
+		condition: blockNonAtomicMove,
+	} );
+
+	blockCommand( {
+		command: 'document/elements/paste',
+		condition: blockNonAtomicPaste,
+	} );
+}
+
+function isEditingComponent(): boolean {
+	const state = getStore()?.getState() as ComponentsSlice | undefined;
+
+	if ( ! state ) {
+		return false;
+	}
+
+	return selectCurrentComponentId( state ) !== null;
+}
+
+export function isElementAtomic( elementType: string ): boolean {
+	return getElementType( elementType ) !== null;
+}
+
+function blockNonAtomicCreate( args: CreateArgs ): boolean {
+	if ( ! isEditingComponent() ) {
+		return false;
+	}
+
+	const { model } = args;
+	const elementType = model?.widgetType || model?.elType;
+
+	if ( ! elementType ) {
+		return false;
+	}
+
+	if ( isElementAtomic( elementType ) ) {
+		return false;
+	}
+
+	notify( NON_ATOMIC_ELEMENT_ALERT );
+	return true;
+}
+
+function blockNonAtomicMove( args: MoveArgs ): boolean {
+	if ( ! isEditingComponent() ) {
+		return false;
+	}
+
+	const { containers = [ args.container ] } = args;
+
+	const hasNonAtomicElement = containers.some( ( container ) => {
+		if ( ! container ) {
+			return false;
+		}
+
+		const allElements = getAllDescendants( container );
+
+		return allElements.some( ( element ) => ! isAtomicWidget( element ) );
+	} );
+
+	if ( hasNonAtomicElement ) {
+		notify( NON_ATOMIC_ELEMENT_ALERT );
+	}
+
+	return hasNonAtomicElement;
+}
+
+function blockNonAtomicPaste( args: PasteArgs ): boolean {
+	if ( ! isEditingComponent() ) {
+		return false;
+	}
+
+	const { storageType } = args;
+
+	if ( storageType !== 'localstorage' ) {
+		return false;
+	}
+
+	const data = (
+		window as unknown as ExtendedWindow & { elementorCommon?: { storage?: { get: () => StorageContent } } }
+	 )?.elementorCommon?.storage?.get();
+
+	if ( ! data?.clipboard?.elements ) {
+		return false;
+	}
+
+	const hasNonAtomicElement = hasNonAtomicElementsInTree( data.clipboard.elements );
+
+	if ( hasNonAtomicElement ) {
+		notify( NON_ATOMIC_ELEMENT_ALERT );
+	}
+
+	return hasNonAtomicElement;
+}
+
+export function hasNonAtomicElementsInTree( elements: ClipboardElement[] ): boolean {
+	for ( const element of elements ) {
+		const elementType = element.widgetType || element.elType;
+
+		if ( elementType && ! isElementAtomic( elementType ) ) {
+			return true;
+		}
+
+		if ( element.elements?.length ) {
+			if ( hasNonAtomicElementsInTree( element.elements ) ) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+export function findNonAtomicElements( elements: ClipboardElement[] ): string[] {
+	const nonAtomicElements: string[] = [];
+
+	for ( const element of elements ) {
+		const elementType = element.widgetType || element.elType;
+
+		if ( elementType && ! isElementAtomic( elementType ) ) {
+			nonAtomicElements.push( elementType );
+		}
+
+		if ( element.elements?.length ) {
+			nonAtomicElements.push( ...findNonAtomicElements( element.elements ) );
+		}
+	}
+
+	return [ ...new Set( nonAtomicElements ) ];
+}
+
+type V1ElementLike = {
+	elType?: string;
+	widgetType?: string;
+	elements?: V1ElementLike[];
+};
+
+export function findNonAtomicElementsInElement( element: V1ElementLike ): string[] {
+	const nonAtomicElements: string[] = [];
+	const elementType = element.widgetType || element.elType;
+
+	if ( elementType && ! isElementAtomic( elementType ) ) {
+		nonAtomicElements.push( elementType );
+	}
+
+	if ( element.elements?.length ) {
+		for ( const child of element.elements ) {
+			nonAtomicElements.push( ...findNonAtomicElementsInElement( child ) );
+		}
+	}
+
+	return [ ...new Set( nonAtomicElements ) ];
+}

--- a/tests/phpunit/elementor/modules/components/test-non-atomic-widget-validator.php
+++ b/tests/phpunit/elementor/modules/components/test-non-atomic-widget-validator.php
@@ -1,0 +1,291 @@
+<?php
+namespace Elementor\Testing\Modules\Components;
+
+use Elementor\Core\Utils\Collection;
+use Elementor\Modules\Components\Non_Atomic_Widget_Validator;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Non_Atomic_Widget_Validator extends Elementor_Test_Base {
+	const ATOMIC_WIDGET_TYPE = 'e-heading';
+	const NON_ATOMIC_WIDGET_TYPE = 'heading';
+	const ATOMIC_CONTAINER_TYPE = 'e-div-block';
+	const NON_ATOMIC_CONTAINER_TYPE = 'container';
+
+	public function test_validate__returns_success_for_empty_elements() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+
+		// Act
+		$result = $validator->validate( [] );
+
+		// Assert
+		$this->assertTrue( $result['success'] );
+		$this->assertEmpty( $result['messages'] );
+	}
+
+	public function test_validate__returns_success_for_atomic_widgets_only() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+		$elements = [
+			$this->create_widget_element( self::ATOMIC_WIDGET_TYPE ),
+		];
+
+		// Act
+		$result = $validator->validate( $elements );
+
+		// Assert
+		$this->assertTrue( $result['success'] );
+		$this->assertEmpty( $result['messages'] );
+	}
+
+	public function test_validate__returns_success_for_atomic_containers_only() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+		$elements = [
+			$this->create_container_element( self::ATOMIC_CONTAINER_TYPE ),
+		];
+
+		// Act
+		$result = $validator->validate( $elements );
+
+		// Assert
+		$this->assertTrue( $result['success'] );
+		$this->assertEmpty( $result['messages'] );
+	}
+
+	public function test_validate__detects_non_atomic_container_at_root() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+		$elements = [
+			$this->create_container_element( self::NON_ATOMIC_CONTAINER_TYPE ),
+		];
+
+		// Act
+		$result = $validator->validate( $elements );
+
+		// Assert
+		$this->assertFalse( $result['success'] );
+		$this->assertNotEmpty( $result['messages'] );
+		$this->assertEquals( Non_Atomic_Widget_Validator::ERROR_CODE, $result['code'] );
+		$this->assertContains( self::NON_ATOMIC_CONTAINER_TYPE, $result['non_atomic_elements'] );
+	}
+
+	public function test_validate__detects_non_atomic_widget_at_root() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+		$elements = [
+			$this->create_widget_element( self::NON_ATOMIC_WIDGET_TYPE ),
+		];
+
+		// Act
+		$result = $validator->validate( $elements );
+
+		// Assert
+		$this->assertFalse( $result['success'] );
+		$this->assertNotEmpty( $result['messages'] );
+		$this->assertEquals( Non_Atomic_Widget_Validator::ERROR_CODE, $result['code'] );
+		$this->assertContains( self::NON_ATOMIC_WIDGET_TYPE, $result['non_atomic_elements'] );
+	}
+
+	public function test_validate__detects_non_atomic_widget_nested_in_atomic_container() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+		$elements = [
+			[
+				'id' => 'container-1',
+				'elType' => self::ATOMIC_CONTAINER_TYPE,
+				'settings' => [],
+				'elements' => [
+					$this->create_widget_element( self::NON_ATOMIC_WIDGET_TYPE ),
+				],
+			],
+		];
+
+		// Act
+		$result = $validator->validate( $elements );
+
+		// Assert
+		$this->assertFalse( $result['success'] );
+		$this->assertContains( self::NON_ATOMIC_WIDGET_TYPE, $result['non_atomic_elements'] );
+	}
+
+	public function test_validate__detects_non_atomic_widget_deeply_nested() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+		$elements = [
+			[
+				'id' => 'container-1',
+				'elType' => self::ATOMIC_CONTAINER_TYPE,
+				'settings' => [],
+				'elements' => [
+					[
+						'id' => 'container-2',
+						'elType' => self::ATOMIC_CONTAINER_TYPE,
+						'settings' => [],
+						'elements' => [
+							[
+								'id' => 'container-3',
+								'elType' => self::ATOMIC_CONTAINER_TYPE,
+								'settings' => [],
+								'elements' => [
+									$this->create_widget_element( self::NON_ATOMIC_WIDGET_TYPE ),
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		// Act
+		$result = $validator->validate( $elements );
+
+		// Assert
+		$this->assertFalse( $result['success'] );
+		$this->assertContains( self::NON_ATOMIC_WIDGET_TYPE, $result['non_atomic_elements'] );
+	}
+
+	public function test_validate__returns_unique_element_types() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+		$elements = [
+			$this->create_widget_element( self::NON_ATOMIC_WIDGET_TYPE ),
+			$this->create_widget_element( self::NON_ATOMIC_WIDGET_TYPE ),
+			$this->create_widget_element( self::NON_ATOMIC_WIDGET_TYPE ),
+		];
+
+		// Act
+		$result = $validator->validate( $elements );
+
+		// Assert
+		$this->assertFalse( $result['success'] );
+		$this->assertCount( 1, $result['non_atomic_elements'] );
+	}
+
+	public function test_validate__detects_multiple_different_non_atomic_elements() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+		$elements = [
+			$this->create_widget_element( 'heading' ),
+			$this->create_widget_element( 'button' ),
+			$this->create_container_element( self::NON_ATOMIC_CONTAINER_TYPE ),
+		];
+
+		// Act
+		$result = $validator->validate( $elements );
+
+		// Assert
+		$this->assertFalse( $result['success'] );
+		$this->assertCount( 3, $result['non_atomic_elements'] );
+		$this->assertContains( 'heading', $result['non_atomic_elements'] );
+		$this->assertContains( 'button', $result['non_atomic_elements'] );
+		$this->assertContains( self::NON_ATOMIC_CONTAINER_TYPE, $result['non_atomic_elements'] );
+	}
+
+	public function test_validate__allows_mixed_atomic_with_non_atomic_returns_failure() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+		$elements = [
+			$this->create_widget_element( self::ATOMIC_WIDGET_TYPE ),
+			$this->create_widget_element( self::NON_ATOMIC_WIDGET_TYPE ),
+		];
+
+		// Act
+		$result = $validator->validate( $elements );
+
+		// Assert
+		$this->assertFalse( $result['success'] );
+		$this->assertContains( self::NON_ATOMIC_WIDGET_TYPE, $result['non_atomic_elements'] );
+	}
+
+	public function test_validate_items__returns_success_for_valid_items() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+		$items = Collection::make( [
+			[
+				'uid' => 'component-1',
+				'elements' => [
+					$this->create_widget_element( self::ATOMIC_WIDGET_TYPE ),
+				],
+			],
+			[
+				'uid' => 'component-2',
+				'elements' => [
+					$this->create_widget_element( self::ATOMIC_WIDGET_TYPE ),
+				],
+			],
+		] );
+
+		// Act
+		$result = $validator->validate_items( $items );
+
+		// Assert
+		$this->assertTrue( $result['success'] );
+		$this->assertEmpty( $result['messages'] );
+	}
+
+	public function test_validate_items__detects_non_atomic_in_any_item() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+		$items = Collection::make( [
+			[
+				'uid' => 'component-1',
+				'elements' => [
+					$this->create_widget_element( self::ATOMIC_WIDGET_TYPE ),
+				],
+			],
+			[
+				'uid' => 'component-2',
+				'elements' => [
+					$this->create_widget_element( self::NON_ATOMIC_WIDGET_TYPE ),
+				],
+			],
+		] );
+
+		// Act
+		$result = $validator->validate_items( $items );
+
+		// Assert
+		$this->assertFalse( $result['success'] );
+		$this->assertContains( self::NON_ATOMIC_WIDGET_TYPE, $result['non_atomic_elements'] );
+	}
+
+	public function test_validate_items__handles_empty_elements() {
+		// Arrange
+		$validator = Non_Atomic_Widget_Validator::make();
+		$items = Collection::make( [
+			[
+				'uid' => 'component-1',
+			],
+		] );
+
+		// Act
+		$result = $validator->validate_items( $items );
+
+		// Assert
+		$this->assertTrue( $result['success'] );
+	}
+
+	private function create_widget_element( string $widget_type, string $id = null ): array {
+		return [
+			'id' => $id ?? 'widget-' . $widget_type . '-' . uniqid(),
+			'elType' => 'widget',
+			'widgetType' => $widget_type,
+			'settings' => [],
+			'elements' => [],
+		];
+	}
+
+	private function create_container_element( string $el_type, string $id = null ): array {
+		return [
+			'id' => $id ?? 'container-' . $el_type . '-' . uniqid(),
+			'elType' => $el_type,
+			'settings' => [],
+			'elements' => [],
+		];
+	}
+}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add validation to prevent saving v3 (non-atomic) widgets inside components to ensure only atomic elements are allowed [ED-22203]

Main changes:
- Created Non_Atomic_Widget_Validator class with recursive validation logic for PHP REST API endpoints
- Added client-side validation blocking create, move, and paste operations for non-atomic elements in component editor
- Integrated validation checks in component creation and update REST API endpoints with 422 error responses

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-22203]: https://elementor.atlassian.net/browse/ED-22203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ