### PR TITLE
Revert "Internal:  Merge inline editing experiment to 3.34 [ED-22507]"

### DIFF
--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -4,9 +4,11 @@ namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Heading;
 use Elementor\Modules\AtomicWidgets\Controls\Section;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Link_Control;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Select_Control;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Textarea_Control;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Inline_Editing_Control;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Widget_Base;
 use Elementor\Modules\AtomicWidgets\Elements\Has_Template;
+use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Html_Prop_Type;
@@ -16,6 +18,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
+use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -43,7 +46,13 @@ class Atomic_Heading extends Atomic_Widget_Base {
 	}
 
 	protected static function define_props_schema(): array {
-		return [
+		$is_feature_active = Plugin::$instance->experiments->is_feature_active( Atomic_Widgets_Module::EXPERIMENT_INLINE_EDITING );
+
+		$title_prop = $is_feature_active
+			? Html_Prop_Type::make()->default( __( 'This is a title', 'elementor' ) )
+			: String_Prop_Type::make()->default( __( 'This is a title', 'elementor' ) );
+
+		$props = [
 			'classes' => Classes_Prop_Type::make()
 				->default( [] ),
 
@@ -52,24 +61,31 @@ class Atomic_Heading extends Atomic_Widget_Base {
 				->default( 'h2' )
 				->description( 'The HTML tag for the heading element. Could be h1, h2, up to h6' ),
 
-			'title' => Html_Prop_Type::make()
-				->default( __( 'This is a title', 'elementor' ) )
+			'title' => $title_prop
 				->description( 'The text content of the heading.' ),
 
 			'link' => Link_Prop_Type::make(),
 
 			'attributes' => Attributes_Prop_Type::make(),
 		];
+
+		return $props;
 	}
 
 	protected function define_atomic_controls(): array {
+		$is_feature_active = Plugin::$instance->experiments->is_feature_active( Atomic_Widgets_Module::EXPERIMENT_INLINE_EDITING );
+
+		$control = $is_feature_active
+			? Inline_Editing_Control::bind_to( 'title' )
+				->set_placeholder( __( 'Type your title here', 'elementor' ) )
+				->set_label( __( 'Title', 'elementor' ) )
+			: Textarea_Control::bind_to( 'title' )
+				->set_placeholder( __( 'Type your title here', 'elementor' ) )
+				->set_label( __( 'Title', 'elementor' ) );
+
 		$content_section = Section::make()
 			->set_label( __( 'Content', 'elementor' ) )
-			->set_items( [
-				Inline_Editing_Control::bind_to( 'title' )
-					->set_placeholder( __( 'Type your title here', 'elementor' ) )
-					->set_label( __( 'Title', 'elementor' ) ),
-			] );
+			->set_items( [ $control ] );
 		return [
 			$content_section,
 			Section::make()

--- a/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.php
+++ b/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.php
@@ -6,7 +6,9 @@ use Elementor\Modules\AtomicWidgets\Elements\Atomic_Widget_Base;
 use Elementor\Modules\AtomicWidgets\Controls\Section;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Link_Control;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Select_Control;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Textarea_Control;
 use Elementor\Modules\AtomicWidgets\Elements\Has_Template;
+use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Html_Prop_Type;
@@ -17,6 +19,7 @@ use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Inline_Editing_Control;
+use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -44,12 +47,17 @@ class Atomic_Paragraph extends Atomic_Widget_Base {
 	}
 
 	protected static function define_props_schema(): array {
-		return [
+		$is_feature_active = Plugin::$instance->experiments->is_feature_active( Atomic_Widgets_Module::EXPERIMENT_INLINE_EDITING );
+
+		$paragraph_prop = $is_feature_active
+			? Html_Prop_Type::make()->default( __( 'Type your paragraph here', 'elementor' ) )
+			: String_Prop_Type::make()->default( __( 'Type your paragraph here', 'elementor' ) );
+
+		$props = [
 			'classes' => Classes_Prop_Type::make()
 				->default( [] ),
 
-			'paragraph' => Html_Prop_Type::make()
-				->default( __( 'Type your paragraph here', 'elementor' ) )
+			'paragraph' => $paragraph_prop
 				->description( 'The text content of the paragraph.' ),
 
 			'tag' => String_Prop_Type::make()
@@ -60,17 +68,25 @@ class Atomic_Paragraph extends Atomic_Widget_Base {
 
 			'attributes' => Attributes_Prop_Type::make(),
 		];
+
+		return $props;
 	}
 
 	protected function define_atomic_controls(): array {
+		$is_feature_active = Plugin::$instance->experiments->is_feature_active( Atomic_Widgets_Module::EXPERIMENT_INLINE_EDITING );
+
+		$control = $is_feature_active
+			? Inline_Editing_Control::bind_to( 'paragraph' )
+				->set_placeholder( __( 'Type your paragraph here', 'elementor' ) )
+				->set_label( __( 'Paragraph', 'elementor' ) )
+			: Textarea_Control::bind_to( 'paragraph' )
+				->set_placeholder( __( 'Type your paragraph here', 'elementor' ) )
+				->set_label( __( 'Paragraph', 'elementor' ) );
+
 		return [
 			Section::make()
 				->set_label( __( 'Content', 'elementor' ) )
-				->set_items( [
-					Inline_Editing_Control::bind_to( 'paragraph' )
-						->set_placeholder( __( 'Type your paragraph here', 'elementor' ) )
-						->set_label( __( 'Paragraph', 'elementor' ) ),
-				] ),
+				->set_items( [ $control ] ),
 			Section::make()
 				->set_label( __( 'Settings', 'elementor' ) )
 				->set_id( 'settings' )

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -113,6 +113,7 @@ class Module extends BaseModule {
 	const EXPERIMENT_NAME = 'e_atomic_elements';
 	const ENFORCE_CAPABILITIES_EXPERIMENT = 'atomic_widgets_should_enforce_capabilities';
 	const EXPERIMENT_EDITOR_MCP = 'editor_mcp';
+	const EXPERIMENT_INLINE_EDITING = 'v4-inline-text-editing';
 
 	const PACKAGES = [
 		'editor-canvas',
@@ -199,6 +200,15 @@ class Module extends BaseModule {
 			'name' => self::EXPERIMENT_EDITOR_MCP,
 			'title' => esc_html__( 'Editor MCP for atomic widgets', 'elementor' ),
 			'description' => esc_html__( 'Editor MCP for atomic widgets.', 'elementor' ),
+			'hidden' => true,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,
+		]);
+
+		Plugin::$instance->experiments->add_feature([
+			'name' => self::EXPERIMENT_INLINE_EDITING,
+			'title' => esc_html__( 'V4 inline text editing', 'elementor' ),
+			'description' => esc_html__( 'New inline text editor for v4', 'elementor' ),
 			'hidden' => true,
 			'default' => Experiments_Manager::STATE_INACTIVE,
 			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,

--- a/packages/packages/core/editor-canvas/src/components/__tests__/elements-overlays.test.tsx
+++ b/packages/packages/core/editor-canvas/src/components/__tests__/elements-overlays.test.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { createDOMElement, createMockElement, createMockElementType, renderWithTheme } from 'test-utils';
 import { getElements, useSelectedElement } from '@elementor/editor-elements';
-import { __privateUseIsRouteActive as useIsRouteActive, useEditMode } from '@elementor/editor-v1-adapters';
+import {
+	__privateUseIsRouteActive as useIsRouteActive,
+	isExperimentActive,
+	useEditMode,
+} from '@elementor/editor-v1-adapters';
 import { screen, waitFor } from '@testing-library/react';
 
 import { hasInlineEditableProperty } from '../../utils/inline-editing-utils';
@@ -13,6 +17,7 @@ jest.mock( '@elementor/editor-v1-adapters', () => ( {
 	...jest.requireActual( '@elementor/editor-v1-adapters' ),
 	useEditMode: jest.fn(),
 	__privateUseIsRouteActive: jest.fn(),
+	isExperimentActive: jest.fn(),
 } ) );
 jest.mock( '../../utils/inline-editing-utils' );
 
@@ -26,6 +31,7 @@ describe( '<ElementsOverlays />', () => {
 		jest.mocked( useEditMode ).mockReturnValue( 'edit' );
 		jest.mocked( useIsRouteActive ).mockReturnValue( false );
 		jest.mocked( hasInlineEditableProperty ).mockReturnValue( false );
+		jest.mocked( isExperimentActive ).mockReturnValue( true );
 
 		jest.mocked( getElements ).mockReturnValue( [
 			createMockElement( {

--- a/packages/packages/core/editor-canvas/src/components/elements-overlays.tsx
+++ b/packages/packages/core/editor-canvas/src/components/elements-overlays.tsx
@@ -3,6 +3,7 @@ import { getElements, useSelectedElement } from '@elementor/editor-elements';
 import {
 	__privateUseIsRouteActive as useIsRouteActive,
 	__privateUseListenTo as useListenTo,
+	isExperimentActive,
 	useEditMode,
 	windowEvent,
 } from '@elementor/editor-v1-adapters';
@@ -21,7 +22,8 @@ const overlayRegistry: ElementOverlayConfig[] = [
 	},
 	{
 		component: InlineEditorOverlay,
-		shouldRender: ( { id, isSelected } ) => isSelected && hasInlineEditableProperty( id ),
+		shouldRender: ( { id, isSelected } ) =>
+			isSelected && hasInlineEditableProperty( id ) && isExperimentActive( 'v4-inline-text-editing' ),
 	},
 ];
 

--- a/tests/playwright/sanity/modules/v4-tests/inline-text-editing/canvas-editing.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/inline-text-editing/canvas-editing.test.ts
@@ -16,6 +16,7 @@ test.describe( 'Inline Editing Canvas @v4-tests', () => {
 		wpAdminPage = new WpAdminPage( page, testInfo, apiRequests );
 
 		await wpAdminPage.setExperiments( { e_atomic_elements: 'active' } );
+		await wpAdminPage.setExperiments( { 'v4-inline-text-editing': 'active' } );
 
 		editor = await wpAdminPage.openNewPage();
 	} );

--- a/tests/playwright/sanity/modules/v4-tests/inline-text-editing/functionality.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/inline-text-editing/functionality.test.ts
@@ -16,6 +16,7 @@ test.describe( 'Inline Editing Control @v4-tests', () => {
 		wpAdminPage = new WpAdminPage( page, testInfo, apiRequests );
 
 		await wpAdminPage.setExperiments( { e_atomic_elements: 'active' } );
+		await wpAdminPage.setExperiments( { 'v4-inline-text-editing': 'active' } );
 
 		editor = await wpAdminPage.openNewPage();
 	} );

--- a/tests/playwright/sanity/modules/v4-tests/inline-text-editing/migration.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/inline-text-editing/migration.test.ts
@@ -1,0 +1,116 @@
+import { BrowserContext, Page, expect } from '@playwright/test';
+import { parallelTest as test } from '../../../../parallelTest';
+import WpAdminPage from '../../../../pages/wp-admin-page';
+import EditorPage from '../../../../pages/editor-page';
+import { INLINE_EDITING_SELECTORS } from './selectors/selectors';
+
+test.describe( 'Inline Text Editing Migration @v4-tests', () => {
+	let wpAdminPage: WpAdminPage;
+	let context: BrowserContext;
+	let page: Page;
+	let editor: EditorPage;
+	let postId: string;
+	const customTitle = 'My Custom Heading Title';
+
+	test( 'Content persists when toggling inline text editing experiment', async ( { browser, apiRequests }, testInfo ) => {
+		context = await browser.newContext();
+		page = await context.newPage();
+		wpAdminPage = new WpAdminPage( page, testInfo, apiRequests );
+
+		await test.step( 'Create page with heading widget without inline editing experiment', async () => {
+			await wpAdminPage.setExperiments( { e_atomic_elements: true } );
+			await wpAdminPage.setExperiments( { 'v4-inline-text-editing': false } );
+
+			editor = await wpAdminPage.openNewPage();
+			const containerId = await editor.addElement( { elType: 'container' }, 'document' );
+			const headingId = await editor.addWidget( { widgetType: 'e-heading', container: containerId } );
+
+			await editor.v4Panel.openTab( 'general' );
+			await editor.v4Panel.fillTextarea( 0, customTitle );
+
+			const previewFrame = editor.getPreviewFrame();
+			const headingElement = previewFrame.locator( `.elementor-element-${ headingId } .e-heading-base` );
+			await expect( headingElement ).toContainText( customTitle );
+
+			await editor.publishPage();
+			postId = await editor.getPageId();
+		} );
+
+		await test.step( 'Verify content on frontend before experiment activation', async () => {
+			await editor.viewPage();
+			const headingOnFrontend = page.locator( INLINE_EDITING_SELECTORS.headingBase ).first();
+			await expect( headingOnFrontend ).toContainText( customTitle );
+		} );
+
+		await test.step( 'Activate inline text editing experiment', async () => {
+			await wpAdminPage.setExperiments( {
+				'v4-inline-text-editing': true,
+			} );
+		} );
+
+		await test.step( 'Verify content exists and is editable after experiment activation', async () => {
+			await page.goto( `/wp-admin/post.php?post=${ postId }&action=elementor` );
+			await wpAdminPage.waitForPanel();
+			editor = new EditorPage( page, testInfo, Number( postId ) );
+
+			const previewFrame = editor.getPreviewFrame();
+			const headingElement = previewFrame.locator( INLINE_EDITING_SELECTORS.headingBase ).first();
+
+			await expect( headingElement ).toContainText( customTitle );
+
+			await headingElement.click();
+			const contentSection = page.getByLabel( INLINE_EDITING_SELECTORS.contentSection );
+			await expect( contentSection ).toBeVisible();
+
+			const textarea = contentSection.locator( INLINE_EDITING_SELECTORS.panelInlineEditor );
+			await expect( textarea ).toBeVisible();
+			await expect( textarea ).toHaveText( customTitle );
+
+			const updatedTitle = `${ customTitle } (Updated)`;
+			await textarea.fill( updatedTitle );
+
+			await expect( headingElement ).toContainText( updatedTitle );
+
+			await editor.publishAndViewPage();
+			const headingOnFrontend = page.locator( INLINE_EDITING_SELECTORS.headingBase ).first();
+			const actualText = await headingOnFrontend.textContent();
+			expect( actualText.trim() ).toContain( updatedTitle );
+		} );
+
+		await test.step( 'Deactivate inline text editing experiment', async () => {
+			await wpAdminPage.setExperiments( {
+				'v4-inline-text-editing': false,
+			} );
+		} );
+
+		await test.step( 'Verify content exists and is editable after experiment deactivation', async () => {
+			await page.goto( `/wp-admin/post.php?post=${ postId }&action=elementor` );
+			await wpAdminPage.waitForPanel();
+			editor = new EditorPage( page, testInfo, Number( postId ) );
+
+			const previewFrame = editor.getPreviewFrame();
+			const headingElement = previewFrame.locator( INLINE_EDITING_SELECTORS.headingBase ).first();
+
+			await expect( headingElement ).toContainText( `${ customTitle } (Updated)` );
+
+			const headingId = await headingElement.locator( '..' ).getAttribute( 'data-id' );
+			await editor.selectElement( headingId );
+
+			const finalTitle = `${ customTitle } (Final)`;
+			await editor.v4Panel.openTab( 'general' );
+			await editor.v4Panel.fillTextarea( 0, finalTitle );
+
+			await expect( headingElement ).toContainText( finalTitle );
+
+			await editor.publishAndViewPage();
+			const headingOnFrontend = page.locator( INLINE_EDITING_SELECTORS.headingBase ).first();
+			await expect( headingOnFrontend ).toContainText( finalTitle );
+		} );
+
+		await test.step( 'Cleanup', async () => {
+			await wpAdminPage.resetExperiments();
+			await context.close();
+		} );
+	} );
+} );
+


### PR DESCRIPTION
Reverts elementor/elementor#34367
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert inline text editing experiment for atomic widgets by restoring feature flag checks and fallback controls to ensure backward compatibility with version 3.34.

Main changes:
- Added experiment flag checks in atomic-heading and atomic-paragraph to conditionally use inline editing or textarea controls
- Updated elements-overlays to gate InlineEditorOverlay rendering behind v4-inline-text-editing experiment flag
- Added migration test suite to verify content persistence when toggling inline editing experiment on/off

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
