### PR TITLE
Revert "Internal: Remove nested-elements experiment [ED-20667]"

### DIFF
--- a/assets/dev/js/frontend/elements-handlers-manager.js
+++ b/assets/dev/js/frontend/elements-handlers-manager.js
@@ -24,8 +24,11 @@ module.exports = function( $ ) {
 		column: columnHandlers,
 	};
 
-	if ( elementorFrontendConfig.experimentalFeatures.container ) {
+	if ( elementorFrontendConfig.experimentalFeatures[ 'nested-elements' ] ) {
 		this.elementsHandlers[ 'nested-tabs.default' ] = () => import( /* webpackChunkName: 'nested-tabs' */ 'elementor/modules/nested-tabs/assets/js/frontend/handlers/nested-tabs' );
+	}
+
+	if ( elementorFrontendConfig.experimentalFeatures[ 'nested-elements' ] ) {
 		this.elementsHandlers[ 'nested-accordion.default' ] = () => import( /* webpackChunkName: 'nested-accordion' */ 'elementor/modules/nested-accordion/assets/js/frontend/handlers/nested-accordion' );
 	}
 

--- a/core/upgrade/upgrades.php
+++ b/core/upgrade/upgrades.php
@@ -868,17 +868,6 @@ class Upgrades {
 		delete_option( 'elementor_experiment-taxonomy-filter' );
 	}
 
-	/**
-	 * Upgrade Elementor 3.35.0 - Merge Nested Elements into Container.
-	 *
-	 * @since 3.35.0
-	 * @static
-	 * @access public
-	 */
-	public static function _v_3_35_0() {
-		delete_option( Experiments_Manager::OPTION_PREFIX . 'nested-elements' );
-	}
-
 	private static function maybe_add_gap_control_data( $option_name ) {
 		$kit_id = get_option( $option_name );
 

--- a/includes/managers/widgets.php
+++ b/includes/managers/widgets.php
@@ -11,6 +11,7 @@ use Elementor\Modules\AtomicWidgets\Elements\Atomic_Image\Atomic_Image;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Paragraph\Atomic_Paragraph;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Svg\Atomic_Svg;
 use Elementor\Modules\NestedAccordion\Widgets\Nested_Accordion;
+use Elementor\Modules\NestedElements\Module as NestedElementsModule;
 use Elementor\Modules\NestedTabs\Widgets\NestedTabs;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -52,7 +53,7 @@ class Widgets_Manager {
 	 * @return array
 	 */
 	private array $promoted_widgets = [
-		'container' => [
+		NestedElementsModule::EXPERIMENT_NAME => [
 			NestedTabs::class,
 			Nested_Accordion::class,
 		],

--- a/includes/widgets/accordion.php
+++ b/includes/widgets/accordion.php
@@ -101,7 +101,7 @@ class Widget_Accordion extends Widget_Base {
 	 * @return bool
 	 */
 	public function show_in_panel(): bool {
-		return ! Plugin::$instance->experiments->is_feature_active( 'container' );
+		return ! Plugin::$instance->experiments->is_feature_active( 'nested-elements', true );
 	}
 
 	public function has_widget_inner_wrapper(): bool {

--- a/includes/widgets/tabs.php
+++ b/includes/widgets/tabs.php
@@ -93,7 +93,7 @@ class Widget_Tabs extends Widget_Base {
 	}
 
 	public function show_in_panel(): bool {
-		return ! Plugin::$instance->experiments->is_feature_active( 'container' );
+		return ! Plugin::$instance->experiments->is_feature_active( 'nested-elements', true );
 	}
 
 	public function has_widget_inner_wrapper(): bool {

--- a/includes/widgets/toggle.php
+++ b/includes/widgets/toggle.php
@@ -101,7 +101,7 @@ class Widget_Toggle extends Widget_Base {
 	 * @return bool
 	 */
 	public function show_in_panel(): bool {
-		return ! Plugin::$instance->experiments->is_feature_active( 'container' );
+		return ! Plugin::$instance->experiments->is_feature_active( 'nested-elements', true );
 	}
 
 	public function has_widget_inner_wrapper(): bool {

--- a/modules/ai/connect/ai.php
+++ b/modules/ai/connect/ai.php
@@ -787,7 +787,7 @@ class Ai extends Library {
 			$context['features']['subscriptions'] = [ 'Pro' ];
 		}
 
-		if ( Plugin::instance()->experiments->is_feature_active( 'container' ) ) {
+		if ( Plugin::instance()->experiments->get_active_features()['nested-elements'] ) {
 			$context['features']['supportedFeatures'][] = 'Nested';
 		}
 

--- a/modules/atomic-widgets/opt-in/opt-in.php
+++ b/modules/atomic-widgets/opt-in/opt-in.php
@@ -5,6 +5,7 @@ namespace Elementor\Modules\AtomicWidgets\OptIn;
 use Elementor\Core\Common\Modules\Ajax\Module as Ajax;
 use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\Modules\GlobalClasses\Module as GlobalClassesModule;
+use Elementor\Modules\NestedElements\Module as NestedElementsModule;
 use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
 use Elementor\Modules\Variables\Module as VariablesModule;
 use Elementor\Plugin;
@@ -22,6 +23,7 @@ class Opt_In {
 	const OPT_IN_FEATURES = [
 		self::EXPERIMENT_NAME,
 		'container',
+		NestedElementsModule::EXPERIMENT_NAME,
 		AtomicWidgetsModule::EXPERIMENT_NAME,
 		GlobalClassesModule::NAME,
 		VariablesModule::EXPERIMENT_NAME,

--- a/modules/nested-accordion/module.php
+++ b/modules/nested-accordion/module.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Module extends BaseModule {
 
 	public static function is_active() {
-		return Plugin::$instance->experiments->is_feature_active( 'container' );
+		return Plugin::$instance->experiments->is_feature_active( 'nested-elements', true );
 	}
 
 	public function get_name() {

--- a/modules/nested-accordion/widgets/nested-accordion.php
+++ b/modules/nested-accordion/widgets/nested-accordion.php
@@ -56,7 +56,7 @@ class Nested_Accordion extends Widget_Nested_Base {
 	}
 
 	public function show_in_panel(): bool {
-		return Plugin::$instance->experiments->is_feature_active( 'container' );
+		return Plugin::$instance->experiments->is_feature_active( 'nested-elements', true );
 	}
 
 	public function has_widget_inner_wrapper(): bool {

--- a/modules/nested-elements/module.php
+++ b/modules/nested-elements/module.php
@@ -1,7 +1,7 @@
 <?php
 namespace Elementor\Modules\NestedElements;
 
-use Elementor\Plugin;
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -9,8 +9,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Module extends \Elementor\Core\Base\Module {
 
-	public static function is_active() {
-		return Plugin::$instance->experiments->is_feature_active( 'container' );
+	const EXPERIMENT_NAME = 'nested-elements';
+
+	public static function get_experimental_data() {
+		return [
+			'name' => self::EXPERIMENT_NAME,
+			'title' => esc_html__( 'Nested Elements', 'elementor' ),
+			'description' => sprintf(
+				'%1$s <a href="https://go.elementor.com/wp-dash-nested-elements/" target="_blank">%2$s</a>',
+				esc_html__( 'Create a rich user experience by layering widgets together inside "Nested" Tabs, etc. When turned on, we’ll automatically enable new nested features. Your old widgets won’t be affected.', 'elementor' ),
+				esc_html__( 'Learn more', 'elementor' )
+			),
+			'release_status' => Experiments_Manager::RELEASE_STATUS_STABLE,
+			'default' => Experiments_Manager::STATE_ACTIVE,
+			'dependencies' => [
+				'container',
+			],
+		];
 	}
 
 	public function get_name() {

--- a/modules/nested-tabs/module.php
+++ b/modules/nested-tabs/module.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Module extends \Elementor\Core\Base\Module {
 
 	public static function is_active() {
-		return Plugin::$instance->experiments->is_feature_active( 'container' );
+		return Plugin::$instance->experiments->is_feature_active( NestedElementsModule::EXPERIMENT_NAME );
 	}
 
 	public function get_name() {

--- a/modules/nested-tabs/widgets/nested-tabs.php
+++ b/modules/nested-tabs/widgets/nested-tabs.php
@@ -51,7 +51,7 @@ class NestedTabs extends Widget_Nested_Base {
 	}
 
 	public function show_in_panel(): bool {
-		return Plugin::$instance->experiments->is_feature_active( 'container' );
+		return Plugin::$instance->experiments->is_feature_active( 'nested-elements', true );
 	}
 
 	protected function tab_content_container( int $index ) {

--- a/tests/phpunit/elementor/core/upgrade/test-upgrades.php
+++ b/tests/phpunit/elementor/core/upgrade/test-upgrades.php
@@ -420,6 +420,7 @@ class Test_Upgrades extends Elementor_Test_Base {
 	public function test_v_3_16_0_container_updates() {
 
 		Plugin::$instance->experiments->set_feature_default_state( 'container', 'active' );
+		Plugin::$instance->experiments->set_feature_default_state( 'nested-elements', 'active' );
 
 		$documents = [];
 		$updater = $this->create_updater();

--- a/tests/playwright/sanity/includes/widgets/tabs.test.ts
+++ b/tests/playwright/sanity/includes/widgets/tabs.test.ts
@@ -26,7 +26,7 @@ test.describe( 'Tabs widget tests', () => {
 		const newTabTitle = 'Super test tab';
 		const defaultText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo.';
 
-		await wpAdmin.setExperiments( { container: 'inactive' } );
+		await wpAdmin.setExperiments( { container: 'inactive', 'nested-elements': 'inactive' } );
 
 		await wpAdmin.openNewPage();
 		await editor.closeNavigatorIfOpen();

--- a/tests/playwright/sanity/modules/nested-accordion/nested-accordion.test.ts
+++ b/tests/playwright/sanity/modules/nested-accordion/nested-accordion.test.ts
@@ -9,7 +9,7 @@ test.describe( 'Nested Accordion tests @nested-accordion', () => {
 	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
 		const page = await browser.newPage();
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.setExperiments( { container: 'inactive' } );
+		await wpAdmin.setExperiments( { container: 'inactive', 'nested-elements': 'inactive' } );
 		await page.close();
 	} );
 


### PR DESCRIPTION
Reverts elementor/elementor#34112
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert previous merge that consolidated nested-elements experiment into container experiment, restoring nested-elements as a separate experimental feature with its own configuration and activation logic.

Main changes:
- Restored nested-elements experiment configuration with stable release status and container dependency in Module class
- Reverted widget visibility and feature checks from 'container' experiment back to 'nested-elements' across 8 widget files
- Removed v_3_35_0 upgrade function that deleted nested-elements experiment option and restored experiment references in frontend handlers

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
