### PR TITLE
Internal: Update component overrides render test mock data [ED-22449]

### DIFF
--- a/tests/phpunit/elementor/modules/components/test-components-ovrrides-rendering.php
+++ b/tests/phpunit/elementor/modules/components/test-components-ovrrides-rendering.php
@@ -223,7 +223,7 @@ class Test_Components_Overrides_Rendering extends Elementor_Test_Base {
                                     'value' => [
                                         'override_key' => 'prop-6',
                                         'override_value' => [
-                                            '$$type' => 'string',
+                                            '$$type' => 'html',
                                             'value' => $accordion_title,
                                         ],
                                         'schema_source' => [
@@ -237,7 +237,7 @@ class Test_Components_Overrides_Rendering extends Elementor_Test_Base {
                                     'value' => [
                                         'override_key' => 'prop-7',
                                         'override_value' => [
-                                            '$$type' => 'string',
+                                            '$$type' => 'html',
                                             'value' => $accordion_subtitle,
                                         ],
                                         'schema_source' => [
@@ -276,7 +276,7 @@ class Test_Components_Overrides_Rendering extends Elementor_Test_Base {
                                     'value' => [
                                         'override_key' => 'prop-9',
                                         'override_value' => [
-                                            '$$type' => 'string',
+                                            '$$type' => 'html',
                                             'value' => $first_card_title,
                                         ],
                                     ],
@@ -352,7 +352,7 @@ class Test_Components_Overrides_Rendering extends Elementor_Test_Base {
                                     'value' => [
                                         'override_key' => 'prop-13',
                                         'override_value' => [
-                                            '$$type' => 'string',
+                                            '$$type' => 'html',
                                             'value' => $second_card_title,
                                         ],
                                         'schema_source' => [


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update test mock data to use correct 'html' type instead of 'string' for component override values in rendering tests.

Main changes:
- Changed $$type from 'string' to 'html' for accordion_title and accordion_subtitle override values
- Updated $$type for first_card_title and second_card_title component override mock data
- Corrected type declarations across four override_value configurations in test fixtures

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
