### PR TITLE
Internal: Change components overlay color to global teal [ED-22217]

### DIFF
--- a/assets/dev/scss/editor/preview/_theme.scss
+++ b/assets/dev/scss/editor/preview/_theme.scss
@@ -36,4 +36,7 @@
 	--e-p-border-global: 			#{$e-teal-300};
 	--e-p-border-global-hover: 		#{$e-teal-400};
 	--e-p-border-global-invert: 	#{$e-gray-900};
+
+	//Global element overlay
+	--e-p-border-global-element: 	#{$e-teal-300};
 }

--- a/assets/dev/scss/editor/preview/preview.scss
+++ b/assets/dev/scss/editor/preview/preview.scss
@@ -492,6 +492,22 @@ html.elementor-html {
 			display: revert;
 		}
 	}
+
+	// Component editing mode - change top level element overlay outline color to global element color
+	:where(.elementor-edit-area-active.elementor-widget-e-component) {
+		> .elementor-section-wrap > :first-child {
+			> .elementor-element-overlay::after {
+				outline-color: var(--e-p-border-global-element);
+			}
+
+			&.elementor-element-editable {
+				> .elementor-element-overlay::after {
+					// When selected, the outline should be inside the element, to avoid overlapping with component edit mode backdrop
+					outline-offset: -1px;
+				}
+			}
+		}
+	}
 }
 
 // Muted elements in the editor

--- a/packages/packages/core/editor-canvas/src/components/elements-overlays.tsx
+++ b/packages/packages/core/editor-canvas/src/components/elements-overlays.tsx
@@ -11,7 +11,6 @@ import type { ElementOverlayConfig } from '../types/element-overlay';
 import { OutlineOverlay } from './outline-overlay';
 
 const ELEMENTS_DATA_ATTR = 'atomic';
