### PR TITLE
Fix: Relocate contact url dynamic tag in list for V4 [ED-22095]

### DIFF
--- a/core/dynamic-tags/base-tag.php
+++ b/core/dynamic-tags/base-tag.php
@@ -41,6 +41,10 @@ abstract class Base_Tag extends Controls_Stack {
 	 */
 	abstract public function get_group();
 
+	public function get_atomic_group() {
+		return $this->get_group();
+	}
+
 	/**
 	 * @since 2.0.0
 	 * @access public
@@ -97,6 +101,7 @@ abstract class Base_Tag extends Controls_Stack {
 			'panel_template' => $panel_template,
 			'categories' => $this->get_categories(),
 			'group' => $this->get_group(),
+			'atomic_group' => $this->get_atomic_group(),
 			'controls' => $this->get_controls(),
 			'content_type' => $this->get_content_type(),
 			'settings_required' => $this->is_settings_required(),

--- a/modules/atomic-widgets/dynamic-tags/dynamic-tags-editor-config.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-tags-editor-config.php
@@ -84,7 +84,7 @@ class Dynamic_Tags_Editor_Config {
 			'name'            => $tag['name'],
 			'categories'      => $tag['categories'],
 			'label'           => $tag['title'] ?? '',
-			'group'           => $tag['group'] ?? '',
+			'group'           => $tag['atomic_group'] ?? $tag['group'] ?? '',
 			'atomic_controls' => [],
 			'props_schema'    => $this->schemas->get( $tag['name'] ),
 		];


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix dynamic tag grouping in V4 by introducing atomic_group fallback mechanism to ensure contact URL tags display in correct list categories.

Main changes:
- Added get_atomic_group() method to Base_Tag class allowing tags to override grouping for atomic widget context
- Updated Base_Tag config export to include atomic_group field alongside existing group field
- Modified Dynamic_Tags_Editor_Config to prioritize atomic_group over group for proper tag categorization in V4

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
