### PR TITLE
Fix: Change nested atomic form submit button text to be html proptype [ED-22859]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.php
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.php
@@ -154,7 +154,7 @@ class Atomic_Form extends Atomic_Element_Base {
 				->build(),
 			Widget_Builder::make( Atomic_Button::get_element_type() )
 				->settings( [
-					'text' => String_Prop_Type::generate( __( 'Submit', 'elementor' ) ),
+					'text' => Html_Prop_Type::generate( __( 'Submit', 'elementor' ) ),
 					'attributes' => Attributes_Prop_Type::generate( [
 						Key_Value_Prop_Type::generate( [
 							'key' => String_Prop_Type::generate( 'type' ),

--- a/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-form.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-form.php
@@ -3,6 +3,7 @@
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Form\Atomic_Form;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Button\Atomic_Button;
 use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Html_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Key_Value_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use ElementorEditorTesting\Elementor_Test_Base;
@@ -26,7 +27,7 @@ class Test_Atomic_Form extends Elementor_Test_Base {
 		$this->assertTrue( $button['isLocked'] ?? false );
 
 		$expected_button_settings = [
-			'text' => String_Prop_Type::generate( __( 'Submit', 'elementor' ) ),
+			'text' => Html_Prop_Type::generate( __( 'Submit', 'elementor' ) ),
 			'attributes' => Attributes_Prop_Type::generate( [
 				Key_Value_Prop_Type::generate( [
 					'key' => String_Prop_Type::generate( 'type' ),


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix atomic form submit button text property type to use Html_Prop_Type instead of String_Prop_Type for proper HTML content handling.

Main changes:
- Changed submit button text property from String_Prop_Type to Html_Prop_Type in atomic-form.php default children configuration
- Updated corresponding test assertion in test-atomic-form.php to validate Html_Prop_Type usage
- Added Html_Prop_Type import to test file for proper type validation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
