### PR TITLE
Internal: Add ellipsis with tooltip to component header [ED-22328]

### DIFF
--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/instance-editing-panel.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/instance-editing-panel.tsx
@@ -3,6 +3,7 @@ import { ControlAdornmentsProvider } from '@elementor/editor-controls';
 import { getFieldIndicators } from '@elementor/editor-editing-panel';
 import { useSelectedElement } from '@elementor/editor-elements';
 import { PanelBody, PanelHeader, PanelHeaderTitle } from '@elementor/editor-panels';
+import { EllipsisWithTooltip } from '@elementor/editor-ui';
 import { ComponentsIcon, PencilIcon } from '@elementor/icons';
 import { Divider, IconButton, Stack, Tooltip } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
@@ -45,12 +46,10 @@ export function InstanceEditingPanel() {
 	return (
 		<>
 			<PanelHeader sx={ { justifyContent: 'start', px: 2 } }>
-				<Stack direction="row" alignContent="space-between" flexGrow={ 1 }>
-					<Stack direction="row" alignItems="center" justifyContent="start" gap={ 1 } flexGrow={ 1 }>
-						<ComponentsIcon fontSize="small" sx={ { color: 'text.tertiary' } } />
-						<PanelHeaderTitle>{ component.name }</PanelHeaderTitle>
-					</Stack>
-					<Tooltip title={ panelTitle }>
+				<Stack direction="row" alignItems="center" flexGrow={ 1 } gap={ 1 } maxWidth="100%">
+					<ComponentsIcon fontSize="small" sx={ { color: 'text.tertiary' } } />
+					<EllipsisWithTooltip title={ component.name } as={ PanelHeaderTitle } />
+					<Tooltip title={ panelTitle } sx={ { marginLeft: 'auto' } }>
 						<IconButton size="tiny" onClick={ handleEditComponent } aria-label={ panelTitle }>
 							<PencilIcon fontSize="tiny" />
 						</IconButton>

--- a/packages/packages/core/editor-panels/src/components/external/panel-header-title.tsx
+++ b/packages/packages/core/editor-panels/src/components/external/panel-header-title.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { forwardRef } from 'react';
 import { styled, Typography as TypographySource, type TypographyProps } from '@elementor/ui';
 
 // This is to override Editor reset.scss that overrides eui styles
@@ -14,10 +15,12 @@ const Typography = styled( TypographySource )< TypographyProps >( ( { theme, var
 	};
 } );
 
-export default function PanelHeaderTitle( { children, ...props }: TypographyProps ) {
+const PanelHeaderTitle = forwardRef< HTMLHeadingElement, TypographyProps >( ( { children, ...props }, ref ) => {
 	return (
-		<Typography component="h2" variant="subtitle1" { ...props }>
+		<Typography ref={ ref } component="h2" variant="subtitle1" { ...props }>
 			{ children }
 		</Typography>
 	);
-}
+} );
+
+export default PanelHeaderTitle;


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add ellipsis with tooltip to component header title to prevent text overflow and improve readability in the instance editing panel.

Main changes:
- Integrated EllipsisWithTooltip component to truncate long component names in panel header with hover tooltip
- Refactored PanelHeaderTitle to forwardRef component enabling ref forwarding for tooltip positioning
- Simplified PanelHeader layout by removing nested Stack components and adding maxWidth constraint

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
