### PR TITLE
Internal: Improve UX when there is a conflict between panel & inline link controls [ED-21984]

### DIFF
--- a/packages/packages/core/editor-canvas/src/legacy/replacements/inline-editing/inline-editing-elements.tsx
+++ b/packages/packages/core/editor-canvas/src/legacy/replacements/inline-editing/inline-editing-elements.tsx
@@ -263,20 +263,21 @@ export default class InlineEditingReplacement extends ReplacementBase {
 					{ isWrapperRendered && (
 						<OutlineOverlay element={ wrapperRef.current as HTMLDivElement } id={ this.id } isSelected />
 					) }
-					<InlineEditor
-						attributes={ {
-							class: wrapperClasses,
-							style: 'outline: none;',
-						} }
-						elementClasses={ elementClasses }
-						value={ propValue }
-						setValue={ this.setContentValue.bind( this ) }
-						onBlur={ this.unmountInlineEditor.bind( this ) }
-						autofocus
-						showToolbar
-						getInitialPopoverPosition={ getInitialPopoverPosition }
-						expectedTag={ expectedTag }
-					/>
+				<InlineEditor
+					attributes={ {
+						class: wrapperClasses,
+						style: 'outline: none;',
+					} }
+					elementClasses={ elementClasses }
+					value={ propValue }
+					setValue={ this.setContentValue.bind( this ) }
+					onBlur={ this.unmountInlineEditor.bind( this ) }
+					autofocus
+					showToolbar
+					getInitialPopoverPosition={ getInitialPopoverPosition }
+					expectedTag={ expectedTag }
+					elementId={ this.id }
+				/>
 				</Box>
 			</ThemeProvider>
 		);

--- a/packages/packages/core/editor-canvas/src/legacy/replacements/inline-editing/inline-editing-elements.tsx
+++ b/packages/packages/core/editor-canvas/src/legacy/replacements/inline-editing/inline-editing-elements.tsx
@@ -263,21 +263,21 @@ export default class InlineEditingReplacement extends ReplacementBase {
 					{ isWrapperRendered && (
 						<OutlineOverlay element={ wrapperRef.current as HTMLDivElement } id={ this.id } isSelected />
 					) }
-				<InlineEditor
-					attributes={ {
-						class: wrapperClasses,
-						style: 'outline: none;',
-					} }
-					elementClasses={ elementClasses }
-					value={ propValue }
-					setValue={ this.setContentValue.bind( this ) }
-					onBlur={ this.unmountInlineEditor.bind( this ) }
-					autofocus
-					showToolbar
-					getInitialPopoverPosition={ getInitialPopoverPosition }
-					expectedTag={ expectedTag }
-					elementId={ this.id }
-				/>
+					<InlineEditor
+						attributes={ {
+							class: wrapperClasses,
+							style: 'outline: none;',
+						} }
+						elementClasses={ elementClasses }
+						value={ propValue }
+						setValue={ this.setContentValue.bind( this ) }
+						onBlur={ this.unmountInlineEditor.bind( this ) }
+						autofocus
+						showToolbar
+						getInitialPopoverPosition={ getInitialPopoverPosition }
+						expectedTag={ expectedTag }
+						elementId={ this.id }
+					/>
 				</Box>
 			</ThemeProvider>
 		);

--- a/packages/packages/libs/editor-controls/src/components/__tests__/inline-editor-toolbar.test.tsx
+++ b/packages/packages/libs/editor-controls/src/components/__tests__/inline-editor-toolbar.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { renderWithTheme } from 'test-utils';
+import { getElementSetting } from '@elementor/editor-elements';
 import { fireEvent, screen } from '@testing-library/react';
 import { type Editor } from '@tiptap/react';
-import { getElementSetting } from '@elementor/editor-elements';
 
 import { InlineEditorToolbar } from '../inline-editor-toolbar';
 
