### PR TITLE
Internal: Load V4 styles from templates and components in templates - v3.35 [ED-22936] 

### DIFF
--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -128,6 +128,7 @@ class Module extends BaseModule {
 		'editor-styles', // TODO: Need to be registered and not enqueued.
 		'editor-styles-repository',
 		'editor-interactions',
+		'editor-templates',
 	];
 
 	public function get_name() {

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -2923,6 +2923,10 @@
       "resolved": "packages/core/editor-styles-repository",
       "link": true
     },
+    "node_modules/@elementor/editor-templates": {
+      "resolved": "packages/core/editor-templates",
+      "link": true
+    },
     "node_modules/@elementor/editor-ui": {
       "resolved": "packages/libs/editor-ui",
       "link": true
@@ -21363,6 +21367,7 @@
         "@elementor/editor-panels": "3.35.0",
         "@elementor/editor-props": "3.35.0",
         "@elementor/editor-styles-repository": "3.35.0",
+        "@elementor/editor-templates": "3.35.0",
         "@elementor/editor-ui": "3.35.0",
         "@elementor/editor-v1-adapters": "3.35.0",
         "@elementor/events": "3.35.0",
@@ -21588,6 +21593,24 @@
         "@elementor/schema": "3.35.0",
         "@elementor/utils": "3.35.0",
         "@wordpress/i18n": "^5.13.0"
+      },
+      "devDependencies": {
+        "tsup": "^8.3.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "packages/core/editor-templates": {
+      "name": "@elementor/editor-templates",
+      "version": "3.35.0",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@elementor/editor": "3.35.0",
+        "@elementor/editor-documents": "3.35.0",
+        "@elementor/editor-styles-repository": "3.35.0",
+        "@elementor/editor-v1-adapters": "3.35.0",
+        "@elementor/store": "3.35.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"

--- a/packages/packages/core/editor-components/src/components/load-template-components.tsx
+++ b/packages/packages/core/editor-components/src/components/load-template-components.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLoadedTemplates } from '@elementor/editor-templates';
+
+import { loadComponentsAssets } from '../store/actions/load-components-assets';
+
+export const LoadTemplateComponents = () => {
+	const templates = useLoadedTemplates();
+
+	useEffect( () => {
+		loadComponentsAssets( templates.flatMap( ( elements ) => elements ?? [] ) );
+	}, [ templates ] );
+
+	return null;
+};

--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -31,6 +31,7 @@ import { CreateComponentForm } from './components/create-component-form/create-c
 import { EditComponent } from './components/edit-component/edit-component';
 import { openEditModeDialog } from './components/in-edit-mode';
 import { InstanceEditingPanel } from './components/instance-editing-panel/instance-editing-panel';
+import { LoadTemplateComponents } from './components/load-template-components';
 import { OverridablePropControl } from './components/overridable-props/overridable-prop-control';
 import { OverridablePropIndicator } from './components/overridable-props/overridable-prop-indicator';
 import { COMPONENT_WIDGET_TYPE, createComponentType } from './create-component-type';
@@ -108,6 +109,11 @@ export function init() {
 		}
 
 		await loadComponentsAssets( ( config?.elements as V1ElementData[] ) ?? [] );
+	} );
+
+	injectIntoLogic( {
+		id: 'templates',
+		component: LoadTemplateComponents,
 	} );
 
 	registerFieldIndicator( {

--- a/packages/packages/core/editor-templates/package.json
+++ b/packages/packages/core/editor-templates/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "@elementor/editor-components",
-  "description": "Elementor editor components",
+  "name": "@elementor/editor-templates",
   "version": "3.35.0",
   "private": false,
   "author": "Elementor Team",
@@ -20,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/elementor/elementor.git",
-    "directory": "packages/core/editor-components"
+    "directory": "packages/core/editor-templates"
   },
   "bugs": {
     "url": "https://github.com/elementor/elementor/issues"
@@ -41,36 +40,15 @@
   },
   "dependencies": {
     "@elementor/editor": "3.35.0",
-    "@elementor/editor-canvas": "3.35.0",
-    "@elementor/editor-controls": "3.35.0",
     "@elementor/editor-documents": "3.35.0",
-    "@elementor/editor-editing-panel": "3.35.0",
-    "@elementor/editor-elements": "3.35.0",
-    "@elementor/editor-elements-panel": "3.35.0",
-    "@elementor/editor-mcp": "3.35.0",
-    "@elementor/editor-panels": "3.35.0",
-    "@elementor/editor-props": "3.35.0",
     "@elementor/editor-styles-repository": "3.35.0",
-    "@elementor/editor-templates": "3.35.0",
-    "@elementor/editor-ui": "3.35.0",
     "@elementor/editor-v1-adapters": "3.35.0",
-    "@elementor/http-client": "3.35.0",
-    "@elementor/icons": "^1.63.0",
-    "@elementor/events": "3.35.0",
-    "@elementor/query": "3.35.0",
-    "@elementor/schema": "3.35.0",
-    "@elementor/store": "3.35.0",
-    "@elementor/ui": "1.36.17",
-    "@elementor/utils": "3.35.0",
-    "@wordpress/i18n": "^5.13.0",
-    "@elementor/editor-notifications": "3.35.0",
-    "@elementor/editor-current-user": "3.35.0"
-  },
-  "peerDependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "@elementor/store": "3.35.0"
   },
   "devDependencies": {
-    "tsup": "^8.5.0"
+    "tsup": "^8.3.5"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1"
   }
 }

