### PR TITLE
Fix: 'Edit' pages of templates haven't washed with new design [ED-22749]

### DIFF
--- a/includes/template-library/sources/local.php
+++ b/includes/template-library/sources/local.php
@@ -1800,6 +1800,12 @@ class Source_Local extends Source_Base {
 				return $elementor_post_types;
 			} );
 
+			add_filter( 'elementor/editor-one/admin-edit-post-types', function ( array $post_types ): array {
+				$post_types[] = self::CPT;
+
+				return $post_types;
+			} );
+
 			add_action( 'elementor/admin/menu/register', function ( Admin_Menu_Manager $admin_menu ) {
 				$this->admin_menu_reorder( $admin_menu );
 			}, 800 );

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -41,6 +41,7 @@
 		}
 
 		#misc-publishing-actions a {
+			font-weight: 600;
 			text-decoration: underline;
 		}
 	}
@@ -83,6 +84,7 @@
 
 		.taxonomy-add-new,
 		#set-post-thumbnail {
+			font-width: 600;
 			color: var(--e-one-palette-text-primary);
 			text-decoration: underline;
 		}

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -40,8 +40,7 @@
 			}
 		}
 
-		.edit-post-status,
-		.edit-timestamp {
+		#misc-publishing-actions a {
 			text-decoration: underline;
 		}
 	}
@@ -82,24 +81,10 @@
 			}
 		}
 
-		.taxonomy-add-new {
-			color: var(--e-one-palette-text-primary);
-			text-decoration: none;
-
-			&:hover,
-			&:focus {
-				text-decoration: underline;
-			}
-		}
-
+		.taxonomy-add-new,
 		#set-post-thumbnail {
 			color: var(--e-one-palette-text-primary);
-			text-decoration: none;
-
-			&:hover,
-			&:focus {
-				text-decoration: underline;
-			}
+			text-decoration: underline;
 		}
 	}
 

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -79,7 +79,7 @@
 
 		.taxonomy-add-new,
 		#set-post-thumbnail {
-			font-width: 600;
+			font-weight: 600;
 			color: var(--e-one-palette-text-primary);
 			text-decoration: underline;
 		}

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -38,6 +38,82 @@
 				text-decoration: underline;
 			}
 		}
+
+		.edit-post-status,
+		.edit-timestamp {
+			text-decoration: underline;
+		}
+	}
+
+	.postbox {
+		.category-tabs {
+			display: flex;
+			border-bottom: 1px solid var(--e-one-palette-divider);
+			margin-bottom: 10px;
+
+			li {
+				margin: 0;
+				padding: 0;
+
+				&.tabs {
+					border-bottom: 2px solid var(--e-one-palette-text-primary);
+					margin-bottom: -1px;
+
+					a {
+						color: var(--e-one-palette-text-primary);
+						font-weight: 500;
+					}
+				}
+
+				a {
+					display: block;
+					padding: 8px 12px;
+					color: var(--e-one-palette-text-tertiary);
+					text-decoration: none;
+					transition: var(--e-a-transition-hover);
+
+					&:hover,
+					&:focus {
+						color: var(--e-one-palette-text-primary);
+						box-shadow: none;
+					}
+				}
+			}
+		}
+
+		.taxonomy-add-new {
+			color: var(--e-one-palette-text-primary);
+			text-decoration: none;
+
+			&:hover,
+			&:focus {
+				text-decoration: underline;
+			}
+		}
+
+		#set-post-thumbnail {
+			color: var(--e-one-palette-text-primary);
+			text-decoration: none;
+
+			&:hover,
+			&:focus {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	#elementor-editor {
+		#elementor-editor-button {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			font-weight: 600;
+			font-size: 16px;
+		}
+
+		#elementor-go-to-edit-page-link {
+			text-decoration: none;
+		}
 	}
 
 	.wrap {
@@ -327,6 +403,20 @@
 		font-size: 1em;
 		color: var(--e-one-palette-text-tertiary);
 		line-height: 1.4;
+	}
+
+	#post-body-content,
+	#revisionsdiv,
+	#elementor-settings-form {
+		a:not(.button):not(.elementor-button):not(.nav-tab) {
+			color: var(--e-one-palette-info-main);
+			text-decoration: none;
+
+			&:hover,
+			&:focus {
+				text-decoration: underline;
+			}
+		}
 	}
 
 	[dir="rtl"] {

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -39,11 +39,6 @@
 				text-decoration: underline;
 			}
 		}
-
-		#misc-publishing-actions a {
-			font-weight: 600;
-			text-decoration: underline;
-		}
 	}
 
 	.postbox {

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -39,6 +39,82 @@
 				text-decoration: underline;
 			}
 		}
