### PR TITLE
Internal: Bump packages [ED-22425]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@automattic/calypso-config/node_modules/@types/node": {
-      "version": "22.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
-      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "version": "22.19.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.6.tgz",
+      "integrity": "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -300,18 +300,18 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@ariakit/core": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.16.tgz",
-      "integrity": "sha512-nPJ0Be8d5ZvRApYGqdLMuYUjP7ktkPmTPOXyZFw+0Illk8LKgF3Q74ctVGuoQurJNDsANXcewzlyXK4vyIAGTA==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.18.tgz",
+      "integrity": "sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==",
       "license": "MIT"
     },
     "node_modules/@automattic/components/node_modules/@ariakit/react": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.19.tgz",
-      "integrity": "sha512-n6q8leSQWXMk4vhcZlpnj8cIlAY0n+1bvVTwHvaVfmec4LjW49MFKkJRZd1AiV+SE73nkxPwSL3IbaS4p1aRxQ==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.21.tgz",
+      "integrity": "sha512-UjP99Y7cWxA5seRECEE0RPZFImkLGFIWPflp65t0BVZwlMw4wp9OJZRHMrnkEkKl5KBE2NR/gbbzwHc6VNGzsA==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.19"
+        "@ariakit/react-core": "0.4.21"
       },
       "funding": {
         "type": "opencollective",
@@ -323,12 +323,12 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@ariakit/react-core": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.19.tgz",
-      "integrity": "sha512-Aj+fu4pMyPXtlBghI+E7KSWItqJkbAqEhut3DlsFAjK9fQdHE+e1tQJG1PtnoEdD9BExkJWQ6R4M5a9HkEhqPA==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.21.tgz",
+      "integrity": "sha512-rUI9uB/gT3mROFja/ka7/JukkdljIZR3eq3BGiQqX4Ni/KBMDvPK8FvVLnC0TGzWcqNY2bbfve8QllvHzuw4fQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/core": "0.4.16",
+        "@ariakit/core": "0.4.18",
         "@floating-ui/dom": "^1.0.0",
         "use-sync-external-store": "^1.2.0"
       },
@@ -355,23 +355,14 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@automattic/components/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
     "node_modules/@automattic/components/node_modules/@wordpress/a11y": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.35.0.tgz",
-      "integrity": "sha512-37DeBnBU20lLpQjwAZx0fkPsrrXT4COMSRhZOiFifv7wCiNW1DIukfqReAc/yZ6x0wOtqXKA3n905D8zm5NF5A==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.37.0.tgz",
+      "integrity": "sha512-OxJL0sBNy2IwFkrLv0X9tOgmdHbvgVajciN8T73S6jTh96iOmdISSb3n+I9fc81X0BB03rv4dh8q6zBb/67U6A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dom-ready": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/dom-ready": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -379,13 +370,13 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/a11y/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.10.0.tgz",
+      "integrity": "sha512-5tLAtnRQNxzA/d0GvVWCyo34Jb18w7xWTnup8hlh1+ehp7ZYTWR1QJihzVAteHoyrxAbTmzzsKyNtr8m+4ZpSQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
+        "@wordpress/hooks": "^4.37.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -470,19 +461,19 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/components/node_modules/@wordpress/compose": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.35.0.tgz",
-      "integrity": "sha512-UUQ31Rfi+KFfqT5wkbTgq0nMh+QfbLvshhm30+EGr8R3bYziHhfLKhIL2YQXf4MIX4owOFdKgbAt4GFeVI24ng==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -497,12 +488,12 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/components/node_modules/@wordpress/date": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.35.0.tgz",
-      "integrity": "sha512-xXJf703MtQCbgoAT1DSwRu+iWcgb6UFAoBnnzq8ohZCICsBxEGOOr+EAgblvFSNPV3MCtUOr98zRCAuGon3Gqw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.37.0.tgz",
+      "integrity": "sha512-T5YF5WLQu71bgw/KXhKcIqIRmAyf6nCq7J448MZlPIr0M9DAVPARXCOxYA4t/FW3PzwpFUARIuO2aNXTTO+nsA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0",
+        "@wordpress/deprecated": "^4.37.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -512,9 +503,9 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/components/node_modules/@wordpress/html-entities": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.35.0.tgz",
-      "integrity": "sha512-43K8viPNNWUxmCKfKN2Dx/TgJitbGeGCfWBj0aloRoeqOUeEuDkWoak+XiIrJKpwYHTYhqtePl7COMWPzwkqbw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.37.0.tgz",
+      "integrity": "sha512-d3uaAoGs20xpvdOTWlpTbxO4a8YwKYyBjoNhkL+w9qAg8NqLk9r2Z1pTj4EbYF9iS6SorDUdnXsTMuZ0/pm4Sw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -566,12 +557,12 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/deprecated": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.35.0.tgz",
-      "integrity": "sha512-+TruZtmDxRfVw02c1de7ofGC3CrcaPCUXCCbwfP6ruy1zM3IC3rtJfyTbqKPqO1y4uI+9Kqe5VEobqRKT3HQSg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.35.0"
+        "@wordpress/hooks": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -579,12 +570,12 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/dom": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.35.0.tgz",
-      "integrity": "sha512-mM/8m548RaWtkBonpCYHprXgyVFjKcFJWyHfWZz17j01xIbzBq+//cR/Lff86EiEuwynedqlFoEJUcgvPkrJZw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0"
+        "@wordpress/deprecated": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -592,9 +583,9 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/dom-ready": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.35.0.tgz",
-      "integrity": "sha512-u8ifPAFsIAkBG3ehcZdnt+b3t2S0gD3dyDMKgl+GO95wq6kJFqo/NYNQqsjeYUMOFX7cL9D0F2gxiBB4D/AQIA==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.37.0.tgz",
+      "integrity": "sha512-igored8VegL2n/koKIyUhgPLhUfTa4N6zWO4gZpyeznr49M5wP/9Ak/tvIljUts9McHc2CVnCYMjZV0Zyz2aWg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -602,14 +593,14 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/element": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.35.0.tgz",
-      "integrity": "sha512-RmxQsk0ANoHtxDc6anbUH/lHL7Mmbbdn016WKHYVh4+79EzN1tBeM8OML2gHpllUISmIYQvO4wIPSmEVzRh+Gw==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.35.0",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -621,9 +612,9 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/escape-html": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.35.0.tgz",
-      "integrity": "sha512-thY7RGAI6UijG3sbBm4IRzMX9lnHkEA/vR3Y0E5BGQYzNFwc+i7t1Lm4scpEBnL3UEQxdlD1wiJTH4pv5olV+Q==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -631,9 +622,9 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -690,9 +681,9 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.35.0.tgz",
-      "integrity": "sha512-ooM/QFzxu8Ueqsv0D/z0+X6grbVws3GFMSxdM12eZO1B0/x6JPAtq4msZkoxqeQ4zoR0ghYHFXzv3k+Ch1tsFw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -700,12 +691,12 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/keycodes": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.35.0.tgz",
-      "integrity": "sha512-+cvb9I4VorJRUsPC4C/2e0QWMz8hkjQIvjz3BjTkIXyWlxsSRSk/+a/YCrfyyA5ysuR9PgwKxxI7/ZaAPvOC6w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -713,13 +704,13 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.10.0.tgz",
+      "integrity": "sha512-5tLAtnRQNxzA/d0GvVWCyo34Jb18w7xWTnup8hlh1+ehp7ZYTWR1QJihzVAteHoyrxAbTmzzsKyNtr8m+4ZpSQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
+        "@wordpress/hooks": "^4.37.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -733,12 +724,12 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/primitives": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.35.0.tgz",
-      "integrity": "sha512-F7FqOM9tkgwc0DwFqsgtOcvREJgBHALbCBFwv1kmxRadknD6YsBdmpamceN2UIHi9NnOM0Gruo2vJNKjoN4bEw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.37.0.tgz",
+      "integrity": "sha512-iPpiS1tu1U5cXxVW6CQ45rqdnIc4Ev5FGyicuuaru0wboC+d2CwoNHxPFDOOpGL16yp8OfSDA13vQY3MJHw7QA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.35.0",
+        "@wordpress/element": "^6.37.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -750,9 +741,9 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/priority-queue": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.35.0.tgz",
-      "integrity": "sha512-kLdPx09CnPMPUL5hI/3SUgbBVEka20iWBxM2pvwJGrn3bleY0WxGqLtoUksn6yQds9d7jjS5cKoBYxY1H8MHgg==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -763,9 +754,9 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/private-apis": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.35.0.tgz",
-      "integrity": "sha512-gpwYCAuWSjSps7KnmPfUSdJUf5iq8P0ln1eZPcnjs3IwRDUrKW9eUrO0jID+XUsi63qi5c+lv9UkwI8M8C9c5A==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.37.0.tgz",
+      "integrity": "sha512-BR5GEHontWnza1tfBm2aX6/GjCZ1xZRrRNN1P0oj9xuvtut3YzCr//pZuyQ+P5maByDthUZjNrvN3UEF1iucbA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -773,13 +764,13 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/react-i18n": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/react-i18n/-/react-i18n-4.35.0.tgz",
-      "integrity": "sha512-nyVhZ96DLzD3TyKlVSNFvnhJNYxIDfyjAt7cpJ+cleKqCBzXZU6DOZa2WEWAiiMbEagmnuXPO1w/VonY/Wsqnw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/react-i18n/-/react-i18n-4.37.0.tgz",
+      "integrity": "sha512-p7TkrKwt8tQ4F6B3vACUKL/BiqEZ7WXaKH/ge4cVjt4mb/dpVq+ns0oBT0azQj/XdgqsqCgQ58UeSf967BzjyQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/i18n": "^6.8.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/i18n": "^6.10.0",
         "utility-types": "^3.10.0"
       },
       "engines": {
@@ -788,13 +779,13 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/react-i18n/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.10.0.tgz",
+      "integrity": "sha512-5tLAtnRQNxzA/d0GvVWCyo34Jb18w7xWTnup8hlh1+ehp7ZYTWR1QJihzVAteHoyrxAbTmzzsKyNtr8m+4ZpSQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
+        "@wordpress/hooks": "^4.37.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -808,19 +799,19 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/rich-text": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.35.0.tgz",
-      "integrity": "sha512-GhR9unaSAeVd2UQ6/WgYyAfP/xSE4VD43XuxY6hV4LaU0Qobi/N38Pamkln4eMhORcY8RzNQSkpFX27Nj/fxTQ==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.37.0.tgz",
+      "integrity": "sha512-uvLLVg77F4meoMMYjtdYcvo4eQxj3mKH8f9dKnkCrOyKOKNCdV5wHDUYWrySkgrAyoBJjTm8hZKK/U3adlPgEg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/escape-html": "^3.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/keycodes": "^4.35.0",
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/keycodes": "^4.37.0",
         "colord": "2.9.3",
         "memize": "^2.1.0"
       },
@@ -833,19 +824,19 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/rich-text/node_modules/@wordpress/compose": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.35.0.tgz",
-      "integrity": "sha512-UUQ31Rfi+KFfqT5wkbTgq0nMh+QfbLvshhm30+EGr8R3bYziHhfLKhIL2YQXf4MIX4owOFdKgbAt4GFeVI24ng==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -860,13 +851,13 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/rich-text/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.10.0.tgz",
+      "integrity": "sha512-5tLAtnRQNxzA/d0GvVWCyo34Jb18w7xWTnup8hlh1+ehp7ZYTWR1QJihzVAteHoyrxAbTmzzsKyNtr8m+4ZpSQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
+        "@wordpress/hooks": "^4.37.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -879,13 +870,13 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@automattic/components/node_modules/@wordpress/url": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.35.0.tgz",
-      "integrity": "sha512-h6KK0OePnc64T50BwVWmQb7xmcMW0XDtfh+1m/a0tlzXGLU4TnBjUUs+a0h0y6Tdla14lc2BtbLJLFwky06vbg==",
+    "node_modules/@automattic/components/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "remove-accents": "^0.5.0"
+        "@wordpress/is-shallow-equal": "^5.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -893,9 +884,9 @@
       }
     },
     "node_modules/@automattic/components/node_modules/@wordpress/warning": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.35.0.tgz",
-      "integrity": "sha512-2UGZuHenf84UHdotBxv9ZCtlsFIy5u4QTUPBnx1gH4N9zEuJs+JiCtlOzgcl0JzT3xFK5y3cXLLVqlhf8tDMBQ==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.37.0.tgz",
+      "integrity": "sha512-oXWyKiYJIa9SuPRNEJiOWn2Qk0RzfxOsDqXcus1OL44swCRtSM+ypm16CJpRhZpMUcsJ6d23PBxTC97C/iiJpQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -917,31 +908,6 @@
       "integrity": "sha512-gR6nY33xC9yJoH4wGLQtZQMXDi6RI3H37ERu7kQCVUzlXjNedpZM7xcA489Opwbq0BSGohtWGsWsntupmxelMg==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@automattic/components/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
-    },
-    "node_modules/@automattic/components/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
-    },
-    "node_modules/@automattic/components/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@automattic/create-calypso-config": {
@@ -981,29 +947,20 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@automattic/i18n-utils/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
     "node_modules/@automattic/i18n-utils/node_modules/@wordpress/compose": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.35.0.tgz",
-      "integrity": "sha512-UUQ31Rfi+KFfqT5wkbTgq0nMh+QfbLvshhm30+EGr8R3bYziHhfLKhIL2YQXf4MIX4owOFdKgbAt4GFeVI24ng==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -1018,12 +975,12 @@
       }
     },
     "node_modules/@automattic/i18n-utils/node_modules/@wordpress/deprecated": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.35.0.tgz",
-      "integrity": "sha512-+TruZtmDxRfVw02c1de7ofGC3CrcaPCUXCCbwfP6ruy1zM3IC3rtJfyTbqKPqO1y4uI+9Kqe5VEobqRKT3HQSg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.35.0"
+        "@wordpress/hooks": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -1031,12 +988,12 @@
       }
     },
     "node_modules/@automattic/i18n-utils/node_modules/@wordpress/dom": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.35.0.tgz",
-      "integrity": "sha512-mM/8m548RaWtkBonpCYHprXgyVFjKcFJWyHfWZz17j01xIbzBq+//cR/Lff86EiEuwynedqlFoEJUcgvPkrJZw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0"
+        "@wordpress/deprecated": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -1044,14 +1001,14 @@
       }
     },
     "node_modules/@automattic/i18n-utils/node_modules/@wordpress/element": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.35.0.tgz",
-      "integrity": "sha512-RmxQsk0ANoHtxDc6anbUH/lHL7Mmbbdn016WKHYVh4+79EzN1tBeM8OML2gHpllUISmIYQvO4wIPSmEVzRh+Gw==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.35.0",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -1063,9 +1020,9 @@
       }
     },
     "node_modules/@automattic/i18n-utils/node_modules/@wordpress/escape-html": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.35.0.tgz",
-      "integrity": "sha512-thY7RGAI6UijG3sbBm4IRzMX9lnHkEA/vR3Y0E5BGQYzNFwc+i7t1Lm4scpEBnL3UEQxdlD1wiJTH4pv5olV+Q==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -1073,9 +1030,9 @@
       }
     },
     "node_modules/@automattic/i18n-utils/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -1104,9 +1061,9 @@
       }
     },
     "node_modules/@automattic/i18n-utils/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.35.0.tgz",
-      "integrity": "sha512-ooM/QFzxu8Ueqsv0D/z0+X6grbVws3GFMSxdM12eZO1B0/x6JPAtq4msZkoxqeQ4zoR0ghYHFXzv3k+Ch1tsFw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -1114,12 +1071,12 @@
       }
     },
     "node_modules/@automattic/i18n-utils/node_modules/@wordpress/keycodes": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.35.0.tgz",
-      "integrity": "sha512-+cvb9I4VorJRUsPC4C/2e0QWMz8hkjQIvjz3BjTkIXyWlxsSRSk/+a/YCrfyyA5ysuR9PgwKxxI7/ZaAPvOC6w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -1127,13 +1084,13 @@
       }
     },
     "node_modules/@automattic/i18n-utils/node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.10.0.tgz",
+      "integrity": "sha512-5tLAtnRQNxzA/d0GvVWCyo34Jb18w7xWTnup8hlh1+ehp7ZYTWR1QJihzVAteHoyrxAbTmzzsKyNtr8m+4ZpSQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
+        "@wordpress/hooks": "^4.37.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -1147,9 +1104,9 @@
       }
     },
     "node_modules/@automattic/i18n-utils/node_modules/@wordpress/priority-queue": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.35.0.tgz",
-      "integrity": "sha512-kLdPx09CnPMPUL5hI/3SUgbBVEka20iWBxM2pvwJGrn3bleY0WxGqLtoUksn6yQds9d7jjS5cKoBYxY1H8MHgg==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -1159,11 +1116,18 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@automattic/i18n-utils/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
+    "node_modules/@automattic/i18n-utils/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
     },
     "node_modules/@automattic/interpolate-components": {
       "version": "1.2.1",
@@ -1215,9 +1179,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@automattic/number-formatters": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@automattic/number-formatters/-/number-formatters-1.0.14.tgz",
-      "integrity": "sha512-SP4NuRAQEJsTzO7nZsljVB9wtwPb0jYc7qqD95hnHnWkp6FykCerQSXo187+E726kAIXmgFU1drqzJtB8pdvSg==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@automattic/number-formatters/-/number-formatters-1.0.16.tgz",
+      "integrity": "sha512-U+WbYP9iObXrxygM5eFkksQ3wF/Qe7oU8ygrYfymCX935zkAPkP8t3rOcnr8G+/QmKRIG3Cq3Yr7kWq5vB3y3Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/date": "^5.19.0",
@@ -1226,12 +1190,12 @@
       }
     },
     "node_modules/@automattic/number-formatters/node_modules/@wordpress/date": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.35.0.tgz",
-      "integrity": "sha512-xXJf703MtQCbgoAT1DSwRu+iWcgb6UFAoBnnzq8ohZCICsBxEGOOr+EAgblvFSNPV3MCtUOr98zRCAuGon3Gqw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.37.0.tgz",
+      "integrity": "sha512-T5YF5WLQu71bgw/KXhKcIqIRmAyf6nCq7J448MZlPIr0M9DAVPARXCOxYA4t/FW3PzwpFUARIuO2aNXTTO+nsA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0",
+        "@wordpress/deprecated": "^4.37.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -1241,12 +1205,12 @@
       }
     },
     "node_modules/@automattic/number-formatters/node_modules/@wordpress/deprecated": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.35.0.tgz",
-      "integrity": "sha512-+TruZtmDxRfVw02c1de7ofGC3CrcaPCUXCCbwfP6ruy1zM3IC3rtJfyTbqKPqO1y4uI+9Kqe5VEobqRKT3HQSg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.35.0"
+        "@wordpress/hooks": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -1254,9 +1218,9 @@
       }
     },
     "node_modules/@automattic/number-formatters/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -1289,29 +1253,20 @@
         "react-dom": "^18.3.1"
       }
     },
-    "node_modules/@automattic/viewport-react/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
     "node_modules/@automattic/viewport-react/node_modules/@wordpress/compose": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.35.0.tgz",
-      "integrity": "sha512-UUQ31Rfi+KFfqT5wkbTgq0nMh+QfbLvshhm30+EGr8R3bYziHhfLKhIL2YQXf4MIX4owOFdKgbAt4GFeVI24ng==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -1326,12 +1281,12 @@
       }
     },
     "node_modules/@automattic/viewport-react/node_modules/@wordpress/deprecated": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.35.0.tgz",
-      "integrity": "sha512-+TruZtmDxRfVw02c1de7ofGC3CrcaPCUXCCbwfP6ruy1zM3IC3rtJfyTbqKPqO1y4uI+9Kqe5VEobqRKT3HQSg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.35.0"
+        "@wordpress/hooks": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -1339,12 +1294,12 @@
       }
     },
     "node_modules/@automattic/viewport-react/node_modules/@wordpress/dom": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.35.0.tgz",
-      "integrity": "sha512-mM/8m548RaWtkBonpCYHprXgyVFjKcFJWyHfWZz17j01xIbzBq+//cR/Lff86EiEuwynedqlFoEJUcgvPkrJZw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0"
+        "@wordpress/deprecated": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -1352,14 +1307,14 @@
       }
     },
     "node_modules/@automattic/viewport-react/node_modules/@wordpress/element": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.35.0.tgz",
-      "integrity": "sha512-RmxQsk0ANoHtxDc6anbUH/lHL7Mmbbdn016WKHYVh4+79EzN1tBeM8OML2gHpllUISmIYQvO4wIPSmEVzRh+Gw==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.35.0",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -1371,9 +1326,9 @@
       }
     },
     "node_modules/@automattic/viewport-react/node_modules/@wordpress/escape-html": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.35.0.tgz",
-      "integrity": "sha512-thY7RGAI6UijG3sbBm4IRzMX9lnHkEA/vR3Y0E5BGQYzNFwc+i7t1Lm4scpEBnL3UEQxdlD1wiJTH4pv5olV+Q==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -1381,39 +1336,19 @@
       }
     },
     "node_modules/@automattic/viewport-react/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/viewport-react/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@automattic/viewport-react/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.35.0.tgz",
-      "integrity": "sha512-ooM/QFzxu8Ueqsv0D/z0+X6grbVws3GFMSxdM12eZO1B0/x6JPAtq4msZkoxqeQ4zoR0ghYHFXzv3k+Ch1tsFw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -1421,12 +1356,12 @@
       }
     },
     "node_modules/@automattic/viewport-react/node_modules/@wordpress/keycodes": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.35.0.tgz",
-      "integrity": "sha512-+cvb9I4VorJRUsPC4C/2e0QWMz8hkjQIvjz3BjTkIXyWlxsSRSk/+a/YCrfyyA5ysuR9PgwKxxI7/ZaAPvOC6w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -1434,9 +1369,9 @@
       }
     },
     "node_modules/@automattic/viewport-react/node_modules/@wordpress/priority-queue": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.35.0.tgz",
-      "integrity": "sha512-kLdPx09CnPMPUL5hI/3SUgbBVEka20iWBxM2pvwJGrn3bleY0WxGqLtoUksn6yQds9d7jjS5cKoBYxY1H8MHgg==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -1446,11 +1381,18 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@automattic/viewport-react/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
+    "node_modules/@automattic/viewport-react/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
     },
     "node_modules/@axe-core/playwright": {
       "version": "4.11.0",
@@ -1466,12 +1408,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
+      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -1480,29 +1422,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
+      "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
+      "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.28.6",
+        "@babel/generator": "^7.28.6",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -1519,9 +1461,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.5.tgz",
-      "integrity": "sha512-fcdRcWahONYo+JRnJg1/AekOacGvKx12Gu0qXJXFi2WBqQA1i7+O5PaxRB7kxE/Op94dExnCiiar6T09pvdHpA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.6.tgz",
+      "integrity": "sha512-QGmsKi2PBO/MHSQk+AAgA9R6OHQr+VqnniFE0eMWZcVcfBZoA2dKn2hUsl3Csg/Plt9opRUWdY7//VXsrIlEiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1538,13 +1480,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
+      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -1567,12 +1509,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -1583,18 +1525,18 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.5.tgz",
-      "integrity": "sha512-q3WC4JfdODypvxArsJQROfupPBq9+lMwjKq7C33GhbFYJsufD0yd/ziwD+hJucLeWsnFPWZjsU2DNFqBPE7jwQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-member-expression-to-functions": "^7.28.5",
         "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.5",
+        "@babel/traverse": "^7.28.6",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -1675,27 +1617,27 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1718,9 +1660,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1745,15 +1687,15 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-      "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
         "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1804,40 +1746,40 @@
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
-      "integrity": "sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+      "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.3",
-        "@babel/types": "^7.28.2"
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
+      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.28.6"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1914,14 +1856,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz",
-      "integrity": "sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+      "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2040,13 +1982,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
-      "integrity": "sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+      "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2056,13 +1998,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2098,13 +2040,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2224,13 +2166,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2273,15 +2215,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
-      "integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.6.tgz",
+      "integrity": "sha512-9knsChgsMzBV5Yh3kkhrZNxH3oCYAfMBkNNaVN4cP2RVlFPe8wYdwwcnOsAbkdDoV9UjFtOXWrWB52M8W4jNeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-remap-async-to-generator": "^7.27.1",
-        "@babel/traverse": "^7.28.0"
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2291,14 +2233,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
-      "integrity": "sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+      "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-remap-async-to-generator": "^7.27.1"
       },
       "engines": {
@@ -2325,13 +2267,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.5.tgz",
-      "integrity": "sha512-45DmULpySVvmq9Pj3X9B+62Xe+DJGov27QravQJU1LLcapR6/10i+gYVAucGGJpHBp5mYxIMK4nDAT/QDLr47g==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+      "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2341,14 +2283,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
-      "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+      "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2358,14 +2300,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
-      "integrity": "sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+      "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.3",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2375,18 +2317,18 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.4.tgz",
-      "integrity": "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+      "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-compilation-targets": "^7.28.6",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.27.1",
-        "@babel/traverse": "^7.28.4"
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2396,14 +2338,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
-      "integrity": "sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+      "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/template": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/template": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2430,14 +2372,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
-      "integrity": "sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+      "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2463,14 +2405,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
-      "integrity": "sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.28.6.tgz",
+      "integrity": "sha512-5suVoXjC14lUN6ZL9OLKIHCNVWCrqGqlmEp/ixdXjvgnEl/kauLvvMO/Xw9NyMc95Joj1AeLVPVMvibBgSoFlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2496,14 +2438,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-explicit-resource-management": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
-      "integrity": "sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
+      "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.28.0"
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2513,13 +2455,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.5.tgz",
-      "integrity": "sha512-D4WIMaFtwa2NizOp+dnoFjRez/ClKiC2BqqImwKd1X28nqBtZEyCYJ2ozQrrzlxAFrcrjxo39S6khe9RNDlGzw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+      "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2580,13 +2522,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-json-strings": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
-      "integrity": "sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+      "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2612,13 +2554,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.5.tgz",
-      "integrity": "sha512-axUuqnUTBuXyHGcJEVVh9pORaN6wC5bYfE7FGzPiaWa3syib9m7g+/IT/4VgCOe2Upef43PHzeAvcrVek6QuuA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+      "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2661,14 +2603,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
-      "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2747,13 +2689,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
-      "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+      "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2763,13 +2705,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
-      "integrity": "sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+      "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2779,17 +2721,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.4.tgz",
-      "integrity": "sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+      "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.28.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5",
         "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/traverse": "^7.28.4"
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2816,13 +2758,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
-      "integrity": "sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+      "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2832,13 +2774,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.5.tgz",
-      "integrity": "sha512-N6fut9IZlPnjPwgiQkXNhb+cT8wQKFlJNqcZkWlcTqkcqx6/kU4ynGmLFoa4LViBSirn05YAwk+sQBbPfxtYzQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+      "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
       },
       "engines": {
@@ -2865,14 +2807,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
-      "integrity": "sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+      "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2882,15 +2824,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
-      "integrity": "sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+      "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-create-class-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2932,17 +2874,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
-      "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
+      "integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-syntax-jsx": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2985,13 +2927,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.4.tgz",
-      "integrity": "sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.6.tgz",
+      "integrity": "sha512-eZhoEZHYQLL5uc1gS5e9/oTknS0sSSAtd5TkKMUp3J+S/CaUjagc0kOUPsEbDmMeva0nC3WWl4SxVY6+OBuxfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3001,14 +2943,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-regexp-modifiers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
-      "integrity": "sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+      "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3070,13 +3012,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
-      "integrity": "sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+      "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
       },
       "engines": {
@@ -3135,17 +3077,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.5.tgz",
-      "integrity": "sha512-x2Qa+v/CuEoX7Dr31iAfr0IhInrVOWZU/2vJMJ00FOR/2nM0BcBEclpaf9sWCDc+v5e9dMrhSH8/atq/kX7+bA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-create-class-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/plugin-syntax-typescript": "^7.27.1"
+        "@babel/plugin-syntax-typescript": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3171,14 +3113,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-property-regex": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
-      "integrity": "sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+      "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3205,14 +3147,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
-      "integrity": "sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+      "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3222,76 +3164,76 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.5.tgz",
-      "integrity": "sha512-S36mOoi1Sb6Fz98fBfE+UZSpYw5mJm0NUHtIKrOuNcqeFauy1J6dIvXm2KRVKobOSaGq4t/hBXdN4HGU3wL9Wg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.6.tgz",
+      "integrity": "sha512-GaTI4nXDrs7l0qaJ6Rg06dtOXTBCG6TMDB44zbqofCIC4PqC7SEvmFFtpxzCDw9W5aJ7RKVshgXTLvLdBFV/qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.3",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-import-assertions": "^7.27.1",
-        "@babel/plugin-syntax-import-attributes": "^7.27.1",
+        "@babel/plugin-syntax-import-assertions": "^7.28.6",
+        "@babel/plugin-syntax-import-attributes": "^7.28.6",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-async-generator-functions": "^7.28.0",
-        "@babel/plugin-transform-async-to-generator": "^7.27.1",
+        "@babel/plugin-transform-async-generator-functions": "^7.28.6",
+        "@babel/plugin-transform-async-to-generator": "^7.28.6",
         "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-        "@babel/plugin-transform-block-scoping": "^7.28.5",
-        "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-class-static-block": "^7.28.3",
-        "@babel/plugin-transform-classes": "^7.28.4",
-        "@babel/plugin-transform-computed-properties": "^7.27.1",
+        "@babel/plugin-transform-block-scoping": "^7.28.6",
+        "@babel/plugin-transform-class-properties": "^7.28.6",
+        "@babel/plugin-transform-class-static-block": "^7.28.6",
+        "@babel/plugin-transform-classes": "^7.28.6",
+        "@babel/plugin-transform-computed-properties": "^7.28.6",
         "@babel/plugin-transform-destructuring": "^7.28.5",
-        "@babel/plugin-transform-dotall-regex": "^7.27.1",
+        "@babel/plugin-transform-dotall-regex": "^7.28.6",
         "@babel/plugin-transform-duplicate-keys": "^7.27.1",
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.28.6",
         "@babel/plugin-transform-dynamic-import": "^7.27.1",
-        "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.28.5",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+        "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
         "@babel/plugin-transform-export-namespace-from": "^7.27.1",
         "@babel/plugin-transform-for-of": "^7.27.1",
         "@babel/plugin-transform-function-name": "^7.27.1",
-        "@babel/plugin-transform-json-strings": "^7.27.1",
+        "@babel/plugin-transform-json-strings": "^7.28.6",
         "@babel/plugin-transform-literals": "^7.27.1",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.28.5",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
         "@babel/plugin-transform-member-expression-literals": "^7.27.1",
         "@babel/plugin-transform-modules-amd": "^7.27.1",
-        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.28.6",
         "@babel/plugin-transform-modules-systemjs": "^7.28.5",
         "@babel/plugin-transform-modules-umd": "^7.27.1",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
         "@babel/plugin-transform-new-target": "^7.27.1",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-        "@babel/plugin-transform-numeric-separator": "^7.27.1",
-        "@babel/plugin-transform-object-rest-spread": "^7.28.4",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
+        "@babel/plugin-transform-numeric-separator": "^7.28.6",
+        "@babel/plugin-transform-object-rest-spread": "^7.28.6",
         "@babel/plugin-transform-object-super": "^7.27.1",
-        "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.28.5",
+        "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
+        "@babel/plugin-transform-optional-chaining": "^7.28.6",
         "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/plugin-transform-private-methods": "^7.27.1",
-        "@babel/plugin-transform-private-property-in-object": "^7.27.1",
+        "@babel/plugin-transform-private-methods": "^7.28.6",
+        "@babel/plugin-transform-private-property-in-object": "^7.28.6",
         "@babel/plugin-transform-property-literals": "^7.27.1",
-        "@babel/plugin-transform-regenerator": "^7.28.4",
-        "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
+        "@babel/plugin-transform-regenerator": "^7.28.6",
+        "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
         "@babel/plugin-transform-reserved-words": "^7.27.1",
         "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-spread": "^7.27.1",
+        "@babel/plugin-transform-spread": "^7.28.6",
         "@babel/plugin-transform-sticky-regex": "^7.27.1",
         "@babel/plugin-transform-template-literals": "^7.27.1",
         "@babel/plugin-transform-typeof-symbol": "^7.27.1",
         "@babel/plugin-transform-unicode-escapes": "^7.27.1",
-        "@babel/plugin-transform-unicode-property-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
         "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
         "babel-plugin-polyfill-corejs2": "^0.4.14",
         "babel-plugin-polyfill-corejs3": "^0.13.0",
@@ -3363,18 +3305,18 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz",
-      "integrity": "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.6.tgz",
+      "integrity": "sha512-kz2fAQ5UzjV7X7D3ySxmj3vRq89dTpqOZWv76Z6pNPztkwb/0Yj1Mtx1xFrYj6mbIHysxtBot8J4o0JLCblcFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3385,31 +3327,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
+      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
+        "@babel/code-frame": "^7.28.6",
+        "@babel/generator": "^7.28.6",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.28.6",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -3417,9 +3359,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
+      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -3474,6 +3416,12 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
+    },
+    "node_modules/@date-fns/utc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.1.tgz",
+      "integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==",
       "license": "MIT"
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -3575,7 +3523,7 @@
     },
     "node_modules/@elementor/elementor-one-assets/node_modules/@elementor/ui": {
       "version": "1.37.2",
-      "resolved": "https://npm.pkg.github.com/download/@elementor/ui/1.37.2/a2fab739507cf7b8256939c241f752710d280f45",
+      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.37.2.tgz",
       "integrity": "sha512-AGdK9be9A6O887daPVFqOJB/cDwMHju8qugsnraB/LRInEV4zo0Yj4dWHeORXshgWEV25q5gzkiaY2ng4uXhfw==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -3605,79 +3553,10 @@
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@elementor/elementor-one-assets/node_modules/@wordpress/api-fetch": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.37.0.tgz",
-      "integrity": "sha512-BFxfDiVKydoDZN1evbdIHzUzbbbW+Clat+2AMPTH+illCD2RcCiascKUu8n0bqQy1JxyzA8Xsm8Arn9cSlOGwA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/i18n": "^6.10.0",
-        "@wordpress/url": "^4.37.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@elementor/elementor-one-assets/node_modules/@wordpress/hooks": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
-      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@elementor/elementor-one-assets/node_modules/@wordpress/i18n": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.10.0.tgz",
-      "integrity": "sha512-5tLAtnRQNxzA/d0GvVWCyo34Jb18w7xWTnup8hlh1+ehp7ZYTWR1QJihzVAteHoyrxAbTmzzsKyNtr8m+4ZpSQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.37.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@elementor/elementor-one-assets/node_modules/@wordpress/url": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.37.0.tgz",
-      "integrity": "sha512-8ofI1OzPON9twQIPczG5WfAtef5hhfZY+FB6cPmwDT5BftQGGO/+v0cHge7pgrRQftSzj4iQ+fQXIdEpIFacgw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@elementor/elementor-one-assets/node_modules/dayjs": {
       "version": "1.11.10",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
       "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
-      "license": "MIT"
-    },
-    "node_modules/@elementor/elementor-one-assets/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
-    },
-    "node_modules/@elementor/elementor-one-assets/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
       "license": "MIT"
     },
     "node_modules/@elementor/icons": {
@@ -3955,10 +3834,452 @@
         "node": ">=16"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4249,9 +4570,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4972,6 +5293,16 @@
         "mitt": "^3.0.0"
       }
     },
