### PR TITLE
Internal: [V4] fix undo/redo for inline editing on canvas

### DIFF
--- a/packages/packages/core/editor-canvas/src/legacy/replacements/inline-editing/inline-editing-elements.tsx
+++ b/packages/packages/core/editor-canvas/src/legacy/replacements/inline-editing/inline-editing-elements.tsx
@@ -130,18 +130,17 @@ export default class InlineEditingReplacement extends ReplacementBase {
 		return propSchema?.[ propertyName ] ?? null;
 	}
 
-	getContentValue() {
+	getHtmlPropValue(): HtmlPropValue | null {
 		const prop = this.getHtmlPropType();
-		const defaultValue = ( prop?.default as StringPropValue | null )?.value ?? '';
 		const settingKey = this.getInlineEditablePropertyName();
 
-		return (
-			htmlPropTypeUtil.extract( this.getSetting( settingKey ) ?? null ) ??
-			stringPropTypeUtil.extract( this.getSetting( settingKey ) ?? null ) ??
-			htmlPropTypeUtil.extract( prop?.default ?? null ) ??
-			defaultValue ??
-			''
-		);
+		return ( this.getSetting( settingKey ) ?? prop?.default ?? null ) as HtmlPropValue | null;
+	}
+
+	getExtractedContentValue() {
+		const propValue = this.getHtmlPropValue();
+
+		return htmlPropTypeUtil.extract( propValue ) ?? stringPropTypeUtil.extract( propValue ) ?? '';
 	}
 
 	setContentValue( value: string | null ) {
@@ -151,13 +150,13 @@ export default class InlineEditingReplacement extends ReplacementBase {
 		undoable(
 			{
 				do: () => {
-					const prevValue = this.getContentValue();
+					const prevValue = this.getHtmlPropValue();
 
 					this.runCommand( settingKey, valueToSave );
 
 					return prevValue;
 				},
-				undo: ( prevValue ) => {
+				undo: ( _, prevValue ) => {
 					this.runCommand( settingKey, prevValue ?? null );
 				},
 			},
@@ -232,7 +231,7 @@ export default class InlineEditingReplacement extends ReplacementBase {
 	}
 
 	InlineEditorApp = ( { wrapperClasses, elementClasses }: { wrapperClasses: string; elementClasses: string } ) => {
-		const propValue = this.getContentValue();
+		const propValue = this.getExtractedContentValue();
 		const expectedTag = this.getExpectedTag();
 		const wrapperRef = useRef< HTMLDivElement | null >( null );
 		const [ isWrapperRendered, setIsWrapperRendered ] = useState( false );

--- a/packages/packages/core/editor-canvas/src/legacy/replacements/inline-editing/inline-editing-elements.tsx
+++ b/packages/packages/core/editor-canvas/src/legacy/replacements/inline-editing/inline-editing-elements.tsx
@@ -8,7 +8,6 @@ import {
 	type HtmlPropValue,
 	type PropType,
 	stringPropTypeUtil,
-	type StringPropValue,
 	type TransformablePropValue,
 } from '@elementor/editor-props';
 import { __privateRunCommandSync as runCommandSync, isExperimentActive, undoable } from '@elementor/editor-v1-adapters';


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix undo/redo functionality for inline editing on canvas by separating value extraction logic and correcting undo callback signature to properly capture previous state.

Main changes:
- Replaced `getContentValue()` with two specialized methods: `getHtmlPropValue()` for retrieving raw prop values and `getExtractedContentValue()` for extracted string content
- Fixed undo callback signature from `(prevValue)` to `(_, prevValue)` to correctly receive captured previous state from do() return value
- Removed unused `StringPropValue` import and simplified prop value extraction logic to use composed utility methods

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