--- a/packages/packages/core/editor-templates/src/__tests__/load-templates.test.ts
+++ b/packages/packages/core/editor-templates/src/__tests__/load-templates.test.ts
@@ -1,0 +1,227 @@
+import { createDOMElement } from 'test-utils';
+import { type Document, getV1CurrentDocument } from '@elementor/editor-documents';
+import { type V1ElementData } from '@elementor/editor-elements';
+import { ajax, getCanvasIframeDocument } from '@elementor/editor-v1-adapters';
+import { __dispatch as dispatch } from '@elementor/store';
+
+import { loadTemplates, unloadTemplates } from '../load-templates';
+import { slice } from '../store';
+
+jest.mock( '@elementor/editor-v1-adapters', () => ( {
+	...jest.requireActual( '@elementor/editor-v1-adapters' ),
+	getCanvasIframeDocument: jest.fn(),
+	ajax: {
+		load: jest.fn(),
+	},
+} ) );
+
+jest.mock( '@elementor/editor-documents', () => ( {
+	getV1CurrentDocument: jest.fn(),
+} ) );
+
+jest.mock( '@elementor/store', () => ( {
+	...jest.requireActual( '@elementor/store' ),
+	__dispatch: jest.fn(),
+} ) );
+
+function createMockDocument( id: number, elements: V1ElementData[] = [] ): Document {
+	return { id, elements } as unknown as Document;
+}
+
+function createTemplateElement( documentId: string ) {
+	return createDOMElement( {
+		tag: 'div',
+		attrs: {
+			'data-elementor-id': documentId,
+			'data-elementor-post-type': 'elementor_library',
+		},
+	} );
+}
+
+describe( 'loadTemplates', () => {
+	const mockLoad = jest.mocked( ajax.load );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		jest.mocked( getV1CurrentDocument ).mockReturnValue( { id: 100 } as ReturnType< typeof getV1CurrentDocument > );
+	} );
+
+	it( 'should do nothing when iframe document is not available', async () => {
+		// Arrange.
+		jest.mocked( getCanvasIframeDocument ).mockReturnValue( null );
+
+		// Act.
+		await loadTemplates();
+
+		// Assert.
+		expect( mockLoad ).not.toHaveBeenCalled();
+		expect( dispatch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should do nothing when no templates exist in canvas', async () => {
+		// Arrange.
+		const body = createDOMElement( {
+			tag: 'body',
+			children: [ createDOMElement( { tag: 'div', attrs: { 'data-elementor-id': '100' } } ) ],
+		} );
+
+		jest.mocked( getCanvasIframeDocument ).mockReturnValue( { body } as unknown as globalThis.Document );
+
+		// Act.
+		await loadTemplates();
+
+		// Assert.
+		expect( mockLoad ).not.toHaveBeenCalled();
+		expect( dispatch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should fetch documents and dispatch setTemplates', async () => {
+		// Arrange.
+		const document200 = createMockDocument( 200 );
+		const document300 = createMockDocument( 300 );
+
+		const body = createDOMElement( {
+			tag: 'body',
+			children: [
+				createDOMElement( {
+					tag: 'div',
+					attrs: { 'data-elementor-id': '100' },
+				} ),
+				createTemplateElement( '200' ),
+				createTemplateElement( '300' ),
+			],
+		} );
+
+		jest.mocked( getCanvasIframeDocument ).mockReturnValue( { body } as unknown as globalThis.Document );
+
+		mockLoad.mockImplementation( ( params ) => {
+			const { id } = params.data as { id: number };
+
+			if ( id === 200 ) {
+				return Promise.resolve( document200 );
+			}
+
+			if ( id === 300 ) {
+				return Promise.resolve( document300 );
+			}
+
+			return Promise.reject( new Error( 'Not found' ) );
+		} );
+
+		// Act.
+		await loadTemplates();
+
+		// Assert.
+		expect( mockLoad ).toHaveBeenCalledTimes( 2 );
+		expect( mockLoad ).toHaveBeenCalledWith(
+			expect.objectContaining( { data: { id: 200 }, action: 'get_document_config' } )
+		);
+		expect( mockLoad ).toHaveBeenCalledWith(
+			expect.objectContaining( { data: { id: 300 }, action: 'get_document_config' } )
+		);
+		expect( dispatch ).toHaveBeenCalledWith( slice.actions.setTemplates( [ document200, document300 ] ) );
+	} );
+
+	it( 'should only discover elements with library post type', async () => {
+		// Arrange.
+		const body = createDOMElement( {
+			tag: 'body',
+			children: [
+				createDOMElement( {
+					tag: 'div',
+					attrs: { 'data-elementor-id': '100' },
+				} ),
+				createTemplateElement( '200' ),
+				createDOMElement( {
+					tag: 'div',
+					attrs: { 'data-elementor-id': '500', 'data-elementor-type': 'wp-post' },
+				} ),
+			],
+		} );
+
+		jest.mocked( getCanvasIframeDocument ).mockReturnValue( { body } as unknown as globalThis.Document );
+		mockLoad.mockResolvedValue( createMockDocument( 200 ) );
+
+		// Act.
+		await loadTemplates();
+
+		// Assert.
+		expect( mockLoad ).toHaveBeenCalledTimes( 1 );
+		expect( mockLoad ).toHaveBeenCalledWith( expect.objectContaining( { data: { id: 200 } } ) );
+		expect( mockLoad ).not.toHaveBeenCalledWith( expect.objectContaining( { data: { id: 500 } } ) );
+	} );
+
+	it( 'should gracefully handle failed document requests', async () => {
+		// Arrange.
+		const document200 = createMockDocument( 200 );
+
+		const body = createDOMElement( {
+			tag: 'body',
+			children: [
+				createDOMElement( {
+					tag: 'div',
+					attrs: { 'data-elementor-id': '100' },
+				} ),
+				createTemplateElement( '200' ),
+				createTemplateElement( '300' ),
+			],
+		} );
+
+		jest.mocked( getCanvasIframeDocument ).mockReturnValue( { body } as unknown as globalThis.Document );
+
+		mockLoad.mockImplementation( ( params ) => {
+			const { id } = params.data as { id: number };
+
+			if ( id === 200 ) {
+				return Promise.resolve( document200 );
+			}
+
+			return Promise.reject( new Error( 'Not found' ) );
+		} );
+
+		// Act.
+		await loadTemplates();
+
+		// Assert.
+		expect( dispatch ).toHaveBeenCalledWith( slice.actions.setTemplates( [ document200 ] ) );
+	} );
+
+	it( 'should deduplicate document IDs', async () => {
+		// Arrange.
+		const body = createDOMElement( {
+			tag: 'body',
+			children: [
+				createDOMElement( {
+					tag: 'div',
+					attrs: { 'data-elementor-id': '100' },
+				} ),
+				createTemplateElement( '200' ),
+				createTemplateElement( '200' ),
+			],
+		} );
+
+		jest.mocked( getCanvasIframeDocument ).mockReturnValue( { body } as unknown as globalThis.Document );
+		mockLoad.mockResolvedValue( createMockDocument( 200 ) );
+
+		// Act.
+		await loadTemplates();
+
+		// Assert.
+		expect( mockLoad ).toHaveBeenCalledTimes( 1 );
+	} );
+} );
+
+describe( 'unloadTemplates', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should dispatch clearTemplates', () => {
+		// Act.
+		unloadTemplates();
+
+		// Assert.
+		expect( dispatch ).toHaveBeenCalledWith( slice.actions.clearTemplates() );
+	} );
+} );

