### PR TITLE
Internal: Fix failing Playwright tests for Editor One - beta [ED-22339]

### DIFF
--- a/tests/playwright/sanity/modules/editor-one/menu-visibility.test.ts
+++ b/tests/playwright/sanity/modules/editor-one/menu-visibility.test.ts
@@ -51,7 +51,7 @@ test.describe( 'Editor One Menu Visibility', () => {
 
 		await wpAdmin.openWordPressDashboard();
 
-		const elementorMenu = page.locator( '#toplevel_page_elementor' );
+		const elementorMenu = page.locator( '#toplevel_page_elementor-home' );
 		await expect( elementorMenu ).toBeVisible();
 
 		await page.goto( '/wp-admin/admin.php?page=elementor' );
@@ -75,7 +75,7 @@ test.describe( 'Editor One Menu Visibility', () => {
 		await wpAdmin.customLogin( editorUser.username, editorUser.password );
 		await wpAdmin.openWordPressDashboard();
 
-		const elementorMenu = editorPage.locator( '#toplevel_page_elementor' );
+		const elementorMenu = editorPage.locator( '#toplevel_page_elementor-home' );
 		await expect( elementorMenu ).toBeVisible();
 
 		await elementorMenu.click();
@@ -113,7 +113,7 @@ test.describe( 'Editor One Menu Visibility', () => {
 		await wpAdmin.customLogin( contributorUser.username, contributorUser.password );
 		await wpAdmin.openWordPressDashboard();
 
-		const elementorMenu = contributorPage.locator( '#toplevel_page_elementor' );
+		const elementorMenu = contributorPage.locator( '#toplevel_page_elementor-home' );
 		await expect( elementorMenu ).toBeVisible();
 
 		await elementorMenu.click();

--- a/tests/playwright/sanity/modules/home/home-screen-one-plan.test.ts
+++ b/tests/playwright/sanity/modules/home/home-screen-one-plan.test.ts
@@ -3,7 +3,7 @@ import { parallelTest as test } from '../../../parallelTest';
 import { saveHomepageSettings, restoreHomepageSettings, mockHomeScreenData, transformMockDataByLicense, navigateToHomeScreen, type HomepageSettings } from './home-screen.helper';
 import { wpCli } from '../../../assets/wp-cli';
 
-test.describe( 'Home screen Edit Website button tests', () => {
+test.describe( 'Home screen Edit site button tests', () => {
 	let originalHomepageSettings: HomepageSettings | null = null;
 
 	test.beforeAll( async ( { browser, apiRequests } ) => {
@@ -30,9 +30,7 @@ test.describe( 'Home screen Edit Website button tests', () => {
 		await context.close();
 	} );
 
-	// TODO: Fix in ED-22339 - Visual regression test failing
-	// https://elementor.atlassian.net/browse/ED-22339
-	test.skip( 'one license variant - UI renders correctly with mocked data', async ( { page, apiRequests, storageState } ) => {
+	test( 'one license variant - UI renders correctly with mocked data', async ( { page, apiRequests, storageState } ) => {
 		const requestContext = await request.newContext( { storageState } );
 		const mockData = transformMockDataByLicense( 'one' );
 
@@ -43,12 +41,10 @@ test.describe( 'Home screen Edit Website button tests', () => {
 		await requestContext.dispose();
 	} );
 
-	// TODO: Fix in ED-22339 - Edit Website button test failing
-	// https://elementor.atlassian.net/browse/ED-22339
-	test.skip( 'Edit Website button has valid Elementor link', async ( { page } ) => {
+	test( 'Edit site button has valid Elementor link', async ( { page } ) => {
 		await page.goto( 'wp-admin/admin.php?page=elementor' );
 
-		const editWebsiteButton = page.locator( 'a:has-text("Edit Website"), button:has-text("Edit Website")' ).first();
+		const editWebsiteButton = page.locator( 'a:has-text("Edit site"), button:has-text("Edit site")' ).first();
 		await expect( editWebsiteButton ).toBeVisible();
 
 		const href = await editWebsiteButton.getAttribute( 'href' );

--- a/tests/playwright/sanity/modules/home/home-screen-ui.test.ts
+++ b/tests/playwright/sanity/modules/home/home-screen-ui.test.ts
@@ -18,10 +18,7 @@ test.describe( 'Home screen visual regression tests', () => {
 	const licenseTypes: LicenseType[] = [ 'free', 'pro' ];
 
 	for ( const licenseType of licenseTypes ) {
-		// TODO: Fix in ED-22339 - Visual regression test failing (pro license variant)
-		// https://elementor.atlassian.net/browse/ED-22339
-		const testFn = 'pro' === licenseType ? test.skip : test;
-		testFn( `${ licenseType } license variant - UI renders correctly with mocked data`, async ( { page, apiRequests, storageState } ) => {
+		test( `${ licenseType } license variant - UI renders correctly with mocked data`, async ( { page, apiRequests, storageState } ) => {
 			const requestContext = await request.newContext( { storageState } );
 			const mockData = transformMockDataByLicense( licenseType );
 			await mockHomeScreenData( page, mockData, apiRequests, requestContext );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## Purpose

Fix failing Playwright tests for Editor One menu functionality by adding comprehensive menu interception logic, admin page detection utilities, and conditional admin actions based on Editor One activation state.

## Main changes

- Added Editor One menu manager with legacy submenu interceptor, slug normalizer, and URL matcher for menu item resolution
- Implemented admin page detection helper `is_elementor_admin_page()` with support for Floating Buttons CPT
- Added conditional admin actions (`admin_action_site_settings_redirect`, `admin_action_edit_website_redirect`) with capability checks and nonce verification

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
