### PR TITLE
Fix: Do not use outputSchema for now [ED-23005]

### DIFF
--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -169,7 +169,8 @@ function createToolRegistry( server: McpServer ) {
 			try {
 				const invocationResult = await opts.handler( opts.schema ? args : {}, extra );
 				return {
-					structuredContent: typeof invocationResult === 'string' ? undefined : invocationResult,
+					// TODO: Uncomment this when the outputSchema is stable
+					// structuredContent: typeof invocationResult === 'string' ? undefined : invocationResult,
 					content: [
 						{
 							type: 'text',
@@ -211,7 +212,8 @@ function createToolRegistry( server: McpServer ) {
 			{
 				description: opts.description,
 				inputSchema,
-				outputSchema,
+				// TODO: Uncomment this when the outputSchema is stable
+				// outputSchema,
 				title: opts.name,
 				annotations,
 			},


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Temporarily disable outputSchema and structuredContent in MCP tool registry to address stability issues until the feature is fully stable.

Main changes:
- Commented out structuredContent property in tool callback return value to prevent structured output handling
- Commented out outputSchema registration parameter in server.registerTool() call with stability TODO notes
- Maintained text-based content return while preserving conditional invocationResult logic for future reactivation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
