### PR TITLE
Internal: Admin menu clean up [ED-22462]

### DIFF
--- a/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-admin-menu-offset.js
+++ b/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-admin-menu-offset.js
@@ -3,8 +3,6 @@ import isRTL from '../../../shared/is-rtl';
 
 const ADMIN_MENU_WRAP_ID = 'adminmenuwrap';
 const WPCONTENT_ID = 'wpcontent';
-const EDITOR_ONE_TOP_BAR_ID = 'editor-one-top-bar';
-const WPADMINBAR_ID = 'wpadminbar';
 const INITIALIZED_DATA_ATTR = 'data-editor-one-offset-initialized';
 const WPFOOTER_ID = 'wpfooter';
 const WPBODY_CONTENT_ID = 'wpbody-content';
@@ -24,20 +22,13 @@ export const useAdminMenuOffset = () => {
 		const wpbodyContent = document.getElementById( WPBODY_CONTENT_ID );
 		wpbodyContent?.insertBefore( wpfooter, wpbodyContent.querySelector( ':scope > .clear' ) );
 
-		const wpAdminBar = document.getElementById( WPADMINBAR_ID );
-		const topBarHeader = document.getElementById( EDITOR_ONE_TOP_BAR_ID )?.querySelector( ':scope > header' );
-
 		const updateOffset = () => {
 			const isRtlLanguage = isRTL();
 			const rect = adminMenuWrap.getBoundingClientRect();
 
 			const offset = isRtlLanguage ? document.documentElement.clientWidth - rect.left : rect.right;
-			const adminBarHeightPx = `${ wpAdminBar?.clientHeight ?? 0 }px`;
-			const topBarHeaderHeightPx = `${ topBarHeader?.clientHeight ?? 0 }px`;
 
 			wpcontent.style.setProperty( '--editor-one-sidebar-left-offset', `${ offset }px` );
-			wpcontent.style.setProperty( '--e-admin-bar-height', adminBarHeightPx );
-			wpcontent.style.setProperty( '--e-top-bar-header-height', topBarHeaderHeightPx );
 		};
 
 		updateOffset();

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -5,6 +5,15 @@
 
 @import "theme-light";
 
+:root {
+	--e-admin-bar-height: 0px;
+	--e-top-bar-header-height: 48px;
+
+	&:has(#wpadminbar) {
+		--e-admin-bar-height: 32px;
+	}
+}
+
 #wpwrap {
 	background-color: var(--e-one-palette-background-default);
 }
@@ -462,7 +471,6 @@ body:has(#editor-one-top-bar > *) {
 
 		@media screen and (min-width: 783px) {
 			position: fixed;
-			bottom: 0;
 			left: calc(var(--editor-one-sidebar-left-offset, 160px) + var(--editor-one-sidebar-navigation-width, 240px));
 			width: calc(100vw - var(--editor-one-sidebar-left-offset, 160px) - var(--editor-one-sidebar-navigation-width, 240px));
 		}
@@ -475,7 +483,7 @@ body:has(#editor-one-top-bar > *) {
 			display: flex;
 			flex-direction: column;
 			overflow-y: auto;
-			height: calc(100vh - var(--e-admin-bar-height, 0px) - var(--e-top-bar-header-height, 0px));
+			height: calc(100vh - var(--e-admin-bar-height) - var(--e-top-bar-header-height));
 		}
 	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Clean up admin menu offset calculations by moving CSS custom properties to root-level definitions and removing unused JavaScript variable definitions.

Main changes:
- Removed unused DOM element queries for wp-admin bar and top bar header from JavaScript hook; calculations now handled via CSS custom properties
- Defined `--e-admin-bar-height` and `--e-top-bar-header-height` CSS variables at :root level with conditional admin bar detection using :has() selector
- Replaced hardcoded height calculation with CSS custom property values in #wpbody-content and removed bottom positioning constraint from #wpbody

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