+    "node_modules/@mixpanel/rrweb-plugin-console-record": {
+      "version": "2.0.0-alpha.18.2",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-plugin-console-record/-/rrweb-plugin-console-record-2.0.0-alpha.18.2.tgz",
+      "integrity": "sha512-Xkwh2gSdLqHRkWSXv8CPVCPQj5L85KnWc5DZQ0CXNRFgm2hTl5/YP6zfUubVs2JVXZHGcSGU+g7JVO2WcFJyyg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@mixpanel/rrweb": "^2.0.0-alpha.18",
+        "@mixpanel/rrweb-utils": "^2.0.0-alpha.18"
+      }
+    },
     "node_modules/@mixpanel/rrweb-snapshot": {
       "version": "2.0.0-alpha.18.2",
       "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.2.tgz",
@@ -5061,7 +5392,7 @@
       "version": "5.0.0-beta.40",
       "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
       "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
-      "deprecated": "This package has been replaced by @base-ui-components/react",
+      "deprecated": "This package has been replaced by @base-ui/react",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
@@ -5226,9 +5557,9 @@
       }
     },
     "node_modules/@mui/private-theming/node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
+      "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
       "license": "MIT"
     },
     "node_modules/@mui/styled-engine": {
@@ -5377,15 +5708,15 @@
       }
     },
     "node_modules/@mui/system/node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
+      "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
       "license": "MIT"
     },
     "node_modules/@mui/types": {
-      "version": "7.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.8.tgz",
-      "integrity": "sha512-ZNXLBjkPV6ftLCmmRCafak3XmSn8YV0tKE/ZOhzKys7TZXUiE0mZxlH8zKDo6j6TTUaDnuij68gIG+0Ucm7Xhw==",
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.10.tgz",
+      "integrity": "sha512-0+4mSjknSu218GW3isRqoxKRTOrTLd/vHi/7UC4+wZcUrOAqD9kRk7UQRL1mcrzqRoe7s3UT6rsRpbLkW5mHpQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4"
@@ -5439,9 +5770,9 @@
       }
     },
     "node_modules/@mui/utils/node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
+      "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
       "license": "MIT"
     },
     "node_modules/@mui/x-date-pickers": {
@@ -6158,18 +6489,18 @@
       }
     },
     "node_modules/@parcel/watcher": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
-      "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.4.tgz",
+      "integrity": "sha512-WYa2tUVV5HiArWPB3ydlOc4R2ivq0IDrlqhMi3l7mVsFEXNcTfxYFPIHXHXIh/ca/y/V5N4E1zecyxdIBjYnkQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "detect-libc": "^1.0.3",
+        "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
-        "micromatch": "^4.0.5",
-        "node-addon-api": "^7.0.0"
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -6179,19 +6510,306 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.5.1",
-        "@parcel/watcher-darwin-arm64": "2.5.1",
-        "@parcel/watcher-darwin-x64": "2.5.1",
-        "@parcel/watcher-freebsd-x64": "2.5.1",
-        "@parcel/watcher-linux-arm-glibc": "2.5.1",
-        "@parcel/watcher-linux-arm-musl": "2.5.1",
-        "@parcel/watcher-linux-arm64-glibc": "2.5.1",
-        "@parcel/watcher-linux-arm64-musl": "2.5.1",
-        "@parcel/watcher-linux-x64-glibc": "2.5.1",
-        "@parcel/watcher-linux-x64-musl": "2.5.1",
-        "@parcel/watcher-win32-arm64": "2.5.1",
-        "@parcel/watcher-win32-ia32": "2.5.1",
-        "@parcel/watcher-win32-x64": "2.5.1"
+        "@parcel/watcher-android-arm64": "2.5.4",
+        "@parcel/watcher-darwin-arm64": "2.5.4",
+        "@parcel/watcher-darwin-x64": "2.5.4",
+        "@parcel/watcher-freebsd-x64": "2.5.4",
+        "@parcel/watcher-linux-arm-glibc": "2.5.4",
+        "@parcel/watcher-linux-arm-musl": "2.5.4",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.4",
+        "@parcel/watcher-linux-arm64-musl": "2.5.4",
+        "@parcel/watcher-linux-x64-glibc": "2.5.4",
+        "@parcel/watcher-linux-x64-musl": "2.5.4",
+        "@parcel/watcher-win32-arm64": "2.5.4",
+        "@parcel/watcher-win32-ia32": "2.5.4",
+        "@parcel/watcher-win32-x64": "2.5.4"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.4.tgz",
+      "integrity": "sha512-hoh0vx4v+b3BNI7Cjoy2/B0ARqcwVNrzN/n7DLq9ZB4I3lrsvhrkCViJyfTj/Qi5xM9YFiH4AmHGK6pgH1ss7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.4.tgz",
+      "integrity": "sha512-kphKy377pZiWpAOyTgQYPE5/XEKVMaj6VUjKT5VkNyUJlr2qZAn8gIc7CPzx+kbhvqHDT9d7EqdOqRXT6vk0zw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.4.tgz",
+      "integrity": "sha512-UKaQFhCtNJW1A9YyVz3Ju7ydf6QgrpNQfRZ35wNKUhTQ3dxJ/3MULXN5JN/0Z80V/KUBDGa3RZaKq1EQT2a2gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.4.tgz",
+      "integrity": "sha512-Dib0Wv3Ow/m2/ttvLdeI2DBXloO7t3Z0oCp4bAb2aqyqOjKPPGrg10pMJJAQ7tt8P4V2rwYwywkDhUia/FgS+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.4.tgz",
+      "integrity": "sha512-I5Vb769pdf7Q7Sf4KNy8Pogl/URRCKu9ImMmnVKYayhynuyGYMzuI4UOWnegQNa2sGpsPSbzDsqbHNMyeyPCgw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.4.tgz",
+      "integrity": "sha512-kGO8RPvVrcAotV4QcWh8kZuHr9bXi9a3bSZw7kFarYR0+fGliU7hd/zevhjw8fnvIKG3J9EO5G6sXNGCSNMYPQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.4.tgz",
+      "integrity": "sha512-KU75aooXhqGFY2W5/p8DYYHt4hrjHZod8AhcGAmhzPn/etTa+lYCDB2b1sJy3sWJ8ahFVTdy+EbqSBvMx3iFlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.4.tgz",
+      "integrity": "sha512-Qx8uNiIekVutnzbVdrgSanM+cbpDD3boB1f8vMtnuG5Zau4/bdDbXyKwIn0ToqFhIuob73bcxV9NwRm04/hzHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.4.tgz",
+      "integrity": "sha512-UYBQvhYmgAv61LNUn24qGQdjtycFBKSK3EXr72DbJqX9aaLbtCOO8+1SkKhD/GNiJ97ExgcHBrukcYhVjrnogA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.4.tgz",
+      "integrity": "sha512-YoRWCVgxv8akZrMhdyVi6/TyoeeMkQ0PGGOf2E4omODrvd1wxniXP+DBynKoHryStks7l+fDAMUBRzqNHrVOpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.4.tgz",
+      "integrity": "sha512-iby+D/YNXWkiQNYcIhg8P5hSjzXEHaQrk2SLrWOUD7VeC4Ohu0WQvmV+HDJokZVJ2UjJ4AGXW3bx7Lls9Ln4TQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.4.tgz",
+      "integrity": "sha512-vQN+KIReG0a2ZDpVv8cgddlf67J8hk1WfZMMP7sMeZmJRSmEax5xNDNWKdgqSe2brOKTQQAs3aCCUal2qBHAyg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.4.tgz",
+      "integrity": "sha512-3A6efb6BOKwyw7yk9ro2vus2YTt2nvcd56AuzxdMiVOxL9umDyN5PKkKfZ/gZ9row41SjVmTVQNWQhaRRGpOKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@paulirish/trace_engine": {
@@ -6880,9 +7498,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -6896,9 +7514,9 @@
       "license": "MIT"
     },
     "node_modules/@sentry/core": {
-      "version": "9.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.46.0.tgz",
-      "integrity": "sha512-it7JMFqxVproAgEtbLgCVBYtQ9fIb+Bu0JD+cEplTN/Ukpe6GaolyYib5geZqslVxhp2sQgT+58aGvfd/k0N8Q==",
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
+      "integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6906,9 +7524,9 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "9.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.46.0.tgz",
-      "integrity": "sha512-pRLqAcd7GTGvN8gex5FtkQR5Mcol8gOy1WlyZZFq4rBbVtMbqKOQRhohwqnb+YrnmtFpj7IZ7KNDo077MvNeOQ==",
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.47.1.tgz",
+      "integrity": "sha512-CDbkasBz3fnWRKSFs6mmaRepM2pa+tbZkrqhPWifFfIkJDidtVW40p6OnquTvPXyPAszCnDZRnZT14xyvNmKPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6942,9 +7560,9 @@
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.34.0",
         "@prisma/instrumentation": "6.11.1",
-        "@sentry/core": "9.46.0",
-        "@sentry/node-core": "9.46.0",
-        "@sentry/opentelemetry": "9.46.0",
+        "@sentry/core": "9.47.1",
+        "@sentry/node-core": "9.47.1",
+        "@sentry/opentelemetry": "9.47.1",
         "import-in-the-middle": "^1.14.2",
         "minimatch": "^9.0.0"
       },
@@ -6953,14 +7571,14 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "9.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.46.0.tgz",
-      "integrity": "sha512-XRVu5pqoklZeh4wqhxCLZkz/ipoKhitctgEFXX9Yh1e1BoHM2pIxT52wf+W6hHM676TFmFXW3uKBjsmRM3AjgA==",
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.47.1.tgz",
+      "integrity": "sha512-7TEOiCGkyShJ8CKtsri9lbgMCbB+qNts2Xq37itiMPN2m+lIukK3OX//L8DC5nfKYZlgikrefS63/vJtm669hQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.46.0",
-        "@sentry/opentelemetry": "9.46.0",
+        "@sentry/core": "9.47.1",
+        "@sentry/opentelemetry": "9.47.1",
         "import-in-the-middle": "^1.14.2"
       },
       "engines": {
@@ -6977,13 +7595,13 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "9.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.46.0.tgz",
-      "integrity": "sha512-w2zTxqrdmwRok0cXBoh+ksXdGRUHUZhlpfL/H2kfTodOL+Mk8rW72qUmfqQceXoqgbz8UyK8YgJbyt+XS5H4Qg==",
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.47.1.tgz",
+      "integrity": "sha512-STtFpjF7lwzeoedDJV+5XA6P89BfmFwFftmHSGSe3UTI8z8IoiR5yB6X2vCjSPvXlfeOs13qCNNCEZyznxM8Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.46.0"
+        "@sentry/core": "9.47.1"
       },
       "engines": {
         "node": ">=18"
@@ -7031,9 +7649,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-actions": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.6.14.tgz",
-      "integrity": "sha512-mDQxylxGGCQSK7tJPkD144J8jWh9IU9ziJMHfB84PKpI/V5ZgqMDnpr2bssTrUaGDqU5e1/z8KcRF+Melhs9pQ==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.6.15.tgz",
+      "integrity": "sha512-zc600PBJqP9hCyRY5escKgKf6Zt9kdNZfm+Jwb46k5/NMSO4tNVeOPGBFxW9kSsIYk8j55sNske+Yh60G+8bcw==",
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -7047,30 +7665,17 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.14"
-      }
-    },
-    "node_modules/@storybook/addon-actions/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@storybook/core": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.14.tgz",
-      "integrity": "sha512-1P/w4FSNRqP8j3JQBOi3yGt8PVOgSRbP66Ok520T78eJBeqx9ukCfl912PQZ7SPbW3TIunBwLXMZOjZwBB/JmA==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.15.tgz",
+      "integrity": "sha512-VFpKcphNurJpSC4fpUfKL3GTXVoL53oytghGR30QIw5jKWwaT50HVbTyb41BLOUuZjmMhUQA8weiQEew6RX0gw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@storybook/theming": "8.6.14",
+        "@storybook/theming": "8.6.15",
         "better-opn": "^3.0.2",
         "browser-assert": "^1.2.1",
         "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
@@ -7129,9 +7734,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/theming": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.14.tgz",
-      "integrity": "sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.15.tgz",
+      "integrity": "sha512-dAbL0XOekyT6XsF49R6Etj3WxQ/LpdJDIswUUeHgVJ6/yd2opZOGbPxnwA3zlmAh1c0tvpPyhSDXxSG79u8e4Q==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -7307,16 +7912,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -7627,9 +8222,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "version": "25.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.8.tgz",
+      "integrity": "sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -7680,12 +8275,12 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.26",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
-      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^17.0.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -7696,12 +8291,6 @@
       "peerDependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/react/node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
     },
     "node_modules/@types/seed-random": {
       "version": "2.2.4",
@@ -7740,9 +8329,9 @@
       "license": "MIT"
     },
     "node_modules/@types/stylis": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
-      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
+      "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7809,6 +8398,15 @@
         "react-autosize-textarea": "^7.1.0"
       }
     },
+    "node_modules/@types/wordpress__block-editor/node_modules/@types/react-dom": {
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0"
+      }
+    },
     "node_modules/@types/wordpress__block-editor/node_modules/@wordpress/element": {
       "version": "4.20.0",
       "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
@@ -7843,6 +8441,15 @@
         "@types/react": "*",
         "@types/wordpress__components": "*",
         "@wordpress/element": "^4.0.0"
+      }
+    },
+    "node_modules/@types/wordpress__blocks/node_modules/@types/react-dom": {
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0"
       }
     },
     "node_modules/@types/wordpress__blocks/node_modules/@wordpress/element": {
@@ -7880,6 +8487,15 @@
         "re-resizable": "^6.4.0"
       }
     },
+    "node_modules/@types/wordpress__components/node_modules/@types/react-dom": {
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0"
+      }
+    },
     "node_modules/@types/wordpress__components/node_modules/@wordpress/element": {
       "version": "4.20.0",
       "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
@@ -7900,116 +8516,33 @@
       }
     },
     "node_modules/@types/wordpress__data": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/wordpress__data/-/wordpress__data-6.0.2.tgz",
-      "integrity": "sha512-Pu67knXXoTWgCpxTKwePNZz/iKkYe8AQbkkSD/Ba1mw8t4zgEM+jJs5IV5N5ij/awwjs4Subj8mkvS3jMTDwyw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wordpress__data/-/wordpress__data-7.0.0.tgz",
+      "integrity": "sha512-d3IBynESbBBEFNl9xwlbZvNB1uy1+yw17YpFGAnfp6vk78e28fD6wnlIVyfWN8xsDcAVPakTmcRvJ57ycoubAQ==",
+      "deprecated": "This is a stub types definition. @wordpress/data provides its own type definitions, so you do not need this installed.",
       "license": "MIT",
       "dependencies": {
-        "@types/react": "*",
-        "redux": "^4.1.0"
+        "@wordpress/data": "*"
       }
     },
     "node_modules/@types/wordpress__keycodes": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/wordpress__keycodes/-/wordpress__keycodes-2.3.3.tgz",
-      "integrity": "sha512-jOI0L5NbLc0Ht/vkbZwgBfgWZbPKexXS+nxlYZ0kHQCjVCM7tdSwptItksCY3Qc9IV2nRc1pTnj/UJC2E2cUQw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/wordpress__notices": {
-      "version": "3.27.6",
-      "resolved": "https://registry.npmjs.org/@types/wordpress__notices/-/wordpress__notices-3.27.6.tgz",
-      "integrity": "sha512-cKK9Cu/br81XqNwxUTRjwGZuLtf6Ug76O77Qc1YF4+RhY8pruxKcWa2+TYzojeh6/83HXw4JjXY7tiI/WD4uoA==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@types/wordpress__keycodes/-/wordpress__keycodes-2.18.0.tgz",
+      "integrity": "sha512-09ku81E6tjB//bI5PatKM/rhTJ0aEmNLvhIn380orea+SX6/09t7luO27zxI0uHSs/1Pxue1ifrMKY+gE5lfzw==",
+      "deprecated": "This is a stub types definition. @wordpress/keycodes provides its own type definitions, so you do not need this installed.",
       "license": "MIT",
       "dependencies": {
-        "@types/react": "*",
-        "@wordpress/data": "^9.13.0"
+        "@wordpress/keycodes": "*"
       }
     },
-    "node_modules/@types/wordpress__notices/node_modules/@wordpress/compose": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
-      "integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
-      "license": "GPL-2.0-or-later",
+    "node_modules/@types/wordpress__notices": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wordpress__notices/-/wordpress__notices-4.0.0.tgz",
+      "integrity": "sha512-mceFxFkj2jJvnzGG3d1AY3nT+IgcTJR5fRaWz2NS+JbqrHNO+YbIlb6cqlvqS9FlrAJvFrSHHhji9dghqNeUow==",
+      "deprecated": "This is a stub types definition. @wordpress/notices provides its own type definitions, so you do not need this installed.",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^3.58.0",
-        "@wordpress/dom": "^3.58.0",
-        "@wordpress/element": "^5.35.0",
-        "@wordpress/is-shallow-equal": "^4.58.0",
-        "@wordpress/keycodes": "^3.58.0",
-        "@wordpress/priority-queue": "^2.58.0",
-        "@wordpress/undo-manager": "^0.18.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/wordpress__notices/node_modules/@wordpress/data": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
-      "integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.35.0",
-        "@wordpress/deprecated": "^3.58.0",
-        "@wordpress/element": "^5.35.0",
-        "@wordpress/is-shallow-equal": "^4.58.0",
-        "@wordpress/priority-queue": "^2.58.0",
-        "@wordpress/private-apis": "^0.40.0",
-        "@wordpress/redux-routine": "^4.58.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/wordpress__notices/node_modules/@wordpress/redux-routine": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.58.0.tgz",
-      "integrity": "sha512-r0mMWFeJr93yPy2uY/M5+gdUUYj0Zu8+21OFFb5hyQ0z7UHIa3IdgQxzCaTbV1LDA1ZYJrjHeCnA6s4gNHjA2Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@types/wordpress__notices/node_modules/@wordpress/undo-manager": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.18.0.tgz",
-      "integrity": "sha512-upbzPEToa095XG+2JXLHaolF1LfXEMFS0lNMYV37myoUS+eZ7/tl9Gx+yU2+OqWy57TMwx33NlWUX/n+ynzPRw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^4.58.0"
-      },
-      "engines": {
-        "node": ">=12"
+        "@wordpress/notices": "*"
       }
     },
     "node_modules/@types/wordpress__rich-text": {
@@ -8024,9 +8557,9 @@
       }
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.34",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.34.tgz",
-      "integrity": "sha512-KExbHVa92aJpw9WDQvzBaGVE2/Pz+pLZQloT2hjL8IqsZnV62rlPOYvNnLmf/L2dyllfVUOVBj64M0z/46eR2A==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8411,15 +8944,15 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.4.tgz",
-      "integrity": "sha512-nPiRSKuvtTN+no/2N1kt2tUh/HoFzeEgOm9fQ6XQk4/ApGqjx0zFIIaLJ6wooR1HIoozvj2j6vTi/1fgAz7UYQ==",
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.0.tgz",
+      "integrity": "sha512-Bl6Gdr7NqkqIP5yP9z1JU///Nmes4Eose6L1HwpuVHwScgDPPuEWbUVhvlZmb8hy0vX9syLk5EGNL700WcBlbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.46.4",
-        "@typescript-eslint/types": "^8.46.4",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.53.0",
+        "@typescript-eslint/types": "^8.53.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8433,14 +8966,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.4.tgz",
-      "integrity": "sha512-tMDbLGXb1wC+McN1M6QeDx7P7c0UWO5z9CXqp7J8E+xGcJuUuevWKxuG8j41FoweS3+L41SkyKKkia16jpX7CA==",
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.0.tgz",
+      "integrity": "sha512-kWNj3l01eOGSdVBnfAF2K1BTh06WS0Yet6JUgb9Cmkqaz3Jlu0fdVUjj9UI8gPidBWSMqDIglmEXifSgDT/D0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.4",
-        "@typescript-eslint/visitor-keys": "8.46.4"
+        "@typescript-eslint/types": "8.53.0",
+        "@typescript-eslint/visitor-keys": "8.53.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8451,9 +8984,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.4.tgz",
-      "integrity": "sha512-+/XqaZPIAk6Cjg7NWgSGe27X4zMGqrFqZ8atJsX3CWxH/jACqWnrWI68h7nHQld0y+k9eTTjb9r+KU4twLoo9A==",
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.0.tgz",
+      "integrity": "sha512-K6Sc0R5GIG6dNoPdOooQ+KtvT5KCKAvTcY8h2rIuul19vxH5OTQk7ArKkd4yTzkw66WnNY0kPPzzcmWA+XRmiA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8656,9 +9189,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.4.tgz",
-      "integrity": "sha512-USjyxm3gQEePdUwJBFjjGNG18xY9A2grDVGuk7/9AkjIF1L+ZrVnwR5VAU5JXtUnBL/Nwt3H31KlRDaksnM7/w==",
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.0.tgz",
+      "integrity": "sha512-Bmh9KX31Vlxa13+PqPvt4RzKRN1XORYSLlAE+sO1i28NkisGbTtSLFVB3l7PWdHtR3E0mVMuC7JilWJ99m2HxQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8670,22 +9203,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.4.tgz",
-      "integrity": "sha512-7oV2qEOr1d4NWNmpXLR35LvCfOkTNymY9oyW+lUHkmCno7aOmIf/hMaydnJBUTBMRCOGZh8YjkFOc8dadEoNGA==",
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.0.tgz",
+      "integrity": "sha512-pw0c0Gdo7Z4xOG987u3nJ8akL9093yEEKv8QTJ+Bhkghj1xyj8cgPaavlr9rq8h7+s6plUJ4QJYw2gCZodqmGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.46.4",
-        "@typescript-eslint/tsconfig-utils": "8.46.4",
-        "@typescript-eslint/types": "8.46.4",
-        "@typescript-eslint/visitor-keys": "8.46.4",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.53.0",
+        "@typescript-eslint/tsconfig-utils": "8.53.0",
+        "@typescript-eslint/types": "8.53.0",
+        "@typescript-eslint/visitor-keys": "8.53.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8712,16 +9244,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.4.tgz",
-      "integrity": "sha512-AbSv11fklGXV6T28dp2Me04Uw90R2iJ30g2bgLz529Koehrmkbs1r7paFqr1vPCZi7hHwYxYtxfyQMRC8QaVSg==",
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.0.tgz",
+      "integrity": "sha512-XDY4mXTez3Z1iRDI5mbRhH4DFSt46oaIFsLg+Zn97+sYrXACziXSQcSelMybnVZ5pa1P6xYkPr5cMJyunM1ZDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.46.4",
-        "@typescript-eslint/types": "8.46.4",
-        "@typescript-eslint/typescript-estree": "8.46.4"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.53.0",
+        "@typescript-eslint/types": "8.53.0",
+        "@typescript-eslint/typescript-estree": "8.53.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8736,13 +9268,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.4.tgz",
-      "integrity": "sha512-/++5CYLQqsO9HFGLI7APrxBJYo+5OCMpViuhV8q5/Qa3o5mMrF//eQHks+PXcsAVaLdn817fMuS7zqoXNNZGaw==",
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.0.tgz",
+      "integrity": "sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/types": "8.53.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -8968,7 +9500,75 @@
         "react-dom": "^17.0.2"
       }
     },
-    "node_modules/@woocommerce/components": {
+    "node_modules/@woocommerce/admin-layout/node_modules/@automattic/tour-kit": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@automattic/tour-kit/-/tour-kit-1.1.3.tgz",
+      "integrity": "sha512-4vHu2g41j0msniRWYMsUie6EYXEQqTQknhem3Payp0mEIYH05dt/rMjsDtSspbmLe2CtjtQoauXKTyXmf4CMWA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@automattic/components": "^2.1.0",
+        "@automattic/viewport": "^1.1.0",
+        "@automattic/viewport-react": "^1.0.0",
+        "@popperjs/core": "^2.11.8",
+        "@wordpress/base-styles": "^4.47.0",
+        "@wordpress/components": "^27.4.0",
+        "@wordpress/dom": "^3.56.0",
+        "@wordpress/element": "^5.33.0",
+        "@wordpress/i18n": "^4.56.0",
+        "@wordpress/icons": "^9.47.0",
+        "@wordpress/primitives": "^3.54.0",
+        "@wordpress/react-i18n": "^3.54.0",
+        "classnames": "^2.3.2",
+        "debug": "^4.3.4",
+        "react-popper": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@wordpress/data": "^9.26.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "redux": "^4.2.1"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@floating-ui/react-dom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
+      "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@types/react-dom": {
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@woocommerce/components": {
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/@woocommerce/components/-/components-12.2.0.tgz",
       "integrity": "sha512-KcBWSyy6pmgmQFZeo8oi1vTBfC3I/qzVzlgxEBDrnBF6MoQ3RVbM9WTyFgZgiAuIUONUasRJjWd4Ifuk72UFTA==",
@@ -9043,46 +9643,792 @@
         "react-dom": "^17.0.2"
       }
     },
-    "node_modules/@woocommerce/components/node_modules/@automattic/tour-kit": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@automattic/tour-kit/-/tour-kit-1.1.3.tgz",
-      "integrity": "sha512-4vHu2g41j0msniRWYMsUie6EYXEQqTQknhem3Payp0mEIYH05dt/rMjsDtSspbmLe2CtjtQoauXKTyXmf4CMWA==",
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/api-fetch": {
+      "version": "6.55.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
+      "integrity": "sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@automattic/components": "^2.1.0",
-        "@automattic/viewport": "^1.1.0",
-        "@automattic/viewport-react": "^1.0.0",
-        "@popperjs/core": "^2.11.8",
-        "@wordpress/base-styles": "^4.47.0",
-        "@wordpress/components": "^27.4.0",
-        "@wordpress/dom": "^3.56.0",
-        "@wordpress/element": "^5.33.0",
-        "@wordpress/i18n": "^4.56.0",
-        "@wordpress/icons": "^9.47.0",
-        "@wordpress/primitives": "^3.54.0",
-        "@wordpress/react-i18n": "^3.54.0",
-        "classnames": "^2.3.2",
-        "debug": "^4.3.4",
-        "react-popper": "^2.3.0"
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/url": "^3.59.0"
       },