+
+		.edit-post-status,
+		.edit-timestamp {
+			text-decoration: underline;
+		}
+	}
+
+	.postbox {
+		.category-tabs {
+			display: flex;
+			border-bottom: 1px solid var(--e-one-palette-divider);
+			margin-bottom: 10px;
+
+			li {
+				margin: 0;
+				padding: 0;
+
+				&.tabs {
+					border-bottom: 2px solid var(--e-one-palette-text-primary);
+					margin-bottom: -1px;
+
+					a {
+						color: var(--e-one-palette-text-primary);
+						font-weight: 500;
+					}
+				}
+
+				a {
+					display: block;
+					padding: 8px 12px;
+					color: var(--e-one-palette-text-tertiary);
+					text-decoration: none;
+					transition: var(--e-a-transition-hover);
+
+					&:hover,
+					&:focus {
+						color: var(--e-one-palette-text-primary);
+						box-shadow: none;
+					}
+				}
+			}
+		}
+
+		.taxonomy-add-new {
+			color: var(--e-one-palette-text-primary);
+			text-decoration: none;
+
+			&:hover,
+			&:focus {
+				text-decoration: underline;
+			}
+		}
+
+		#set-post-thumbnail {
+			color: var(--e-one-palette-text-primary);
+			text-decoration: none;
+
+			&:hover,
+			&:focus {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	#elementor-editor {
+		#elementor-editor-button {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			font-weight: 600;
+			font-size: 16px;
+		}
+
+		#elementor-go-to-edit-page-link {
+			text-decoration: none;
+		}
 	}
 
 	.postbox {

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -31,7 +31,7 @@
 		a:not(.button),
 		.eps-button:not(.e-site-editor-conditions__add-button) {
 			color: var(--e-one-palette-text-primary);
-			text-decoration: none;
+			text-decoration: underline;
 
 			&:hover,
 			&:focus {
@@ -39,8 +39,7 @@
 			}
 		}
 
-		.edit-post-status,
-		.edit-timestamp {
+		#misc-publishing-actions a {
 			text-decoration: underline;
 		}
 	}
@@ -81,24 +80,10 @@
 			}
 		}
 
-		.taxonomy-add-new {
-			color: var(--e-one-palette-text-primary);
-			text-decoration: none;
-
-			&:hover,
-			&:focus {
-				text-decoration: underline;
-			}
-		}
-
+		.taxonomy-add-new,
 		#set-post-thumbnail {
 			color: var(--e-one-palette-text-primary);
-			text-decoration: none;
-
-			&:hover,
-			&:focus {
-				text-decoration: underline;
-			}
+			text-decoration: underline;
 		}
 	}
 

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -30,6 +30,7 @@
 
 		a:not(.button),
 		.eps-button:not(.e-site-editor-conditions__add-button) {
+			font-weight: 600;
 			color: var(--e-one-palette-text-primary);
 			text-decoration: underline;
 
@@ -40,6 +41,7 @@
 		}
 
 		#misc-publishing-actions a {
+			font-weight: 600;
 			text-decoration: underline;
 		}
 	}
@@ -82,6 +84,7 @@
 
 		.taxonomy-add-new,
 		#set-post-thumbnail {
+			font-width: 600;
 			color: var(--e-one-palette-text-primary);
 			text-decoration: underline;
 		}

--- a/modules/editor-one/assets/scss/theme-light.scss
+++ b/modules/editor-one/assets/scss/theme-light.scss
@@ -25,7 +25,7 @@
 	--e-one-palette-warning-contrast-text: #ffffff;
 	--e-one-palette-warning-contrastText: var(--e-one-palette-warning-contrast-text);
 	--e-one-palette-info-light: #3b82f6;
-	--e-one-palette-info-main: #2563e;
+	--e-one-palette-info-main: #2563eb;
 	--e-one-palette-info-dark: #1d4ed8;
 	--e-one-palette-info-contrast-text: #ffffff;
 	--e-one-palette-info-contrastText: var(--e-one-palette-info-contrast-text);


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md
<img width="1656" height="850" alt="image" src="https://github.com/user-attachments/assets/fe820db9-29e9-4195-ae5b-71ce20e93b24" />


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix template edit pages styling to align with new Elementor One design system by updating admin UI filters and applying consistent typography and color treatments.
Main changes:
- Added admin-edit-post-types filter to register template post types in admin edit views for proper design application
- Updated link styling with font-weight 600, underline decoration, and info-main color across post edit areas, tabs, and publishing actions
- Fixed malformed CSS color variable (#2563e to #2563eb) and removed duplicate postbox category-tabs ruleset with typo (font-width to font-weight)

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
