### PR TITLE
Internal: Fix failing Home screen tests when Editor One is experiment is active [ED-22448]

### DIFF
--- a/tests/phpunit/elementor/modules/home/transformations/test-filter-add-ons-by-license.php
+++ b/tests/phpunit/elementor/modules/home/transformations/test-filter-add-ons-by-license.php
@@ -31,11 +31,11 @@ class Test_Filter_Add_Ons_By_License extends PHPUnit_TestCase {
 			return 'pro';
 		} );
 
-		$original_data = $this->mock_home_screen_data_with_hide_section_free();
+		$original_data = $this->mock_home_screen_data_with_hide_section_pro();
 		$transformation = new Filter_Add_Ons_By_License( [] );
 
 		$transformed_data = $transformation->transform( $original_data );
-		$expected_data = $this->mock_home_screen_data_with_hide_section_free();
+		$expected_data = $this->mock_home_screen_data_with_hide_section_pro();
 
 		$this->assertEquals( $expected_data, $transformed_data );
 		$this->assertArrayHasKey( 'add_ons', $transformed_data );
@@ -60,6 +60,28 @@ class Test_Filter_Add_Ons_By_License extends PHPUnit_TestCase {
 		return [
 			'add_ons' => [
 				'hide_section' => [ 'one' ],
+				'header' => [
+					'title' => 'Test Add-ons Title',
+					'description' => 'Test description',
+				],
+				'repeater' => [
+					[
+						'title' => 'Test Plugin',
+						'url' => 'https://example.com',
+					],
+				],
+			],
+			'misc' => [
+				'Name' => 'Microsoft',
+				'Version' => 'Windows',
+			],
+		];
+	}
+
+	private function mock_home_screen_data_with_hide_section_pro() {
+		return [
+			'add_ons' => [
+				'hide_section' => [ 'pro' ],
 				'header' => [
 					'title' => 'Test Add-ons Title',
 					'description' => 'Test description',

--- a/tests/phpunit/elementor/modules/home/transformations/test-filter-add-ons-by-license.php
+++ b/tests/phpunit/elementor/modules/home/transformations/test-filter-add-ons-by-license.php
@@ -1,23 +1,10 @@
 <?php
 namespace Elementor\Tests\Phpunit\Elementor\Modules\Home\Transformations;
 
-use Elementor\Core\Experiments\Manager as Experiments_Manager;
-use Elementor\Modules\EditorOne\Module as EditorOneModule;
 use Elementor\Modules\Home\Transformations\Filter_Add_Ons_By_License;
-use Elementor\Plugin;
 use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 
 class Test_Filter_Add_Ons_By_License extends PHPUnit_TestCase {
-
-	public function setUp(): void {
-		parent::setUp();
-
-		$experiments = Plugin::$instance->experiments;
-		$experiments->set_feature_default_state(
-			EditorOneModule::EXPERIMENT_NAME,
-			Experiments_Manager::STATE_INACTIVE
-		);
-	}
 
 	public function tearDown(): void {
 		remove_all_filters( 'elementor/admin/homescreen_promotion_tier' );
@@ -72,7 +59,7 @@ class Test_Filter_Add_Ons_By_License extends PHPUnit_TestCase {
 	private function mock_home_screen_data_with_hide_section_free() {
 		return [
 			'add_ons' => [
-				'hide_section' => [ 'free' ],
+				'hide_section' => [ 'one' ],
 				'header' => [
 					'title' => 'Test Add-ons Title',
 					'description' => 'Test description',
@@ -122,5 +109,4 @@ class Test_Filter_Add_Ons_By_License extends PHPUnit_TestCase {
 		];
 	}
 }
-
 

--- a/tests/phpunit/elementor/modules/home/transformations/test-filter-get-started-by-license.php
+++ b/tests/phpunit/elementor/modules/home/transformations/test-filter-get-started-by-license.php
@@ -14,7 +14,7 @@ class Test_Filter_Get_Started_By_License extends PHPUnit_TestCase {
 
 		// Act
 		$transformed_data = $transformation->transform( $original_data );
-		$expected_data = $this->mock_home_screen_data_transformed_core();
+		$expected_data = $this->mock_home_screen_data_transformed_pro();
 
 		// Assert
 		$this->assertEquals( $transformed_data, $expected_data );
@@ -43,6 +43,14 @@ class Test_Filter_Get_Started_By_License extends PHPUnit_TestCase {
 						'key' => 'value',
 					],
 					'license' => [
+						'one'
+					],
+				],
+				[
+					'thing' => [
+						'key' => 'value',
+					],
+					'license' => [
 						'free'
 					],
 				],
@@ -52,14 +60,6 @@ class Test_Filter_Get_Started_By_License extends PHPUnit_TestCase {
 					],
 					'license' => [
 						'pro'
-					],
-				],
-				[
-					'thing' => [
-						'key' => 'value',
-					],
-					'license' => [
-						'one'
 					],
 				],
 			],

--- a/tests/phpunit/elementor/modules/home/transformations/test-filter-get-started-by-license.php
+++ b/tests/phpunit/elementor/modules/home/transformations/test-filter-get-started-by-license.php
@@ -1,23 +1,10 @@
 <?php
 namespace Elementor\Tests\Phpunit\Elementor\Modules\Home\Transformations;
 
-use Elementor\Core\Experiments\Manager as Experiments_Manager;
-use Elementor\Modules\EditorOne\Module as EditorOneModule;
 use Elementor\Modules\Home\Transformations\Filter_Get_Started_By_License;
-use Elementor\Plugin;
 use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 
 class Test_Filter_Get_Started_By_License extends PHPUnit_TestCase {
-
-	public function setUp(): void {
-		parent::setUp();
-
-		$experiments = Plugin::$instance->experiments;
-		$experiments->set_feature_default_state(
-			EditorOneModule::EXPERIMENT_NAME,
-			Experiments_Manager::STATE_INACTIVE
-		);
-	}
 
 	public function test_transform__core_plugin() {
 		// Arrange
@@ -67,6 +54,14 @@ class Test_Filter_Get_Started_By_License extends PHPUnit_TestCase {
 						'pro'
 					],
 				],
+				[
+					'thing' => [
+						'key' => 'value',
+					],
+					'license' => [
+						'one'
+					],
+				],
 			],
 			'misc' => [
 				'Name' => 'Microsoft',
@@ -99,7 +94,7 @@ class Test_Filter_Get_Started_By_License extends PHPUnit_TestCase {
 					'key' => 'value',
 				],
 				'license' => [
-					'pro'
+					'one'
 				],
 			],
 			'misc' => [

--- a/tests/phpunit/elementor/modules/home/transformations/test-filter-sidebar-promotion-by-license.php
+++ b/tests/phpunit/elementor/modules/home/transformations/test-filter-sidebar-promotion-by-license.php
@@ -1,23 +1,10 @@
 <?php
 namespace Elementor\Tests\Phpunit\Elementor\Modules\Home\Transformations;
 
-use Elementor\Core\Experiments\Manager as Experiments_Manager;
-use Elementor\Modules\EditorOne\Module as EditorOneModule;
 use Elementor\Modules\Home\Transformations\Filter_Sidebar_Promotion_By_License;
-use Elementor\Plugin;
 use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 
 class Test_Filter_Sidebar_Promotion_By_License extends PHPUnit_TestCase {
-
-	public function setUp(): void {
-		parent::setUp();
-
-		$experiments = Plugin::$instance->experiments;
-		$experiments->set_feature_default_state(
-			EditorOneModule::EXPERIMENT_NAME,
-			Experiments_Manager::STATE_INACTIVE
-		);
-	}
 
 	public function test_transform__core_plugin() {
 		// Arrange
@@ -85,6 +72,15 @@ class Test_Filter_Sidebar_Promotion_By_License extends PHPUnit_TestCase {
 					],
 					'is_enabled' => 'true',
 				],
+				[
+					'data' => [
+						'key' => 'value',
+					],
+					'license' => [
+						'one'
+					],
+					'is_enabled' => 'true',
+				],
 			],
 			'misc' => [
 				'Name' => 'Microsoft',
@@ -122,7 +118,6 @@ class Test_Filter_Sidebar_Promotion_By_License extends PHPUnit_TestCase {
 		];
 	}
 
-
 	private function mock_home_screen_data_transformed_core() {
 		return [
 			'sidebar_promotion_variants' => [
@@ -130,7 +125,7 @@ class Test_Filter_Sidebar_Promotion_By_License extends PHPUnit_TestCase {
 					'key' => 'value',
 				],
 				'license' => [
-					'free'
+					'one'
 				],
 				'is_enabled' => 'true',
 			],
@@ -148,7 +143,7 @@ class Test_Filter_Sidebar_Promotion_By_License extends PHPUnit_TestCase {
 					'key' => 'value',
 				],
 				'license' => [
-					'pro'
+					'one'
 				],
 				'is_enabled' => 'true',
 			],
@@ -168,4 +163,3 @@ class Test_Filter_Sidebar_Promotion_By_License extends PHPUnit_TestCase {
 		];
 	}
 }
-

--- a/tests/phpunit/elementor/modules/home/transformations/test-filter-top-section-by-license.php
+++ b/tests/phpunit/elementor/modules/home/transformations/test-filter-top-section-by-license.php
@@ -29,7 +29,7 @@ class Test_Filter_Top_Section_By_License extends PHPUnit_TestCase {
 
 		// Act
 		$transformed_data = $transformation->transform( $original_data );
-		$expected_data = $this->mock_top_section_data_transformed_core();
+		$expected_data = $this->mock_top_section_data_transformed_one();
 
 		// Assert
 		$this->assertEquals( $transformed_data, $expected_data );
@@ -74,9 +74,6 @@ class Test_Filter_Top_Section_By_License extends PHPUnit_TestCase {
 	private function mock_top_section_data() {
 		return [
 			'top_with_licences' => [
-				$this->mock_top_section_data_transformed_core()['top_with_licences'],
-				$this->mock_top_section_data_transformed_pro()['top_with_licences'],
-				$this->mock_top_section_data_transformed_essential()['top_with_licences'],
 				[
 					'thing' => [
 						'key' => 'value',
@@ -85,6 +82,9 @@ class Test_Filter_Top_Section_By_License extends PHPUnit_TestCase {
 						'one'
 					],
 				],
+				$this->mock_top_section_data_transformed_core()['top_with_licences'],
+				$this->mock_top_section_data_transformed_pro()['top_with_licences'],
+				$this->mock_top_section_data_transformed_essential()['top_with_licences'],
 			],
 			'misc' => [
 				'Name' => 'Microsoft',
@@ -128,6 +128,23 @@ class Test_Filter_Top_Section_By_License extends PHPUnit_TestCase {
 	}
 
 	private function mock_top_section_data_transformed_essential() {
+		return [
+			'top_with_licences' => [
+				'thing' => [
+					'key' => 'value',
+				],
+				'license' => [
+					'one'
+				],
+			],
+			'misc' => [
+				'Name' => 'Microsoft',
+				'Version' => 'Windows',
+			],
+		];
+	}
+
+	private function mock_top_section_data_transformed_one() {
 		return [
 			'top_with_licences' => [
 				'thing' => [

--- a/tests/phpunit/elementor/modules/home/transformations/test-filter-top-section-by-license.php
+++ b/tests/phpunit/elementor/modules/home/transformations/test-filter-top-section-by-license.php
@@ -2,21 +2,12 @@
 
 namespace Elementor\Tests\Phpunit\Elementor\Modules\Home\Transformations;
 
-use Elementor\Core\Experiments\Manager as Experiments_Manager;
-use Elementor\Modules\EditorOne\Module as EditorOneModule;
 use Elementor\Modules\Home\Transformations\Filter_Top_Section_By_License;
-use Elementor\Plugin;
 use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 
 class Test_Filter_Top_Section_By_License extends PHPUnit_TestCase {
 	public function setUp(): void {
 		parent::setUp();
-
-		$experiments = Plugin::$instance->experiments;
-		$experiments->set_feature_default_state(
-			EditorOneModule::EXPERIMENT_NAME,
-			Experiments_Manager::STATE_INACTIVE
-		);
 
 		add_filter( 'elementor/admin/homescreen_promotion_tier', function() {
 			return 'free';
@@ -86,6 +77,14 @@ class Test_Filter_Top_Section_By_License extends PHPUnit_TestCase {
 				$this->mock_top_section_data_transformed_core()['top_with_licences'],
 				$this->mock_top_section_data_transformed_pro()['top_with_licences'],
 				$this->mock_top_section_data_transformed_essential()['top_with_licences'],
+				[
+					'thing' => [
+						'key' => 'value',
+					],
+					'license' => [
+						'one'
+					],
+				],
 			],
 			'misc' => [
 				'Name' => 'Microsoft',
@@ -118,7 +117,7 @@ class Test_Filter_Top_Section_By_License extends PHPUnit_TestCase {
 					'key' => 'value',
 				],
 				'license' => [
-					'pro'
+					'one'
 				],
 			],
 			'misc' => [
@@ -135,7 +134,7 @@ class Test_Filter_Top_Section_By_License extends PHPUnit_TestCase {
 					'key' => 'value',
 				],
 				'license' => [
-					'pro'
+					'one'
 				],
 			],
 			'misc' => [


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix failing PHPUnit tests in Home screen module by removing Editor One experiment state initialization that was interfering with test execution when experiment is active.

Main changes:
- Removed setUp() methods that forcibly set Editor One experiment to inactive state across all transformation test classes
- Updated test mock data to use 'one' tier instead of 'free'/'pro' tiers for license filtering validation
- Added new mock method for 'one' tier transformation data in top section license filter test

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