-      "peerDependencies": {
-        "@wordpress/data": "^9.26.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "redux": "^4.2.1"
+      "engines": {
+        "node": ">=12"
       }
     },
-    "node_modules/@woocommerce/components/node_modules/@wordpress/base-styles": {
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/autop": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.58.0.tgz",
+      "integrity": "sha512-RsdUV57A+DTJGU3slq/S9vTOtVkatnT1YyGIK3UDKaEhXkvBPtLTWwd3WR13GCfjFZ5XupH9FAGUQFkOve0eKQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/base-styles": {
       "version": "4.49.0",
       "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.49.0.tgz",
       "integrity": "sha512-yFRYqNtd26ULZ0oAHhCu/IcaA0XHI3E7kRCKajZqUvyRQj7YprXnpD3o0/pnwvF6ZFTXzCX8pXHjUc2TIv97ig==",
       "license": "GPL-2.0-or-later"
     },
-    "node_modules/@woocommerce/components/node_modules/dompurify": {
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/blob": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.58.0.tgz",
+      "integrity": "sha512-6L3WqbOWEGFOSs3vLMwJ83YScggCiJ9NvZj1kC7mgeiP302UP2Fxkt4KlfjeTsD350XcvakkD/57wRkHXd819Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/block-editor": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-9.8.0.tgz",
+      "integrity": "sha512-zIPqEysaLFJMnVKU/yCoCEBT3Co9xsa4Ow91T/LI94ll3LeWG/pyiX4PSSQNTx74AqbcNO2p79LVON4FLdu+mQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@react-spring/web": "^9.4.5",
+        "@wordpress/a11y": "^3.16.0",
+        "@wordpress/api-fetch": "^6.13.0",
+        "@wordpress/blob": "^3.16.0",
+        "@wordpress/blocks": "^11.15.0",
+        "@wordpress/components": "^20.0.0",
+        "@wordpress/compose": "^5.14.0",
+        "@wordpress/data": "^7.0.0",
+        "@wordpress/date": "^4.16.0",
+        "@wordpress/deprecated": "^3.16.0",
+        "@wordpress/dom": "^3.16.0",
+        "@wordpress/element": "^4.14.0",
+        "@wordpress/hooks": "^3.16.0",
+        "@wordpress/html-entities": "^3.16.0",
+        "@wordpress/i18n": "^4.16.0",
+        "@wordpress/icons": "^9.7.0",
+        "@wordpress/is-shallow-equal": "^4.16.0",
+        "@wordpress/keyboard-shortcuts": "^3.14.0",
+        "@wordpress/keycodes": "^3.16.0",
+        "@wordpress/notices": "^3.16.0",
+        "@wordpress/rich-text": "^5.14.0",
+        "@wordpress/shortcode": "^3.16.0",
+        "@wordpress/style-engine": "^0.15.0",
+        "@wordpress/token-list": "^2.16.0",
+        "@wordpress/url": "^3.17.0",
+        "@wordpress/warning": "^2.16.0",
+        "@wordpress/wordcount": "^3.16.0",
+        "change-case": "^4.1.2",
+        "classnames": "^2.3.1",
+        "colord": "^2.7.0",
+        "diff": "^4.0.2",
+        "dom-scroll-into-view": "^1.2.1",
+        "inherits": "^2.0.3",
+        "lodash": "^4.17.21",
+        "react-autosize-textarea": "^7.1.0",
+        "react-easy-crop": "^3.0.0",
+        "rememo": "^4.0.0",
+        "remove-accents": "^0.4.2",
+        "traverse": "^0.6.6"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/block-editor/node_modules/@wordpress/components": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-20.0.0.tgz",
+      "integrity": "sha512-RBPjtGLSoiV5YKhrBYh+/X8LbzbA99BJaB4Q+P0e1rVOwGzeBF3M7YEjmg1PrrzWaItqJZTvDoyZo+ql7c0KfA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "^1.0.0",
+        "@use-gesture/react": "^10.2.6",
+        "@wordpress/a11y": "^3.16.0",
+        "@wordpress/compose": "^5.14.0",
+        "@wordpress/date": "^4.16.0",
+        "@wordpress/deprecated": "^3.16.0",
+        "@wordpress/dom": "^3.16.0",
+        "@wordpress/element": "^4.14.0",
+        "@wordpress/escape-html": "^2.16.0",
+        "@wordpress/hooks": "^3.16.0",
+        "@wordpress/i18n": "^4.16.0",
+        "@wordpress/icons": "^9.7.0",
+        "@wordpress/is-shallow-equal": "^4.16.0",
+        "@wordpress/keycodes": "^3.16.0",
+        "@wordpress/primitives": "^3.14.0",
+        "@wordpress/rich-text": "^5.14.0",
+        "@wordpress/warning": "^2.16.0",
+        "change-case": "^4.1.2",
+        "classnames": "^2.3.1",
+        "colord": "^2.7.0",
+        "date-fns": "^2.28.0",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^6.0.15",
+        "framer-motion": "^6.2.8",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.1",
+        "reakit": "^1.3.8",
+        "remove-accents": "^0.4.2",
+        "use-lilius": "^2.0.1",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/block-editor/node_modules/@wordpress/compose": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
+      "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.8",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/block-editor/node_modules/@wordpress/data": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-7.6.0.tgz",
+      "integrity": "sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "@wordpress/redux-routine": "^4.22.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "redux": "^4.1.2",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/block-editor/node_modules/@wordpress/element": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
+      "integrity": "sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/react": "^17.0.37",
+        "@types/react-dom": "^17.0.11",
+        "@wordpress/escape-html": "^2.22.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/block-editor/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/block-editor/node_modules/remove-accents": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+      "license": "MIT"
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/block-serialization-default-parser": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.58.0.tgz",
+      "integrity": "sha512-++fowmFEJC+1SwiCGuLPO9k+g3rgI2SCAA/p8/Bc1rNgnKB+rowzmQvSIIlRpcUkmOxHOrH5uruOEX27Ksg6uw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/blocks": {
+      "version": "11.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.21.0.tgz",
+      "integrity": "sha512-FlOrF0VMugW7wW9LAAF3ixUp2t1HsEGTBjqERYr7dYQIJI8yIII7/Zh2Opuzq0baWaA7kqexUQeD6sYSOcu8lA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/autop": "^3.22.0",
+        "@wordpress/blob": "^3.22.0",
+        "@wordpress/block-serialization-default-parser": "^4.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/hooks": "^3.22.0",
+        "@wordpress/html-entities": "^3.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/shortcode": "^3.22.0",
+        "change-case": "^4.1.2",
+        "colord": "^2.7.0",
+        "hpq": "^1.3.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "rememo": "^4.0.0",
+        "remove-accents": "^0.4.2",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/blocks/node_modules/@wordpress/compose": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
+      "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.8",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/blocks/node_modules/@wordpress/data": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-7.6.0.tgz",
+      "integrity": "sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "@wordpress/redux-routine": "^4.22.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "redux": "^4.1.2",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/blocks/node_modules/@wordpress/element": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
+      "integrity": "sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/react": "^17.0.37",
+        "@types/react-dom": "^17.0.11",
+        "@wordpress/escape-html": "^2.22.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/blocks/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/blocks/node_modules/remove-accents": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+      "license": "MIT"
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/data": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
+      "integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/redux-routine": "^4.58.0",
+        "deepmerge": "^4.3.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "redux": "^4.1.2",
+        "rememo": "^4.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/keyboard-shortcuts": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-3.20.0.tgz",
+      "integrity": "sha512-78JTtqw6CGm9aMrZmRjvlQ8+skK/8ZV2rNd58ZpWT9Htp5jEB5ddt34P5wn04UiDOFFd13sy5HOqhsUFHh4qFA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "rememo": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/compose": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
+      "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.8",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/data": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-7.6.0.tgz",
+      "integrity": "sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "@wordpress/redux-routine": "^4.22.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "redux": "^4.1.2",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/element": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
+      "integrity": "sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/react": "^17.0.37",
+        "@types/react-dom": "^17.0.11",
+        "@wordpress/escape-html": "^2.22.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/notices": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-3.31.0.tgz",
+      "integrity": "sha512-9WyaFaSr/vQc1K7cZLyPw1xBKqWfjpAKMJzWMzHYjwk1ldibhBWVLukicuolD6Y+9l+97IZHCoESBQwUeFo79Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.31.0",
+        "@wordpress/data": "^9.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/redux-routine": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.58.0.tgz",
+      "integrity": "sha512-r0mMWFeJr93yPy2uY/M5+gdUUYj0Zu8+21OFFb5hyQ0z7UHIa3IdgQxzCaTbV1LDA1ZYJrjHeCnA6s4gNHjA2Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "rungen": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "redux": ">=4"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/rich-text": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.20.0.tgz",
+      "integrity": "sha512-7W4PksJ6/SnQ+KuwvZ0dlKSwbaS6ejvWBm2N8R5S79AzbdmB69BpDCz0U/GUfGDXDhrU9dpzg5NIivoW2LC8Kg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/escape-html": "^2.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "memize": "^1.1.0",
+        "rememo": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/rich-text/node_modules/@wordpress/compose": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
+      "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.8",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/rich-text/node_modules/@wordpress/data": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-7.6.0.tgz",
+      "integrity": "sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "@wordpress/redux-routine": "^4.22.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "redux": "^4.1.2",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
+      "integrity": "sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/react": "^17.0.37",
+        "@types/react-dom": "^17.0.11",
+        "@wordpress/escape-html": "^2.22.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/rich-text/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/shortcode": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.58.0.tgz",
+      "integrity": "sha512-yM3Y25XqLfz/X6xXowXbrTvk+tslKeALNNESI5nGt1X7wWPsYQDOqyBb1HT9TglSLFgWYlQlNtgEbz07dEiDgQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "memize": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/style-engine": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-0.15.0.tgz",
+      "integrity": "sha512-F6wt4g8xnli6bOR0Syd4iz4r5jFha7DZLzi2krmgH3cSTK4DDPj2g1YOJrRIEqXX4aPmdZDurTqQZoJvt9qaqQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/token-list": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.58.0.tgz",
+      "integrity": "sha512-xzNGzAZ87GERq7rZvZjMv742nj37tSLFBb8+c7oaLdpUpfn8YTaXQacvphdN2jmtfHvEZHivW7hErwqF9eQW/A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/url": {
+      "version": "3.59.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
+      "integrity": "sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/@wordpress/wordcount": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.58.0.tgz",
+      "integrity": "sha512-cxmOOh8d4VeIC3B9HcqhlTQePmNkNrPeHQLj6xWHfC0Elflj+kYAjsTwkjVQ3tBMC4+mQzva1O8tFSVh02gs7w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/dompurify": {
       "version": "2.5.8",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
       "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
       "license": "(MPL-2.0 OR Apache-2.0)"
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/framer-motion": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
+      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/dom": "10.12.0",
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "popmotion": "11.0.3",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
+        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/framer-motion/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/react-easy-crop": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-3.5.3.tgz",
+      "integrity": "sha512-ApTbh+lzKAvKqYW81ihd5J6ZTNN3vPDwi6ncFuUrHPI4bko2DlYOESkRm+0NYoW0H8YLaD7bxox+Z3EvIzAbUA==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
+      }
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/tslib": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+      "license": "0BSD"
+    },
+    "node_modules/@woocommerce/admin-layout/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/@woocommerce/csv-export": {
       "version": "1.7.0",
@@ -9105,6 +10451,15 @@
         "@wordpress/element": "^4.1.1",
         "@wordpress/html-entities": "^3.3.1",
         "@wordpress/i18n": "^3.20.0"
+      }
+    },
+    "node_modules/@woocommerce/currency/node_modules/@types/react-dom": {
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0"
       }
     },
     "node_modules/@woocommerce/currency/node_modules/@wordpress/deprecated": {
@@ -9163,6 +10518,12 @@
         "pot-to-php": "tools/pot-to-php.js"
       }
     },
+    "node_modules/@woocommerce/currency/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
     "node_modules/@woocommerce/data": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@woocommerce/data/-/data-4.1.0.tgz",
@@ -9191,6 +10552,170 @@
         "moment": "^2.18.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/data/node_modules/@types/react-dom": {
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/api-fetch": {
+      "version": "6.55.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
+      "integrity": "sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/url": "^3.59.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/autop": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.58.0.tgz",
+      "integrity": "sha512-RsdUV57A+DTJGU3slq/S9vTOtVkatnT1YyGIK3UDKaEhXkvBPtLTWwd3WR13GCfjFZ5XupH9FAGUQFkOve0eKQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/blob": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.58.0.tgz",
+      "integrity": "sha512-6L3WqbOWEGFOSs3vLMwJ83YScggCiJ9NvZj1kC7mgeiP302UP2Fxkt4KlfjeTsD350XcvakkD/57wRkHXd819Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/block-serialization-default-parser": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.58.0.tgz",
+      "integrity": "sha512-++fowmFEJC+1SwiCGuLPO9k+g3rgI2SCAA/p8/Bc1rNgnKB+rowzmQvSIIlRpcUkmOxHOrH5uruOEX27Ksg6uw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/blocks": {
+      "version": "11.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.21.0.tgz",
+      "integrity": "sha512-FlOrF0VMugW7wW9LAAF3ixUp2t1HsEGTBjqERYr7dYQIJI8yIII7/Zh2Opuzq0baWaA7kqexUQeD6sYSOcu8lA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/autop": "^3.22.0",
+        "@wordpress/blob": "^3.22.0",
+        "@wordpress/block-serialization-default-parser": "^4.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/hooks": "^3.22.0",
+        "@wordpress/html-entities": "^3.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/shortcode": "^3.22.0",
+        "change-case": "^4.1.2",
+        "colord": "^2.7.0",
+        "hpq": "^1.3.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "rememo": "^4.0.0",
+        "remove-accents": "^0.4.2",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/blocks/node_modules/@wordpress/data": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-7.6.0.tgz",
+      "integrity": "sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "@wordpress/redux-routine": "^4.22.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "redux": "^4.1.2",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/blocks/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/blocks/node_modules/remove-accents": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+      "license": "MIT"
+    },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/compose": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
+      "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.8",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
       }
     },
     "node_modules/@woocommerce/data/node_modules/@wordpress/core-data": {
@@ -9251,6 +10776,12 @@
         "react": "^17.0.0"
       }
     },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/core-data/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
     "node_modules/@woocommerce/data/node_modules/@wordpress/data": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.15.0.tgz",
@@ -9298,6 +10829,26 @@
         "node": ">=12"
       }
     },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@woocommerce/data/node_modules/@wordpress/redux-routine": {
       "version": "4.58.0",
       "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.58.0.tgz",
@@ -9316,11 +10867,46 @@
         "redux": ">=4"
       }
     },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/shortcode": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.58.0.tgz",
+      "integrity": "sha512-yM3Y25XqLfz/X6xXowXbrTvk+tslKeALNNESI5nGt1X7wWPsYQDOqyBb1HT9TglSLFgWYlQlNtgEbz07dEiDgQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "memize": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/data/node_modules/@wordpress/url": {
+      "version": "3.59.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
+      "integrity": "sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@woocommerce/data/node_modules/dompurify": {
       "version": "2.5.8",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
       "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
       "license": "(MPL-2.0 OR Apache-2.0)"
+    },
+    "node_modules/@woocommerce/data/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/@woocommerce/date": {
       "version": "4.2.0",
@@ -9337,6 +10923,26 @@
       },
       "peerDependencies": {
         "lodash": "^4.17.0"
+      }
+    },
+    "node_modules/@woocommerce/date/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@woocommerce/navigation": {
@@ -9411,6 +11017,29 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@woocommerce/navigation/node_modules/@types/react-dom": {
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/api-fetch": {
+      "version": "6.55.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
+      "integrity": "sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/url": "^3.59.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@woocommerce/navigation/node_modules/@wordpress/components": {
       "version": "19.17.0",
       "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-19.17.0.tgz",
@@ -9466,6 +11095,128 @@
         "react-dom": "^17.0.0"
       }
     },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/components/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/components/node_modules/remove-accents": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+      "license": "MIT"
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/compose": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
+      "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.8",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/data": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
+      "integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/redux-routine": "^4.58.0",
+        "deepmerge": "^4.3.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "redux": "^4.1.2",
+        "rememo": "^4.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/data/node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/data/node_modules/@wordpress/compose": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
+      "integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/dom": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/keycodes": "^3.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/undo-manager": "^0.18.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.11",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/data/node_modules/@wordpress/element": {
+      "version": "5.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.35.0.tgz",
+      "integrity": "sha512-puswpGcIdS+0A2g28uHriMkZqqRCmzFczue5Tk99VNtzBdehyk7Ae+DZ4xw5yT6GqYai8NTqv6MRwCB78uh5Mw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/react": "^18.2.79",
+        "@types/react-dom": "^18.2.25",
+        "@wordpress/escape-html": "^2.58.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@woocommerce/navigation/node_modules/@wordpress/element": {
       "version": "4.20.0",
       "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
@@ -9485,13 +11236,125 @@
         "node": ">=12"
       }
     },
-    "node_modules/@woocommerce/navigation/node_modules/@wordpress/hooks": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
-      "integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0"
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/notices": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-3.31.0.tgz",
+      "integrity": "sha512-9WyaFaSr/vQc1K7cZLyPw1xBKqWfjpAKMJzWMzHYjwk1ldibhBWVLukicuolD6Y+9l+97IZHCoESBQwUeFo79Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.31.0",
+        "@wordpress/data": "^9.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/redux-routine": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.58.0.tgz",
+      "integrity": "sha512-r0mMWFeJr93yPy2uY/M5+gdUUYj0Zu8+21OFFb5hyQ0z7UHIa3IdgQxzCaTbV1LDA1ZYJrjHeCnA6s4gNHjA2Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "rungen": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "redux": ">=4"
+      }
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/rich-text": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.20.0.tgz",
+      "integrity": "sha512-7W4PksJ6/SnQ+KuwvZ0dlKSwbaS6ejvWBm2N8R5S79AzbdmB69BpDCz0U/GUfGDXDhrU9dpzg5NIivoW2LC8Kg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/escape-html": "^2.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "memize": "^1.1.0",
+        "rememo": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/rich-text/node_modules/@wordpress/data": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-7.6.0.tgz",
+      "integrity": "sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "@wordpress/redux-routine": "^4.22.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "redux": "^4.1.2",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/rich-text/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
+    "node_modules/@woocommerce/navigation/node_modules/@wordpress/url": {
+      "version": "3.59.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
+      "integrity": "sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "remove-accents": "^0.5.0"
       },
       "engines": {
         "node": ">=12"
@@ -9518,6 +11381,15 @@
         "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@woocommerce/navigation/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@woocommerce/number": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.4.0.tgz",
@@ -9541,36 +11413,54 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/api-fetch": {
-      "version": "6.55.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
-      "integrity": "sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==",
+    "node_modules/@wordpress/a11y/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.58.0",
-        "@wordpress/url": "^3.59.0"
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/api-fetch": {
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.37.0.tgz",
+      "integrity": "sha512-BFxfDiVKydoDZN1evbdIHzUzbbbW+Clat+2AMPTH+illCD2RcCiascKUu8n0bqQy1JxyzA8Xsm8Arn9cSlOGwA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/url": "^4.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/autop": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.58.0.tgz",
-      "integrity": "sha512-RsdUV57A+DTJGU3slq/S9vTOtVkatnT1YyGIK3UDKaEhXkvBPtLTWwd3WR13GCfjFZ5XupH9FAGUQFkOve0eKQ==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.37.0.tgz",
+      "integrity": "sha512-i1T5i2tiG4USM52xgONDYjzJimJA+tMJX+cP+pcgepWcDFKE5WCU0tgQClLuilrHqGe5sykAWnH1QigCz3uLSg==",
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-5.35.0.tgz",
-      "integrity": "sha512-LVDUawBIB2yBRoWl18JgCwdfg/2nAUo5aSRmrZOq3J8iPLozA1XQl8fA7wUsalRRq6ZWd8NLTVibMB9U2qPtug==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-5.37.0.tgz",
+      "integrity": "sha512-QjphjEyCd6DRnCfdk7joXheusTggSv9zFwCxLsRyQkGwfEYpneBHSlEydB1gj+Luhl5kDjU4567iRuIXxKQIFA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -9606,9 +11496,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.11.0.tgz",
-      "integrity": "sha512-olV27w/QCztQj7xs/WssxrGJh7jyI+dVsQBw1p+LOo+XxRhFq6MvcUH6vEBXpU78ICtlqEx/uR3eYwEy1hQhUw==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.13.0.tgz",
+      "integrity": "sha512-+APLd5GqzzJ/atVVs3LGPcCRRy8mVfVQi1QY+cseNAQbRe4LvsDarLbzkblWEwuksxgUGmVGDC3fDNxrwszJ2A==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9616,233 +11506,479 @@
       }
     },
     "node_modules/@wordpress/blob": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.58.0.tgz",
-      "integrity": "sha512-6L3WqbOWEGFOSs3vLMwJ83YScggCiJ9NvZj1kC7mgeiP302UP2Fxkt4KlfjeTsD350XcvakkD/57wRkHXd819Q==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.37.0.tgz",
+      "integrity": "sha512-R0Dr8WkRKUszHNcif7zaCPUDmMSOOOsfC5as8kNMm8EKFPKh24FsB4LWryljafji2ZWwNPQ6x+eGUqpJwmMq9w==",
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/block-editor": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-9.8.0.tgz",
-      "integrity": "sha512-zIPqEysaLFJMnVKU/yCoCEBT3Co9xsa4Ow91T/LI94ll3LeWG/pyiX4PSSQNTx74AqbcNO2p79LVON4FLdu+mQ==",
+      "version": "15.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.10.0.tgz",
+      "integrity": "sha512-P8SXWUPEs3OovtlpbXJmC+4an0jolgdC+toaknOvNi1o3SAH44G8o4NYyXMgyhr5ub/+hsRQplEjInFJ/SZ+iA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
         "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^3.16.0",
-        "@wordpress/api-fetch": "^6.13.0",
-        "@wordpress/blob": "^3.16.0",
-        "@wordpress/blocks": "^11.15.0",
-        "@wordpress/components": "^20.0.0",
-        "@wordpress/compose": "^5.14.0",
-        "@wordpress/data": "^7.0.0",
-        "@wordpress/date": "^4.16.0",
-        "@wordpress/deprecated": "^3.16.0",
-        "@wordpress/dom": "^3.16.0",
-        "@wordpress/element": "^4.14.0",
-        "@wordpress/hooks": "^3.16.0",
-        "@wordpress/html-entities": "^3.16.0",
-        "@wordpress/i18n": "^4.16.0",
-        "@wordpress/icons": "^9.7.0",
-        "@wordpress/is-shallow-equal": "^4.16.0",
-        "@wordpress/keyboard-shortcuts": "^3.14.0",
-        "@wordpress/keycodes": "^3.16.0",
-        "@wordpress/notices": "^3.16.0",
-        "@wordpress/rich-text": "^5.14.0",
-        "@wordpress/shortcode": "^3.16.0",
-        "@wordpress/style-engine": "^0.15.0",
-        "@wordpress/token-list": "^2.16.0",
-        "@wordpress/url": "^3.17.0",
-        "@wordpress/warning": "^2.16.0",
-        "@wordpress/wordcount": "^3.16.0",
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/api-fetch": "^7.37.0",
+        "@wordpress/base-styles": "^6.13.0",
+        "@wordpress/blob": "^4.37.0",
+        "@wordpress/block-serialization-default-parser": "^5.37.0",
+        "@wordpress/blocks": "^15.10.0",
+        "@wordpress/commands": "^1.37.0",
+        "@wordpress/components": "^31.0.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/dataviews": "^11.1.0",
+        "@wordpress/date": "^5.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/global-styles-engine": "^1.4.0",
+        "@wordpress/hooks": "^4.37.0",
+        "@wordpress/html-entities": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/icons": "^11.4.0",
+        "@wordpress/image-cropper": "^1.1.0",
+        "@wordpress/interactivity": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keyboard-shortcuts": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/notices": "^5.37.0",
+        "@wordpress/preferences": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/rich-text": "^7.37.0",
+        "@wordpress/style-engine": "^2.37.0",
+        "@wordpress/token-list": "^3.37.0",
+        "@wordpress/upload-media": "^0.22.0",
+        "@wordpress/url": "^4.37.0",
+        "@wordpress/warning": "^3.37.0",
+        "@wordpress/wordcount": "^4.37.0",
         "change-case": "^4.1.2",
-        "classnames": "^2.3.1",
+        "clsx": "^2.1.1",
         "colord": "^2.7.0",
+        "deepmerge": "^4.3.0",
         "diff": "^4.0.2",
-        "dom-scroll-into-view": "^1.2.1",
-        "inherits": "^2.0.3",
-        "lodash": "^4.17.21",
+        "fast-deep-equal": "^3.1.3",
+        "memize": "^2.1.0",
+        "parsel-js": "^1.1.2",
+        "postcss": "^8.4.21",
+        "postcss-prefix-selector": "^1.16.0",
+        "postcss-urlrebase": "^1.4.0",
         "react-autosize-textarea": "^7.1.0",
-        "react-easy-crop": "^3.0.0",
-        "rememo": "^4.0.0",
-        "remove-accents": "^0.4.2",
-        "traverse": "^0.6.6"
+        "react-easy-crop": "^5.0.6",
+        "remove-accents": "^0.5.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/block-editor/node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+    "node_modules/@wordpress/block-editor/node_modules/@ariakit/core": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.18.tgz",
+      "integrity": "sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@ariakit/react": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.21.tgz",
+      "integrity": "sha512-UjP99Y7cWxA5seRECEE0RPZFImkLGFIWPflp65t0BVZwlMw4wp9OJZRHMrnkEkKl5KBE2NR/gbbzwHc6VNGzsA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@emotion/memoize": "0.7.4"
+        "@ariakit/react-core": "0.4.21"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ariakit"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@wordpress/block-editor/node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+    "node_modules/@wordpress/block-editor/node_modules/@ariakit/react-core": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.21.tgz",
+      "integrity": "sha512-rUI9uB/gT3mROFja/ka7/JukkdljIZR3eq3BGiQqX4Ni/KBMDvPK8FvVLnC0TGzWcqNY2bbfve8QllvHzuw4fQ==",
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "@ariakit/core": "0.4.18",
+        "@floating-ui/dom": "^1.0.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@wordpress/block-editor/node_modules/@floating-ui/react-dom": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
-      "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.2.1"
+        "@floating-ui/dom": "^1.6.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/components": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-20.0.0.tgz",
-      "integrity": "sha512-RBPjtGLSoiV5YKhrBYh+/X8LbzbA99BJaB4Q+P0e1rVOwGzeBF3M7YEjmg1PrrzWaItqJZTvDoyZo+ql7c0KfA==",
+    "node_modules/@wordpress/block-editor/node_modules/@types/gradient-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-1.1.0.tgz",
+      "integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/a11y": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.37.0.tgz",
+      "integrity": "sha512-OxJL0sBNy2IwFkrLv0X9tOgmdHbvgVajciN8T73S6jTh96iOmdISSb3n+I9fc81X0BB03rv4dh8q6zBb/67U6A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
+        "@wordpress/dom-ready": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/components": {
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-31.0.0.tgz",
+      "integrity": "sha512-2Oz4r+4KCDTV5fMC2l9bDYfRAsLQLs29fLB4PelckW+X3KhhFM6gz5vx5N7hO3WLY19Fn6qKZgtgJjOKWG7+1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.7.1",
         "@emotion/css": "^11.7.1",
         "@emotion/react": "^11.7.1",
         "@emotion/serialize": "^1.0.2",
         "@emotion/styled": "^11.6.0",
         "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^1.0.0",
-        "@use-gesture/react": "^10.2.6",
-        "@wordpress/a11y": "^3.16.0",
-        "@wordpress/compose": "^5.14.0",
-        "@wordpress/date": "^4.16.0",
-        "@wordpress/deprecated": "^3.16.0",
-        "@wordpress/dom": "^3.16.0",
-        "@wordpress/element": "^4.14.0",
-        "@wordpress/escape-html": "^2.16.0",
-        "@wordpress/hooks": "^3.16.0",
-        "@wordpress/i18n": "^4.16.0",
-        "@wordpress/icons": "^9.7.0",
-        "@wordpress/is-shallow-equal": "^4.16.0",
-        "@wordpress/keycodes": "^3.16.0",
-        "@wordpress/primitives": "^3.14.0",
-        "@wordpress/rich-text": "^5.14.0",
-        "@wordpress/warning": "^2.16.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/base-styles": "^6.13.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/date": "^5.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/hooks": "^4.37.0",
+        "@wordpress/html-entities": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/icons": "^11.4.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/primitives": "^4.37.0",
+        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/rich-text": "^7.37.0",
+        "@wordpress/warning": "^3.37.0",
         "change-case": "^4.1.2",
-        "classnames": "^2.3.1",
+        "clsx": "^2.1.1",
         "colord": "^2.7.0",
-        "date-fns": "^2.28.0",
-        "dom-scroll-into-view": "^1.2.1",
-        "downshift": "^6.0.15",
-        "framer-motion": "^6.2.8",
-        "gradient-parser": "^0.1.5",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
         "highlight-words-core": "^1.2.2",
-        "lodash": "^4.17.21",
-        "memize": "^1.1.0",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
         "re-resizable": "^6.4.0",
         "react-colorful": "^5.3.1",
-        "reakit": "^1.3.8",
-        "remove-accents": "^0.4.2",
-        "use-lilius": "^2.0.1",
-        "uuid": "^8.3.0"
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/data": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-7.6.0.tgz",
-      "integrity": "sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==",
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/compose": {
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^5.20.0",
-        "@wordpress/deprecated": "^3.22.0",
-        "@wordpress/element": "^4.20.0",
-        "@wordpress/is-shallow-equal": "^4.22.0",
-        "@wordpress/priority-queue": "^2.22.0",
-        "@wordpress/redux-routine": "^4.22.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "lodash": "^4.17.21",
-        "redux": "^4.1.2",
-        "turbo-combine-reducers": "^1.0.2",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.11",
+        "mousetrap": "^1.6.5",
         "use-memo-one": "^1.1.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/date": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.37.0.tgz",
