### PR TITLE
Fix: Update element stacking on License page - GA update [ED-22873]

### DIFF
--- a/assets/dev/scss/admin/_license.scss
+++ b/assets/dev/scss/admin/_license.scss
@@ -1,7 +1,15 @@
 // License Page
-.wrap.elementor-admin-page-license {
+#wpcontent .wrap.elementor-admin-page-license {
+	flex-direction: column;
+	align-items: flex-start;
+	flex-wrap: nowrap;
+
+	*, *::before, *::after {
+		box-sizing: border-box;
+	}
 
 	.elementor-license-box {
+		width: 100%;
 		max-width: 600px;
 		background: white;
 		margin: 20px 0;

--- a/assets/dev/scss/admin/_license.scss
+++ b/assets/dev/scss/admin/_license.scss
@@ -4,16 +4,13 @@
 	align-items: flex-start;
 	flex-wrap: nowrap;
 
-	*, *::before, *::after {
-		box-sizing: border-box;
-	}
-
 	.elementor-license-box {
 		width: 100%;
 		max-width: 600px;
 		background: white;
 		margin: 20px 0;
 		padding: 20px 20px;
+		box-sizing: border-box;
 
 	h3 {
 		display: flex;


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix layout stacking issues on the Elementor License admin page by adding flex container constraints and proper width handling.

Main changes:
- Added more specific CSS selector (#wpcontent prefix) to increase specificity and override conflicting styles
- Applied flex-direction column with nowrap to license page wrapper for proper vertical stacking
- Set license box to full width with box-sizing border-box to prevent overflow issues

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
