### PR TITLE
Internal: Components tab should be second and Globals third [ED-22216]

### DIFF
--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -74,6 +74,7 @@ export function init() {
 		id: 'components',
 		label: __( 'Components', 'elementor' ),
 		component: Components,
+		position: 1,
 	} );
 
 	injectIntoTop( {

--- a/packages/packages/core/editor-elements-panel/src/inject-tab.ts
+++ b/packages/packages/core/editor-elements-panel/src/inject-tab.ts
@@ -17,9 +17,10 @@ type Config = {
 	id: string;
 	label: string;
 	component: ComponentType;
+	position?: number;
 };
 
-export function injectTab( { id, label, component }: Config ) {
+export function injectTab( { id, label, component, position }: Config ) {
 	registerTab( { id, label, component } );
 
 	listenTo( v1ReadyEvent(), () => {
@@ -44,6 +45,7 @@ export function injectTab( { id, label, component }: Config ) {
 			label,
 			route,
 			isActive: 'route' in e && e.route === route,
+			position,
 		} );
 	} );
 }

--- a/packages/packages/core/editor-elements-panel/src/utils/create-tab-nav-item.ts
+++ b/packages/packages/core/editor-elements-panel/src/utils/create-tab-nav-item.ts
@@ -6,9 +6,10 @@ type Args = {
 	label: string;
 	route: string;
 	isActive: boolean;
+	position?: number;
 };
 
-export function createTabNavItem( { id, label, route, isActive }: Args ): void {
+export function createTabNavItem( { id, label, route, isActive, position }: Args ): void {
 	const wrapper = getNavigationWrapperElement();
 
 	const btn = document.createElement( 'button' );
@@ -25,5 +26,9 @@ export function createTabNavItem( { id, label, route, isActive }: Args ): void {
 		getWindow().$e.route( route );
 	} );
 
-	wrapper.appendChild( btn );
+	if ( position !== undefined && wrapper.children[ position ] ) {
+		wrapper.insertBefore( btn, wrapper.children[ position ] );
+	} else {
+		wrapper.appendChild( btn );
+	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add position control to tab injection system to reorder Components tab to second position in the editor elements panel navigation.

Main changes:
- Extended injectTab and createTabNavItem functions with optional position parameter for controlling tab insertion order
- Modified Components tab registration to inject at position 1 (second tab) instead of appending to end
- Implemented conditional DOM insertion using insertBefore when position specified, otherwise appendChild as fallback

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
