### PR TITLE
Internal: Prevent interactions with widgets inside non-edited components [ED-22199]

### DIFF
--- a/assets/dev/scss/editor/preview/preview.scss
+++ b/assets/dev/scss/editor/preview/preview.scss
@@ -556,7 +556,7 @@ html.elementor-html {
 .elementor-widget-e-component[data-atomic] {
 	&.elementor-edit-area-active {
 		& > * > * {
-			pointer-events: revert;
+			pointer-events: initial;
 		}
 	}
 

--- a/assets/dev/scss/editor/preview/preview.scss
+++ b/assets/dev/scss/editor/preview/preview.scss
@@ -552,6 +552,21 @@ html.elementor-html {
 	pointer-events: none;
 }
 
+
+.elementor-widget-e-component[data-atomic] {
+	&.elementor-edit-area-active {
+		& > * > * {
+			pointer-events: revert;
+		}
+	}
+
+	&:not(.elementor-edit-area-active) {
+		& > * > * {
+			pointer-events: none;
+		}
+	}
+}
+
 @import "section";
 @import "column";
 @import "widget";


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Prevent unintended interactions with widgets inside non-edited atomic components by conditionally disabling pointer events based on edit state.
Main changes:
- Added CSS rule for `.elementor-widget-e-component[data-atomic]` to disable pointer-events on child widgets when component is not in edit mode
- Enabled pointer-events restoration for nested elements only when `.elementor-edit-area-active` class is present on the component

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
