### PR TITLE
Fix: Invalid space_between_widgets in columns [ED-22224]

### DIFF
--- a/includes/elements/column.php
+++ b/includes/elements/column.php
@@ -229,7 +229,7 @@ class Element_Column extends Element_Base {
 		$optimized_markup = Plugin::$instance->experiments->is_feature_active( 'e_optimized_markup' );
 		$space_between_widgets = $optimized_markup
 			? '--kit-widget-spacing: {{VALUE}}px'
-			: 'margin-block-end:: {{VALUE}}px';
+			: 'margin-block-end: {{VALUE}}px';
 
 		$this->add_responsive_control(
 			'space_between_widgets',


### PR DESCRIPTION
Fix: https://github.com/elementor/elementor/issues/34033
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix CSS syntax error in column widget spacing by removing duplicate colon in margin-block-end property declaration.

Main changes:
- Corrected invalid CSS property 'margin-block-end::' to 'margin-block-end:' in non-optimized markup path
- Fixed fallback widget spacing CSS for columns when e_optimized_markup feature is disabled

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
