### PR TITLE
Internal: Block rendering for component in the editor (circular rendering) [ED-22160]

### DIFF
--- a/packages/packages/core/editor-components/src/types.ts
+++ b/packages/packages/core/editor-components/src/types.ts
@@ -77,6 +77,7 @@ export type ComponentOverridable = {
 
 export type ComponentRenderContext = RenderContext< {
 	overrides?: Record< string, unknown >;
+	ancestors?: Set< number | string >;
 } >;
 
 export type UpdatedComponentName = {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Prevent circular rendering of components in the editor by tracking component ancestry chain and blocking self-referential component instances.

Main changes:
- Added ancestry tracking using Set in ComponentRenderContext to maintain chain of parent component IDs
- Implemented circular reference detection that clears component_instance when component renders itself
- Enhanced getRenderContext to build and propagate ancestor chain from parent to child components

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
