### PR TITLE
Fix: Undo/redo breaks of tabs breaks history [ED-22727]

### DIFF
--- a/packages/packages/libs/editor-elements/src/index.ts
+++ b/packages/packages/libs/editor-elements/src/index.ts
@@ -22,7 +22,7 @@ export {
 	type DuplicateElementsParams,
 } from './sync/duplicate-elements';
 export { generateElementId } from './sync/generate-element-id';
-export { getContainer, selectElement } from './sync/get-container';
+export { getContainer, getRealContainer, selectElement } from './sync/get-container';
 export { getCurrentDocumentContainer } from './sync/get-current-document-container';
 export { getCurrentDocumentId } from './sync/get-current-document-id';
 export { getElementEditorSettings } from './sync/get-element-editor-settings';

--- a/packages/packages/libs/editor-elements/src/index.ts
+++ b/packages/packages/libs/editor-elements/src/index.ts
@@ -22,7 +22,7 @@ export {
 	type DuplicateElementsParams,
 } from './sync/duplicate-elements';
 export { generateElementId } from './sync/generate-element-id';
-export { getContainer, getRealContainer, selectElement } from './sync/get-container';
+export { getContainer, selectElement } from './sync/get-container';
 export { getCurrentDocumentContainer } from './sync/get-current-document-container';
 export { getCurrentDocumentId } from './sync/get-current-document-id';
 export { getElementEditorSettings } from './sync/get-element-editor-settings';

