### PR TITLE
Internal: Make overridable props loading async [ED-22587]

### DIFF
--- a/packages/packages/core/editor-components/src/store/actions/load-components-assets.ts
+++ b/packages/packages/core/editor-components/src/store/actions/load-components-assets.ts
@@ -8,11 +8,10 @@ import { loadComponentsStyles } from './load-components-styles';
 export async function loadComponentsAssets( elements: V1ElementData[] ) {
 	const documents = await getComponentDocuments( elements );
 
-	return Promise.all( [
-		updateDocumentState( documents ),
-		loadComponentsOverridableProps( [ ...documents.keys() ] ),
-		loadComponentsStyles( documents ),
-	] );
+	updateDocumentState( documents );
+	loadComponentsStyles( documents );
+
+	await loadComponentsOverridableProps( [ ...documents.keys() ] );
 }
 
 function updateDocumentState( documents: ComponentDocumentsMap ) {

--- a/packages/packages/core/editor-components/src/store/actions/load-components-overridable-props.ts
+++ b/packages/packages/core/editor-components/src/store/actions/load-components-overridable-props.ts
@@ -8,7 +8,7 @@ export function loadComponentsOverridableProps( componentIds: number[] ) {
 		return;
 	}
 
-	componentIds.forEach( loadComponentOverrides );
+	return Promise.all( componentIds.map( loadComponentOverrides ) );
 }
 
 async function loadComponentOverrides( componentId: number ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor component assets loading to make overridable props loading asynchronous and properly awaited, ensuring data availability before component rendering.

Main changes:
- Changed loadComponentsOverridableProps to return Promise.all instead of synchronous forEach for parallel async execution
- Removed Promise.all wrapper around updateDocumentState, loadComponentsStyles, and loadComponentsOverridableProps in loadComponentsAssets
- Added explicit await for loadComponentsOverridableProps while making updateDocumentState and loadComponentsStyles synchronous sequential calls

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
