### PR TITLE
Fix: Allow negative value for drop-shadow position [ED-22380]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/filter-control/drop-shadow/drop-shadow-item-content.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/filter-control/drop-shadow/drop-shadow-item-content.tsx
@@ -52,6 +52,7 @@ export const DropShadowItemContent = ( { anchorEl }: { anchorEl?: HTMLElement | 
 								<SizeControl
 									anchorRef={ rowRefs[ item.rowIndex ] }
 									enablePropTypeUnits
+									min={ item.bind === 'blur' ? 0 : -Number.MAX_SAFE_INTEGER }
 									defaultUnit="px"
 								/>
 							) }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix drop-shadow control validation to allow negative position values while maintaining non-negative blur constraint in filter controls.

Main changes:
- Added conditional min value validation to SizeControl for drop-shadow properties (0 for blur, negative for positions)
- Updated DropShadowItemContent component to use Number.MAX_SAFE_INTEGER for position fields allowing full negative range
- Fixed UI constraint preventing users from setting negative x/y offsets in drop-shadow filter configuration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
