### PR TITLE
Internal: Bump packages [ED-22425]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "elementor/wp-one-package": "1.0.45"
+        "elementor/wp-one-package": "1.0.46"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a57d151b5a92c57053c108c7d93876e9",
+    "content-hash": "50e22c48ebc837c751a18b0f716e41ba",
     "packages": [
         {
             "name": "elementor/wp-notifications-package",
@@ -39,16 +39,16 @@
         },
         {
             "name": "elementor/wp-one-package",
-            "version": "1.0.45",
+            "version": "1.0.46",
             "source": {
                 "type": "git",
                 "url": "git@github.com:elementor/wp-one-package.git",
-                "reference": "6317ddc7e1614e7e24c3d1e454a7139ed51d3b34"
+                "reference": "744191f07ac0dcb266dc4a9ee49bb12616a53bb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.45",
-                "reference": "6317ddc7e1614e7e24c3d1e454a7139ed51d3b34",
+                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.46",
+                "reference": "744191f07ac0dcb266dc4a9ee49bb12616a53bb8",
                 "shasum": ""
             },
             "require": {
@@ -77,9 +77,9 @@
                 ]
             },
             "support": {
-                "source": "https://github.com/elementor/wp-one-package/tree/1.0.45"
+                "source": "https://github.com/elementor/wp-one-package/tree/1.0.46"
             },
-            "time": "2026-01-14T11:38:37+00:00"
+            "time": "2026-01-15T15:47:17+00:00"
         }
     ],
     "packages-dev": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "elementor",
       "version": "3.34.0",
       "dependencies": {
-        "@elementor/elementor-one-assets": "0.4.18",
+        "@elementor/elementor-one-assets": "^0.4.21",
         "@elementor/icons": "1.63.0",
         "@elementor/ui": "1.36.17",
         "@reach/router": "1.3.4",
@@ -3550,9 +3550,9 @@
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@elementor/elementor-one-assets": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.18.tgz",
-      "integrity": "sha512-OS0ozMfIRiGqYXvPcwaoTSXmizix9skM8jAda2PId+Lx/rZmm0ThuK1+XYJOV+ttIynYxbrQ6PpJKTKNfI8uYw==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.21.tgz",
+      "integrity": "sha512-VadsUmLFVDDiAck4V8qyukc1a06Z6OFnHDKTWRsyXOl6V7Mr2yo8c6ugorduHzvkWQA+xxwFBgZzAQN3UICg5g==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/icons": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "write": "^2.0.0"
   },
   "dependencies": {
-    "@elementor/elementor-one-assets": "0.4.18",
+    "@elementor/elementor-one-assets": "^0.4.21",
     "@elementor/icons": "1.63.0",
     "@elementor/ui": "1.36.17",
     "@reach/router": "1.3.4",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Bump package versions to incorporate latest updates from Elementor's one-package and asset distribution.

Main changes:
- Updated elementor/wp-one-package from 1.0.45 to 1.0.46 in composer.json dependencies
- Upgraded @elementor/elementor-one-assets from 0.4.18 to ^0.4.21 in package.json dependencies

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
