### PR TITLE
Fix: What’s New panel is empty when only Editor Core is installed [AC…

### DIFF
--- a/.grunt-config/copy.js
+++ b/.grunt-config/copy.js
@@ -63,6 +63,7 @@ const getBuildFiles = [
 	'vendor/autoload.php',
 	'vendor/composer/**',
 	'vendor/elementor/wp-one-package/**',
+	'vendor/elementor/wp-notifications-package/**',
 ];
 
 const copy = {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix empty What's New panel by including missing wp-notifications-package dependency in build configuration for Editor Core installations.

Main changes:
- Added 'vendor/elementor/wp-notifications-package/**' to getBuildFiles array in copy.js build configuration
- Ensures notifications package is properly bundled during build process for standalone Editor Core installations

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
