### PR TITLE
Internal: Persist templated elements view [ED-22287]

### DIFF
--- a/packages/packages/core/editor-canvas/src/legacy/__tests__/create-templated-element-type.test.ts
+++ b/packages/packages/core/editor-canvas/src/legacy/__tests__/create-templated-element-type.test.ts
@@ -1,0 +1,56 @@
+import { mockLegacyElementor } from 'test-utils';
+
+import { createTemplatedElementType } from '../create-templated-element-type';
+
+const MOCK_ELEMENT_TYPE = 'test-element';
+
+const createMockRenderer = () => ( {
+	register: jest.fn(),
+	render: jest.fn( () => Promise.resolve( '<div>Element</div>' ) ),
+} );
+
+const createMockElementConfig = () => ( {
+	twig_templates: {},
+	twig_main_template: 'main',
+	atomic_props_schema: {},
+	base_styles_dictionary: {},
+} );
+
+describe( 'createTemplatedElementType', () => {
+	beforeEach( () => {
+		mockLegacyElementor();
+	} );
+
+	it( 'should return the correct element type', () => {
+		// Arrange
+		const ElementType = createTemplatedElementType( {
+			type: MOCK_ELEMENT_TYPE,
+			renderer: createMockRenderer(),
+			element: createMockElementConfig(),
+		} );
+
+		// Act
+		const typeInstance = new ElementType();
+
+		// Assert
+		expect( typeInstance.getType() ).toBe( MOCK_ELEMENT_TYPE );
+	} );
+
+	it( 'should return the same view class for multiple type instances', () => {
+		// Arrange
+		const ElementType = createTemplatedElementType( {
+			type: MOCK_ELEMENT_TYPE,
+			renderer: createMockRenderer(),
+			element: createMockElementConfig(),
+		} );
+
+		// Act
+		const typeInstance1 = new ElementType();
+		const typeInstance2 = new ElementType();
+		const viewClass1 = typeInstance1.getView();
+		const viewClass2 = typeInstance2.getView();
+
+		// Assert
+		expect( viewClass1 ).toBe( viewClass2 );
+	} );
+} );

--- a/packages/packages/core/editor-canvas/src/legacy/create-templated-element-type.ts
+++ b/packages/packages/core/editor-canvas/src/legacy/create-templated-element-type.ts
@@ -30,17 +30,19 @@ export function createTemplatedElementType( {
 }: CreateTemplatedElementTypeOptions ): typeof ElementType {
 	const legacyWindow = window as unknown as LegacyWindow;
 
+	const view = createTemplatedElementView( {
+		type,
+		renderer,
+		element,
+	} );
+
 	return class extends legacyWindow.elementor.modules.elements.types.Widget {
 		getType() {
 			return type;
 		}
 
 		getView() {
-			return createTemplatedElementView( {
-				type,
-				renderer,
-				element,
-			} );
+			return view;
 		}
 	};
 }

--- a/packages/packages/core/editor-canvas/src/legacy/replacements/__tests__/manager.test.ts
+++ b/packages/packages/core/editor-canvas/src/legacy/replacements/__tests__/manager.test.ts
@@ -1,0 +1,56 @@
+import { mockLegacyElementor } from 'test-utils';
+
+import { createTemplatedElementTypeWithReplacements } from '../manager';
+
+const MOCK_ELEMENT_TYPE = 'test-element';
+
+const createMockRenderer = () => ( {
+	register: jest.fn(),
+	render: jest.fn( () => Promise.resolve( '<div>Element</div>' ) ),
+} );
+
+const createMockElementConfig = () => ( {
+	twig_templates: {},
+	twig_main_template: 'main',
+	atomic_props_schema: {},
+	base_styles_dictionary: {},
+} );
+
+describe( 'createTemplatedElementTypeWithReplacements', () => {
+	beforeEach( () => {
+		mockLegacyElementor();
+	} );
+
+	it( 'should return the correct element type', () => {
+		// Arrange
+		const ElementType = createTemplatedElementTypeWithReplacements( {
+			type: MOCK_ELEMENT_TYPE,
+			renderer: createMockRenderer(),
+			element: createMockElementConfig(),
+		} );
+
+		// Act
+		const typeInstance = new ElementType();
+
+		// Assert
+		expect( typeInstance.getType() ).toBe( MOCK_ELEMENT_TYPE );
+	} );
+
+	it( 'should return the same view class for multiple type instances', () => {
+		// Arrange
+		const ElementType = createTemplatedElementTypeWithReplacements( {
+			type: MOCK_ELEMENT_TYPE,
+			renderer: createMockRenderer(),
+			element: createMockElementConfig(),
+		} );
+
+		// Act
+		const typeInstance1 = new ElementType();
+		const typeInstance2 = new ElementType();
+		const viewClass1 = typeInstance1.getView();
+		const viewClass2 = typeInstance2.getView();
+
+		// Assert
+		expect( viewClass1 ).toBe( viewClass2 );
+	} );
+} );

--- a/packages/packages/core/editor-canvas/src/legacy/replacements/manager.ts
+++ b/packages/packages/core/editor-canvas/src/legacy/replacements/manager.ts
@@ -112,17 +112,19 @@ export const createTemplatedElementTypeWithReplacements = ( {
 }: CreateTemplatedElementTypeOptions ): typeof ElementType => {
 	const legacyWindow = window as unknown as LegacyWindow;
 
+	const view = createViewWithReplacements( {
+		type,
+		renderer,
+		element,
+	} );
+
 	return class extends legacyWindow.elementor.modules.elements.types.Widget {
 		getType() {
 			return type;
 		}
 
 		getView() {
-			return createViewWithReplacements( {
-				type,
-				renderer,
-				element,
-			} );
+			return view;
 		}
 	};
 };

