### PR TITLE
test hein onboarding

### DIFF
--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -9,10 +9,6 @@ export default class extends elementorModules.Module {
 	onInit() {
 		this.config = eventsConfig;
 
-		if ( ! this.canSendEvents() ) {
-			return;
-		}
-
 		mixpanel.init(
 			elementorCommon.config.editor_events?.token,
 			{
@@ -29,7 +25,9 @@ export default class extends elementorModules.Module {
 			},
 		);
 
-		this.enableTracking();
+		if ( ! this.canSendEvents() ) {
+			this.enableTracking();
+		}
 	}
 
 	enableTracking() {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Mixpanel initialization to ensure tracking is enabled only when events can be sent, preventing unnecessary analytics overhead

Main changes:
- Moved canSendEvents() validation check to execute after mixpanel.init() instead of before initialization
- Changed conditional logic to call enableTracking() only when canSendEvents() returns false
- Removed unconditional enableTracking() call that was executing regardless of event sending capability

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
