### PR TITLE
Fix: Revert Elementor One menu update [ED-22819]

### DIFF
--- a/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-admin-menu-offset.js
+++ b/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-admin-menu-offset.js
@@ -28,9 +28,9 @@ export const useAdminMenuOffset = () => {
 		wpbodyContent?.insertBefore( wpfooter, wpbodyContent.querySelector( ':scope > .clear' ) );
 
 		const wpAdminBar = document.getElementById( WPADMINBAR_ID );
+		const topBarHeader = document.getElementById( EDITOR_ONE_TOP_BAR_ID )?.querySelector( ':scope > header' );
 
 		const updateOffset = () => {
-			const topBarHeader = document.getElementById( EDITOR_ONE_TOP_BAR_ID )?.querySelector( ':scope > header' );
 			const isRTL = getIsRTL();
 			const rect = adminMenuWrap.getBoundingClientRect();
 
@@ -48,12 +48,6 @@ export const useAdminMenuOffset = () => {
 		const resizeObserver = new ResizeObserver( updateOffset );
 
 		resizeObserver.observe( wpcontent );
-
-		const topBar = document.getElementById( EDITOR_ONE_TOP_BAR_ID );
-		if ( topBar ) {
-			resizeObserver.observe( topBar );
-		}
-
 		window.addEventListener( 'resize', updateOffset );
 
 		wpcontent.setAttribute( INITIALIZED_DATA_ATTR, 'true' );

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -169,7 +169,7 @@
 	#screen-meta-links {
 		display: flex;
 		justify-content: flex-end;
-		margin-block: 1px 10px;
+		margin-block-end: 10px;
 		margin-inline: 32px;
 
 		.show-settings {

--- a/modules/editor-one/assets/scss/sidebar-navigation.scss
+++ b/modules/editor-one/assets/scss/sidebar-navigation.scss
@@ -30,13 +30,6 @@
 }
 
 .e-has-sidebar-navigation {
-	-ms-overflow-style: none; /* IE and Edge */
-	scrollbar-width: none; /* Firefox */
-
-	&::-webkit-scrollbar {
-		display: none; /* Hide scrollbar for Chrome, Safari and Opera */
-	}
-
 	&:has(.e-sidebar-collapsed) {
 		--editor-one-sidebar-navigation-width: var(--editor-one-sidebar-navigation-width-collapsed);
 	}


### PR DESCRIPTION
Reverts elementor/elementor#34640
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert recent Elementor One menu updates that caused layout and resize observer issues in the admin sidebar navigation system.

Main changes:
- Moved topBarHeader element query outside updateOffset function to fix reference scope issues
- Removed ResizeObserver monitoring on top bar element to prevent unnecessary layout recalculations
- Reverted CSS scrollbar hiding rules and margin-block property in screen-meta-links styles

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
