### PR TITLE
Internal: Add data attribute to identify elements in panel

### DIFF
--- a/includes/editor-templates/panel-elements.php
+++ b/includes/editor-templates/panel-elements.php
@@ -81,7 +81,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <script type="text/template" id="tmpl-elementor-element-library-element">
 	<# const v4Categories = ['v4-elements', 'atomic-form']; #>
-	<button class="elementor-element" data-element-library-element-type="{{ elType === 'widget' ? widgetType : elType }}">
+	<button class="elementor-element" data-library-element-type="{{ elType === 'widget' ? widgetType : elType }}">
 	<# if ( obj.integration ) { #>
 			<i class="eicon-plug"></i>
 		<# } else if ( false === obj.editable ) { #>

--- a/includes/editor-templates/panel-elements.php
+++ b/includes/editor-templates/panel-elements.php
@@ -81,7 +81,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <script type="text/template" id="tmpl-elementor-element-library-element">
 	<# const v4Categories = ['v4-elements', 'atomic-form']; #>
-	<button class="elementor-element">
+	<button class="elementor-element" data-element-library-element-type="{{ elType === 'widget' ? widgetType : elType }}">
 	<# if ( obj.integration ) { #>
 			<i class="eicon-plug"></i>
 		<# } else if ( false === obj.editable ) { #>


### PR DESCRIPTION
## Summary

- Add `data-element-library-element-type` attribute to the element button in the elements panel
- The attribute exposes the element type (widget type for widgets, element type otherwise) for external identification

## Why?

This enables external tools and automation to identify specific elements in the elements panel by their type.

## Changelog

`Internal`
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add data-library-element-type attribute to panel element buttons for improved element identification and testing capabilities in the Elementor editor.

Main changes:
- Added data-library-element-type attribute to button elements in panel template using conditional logic for widgets vs other element types
- Attribute dynamically populates with widgetType for widgets or elType for other elements enabling programmatic element identification

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
