### PR TITLE
Internal: Refactors promotions to use shared component [ED-21157]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/components/promotions/custom-css.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/promotions/custom-css.tsx
@@ -1,17 +1,12 @@
 import * as React from 'react';
-import { useState } from 'react';
-import { PromotionChip, PromotionInfotip } from '@elementor/editor-ui';
+import { useRef } from 'react';
+import { PromotionTrigger, type PromotionTriggerRef } from '@elementor/editor-controls';
 import { __ } from '@wordpress/i18n';
 
 import { StyleTabSection } from '../style-tab-section';
 
-function getCustomCssPromotion() {
-	return window.elementor?.config?.v4Promotions?.customCss;
-}
-
 export const CustomCssSection = () => {
-	const [ showInfoTip, setShowInfoTip ] = useState( false );
-	const promotion = getCustomCssPromotion();
+	const triggerRef = useRef< PromotionTriggerRef >( null );
 
 	return (
 		<StyleTabSection
@@ -19,25 +14,8 @@ export const CustomCssSection = () => {
 				name: 'Custom CSS',
 				title: __( 'Custom CSS', 'elementor' ),
 				action: {
-					component: (
-						<PromotionInfotip
-							title={ promotion?.title ?? '' }
-							content={ promotion?.content ?? '' }
-							assetUrl={ promotion?.image ?? '' }
-							ctaUrl={ promotion?.ctaUrl ?? '' }
-							open={ showInfoTip }
-							onClose={ () => {
-								setShowInfoTip( false );
-							} }
-						>
-							<PromotionChip />
-						</PromotionInfotip>
-					),
-					onClick: () => {
-						if ( ! showInfoTip ) {
-							setShowInfoTip( true );
-						}
-					},
+					component: <PromotionTrigger ref={ triggerRef } promotionKey="customCss" />,
+					onClick: () => triggerRef.current?.toggle(),
 				},
 			} }
 		/>

--- a/packages/packages/core/editor-editing-panel/src/index.ts
+++ b/packages/packages/core/editor-editing-panel/src/index.ts
@@ -25,7 +25,6 @@ export { usePanelActions, usePanelStatus } from './panel';
 export { registerStyleProviderToColors } from './provider-colors-registry';
 export { getFieldIndicators, registerFieldIndicator, FIELD_TYPE } from './field-indicators-registry';
 export { registerEditingPanelReplacement } from './editing-panel-replacement-registry';
-export { type V4PromotionData } from './components/promotions/types';
 
 export { doApplyClasses, doGetAppliedClasses, doUnapplyClass } from './apply-unapply-actions';
 export { setLicenseConfig } from './hooks/use-license-config';

--- a/packages/packages/libs/editor-controls/src/components/promotions/__tests__/display-conditions-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/components/promotions/__tests__/display-conditions-control.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createMockPropType, renderControl } from 'test-utils';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 import { DisplayConditionsControl } from '../display-conditions-control';
 
@@ -8,19 +8,75 @@ jest.mock( '@wordpress/i18n', () => ( {
 	__: ( str: string ) => str,
 } ) );
 
+const mockPromotion = {
+	title: 'Upgrade to Pro',
+	content: 'Unlock display conditions feature',
+	image: 'https://example.com/promo-image.png',
+	ctaUrl: 'https://example.com/upgrade',
+};
+
 const propType = createMockPropType( { kind: 'array' } );
 