+      "integrity": "sha512-T5YF5WLQu71bgw/KXhKcIqIRmAyf6nCq7J448MZlPIr0M9DAVPARXCOxYA4t/FW3PzwpFUARIuO2aNXTTO+nsA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/deprecated": "^4.37.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/deprecated": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/hooks": "^4.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/dom": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/deprecated": "^4.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/dom-ready": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.37.0.tgz",
+      "integrity": "sha512-igored8VegL2n/koKIyUhgPLhUfTa4N6zWO4gZpyeznr49M5wP/9Ak/tvIljUts9McHc2CVnCYMjZV0Zyz2aWg==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/block-editor/node_modules/@wordpress/element": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
-      "integrity": "sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^17.0.37",
-        "@types/react-dom": "^17.0.11",
-        "@wordpress/escape-html": "^2.22.0",
+        "@types/react": "^18.2.79",
+        "@types/react-dom": "^18.2.25",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/escape-html": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/block-editor/node_modules/@wordpress/hooks": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
-      "integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/redux-routine": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.58.0.tgz",
-      "integrity": "sha512-r0mMWFeJr93yPy2uY/M5+gdUUYj0Zu8+21OFFb5hyQ0z7UHIa3IdgQxzCaTbV1LDA1ZYJrjHeCnA6s4gNHjA2Q==",
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/html-entities": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.37.0.tgz",
+      "integrity": "sha512-d3uaAoGs20xpvdOTWlpTbxO4a8YwKYyBjoNhkL+w9qAg8NqLk9r2Z1pTj4EbYF9iS6SorDUdnXsTMuZ0/pm4Sw==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/icons": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.4.0.tgz",
+      "integrity": "sha512-3sis5bwTyDOrLy83Mp799NNJuEgbTOWwHpxnGNmabEDA3BbBYPnr0soSGSFe201nqNKiVwL/TcpRaQ91SoEHTQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/primitives": "^4.37.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "redux": ">=4"
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/is-shallow-equal": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.10.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/primitives": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.37.0.tgz",
+      "integrity": "sha512-iPpiS1tu1U5cXxVW6CQ45rqdnIc4Ev5FGyicuuaru0wboC+d2CwoNHxPFDOOpGL16yp8OfSDA13vQY3MJHw7QA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.37.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/priority-queue": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "requestidlecallback": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/private-apis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.37.0.tgz",
+      "integrity": "sha512-BR5GEHontWnza1tfBm2aX6/GjCZ1xZRrRNN1P0oj9xuvtut3YzCr//pZuyQ+P5maByDthUZjNrvN3UEF1iucbA==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/rich-text": {
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.37.0.tgz",
+      "integrity": "sha512-uvLLVg77F4meoMMYjtdYcvo4eQxj3mKH8f9dKnkCrOyKOKNCdV5wHDUYWrySkgrAyoBJjTm8hZKK/U3adlPgEg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "colord": "2.9.3",
+        "memize": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/warning": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.37.0.tgz",
+      "integrity": "sha512-oXWyKiYJIa9SuPRNEJiOWn2Qk0RzfxOsDqXcus1OL44swCRtSM+ypm16CJpRhZpMUcsJ6d23PBxTC97C/iiJpQ==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@wordpress/block-editor/node_modules/diff": {
@@ -9854,25 +11990,12 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/@wordpress/block-editor/node_modules/framer-motion": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
-      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/dom": "10.12.0",
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "popmotion": "11.0.3",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      },
-      "optionalDependencies": {
-        "@emotion/is-prop-valid": "^0.8.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
-        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
+    "node_modules/@wordpress/block-editor/node_modules/gradient-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.1.1.tgz",
+      "integrity": "sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@wordpress/block-library": {
@@ -9956,6 +12079,53 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@wordpress/block-library/node_modules/@types/react-dom": {
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/api-fetch": {
+      "version": "6.55.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
+      "integrity": "sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/url": "^3.59.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/autop": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.58.0.tgz",
+      "integrity": "sha512-RsdUV57A+DTJGU3slq/S9vTOtVkatnT1YyGIK3UDKaEhXkvBPtLTWwd3WR13GCfjFZ5XupH9FAGUQFkOve0eKQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/blob": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.58.0.tgz",
+      "integrity": "sha512-6L3WqbOWEGFOSs3vLMwJ83YScggCiJ9NvZj1kC7mgeiP302UP2Fxkt4KlfjeTsD350XcvakkD/57wRkHXd819Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wordpress/block-library/node_modules/@wordpress/block-editor": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-10.5.0.tgz",
@@ -10009,6 +12179,57 @@
       "peerDependencies": {
         "react": "^17.0.0",
         "react-dom": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/block-serialization-default-parser": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.58.0.tgz",
+      "integrity": "sha512-++fowmFEJC+1SwiCGuLPO9k+g3rgI2SCAA/p8/Bc1rNgnKB+rowzmQvSIIlRpcUkmOxHOrH5uruOEX27Ksg6uw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/blocks": {
+      "version": "11.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.21.0.tgz",
+      "integrity": "sha512-FlOrF0VMugW7wW9LAAF3ixUp2t1HsEGTBjqERYr7dYQIJI8yIII7/Zh2Opuzq0baWaA7kqexUQeD6sYSOcu8lA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/autop": "^3.22.0",
+        "@wordpress/blob": "^3.22.0",
+        "@wordpress/block-serialization-default-parser": "^4.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/hooks": "^3.22.0",
+        "@wordpress/html-entities": "^3.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/shortcode": "^3.22.0",
+        "change-case": "^4.1.2",
+        "colord": "^2.7.0",
+        "hpq": "^1.3.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "rememo": "^4.0.0",
+        "remove-accents": "^0.4.2",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
       }
     },
     "node_modules/@wordpress/block-library/node_modules/@wordpress/components": {
@@ -10068,39 +12289,30 @@
         "react-dom": "^17.0.0"
       }
     },
-    "node_modules/@wordpress/block-library/node_modules/@wordpress/components/node_modules/derive-valtio": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/derive-valtio/-/derive-valtio-0.1.0.tgz",
-      "integrity": "sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "valtio": "*"
-      }
-    },
-    "node_modules/@wordpress/block-library/node_modules/@wordpress/components/node_modules/valtio": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.13.2.tgz",
-      "integrity": "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==",
-      "license": "MIT",
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/compose": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
+      "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "derive-valtio": "0.1.0",
-        "proxy-compare": "2.6.0",
-        "use-sync-external-store": "1.2.0"
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.8",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
       },
       "engines": {
-        "node": ">=12.20.0"
+        "node": ">=12"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
+        "react": "^17.0.0"
       }
     },
     "node_modules/@wordpress/block-library/node_modules/@wordpress/core-data": {
@@ -10181,13 +12393,144 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/block-library/node_modules/@wordpress/hooks": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
-      "integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0"
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/i18n/node_modules/memize": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/keyboard-shortcuts": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-3.20.0.tgz",
+      "integrity": "sha512-78JTtqw6CGm9aMrZmRjvlQ8+skK/8ZV2rNd58ZpWT9Htp5jEB5ddt34P5wn04UiDOFFd13sy5HOqhsUFHh4qFA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "rememo": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/notices": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-3.31.0.tgz",
+      "integrity": "sha512-9WyaFaSr/vQc1K7cZLyPw1xBKqWfjpAKMJzWMzHYjwk1ldibhBWVLukicuolD6Y+9l+97IZHCoESBQwUeFo79Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.31.0",
+        "@wordpress/data": "^9.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/notices/node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
+      "integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/dom": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/keycodes": "^3.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/undo-manager": "^0.18.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.11",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/notices/node_modules/@wordpress/data": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
+      "integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/redux-routine": "^4.58.0",
+        "deepmerge": "^4.3.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "redux": "^4.1.2",
+        "rememo": "^4.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/notices/node_modules/@wordpress/element": {
+      "version": "5.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.35.0.tgz",
+      "integrity": "sha512-puswpGcIdS+0A2g28uHriMkZqqRCmzFczue5Tk99VNtzBdehyk7Ae+DZ4xw5yT6GqYai8NTqv6MRwCB78uh5Mw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/react": "^18.2.79",
+        "@types/react-dom": "^18.2.25",
+        "@wordpress/escape-html": "^2.58.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
       },
       "engines": {
         "node": ">=12"
@@ -10211,6 +12554,50 @@
         "redux": ">=4"
       }
     },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/rich-text": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.20.0.tgz",
+      "integrity": "sha512-7W4PksJ6/SnQ+KuwvZ0dlKSwbaS6ejvWBm2N8R5S79AzbdmB69BpDCz0U/GUfGDXDhrU9dpzg5NIivoW2LC8Kg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/escape-html": "^2.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "memize": "^1.1.0",
+        "rememo": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/shortcode": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.58.0.tgz",
+      "integrity": "sha512-yM3Y25XqLfz/X6xXowXbrTvk+tslKeALNNESI5nGt1X7wWPsYQDOqyBb1HT9TglSLFgWYlQlNtgEbz07dEiDgQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "memize": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/shortcode/node_modules/memize": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
+      "license": "MIT"
+    },
     "node_modules/@wordpress/block-library/node_modules/@wordpress/style-engine": {
       "version": "1.41.0",
       "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-1.41.0.tgz",
@@ -10219,6 +12606,49 @@
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "change-case": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/token-list": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.58.0.tgz",
+      "integrity": "sha512-xzNGzAZ87GERq7rZvZjMv742nj37tSLFBb8+c7oaLdpUpfn8YTaXQacvphdN2jmtfHvEZHivW7hErwqF9eQW/A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/url": {
+      "version": "3.59.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
+      "integrity": "sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/url/node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/wordcount": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.58.0.tgz",
+      "integrity": "sha512-cxmOOh8d4VeIC3B9HcqhlTQePmNkNrPeHQLj6xWHfC0Elflj+kYAjsTwkjVQ3tBMC4+mQzva1O8tFSVh02gs7w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
       },
       "engines": {
         "node": ">=12"
@@ -10254,6 +12684,12 @@
         "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@wordpress/block-library/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
     "node_modules/@wordpress/block-library/node_modules/react-easy-crop": {
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-4.7.5.tgz",
@@ -10274,141 +12710,290 @@
       "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
       "license": "0BSD"
     },
-    "node_modules/@wordpress/block-library/node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+    "node_modules/@wordpress/block-library/node_modules/remove-accents": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/block-library/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.58.0.tgz",
-      "integrity": "sha512-++fowmFEJC+1SwiCGuLPO9k+g3rgI2SCAA/p8/Bc1rNgnKB+rowzmQvSIIlRpcUkmOxHOrH5uruOEX27Ksg6uw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.37.0.tgz",
+      "integrity": "sha512-fLUHChZv5sjbX+vkn2EJuEuUdAvCfx1tdmCuTi94O43/AsQc8u6sva7gtd59uttiJXKkLS9sPiM8oaoXCMb8Tw==",
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/blocks": {
-      "version": "11.21.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.21.0.tgz",
-      "integrity": "sha512-FlOrF0VMugW7wW9LAAF3ixUp2t1HsEGTBjqERYr7dYQIJI8yIII7/Zh2Opuzq0baWaA7kqexUQeD6sYSOcu8lA==",
+      "version": "15.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.10.0.tgz",
+      "integrity": "sha512-Bf5sp9QfifDpUsdjh5Vffjdt+SUfTAZJVFsEqN1GqB9Xfh0bXMXx0VtRjgqtdNdGd+0GX9WUhm3IVVizBCcyLw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/autop": "^3.22.0",
-        "@wordpress/blob": "^3.22.0",
-        "@wordpress/block-serialization-default-parser": "^4.22.0",
-        "@wordpress/compose": "^5.20.0",
-        "@wordpress/data": "^7.6.0",
-        "@wordpress/deprecated": "^3.22.0",
-        "@wordpress/dom": "^3.22.0",
-        "@wordpress/element": "^4.20.0",
-        "@wordpress/hooks": "^3.22.0",
-        "@wordpress/html-entities": "^3.22.0",
-        "@wordpress/i18n": "^4.22.0",
-        "@wordpress/is-shallow-equal": "^4.22.0",
-        "@wordpress/shortcode": "^3.22.0",
+        "@wordpress/autop": "^4.37.0",
+        "@wordpress/blob": "^4.37.0",
+        "@wordpress/block-serialization-default-parser": "^5.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/hooks": "^4.37.0",
+        "@wordpress/html-entities": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/rich-text": "^7.37.0",
+        "@wordpress/shortcode": "^4.37.0",
+        "@wordpress/warning": "^3.37.0",
         "change-case": "^4.1.2",
         "colord": "^2.7.0",
+        "fast-deep-equal": "^3.1.3",
         "hpq": "^1.3.0",
         "is-plain-object": "^5.0.0",
-        "lodash": "^4.17.21",
-        "memize": "^1.1.0",
-        "rememo": "^4.0.0",
-        "remove-accents": "^0.4.2",
+        "memize": "^2.1.0",
+        "react-is": "^18.3.0",
+        "remove-accents": "^0.5.0",
         "showdown": "^1.9.1",
         "simple-html-tokenizer": "^0.5.7",
-        "uuid": "^8.3.0"
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/data": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-7.6.0.tgz",
-      "integrity": "sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==",
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/a11y": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.37.0.tgz",
+      "integrity": "sha512-OxJL0sBNy2IwFkrLv0X9tOgmdHbvgVajciN8T73S6jTh96iOmdISSb3n+I9fc81X0BB03rv4dh8q6zBb/67U6A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^5.20.0",
-        "@wordpress/deprecated": "^3.22.0",
-        "@wordpress/element": "^4.20.0",
-        "@wordpress/is-shallow-equal": "^4.22.0",
-        "@wordpress/priority-queue": "^2.22.0",
-        "@wordpress/redux-routine": "^4.22.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "lodash": "^4.17.21",
-        "redux": "^4.1.2",
-        "turbo-combine-reducers": "^1.0.2",
+        "@wordpress/dom-ready": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/compose": {
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.11",
+        "mousetrap": "^1.6.5",
         "use-memo-one": "^1.1.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/deprecated": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/hooks": "^4.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/dom": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/deprecated": "^4.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/dom-ready": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.37.0.tgz",
+      "integrity": "sha512-igored8VegL2n/koKIyUhgPLhUfTa4N6zWO4gZpyeznr49M5wP/9Ak/tvIljUts9McHc2CVnCYMjZV0Zyz2aWg==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/blocks/node_modules/@wordpress/element": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
-      "integrity": "sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^17.0.37",
-        "@types/react-dom": "^17.0.11",
-        "@wordpress/escape-html": "^2.22.0",
+        "@types/react": "^18.2.79",
+        "@types/react-dom": "^18.2.25",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/escape-html": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/blocks/node_modules/@wordpress/hooks": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
-      "integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/redux-routine": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.58.0.tgz",
-      "integrity": "sha512-r0mMWFeJr93yPy2uY/M5+gdUUYj0Zu8+21OFFb5hyQ0z7UHIa3IdgQxzCaTbV1LDA1ZYJrjHeCnA6s4gNHjA2Q==",
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/html-entities": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.37.0.tgz",
+      "integrity": "sha512-d3uaAoGs20xpvdOTWlpTbxO4a8YwKYyBjoNhkL+w9qAg8NqLk9r2Z1pTj4EbYF9iS6SorDUdnXsTMuZ0/pm4Sw==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/is-shallow-equal": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/keycodes": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/priority-queue": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "requestidlecallback": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/private-apis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.37.0.tgz",
+      "integrity": "sha512-BR5GEHontWnza1tfBm2aX6/GjCZ1xZRrRNN1P0oj9xuvtut3YzCr//pZuyQ+P5maByDthUZjNrvN3UEF1iucbA==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/rich-text": {
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.37.0.tgz",
+      "integrity": "sha512-uvLLVg77F4meoMMYjtdYcvo4eQxj3mKH8f9dKnkCrOyKOKNCdV5wHDUYWrySkgrAyoBJjTm8hZKK/U3adlPgEg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "colord": "2.9.3",
+        "memize": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "redux": ">=4"
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/@wordpress/warning": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.37.0.tgz",
+      "integrity": "sha512-oXWyKiYJIa9SuPRNEJiOWn2Qk0RzfxOsDqXcus1OL44swCRtSM+ypm16CJpRhZpMUcsJ6d23PBxTC97C/iiJpQ==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/browserslist-config": {
@@ -10422,19 +13007,19 @@
       }
     },
     "node_modules/@wordpress/commands": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.35.0.tgz",
-      "integrity": "sha512-a4NTHMRKq+Hk0sBg1eFPk4CiMGqJkWyilml2M4Sk1bT3xFCMBmXaYWtC+k82e5EzmyU/W+b+/sctHkb8m3eeeg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.37.0.tgz",
+      "integrity": "sha512-1oosAowqYxo0sQ7IyFfXeCsLEDQaZhx6eCpucMDH9IX8KtxudRfqYSc6StTfKR4kXntce4yBI4h9cA7UyX4zdA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^6.11.0",
-        "@wordpress/components": "^30.8.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/icons": "^11.2.0",
-        "@wordpress/keyboard-shortcuts": "^5.35.0",
-        "@wordpress/private-apis": "^1.35.0",
+        "@wordpress/base-styles": "^6.13.0",
+        "@wordpress/components": "^31.0.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/icons": "^11.4.0",
+        "@wordpress/keyboard-shortcuts": "^5.37.0",
+        "@wordpress/private-apis": "^1.37.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0"
       },
@@ -10448,18 +13033,18 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@ariakit/core": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.16.tgz",
-      "integrity": "sha512-nPJ0Be8d5ZvRApYGqdLMuYUjP7ktkPmTPOXyZFw+0Illk8LKgF3Q74ctVGuoQurJNDsANXcewzlyXK4vyIAGTA==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.18.tgz",
+      "integrity": "sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==",
       "license": "MIT"
     },
     "node_modules/@wordpress/commands/node_modules/@ariakit/react": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.19.tgz",
-      "integrity": "sha512-n6q8leSQWXMk4vhcZlpnj8cIlAY0n+1bvVTwHvaVfmec4LjW49MFKkJRZd1AiV+SE73nkxPwSL3IbaS4p1aRxQ==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.21.tgz",
+      "integrity": "sha512-UjP99Y7cWxA5seRECEE0RPZFImkLGFIWPflp65t0BVZwlMw4wp9OJZRHMrnkEkKl5KBE2NR/gbbzwHc6VNGzsA==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.19"
+        "@ariakit/react-core": "0.4.21"
       },
       "funding": {
         "type": "opencollective",
@@ -10471,12 +13056,12 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@ariakit/react-core": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.19.tgz",
-      "integrity": "sha512-Aj+fu4pMyPXtlBghI+E7KSWItqJkbAqEhut3DlsFAjK9fQdHE+e1tQJG1PtnoEdD9BExkJWQ6R4M5a9HkEhqPA==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.21.tgz",
+      "integrity": "sha512-rUI9uB/gT3mROFja/ka7/JukkdljIZR3eq3BGiQqX4Ni/KBMDvPK8FvVLnC0TGzWcqNY2bbfve8QllvHzuw4fQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/core": "0.4.16",
+        "@ariakit/core": "0.4.18",
         "@floating-ui/dom": "^1.0.0",
         "use-sync-external-store": "^1.2.0"
       },
@@ -10504,23 +13089,14 @@
       "integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==",
       "license": "MIT"
     },
-    "node_modules/@wordpress/commands/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
     "node_modules/@wordpress/commands/node_modules/@wordpress/a11y": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.35.0.tgz",
-      "integrity": "sha512-37DeBnBU20lLpQjwAZx0fkPsrrXT4COMSRhZOiFifv7wCiNW1DIukfqReAc/yZ6x0wOtqXKA3n905D8zm5NF5A==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.37.0.tgz",
+      "integrity": "sha512-OxJL0sBNy2IwFkrLv0X9tOgmdHbvgVajciN8T73S6jTh96iOmdISSb3n+I9fc81X0BB03rv4dh8q6zBb/67U6A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dom-ready": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/dom-ready": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10528,12 +13104,13 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/components": {
-      "version": "30.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.8.0.tgz",
-      "integrity": "sha512-lVcPXXeip41K6VmvVLkIPPbhsfIn5QZ9AFozkPEZPDOcpFvvYTnT4hDRM5+Pi9xrO2TOGhbXoJmYlFjAx19xSw==",
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-31.0.0.tgz",
+      "integrity": "sha512-2Oz4r+4KCDTV5fMC2l9bDYfRAsLQLs29fLB4PelckW+X3KhhFM6gz5vx5N7hO3WLY19Fn6qKZgtgJjOKWG7+1w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.7.1",
         "@emotion/css": "^11.7.1",
         "@emotion/react": "^11.7.1",
@@ -10544,24 +13121,24 @@
         "@types/gradient-parser": "1.1.0",
         "@types/highlight-words-core": "1.2.1",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/base-styles": "^6.11.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/date": "^5.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/escape-html": "^3.35.0",
-        "@wordpress/hooks": "^4.35.0",
-        "@wordpress/html-entities": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/icons": "^11.2.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/primitives": "^4.35.0",
-        "@wordpress/private-apis": "^1.35.0",
-        "@wordpress/rich-text": "^7.35.0",
-        "@wordpress/warning": "^3.35.0",
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/base-styles": "^6.13.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/date": "^5.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/hooks": "^4.37.0",
+        "@wordpress/html-entities": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/icons": "^11.4.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/primitives": "^4.37.0",
+        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/rich-text": "^7.37.0",
+        "@wordpress/warning": "^3.37.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -10590,19 +13167,19 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/compose": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.35.0.tgz",
-      "integrity": "sha512-UUQ31Rfi+KFfqT5wkbTgq0nMh+QfbLvshhm30+EGr8R3bYziHhfLKhIL2YQXf4MIX4owOFdKgbAt4GFeVI24ng==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -10617,12 +13194,12 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/date": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.35.0.tgz",
-      "integrity": "sha512-xXJf703MtQCbgoAT1DSwRu+iWcgb6UFAoBnnzq8ohZCICsBxEGOOr+EAgblvFSNPV3MCtUOr98zRCAuGon3Gqw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.37.0.tgz",
+      "integrity": "sha512-T5YF5WLQu71bgw/KXhKcIqIRmAyf6nCq7J448MZlPIr0M9DAVPARXCOxYA4t/FW3PzwpFUARIuO2aNXTTO+nsA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0",
+        "@wordpress/deprecated": "^4.37.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -10632,12 +13209,12 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/deprecated": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.35.0.tgz",
-      "integrity": "sha512-+TruZtmDxRfVw02c1de7ofGC3CrcaPCUXCCbwfP6ruy1zM3IC3rtJfyTbqKPqO1y4uI+9Kqe5VEobqRKT3HQSg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.35.0"
+        "@wordpress/hooks": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10645,12 +13222,12 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/dom": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.35.0.tgz",
-      "integrity": "sha512-mM/8m548RaWtkBonpCYHprXgyVFjKcFJWyHfWZz17j01xIbzBq+//cR/Lff86EiEuwynedqlFoEJUcgvPkrJZw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0"
+        "@wordpress/deprecated": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10658,9 +13235,9 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/dom-ready": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.35.0.tgz",
-      "integrity": "sha512-u8ifPAFsIAkBG3ehcZdnt+b3t2S0gD3dyDMKgl+GO95wq6kJFqo/NYNQqsjeYUMOFX7cL9D0F2gxiBB4D/AQIA==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.37.0.tgz",
+      "integrity": "sha512-igored8VegL2n/koKIyUhgPLhUfTa4N6zWO4gZpyeznr49M5wP/9Ak/tvIljUts9McHc2CVnCYMjZV0Zyz2aWg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -10668,14 +13245,14 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/element": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.35.0.tgz",
-      "integrity": "sha512-RmxQsk0ANoHtxDc6anbUH/lHL7Mmbbdn016WKHYVh4+79EzN1tBeM8OML2gHpllUISmIYQvO4wIPSmEVzRh+Gw==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.35.0",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -10687,9 +13264,9 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/escape-html": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.35.0.tgz",
-      "integrity": "sha512-thY7RGAI6UijG3sbBm4IRzMX9lnHkEA/vR3Y0E5BGQYzNFwc+i7t1Lm4scpEBnL3UEQxdlD1wiJTH4pv5olV+Q==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -10697,9 +13274,9 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -10707,68 +13284,23 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/html-entities": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.35.0.tgz",
-      "integrity": "sha512-43K8viPNNWUxmCKfKN2Dx/TgJitbGeGCfWBj0aloRoeqOUeEuDkWoak+XiIrJKpwYHTYhqtePl7COMWPzwkqbw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.37.0.tgz",
+      "integrity": "sha512-d3uaAoGs20xpvdOTWlpTbxO4a8YwKYyBjoNhkL+w9qAg8NqLk9r2Z1pTj4EbYF9iS6SorDUdnXsTMuZ0/pm4Sw==",
       "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/icons": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.2.0.tgz",
-      "integrity": "sha512-9OIymLlwanLkSjKbUyKwF4Z4LnCojQsulQNGsZVpaqx7ryqEGEMvNJ5BvrzUWBoQpX9nvJBvK+obE1zxE0vt+g==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.4.0.tgz",
+      "integrity": "sha512-3sis5bwTyDOrLy83Mp799NNJuEgbTOWwHpxnGNmabEDA3BbBYPnr0soSGSFe201nqNKiVwL/TcpRaQ91SoEHTQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/primitives": "^4.35.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.35.0.tgz",
-      "integrity": "sha512-ooM/QFzxu8Ueqsv0D/z0+X6grbVws3GFMSxdM12eZO1B0/x6JPAtq4msZkoxqeQ4zoR0ghYHFXzv3k+Ch1tsFw==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.35.0.tgz",
-      "integrity": "sha512-RD5LiguBORTOmW6iGMVtJ8OXReKK0LO1ZdTiDf0sIjTV9Z++O+OQzfknA7ViZhysqHOqNVdK/laFpiDuizppGw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/keycodes": "^4.35.0"
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/primitives": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10778,13 +13310,23 @@
         "react": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/commands/node_modules/@wordpress/is-shallow-equal": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/commands/node_modules/@wordpress/keycodes": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.35.0.tgz",
-      "integrity": "sha512-+cvb9I4VorJRUsPC4C/2e0QWMz8hkjQIvjz3BjTkIXyWlxsSRSk/+a/YCrfyyA5ysuR9PgwKxxI7/ZaAPvOC6w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10792,12 +13334,12 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/primitives": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.35.0.tgz",
-      "integrity": "sha512-F7FqOM9tkgwc0DwFqsgtOcvREJgBHALbCBFwv1kmxRadknD6YsBdmpamceN2UIHi9NnOM0Gruo2vJNKjoN4bEw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.37.0.tgz",
+      "integrity": "sha512-iPpiS1tu1U5cXxVW6CQ45rqdnIc4Ev5FGyicuuaru0wboC+d2CwoNHxPFDOOpGL16yp8OfSDA13vQY3MJHw7QA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.35.0",
+        "@wordpress/element": "^6.37.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -10809,9 +13351,9 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/priority-queue": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.35.0.tgz",
-      "integrity": "sha512-kLdPx09CnPMPUL5hI/3SUgbBVEka20iWBxM2pvwJGrn3bleY0WxGqLtoUksn6yQds9d7jjS5cKoBYxY1H8MHgg==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -10822,9 +13364,9 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/private-apis": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.35.0.tgz",
-      "integrity": "sha512-gpwYCAuWSjSps7KnmPfUSdJUf5iq8P0ln1eZPcnjs3IwRDUrKW9eUrO0jID+XUsi63qi5c+lv9UkwI8M8C9c5A==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.37.0.tgz",
+      "integrity": "sha512-BR5GEHontWnza1tfBm2aX6/GjCZ1xZRrRNN1P0oj9xuvtut3YzCr//pZuyQ+P5maByDthUZjNrvN3UEF1iucbA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -10832,19 +13374,19 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/rich-text": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.35.0.tgz",
-      "integrity": "sha512-GhR9unaSAeVd2UQ6/WgYyAfP/xSE4VD43XuxY6hV4LaU0Qobi/N38Pamkln4eMhORcY8RzNQSkpFX27Nj/fxTQ==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.37.0.tgz",
+      "integrity": "sha512-uvLLVg77F4meoMMYjtdYcvo4eQxj3mKH8f9dKnkCrOyKOKNCdV5wHDUYWrySkgrAyoBJjTm8hZKK/U3adlPgEg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/escape-html": "^3.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/keycodes": "^4.35.0",
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/keycodes": "^4.37.0",
         "colord": "2.9.3",
         "memize": "^2.1.0"
       },
@@ -10856,10 +13398,23 @@
         "react": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/commands/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/commands/node_modules/@wordpress/warning": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.35.0.tgz",
-      "integrity": "sha512-2UGZuHenf84UHdotBxv9ZCtlsFIy5u4QTUPBnx1gH4N9zEuJs+JiCtlOzgcl0JzT3xFK5y3cXLLVqlhf8tDMBQ==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.37.0.tgz",
+      "integrity": "sha512-oXWyKiYJIa9SuPRNEJiOWn2Qk0RzfxOsDqXcus1OL44swCRtSM+ypm16CJpRhZpMUcsJ6d23PBxTC97C/iiJpQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -10881,31 +13436,6 @@
       "integrity": "sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/commands/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/commands/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/components": {
@@ -10970,7 +13500,36 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/components/node_modules/@wordpress/compose": {
+    "node_modules/@wordpress/components/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@wordpress/compose": {
       "version": "6.35.0",
       "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
       "integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
@@ -10997,203 +13556,28 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/components/node_modules/@wordpress/data": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
-      "integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.35.0",
-        "@wordpress/deprecated": "^3.58.0",
-        "@wordpress/element": "^5.35.0",
-        "@wordpress/is-shallow-equal": "^4.58.0",
-        "@wordpress/priority-queue": "^2.58.0",
-        "@wordpress/private-apis": "^0.40.0",
-        "@wordpress/redux-routine": "^4.58.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/components/node_modules/@wordpress/hooks": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
-      "integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/components/node_modules/@wordpress/redux-routine": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.58.0.tgz",
-      "integrity": "sha512-r0mMWFeJr93yPy2uY/M5+gdUUYj0Zu8+21OFFb5hyQ0z7UHIa3IdgQxzCaTbV1LDA1ZYJrjHeCnA6s4gNHjA2Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/components/node_modules/@wordpress/rich-text": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-6.35.0.tgz",
-      "integrity": "sha512-h6/XftSqo9UQZebuNZyLfOVu+ButBLITW/BILsKeJhSpmM19VNdz8UhVGLp+xQPE+/GPCIMJrhhqipISDfc2Ig==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.58.0",
-        "@wordpress/compose": "^6.35.0",
-        "@wordpress/data": "^9.28.0",
-        "@wordpress/deprecated": "^3.58.0",
-        "@wordpress/element": "^5.35.0",
-        "@wordpress/escape-html": "^2.58.0",
-        "@wordpress/i18n": "^4.58.0",
-        "@wordpress/keycodes": "^3.58.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/components/node_modules/@wordpress/undo-manager": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.18.0.tgz",
-      "integrity": "sha512-upbzPEToa095XG+2JXLHaolF1LfXEMFS0lNMYV37myoUS+eZ7/tl9Gx+yU2+OqWy57TMwx33NlWUX/n+ynzPRw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^4.58.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/components/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@wordpress/components/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/components/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/components/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@wordpress/compose": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
-      "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^3.22.0",
-        "@wordpress/dom": "^3.22.0",
-        "@wordpress/element": "^4.20.0",
-        "@wordpress/is-shallow-equal": "^4.22.0",
-        "@wordpress/keycodes": "^3.22.0",
-        "@wordpress/priority-queue": "^2.22.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.8",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0"
-      }
-    },
-    "node_modules/@wordpress/compose/node_modules/@wordpress/element": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
-      "integrity": "sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^17.0.37",
-        "@types/react-dom": "^17.0.11",
-        "@wordpress/escape-html": "^2.22.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@wordpress/core-data": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.35.0.tgz",
-      "integrity": "sha512-fR85hKuiruHfx0G579SY5KySsb2+Rjfk3DKx4Zp21cYCOTu1a0/9vlIebuO9n1r8GplcelAFseAYoZP4OXaFLA==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.37.0.tgz",
+      "integrity": "sha512-PXvOobH9dj2GSJ7MFG4loCSIbZZkfEDQ3Ngm6tAI3LV4WaGCjqVebDx8aT9zT21jzZWIX757a3DedHOyCiFxog==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.35.0",
-        "@wordpress/block-editor": "^15.8.0",
-        "@wordpress/blocks": "^15.8.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/html-entities": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/private-apis": "^1.35.0",
-        "@wordpress/rich-text": "^7.35.0",
-        "@wordpress/sync": "^1.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
-        "@wordpress/url": "^4.35.0",
-        "@wordpress/warning": "^3.35.0",
+        "@wordpress/api-fetch": "^7.37.0",
+        "@wordpress/block-editor": "^15.10.0",
+        "@wordpress/blocks": "^15.10.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/html-entities": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/rich-text": "^7.37.0",
+        "@wordpress/sync": "^1.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
+        "@wordpress/url": "^4.37.0",
+        "@wordpress/warning": "^3.37.0",
         "change-case": "^4.1.2",
         "equivalent-key-map": "^0.2.2",
         "fast-deep-equal": "^3.1.3",
