### PR TITLE
Fix: Transform values in repeater preview label out of order [ED-21565]

### DIFF
--- a/packages/packages/libs/editor-controls/src/components/repeater/repeater-popover.tsx
+++ b/packages/packages/libs/editor-controls/src/components/repeater/repeater-popover.tsx
@@ -5,6 +5,7 @@ export const RepeaterPopover = ( { children, width, ...props }: PopoverProps & {
 	return (
 		<Popover
 			disablePortal
+			disableEnforceFocus
 			anchorOrigin={ { vertical: 'bottom', horizontal: 'left' } }
 			slotProps={ {
 				paper: {

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/transform-label.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/transform-label.tsx
@@ -6,9 +6,13 @@ import { __ } from '@wordpress/i18n';
 import { CUSTOM_SIZE_LABEL } from '../size-control';
 import { defaultValues, TransformFunctionKeys } from './initial-values';
 
+const orderedAxis = [ 'x', 'y', 'z' ];
+
 const formatLabel = ( value: TransformFunctionsItemPropValue[ 'value' ], functionType: keyof typeof defaultValues ) => {
-	return Object.values( value )
-		.map( ( axis ) => {
+	return orderedAxis
+		.map( ( axisKey ) => {
+			const axis = value[ axisKey as keyof typeof value ];
+
 			if ( functionType === 'scale' ) {
 				return axis?.value || defaultValues[ functionType ];
 			}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix transform values display order in repeater preview labels by ensuring consistent x, y, z axis ordering instead of unpredictable object iteration.

Main changes:
- Added explicit axis ordering array to control transform value display sequence in preview labels
- Replaced Object.values() iteration with ordered map over predefined axis keys to fix label formatting
- Added disableEnforceFocus prop to RepeaterPopover to prevent focus conflicts during transform value editing

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
