### PR TITLE
Internal: Pin elementor assets to a specific version [ED-22694]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "elementor",
       "version": "4.0.0",
       "dependencies": {
-        "@elementor/elementor-one-assets": "^0.4.21",
+        "@elementor/elementor-one-assets": "0.4.21",
         "@elementor/icons": "1.63.0",
         "@elementor/ui": "1.36.17",
         "@reach/router": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "write": "^2.0.0"
   },
   "dependencies": {
-    "@elementor/elementor-one-assets": "^0.4.21",
+    "@elementor/elementor-one-assets": "0.4.21",
     "@elementor/icons": "1.63.0",
     "@elementor/ui": "1.36.17",
     "@reach/router": "1.3.4",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Pin @elementor/elementor-one-assets dependency to exact version 0.4.21 to ensure consistent builds and prevent unexpected breaking changes from patch updates.

Main changes:
- Removed caret (^) version range from @elementor/elementor-one-assets dependency, locking it to exact version 0.4.21

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
