### PR TITLE
Internal: VQA fixes [ED-22181]

### DIFF
--- a/core/admin/editor-one-menu/menu/third-party-pages-menu.php
+++ b/core/admin/editor-one-menu/menu/third-party-pages-menu.php
@@ -24,7 +24,7 @@ class Third_Party_Pages_Menu implements Menu_Item_Third_Level_Interface {
 	}
 
 	public function get_label(): string {
-		return esc_html__( 'Third Party Pages', 'elementor' );
+		return esc_html__( 'Addons', 'elementor' );
 	}
 
 	public function get_position(): int {

--- a/modules/editor-one/assets/js/sidebar-navigation/components/shared/icon-map.js
+++ b/modules/editor-one/assets/js/sidebar-navigation/components/shared/icon-map.js
@@ -5,6 +5,7 @@ import InfoCircleIcon from '@elementor/icons/InfoCircleIcon';
 import SendIcon from '@elementor/icons/SendIcon';
 import SettingsIcon from '@elementor/icons/SettingsIcon';
 import UsersIcon from '@elementor/icons/UsersIcon';
+import PlugIcon from '@elementor/icons/PlugIcon';
 import ToolIcon from '../icons/tool';
 
 export const ICON_MAP = {
@@ -16,6 +17,7 @@ export const ICON_MAP = {
 	settings: SettingsIcon,
 	tool: ToolIcon,
 	users: UsersIcon,
+	extension: PlugIcon,
 };
 
 export const DEFAULT_ICON = HomeIcon;

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -5,6 +5,10 @@
 
 @import "theme-light";
 
+#wpwrap {
+	background-color: var(--e-one-palette-background-default);
+}
+
 #wpcontent {
 	background-color: var(--e-one-palette-background-default);
 

--- a/modules/editor-one/classes/editor-one-pointer.php
+++ b/modules/editor-one/classes/editor-one-pointer.php
@@ -61,7 +61,9 @@ class Editor_One_Pointer {
 						content: <?php echo wp_json_encode( $pointer_content ); ?>,
 						position: {
 							edge: 'top',
-							align: 'left'
+							align: 'left',
+							at: 'left+20 bottom',
+							my: 'left top'
 						},
 						close: function() {
 							markIntroductionAsViewed();


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix VQA (Visual Quality Assurance) issues in Editor One interface by correcting menu labels, pointer positioning, and styling inconsistencies.

Main changes:
- Renamed "Third Party Pages" menu label to "Addons" for clearer user-facing terminology
- Adjusted pointer tooltip positioning with custom alignment coordinates (left+20 bottom) for better visual placement
- Added PlugIcon to icon map for extension menu item support
- Fixed background color consistency by applying theme background to wpwrap container

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
