### PR TITLE
Fix: Extra separator space in WP Admin Menu [ED-22959]

### DIFF
--- a/core/admin/editor-one-menu/elementor-one-menu-manager.php
+++ b/core/admin/editor-one-menu/elementor-one-menu-manager.php
@@ -188,7 +188,8 @@ class Elementor_One_Menu_Manager {
 	public function hide_legacy_templates_menu(): void {
 		?>
 		<style type="text/css">
-			#menu-posts-elementor_library {
+			#menu-posts-elementor_library,
+			#menu-posts-elementor_library + .wp-not-current-submenu.wp-menu-separator {
 				display: none !important;
 			}
 		</style>
@@ -200,6 +201,7 @@ class Elementor_One_Menu_Manager {
 		<style type="text/css">
 			#toplevel_page_elementor,
 			#toplevel_page_elementor + .wp-not-current-submenu.wp-menu-separator,
+			.wp-not-current-submenu.wp-menu-separator.elementor,
 			#toplevel_page_elementor-home + .wp-not-current-submenu.wp-menu-separator {
 				display: none !important;
 			}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix WordPress Admin menu separator visibility issues by hiding orphaned menu separators left after legacy Elementor menu items are removed.

Main changes:
- Added CSS selector to hide menu separator following elementor_library custom post type menu item
- Added selector for standalone elementor-classed separators to prevent extra spacing in admin menu
- Extended hide_old_elementor_menu to target additional orphaned separator elements in WordPress admin

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
