### PR TITLE
Internal: Overrides property groups should have a divider like we have in the atoms [ED-22302]

### DIFF
--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/instance-editing-panel.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/instance-editing-panel.tsx
@@ -4,7 +4,7 @@ import { getFieldIndicators } from '@elementor/editor-editing-panel';
 import { useSelectedElement } from '@elementor/editor-elements';
 import { PanelBody, PanelHeader, PanelHeaderTitle } from '@elementor/editor-panels';
 import { ComponentsIcon, PencilIcon } from '@elementor/icons';
-import { IconButton, Stack, Tooltip } from '@elementor/ui';
+import { Divider, IconButton, Stack, Tooltip } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { useComponentInstanceSettings } from '../../hooks/use-component-instance-settings';
@@ -64,12 +64,15 @@ export function InstanceEditingPanel() {
 					) : (
 						<Stack direction="column" alignItems="stretch">
 							{ groups.map( ( group ) => (
-								<OverridePropsGroup
-									key={ group.id }
-									group={ group }
-									props={ overridableProps.props }
-									overrides={ overrides }
-								/>
+								<>
+									<OverridePropsGroup
+										key={ group.id }
+										group={ group }
+										props={ overridableProps.props }
+										overrides={ overrides }
+									/>
+									<Divider />
+								</>
 							) ) }
 						</Stack>
 					) }

--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/instance-editing-panel.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/instance-editing-panel.tsx
@@ -64,15 +64,14 @@ export function InstanceEditingPanel() {
 					) : (
 						<Stack direction="column" alignItems="stretch">
 							{ groups.map( ( group ) => (
-								<>
+								<React.Fragment key={ group.id }>
 									<OverridePropsGroup
-										key={ group.id }
 										group={ group }
 										props={ overridableProps.props }
 										overrides={ overrides }
 									/>
 									<Divider />
-								</>
+								</React.Fragment>
 							) ) }
 						</Stack>
 					) }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add visual dividers between property groups in the instance editing panel to improve visual hierarchy and consistency with atom component styling.

Main changes:
- Imported Divider component from @elementor/ui library for visual separation
- Wrapped OverridePropsGroup components in React.Fragment with Divider elements to add visual breaks between each group
- Reorganized component structure to place Divider after each property group in the render output

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
