### PR TITLE
Fix: V3 handlers are not working for wordpress themes

### DIFF
--- a/assets/dev/js/modules/modules.js
+++ b/assets/dev/js/modules/modules.js
@@ -7,7 +7,7 @@ import ForceMethodImplementation from './imports/force-method-implementation';
 import { createGetInitialState } from '../../../../app/modules/import-export-customization/assets/js/shared/utils/template-registry-helpers';
 import { customizationDialogsRegistry } from '../../../../app/modules/import-export-customization/assets/js/shared/registry/customization-dialogs';
 
-export default window.elementorModules = {
+const baseModules = {
 	Module,
 	ViewModule,
 	ArgsObject,
@@ -23,3 +23,11 @@ export default window.elementorModules = {
 		customizationDialogsRegistry,
 	},
 };
+
+if ( ! window.elementorModules ) {
+	window.elementorModules = baseModules;
+} else {
+	Object.assign( window.elementorModules, baseModules );
+}
+
+export default window.elementorModules;


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix V3 handler initialization conflicts in WordPress themes by implementing safe module registration that preserves existing elementorModules properties.

Main changes:
- Replaced direct window.elementorModules assignment with conditional initialization to prevent overwriting existing theme modules
- Added Object.assign fallback to merge baseModules with existing elementorModules when already defined
- Extracted module definitions into baseModules constant to enable safe conditional registration logic

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