@@ -11207,317 +13591,36 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@ariakit/core": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.16.tgz",
-      "integrity": "sha512-nPJ0Be8d5ZvRApYGqdLMuYUjP7ktkPmTPOXyZFw+0Illk8LKgF3Q74ctVGuoQurJNDsANXcewzlyXK4vyIAGTA==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/core-data/node_modules/@ariakit/react": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.19.tgz",
-      "integrity": "sha512-n6q8leSQWXMk4vhcZlpnj8cIlAY0n+1bvVTwHvaVfmec4LjW49MFKkJRZd1AiV+SE73nkxPwSL3IbaS4p1aRxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/react-core": "0.4.19"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@ariakit/react-core": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.19.tgz",
-      "integrity": "sha512-Aj+fu4pMyPXtlBghI+E7KSWItqJkbAqEhut3DlsFAjK9fQdHE+e1tQJG1PtnoEdD9BExkJWQ6R4M5a9HkEhqPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/core": "0.4.16",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.2.0"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@floating-ui/react-dom": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.6.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@types/gradient-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-1.1.0.tgz",
-      "integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/core-data/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/a11y": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.35.0.tgz",
-      "integrity": "sha512-37DeBnBU20lLpQjwAZx0fkPsrrXT4COMSRhZOiFifv7wCiNW1DIukfqReAc/yZ6x0wOtqXKA3n905D8zm5NF5A==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.37.0.tgz",
+      "integrity": "sha512-OxJL0sBNy2IwFkrLv0X9tOgmdHbvgVajciN8T73S6jTh96iOmdISSb3n+I9fc81X0BB03rv4dh8q6zBb/67U6A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dom-ready": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/dom-ready": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/api-fetch": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.35.0.tgz",
-      "integrity": "sha512-jWIhNUVYkUOsVLvGodBhzLe4DR+gCNmh7sm91Vce/79M+DXMtEFLc8jHJ5kXKudnPPTzy29KF1ZzZJ9rm9sqRQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/url": "^4.35.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/autop": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.35.0.tgz",
-      "integrity": "sha512-Tpfl9BOgrOl+SpPDcOA77qotuJIzO7umqlSU4YgBFxxvOQM2L/+dJhBhzngfLKUoF9jcm7j12e7M9X9X216w+Q==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/blob": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.35.0.tgz",
-      "integrity": "sha512-8b+A6in2dH+PPhGGI84GwNPyi8mxXUgsTsBG9Ey/WCYRFWXJmqhkgTUnZIi4PvieJbmmAILI9oyfMPSfeAb0sg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/block-editor": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.8.0.tgz",
-      "integrity": "sha512-R9Nh7A5a9HFebNllLztVMSRS3bsyG8H7y+hmztF3+YdtQqLO0SVdkiaYrx3mPEUnmzd88dERpLfMOFtzCDUVwg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@emotion/react": "^11.7.1",
-        "@emotion/styled": "^11.6.0",
-        "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/api-fetch": "^7.35.0",
-        "@wordpress/base-styles": "^6.11.0",
-        "@wordpress/blob": "^4.35.0",
-        "@wordpress/block-serialization-default-parser": "^5.35.0",
-        "@wordpress/blocks": "^15.8.0",
-        "@wordpress/commands": "^1.35.0",
-        "@wordpress/components": "^30.8.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/date": "^5.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/escape-html": "^3.35.0",
-        "@wordpress/global-styles-engine": "^1.2.0",
-        "@wordpress/hooks": "^4.35.0",
-        "@wordpress/html-entities": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/icons": "^11.2.0",
-        "@wordpress/interactivity": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keyboard-shortcuts": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/notices": "^5.35.0",
-        "@wordpress/preferences": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/private-apis": "^1.35.0",
-        "@wordpress/rich-text": "^7.35.0",
-        "@wordpress/style-engine": "^2.35.0",
-        "@wordpress/token-list": "^3.35.0",
-        "@wordpress/upload-media": "^0.20.0",
-        "@wordpress/url": "^4.35.0",
-        "@wordpress/warning": "^3.35.0",
-        "@wordpress/wordcount": "^4.35.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "deepmerge": "^4.3.0",
-        "diff": "^4.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "memize": "^2.1.0",
-        "parsel-js": "^1.1.2",
-        "postcss": "^8.4.21",
-        "postcss-prefix-selector": "^1.16.0",
-        "postcss-urlrebase": "^1.4.0",
-        "react-autosize-textarea": "^7.1.0",
-        "react-easy-crop": "^5.0.6",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.35.0.tgz",
-      "integrity": "sha512-uLUGNu7Jj7Nk67vkDfAZeNTjLMUuD3PXlWW+75M641wTzGtMrrHSKTNHGoo7W4LyykaDmgfiTToZAu0REIgbJg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/blocks": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.8.0.tgz",
-      "integrity": "sha512-2PpklyJiRvrh7ozH+TTUQr/X0HmpemgG3z4tDi1XX+dDe10FJCvihTJa+/D9sbZQFk1zDJUzN1Kdr0elsGkRpA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/autop": "^4.35.0",
-        "@wordpress/blob": "^4.35.0",
-        "@wordpress/block-serialization-default-parser": "^5.35.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/hooks": "^4.35.0",
-        "@wordpress/html-entities": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/private-apis": "^1.35.0",
-        "@wordpress/rich-text": "^7.35.0",
-        "@wordpress/shortcode": "^4.35.0",
-        "@wordpress/warning": "^3.35.0",
-        "change-case": "^4.1.2",
-        "colord": "^2.7.0",
-        "fast-deep-equal": "^3.1.3",
-        "hpq": "^1.3.0",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "react-is": "^18.3.0",
-        "remove-accents": "^0.5.0",
-        "showdown": "^1.9.1",
-        "simple-html-tokenizer": "^0.5.7",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/components": {
-      "version": "30.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.8.0.tgz",
-      "integrity": "sha512-lVcPXXeip41K6VmvVLkIPPbhsfIn5QZ9AFozkPEZPDOcpFvvYTnT4hDRM5+Pi9xrO2TOGhbXoJmYlFjAx19xSw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.15",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "2.0.8",
-        "@types/gradient-parser": "1.1.0",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/base-styles": "^6.11.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/date": "^5.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/escape-html": "^3.35.0",
-        "@wordpress/hooks": "^4.35.0",
-        "@wordpress/html-entities": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/icons": "^11.2.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/primitives": "^4.35.0",
-        "@wordpress/private-apis": "^1.35.0",
-        "@wordpress/rich-text": "^7.35.0",
-        "@wordpress/warning": "^3.35.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.15.0",
-        "gradient-parser": "1.1.1",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "react-day-picker": "^9.7.0",
-        "remove-accents": "^0.5.0",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/compose": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.35.0.tgz",
-      "integrity": "sha512-UUQ31Rfi+KFfqT5wkbTgq0nMh+QfbLvshhm30+EGr8R3bYziHhfLKhIL2YQXf4MIX4owOFdKgbAt4GFeVI24ng==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -11531,28 +13634,13 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/date": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.35.0.tgz",
-      "integrity": "sha512-xXJf703MtQCbgoAT1DSwRu+iWcgb6UFAoBnnzq8ohZCICsBxEGOOr+EAgblvFSNPV3MCtUOr98zRCAuGon3Gqw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/deprecated": "^4.35.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/deprecated": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.35.0.tgz",
-      "integrity": "sha512-+TruZtmDxRfVw02c1de7ofGC3CrcaPCUXCCbwfP6ruy1zM3IC3rtJfyTbqKPqO1y4uI+9Kqe5VEobqRKT3HQSg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.35.0"
+        "@wordpress/hooks": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11560,12 +13648,12 @@
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/dom": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.35.0.tgz",
-      "integrity": "sha512-mM/8m548RaWtkBonpCYHprXgyVFjKcFJWyHfWZz17j01xIbzBq+//cR/Lff86EiEuwynedqlFoEJUcgvPkrJZw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0"
+        "@wordpress/deprecated": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11573,9 +13661,9 @@
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/dom-ready": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.35.0.tgz",
-      "integrity": "sha512-u8ifPAFsIAkBG3ehcZdnt+b3t2S0gD3dyDMKgl+GO95wq6kJFqo/NYNQqsjeYUMOFX7cL9D0F2gxiBB4D/AQIA==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.37.0.tgz",
+      "integrity": "sha512-igored8VegL2n/koKIyUhgPLhUfTa4N6zWO4gZpyeznr49M5wP/9Ak/tvIljUts9McHc2CVnCYMjZV0Zyz2aWg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -11583,14 +13671,14 @@
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/element": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.35.0.tgz",
-      "integrity": "sha512-RmxQsk0ANoHtxDc6anbUH/lHL7Mmbbdn016WKHYVh4+79EzN1tBeM8OML2gHpllUISmIYQvO4wIPSmEVzRh+Gw==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.35.0",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -11602,9 +13690,9 @@
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/escape-html": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.35.0.tgz",
-      "integrity": "sha512-thY7RGAI6UijG3sbBm4IRzMX9lnHkEA/vR3Y0E5BGQYzNFwc+i7t1Lm4scpEBnL3UEQxdlD1wiJTH4pv5olV+Q==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -11612,9 +13700,9 @@
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -11622,128 +13710,42 @@
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/html-entities": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.35.0.tgz",
-      "integrity": "sha512-43K8viPNNWUxmCKfKN2Dx/TgJitbGeGCfWBj0aloRoeqOUeEuDkWoak+XiIrJKpwYHTYhqtePl7COMWPzwkqbw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.37.0.tgz",
+      "integrity": "sha512-d3uaAoGs20xpvdOTWlpTbxO4a8YwKYyBjoNhkL+w9qAg8NqLk9r2Z1pTj4EbYF9iS6SorDUdnXsTMuZ0/pm4Sw==",
       "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/icons": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.2.0.tgz",
-      "integrity": "sha512-9OIymLlwanLkSjKbUyKwF4Z4LnCojQsulQNGsZVpaqx7ryqEGEMvNJ5BvrzUWBoQpX9nvJBvK+obE1zxE0vt+g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/primitives": "^4.35.0"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.35.0.tgz",
-      "integrity": "sha512-ooM/QFzxu8Ueqsv0D/z0+X6grbVws3GFMSxdM12eZO1B0/x6JPAtq4msZkoxqeQ4zoR0ghYHFXzv3k+Ch1tsFw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.35.0.tgz",
-      "integrity": "sha512-RD5LiguBORTOmW6iGMVtJ8OXReKK0LO1ZdTiDf0sIjTV9Z++O+OQzfknA7ViZhysqHOqNVdK/laFpiDuizppGw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/keycodes": "^4.35.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/keycodes": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.35.0.tgz",
-      "integrity": "sha512-+cvb9I4VorJRUsPC4C/2e0QWMz8hkjQIvjz3BjTkIXyWlxsSRSk/+a/YCrfyyA5ysuR9PgwKxxI7/ZaAPvOC6w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/notices": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.35.0.tgz",
-      "integrity": "sha512-AIyBM7rtlCG6X2kSR2eRG64Cs0llfXXpecD4EU0+vjUSQU/gBzlL/UUNwt69fe6RdbZEmsQkQmJ8WQk8YfAMIA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/data": "^10.35.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/primitives": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.35.0.tgz",
-      "integrity": "sha512-F7FqOM9tkgwc0DwFqsgtOcvREJgBHALbCBFwv1kmxRadknD6YsBdmpamceN2UIHi9NnOM0Gruo2vJNKjoN4bEw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^6.35.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/priority-queue": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.35.0.tgz",
-      "integrity": "sha512-kLdPx09CnPMPUL5hI/3SUgbBVEka20iWBxM2pvwJGrn3bleY0WxGqLtoUksn6yQds9d7jjS5cKoBYxY1H8MHgg==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -11754,9 +13756,9 @@
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/private-apis": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.35.0.tgz",
-      "integrity": "sha512-gpwYCAuWSjSps7KnmPfUSdJUf5iq8P0ln1eZPcnjs3IwRDUrKW9eUrO0jID+XUsi63qi5c+lv9UkwI8M8C9c5A==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.37.0.tgz",
+      "integrity": "sha512-BR5GEHontWnza1tfBm2aX6/GjCZ1xZRrRNN1P0oj9xuvtut3YzCr//pZuyQ+P5maByDthUZjNrvN3UEF1iucbA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -11764,19 +13766,19 @@
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/rich-text": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.35.0.tgz",
-      "integrity": "sha512-GhR9unaSAeVd2UQ6/WgYyAfP/xSE4VD43XuxY6hV4LaU0Qobi/N38Pamkln4eMhORcY8RzNQSkpFX27Nj/fxTQ==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.37.0.tgz",
+      "integrity": "sha512-uvLLVg77F4meoMMYjtdYcvo4eQxj3mKH8f9dKnkCrOyKOKNCdV5wHDUYWrySkgrAyoBJjTm8hZKK/U3adlPgEg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/escape-html": "^3.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/keycodes": "^4.35.0",
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/keycodes": "^4.37.0",
         "colord": "2.9.3",
         "memize": "^2.1.0"
       },
