### PR TITLE
Fix: Display drafts of nested documents in preview [ED-22213]

### DIFF
--- a/core/documents-manager.php
+++ b/core/documents-manager.php
@@ -275,7 +275,7 @@ class Documents_Manager {
 	 */
 	public function get_doc_for_frontend( $post_id ) {
 		$preview_id = (int) Utils::get_super_global_value( $_GET, 'preview_id' );
-		$is_preview = is_preview() && $post_id === $preview_id;
+		$is_preview = is_preview();
 		$is_nonce_verify = wp_verify_nonce( Utils::get_super_global_value( $_GET, 'preview_nonce' ), 'post_preview_' . $preview_id );
 
 		if ( ( $is_preview && $is_nonce_verify ) || Plugin::$instance->preview->is_preview_mode() ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix nested document preview functionality by removing post ID validation that prevented draft versions of child documents from displaying in preview mode.

Main changes:
- Removed post_id comparison check from is_preview condition in get_doc_for_frontend() method
- Enabled draft/autosave retrieval for all nested documents during preview, not just matching preview_id
- Fixed preview mode to correctly display child document drafts within parent document context

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
