### PR TITLE
Internal: Content updates for editor one - beta [ED-22343]

### DIFF
--- a/modules/editor-one/assets/js/sidebar-navigation/components/shared/icon-map.js
+++ b/modules/editor-one/assets/js/sidebar-navigation/components/shared/icon-map.js
@@ -2,23 +2,23 @@ import AdjustmentsIcon from '@elementor/icons/AdjustmentsIcon';
 import FolderIcon from '@elementor/icons/FolderIcon';
 import RocketIcon from '@elementor/icons/RocketIcon';
 import HomeIcon from '@elementor/icons/HomeIcon';
-import InfoCircleIcon from '@elementor/icons/InfoCircleIcon';
 import SendIcon from '@elementor/icons/SendIcon';
 import SettingsIcon from '@elementor/icons/SettingsIcon';
 import UsersIcon from '@elementor/icons/UsersIcon';
 import PlugIcon from '@elementor/icons/PlugIcon';
 import ToolIcon from '../icons/tool';
+import FileSettingsIcon from '@elementor/icons/FileSettingsIcon';
 
 export const ICON_MAP = {
 	adjustments: AdjustmentsIcon,
 	folder: FolderIcon,
 	home: RocketIcon,
-	'info-circle': InfoCircleIcon,
 	send: SendIcon,
 	settings: SettingsIcon,
 	tool: ToolIcon,
 	users: UsersIcon,
 	extension: PlugIcon,
+	'file-settings': FileSettingsIcon,
 };
 
 export const DEFAULT_ICON = HomeIcon;

--- a/modules/home/assets/js/components/editor-screen/header-section.js
+++ b/modules/home/assets/js/components/editor-screen/header-section.js
@@ -27,7 +27,7 @@ const HeaderSection = ( props ) => {
 				target="_blank"
 				rel="noopener noreferrer"
 			>
-				{ __( 'Edit Website', 'elementor' ) }
+				{ __( 'Edit site', 'elementor' ) }
 			</Button>
 		</Paper>
 	);

--- a/modules/system-info/admin-menu-items/editor-one-system-menu.php
+++ b/modules/system-info/admin-menu-items/editor-one-system-menu.php
@@ -36,7 +36,7 @@ class Editor_One_System_Menu implements Menu_Item_Third_Level_Interface {
 	}
 
 	public function get_icon(): string {
-		return 'info-circle';
+		return 'file-settings';
 	}
 
 	public function get_group_id(): string {

--- a/tests/phpunit/elementor/modules/editor-one/snapshots/menu-config-snapshot.json
+++ b/tests/phpunit/elementor/modules/editor-one/snapshots/menu-config-snapshot.json
@@ -69,7 +69,7 @@
                 "slug": "elementor-system",
                 "label": "System",
                 "url": "/wp-admin/admin.php?page=elementor-system-info",
-                "icon": "info-circle",
+                "icon": "file-settings",
                 "group_id": "elementor-editor-system",
                 "priority": 80,
                 "has_divider_before": false


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update editor one beta UI elements by replacing system menu icon and revising button label for improved visual consistency.

Main changes:
- Replaced 'info-circle' icon with 'file-settings' icon across system menu and icon map components
- Updated button text from 'Edit Website' to 'Edit site' in header section component
- Synchronized icon changes in PHP menu configuration and JavaScript icon mapping files

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
