### PR TITLE
Fix: Editor home page title should be "Quick Start" [ED-22627]

### DIFF
--- a/modules/home/assets/js/components/editor-screen/header-section.js
+++ b/modules/home/assets/js/components/editor-screen/header-section.js
@@ -17,7 +17,7 @@ const HeaderSection = ( props ) => {
 			} }
 		>
 			<Typography variant="h5">
-				{ __( 'Home', 'elementor' ) }
+				{ __( 'Quick Start', 'elementor' ) }
 			</Typography>
 			<Button
 				variant="contained"


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix editor home page header text from "Home" to "Quick Start" to improve user interface clarity and align with product naming conventions.
Main changes:
- Updated Typography component in HeaderSection to display "Quick Start" instead of "Home" using i18n translation function

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
