### PR TITLE
Internal: Bump versions [ED-22876]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "elementor/wp-one-package": "1.0.51"
+        "elementor/wp-one-package": "1.0.50"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "elementor/wp-one-package": "1.0.48"
+        "elementor/wp-one-package": "1.0.50"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "elementor/wp-one-package": "1.0.50"
+        "elementor/wp-one-package": "1.0.51"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1742fc0d1cefcbe30d4e24c579cf697d",
+    "content-hash": "bec4b340e069d1acf19c88467031029e",
     "packages": [
         {
             "name": "elementor/wp-notifications-package",
@@ -39,16 +39,16 @@
         },
         {
             "name": "elementor/wp-one-package",
-            "version": "1.0.48",
+            "version": "1.0.50",
             "source": {
                 "type": "git",
                 "url": "git@github.com:elementor/wp-one-package.git",
-                "reference": "6fba587dcdb214de923dc91eedf9eec9286ebe90"
+                "reference": "62b0129863429c03ef989580937e542553a3c27f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.48",
-                "reference": "6fba587dcdb214de923dc91eedf9eec9286ebe90",
+                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.50",
+                "reference": "62b0129863429c03ef989580937e542553a3c27f",
                 "shasum": ""
             },
             "require": {
@@ -77,9 +77,9 @@
                 ]
             },
             "support": {
-                "source": "https://github.com/elementor/wp-one-package/tree/1.0.48"
+                "source": "https://github.com/elementor/wp-one-package/tree/1.0.50"
             },
-            "time": "2026-01-29T17:06:07+00:00"
+            "time": "2026-02-08T13:26:18+00:00"
         }
     ],
     "packages-dev": [
@@ -4633,13 +4633,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd99e1246673bd03eedbf2290aa843f1",
+    "content-hash": "bec4b340e069d1acf19c88467031029e",
     "packages": [
         {
             "name": "elementor/wp-notifications-package",
@@ -39,16 +39,16 @@
         },
         {
             "name": "elementor/wp-one-package",
-            "version": "1.0.51",
+            "version": "1.0.50",
             "source": {
                 "type": "git",
                 "url": "git@github.com:elementor/wp-one-package.git",
-                "reference": "407004e352fcbc89345ce8b28e7d63f4b0245aa6"
+                "reference": "62b0129863429c03ef989580937e542553a3c27f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.51",
-                "reference": "407004e352fcbc89345ce8b28e7d63f4b0245aa6",
+                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.50",
+                "reference": "62b0129863429c03ef989580937e542553a3c27f",
                 "shasum": ""
             },
             "require": {
@@ -77,9 +77,9 @@
                 ]
             },
             "support": {
-                "source": "https://github.com/elementor/wp-one-package/tree/1.0.51"
+                "source": "https://github.com/elementor/wp-one-package/tree/1.0.50"
             },
-            "time": "2026-02-10T07:44:18+00:00"
+            "time": "2026-02-08T13:26:18+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bec4b340e069d1acf19c88467031029e",
+    "content-hash": "bd99e1246673bd03eedbf2290aa843f1",
     "packages": [
         {
             "name": "elementor/wp-notifications-package",
@@ -39,16 +39,16 @@
         },
         {
             "name": "elementor/wp-one-package",
-            "version": "1.0.50",
+            "version": "1.0.51",
             "source": {
                 "type": "git",
                 "url": "git@github.com:elementor/wp-one-package.git",
-                "reference": "62b0129863429c03ef989580937e542553a3c27f"
+                "reference": "407004e352fcbc89345ce8b28e7d63f4b0245aa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.50",
-                "reference": "62b0129863429c03ef989580937e542553a3c27f",
+                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.51",
+                "reference": "407004e352fcbc89345ce8b28e7d63f4b0245aa6",
                 "shasum": ""
             },
             "require": {
@@ -77,9 +77,9 @@
                 ]
             },
             "support": {
-                "source": "https://github.com/elementor/wp-one-package/tree/1.0.50"
+                "source": "https://github.com/elementor/wp-one-package/tree/1.0.51"
             },
-            "time": "2026-02-08T13:26:18+00:00"
+            "time": "2026-02-10T07:44:18+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update elementor/wp-one-package dependency from version 1.0.48 to 1.0.51 to incorporate latest package improvements and fixes.
Main changes:
- Bumped elementor/wp-one-package dependency version from 1.0.48 to 1.0.51 in composer.json requirements

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
