### PR TITLE
Internal: Remove default frontend assets loader

### DIFF
--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs/atomic-tabs.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs/atomic-tabs.php
@@ -189,7 +189,7 @@ class Atomic_Tabs extends Atomic_Element_Base {
 		wp_register_script(
 			'elementor-tabs-preview-handler',
 			"{$assets_url}js/tabs-preview-handler{$min_suffix}.js",
-			[ Frontend_Assets_Loader::FRONTEND_HANDLERS_HANDLE, Frontend_Assets_Loader::ALPINEJS_HANDLE ],
+			[ Frontend_Assets_Loader::FRONTEND_HANDLERS_HANDLE, Frontend_Assets_Loader::ALPINEJS_HANDLE ], // We will only load this, if we have a Tabs widget.
 			ELEMENTOR_VERSION,
 			true
 		);

--- a/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.php
+++ b/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.php
@@ -130,7 +130,7 @@ class Atomic_Youtube extends Atomic_Widget_Base {
 		wp_register_script(
 			'elementor-youtube-handler',
 			"{$assets_url}js/youtube-handler{$min_suffix}.js",
-			[ Frontend_Assets_Loader::FRONTEND_HANDLERS_HANDLE ],
+			[ Frontend_Assets_Loader::FRONTEND_HANDLERS_HANDLE ], // We will only load this, if we have a YouTube atom.
 			ELEMENTOR_VERSION,
 			true
 		);

--- a/modules/atomic-widgets/elements/base/atomic-element-base.php
+++ b/modules/atomic-widgets/elements/base/atomic-element-base.php
@@ -3,7 +3,6 @@
 namespace Elementor\Modules\AtomicWidgets\Elements\Base;
 
 use Elementor\Element_Base;
-use Elementor\Modules\AtomicWidgets\Elements\Loader\Frontend_Assets_Loader;
 use Elementor\Modules\AtomicWidgets\PropDependencies\Manager as Dependency_Manager;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Concerns\Has_Meta;
@@ -33,7 +32,6 @@ abstract class Atomic_Element_Base extends Element_Base {
 		$this->styles = $data['styles'] ?? [];
 		$this->interactions = $this->parse_atomic_interactions( $data['interactions'] ?? [] );
 		$this->editor_settings = $data['editor_settings'] ?? [];
-		$this->add_script_depends( Frontend_Assets_Loader::ATOMIC_WIDGETS_HANDLER );
 		if ( static::$widget_description ) {
 			$this->description( static::$widget_description );
 		}

--- a/modules/atomic-widgets/elements/base/atomic-widget-base.php
+++ b/modules/atomic-widgets/elements/base/atomic-widget-base.php
@@ -2,7 +2,6 @@
 
 namespace Elementor\Modules\AtomicWidgets\Elements\Base;
 
-use Elementor\Modules\AtomicWidgets\Elements\Loader\Frontend_Assets_Loader;
 use Elementor\Modules\AtomicWidgets\PropDependencies\Manager as Dependency_Manager;
 use Elementor\Modules\AtomicWidgets\PropTypes\Concerns\Has_Meta;
 use Elementor\Widget_Base;
@@ -87,9 +86,5 @@ abstract class Atomic_Widget_Base extends Widget_Base {
 
 	public static function generate() {
 		return Widget_Builder::make( static::get_element_type() );
-	}
-
-	public function get_script_depends() {
-		return [ Frontend_Assets_Loader::ATOMIC_WIDGETS_HANDLER ];
 	}
 }

--- a/modules/atomic-widgets/elements/loader/frontend-assets-loader.php
+++ b/modules/atomic-widgets/elements/loader/frontend-assets-loader.php
@@ -28,7 +28,7 @@ class Frontend_Assets_Loader {
 		wp_register_script(
 			self::FRONTEND_HANDLERS_HANDLE,
 			"{$assets_url}js/packages/frontend-handlers/frontend-handlers{$min_suffix}.js",
-			[ 'jquery' ],
+			[],
 			ELEMENTOR_VERSION,
 			true
 		);


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove default frontend assets loader dependency from atomic widgets base classes to enable conditional script loading only when specific widgets are used.

Main changes:
- Removed automatic ATOMIC_WIDGETS_HANDLER script dependency from Atomic_Element_Base and Atomic_Widget_Base constructors
- Eliminated jQuery dependency from FRONTEND_HANDLERS_HANDLE script registration to reduce default bundle size
- Added explicit dependency declarations with clarifying comments in atomic-tabs and atomic-youtube widget registrations

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
