### PR TITLE
Internal: Update workflows for Onboarding and Cloud Templates [ED-22857]

### DIFF
--- a/app/modules/onboarding/assets/js/utils/modules/event-dispatcher.js
+++ b/app/modules/onboarding/assets/js/utils/modules/event-dispatcher.js
@@ -25,7 +25,6 @@ export const ONBOARDING_EVENTS_MAP = {
 	CREATE_ACCOUNT_STATUS: 'core_onboarding_create_account_status',
 	STEP1_CLICKED_CONNECT: 'core_onboarding_s1_clicked_connect',
 	AB_101_START_AS_FREE_USER: 'ab_101_start_as_free_user',
-	SESSION_REPLAY_START: 'onboarding_session_replay_start',
 };
 
 export const ONBOARDING_STEP_NAMES = {

--- a/app/modules/onboarding/assets/js/utils/modules/onboarding-tracker.js
+++ b/app/modules/onboarding/assets/js/utils/modules/onboarding-tracker.js
@@ -622,14 +622,18 @@ class OnboardingTracker {
 			StorageManager.setString( endStateSentKey, 'true' );
 			TimingManager.clearStepStartTime( stepNumber );
 			this.sendStoredEventsIfConnected();
-		} else if ( 1 === stepNumber ) {
-			this.storeStep1EndStateForLater( eventData, storageKey );
-		} else {
-			this.dispatchEventWithoutTrigger( eventName, eventData );
-			StorageManager.remove( storageKey );
-			StorageManager.setString( endStateSentKey, 'true' );
-			TimingManager.clearStepStartTime( stepNumber );
+			return;
 		}
+
+		if ( ONBOARDING_STEP_NAMES.CONNECT === stepName ) {
+			this.storeStep1EndStateForLater( eventData, storageKey );
+			return;
+		}
+
+		this.dispatchEventWithoutTrigger( eventName, eventData );
+		StorageManager.remove( storageKey );
+		StorageManager.setString( endStateSentKey, 'true' );
+		TimingManager.clearStepStartTime( stepNumber );
 	}
 
 	getStepNumber( pageId ) {

--- a/app/modules/onboarding/assets/js/utils/modules/onboarding-tracker.js
+++ b/app/modules/onboarding/assets/js/utils/modules/onboarding-tracker.js
@@ -5,8 +5,6 @@ import TimingManager from './timing-manager.js';
 import PostOnboardingTracker from './post-onboarding-tracker.js';
 
 class OnboardingTracker {
-	#hasAttemptedSessionRecording = false;
-
 	constructor() {
 		this.initializeEventConfigs();
 		this.initializeEventListeners();
@@ -146,21 +144,9 @@ class OnboardingTracker {
 		}, true );
 
 		this.setupUrlChangeDetection();
-		this.setupSessionRecordingCleanup();
-	}
-
-	setupSessionRecordingCleanup() {
-		this.handleBeforeUnload = this.handleBeforeUnload.bind( this );
-		window.addEventListener( 'beforeunload', this.handleBeforeUnload );
-	}
-
-	handleBeforeUnload() {
-		this.stopSessionRecordingIfNeeded();
 	}
 
 	onDestroy() {
-		this.stopSessionRecordingIfNeeded();
-		window.removeEventListener( 'beforeunload', this.handleBeforeUnload );
 	}
 
 	setupUrlChangeDetection() {
@@ -633,10 +619,6 @@ class OnboardingTracker {
 		eventData = TimingManager.addTimingToEventData( eventData, stepNumber );
 		eventData[ endStateProperty ] = actions;
 
-		if ( ONBOARDING_STEP_NAMES.SITE_STARTER === stepName ) {
-			this.stopSessionRecordingIfNeeded();
-		}
-
 		if ( EventDispatcher.canSendEvents() ) {
 			this.dispatchEventWithoutTrigger( eventName, eventData );
 			StorageManager.remove( storageKey );
@@ -1083,58 +1065,6 @@ class OnboardingTracker {
 		StorageManager.remove( storageKey );
 	}
 
-	startSessionRecordingIfNeeded() {
-		if ( this.#hasAttemptedSessionRecording ) {
-			return;
-		}
-
-		if ( ! elementorCommon?.config?.editor_events?.session_replays?.coreOnboarding ) {
-			return;
-		}
-
-		const featureFlagPromise = elementorCommon?.eventsManager?.featureFlagIsActive?.( 'core-onboarding-session-replays' );
-		if ( ! featureFlagPromise ) {
-			return;
-		}
-
-		this.#hasAttemptedSessionRecording = true;
-
-		featureFlagPromise
-			.then( ( isFeatureFlagActive ) => {
-				if ( ! isFeatureFlagActive ) {
-					return;
-				}
-
-				this.startSessionRecording();
-			} )
-			.catch( () => {} );
-	}
-
-	startSessionRecording() {
-		if ( ! EventDispatcher.canSendEvents() ) {
-			return;
-		}
-
-		if ( elementorCommon?.eventsManager?.isSessionRecordingInProgress?.() ) {
-			return;
-		}
-
-		elementorCommon.eventsManager?.dispatchEvent( ONBOARDING_EVENTS_MAP.SESSION_REPLAY_START, {
-			location: 'plugin_onboarding',
-		} );
-
-		elementorCommon.eventsManager?.startSessionRecording();
-	}
-
-	stopSessionRecordingIfNeeded() {
-		if ( ! this.#hasAttemptedSessionRecording ) {
-			return;
-		}
-
-		elementorCommon.eventsManager?.stopSessionRecording();
-		this.#hasAttemptedSessionRecording = false;
-	}
-
 	onStepLoad( currentStep ) {
 		const stepNumber = this.getStepNumber( currentStep );
 
@@ -1145,7 +1075,6 @@ class OnboardingTracker {
 		}
 
 		if ( 2 === stepNumber || 'hello' === currentStep || 'hello_biz' === currentStep ) {
-			this.startSessionRecordingIfNeeded();
 			this.sendStoredStep1EventsOnStep2();
 			this.sendExperimentStarted( 201 );
 			this.sendExperimentStarted( 202 );

--- a/app/modules/onboarding/assets/js/utils/modules/onboarding-tracker.js
+++ b/app/modules/onboarding/assets/js/utils/modules/onboarding-tracker.js
@@ -146,9 +146,6 @@ class OnboardingTracker {
 		this.setupUrlChangeDetection();
 	}
 
-	onDestroy() {
-	}
-
 	setupUrlChangeDetection() {
 		let lastUrl = window.location.href;
 		const urlChangeDetector = () => {
@@ -625,18 +622,14 @@ class OnboardingTracker {
 			StorageManager.setString( endStateSentKey, 'true' );
 			TimingManager.clearStepStartTime( stepNumber );
 			this.sendStoredEventsIfConnected();
-			return;
-		}
-
-		if ( ONBOARDING_STEP_NAMES.CONNECT === stepName ) {
+		} else if ( 1 === stepNumber ) {
 			this.storeStep1EndStateForLater( eventData, storageKey );
-			return;
+		} else {
+			this.dispatchEventWithoutTrigger( eventName, eventData );
+			StorageManager.remove( storageKey );
+			StorageManager.setString( endStateSentKey, 'true' );
+			TimingManager.clearStepStartTime( stepNumber );
 		}
-
-		this.dispatchEventWithoutTrigger( eventName, eventData );
-		StorageManager.remove( storageKey );
-		StorageManager.setString( endStateSentKey, 'true' );
-		TimingManager.clearStepStartTime( stepNumber );
 	}
 
 	getStepNumber( pageId ) {

--- a/assets/dev/js/editor/components/template-library/event-manager/index.js
+++ b/assets/dev/js/editor/components/template-library/event-manager/index.js
@@ -16,7 +16,6 @@ const EVENTS_MAP = {
 	UPGRADE_CLICKED: 'upgrade_clicked',
 	PAGE_VIEWED: 'page_viewed',
 	DELETION_UNDO: 'deletion_undo',
-	CT_RECORDING_START: 'ctemplates_session_replay_start',
 	CT_BADGE_HOVER: 'ct_badge_hover',
 };
 
@@ -175,24 +174,6 @@ export class EventManager {
 		return this.sendEvent( EVENTS_MAP.DELETION_UNDO, {
 			...data,
 		} );
-	}
-
-	sendCloudTemplatesSessionRecordingStartEvent() {
-		return this.sendEvent( EVENTS_MAP.CT_RECORDING_START, {
-			location: elementorCommon.eventsManager.config.locations.templatesLibrary.library,
-		} );
-	}
-
-	startSessionRecording() {
-		return elementorCommon.eventsManager.startSessionRecording();
-	}
-
-	stopSessionRecording() {
-		return elementorCommon.eventsManager.stopSessionRecording();
-	}
-
-	isSessionRecordingInProgress() {
-		return elementorCommon.eventsManager.isSessionRecordingInProgress();
 	}
 
 	sendCTBadgeEvent( data ) {

--- a/assets/dev/js/editor/components/template-library/manager.js
+++ b/assets/dev/js/editor/components/template-library/manager.js
@@ -987,15 +987,6 @@ const TemplateLibraryManager = function() {
 			options.refresh = true;
 		}
 
-		const shouldStartSessionRecording = 'cloud' === query.source &&
-			elementorCommon.config.editor_events.session_replays?.cloudTemplates &&
-			! elementor.templates.eventManager.isSessionRecordingInProgress();
-
-		if ( shouldStartSessionRecording ) {
-			elementor.templates.eventManager.startSessionRecording();
-			elementor.templates.eventManager.sendCloudTemplatesSessionRecordingStartEvent();
-		}
-
 		this.setFilter( 'parent', null, query );
 
 		const loadTemplatesData = () => {

--- a/assets/dev/js/editor/components/template-library/views/library-layout.js
+++ b/assets/dev/js/editor/components/template-library/views/library-layout.js
@@ -39,17 +39,6 @@ module.exports = elementorModules.common.views.modal.Layout.extend( {
 		};
 	},
 
-	initialize() {
-		elementorModules.common.views.modal.Layout.prototype.initialize.call( this );
-	},
-
-	initModal() {
-		elementorModules.common.views.modal.Layout.prototype.initModal.call( this );
-	},
-
-	onDestroy() {
-	},
-
 	getLogoOptions() {
 		return {
 			title: __( 'Library', 'elementor' ),

--- a/assets/dev/js/editor/components/template-library/views/library-layout.js
+++ b/assets/dev/js/editor/components/template-library/views/library-layout.js
@@ -41,26 +41,13 @@ module.exports = elementorModules.common.views.modal.Layout.extend( {
 
 	initialize() {
 		elementorModules.common.views.modal.Layout.prototype.initialize.call( this );
-
-		this.handleBeforeUnload = this.handleBeforeUnload.bind( this );
-		window.addEventListener( 'beforeunload', this.handleBeforeUnload );
 	},
 
 	initModal() {
 		elementorModules.common.views.modal.Layout.prototype.initModal.call( this );
-
-		this.modal.on( 'hide', () => {
-			elementor.templates.eventManager.stopSessionRecording();
-		} );
 	},
 
 	onDestroy() {
-		elementor.templates.eventManager.stopSessionRecording();
-		window.removeEventListener( 'beforeunload', this.handleBeforeUnload );
-	},
-
-	handleBeforeUnload() {
-		elementor.templates.eventManager.stopSessionRecording();
 	},
 
 	getLogoOptions() {

--- a/assets/dev/js/editor/components/template-library/views/parts/save-template.js
+++ b/assets/dev/js/editor/components/template-library/views/parts/save-template.js
@@ -84,14 +84,6 @@ const TemplateLibrarySaveTemplateView = Marionette.ItemView.extend( {
 			location: elementorCommon.eventsManager.config.secondaryLocations.templateLibrary[ `${ context }Modal` ],
 		} );
 
-		const shouldStartSessionRecording = elementorCommon.config.editor_events.session_replays?.cloudTemplates &&
-		! elementor.templates.eventManager.isSessionRecordingInProgress();
-
-		if ( shouldStartSessionRecording ) {
-			elementor.templates.eventManager.startSessionRecording();
-			elementor.templates.eventManager.sendCloudTemplatesSessionRecordingStartEvent();
-		}
-
 		if ( SAVE_CONTEXTS.SAVE === context ) {
 			this.handleSaveAction();
 		}

--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -17,7 +17,17 @@ export default class extends elementorModules.Module {
 	}
 
 	initializeMixpanel() {
-		mixpanel.init( elementorCommon.config.editor_events?.token, { persistence: 'localStorage', autocapture: false } );
+		mixpanel.init(
+			elementorCommon.config.editor_events?.token,
+			{
+				persistence: 'localStorage',
+				autocapture: false,
+				flags: true,
+				api_hosts: {
+					flags: 'https://api-eu.mixpanel.com',
+				},
+			},
+		);
 	}
 
 	enableTracking() {

--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -17,21 +17,7 @@ export default class extends elementorModules.Module {
 	}
 
 	initializeMixpanel() {
-		mixpanel.init(
-			elementorCommon.config.editor_events?.token,
-			{
-				persistence: 'localStorage',
-				autocapture: false,
-				record_sessions_percent: 0,
-				record_idle_timeout_ms: 60000,
-				record_max_ms: 300000,
-				record_mask_text_selector: '',
-				flags: true,
-				api_hosts: {
-					flags: 'https://api-eu.mixpanel.com',
-				},
-			},
-		);
+		mixpanel.init( elementorCommon.config.editor_events?.token, { persistence: 'localStorage', autocapture: false } );
 	}
 
 	enableTracking() {

--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -4,7 +4,6 @@ import { TIERS } from 'elementor-utils/tiers';
 
 export default class extends elementorModules.Module {
 	trackingEnabled = false;
-	#sessionRecordingInProgress = false;
 
 	onInit() {
 		this.config = eventsConfig;
@@ -78,40 +77,6 @@ export default class extends elementorModules.Module {
 		};
 
 		mixpanel.track( name, eventData, options );
-	}
-
-	startSessionRecording() {
-		if ( ! this.canSendEvents() || this.isSessionRecordingInProgress() ) {
-			return;
-		}
-
-		if ( ! this.trackingEnabled ) {
-			this.enableTracking();
-		}
-
-		mixpanel.start_session_recording();
-		this.setSessionRecordingInProgress( true );
-	}
-
-	stopSessionRecording() {
-		if ( ! this.canSendEvents() || ! this.isSessionRecordingInProgress() ) {
-			return;
-		}
-
-		mixpanel.stop_session_recording();
-		this.setSessionRecordingInProgress( false );
-	}
-
-	setSessionRecordingInProgress( value ) {
-		if ( 'boolean' !== typeof value ) {
-			return;
-		}
-
-		this.#sessionRecordingInProgress = value;
-	}
-
-	isSessionRecordingInProgress() {
-		return this.#sessionRecordingInProgress;
 	}
 
 	async featureFlagIsActive( flagName ) {

--- a/core/common/modules/events-manager/module.php
+++ b/core/common/modules/events-manager/module.php
@@ -29,12 +29,10 @@ class Module extends BaseModule {
 			! Tracker::has_terms_changed( '2025-07-07' ) &&
 			Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME );
 
-		$session_replays = [];
 		$is_flags_enabled = false;
 
 		if ( $can_send_events ) {
 			$mixpanel_config = self::get_remote_mixpanel_config();
-			$session_replays = $mixpanel_config[0]['sessionReplays'] ?? [];
 			$is_flags_enabled = $mixpanel_config[0]['flags'] ?? false;
 		}
 
@@ -49,7 +47,6 @@ class Module extends BaseModule {
 			'subscription_id' => self::get_subscription_id(),
 			'subscription' => self::get_subscription(),
 			'token' => ELEMENTOR_EDITOR_EVENTS_MIXPANEL_TOKEN,
-			'session_replays' => $session_replays,
 			'flags_enabled' => $is_flags_enabled,
 		];
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove session recording functionality and related configuration from onboarding and cloud templates workflows to simplify event tracking implementation.

Main changes:
- Removed session replay configuration variables and event dispatching from onboarding tracker, cloud templates manager, and template library views
- Eliminated session recording methods (startSessionRecording, stopSessionRecording, isSessionRecordingInProgress) from events manager module and related event handlers
- Cleaned up Mixpanel session recording configuration options (record_sessions_percent, record_idle_timeout_ms, record_max_ms, record_mask_text_selector) from initialization settings

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
