### PR TITLE
Fix: Revert main Elementor One menu update [ED-22819]

### DIFF
--- a/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-admin-menu-offset.js
+++ b/modules/editor-one/assets/js/sidebar-navigation/components/hooks/use-admin-menu-offset.js
@@ -2,11 +2,7 @@ import { useEffect, useRef } from '@wordpress/element';
 
 const ADMIN_MENU_WRAP_ID = 'adminmenuwrap';
 const WPCONTENT_ID = 'wpcontent';
-const EDITOR_ONE_TOP_BAR_ID = 'editor-one-top-bar';
-const WPADMINBAR_ID = 'wpadminbar';
 const INITIALIZED_DATA_ATTR = 'data-editor-one-offset-initialized';
-const WPFOOTER_ID = 'wpfooter';
-const WPBODY_CONTENT_ID = 'wpbody-content';
 
 const getIsRTL = () => {
 	return 'rtl' === document.dir || document.body.classList.contains( 'rtl' );
@@ -23,24 +19,13 @@ export const useAdminMenuOffset = () => {
 			return;
 		}
 
-		const wpfooter = document.getElementById( WPFOOTER_ID );
-		const wpbodyContent = document.getElementById( WPBODY_CONTENT_ID );
-		wpbodyContent?.insertBefore( wpfooter, wpbodyContent.querySelector( ':scope > .clear' ) );
-
-		const wpAdminBar = document.getElementById( WPADMINBAR_ID );
-		const topBarHeader = document.getElementById( EDITOR_ONE_TOP_BAR_ID )?.querySelector( ':scope > header' );
-
 		const updateOffset = () => {
 			const isRTL = getIsRTL();
 			const rect = adminMenuWrap.getBoundingClientRect();
 
 			const offset = isRTL ? window.innerWidth - rect.left : rect.right;
-			const adminBarHeightPx = `${ wpAdminBar?.clientHeight ?? 0 }px`;
-			const topBarHeaderHeightPx = `${ topBarHeader?.clientHeight ?? 0 }px`;
 
 			wpcontent.style.setProperty( '--editor-one-sidebar-left-offset', `${ offset }px` );
-			wpcontent.style.setProperty( '--e-admin-bar-height', adminBarHeightPx );
-			wpcontent.style.setProperty( '--e-top-bar-header-height', topBarHeaderHeightPx );
 		};
 
 		updateOffset();

--- a/modules/editor-one/assets/scss/_common.scss
+++ b/modules/editor-one/assets/scss/_common.scss
@@ -107,9 +107,8 @@
 
 	.wrap {
 		background-color: var(--e-one-palette-background-default);
-		margin: 0;
-		padding-block-start: 24px;
-		padding-inline: 32px;
+		margin: 20px 32px;
+		margin-block-start: 24px;
 		max-width: 100%;
 		display: flex;
 		flex-wrap: wrap;
@@ -455,28 +454,6 @@
 	}
 }
 
-body:has(#editor-one-top-bar > *) {
-
-	#wpbody {
-		margin-block-start: 50px;
-		padding-block-end: 0;
-
-		@media screen and (min-width: 783px) {
-			position: fixed;
-			bottom: 0;
-			left: calc(var(--editor-one-sidebar-left-offset, 160px) + var(--editor-one-sidebar-navigation-width, 240px));
-			width: calc(100vw - var(--editor-one-sidebar-left-offset, 160px) - var(--editor-one-sidebar-navigation-width, 240px));
-		}
-	}
-
-	#wpcontent #wpbody-content {
-		padding-block-end: 0;
-
-		@media screen and (min-width: 783px) {
-			display: flex;
-			flex-direction: column;
-			overflow-y: auto;
-			height: calc(100vh - var(--e-admin-bar-height, 0px) - var(--e-top-bar-header-height, 0px));
-		}
-	}
+body:has(#editor-one-top-bar > *) #wpcontent #wpbody-content {
+	margin-block-start: 50px;
 }

--- a/modules/editor-one/assets/scss/sidebar-navigation.scss
+++ b/modules/editor-one/assets/scss/sidebar-navigation.scss
@@ -14,6 +14,12 @@
 		width: var(--editor-one-sidebar-navigation-width);
 		max-width: var(--editor-one-sidebar-navigation-width);
 	}
+
+	&.e-sidebar-collapsed {
+		nav {
+			width: var(--editor-one-sidebar-navigation-width-collapsed);
+		}
+	}
 }
 
 .e-sidebar-transitioning {
@@ -30,29 +36,27 @@
 }
 
 .e-has-sidebar-navigation {
-	&:has(.e-sidebar-collapsed) {
-		--editor-one-sidebar-navigation-width: var(--editor-one-sidebar-navigation-width-collapsed);
-	}
-
 	#wpcontent {
 		padding-inline-start: var(--editor-one-sidebar-navigation-width);
 	}
 
-	#wpwrap > #wpfooter {
-		display: none;
-	}
-
-	#wpcontent #wpfooter {
-		background-color: transparent;
-		position: relative;
-		margin-inline: 0;
-		margin-block-start: auto;
-		padding-block-start: 18px;
+	#wpfooter {
+		margin-inline-start: var(--editor-one-sidebar-navigation-width);
 
 		#footer-left {
 			float: none;
 			text-align: center;
 			margin: 0 auto;
+		}
+	}
+
+	&.e-sidebar-is-collapsed {
+		#wpcontent {
+			padding-inline-start: var(--editor-one-sidebar-navigation-width-collapsed);
+		}
+
+		#wpfooter {
+			margin-inline-start: var(--editor-one-sidebar-navigation-width-collapsed);
 		}
 	}
 

--- a/modules/editor-one/assets/scss/top-bar.scss
+++ b/modules/editor-one/assets/scss/top-bar.scss
@@ -1,12 +1,6 @@
 @import "sidebar-variables";
 
 #editor-one-top-bar {
-	--editor-one-sidebar-admin-top-bar-height: 48px;
-
-	&:not(:has(header)) {
-		height: var(--editor-one-sidebar-admin-top-bar-height);
-	}
-
 	> * {
 		inset-block-start: var(--editor-one-wordpress-admin-bar-height, 32px);
 		inset-inline-start: var(--editor-one-sidebar-left-offset, 160px);


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert main Elementor One menu layout changes that modified WordPress admin layout positioning and footer behavior.

Main changes:
- Removed fixed positioning and height calculations for wpbody and wpbody-content elements
- Reverted footer manipulation logic that relocated wpfooter element within DOM structure  
- Restored standard margin/padding for wrap element and simplified sidebar collapsed state handling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
