### PR TITLE
Internal: Fix component header size [ED-22510]

### DIFF
--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/instance-editing-panel.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/instance-editing-panel.tsx
@@ -52,7 +52,7 @@ export function InstanceEditingPanel() {
 			<PanelHeader sx={ { justifyContent: 'start', px: 2 } }>
 				<Stack direction="row" alignItems="center" flexGrow={ 1 } gap={ 1 } maxWidth="100%">
 					<ComponentsIcon fontSize="small" sx={ { color: 'text.tertiary' } } />
-					<EllipsisWithTooltip title={ component.name } as={ PanelHeaderTitle } />
+					<EllipsisWithTooltip title={ component.name } as={ PanelHeaderTitle } sx={ { flexGrow: 1 } } />
 					{ canEdit && (
 						<Tooltip title={ panelTitle }>
 							<IconButton size="tiny" onClick={ handleEditComponent } aria-label={ panelTitle }>


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix component header title overflow by adding flex-grow styling to prevent text truncation and ensure proper ellipsis behavior in the instance editing panel.

Main changes:
- Added `sx={{ flexGrow: 1 }}` prop to EllipsisWithTooltip component for proper flex container behavior
- Ensures component name text fills available space before triggering ellipsis truncation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
