### PR TITLE
Internal: Entering component edit mode improvements [ED-22208]

### DIFF
--- a/assets/dev/js/editor/regions/navigator/commands/expand-all.js
+++ b/assets/dev/js/editor/regions/navigator/commands/expand-all.js
@@ -1,0 +1,22 @@
+export class ExpandAll extends $e.modules.CommandBase {
+	apply() {
+		if ( this.component.isOpen ) {
+			this.expandAllElements();
+		} else {
+			this.openNavigator();
+		}
+	}
+
+	openNavigator() {
+		$e.run( 'navigator/open', { expandAllElements: true } );
+	}
+
+	expandAllElements() {
+		this.component.manager.currentView.elements.currentView.recursiveChildInvoke(
+			'toggleList',
+			true,
+		);
+	}
+}
+
+export default ExpandAll;

--- a/assets/dev/js/editor/regions/navigator/commands/index.js
+++ b/assets/dev/js/editor/regions/navigator/commands/index.js
@@ -1,3 +1,4 @@
 export { Close } from './close';
+export { ExpandAll } from './expand-all';
 export { Open } from './open';
 export { Toggle } from './toggle';

--- a/assets/dev/js/editor/regions/navigator/commands/open.js
+++ b/assets/dev/js/editor/regions/navigator/commands/open.js
@@ -1,6 +1,6 @@
 export class Open extends $e.modules.CommandBase {
-	apply() {
-		$e.route( this.component.getNamespace() );
+	apply( args ) {
+		$e.route( this.component.getNamespace(), args );
 	}
 }
 

--- a/assets/dev/js/editor/regions/navigator/component.js
+++ b/assets/dev/js/editor/regions/navigator/component.js
@@ -28,7 +28,7 @@ export default class Component extends ComponentBase {
 	open( args ) {
 		const { model = false, expandAllElements = false } = args;
 
-		this.manager.open( model, expandAllElements );
+		this.manager.open( model, { expandAllElements } );
 
 		return true;
 	}

--- a/assets/dev/js/editor/regions/navigator/component.js
+++ b/assets/dev/js/editor/regions/navigator/component.js
@@ -26,9 +26,9 @@ export default class Component extends ComponentBase {
 	}
 
 	open( args ) {
-		const { model = false } = args;
+		const { model = false, expandAllElements = false } = args;
 
-		this.manager.open( model );
+		this.manager.open( model, expandAllElements );
 
 		return true;
 	}

--- a/assets/dev/js/editor/regions/navigator/navigator.js
+++ b/assets/dev/js/editor/regions/navigator/navigator.js
@@ -96,7 +96,7 @@ export default class extends BaseRegion {
 		this.$el.resizable( this.getResizableOptions() );
 	}
 
-	open( model, options = { expandAllElements: false } ) {
+	open( model, options ) {
 		this.$el.show();
 
 		this.setSize();
@@ -109,7 +109,7 @@ export default class extends BaseRegion {
 			model.trigger( 'request:edit' );
 		}
 
-		if ( options.expandAllElements ) {
+		if ( options?.expandAllElements ) {
 			this.currentView.elements.currentView.recursiveChildInvoke( 'toggleList', true );
 		}
 

--- a/assets/dev/js/editor/regions/navigator/navigator.js
+++ b/assets/dev/js/editor/regions/navigator/navigator.js
@@ -96,7 +96,7 @@ export default class extends BaseRegion {
 		this.$el.resizable( this.getResizableOptions() );
 	}
 
-	open( model ) {
+	open( model, expandAllElements = false ) {
 		this.$el.show();
 
 		this.setSize();
@@ -107,6 +107,10 @@ export default class extends BaseRegion {
 
 		if ( model ) {
 			model.trigger( 'request:edit' );
+		}
+
+		if ( expandAllElements ) {
+			this.currentView.elements.currentView.recursiveChildInvoke( 'toggleList', true );
 		}
 
 		this.saveStorage( 'visible', true );

--- a/assets/dev/js/editor/regions/navigator/navigator.js
+++ b/assets/dev/js/editor/regions/navigator/navigator.js
@@ -96,7 +96,7 @@ export default class extends BaseRegion {
 		this.$el.resizable( this.getResizableOptions() );
 	}
 
-	open( model, expandAllElements = false ) {
+	open( model, options = { expandAllElements: false } ) {
 		this.$el.show();
 
 		this.setSize();
@@ -109,7 +109,7 @@ export default class extends BaseRegion {
 			model.trigger( 'request:edit' );
 		}
 
-		if ( expandAllElements ) {
+		if ( options.expandAllElements ) {
 			this.currentView.elements.currentView.recursiveChildInvoke( 'toggleList', true );
 		}
 

--- a/assets/dev/scss/editor/preview/preview.scss
+++ b/assets/dev/scss/editor/preview/preview.scss
@@ -480,6 +480,19 @@ html.elementor-html {
 	.elementor-widget-empty {
 		display: none;
 	}
+
+	// Show elements overlays when an embedded document is being edited
+	// For example, when a component is being edited.
+	:where(.elementor-edit-area-active) {
+		.elementor-element-overlay,
+		.elementor-empty,
+		.elementor-add-section,
+		.elementor-add-section-inline,
+		.elementor-empty-view,
+		.elementor-widget-empty {
+			display: revert;
+		}
+	}
 }
 
 // Muted elements in the editor

--- a/packages/packages/core/editor-components/src/utils/expand-navigator.ts
+++ b/packages/packages/core/editor-components/src/utils/expand-navigator.ts
@@ -1,0 +1,5 @@
+import { __privateRunCommand as runCommand } from '@elementor/editor-v1-adapters';
+
+export async function expandNavigator() {
+	await runCommand( 'navigator/expand-all' );
+}

--- a/packages/packages/core/editor-components/src/utils/switch-to-component.ts
+++ b/packages/packages/core/editor-components/src/utils/switch-to-component.ts
@@ -22,8 +22,8 @@ export async function switchToComponent(
 	const topLevelElement = currentDocumentContainer?.children?.[ 0 ];
 
 	if ( topLevelElement ) {
-		await selectElement( topLevelElement.id );
-		await expandNavigator();
+		selectElement( topLevelElement.id );
+		expandNavigator();
 	}
 }
 

--- a/packages/packages/core/editor-components/src/utils/switch-to-component.ts
+++ b/packages/packages/core/editor-components/src/utils/switch-to-component.ts
@@ -1,19 +1,30 @@
+import { getCurrentDocumentContainer, selectElement } from '@elementor/editor-elements';
 import { __privateRunCommand as runCommand } from '@elementor/editor-v1-adapters';
 
-export function switchToComponent(
+import { expandNavigator } from './expand-navigator';
+
+export async function switchToComponent(
 	componentId: number | string,
 	componentInstanceId?: string | null,
 	element?: HTMLElement | null
 ) {
 	const selector = getSelector( element, componentInstanceId );
 
-	runCommand( 'editor/documents/switch', {
+	await runCommand( 'editor/documents/switch', {
 		id: componentId,
 		selector,
 		mode: 'autosave',
 		setAsInitial: false,
 		shouldScroll: false,
 	} );
+
+	const currentDocumentContainer = getCurrentDocumentContainer();
+	const topLevelElement = currentDocumentContainer?.children?.[ 0 ];
+
+	if ( topLevelElement ) {
+		await selectElement( topLevelElement.id );
+		await expandNavigator();
+	}
 }
 
 function getSelector( element?: HTMLElement | null, componentInstanceId?: string | null ): string | undefined {


### PR DESCRIPTION
When entering component edit mode: 

1. The top-level container should be selected 

2. The navigator should be opened and all items expanded
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enhance component edit mode navigation by adding auto-expand functionality and improving element selection when entering embedded document editing context.

Main changes:
- Added ExpandAll command to navigator with conditional logic for opening/expanding based on navigator state
- Enhanced navigator open() method to accept expandAllElements option for automatic tree expansion
- Modified switchToComponent() to auto-select top-level element and expand navigator when entering edit mode
- Added CSS rules to display element overlays in embedded documents with elementor-edit-area-active class

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
