### PR TITLE
Tweak: Children perspective controls should show only for non-widgets. [ED-21004]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/transform-control/__tests__/transform-repeater-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/__tests__/transform-repeater-control.test.tsx
@@ -11,6 +11,33 @@ import { fireEvent, screen } from '@testing-library/react';
 
 import { TransformRepeaterControl } from '../transform-repeater-control';
 
+jest.mock( '@elementor/editor-elements', () => ( {
+	...jest.requireActual( '@elementor/editor-elements' ),
+	useSelectedElement: jest.fn( () => ( {
+		element: { id: 'test-element-id', type: 'e-flexbox' },
+		elementType: { key: 'e-flexbox' },
+	} ) ),
+	getContainer: jest.fn( () => ( {
+		id: 'test-element-id',
+		model: {
+			get: jest.fn( ( key: string ) => {
+				if ( key === 'widgetType' ) {
+					return 'e-flexbox';
+				}
+				if ( key === 'elType' ) {
+					return 'e-flexbox';
+				}
+				return null;
+			} ),
+		},
+	} ) ),
+	getWidgetsCache: jest.fn( () => ( {
+		'e-flexbox': {
+			meta: { is_container: true },
+		},
+	} ) ),
+} ) );
+
 type DimensionPropValue< T extends string[] > = {
 	[ K in T[ number ] ]?: {
 		$$type: 'size';

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/__tests__/transform-settings-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/__tests__/transform-settings-control.test.tsx
@@ -1,0 +1,162 @@
+import * as React from 'react';
+import { createMockPropType } from 'test-utils';
+import { type PopupState } from '@elementor/ui';
+import { render, screen } from '@testing-library/react';
+
+import { PropProvider } from '../../../bound-prop-context';
+import { ControlActionsProvider } from '../../../control-actions/control-actions-context';
+import { TransformSettingsControl } from '../transform-settings-control';
+
+const CHILDREN_PERSPECTIVE_LABEL = 'Children perspective';
+const TRANSFORM_LABEL = 'Transform';
+
+describe( 'TransformSettingsControl', () => {
+	const sizePropType = createMockPropType( {
+		kind: 'object',
+		shape: {
+			unit: createMockPropType( { kind: 'plain' } ),
+			size: createMockPropType( { kind: 'plain' } ),
+		},
+	} );
+
+	const propType = createMockPropType( {
+		kind: 'object',
+		shape: {
+			'transform-origin': createMockPropType( {
+				kind: 'object',
+				shape: {
+					x: sizePropType,
+					y: sizePropType,
+					z: sizePropType,
+				},
+			} ),
+			perspective: sizePropType,
+			'perspective-origin': createMockPropType( {
+				kind: 'object',
+				shape: {
+					x: sizePropType,
+					y: sizePropType,
+				},
+			} ),
+		},
+	} );
+
+	const mockPopupState = {
+		isOpen: true,
+		close: jest.fn(),
+		open: jest.fn(),
+		toggle: jest.fn(),
+		setOpen: jest.fn(),
+		onBlur: jest.fn(),
+		onMouseLeave: jest.fn(),
+		setAnchorEl: jest.fn(),
+		setAnchorElUsed: false,
+		anchorEl: undefined,
+		anchorPosition: undefined,
+		disableAutoFocus: false,
+		disableRestoreFocus: false,
+		variant: 'popover' as const,
+		popupId: 'test-popup',
+		_openEventType: null,
+		_childPopupState: null,
+		_setChildPopupState: jest.fn(),
+	} as PopupState;
+
+	const anchorRef = { current: document.createElement( 'div' ) };
+
+	it( 'should render transform origin control', () => {
+		// Arrange & Act
+		render(
+			<ControlActionsProvider items={ [] }>
+				<PropProvider propType={ propType } value={ null } setValue={ jest.fn() }>
+					<TransformSettingsControl
+						popupState={ mockPopupState }
+						anchorRef={ anchorRef }
+						showChildrenPerspective={ false }
+					/>
+				</PropProvider>
+			</ControlActionsProvider>
+		);
+
+		// Assert
+		expect( screen.getByText( TRANSFORM_LABEL ) ).toBeInTheDocument();
+	} );
+
+	it( 'should show children perspective control when showChildrenPerspective is true', () => {
+		// Arrange & Act
+		render(
+			<ControlActionsProvider items={ [] }>
+				<PropProvider propType={ propType } value={ null } setValue={ jest.fn() }>
+					<TransformSettingsControl
+						popupState={ mockPopupState }
+						anchorRef={ anchorRef }
+						showChildrenPerspective={ true }
+					/>
+				</PropProvider>
+			</ControlActionsProvider>
+		);
+
+		// Assert
+		expect( screen.getByText( TRANSFORM_LABEL ) ).toBeInTheDocument();
+		expect( screen.getByText( CHILDREN_PERSPECTIVE_LABEL ) ).toBeInTheDocument();
+	} );
+
+	it( 'should hide children perspective control when showChildrenPerspective is false', () => {
+		// Arrange & Act
+		render(
+			<ControlActionsProvider items={ [] }>
+				<PropProvider propType={ propType } value={ null } setValue={ jest.fn() }>
+					<TransformSettingsControl
+						popupState={ mockPopupState }
+						anchorRef={ anchorRef }
+						showChildrenPerspective={ false }
+					/>
+				</PropProvider>
+			</ControlActionsProvider>
+		);
+
+		// Assert
+		expect( screen.getByText( TRANSFORM_LABEL ) ).toBeInTheDocument();
+		expect( screen.queryByText( CHILDREN_PERSPECTIVE_LABEL ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render divider before children perspective when showChildrenPerspective is false', () => {
+		// Arrange & Act
+		const { baseElement } = render(
+			<ControlActionsProvider items={ [] }>
+				<PropProvider propType={ propType } value={ null } setValue={ jest.fn() }>
+					<TransformSettingsControl
+						popupState={ mockPopupState }
+						anchorRef={ anchorRef }
+						showChildrenPerspective={ false }
+					/>
+				</PropProvider>
+			</ControlActionsProvider>
+		);
+
+		// Assert
+		// eslint-disable-next-line testing-library/no-node-access
+		const dividers = baseElement.querySelectorAll( 'hr' );
+		expect( dividers ).toHaveLength( 1 );
+	} );
+
+	it( 'should render divider before children perspective when showChildrenPerspective is true', () => {
+		// Arrange & Act
+		const { baseElement } = render(
+			<ControlActionsProvider items={ [] }>
+				<PropProvider propType={ propType } value={ null } setValue={ jest.fn() }>
+					<TransformSettingsControl
+						popupState={ mockPopupState }
+						anchorRef={ anchorRef }
+						showChildrenPerspective={ true }
+					/>
+				</PropProvider>
+			</ControlActionsProvider>
+		);
+
+		// Assert
+		// eslint-disable-next-line testing-library/no-node-access
+		const dividers = baseElement.querySelectorAll( 'hr' );
+		expect( dividers ).toHaveLength( 2 );
+	} );
+} );

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/transform-repeater-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/transform-repeater-control.tsx
@@ -13,6 +13,7 @@ import { EditItemPopover } from '../../components/control-repeater/items/edit-it
 import { RepeaterHeader } from '../../components/repeater/repeater-header';
 import { ControlAdornments } from '../../control-adornments/control-adornments';
 import { createControl } from '../../create-control';
+import { useElementCanHaveChildren } from '../../hooks/use-element-can-have-children';
 import { initialRotateValue, initialScaleValue, initialSkewValue, initialTransformValue } from './initial-values';
 import { TransformContent } from './transform-content';
 import { TransformIcon } from './transform-icon';
@@ -25,10 +26,15 @@ export const TransformRepeaterControl = createControl( () => {
 	const context = useBoundProp( transformPropTypeUtil );
 	const headerRef = useRef< HTMLDivElement >( null );
 	const popupState = usePopupState( { variant: 'popover' } );
+	const showChildrenPerspective = useElementCanHaveChildren();
 
 	return (
 		<PropProvider { ...context }>
-			<TransformSettingsControl popupState={ popupState } anchorRef={ headerRef } />
+			<TransformSettingsControl
+				popupState={ popupState }
+				anchorRef={ headerRef }
+				showChildrenPerspective={ showChildrenPerspective }
+			/>
 			<PropKeyProvider bind={ 'transform-functions' }>
 				<Repeater headerRef={ headerRef } propType={ context.propType } popupState={ popupState } />
 			</PropKeyProvider>

--- a/packages/packages/libs/editor-controls/src/controls/transform-control/transform-settings-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transform-control/transform-settings-control.tsx
@@ -14,9 +14,11 @@ const SIZE = 'tiny';
 export const TransformSettingsControl = ( {
 	popupState,
 	anchorRef,
+	showChildrenPerspective,
 }: {
 	popupState: PopupState;
 	anchorRef: React.RefObject< HTMLDivElement | null >;
+	showChildrenPerspective: boolean;
 } ) => {
 	const popupProps = bindPopover( {
 		...popupState,
@@ -47,10 +49,14 @@ export const TransformSettingsControl = ( {
 				<PropKeyProvider bind={ 'transform-origin' }>
 					<TransformOriginControl />
 				</PropKeyProvider>
-				<Box sx={ { my: 0.5 } }>
-					<Divider />
-				</Box>
-				<ChildrenPerspectiveControl />
+				{ showChildrenPerspective && (
+					<>
+						<Box sx={ { my: 0.5 } }>
+							<Divider />
+						</Box>
+						<ChildrenPerspectiveControl />
+					</>
+				) }
 			</PopoverContent>
 		</Popover>
 	);

--- a/packages/packages/libs/editor-controls/src/hooks/use-element-can-have-children.ts
+++ b/packages/packages/libs/editor-controls/src/hooks/use-element-can-have-children.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { getContainer, useSelectedElement } from '@elementor/editor-elements';
+
+export const useElementCanHaveChildren = (): boolean => {
+	const { element } = useSelectedElement();
+	const elementId = element?.id || '';
+
+	return useMemo( () => {
+		const container = getContainer( elementId );
+
+		if ( ! container ) {
+			return false;
+		}
+
+		return container.model.get( 'elType' ) !== 'widget';
+	}, [ elementId ] );
+};

--- a/packages/packages/libs/editor-controls/src/index.ts
+++ b/packages/packages/libs/editor-controls/src/index.ts
@@ -81,3 +81,4 @@ export {
 
 // hooks
 export { useSyncExternalState } from './hooks/use-sync-external-state';
+export { useElementCanHaveChildren } from './hooks/use-element-can-have-children';


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Hide children perspective controls in transform settings for widget elements to prevent incorrect configuration of non-applicable 3D transform properties.

Main changes:
- Added useElementCanHaveChildren hook to detect non-widget elements by checking container elType property
- Conditionally rendered ChildrenPerspectiveControl component based on element type in TransformSettingsControl
- Created comprehensive test coverage for conditional rendering logic and element type detection

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
