### PR TITLE
Internal: Delete component validation message [ED-22268]

### DIFF
--- a/packages/packages/core/editor-components/src/components/components-tab/components-item.tsx
+++ b/packages/packages/core/editor-components/src/components/components-tab/components-item.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { endDragElementFromPanel, startDragElementFromPanel } from '@elementor/editor-canvas';
 import { dropElement, type DropElementParams, type V1ElementData } from '@elementor/editor-elements';
 import { EditableField, EllipsisWithTooltip, MenuListItem, useEditable, WarningInfotip } from '@elementor/editor-ui';
@@ -26,6 +26,7 @@ import { type Component } from '../../types';
 import { validateComponentName } from '../../utils/component-name-validation';
 import { getContainerForNewElement } from '../../utils/get-container-for-new-element';
 import { createComponentModel } from '../create-component-form/utils/replace-element-with-component';
+import { DeleteConfirmationDialog } from './delete-confirmation-dialog';
 
 type ComponentItemProps = {
 	component: Omit< Component, 'id' > & { id?: number };
@@ -34,6 +35,7 @@ type ComponentItemProps = {
 
 export const ComponentItem = ( { component, renameComponent }: ComponentItemProps ) => {
 	const itemRef = useRef< HTMLElement >( null );
+	const [ isDeleteDialogOpen, setIsDeleteDialogOpen ] = useState( false );
 
 	const {
 		ref: editableRef,
@@ -63,14 +65,22 @@ export const ComponentItem = ( { component, renameComponent }: ComponentItemProp
 		endDragElementFromPanel();
 	};
 
-	const handleArchiveClick = () => {
+	const handleDeleteClick = () => {
 		popupState.close();
+		setIsDeleteDialogOpen( true );
+	};
 
+	const handleDeleteConfirm = () => {
 		if ( ! component.id ) {
 			throw new Error( 'Component ID is required' );
 		}
 
+		setIsDeleteDialogOpen( false );
 		archiveComponent( component.id );
+	};
+
+	const handleDeleteDialogClose = () => {
+		setIsDeleteDialogOpen( false );
 	};
 
 	return (
@@ -155,12 +165,17 @@ export const ComponentItem = ( { component, renameComponent }: ComponentItemProp
 				>
 					{ __( 'Rename', 'elementor' ) }
 				</MenuListItem>
-				<MenuListItem sx={ { minWidth: '160px' } } onClick={ handleArchiveClick }>
+				<MenuListItem sx={ { minWidth: '160px' } } onClick={ handleDeleteClick }>
 					<Typography variant="caption" sx={ { color: 'error.light' } }>
-						{ __( 'Archive', 'elementor' ) }
+						{ __( 'Delete', 'elementor' ) }
 					</Typography>
 				</MenuListItem>
 			</Menu>
+			<DeleteConfirmationDialog
+				open={ isDeleteDialogOpen }
+				onClose={ handleDeleteDialogClose }
+				onConfirm={ handleDeleteConfirm }
+			/>
 		</Stack>
 	);
 };

--- a/packages/packages/core/editor-components/src/components/components-tab/components-item.tsx
+++ b/packages/packages/core/editor-components/src/components/components-tab/components-item.tsx
@@ -75,7 +75,7 @@ export const ComponentItem = ( { component, renameComponent }: ComponentItemProp
 			throw new Error( 'Component ID is required' );
 		}
 
-        setIsDeleteDialogOpen( false );
+		setIsDeleteDialogOpen( false );
 		archiveComponent( component.id, component.name );
 	};
 

--- a/packages/packages/core/editor-components/src/components/components-tab/delete-confirmation-dialog.tsx
+++ b/packages/packages/core/editor-components/src/components/components-tab/delete-confirmation-dialog.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { AlertOctagonFilledIcon } from '@elementor/icons';
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+const TITLE_ID = 'delete-component-dialog';
+
+type DeleteConfirmationDialogProps = {
+	open: boolean;
+	onClose: () => void;
+	onConfirm: () => void;
+};
+
+export function DeleteConfirmationDialog( { open, onClose, onConfirm }: DeleteConfirmationDialogProps ) {
+	return (
+		<Dialog open={ open } onClose={ onClose } aria-labelledby={ TITLE_ID } maxWidth="xs">
+			<DialogTitle id={ TITLE_ID } display="flex" alignItems="center" gap={ 1 } sx={ { lineHeight: 1 } }>
+				<AlertOctagonFilledIcon color="error" />
+				{ __( 'Delete this component?', 'elementor' ) }
+			</DialogTitle>
+			<DialogContent>
+				<DialogContentText variant="body2" color="textPrimary">
+					{ __(
+						'Existing instances on your pages will remain functional. You will no longer find this component in your list.',
+						'elementor'
+					) }
+				</DialogContentText>
+			</DialogContent>
+			<DialogActions>
+				<Button color="secondary" onClick={ onClose }>
+					{ __( 'Not now', 'elementor' ) }
+				</Button>
+				<Button
+					autoFocus
+					variant="contained"
+					color="error"
+					onClick={ onConfirm }
+				>
+					{ __( 'Delete', 'elementor' ) }
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
+}
+

--- a/packages/packages/core/editor-components/src/components/components-tab/delete-confirmation-dialog.tsx
+++ b/packages/packages/core/editor-components/src/components/components-tab/delete-confirmation-dialog.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
-import { AlertOctagonFilledIcon } from '@elementor/icons';
-import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@elementor/ui';
+import { ConfirmationDialog } from '@elementor/editor-ui';
 import { __ } from '@wordpress/i18n';
-
-const TITLE_ID = 'delete-component-dialog';
 
 type DeleteConfirmationDialogProps = {
 	open: boolean;
@@ -13,33 +10,20 @@ type DeleteConfirmationDialogProps = {
 
 export function DeleteConfirmationDialog( { open, onClose, onConfirm }: DeleteConfirmationDialogProps ) {
 	return (
-		<Dialog open={ open } onClose={ onClose } aria-labelledby={ TITLE_ID } maxWidth="xs">
-			<DialogTitle id={ TITLE_ID } display="flex" alignItems="center" gap={ 1 } sx={ { lineHeight: 1 } }>
-				<AlertOctagonFilledIcon color="error" />
+		<ConfirmationDialog open={ open } onClose={ onClose }>
+			<ConfirmationDialog.Title>
 				{ __( 'Delete this component?', 'elementor' ) }
-			</DialogTitle>
-			<DialogContent>
-				<DialogContentText variant="body2" color="textPrimary">
+			</ConfirmationDialog.Title>
+			<ConfirmationDialog.Content>
+				<ConfirmationDialog.ContentText>
 					{ __(
 						'Existing instances on your pages will remain functional. You will no longer find this component in your list.',
 						'elementor'
 					) }
-				</DialogContentText>
-			</DialogContent>
-			<DialogActions>
-				<Button color="secondary" onClick={ onClose }>
-					{ __( 'Not now', 'elementor' ) }
-				</Button>
-				<Button
-					autoFocus
-					variant="contained"
-					color="error"
-					onClick={ onConfirm }
-				>
-					{ __( 'Delete', 'elementor' ) }
-				</Button>
-			</DialogActions>
-		</Dialog>
+				</ConfirmationDialog.ContentText>
+			</ConfirmationDialog.Content>
+			<ConfirmationDialog.Actions onClose={ onClose } onConfirm={ onConfirm } />
+		</ConfirmationDialog>
 	);
 }
 

--- a/packages/packages/core/editor-components/src/components/components-tab/delete-confirmation-dialog.tsx
+++ b/packages/packages/core/editor-components/src/components/components-tab/delete-confirmation-dialog.tsx
@@ -11,9 +11,7 @@ type DeleteConfirmationDialogProps = {
 export function DeleteConfirmationDialog( { open, onClose, onConfirm }: DeleteConfirmationDialogProps ) {
 	return (
 		<ConfirmationDialog open={ open } onClose={ onClose }>
-			<ConfirmationDialog.Title>
-				{ __( 'Delete this component?', 'elementor' ) }
-			</ConfirmationDialog.Title>
+			<ConfirmationDialog.Title>{ __( 'Delete this component?', 'elementor' ) }</ConfirmationDialog.Title>
 			<ConfirmationDialog.Content>
 				<ConfirmationDialog.ContentText>
 					{ __(
@@ -26,4 +24,3 @@ export function DeleteConfirmationDialog( { open, onClose, onConfirm }: DeleteCo
 		</ConfirmationDialog>
 	);
 }
-

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/delete-confirmation-dialog.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/delete-confirmation-dialog.tsx
@@ -1,35 +1,27 @@
 import * as React from 'react';
 import { createContext, useContext, useState } from 'react';
 import { type StyleDefinition } from '@elementor/editor-styles';
-import { AlertOctagonFilledIcon } from '@elementor/icons';
-import {
-	Button,
-	Dialog,
-	DialogActions,
-	DialogContent,
-	DialogContentText,
-	DialogTitle,
-	Typography,
-} from '@elementor/ui';
+import { ConfirmationDialog } from '@elementor/editor-ui';
+import { Typography } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { useCssClassUsageByID } from '../../hooks/use-css-class-usage-by-id';
 import { deleteClass } from './delete-class';
 
-type DeleteConfirmationDialogProps = Pick< StyleDefinition, 'id' | 'label' >;
+type DeleteClassDialogProps = Pick< StyleDefinition, 'id' | 'label' >;
 
 type DeleteConfirmationContext = {
-	openDialog: ( props: DeleteConfirmationDialogProps ) => void;
+	openDialog: ( props: DeleteClassDialogProps ) => void;
 	closeDialog: () => void;
-	dialogProps: DeleteConfirmationDialogProps | null;
+	dialogProps: DeleteClassDialogProps | null;
 };
 
 const context = createContext< DeleteConfirmationContext | null >( null );
 
 export const DeleteConfirmationProvider = ( { children }: React.PropsWithChildren ) => {
-	const [ dialogProps, setDialogProps ] = useState< DeleteConfirmationDialogProps | null >( null );
+	const [ dialogProps, setDialogProps ] = useState< DeleteClassDialogProps | null >( null );
 
-	const openDialog = ( props: DeleteConfirmationDialogProps ) => {
+	const openDialog = ( props: DeleteClassDialogProps ) => {
 		setDialogProps( props );
 	};
 
@@ -40,23 +32,22 @@ export const DeleteConfirmationProvider = ( { children }: React.PropsWithChildre
 	return (
 		<context.Provider value={ { openDialog, closeDialog, dialogProps } }>
 			{ children }
-			{ !! dialogProps && <DeleteConfirmationDialog { ...dialogProps } /> }
+			{ !! dialogProps && <DeleteClassDialog { ...dialogProps } /> }
 		</context.Provider>
 	);
 };
 
-const TITLE_ID = 'delete-class-dialog';
-
-const DeleteConfirmationDialog = ( { label, id }: DeleteConfirmationDialogProps ) => {
+const DeleteClassDialog = ( { label, id }: DeleteClassDialogProps ) => {
 	const { closeDialog } = useDeleteConfirmation();
 	const {
 		data: { total, content },
 	} = useCssClassUsageByID( id );
-	const onConfirm = () => {
-		//
+
+	const handleConfirm = () => {
 		closeDialog();
 		deleteClass( id );
 	};
+
 	// translators: %1: total usage count, %2: number of pages
 	const text =
 		total && content.length
@@ -72,36 +63,19 @@ const DeleteConfirmationDialog = ( { label, id }: DeleteConfirmationDialogProps 
 			  );
 
 	return (
-		<Dialog open onClose={ closeDialog } aria-labelledby={ TITLE_ID } maxWidth="xs">
-			<DialogTitle id={ TITLE_ID } display="flex" alignItems="center" gap={ 1 } sx={ { lineHeight: 1 } }>
-				<AlertOctagonFilledIcon color="error" />
-				{ __( 'Delete this class?', 'elementor' ) }
-			</DialogTitle>
-			<DialogContent>
-				<DialogContentText variant="body2" color="textPrimary">
+		<ConfirmationDialog open onClose={ closeDialog }>
+			<ConfirmationDialog.Title>{ __( 'Delete this class?', 'elementor' ) }</ConfirmationDialog.Title>
+			<ConfirmationDialog.Content>
+				<ConfirmationDialog.ContentText>
 					{ __( 'Deleting', 'elementor' ) }
 					<Typography variant="subtitle2" component="span">
 						&nbsp;{ label }&nbsp;
 					</Typography>
 					{ text }
-				</DialogContentText>
-			</DialogContent>
-			<DialogActions>
-				<Button color="secondary" onClick={ closeDialog }>
-					{ __( 'Not now', 'elementor' ) }
-				</Button>
-
-				<Button
-					// eslint-disable-next-line jsx-a11y/no-autofocus
-					autoFocus
-					variant="contained"
-					color="error"
-					onClick={ onConfirm }
-				>
-					{ __( 'Delete', 'elementor' ) }
-				</Button>
-			</DialogActions>
-		</Dialog>
+				</ConfirmationDialog.ContentText>
+			</ConfirmationDialog.Content>
+			<ConfirmationDialog.Actions onClose={ closeDialog } onConfirm={ handleConfirm } />
+		</ConfirmationDialog>
 	);
 };
 

--- a/packages/packages/core/editor-variables/src/components/ui/delete-confirmation-dialog.tsx
+++ b/packages/packages/core/editor-variables/src/components/ui/delete-confirmation-dialog.tsx
@@ -1,37 +1,21 @@
 import * as React from 'react';
-import { AlertOctagonFilledIcon } from '@elementor/icons';
-import {
-	Button,
-	Dialog,
-	DialogActions,
-	DialogContent,
-	DialogContentText,
-	DialogTitle,
-	Typography,
-} from '@elementor/ui';
+import { ConfirmationDialog } from '@elementor/editor-ui';
+import { Typography } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
-const TITLE_ID = 'delete-variable-dialog';
-
-export const DeleteConfirmationDialog = ( {
-	open,
-	label,
-	closeDialog,
-	onConfirm,
-}: {
+type DeleteConfirmationDialogProps = {
 	open: boolean;
 	label: string;
 	closeDialog: () => void;
 	onConfirm: () => void;
-} ) => {
+};
+
+export const DeleteConfirmationDialog = ( { open, label, closeDialog, onConfirm }: DeleteConfirmationDialogProps ) => {
 	return (
-		<Dialog open={ open } onClose={ closeDialog } aria-labelledby={ TITLE_ID } maxWidth="xs">
-			<DialogTitle id={ TITLE_ID } display="flex" alignItems="center" gap={ 1 } sx={ { lineHeight: 1 } }>
-				<AlertOctagonFilledIcon color="error" />
-				{ __( 'Delete this variable?', 'elementor' ) }
-			</DialogTitle>
-			<DialogContent>
-				<DialogContentText variant="body2" color="textPrimary">
+		<ConfirmationDialog open={ open } onClose={ closeDialog }>
+			<ConfirmationDialog.Title>{ __( 'Delete this variable?', 'elementor' ) }</ConfirmationDialog.Title>
+			<ConfirmationDialog.Content>
+				<ConfirmationDialog.ContentText>
 					{ __( 'All elements using', 'elementor' ) }
 					&nbsp;
 					<Typography variant="subtitle2" component="span" sx={ { lineBreak: 'anywhere' } }>
@@ -39,16 +23,9 @@ export const DeleteConfirmationDialog = ( {
 					</Typography>
 					&nbsp;
 					{ __( 'will keep their current values, but the variable itself will be removed.', 'elementor' ) }
-				</DialogContentText>
-			</DialogContent>
-			<DialogActions>
-				<Button color="secondary" onClick={ closeDialog }>
-					{ __( 'Not now', 'elementor' ) }
-				</Button>
-				<Button variant="contained" color="error" onClick={ onConfirm }>
-					{ __( 'Delete', 'elementor' ) }
-				</Button>
-			</DialogActions>
-		</Dialog>
+				</ConfirmationDialog.ContentText>
+			</ConfirmationDialog.Content>
+			<ConfirmationDialog.Actions onClose={ closeDialog } onConfirm={ onConfirm } />
+		</ConfirmationDialog>
 	);
 };

--- a/packages/packages/libs/editor-ui/src/components/confirmation-dialog.tsx
+++ b/packages/packages/libs/editor-ui/src/components/confirmation-dialog.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { AlertOctagonFilledIcon } from '@elementor/icons';
+import {
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogContentText,
+	type DialogContentTextProps,
+	type DialogProps,
+	DialogTitle,
+} from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+const TITLE_ID = 'confirmation-dialog';
+
+type ConfirmationDialogProps = Pick< DialogProps, 'open' | 'onClose' | 'children' >;
+
+export const ConfirmationDialog = ( { open, onClose, children }: ConfirmationDialogProps ) => (
+	<Dialog open={ open } onClose={ onClose } aria-labelledby={ TITLE_ID } maxWidth="xs">
+		{ children }
+	</Dialog>
+);
+
+const ConfirmationDialogTitle = ( { children }: React.PropsWithChildren ) => (
+	<DialogTitle id={ TITLE_ID } display="flex" alignItems="center" gap={ 1 } sx={ { lineHeight: 1 } }>
+		<AlertOctagonFilledIcon color="error" />
+		{ children }
+	</DialogTitle>
+);
+
+const ConfirmationDialogContent = ( { children }: React.PropsWithChildren ) => (
+	<DialogContent>{ children }</DialogContent>
+);
+
+const ConfirmationDialogContentText = ( props: DialogContentTextProps ) => (
+	<DialogContentText variant="body2" color="textPrimary" { ...props } />
+);
+
+type ConfirmationDialogActionsProps = {
+	onClose: () => void;
+	onConfirm: () => void;
+	cancelLabel?: string;
+	confirmLabel?: string;
+};
+
+const ConfirmationDialogActions = ( {
+	onClose,
+	onConfirm,
+	cancelLabel,
+	confirmLabel,
+}: ConfirmationDialogActionsProps ) => (
+	<DialogActions>
+		<Button color="secondary" onClick={ onClose }>
+			{ cancelLabel ?? __( 'Not now', 'elementor' ) }
+		</Button>
+		{ /* eslint-disable-next-line jsx-a11y/no-autofocus */ }
+		<Button autoFocus variant="contained" color="error" onClick={ onConfirm }>
+			{ confirmLabel ?? __( 'Delete', 'elementor' ) }
+		</Button>
+	</DialogActions>
+);
+
+ConfirmationDialog.Title = ConfirmationDialogTitle;
+ConfirmationDialog.Content = ConfirmationDialogContent;
+ConfirmationDialog.ContentText = ConfirmationDialogContentText;
+ConfirmationDialog.Actions = ConfirmationDialogActions;

--- a/packages/packages/libs/editor-ui/src/index.ts
+++ b/packages/packages/libs/editor-ui/src/index.ts
@@ -18,6 +18,7 @@ export { PromotionChip } from './components/promotion-chip';
 
 export * from './components/popover';
 export * from './components/save-changes-dialog';
+export { ConfirmationDialog } from './components/confirmation-dialog';
 
 // hooks
 export { useEditable } from './hooks/use-editable';


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Standardize delete confirmation dialogs across components, variables, and global classes by extracting common confirmation UI into a reusable ConfirmationDialog component in editor-ui library.

Main changes:
- Created shared ConfirmationDialog component in editor-ui with title, content, and action button subcomponents
- Refactored delete confirmation dialogs in components-tab, global-classes, and variables to use new shared dialog
- Added comprehensive test coverage for component deletion workflow including dialog interactions and keyboard events

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
