### PR TITLE
Fix: Prevent double serialization of metadata during import (#21224)

### DIFF
--- a/core/base/document.php
+++ b/core/base/document.php
@@ -1537,6 +1537,7 @@ abstract class Document extends Controls_Stack {
 	 * @return bool|int
 	 */
 	public function update_meta( $key, $value ) {
+    $value = maybe_unserialize( $value );
 		// Use `update_metadata` in order to work also with revisions.
 		return update_metadata( 'post', $this->post->ID, $key, $value );
 	}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Prevent double serialization of already serialized metadata during import

## Description
An explanation of what is done in this PR

* When importing content via Import/Export Kit, postmeta values that are already serialized get passed to `update_metadata()`, which serializes them again. This results in corrupted data (e.g., `a:1:{s:3:"foo";s:3:"bar";}` becomes `s:26:"a:1:{s:3:"foo";s:3:"bar";}";`).
* This fix adds a `maybe_unserialize()` call in the `update_meta()` method before passing the value to `update_metadata()`. WordPress will then properly re-serialize the data, preventing double serialization.

## Test instructions
This PR can be tested by following these steps:

* Deactivate all plugins except Elementor
* Create and publish an Elementor page
* Add a postmeta row to the page with `meta_key` = "foobar" and a serialized `meta_value` like `a:1:{s:3:"foo";s:3:"bar";}`
* Export using Elementor's Import/Export Kit tool
* Delete the page
* Import the exported content back
* Verify the postmeta value remains `a:1:{s:3:"foo";s:3:"bar";}` and is not double-serialized

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #21224