### PR TITLE
Fix: Fix image control override indicator

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/image-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/image-control.tsx
@@ -6,11 +6,11 @@ import { __ } from '@wordpress/i18n';
 
 import { PropKeyProvider, PropProvider, useBoundProp } from '../bound-prop-context';
 import { ControlFormLabel } from '../components/control-form-label';
+import { ControlLabel } from '../components/control-label';
 import { createControl } from '../create-control';
 import { useUnfilteredFilesUpload } from '../hooks/use-unfiltered-files-upload';
 import { ImageMediaControl } from './image-media-control';
 import { SelectControl } from './select-control';
-import { ControlLabel } from '../components/control-label';
 
 type ImageControlProps = {
 	sizes: { label: string; value: string }[];

--- a/packages/packages/libs/editor-controls/src/controls/image-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/image-control.tsx
@@ -10,6 +10,7 @@ import { createControl } from '../create-control';
 import { useUnfilteredFilesUpload } from '../hooks/use-unfiltered-files-upload';
 import { ImageMediaControl } from './image-media-control';
 import { SelectControl } from './select-control';
+import { ControlLabel } from '../components/control-label';
 
 type ImageControlProps = {
 	sizes: { label: string; value: string }[];
@@ -21,7 +22,7 @@ export const ImageControl = createControl( ( { sizes }: ImageControlProps ) => {
 	return (
 		<PropProvider { ...propContext }>
 			<Stack gap={ 1.5 }>
-				<ControlFormLabel>{ __( 'Image', 'elementor' ) }</ControlFormLabel>
+				<ControlLabel>{ __( 'Image', 'elementor' ) }</ControlLabel>
 				<ImageSrcControl />
 				<Grid container gap={ 1.5 } alignItems="center" flexWrap="nowrap">
 					<Grid item xs={ 6 }>


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Fix image control override indicator by replacing ControlFormLabel with ControlLabel component for proper state visualization.
Main changes:
- Replaced ControlFormLabel with ControlLabel for main "Image" label to enable override indicator display
- Added ControlLabel import from components directory to support override state tracking
- Maintained ControlFormLabel for "Resolution" sub-label to preserve existing form field behavior
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
