### PR TITLE
Internal: Update component error message texts [ED-22223]

### DIFF
--- a/modules/components/components-rest-api.php
+++ b/modules/components/components-rest-api.php
@@ -533,7 +533,8 @@ class Components_REST_API {
 		if ( ! $circular_result['success'] ) {
 			return Error_Builder::make( 'circular_dependency_detected' )
 				->set_status( 422 )
-				->set_message( implode( ', ', $circular_result['messages'] ) )
+				->set_message( __( "Can't add this component - components that contain each other can't be nested.", 'elementor' ) )
+				->set_meta( [ 'caused_by' => $circular_result['messages'] ] )
 				->build();
 		}
 
@@ -542,7 +543,8 @@ class Components_REST_API {
 		if ( ! $non_atomic_result['success'] ) {
 			return Error_Builder::make( Non_Atomic_Widget_Validator::ERROR_CODE )
 				->set_status( 422 )
-				->set_message( implode( ', ', $non_atomic_result['messages'] ) )
+				->set_message( __( 'Components require Atomic elements only. Remove Widgets to create this component.', 'elementor' ) )
+				->set_meta( [ 'non_atomic_elements' => $non_atomic_result['non_atomic_elements'] ] )
 				->build();
 		}
 

--- a/modules/components/components-rest-api.php
+++ b/modules/components/components-rest-api.php
@@ -321,7 +321,8 @@ class Components_REST_API {
 		if ( ! $circular_result['success'] ) {
 			return Error_Builder::make( 'circular_dependency_detected' )
 				->set_status( 422 )
-				->set_message( implode( ', ', $circular_result['messages'] ) )
+				->set_message( __( "Can't add this component - components that contain each other can't be nested.", 'elementor' ) )
+				->set_meta( [ 'caused_by' => $circular_result['messages'] ] )
 				->build();
 		}
 
@@ -330,7 +331,8 @@ class Components_REST_API {
 		if ( ! $non_atomic_result['success'] ) {
 			return Error_Builder::make( Non_Atomic_Widget_Validator::ERROR_CODE )
 				->set_status( 422 )
-				->set_message( implode( ', ', $non_atomic_result['messages'] ) )
+				->set_message( __( 'Components require atomic elements only. Remove widgets to create this component.', 'elementor' ) )
+				->set_meta( [ 'non_atomic_elements' => $non_atomic_result['non_atomic_elements'] ] )
 				->build();
 		}
 
@@ -543,7 +545,7 @@ class Components_REST_API {
 		if ( ! $non_atomic_result['success'] ) {
 			return Error_Builder::make( Non_Atomic_Widget_Validator::ERROR_CODE )
 				->set_status( 422 )
-				->set_message( __( 'Components require Atomic elements only. Remove Widgets to create this component.', 'elementor' ) )
+				->set_message( __( 'Components require atomic elements only. Remove widgets to create this component.', 'elementor' ) )
 				->set_meta( [ 'non_atomic_elements' => $non_atomic_result['non_atomic_elements'] ] )
 				->build();
 		}

--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -101,7 +101,7 @@ class Module extends BaseModule {
 		$result = Circular_Dependency_Validator::make()->validate( $component_id, $elements );
 
 		if ( ! $result['success'] ) {
-			throw new \Exception( __( "Can't add this component - components that contain each other can't be nested.", 'elementor' ) );
+			throw new \Exception( esc_html__( "Can't add this component - components that contain each other can't be nested.", 'elementor' ) );
 		}
 	}
 

--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -101,7 +101,7 @@ class Module extends BaseModule {
 		$result = Circular_Dependency_Validator::make()->validate( $component_id, $elements );
 
 		if ( ! $result['success'] ) {
-			throw new \Exception( esc_html( implode( ', ', $result['messages'] ) ) );
+			throw new \Exception( __( "Can't add this component - components that contain each other can't be nested.", 'elementor' ) );
 		}
 	}
 

--- a/packages/packages/core/editor-components/src/components/create-component-form/create-component-form.tsx
+++ b/packages/packages/core/editor-components/src/components/create-component-form/create-component-form.tsx
@@ -54,7 +54,7 @@ export function CreateComponentForm() {
 				notify( {
 					type: 'default',
 					message: __(
-						'Components require Atomic elements only. Remove Widgets to create this component.',
+						'Components require atomic elements only. Remove widgets to create this component.',
 						'elementor'
 					),
 					id: 'non-atomic-element-save-blocked',

--- a/packages/packages/core/editor-components/src/components/create-component-form/create-component-form.tsx
+++ b/packages/packages/core/editor-components/src/components/create-component-form/create-component-form.tsx
@@ -54,7 +54,7 @@ export function CreateComponentForm() {
 				notify( {
 					type: 'default',
 					message: __(
-						'Cannot save as component - contains non-supported elements. Only atomic elements are allowed inside components.',
+						'Components require Atomic elements only. Remove Widgets to create this component.',
 						'elementor'
 					),
 					id: 'non-atomic-element-save-blocked',

--- a/packages/packages/core/editor-components/src/prevent-circular-nesting.ts
+++ b/packages/packages/core/editor-components/src/prevent-circular-nesting.ts
@@ -49,7 +49,7 @@ type StorageContent = {
 
 const COMPONENT_CIRCULAR_NESTING_ALERT: NotificationData = {
 	type: 'default',
-	message: __( 'Cannot add this component here - it would create a circular reference.', 'elementor' ),
+	message: __( "Can't add this component - components that contain each other can't be nested.", 'elementor' ),
 	id: 'circular-component-nesting-blocked',
 };
 

--- a/packages/packages/core/editor-components/src/prevent-non-atomic-nesting.ts
+++ b/packages/packages/core/editor-components/src/prevent-non-atomic-nesting.ts
@@ -42,7 +42,7 @@ type StorageContent = {
 
 const NON_ATOMIC_ELEMENT_ALERT: NotificationData = {
 	type: 'default',
-	message: __( 'Cannot add this element here - only atomic elements are allowed inside components.', 'elementor' ),
+	message: __( "This Widget isn't compatible with components. Use Atomic elements instead.", 'elementor' ),
 	id: 'non-atomic-element-blocked',
 };
 

--- a/packages/packages/core/editor-components/src/prevent-non-atomic-nesting.ts
+++ b/packages/packages/core/editor-components/src/prevent-non-atomic-nesting.ts
@@ -42,7 +42,7 @@ type StorageContent = {
 
 const NON_ATOMIC_ELEMENT_ALERT: NotificationData = {
 	type: 'default',
-	message: __( "This Widget isn't compatible with components. Use Atomic elements instead.", 'elementor' ),
+	message: __( "This widget isn't compatible with components. Use atomic elements instead.", 'elementor' ),
 	id: 'non-atomic-element-blocked',
 };
 


### PR DESCRIPTION
## Summary

Updates the error message texts for component-related errors as specified in [ED-22223](https://elementor.atlassian.net/browse/ED-22223).

## Changes

### 1. Circular Nesting Error
**Scenario**: User attempts to nest a component that would create circular reference (e.g., Comp A → Comp B → trying to add Comp A to Comp B)

- **Before**: "Cannot add this component here - it would create a circular reference."
- **After**: "Can't add this component - components that contain each other can't be nested."

### 2. Non-Atomic Element in Edit Mode
**Scenario**: User drops/adds a v3 (non-atomic) widget while editing a component

- **Before**: "Cannot add this element here - only atomic elements are allowed inside components."
- **After**: "This Widget isn't compatible with components. Use Atomic elements instead."

### 3. Composition with v3 Elements (Save as Component)
**Scenario**: User tries to save an element as a component when it contains non-atomic widgets

- **Before**: "Cannot save as component - contains non-supported elements. Only atomic elements are allowed inside components."
- **After**: "Components require Atomic elements only. Remove Widgets to create this component."

## Files Changed
- `packages/packages/core/editor-components/src/prevent-circular-nesting.ts`
- `packages/packages/core/editor-components/src/prevent-non-atomic-nesting.ts`
- `packages/packages/core/editor-components/src/components/create-component-form/create-component-form.tsx`

## Testing
- All existing tests pass ✅
- Text-only changes - no logic modifications

[ED-22223]: https://elementor.atlassian.net/browse/ED-22223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update component validation error messages across REST API and editor to improve user clarity and provide structured error metadata for better debugging.

Main changes:
- Replaced technical concatenated error messages with user-friendly translatable text using __() function
- Added structured metadata fields (caused_by, non_atomic_elements) to API error responses for client consumption
- Standardized error messaging across PHP backend and TypeScript frontend validation handlers

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
