### PR TITLE
Internal: Events flow update [ED-22288]

### DIFF
--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -8,7 +8,7 @@ export default class extends elementorModules.Module {
 
 	onInit() {
 		this.config = eventsConfig;
-		
+
 		if ( ! this.canSendEvents() ) {
 			return;
 		}

--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -12,7 +12,7 @@ export default class extends elementorModules.Module {
 		if ( ! this.canSendEvents() ) {
 			return;
 		}
-
+in
 		mixpanel.init(
 			elementorCommon.config.editor_events?.token,
 			{

--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -12,7 +12,7 @@ export default class extends elementorModules.Module {
 		if ( ! this.canSendEvents() ) {
 			return;
 		}
-in
+
 		mixpanel.init(
 			elementorCommon.config.editor_events?.token,
 			{

--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -7,6 +7,10 @@ export default class extends elementorModules.Module {
 	#sessionRecordingInProgress = false;
 
 	onInit() {
+		if ( ! this.canSendEvents() ) {
+			return;
+		}
+
 		this.config = eventsConfig;
 
 		mixpanel.init(
@@ -25,7 +29,7 @@ export default class extends elementorModules.Module {
 			},
 		);
 
-		if ( elementorCommon.config.editor_events?.can_send_events ) {
+		if ( this.canSendEvents() ) {
 			this.enableTracking();
 		}
 	}
@@ -51,7 +55,7 @@ export default class extends elementorModules.Module {
 	}
 
 	dispatchEvent( name, data, options = {} ) {
-		if ( ! elementorCommon.config.editor_events?.can_send_events ) {
+		if ( ! this.canSendEvents() ) {
 			return;
 		}
 
@@ -76,7 +80,7 @@ export default class extends elementorModules.Module {
 	}
 
 	startSessionRecording() {
-		if ( ! elementorCommon.config.editor_events?.can_send_events || this.isSessionRecordingInProgress() ) {
+		if ( ! this.canSendEvents() || this.isSessionRecordingInProgress() ) {
 			return;
 		}
 
@@ -89,7 +93,7 @@ export default class extends elementorModules.Module {
 	}
 
 	stopSessionRecording() {
-		if ( ! elementorCommon.config.editor_events?.can_send_events || ! this.isSessionRecordingInProgress() ) {
+		if ( ! this.canSendEvents() || ! this.isSessionRecordingInProgress() ) {
 			return;
 		}
 
@@ -120,7 +124,7 @@ export default class extends elementorModules.Module {
 
 	async getExperimentVariant( experimentName, defaultValue = 'control' ) {
 		try {
-			if ( ! elementorCommon.config.editor_events?.can_send_events ) {
+			if ( ! this.canSendEvents() ) {
 				return defaultValue;
 			}
 
@@ -164,5 +168,9 @@ export default class extends elementorModules.Module {
 		}
 
 		mixpanel.track( '$experiment_started', { 'Experiment name': experimentName, 'Variant name': experimentVariant } );
+	}
+
+	canSendEvents() {
+		return !! elementorCommon?.config?.editor_events?.can_send_events;
 	}
 }

--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -7,11 +7,11 @@ export default class extends elementorModules.Module {
 	#sessionRecordingInProgress = false;
 
 	onInit() {
+		this.config = eventsConfig;
+		
 		if ( ! this.canSendEvents() ) {
 			return;
 		}
-
-		this.config = eventsConfig;
 
 		mixpanel.init(
 			elementorCommon.config.editor_events?.token,

--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -29,9 +29,7 @@ export default class extends elementorModules.Module {
 			},
 		);
 
-		if ( this.canSendEvents() ) {
-			this.enableTracking();
-		}
+		this.enableTracking();
 	}
 
 	enableTracking() {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor events manager to centralize event permission checks and improve initialization flow for Mixpanel tracking service.

Main changes:
- Extracted repeated permission checks into canSendEvents() method used across dispatchEvent, session recording, and experiment tracking
- Moved enableTracking() call from conditional block to always execute after Mixpanel initialization when events allowed
- Added early return in onInit() to prevent Mixpanel initialization when event sending is disabled

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