@@ -11788,49 +13790,13 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/shortcode": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.35.0.tgz",
-      "integrity": "sha512-+7dcPxBeee9LLwhS88MoNuLndoQQxwyQLlXCzWX0Min6YLWFXd0b+hmsRUlOE7qzbuZbHyW3mCk8ot9p3xK3sw==",
+    "node_modules/@wordpress/core-data/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "memize": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/style-engine": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.35.0.tgz",
-      "integrity": "sha512-HfnxMwTgpdNI54Zwh5BTDJPikBPawRyOMw1cIu7z24DThiwADaefBbI2RFinT3DyneKqwzo3Az5wKatgxBrmZQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/token-list": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.35.0.tgz",
-      "integrity": "sha512-IQGnoS580BhrEtr9CzcFjl5XcxI0Q7UMx55rl4R3NKiZ+mPk3zFwXztogPvffSUIcw5mg73iNEfoN6EJFoa87g==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/url": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.35.0.tgz",
-      "integrity": "sha512-h6KK0OePnc64T50BwVWmQb7xmcMW0XDtfh+1m/a0tlzXGLU4TnBjUUs+a0h0y6Tdla14lc2BtbLJLFwky06vbg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "remove-accents": "^0.5.0"
+        "@wordpress/is-shallow-equal": "^5.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11838,103 +13804,28 @@
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/warning": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.35.0.tgz",
-      "integrity": "sha512-2UGZuHenf84UHdotBxv9ZCtlsFIy5u4QTUPBnx1gH4N9zEuJs+JiCtlOzgcl0JzT3xFK5y3cXLLVqlhf8tDMBQ==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.37.0.tgz",
+      "integrity": "sha512-oXWyKiYJIa9SuPRNEJiOWn2Qk0RzfxOsDqXcus1OL44swCRtSM+ypm16CJpRhZpMUcsJ6d23PBxTC97C/iiJpQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/wordcount": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.35.0.tgz",
-      "integrity": "sha512-Qzs7z4fRtx2gZQ9d09ISmO+b5ZhZc82zBG3BdlVxDQK/PtlY0TdpFnBEtn7BxOv+WUHP8dJ1eG1p9qsXrxMSRg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/gradient-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.1.1.tgz",
-      "integrity": "sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/core-data/node_modules/react-easy-crop": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.3.tgz",
-      "integrity": "sha512-iKwFTnAsq+IVuyF6N0Q3zjRx9DG1NMySkwWxVfM/xAOeHYH1vhvM+V2kFiq5HOIQGWouITjfltCx54mbDpMpmA==",
-      "license": "MIT",
-      "dependencies": {
-        "normalize-wheel": "^1.0.1",
-        "tslib": "^2.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.4.0",
-        "react-dom": ">=16.4.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/core-data/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/data": {
-      "version": "10.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.35.0.tgz",
-      "integrity": "sha512-rAhyjbnDI9lOPBiJITDOwHJd8+WNmkurqwMJYDjJRqCYAl/mPx9vy6JIgIkyRWQQNiGYrCAv1z6qLqS2Cypg3Q==",
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.37.0.tgz",
+      "integrity": "sha512-6bKkEoD5WR/lCmJogx9WxgldhMQPvgV1TlCIXhx6xp9uVzqjjgdRmSwZ8IJR13QQ9GGHn7vWb59GtW4lF2FMNA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/private-apis": "^1.35.0",
-        "@wordpress/redux-routine": "^5.35.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/redux-routine": "^5.37.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -11966,31 +13857,18 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/data-controls/node_modules/@wordpress/compose": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
-      "integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
+    "node_modules/@wordpress/data-controls/node_modules/@wordpress/api-fetch": {
+      "version": "6.55.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
+      "integrity": "sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^3.58.0",
-        "@wordpress/dom": "^3.58.0",
-        "@wordpress/element": "^5.35.0",
-        "@wordpress/is-shallow-equal": "^4.58.0",
-        "@wordpress/keycodes": "^3.58.0",
-        "@wordpress/priority-queue": "^2.58.0",
-        "@wordpress/undo-manager": "^0.18.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/url": "^3.59.0"
       },
       "engines": {
         "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/data-controls/node_modules/@wordpress/data": {
@@ -12022,6 +13900,26 @@
         "react": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/data-controls/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wordpress/data-controls/node_modules/@wordpress/redux-routine": {
       "version": "4.58.0",
       "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.58.0.tgz",
@@ -12040,42 +13938,33 @@
         "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/data-controls/node_modules/@wordpress/undo-manager": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.18.0.tgz",
-      "integrity": "sha512-upbzPEToa095XG+2JXLHaolF1LfXEMFS0lNMYV37myoUS+eZ7/tl9Gx+yU2+OqWy57TMwx33NlWUX/n+ynzPRw==",
+    "node_modules/@wordpress/data-controls/node_modules/@wordpress/url": {
+      "version": "3.59.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
+      "integrity": "sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^4.58.0"
+        "remove-accents": "^0.5.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/data/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
     "node_modules/@wordpress/data/node_modules/@wordpress/compose": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.35.0.tgz",
-      "integrity": "sha512-UUQ31Rfi+KFfqT5wkbTgq0nMh+QfbLvshhm30+EGr8R3bYziHhfLKhIL2YQXf4MIX4owOFdKgbAt4GFeVI24ng==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -12090,12 +13979,12 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/deprecated": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.35.0.tgz",
-      "integrity": "sha512-+TruZtmDxRfVw02c1de7ofGC3CrcaPCUXCCbwfP6ruy1zM3IC3rtJfyTbqKPqO1y4uI+9Kqe5VEobqRKT3HQSg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.35.0"
+        "@wordpress/hooks": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -12103,12 +13992,12 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/dom": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.35.0.tgz",
-      "integrity": "sha512-mM/8m548RaWtkBonpCYHprXgyVFjKcFJWyHfWZz17j01xIbzBq+//cR/Lff86EiEuwynedqlFoEJUcgvPkrJZw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0"
+        "@wordpress/deprecated": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -12116,14 +14005,14 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/element": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.35.0.tgz",
-      "integrity": "sha512-RmxQsk0ANoHtxDc6anbUH/lHL7Mmbbdn016WKHYVh4+79EzN1tBeM8OML2gHpllUISmIYQvO4wIPSmEVzRh+Gw==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.35.0",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -12135,9 +14024,9 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/escape-html": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.35.0.tgz",
-      "integrity": "sha512-thY7RGAI6UijG3sbBm4IRzMX9lnHkEA/vR3Y0E5BGQYzNFwc+i7t1Lm4scpEBnL3UEQxdlD1wiJTH4pv5olV+Q==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -12145,39 +14034,19 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/data/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.35.0.tgz",
-      "integrity": "sha512-ooM/QFzxu8Ueqsv0D/z0+X6grbVws3GFMSxdM12eZO1B0/x6JPAtq4msZkoxqeQ4zoR0ghYHFXzv3k+Ch1tsFw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -12185,12 +14054,12 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/keycodes": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.35.0.tgz",
-      "integrity": "sha512-+cvb9I4VorJRUsPC4C/2e0QWMz8hkjQIvjz3BjTkIXyWlxsSRSk/+a/YCrfyyA5ysuR9PgwKxxI7/ZaAPvOC6w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -12198,9 +14067,9 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/priority-queue": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.35.0.tgz",
-      "integrity": "sha512-kLdPx09CnPMPUL5hI/3SUgbBVEka20iWBxM2pvwJGrn3bleY0WxGqLtoUksn6yQds9d7jjS5cKoBYxY1H8MHgg==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -12211,26 +14080,477 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/private-apis": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.35.0.tgz",
-      "integrity": "sha512-gpwYCAuWSjSps7KnmPfUSdJUf5iq8P0ln1eZPcnjs3IwRDUrKW9eUrO0jID+XUsi63qi5c+lv9UkwI8M8C9c5A==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.37.0.tgz",
+      "integrity": "sha512-BR5GEHontWnza1tfBm2aX6/GjCZ1xZRrRNN1P0oj9xuvtut3YzCr//pZuyQ+P5maByDthUZjNrvN3UEF1iucbA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/data/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
+    "node_modules/@wordpress/data/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
     },
     "node_modules/@wordpress/data/node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
+    },
+    "node_modules/@wordpress/dataviews": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-11.1.0.tgz",
+      "integrity": "sha512-gu5UzMH4jSOH9wXT/3C7tRoo8eTLsqgoAq38ND3ERFqwO9hEPmkPRK+4JFW6mkckTHjSOc173cJXrV2wIXd2+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@wordpress/base-styles": "^6.13.0",
+        "@wordpress/components": "^31.0.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/date": "^5.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/icons": "^11.4.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/primitives": "^4.37.0",
+        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/url": "^4.37.0",
+        "@wordpress/warning": "^3.37.0",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "date-fns": "^4.1.0",
+        "deepmerge": "4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@ariakit/core": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.18.tgz",
+      "integrity": "sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@ariakit/react": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.21.tgz",
+      "integrity": "sha512-UjP99Y7cWxA5seRECEE0RPZFImkLGFIWPflp65t0BVZwlMw4wp9OJZRHMrnkEkKl5KBE2NR/gbbzwHc6VNGzsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react-core": "0.4.21"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ariakit"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@ariakit/react-core": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.21.tgz",
+      "integrity": "sha512-rUI9uB/gT3mROFja/ka7/JukkdljIZR3eq3BGiQqX4Ni/KBMDvPK8FvVLnC0TGzWcqNY2bbfve8QllvHzuw4fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/core": "0.4.18",
+        "@floating-ui/dom": "^1.0.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@floating-ui/react-dom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@types/gradient-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-1.1.0.tgz",
+      "integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/a11y": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.37.0.tgz",
+      "integrity": "sha512-OxJL0sBNy2IwFkrLv0X9tOgmdHbvgVajciN8T73S6jTh96iOmdISSb3n+I9fc81X0BB03rv4dh8q6zBb/67U6A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/dom-ready": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-31.0.0.tgz",
+      "integrity": "sha512-2Oz4r+4KCDTV5fMC2l9bDYfRAsLQLs29fLB4PelckW+X3KhhFM6gz5vx5N7hO3WLY19Fn6qKZgtgJjOKWG7+1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/base-styles": "^6.13.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/date": "^5.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/hooks": "^4.37.0",
+        "@wordpress/html-entities": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/icons": "^11.4.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/primitives": "^4.37.0",
+        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/rich-text": "^7.37.0",
+        "@wordpress/warning": "^3.37.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/compose": {
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.11",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/date": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.37.0.tgz",
+      "integrity": "sha512-T5YF5WLQu71bgw/KXhKcIqIRmAyf6nCq7J448MZlPIr0M9DAVPARXCOxYA4t/FW3PzwpFUARIuO2aNXTTO+nsA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/deprecated": "^4.37.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/deprecated": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/hooks": "^4.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/dom": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/deprecated": "^4.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/dom-ready": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.37.0.tgz",
+      "integrity": "sha512-igored8VegL2n/koKIyUhgPLhUfTa4N6zWO4gZpyeznr49M5wP/9Ak/tvIljUts9McHc2CVnCYMjZV0Zyz2aWg==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/element": {
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/react": "^18.2.79",
+        "@types/react-dom": "^18.2.25",
+        "@wordpress/escape-html": "^3.37.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/escape-html": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/hooks": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/html-entities": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.37.0.tgz",
+      "integrity": "sha512-d3uaAoGs20xpvdOTWlpTbxO4a8YwKYyBjoNhkL+w9qAg8NqLk9r2Z1pTj4EbYF9iS6SorDUdnXsTMuZ0/pm4Sw==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.4.0.tgz",
+      "integrity": "sha512-3sis5bwTyDOrLy83Mp799NNJuEgbTOWwHpxnGNmabEDA3BbBYPnr0soSGSFe201nqNKiVwL/TcpRaQ91SoEHTQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/primitives": "^4.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/is-shallow-equal": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/keycodes": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.10.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/primitives": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.37.0.tgz",
+      "integrity": "sha512-iPpiS1tu1U5cXxVW6CQ45rqdnIc4Ev5FGyicuuaru0wboC+d2CwoNHxPFDOOpGL16yp8OfSDA13vQY3MJHw7QA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.37.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/priority-queue": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "requestidlecallback": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/private-apis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.37.0.tgz",
+      "integrity": "sha512-BR5GEHontWnza1tfBm2aX6/GjCZ1xZRrRNN1P0oj9xuvtut3YzCr//pZuyQ+P5maByDthUZjNrvN3UEF1iucbA==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/rich-text": {
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.37.0.tgz",
+      "integrity": "sha512-uvLLVg77F4meoMMYjtdYcvo4eQxj3mKH8f9dKnkCrOyKOKNCdV5wHDUYWrySkgrAyoBJjTm8hZKK/U3adlPgEg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "colord": "2.9.3",
+        "memize": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/warning": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.37.0.tgz",
+      "integrity": "sha512-oXWyKiYJIa9SuPRNEJiOWn2Qk0RzfxOsDqXcus1OL44swCRtSM+ypm16CJpRhZpMUcsJ6d23PBxTC97C/iiJpQ==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/gradient-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.1.1.tgz",
+      "integrity": "sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/@wordpress/date": {
       "version": "4.58.0",
@@ -12255,18 +14575,6 @@
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/hooks": "^3.58.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/deprecated/node_modules/@wordpress/hooks": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
-      "integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
       },
       "engines": {
         "node": ">=12"
@@ -12314,15 +14622,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/element/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/escape-html": {
@@ -12429,15 +14728,15 @@
       }
     },
     "node_modules/@wordpress/global-styles-engine": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.2.0.tgz",
-      "integrity": "sha512-Bg+oaSkhDzPgefMkAVqMjItSya990wQwXbt8zdiZQFdEoSeyA5FvMWL55ESR01f6hcoUCM+6r8OfUenuDI1nuw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.4.0.tgz",
+      "integrity": "sha512-gGwyqI3ntyeHQTRs8HRT2I+TrBWDU95mTp6y5n3FdTaya+Sl5fHVDdWs/MBcaZBipyLbp/TQVKKP1zM3FZHyLw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/blocks": "^15.8.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/style-engine": "^2.35.0",
+        "@wordpress/blocks": "^15.10.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/style-engine": "^2.37.0",
         "colord": "^2.9.2",
         "deepmerge": "^4.3.0",
         "fast-deep-equal": "^3.1.3",
@@ -12449,368 +14748,10 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/a11y": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.35.0.tgz",
-      "integrity": "sha512-37DeBnBU20lLpQjwAZx0fkPsrrXT4COMSRhZOiFifv7wCiNW1DIukfqReAc/yZ6x0wOtqXKA3n905D8zm5NF5A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/dom-ready": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/autop": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.35.0.tgz",
-      "integrity": "sha512-Tpfl9BOgrOl+SpPDcOA77qotuJIzO7umqlSU4YgBFxxvOQM2L/+dJhBhzngfLKUoF9jcm7j12e7M9X9X216w+Q==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/blob": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.35.0.tgz",
-      "integrity": "sha512-8b+A6in2dH+PPhGGI84GwNPyi8mxXUgsTsBG9Ey/WCYRFWXJmqhkgTUnZIi4PvieJbmmAILI9oyfMPSfeAb0sg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.35.0.tgz",
-      "integrity": "sha512-uLUGNu7Jj7Nk67vkDfAZeNTjLMUuD3PXlWW+75M641wTzGtMrrHSKTNHGoo7W4LyykaDmgfiTToZAu0REIgbJg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/blocks": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.8.0.tgz",
-      "integrity": "sha512-2PpklyJiRvrh7ozH+TTUQr/X0HmpemgG3z4tDi1XX+dDe10FJCvihTJa+/D9sbZQFk1zDJUzN1Kdr0elsGkRpA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/autop": "^4.35.0",
-        "@wordpress/blob": "^4.35.0",
-        "@wordpress/block-serialization-default-parser": "^5.35.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/hooks": "^4.35.0",
-        "@wordpress/html-entities": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/private-apis": "^1.35.0",
-        "@wordpress/rich-text": "^7.35.0",
-        "@wordpress/shortcode": "^4.35.0",
-        "@wordpress/warning": "^3.35.0",
-        "change-case": "^4.1.2",
-        "colord": "^2.7.0",
-        "fast-deep-equal": "^3.1.3",
-        "hpq": "^1.3.0",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "react-is": "^18.3.0",
-        "remove-accents": "^0.5.0",
-        "showdown": "^1.9.1",
-        "simple-html-tokenizer": "^0.5.7",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/compose": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.35.0.tgz",
-      "integrity": "sha512-UUQ31Rfi+KFfqT5wkbTgq0nMh+QfbLvshhm30+EGr8R3bYziHhfLKhIL2YQXf4MIX4owOFdKgbAt4GFeVI24ng==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/deprecated": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.35.0.tgz",
-      "integrity": "sha512-+TruZtmDxRfVw02c1de7ofGC3CrcaPCUXCCbwfP6ruy1zM3IC3rtJfyTbqKPqO1y4uI+9Kqe5VEobqRKT3HQSg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/hooks": "^4.35.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/dom": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.35.0.tgz",
-      "integrity": "sha512-mM/8m548RaWtkBonpCYHprXgyVFjKcFJWyHfWZz17j01xIbzBq+//cR/Lff86EiEuwynedqlFoEJUcgvPkrJZw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/deprecated": "^4.35.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/dom-ready": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.35.0.tgz",
-      "integrity": "sha512-u8ifPAFsIAkBG3ehcZdnt+b3t2S0gD3dyDMKgl+GO95wq6kJFqo/NYNQqsjeYUMOFX7cL9D0F2gxiBB4D/AQIA==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/element": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.35.0.tgz",
-      "integrity": "sha512-RmxQsk0ANoHtxDc6anbUH/lHL7Mmbbdn016WKHYVh4+79EzN1tBeM8OML2gHpllUISmIYQvO4wIPSmEVzRh+Gw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.35.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/escape-html": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.35.0.tgz",
-      "integrity": "sha512-thY7RGAI6UijG3sbBm4IRzMX9lnHkEA/vR3Y0E5BGQYzNFwc+i7t1Lm4scpEBnL3UEQxdlD1wiJTH4pv5olV+Q==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/html-entities": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.35.0.tgz",
-      "integrity": "sha512-43K8viPNNWUxmCKfKN2Dx/TgJitbGeGCfWBj0aloRoeqOUeEuDkWoak+XiIrJKpwYHTYhqtePl7COMWPzwkqbw==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.35.0.tgz",
-      "integrity": "sha512-ooM/QFzxu8Ueqsv0D/z0+X6grbVws3GFMSxdM12eZO1B0/x6JPAtq4msZkoxqeQ4zoR0ghYHFXzv3k+Ch1tsFw==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/keycodes": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.35.0.tgz",
-      "integrity": "sha512-+cvb9I4VorJRUsPC4C/2e0QWMz8hkjQIvjz3BjTkIXyWlxsSRSk/+a/YCrfyyA5ysuR9PgwKxxI7/ZaAPvOC6w==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/i18n": "^6.8.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/priority-queue": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.35.0.tgz",
-      "integrity": "sha512-kLdPx09CnPMPUL5hI/3SUgbBVEka20iWBxM2pvwJGrn3bleY0WxGqLtoUksn6yQds9d7jjS5cKoBYxY1H8MHgg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/private-apis": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.35.0.tgz",
-      "integrity": "sha512-gpwYCAuWSjSps7KnmPfUSdJUf5iq8P0ln1eZPcnjs3IwRDUrKW9eUrO0jID+XUsi63qi5c+lv9UkwI8M8C9c5A==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/rich-text": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.35.0.tgz",
-      "integrity": "sha512-GhR9unaSAeVd2UQ6/WgYyAfP/xSE4VD43XuxY6hV4LaU0Qobi/N38Pamkln4eMhORcY8RzNQSkpFX27Nj/fxTQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/escape-html": "^3.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "colord": "2.9.3",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/shortcode": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.35.0.tgz",
-      "integrity": "sha512-+7dcPxBeee9LLwhS88MoNuLndoQQxwyQLlXCzWX0Min6YLWFXd0b+hmsRUlOE7qzbuZbHyW3mCk8ot9p3xK3sw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "memize": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/style-engine": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.35.0.tgz",
-      "integrity": "sha512-HfnxMwTgpdNI54Zwh5BTDJPikBPawRyOMw1cIu7z24DThiwADaefBbI2RFinT3DyneKqwzo3Az5wKatgxBrmZQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/warning": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.35.0.tgz",
-      "integrity": "sha512-2UGZuHenf84UHdotBxv9ZCtlsFIy5u4QTUPBnx1gH4N9zEuJs+JiCtlOzgcl0JzT3xFK5y3cXLLVqlhf8tDMBQ==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@wordpress/hooks": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.6.1.tgz",
-      "integrity": "sha512-4sIngmH64M1jzcprfkffo1GHsQbd/QNbTweq6cSPIJNorKfE63Inf59NQ6r0pq6+Nz+cuq64eMz5v4eyngjZ/A==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
+      "integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
@@ -12832,42 +14773,34 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
-      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.10.0.tgz",
+      "integrity": "sha512-5tLAtnRQNxzA/d0GvVWCyo34Jb18w7xWTnup8hlh1+ehp7ZYTWR1QJihzVAteHoyrxAbTmzzsKyNtr8m+4ZpSQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.58.0",
+        "@tannin/sprintf": "^1.3.2",
+        "@wordpress/hooks": "^4.37.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
         "tannin": "^1.2.0"
       },
       "bin": {
         "pot-to-php": "tools/pot-to-php.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/i18n/node_modules/@wordpress/hooks": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
-      "integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
-    },
-    "node_modules/@wordpress/i18n/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
     },
     "node_modules/@wordpress/icons": {
       "version": "9.49.0",
@@ -12883,10 +14816,64 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/image-cropper": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.1.0.tgz",
+      "integrity": "sha512-UT5f/8AdWxRo0wiEOpAeOk8UNdHJEXfNYy9MZ1kit7mG0o8WW7T8+0Rroktbz5wej4T38KYI3zDOMXGlBhr43g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.37.0",
+        "clsx": "^2.1.1",
+        "dequal": "^2.0.3",
+        "react-easy-crop": "^5.4.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/image-cropper/node_modules/@wordpress/element": {
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/react": "^18.2.79",
+        "@types/react-dom": "^18.2.25",
+        "@wordpress/escape-html": "^3.37.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/image-cropper/node_modules/@wordpress/escape-html": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/image-cropper/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@wordpress/interactivity": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.35.0.tgz",
-      "integrity": "sha512-EVnmHNFHHgGGr5n7wl5cLkvkvfpWp06d2CIVfebJmsVKkZyIEpXGuG9LdTWv3dMjP6nlRmPX2VNVejswMeER8A==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.37.0.tgz",
+      "integrity": "sha512-xxXBu+j60POjCKo/9mFc6gKb7KfR8t0+vxUFJciuMVjuBnUT2Xyld+S4bhaAn9s8hjbANMwMIr7c7c6CVck9gw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@preact/signals": "^1.3.0",
@@ -12910,87 +14897,63 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-3.20.0.tgz",
-      "integrity": "sha512-78JTtqw6CGm9aMrZmRjvlQ8+skK/8ZV2rNd58ZpWT9Htp5jEB5ddt34P5wn04UiDOFFd13sy5HOqhsUFHh4qFA==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.37.0.tgz",
+      "integrity": "sha512-9IJFAYBbUQy2GLJGf0T1yBsOMfh5GuKkt+wvnWYqO1nTn1MqDu/YAibPQgv4a5Ftzc2jH6RuLlelaIepOEE4Qw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/data": "^7.6.0",
-        "@wordpress/element": "^4.20.0",
-        "@wordpress/keycodes": "^3.22.0",
-        "rememo": "^4.0.0"
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/keycodes": "^4.37.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/data": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-7.6.0.tgz",
-      "integrity": "sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^5.20.0",
-        "@wordpress/deprecated": "^3.22.0",
-        "@wordpress/element": "^4.20.0",
-        "@wordpress/is-shallow-equal": "^4.22.0",
-        "@wordpress/priority-queue": "^2.22.0",
-        "@wordpress/redux-routine": "^4.22.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "lodash": "^4.17.21",
-        "redux": "^4.1.2",
-        "turbo-combine-reducers": "^1.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/element": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
-      "integrity": "sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^17.0.37",
-        "@types/react-dom": "^17.0.11",
-        "@wordpress/escape-html": "^2.22.0",
+        "@types/react": "^18.2.79",
+        "@types/react-dom": "^18.2.25",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/redux-routine": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.58.0.tgz",
-      "integrity": "sha512-r0mMWFeJr93yPy2uY/M5+gdUUYj0Zu8+21OFFb5hyQ0z7UHIa3IdgQxzCaTbV1LDA1ZYJrjHeCnA6s4gNHjA2Q==",
+    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/escape-html": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/keycodes": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/keycodes": {
@@ -13001,6 +14964,26 @@
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/i18n": "^4.58.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
       },
       "engines": {
         "node": ">=12"
@@ -13018,6 +15001,41 @@
         "@wordpress/element": "^4.4.1",
         "@wordpress/i18n": "^4.6.1",
         "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/media-utils/node_modules/@types/react-dom": {
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-utils/node_modules/@wordpress/api-fetch": {
+      "version": "6.55.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
+      "integrity": "sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/url": "^3.59.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/media-utils/node_modules/@wordpress/blob": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.58.0.tgz",
+      "integrity": "sha512-6L3WqbOWEGFOSs3vLMwJ83YScggCiJ9NvZj1kC7mgeiP302UP2Fxkt4KlfjeTsD350XcvakkD/57wRkHXd819Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
       },
       "engines": {
         "node": ">=12"
@@ -13042,120 +15060,93 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/notices": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-3.31.0.tgz",
-      "integrity": "sha512-9WyaFaSr/vQc1K7cZLyPw1xBKqWfjpAKMJzWMzHYjwk1ldibhBWVLukicuolD6Y+9l+97IZHCoESBQwUeFo79Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.31.0",
-        "@wordpress/data": "^9.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
-      "integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^3.58.0",
-        "@wordpress/dom": "^3.58.0",
-        "@wordpress/element": "^5.35.0",
-        "@wordpress/is-shallow-equal": "^4.58.0",
-        "@wordpress/keycodes": "^3.58.0",
-        "@wordpress/priority-queue": "^2.58.0",
-        "@wordpress/undo-manager": "^0.18.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/data": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
-      "integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.35.0",
-        "@wordpress/deprecated": "^3.58.0",
-        "@wordpress/element": "^5.35.0",
-        "@wordpress/is-shallow-equal": "^4.58.0",
-        "@wordpress/priority-queue": "^2.58.0",
-        "@wordpress/private-apis": "^0.40.0",
-        "@wordpress/redux-routine": "^4.58.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/redux-routine": {
+    "node_modules/@wordpress/media-utils/node_modules/@wordpress/i18n": {
       "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.58.0.tgz",
-      "integrity": "sha512-r0mMWFeJr93yPy2uY/M5+gdUUYj0Zu8+21OFFb5hyQ0z7UHIa3IdgQxzCaTbV1LDA1ZYJrjHeCnA6s4gNHjA2Q==",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
       },
       "engines": {
         "node": ">=12"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/undo-manager": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.18.0.tgz",
-      "integrity": "sha512-upbzPEToa095XG+2JXLHaolF1LfXEMFS0lNMYV37myoUS+eZ7/tl9Gx+yU2+OqWy57TMwx33NlWUX/n+ynzPRw==",
+    "node_modules/@wordpress/media-utils/node_modules/@wordpress/url": {
+      "version": "3.59.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
+      "integrity": "sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^4.58.0"
+        "remove-accents": "^0.5.0"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/notices": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.37.0.tgz",
+      "integrity": "sha512-b/bJSCXJR8wsdJQMcUxKIhodp6CwephHdUEEMGaZMbsU252m6gZ2FF2kH49XeQSNr4fTLQjRHWaZUpijApAzBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/data": "^10.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/notices/node_modules/@wordpress/a11y": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.37.0.tgz",
+      "integrity": "sha512-OxJL0sBNy2IwFkrLv0X9tOgmdHbvgVajciN8T73S6jTh96iOmdISSb3n+I9fc81X0BB03rv4dh8q6zBb/67U6A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/dom-ready": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/notices/node_modules/@wordpress/dom-ready": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.37.0.tgz",
+      "integrity": "sha512-igored8VegL2n/koKIyUhgPLhUfTa4N6zWO4gZpyeznr49M5wP/9Ak/tvIljUts9McHc2CVnCYMjZV0Zyz2aWg==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/plugins": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.35.0.tgz",
-      "integrity": "sha512-idNlIINRyDN0riMTRPlB91LBgPz/yJTDbwMGByQV8c470TS1HCO/kuGGQ8e/xwj1XNTcUO4dzPVSyHFYFK3BkA==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.37.0.tgz",
+      "integrity": "sha512-GMwLm8ACRDyldEg6gRqyPUPvW/1KujKB9gzYIKSPM5WvTB3SjJQ/uUb47GhS3Hru/3JvjEhqtIeNemDxcehNmw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/components": "^30.8.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/hooks": "^4.35.0",
-        "@wordpress/icons": "^11.2.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
+        "@wordpress/components": "^31.0.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/hooks": "^4.37.0",
+        "@wordpress/icons": "^11.4.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
         "memize": "^2.0.1"
       },
       "engines": {
@@ -13168,18 +15159,18 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@ariakit/core": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.16.tgz",
-      "integrity": "sha512-nPJ0Be8d5ZvRApYGqdLMuYUjP7ktkPmTPOXyZFw+0Illk8LKgF3Q74ctVGuoQurJNDsANXcewzlyXK4vyIAGTA==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.18.tgz",
+      "integrity": "sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==",
       "license": "MIT"
     },
     "node_modules/@wordpress/plugins/node_modules/@ariakit/react": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.19.tgz",
-      "integrity": "sha512-n6q8leSQWXMk4vhcZlpnj8cIlAY0n+1bvVTwHvaVfmec4LjW49MFKkJRZd1AiV+SE73nkxPwSL3IbaS4p1aRxQ==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.21.tgz",
+      "integrity": "sha512-UjP99Y7cWxA5seRECEE0RPZFImkLGFIWPflp65t0BVZwlMw4wp9OJZRHMrnkEkKl5KBE2NR/gbbzwHc6VNGzsA==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.19"
+        "@ariakit/react-core": "0.4.21"
       },
       "funding": {
         "type": "opencollective",
@@ -13191,12 +15182,12 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@ariakit/react-core": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.19.tgz",
-      "integrity": "sha512-Aj+fu4pMyPXtlBghI+E7KSWItqJkbAqEhut3DlsFAjK9fQdHE+e1tQJG1PtnoEdD9BExkJWQ6R4M5a9HkEhqPA==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.21.tgz",
+      "integrity": "sha512-rUI9uB/gT3mROFja/ka7/JukkdljIZR3eq3BGiQqX4Ni/KBMDvPK8FvVLnC0TGzWcqNY2bbfve8QllvHzuw4fQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/core": "0.4.16",
+        "@ariakit/core": "0.4.18",
         "@floating-ui/dom": "^1.0.0",
         "use-sync-external-store": "^1.2.0"
       },
@@ -13224,23 +15215,14 @@
       "integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==",
       "license": "MIT"
     },
-    "node_modules/@wordpress/plugins/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/a11y": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.35.0.tgz",
-      "integrity": "sha512-37DeBnBU20lLpQjwAZx0fkPsrrXT4COMSRhZOiFifv7wCiNW1DIukfqReAc/yZ6x0wOtqXKA3n905D8zm5NF5A==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.37.0.tgz",
+      "integrity": "sha512-OxJL0sBNy2IwFkrLv0X9tOgmdHbvgVajciN8T73S6jTh96iOmdISSb3n+I9fc81X0BB03rv4dh8q6zBb/67U6A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dom-ready": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/dom-ready": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -13248,12 +15230,13 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/components": {
-      "version": "30.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.8.0.tgz",
-      "integrity": "sha512-lVcPXXeip41K6VmvVLkIPPbhsfIn5QZ9AFozkPEZPDOcpFvvYTnT4hDRM5+Pi9xrO2TOGhbXoJmYlFjAx19xSw==",
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-31.0.0.tgz",
+      "integrity": "sha512-2Oz4r+4KCDTV5fMC2l9bDYfRAsLQLs29fLB4PelckW+X3KhhFM6gz5vx5N7hO3WLY19Fn6qKZgtgJjOKWG7+1w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.7.1",
         "@emotion/css": "^11.7.1",
         "@emotion/react": "^11.7.1",
@@ -13264,24 +15247,24 @@
         "@types/gradient-parser": "1.1.0",
         "@types/highlight-words-core": "1.2.1",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/base-styles": "^6.11.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/date": "^5.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/escape-html": "^3.35.0",
-        "@wordpress/hooks": "^4.35.0",
-        "@wordpress/html-entities": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/icons": "^11.2.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/primitives": "^4.35.0",
-        "@wordpress/private-apis": "^1.35.0",
-        "@wordpress/rich-text": "^7.35.0",
-        "@wordpress/warning": "^3.35.0",
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/base-styles": "^6.13.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/date": "^5.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/hooks": "^4.37.0",
+        "@wordpress/html-entities": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/icons": "^11.4.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/primitives": "^4.37.0",
+        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/rich-text": "^7.37.0",
+        "@wordpress/warning": "^3.37.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -13310,19 +15293,19 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/compose": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.35.0.tgz",
-      "integrity": "sha512-UUQ31Rfi+KFfqT5wkbTgq0nMh+QfbLvshhm30+EGr8R3bYziHhfLKhIL2YQXf4MIX4owOFdKgbAt4GFeVI24ng==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -13337,12 +15320,12 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/date": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.35.0.tgz",
-      "integrity": "sha512-xXJf703MtQCbgoAT1DSwRu+iWcgb6UFAoBnnzq8ohZCICsBxEGOOr+EAgblvFSNPV3MCtUOr98zRCAuGon3Gqw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.37.0.tgz",
+      "integrity": "sha512-T5YF5WLQu71bgw/KXhKcIqIRmAyf6nCq7J448MZlPIr0M9DAVPARXCOxYA4t/FW3PzwpFUARIuO2aNXTTO+nsA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0",
+        "@wordpress/deprecated": "^4.37.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -13352,12 +15335,12 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/deprecated": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.35.0.tgz",
-      "integrity": "sha512-+TruZtmDxRfVw02c1de7ofGC3CrcaPCUXCCbwfP6ruy1zM3IC3rtJfyTbqKPqO1y4uI+9Kqe5VEobqRKT3HQSg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.35.0"
+        "@wordpress/hooks": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -13365,12 +15348,12 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/dom": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.35.0.tgz",
-      "integrity": "sha512-mM/8m548RaWtkBonpCYHprXgyVFjKcFJWyHfWZz17j01xIbzBq+//cR/Lff86EiEuwynedqlFoEJUcgvPkrJZw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0"
+        "@wordpress/deprecated": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -13378,9 +15361,9 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/dom-ready": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.35.0.tgz",
-      "integrity": "sha512-u8ifPAFsIAkBG3ehcZdnt+b3t2S0gD3dyDMKgl+GO95wq6kJFqo/NYNQqsjeYUMOFX7cL9D0F2gxiBB4D/AQIA==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.37.0.tgz",
+      "integrity": "sha512-igored8VegL2n/koKIyUhgPLhUfTa4N6zWO4gZpyeznr49M5wP/9Ak/tvIljUts9McHc2CVnCYMjZV0Zyz2aWg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -13388,14 +15371,14 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/element": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.35.0.tgz",
-      "integrity": "sha512-RmxQsk0ANoHtxDc6anbUH/lHL7Mmbbdn016WKHYVh4+79EzN1tBeM8OML2gHpllUISmIYQvO4wIPSmEVzRh+Gw==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.35.0",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -13407,9 +15390,9 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/escape-html": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.35.0.tgz",
-      "integrity": "sha512-thY7RGAI6UijG3sbBm4IRzMX9lnHkEA/vR3Y0E5BGQYzNFwc+i7t1Lm4scpEBnL3UEQxdlD1wiJTH4pv5olV+Q==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -13417,9 +15400,9 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -13427,53 +15410,36 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/html-entities": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.35.0.tgz",
-      "integrity": "sha512-43K8viPNNWUxmCKfKN2Dx/TgJitbGeGCfWBj0aloRoeqOUeEuDkWoak+XiIrJKpwYHTYhqtePl7COMWPzwkqbw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.37.0.tgz",
+      "integrity": "sha512-d3uaAoGs20xpvdOTWlpTbxO4a8YwKYyBjoNhkL+w9qAg8NqLk9r2Z1pTj4EbYF9iS6SorDUdnXsTMuZ0/pm4Sw==",
       "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/icons": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.2.0.tgz",
-      "integrity": "sha512-9OIymLlwanLkSjKbUyKwF4Z4LnCojQsulQNGsZVpaqx7ryqEGEMvNJ5BvrzUWBoQpX9nvJBvK+obE1zxE0vt+g==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.4.0.tgz",
+      "integrity": "sha512-3sis5bwTyDOrLy83Mp799NNJuEgbTOWwHpxnGNmabEDA3BbBYPnr0soSGSFe201nqNKiVwL/TcpRaQ91SoEHTQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/primitives": "^4.35.0"
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/primitives": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.35.0.tgz",
-      "integrity": "sha512-ooM/QFzxu8Ueqsv0D/z0+X6grbVws3GFMSxdM12eZO1B0/x6JPAtq4msZkoxqeQ4zoR0ghYHFXzv3k+Ch1tsFw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -13481,12 +15447,12 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/keycodes": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.35.0.tgz",
-      "integrity": "sha512-+cvb9I4VorJRUsPC4C/2e0QWMz8hkjQIvjz3BjTkIXyWlxsSRSk/+a/YCrfyyA5ysuR9PgwKxxI7/ZaAPvOC6w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -13494,12 +15460,12 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/primitives": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.35.0.tgz",
-      "integrity": "sha512-F7FqOM9tkgwc0DwFqsgtOcvREJgBHALbCBFwv1kmxRadknD6YsBdmpamceN2UIHi9NnOM0Gruo2vJNKjoN4bEw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.37.0.tgz",
+      "integrity": "sha512-iPpiS1tu1U5cXxVW6CQ45rqdnIc4Ev5FGyicuuaru0wboC+d2CwoNHxPFDOOpGL16yp8OfSDA13vQY3MJHw7QA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.35.0",
+        "@wordpress/element": "^6.37.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -13511,9 +15477,9 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/priority-queue": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.35.0.tgz",
-      "integrity": "sha512-kLdPx09CnPMPUL5hI/3SUgbBVEka20iWBxM2pvwJGrn3bleY0WxGqLtoUksn6yQds9d7jjS5cKoBYxY1H8MHgg==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -13524,9 +15490,9 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/private-apis": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.35.0.tgz",
-      "integrity": "sha512-gpwYCAuWSjSps7KnmPfUSdJUf5iq8P0ln1eZPcnjs3IwRDUrKW9eUrO0jID+XUsi63qi5c+lv9UkwI8M8C9c5A==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.37.0.tgz",
+      "integrity": "sha512-BR5GEHontWnza1tfBm2aX6/GjCZ1xZRrRNN1P0oj9xuvtut3YzCr//pZuyQ+P5maByDthUZjNrvN3UEF1iucbA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -13534,19 +15500,19 @@
       }
     },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/rich-text": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.35.0.tgz",
-      "integrity": "sha512-GhR9unaSAeVd2UQ6/WgYyAfP/xSE4VD43XuxY6hV4LaU0Qobi/N38Pamkln4eMhORcY8RzNQSkpFX27Nj/fxTQ==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.37.0.tgz",
+      "integrity": "sha512-uvLLVg77F4meoMMYjtdYcvo4eQxj3mKH8f9dKnkCrOyKOKNCdV5wHDUYWrySkgrAyoBJjTm8hZKK/U3adlPgEg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/escape-html": "^3.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/keycodes": "^4.35.0",
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/keycodes": "^4.37.0",
         "colord": "2.9.3",
         "memize": "^2.1.0"
       },
@@ -13558,10 +15524,23 @@
         "react": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/plugins/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/plugins/node_modules/@wordpress/warning": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.35.0.tgz",
-      "integrity": "sha512-2UGZuHenf84UHdotBxv9ZCtlsFIy5u4QTUPBnx1gH4N9zEuJs+JiCtlOzgcl0JzT3xFK5y3cXLLVqlhf8tDMBQ==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.37.0.tgz",
+      "integrity": "sha512-oXWyKiYJIa9SuPRNEJiOWn2Qk0RzfxOsDqXcus1OL44swCRtSM+ypm16CJpRhZpMUcsJ6d23PBxTC97C/iiJpQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -13585,47 +15564,22 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@wordpress/plugins/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/plugins/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/plugins/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@wordpress/preferences": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.35.0.tgz",
-      "integrity": "sha512-y0z2F2ZAVIJou/7lcFIVaSFmETUgZOfPdFKUBRJ3LoA8wm0RGUg1ZnFcNA4zT9E6K0b6YqsqgNsVT70XvGsQXg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.37.0.tgz",
+      "integrity": "sha512-+GOmfe+i47SA74zDi+j6jYxoI0sZv2056tDbf+uGBF8rOEceQaLEhs+24fY/shAJV3Umf09yltXph5kdfs05/w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/base-styles": "^6.11.0",
-        "@wordpress/components": "^30.8.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/icons": "^11.2.0",
-        "@wordpress/private-apis": "^1.35.0",
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/base-styles": "^6.13.0",
+        "@wordpress/components": "^31.0.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/icons": "^11.4.0",
+        "@wordpress/private-apis": "^1.37.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -13638,18 +15592,18 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@ariakit/core": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.16.tgz",
-      "integrity": "sha512-nPJ0Be8d5ZvRApYGqdLMuYUjP7ktkPmTPOXyZFw+0Illk8LKgF3Q74ctVGuoQurJNDsANXcewzlyXK4vyIAGTA==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.18.tgz",
+      "integrity": "sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==",
       "license": "MIT"
     },
     "node_modules/@wordpress/preferences/node_modules/@ariakit/react": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.19.tgz",
-      "integrity": "sha512-n6q8leSQWXMk4vhcZlpnj8cIlAY0n+1bvVTwHvaVfmec4LjW49MFKkJRZd1AiV+SE73nkxPwSL3IbaS4p1aRxQ==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.21.tgz",
+      "integrity": "sha512-UjP99Y7cWxA5seRECEE0RPZFImkLGFIWPflp65t0BVZwlMw4wp9OJZRHMrnkEkKl5KBE2NR/gbbzwHc6VNGzsA==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.19"
+        "@ariakit/react-core": "0.4.21"
       },
       "funding": {
         "type": "opencollective",
@@ -13661,12 +15615,12 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@ariakit/react-core": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.19.tgz",
-      "integrity": "sha512-Aj+fu4pMyPXtlBghI+E7KSWItqJkbAqEhut3DlsFAjK9fQdHE+e1tQJG1PtnoEdD9BExkJWQ6R4M5a9HkEhqPA==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.21.tgz",
+      "integrity": "sha512-rUI9uB/gT3mROFja/ka7/JukkdljIZR3eq3BGiQqX4Ni/KBMDvPK8FvVLnC0TGzWcqNY2bbfve8QllvHzuw4fQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/core": "0.4.16",
+        "@ariakit/core": "0.4.18",
         "@floating-ui/dom": "^1.0.0",
         "use-sync-external-store": "^1.2.0"
       },
@@ -13694,23 +15648,14 @@
       "integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==",
       "license": "MIT"
     },
-    "node_modules/@wordpress/preferences/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/a11y": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.35.0.tgz",
-      "integrity": "sha512-37DeBnBU20lLpQjwAZx0fkPsrrXT4COMSRhZOiFifv7wCiNW1DIukfqReAc/yZ6x0wOtqXKA3n905D8zm5NF5A==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.37.0.tgz",
+      "integrity": "sha512-OxJL0sBNy2IwFkrLv0X9tOgmdHbvgVajciN8T73S6jTh96iOmdISSb3n+I9fc81X0BB03rv4dh8q6zBb/67U6A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dom-ready": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/dom-ready": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -13718,12 +15663,13 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
-      "version": "30.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.8.0.tgz",
-      "integrity": "sha512-lVcPXXeip41K6VmvVLkIPPbhsfIn5QZ9AFozkPEZPDOcpFvvYTnT4hDRM5+Pi9xrO2TOGhbXoJmYlFjAx19xSw==",
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-31.0.0.tgz",
+      "integrity": "sha512-2Oz4r+4KCDTV5fMC2l9bDYfRAsLQLs29fLB4PelckW+X3KhhFM6gz5vx5N7hO3WLY19Fn6qKZgtgJjOKWG7+1w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.7.1",
         "@emotion/css": "^11.7.1",
         "@emotion/react": "^11.7.1",
@@ -13734,24 +15680,24 @@
         "@types/gradient-parser": "1.1.0",
         "@types/highlight-words-core": "1.2.1",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/base-styles": "^6.11.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/date": "^5.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/escape-html": "^3.35.0",
-        "@wordpress/hooks": "^4.35.0",
-        "@wordpress/html-entities": "^4.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/icons": "^11.2.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/primitives": "^4.35.0",
-        "@wordpress/private-apis": "^1.35.0",
-        "@wordpress/rich-text": "^7.35.0",
-        "@wordpress/warning": "^3.35.0",
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/base-styles": "^6.13.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/date": "^5.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/hooks": "^4.37.0",
+        "@wordpress/html-entities": "^4.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/icons": "^11.4.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/primitives": "^4.37.0",
+        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/rich-text": "^7.37.0",
+        "@wordpress/warning": "^3.37.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -13780,19 +15726,19 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/compose": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.35.0.tgz",
-      "integrity": "sha512-UUQ31Rfi+KFfqT5wkbTgq0nMh+QfbLvshhm30+EGr8R3bYziHhfLKhIL2YQXf4MIX4owOFdKgbAt4GFeVI24ng==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -13807,12 +15753,12 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/date": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.35.0.tgz",
-      "integrity": "sha512-xXJf703MtQCbgoAT1DSwRu+iWcgb6UFAoBnnzq8ohZCICsBxEGOOr+EAgblvFSNPV3MCtUOr98zRCAuGon3Gqw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.37.0.tgz",
+      "integrity": "sha512-T5YF5WLQu71bgw/KXhKcIqIRmAyf6nCq7J448MZlPIr0M9DAVPARXCOxYA4t/FW3PzwpFUARIuO2aNXTTO+nsA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0",
+        "@wordpress/deprecated": "^4.37.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -13822,12 +15768,12 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/deprecated": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.35.0.tgz",
-      "integrity": "sha512-+TruZtmDxRfVw02c1de7ofGC3CrcaPCUXCCbwfP6ruy1zM3IC3rtJfyTbqKPqO1y4uI+9Kqe5VEobqRKT3HQSg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.35.0"
+        "@wordpress/hooks": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -13835,12 +15781,12 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/dom": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.35.0.tgz",
-      "integrity": "sha512-mM/8m548RaWtkBonpCYHprXgyVFjKcFJWyHfWZz17j01xIbzBq+//cR/Lff86EiEuwynedqlFoEJUcgvPkrJZw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0"
+        "@wordpress/deprecated": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -13848,9 +15794,9 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/dom-ready": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.35.0.tgz",
-      "integrity": "sha512-u8ifPAFsIAkBG3ehcZdnt+b3t2S0gD3dyDMKgl+GO95wq6kJFqo/NYNQqsjeYUMOFX7cL9D0F2gxiBB4D/AQIA==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.37.0.tgz",
+      "integrity": "sha512-igored8VegL2n/koKIyUhgPLhUfTa4N6zWO4gZpyeznr49M5wP/9Ak/tvIljUts9McHc2CVnCYMjZV0Zyz2aWg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -13858,14 +15804,14 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/element": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.35.0.tgz",
-      "integrity": "sha512-RmxQsk0ANoHtxDc6anbUH/lHL7Mmbbdn016WKHYVh4+79EzN1tBeM8OML2gHpllUISmIYQvO4wIPSmEVzRh+Gw==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.35.0",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -13877,9 +15823,9 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/escape-html": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.35.0.tgz",
-      "integrity": "sha512-thY7RGAI6UijG3sbBm4IRzMX9lnHkEA/vR3Y0E5BGQYzNFwc+i7t1Lm4scpEBnL3UEQxdlD1wiJTH4pv5olV+Q==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -13887,9 +15833,9 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -13897,53 +15843,36 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/html-entities": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.35.0.tgz",
-      "integrity": "sha512-43K8viPNNWUxmCKfKN2Dx/TgJitbGeGCfWBj0aloRoeqOUeEuDkWoak+XiIrJKpwYHTYhqtePl7COMWPzwkqbw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.37.0.tgz",
+      "integrity": "sha512-d3uaAoGs20xpvdOTWlpTbxO4a8YwKYyBjoNhkL+w9qAg8NqLk9r2Z1pTj4EbYF9iS6SorDUdnXsTMuZ0/pm4Sw==",
       "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/icons": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.2.0.tgz",
-      "integrity": "sha512-9OIymLlwanLkSjKbUyKwF4Z4LnCojQsulQNGsZVpaqx7ryqEGEMvNJ5BvrzUWBoQpX9nvJBvK+obE1zxE0vt+g==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.4.0.tgz",
+      "integrity": "sha512-3sis5bwTyDOrLy83Mp799NNJuEgbTOWwHpxnGNmabEDA3BbBYPnr0soSGSFe201nqNKiVwL/TcpRaQ91SoEHTQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/primitives": "^4.35.0"
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/primitives": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.35.0.tgz",
-      "integrity": "sha512-ooM/QFzxu8Ueqsv0D/z0+X6grbVws3GFMSxdM12eZO1B0/x6JPAtq4msZkoxqeQ4zoR0ghYHFXzv3k+Ch1tsFw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -13951,12 +15880,12 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/keycodes": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.35.0.tgz",
-      "integrity": "sha512-+cvb9I4VorJRUsPC4C/2e0QWMz8hkjQIvjz3BjTkIXyWlxsSRSk/+a/YCrfyyA5ysuR9PgwKxxI7/ZaAPvOC6w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -13964,12 +15893,12 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/primitives": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.35.0.tgz",
-      "integrity": "sha512-F7FqOM9tkgwc0DwFqsgtOcvREJgBHALbCBFwv1kmxRadknD6YsBdmpamceN2UIHi9NnOM0Gruo2vJNKjoN4bEw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.37.0.tgz",
+      "integrity": "sha512-iPpiS1tu1U5cXxVW6CQ45rqdnIc4Ev5FGyicuuaru0wboC+d2CwoNHxPFDOOpGL16yp8OfSDA13vQY3MJHw7QA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.35.0",
+        "@wordpress/element": "^6.37.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -13981,9 +15910,9 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/priority-queue": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.35.0.tgz",
-      "integrity": "sha512-kLdPx09CnPMPUL5hI/3SUgbBVEka20iWBxM2pvwJGrn3bleY0WxGqLtoUksn6yQds9d7jjS5cKoBYxY1H8MHgg==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -13994,9 +15923,9 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/private-apis": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.35.0.tgz",
-      "integrity": "sha512-gpwYCAuWSjSps7KnmPfUSdJUf5iq8P0ln1eZPcnjs3IwRDUrKW9eUrO0jID+XUsi63qi5c+lv9UkwI8M8C9c5A==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.37.0.tgz",
+      "integrity": "sha512-BR5GEHontWnza1tfBm2aX6/GjCZ1xZRrRNN1P0oj9xuvtut3YzCr//pZuyQ+P5maByDthUZjNrvN3UEF1iucbA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -14004,19 +15933,19 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/rich-text": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.35.0.tgz",
-      "integrity": "sha512-GhR9unaSAeVd2UQ6/WgYyAfP/xSE4VD43XuxY6hV4LaU0Qobi/N38Pamkln4eMhORcY8RzNQSkpFX27Nj/fxTQ==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.37.0.tgz",
+      "integrity": "sha512-uvLLVg77F4meoMMYjtdYcvo4eQxj3mKH8f9dKnkCrOyKOKNCdV5wHDUYWrySkgrAyoBJjTm8hZKK/U3adlPgEg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.35.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/escape-html": "^3.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/keycodes": "^4.35.0",
+        "@wordpress/a11y": "^4.37.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/escape-html": "^3.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/keycodes": "^4.37.0",
         "colord": "2.9.3",
         "memize": "^2.1.0"
       },
