### PR TITLE
Internal: Bump packages [ED-22747]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "elementor/wp-one-package": "1.0.46"
+        "elementor/wp-one-package": "1.0.47"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50e22c48ebc837c751a18b0f716e41ba",
+    "content-hash": "afefbc3b9775f68c3a6f40f06abb31ed",
     "packages": [
         {
             "name": "elementor/wp-notifications-package",
@@ -39,16 +39,16 @@
         },
         {
             "name": "elementor/wp-one-package",
-            "version": "1.0.46",
+            "version": "1.0.47",
             "source": {
                 "type": "git",
                 "url": "git@github.com:elementor/wp-one-package.git",
-                "reference": "744191f07ac0dcb266dc4a9ee49bb12616a53bb8"
+                "reference": "79b558c889e20b2dfd7aaff33ddf902746a9aac8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.46",
-                "reference": "744191f07ac0dcb266dc4a9ee49bb12616a53bb8",
+                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.47",
+                "reference": "79b558c889e20b2dfd7aaff33ddf902746a9aac8",
                 "shasum": ""
             },
             "require": {
@@ -77,9 +77,9 @@
                 ]
             },
             "support": {
-                "source": "https://github.com/elementor/wp-one-package/tree/1.0.46"
+                "source": "https://github.com/elementor/wp-one-package/tree/1.0.47"
             },
-            "time": "2026-01-15T15:47:17+00:00"
+            "time": "2026-01-28T11:16:24+00:00"
         }
     ],
     "packages-dev": [
@@ -1366,16 +1366,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.31",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "945d0b7f346a084ce5549e95289962972c4272e5"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/945d0b7f346a084ce5549e95289962972c4272e5",
-                "reference": "945d0b7f346a084ce5549e95289962972c4272e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
@@ -1397,7 +1397,7 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.9",
+                "sebastian/comparator": "^4.0.10",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
                 "sebastian/exporter": "^4.0.8",
@@ -1449,7 +1449,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.31"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -1473,7 +1473,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-06T07:45:52+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
             "name": "psr/container",
@@ -1742,16 +1742,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.9",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
@@ -1804,7 +1804,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -1824,7 +1824,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:51:50+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "elementor",
       "version": "4.0.0",
       "dependencies": {
-        "@elementor/elementor-one-assets": "0.4.21",
+        "@elementor/elementor-one-assets": "0.4.26",
         "@elementor/icons": "1.63.0",
         "@elementor/ui": "1.36.17",
         "@reach/router": "1.3.4",
@@ -3552,9 +3552,9 @@
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@elementor/elementor-one-assets": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.21.tgz",
-      "integrity": "sha512-VadsUmLFVDDiAck4V8qyukc1a06Z6OFnHDKTWRsyXOl6V7Mr2yo8c6ugorduHzvkWQA+xxwFBgZzAQN3UICg5g==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.26.tgz",
+      "integrity": "sha512-d4zROC+dxrMU0wRzJ51sqkuxgbZGFwLHuMg3W0sAvhMufCpJr6arrI/OsNdOA0aQHEgUUV7Be/p2X+Di/TVFIg==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/icons": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "write": "^2.0.0"
   },
   "dependencies": {
-    "@elementor/elementor-one-assets": "0.4.21",
+    "@elementor/elementor-one-assets": "0.4.26",
     "@elementor/icons": "1.63.0",
     "@elementor/ui": "1.36.17",
     "@reach/router": "1.3.4",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update internal Elementor package dependencies to align with latest stable versions and maintain compatibility across the WordPress builder ecosystem.

Main changes:
- Upgraded elementor/wp-one-package from version 1.0.46 to 1.0.47 in Composer dependencies
- Upgraded @elementor/elementor-one-assets from version 0.4.21 to 0.4.26 in NPM dependencies

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
