### PR TITLE
Internal: Allow empty overridable origin value [ED-22351]

### DIFF
--- a/modules/components/prop-types/overridable-prop-type.php
+++ b/modules/components/prop-types/overridable-prop-type.php
@@ -29,28 +29,21 @@ class Overridable_Prop_Type extends Plain_Prop_Type {
 			return false;
 		}
 
-		$required_fields = [
-			'override_key' => 'is_string',
-			'origin_value' => 'is_array',
-		];
+		if ( ! array_key_exists( 'override_key', $value ) || ! is_string( $value['override_key'] ) ) {
+			return false;
+		}
 
-		$is_valid_structure = true;
-		foreach ( $required_fields as $field => $validator ) {
-			if ( ! array_key_exists( $field, $value ) || ! call_user_func( $validator, $value[ $field ] ) ) {
-				$is_valid_structure = false;
-				break;
-			}
+		if ( ! array_key_exists( 'origin_value', $value ) ) {
+			return false;
 		}
 
 		$origin_prop_type = $this->get_origin_prop_type();
 
-		if ( ! $is_valid_structure || ! $origin_prop_type ) {
+		if ( ! $origin_prop_type ) {
 			return false;
 		}
 
-		['origin_value' => $origin_value] = $value;
-
-		return $origin_prop_type->validate( $origin_value );
+		return $origin_prop_type->validate( $value['origin_value'] );
 	}
 
 	protected function sanitize_value( $value ): ?array {
@@ -63,7 +56,7 @@ class Overridable_Prop_Type extends Plain_Prop_Type {
 		}
 
 		$sanitized_override_key = sanitize_key( $override_key );
-		$sanitized_origin_value = $origin_prop_type->sanitize( $origin_value );
+		$sanitized_origin_value = is_null( $origin_value ) ? null : $origin_prop_type->sanitize( $origin_value );
 
 		return [
 			'override_key' => $sanitized_override_key,

--- a/tests/phpunit/elementor/modules/components/prop-types/test-overridable-prop-type.php
+++ b/tests/phpunit/elementor/modules/components/prop-types/test-overridable-prop-type.php
@@ -66,6 +66,48 @@ class Test_Overridable_Prop_Type extends Elementor_Test_Base {
 		$this->assertFalse( $result );
 	}
 
+	public function test_validate__passes_with_null_origin_value() {
+		// Arrange
+		$prop_type = Overridable_Prop_Type::make()
+			->set_origin_prop_type( String_Prop_Type::make() );
+
+		// Act
+		$result = $prop_type->validate( [
+			'$$type' => 'overridable',
+			'value' => [
+				'override_key' => 'my-override-key',
+				'origin_value' => null,
+			],
+		] );
+
+		// Assert
+		$this->assertTrue( $result );
+	}
+
+	public function test_sanitize__handles_null_origin_value() {
+		// Arrange
+		$prop_type = Overridable_Prop_Type::make()
+			->set_origin_prop_type( String_Prop_Type::make() );
+
+		// Act
+		$result = $prop_type->sanitize( [
+			'$$type' => 'overridable',
+			'value' => [
+				'override_key' => 'my-override-key',
+				'origin_value' => null,
+			],
+		] );
+
+		// Assert
+		$this->assertEquals( [
+			'$$type' => 'overridable',
+			'value' => [
+				'override_key' => 'my-override-key',
+				'origin_value' => null,
+			],
+		], $result );
+	}
+
 	public function test_validate__fails_when_origin_value_invalid_against_origin_prop_type() {
 		// Arrange
 		$prop_type = Overridable_Prop_Type::make()


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Allow null/empty origin values in overridable property types by removing strict type validation and adding null-safe sanitization to support optional origin values.

Main changes:
- Refactored validation logic to accept null origin_value instead of requiring array type, enabling optional origin configurations
- Added null-safe sanitization in sanitize_value() method to prevent errors when origin_value is null
- Added test coverage for null origin_value validation and sanitization workflows

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
