### PR TITLE
Internal: Add prop label to save as component tool [ED-22182]

### DIFF
--- a/packages/packages/core/editor-components/src/mcp/__tests__/save-as-component-tool.test.ts
+++ b/packages/packages/core/editor-components/src/mcp/__tests__/save-as-component-tool.test.ts
@@ -131,6 +131,7 @@ describe( 'save-as-component-tool handler', () => {
 						heading_text: {
 							elementId: TEST_CHILD_ELEMENT_ID,
 							propKey: 'text',
+							label: 'Heading Text',
 						},
 					},
 				},
@@ -269,6 +270,7 @@ describe( 'save-as-component-tool handler', () => {
 							heading_text: {
 								elementId: TEST_CHILD_ELEMENT_ID,
 								propKey: 'text',
+								label: 'Heading Text',
 							},
 						},
 					},
@@ -292,6 +294,7 @@ describe( 'save-as-component-tool handler', () => {
 							heading_text: {
 								elementId: 'non-existent-child-id',
 								propKey: 'text',
+								label: 'Heading Text',
 							},
 						},
 					},
@@ -326,6 +329,7 @@ describe( 'save-as-component-tool handler', () => {
 							heading_invalid: {
 								elementId: TEST_CHILD_ELEMENT_ID,
 								propKey: 'nonExistentProp',
+								label: 'Invalid Prop',
 							},
 						},
 					},
@@ -356,6 +360,7 @@ describe( 'save-as-component-tool handler', () => {
 							heading_text: {
 								elementId: TEST_CHILD_ELEMENT_ID,
 								propKey: 'text',
+								label: 'Heading Text',
 							},
 						},
 					},


### PR DESCRIPTION
- Add required 'label' field to overridable_props schema
- Update enrichOverridableProps to use provided label instead of auto-generating
- Remove unused generateLabel function
- Update prompt documentation and examples with label field
- Update tests to include label field

Closes ED-22182

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add required label property to save-as-component tool schema for improved component property identification and user experience.

Main changes:
- Added mandatory 'label' field to InputSchema for overridable properties with user-friendly naming requirements
- Updated enrichOverridableProps function to accept and use label from input instead of auto-generation
- Removed generateLabel helper function that previously created technical prop identifiers
- Updated tool documentation and examples to require unique, descriptive labels for each property

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