+const defaultProps = {
+	bind: 'display-conditions',
+	propType,
+	value: { $$type: 'array', value: [] },
+};
+
+const setupWindowElementor = ( promotion = mockPromotion ) => {
+	global.window.elementor = {
+		config: {
+			v4Promotions: {
+				displayConditions: promotion,
+			},
+		},
+	} as typeof window.elementor;
+};
+
+const cleanupWindowElementor = () => {
+	delete global.window.elementor;
+};
+
 describe( 'DisplayConditionsControl', () => {
-	it( 'should render promotion chip and icon when isPromotion is true', () => {
+	beforeEach( () => {
+		setupWindowElementor();
+	} );
+
+	afterEach( () => {
+		cleanupWindowElementor();
+	} );
+
+	it( 'should render promotion chip and icon button', () => {
 		// Arrange & Act.
-		renderControl( <DisplayConditionsControl />, {
-			bind: 'display-conditions',
-			propType,
-			value: { $$type: 'array', value: [] },
-		} );
+		renderControl( <DisplayConditionsControl />, defaultProps );
 
 		// Assert.
 		expect( screen.getByLabelText( 'Promotion chip' ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Display Conditions' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'should open infotip when clicking promotion chip', () => {
+		// Arrange.
+		renderControl( <DisplayConditionsControl />, defaultProps );
+		const chip = screen.getByLabelText( 'Promotion chip' );
+
+		// Act.
+		fireEvent.click( chip );
+
+		// Assert.
+		expect( screen.getByText( mockPromotion.title ) ).toBeInTheDocument();
+		expect( screen.getByText( mockPromotion.content ) ).toBeInTheDocument();
+	} );
+
+	it( 'should open infotip when clicking icon button', () => {
+		// Arrange.
+		renderControl( <DisplayConditionsControl />, defaultProps );
+		const button = screen.getByRole( 'button', { name: 'Display Conditions' } );
+
+		// Act.
+		fireEvent.click( button );
+
+		// Assert.
+		expect( screen.getByText( mockPromotion.title ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/packages/libs/editor-controls/src/components/promotions/display-conditions-control.tsx
+++ b/packages/packages/libs/editor-controls/src/components/promotions/display-conditions-control.tsx
@@ -1,21 +1,16 @@
 import * as React from 'react';
-import { useState } from 'react';
-import { PromotionChip, PromotionInfotip } from '@elementor/editor-ui';
+import { useRef } from 'react';
 import { SitemapIcon } from '@elementor/icons';
-import { Box, IconButton, Stack, Tooltip } from '@elementor/ui';
+import { IconButton, Stack, Tooltip } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { createControl } from '../../create-control';
+import { PromotionTrigger, type PromotionTriggerRef } from './promotion-trigger';
 
 const ARIA_LABEL = __( 'Display Conditions', 'elementor' );
 
-function getDisplayConditionPromotion() {
-	return window.elementor?.config?.v4Promotions?.displayConditions;
-}
-
 export const DisplayConditionsControl = createControl( () => {
-	const [ isInfotipOpen, setIsInfotipOpen ] = useState( false );
-	const promotion = getDisplayConditionPromotion();
+	const triggerRef = useRef< PromotionTriggerRef >( null );
 
 	return (
 		<Stack
@@ -26,27 +21,13 @@ export const DisplayConditionsControl = createControl( () => {
 				alignItems: 'center',
 			} }
 		>
-			<PromotionInfotip
-				title={ promotion?.title ?? '' }
-				content={ promotion?.content ?? '' }
-				assetUrl={ promotion?.image ?? '' }
-				ctaUrl={ promotion?.ctaUrl ?? '' }
-				open={ isInfotipOpen }
-				onClose={ () => setIsInfotipOpen( false ) }
-			>
-				<Box
-					onClick={ () => setIsInfotipOpen( ( prev ) => ! prev ) }
-					sx={ { cursor: 'pointer', display: 'inline-flex' } }
-				>
-					<PromotionChip />
-				</Box>
-			</PromotionInfotip>
+			<PromotionTrigger ref={ triggerRef } promotionKey="displayConditions" />
 			<Tooltip title={ ARIA_LABEL } placement="top">
 				<IconButton
 					size="tiny"
 					aria-label={ ARIA_LABEL }
 					data-behavior="display-conditions"
-					onClick={ () => setIsInfotipOpen( ( prev ) => ! prev ) }
+					onClick={ () => triggerRef.current?.toggle() }
 					sx={ {
 						border: '1px solid',
 						borderColor: 'divider',

--- a/packages/packages/libs/editor-controls/src/components/promotions/promotion-trigger.tsx
+++ b/packages/packages/libs/editor-controls/src/components/promotions/promotion-trigger.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { forwardRef, useImperativeHandle, useState } from 'react';
+import { type MouseEvent } from 'react';
+import { PromotionChip, PromotionInfotip } from '@elementor/editor-ui';
+import { Box } from '@elementor/ui';
+
+import type { V4PromotionData, V4PromotionKey } from './types';
+
+function getV4Promotion( key: V4PromotionKey ): V4PromotionData | undefined {
+	return window.elementor?.config?.v4Promotions?.[ key ];
+}
+
+type PromotionTriggerProps = {
+	promotionKey: V4PromotionKey;
+	children?: React.ReactNode;
+};
+
+export type PromotionTriggerRef = {
+	toggle: () => void;
+};
+
+export const PromotionTrigger = forwardRef< PromotionTriggerRef, PromotionTriggerProps >(
+	( { promotionKey, children }, ref ) => {
+		const [ isOpen, setIsOpen ] = useState( false );
+		const promotion = getV4Promotion( promotionKey );
+
+		const toggle = () => setIsOpen( ( prev ) => ! prev );
+
+		useImperativeHandle( ref, () => ( { toggle } ), [] );
+
+		return (
+			<>
+				{ promotion && (
+					<PromotionInfotip
+						title={ promotion.title }
+						content={ promotion.content }
+						assetUrl={ promotion.image }
+						ctaUrl={ promotion.ctaUrl }
+						open={ isOpen }
+						onClose={ ( e: MouseEvent | Event ) => {
+							e.stopPropagation();
+							setIsOpen( false );
+						} }
+					>
+						<Box
+							onClick={ ( e: React.MouseEvent ) => {
+								e.stopPropagation();
+								toggle();
+							} }
+							sx={ { cursor: 'pointer', display: 'inline-flex' } }
+						>
+							{ children ?? <PromotionChip /> }
+						</Box>
+					</PromotionInfotip>
+				) }
+			</>
+		);
+	}
+);

--- a/packages/packages/libs/editor-controls/src/components/promotions/promotion-trigger.tsx
+++ b/packages/packages/libs/editor-controls/src/components/promotions/promotion-trigger.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { forwardRef, useImperativeHandle, useState } from 'react';
-import { type MouseEvent } from 'react';
 import { PromotionChip, PromotionInfotip } from '@elementor/editor-ui';
 import { Box } from '@elementor/ui';
 
@@ -37,13 +36,13 @@ export const PromotionTrigger = forwardRef< PromotionTriggerRef, PromotionTrigge
 						assetUrl={ promotion.image }
 						ctaUrl={ promotion.ctaUrl }
 						open={ isOpen }
-						onClose={ ( e: MouseEvent | Event ) => {
+						onClose={ ( e: MouseEvent ) => {
 							e.stopPropagation();
 							setIsOpen( false );
 						} }
 					>
 						<Box
-							onClick={ ( e: React.MouseEvent ) => {
+							onClick={ ( e: MouseEvent ) => {
 								e.stopPropagation();
 								toggle();
 							} }

--- a/packages/packages/libs/editor-controls/src/components/promotions/promotion-trigger.tsx
+++ b/packages/packages/libs/editor-controls/src/components/promotions/promotion-trigger.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { forwardRef, useImperativeHandle, useState } from 'react';
+import { forwardRef, type ReactNode, useImperativeHandle, useState } from 'react';
 import { PromotionChip, PromotionInfotip } from '@elementor/editor-ui';
 import { Box } from '@elementor/ui';
 
@@ -11,7 +11,7 @@ function getV4Promotion( key: V4PromotionKey ): V4PromotionData | undefined {
 
 type PromotionTriggerProps = {
 	promotionKey: V4PromotionKey;
-	children?: React.ReactNode;
+	children?: ReactNode;
 };
 
 export type PromotionTriggerRef = {

--- a/packages/packages/libs/editor-controls/src/components/promotions/types.ts
+++ b/packages/packages/libs/editor-controls/src/components/promotions/types.ts
@@ -5,4 +5,4 @@ export type V4PromotionData = {
 	ctaUrl: string;
 };
 
-export type V4PromotionKeys = 'displayConditions' | 'customCss';
+export type V4PromotionKey = 'displayConditions' | 'customCss';

--- a/packages/packages/libs/editor-controls/src/index.ts
+++ b/packages/packages/libs/editor-controls/src/index.ts
@@ -35,10 +35,11 @@ export { enqueueFont } from './controls/font-family-control/enqueue-font';
 export { transitionProperties, transitionsItemsList } from './controls/transition-control/data';
 export { DateTimeControl } from './controls/date-time-control';
 export { InlineEditingControl } from './controls/inline-editing-control';
-export { DisplayConditionsControl } from './components/promotions/display-conditions-control';
 
 // components
 export { ControlFormLabel } from './components/control-form-label';
+export { DisplayConditionsControl } from './components/promotions/display-conditions-control';
+export { PromotionTrigger } from './components/promotions/promotion-trigger';
 export { ControlToggleButtonGroup } from './components/control-toggle-button-group';
 export { ToggleButtonGroupUi } from './components/control-toggle-button-group';
 export { ClearIconButton } from './components/icon-buttons/clear-icon-button';
@@ -65,6 +66,8 @@ export type { ExtendedOption, Unit, LengthUnit, AngleUnit, TimeUnit } from './ut
 export type { ToggleControlProps } from './controls/toggle-control';
 export type { FontCategory } from './controls/font-family-control/font-family-control';
 export type { InlineEditorToolbarProps } from './components/inline-editor-toolbar';
+export type { V4PromotionData, V4PromotionKey } from './components/promotions/types';
+export type { PromotionTriggerRef } from './components/promotions/promotion-trigger';
 
 // providers
 export {

--- a/packages/packages/libs/editor-ui/src/components/promotion-infotip.tsx
+++ b/packages/packages/libs/editor-ui/src/components/promotion-infotip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { type MouseEvent, useEffect } from 'react';
+import { useEffect } from 'react';
 import { getCanvasIframeDocument } from '@elementor/editor-v1-adapters';
 import {
 	Card,
@@ -20,7 +20,7 @@ type InfotipCardProps = {
 	content: string;
 	assetUrl: string;
 	ctaUrl: string;
-	onClose: ( e: MouseEvent | Event ) => void;
+	onClose: ( e: MouseEvent ) => void;
 };
 
 type PromotionInfotipProps = React.PropsWithChildren<

--- a/packages/packages/libs/editor-ui/src/components/promotion-infotip.tsx
+++ b/packages/packages/libs/editor-ui/src/components/promotion-infotip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEffect } from 'react';
+import { type MouseEvent, useEffect } from 'react';
 import { getCanvasIframeDocument } from '@elementor/editor-v1-adapters';
 import {
 	Card,
@@ -20,7 +20,7 @@ type InfotipCardProps = {
 	content: string;
 	assetUrl: string;
 	ctaUrl: string;
-	onClose: () => void;
+	onClose: ( e: MouseEvent | Event ) => void;
 };
 
 type PromotionInfotipProps = React.PropsWithChildren<

--- a/packages/types/global.d.ts
+++ b/packages/types/global.d.ts
@@ -2,7 +2,7 @@ import type { InteractionsConfig, DynamicTags, DynamicTagsManager, DynamicTag } 
 import type { ControlItem, V1Element } from '@elementor/editor-elements';
 import type { PropsSchema } from '@elementor/editor-props';
 import type { SupportedFonts, EnqueueFont } from '@elementor/editor-v1-adapters';
-import type { V4PromotionData, V4PromotionKeys } from '@elementor/editor-editing-panel';
+import type { V4PromotionData, V4PromotionKey } from '@elementor/editor-controls';
 
 declare global {
 	interface Window {
@@ -37,7 +37,7 @@ declare global {
 					tags: DynamicTags;
 					groups: Record< DynamicTag[ 'group' ], { title: string } >;
 				};
-				v4Promotions?: Record< V4PromotionKeys, V4PromotionData >;
+				v4Promotions?: Record< V4PromotionKey, V4PromotionData >;
 			};
 			dynamicTags?: DynamicTagsManager;
 			selection?: {


### PR DESCRIPTION
Moves promotion logic into a shared component for reuse across editor controls and editing panel sections.

This change simplifies the implementation of promotions by providing a unified way to trigger promotion infoboxes.

Also renames promotion types for clarity.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor promotion UI components into a shared, reusable PromotionTrigger component with imperative ref control to eliminate code duplication across Custom CSS and Display Conditions features.

Main changes:
- Created centralized PromotionTrigger component with forwardRef API for imperative toggle control and moved promotion logic from multiple files
- Refactored CustomCssSection and DisplayConditionsControl to use shared PromotionTrigger component, removing local state and promotion fetching logic
- Updated type exports moving V4PromotionData and V4PromotionKey from editor-editing-panel to editor-controls package for better modularity

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
