### PR TITLE
Internal: Update handlers lifecycle events [ED-22280]

### DIFF
--- a/packages/packages/core/frontend-handlers/src/__tests__/index.test.ts
+++ b/packages/packages/core/frontend-handlers/src/__tests__/index.test.ts
@@ -218,12 +218,56 @@ describe( 'Frontend Handlers', () => {
 			// Act
 			window.dispatchEvent(
 				new CustomEvent( 'elementor/element/destroy', {
-					detail: { id: ELEMENT_ID, type: WIDGET_ELEMENT_TYPE },
+					detail: { id: ELEMENT_ID, type: WIDGET_ELEMENT_TYPE, element },
 				} )
 			);
 
 			// Assert
 			expect( unmountCallback ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should dispatch destroyed event when element is destroyed', () => {
+			// Arrange
+			const ELEMENT_ID = 'element-1';
+			const destroyedEventCallback = jest.fn();
+
+			register( {
+				elementType: WIDGET_ELEMENT_TYPE,
+				id: 'widget-handler',
+				callback: () => undefined,
+			} );
+
+			const element = document.createElement( 'div' );
+			element.setAttribute( 'data-e-type', WIDGET_ELEMENT_TYPE );
+			element.setAttribute( 'data-id', ELEMENT_ID );
+			document.body.appendChild( element );
+
+			window.dispatchEvent(
+				new CustomEvent( 'elementor/element/render', {
+					detail: { id: ELEMENT_ID, type: WIDGET_ELEMENT_TYPE, element },
+				} )
+			);
+
+			element.addEventListener( 'elementor/element/destroyed', destroyedEventCallback );
+
+			// Act
+			window.dispatchEvent(
+				new CustomEvent( 'elementor/element/destroy', {
+					detail: { id: ELEMENT_ID, type: WIDGET_ELEMENT_TYPE, element },
+				} )
+			);
+
+			// Assert
+			expect( destroyedEventCallback ).toHaveBeenCalledTimes( 1 );
+			expect( destroyedEventCallback ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					detail: expect.objectContaining( {
+						element,
+						elementType: WIDGET_ELEMENT_TYPE,
+						elementId: ELEMENT_ID,
+					} ),
+				} )
+			);
 		} );
 
 		it( 'should cleanup on re-render before new initialization', () => {
@@ -333,7 +377,7 @@ describe( 'Frontend Handlers', () => {
 			// Act
 			window.dispatchEvent(
 				new CustomEvent( 'elementor/element/destroy', {
-					detail: { id: ELEMENT_ID, type: WIDGET_ELEMENT_TYPE },
+					detail: { id: ELEMENT_ID, type: WIDGET_ELEMENT_TYPE, element },
 				} )
 			);
 
@@ -384,6 +428,62 @@ describe( 'Frontend Handlers', () => {
 
 			// Assert
 			expect( childRenderCallback ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should trigger destroy callback when child of specified type is destroyed', () => {
+			// Arrange
+			const PARENT_ID = 'parent-1';
+			const CHILD_ID = 'child-1';
+			const childDestroyCallback = jest.fn();
+
+			register( {
+				elementType: PARENT_ELEMENT_TYPE,
+				id: 'parent-handler',
+				callback: ( { listenToChildren } ) => {
+					listenToChildren( [ CHILD_ELEMENT_TYPE ] ).render( childDestroyCallback );
+					return undefined;
+				},
+			} );
+
+			register( {
+				elementType: CHILD_ELEMENT_TYPE,
+				id: 'child-handler',
+				callback: () => undefined,
+			} );
+
+			const parent = document.createElement( 'div' );
+			parent.setAttribute( 'data-e-type', PARENT_ELEMENT_TYPE );
+			parent.setAttribute( 'data-id', PARENT_ID );
+			document.body.appendChild( parent );
+
+			const child = document.createElement( 'div' );
+			child.setAttribute( 'data-e-type', CHILD_ELEMENT_TYPE );
+			child.setAttribute( 'data-id', CHILD_ID );
+			parent.appendChild( child );
+
+			window.dispatchEvent(
+				new CustomEvent( 'elementor/element/render', {
+					detail: { id: PARENT_ID, type: PARENT_ELEMENT_TYPE, element: parent },
+				} )
+			);
+
+			window.dispatchEvent(
+				new CustomEvent( 'elementor/element/render', {
+					detail: { id: CHILD_ID, type: CHILD_ELEMENT_TYPE, element: child },
+				} )
+			);
+
+			childDestroyCallback.mockClear();
+
+			// Act
+			window.dispatchEvent(
+				new CustomEvent( 'elementor/element/destroy', {
+					detail: { id: CHILD_ID, type: CHILD_ELEMENT_TYPE, element: child },
+				} )
+			);
+
+			// Assert
+			expect( childDestroyCallback ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'should not trigger callback for non-descendant elements', () => {
@@ -463,7 +563,7 @@ describe( 'Frontend Handlers', () => {
 			// Destroy Parent (should remove listener)
 			window.dispatchEvent(
 				new CustomEvent( 'elementor/element/destroy', {
-					detail: { id: PARENT_ID, type: PARENT_ELEMENT_TYPE },
+					detail: { id: PARENT_ID, type: PARENT_ELEMENT_TYPE, element: parent },
 				} )
 			);
 

--- a/packages/packages/core/frontend-handlers/src/init.ts
+++ b/packages/packages/core/frontend-handlers/src/init.ts
@@ -12,10 +12,10 @@ export function init() {
 	} );
 
 	window.addEventListener( 'elementor/element/destroy', ( _event ) => {
-		const event = _event as CustomEvent< { id: string; type: string } >;
-		const { id, type } = event.detail;
+		const event = _event as CustomEvent< { id: string; type: string; element: Element } >;
+		const { id, type, element } = event.detail;
 
-		onElementDestroy( { elementType: type, elementId: id } );
+		onElementDestroy( { elementType: type, elementId: id, element } );
 	} );
 
 	document.addEventListener( 'DOMContentLoaded', () => {

--- a/packages/packages/core/frontend-handlers/src/lifecycle-events.ts
+++ b/packages/packages/core/frontend-handlers/src/lifecycle-events.ts
@@ -101,7 +101,15 @@ export const onElementRender = ( {
 	} );
 };
 
-export const onElementDestroy = ( { elementType, elementId, element }: { elementType: string; elementId: string; element?: Element } ) => {
+export const onElementDestroy = ( {
+	elementType,
+	elementId,
+	element,
+}: {
+	elementType: string;
+	elementId: string;
+	element?: Element;
+} ) => {
 	const unmount = unmountCallbacks.get( elementType )?.get( elementId );
 
 	if ( element ) {

--- a/packages/packages/core/frontend-handlers/src/lifecycle-events.ts
+++ b/packages/packages/core/frontend-handlers/src/lifecycle-events.ts
@@ -3,6 +3,22 @@ import { handlers } from './handlers-registry';
 const unmountCallbacks: Map< string, Map< string, () => void > > = new Map();
 
 const ELEMENT_RENDERED_EVENT_NAME = 'elementor/element/rendered';
+const ELEMENT_DESTROYED_EVENT_NAME = 'elementor/element/destroyed';
+
+type LifecycleEventParams = {
+	element: Element;
+	elementType: string;
+	elementId: string;
+};
+
+const dispatchDestroyedEvent = ( params: LifecycleEventParams ) => {
+	params.element.dispatchEvent(
+		new CustomEvent( ELEMENT_DESTROYED_EVENT_NAME, {
+			bubbles: true,
+			detail: params,
+		} )
+	);
+};
 
 export const onElementRender = ( {
 	element,
@@ -47,19 +63,18 @@ export const onElementRender = ( {
 
 		const listenToChildren = ( elementTypes: string[] ) => ( {
 			render: ( callback: () => void ) => {
-				element.addEventListener(
-					ELEMENT_RENDERED_EVENT_NAME,
-					( event ) => {
-						const { elementType: childType } = ( event as CustomEvent ).detail;
+				const listener = ( event: Event ) => {
+					const { elementType: childType } = ( event as CustomEvent ).detail;
 
-						if ( ! elementTypes.includes( childType ) ) {
-							return;
-						}
+					if ( ! elementTypes.includes( childType ) ) {
+						return;
+					}
 
-						callback();
-					},
-					{ signal: controller.signal }
-				);
+					callback();
+				};
+
+				element.addEventListener( ELEMENT_RENDERED_EVENT_NAME, listener, { signal: controller.signal } );
+				element.addEventListener( ELEMENT_DESTROYED_EVENT_NAME, listener, { signal: controller.signal } );
 			},
 		} );
 
@@ -86,8 +101,12 @@ export const onElementRender = ( {
 	} );
 };
 
-export const onElementDestroy = ( { elementType, elementId }: { elementType: string; elementId: string } ) => {
+export const onElementDestroy = ( { elementType, elementId, element }: { elementType: string; elementId: string; element: Element } ) => {
 	const unmount = unmountCallbacks.get( elementType )?.get( elementId );
+
+	if ( element ) {
+		dispatchDestroyedEvent( { element, elementType, elementId } );
+	}
 
 	if ( ! unmount ) {
 		return;

--- a/packages/packages/core/frontend-handlers/src/lifecycle-events.ts
+++ b/packages/packages/core/frontend-handlers/src/lifecycle-events.ts
@@ -101,7 +101,7 @@ export const onElementRender = ( {
 	} );
 };
 
-export const onElementDestroy = ( { elementType, elementId, element }: { elementType: string; elementId: string; element: Element } ) => {
+export const onElementDestroy = ( { elementType, elementId, element }: { elementType: string; elementId: string; element?: Element } ) => {
 	const unmount = unmountCallbacks.get( elementType )?.get( elementId );
 
 	if ( element ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update element lifecycle event handling to dispatch destruction events and enable parent handlers to listen for child element destruction alongside rendering events.

Main changes:
- Added `elementor/element/destroyed` event dispatch in `onElementDestroy` with element reference propagation through event detail
- Extended `listenToChildren` API to register listeners for both render and destroy events using shared event handler
- Updated `elementor/element/destroy` event to include element reference in CustomEvent detail for proper event bubbling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