--- a/packages/packages/core/editor-templates/src/__tests__/render-template-styles.test.tsx
+++ b/packages/packages/core/editor-templates/src/__tests__/render-template-styles.test.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { createMockStyleDefinition, renderWithStore } from 'test-utils';
+import { type Document } from '@elementor/editor-documents';
+import { type V1ElementData } from '@elementor/editor-elements';
+import { __createStore, __dispatch, __registerSlice, type SliceState, type Store } from '@elementor/store';
+
+import { RenderTemplateStyles } from '../render-template-styles';
+import { slice } from '../store';
+import { clearTemplatesStyles, templatesStylesProvider } from '../templates-styles-provider';
+
+function createMockDocument( id: number, elements: V1ElementData[] = [] ): Document {
+	return { id, elements } as unknown as Document;
+}
+
+function createMockElementData( overrides: Partial< V1ElementData > = {} ): V1ElementData {
+	return {
+		id: '1',
+		elType: 'widget',
+		widgetType: 'heading',
+		settings: {},
+		styles: {},
+		elements: [],
+		...overrides,
+	} as V1ElementData;
+}
+
+describe( 'RenderTemplateStyles', () => {
+	let store: Store< SliceState< typeof slice > >;
+
+	beforeEach( () => {
+		__registerSlice( slice );
+		store = __createStore();
+
+		clearTemplatesStyles();
+	} );
+
+	it( 'should extract styles from templates and add them to the provider', () => {
+		// Arrange.
+		const style1 = createMockStyleDefinition( { id: 'style-1' } );
+		const style2 = createMockStyleDefinition( { id: 'style-2' } );
+
+		__dispatch(
+			slice.actions.setTemplates( [
+				createMockDocument( 200, [ createMockElementData( { styles: { 'style-1': style1 } } ) ] ),
+				createMockDocument( 300, [ createMockElementData( { styles: { 'style-2': style2 } } ) ] ),
+			] )
+		);
+
+		// Act.
+		renderWithStore( <RenderTemplateStyles />, store );
+
+		// Assert.
+		const styles = templatesStylesProvider.actions.all();
+		expect( styles ).toHaveLength( 2 );
+		expect( styles ).toContainEqual( style1 );
+		expect( styles ).toContainEqual( style2 );
+	} );
+
+	it( 'should extract styles from nested elements', () => {
+		// Arrange.
+		const parentStyle = createMockStyleDefinition( { id: 'parent-style' } );
+		const childStyle = createMockStyleDefinition( { id: 'child-style' } );
+
+		__dispatch(
+			slice.actions.setTemplates( [
+				createMockDocument( 200, [
+					createMockElementData( {
+						styles: { 'parent-style': parentStyle },
+						elements: [
+							createMockElementData( {
+								id: '2',
+								styles: { 'child-style': childStyle },
+							} ),
+						],
+					} ),
+				] ),
+			] )
+		);
+
+		// Act.
+		renderWithStore( <RenderTemplateStyles />, store );
+
+		// Assert.
+		const styles = templatesStylesProvider.actions.all();
+		expect( styles ).toHaveLength( 2 );
+		expect( styles ).toContainEqual( parentStyle );
+		expect( styles ).toContainEqual( childStyle );
+	} );
+
+	it( 'should handle templates with no elements', () => {
+		// Arrange.
+		__dispatch( slice.actions.setTemplates( [ createMockDocument( 200 ) ] ) );
+
+		// Act.
+		renderWithStore( <RenderTemplateStyles />, store );
+
+		// Assert.
+		expect( templatesStylesProvider.actions.all() ).toEqual( [] );
+	} );
+
+	it( 'should render nothing', () => {
+		// Act.
+		const { container } = renderWithStore( <RenderTemplateStyles />, store );
+
+		// Assert.
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/packages/packages/core/editor-templates/src/__tests__/templates-styles-provider.test.ts
+++ b/packages/packages/core/editor-templates/src/__tests__/templates-styles-provider.test.ts
@@ -1,0 +1,107 @@
+import { createMockStyleDefinition } from 'test-utils';
+
+import { addTemplateStyles, clearTemplatesStyles, templatesStylesProvider } from '../templates-styles-provider';
+
+describe( 'templatesStylesProvider', () => {
+	afterEach( () => {
+		clearTemplatesStyles();
+	} );
+
+	it( 'should expose the static key', () => {
+		// Act.
+		const key = templatesStylesProvider.getKey();
+
+		// Assert.
+		expect( key ).toBe( 'templates-styles' );
+	} );
+
+	it( 'should return empty array when no styles are set', () => {
+		// Act.
+		const styles = templatesStylesProvider.actions.all();
+
+		// Assert.
+		expect( styles ).toEqual( [] );
+	} );
+
+	it( 'should return all styles after addTemplateStyles', () => {
+		// Arrange.
+		const style1 = createMockStyleDefinition( { id: 's-1' } );
+		const style2 = createMockStyleDefinition( { id: 's-2' } );
+
+		// Act.
+		addTemplateStyles( [ style1, style2 ] );
+
+		// Assert.
+		expect( templatesStylesProvider.actions.all() ).toEqual( [ style1, style2 ] );
+	} );
+
+	it( 'should get a single style by id', () => {
+		// Arrange.
+		const style1 = createMockStyleDefinition( { id: 's-1' } );
+		const style2 = createMockStyleDefinition( { id: 's-2' } );
+		addTemplateStyles( [ style1, style2 ] );
+
+		// Act & Assert.
+		expect( templatesStylesProvider.actions.get( 's-1' ) ).toStrictEqual( style1 );
+		expect( templatesStylesProvider.actions.get( 's-2' ) ).toStrictEqual( style2 );
+	} );
+
+	it( 'should return null for unknown style id', () => {
+		// Arrange.
+		addTemplateStyles( [ createMockStyleDefinition( { id: 's-1' } ) ] );
+
+		// Act.
+		const result = templatesStylesProvider.actions.get( 'non-existent' );
+
+		// Assert.
+		expect( result ).toBeNull();
+	} );
+
+	it( 'should clear styles', () => {
+		// Arrange.
+		addTemplateStyles( [ createMockStyleDefinition( { id: 's-1' } ) ] );
+
+		// Act.
+		clearTemplatesStyles();
+
+		// Assert.
+		expect( templatesStylesProvider.actions.all() ).toEqual( [] );
+	} );
+
+	it( 'should notify subscribers when styles are set', () => {
+		// Arrange.
+		const callback = jest.fn();
+		templatesStylesProvider.subscribe( callback );
+
+		// Act.
+		addTemplateStyles( [ createMockStyleDefinition( { id: 's-1' } ) ] );
+
+		// Assert.
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should notify subscribers when styles are cleared', () => {
+		// Arrange.
+		const callback = jest.fn();
+		templatesStylesProvider.subscribe( callback );
+
+		// Act.
+		clearTemplatesStyles();
+
+		// Assert.
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should stop notifying after unsubscribe', () => {
+		// Arrange.
+		const callback = jest.fn();
+		const unsubscribe = templatesStylesProvider.subscribe( callback );
+
+		// Act.
+		unsubscribe();
+		addTemplateStyles( [ createMockStyleDefinition( { id: 's-1' } ) ] );
+
+		// Assert.
+		expect( callback ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/packages/core/editor-templates/src/__tests__/use-loaded-templates.test.ts
+++ b/packages/packages/core/editor-templates/src/__tests__/use-loaded-templates.test.ts
@@ -1,0 +1,53 @@
+import { createMockDocument, createMockElementData, renderHookWithStore } from 'test-utils';
+import { __createStore, __dispatch, __registerSlice, type SliceState, type Store } from '@elementor/store';
+
+import { slice } from '../store';
+import { useLoadedTemplates } from '../use-loaded-templates';
+
+describe( 'useLoadedTemplates', () => {
+	let store: Store< SliceState< typeof slice > >;
+
+	beforeEach( () => {
+		__registerSlice( slice );
+		store = __createStore();
+	} );
+
+	it( 'should call the callback when templates are loaded', () => {
+		// Arrange.
+		const doc = createMockDocument( { id: 1, elements: [ createMockElementData( { id: 'test-1' } ) ] } );
+
+		// Act.
+		const { result } = renderHookWithStore( () => useLoadedTemplates(), store );
+
+		// Assert.
+		expect( result.current ).toEqual( [] );
+
+		// Act.
+		__dispatch( slice.actions.setTemplates( [ doc ] ) );
+
+		const { result: result2 } = renderHookWithStore( () => useLoadedTemplates(), store );
+
+		// Assert.
+		expect( result2.current ).toEqual( [ doc.elements ] );
+	} );
+
+	it( 'should call the callback again when templates change', () => {
+		// Arrange.
+		const doc1 = createMockDocument( { id: 1, elements: [ createMockElementData( { id: 'test-1' } ) ] } );
+		const doc2 = createMockDocument( { id: 2, elements: [ createMockElementData( { id: 'test-2' } ) ] } );
+
+		const { result } = renderHookWithStore( () => useLoadedTemplates(), store );
+
+		// Assert.
+		expect( result.current ).toEqual( [] );
+
+		// Act.
+		__dispatch( slice.actions.setTemplates( [ doc1 ] ) );
+		__dispatch( slice.actions.setTemplates( [ doc2 ] ) );
+
+		const { result: result2 } = renderHookWithStore( () => useLoadedTemplates(), store );
+
+		// Assert.
+		expect( result2.current ).toEqual( [ doc1.elements, doc2.elements ] );
+	} );
+} );

--- a/packages/packages/core/editor-templates/src/index.ts
+++ b/packages/packages/core/editor-templates/src/index.ts
@@ -1,0 +1,2 @@
+export { init } from './init';
+export { useLoadedTemplates } from './use-loaded-templates';

--- a/packages/packages/core/editor-templates/src/init.ts
+++ b/packages/packages/core/editor-templates/src/init.ts
@@ -1,0 +1,26 @@
+import { injectIntoLogic } from '@elementor/editor';
+import { stylesRepository } from '@elementor/editor-styles-repository';
+import { registerDataHook } from '@elementor/editor-v1-adapters';
+import { __registerSlice as registerSlice } from '@elementor/store';
+
+import { loadTemplates, unloadTemplates } from './load-templates';
+import { RenderTemplateStyles } from './render-template-styles';
+import { slice } from './store';
+import { clearTemplatesStyles, templatesStylesProvider } from './templates-styles-provider';
+
+export function init() {
+	registerSlice( slice );
+	stylesRepository.register( templatesStylesProvider );
+
+	registerDataHook( 'after', 'editor/documents/attach-preview', async () => {
+		unloadTemplates();
+		clearTemplatesStyles();
+
+		await loadTemplates();
+	} );
+
+	injectIntoLogic( {
+		id: 'templates-styles',
+		component: RenderTemplateStyles,
+	} );
+}

--- a/packages/packages/core/editor-templates/src/load-templates.ts
+++ b/packages/packages/core/editor-templates/src/load-templates.ts
@@ -1,0 +1,60 @@
+import { type Document, getV1CurrentDocument } from '@elementor/editor-documents';
+import { ajax, getCanvasIframeDocument } from '@elementor/editor-v1-adapters';
+import { __dispatch as dispatch } from '@elementor/store';
+
+import { slice } from './store';
+
+const TEMPLATE_ATTRIBUTE = 'data-elementor-post-type="elementor_library"';
+const DOCUMENT_WRAPPER_ATTR = 'data-elementor-id';
+
+export async function loadTemplates() {
+	const iframeDocument = getCanvasIframeDocument();
+
+	if ( ! iframeDocument ) {
+		return;
+	}
+
+	const currentDocumentId = getV1CurrentDocument()?.id;
+	const templateIds = getTemplateIds( iframeDocument, currentDocumentId );
+
+	if ( ! templateIds.length ) {
+		return;
+	}
+
+	const documents = await fetchDocuments( templateIds );
+
+	dispatch( slice.actions.setTemplates( documents ) );
+}
+
+export function unloadTemplates() {
+	dispatch( slice.actions.clearTemplates() );
+}
+
+function getTemplateIds( iframeDocument: globalThis.Document, currentDocumentId?: number ): number[] {
+	const elements = [ ...iframeDocument.body.querySelectorAll< HTMLElement >( `[${ TEMPLATE_ATTRIBUTE }]` ) ];
+
+	const ids = elements
+		.map( ( el ) => Number( el.getAttribute( DOCUMENT_WRAPPER_ATTR ) ) )
+		.filter( ( id ) => ! isNaN( id ) && id !== currentDocumentId );
+
+	return [ ...new Set( ids ) ];
+}
+
+async function fetchDocuments( ids: number[] ): Promise< Document[] > {
+	const results = await Promise.all(
+		ids.map( async ( id ) => {
+			try {
+				// using ajax.load instead of the document-manager as the latter causes an issue when trying to edit a template
+				return await ajax.load< { id: number }, Document >( {
+					data: { id },
+					action: 'get_document_config',
+					unique_id: `template-${ id }`,
+				} );
+			} catch {
+				return null;
+			}
+		} )
+	);
+
+	return results.filter( ( doc ): doc is Document => doc !== null );
+}

--- a/packages/packages/core/editor-templates/src/render-template-styles.tsx
+++ b/packages/packages/core/editor-templates/src/render-template-styles.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { type V1ElementData } from '@elementor/editor-elements';
+import { type StyleDefinition } from '@elementor/editor-styles';
+
+import { addTemplateStyles } from './templates-styles-provider';
+import { useLoadedTemplates } from './use-loaded-templates';
+
+export const RenderTemplateStyles = () => {
+	const templates = useLoadedTemplates();
+
+	useEffect( () => {
+		const styles = templates.flatMap( extractStylesFromDocument );
+
+		addTemplateStyles( styles );
+	}, [ templates ] );
+
+	return null;
+};
+
+function extractStylesFromDocument( elements: V1ElementData[] ): StyleDefinition[] {
+	if ( ! elements.length ) {
+		return [];
+	}
+
+	return elements.flatMap( extractStylesFromElement );
+}
+
+function extractStylesFromElement( element: V1ElementData ): StyleDefinition[] {
+	return [
+		...Object.values( element.styles ?? {} ),
+		...( element.elements ?? [] ).flatMap( extractStylesFromElement ),
+	];
+}

--- a/packages/packages/core/editor-templates/src/store.ts
+++ b/packages/packages/core/editor-templates/src/store.ts
@@ -1,0 +1,35 @@
+import { type Document } from '@elementor/editor-documents';
+import { type V1ElementData } from '@elementor/editor-elements';
+import { __createSelector, __createSlice, type PayloadAction, type SliceState } from '@elementor/store';
+
+type State = {
+	entities: Record< Document[ 'id' ], V1ElementData[] >;
+};
+
+const initialState: State = {
+	entities: {},
+};
+
+export const slice = __createSlice( {
+	name: 'templates',
+	initialState,
+	reducers: {
+		setTemplates( state, action: PayloadAction< Document[] > ) {
+			action.payload.forEach( ( doc ) => {
+				state.entities[ doc.id ] = doc.elements ?? [];
+			} );
+		},
+
+		clearTemplates( state ) {
+			state.entities = {};
+		},
+	},
+} );
+
+export type Slice = SliceState< typeof slice >;
+
+const selectEntities = ( state: Slice ) => state.templates.entities;
+
+export const selectTemplates = __createSelector( [ selectEntities ], ( entities ): V1ElementData[][] =>
+	Object.values( entities )
+);

--- a/packages/packages/core/editor-templates/src/templates-styles-provider.ts
+++ b/packages/packages/core/editor-templates/src/templates-styles-provider.ts
@@ -1,0 +1,31 @@
+import { type StyleDefinition } from '@elementor/editor-styles';
+import { createStylesProvider } from '@elementor/editor-styles-repository';
+
+let styles: StyleDefinition[] = [];
+const listeners = new Set< () => void >();
+
+export function addTemplateStyles( newStyles: StyleDefinition[] ) {
+	styles = [ ...styles, ...newStyles ];
+	listeners.forEach( ( cb ) => cb() );
+}
+
+export function clearTemplatesStyles() {
+	styles = [];
+	listeners.forEach( ( cb ) => cb() );
+}
+
+export const templatesStylesProvider = createStylesProvider( {
+	key: 'templates-styles',
+	priority: 50,
+	subscribe: ( cb ) => {
+		listeners.add( cb );
+
+		return () => {
+			listeners.delete( cb );
+		};
+	},
+	actions: {
+		all: () => styles,
+		get: ( id ) => styles.find( ( style ) => style.id === id ) ?? null,
+	},
+} );

--- a/packages/packages/core/editor-templates/src/use-loaded-templates.ts
+++ b/packages/packages/core/editor-templates/src/use-loaded-templates.ts
@@ -1,0 +1,7 @@
+import { __useSelector as useSelector } from '@elementor/store';
+
+import { selectTemplates } from './store';
+
+export function useLoadedTemplates() {
+	return useSelector( selectTemplates );
+}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add editor-templates package to load and manage V4 styles from nested templates and components within the Elementor editor canvas.

Main changes:
- Created editor-templates package with store, styles provider, and template loading logic from iframe document
- Integrated template styles into editor-styles-repository using templatesStylesProvider with priority 50 for automatic style injection
- Added LoadTemplateComponents component to load component assets when templates change in editor

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