@@ -14028,10 +15957,23 @@
         "react": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/preferences/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/warning": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.35.0.tgz",
-      "integrity": "sha512-2UGZuHenf84UHdotBxv9ZCtlsFIy5u4QTUPBnx1gH4N9zEuJs+JiCtlOzgcl0JzT3xFK5y3cXLLVqlhf8tDMBQ==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.37.0.tgz",
+      "integrity": "sha512-oXWyKiYJIa9SuPRNEJiOWn2Qk0RzfxOsDqXcus1OL44swCRtSM+ypm16CJpRhZpMUcsJ6d23PBxTC97C/iiJpQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -14053,31 +15995,6 @@
       "integrity": "sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/preferences/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/preferences/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/prettier-config": {
@@ -14156,10 +16073,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/react-i18n/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wordpress/redux-routine": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.35.0.tgz",
-      "integrity": "sha512-qc3MLyPWzpujvrP1wVg3xCAuZF+BItGSIIOikMk6xLN63FlNRxjh88gZ65evjU47Ik5KOjYqx3bt/GFdmzJOxw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.37.0.tgz",
+      "integrity": "sha512-gavsOxTobcOquwl9Kpra0qR30H0vQPK1Rw+K7GDK9bNyJ+/9t4Jio0F6uVN3uQg48h/HomgRX86KCrTET9ntNA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -14229,6 +16166,53 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@types/react-dom": {
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/api-fetch": {
+      "version": "6.55.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
+      "integrity": "sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/url": "^3.59.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/autop": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.58.0.tgz",
+      "integrity": "sha512-RsdUV57A+DTJGU3slq/S9vTOtVkatnT1YyGIK3UDKaEhXkvBPtLTWwd3WR13GCfjFZ5XupH9FAGUQFkOve0eKQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/blob": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.58.0.tgz",
+      "integrity": "sha512-6L3WqbOWEGFOSs3vLMwJ83YScggCiJ9NvZj1kC7mgeiP302UP2Fxkt4KlfjeTsD350XcvakkD/57wRkHXd819Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/block-editor": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-10.5.0.tgz",
@@ -14283,6 +16267,75 @@
         "react": "^17.0.0",
         "react-dom": "^17.0.0"
       }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/block-editor/node_modules/remove-accents": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/block-serialization-default-parser": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.58.0.tgz",
+      "integrity": "sha512-++fowmFEJC+1SwiCGuLPO9k+g3rgI2SCAA/p8/Bc1rNgnKB+rowzmQvSIIlRpcUkmOxHOrH5uruOEX27Ksg6uw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/blocks": {
+      "version": "11.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.21.0.tgz",
+      "integrity": "sha512-FlOrF0VMugW7wW9LAAF3ixUp2t1HsEGTBjqERYr7dYQIJI8yIII7/Zh2Opuzq0baWaA7kqexUQeD6sYSOcu8lA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/autop": "^3.22.0",
+        "@wordpress/blob": "^3.22.0",
+        "@wordpress/block-serialization-default-parser": "^4.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/hooks": "^3.22.0",
+        "@wordpress/html-entities": "^3.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/shortcode": "^3.22.0",
+        "change-case": "^4.1.2",
+        "colord": "^2.7.0",
+        "hpq": "^1.3.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "rememo": "^4.0.0",
+        "remove-accents": "^0.4.2",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/blocks/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/blocks/node_modules/remove-accents": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+      "license": "MIT"
     },
     "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components": {
       "version": "22.1.0",
@@ -14341,39 +16394,42 @@
         "react-dom": "^17.0.0"
       }
     },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components/node_modules/derive-valtio": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/derive-valtio/-/derive-valtio-0.1.0.tgz",
-      "integrity": "sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "valtio": "*"
-      }
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
     },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components/node_modules/valtio": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.13.2.tgz",
-      "integrity": "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==",
-      "license": "MIT",
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components/node_modules/remove-accents": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/compose": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
+      "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "derive-valtio": "0.1.0",
-        "proxy-compare": "2.6.0",
-        "use-sync-external-store": "1.2.0"
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.8",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
       },
       "engines": {
-        "node": ">=12.20.0"
+        "node": ">=12"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
+        "react": "^17.0.0"
       }
     },
     "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/core-data": {
@@ -14406,6 +16462,12 @@
       "peerDependencies": {
         "react": "^17.0.0"
       }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/core-data/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
     },
     "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/data": {
       "version": "7.6.0",
@@ -14454,13 +16516,138 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/hooks": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
-      "integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0"
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/keyboard-shortcuts": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-3.20.0.tgz",
+      "integrity": "sha512-78JTtqw6CGm9aMrZmRjvlQ8+skK/8ZV2rNd58ZpWT9Htp5jEB5ddt34P5wn04UiDOFFd13sy5HOqhsUFHh4qFA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "rememo": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/notices": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-3.31.0.tgz",
+      "integrity": "sha512-9WyaFaSr/vQc1K7cZLyPw1xBKqWfjpAKMJzWMzHYjwk1ldibhBWVLukicuolD6Y+9l+97IZHCoESBQwUeFo79Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.31.0",
+        "@wordpress/data": "^9.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/notices/node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
+      "integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/dom": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/keycodes": "^3.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/undo-manager": "^0.18.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.11",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/notices/node_modules/@wordpress/data": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
+      "integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/redux-routine": "^4.58.0",
+        "deepmerge": "^4.3.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "redux": "^4.1.2",
+        "rememo": "^4.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/notices/node_modules/@wordpress/element": {
+      "version": "5.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.35.0.tgz",
+      "integrity": "sha512-puswpGcIdS+0A2g28uHriMkZqqRCmzFczue5Tk99VNtzBdehyk7Ae+DZ4xw5yT6GqYai8NTqv6MRwCB78uh5Mw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/react": "^18.2.79",
+        "@types/react-dom": "^18.2.25",
+        "@wordpress/escape-html": "^2.58.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
       },
       "engines": {
         "node": ">=12"
@@ -14484,6 +16671,50 @@
         "redux": ">=4"
       }
     },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/rich-text": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.20.0.tgz",
+      "integrity": "sha512-7W4PksJ6/SnQ+KuwvZ0dlKSwbaS6ejvWBm2N8R5S79AzbdmB69BpDCz0U/GUfGDXDhrU9dpzg5NIivoW2LC8Kg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/escape-html": "^2.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "memize": "^1.1.0",
+        "rememo": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/rich-text/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/shortcode": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.58.0.tgz",
+      "integrity": "sha512-yM3Y25XqLfz/X6xXowXbrTvk+tslKeALNNESI5nGt1X7wWPsYQDOqyBb1HT9TglSLFgWYlQlNtgEbz07dEiDgQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "memize": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/style-engine": {
       "version": "1.41.0",
       "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-1.41.0.tgz",
@@ -14492,6 +16723,43 @@
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "change-case": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/token-list": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.58.0.tgz",
+      "integrity": "sha512-xzNGzAZ87GERq7rZvZjMv742nj37tSLFBb8+c7oaLdpUpfn8YTaXQacvphdN2jmtfHvEZHivW7hErwqF9eQW/A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/url": {
+      "version": "3.59.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
+      "integrity": "sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/wordcount": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.58.0.tgz",
+      "integrity": "sha512-cxmOOh8d4VeIC3B9HcqhlTQePmNkNrPeHQLj6xWHfC0Elflj+kYAjsTwkjVQ3tBMC4+mQzva1O8tFSVh02gs7w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
       },
       "engines": {
         "node": ">=12"
@@ -14547,82 +16815,83 @@
       "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
       "license": "0BSD"
     },
-    "node_modules/@wordpress/reusable-blocks/node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+    "node_modules/@wordpress/reusable-blocks/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/rich-text": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.20.0.tgz",
-      "integrity": "sha512-7W4PksJ6/SnQ+KuwvZ0dlKSwbaS6ejvWBm2N8R5S79AzbdmB69BpDCz0U/GUfGDXDhrU9dpzg5NIivoW2LC8Kg==",
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-6.35.0.tgz",
+      "integrity": "sha512-h6/XftSqo9UQZebuNZyLfOVu+ButBLITW/BILsKeJhSpmM19VNdz8UhVGLp+xQPE+/GPCIMJrhhqipISDfc2Ig==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.22.0",
-        "@wordpress/compose": "^5.20.0",
-        "@wordpress/data": "^7.6.0",
-        "@wordpress/deprecated": "^3.22.0",
-        "@wordpress/element": "^4.20.0",
-        "@wordpress/escape-html": "^2.22.0",
-        "@wordpress/i18n": "^4.22.0",
-        "@wordpress/keycodes": "^3.22.0",
-        "memize": "^1.1.0",
-        "rememo": "^4.0.0"
+        "@wordpress/a11y": "^3.58.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/escape-html": "^2.58.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/keycodes": "^3.58.0",
+        "memize": "^2.1.0"
       },
       "engines": {
         "node": ">=12"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/rich-text/node_modules/@wordpress/data": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-7.6.0.tgz",
-      "integrity": "sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==",
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
+      "integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^5.20.0",
-        "@wordpress/deprecated": "^3.22.0",
-        "@wordpress/element": "^4.20.0",
-        "@wordpress/is-shallow-equal": "^4.22.0",
-        "@wordpress/priority-queue": "^2.22.0",
-        "@wordpress/redux-routine": "^4.22.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/redux-routine": "^4.58.0",
+        "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
         "is-promise": "^4.0.0",
-        "lodash": "^4.17.21",
         "redux": "^4.1.2",
-        "turbo-combine-reducers": "^1.0.2",
+        "rememo": "^4.0.2",
         "use-memo-one": "^1.1.1"
       },
       "engines": {
         "node": ">=12"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
-      "integrity": "sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==",
+    "node_modules/@wordpress/rich-text/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@types/react": "^17.0.37",
-        "@types/react-dom": "^17.0.11",
-        "@wordpress/escape-html": "^2.22.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
       },
       "engines": {
         "node": ">=12"
@@ -14702,6 +16971,116 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@wordpress/server-side-render/node_modules/@types/react-dom": {
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/api-fetch": {
+      "version": "6.55.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
+      "integrity": "sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/url": "^3.59.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/autop": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.58.0.tgz",
+      "integrity": "sha512-RsdUV57A+DTJGU3slq/S9vTOtVkatnT1YyGIK3UDKaEhXkvBPtLTWwd3WR13GCfjFZ5XupH9FAGUQFkOve0eKQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/blob": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.58.0.tgz",
+      "integrity": "sha512-6L3WqbOWEGFOSs3vLMwJ83YScggCiJ9NvZj1kC7mgeiP302UP2Fxkt4KlfjeTsD350XcvakkD/57wRkHXd819Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/block-serialization-default-parser": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.58.0.tgz",
+      "integrity": "sha512-++fowmFEJC+1SwiCGuLPO9k+g3rgI2SCAA/p8/Bc1rNgnKB+rowzmQvSIIlRpcUkmOxHOrH5uruOEX27Ksg6uw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/blocks": {
+      "version": "11.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.21.0.tgz",
+      "integrity": "sha512-FlOrF0VMugW7wW9LAAF3ixUp2t1HsEGTBjqERYr7dYQIJI8yIII7/Zh2Opuzq0baWaA7kqexUQeD6sYSOcu8lA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/autop": "^3.22.0",
+        "@wordpress/blob": "^3.22.0",
+        "@wordpress/block-serialization-default-parser": "^4.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/hooks": "^3.22.0",
+        "@wordpress/html-entities": "^3.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/shortcode": "^3.22.0",
+        "change-case": "^4.1.2",
+        "colord": "^2.7.0",
+        "hpq": "^1.3.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "rememo": "^4.0.0",
+        "remove-accents": "^0.4.2",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/blocks/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/blocks/node_modules/remove-accents": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+      "license": "MIT"
+    },
     "node_modules/@wordpress/server-side-render/node_modules/@wordpress/components": {
       "version": "22.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-22.1.0.tgz",
@@ -14759,39 +17138,42 @@
         "react-dom": "^17.0.0"
       }
     },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/components/node_modules/derive-valtio": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/derive-valtio/-/derive-valtio-0.1.0.tgz",
-      "integrity": "sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "valtio": "*"
-      }
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/components/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
     },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/components/node_modules/valtio": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.13.2.tgz",
-      "integrity": "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==",
-      "license": "MIT",
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/components/node_modules/remove-accents": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/compose": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
+      "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "derive-valtio": "0.1.0",
-        "proxy-compare": "2.6.0",
-        "use-sync-external-store": "1.2.0"
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.8",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
       },
       "engines": {
-        "node": ">=12.20.0"
+        "node": ">=12"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
+        "react": "^17.0.0"
       }
     },
     "node_modules/@wordpress/server-side-render/node_modules/@wordpress/data": {
@@ -14841,13 +17223,21 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/hooks": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
-      "integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/i18n": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+      "integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0"
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.58.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
       },
       "engines": {
         "node": ">=12"
@@ -14871,6 +17261,63 @@
         "redux": ">=4"
       }
     },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/rich-text": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.20.0.tgz",
+      "integrity": "sha512-7W4PksJ6/SnQ+KuwvZ0dlKSwbaS6ejvWBm2N8R5S79AzbdmB69BpDCz0U/GUfGDXDhrU9dpzg5NIivoW2LC8Kg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/escape-html": "^2.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "memize": "^1.1.0",
+        "rememo": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/rich-text/node_modules/memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/shortcode": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.58.0.tgz",
+      "integrity": "sha512-yM3Y25XqLfz/X6xXowXbrTvk+tslKeALNNESI5nGt1X7wWPsYQDOqyBb1HT9TglSLFgWYlQlNtgEbz07dEiDgQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "memize": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/url": {
+      "version": "3.59.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
+      "integrity": "sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wordpress/server-side-render/node_modules/framer-motion": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
@@ -14892,56 +17339,50 @@
         "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@wordpress/server-side-render/node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+    "node_modules/@wordpress/server-side-render/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/shortcode": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.58.0.tgz",
-      "integrity": "sha512-yM3Y25XqLfz/X6xXowXbrTvk+tslKeALNNESI5nGt1X7wWPsYQDOqyBb1HT9TglSLFgWYlQlNtgEbz07dEiDgQ==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.37.0.tgz",
+      "integrity": "sha512-zLD0bQP5u9eGoJPD4tyn02vqTmSGX0OSZbomUkhv1uAyHkfYSqddrxC/uURNDm7tPl6u3ovB7sVnt0sPJH+ljg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
         "memize": "^2.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/shortcode/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/style-engine": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-0.15.0.tgz",
-      "integrity": "sha512-F6wt4g8xnli6bOR0Syd4iz4r5jFha7DZLzi2krmgH3cSTK4DDPj2g1YOJrRIEqXX4aPmdZDurTqQZoJvt9qaqQ==",
+      "version": "2.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.37.0.tgz",
+      "integrity": "sha512-2utcjtcQB/WeiXVco0IkZGRMw7UXiOJZpzY3HiGRypRe2J/w2AC1dFMxE45K+lKXiEB6RahYc5HQmRWq0/i+vg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "lodash": "^4.17.21"
+        "change-case": "^4.1.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/sync": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.35.0.tgz",
-      "integrity": "sha512-2q7gYcw7fB5csO4LC12ZMe9UYoTCbmU+lTN4sdgmVr1bGs2Zm4Xm1ZAtq1wfrmVNYR10WysK+qKNxxyegNbWSg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.37.0.tgz",
+      "integrity": "sha512-/E8dEZzKLdTRZzo7cVI1sUPeS7km+euhfMv3v0M4fT+4GEhuEqUzclzwDnnraA41auslSakntWA5VPz84WTQKw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/simple-peer": "^9.11.5",
-        "@wordpress/hooks": "^4.35.0",
-        "@wordpress/url": "^4.35.0",
+        "@wordpress/hooks": "^4.37.0",
+        "@wordpress/url": "^4.37.0",
         "import-locals": "^2.0.0",
         "lib0": "^0.2.42",
         "simple-peer": "^9.11.0",
@@ -14956,84 +17397,53 @@
       }
     },
     "node_modules/@wordpress/sync/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
-    },
-    "node_modules/@wordpress/sync/node_modules/@wordpress/url": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.35.0.tgz",
-      "integrity": "sha512-h6KK0OePnc64T50BwVWmQb7xmcMW0XDtfh+1m/a0tlzXGLU4TnBjUUs+a0h0y6Tdla14lc2BtbLJLFwky06vbg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/sync/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
     },
     "node_modules/@wordpress/token-list": {
-      "version": "2.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.58.0.tgz",
-      "integrity": "sha512-xzNGzAZ87GERq7rZvZjMv742nj37tSLFBb8+c7oaLdpUpfn8YTaXQacvphdN2jmtfHvEZHivW7hErwqF9eQW/A==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.37.0.tgz",
+      "integrity": "sha512-PHpuRoBC4kgUzJe7aNk/uYGwff5HMsIAKLlVOQ5K9Uw3BJipk56HupsGmXxQ5bKMZetlsOfUHU5dZF3SPZAL5g==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/undo-manager": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.18.0.tgz",
+      "integrity": "sha512-upbzPEToa095XG+2JXLHaolF1LfXEMFS0lNMYV37myoUS+eZ7/tl9Gx+yU2+OqWy57TMwx33NlWUX/n+ynzPRw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0"
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/is-shallow-equal": "^4.58.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/undo-manager": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.35.0.tgz",
-      "integrity": "sha512-WyJWGLhLvkB2FF/o+QmgAoPo3NTEi5HQDwYbSEpw1pUZm7W3U/QwcaW6cWW3D/9OUtnHY4kfMGxrI5del2tYyA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/is-shallow-equal": "^5.35.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/undo-manager/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.35.0.tgz",
-      "integrity": "sha512-ooM/QFzxu8Ueqsv0D/z0+X6grbVws3GFMSxdM12eZO1B0/x6JPAtq4msZkoxqeQ4zoR0ghYHFXzv3k+Ch1tsFw==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/upload-media": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.20.0.tgz",
-      "integrity": "sha512-EFQz8pHK2fh6c0JP3dEPeuIy8SYF7f1YmjpMvMO37y25da92w5RARECAiBXncyopc6zUmW/X6PySlT72DA8kKQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.22.0.tgz",
+      "integrity": "sha512-IQ5/FLmCZm0n/DotF4ZfiYX6pQG8zqVVTfLP/MCIdIKuFHqFs0Z1CAE20qnPDC7kRH+GaGmIIKIYOS0d0rIIdA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.35.0",
-        "@wordpress/blob": "^4.35.0",
-        "@wordpress/compose": "^7.35.0",
-        "@wordpress/data": "^10.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/preferences": "^4.35.0",
-        "@wordpress/private-apis": "^1.35.0",
-        "@wordpress/url": "^4.35.0",
+        "@wordpress/api-fetch": "^7.37.0",
+        "@wordpress/blob": "^4.37.0",
+        "@wordpress/compose": "^7.37.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/i18n": "^6.10.0",
+        "@wordpress/preferences": "^4.37.0",
+        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/url": "^4.37.0",
         "uuid": "^9.0.1"
       },
       "engines": {
@@ -15045,53 +17455,20 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/upload-media/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/upload-media/node_modules/@wordpress/api-fetch": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.35.0.tgz",
-      "integrity": "sha512-jWIhNUVYkUOsVLvGodBhzLe4DR+gCNmh7sm91Vce/79M+DXMtEFLc8jHJ5kXKudnPPTzy29KF1ZzZJ9rm9sqRQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/i18n": "^6.8.0",
-        "@wordpress/url": "^4.35.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/upload-media/node_modules/@wordpress/blob": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.35.0.tgz",
-      "integrity": "sha512-8b+A6in2dH+PPhGGI84GwNPyi8mxXUgsTsBG9Ey/WCYRFWXJmqhkgTUnZIi4PvieJbmmAILI9oyfMPSfeAb0sg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/compose": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.35.0.tgz",
-      "integrity": "sha512-UUQ31Rfi+KFfqT5wkbTgq0nMh+QfbLvshhm30+EGr8R3bYziHhfLKhIL2YQXf4MIX4owOFdKgbAt4GFeVI24ng==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -15106,12 +17483,12 @@
       }
     },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/deprecated": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.35.0.tgz",
-      "integrity": "sha512-+TruZtmDxRfVw02c1de7ofGC3CrcaPCUXCCbwfP6ruy1zM3IC3rtJfyTbqKPqO1y4uI+9Kqe5VEobqRKT3HQSg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.35.0"
+        "@wordpress/hooks": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -15119,12 +17496,12 @@
       }
     },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/dom": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.35.0.tgz",
-      "integrity": "sha512-mM/8m548RaWtkBonpCYHprXgyVFjKcFJWyHfWZz17j01xIbzBq+//cR/Lff86EiEuwynedqlFoEJUcgvPkrJZw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0"
+        "@wordpress/deprecated": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -15132,14 +17509,14 @@
       }
     },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/element": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.35.0.tgz",
-      "integrity": "sha512-RmxQsk0ANoHtxDc6anbUH/lHL7Mmbbdn016WKHYVh4+79EzN1tBeM8OML2gHpllUISmIYQvO4wIPSmEVzRh+Gw==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.35.0",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -15151,9 +17528,9 @@
       }
     },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/escape-html": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.35.0.tgz",
-      "integrity": "sha512-thY7RGAI6UijG3sbBm4IRzMX9lnHkEA/vR3Y0E5BGQYzNFwc+i7t1Lm4scpEBnL3UEQxdlD1wiJTH4pv5olV+Q==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -15161,39 +17538,19 @@
       }
     },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/upload-media/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.35.0.tgz",
-      "integrity": "sha512-ooM/QFzxu8Ueqsv0D/z0+X6grbVws3GFMSxdM12eZO1B0/x6JPAtq4msZkoxqeQ4zoR0ghYHFXzv3k+Ch1tsFw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -15201,12 +17558,12 @@
       }
     },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/keycodes": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.35.0.tgz",
-      "integrity": "sha512-+cvb9I4VorJRUsPC4C/2e0QWMz8hkjQIvjz3BjTkIXyWlxsSRSk/+a/YCrfyyA5ysuR9PgwKxxI7/ZaAPvOC6w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -15214,9 +17571,9 @@
       }
     },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/priority-queue": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.35.0.tgz",
-      "integrity": "sha512-kLdPx09CnPMPUL5hI/3SUgbBVEka20iWBxM2pvwJGrn3bleY0WxGqLtoUksn6yQds9d7jjS5cKoBYxY1H8MHgg==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -15227,71 +17584,40 @@
       }
     },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/private-apis": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.35.0.tgz",
-      "integrity": "sha512-gpwYCAuWSjSps7KnmPfUSdJUf5iq8P0ln1eZPcnjs3IwRDUrKW9eUrO0jID+XUsi63qi5c+lv9UkwI8M8C9c5A==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.37.0.tgz",
+      "integrity": "sha512-BR5GEHontWnza1tfBm2aX6/GjCZ1xZRrRNN1P0oj9xuvtut3YzCr//pZuyQ+P5maByDthUZjNrvN3UEF1iucbA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/upload-media/node_modules/@wordpress/url": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.35.0.tgz",
-      "integrity": "sha512-h6KK0OePnc64T50BwVWmQb7xmcMW0XDtfh+1m/a0tlzXGLU4TnBjUUs+a0h0y6Tdla14lc2BtbLJLFwky06vbg==",
+    "node_modules/@wordpress/upload-media/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "remove-accents": "^0.5.0"
+        "@wordpress/is-shallow-equal": "^5.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/upload-media/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/upload-media/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/upload-media/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "3.59.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
-      "integrity": "sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.37.0.tgz",
+      "integrity": "sha512-8ofI1OzPON9twQIPczG5WfAtef5hhfZY+FB6cPmwDT5BftQGGO/+v0cHge7pgrRQftSzj4iQ+fQXIdEpIFacgw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.16.0",
         "remove-accents": "^0.5.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
-    },
-    "node_modules/@wordpress/url/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
     },
     "node_modules/@wordpress/viewport": {
       "version": "4.20.0",
@@ -15302,6 +17628,41 @@
         "@babel/runtime": "^7.16.0",
         "@wordpress/compose": "^5.20.0",
         "@wordpress/data": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/viewport/node_modules/@types/react-dom": {
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/viewport/node_modules/@wordpress/compose": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
+      "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.8",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -15385,15 +17746,13 @@
       }
     },
     "node_modules/@wordpress/wordcount": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.58.0.tgz",
