### PR TITLE
Internal: Support disabled state for replay [ED-22633]

### DIFF
--- a/packages/packages/core/editor-interactions/src/components/controls/replay.tsx
+++ b/packages/packages/core/editor-interactions/src/components/controls/replay.tsx
@@ -21,7 +21,5 @@ export function Replay( { onChange }: ReplayFieldProps ) {
 		},
 	];
 
-	return (
-		<ToggleButtonGroupUi items={ options } exclusive onChange={ onChange } value={ false } />
-	);
+	return <ToggleButtonGroupUi items={ options } exclusive onChange={ onChange } value={ false } />;
 }

--- a/packages/packages/core/editor-interactions/src/components/controls/replay.tsx
+++ b/packages/packages/core/editor-interactions/src/components/controls/replay.tsx
@@ -5,21 +5,23 @@ import { __ } from '@wordpress/i18n';
 
 import { type ReplayFieldProps } from '../../types';
 
-export function Replay( { disabled = true }: ReplayFieldProps ) {
+export function Replay( { onChange }: ReplayFieldProps ) {
 	const options: ToggleButtonGroupItem< boolean >[] = [
 		{
 			value: false,
+			disabled: false,
 			label: __( 'No', 'elementor' ),
 			renderContent: ( { size } ) => <MinusIcon fontSize={ size } />,
 		},
 		{
 			value: true,
+			disabled: true,
 			label: __( 'Yes', 'elementor' ),
 			renderContent: ( { size } ) => <CheckIcon fontSize={ size } />,
 		},
 	];
 
 	return (
-		<ToggleButtonGroupUi items={ options } exclusive onChange={ () => {} } value={ false } disabled={ disabled } />
+		<ToggleButtonGroupUi items={ options } exclusive onChange={ onChange } value={ false } />
 	);
 }


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor Replay component to support granular disabled state control per toggle button option instead of disabling the entire component.

Main changes:
- Removed component-level disabled prop from Replay function signature and ToggleButtonGroupUi component
- Added individual disabled property to each toggle button item (false for "No" option, true for "Yes" option)
- Replaced no-op onChange handler with actual onChange prop passed from parent component

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
