### PR TITLE
Internal: Add tooltip to component properties button [ED-22499]

### DIFF
--- a/packages/packages/core/editor-components/src/components/component-panel-header/__tests__/component-panel-header.test.tsx
+++ b/packages/packages/core/editor-components/src/components/component-panel-header/__tests__/component-panel-header.test.tsx
@@ -192,7 +192,7 @@ describe( '<ComponentPanelHeader />', () => {
 		renderWithStore( <ComponentPanelHeader />, store );
 
 		// Act
-		const badgeButton = screen.getByLabelText( 'View exposed properties' );
+		const badgeButton = screen.getByLabelText( 'Component properties' );
 		fireEvent.click( badgeButton );
 
 		// Assert

--- a/packages/packages/core/editor-components/src/components/component-panel-header/component-badge.tsx
+++ b/packages/packages/core/editor-components/src/components/component-panel-header/component-badge.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useEffect, useRef } from 'react';
 import { ComponentPropListIcon } from '@elementor/icons';
-import { Badge, Box, keyframes, styled, ToggleButton } from '@elementor/ui';
+import { Badge, Box, keyframes, styled, ToggleButton, Tooltip } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 export const ComponentsBadge = React.forwardRef<
@@ -26,14 +26,16 @@ export const ComponentsBadge = React.forwardRef<
 				</Box>
 			}
 		>
-			<ToggleButton
-				value="exposed properties"
-				size="tiny"
-				onClick={ onClick }
-				aria-label={ __( 'View exposed properties', 'elementor' ) }
-			>
-				<ComponentPropListIcon fontSize="tiny" />
-			</ToggleButton>
+			<Tooltip title={ __( 'Component properties', 'elementor' ) }>
+				<ToggleButton
+					value="exposed properties"
+					size="tiny"
+					onClick={ onClick }
+					aria-label={ __( 'Component properties', 'elementor' ) }
+				>
+					<ComponentPropListIcon fontSize="tiny" />
+				</ToggleButton>
+			</Tooltip>
 		</StyledBadge>
 	);
 } );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add tooltip to component properties button in editor UI to improve user experience and accessibility by providing contextual help on hover.

Main changes:
- Wrapped ToggleButton with Tooltip component displaying "Component properties" text on hover
- Updated aria-label from "View exposed properties" to "Component properties" for consistency
- Added Tooltip import from @elementor/ui package in component-badge.tsx

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
