### PR TITLE
Internal: Clean up of legacy menu registrations [ED-22664]

### DIFF
--- a/core/admin/editor-one-menu/elementor-one-menu-manager.php
+++ b/core/admin/editor-one-menu/elementor-one-menu-manager.php
@@ -51,7 +51,7 @@ class Elementor_One_Menu_Manager {
 		add_action( 'admin_head', [ $this, 'hide_legacy_templates_menu' ] );
 		add_action( 'admin_head', [ $this, 'hide_old_elementor_menu' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_menu_assets' ] );
-		add_action( 'admin_print_scripts-elementor_page_elementor-editor', [ $this, 'enqueue_home_screen_on_editor_page' ] );
+		add_action( 'admin_print_scripts-toplevel_page_elementor', [ $this, 'enqueue_home_screen_on_editor_page' ] );
 	}
 
 	public function check_if_pro_module_is_enabled(): void {
@@ -76,6 +76,9 @@ class Elementor_One_Menu_Manager {
 		do_action( 'elementor/editor-one/menu/register_submenus' );
 	}
 
+	/**
+	 * TODO: This can be removed in v4.1.0 [ED-22806]
+	 */
 	public function register_pro_submenus(): void {
 		if ( ! $this->is_pro_module_enabled &&
 			Utils::has_pro() &&

--- a/core/common/modules/connect/admin.php
+++ b/core/common/modules/connect/admin.php
@@ -114,12 +114,6 @@ class Admin {
 
 		add_action( 'elementor/editor-one/menu/register', [ $this, 'register_editor_one_menu' ] );
 
-		add_action( 'elementor/admin/menu/after_register', function ( Admin_Menu_Manager $admin_menu, array $hooks ) {
-			if ( ! empty( $hooks[ static::PAGE_ID ] ) ) {
-				add_action( 'load-' . $hooks[ static::PAGE_ID ], [ $this, 'on_load_page' ] );
-			}
-		}, 10, 2 );
-
 		add_action( 'elementor/editor-one/menu/after_register_hidden_submenus', function ( array $hooks ) {
 			if ( ! empty( $hooks[ static::PAGE_ID ] ) ) {
 				add_action( 'load-' . $hooks[ static::PAGE_ID ], [ $this, 'on_load_page' ] );

--- a/modules/apps/module.php
+++ b/modules/apps/module.php
@@ -22,12 +22,6 @@ class Module extends BaseModule {
 
 		Admin_Pointer::add_hooks();
 
-		add_action( 'elementor/admin/menu/after_register', function ( Admin_Menu_Manager $admin_menu, array $hooks ) {
-			if ( ! empty( $hooks[ static::PAGE_ID ] ) ) {
-				add_action( "admin_print_scripts-{$hooks[ static::PAGE_ID ]}", [ $this, 'enqueue_assets' ] );
-			}
-		}, 10, 2 );
-
 		add_filter( 'elementor/finder/categories', function( array $categories ) {
 			$categories['site']['items']['apps'] = [
 				'title' => esc_html__( 'Add-ons', 'elementor' ),

--- a/modules/element-manager/module.php
+++ b/modules/element-manager/module.php
@@ -34,10 +34,6 @@ class Module extends BaseModule {
 			$this->enqueue_assets_for_editor_one_menu( $hooks );
 		} );
 
-		add_action( 'elementor/admin/menu/after_register', function ( Admin_Menu_Manager $admin_menu, array $hooks ) {
-			$this->enqueue_assets_for_editor_one_menu( $hooks );
-		}, 10, 2 );
-
 		add_filter( 'elementor/widgets/is_widget_enabled', function( $should_register, Widget_Base $widget_instance ) {
 			return ! Options::is_element_disabled( $widget_instance->get_name() );
 		}, 10, 2 );

--- a/modules/home/module.php
+++ b/modules/home/module.php
@@ -1,7 +1,6 @@
 <?php
 namespace Elementor\Modules\Home;
 
-use Elementor\Core\Admin\Menu\Admin_Menu_Manager;
 use Elementor\Core\Base\App as BaseApp;
 use Elementor\Includes\EditorAssetsAPI;
 use Elementor\Settings;
@@ -22,11 +21,6 @@ class Module extends BaseApp {
 
 	public function __construct() {
 		parent::__construct();
-
-		add_action( 'elementor/admin/menu/after_register', function ( Admin_Menu_Manager $admin_menu, array $hooks ) {
-			$hook_suffix = 'toplevel_page_elementor';
-			add_action( "admin_print_scripts-{$hook_suffix}", [ $this, 'enqueue_home_screen_scripts' ] );
-		}, 10, 2 );
 
 		add_filter( 'elementor/document/urls/edit', [ $this, 'add_active_document_to_edit_link' ] );
 	}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove deprecated legacy admin menu registration hooks and consolidate menu initialization to use only the editor-one menu system for improved code maintainability.

Main changes:
- Removed legacy `elementor/admin/menu/after_register` and `elementor/admin/menu/register` action hooks across multiple modules
- Consolidated admin menu hooks to use `elementor/editor-one/menu/after_register_hidden_submenus` for consistent menu registration
- Updated admin script enqueue hook from `admin_print_scripts-elementor_page_elementor-editor` to `admin_print_scripts-toplevel_page_elementor` in menu manager

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