-const GLOBAL_ELEMENTS = [ 'e-component' ];
 
 const overlayRegistry: ElementOverlayConfig[] = [
 	{
@@ -33,9 +32,8 @@ export function ElementsOverlays() {
 		return null;
 	}
 
-	return elements.map( ( { id, domElement, widgetType, elementType } ) => {
+	return elements.map( ( { id, domElement, isGlobal } ) => {
 		const isSelected = selected.element?.id === id;
-		const isGlobal = GLOBAL_ELEMENTS.includes( widgetType ) || GLOBAL_ELEMENTS.includes( elementType );
 
 		return overlayRegistry.map(
 			( { shouldRender, component: Overlay }, index ) =>
@@ -55,8 +53,7 @@ export function ElementsOverlays() {
 type ElementData = {
 	id: string;
 	domElement: HTMLElement;
-	widgetType: string;
-	elementType: string;
+	isGlobal: boolean;
 };
 
 function useElementsDom() {
@@ -68,8 +65,7 @@ function useElementsDom() {
 				.map( ( element ) => ( {
 					id: element.id,
 					domElement: element.view?.getDomElement?.()?.get?.( 0 ),
-					widgetType: element.model.get( 'widgetType' ) ?? '',
-					elementType: element.model.get( 'elType' ),
+					isGlobal: element.model.get( 'isGlobal' ) ?? false,
 				} ) )
 				.filter( ( item ): item is ElementData => !! item.domElement );
 		}

--- a/packages/packages/core/editor-canvas/src/components/outline-overlay.tsx
+++ b/packages/packages/core/editor-canvas/src/components/outline-overlay.tsx
@@ -14,14 +14,18 @@ type Props = ElementOverlayProps & {
 };
 
 const OverlayBox = styled( Box, {
-	shouldForwardProp: ( prop ) => prop !== 'isSelected' && prop !== 'isSmallerOffset',
-} )< Pick< Props, 'isSelected' | 'isSmallerOffset' > >( ( { theme, isSelected, isSmallerOffset } ) => ( {
-	outline: `${ isSelected ? '2px' : '1px' } solid ${ theme.palette.primary.light }`,
-	outlineOffset: isSelected && ! isSmallerOffset ? '-2px' : '-1px',
-	pointerEvents: 'none',
-} ) );
+	shouldForwardProp: ( prop ) => prop !== 'isSelected' && prop !== 'isSmallerOffset' && prop !== 'isGlobal',
+} )< Pick< Props, 'isSelected' | 'isSmallerOffset' | 'isGlobal' > >(
+	( { theme, isSelected, isSmallerOffset, isGlobal } ) => ( {
+		outline: `${ isSelected ? '2px' : '1px' } solid ${
+			isGlobal ? theme.palette.global.main : theme.palette.primary.light
+		}`,
+		outlineOffset: isSelected && ! isSmallerOffset ? '-2px' : '-1px',
+		pointerEvents: 'none',
+	} )
+);
 
-export const OutlineOverlay = ( { element, isSelected, id }: Props ): React.ReactElement | false => {
+export const OutlineOverlay = ( { element, isSelected, id, isGlobal = false }: Props ): React.ReactElement | false => {
 	const { context, floating, isVisible } = useFloatingOnElement( { element, isSelected } );
 	const { getFloatingProps, getReferenceProps } = useInteractions( [ useHover( context ) ] );
 	const hasOverlapping = useHasOverlapping();
@@ -36,6 +40,7 @@ export const OutlineOverlay = ( { element, isSelected, id }: Props ): React.Reac
 				<OverlayBox
 					ref={ floating.setRef }
 					isSelected={ isSelected }
+					isGlobal={ isGlobal }
 					style={ floating.styles }
 					data-element-overlay={ id }
 					role="presentation"

--- a/packages/packages/core/editor-canvas/src/types/element-overlay.ts
+++ b/packages/packages/core/editor-canvas/src/types/element-overlay.ts
@@ -4,6 +4,7 @@ export type ElementOverlayProps = {
 	element: HTMLElement;
 	id: string;
 	isSelected: boolean;
+	isGlobal?: boolean;
 };
 
 export type OverlayFilterArgs = {

--- a/packages/packages/core/editor-components/src/components/edit-component/component-modal.tsx
+++ b/packages/packages/core/editor-components/src/components/edit-component/component-modal.tsx
@@ -53,7 +53,7 @@ function Backdrop( { canvas, element, onClose }: { canvas: HTMLDocument; element
 		zIndex: 999,
 		pointerEvents: 'painted',
 		cursor: 'pointer',
-		clipPath: getRoundedRectPath( rect, canvas.defaultView as Window, 5 ),
+		clipPath: getRectPath( rect, canvas.defaultView as Window ),
 	};
 
 	const handleKeyDown = ( event: React.KeyboardEvent ) => {
@@ -75,14 +75,12 @@ function Backdrop( { canvas, element, onClose }: { canvas: HTMLDocument; element
 	);
 }
 
-function getRoundedRectPath( rect: DOMRect, viewport: Window, borderRadius: number ) {
-	const padding = borderRadius / 2;
+function getRectPath( rect: DOMRect, viewport: Window ) {
 	const { x: originalX, y: originalY, width: originalWidth, height: originalHeight } = rect;
-	const x = originalX - padding;
-	const y = originalY - padding;
-	const width = originalWidth + 2 * padding;
-	const height = originalHeight + 2 * padding;
-	const radius = Math.min( borderRadius, width / 2, height / 2 );
+	const x = originalX;
+	const y = originalY;
+	const width = originalWidth;
+	const height = originalHeight;
 
 	const { innerWidth: vw, innerHeight: vh } = viewport;
 
@@ -91,15 +89,11 @@ function getRoundedRectPath( rect: DOMRect, viewport: Window, borderRadius: numb
 		L ${ vw } ${ vh }
 		L 0 ${ vh }
 		Z
-		M ${ x + radius } ${ y }
-		L ${ x + width - radius } ${ y }
-		A ${ radius } ${ radius } 0 0 1 ${ x + width } ${ y + radius }
-		L ${ x + width } ${ y + height - radius }
-		A ${ radius } ${ radius } 0 0 1 ${ x + width - radius } ${ y + height }
-		L ${ x + radius } ${ y + height }
-		A ${ radius } ${ radius } 0 0 1 ${ x } ${ y + height - radius }
-		L ${ x } ${ y + radius }
-		A ${ radius } ${ radius } 0 0 1 ${ x + radius } ${ y }
+		M ${ x } ${ y }
+		L ${ x + width } ${ y }
+		L ${ x + width } ${ y + height }
+		L ${ x } ${ y + height }
+		L ${ x } ${ y }
     	Z'
 	)`;
 

--- a/packages/packages/core/editor-components/src/create-component-type.ts
+++ b/packages/packages/core/editor-components/src/create-component-type.ts
@@ -43,6 +43,7 @@ type ContextMenuGroup = {
 
 type ComponentModel = ElementModel & {
 	componentId?: number | string;
+	isGlobal: boolean;
 };
 
 type ComponentModelInstance = BackboneModel< ComponentModel > & {
@@ -332,6 +333,8 @@ function createComponentModel(): BackboneModelConstructor< ComponentModel > {
 					this.set( 'componentId', componentId );
 				}
 			}
+
+			this.set( 'isGlobal', true );
 		},
 
 		getTitle( this: ComponentModelInstance ): string {

--- a/packages/packages/libs/editor-elements/src/sync/types.ts
+++ b/packages/packages/libs/editor-elements/src/sync/types.ts
@@ -110,6 +110,7 @@ export type V1ElementModelProps = {
 	settings?: V1ElementSettingsProps;
 	editor_settings?: V1ElementEditorSettingsProps;
 	interactions?: string | ElementInteractions;
+	isGlobal?: boolean;
 };
 
 export type V1ElementData = Omit< V1ElementModelProps, 'elements' > & {


### PR DESCRIPTION
Component widget outside edit mode
<img width="1927" height="856" alt="image" src="https://github.com/user-attachments/assets/7794105f-dd46-4cdd-b9cb-29548efc3833" />


Inside edit mode - top-level element gets teal overlay
<img width="1922" height="857" alt="image" src="https://github.com/user-attachments/assets/5a93b844-13a2-43ce-8de0-cc4414cdb432" />
 
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update component element overlay styling to use global teal color scheme for improved visual distinction in the editor canvas.

Main changes:
- Modified OutlineOverlay to conditionally apply global teal color based on isGlobal prop instead of primary color
- Refactored useElementsDom to return ElementData objects with isGlobal flag from element model
- Updated component editing mode backdrop to use sharp rectangular clipping path without rounded corners

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
