### PR TITLE
Revert "Internal: Clear cache on components switch [ED-22520]"

### DIFF
--- a/packages/packages/core/editor-components/src/store/store.ts
+++ b/packages/packages/core/editor-components/src/store/store.ts
@@ -121,13 +121,6 @@ export const slice = createSlice( {
 
 			component.overridableProps = payload.overridableProps;
 		},
-		clearOverridableProps: ( state, { payload }: PayloadAction< { componentId: ComponentId } > ) => {
-			const component = state.data.find( ( comp ) => comp.id === payload.componentId );
-
-			if ( component ) {
-				component.overridableProps = undefined;
-			}
-		},
 		rename: ( state, { payload }: PayloadAction< { componentUid: string; name: string } > ) => {
 			const component = state.data.find( ( comp ) => comp.uid === payload.componentUid );
 

--- a/packages/packages/core/editor-components/src/sync/__tests__/update-components-before-save.test.ts
+++ b/packages/packages/core/editor-components/src/sync/__tests__/update-components-before-save.test.ts
@@ -1,7 +1,7 @@
 import { createMockDocument } from 'test-utils';
 
 import { apiClient } from '../../api';
-import { invalidateComponentCache } from '../../utils/component-document-data';
+import { invalidateComponentDocumentData } from '../../utils/component-document-data';
 import { type ComponentDocumentsMap, getComponentDocuments } from '../../utils/get-component-documents';
 import { publishDraftComponentsInPageBeforeSave } from '../publish-draft-components-in-page-before-save';
 
@@ -113,10 +113,10 @@ describe( 'publishDraftComponentsInPageBeforeSave', () => {
 
 		// Assert
 		expect( apiClient.updateStatuses ).toHaveBeenCalledWith( [ 1000, 3000, 4000 ], 'publish' );
-		expect( invalidateComponentCache ).toHaveBeenCalledTimes( 3 );
-		expect( invalidateComponentCache ).toHaveBeenNthCalledWith( 1, 1000 );
-		expect( invalidateComponentCache ).toHaveBeenNthCalledWith( 2, 3000 );
-		expect( invalidateComponentCache ).toHaveBeenNthCalledWith( 3, 4000 );
+		expect( invalidateComponentDocumentData ).toHaveBeenCalledTimes( 3 );
+		expect( invalidateComponentDocumentData ).toHaveBeenNthCalledWith( 1, 1000 );
+		expect( invalidateComponentDocumentData ).toHaveBeenNthCalledWith( 2, 3000 );
+		expect( invalidateComponentDocumentData ).toHaveBeenNthCalledWith( 3, 4000 );
 	} );
 
 	it( 'should not update any components when not publishing', async () => {
@@ -147,7 +147,7 @@ describe( 'publishDraftComponentsInPageBeforeSave', () => {
 
 		// Assert
 		expect( apiClient.updateStatuses ).not.toHaveBeenCalled();
-		expect( invalidateComponentCache ).not.toHaveBeenCalled();
+		expect( invalidateComponentDocumentData ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should not update any components when all components are published', async () => {
@@ -178,6 +178,6 @@ describe( 'publishDraftComponentsInPageBeforeSave', () => {
 
 		// Assert
 		expect( apiClient.updateStatuses ).not.toHaveBeenCalled();
-		expect( invalidateComponentCache ).not.toHaveBeenCalled();
+		expect( invalidateComponentDocumentData ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/packages/core/editor-components/src/sync/publish-draft-components-in-page-before-save.ts
+++ b/packages/packages/core/editor-components/src/sync/publish-draft-components-in-page-before-save.ts
@@ -3,7 +3,7 @@ import { type V1ElementData } from '@elementor/editor-elements';
 
 import { apiClient } from '../api';
 import { type DocumentSaveStatus } from '../types';
-import { invalidateComponentCache } from '../utils/component-document-data';
+import { invalidateComponentDocumentData } from '../utils/component-document-data';
 import { getComponentDocuments } from '../utils/get-component-documents';
 
 type Options = {
@@ -26,5 +26,5 @@ export async function publishDraftComponentsInPageBeforeSave( { status, elements
 
 	await apiClient.updateStatuses( draftIds, 'publish' );
 
-	draftIds.forEach( ( id ) => invalidateComponentCache( id ) );
+	draftIds.forEach( ( id ) => invalidateComponentDocumentData( id ) );
 }

--- a/packages/packages/core/editor-components/src/utils/__tests__/switch-to-component.test.ts
+++ b/packages/packages/core/editor-components/src/utils/__tests__/switch-to-component.test.ts
@@ -1,10 +1,4 @@
-import { __privateRunCommand as runCommand } from '@elementor/editor-v1-adapters';
-
-import { invalidateComponentCache } from '../component-document-data';
-import { buildUniqueSelector, switchToComponent } from '../switch-to-component';
-
-jest.mock( '@elementor/editor-v1-adapters' );
-jest.mock( '../component-document-data' );
+import { buildUniqueSelector } from '../switch-to-component';
 
 const COMPONENT_A_INSTANCE_1_ID = 'component-a-instance-1';
 const COMPONENT_A_INSTANCE_2_ID = 'component-a-instance-2';
@@ -166,29 +160,5 @@ describe( 'buildUniqueSelector', () => {
 		expect( result ).not.toContain( 'container-1' );
 		expect( result ).not.toContain( 'container-2' );
 		expect( result ).not.toContain( 'container-3' );
-	} );
-} );
-
-describe( 'switchToComponent', () => {
-	const COMPONENT_ID = 1234;
-	const INSTANCE_ID = 'instance-abc';
-
-	it( 'should invalidate component cache before switching document', async () => {
-		// Arrange
-		const callOrder: string[] = [];
-		jest.mocked( invalidateComponentCache ).mockImplementation( () => {
-			callOrder.push( 'invalidateComponentCache' );
-		} );
-		jest.mocked( runCommand ).mockImplementation( async () => {
-			callOrder.push( 'runCommand' );
-		} );
-
-		// Act
-		await switchToComponent( COMPONENT_ID, INSTANCE_ID );
-
-		// Assert
-		expect( invalidateComponentCache ).toHaveBeenCalledWith( COMPONENT_ID );
-		expect( runCommand ).toHaveBeenCalledWith( 'editor/documents/switch', expect.any( Object ) );
-		expect( callOrder ).toEqual( [ 'invalidateComponentCache', 'runCommand' ] );
 	} );
 } );

--- a/packages/packages/core/editor-components/src/utils/component-document-data.ts
+++ b/packages/packages/core/editor-components/src/utils/component-document-data.ts
@@ -1,7 +1,4 @@
 import { type Document, getV1DocumentsManager } from '@elementor/editor-documents';
-import { __dispatch as dispatch } from '@elementor/store';
-
-import { slice } from '../store/store';
 
 type ComponentDocumentData = Document;
 
@@ -15,10 +12,8 @@ export const getComponentDocumentData = async ( id: number ) => {
 	}
 };
 
-export const invalidateComponentCache = ( id: number ) => {
+export const invalidateComponentDocumentData = ( id: number ) => {
 	const documentManager = getV1DocumentsManager();
 
 	documentManager.invalidateCache( id );
-	dispatch( slice.actions.removeStyles( { id } ) );
-	dispatch( slice.actions.clearOverridableProps( { componentId: id } ) );
 };

--- a/packages/packages/core/editor-components/src/utils/switch-to-component.ts
+++ b/packages/packages/core/editor-components/src/utils/switch-to-component.ts
@@ -1,17 +1,14 @@
 import { getCurrentDocumentContainer, selectElement } from '@elementor/editor-elements';
 import { __privateRunCommand as runCommand } from '@elementor/editor-v1-adapters';
 
-import { invalidateComponentCache } from './component-document-data';
 import { expandNavigator } from './expand-navigator';
 
 export async function switchToComponent(
-	componentId: number,
+	componentId: number | string,
 	componentInstanceId?: string | null,
 	element?: HTMLElement | null
 ) {
 	const selector = getSelector( element, componentInstanceId );
-
-	invalidateComponentCache( componentId );
 
 	await runCommand( 'editor/documents/switch', {
 		id: componentId,


### PR DESCRIPTION
Reverts elementor/elementor#34385
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert cache clearing mechanism for component switching functionality to restore previous behavior before ED-22520 implementation.

Main changes:
- Removed clearOverridableProps reducer and invalidateComponentCache function that cleared component styles and props
- Renamed invalidateComponentCache to invalidateComponentDocumentData, removing store dispatch calls for cache clearing
- Removed preemptive cache invalidation from switchToComponent function before document switching

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