-      "integrity": "sha512-cxmOOh8d4VeIC3B9HcqhlTQePmNkNrPeHQLj6xWHfC0Elflj+kYAjsTwkjVQ3tBMC4+mQzva1O8tFSVh02gs7w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.37.0.tgz",
+      "integrity": "sha512-Uyl9aR4Tpr/AVoTcqQjkvGE8FE1jXOOooUwcEWCxxe4OLyyKDBs/uJJ2afXzgxc/gNI/QGHArdOA0UArywcnng==",
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wp-playground/client": {
@@ -16175,9 +18534,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.22",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.22.tgz",
-      "integrity": "sha512-ARe0v/t9gO28Bznv6GgqARmVqcWOV3mfgUPn9becPHMiD3o9BwlRgaeccZnwTpZ7Zwqrm+c1sUSsMxIzQzc8Xg==",
+      "version": "10.4.23",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.23.tgz",
+      "integrity": "sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==",
       "dev": true,
       "funding": [
         {
@@ -16195,10 +18554,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.27.0",
-        "caniuse-lite": "^1.0.30001754",
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001760",
         "fraction.js": "^5.3.4",
-        "normalize-range": "^0.1.2",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
       },
@@ -16234,9 +18592,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
-      "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -16262,6 +18620,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-core": {
@@ -16524,9 +18897,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.1.tgz",
-      "integrity": "sha512-zGUCsm3yv/ePt2PHNbVxjjn0nNB1MkIaR4wOCxJ2ig5pCf5cCVAYJXVhQg/3OhhJV6DB1ts7Hv0oUaElc2TPQg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
+      "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -16645,18 +19018,18 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.27",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.27.tgz",
-      "integrity": "sha512-2CXFpkjVnY2FT+B6GrSYxzYf65BJWEqz5tIRHCvNsZZ2F3CmsCB37h8SpYgKG7y9C4YAeTipIPWG7EmFmhAeXA==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
+      "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
+      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16712,24 +19085,24 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
@@ -16766,22 +19139,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/body-scroll-lock": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
@@ -16798,6 +19155,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
       "integrity": "sha512-WmJJU2e9Y6M5UzTOkHaM7xJGAPQD8PNzx3bAd2+uhZAim6wDk6dAZxPVYLF67XhbR4hmKGh33Lpmh4XWrCH5Mg==",
+      "deprecated": "No longer maintained. Please upgrade to a stable version.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16881,9 +19239,9 @@
       "license": "MIT"
     },
     "node_modules/browserslist": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
-      "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "funding": [
         {
           "type": "opencollective",
@@ -16900,11 +19258,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.25",
-        "caniuse-lite": "^1.0.30001754",
-        "electron-to-chromium": "^1.5.249",
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
         "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.1.4"
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -17086,9 +19444,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001754",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
-      "integrity": "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==",
+      "version": "1.0.30001764",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
+      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
       "funding": [
         {
           "type": "opencollective",
@@ -17256,9 +19614,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-11.0.0.tgz",
-      "integrity": "sha512-cM3DI+OOb89T3wO8cpPSro80Q9eKYJ7hGVXoGS3GkDPxnYSqiv+6xwpIf6XERyJ9Tdsl09hmNmY94BkgZdVekw==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-12.0.1.tgz",
+      "integrity": "sha512-fGg+6jr0xjQhzpy5N4ErZxQ4wF7KLEvhGZXD6EgvZKDhu7iOhZXnZhcDxPJDcwTcrD48NPzOCo84RP2lv3Z+Cg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17764,9 +20122,9 @@
       "license": "MIT"
     },
     "node_modules/core-js": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.46.0.tgz",
-      "integrity": "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
+      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -17775,12 +20133,12 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.46.0.tgz",
-      "integrity": "sha512-p9hObIIEENxSV8xIu+V68JjSeARg6UVMG5mR+JEUguG3sI6MsiS1njz2jHmyJDvA+8jX/sytkBHup6kxhM9law==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz",
+      "integrity": "sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.26.3"
+        "browserslist": "^4.28.0"
       },
       "funding": {
         "type": "opencollective",
@@ -17788,9 +20146,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.46.0.tgz",
-      "integrity": "sha512-NMCW30bHNofuhwLhYPt66OLOKTMbOhgTTatKVbaQC3KRHpTCiRIBYvtshr+NBYSnBxwAFhjW/RfJ0XbIjS16rw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.47.0.tgz",
+      "integrity": "sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -17997,9 +20355,9 @@
       }
     },
     "node_modules/css-declaration-sorter": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.0.tgz",
-      "integrity": "sha512-LQF6N/3vkAMYF4xoHLJfG718HRJh34Z8BnNhd6bosOMIVjMlhuZK5++oZa3uYAgrI5+7x2o27gUqTR2U/KjUOQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
+      "integrity": "sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -18230,9 +20588,9 @@
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/custom-event": {
@@ -18445,12 +20803,10 @@
       }
     },
     "node_modules/date-fns-jalali": {
-      "version": "2.13.0-0",
-      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-2.13.0-0.tgz",
-      "integrity": "sha512-yjlI9O18Z6ryGNagryrLO8OQ+3rishM3+A0UOX2UX10cWMn2NTlQcQ+ywTEJvF5IJz0FwX/slt2nCcpyQ/c8gw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
     },
     "node_modules/date-format": {
       "version": "4.0.14",
@@ -18525,9 +20881,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
-      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
+      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -18702,6 +21058,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/derive-valtio": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/derive-valtio/-/derive-valtio-0.1.0.tgz",
+      "integrity": "sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "valtio": "*"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -18724,17 +21089,14 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
       "engines": {
-        "node": ">=0.10"
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -18833,9 +21195,9 @@
       }
     },
     "node_modules/docker-compose/node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -18843,6 +21205,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/doctrine": {
@@ -18974,9 +21339,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
-      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -19112,9 +21477,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.250",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.250.tgz",
-      "integrity": "sha512-/5UMj9IiGDMOFBnN4i7/Ry5onJrAGSbOGo3s9FEKmwobGq6xw832ccET0CE3CkkMBZ8GJSlUIesZofpyurqDXw==",
+      "version": "1.5.267",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
+      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -19183,9 +21548,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
-      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.5.tgz",
+      "integrity": "sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19195,9 +21560,9 @@
         "base64id": "2.0.0",
         "cookie": "~0.7.2",
         "cors": "~2.8.5",
-        "debug": "~4.3.1",
+        "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
+        "ws": "~8.18.3"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -19213,28 +21578,10 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/engine.io/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/engine.io/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19254,9 +21601,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
-      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+      "version": "5.18.4",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
+      "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19376,9 +21723,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.2",
@@ -19483,27 +21830,27 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
-      "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
+      "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.6",
+        "es-abstract": "^1.24.1",
         "es-errors": "^1.3.0",
-        "es-set-tostringtag": "^2.0.3",
+        "es-set-tostringtag": "^2.1.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.6",
+        "get-intrinsic": "^1.3.0",
         "globalthis": "^1.0.4",
         "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
         "has-proto": "^1.2.0",
         "has-symbols": "^1.1.0",
         "internal-slot": "^1.1.0",
-        "iterator.prototype": "^1.1.4",
+        "iterator.prototype": "^1.1.5",
         "safe-array-concat": "^1.1.3"
       },
       "engines": {
@@ -19511,9 +21858,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -20197,14 +22544,14 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
-      "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.11.7"
+        "prettier-linter-helpers": "^1.0.1",
+        "synckit": "^0.11.12"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -20604,9 +22951,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -20932,9 +23279,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -21387,6 +23734,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -22700,9 +25062,9 @@
       }
     },
     "node_modules/grunt-webpack": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-webpack/-/grunt-webpack-7.0.0.tgz",
-      "integrity": "sha512-HjeKSoE94ZNAqLLBT/Iwew6MoUpyBpRDGIofrO51Btl+X7RzRXh7ERUm844RzOQuFF2IQ51MxsfC1zb7ylJ8XA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-webpack/-/grunt-webpack-7.0.1.tgz",
+      "integrity": "sha512-3Mo0UfZE7v5CnSCIkN6tGMlKDOCr0okvk8SQrL9X/6JhrE2sQlGwFEI5Q6j89rZ9DTl9jEjkIev/hfR0x85wKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22788,9 +25150,9 @@
       }
     },
     "node_modules/grunt/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23196,26 +25558,30 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -23314,29 +25680,20 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/i18n-calypso/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
     "node_modules/i18n-calypso/node_modules/@wordpress/compose": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.35.0.tgz",
-      "integrity": "sha512-UUQ31Rfi+KFfqT5wkbTgq0nMh+QfbLvshhm30+EGr8R3bYziHhfLKhIL2YQXf4MIX4owOFdKgbAt4GFeVI24ng==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
+      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.35.0",
-        "@wordpress/dom": "^4.35.0",
-        "@wordpress/element": "^6.35.0",
-        "@wordpress/is-shallow-equal": "^5.35.0",
-        "@wordpress/keycodes": "^4.35.0",
-        "@wordpress/priority-queue": "^3.35.0",
-        "@wordpress/undo-manager": "^1.35.0",
+        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/dom": "^4.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/is-shallow-equal": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/priority-queue": "^3.37.0",
+        "@wordpress/undo-manager": "^1.37.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -23351,12 +25708,12 @@
       }
     },
     "node_modules/i18n-calypso/node_modules/@wordpress/deprecated": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.35.0.tgz",
-      "integrity": "sha512-+TruZtmDxRfVw02c1de7ofGC3CrcaPCUXCCbwfP6ruy1zM3IC3rtJfyTbqKPqO1y4uI+9Kqe5VEobqRKT3HQSg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
+      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.35.0"
+        "@wordpress/hooks": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -23364,12 +25721,12 @@
       }
     },
     "node_modules/i18n-calypso/node_modules/@wordpress/dom": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.35.0.tgz",
-      "integrity": "sha512-mM/8m548RaWtkBonpCYHprXgyVFjKcFJWyHfWZz17j01xIbzBq+//cR/Lff86EiEuwynedqlFoEJUcgvPkrJZw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
+      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.35.0"
+        "@wordpress/deprecated": "^4.37.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -23377,14 +25734,14 @@
       }
     },
     "node_modules/i18n-calypso/node_modules/@wordpress/element": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.35.0.tgz",
-      "integrity": "sha512-RmxQsk0ANoHtxDc6anbUH/lHL7Mmbbdn016WKHYVh4+79EzN1tBeM8OML2gHpllUISmIYQvO4wIPSmEVzRh+Gw==",
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
+      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.35.0",
+        "@wordpress/escape-html": "^3.37.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -23396,9 +25753,9 @@
       }
     },
     "node_modules/i18n-calypso/node_modules/@wordpress/escape-html": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.35.0.tgz",
-      "integrity": "sha512-thY7RGAI6UijG3sbBm4IRzMX9lnHkEA/vR3Y0E5BGQYzNFwc+i7t1Lm4scpEBnL3UEQxdlD1wiJTH4pv5olV+Q==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
+      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -23406,39 +25763,19 @@
       }
     },
     "node_modules/i18n-calypso/node_modules/@wordpress/hooks": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.35.0.tgz",
-      "integrity": "sha512-PQcAv/zfMYn5sPScOWDu1vgYkyHaDFt7+1IHvwR0RGE0AdQrdnKjvm6VJ4ALugA+zvJZkBZxLk5Gm+NZGAWIMg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
+      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
       "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/i18n-calypso/node_modules/@wordpress/i18n": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.8.0.tgz",
-      "integrity": "sha512-lNMjf0VXWm2qzkEI+v1psvb26FN+B32sO6nLOFxs5Lay/E0WVqCw31DiRw8nETlzVwsMheO+iy0lCSOLvg+jog==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.35.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/i18n-calypso/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.35.0.tgz",
-      "integrity": "sha512-ooM/QFzxu8Ueqsv0D/z0+X6grbVws3GFMSxdM12eZO1B0/x6JPAtq4msZkoxqeQ4zoR0ghYHFXzv3k+Ch1tsFw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
+      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -23446,12 +25783,12 @@
       }
     },
     "node_modules/i18n-calypso/node_modules/@wordpress/keycodes": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.35.0.tgz",
-      "integrity": "sha512-+cvb9I4VorJRUsPC4C/2e0QWMz8hkjQIvjz3BjTkIXyWlxsSRSk/+a/YCrfyyA5ysuR9PgwKxxI7/ZaAPvOC6w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
+      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.8.0"
+        "@wordpress/i18n": "^6.10.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -23459,9 +25796,9 @@
       }
     },
     "node_modules/i18n-calypso/node_modules/@wordpress/priority-queue": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.35.0.tgz",
-      "integrity": "sha512-kLdPx09CnPMPUL5hI/3SUgbBVEka20iWBxM2pvwJGrn3bleY0WxGqLtoUksn6yQds9d7jjS5cKoBYxY1H8MHgg==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
+      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -23471,11 +25808,18 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/i18n-calypso/node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
+    "node_modules/i18n-calypso/node_modules/@wordpress/undo-manager": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
+      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.37.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
     },
     "node_modules/i18next": {
       "version": "23.16.8",
@@ -24620,9 +26964,9 @@
       }
     },
     "node_modules/istanbul/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26804,9 +29148,9 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
-      "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -27042,12 +29386,12 @@
       }
     },
     "node_modules/locutus": {
-      "version": "2.0.32",
-      "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.32.tgz",
-      "integrity": "sha512-fr7OCpbE4xeefhHqfh6hM2/l9ZB3XvClHgtgFnQNImrM/nqL950o6FO98vmUH8GysfQRCcyBYtZ4C8GcY52Edw==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.37.tgz",
+      "integrity": "sha512-9hllI+0bX5iIebWuZfHg2Q2jJ5Qmd9vTs6QEzA+gu8MdPOQ6Swd0Tdr3dCyShTomqdGjBshOep4dbZdwXbSD6g==",
       "license": "MIT",
       "engines": {
-        "node": ">= 10",
+        "node": ">= 22",
         "yarn": ">= 1"
       }
     },
@@ -27058,9 +29402,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.17.22",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
+      "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -27376,13 +29720,6 @@
         "remove-accents": "0.5.0"
       }
     },
-    "node_modules/match-sorter/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/material-ui-popup-state": {
       "version": "5.0.11",
       "resolved": "https://registry.npmjs.org/material-ui-popup-state/-/material-ui-popup-state-5.0.11.tgz",
@@ -27578,9 +29915,9 @@
       }
     },
     "node_modules/memize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
-      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
       "license": "MIT"
     },
     "node_modules/memoize-one": {
@@ -28198,12 +30535,13 @@
       "license": "MIT"
     },
     "node_modules/mixpanel-browser": {
-      "version": "2.71.1",
-      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.71.1.tgz",
-      "integrity": "sha512-TKE+3PhhyPHgkgosAtESs6g++waMmm99G0f/jGLPVGTyY4Wi3BwmqsFaxrvm6rsKt4JY6L1vkdHhoMnfG8+juA==",
+      "version": "2.73.0",
+      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.73.0.tgz",
+      "integrity": "sha512-Ny+6BVeWJozZoyrzB+5/6LTqBZ0gDY1pwcs7PQLQVGPKMTdL8qAz0yV4H8ykGQEA5KrW2Ky/KZ3uMEHGjE7oSA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mixpanel/rrweb": "2.0.0-alpha.18.2"
+        "@mixpanel/rrweb": "2.0.0-alpha.18.2",
+        "@mixpanel/rrweb-plugin-console-record": "2.0.0-alpha.18.2"
       }
     },
     "node_modules/mkdirp": {
@@ -28457,16 +30795,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/normalize-wheel": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
@@ -28510,9 +30838,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.22",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
-      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -29212,9 +31540,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+      "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
       "dev": true,
       "license": "MIT"
     },
@@ -29321,9 +31649,9 @@
       }
     },
     "node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "dev": true,
       "license": "MIT"
     },
@@ -29540,9 +31868,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -29647,6 +31975,21 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/playwright/node_modules/playwright-core": {
@@ -30155,9 +32498,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -30230,9 +32573,9 @@
       }
     },
     "node_modules/postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -30263,9 +32606,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.27.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
-      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+      "version": "10.28.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
+      "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -30283,9 +32626,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
+      "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -30299,9 +32642,9 @@
       }
     },
     "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -30615,28 +32958,28 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.30.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.30.0.tgz",
-      "integrity": "sha512-2S3Smy0t0W4wJnNvDe7W0bE7wDmZjfZ3ljfMgJd6hn2Hq/f0jgN+x9PULZo2U3fu5UUIJ+JP8cNUGllu8P91Pg==",
+      "version": "24.35.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.35.0.tgz",
+      "integrity": "sha512-vt1zc2ME0kHBn7ZDOqLvgvrYD5bqNv5y2ZNXzYnCv8DEtZGw/zKhljlrGuImxptZ4rq+QI9dFGrUIYqG4/IQzA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.13",
-        "chromium-bidi": "11.0.0",
+        "@puppeteer/browsers": "2.11.1",
+        "chromium-bidi": "12.0.1",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1521046",
+        "devtools-protocol": "0.0.1534754",
         "typed-query-selector": "^2.12.0",
-        "webdriver-bidi-protocol": "0.3.8",
-        "ws": "^8.18.3"
+        "webdriver-bidi-protocol": "0.3.10",
+        "ws": "^8.19.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-      "version": "2.10.13",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.13.tgz",
-      "integrity": "sha512-a9Ruw3j3qlnB5a/zHRTkruppynxqaeE4H9WNj5eYGRWqw0ZauZ23f4W2ARf3hghF5doozyD+CRtt7XSYuYRI/Q==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.1.tgz",
+      "integrity": "sha512-YmhAxs7XPuxN0j7LJloHpfD1ylhDuFmmwMvfy/+6nBSrETT2ycL53LrhgPtR+f+GcPSybQVuQ5inWWu5MrWCpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -30656,9 +32999,9 @@
       }
     },
     "node_modules/puppeteer-core/node_modules/devtools-protocol": {
-      "version": "0.0.1521046",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
-      "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
+      "version": "0.0.1534754",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
+      "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -30791,9 +33134,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -30840,9 +33183,9 @@
       "license": "MIT"
     },
     "node_modules/qunit": {
-      "version": "2.24.2",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.24.2.tgz",
-      "integrity": "sha512-dWlYs+Q9AIDT3eHKgkpEpWrSjHjqTJNCAJr1tUo5bQuDMzlZvaqCz1bNZhqzNu41ibkIQ7b50S9y6IMlrrUfNQ==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.25.0.tgz",
+      "integrity": "sha512-MONPKgjavgTqArCwZOEz8nEMbA19zNXIp5ZOW9rPYj5cbgQp0fiI36c9dPTSzTRRzx+KcfB5eggYB/ENqxi0+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -30896,16 +33239,16 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
@@ -31023,9 +33366,9 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "9.11.1",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.11.1.tgz",
-      "integrity": "sha512-l3ub6o8NlchqIjPKrRFUCkTUEq6KwemQlfv3XZzzwpUeGwmDJ+0u0Upmt38hJyd7D/vn2dQoOoLV/qAp0o3uUw==",
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.13.0.tgz",
+      "integrity": "sha512-euzj5Hlq+lOHqI53NiuNhCP8HWgsPf/bBAVijR50hNaY1XwjKjShAnIe8jm8RD2W9IJUvihDIZ+KrmqfFzNhFQ==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
@@ -31042,12 +33385,6 @@
       "peerDependencies": {
         "react": ">=16.8.0"
       }
-    },
-    "node_modules/react-day-picker/node_modules/date-fns-jalali": {
-      "version": "4.1.0-0",
-      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
-      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
-      "license": "MIT"
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
@@ -31086,24 +33423,18 @@
       }
     },
     "node_modules/react-easy-crop": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-3.5.3.tgz",
-      "integrity": "sha512-ApTbh+lzKAvKqYW81ihd5J6ZTNN3vPDwi6ncFuUrHPI4bko2DlYOESkRm+0NYoW0H8YLaD7bxox+Z3EvIzAbUA==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.6.tgz",
+      "integrity": "sha512-Jw3/ozs8uXj3NpL511Suc4AHY+mLRO23rUgipXvNYKqezcFSYHxe4QXibBymkOoY6oOtLVMPO2HNPRHYvMPyTw==",
       "license": "MIT",
       "dependencies": {
         "normalize-wheel": "^1.0.1",
-        "tslib": "2.0.1"
+        "tslib": "^2.0.1"
       },
       "peerDependencies": {
         "react": ">=16.4.0",
         "react-dom": ">=16.4.0"
       }
-    },
-    "node_modules/react-easy-crop/node_modules/tslib": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
-      "license": "0BSD"
     },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
@@ -31350,9 +33681,9 @@
       }
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
-      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
       "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
@@ -31397,12 +33728,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
-      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0"
+        "@remix-run/router": "1.23.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -31412,13 +33743,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
-      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.1"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -31969,9 +34300,9 @@
       "license": "MIT"
     },
     "node_modules/remove-accents": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
-      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
       "license": "MIT"
     },
     "node_modules/requestidlecallback": {
@@ -32315,9 +34646,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.94.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.94.0.tgz",
-      "integrity": "sha512-Dqh7SiYcaFtdv5Wvku6QgS5IGPm281L+ZtVD1U2FJa7Q0EFRlq8Z3sjYtz6gYObsYThUOz9ArwFqPZx+1azILQ==",
+      "version": "1.97.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
+      "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -32366,11 +34697,14 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
       "dev": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -33003,16 +35337,16 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
-      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "cors": "~2.8.5",
-        "debug": "~4.3.2",
+        "debug": "~4.4.1",
         "engine.io": "~6.6.0",
         "socket.io-adapter": "~2.5.2",
         "socket.io-parser": "~4.2.4"
@@ -33022,38 +35356,20 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
-      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "~4.3.4",
-        "ws": "~8.17.1"
-      }
-    },
-    "node_modules/socket.io-adapter/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
       }
     },
     "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -33073,53 +35389,17 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
+      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
+        "debug": "~4.4.1"
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io-parser/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socket.io/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/socks": {
@@ -33324,13 +35604,13 @@
       }
     },
     "node_modules/storybook": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.14.tgz",
-      "integrity": "sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.15.tgz",
+      "integrity": "sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@storybook/core": "8.6.14"
+        "@storybook/core": "8.6.15"
       },
       "bin": {
         "getstorybook": "bin/index.cjs",
@@ -33702,21 +35982,21 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.1.19",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
-      "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.6.tgz",
+      "integrity": "sha512-eRtK6PXWk3juH+8X9cyfItRk6a0JM+0Cw2gSr9jM3T3WeErb+UPObTRkVCHAv9maYfvPof77h1wq3325I0iI7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@emotion/is-prop-valid": "1.2.2",
-        "@emotion/unitless": "0.8.1",
-        "@types/stylis": "4.2.5",
+        "@emotion/is-prop-valid": "1.4.0",
+        "@emotion/unitless": "0.10.0",
+        "@types/stylis": "4.2.7",
         "css-to-react-native": "3.2.0",
-        "csstype": "3.1.3",
+        "csstype": "3.2.3",
         "postcss": "8.4.49",
         "shallowequal": "1.1.0",
-        "stylis": "4.3.2",
-        "tslib": "2.6.2"
+        "stylis": "4.3.6",
+        "tslib": "2.8.1"
       },
       "engines": {
         "node": ">= 16"
@@ -33729,30 +36009,6 @@
         "react": ">= 16.8.0",
         "react-dom": ">= 16.8.0"
       }
-    },
-    "node_modules/styled-components/node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
-      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.8.1"
-      }
-    },
-    "node_modules/styled-components/node_modules/@emotion/memoize": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/styled-components/node_modules/@emotion/unitless": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/styled-components/node_modules/postcss": {
       "version": "8.4.49",
@@ -33784,18 +36040,11 @@
       }
     },
     "node_modules/styled-components/node_modules/stylis": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
-      "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/styled-components/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/stylehacks": {
       "version": "7.0.7",
@@ -33994,9 +36243,9 @@
       "license": "MIT"
     },
     "node_modules/synckit": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -34070,21 +36319,6 @@
         "streamx": "^2.15.0"
       }
     },
-    "node_modules/tar-stream/node_modules/b4a": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/terser": {
       "version": "5.44.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
@@ -34105,9 +36339,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+      "version": "5.3.16",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
+      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -34231,21 +36465,6 @@
         "b4a": "^1.6.4"
       }
     },
-    "node_modules/text-decoder/node_modules/b4a": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -34337,21 +36556,69 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tldts-core": {
-      "version": "7.0.17",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.17.tgz",
-      "integrity": "sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==",
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tldts-icann": {
-      "version": "7.0.17",
-      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.17.tgz",
-      "integrity": "sha512-up4oFDoumyz2RscRxoYRxf+2OvIKUHjh7rUvuGWI0PZ/47k35sadoi2JyKR0AIfTw09qcfix8bUxXFQhY1QZIQ==",
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.19.tgz",
+      "integrity": "sha512-PZgda8E2cXMNa7QlBbiZh3vcS8UaPTDRIBmcGPDlujSMtQLrzjvikeJxzQSqWxn3muaMJ7BsC+aL464Yl2I6cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.17"
+        "tldts-core": "^7.0.19"
       }
     },
     "node_modules/tmp": {
@@ -34501,9 +36768,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -35160,9 +37427,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -35385,9 +37652,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -35453,12 +37724,47 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.23",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
-      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "version": "13.15.26",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
+      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/valtio": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.13.2.tgz",
+      "integrity": "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==",
+      "license": "MIT",
+      "dependencies": {
+        "derive-valtio": "0.1.0",
+        "proxy-compare": "2.6.0",
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/valtio/node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/vary": {
@@ -35567,9 +37873,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -35590,9 +37896,9 @@
       }
     },
     "node_modules/webdriver-bidi-protocol": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.8.tgz",
-      "integrity": "sha512-21Yi2GhGntMc671vNBCjiAeEVknXjVRoyu+k+9xOMShu+ZQfpGQwnBqbNz/Sv4GXZ6JmutlPAi2nIJcrymAWuQ==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.10.tgz",
+      "integrity": "sha512-5LAE43jAVLOhB/QqX4bwSiv0Hg1HBfMmOuwBSXHdvg4GMGu9Y0lIq7p4R/yySu6w74WmaR4GM4H9t2IwLW7hgw==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -35607,9 +37913,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.102.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
-      "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
+      "version": "5.104.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
+      "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -35621,21 +37927,21 @@
         "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.15.0",
         "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.26.3",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.3",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.17.4",
+        "es-module-lexer": "^2.0.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
+        "loader-runner": "^4.3.1",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.11",
+        "terser-webpack-plugin": "^5.3.16",
         "watchpack": "^2.4.4",
         "webpack-sources": "^3.3.3"
       },
@@ -35709,6 +38015,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
       "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -35836,9 +38143,9 @@
       "license": "ISC"
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -35962,9 +38269,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -36043,9 +38350,9 @@
       }
     },
     "node_modules/y-protocols": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
-      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.85"
@@ -36155,9 +38462,9 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.27",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
-      "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+      "version": "13.6.29",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
+      "integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.99"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "elementor",
       "version": "3.34.0",
       "dependencies": {
-        "@elementor/elementor-one-assets": "0.4.18",
+        "@elementor/elementor-one-assets": "^0.4.21",
         "@elementor/icons": "1.63.0",
         "@elementor/ui": "1.36.17",
         "@reach/router": "1.3.4",
@@ -3550,9 +3550,9 @@
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@elementor/elementor-one-assets": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.18.tgz",
-      "integrity": "sha512-OS0ozMfIRiGqYXvPcwaoTSXmizix9skM8jAda2PId+Lx/rZmm0ThuK1+XYJOV+ttIynYxbrQ6PpJKTKNfI8uYw==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.21.tgz",
+      "integrity": "sha512-VadsUmLFVDDiAck4V8qyukc1a06Z6OFnHDKTWRsyXOl6V7Mr2yo8c6ugorduHzvkWQA+xxwFBgZzAQN3UICg5g==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/icons": "^1.60.0",
@@ -3575,7 +3575,7 @@
     },
     "node_modules/@elementor/elementor-one-assets/node_modules/@elementor/ui": {
       "version": "1.37.2",
-      "resolved": "https://registry.npmjs.org/@elementor/ui/-/ui-1.37.2.tgz",
+      "resolved": "https://npm.pkg.github.com/download/@elementor/ui/1.37.2/a2fab739507cf7b8256939c241f752710d280f45",
       "integrity": "sha512-AGdK9be9A6O887daPVFqOJB/cDwMHju8qugsnraB/LRInEV4zo0Yj4dWHeORXshgWEV25q5gzkiaY2ng4uXhfw==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -7197,9 +7197,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.14",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.14.tgz",
-      "integrity": "sha512-/6di2yNI+YxpVrH9Ig74Q+puKnkCE+D0LGyagJEGndJHJc6ahkcc/UqirHKy8zCYE/N9KLggxcQvzYCsUBWgdw==",
+      "version": "5.90.17",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.17.tgz",
+      "integrity": "sha512-hDww+RyyYhjhUfoYQ4es6pbgxY7LNiPWxt4l1nJqhByjndxJ7HIjDxTBtfvMr5HwjYavMrd+ids5g4Rfev3lVQ==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -7208,13 +7208,13 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.90.14",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.14.tgz",
-      "integrity": "sha512-JAMuULej09hrZ14W9+mxoRZ44rR2BuZfCd6oKTQVNfynQxCN3muH3jh3W46gqZNw5ZqY0ZVaS43Imb3dMr6tgw==",
+      "version": "5.90.17",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.17.tgz",
+      "integrity": "sha512-PGc2u9KLwohDUSchjW9MZqeDQJfJDON7y4W7REdNBgiFKxQy+Pf7eGjiFWEj5xPqKzAeHYdAb62IWI1a9UJyGQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@tanstack/query-core": "5.90.14"
+        "@tanstack/query-core": "5.90.17"
       },
       "funding": {
         "type": "github",
@@ -31112,9 +31112,9 @@
       "license": "MIT"
     },
     "node_modules/react-hook-form": {
-      "version": "7.69.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.69.0.tgz",
-      "integrity": "sha512-yt6ZGME9f4F6WHwevrvpAjh42HMvocuSnSIHUGycBqXIJdhqGSPQzTpGF+1NLREk/58IdPxEMfPcFCjlMhclGw==",
+      "version": "7.71.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
+      "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "write": "^2.0.0"
   },
   "dependencies": {
-    "@elementor/elementor-one-assets": "0.4.18",
+    "@elementor/elementor-one-assets": "^0.4.21",
     "@elementor/icons": "1.63.0",
     "@elementor/ui": "1.36.17",
     "@reach/router": "1.3.4",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update @elementor/elementor-one-assets dependency to version 0.4.21 and change version pinning strategy from exact to caret range for better compatibility.

Main changes:
- Upgraded @elementor/elementor-one-assets from 0.4.18 to 0.4.21 to incorporate latest fixes and improvements
- Changed version constraint from exact pin (0.4.18) to caret range (^0.4.21) for automatic patch updates

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
