### PR TITLE
Revert "Fix: Slide animation distance to move elements completely off-screen [ED-21995]"

### DIFF
--- a/modules/interactions/assets/js/editor-interactions.js
+++ b/modules/interactions/assets/js/editor-interactions.js
@@ -29,7 +29,7 @@ function extractAnimationId( interaction ) {
 }
 
 function applyAnimation( element, animConfig, animateFunc ) {
-	const keyframes = getKeyframes( animConfig.effect, animConfig.type, animConfig.direction, element );
+	const keyframes = getKeyframes( animConfig.effect, animConfig.type, animConfig.direction );
 	const options = {
 		duration: animConfig.duration / 1000,
 		delay: animConfig.delay / 1000,

--- a/modules/interactions/assets/js/interactions-utils.js
+++ b/modules/interactions/assets/js/interactions-utils.js
@@ -8,43 +8,12 @@ export const config = window.ElementorInteractionsConfig?.constants || {
 	easing: 'linear',
 };
 
-function calculateSlideDistance( element, direction ) {
-	if ( ! element ) {
-		return config.slideDistance;
-	}
-
-	const rect = element.getBoundingClientRect();
-	const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
-	const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-	const isLtr = 'ltr' === document.documentElement.dir || 'ltr' === document.body.dir;
-
-	switch ( direction ) {
-		case 'left':
-			return Math.min( ( isLtr ? rect.left : rect.right ) + rect.width, viewportWidth + rect.width );
-		case 'right':
-			return Math.min( viewportWidth - ( isLtr ? rect.right : rect.left ) + rect.width, viewportWidth + rect.width );
-		case 'top':
-			return Math.min( rect.top + rect.height, viewportHeight + rect.height );
-		case 'bottom':
-			return Math.min( viewportHeight - rect.bottom + rect.height, viewportHeight + rect.height );
-		default:
-			return config.slideDistance;
-	}
-}
-
-export function getKeyframes( effect, type, direction, element = null ) {
+export function getKeyframes( effect, type, direction ) {
 	const isIn = 'in' === type;
 	const keyframes = {};
-	const hasDirection = !! direction;
 
 	if ( 'fade' === effect ) {
-		if ( hasDirection && isIn ) {
-			keyframes.opacity = [ 0, 0, 0.2, 0.6, 1 ];
-		} else if ( hasDirection && ! isIn ) {
-			keyframes.opacity = [ 1, 0.8, 0.4, 0, 0 ];
-		} else {
-			keyframes.opacity = isIn ? [ 0, 1 ] : [ 1, 0 ];
-		}
+		keyframes.opacity = isIn ? [ 0, 1 ] : [ 1, 0 ];
 	}
 
 	if ( 'scale' === effect ) {
@@ -52,7 +21,7 @@ export function getKeyframes( effect, type, direction, element = null ) {
 	}
 
 	if ( direction ) {
-		const distance = calculateSlideDistance( element, direction );
+		const distance = config.slideDistance;
 		const movement = {
 			left: { x: isIn ? [ -distance, 0 ] : [ 0, -distance ] },
 			right: { x: isIn ? [ distance, 0 ] : [ 0, distance ] },

--- a/modules/interactions/assets/js/interactions.js
+++ b/modules/interactions/assets/js/interactions.js
@@ -2,7 +2,7 @@ import { config, getKeyframes, parseAnimationName } from './interactions-utils.j
 
 function scrollOutAnimation( element, transition, animConfig, keyframes, options, animateFunc, inViewFunc ) {
 	const viewOptions = { amount: 0.85, root: null };
-	const resetKeyframes = getKeyframes( animConfig.effect, 'in', animConfig.direction, element );
+	const resetKeyframes = getKeyframes( animConfig.effect, 'in', animConfig.direction );
 
 	animateFunc( element, resetKeyframes, { duration: 0 } );
 
@@ -37,7 +37,7 @@ function defaultAnimation( element, transition, keyframes, options, animateFunc 
 }
 
 function applyAnimation( element, animConfig, animateFunc, inViewFunc ) {
-	const keyframes = getKeyframes( animConfig.effect, animConfig.type, animConfig.direction, element );
+	const keyframes = getKeyframes( animConfig.effect, animConfig.type, animConfig.direction );
 	const options = {
 		duration: animConfig.duration / 1000,
 		delay: animConfig.delay / 1000,


### PR DESCRIPTION
Reverts elementor/elementor#33850
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert previous changes to animation distance calculation that adjusted slide animations based on element position and viewport dimensions.

Main changes:
- Removed calculateSlideDistance() function that computed element-specific animation distances based on viewport boundaries
- Restored fixed slideDistance value from config instead of dynamic distance calculations
- Simplified fade animation opacity keyframes by removing directional multi-step transitions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
