### PR TITLE
Internal: Fix deleting overridable after element is deleted [ED-22409]

### DIFF
--- a/packages/packages/core/editor-components/src/hooks/cleanup-overridable-props-on-delete.ts
+++ b/packages/packages/core/editor-components/src/hooks/cleanup-overridable-props-on-delete.ts
@@ -11,35 +11,35 @@ type DeleteCommandArgs = {
 };
 
 export function initCleanupOverridablePropsOnDelete() {
-	registerDataHook( 'after', 'document/elements/delete', ( args: DeleteCommandArgs ) => {
+	registerDataHook( 'dependency', 'document/elements/delete', ( args: DeleteCommandArgs ) => {
 		const state = getState() as ComponentsSlice | undefined;
 
 		if ( ! state ) {
-			return;
+			return true;
 		}
 
 		const currentComponentId = selectCurrentComponentId( state );
 
 		if ( ! currentComponentId ) {
-			return;
+			return true;
 		}
 
 		const overridableProps = selectOverridableProps( state, currentComponentId );
 
 		if ( ! overridableProps || Object.keys( overridableProps.props ).length === 0 ) {
-			return;
+			return true;
 		}
 
 		const containers = args.containers ?? ( args.container ? [ args.container ] : [] );
 
 		if ( containers.length === 0 ) {
-			return;
+			return true;
 		}
 
 		const deletedElementIds = collectDeletedElementIds( containers );
 
 		if ( deletedElementIds.length === 0 ) {
-			return;
+			return true;
 		}
 
 		const propKeysToDelete = Object.entries( overridableProps.props )
@@ -47,7 +47,7 @@ export function initCleanupOverridablePropsOnDelete() {
 			.map( ( [ propKey ] ) => propKey );
 
 		if ( propKeysToDelete.length === 0 ) {
-			return;
+			return true;
 		}
 
 		const remainingProps = Object.fromEntries(
@@ -69,6 +69,8 @@ export function initCleanupOverridablePropsOnDelete() {
 				},
 			} )
 		);
+
+		return true;
 	} );
 }
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix cleanup hook timing to prevent overridable props deletion errors when referenced elements are removed from the document.

Main changes:
- Changed registerDataHook from 'after' to 'dependency' phase to execute before element deletion completes
- Updated all early return statements to return true for proper hook chain continuation
- Added explicit return true after successful cleanup operation to signal dependency resolution

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
