### PR TITLE
Internal: Make html-v3 children optional consistently [ED-23002]

### DIFF
--- a/modules/atomic-widgets/prop-types/html-v3-prop-type.php
+++ b/modules/atomic-widgets/prop-types/html-v3-prop-type.php
@@ -40,11 +40,7 @@ class Html_V3_Prop_Type extends Object_Prop_Type {
 			return false;
 		}
 
-		if ( ! array_key_exists( 'children', $value ) ) {
-			return false;
-		}
-
-		if ( ! is_array( $value['children'] ) ) {
+		if ( array_key_exists( 'children', $value ) && ! is_array( $value['children'] ) ) {
 			return false;
 		}
 
@@ -72,7 +68,9 @@ class Html_V3_Prop_Type extends Object_Prop_Type {
 			$value['content']['value'] = $this->sanitize_html_content( $value['content']['value'] );
 		}
 
-		$value['children'] = $this->sanitize_children( $value['children'] );
+		if ( isset( $value['children'] ) && is_array( $value['children'] ) ) {
+			$value['children'] = $this->sanitize_children( $value['children'] );
+		}
 
 		return $value;
 	}

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-html-v3-prop-type.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-html-v3-prop-type.php
@@ -309,4 +309,21 @@ class Test_Html_V3_Prop_Type extends TestCase {
 		// Assert.
 		$this->assertNull( $result['value']['content'] );
 	}
+
+	public function test_sanitize__handles_missing_children() {
+		// Arrange.
+		$prop_type = Html_V3_Prop_Type::make();
+
+		// Act.
+		$result = $prop_type->sanitize( [
+			'$$type' => 'html-v3',
+			'value' => [
+				'content' => String_Prop_Type::generate( 'Hello' ),
+			],
+		] );
+
+		// Assert.
+		$this->assertSame( 'Hello', $result['value']['content']['value'] );
+		$this->assertArrayNotHasKey( 'children', $result['value'] );
+	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-html-v3-prop-type.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-html-v3-prop-type.php
@@ -85,7 +85,7 @@ class Test_Html_V3_Prop_Type extends TestCase {
 		$this->assertFalse( $result );
 	}
 
-	public function test_validate__fails_when_children_missing() {
+	public function test_validate__passes_when_children_missing() {
 		// Arrange.
 		$prop_type = Html_V3_Prop_Type::make();
 
@@ -98,7 +98,7 @@ class Test_Html_V3_Prop_Type extends TestCase {
 		] );
 
 		// Assert.
-		$this->assertFalse( $result );
+		$this->assertTrue( $result );
 	}
 
 	public function test_validate__fails_when_content_is_plain_string() {


### PR DESCRIPTION
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Make children field optional in html-v3 prop type validation and sanitization to allow flexible component composition without requiring children elements.

Main changes:
- Modified validation logic to accept missing children field by checking existence before type validation instead of requiring it
- Updated sanitize_value method to conditionally process children only when present using isset check
- Added test cases verifying children field is optional and sanitization handles missing children correctly

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
