### PR TITLE
Internal: Fix failed tests for ally

### DIFF
--- a/tests/playwright/pages/editor-page.ts
+++ b/tests/playwright/pages/editor-page.ts
@@ -200,9 +200,14 @@ export default class EditorPage extends BasePage {
 
 		for ( const selector of announcementSelectors ) {
 			if ( await this.page.locator( `#${ selector }` ).count() > 0 ) {
+				await this.page.keyboard.press( 'Escape' );
 				await this.page.evaluate( ( id ) => document.getElementById( id )?.remove(), selector );
 			}
 		}
+
+		await this.page.evaluate( () => {
+			document.querySelectorAll( '.MuiDialog-root, .MuiModal-root' ).forEach( ( el ) => el.remove() );
+		} );
 	}
 
 	/**

--- a/tests/playwright/pages/wp-admin-page.ts
+++ b/tests/playwright/pages/wp-admin-page.ts
@@ -401,9 +401,14 @@ export default class WpAdminPage extends BasePage {
 
 		for ( const selector of announcementSelectors ) {
 			if ( await this.page.locator( `#${ selector }` ).count() > 0 ) {
+				await this.page.keyboard.press( 'Escape' );
 				await this.page.evaluate( ( id ) => document.getElementById( id )?.remove(), selector );
 			}
 		}
+
+		await this.page.evaluate( () => {
+			document.querySelectorAll( '.MuiDialog-root, .MuiModal-root' ).forEach( ( el ) => el.remove() );
+		} );
 
 		let window: WindowType;
 		await this.page.evaluate( () => {

--- a/tests/playwright/sanity/modules/favorites/assets/js/editor/types/widgets/helpers.ts
+++ b/tests/playwright/sanity/modules/favorites/assets/js/editor/types/widgets/helpers.ts
@@ -16,6 +16,17 @@ export default class FavoriteWidgetsHelper {
 		await this.page.click( `.elementor-context-menu >> :text("Remove from Favorites")` );
 	}
 
+	async ensureNotFavorited( widgetTitle: string ) {
+		await this.openPanelElementContextMenu( widgetTitle );
+		const removeButton = this.page.locator( '.elementor-context-menu' ).locator( ':text("Remove from Favorites")' );
+
+		if ( await removeButton.isVisible() ) {
+			await removeButton.click();
+		} else {
+			await this.page.keyboard.press( 'Escape' );
+		}
+	}
+
 	async openPanelElementContextMenu( widgetTitle: string ) {
 		await this.page.click( `.elementor-element >> :text("${ widgetTitle }")`, { button: 'right' } );
 		await this.page.waitForSelector( '.elementor-context-menu' );

--- a/tests/playwright/sanity/modules/favorites/assets/js/editor/types/widgets/widgets.test.ts
+++ b/tests/playwright/sanity/modules/favorites/assets/js/editor/types/widgets/widgets.test.ts
@@ -13,6 +13,7 @@ test.describe( 'Favorite widgets', () => {
 		const favoriteToAdd = 'Button';
 
 		const favoriteWidgets = new FavoriteWidgetsHelper( page );
+		await favoriteWidgets.ensureNotFavorited( favoriteToAdd );
 		await favoriteWidgets.add( favoriteToAdd );
 
 		const expectFavoriteVisible = async () => {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix flaky Playwright test failures by improving cleanup of modal dialogs and announcement popups that were interfering with test execution.

Main changes:
- Added Escape key press and MuiDialog/MuiModal DOM cleanup to closeAnnouncementsIfVisible() in editor and admin pages
- Implemented ensureNotFavorited() helper method to guarantee clean state before adding favorite widgets in tests

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
