### PR TITLE
Internal: Ui fix in atomic form [ED-22813]

### DIFF
--- a/modules/atomic-widgets/controls/types/toggle-control.php
+++ b/modules/atomic-widgets/controls/types/toggle-control.php
@@ -44,6 +44,12 @@ class Toggle_Control extends Atomic_Control_Base {
 		return $this;
 	}
 
+	public function set_full_width( bool $full_width ): self {
+		$this->full_width = $full_width;
+
+		return $this;
+	}
+
 	public function set_exclusive( bool $exclusive ): self {
 		$this->exclusive = $exclusive;
 

--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.php
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.php
@@ -83,7 +83,8 @@ class Atomic_Form extends Atomic_Element_Base {
 				] )
 				->set_exclusive( true )
 				->set_convert_options( true )
-				->set_size( 'tiny' );
+				->set_size( 'tiny' )
+				->set_full_width( true );
 		}
 
 		return [

--- a/packages/packages/libs/editor-controls/src/components/control-toggle-button-group.tsx
+++ b/packages/packages/libs/editor-controls/src/components/control-toggle-button-group.tsx
@@ -115,8 +115,13 @@ export const ToggleButtonGroupUi = React.forwardRef(
 			const isOffLimits = menuItems?.length;
 			const itemsCount = isOffLimits ? fixedItems.length + 1 : fixedItems.length;
 			const templateColumnsSuffix = isOffLimits ? 'auto' : '';
+
+			if ( fullWidth ) {
+				return `repeat(${ itemsCount }, 1fr) ${ templateColumnsSuffix }`;
+			}
+
 			return `repeat(${ itemsCount }, minmax(0, 25%)) ${ templateColumnsSuffix }`;
-		}, [ menuItems?.length, fixedItems.length ] );
+		}, [ menuItems?.length, fixedItems.length, fullWidth ] );
 
 		const shouldShowExclusivePlaceholder = exclusive && ( value === null || value === undefined || value === '' );
 


### PR DESCRIPTION
we want the buttons to be on all width 
<img width="662" height="198" alt="image" src="https://github.com/user-attachments/assets/710f461a-ed06-4561-9214-e65b2cd63b87" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix toggle control layout in atomic form by adding full-width support to prevent UI rendering issues with button spacing.

Main changes:
- Added set_full_width() method to Toggle_Control class to enable full-width layout configuration
- Updated atomic form toggle control to use tiny size with full-width enabled
- Modified ToggleButtonGroupUi grid template to distribute buttons evenly when fullWidth prop is true

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
