### PR TITLE
Fix: Inactive experiments still show green dot [ED-22713]

### DIFF
--- a/core/experiments/manager.php
+++ b/core/experiments/manager.php
@@ -640,7 +640,11 @@ class Manager extends Base_Object {
 
 		$is_feature_active = $this->is_feature_active( $feature['name'] );
 
-		$indicator_classes = 'e-experiment__title__indicator e-experiment__title__indicator--active';
+		$indicator_classes = 'e-experiment__title__indicator';
+
+		if ( $is_feature_active ) {
+			$indicator_classes .= ' e-experiment__title__indicator--active';
+		}
 
 		$indicator_tooltip = $this->get_feature_state_label( $feature );
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix incorrect active state indicator in experiment feature settings by conditionally applying the active CSS class based on actual feature status.

Main changes:
- Changed indicator CSS classes from always-active to conditional based on is_feature_active() check
- Added logic to append 'e-experiment__title__indicator--active' class only when feature is actually active
- Removed hardcoded active state class that was causing inactive experiments to display green indicator

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
