### PR TITLE
Internal: Remove admin notice/promotion for "Send" [ED-22229]

### DIFF
--- a/core/admin/admin-notices.php
+++ b/core/admin/admin-notices.php
@@ -33,7 +33,6 @@ class Admin_Notices extends Module {
 		'rate_us_feedback',
 		'role_manager_promote',
 		'experiment_promotion',
-		'send_app_promotion',
 		'site_mailer_promotion',
 		'plugin_image_optimization',
 		'ally_pages_promotion',
@@ -468,56 +467,6 @@ class Admin_Notices extends Module {
 
 		$detected_form_plugin = false;
 		return $detected_form_plugin;
-	}
-
-	private function notice_send_app_promotion() {
-		return self::EXIT_EARLY_FOR_BACKWARD_COMPATIBILITY;
-
-		$notice_id = 'send_app_promotion';
-
-		if ( ! $this->is_elementor_page() && ! $this->is_elementor_admin_screen() ) {
-			return false;
-		}
-
-		if ( time() < $this->get_install_time() + ( 60 * DAY_IN_SECONDS ) ) {
-			return false;
-		}
-
-		if ( ! current_user_can( 'install_plugins' ) || User::is_user_notice_viewed( $notice_id ) ) {
-			return false;
-		}
-
-		$plugin_file_path = 'send/send-app.php';
-		$plugin_slug = 'send-app';
-
-		$cta_data = $this->get_plugin_cta_data( $plugin_slug, $plugin_file_path );
-		if ( empty( $cta_data ) ) {
-			return false;
-		}
-
-		$title = sprintf( esc_html__( 'Turn leads into loyal shoppers', 'elementor' ) );
-
-		$options = [
-			'title' => $title,
-			'description' => esc_html__( 'Collecting leads is just the beginning. With Send by Elementor, you can manage contacts, launch automations, and turn form submissions into sales.', 'elementor' ),
-			'id' => $notice_id,
-			'type' => 'cta',
-			'button' => [
-				'text' => $cta_data['text'],
-				'url' => $cta_data['url'],
-				'type' => 'cta',
-			],
-			'button_secondary' => [
-				'text' => esc_html__( 'Learn more', 'elementor' ),
-				'url' => 'https://go.elementor.com/Formslearnmore',
-				'new_tab' => true,
-				'type' => 'cta',
-			],
-		];
-
-		$this->print_admin_notice( $options );
-
-		return true;
 	}
 
 	private function notice_local_google_fonts_disabled() {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove deprecated Send app promotional notice from admin interface to clean up unused marketing code and reduce notification clutter.

Main changes:
- Removed 'send_app_promotion' from OPTIONED_NOTICES array to stop tracking this notice type
- Deleted notice_send_app_promotion() method including plugin CTA logic and promotional content
- Eliminated 62 lines of unused promotion code including time-based display conditions and user permission checks

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
