### PR TITLE
Internal: Migration html-v2 to html-v3 [ED-23002]

### DIFF
--- a/migrations/manifest.json
+++ b/migrations/manifest.json
@@ -15,6 +15,11 @@
       "fromType": "html",
       "toType": "html-v2",
       "path": "operations/html-to-html-v2.json"
+    },
+		"html-v2-to-html-v3": {
+      "fromType": "html-v2",
+      "toType": "html-v3",
+      "path": "operations/html-v2-to-html-v3.json"
     }
   }
 }

--- a/migrations/manifest.json
+++ b/migrations/manifest.json
@@ -16,7 +16,7 @@
       "toType": "html-v2",
       "path": "operations/html-to-html-v2.json"
     },
-		"html-v2-to-html-v3": {
+    "html-v2-to-html-v3": {
       "fromType": "html-v2",
       "toType": "html-v3",
       "path": "operations/html-v2-to-html-v3.json"

--- a/migrations/operations/html-v2-to-html-v3.json
+++ b/migrations/operations/html-v2-to-html-v3.json
@@ -1,0 +1,22 @@
+{
+  "up": [
+    {
+      "op": { "fn": "move", "src": "value.content", "dest": "value.content.value", "clean": false }
+    },
+    {
+      "op": { "fn": "set", "path": "value.content.$$type", "value": "string" },
+      "condition": { "fn": "exists", "path": "value.content.value" }
+    },
+    {
+      "op": { "fn": "set", "path": "$$type", "value": "html-v3" }
+    }
+  ],
+  "down": [
+    {
+      "op": { "fn": "move", "src": "value.content.value", "dest": "value.content", "clean": false }
+    },
+    {
+      "op": { "fn": "set", "path": "$$type", "value": "html-v2" }
+    }
+  ]
+}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add migration operations to transform html-v2 data structures to html-v3 format with bidirectional conversion support.

Main changes:
- Created html-v2-to-html-v3.json defining up/down migration operations with nested content structure transformation
- Added html-v2-to-html-v3 migration entry in manifest.json mapping fromType html-v2 to toType html-v3
- Implemented content field restructuring by moving value to nested value.content.value with type annotation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
