### PR TITLE
Internal: Mixpanel.json being fetched on every page load [ED-22665]

### DIFF
--- a/core/common/modules/events-manager/module.php
+++ b/core/common/modules/events-manager/module.php
@@ -29,9 +29,14 @@ class Module extends BaseModule {
 			! Tracker::has_terms_changed( '2025-07-07' ) &&
 			Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME );
 
-		$mixpanel_config = self::get_remote_mixpanel_config();
-		$session_replays = $mixpanel_config[0]['sessionReplays'] ?? [];
-		$is_flags_enabled = $mixpanel_config[0]['flags'] ?? false;
+		$session_replays = [];
+		$is_flags_enabled = false;
+
+		if ( $can_send_events ) {
+			$mixpanel_config = self::get_remote_mixpanel_config();
+			$session_replays = $mixpanel_config[0]['sessionReplays'] ?? [];
+			$is_flags_enabled = $mixpanel_config[0]['flags'] ?? false;
+		}
 
 		$settings = [
 			'can_send_events' => $can_send_events,


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Optimize Mixpanel configuration loading by conditionally fetching remote config only when event tracking is enabled, preventing unnecessary API calls on every page load.

Main changes:
- Wrapped get_remote_mixpanel_config() call in conditional check to execute only when $can_send_events is true
- Moved session replays and flags initialization inside conditional block to avoid unnecessary variable assignments
- Reduced remote API calls by skipping Mixpanel config fetch when tracking is disabled or not allowed

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