--- a/packages/packages/libs/editor-elements/src/sync/__tests__/get-container.test.ts
+++ b/packages/packages/libs/editor-elements/src/sync/__tests__/get-container.test.ts
@@ -1,4 +1,4 @@
-import { getContainer, getRealContainer } from '../get-container';
+import { getContainer } from '../get-container';
 import { type ExtendedWindow } from '../types';
 
 describe( 'getContainer', () => {
@@ -25,102 +25,13 @@ describe( 'getContainer', () => {
 		expect( result ).toBe( container );
 	} );
 
-	it( 'should return null if the container is not found and no document structure exists', () => {
+	it( 'should return null if the container is not found', () => {
 		// Arrange.
 		const elementID = '1-heading';
 		mockGetContainer.mockReturnValue( undefined );
 
 		// Act.
 		const result = getContainer( elementID );
-
-		// Assert.
-		expect( result ).toBe( null );
-	} );
-
-	it( 'should return virtual container from document model when real container is not found', () => {
-		// Arrange.
-		const elementID = 'child-element';
-		const mockChildModel = {
-			get: jest.fn( ( key: string ) => {
-				if ( key === 'id' ) {
-					return elementID;
-				}
-				if ( key === 'settings' ) {
-					return { text: 'test' };
-				}
-				return undefined;
-			} ),
-			set: jest.fn(),
-			toJSON: jest.fn(),
-		};
-		const mockParentModel = {
-			get: jest.fn( ( key: string ) => {
-				if ( key === 'id' ) {
-					return 'parent-element';
-				}
-				if ( key === 'elements' ) {
-					return [ mockChildModel ];
-				}
-				if ( key === 'settings' ) {
-					return {};
-				}
-				return undefined;
-			} ),
-			set: jest.fn(),
-			toJSON: jest.fn(),
-		};
-		const documentContainer = {
-			model: {
-				get: jest.fn( ( key: string ) => {
-					if ( key === 'elements' ) {
-						return [ mockParentModel ];
-					}
-					return undefined;
-				} ),
-			},
-		};
-
-		mockGetContainer.mockReturnValue( undefined );
-
-		const extendedWindow = window as unknown as ExtendedWindow;
-
-		extendedWindow.elementor = {
-			...extendedWindow.elementor,
-			getContainer: mockGetContainer,
-			documents: {
-				getCurrent: () => ( { container: documentContainer } ),
-			},
-		};
-
-		// Act.
-		const result = getContainer( elementID );
-
-		// Assert.
-		expect( result ).not.toBe( null );
-		expect( result?.id ).toBe( elementID );
-		expect( result?.model ).toBe( mockChildModel );
-		expect( result?.view ).toBeUndefined();
-	} );
-} );
-
-describe( 'getRealContainer', () => {
-	const mockGetContainer = jest.fn();
-
-	beforeEach( () => {
-		const extendedWindow = window as unknown as ExtendedWindow;
-
-		extendedWindow.elementor = {
-			getContainer: mockGetContainer,
-		};
-	} );
-
-	it( 'should return null if the real container is not found (no fallback)', () => {
-		// Arrange.
-		const elementID = '1-heading';
-		mockGetContainer.mockReturnValue( undefined );
-
-		// Act.
-		const result = getRealContainer( elementID );
 
 		// Assert.
 		expect( result ).toBe( null );

--- a/packages/packages/libs/editor-elements/src/sync/__tests__/get-container.test.ts
+++ b/packages/packages/libs/editor-elements/src/sync/__tests__/get-container.test.ts
@@ -1,4 +1,4 @@
-import { getContainer } from '../get-container';
+import { getContainer, getRealContainer } from '../get-container';
 import { type ExtendedWindow } from '../types';
 
 describe( 'getContainer', () => {
@@ -25,14 +25,102 @@ describe( 'getContainer', () => {
 		expect( result ).toBe( container );
 	} );
 
-	it( 'should return null if the container is not found', () => {
+	it( 'should return null if the container is not found and no document structure exists', () => {
 		// Arrange.
 		const elementID = '1-heading';
-		const container = undefined;
-		mockGetContainer.mockReturnValue( container );
+		mockGetContainer.mockReturnValue( undefined );
 
 		// Act.
 		const result = getContainer( elementID );
+
+		// Assert.
+		expect( result ).toBe( null );
+	} );
+
+	it( 'should return virtual container from document model when real container is not found', () => {
+		// Arrange.
+		const elementID = 'child-element';
+		const mockChildModel = {
+			get: jest.fn( ( key: string ) => {
+				if ( key === 'id' ) {
+					return elementID;
+				}
+				if ( key === 'settings' ) {
+					return { text: 'test' };
+				}
+				return undefined;
+			} ),
+			set: jest.fn(),
+			toJSON: jest.fn(),
+		};
+		const mockParentModel = {
+			get: jest.fn( ( key: string ) => {
+				if ( key === 'id' ) {
+					return 'parent-element';
+				}
+				if ( key === 'elements' ) {
+					return [ mockChildModel ];
+				}
+				if ( key === 'settings' ) {
+					return {};
+				}
+				return undefined;
+			} ),
+			set: jest.fn(),
+			toJSON: jest.fn(),
+		};
+		const documentContainer = {
+			model: {
+				get: jest.fn( ( key: string ) => {
+					if ( key === 'elements' ) {
+						return [ mockParentModel ];
+					}
+					return undefined;
+				} ),
+			},
+		};
+
+		mockGetContainer.mockReturnValue( undefined );
+
+		const extendedWindow = window as unknown as ExtendedWindow;
+
+		extendedWindow.elementor = {
+			...extendedWindow.elementor,
+			getContainer: mockGetContainer,
+			documents: {
+				getCurrent: () => ( { container: documentContainer } ),
+			},
+		};
+
+		// Act.
+		const result = getContainer( elementID );
+
+		// Assert.
+		expect( result ).not.toBe( null );
+		expect( result?.id ).toBe( elementID );
+		expect( result?.model ).toBe( mockChildModel );
+		expect( result?.view ).toBeUndefined();
+	} );
+} );
+
+describe( 'getRealContainer', () => {
+	const mockGetContainer = jest.fn();
+
+	beforeEach( () => {
+		const extendedWindow = window as unknown as ExtendedWindow;
+
+		extendedWindow.elementor = {
+			getContainer: mockGetContainer,
+		};
+	} );
+
+	it( 'should return null if the real container is not found (no fallback)', () => {
+		// Arrange.
+		const elementID = '1-heading';
+		mockGetContainer.mockReturnValue( undefined );
+
+		// Act.
+		const result = getRealContainer( elementID );
 
 		// Assert.
 		expect( result ).toBe( null );

--- a/packages/packages/libs/editor-elements/src/sync/__tests__/update-element-settings.test.ts
+++ b/packages/packages/libs/editor-elements/src/sync/__tests__/update-element-settings.test.ts
@@ -1,7 +1,7 @@
 import { updateElementSettings } from '@elementor/editor-elements';
 import { __privateRunCommandSync as runCommandSync } from '@elementor/editor-v1-adapters';
 
-import { getContainer } from '../get-container';
+import { getRealContainer } from '../get-container';
 
 jest.mock( '../get-container' );
 jest.mock( '@elementor/editor-v1-adapters' );
@@ -12,7 +12,7 @@ describe( 'updateElementSettings', () => {
 		const element = { id: 'test-element-id' };
 		const props = { testProp: 'test-value' };
 
-		jest.mocked( getContainer ).mockImplementation( ( elementId ) => {
+		jest.mocked( getRealContainer ).mockImplementation( ( elementId ) => {
 			return elementId === element.id ? ( element as never ) : null;
 		} );
 
@@ -34,7 +34,7 @@ describe( 'updateElementSettings', () => {
 		const element = { id: 'test-element-id' };
 		const props = { testProp: 'test-value' };
 
-		jest.mocked( getContainer ).mockImplementation( ( elementId ) => {
+		jest.mocked( getRealContainer ).mockImplementation( ( elementId ) => {
 			return elementId === element.id ? ( element as never ) : null;
 		} );
 

--- a/packages/packages/libs/editor-elements/src/sync/__tests__/update-element-settings.test.ts
+++ b/packages/packages/libs/editor-elements/src/sync/__tests__/update-element-settings.test.ts
@@ -1,9 +1,10 @@
 import { updateElementSettings } from '@elementor/editor-elements';
 import { __privateRunCommandSync as runCommandSync } from '@elementor/editor-v1-adapters';
 
-import { getRealContainer } from '../get-container';
+import { getContainer } from '../get-container';
 
 jest.mock( '../get-container' );
+jest.mock( '../get-model' );
 jest.mock( '@elementor/editor-v1-adapters' );
 
 describe( 'updateElementSettings', () => {
@@ -12,7 +13,7 @@ describe( 'updateElementSettings', () => {
 		const element = { id: 'test-element-id' };
 		const props = { testProp: 'test-value' };
 
-		jest.mocked( getRealContainer ).mockImplementation( ( elementId ) => {
+		jest.mocked( getContainer ).mockImplementation( ( elementId ) => {
 			return elementId === element.id ? ( element as never ) : null;
 		} );
 
@@ -34,7 +35,7 @@ describe( 'updateElementSettings', () => {
 		const element = { id: 'test-element-id' };
 		const props = { testProp: 'test-value' };
 
-		jest.mocked( getRealContainer ).mockImplementation( ( elementId ) => {
+		jest.mocked( getContainer ).mockImplementation( ( elementId ) => {
 			return elementId === element.id ? ( element as never ) : null;
 		} );
 

--- a/packages/packages/libs/editor-elements/src/sync/create-element.ts
+++ b/packages/packages/libs/editor-elements/src/sync/create-element.ts
@@ -1,12 +1,14 @@
 import { __privateRunCommandSync as runCommandSync } from '@elementor/editor-v1-adapters';
 
-import { getContainer } from './get-container';
+import { getContainer, getRealContainer } from './get-container';
+import { getModel, type V1Collection, type V1Model } from './get-model';
 import { type V1Element, type V1ElementModelProps, type V1ElementSettingsProps } from './types';
 
 type Options = {
 	useHistory?: boolean;
 	at?: number;
 	clone?: boolean;
+	edit?: boolean;
 };
 
 export type CreateElementParams = {
@@ -15,16 +17,69 @@ export type CreateElementParams = {
 	model?: Omit< V1ElementModelProps, 'settings' | 'id' > & { settings?: V1ElementSettingsProps; id?: string };
 };
 
-export function createElement( { containerId, model, options }: CreateElementParams ) {
-	const container = getContainer( containerId );
+export function createElement( { containerId, model, options }: CreateElementParams ): V1Element {
+	const realContainer = getRealContainer( containerId );
 
-	if ( ! container ) {
-		throw new Error( `Container with ID "${ containerId }" not found` );
+	if ( realContainer ) {
+		return createElementViaContainer( { container: realContainer, model, options } );
 	}
 
+	return createElementViaModel( { containerId, model, options } );
+}
+
+function createElementViaContainer( {
+	container,
+	model,
+	options,
+}: {
+	container: NonNullable< ReturnType< typeof getRealContainer > >;
+	model: CreateElementParams[ 'model' ];
+	options: CreateElementParams[ 'options' ];
+} ): V1Element {
 	return runCommandSync< V1Element >( 'document/elements/create', {
 		container,
 		model,
 		options: { edit: false, ...options },
 	} );
+}
+
+function createElementViaModel( { containerId, model: modelData, options = {} }: CreateElementParams ): V1Element {
+	const targetResult = getModel( containerId );
+
+	if ( ! targetResult ) {
+		throw new Error( `Container with ID "${ containerId }" not found` );
+	}
+
+	const { model: targetModel } = targetResult;
+	const targetCollection = targetModel.get( 'elements' ) as V1Collection | undefined;
+
+	if ( ! targetCollection ) {
+		throw new Error( `Container with ID "${ containerId }" has no elements collection` );
+	}
+
+	const newModel = createModelFromData( modelData );
+	const insertAt = options.at;
+
+	if ( insertAt !== undefined ) {
+		targetCollection.add( newModel, { at: insertAt }, true );
+	} else {
+		targetCollection.add( newModel, {}, true );
+	}
+
+	const elementId = modelData?.id ?? newModel.get( 'id' );
+	const container = getContainer( elementId );
+
+	if ( container ) {
+		return container;
+	}
+
+	return {
+		id: elementId,
+		model: newModel,
+		settings: newModel.get( 'settings' ) ?? {},
+	} as V1Element;
+}
+
+function createModelFromData( modelData: CreateElementParams[ 'model' ] ): V1Model {
+	return modelData as unknown as V1Model;
 }

--- a/packages/packages/libs/editor-elements/src/sync/delete-element.ts
+++ b/packages/packages/libs/editor-elements/src/sync/delete-element.ts
@@ -1,6 +1,6 @@
 import { __privateRunCommand as runCommand } from '@elementor/editor-v1-adapters';
 
-import { getRealContainer } from './get-container';
+import { getContainer } from './get-container';
 import { findModelWithParent } from './get-model';
 
 type Options = {
@@ -15,7 +15,7 @@ export function deleteElement( {
 	elementId: string;
 	options?: Options;
 } ): Promise< void > {
-	const container = getRealContainer( elementId );
+	const container = getContainer( elementId );
 
 	if ( container ) {
 		return runCommand( 'document/elements/delete', {

--- a/packages/packages/libs/editor-elements/src/sync/get-container.ts
+++ b/packages/packages/libs/editor-elements/src/sync/get-container.ts
@@ -1,18 +1,44 @@
 import { __privateRunCommand as runCommand } from '@elementor/editor-v1-adapters';
 
+import { createVirtualContainer, findModelWithParent } from './get-model';
 import { type ExtendedWindow, type V1Element } from './types';
 
 export function getContainer( id: string ): V1Element | null {
 	const extendedWindow = window as unknown as ExtendedWindow;
 	const container = extendedWindow.elementor?.getContainer?.( id );
 
+	if ( container ) {
+		return container;
+	}
+
+	return getContainerFromModel( id );
+}
+
+export function getRealContainer( id: string ): V1Element | null {
+	const extendedWindow = window as unknown as ExtendedWindow;
+	const container = extendedWindow.elementor?.getContainer?.( id );
+
 	return container ?? null;
+}
+
+function getContainerFromModel( id: string ): V1Element | null {
+	const result = findModelWithParent( id );
+
+	if ( ! result ) {
+		return null;
+	}
+
+	const { model, parentModel } = result;
+
+	return createVirtualContainer( model, parentModel );
 }
 
 export const selectElement = ( elementId: string ) => {
 	try {
-		const container = getContainer( elementId );
+		const container = getRealContainer( elementId );
 
-		runCommand( 'document/elements/select', { container } );
+		if ( container ) {
+			runCommand( 'document/elements/select', { container } );
+		}
 	} catch {}
 };

--- a/packages/packages/libs/editor-elements/src/sync/get-container.ts
+++ b/packages/packages/libs/editor-elements/src/sync/get-container.ts
@@ -1,41 +1,17 @@
 import { __privateRunCommand as runCommand } from '@elementor/editor-v1-adapters';
 
-import { createVirtualContainer, findModelWithParent } from './get-model';
 import { type ExtendedWindow, type V1Element } from './types';
 
 export function getContainer( id: string ): V1Element | null {
 	const extendedWindow = window as unknown as ExtendedWindow;
 	const container = extendedWindow.elementor?.getContainer?.( id );
 
-	if ( container ) {
-		return container;
-	}
-
-	return getContainerFromModel( id );
-}
-
-export function getRealContainer( id: string ): V1Element | null {
-	const extendedWindow = window as unknown as ExtendedWindow;
-	const container = extendedWindow.elementor?.getContainer?.( id );
-
 	return container ?? null;
-}
-
-function getContainerFromModel( id: string ): V1Element | null {
-	const result = findModelWithParent( id );
-
-	if ( ! result ) {
-		return null;
-	}
-
-	const { model, parentModel } = result;
-
-	return createVirtualContainer( model, parentModel );
 }
 
 export const selectElement = ( elementId: string ) => {
 	try {
-		const container = getRealContainer( elementId );
+		const container = getContainer( elementId );
 
 		if ( container ) {
 			runCommand( 'document/elements/select', { container } );

--- a/packages/packages/libs/editor-elements/src/sync/get-element-editor-settings.ts
+++ b/packages/packages/libs/editor-elements/src/sync/get-element-editor-settings.ts
@@ -1,8 +1,19 @@
 import { type ElementID } from '../types';
 import { getContainer } from './get-container';
+import { findModel } from './get-model';
 
 export function getElementEditorSettings( elementId: ElementID ) {
 	const container = getContainer( elementId );
 
-	return container?.model.get( 'editor_settings' ) ?? {};
+	if ( container ) {
+		return container.model.get( 'editor_settings' ) ?? {};
+	}
+
+	const result = findModel( elementId );
+
+	if ( ! result ) {
+		return {};
+	}
+
+	return result.model.get( 'editor_settings' ) ?? {};
 }

--- a/packages/packages/libs/editor-elements/src/sync/get-element-setting.ts
+++ b/packages/packages/libs/editor-elements/src/sync/get-element-setting.ts
@@ -1,10 +1,23 @@
 import { type ElementID } from '../types';
 import { getContainer } from './get-container';
+import { findModel } from './get-model';
 
 export const getElementSetting = < TValue >( elementId: ElementID, settingKey: string ): TValue | null => {
 	const container = getContainer( elementId );
 
-	return ( container?.settings?.get( settingKey ) as TValue ) ?? null;
+	if ( container ) {
+		return ( container.settings?.get( settingKey ) as TValue ) ?? null;
+	}
+
+	const result = findModel( elementId );
+
+	if ( ! result ) {
+		return null;
+	}
+
+	const settings = result.model.get( 'settings' ) ?? {};
+
+	return ( settings[ settingKey ] as TValue ) ?? null;
 };
 
 export const getElementSettings = < TValue >(

--- a/packages/packages/libs/editor-elements/src/sync/get-elements.ts
+++ b/packages/packages/libs/editor-elements/src/sync/get-elements.ts
@@ -1,10 +1,11 @@
 import { type ElementID } from '../types';
 import { getContainer } from './get-container';
 import { getCurrentDocumentContainer } from './get-current-document-container';
+import { findModel } from './get-model';
 import { type V1Element } from './types';
 
 export function getElements( root?: ElementID ): V1Element[] {
-	const container = root ? getContainer( root ) : getCurrentDocumentContainer();
+	const container = root ? getContainerOrVirtual( root ) : getCurrentDocumentContainer();
 
 	if ( ! container ) {
 		return [];
@@ -15,4 +16,20 @@ export function getElements( root?: ElementID ): V1Element[] {
 	);
 
 	return [ container, ...children ];
+}
+
+function getContainerOrVirtual( id: ElementID ): V1Element | null {
+	const container = getContainer( id );
+
+	if ( container ) {
+		return container;
+	}
+
+	const result = findModel( id );
+
+	if ( ! result ) {
+		return null;
+	}
+
+	return { model: result.model } as V1Element;
 }

--- a/packages/packages/libs/editor-elements/src/sync/get-model.ts
+++ b/packages/packages/libs/editor-elements/src/sync/get-model.ts
@@ -1,9 +1,22 @@
-import { type ExtendedWindow, type V1Element } from './types';
+import { type ExtendedWindow, type V1Element, type V1ElementSettingsProps } from './types';
 
-type V1Model = V1Element[ 'model' ];
+export type V1Model = V1Element[ 'model' ];
+
+export type V1Collection = V1Model[] & {
+	remove: ( model: V1Model ) => void;
+	add: ( model: V1Model, options?: { at?: number }, silent?: boolean ) => void;
+	indexOf: ( model: V1Model ) => number;
+};
 
 export type ModelResult = {
 	model: V1Model;
+};
+
+export type ModelWithParentResult = {
+	model: V1Model;
+	parentModel: V1Model;
+	collection: V1Collection;
+	index: number;
 };
 
 export function getModel( id: string, parentModel?: V1Model ): ModelResult | null {
@@ -16,10 +29,60 @@ export function getModel( id: string, parentModel?: V1Model ): ModelResult | nul
 
 	if ( parentModel ) {
 		const childModels = parentModel.get( 'elements' ) ?? [];
-		const model = childModels.find( ( m ) => m.get( 'id' ) === id );
+		const model = childModels.find( ( m: V1Model ) => m.get( 'id' ) === id );
 
 		if ( model ) {
 			return { model };
+		}
+
+		return null;
+	}
+
+	const result = findModelWithParent( id );
+
+	if ( result ) {
+		return { model: result.model };
+	}
+
+	return null;
+}
+
+export function findModelWithParent( id: string ): ModelWithParentResult | null {
+	const extendedWindow = window as unknown as ExtendedWindow;
+	const documentContainer = extendedWindow.elementor?.documents?.getCurrent?.()?.container;
+
+	if ( ! documentContainer ) {
+		return null;
+	}
+
+	return findModelWithParentRecursive( id, documentContainer.model );
+}
+
+function findModelWithParentRecursive( id: string, parentModel: V1Model ): ModelWithParentResult | null {
+	const collection = parentModel.get( 'elements' ) as V1Collection | undefined;
+
+	if ( ! collection ) {
+		return null;
+	}
+
+	const childModels = [ ...collection ] as V1Model[];
+
+	for ( let index = 0; index < childModels.length; index++ ) {
+		const childModel = childModels[ index ];
+
+		if ( childModel.get( 'id' ) === id ) {
+			return {
+				model: childModel,
+				parentModel,
+				collection,
+				index,
+			};
+		}
+
+		const found = findModelWithParentRecursive( id, childModel );
+
+		if ( found ) {
+			return found;
 		}
 	}
 
@@ -50,4 +113,33 @@ export function getElementChildren( model: V1Model, predicate?: ( model: V1Model
 	return childModels
 		.filter( ( childModel ) => ! predicate || predicate( childModel ) )
 		.map( ( childModel ) => ( { model: childModel } ) );
+}
+
+export function createVirtualContainer( model: V1Model, parentModel?: V1Model ): V1Element {
+	const rawSettings = ( model.get( 'settings' ) ?? {} ) as V1ElementSettingsProps;
+
+	const settingsProxy = createSettingsProxy( rawSettings, model );
+
+	const virtualContainer: V1Element = {
+		id: model.get( 'id' ) as string,
+		model,
+		settings: settingsProxy,
+		view: undefined,
+		parent: parentModel ? createVirtualContainer( parentModel ) : undefined,
+	};
+
+	return virtualContainer;
+}
+
+type SettingsModel = V1Element[ 'settings' ];
+
+function createSettingsProxy( rawSettings: V1ElementSettingsProps, parentModel: V1Model ): SettingsModel {
+	return {
+		get: ( key ) => rawSettings[ key ],
+		set: ( key, value ) => {
+			rawSettings[ key ] = value;
+			parentModel.set( 'settings', rawSettings );
+		},
+		toJSON: () => rawSettings,
+	} as SettingsModel;
 }

--- a/packages/packages/libs/editor-elements/src/sync/move-element.ts
+++ b/packages/packages/libs/editor-elements/src/sync/move-element.ts
@@ -1,6 +1,8 @@
 import { createElement } from './create-element';
 import { deleteElement } from './delete-element';
-import { getContainer } from './get-container';
+import { getContainer, getRealContainer } from './get-container';
+import { findModelWithParent, getModel, type V1Collection } from './get-model';
+import { type V1Element } from './types';
 
 type Options = {
 	useHistory?: boolean;
@@ -14,9 +16,20 @@ export type MoveElementParams = {
 	options?: Options;
 };
 
-export function moveElement( { elementId, targetContainerId, options = {} }: MoveElementParams ) {
-	const container = getContainer( elementId );
-	const target = getContainer( targetContainerId );
+export function moveElement( { elementId, targetContainerId, options = {} }: MoveElementParams ): V1Element {
+	const sourceContainer = getRealContainer( elementId );
+	const targetContainer = getRealContainer( targetContainerId );
+
+	if ( sourceContainer && targetContainer ) {
+		return moveElementViaContainers( { elementId, targetContainerId, options } );
+	}
+
+	return moveElementViaModels( { elementId, targetContainerId, options } );
+}
+
+function moveElementViaContainers( { elementId, targetContainerId, options = {} }: MoveElementParams ): V1Element {
+	const container = getRealContainer( elementId );
+	const target = getRealContainer( targetContainerId );
 
 	if ( ! container ) {
 		throw new Error( `Element with ID "${ elementId }" not found` );
@@ -30,16 +43,56 @@ export function moveElement( { elementId, targetContainerId, options = {} }: Mov
 
 	deleteElement( {
 		elementId,
-		// prevent inner history from being created
 		options: { ...options, useHistory: false },
 	} );
 
 	const newContainer = createElement( {
 		containerId: targetContainerId,
 		model: modelToRecreate,
-		// prevent inner history from being created
 		options: { edit: false, ...options, useHistory: false },
 	} );
 
 	return newContainer;
+}
+
+function moveElementViaModels( { elementId, targetContainerId, options = {} }: MoveElementParams ): V1Element {
+	const sourceResult = findModelWithParent( elementId );
+	const targetResult = getModel( targetContainerId );
+
+	if ( ! sourceResult ) {
+		throw new Error( `Element with ID "${ elementId }" not found` );
+	}
+
+	if ( ! targetResult ) {
+		throw new Error( `Target container with ID "${ targetContainerId }" not found` );
+	}
+
+	const { model, collection: sourceCollection } = sourceResult;
+	const targetCollection = targetResult.model.get( 'elements' ) as V1Collection | undefined;
+
+	if ( ! targetCollection ) {
+		throw new Error( `Target container with ID "${ targetContainerId }" has no elements collection` );
+	}
+
+	sourceCollection.remove( model );
+
+	const insertAt = options.at;
+
+	if ( insertAt !== undefined ) {
+		targetCollection.add( model, { at: insertAt }, true );
+	} else {
+		targetCollection.add( model, {}, true );
+	}
+
+	const container = getContainer( elementId );
+
+	if ( container ) {
+		return container;
+	}
+
+	return {
+		id: elementId,
+		model,
+		settings: model.get( 'settings' ) ?? {},
+	} as V1Element;
 }

--- a/packages/packages/libs/editor-elements/src/sync/move-element.ts
+++ b/packages/packages/libs/editor-elements/src/sync/move-element.ts
@@ -1,6 +1,6 @@
 import { createElement } from './create-element';
 import { deleteElement } from './delete-element';
-import { getContainer, getRealContainer } from './get-container';
+import { getContainer } from './get-container';
 import { findModelWithParent, getModel, type V1Collection } from './get-model';
 import { type V1Element } from './types';
 
@@ -17,8 +17,8 @@ export type MoveElementParams = {
 };
 
 export function moveElement( { elementId, targetContainerId, options = {} }: MoveElementParams ): V1Element {
-	const sourceContainer = getRealContainer( elementId );
-	const targetContainer = getRealContainer( targetContainerId );
+	const sourceContainer = getContainer( elementId );
+	const targetContainer = getContainer( targetContainerId );
 
 	if ( sourceContainer && targetContainer ) {
 		return moveElementViaContainers( { elementId, targetContainerId, options } );
@@ -28,8 +28,8 @@ export function moveElement( { elementId, targetContainerId, options = {} }: Mov
 }
 
 function moveElementViaContainers( { elementId, targetContainerId, options = {} }: MoveElementParams ): V1Element {
-	const container = getRealContainer( elementId );
-	const target = getRealContainer( targetContainerId );
+	const container = getContainer( elementId );
+	const target = getContainer( targetContainerId );
 
 	if ( ! container ) {
 		throw new Error( `Element with ID "${ elementId }" not found` );
@@ -78,11 +78,7 @@ function moveElementViaModels( { elementId, targetContainerId, options = {} }: M
 
 	const insertAt = options.at;
 
-	if ( insertAt !== undefined ) {
-		targetCollection.add( model, { at: insertAt }, true );
-	} else {
-		targetCollection.add( model, {}, true );
-	}
+	targetCollection.add( model, insertAt !== undefined ? { at: insertAt } : {}, true );
 
 	const container = getContainer( elementId );
 

--- a/packages/packages/libs/editor-elements/src/sync/update-element-editor-settings.ts
+++ b/packages/packages/libs/editor-elements/src/sync/update-element-editor-settings.ts
@@ -2,6 +2,7 @@ import { __privateRunCommandSync as runCommandSync } from '@elementor/editor-v1-
 
 import { type V1ElementModelProps } from '..';
 import { getContainer } from './get-container';
+import { findModel } from './get-model';
 
 export const updateElementEditorSettings = ( {
 	elementId,
@@ -12,16 +13,39 @@ export const updateElementEditorSettings = ( {
 } ) => {
 	const element = getContainer( elementId );
 
-	if ( ! element ) {
-		throw new Error( `Element with id ${ elementId } not found` );
+	if ( element ) {
+		updateViaContainer( element, settings );
+		return;
 	}
 
+	updateViaModel( elementId, settings );
+};
+
+function updateViaContainer(
+	element: NonNullable< ReturnType< typeof getContainer > >,
+	settings: V1ElementModelProps[ 'editor_settings' ]
+) {
 	const editorSettings = element.model.get( 'editor_settings' ) ?? {};
 
 	element.model.set( 'editor_settings', { ...editorSettings, ...settings } );
 
 	setDocumentModifiedStatus( true );
-};
+}
+
+function updateViaModel( elementId: string, settings: V1ElementModelProps[ 'editor_settings' ] ) {
+	const result = findModel( elementId );
+
+	if ( ! result ) {
+		throw new Error( `Element with id ${ elementId } not found` );
+	}
+
+	const { model } = result;
+	const editorSettings = model.get( 'editor_settings' ) ?? {};
+
+	model.set( 'editor_settings', { ...editorSettings, ...settings } );
+
+	setDocumentModifiedStatus( true );
+}
 
 function setDocumentModifiedStatus( status: boolean ) {
 	runCommandSync( 'document/save/set-is-modified', { status }, { internal: true } );

--- a/packages/packages/libs/editor-elements/src/sync/update-element-interactions.ts
+++ b/packages/packages/libs/editor-elements/src/sync/update-element-interactions.ts
@@ -2,6 +2,7 @@ import { __privateRunCommandSync as runCommandSync } from '@elementor/editor-v1-
 
 import { type V1ElementModelProps } from '..';
 import { getContainer } from './get-container';
+import { findModel } from './get-model';
 
 export const updateElementInteractions = ( {
 	elementId,
@@ -12,16 +13,40 @@ export const updateElementInteractions = ( {
 } ) => {
 	const element = getContainer( elementId );
 
-	if ( ! element ) {
-		throw new Error( `Element with id ${ elementId } not found` );
+	if ( element ) {
+		updateViaContainer( element, interactions );
+		return;
 	}
 
+	updateViaModel( elementId, interactions );
+};
+
+function updateViaContainer(
+	element: NonNullable< ReturnType< typeof getContainer > >,
+	interactions: V1ElementModelProps[ 'interactions' ]
+) {
 	element.model.set( 'interactions', interactions );
 
 	window.dispatchEvent( new CustomEvent( 'elementor/element/update_interactions' ) );
 
 	setDocumentModifiedStatus( true );
-};
+}
+
+function updateViaModel( elementId: string, interactions: V1ElementModelProps[ 'interactions' ] ) {
+	const result = findModel( elementId );
+
+	if ( ! result ) {
+		throw new Error( `Element with id ${ elementId } not found` );
+	}
+
+	const { model } = result;
+
+	model.set( 'interactions', interactions );
+
+	window.dispatchEvent( new CustomEvent( 'elementor/element/update_interactions' ) );
+
+	setDocumentModifiedStatus( true );
+}
 
 export const playElementInteractions = ( elementId: string, interactionId: string ) => {
 	window.top?.dispatchEvent(

--- a/packages/packages/libs/editor-elements/src/sync/update-element-settings.ts
+++ b/packages/packages/libs/editor-elements/src/sync/update-element-settings.ts
@@ -2,7 +2,7 @@ import { type Props } from '@elementor/editor-props';
 import { __privateRunCommandSync as runCommandSync } from '@elementor/editor-v1-adapters';
 
 import { type ElementID } from '../types';
-import { getContainer } from './get-container';
+import { getContainer, getRealContainer } from './get-container';
 
 export type UpdateElementSettingsArgs = {
 	id: ElementID;
@@ -11,8 +11,21 @@ export type UpdateElementSettingsArgs = {
 };
 
 export const updateElementSettings = ( { id, props, withHistory = true }: UpdateElementSettingsArgs ) => {
-	const container = getContainer( id );
+	const realContainer = getRealContainer( id );
 
+	if ( realContainer ) {
+		updateViaCommand( realContainer, props, withHistory );
+		return;
+	}
+
+	updateViaModel( id, props );
+};
+
+function updateViaCommand(
+	container: NonNullable< ReturnType< typeof getRealContainer > >,
+	props: Props,
+	withHistory: boolean
+) {
 	const args = {
 		container,
 		settings: { ...props },
@@ -23,4 +36,16 @@ export const updateElementSettings = ( { id, props, withHistory = true }: Update
 	} else {
 		runCommandSync( 'document/elements/set-settings', args, { internal: true } );
 	}
-};
+}
+
+function updateViaModel( id: ElementID, props: Props ) {
+	const container = getContainer( id );
+
+	if ( ! container ) {
+		return;
+	}
+
+	const currentSettings = container.model.get( 'settings' ) ?? {};
+
+	container.model.set( 'settings', { ...currentSettings, ...props } );
+}

--- a/packages/packages/libs/editor-elements/src/sync/update-element-settings.ts
+++ b/packages/packages/libs/editor-elements/src/sync/update-element-settings.ts
@@ -2,7 +2,8 @@ import { type Props } from '@elementor/editor-props';
 import { __privateRunCommandSync as runCommandSync } from '@elementor/editor-v1-adapters';
 
 import { type ElementID } from '../types';
-import { getContainer, getRealContainer } from './get-container';
+import { getContainer } from './get-container';
+import { findModel } from './get-model';
 
 export type UpdateElementSettingsArgs = {
 	id: ElementID;
@@ -11,10 +12,10 @@ export type UpdateElementSettingsArgs = {
 };
 
 export const updateElementSettings = ( { id, props, withHistory = true }: UpdateElementSettingsArgs ) => {
-	const realContainer = getRealContainer( id );
+	const container = getContainer( id );
 
-	if ( realContainer ) {
-		updateViaCommand( realContainer, props, withHistory );
+	if ( container ) {
+		updateViaCommand( container, props, withHistory );
 		return;
 	}
 
@@ -22,7 +23,7 @@ export const updateElementSettings = ( { id, props, withHistory = true }: Update
 };
 
 function updateViaCommand(
-	container: NonNullable< ReturnType< typeof getRealContainer > >,
+	container: NonNullable< ReturnType< typeof getContainer > >,
 	props: Props,
 	withHistory: boolean
 ) {
@@ -39,13 +40,14 @@ function updateViaCommand(
 }
 
 function updateViaModel( id: ElementID, props: Props ) {
-	const container = getContainer( id );
+	const result = findModel( id );
 
-	if ( ! container ) {
+	if ( ! result ) {
 		return;
 	}
 
-	const currentSettings = container.model.get( 'settings' ) ?? {};
+	const { model } = result;
+	const currentSettings = model.get( 'settings' ) ?? {};
 
-	container.model.set( 'settings', { ...currentSettings, ...props } );
+	model.set( 'settings', { ...currentSettings, ...props } );
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix undo/redo history breakage by implementing fallback model-based operations for elements that lack containers, enabling history preservation across tab operations and non-container scenarios.

Main changes:
- Added dual-path execution strategy: container-based operations via Elementor commands for standard elements, model-based direct operations for orphaned elements without containers
- Implemented recursive model lookup functions (findModel, findModelWithParent) to locate and manipulate elements in document hierarchy when containers unavailable
- Extended all element manipulation functions (create, delete, move, update) with model-based fallbacks to handle undo/redo history operations correctly in edge cases

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
