### PR TITLE
Fix: Theme builder - eligible and ineligible based on entry point [ED-22475]

### DIFF
--- a/app/admin-menu-items/editor-one-theme-builder-menu.php
+++ b/app/admin-menu-items/editor-one-theme-builder-menu.php
@@ -6,8 +6,8 @@ use Elementor\Core\Admin\EditorOneMenu\Interfaces\Menu_Item_Interface;
 use Elementor\Core\Admin\EditorOneMenu\Interfaces\Menu_Item_With_Custom_Url_Interface;
 use Elementor\Core\Admin\Menu\Interfaces\Admin_Menu_Item_With_Page;
 use Elementor\Modules\EditorOne\Classes\Menu_Config;
+use Elementor\Modules\EditorOne\Classes\Menu_Data_Provider;
 use Elementor\App\App;
-use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -28,7 +28,7 @@ class Editor_One_Theme_Builder_Menu implements Menu_Item_Interface, Admin_Menu_I
 	}
 
 	public function get_label(): string {
-		return esc_html__( 'Theme builder', 'elementor' );
+		return esc_html__( 'Theme Builder', 'elementor' );
 	}
 
 	public function get_position(): int {
@@ -40,14 +40,7 @@ class Editor_One_Theme_Builder_Menu implements Menu_Item_Interface, Admin_Menu_I
 	}
 
 	public function get_menu_url(): string {
-		$return_to = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
-
-		return add_query_arg(
-			[
-				'return_to' => $return_to,
-			],
-			Plugin::instance()->app->get_base_url()
-		) . '#/site-editor/promotion';
+		return Menu_Data_Provider::instance()->get_theme_builder_url();
 	}
 
 	public function get_group_id(): string {

--- a/tests/phpunit/elementor/modules/editor-one/snapshots/menu-config-snapshot.json
+++ b/tests/phpunit/elementor/modules/editor-one/snapshots/menu-config-snapshot.json
@@ -126,7 +126,7 @@
                 {
                     "slug": "elementor-app",
                     "label": "Theme Builder",
-                    "url": "/wp-admin/admin.php?page=elementor-app&ver=3.35.0&return_to=%2Fwp-admin%2Fpost.php%3Fpost%3D1454&action=elementor#/site-editor/promotion",
+                    "url": "/wp-admin/admin.php?page=elementor-app&ver=3.35.0&return_to=%2Fwp-admin%2Fpost.php%3Fpost%3D1454&action=elementor#site-editor/promotion",
                     "priority": 15
                 },
                 {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor Theme Builder menu URL generation to use centralized Menu_Data_Provider for dynamic entry point routing based on user eligibility status.

Main changes:
- Replaced inline URL construction with Menu_Data_Provider::instance()->get_theme_builder_url() for centralized eligibility-based routing logic
- Updated Menu_Data_Provider import replacing Plugin class dependency to improve architectural separation
- Standardized Theme Builder label capitalization from 'Theme builder' to 'Theme Builder' for UI consistency

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
