### PR TITLE
Add label parameter to save-as-component MCP tool for user-friendly property names

### DIFF
--- a/modules/components/components-rest-api.php
+++ b/modules/components/components-rest-api.php
@@ -533,7 +533,8 @@ class Components_REST_API {
 		if ( ! $circular_result['success'] ) {
 			return Error_Builder::make( 'circular_dependency_detected' )
 				->set_status( 422 )
-				->set_message( implode( ', ', $circular_result['messages'] ) )
+				->set_message( __( "Can't add this component - components that contain each other can't be nested.", 'elementor' ) )
+				->set_meta( [ 'caused_by' => $circular_result['messages'] ] )
 				->build();
 		}
 
@@ -542,7 +543,8 @@ class Components_REST_API {
 		if ( ! $non_atomic_result['success'] ) {
 			return Error_Builder::make( Non_Atomic_Widget_Validator::ERROR_CODE )
 				->set_status( 422 )
-				->set_message( implode( ', ', $non_atomic_result['messages'] ) )
+				->set_message( __( 'Components require Atomic elements only. Remove Widgets to create this component.', 'elementor' ) )
+				->set_meta( [ 'non_atomic_elements' => $non_atomic_result['non_atomic_elements'] ] )
 				->build();
 		}
 

--- a/packages/packages/core/editor-components/src/components/create-component-form/create-component-form.tsx
+++ b/packages/packages/core/editor-components/src/components/create-component-form/create-component-form.tsx
@@ -54,7 +54,7 @@ export function CreateComponentForm() {
 				notify( {
 					type: 'default',
 					message: __(
-						'Cannot save as component - contains non-supported elements. Only atomic elements are allowed inside components.',
+						'Components require Atomic elements only. Remove Widgets to create this component.',
 						'elementor'
 					),
 					id: 'non-atomic-element-save-blocked',

--- a/packages/packages/core/editor-components/src/mcp/__tests__/save-as-component-tool.test.ts
+++ b/packages/packages/core/editor-components/src/mcp/__tests__/save-as-component-tool.test.ts
@@ -131,6 +131,7 @@ describe( 'save-as-component-tool handler', () => {
 						heading_text: {
 							elementId: TEST_CHILD_ELEMENT_ID,
 							propKey: 'text',
+							label: 'Heading Text',
 						},
 					},
 				},
@@ -269,6 +270,7 @@ describe( 'save-as-component-tool handler', () => {
 							heading_text: {
 								elementId: TEST_CHILD_ELEMENT_ID,
 								propKey: 'text',
+								label: 'Heading Text',
 							},
 						},
 					},
@@ -292,6 +294,7 @@ describe( 'save-as-component-tool handler', () => {
 							heading_text: {
 								elementId: 'non-existent-child-id',
 								propKey: 'text',
+								label: 'Heading Text',
 							},
 						},
 					},
@@ -326,6 +329,7 @@ describe( 'save-as-component-tool handler', () => {
 							heading_invalid: {
 								elementId: TEST_CHILD_ELEMENT_ID,
 								propKey: 'nonExistentProp',
+								label: 'Invalid Prop',
 							},
 						},
 					},
@@ -356,6 +360,7 @@ describe( 'save-as-component-tool handler', () => {
 							heading_text: {
 								elementId: TEST_CHILD_ELEMENT_ID,
 								propKey: 'text',
+								label: 'Heading Text',
 							},
 						},
 					},

--- a/packages/packages/core/editor-components/src/prevent-circular-nesting.ts
+++ b/packages/packages/core/editor-components/src/prevent-circular-nesting.ts
@@ -49,7 +49,7 @@ type StorageContent = {
 
 const COMPONENT_CIRCULAR_NESTING_ALERT: NotificationData = {
 	type: 'default',
-	message: __( 'Cannot add this component here - it would create a circular reference.', 'elementor' ),
+	message: __( "Can't add this component - components that contain each other can't be nested.", 'elementor' ),
 	id: 'circular-component-nesting-blocked',
 };
 

--- a/packages/packages/core/editor-components/src/prevent-non-atomic-nesting.ts
+++ b/packages/packages/core/editor-components/src/prevent-non-atomic-nesting.ts
@@ -42,7 +42,7 @@ type StorageContent = {
 
 const NON_ATOMIC_ELEMENT_ALERT: NotificationData = {
 	type: 'default',
-	message: __( 'Cannot add this element here - only atomic elements are allowed inside components.', 'elementor' ),
+	message: __( "This Widget isn't compatible with components. Use Atomic elements instead.", 'elementor' ),
 	id: 'non-atomic-element-blocked',
 };
 


### PR DESCRIPTION
## Summary

When AI generates component properties via the `save-as-component` MCP tool, it now assigns meaningful, user-friendly names instead of auto-generated ones.

## Changes

- **Schema**: Added required `label` field to `overridable_props` schema
- **Logic**: Updated `enrichOverridableProps` to use provided label instead of auto-generating
- **Cleanup**: Removed unused `generateLabel` function
- **Documentation**: Updated prompt documentation and examples to include label field
- **Tests**: Updated all test cases to include the required label field

## Example

Before (auto-generated):
```
prop_abc123 - text
```

After (user-friendly):
```
Hero Headline
CTA Button Text
```

## Testing

- ✅ All existing tests pass
- ✅ No lint errors

Closes [ED-22182](https://elementor.atlassian.net/browse/ED-22182)

[ED-22182]: https://elementor.atlassian.net/browse/ED-22182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add label parameter to save-as-component MCP tool enabling user-friendly display names for component properties instead of auto-generated identifiers.

Main changes:
- Added required `label` field to overridable_props schema in save-as-component-tool InputSchema for custom property naming
- Removed auto-generated label function and passed user-provided labels directly to enrichedProps structure
- Updated error messages across validation and UI components for improved clarity and user experience
- Updated MCP tool documentation and examples to include label parameter usage guidance

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
