### PR TITLE
CI: Cherry-pick PR 34435 to 3.34 Update Playwright workflow to include branch conditions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - 'main'
-      - '3.[0-9][0-9]'
+      - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -21,7 +21,7 @@ on:
   push:
     branches:
       - 'main'
-      - '3.[0-9][0-9]'
+      - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/css-file-check.yml
+++ b/.github/workflows/css-file-check.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'main'
-      - '3.[0-9][0-9]'
+      - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - 'main'
-      - '3.[0-9][0-9]'
+      - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,6 +3,9 @@ name: Playwright
 on:
   pull_request:
     types: [labeled, synchronize, opened, reopened, ready_for_review]
+    branches:
+      - main
+      - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -42,7 +45,7 @@ jobs:
   build-plugin:
     if: |
       contains(github.event.pull_request.labels.*.name, 'run-tests') ||
-      (!github.event.pull_request.draft && github.event_name == 'pull_request' && github.base_ref == 'main') ||
+      (!github.event.pull_request.draft && github.event_name == 'pull_request') ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     name: Build plugin
@@ -55,7 +58,7 @@ jobs:
     if: |
       github.event.inputs.tag == '' &&
       (contains(github.event.pull_request.labels.*.name, 'run-tests') ||
-      (!github.event.pull_request.draft && github.event_name == 'pull_request' && github.base_ref == 'main') ||
+      (!github.event.pull_request.draft && github.event_name == 'pull_request') ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch')
     strategy:

--- a/.github/workflows/plugin-upgrade-test.yml
+++ b/.github/workflows/plugin-upgrade-test.yml
@@ -4,7 +4,7 @@ on:
   #push:
     # branches:
     #   - 'main'
-    #   - '3.[0-9][0-9]'
+    #   - '[0-9].[0-9][0-9]'
     # paths-ignore:
     #   - '**.md'
     #   - '**.txt'


### PR DESCRIPTION
Automatic cherry-pick of [#34435](https://github.com/elementor/elementor/pull/34435) to `3.34` branch.

**Source:** elementor/elementor
**Original Author:** @Ntnelbaba
**Trigger:** Manual cherry-pick
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update GitHub Actions workflow branch patterns to support version-specific release branches using generic regex pattern for improved CI flexibility.

Main changes:
- Replaced hardcoded '3.[0-9][0-9]' branch pattern with generic '[0-9].[0-9][0-9]' across all workflow files
- Added branch conditions to Playwright workflow pull_request trigger for main and version branches
- Removed github.base_ref restriction from Playwright build-plugin and test job conditionals to enable cross-branch testing

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
