### PR TITLE
Fix(components): Disable exposing tabs menu items [ED-22592] (#34366)

### DIFF
--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs.php
@@ -62,7 +62,8 @@ class Atomic_Tabs extends Atomic_Element_Base {
 			'classes' => Classes_Prop_Type::make()
 				->default( [] ),
 			'default-active-tab' => Number_Prop_Type::make()
-				->default( 0 ),
+				->default( 0 )
+				->meta( Overridable_Prop_Type::ignore() ),
 			'attributes' => Attributes_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() ),
 		];
 	}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Disable exposing default-active-tab property in tabs menu items to prevent unwanted configuration overrides in nested component contexts.

Main changes:
- Added Overridable_Prop_Type::ignore() meta to default-active-tab property to prevent exposure in menu items
- Consolidated default value declaration with override prevention on single property definition

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