--- a/packages/packages/core/editor-components/src/__tests__/create-component-type.test.ts
+++ b/packages/packages/core/editor-components/src/__tests__/create-component-type.test.ts
@@ -5,12 +5,23 @@ import type {
 	ElementModel,
 	LegacyWindow,
 } from '@elementor/editor-canvas';
-import { jest } from '@jest/globals';
 
 import { COMPONENT_WIDGET_TYPE, type ContextMenuAction, createComponentType } from '../create-component-type';
 import type { ExtendedWindow } from '../types';
 
 const MOCK_COMPONENT_ID = 123;
+
+const createMockRenderer = () => ( {
+	register: jest.fn(),
+	render: jest.fn( () => Promise.resolve( '<div>Component</div>' ) ),
+} as CreateTemplatedElementTypeOptions[ 'renderer' ] );
+
+const createMockElementConfig = () => ( {
+	twig_templates: {},
+	twig_main_template: 'main',
+	atomic_props_schema: {},
+	base_styles_dictionary: {},
+} );
 
 describe( 'createComponentType', () => {
 	let mockElementorWindow: LegacyWindow[ 'elementor' ];
@@ -310,5 +321,23 @@ describe( 'createComponentType', () => {
 
 		expect( actions ).toHaveLength( 1 );
 		expect( actions.some( ( action ) => action.name === 'edit component' ) ).toBe( false );
+	} );
+
+	it( 'should return the same view class for multiple type instances', () => {
+		// Arrange
+		const ComponentType = createComponentType( {
+			type: COMPONENT_WIDGET_TYPE,
+			renderer: createMockRenderer(),
+			element: createMockElementConfig(),
+		} );
+
+		// Act
+		const typeInstance1 = new ComponentType();
+		const typeInstance2 = new ComponentType();
+		const viewClass1 = typeInstance1.getView();
+		const viewClass2 = typeInstance2.getView();
+
+		// Assert
+		expect( viewClass1 ).toBe( viewClass2 );
 	} );
 } );

--- a/packages/packages/core/editor-components/src/__tests__/create-component-type.test.ts
+++ b/packages/packages/core/editor-components/src/__tests__/create-component-type.test.ts
@@ -11,10 +11,11 @@ import type { ExtendedWindow } from '../types';
 
 const MOCK_COMPONENT_ID = 123;
 
-const createMockRenderer = () => ( {
-	register: jest.fn(),
-	render: jest.fn( () => Promise.resolve( '<div>Component</div>' ) ),
-} as CreateTemplatedElementTypeOptions[ 'renderer' ] );
+const createMockRenderer = () =>
+	( {
+		register: jest.fn(),
+		render: jest.fn( () => Promise.resolve( '<div>Component</div>' ) ),
+	} ) as CreateTemplatedElementTypeOptions[ 'renderer' ];
 
 const createMockElementConfig = () => ( {
 	twig_templates: {},

--- a/packages/packages/core/editor-components/src/create-component-type.ts
+++ b/packages/packages/core/editor-components/src/create-component-type.ts
@@ -83,13 +83,15 @@ export function createComponentType(
 	const legacyWindow = window as unknown as LegacyWindow;
 	const WidgetType = legacyWindow.elementor.modules.elements.types.Widget;
 
+	const view = createComponentView( { ...options } );
+
 	return class extends WidgetType {
 		getType() {
 			return options.type;
 		}
 
 		getView() {
-			return createComponentView( { ...options } );
+			return view;
 		}
 
 		getModel(): BackboneModelConstructor< ComponentModel > {

--- a/packages/tests/test-utils/index.ts
+++ b/packages/tests/test-utils/index.ts
@@ -24,3 +24,4 @@ export { default as renderHookWithStore } from './render-hook-with-store';
 export { default as renderWithQuery } from './render-with-query';
 export { default as renderWithStore } from './render-with-store';
 export { mockTracking, createMockTrackingModule } from './mock-tracking';
+export { mockLegacyElementor } from './mock-legacy-elementor';

--- a/packages/tests/test-utils/mock-legacy-elementor.ts
+++ b/packages/tests/test-utils/mock-legacy-elementor.ts
@@ -1,0 +1,33 @@
+import type { LegacyWindow } from '@elementor/editor-canvas';
+
+export const mockLegacyElementor = () => {
+	const mockBaseView = class {
+		getContextMenuGroups() {
+			return [];
+		}
+	};
+
+	const legacyWindow = window as unknown as LegacyWindow;
+
+	legacyWindow.elementor = {
+		modules: {
+			elements: {
+				types: {
+					Widget: class {
+						getType() {
+							return 'widget';
+						}
+
+						getView() {
+							return mockBaseView;
+						}
+					},
+				},
+				views: {
+					Widget: mockBaseView,
+				},
+			},
+		},
+	} as unknown as LegacyWindow[ 'elementor' ];
+};
+


### PR DESCRIPTION
based on [approved pr](https://github.com/elementor/elementor/pull/34100)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Optimize templated element view instantiation by persisting view class references to prevent redundant creation on every getView() call.

Main changes:
- Moved createTemplatedElementView and createViewWithReplacements calls outside getView() method to persist view instances
- Applied same optimization pattern to createComponentView in create-component-type.ts for consistency
- Added unit tests verifying view class persistence across multiple ElementType instances

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
