### PR TITLE
Fix: Title duplication is not validated when creating a override [ED-22299]

### DIFF
--- a/packages/packages/core/editor-components/src/components/component-properties-panel/properties-group.tsx
+++ b/packages/packages/core/editor-components/src/components/component-properties-panel/properties-group.tsx
@@ -149,6 +149,7 @@ export function PropertiesGroup( {
 										sortableTriggerProps={ { ...triggerProps, style: triggerStyle } }
 										isDragPlaceholder={ isItemDragPlaceholder }
 										groups={ allGroups }
+										existingLabels={ Object.values( props ).map( ( p ) => p.label ) }
 										onDelete={ onPropertyDelete }
 										onUpdate={ ( data ) => onPropertyUpdate( prop.overrideKey, data ) }
 									/>

--- a/packages/packages/core/editor-components/src/components/component-properties-panel/property-item.tsx
+++ b/packages/packages/core/editor-components/src/components/component-properties-panel/property-item.tsx
@@ -12,6 +12,7 @@ type PropertyItemProps = {
 	sortableTriggerProps: SortableTriggerProps;
 	isDragPlaceholder?: boolean;
 	groups: { value: string; label: string }[];
+	existingLabels: string[];
 	onDelete: ( propKey: string ) => void;
 	onUpdate: ( data: { label: string; group: string | null } ) => void;
 };
@@ -21,6 +22,7 @@ export function PropertyItem( {
 	sortableTriggerProps,
 	isDragPlaceholder,
 	groups,
+	existingLabels,
 	onDelete,
 	onUpdate,
 }: PropertyItemProps ) {
@@ -99,6 +101,7 @@ export function PropertyItem( {
 					onSubmit={ handleSubmit }
 					currentValue={ prop }
 					groups={ groups }
+					existingLabels={ existingLabels }
 					sx={ { width: '100%' } }
 				/>
 			</Popover>

--- a/packages/packages/core/editor-components/src/components/overridable-props/__tests__/overridable-prop-indicator.test.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/__tests__/overridable-prop-indicator.test.tsx
@@ -236,6 +236,331 @@ describe( 'OverridablePropIndicator', () => {
 	);
 } );
 
+describe( 'OverridablePropForm duplicate validation', () => {
+	let store: Store< ComponentsSlice >;
+
+	const EXISTING_PROP_KEY = 'existing-prop-key';
+	const EXISTING_PROP_LABEL = 'Existing Label';
+
+	beforeEach( () => {
+		__registerSlice( slice );
+		store = __createStore();
+
+		jest.mocked( useElement ).mockReturnValue( {
+			element: { id: MOCK_ELEMENT_ID, type: MOCK_WIDGET_TYPE },
+			elementType: { key: MOCK_WIDGET_TYPE, propsSchema: {}, controls: [], title: 'Test Element' },
+		} );
+	} );
+
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	it( 'should show error when entering duplicate property name', () => {
+		// Arrange
+		const componentData: PublishedComponent = {
+			id: MOCK_COMPONENT_ID,
+			uid: `component-${ MOCK_COMPONENT_ID }`,
+			name: 'Test Component',
+			overridableProps: {
+				props: {
+					[ EXISTING_PROP_KEY ]: {
+						overrideKey: EXISTING_PROP_KEY,
+						elementId: 'other-element',
+						propKey: 'other-prop',
+						widgetType: MOCK_WIDGET_TYPE,
+						elType: MOCK_EL_TYPE,
+						originValue: { $$type: 'string', value: 'Test' },
+						label: EXISTING_PROP_LABEL,
+						groupId: 'default',
+					},
+				},
+				groups: {
+					items: {
+						default: { id: 'default', label: 'Default', props: [ EXISTING_PROP_KEY ] },
+					},
+					order: [ 'default' ],
+				},
+			},
+		};
+
+		dispatch( slice.actions.load( [ componentData ] ) );
+		dispatch( slice.actions.setCurrentComponentId( MOCK_COMPONENT_ID ) );
+
+		const boundProp = mockBoundProp( { bind: 'title', value: stringPropTypeUtil.create( 'Test' ) } );
+		jest.mocked( useBoundProp ).mockImplementation( ( propUtil ) => {
+			if ( propUtil ) {
+				return { ...boundProp, value: null };
+			}
+			return boundProp;
+		} );
+
+		renderWithStore( <OverridablePropIndicator />, store );
+
+		// Act
+		const indicator = screen.getByLabelText( 'Make prop overridable' );
+		fireEvent.click( indicator );
+
+		const nameInput = screen.getByPlaceholderText( 'Enter value' );
+		fireEvent.change( nameInput, { target: { value: EXISTING_PROP_LABEL } } );
+
+		// Assert
+		expect( screen.getByText( 'Property name already exists' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Create' } ) ).toBeDisabled();
+	} );
+
+	it( 'should show error when property name is empty or whitespace', () => {
+		// Arrange
+		const componentData: PublishedComponent = {
+			id: MOCK_COMPONENT_ID,
+			uid: `component-${ MOCK_COMPONENT_ID }`,
+			name: 'Test Component',
+			overridableProps: {
+				props: {},
+				groups: { items: {}, order: [] },
+			},
+		};
+
+		dispatch( slice.actions.load( [ componentData ] ) );
+		dispatch( slice.actions.setCurrentComponentId( MOCK_COMPONENT_ID ) );
+
+		const boundProp = mockBoundProp( { bind: 'title', value: stringPropTypeUtil.create( 'Test' ) } );
+		jest.mocked( useBoundProp ).mockImplementation( ( propUtil ) => {
+			if ( propUtil ) {
+				return { ...boundProp, value: null };
+			}
+			return boundProp;
+		} );
+
+		renderWithStore( <OverridablePropIndicator />, store );
+
+		// Act
+		const indicator = screen.getByLabelText( 'Make prop overridable' );
+		fireEvent.click( indicator );
+
+		const nameInput = screen.getByPlaceholderText( 'Enter value' );
+
+		// Type a value first, then clear it
+		fireEvent.change( nameInput, { target: { value: 'Some Value' } } );
+		fireEvent.change( nameInput, { target: { value: '' } } );
+
+		// Assert - empty name error
+		expect( screen.getByText( 'Property name is required' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Create' } ) ).toBeDisabled();
+
+		// Act - try whitespace only
+		fireEvent.change( nameInput, { target: { value: '   ' } } );
+
+		// Assert - still shows error
+		expect( screen.getByText( 'Property name is required' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Create' } ) ).toBeDisabled();
+	} );
+
+	it( 'should prevent form submission with empty value when pressing Enter', () => {
+		// Arrange
+		const componentData: PublishedComponent = {
+			id: MOCK_COMPONENT_ID,
+			uid: `component-${ MOCK_COMPONENT_ID }`,
+			name: 'Test Component',
+			overridableProps: {
+				props: {},
+				groups: { items: {}, order: [] },
+			},
+		};
+
+		dispatch( slice.actions.load( [ componentData ] ) );
+		dispatch( slice.actions.setCurrentComponentId( MOCK_COMPONENT_ID ) );
+
+		const boundProp = mockBoundProp( { bind: 'title', value: stringPropTypeUtil.create( 'Test' ) } );
+		jest.mocked( useBoundProp ).mockImplementation( ( propUtil ) => {
+			if ( propUtil ) {
+				return { ...boundProp, value: null };
+			}
+			return boundProp;
+		} );
+
+		renderWithStore( <OverridablePropIndicator />, store );
+
+		// Act - open the form
+		const indicator = screen.getByLabelText( 'Make prop overridable' );
+		fireEvent.click( indicator );
+
+		// Submit by pressing Enter on the input
+		const nameInput = screen.getByPlaceholderText( 'Enter value' );
+		fireEvent.keyDown( nameInput, { key: 'Enter', code: 'Enter' } );
+
+		// Assert - error should be shown, form should still be open
+		expect( screen.getByText( 'Property name is required' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'Enter value' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should detect duplicate case-insensitively', () => {
+		// Arrange
+		const componentData: PublishedComponent = {
+			id: MOCK_COMPONENT_ID,
+			uid: `component-${ MOCK_COMPONENT_ID }`,
+			name: 'Test Component',
+			overridableProps: {
+				props: {
+					[ EXISTING_PROP_KEY ]: {
+						overrideKey: EXISTING_PROP_KEY,
+						elementId: 'other-element',
+						propKey: 'other-prop',
+						widgetType: MOCK_WIDGET_TYPE,
+						elType: MOCK_EL_TYPE,
+						originValue: { $$type: 'string', value: 'Test' },
+						label: EXISTING_PROP_LABEL,
+						groupId: 'default',
+					},
+				},
+				groups: {
+					items: {
+						default: { id: 'default', label: 'Default', props: [ EXISTING_PROP_KEY ] },
+					},
+					order: [ 'default' ],
+				},
+			},
+		};
+
+		dispatch( slice.actions.load( [ componentData ] ) );
+		dispatch( slice.actions.setCurrentComponentId( MOCK_COMPONENT_ID ) );
+
+		const boundProp = mockBoundProp( { bind: 'title', value: stringPropTypeUtil.create( 'Test' ) } );
+		jest.mocked( useBoundProp ).mockImplementation( ( propUtil ) => {
+			if ( propUtil ) {
+				return { ...boundProp, value: null };
+			}
+			return boundProp;
+		} );
+
+		renderWithStore( <OverridablePropIndicator />, store );
+
+		// Act
+		const indicator = screen.getByLabelText( 'Make prop overridable' );
+		fireEvent.click( indicator );
+
+		const nameInput = screen.getByPlaceholderText( 'Enter value' );
+		fireEvent.change( nameInput, { target: { value: 'EXISTING LABEL' } } );
+
+		// Assert
+		expect( screen.getByText( 'Property name already exists' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Create' } ) ).toBeDisabled();
+	} );
+
+	it( 'should allow saving with same label when editing existing property', () => {
+		// Arrange
+		const currentValue = componentOverridablePropTypeUtil.create( {
+			override_key: EXISTING_PROP_KEY,
+			origin_value: { $$type: 'string', value: 'Test' },
+		} );
+
+		const componentData: PublishedComponent = {
+			id: MOCK_COMPONENT_ID,
+			uid: `component-${ MOCK_COMPONENT_ID }`,
+			name: 'Test Component',
+			overridableProps: {
+				props: {
+					[ EXISTING_PROP_KEY ]: {
+						overrideKey: EXISTING_PROP_KEY,
+						elementId: MOCK_ELEMENT_ID,
+						propKey: 'title',
+						widgetType: MOCK_WIDGET_TYPE,
+						elType: MOCK_EL_TYPE,
+						originValue: currentValue,
+						label: EXISTING_PROP_LABEL,
+						groupId: 'default',
+					},
+				},
+				groups: {
+					items: {
+						default: { id: 'default', label: 'Default', props: [ EXISTING_PROP_KEY ] },
+					},
+					order: [ 'default' ],
+				},
+			},
+		};
+
+		dispatch( slice.actions.load( [ componentData ] ) );
+		dispatch( slice.actions.setCurrentComponentId( MOCK_COMPONENT_ID ) );
+
+		jest.mocked( useBoundProp ).mockImplementation( ( propUtil ) => {
+			if ( propUtil ) {
+				return { ...mockBoundProp( { bind: 'title', value: currentValue } ), value: currentValue?.value };
+			}
+			return mockBoundProp( { bind: 'title', value: currentValue } );
+		} );
+
+		renderWithStore( <OverridablePropIndicator />, store );
+
+		// Act
+		const indicator = screen.getByLabelText( 'Overridable property' );
+		fireEvent.click( indicator );
+
+		// Assert
+		expect( screen.queryByText( 'Property name already exists' ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Update' } ) ).not.toBeDisabled();
+	} );
+
+	it( 'should clear error when entering unique name', () => {
+		// Arrange
+		const componentData: PublishedComponent = {
+			id: MOCK_COMPONENT_ID,
+			uid: `component-${ MOCK_COMPONENT_ID }`,
+			name: 'Test Component',
+			overridableProps: {
+				props: {
+					[ EXISTING_PROP_KEY ]: {
+						overrideKey: EXISTING_PROP_KEY,
+						elementId: 'other-element',
+						propKey: 'other-prop',
+						widgetType: MOCK_WIDGET_TYPE,
+						elType: MOCK_EL_TYPE,
+						originValue: { $$type: 'string', value: 'Test' },
+						label: EXISTING_PROP_LABEL,
+						groupId: 'default',
+					},
+				},
+				groups: {
+					items: {
+						default: { id: 'default', label: 'Default', props: [ EXISTING_PROP_KEY ] },
+					},
+					order: [ 'default' ],
+				},
+			},
+		};
+
+		dispatch( slice.actions.load( [ componentData ] ) );
+		dispatch( slice.actions.setCurrentComponentId( MOCK_COMPONENT_ID ) );
+
+		const boundProp = mockBoundProp( { bind: 'title', value: stringPropTypeUtil.create( 'Test' ) } );
+		jest.mocked( useBoundProp ).mockImplementation( ( propUtil ) => {
+			if ( propUtil ) {
+				return { ...boundProp, value: null };
+			}
+			return boundProp;
+		} );
+
+		renderWithStore( <OverridablePropIndicator />, store );
+
+		// Act
+		const indicator = screen.getByLabelText( 'Make prop overridable' );
+		fireEvent.click( indicator );
+
+		const nameInput = screen.getByPlaceholderText( 'Enter value' );
+		fireEvent.change( nameInput, { target: { value: EXISTING_PROP_LABEL } } );
+
+		// Assert - error shown
+		expect( screen.getByText( 'Property name already exists' ) ).toBeInTheDocument();
+
+		// Act - change to unique name
+		fireEvent.change( nameInput, { target: { value: 'Unique Name' } } );
+
+		// Assert - error cleared
+		expect( screen.queryByText( 'Property name already exists' ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Create' } ) ).not.toBeDisabled();
+	} );
+} );
+
 function mockBoundProp( {
 	bind,
 	value,

--- a/packages/packages/core/editor-components/src/components/overridable-props/__tests__/overridable-prop-indicator.test.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/__tests__/overridable-prop-indicator.test.tsx
@@ -498,7 +498,7 @@ describe( 'OverridablePropForm duplicate validation', () => {
 
 		// Assert
 		expect( screen.queryByText( 'Property name already exists' ) ).not.toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'Update' } ) ).not.toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Update' } ) ).toBeEnabled();
 	} );
 
 	it( 'should clear error when entering unique name', () => {
@@ -557,7 +557,7 @@ describe( 'OverridablePropForm duplicate validation', () => {
 
 		// Assert - error cleared
 		expect( screen.queryByText( 'Property name already exists' ) ).not.toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'Create' } ) ).not.toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Create' } ) ).toBeEnabled();
 	} );
 } );
 

--- a/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-form.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-form.tsx
@@ -22,7 +22,7 @@ type Props = {
 export function OverridablePropForm( { onSubmit, groups, currentValue, existingLabels = [], sx }: Props ) {
 	const [ propLabel, setPropLabel ] = useState< string | null >( currentValue?.label ?? null );
 	const [ group, setGroup ] = useState< string | null >( currentValue?.groupId ?? groups?.[ 0 ]?.value ?? null );
-	const [ error, setError ] = useState< string >( '' );
+	const [ error, setError ] = useState< string | null >( null );
 
 	const name = __( 'Name', 'elementor' );
 	const groupName = __( 'Group Name', 'elementor' );
@@ -33,10 +33,10 @@ export function OverridablePropForm( { onSubmit, groups, currentValue, existingL
 	const ctaLabel = isCreate ? __( 'Create', 'elementor' ) : __( 'Update', 'elementor' );
 
 	const handleSubmit = () => {
-		const validationError = validatePropLabel( propLabel ?? '', existingLabels, currentValue?.label );
+		const validationResult = validatePropLabel( propLabel ?? '', existingLabels, currentValue?.label );
 
-		if ( validationError ) {
-			setError( validationError );
+		if ( ! validationResult.isValid ) {
+			setError( validationResult.errorMessage );
 			return;
 		}
 
@@ -71,7 +71,12 @@ export function OverridablePropForm( { onSubmit, groups, currentValue, existingL
 							onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) => {
 								const newValue = e.target.value;
 								setPropLabel( newValue );
-								setError( validatePropLabel( newValue, existingLabels, currentValue?.label ) );
+								const validationResult = validatePropLabel(
+									newValue,
+									existingLabels,
+									currentValue?.label
+								);
+								setError( validationResult.errorMessage );
 							} }
 							error={ Boolean( error ) }
 							helperText={ error }

--- a/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-indicator.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-indicator.tsx
@@ -121,6 +121,7 @@ export function Content( { componentId, overridableProps }: Props ) {
 						value: groupId,
 						label: overridableProps.groups.items[ groupId ].label,
 					} ) ) }
+					existingLabels={ Object.values( overridableProps?.props ?? {} ).map( ( prop ) => prop.label ) }
 					currentValue={ overridableConfig }
 				/>
 			</Popover>

--- a/packages/packages/core/editor-components/src/components/overridable-props/utils/validate-prop-label.ts
+++ b/packages/packages/core/editor-components/src/components/overridable-props/utils/validate-prop-label.ts
@@ -5,11 +5,20 @@ export const ERROR_MESSAGES = {
 	DUPLICATE_NAME: __( 'Property name already exists', 'elementor' ),
 } as const;
 
-export function validatePropLabel( label: string, existingLabels: string[], currentLabel?: string ): string {
+type ValidationResult = {
+	isValid: boolean;
+	errorMessage: string | null;
+};
+
+export function validatePropLabel(
+	label: string,
+	existingLabels: string[],
+	currentLabel?: string
+): ValidationResult {
 	const trimmedLabel = label.trim();
 
 	if ( ! trimmedLabel ) {
-		return ERROR_MESSAGES.EMPTY_NAME;
+		return { isValid: false, errorMessage: ERROR_MESSAGES.EMPTY_NAME };
 	}
 
 	const normalizedLabel = trimmedLabel.toLowerCase();
@@ -26,9 +35,8 @@ export function validatePropLabel( label: string, existingLabels: string[], curr
 	} );
 
 	if ( isDuplicate ) {
-		return ERROR_MESSAGES.DUPLICATE_NAME;
+		return { isValid: false, errorMessage: ERROR_MESSAGES.DUPLICATE_NAME };
 	}
 
-	return '';
+	return { isValid: true, errorMessage: null };
 }
-

--- a/packages/packages/core/editor-components/src/components/overridable-props/utils/validate-prop-label.ts
+++ b/packages/packages/core/editor-components/src/components/overridable-props/utils/validate-prop-label.ts
@@ -10,11 +10,7 @@ type ValidationResult = {
 	errorMessage: string | null;
 };
 
-export function validatePropLabel(
-	label: string,
-	existingLabels: string[],
-	currentLabel?: string
-): ValidationResult {
+export function validatePropLabel( label: string, existingLabels: string[], currentLabel?: string ): ValidationResult {
 	const trimmedLabel = label.trim();
 
 	if ( ! trimmedLabel ) {

--- a/packages/packages/core/editor-components/src/components/overridable-props/utils/validate-prop-label.ts
+++ b/packages/packages/core/editor-components/src/components/overridable-props/utils/validate-prop-label.ts
@@ -1,0 +1,34 @@
+import { __ } from '@wordpress/i18n';
+
+export const ERROR_MESSAGES = {
+	EMPTY_NAME: __( 'Property name is required', 'elementor' ),
+	DUPLICATE_NAME: __( 'Property name already exists', 'elementor' ),
+} as const;
+
+export function validatePropLabel( label: string, existingLabels: string[], currentLabel?: string ): string {
+	const trimmedLabel = label.trim();
+
+	if ( ! trimmedLabel ) {
+		return ERROR_MESSAGES.EMPTY_NAME;
+	}
+
+	const normalizedLabel = trimmedLabel.toLowerCase();
+	const normalizedCurrentLabel = currentLabel?.trim().toLowerCase();
+
+	const isDuplicate = existingLabels.some( ( existingLabel ) => {
+		const normalizedExisting = existingLabel.trim().toLowerCase();
+
+		if ( normalizedCurrentLabel && normalizedExisting === normalizedCurrentLabel ) {
+			return false;
+		}
+
+		return normalizedExisting === normalizedLabel;
+	} );
+
+	if ( isDuplicate ) {
+		return ERROR_MESSAGES.DUPLICATE_NAME;
+	}
+
+	return '';
+}
+


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix property label duplication validation in component override creation to prevent users from creating properties with identical names.

Main changes:
- Added validatePropLabel utility function with case-insensitive duplicate detection and empty name validation
- Implemented real-time validation in OverridablePropForm with error display and disabled submit when invalid
- Passed existingLabels prop through component hierarchy to enable duplicate checking across all properties

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
