### PR TITLE
Internal: Create control rerenders control

### DIFF
--- a/packages/packages/core/editor-components/src/components/overridable-props/__tests__/overridable-prop-control.test.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/__tests__/overridable-prop-control.test.tsx
@@ -343,11 +343,6 @@ const DYNAMIC_TYPE = 'dynamic';
 
 const isDynamicValue = ( value: unknown ) => isTransformable( value ) && value.$$type === DYNAMIC_TYPE;
 
-const dynamicReplacement: ControlReplacement = {
-	component: () => <div role="alert">Dynamic Control Replacement</div>,
-	condition: ( { value } ) => isDynamicValue( value ),
-};
-
 describe( 'OverridablePropControl with control replacements', () => {
 	let store: Store< ComponentsSlice >;
 
@@ -370,7 +365,7 @@ describe( 'OverridablePropControl with control replacements', () => {
 			elementType: mockElementType,
 		} );
 
-		mockGetControlReplacements.mockReturnValue( [ dynamicReplacement ] );
+		mockGetControlReplacements.mockReturnValue( [] );
 	} );
 
 	afterEach( () => {
@@ -379,6 +374,13 @@ describe( 'OverridablePropControl with control replacements', () => {
 
 	it( 'should apply control replacement when inner value matches replacement condition', () => {
 		// Arrange
+		const dynamicReplacement: ControlReplacement = {
+			component: () => <div role="alert">Dynamic Control Replacement</div>,
+			condition: ( { value } ) => isDynamicValue( value ),
+		};
+
+		mockGetControlReplacements.mockReturnValue( [ dynamicReplacement ] );
+
 		const dynamicOriginValue = createMockDynamicValue( 'test-tag', 'test-group' );
 
 		const value = componentOverridablePropTypeUtil.create( {
@@ -399,6 +401,13 @@ describe( 'OverridablePropControl with control replacements', () => {
 
 	it( 'should render original control when inner value does not match any replacement condition', () => {
 		// Arrange
+		const dynamicReplacement: ControlReplacement = {
+			component: () => <div role="alert">Dynamic Control Replacement</div>,
+			condition: ( { value } ) => isDynamicValue( value ),
+		};
+
+		mockGetControlReplacements.mockReturnValue( [ dynamicReplacement ] );
+
 		const value = componentOverridablePropTypeUtil.create( {
 			override_key: MOCK_OVERRIDE_KEY,
 			origin_value: stringPropTypeUtil.create( 'Regular Text Value' ),
@@ -423,12 +432,12 @@ describe( 'OverridablePropControl with control replacements', () => {
 			</div>
 		);
 
-		mockGetControlReplacements.mockReturnValue( [
-			{
-				component: ReplacementWithOriginal,
-				condition: ( { value } ) => isDynamicValue( value ),
-			},
-		] );
+		const dynamicReplacement: ControlReplacement = {
+			component: ReplacementWithOriginal,
+			condition: ( { value } ) => isDynamicValue( value ),
+		};
+
+		mockGetControlReplacements.mockReturnValue( [ dynamicReplacement ] );
 
 		const dynamicOriginValue = createMockDynamicValue( 'test-tag', 'test-group' );
 

--- a/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-control.tsx
+++ b/packages/packages/core/editor-components/src/components/overridable-props/overridable-prop-control.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { type ComponentType } from 'react';
 import {
 	ControlReplacementsProvider,
-	createControl,
 	PropKeyProvider,
 	PropProvider,
 	useBoundProp,
+	useControlReplacement,
 } from '@elementor/editor-controls';
 import { createTopLevelObjectType, getControlReplacements, useElement } from '@elementor/editor-editing-panel';
 import { type PropValue } from '@elementor/editor-props';
@@ -26,7 +26,6 @@ export function OverridablePropControl< T extends object >( {
 	...props
 }: T & { OriginalControl: ComponentType< T > } ) {
 	const { elementType } = useElement();
-	const Control = createControl( OriginalControl );
 
 	const { value, bind, setValue, placeholder, ...propContext } = useBoundProp( componentOverridablePropTypeUtil );
 	const componentId = useCurrentComponentId();
@@ -97,10 +96,31 @@ export function OverridablePropControl< T extends object >( {
 			>
 				<PropKeyProvider bind={ bind }>
 					<ControlReplacementsProvider replacements={ filteredReplacements }>
-						<Control { ...( props as T ) } />
+						<ControlWithReplacements OriginalControl={ OriginalControl } props={ props as T } />
 					</ControlReplacementsProvider>
 				</PropKeyProvider>
 			</PropProvider>
 		</OverridablePropProvider>
 	);
+}
+
+type ControlComponentType = ComponentType< object & { OriginalControl: ComponentType } >;
+
+function ControlWithReplacements< T extends object >( {
+	OriginalControl,
+	props,
+}: {
+	OriginalControl: ComponentType< T >;
+	props: T;
+} ) {
+	const { ControlToRender, isReplaced } = useControlReplacement( OriginalControl as ControlComponentType );
+
+	if ( isReplaced ) {
+		const ReplacementControl = ControlToRender as unknown as ComponentType<
+			T & { OriginalControl: ComponentType< T > }
+		>;
+		return <ReplacementControl { ...props } OriginalControl={ OriginalControl } />;
+	}
+
+	return <OriginalControl { ...props } />;
 }

--- a/packages/packages/libs/editor-controls/src/index.ts
+++ b/packages/packages/libs/editor-controls/src/index.ts
@@ -68,6 +68,7 @@ export type { FontCategory } from './controls/font-family-control/font-family-co
 export {
 	createControlReplacementsRegistry,
 	ControlReplacementsProvider,
+	useControlReplacement,
 	type ControlReplacement,
 } from './control-replacements';
 export { ControlActionsProvider, useControlActions } from './control-actions/control-actions-context';


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor control replacement logic to prevent unnecessary rerenders by moving createControl call from component body to dedicated hook-based component.

Main changes:
- Replaced inline createControl() with useControlReplacement hook to memoize control creation and prevent rerenders
- Extracted ControlWithReplacements component to handle control replacement logic with proper React rendering pattern
- Moved dynamic replacement definitions from global scope into test cases for better test isolation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
