### PR TITLE
Fix: Core enqueue script warnings when V4 is disabled [ED-23052]

### DIFF
--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -28,35 +28,35 @@ class Module extends BaseModule {
 	public function get_name() {
 		return 'components';
 	}
-
-	public function is_experiment_active() {
-		return Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME )
-			&& Plugin::$instance->experiments->is_feature_active( AtomicWidgetsModule::EXPERIMENT_NAME );
-	}
-
+	
 	public function __construct() {
 		parent::__construct();
-
+		
 		if ( ! $this->is_experiment_active() ) {
 			return;
 		}
-
+		
 		$this->register_component_post_type();
-
+		
 		add_filter( 'elementor/editor/v2/packages', fn ( $packages ) => $this->add_packages( $packages ) );
 		add_filter( 'elementor/atomic-widgets/props-schema', fn ( $schema ) => $this->modify_props_schema( $schema ) );
 		add_action( 'elementor/documents/register', fn ( $documents_manager ) => $this->register_document_type( $documents_manager ) );
 		add_action( 'elementor/document/before_save', fn( Document $document, array $data ) => $this->validate_circular_dependencies( $document, $data ), 10, 2 );
 		add_action( 'elementor/document/after_save', fn( Document $document, array $data ) => $this->set_component_overridable_props( $document, $data ), 10, 2 );
 		add_filter( 'elementor/global_classes/additional_post_types', fn( $post_types ) => array_merge( $post_types, [ Component_Document::TYPE ] ) );
-
+		
 		add_action( 'elementor/atomic-widgets/settings/transformers/register', fn ( $transformers ) => $this->register_settings_transformers( $transformers ) );
-
+		
 		( Component_Lock_Manager::get_instance()->register_hooks() );
 		( new Component_Styles() )->register_hooks();
 		( new Components_REST_API() )->register_hooks();
 	}
-
+	
+	public function is_experiment_active() {
+		return Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME )
+			&& Plugin::$instance->experiments->is_feature_active( AtomicWidgetsModule::EXPERIMENT_NAME );
+	}
+	
 	public static function get_experimental_data() {
 		return [
 			'name'           => self::EXPERIMENT_NAME,

--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -3,6 +3,8 @@ namespace Elementor\Modules\Components;
 
 use Elementor\Core\Base\Module as BaseModule;
 use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
+use Elementor\Plugin;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers_Registry;
 use Elementor\Modules\Components\Styles\Component_Styles;
 use Elementor\Modules\Components\Documents\Component as Component_Document;
@@ -27,8 +29,17 @@ class Module extends BaseModule {
 		return 'components';
 	}
 
+	public function is_experiment_active() {
+		return Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME )
+			&& Plugin::$instance->experiments->is_feature_active( AtomicWidgetsModule::EXPERIMENT_NAME );
+	}
+
 	public function __construct() {
 		parent::__construct();
+
+		if ( ! $this->is_experiment_active() ) {
+			return;
+		}
 
 		$this->register_component_post_type();
 

--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -28,35 +28,35 @@ class Module extends BaseModule {
 	public function get_name() {
 		return 'components';
 	}
-	
+
 	public function __construct() {
 		parent::__construct();
-		
+
 		if ( ! $this->is_experiment_active() ) {
 			return;
 		}
-		
+
 		$this->register_component_post_type();
-		
+
 		add_filter( 'elementor/editor/v2/packages', fn ( $packages ) => $this->add_packages( $packages ) );
 		add_filter( 'elementor/atomic-widgets/props-schema', fn ( $schema ) => $this->modify_props_schema( $schema ) );
 		add_action( 'elementor/documents/register', fn ( $documents_manager ) => $this->register_document_type( $documents_manager ) );
 		add_action( 'elementor/document/before_save', fn( Document $document, array $data ) => $this->validate_circular_dependencies( $document, $data ), 10, 2 );
 		add_action( 'elementor/document/after_save', fn( Document $document, array $data ) => $this->set_component_overridable_props( $document, $data ), 10, 2 );
 		add_filter( 'elementor/global_classes/additional_post_types', fn( $post_types ) => array_merge( $post_types, [ Component_Document::TYPE ] ) );
-		
+
 		add_action( 'elementor/atomic-widgets/settings/transformers/register', fn ( $transformers ) => $this->register_settings_transformers( $transformers ) );
-		
+
 		( Component_Lock_Manager::get_instance()->register_hooks() );
 		( new Component_Styles() )->register_hooks();
 		( new Components_REST_API() )->register_hooks();
 	}
-	
+
 	public function is_experiment_active() {
 		return Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME )
 			&& Plugin::$instance->experiments->is_feature_active( AtomicWidgetsModule::EXPERIMENT_NAME );
 	}
-	
+
 	public static function get_experimental_data() {
 		return [
 			'name'           => self::EXPERIMENT_NAME,


### PR DESCRIPTION
## Description

Follow-up fix to [ED-22814](https://elementor.atlassian.net/browse/ED-22814), addressing the same issue but in Editor Core.

After WordPress 6.9.1, users with PHP DEBUG mode enabled and Editor V4 disabled see PHP warnings like:

```
Notice: Function WP_Scripts::add was called incorrectly.
The script with the handle "elementor-v2-editor-components" was enqueued with dependencies that are not registered:
elementor-v2-editor-canvas, elementor-v2-editor-controls, elementor-v2-editor-editing-panel, elementor-v2-editor-elements, elementor-v2-editor-props, elementor-v2-editor-styles-repository.
```

**Root Cause:** The `components` module always registered `editor-components` to the `elementor/editor/v2/packages` filter. However, `editor-components` depends on packages (`editor-canvas`, `editor-controls`, `editor-editing-panel`, `editor-elements`, `editor-props`, `editor-styles-repository`) that are only registered by the `atomic-widgets` module when it's active.

When `atomic-widgets` is inactive (V4 disabled), those dependency handles don't get registered, causing WP 6.9.1's new validation to emit warnings.

**Fix:** Guard the `elementor/editor/v2/packages` filter registration with an `AtomicWidgetsModule::is_active()` check, matching the pattern used in `interactions/module.php` and the Pro fix for ED-22814.

## Quality assurance

- [x] This code does not break any APIs
- [x] I have tested this code against all the relevant Core versions
- [x] I have tested this code against the relevant competitor plugins

Fixes https://elementor.atlassian.net/browse/ED-23052

References: https://github.com/elementor/elementor/issues/34617, https://github.com/elementor/elementor/issues/34831

[ED-22814]: https://elementor.atlassian.net/browse/ED-22814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix PHP warnings in core script enqueue by adding experiment activation check to prevent Components module initialization when V4 feature is disabled.

Main changes:
- Added is_experiment_active() guard in constructor to halt initialization if experiments are disabled
- Implemented is_experiment_active() method checking both Components and AtomicWidgets experiment flags
- Added AtomicWidgetsModule and Plugin namespace imports to support experiment validation logic

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
