### PR TITLE
Fix: Closing Angie breaks the sidebar menu [ED-22306]

### DIFF
--- a/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-sidebar-position.js
+++ b/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-sidebar-position.js
@@ -30,22 +30,13 @@ export const useSidebarPosition = () => {
 		updateSidebarPosition();
 
 		const wpcontent = document.getElementById( WPCONTENT_ID );
-
-		if ( wpcontent ) {
-			const resizeObserver = new ResizeObserver( updateSidebarPosition );
-			resizeObserver.observe( wpcontent );
-
-			window.addEventListener( 'resize', updateSidebarPosition );
-
-			return () => {
-				resizeObserver.disconnect();
-				window.removeEventListener( 'resize', updateSidebarPosition );
-			};
-		}
+		const resizeObserver = new ResizeObserver( updateSidebarPosition );
+		resizeObserver.observe( wpcontent );
 
 		window.addEventListener( 'resize', updateSidebarPosition );
 
 		return () => {
+			resizeObserver.disconnect();
 			window.removeEventListener( 'resize', updateSidebarPosition );
 		};
 	}, [] );

--- a/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-sidebar-position.js
+++ b/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-sidebar-position.js
@@ -1,7 +1,7 @@
 import { useEffect } from '@wordpress/element';
 
 const ADMIN_MENU_WRAP_ID = 'adminmenuwrap';
-const WPADMINBAR_ID = 'wpadminbar';
+const WPCONTENT_ID = 'wpcontent';
 const SIDEBAR_CONTAINER_ID = 'editor-one-sidebar-navigation';
 
 const getIsRTL = () => {
@@ -29,11 +29,11 @@ export const useSidebarPosition = () => {
 
 		updateSidebarPosition();
 
-		const wpadminbar = document.getElementById( WPADMINBAR_ID );
+		const wpcontent = document.getElementById( WPCONTENT_ID );
 
-		if ( wpadminbar ) {
+		if ( wpcontent ) {
 			const resizeObserver = new ResizeObserver( updateSidebarPosition );
-			resizeObserver.observe( wpadminbar );
+			resizeObserver.observe( wpcontent );
 
 			window.addEventListener( 'resize', updateSidebarPosition );
 

--- a/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-sidebar-position.js
+++ b/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-sidebar-position.js
@@ -1,8 +1,8 @@
 import { useEffect } from '@wordpress/element';
 
 const ADMIN_MENU_WRAP_ID = 'adminmenuwrap';
+const WPADMINBAR_ID = 'wpadminbar';
 const SIDEBAR_CONTAINER_ID = 'editor-one-sidebar-navigation';
-const TRANSITION_DELAY = 350;
 
 const getIsRTL = () => {
 	return 'rtl' === document.dir || document.body.classList.contains( 'rtl' );
@@ -29,29 +29,23 @@ export const useSidebarPosition = () => {
 
 		updateSidebarPosition();
 
-		const resizeObserver = new ResizeObserver( updateSidebarPosition );
-		resizeObserver.observe( adminMenuWrap );
+		const wpadminbar = document.getElementById( WPADMINBAR_ID );
 
-		const mutationObserver = new MutationObserver( () => {
-			updateSidebarPosition();
-			setTimeout( updateSidebarPosition, TRANSITION_DELAY );
-		} );
+		if ( wpadminbar ) {
+			const resizeObserver = new ResizeObserver( updateSidebarPosition );
+			resizeObserver.observe( wpadminbar );
 
-		mutationObserver.observe( document.body, {
-			attributes: true,
-			attributeFilter: [ 'class' ],
-		} );
+			window.addEventListener( 'resize', updateSidebarPosition );
 
-		mutationObserver.observe( document.documentElement, {
-			attributes: true,
-			attributeFilter: [ 'class' ],
-		} );
+			return () => {
+				resizeObserver.disconnect();
+				window.removeEventListener( 'resize', updateSidebarPosition );
+			};
+		}
 
 		window.addEventListener( 'resize', updateSidebarPosition );
 
 		return () => {
-			resizeObserver.disconnect();
-			mutationObserver.disconnect();
 			window.removeEventListener( 'resize', updateSidebarPosition );
 		};
 	}, [] );

--- a/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-sidebar-position.js
+++ b/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-sidebar-position.js
@@ -31,8 +31,8 @@ export const useSidebarPosition = () => {
 
 		const wpcontent = document.getElementById( WPCONTENT_ID );
 		const resizeObserver = new ResizeObserver( updateSidebarPosition );
-		resizeObserver.observe( wpcontent );
 
+		resizeObserver.observe( wpcontent );
 		window.addEventListener( 'resize', updateSidebarPosition );
 
 		return () => {

--- a/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-sidebar-position.js
+++ b/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-sidebar-position.js
@@ -2,6 +2,7 @@ import { useEffect } from '@wordpress/element';
 
 const ADMIN_MENU_WRAP_ID = 'adminmenuwrap';
 const SIDEBAR_CONTAINER_ID = 'editor-one-sidebar-navigation';
+const TRANSITION_DELAY = 350;
 
 const getIsRTL = () => {
 	return 'rtl' === document.dir || document.body.classList.contains( 'rtl' );
@@ -29,12 +30,28 @@ export const useSidebarPosition = () => {
 		updateSidebarPosition();
 
 		const resizeObserver = new ResizeObserver( updateSidebarPosition );
-
 		resizeObserver.observe( adminMenuWrap );
+
+		const mutationObserver = new MutationObserver( () => {
+			updateSidebarPosition();
+			setTimeout( updateSidebarPosition, TRANSITION_DELAY );
+		} );
+
+		mutationObserver.observe( document.body, {
+			attributes: true,
+			attributeFilter: [ 'class' ],
+		} );
+
+		mutationObserver.observe( document.documentElement, {
+			attributes: true,
+			attributeFilter: [ 'class' ],
+		} );
+
 		window.addEventListener( 'resize', updateSidebarPosition );
 
 		return () => {
 			resizeObserver.disconnect();
+			mutationObserver.disconnect();
 			window.removeEventListener( 'resize', updateSidebarPosition );
 		};
 	}, [] );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix sidebar positioning by observing the wpcontent container instead of adminmenuwrap to properly handle body class changes and layout updates.

Main changes:
- Changed ResizeObserver target from adminMenuWrap to wpcontent element for more accurate layout tracking
- Added WPCONTENT_ID constant and corresponding element reference for wpcontent container observation
- Updated observer initialization to monitor wpcontent instead of removed adminMenuWrap observation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
