### PR TITLE
Fix: Page updates [ED-22304]

### DIFF
--- a/includes/template-library/sources/admin-menu-items/editor-one-saved-templates-menu.php
+++ b/includes/template-library/sources/admin-menu-items/editor-one-saved-templates-menu.php
@@ -3,6 +3,7 @@
 namespace Elementor\Includes\TemplateLibrary\Sources\AdminMenuItems;
 
 use Elementor\Core\Admin\EditorOneMenu\Interfaces\Menu_Item_Interface;
+use Elementor\Core\Admin\EditorOneMenu\Interfaces\Menu_Item_With_Custom_Url_Interface;
 use Elementor\Modules\EditorOne\Classes\Menu_Config;
 use Elementor\TemplateLibrary\Source_Local;
 
@@ -10,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class Editor_One_Saved_Templates_Menu implements Menu_Item_Interface {
+class Editor_One_Saved_Templates_Menu implements Menu_Item_Interface, Menu_Item_With_Custom_Url_Interface {
 
 	public function get_capability(): string {
 		return 'edit_posts';
@@ -34,6 +35,10 @@ class Editor_One_Saved_Templates_Menu implements Menu_Item_Interface {
 
 	public function get_slug(): string {
 		return Source_Local::ADMIN_MENU_SLUG;
+	}
+
+	public function get_menu_url(): string {
+		return Source_Local::get_admin_url();
 	}
 
 	public function get_group_id(): string {

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -24,7 +24,7 @@
 
 	.wrap {
 		background-color: var(--e-one-palette-background-default);
-		margin: 20px;
+		margin: 20px 32px;
 		margin-block-start: 24px;
 		max-width: 100%;
 		display: flex;

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -13,7 +13,7 @@
 	background-color: var(--e-one-palette-background-default);
 
 	#wpbody-content,
-	#wpbody-content > * {
+	#wpbody-content>* {
 		background-color: var(--e-one-palette-background-default);
 	}
 
@@ -37,7 +37,7 @@
 			align-items: center;
 		}
 
-		> h1.wp-heading-inline {
+		>h1.wp-heading-inline {
 			font-family: var(--e-one-typography-fontFamily);
 			font-weight: 700;
 			font-size: 24px;
@@ -48,27 +48,27 @@
 			flex-grow: 1;
 		}
 
-		> .page-title-action {
+		>.page-title-action {
 			margin-inline-start: 8px;
 		}
 
-		> hr.wp-header-end {
+		>hr.wp-header-end {
 			flex-basis: 100%;
 			margin-block: 20px 0;
 		}
 
-		> *:not(h1.wp-heading-inline):not(.page-title-action):not(hr.wp-header-end) {
+		>*:not(h1.wp-heading-inline):not(.page-title-action):not(hr.wp-header-end) {
 			flex-basis: 100%;
 		}
 	}
 
-	#screen-meta-links + .wrap {
+	#screen-meta-links+.wrap {
 		margin-block-start: 60px;
 	}
 
 	#wpbody-content,
 	.elementor-settings-form-page,
-	.elementor-settings-form-page > *,
+	.elementor-settings-form-page>*,
 	.form-table,
 	.form-table th,
 	.form-table td,
@@ -183,6 +183,7 @@
 		background-color: var(--e-one-palette-background-default);
 		display: flex;
 		align-items: flex-end;
+		flex-wrap: wrap;
 		gap: 8px;
 		position: relative;
 
@@ -270,7 +271,7 @@
 		}
 	}
 
-	.elementor-settings-form-page h2 ~ p {
+	.elementor-settings-form-page h2~p {
 		margin-block: 1em;
 		font-size: 1em;
 		color: var(--e-one-palette-text-tertiary);
@@ -302,4 +303,3 @@
 		}
 	}
 }
-

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -13,7 +13,7 @@
 	background-color: var(--e-one-palette-background-default);
 
 	#wpbody-content,
-	#wpbody-content>* {
+	#wpbody-content > * {
 		background-color: var(--e-one-palette-background-default);
 	}
 
@@ -37,7 +37,7 @@
 			align-items: center;
 		}
 
-		>h1.wp-heading-inline {
+		> h1.wp-heading-inline {
 			font-family: var(--e-one-typography-fontFamily);
 			font-weight: 700;
 			font-size: 24px;
@@ -48,27 +48,27 @@
 			flex-grow: 1;
 		}
 
-		>.page-title-action {
+		> .page-title-action {
 			margin-inline-start: 8px;
 		}
 
-		>hr.wp-header-end {
+		> hr.wp-header-end {
 			flex-basis: 100%;
 			margin-block: 20px 0;
 		}
 
-		>*:not(h1.wp-heading-inline):not(.page-title-action):not(hr.wp-header-end) {
+		> *:not(h1.wp-heading-inline):not(.page-title-action):not(hr.wp-header-end) {
 			flex-basis: 100%;
 		}
 	}
 
-	#screen-meta-links+.wrap {
+	#screen-meta-link + .wrap {
 		margin-block-start: 60px;
 	}
 
 	#wpbody-content,
 	.elementor-settings-form-page,
-	.elementor-settings-form-page>*,
+	.elementor-settings-form-page > *,
 	.form-table,
 	.form-table th,
 	.form-table td,
@@ -271,7 +271,7 @@
 		}
 	}
 
-	.elementor-settings-form-page h2~p {
+	.elementor-settings-form-page h2 ~ p {
 		margin-block: 1em;
 		font-size: 1em;
 		color: var(--e-one-palette-text-tertiary);

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -308,4 +308,8 @@
 			}
 		}
 	}
+
+	.e-feature-promotion {
+		max-width: calc(100% - 64px);
+	}
 }

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -300,6 +300,12 @@
 					color: var(--e-one-palette-text-primary);
 				}
 			}
+
+			@media screen and (min-width: 783px) {
+				&+#posts-filter .search-box {
+					margin-block-start: -25px;
+				}
+			}
 		}
 	}
 }

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -62,7 +62,7 @@
 		}
 	}
 
-	#screen-meta-link + .wrap {
+	#screen-meta-links + .wrap {
 		margin-block-start: 60px;
 	}
 

--- a/tests/phpunit/elementor/modules/editor-one/snapshots/menu-config-snapshot.json
+++ b/tests/phpunit/elementor/modules/editor-one/snapshots/menu-config-snapshot.json
@@ -120,7 +120,7 @@
                 {
                     "slug": "edit.php?post_type=elementor_library",
                     "label": "Saved Templates",
-                    "url": "/wp-admin/edit.php?post_type=elementor_library",
+                    "url": "/wp-admin/edit.php?post_type=elementor_library&tabs_group=library",
                     "priority": 10
                 },
                 {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Saved Templates menu navigation by implementing custom URL interface to properly redirect to the library tabs view in the Editor One admin menu.

Main changes:
- Implemented Menu_Item_With_Custom_Url_Interface in Editor_One_Saved_Templates_Menu to add custom URL with tabs_group parameter
- Updated admin page layout margins from 20px to 32px horizontal padding for improved spacing consistency
- Added responsive CSS adjustments for subsubsub menu and feature promotion banner width constraints

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
