### PR TITLE
Internal: Skip home screen screenshot test [ED-22627]

### DIFF
--- a/tests/playwright/sanity/modules/home/editor-screen-ui.test.ts
+++ b/tests/playwright/sanity/modules/home/editor-screen-ui.test.ts
@@ -27,7 +27,7 @@ test.describe( 'Editor screen UI tests', () => {
 		await context.close();
 	} );
 
-	test( 'free license variant - UI renders correctly with mocked data', async ( { page, apiRequests, storageState } ) => {
+	test.skip( 'free license variant - UI renders correctly with mocked data', async ( { page, apiRequests, storageState } ) => {
 		const requestContext = await request.newContext( { storageState } );
 		const mockData = transformMockDataByLicense( 'free' );
 
@@ -38,7 +38,7 @@ test.describe( 'Editor screen UI tests', () => {
 		await requestContext.dispose();
 	} );
 
-	test( 'pro license variant - UI renders correctly with mocked data', async ( { page, apiRequests, storageState } ) => {
+	test.skip( 'pro license variant - UI renders correctly with mocked data', async ( { page, apiRequests, storageState } ) => {
 		const requestContext = await request.newContext( { storageState } );
 		const mockData = transformMockDataByLicense( 'pro' );
 
@@ -49,7 +49,7 @@ test.describe( 'Editor screen UI tests', () => {
 		await requestContext.dispose();
 	} );
 
-	test( 'one license variant - UI renders correctly with mocked data', async ( { page, apiRequests, storageState } ) => {
+	test.skip( 'one license variant - UI renders correctly with mocked data', async ( { page, apiRequests, storageState } ) => {
 		const requestContext = await request.newContext( { storageState } );
 		const mockData = transformMockDataByLicense( 'one' );
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Disable failing home screen screenshot tests across all license variants to unblock CI pipeline while investigation continues per ED-22627.

Main changes:
- Added test.skip() to three Playwright screenshot tests for free, pro, and one license variants
- Tests remain in codebase for future re-enabling once underlying UI rendering issues are resolved

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
