### PR TITLE
Internal: Update handlers lifecycle events [ED-22280]

### DIFF
--- a/packages/packages/core/frontend-handlers/src/__tests__/index.test.ts
+++ b/packages/packages/core/frontend-handlers/src/__tests__/index.test.ts
@@ -248,7 +248,6 @@ describe( 'Frontend Handlers', () => {
 				} )
 			);
 
-			// Add listener after render to only catch actual destroy events
 			element.addEventListener( 'elementor/element/destroyed', destroyedEventCallback );
 
 			// Act
@@ -462,24 +461,21 @@ describe( 'Frontend Handlers', () => {
 			child.setAttribute( 'data-id', CHILD_ID );
 			parent.appendChild( child );
 
-			// Render parent first (this sets up the destroy listener)
 			window.dispatchEvent(
 				new CustomEvent( 'elementor/element/render', {
 					detail: { id: PARENT_ID, type: PARENT_ELEMENT_TYPE, element: parent },
 				} )
 			);
 
-			// Render child
 			window.dispatchEvent(
 				new CustomEvent( 'elementor/element/render', {
 					detail: { id: CHILD_ID, type: CHILD_ELEMENT_TYPE, element: child },
 				} )
 			);
 
-			// Reset callback count after renders (to ignore destroy events from render cleanup)
 			childDestroyCallback.mockClear();
 
-			// Act - destroy child
+			// Act
 			window.dispatchEvent(
 				new CustomEvent( 'elementor/element/destroy', {
 					detail: { id: CHILD_ID, type: CHILD_ELEMENT_TYPE, element: child },

--- a/packages/packages/core/frontend-handlers/src/init.ts
+++ b/packages/packages/core/frontend-handlers/src/init.ts
@@ -13,10 +13,10 @@ export function init() {
 	} );
 
 	window.addEventListener( 'elementor/element/destroy', ( _event ) => {
-		const event = _event as CustomEvent< { id: string; type: string } >;
-		const { id, type } = event.detail;
+		const event = _event as CustomEvent< { id: string; type: string; element: Element } >;
+		const { id, type, element } = event.detail;
 
-		onElementDestroy( { elementType: type, elementId: id } );
+		onElementDestroy( { elementType: type, elementId: id, element } );
 	} );
 
 	document.addEventListener( 'DOMContentLoaded', () => {

--- a/packages/packages/core/frontend-handlers/src/lifecycle-events.ts
+++ b/packages/packages/core/frontend-handlers/src/lifecycle-events.ts
@@ -4,6 +4,31 @@ const unmountElementTypeCallbacks: Map< string, Map< string, () => void > > = ne
 const unmountElementSelectorCallbacks: Map< string, Map< string, () => void > > = new Map();
 
 const ELEMENT_RENDERED_EVENT_NAME = 'elementor/element/rendered';
+const ELEMENT_DESTROYED_EVENT_NAME = 'elementor/element/destroyed';
+
+type LifecycleEventParams = {
+	element: Element;
+	elementType: string;
+	elementId: string;
+};
+
+const dispatchRenderedEvent = ( params: LifecycleEventParams ) => {
+	params.element.dispatchEvent(
+		new CustomEvent( ELEMENT_RENDERED_EVENT_NAME, {
+			bubbles: true,
+			detail: params,
+		} )
+	);
+};
+
+const dispatchDestroyedEvent = ( params: LifecycleEventParams ) => {
+	params.element.dispatchEvent(
+		new CustomEvent( ELEMENT_DESTROYED_EVENT_NAME, {
+			bubbles: true,
+			detail: params,
+		} )
+	);
+};
 
 export const onElementRender = ( {
 	element,
@@ -17,26 +42,13 @@ export const onElementRender = ( {
 	const controller = new AbortController();
 	const manualUnmount: ( () => void )[] = [];
 
-	const dispatchRenderedEvent = () => {
-		element.dispatchEvent(
-			new CustomEvent( ELEMENT_RENDERED_EVENT_NAME, {
-				bubbles: true,
-				detail: {
-					element,
-					elementType,
-					elementId,
-				},
-			} )
-		);
-	};
-
 	// When the rendered event is dispatched, the element is not yet connected to the DOM (marrionet view case)
 	if ( ! element.isConnected ) {
 		requestAnimationFrame( () => {
-			dispatchRenderedEvent();
+			dispatchRenderedEvent( { element, elementType, elementId } );
 		} );
 	} else {
-		dispatchRenderedEvent();
+		dispatchRenderedEvent( { element, elementType, elementId } );
 	}
 
 	if ( ! elementTypeHandlers.has( elementType ) ) {
@@ -48,19 +60,18 @@ export const onElementRender = ( {
 
 		const listenToChildren = ( elementTypes: string[] ) => ( {
 			render: ( callback: () => void ) => {
-				element.addEventListener(
-					ELEMENT_RENDERED_EVENT_NAME,
-					( event ) => {
-						const { elementType: childType } = ( event as CustomEvent ).detail;
+				const listener = ( event: Event ) => {
+					const { elementType: childType } = ( event as CustomEvent ).detail;
 
-						if ( ! elementTypes.includes( childType ) ) {
-							return;
-						}
+					if ( ! elementTypes.includes( childType ) ) {
+						return;
+					}
 
-						callback();
-					},
-					{ signal: controller.signal }
-				);
+					callback();
+				};
+
+				element.addEventListener( ELEMENT_RENDERED_EVENT_NAME, listener, { signal: controller.signal } );
+				element.addEventListener( ELEMENT_DESTROYED_EVENT_NAME, listener, { signal: controller.signal } );
 			},
 		} );
 
@@ -129,8 +140,20 @@ export const onElementSelectorRender = ( {
 	} );
 };
 
-export const onElementDestroy = ( { elementType, elementId }: { elementType: string; elementId: string } ) => {
+export const onElementDestroy = ( {
+	elementType,
+	elementId,
+	element,
+}: {
+	elementType: string;
+	elementId: string;
+	element?: Element;
+} ) => {
 	const unmount = unmountElementTypeCallbacks.get( elementType )?.get( elementId );
+
+	if ( element ) {
+		dispatchDestroyedEvent( { element, elementType, elementId } );
+	}
 
 	if ( ! unmount ) {
 		return;

--- a/packages/packages/core/frontend-handlers/src/lifecycle-events.ts
+++ b/packages/packages/core/frontend-handlers/src/lifecycle-events.ts
@@ -33,7 +33,6 @@ export const onElementRender = ( {
 	const controller = new AbortController();
 	const manualUnmount: ( () => void )[] = [];
 
-	// When the rendered event is dispatched, the element is not yet connected to the DOM (marrionet view case)
 	const dispatchRenderedEvent = () => {
 		onElementSelectorRender( { element, elementId, controller } );
 
@@ -167,8 +166,8 @@ export const onElementDestroy = ( {
 		dispatchDestroyedEvent( { element, elementType, elementId } );
 	}
 
-	if ( ! unmount ) {
-		return;
+	if ( unmount ) {
+		unmount();
 	}
 
 	if ( unmountSelector?.size ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update element lifecycle event system to dispatch custom destroyed events and enable parent-child element destruction tracking through bubbling events.

Main changes:
- Added `elementor/element/destroyed` custom event dispatched from element during destruction, enabling listeners to react to child element removal
- Enhanced `onElementDestroy` function to accept optional `element` parameter and dispatch destroyed event with element reference and metadata
- Extended `listenToChildren` callback to listen for both render and destroyed events, allowing unified child lifecycle monitoring

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