@@ -205,7 +205,7 @@ describe( 'InlineEditorToolbar', () => {
 		it( 'should hide link button when element has LinkControl link', () => {
 			// Arrange
 			const mockEditor = createMockEditor();
-			
+
 			jest.mocked( getElementSetting ).mockReturnValue( {
 				value: {
 					destination: 'https://example.com',
@@ -222,7 +222,7 @@ describe( 'InlineEditorToolbar', () => {
 		it( 'should show link button when element has no LinkControl link', () => {
 			// Arrange
 			const mockEditor = createMockEditor();
-			
+
 			jest.mocked( getElementSetting ).mockReturnValue( null );
 
 			// Act

--- a/packages/packages/libs/editor-controls/src/components/__tests__/inline-editor-toolbar.test.tsx
+++ b/packages/packages/libs/editor-controls/src/components/__tests__/inline-editor-toolbar.test.tsx
@@ -2,8 +2,13 @@ import * as React from 'react';
 import { renderWithTheme } from 'test-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import { type Editor } from '@tiptap/react';
+import { getElementSetting } from '@elementor/editor-elements';
 
 import { InlineEditorToolbar } from '../inline-editor-toolbar';
+
+jest.mock( '@elementor/editor-elements', () => ( {
+	getElementSetting: jest.fn(),
+} ) );
 
 type MockEditorOptions = {
 	activeFormats?: string[];
@@ -187,6 +192,44 @@ describe( 'InlineEditorToolbar', () => {
 
 			// Assert.
 			expect( newTabButton ).toHaveAttribute( 'aria-pressed', 'true' );
+		} );
+	} );
+
+	describe( 'Link button visibility based on LinkControl', () => {
+		const ELEMENT_ID = 'test-element-123';
+
+		beforeEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		it( 'should hide link button when element has LinkControl link', () => {
+			// Arrange
+			const mockEditor = createMockEditor();
+			
+			jest.mocked( getElementSetting ).mockReturnValue( {
+				value: {
+					destination: 'https://example.com',
+				},
+			} );
+
+			// Act
+			renderWithTheme( <InlineEditorToolbar editor={ mockEditor } elementId={ ELEMENT_ID } /> );
+
+			// Assert
+			expect( screen.queryByLabelText( 'Link' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should show link button when element has no LinkControl link', () => {
+			// Arrange
+			const mockEditor = createMockEditor();
+			
+			jest.mocked( getElementSetting ).mockReturnValue( null );
+
+			// Act
+			renderWithTheme( <InlineEditorToolbar editor={ mockEditor } elementId={ ELEMENT_ID } /> );
+
+			// Assert
+			expect( screen.getByLabelText( 'Link' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/packages/packages/libs/editor-controls/src/components/inline-editor-toolbar.tsx
+++ b/packages/packages/libs/editor-controls/src/components/inline-editor-toolbar.tsx
@@ -26,11 +26,8 @@ import { __ } from '@wordpress/i18n';
 
 import { UrlPopover } from './url-popover';
 
-const checkIfElementHasLink = ( elementId: ElementID ): boolean => {
-	const linkValue = getElementSetting< LinkPropValue >( elementId, 'link' );
-
-	return linkValue !== null && linkValue?.value?.destination !== null;
-};
+const checkIfElementHasLink = ( elementId: ElementID ): boolean =>
+	!! getElementSetting< LinkPropValue >( elementId, 'link' )?.value?.destination;
 
 type InlineEditorToolbarProps = {
 	editor: Editor;
@@ -115,7 +112,6 @@ export const InlineEditorToolbar = ( { editor, elementId }: InlineEditorToolbarP
 	const [ openInNewTab, setOpenInNewTab ] = useState( false );
 	const toolbarRef = useRef< HTMLDivElement >( null );
 	const linkPopupState = usePopupState( { variant: 'popover' } );
-
 	const hasLinkOnElement = elementId ? checkIfElementHasLink( elementId ) : false;
 
 	const editorState = useEditorState( {

--- a/packages/packages/libs/editor-controls/src/components/inline-editor-toolbar.tsx
+++ b/packages/packages/libs/editor-controls/src/components/inline-editor-toolbar.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { useMemo, useRef, useState } from 'react';
+import { type ElementID, getElementSetting } from '@elementor/editor-elements';
+import { type LinkPropValue } from '@elementor/editor-props';
 import {
 	BoldIcon,
 	ItalicIcon,
@@ -24,12 +26,9 @@ import { __ } from '@wordpress/i18n';
 
 import { UrlPopover } from './url-popover';
 
-import { getElementSetting, type ElementID } from '@elementor/editor-elements';
-import { type LinkPropValue } from '@elementor/editor-props';
-
 const checkIfElementHasLink = ( elementId: ElementID ): boolean => {
 	const linkValue = getElementSetting< LinkPropValue >( elementId, 'link' );
-	
+
 	return linkValue !== null && linkValue?.value?.destination !== null;
 };
 
@@ -126,11 +125,11 @@ export const InlineEditorToolbar = ( { editor, elementId }: InlineEditorToolbarP
 
 	const formatButtonsList = useMemo( () => {
 		const buttons = Object.values( formatButtons );
-		
+
 		if ( hasLinkOnElement ) {
 			return buttons.filter( ( button ) => button.action !== 'link' );
 		}
-		
+
 		return buttons;
 	}, [ hasLinkOnElement ] );
 

--- a/packages/packages/libs/editor-controls/src/components/inline-editor-toolbar.tsx
+++ b/packages/packages/libs/editor-controls/src/components/inline-editor-toolbar.tsx
@@ -157,6 +157,15 @@ export const InlineEditorToolbar = ( { editor, elementId }: InlineEditorToolbarP
 		} else {
 			editor.chain().focus().unsetLink().run();
 		}
+
+		if ( elementId ) {
+			window.dispatchEvent(
+				new CustomEvent( 'elementor:inline-link-changed', {
+					detail: { elementId },
+				} )
+			);
+		}
+
 		linkPopupState.close();
 	};
 

--- a/packages/packages/libs/editor-controls/src/components/inline-editor.tsx
+++ b/packages/packages/libs/editor-controls/src/components/inline-editor.tsx
@@ -31,6 +31,8 @@ const ITALIC_KEYBOARD_SHORTCUT = 'i';
 const BOLD_KEYBOARD_SHORTCUT = 'b';
 const UNDERLINE_KEYBOARD_SHORTCUT = 'u';
 
+import type { ElementID } from '@elementor/editor-elements';
+
 type InlineEditorProps = {
 	value: string | null;
 	setValue: ( value: string | null ) => void;
@@ -42,6 +44,7 @@ type InlineEditorProps = {
 	autofocus?: boolean;
 	getInitialPopoverPosition?: () => { left: number; top: number };
 	expectedTag?: string | null;
+	elementId?: ElementID;
 };
 
 const INITIAL_STYLE = 'margin:0;padding:0;';
@@ -124,6 +127,7 @@ export const InlineEditor = forwardRef(
 			onBlur = undefined,
 			getInitialPopoverPosition = undefined,
 			expectedTag = null,
+			elementId = undefined,
 		}: InlineEditorProps,
 		ref
 	) => {
@@ -289,7 +293,7 @@ export const InlineEditor = forwardRef(
 						anchorOrigin={ { vertical: 'top', horizontal: 'center' } }
 						transformOrigin={ { vertical: 'bottom', horizontal: 'center' } }
 					>
-						<InlineEditorToolbar editor={ editor } />
+						<InlineEditorToolbar editor={ editor } elementId={ elementId } />
 					</Popover>
 				) }
 			</>

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/link-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/link-control.test.tsx
@@ -492,4 +492,45 @@ describe( '<LinkControl />', () => {
 			expect( selectElement ).toHaveBeenCalledWith( restrictionState.elementId );
 		}
 	);
+
+	it( 'should disable adding link when inline link exists from toolbar', () => {
+		// Arrange
+		const inlineLinkRestriction: LinkInLinkRestriction = {
+			shouldRestrict: true,
+			reason: 'descendant',
+			elementId: '1',
+		};
+
+		jest.mocked( getLinkInLinkRestriction ).mockReturnValue( inlineLinkRestriction );
+
+		// Act
+		renderControl( <LinkControl { ...globalProps } placeholder="test" />, baseProps );
+
+		const toggleButton = screen.getByRole( 'button', { name: 'Toggle link' } );
+
+		// Assert
+		expect( toggleButton ).toBeDisabled();
+	} );
+
+	it( 'should show tooltip when inline link restriction is active', async () => {
+		// Arrange
+		const inlineLinkRestriction: LinkInLinkRestriction = {
+			shouldRestrict: true,
+			reason: 'descendant',
+			elementId: '1',
+		};
+
+		jest.mocked( getLinkInLinkRestriction ).mockReturnValue( inlineLinkRestriction );
+
+		// Act
+		renderControl( <LinkControl { ...globalProps } placeholder="test" />, baseProps );
+
+		const toggleButton = screen.getByRole( 'button', { name: 'Toggle link' } );
+		fireEvent.mouseOver( toggleButton );
+
+		// Assert
+		await waitFor( () => {
+			expect( screen.getByText( 'from the elements inside of it', { exact: false } ) ).toBeInTheDocument();
+		} );
+	} );
 } );

--- a/packages/packages/libs/editor-controls/src/controls/link-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/link-control.tsx
@@ -77,12 +77,16 @@ export const LinkControl = createControl( ( props: Props ) => {
 		const newState = ! isActive;
 		setIsActive( newState );
 
+		if ( ! newState && value !== null ) {
+			setValue( null );
+		}
+
 		if ( newState && linkSessionValue?.value ) {
 			setValue( linkSessionValue.value );
 		}
 
 		setLinkSessionValue( {
-			value: value || linkSessionValue?.value,
+			value: linkSessionValue?.value,
 			meta: { isEnabled: newState },
 		} );
 	};

--- a/packages/packages/libs/editor-controls/src/controls/link-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/link-control.tsx
@@ -77,16 +77,12 @@ export const LinkControl = createControl( ( props: Props ) => {
 		const newState = ! isActive;
 		setIsActive( newState );
 
-		if ( ! newState && value !== null ) {
-			setValue( null );
-		}
-
 		if ( newState && linkSessionValue?.value ) {
 			setValue( linkSessionValue.value );
 		}
 
 		setLinkSessionValue( {
-			value: linkSessionValue?.value,
+			value: value || linkSessionValue?.value,
 			meta: { isEnabled: newState },
 		} );
 	};

--- a/packages/packages/libs/editor-controls/src/controls/link-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/link-control.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { getLinkInLinkRestriction } from '@elementor/editor-elements';
 import { linkPropTypeUtil, type LinkPropValue } from '@elementor/editor-props';
 import { MinusIcon, PlusIcon } from '@elementor/icons';
@@ -56,6 +56,16 @@ export const LinkControl = createControl( ( props: Props ) => {
 
 	const [ linkInLinkRestriction, setLinkInLinkRestriction ] = useState( getLinkInLinkRestriction( elementId ) );
 	const shouldDisableAddingLink = ! isActive && linkInLinkRestriction.shouldRestrict;
+
+	useEffect( () => {
+		const checkRestriction = () => {
+			setLinkInLinkRestriction( getLinkInLinkRestriction( elementId ) );
+		};
+
+		const intervalId = setInterval( checkRestriction, 500 );
+
+		return () => clearInterval( intervalId );
+	}, [ elementId ] );
 
 	const onEnabledChange = () => {
 		setLinkInLinkRestriction( getLinkInLinkRestriction( elementId ) );

--- a/packages/packages/libs/editor-controls/src/controls/link-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/link-control.tsx
@@ -59,13 +59,19 @@ export const LinkControl = createControl( ( props: Props ) => {
 
 	useEffect( () => {
 		const checkRestriction = () => {
-			setLinkInLinkRestriction( getLinkInLinkRestriction( elementId ) );
+			const newRestriction = getLinkInLinkRestriction( elementId );
+
+			if ( newRestriction.shouldRestrict && ! linkInLinkRestriction.shouldRestrict && isActive ) {
+				setIsActive( false );
+			}
+
+			setLinkInLinkRestriction( newRestriction );
 		};
 
 		const intervalId = setInterval( checkRestriction, 500 );
 
 		return () => clearInterval( intervalId );
-	}, [ elementId ] );
+	}, [ elementId, linkInLinkRestriction.shouldRestrict, isActive ] );
 
 	const onEnabledChange = () => {
 		setLinkInLinkRestriction( getLinkInLinkRestriction( elementId ) );

--- a/packages/packages/libs/editor-controls/src/controls/link-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/link-control.tsx
@@ -68,7 +68,7 @@ export const LinkControl = createControl( ( props: Props ) => {
 			setLinkInLinkRestriction( newRestriction );
 		};
 
-		const intervalId = setInterval( checkRestriction, 500 );
+		const intervalId = setInterval( checkRestriction, 1000 );
 
 		return () => clearInterval( intervalId );
 	}, [ elementId, linkInLinkRestriction.shouldRestrict, isActive ] );

--- a/packages/packages/libs/editor-controls/src/controls/link-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/link-control.tsx
@@ -73,6 +73,8 @@ export const LinkControl = createControl( ( props: Props ) => {
 	);
 
 	useEffect( () => {
+		debouncedCheckRestriction();
+
 		const handleInlineLinkChanged = ( event: Event ) => {
 			const customEvent = event as CustomEvent< { elementId: string } >;
 

--- a/packages/packages/libs/editor-elements/src/link-restriction.ts
+++ b/packages/packages/libs/editor-elements/src/link-restriction.ts
@@ -130,7 +130,7 @@ function checkForInlineLink( elementId: string ): boolean {
 	}
 
 	const linkSetting = getElementSetting< { value?: { destination?: unknown } } >( elementId, 'link' );
-	
+
 	if ( linkSetting?.value?.destination ) {
 		return false;
 	}

--- a/packages/packages/libs/editor-elements/src/link-restriction.ts
+++ b/packages/packages/libs/editor-elements/src/link-restriction.ts
@@ -1,4 +1,5 @@
 import { getContainer } from './sync/get-container';
+import { getElementSetting } from './sync/get-element-setting';
 
 const ANCHOR_SELECTOR = 'a, [data-action-link]';
 
@@ -22,6 +23,16 @@ export function getLinkInLinkRestriction( elementId: string ): LinkInLinkRestric
 			shouldRestrict: true,
 			reason: 'descendant',
 			elementId: anchoredDescendantId,
+		};
+	}
+
+	const hasInlineLink = checkForInlineLink( elementId );
+
+	if ( hasInlineLink ) {
+		return {
+			shouldRestrict: true,
+			reason: 'descendant',
+			elementId,
 		};
 	}
 
@@ -105,6 +116,26 @@ function doesElementContainAnchor( element: Element ): boolean {
 
 function findElementIdOf( element: Element ): string | null {
 	return element.closest< HTMLElement >( '[data-id]' )?.dataset.id || null;
+}
+
+function checkForInlineLink( elementId: string ): boolean {
+	const element = getElementDOM( elementId );
+
+	if ( ! element ) {
+		return false;
+	}
+
+	if ( element.matches( ANCHOR_SELECTOR ) ) {
+		return false;
+	}
+
+	const linkSetting = getElementSetting< { value?: { destination?: unknown } } >( elementId, 'link' );
+	
+	if ( linkSetting?.value?.destination ) {
+		return false;
+	}
+
+	return element.querySelector( ANCHOR_SELECTOR ) !== null;
 }
 
 function getElementDOM( id: string ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Improve user experience by preventing conflicts between panel link controls and inline text editor link controls, ensuring only one link type can be active per element.

Main changes:
- Hide inline editor link button when element has panel LinkControl link configured to prevent duplicate links
- Add debounced event system to synchronize link restriction state between inline editor and LinkControl panel
- Enhance link-in-link restriction logic to detect inline links and prevent panel link activation when present

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
