### PR TITLE
Internal: Events flow update [ED-22288]

### DIFF
--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -9,6 +9,10 @@ export default class extends elementorModules.Module {
 	onInit() {
 		this.config = eventsConfig;
 
+		if ( ! this.canSendEvents() ) {
+			return;
+		}
+
 		mixpanel.init(
 			elementorCommon.config.editor_events?.token,
 			{
@@ -25,9 +29,7 @@ export default class extends elementorModules.Module {
 			},
 		);
 
-		if ( elementorCommon.config.editor_events?.can_send_events ) {
-			this.enableTracking();
-		}
+		this.enableTracking();
 	}
 
 	enableTracking() {
@@ -51,7 +53,7 @@ export default class extends elementorModules.Module {
 	}
 
 	dispatchEvent( name, data, options = {} ) {
-		if ( ! elementorCommon.config.editor_events?.can_send_events ) {
+		if ( ! this.canSendEvents() ) {
 			return;
 		}
 
@@ -76,7 +78,7 @@ export default class extends elementorModules.Module {
 	}
 
 	startSessionRecording() {
-		if ( ! elementorCommon.config.editor_events?.can_send_events || this.isSessionRecordingInProgress() ) {
+		if ( ! this.canSendEvents() || this.isSessionRecordingInProgress() ) {
 			return;
 		}
 
@@ -89,7 +91,7 @@ export default class extends elementorModules.Module {
 	}
 
 	stopSessionRecording() {
-		if ( ! elementorCommon.config.editor_events?.can_send_events || ! this.isSessionRecordingInProgress() ) {
+		if ( ! this.canSendEvents() || ! this.isSessionRecordingInProgress() ) {
 			return;
 		}
 
@@ -120,7 +122,7 @@ export default class extends elementorModules.Module {
 
 	async getExperimentVariant( experimentName, defaultValue = 'control' ) {
 		try {
-			if ( ! elementorCommon.config.editor_events?.can_send_events ) {
+			if ( ! this.canSendEvents() ) {
 				return defaultValue;
 			}
 
@@ -164,5 +166,9 @@ export default class extends elementorModules.Module {
 		}
 
 		mixpanel.track( '$experiment_started', { 'Experiment name': experimentName, 'Variant name': experimentVariant } );
+	}
+
+	canSendEvents() {
+		return !! elementorCommon?.config?.editor_events?.can_send_events;
 	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor events manager to centralize event-sending permission checks through a dedicated method, improving code maintainability and reducing redundancy across the events flow.

Main changes:
- Introduced `canSendEvents()` method that encapsulates the permission check logic, replacing scattered `elementorCommon.config.editor_events?.can_send_events` calls throughout the module
- Moved permission validation to module initialization in `onInit()` to fail fast if events cannot be sent, preventing unnecessary Mixpanel setup
- Applied consistent permission checks across `dispatchEvent()`, `startSessionRecording()`, `stopSessionRecording()`, and `getExperimentVariant()` methods using the new centralized method

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
