### PR TITLE
Fix: Inline editing infinite delete [ED-22320] Cherry pick to 3.35

### DIFF
--- a/packages/packages/core/editor-canvas/src/legacy/create-element-type.ts
+++ b/packages/packages/core/editor-canvas/src/legacy/create-element-type.ts
@@ -80,12 +80,18 @@ export function createElementViewClassDeclaration(): typeof ElementView {
 		}
 
 		#dispatchPreviewEvent( eventType: string ) {
+			const element = this.getDomElement().get( 0 );
+
+			if ( ! element ) {
+				return;
+			}
+			
 			legacyWindow.elementor?.$preview?.[ 0 ]?.contentWindow.dispatchEvent(
 				new CustomEvent( eventType, {
 					detail: {
 						id: this.model.get( 'id' ),
 						type: this.model.get( 'widgetType' ),
-						element: this.getDomElement().get( 0 ),
+						element,
 					},
 				} )
 			);

--- a/packages/packages/core/editor-canvas/src/legacy/create-element-type.ts
+++ b/packages/packages/core/editor-canvas/src/legacy/create-element-type.ts
@@ -85,7 +85,7 @@ export function createElementViewClassDeclaration(): typeof ElementView {
 			if ( ! element ) {
 				return;
 			}
-			
+
 			legacyWindow.elementor?.$preview?.[ 0 ]?.contentWindow.dispatchEvent(
 				new CustomEvent( eventType, {
 					detail: {

--- a/packages/packages/core/editor-canvas/src/legacy/replacements/inline-editing/inline-editing-elements.tsx
+++ b/packages/packages/core/editor-canvas/src/legacy/replacements/inline-editing/inline-editing-elements.tsx
@@ -122,12 +122,12 @@ export default class InlineEditingReplacement extends ReplacementBase {
 	getExtractedContentValue() {
 		const propValue = this.getInlineEditablePropValue();
 
-		return htmlPropTypeUtil.extract( propValue ) ?? stringPropTypeUtil.extract( propValue ) ?? '';
+		return htmlPropTypeUtil.extract( propValue ) ?? '';
 	}
 
 	setContentValue( value: string | null ) {
 		const settingKey = this.getInlineEditablePropertyName();
-		const valueToSave = value ? htmlPropTypeUtil.create( value ) : null;
+		const valueToSave = htmlPropTypeUtil.create( value || '' );
 
 		undoable(
 			{

--- a/packages/packages/libs/editor-controls/src/controls/inline-editing-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/inline-editing-control.tsx
@@ -19,7 +19,7 @@ export const InlineEditingControl = createControl(
 		props?: ComponentProps< 'div' >;
 	} ) => {
 		const { value, setValue } = useBoundProp( htmlPropTypeUtil );
-		const handleChange = ( newValue: unknown ) => setValue( newValue as string );
+		const handleChange = ( newValue: unknown ) => setValue( ( newValue ?? '' ) as string );
 
 		return (
 			<ControlActions>


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix infinite delete bug in inline editing system by adding null safety checks and standardizing empty value handling across editor components.

Main changes:
- Added null check in #dispatchPreviewEvent to prevent errors when DOM element is undefined before dispatching events
- Removed fallback to stringPropTypeUtil in getExtractedContentValue to ensure consistent empty string return for null values
- Modified inline editing control to coalesce null/undefined values to empty strings preventing unintended deletions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
