### PR TITLE
Internal: Add basic interactions MCP [ED-23104]

### DIFF
--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -21220,11 +21220,13 @@
       "dependencies": {
         "@elementor/editor-controls": "4.0.0",
         "@elementor/editor-elements": "4.0.0",
+        "@elementor/editor-mcp": "4.0.0",
         "@elementor/editor-props": "^4.0.0",
-        "@elementor/editor-responsive": "4.0.0-524",
+        "@elementor/editor-responsive": "4.0.0",
         "@elementor/editor-ui": "4.0.0",
         "@elementor/editor-v1-adapters": "4.0.0",
         "@elementor/icons": "^1.68.0",
+        "@elementor/schema": "4.0.0",
         "@elementor/session": "4.0.0",
         "@elementor/ui": "1.36.17",
         "@elementor/utils": "4.0.0",
@@ -21236,19 +21238,6 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
-      }
-    },
-    "packages/core/editor-interactions/node_modules/@elementor/editor-responsive": {
-      "version": "4.0.0-524",
-      "resolved": "https://registry.npmjs.org/@elementor/editor-responsive/-/editor-responsive-4.0.0-524.tgz",
-      "integrity": "sha512-lI3954qkUS2o4Gj9LnYHurqPu0hlxhw0IfffgWYQyJ1fq/HNdFIQ1zA3m0AbADyreJh+gDTtfMHlE3i5x/fZEg==",
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "@elementor/editor-v1-adapters": "4.0.0-524",
-        "@wordpress/i18n": "^5.13.0"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
       }
     },
     "packages/core/editor-interactions/node_modules/@elementor/editor-responsive/node_modules/@elementor/editor-v1-adapters": {

--- a/packages/packages/core/editor-canvas/src/init.tsx
+++ b/packages/packages/core/editor-canvas/src/init.tsx
@@ -1,5 +1,4 @@
 import { injectIntoLogic, injectIntoTop } from '@elementor/editor';
-import { init as initInteractionsRepository } from '@elementor/editor-interactions';
 import { getMCPByDomain } from '@elementor/editor-mcp';
 
 import { ClassesRename } from './components/classes-rename';
@@ -31,8 +30,6 @@ export function init() {
 	initLegacyViews();
 
 	initSettingsTransformers();
-
-	initInteractionsRepository();
 
 	injectIntoTop( {
 		id: 'elements-overlays',

--- a/packages/packages/core/editor-interactions/package.json
+++ b/packages/packages/core/editor-interactions/package.json
@@ -41,11 +41,13 @@
   "dependencies": {
     "@elementor/editor-controls": "4.0.0",
     "@elementor/editor-elements": "4.0.0",
+    "@elementor/editor-mcp": "4.0.0",
     "@elementor/editor-props": "^4.0.0",
     "@elementor/editor-responsive": "4.0.0-524",
     "@elementor/editor-ui": "4.0.0",
     "@elementor/editor-v1-adapters": "4.0.0",
     "@elementor/icons": "^1.68.0",
+    "@elementor/schema": "4.0.0",
     "@elementor/session": "4.0.0",
     "@elementor/ui": "1.36.17",
     "@elementor/utils": "4.0.0",

--- a/packages/packages/core/editor-interactions/package.json
+++ b/packages/packages/core/editor-interactions/package.json
@@ -43,7 +43,7 @@
     "@elementor/editor-elements": "4.0.0",
     "@elementor/editor-mcp": "4.0.0",
     "@elementor/editor-props": "^4.0.0",
-    "@elementor/editor-responsive": "4.0.0-524",
+    "@elementor/editor-responsive": "4.0.0",
     "@elementor/editor-ui": "4.0.0",
     "@elementor/editor-v1-adapters": "4.0.0",
     "@elementor/icons": "^1.68.0",

--- a/packages/packages/core/editor-interactions/src/init.ts
+++ b/packages/packages/core/editor-interactions/src/init.ts
@@ -7,7 +7,7 @@ import { Trigger } from './components/controls/trigger';
 import { initCleanInteractionIdsOnDuplicate } from './hooks/on-duplicate';
 import { registerInteractionsControl } from './interactions-controls-registry';
 import { interactionsRepository } from './interactions-repository';
-import { initMcpIntegration } from './mcp';
+import { initMcpInteractions } from './mcp';
 import { documentElementsInteractionsProvider } from './providers/document-elements-interactions-provider';
 
 export function init() {
@@ -51,7 +51,8 @@ export function init() {
 			component: Effect,
 			options: [ 'fade', 'slide', 'scale' ],
 		} );
-		initMcpIntegration();
+
+		initMcpInteractions();
 	} catch ( error ) {
 		throw error;
 	}

--- a/packages/packages/core/editor-interactions/src/init.ts
+++ b/packages/packages/core/editor-interactions/src/init.ts
@@ -7,6 +7,7 @@ import { Trigger } from './components/controls/trigger';
 import { initCleanInteractionIdsOnDuplicate } from './hooks/on-duplicate';
 import { registerInteractionsControl } from './interactions-controls-registry';
 import { interactionsRepository } from './interactions-repository';
+import { initMcpIntegration } from './mcp';
 import { documentElementsInteractionsProvider } from './providers/document-elements-interactions-provider';
 
 export function init() {
@@ -50,6 +51,7 @@ export function init() {
 			component: Effect,
 			options: [ 'fade', 'slide', 'scale' ],
 		} );
+		initMcpIntegration();
 	} catch ( error ) {
 		throw error;
 	}

--- a/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
@@ -2,8 +2,8 @@ import { updateElementInteractions } from '@elementor/editor-elements';
 
 import { interactionsRepository } from '../../interactions-repository';
 import { createInteractionItem } from '../../utils/prop-value-utils';
-import { initManageElementInteractionTool } from '../tools/manage-element-interaction-tool';
 import { MAX_INTERACTIONS_PER_ELEMENT } from '../constants';
+import { initManageElementInteractionTool } from '../tools/manage-element-interaction-tool';
 
 jest.mock( '../../interactions-repository', () => ( {
 	interactionsRepository: {
@@ -226,7 +226,7 @@ describe( 'manage-element-interaction tool', () => {
 			expect( result.interactionCount ).toBe( 2 );
 		} );
 
-		it( `throws when element already has ${MAX_INTERACTIONS_PER_ELEMENT} interactions`, () => {
+		it( `throws when element already has ${ MAX_INTERACTIONS_PER_ELEMENT } interactions`, () => {
 			const items = Array.from( { length: MAX_INTERACTIONS_PER_ELEMENT }, ( _, i ) =>
 				createInteractionItem( {
 					interactionId: `id-${ i }`,
@@ -252,7 +252,7 @@ describe( 'manage-element-interaction tool', () => {
 					effect: 'fade',
 					effectType: 'in',
 				} )
-			).toThrow( new RegExp(`${MAX_INTERACTIONS_PER_ELEMENT}`, 'i') );
+			).toThrow( new RegExp( `${ MAX_INTERACTIONS_PER_ELEMENT }`, 'i' ) );
 		} );
 	} );
 

--- a/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
@@ -1,0 +1,502 @@
+import { updateElementInteractions } from '@elementor/editor-elements';
+
+import { interactionsRepository } from '../../interactions-repository';
+import { createInteractionItem, createInteractionBreakpoints } from '../../utils/prop-value-utils';
+import { initManageElementInteractionTool } from '../tools/manage-element-interaction-tool';
+
+jest.mock( '../../interactions-repository', () => ( {
+	interactionsRepository: {
+		all: jest.fn(),
+	},
+} ) );
+
+jest.mock( '@elementor/editor-elements', () => ( {
+	updateElementInteractions: jest.fn(),
+} ) );
+
+const mockAll = interactionsRepository.all as jest.Mock;
+const mockUpdateElementInteractions = updateElementInteractions as jest.Mock;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createRegistryAndGetHandler(): ( args: Record< string, unknown > ) => unknown {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let capturedHandler: ( ( args: any ) => unknown ) | null = null;
+
+	const reg = {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		addTool: jest.fn( ( opts: { handler: ( args: any ) => unknown } ) => {
+			capturedHandler = opts.handler;
+		} ),
+		resource: jest.fn(),
+		setMCPDescription: jest.fn(),
+		getActiveChatInfo: jest.fn(),
+		sendResourceUpdated: jest.fn(),
+		waitForReady: jest.fn(),
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		mcpServer: {} as any,
+	};
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	initManageElementInteractionTool( reg as any );
+
+	return ( args: Record< string, unknown > ) => {
+		if ( ! capturedHandler ) {
+			throw new Error( 'addTool was not called' );
+		}
+		return capturedHandler( args );
+	};
+}
+
+function makeElementData( elementId: string, items = [] as ReturnType< typeof createInteractionItem >[] ) {
+	return {
+		elementId,
+		dataId: elementId,
+		interactions: {
+			version: 1,
+			items,
+		},
+	};
+}
+
+describe( 'manage-element-interaction tool', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'get action', () => {
+		it( 'returns empty list when element has no interactions', () => {
+			mockAll.mockReturnValue( [] );
+
+			const callHandler = createRegistryAndGetHandler();
+			const result = JSON.parse( callHandler( { elementId: 'el-123', action: 'get' } ) as string );
+
+			expect( result.elementId ).toBe( 'el-123' );
+			expect( result.interactions ).toEqual( [] );
+			expect( result.count ).toBe( 0 );
+		} );
+
+		it( 'returns interaction summary for an element', () => {
+			const item = createInteractionItem( {
+				interactionId: 'temp-abc123',
+				trigger: 'load',
+				effect: 'fade',
+				type: 'in',
+				direction: '',
+				duration: 600,
+				delay: 0,
+				replay: false,
+				easing: 'easeIn',
+			} );
+
+			mockAll.mockReturnValue( [ makeElementData( 'el-456', [ item ] ) ] );
+
+			const callHandler = createRegistryAndGetHandler();
+			const result = JSON.parse( callHandler( { elementId: 'el-456', action: 'get' } ) as string );
+
+			expect( result.count ).toBe( 1 );
+			expect( result.interactions[ 0 ] ).toMatchObject( {
+				id: 'temp-abc123',
+				trigger: 'load',
+				effect: 'fade',
+				effectType: 'in',
+				direction: '',
+				easing: 'easeIn',
+				excludedBreakpoints: [],
+			} );
+		} );
+
+		it( 'includes excludedBreakpoints in the response', () => {
+			const item = createInteractionItem( {
+				interactionId: 'bp-id',
+				trigger: 'load',
+				effect: 'fade',
+				type: 'in',
+				duration: 300,
+				delay: 0,
+				replay: false,
+				easing: 'easeIn',
+				excludedBreakpoints: [ 'mobile', 'tablet' ],
+			} );
+
+			mockAll.mockReturnValue( [ makeElementData( 'el-bp', [ item ] ) ] );
+
+			const callHandler = createRegistryAndGetHandler();
+			const result = JSON.parse( callHandler( { elementId: 'el-bp', action: 'get' } ) as string );
+
+			expect( result.interactions[ 0 ].excludedBreakpoints ).toEqual( [ 'mobile', 'tablet' ] );
+		} );
+
+		it( 'does not call updateElementInteractions', () => {
+			mockAll.mockReturnValue( [] );
+			const callHandler = createRegistryAndGetHandler();
+			callHandler( { elementId: 'el-123', action: 'get' } );
+
+			expect( mockUpdateElementInteractions ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'add action', () => {
+		it( 'adds an interaction to an element with no existing interactions', () => {
+			mockAll.mockReturnValue( [] );
+
+			const callHandler = createRegistryAndGetHandler();
+			const result = JSON.parse(
+				callHandler( {
+					elementId: 'el-123',
+					action: 'add',
+					trigger: 'load',
+					effect: 'fade',
+					effectType: 'in',
+					direction: '',
+					duration: 600,
+					delay: 0,
+					easing: 'easeIn',
+				} ) as string
+			);
+
+			expect( result.success ).toBe( true );
+			expect( result.interactionCount ).toBe( 1 );
+			expect( mockUpdateElementInteractions ).toHaveBeenCalledWith(
+				expect.objectContaining( { elementId: 'el-123' } )
+			);
+		} );
+
+		it( 'does not set replay (PRO-only) on new interactions', () => {
+			mockAll.mockReturnValue( [] );
+
+			const callHandler = createRegistryAndGetHandler();
+			callHandler( {
+				elementId: 'el-noreplay',
+				action: 'add',
+				trigger: 'load',
+				effect: 'fade',
+				effectType: 'in',
+			} );
+
+			const interactions = mockUpdateElementInteractions.mock.calls[ 0 ][ 0 ].interactions;
+			const createdItem = interactions.items[ 0 ];
+			expect( createdItem.value.animation.value.config.value.replay.value ).toBe( false );
+		} );
+
+		it( 'sets excludedBreakpoints when provided', () => {
+			mockAll.mockReturnValue( [] );
+
+			const callHandler = createRegistryAndGetHandler();
+			callHandler( {
+				elementId: 'el-bp-add',
+				action: 'add',
+				trigger: 'load',
+				effect: 'fade',
+				effectType: 'in',
+				excludedBreakpoints: [ 'mobile' ],
+			} );
+
+			const interactions = mockUpdateElementInteractions.mock.calls[ 0 ][ 0 ].interactions;
+			const createdItem = interactions.items[ 0 ];
+			expect( createdItem.value.breakpoints ).toBeDefined();
+			expect( createdItem.value.breakpoints.value.excluded.value[ 0 ].value ).toBe( 'mobile' );
+		} );
+
+		it( 'appends to existing interactions', () => {
+			const existingItem = createInteractionItem( {
+				interactionId: 'existing-id',
+				trigger: 'load',
+				effect: 'fade',
+				type: 'in',
+				duration: 300,
+				delay: 0,
+				replay: false,
+				easing: 'easeIn',
+			} );
+
+			mockAll.mockReturnValue( [ makeElementData( 'el-456', [ existingItem ] ) ] );
+
+			const callHandler = createRegistryAndGetHandler();
+			const result = JSON.parse(
+				callHandler( {
+					elementId: 'el-456',
+					action: 'add',
+					trigger: 'scrollIn',
+					effect: 'slide',
+					effectType: 'out',
+					direction: 'top',
+				} ) as string
+			);
+
+			expect( result.interactionCount ).toBe( 2 );
+		} );
+
+		it( 'throws when element already has 5 interactions', () => {
+			const items = Array.from( { length: 5 }, ( _, i ) =>
+				createInteractionItem( {
+					interactionId: `id-${ i }`,
+					trigger: 'load',
+					effect: 'fade',
+					type: 'in',
+					duration: 300,
+					delay: 0,
+					replay: false,
+					easing: 'easeIn',
+				} )
+			);
+
+			mockAll.mockReturnValue( [ makeElementData( 'el-full', items ) ] );
+
+			const callHandler = createRegistryAndGetHandler();
+
+			expect( () =>
+				callHandler( { elementId: 'el-full', action: 'add', trigger: 'load', effect: 'fade', effectType: 'in' } )
+			).toThrow( /max/i );
+		} );
+	} );
+
+	describe( 'update action', () => {
+		it( 'updates trigger and duration of an existing interaction', () => {
+			const existingItem = createInteractionItem( {
+				interactionId: 'update-me',
+				trigger: 'load',
+				effect: 'fade',
+				type: 'in',
+				duration: 300,
+				delay: 0,
+				replay: false,
+				easing: 'easeIn',
+			} );
+
+			mockAll.mockReturnValue( [ makeElementData( 'el-789', [ existingItem ] ) ] );
+
+			const callHandler = createRegistryAndGetHandler();
+			const result = JSON.parse(
+				callHandler( {
+					elementId: 'el-789',
+					action: 'update',
+					interactionId: 'update-me',
+					trigger: 'scrollIn',
+					duration: 800,
+				} ) as string
+			);
+
+			expect( result.success ).toBe( true );
+
+			const updatedItem = mockUpdateElementInteractions.mock.calls[ 0 ][ 0 ].interactions.items[ 0 ];
+			expect( updatedItem.value.trigger.value ).toBe( 'scrollIn' );
+		} );
+
+		it( 'preserves replay=false from existing item (PRO-only)', () => {
+			const existingItem = createInteractionItem( {
+				interactionId: 'replay-test',
+				trigger: 'load',
+				effect: 'fade',
+				type: 'in',
+				duration: 300,
+				delay: 0,
+				replay: false,
+				easing: 'easeIn',
+			} );
+
+			mockAll.mockReturnValue( [ makeElementData( 'el-replay', [ existingItem ] ) ] );
+
+			const callHandler = createRegistryAndGetHandler();
+			callHandler( {
+				elementId: 'el-replay',
+				action: 'update',
+				interactionId: 'replay-test',
+				duration: 500,
+			} );
+
+			const updatedItem = mockUpdateElementInteractions.mock.calls[ 0 ][ 0 ].interactions.items[ 0 ];
+			expect( updatedItem.value.animation.value.config.value.replay.value ).toBe( false );
+		} );
+
+		it( 'updates excludedBreakpoints when provided', () => {
+			const existingItem = createInteractionItem( {
+				interactionId: 'bp-update',
+				trigger: 'load',
+				effect: 'fade',
+				type: 'in',
+				duration: 300,
+				delay: 0,
+				replay: false,
+				easing: 'easeIn',
+				excludedBreakpoints: [ 'mobile' ],
+			} );
+
+			mockAll.mockReturnValue( [ makeElementData( 'el-bp', [ existingItem ] ) ] );
+
+			const callHandler = createRegistryAndGetHandler();
+			callHandler( {
+				elementId: 'el-bp',
+				action: 'update',
+				interactionId: 'bp-update',
+				excludedBreakpoints: [ 'mobile', 'tablet' ],
+			} );
+
+			const updatedItem = mockUpdateElementInteractions.mock.calls[ 0 ][ 0 ].interactions.items[ 0 ];
+			expect( updatedItem.value.breakpoints.value.excluded.value ).toHaveLength( 2 );
+		} );
+
+		it( 'preserves existing excludedBreakpoints when not specified in update', () => {
+			const existingItem = createInteractionItem( {
+				interactionId: 'bp-preserve',
+				trigger: 'load',
+				effect: 'fade',
+				type: 'in',
+				duration: 300,
+				delay: 0,
+				replay: false,
+				easing: 'easeIn',
+				excludedBreakpoints: [ 'mobile' ],
+			} );
+
+			mockAll.mockReturnValue( [ makeElementData( 'el-preserve', [ existingItem ] ) ] );
+
+			const callHandler = createRegistryAndGetHandler();
+			callHandler( {
+				elementId: 'el-preserve',
+				action: 'update',
+				interactionId: 'bp-preserve',
+				duration: 500,
+			} );
+
+			const updatedItem = mockUpdateElementInteractions.mock.calls[ 0 ][ 0 ].interactions.items[ 0 ];
+			expect( updatedItem.value.breakpoints.value.excluded.value[ 0 ].value ).toBe( 'mobile' );
+		} );
+
+		it( 'throws when interactionId is missing', () => {
+			mockAll.mockReturnValue( [] );
+			const callHandler = createRegistryAndGetHandler();
+
+			expect( () =>
+				callHandler( { elementId: 'el-abc', action: 'update', trigger: 'load' } )
+			).toThrow( /interactionId is required/ );
+		} );
+
+		it( 'throws when interaction ID is not found', () => {
+			const existingItem = createInteractionItem( {
+				interactionId: 'real-id',
+				trigger: 'load',
+				effect: 'fade',
+				type: 'in',
+				duration: 300,
+				delay: 0,
+				replay: false,
+				easing: 'easeIn',
+			} );
+
+			mockAll.mockReturnValue( [ makeElementData( 'el-abc', [ existingItem ] ) ] );
+			const callHandler = createRegistryAndGetHandler();
+
+			expect( () =>
+				callHandler( { elementId: 'el-abc', action: 'update', interactionId: 'ghost-id', trigger: 'scrollIn' } )
+			).toThrow( /not found/ );
+		} );
+	} );
+
+	describe( 'delete action', () => {
+		it( 'removes the specified interaction and keeps the rest', () => {
+			const item1 = createInteractionItem( {
+				interactionId: 'keep-me',
+				trigger: 'load',
+				effect: 'fade',
+				type: 'in',
+				duration: 300,
+				delay: 0,
+				replay: false,
+				easing: 'easeIn',
+			} );
+
+			const item2 = createInteractionItem( {
+				interactionId: 'delete-me',
+				trigger: 'scrollIn',
+				effect: 'slide',
+				type: 'out',
+				duration: 500,
+				delay: 0,
+				replay: false,
+				easing: 'easeIn',
+			} );
+
+			mockAll.mockReturnValue( [ makeElementData( 'el-del', [ item1, item2 ] ) ] );
+
+			const callHandler = createRegistryAndGetHandler();
+			const result = JSON.parse(
+				callHandler( { elementId: 'el-del', action: 'delete', interactionId: 'delete-me' } ) as string
+			);
+
+			expect( result.success ).toBe( true );
+			expect( result.interactionCount ).toBe( 1 );
+
+			const remaining = mockUpdateElementInteractions.mock.calls[ 0 ][ 0 ].interactions.items;
+			expect( remaining[ 0 ].value.interaction_id.value ).toBe( 'keep-me' );
+		} );
+
+		it( 'throws when interactionId is missing', () => {
+			mockAll.mockReturnValue( [] );
+			const callHandler = createRegistryAndGetHandler();
+
+			expect( () =>
+				callHandler( { elementId: 'el-abc', action: 'delete' } )
+			).toThrow( /interactionId is required/ );
+		} );
+
+		it( 'throws when interaction ID is not found', () => {
+			const item = createInteractionItem( {
+				interactionId: 'real-id',
+				trigger: 'load',
+				effect: 'fade',
+				type: 'in',
+				duration: 300,
+				delay: 0,
+				replay: false,
+				easing: 'easeIn',
+			} );
+
+			mockAll.mockReturnValue( [ makeElementData( 'el-abc', [ item ] ) ] );
+			const callHandler = createRegistryAndGetHandler();
+
+			expect( () =>
+				callHandler( { elementId: 'el-abc', action: 'delete', interactionId: 'ghost-id' } )
+			).toThrow( /not found/ );
+		} );
+	} );
+
+	describe( 'clear action', () => {
+		it( 'removes all interactions from an element', () => {
+			const items = Array.from( { length: 3 }, ( _, i ) =>
+				createInteractionItem( {
+					interactionId: `id-${ i }`,
+					trigger: 'load',
+					effect: 'fade',
+					type: 'in',
+					duration: 300,
+					delay: 0,
+					replay: false,
+					easing: 'easeIn',
+				} )
+			);
+
+			mockAll.mockReturnValue( [ makeElementData( 'el-clear', items ) ] );
+
+			const callHandler = createRegistryAndGetHandler();
+			const result = JSON.parse(
+				callHandler( { elementId: 'el-clear', action: 'clear' } ) as string
+			);
+
+			expect( result.success ).toBe( true );
+			expect( result.interactionCount ).toBe( 0 );
+			expect( mockUpdateElementInteractions.mock.calls[ 0 ][ 0 ].interactions.items ).toHaveLength( 0 );
+		} );
+
+		it( 'succeeds for an element with no existing interactions', () => {
+			mockAll.mockReturnValue( [] );
+
+			const callHandler = createRegistryAndGetHandler();
+			const result = JSON.parse(
+				callHandler( { elementId: 'el-empty', action: 'clear' } ) as string
+			);
+
+			expect( result.success ).toBe( true );
+			expect( result.interactionCount ).toBe( 0 );
+		} );
+	} );
+} );

--- a/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
@@ -3,6 +3,7 @@ import { updateElementInteractions } from '@elementor/editor-elements';
 import { interactionsRepository } from '../../interactions-repository';
 import { createInteractionItem } from '../../utils/prop-value-utils';
 import { initManageElementInteractionTool } from '../tools/manage-element-interaction-tool';
+import { MAX_INTERACTIONS_PER_ELEMENT } from '../constants';
 
 jest.mock( '../../interactions-repository', () => ( {
 	interactionsRepository: {
@@ -17,7 +18,6 @@ jest.mock( '@elementor/editor-elements', () => ( {
 const mockAll = interactionsRepository.all as jest.Mock;
 const mockUpdateElementInteractions = updateElementInteractions as jest.Mock;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function createRegistryAndGetHandler(): ( args: Record< string, unknown > ) => unknown {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let capturedHandler: ( ( args: any ) => unknown ) | null = null;
@@ -226,8 +226,8 @@ describe( 'manage-element-interaction tool', () => {
 			expect( result.interactionCount ).toBe( 2 );
 		} );
 
-		it( 'throws when element already has 5 interactions', () => {
-			const items = Array.from( { length: 5 }, ( _, i ) =>
+		it( `throws when element already has ${MAX_INTERACTIONS_PER_ELEMENT} interactions`, () => {
+			const items = Array.from( { length: MAX_INTERACTIONS_PER_ELEMENT }, ( _, i ) =>
 				createInteractionItem( {
 					interactionId: `id-${ i }`,
 					trigger: 'load',
@@ -245,8 +245,14 @@ describe( 'manage-element-interaction tool', () => {
 			const callHandler = createRegistryAndGetHandler();
 
 			expect( () =>
-				callHandler( { elementId: 'el-full', action: 'add', trigger: 'load', effect: 'fade', effectType: 'in' } )
-			).toThrow( /max/i );
+				callHandler( {
+					elementId: 'el-full',
+					action: 'add',
+					trigger: 'load',
+					effect: 'fade',
+					effectType: 'in',
+				} )
+			).toThrow( new RegExp(`${MAX_INTERACTIONS_PER_ELEMENT}`, 'i') );
 		} );
 	} );
 
@@ -366,9 +372,9 @@ describe( 'manage-element-interaction tool', () => {
 			mockAll.mockReturnValue( [] );
 			const callHandler = createRegistryAndGetHandler();
 
-			expect( () =>
-				callHandler( { elementId: 'el-abc', action: 'update', trigger: 'load' } )
-			).toThrow( /interactionId is required/ );
+			expect( () => callHandler( { elementId: 'el-abc', action: 'update', trigger: 'load' } ) ).toThrow(
+				/interactionId is required/
+			);
 		} );
 
 		it( 'throws when interaction ID is not found', () => {
@@ -434,9 +440,9 @@ describe( 'manage-element-interaction tool', () => {
 			mockAll.mockReturnValue( [] );
 			const callHandler = createRegistryAndGetHandler();
 
-			expect( () =>
-				callHandler( { elementId: 'el-abc', action: 'delete' } )
-			).toThrow( /interactionId is required/ );
+			expect( () => callHandler( { elementId: 'el-abc', action: 'delete' } ) ).toThrow(
+				/interactionId is required/
+			);
 		} );
 
 		it( 'throws when interaction ID is not found', () => {
@@ -454,9 +460,9 @@ describe( 'manage-element-interaction tool', () => {
 			mockAll.mockReturnValue( [ makeElementData( 'el-abc', [ item ] ) ] );
 			const callHandler = createRegistryAndGetHandler();
 
-			expect( () =>
-				callHandler( { elementId: 'el-abc', action: 'delete', interactionId: 'ghost-id' } )
-			).toThrow( /not found/ );
+			expect( () => callHandler( { elementId: 'el-abc', action: 'delete', interactionId: 'ghost-id' } ) ).toThrow(
+				/not found/
+			);
 		} );
 	} );
 
@@ -478,9 +484,7 @@ describe( 'manage-element-interaction tool', () => {
 			mockAll.mockReturnValue( [ makeElementData( 'el-clear', items ) ] );
 
 			const callHandler = createRegistryAndGetHandler();
-			const result = JSON.parse(
-				callHandler( { elementId: 'el-clear', action: 'clear' } ) as string
-			);
+			const result = JSON.parse( callHandler( { elementId: 'el-clear', action: 'clear' } ) as string );
 
 			expect( result.success ).toBe( true );
 			expect( result.interactionCount ).toBe( 0 );
@@ -491,9 +495,7 @@ describe( 'manage-element-interaction tool', () => {
 			mockAll.mockReturnValue( [] );
 
 			const callHandler = createRegistryAndGetHandler();
-			const result = JSON.parse(
-				callHandler( { elementId: 'el-empty', action: 'clear' } ) as string
-			);
+			const result = JSON.parse( callHandler( { elementId: 'el-empty', action: 'clear' } ) as string );
 
 			expect( result.success ).toBe( true );
 			expect( result.interactionCount ).toBe( 0 );
@@ -510,7 +512,13 @@ describe( 'manage-element-interaction tool', () => {
 			const callHandler = createRegistryAndGetHandler();
 
 			expect( () =>
-				callHandler( { elementId: 'el-missing', action: 'add', trigger: 'load', effect: 'fade', effectType: 'in' } )
+				callHandler( {
+					elementId: 'el-missing',
+					action: 'add',
+					trigger: 'load',
+					effect: 'fade',
+					effectType: 'in',
+				} )
 			).toThrow( /Failed to update interactions for element "el-missing"/ );
 		} );
 
@@ -523,7 +531,13 @@ describe( 'manage-element-interaction tool', () => {
 			const callHandler = createRegistryAndGetHandler();
 
 			expect( () =>
-				callHandler( { elementId: 'el-missing', action: 'add', trigger: 'load', effect: 'fade', effectType: 'in' } )
+				callHandler( {
+					elementId: 'el-missing',
+					action: 'add',
+					trigger: 'load',
+					effect: 'fade',
+					effectType: 'in',
+				} )
 			).toThrow( /Element not found/ );
 		} );
 	} );

--- a/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
@@ -1,7 +1,7 @@
 import { updateElementInteractions } from '@elementor/editor-elements';
 
 import { interactionsRepository } from '../../interactions-repository';
-import { createInteractionItem, createInteractionBreakpoints } from '../../utils/prop-value-utils';
+import { createInteractionItem } from '../../utils/prop-value-utils';
 import { initManageElementInteractionTool } from '../tools/manage-element-interaction-tool';
 
 jest.mock( '../../interactions-repository', () => ( {
@@ -497,6 +497,34 @@ describe( 'manage-element-interaction tool', () => {
 
 			expect( result.success ).toBe( true );
 			expect( result.interactionCount ).toBe( 0 );
+		} );
+	} );
+
+	describe( 'error handling', () => {
+		it( 'wraps updateElementInteractions errors with element context', () => {
+			mockAll.mockReturnValue( [] );
+			mockUpdateElementInteractions.mockImplementationOnce( () => {
+				throw new Error( 'Element not found' );
+			} );
+
+			const callHandler = createRegistryAndGetHandler();
+
+			expect( () =>
+				callHandler( { elementId: 'el-missing', action: 'add', trigger: 'load', effect: 'fade', effectType: 'in' } )
+			).toThrow( /Failed to update interactions for element "el-missing"/ );
+		} );
+
+		it( 'includes the original error message in the thrown error', () => {
+			mockAll.mockReturnValue( [] );
+			mockUpdateElementInteractions.mockImplementationOnce( () => {
+				throw new Error( 'Element not found' );
+			} );
+
+			const callHandler = createRegistryAndGetHandler();
+
+			expect( () =>
+				callHandler( { elementId: 'el-missing', action: 'add', trigger: 'load', effect: 'fade', effectType: 'in' } )
+			).toThrow( /Element not found/ );
 		} );
 	} );
 } );

--- a/packages/packages/core/editor-interactions/src/mcp/constants.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_INTERACTIONS_PER_ELEMENT = 5;

--- a/packages/packages/core/editor-interactions/src/mcp/index.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/index.ts
@@ -3,7 +3,7 @@ import { getMCPByDomain } from '@elementor/editor-mcp';
 import { initInteractionsSchemaResource } from './resources/interactions-schema-resource';
 import { initManageElementInteractionTool } from './tools/manage-element-interaction-tool';
 
-export const initMcpIntegration = () => {
+export const initMcpInteractions = () => {
 	const reg = getMCPByDomain( 'interactions', {
 		instructions:
 			'MCP server for managing element interactions and animations. Use this to add, modify, or remove animations and motion effects triggered by user events such as page load or scroll-into-view.',

--- a/packages/packages/core/editor-interactions/src/mcp/index.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/index.ts
@@ -1,0 +1,13 @@
+import { getMCPByDomain } from '@elementor/editor-mcp';
+
+import { initInteractionsSchemaResource } from './resources/interactions-schema-resource';
+import { initManageElementInteractionTool } from './tools/manage-element-interaction-tool';
+
+export const initMcpIntegration = () => {
+	const reg = getMCPByDomain( 'interactions', {
+		instructions:
+			'MCP server for managing element interactions and animations. Use this to add, modify, or remove animations and motion effects triggered by user events such as page load or scroll-into-view.',
+	} );
+	initInteractionsSchemaResource( reg );
+	initManageElementInteractionTool( reg );
+};

--- a/packages/packages/core/editor-interactions/src/mcp/resources/interactions-schema-resource.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/resources/interactions-schema-resource.ts
@@ -22,11 +22,11 @@ const schema = {
 		{ value: 'out', label: 'Out' },
 	],
 	directions: [
-		{ value: 'top', label: 'Top', note: 'Only relevant for slide effect' },
-		{ value: 'bottom', label: 'Bottom', note: 'Only relevant for slide effect' },
-		{ value: 'left', label: 'Left', note: 'Only relevant for slide effect' },
-		{ value: 'right', label: 'Right', note: 'Only relevant for slide effect' },
-		{ value: '', label: 'None', note: 'Use empty string for effects without direction (e.g. fade, scale)' },
+		{ value: 'top', label: 'Top', note: '' },
+		{ value: 'bottom', label: 'Bottom', note: '' },
+		{ value: 'left', label: 'Left', note: '' },
+		{ value: 'right', label: 'Right', note: '' },
+		{ value: '', label: 'None', note: 'Slide animation must have a direction' },
 	],
 	easings: Object.entries( EASING_OPTIONS ).map( ( [ value, label ] ) => ( { value, label } ) ),
 	timing: {
@@ -36,7 +36,6 @@ const schema = {
 	excludedBreakpoints: {
 		type: 'string[]',
 		description: 'List of breakpoint IDs on which this interaction is disabled. Omit to enable on all breakpoints.',
-		note: 'Replay is a PRO-only feature and cannot be set via this tool.',
 	},
 	maxInteractionsPerElement: MAX_INTERACTIONS_PER_ELEMENT,
 };

--- a/packages/packages/core/editor-interactions/src/mcp/resources/interactions-schema-resource.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/resources/interactions-schema-resource.ts
@@ -1,7 +1,7 @@
 import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 
 import { EASING_OPTIONS } from '../../components/controls/easing';
-import { TRIGGER_OPTIONS, BASE_TRIGGERS } from '../../components/controls/trigger';
+import { BASE_TRIGGERS, TRIGGER_OPTIONS } from '../../components/controls/trigger';
 import { MAX_INTERACTIONS_PER_ELEMENT } from '../constants';
 
 export const INTERACTIONS_SCHEMA_URI = 'elementor://interactions/schema';
@@ -46,7 +46,8 @@ export const initInteractionsSchemaResource = ( reg: MCPRegistryEntry ) => {
 		'interactions-schema',
 		INTERACTIONS_SCHEMA_URI,
 		{
-			description: 'Schema describing all available options for element interactions (triggers, effects, easings, timing, breakpoints, etc.).',
+			description:
+				'Schema describing all available options for element interactions (triggers, effects, easings, timing, breakpoints, etc.).',
 		},
 		async () => {
 			return {

--- a/packages/packages/core/editor-interactions/src/mcp/resources/interactions-schema-resource.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/resources/interactions-schema-resource.ts
@@ -1,0 +1,64 @@
+import { type MCPRegistryEntry } from '@elementor/editor-mcp';
+
+import { EASING_OPTIONS } from '../../components/controls/easing';
+import { TRIGGER_OPTIONS, BASE_TRIGGERS } from '../../components/controls/trigger';
+
+export const INTERACTIONS_SCHEMA_URI = 'elementor://interactions/schema';
+
+const MAX_INTERACTIONS_PER_ELEMENT = 5;
+
+const schema = {
+	triggers: BASE_TRIGGERS.map( ( key ) => ( {
+		value: key,
+		label: TRIGGER_OPTIONS[ key as keyof typeof TRIGGER_OPTIONS ] ?? key,
+	} ) ),
+	effects: [
+		{ value: 'fade', label: 'Fade' },
+		{ value: 'slide', label: 'Slide' },
+		{ value: 'scale', label: 'Scale' },
+	],
+	effectTypes: [
+		{ value: 'in', label: 'In' },
+		{ value: 'out', label: 'Out' },
+	],
+	directions: [
+		{ value: 'top', label: 'Top', note: 'Only relevant for slide effect' },
+		{ value: 'bottom', label: 'Bottom', note: 'Only relevant for slide effect' },
+		{ value: 'left', label: 'Left', note: 'Only relevant for slide effect' },
+		{ value: 'right', label: 'Right', note: 'Only relevant for slide effect' },
+		{ value: '', label: 'None', note: 'Use empty string for effects without direction (e.g. fade, scale)' },
+	],
+	easings: Object.entries( EASING_OPTIONS ).map( ( [ value, label ] ) => ( { value, label } ) ),
+	timing: {
+		duration: { min: 0, max: 10000, unit: 'ms', description: 'Animation duration in milliseconds' },
+		delay: { min: 0, max: 10000, unit: 'ms', description: 'Animation delay in milliseconds' },
+	},
+	excludedBreakpoints: {
+		type: 'string[]',
+		description: 'List of breakpoint IDs on which this interaction is disabled. Omit to enable on all breakpoints.',
+		note: 'Replay is a PRO-only feature and cannot be set via this tool.',
+	},
+	maxInteractionsPerElement: MAX_INTERACTIONS_PER_ELEMENT,
+};
+
+export const initInteractionsSchemaResource = ( reg: MCPRegistryEntry ) => {
+	const { resource } = reg;
+
+	resource(
+		'interactions-schema',
+		INTERACTIONS_SCHEMA_URI,
+		{
+			description: 'Schema describing all available options for element interactions (triggers, effects, easings, timing, breakpoints, etc.).',
+		},
+		async () => {
+			return {
+				contents: [
+					{
+						uri: INTERACTIONS_SCHEMA_URI,
+						text: JSON.stringify( schema, null, 2 ),
+					},
+				],
+			};
+		}
+	);
+};

--- a/packages/packages/core/editor-interactions/src/mcp/resources/interactions-schema-resource.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/resources/interactions-schema-resource.ts
@@ -2,10 +2,9 @@ import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 
 import { EASING_OPTIONS } from '../../components/controls/easing';
 import { TRIGGER_OPTIONS, BASE_TRIGGERS } from '../../components/controls/trigger';
+import { MAX_INTERACTIONS_PER_ELEMENT } from '../constants';
 
 export const INTERACTIONS_SCHEMA_URI = 'elementor://interactions/schema';
-
-const MAX_INTERACTIONS_PER_ELEMENT = 5;
 
 const schema = {
 	triggers: BASE_TRIGGERS.map( ( key ) => ( {

--- a/packages/packages/core/editor-interactions/src/mcp/tools/manage-element-interaction-tool.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/tools/manage-element-interaction-tool.ts
@@ -59,8 +59,7 @@ Use excludedBreakpoints to disable the animation on specific responsive breakpoi
 				.describe( 'Whether the animation plays in or out' ),
 			direction: z
 				.enum( [ 'top', 'bottom', 'left', 'right', '' ] )
-				.optional()
-				.describe( 'Direction for slide effect. Use empty string for fade/scale.' ),
+				.optional(),
 			duration: z
 				.number()
 				.min( 0 )

--- a/packages/packages/core/editor-interactions/src/mcp/tools/manage-element-interaction-tool.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/tools/manage-element-interaction-tool.ts
@@ -1,15 +1,15 @@
-import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 import { updateElementInteractions } from '@elementor/editor-elements';
+import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 import { z } from '@elementor/schema';
 
 import { DEFAULT_VALUES } from '../../components/interaction-details';
-import { type ElementInteractions } from '../../types';
 import { interactionsRepository } from '../../interactions-repository';
+import { type ElementInteractions } from '../../types';
 import {
 	createInteractionItem,
 	extractExcludedBreakpoints,
-	extractString,
 	extractSize,
+	extractString,
 } from '../../utils/prop-value-utils';
 import { generateTempInteractionId } from '../../utils/temp-id-utils';
 import { MAX_INTERACTIONS_PER_ELEMENT } from '../constants';
@@ -45,38 +45,16 @@ Use excludedBreakpoints to disable the animation on specific responsive breakpoi
 				.string()
 				.optional()
 				.describe( 'Interaction ID — required for update and delete. Obtain from a prior "get" call.' ),
-			trigger: z
-				.enum( [ 'load', 'scrollIn' ] )
-				.optional()
-				.describe( 'Event that triggers the animation' ),
-			effect: z
-				.enum( [ 'fade', 'slide', 'scale' ] )
-				.optional()
-				.describe( 'Animation effect type' ),
-			effectType: z
-				.enum( [ 'in', 'out' ] )
-				.optional()
-				.describe( 'Whether the animation plays in or out' ),
+			trigger: z.enum( [ 'load', 'scrollIn' ] ).optional().describe( 'Event that triggers the animation' ),
+			effect: z.enum( [ 'fade', 'slide', 'scale' ] ).optional().describe( 'Animation effect type' ),
+			effectType: z.enum( [ 'in', 'out' ] ).optional().describe( 'Whether the animation plays in or out' ),
 			direction: z
 				.enum( [ 'top', 'bottom', 'left', 'right', '' ] )
 				.optional()
 				.describe( 'Direction for slide effect. Use empty string for fade/scale.' ),
-			duration: z
-				.number()
-				.min( 0 )
-				.max( 10000 )
-				.optional()
-				.describe( 'Animation duration in milliseconds' ),
-			delay: z
-				.number()
-				.min( 0 )
-				.max( 10000 )
-				.optional()
-				.describe( 'Animation delay in milliseconds' ),
-			easing: z
-				.string()
-				.optional()
-				.describe( 'Easing function. See interactions schema for options.' ),
+			duration: z.number().min( 0 ).max( 10000 ).optional().describe( 'Animation duration in milliseconds' ),
+			delay: z.number().min( 0 ).max( 10000 ).optional().describe( 'Animation delay in milliseconds' ),
+			easing: z.string().optional().describe( 'Easing function. See interactions schema for options.' ),
 			excludedBreakpoints: z
 				.array( z.string() )
 				.optional()
@@ -171,7 +149,9 @@ Use excludedBreakpoints to disable the animation on specific responsive breakpoi
 					);
 
 					if ( itemIndex === -1 ) {
-						throw new Error( `Interaction with ID "${ interactionId }" not found on element "${ elementId }".` );
+						throw new Error(
+							`Interaction with ID "${ interactionId }" not found on element "${ elementId }".`
+						);
 					}
 
 					const existingItem = updatedItems[ itemIndex ];
@@ -187,11 +167,13 @@ Use excludedBreakpoints to disable the animation on specific responsive breakpoi
 						effect: effect ?? extractString( existingAnimation.effect ),
 						type: effectType ?? extractString( existingAnimation.type ),
 						direction: direction !== undefined ? direction : extractString( existingAnimation.direction ),
-						duration: duration !== undefined ? duration : ( extractSize( existingTiming.duration ) as number ),
+						duration:
+							duration !== undefined ? duration : ( extractSize( existingTiming.duration ) as number ),
 						delay: delay !== undefined ? delay : ( extractSize( existingTiming.delay ) as number ),
 						replay: existingConfig.replay?.value ?? DEFAULT_VALUES.replay,
 						easing: easing ?? extractString( existingConfig.easing ),
-						excludedBreakpoints: excludedBreakpoints !== undefined ? excludedBreakpoints : existingExcludedBreakpoints,
+						excludedBreakpoints:
+							excludedBreakpoints !== undefined ? excludedBreakpoints : existingExcludedBreakpoints,
 					} );
 
 					updatedItems = [
@@ -213,7 +195,9 @@ Use excludedBreakpoints to disable the animation on specific responsive breakpoi
 					);
 
 					if ( updatedItems.length === beforeCount ) {
-						throw new Error( `Interaction with ID "${ interactionId }" not found on element "${ elementId }".` );
+						throw new Error(
+							`Interaction with ID "${ interactionId }" not found on element "${ elementId }".`
+						);
 					}
 					break;
 				}
@@ -233,7 +217,9 @@ Use excludedBreakpoints to disable the animation on specific responsive breakpoi
 				updateElementInteractions( { elementId, interactions: updatedInteractions } );
 			} catch ( error ) {
 				throw new Error(
-					`Failed to update interactions for element "${ elementId }": ${ error instanceof Error ? error.message : 'Unknown error' }`
+					`Failed to update interactions for element "${ elementId }": ${
+						error instanceof Error ? error.message : 'Unknown error'
+					}`
 				);
 			}
 

--- a/packages/packages/core/editor-interactions/src/mcp/tools/manage-element-interaction-tool.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/tools/manage-element-interaction-tool.ts
@@ -1,0 +1,242 @@
+import { type MCPRegistryEntry } from '@elementor/editor-mcp';
+import { updateElementInteractions } from '@elementor/editor-elements';
+import { z } from '@elementor/schema';
+
+import { type ElementInteractions } from '../../types';
+import { interactionsRepository } from '../../interactions-repository';
+import {
+	createInteractionItem,
+	extractExcludedBreakpoints,
+	extractString,
+	extractSize,
+} from '../../utils/prop-value-utils';
+import { generateTempInteractionId } from '../../utils/temp-id-utils';
+import { INTERACTIONS_SCHEMA_URI } from '../resources/interactions-schema-resource';
+
+const MAX_INTERACTIONS_PER_ELEMENT = 5;
+
+const EMPTY_INTERACTIONS: ElementInteractions = {
+	version: 1,
+	items: [],
+};
+
+export const initManageElementInteractionTool = ( reg: MCPRegistryEntry ) => {
+	const { addTool } = reg;
+
+	addTool( {
+		name: 'manage-element-interaction',
+		description: `Read or manage interactions (animations) on an element. Always call with action=get first to see existing interactions before making changes.
+
+Actions:
+- get: Read the current interactions on the element.
+- add: Add a new interaction (max ${ MAX_INTERACTIONS_PER_ELEMENT } per element).
+- update: Update an existing interaction by its interactionId.
+- delete: Remove a specific interaction by its interactionId.
+- clear: Remove all interactions from the element.
+
+For add/update, provide: trigger, effect, effectType, direction (empty string for non-slide effects), duration, delay, easing.
+Use excludedBreakpoints to disable the animation on specific responsive breakpoints (e.g. ["mobile", "tablet"]).`,
+		schema: {
+			elementId: z.string().describe( 'The ID of the element to read or modify interactions on' ),
+			action: z
+				.enum( [ 'get', 'add', 'update', 'delete', 'clear' ] )
+				.describe( 'Operation to perform. Use "get" first to inspect existing interactions.' ),
+			interactionId: z
+				.string()
+				.optional()
+				.describe( 'Interaction ID — required for update and delete. Obtain from a prior "get" call.' ),
+			trigger: z
+				.enum( [ 'load', 'scrollIn' ] )
+				.optional()
+				.describe( 'Event that triggers the animation' ),
+			effect: z
+				.enum( [ 'fade', 'slide', 'scale' ] )
+				.optional()
+				.describe( 'Animation effect type' ),
+			effectType: z
+				.enum( [ 'in', 'out' ] )
+				.optional()
+				.describe( 'Whether the animation plays in or out' ),
+			direction: z
+				.enum( [ 'top', 'bottom', 'left', 'right', '' ] )
+				.optional()
+				.describe( 'Direction for slide effect. Use empty string for fade/scale.' ),
+			duration: z
+				.number()
+				.min( 0 )
+				.max( 10000 )
+				.optional()
+				.describe( 'Animation duration in milliseconds' ),
+			delay: z
+				.number()
+				.min( 0 )
+				.max( 10000 )
+				.optional()
+				.describe( 'Animation delay in milliseconds' ),
+			easing: z
+				.string()
+				.optional()
+				.describe( 'Easing function. See interactions schema for options.' ),
+			excludedBreakpoints: z
+				.array( z.string() )
+				.optional()
+				.describe(
+					'Breakpoint IDs on which this interaction is disabled (e.g. ["mobile", "tablet"]). Omit to enable on all breakpoints.'
+				),
+		},
+		requiredResources: [
+			{ uri: INTERACTIONS_SCHEMA_URI, description: 'Interactions schema with all available options' },
+		],
+		isDestructive: true,
+		handler: ( input ) => {
+			const {
+				elementId,
+				action,
+				interactionId,
+				trigger,
+				effect,
+				effectType,
+				direction,
+				duration,
+				delay,
+				easing,
+				excludedBreakpoints,
+			} = input;
+
+			const allInteractions = interactionsRepository.all();
+			const elementData = allInteractions.find( ( data ) => data.elementId === elementId );
+			const currentInteractions: ElementInteractions = elementData?.interactions ?? EMPTY_INTERACTIONS;
+
+			if ( action === 'get' ) {
+				const summary = currentInteractions.items.map( ( item ) => {
+					const { value } = item;
+					const animValue = value.animation.value;
+					const timingValue = animValue.timing_config.value;
+					const configValue = animValue.config.value;
+
+					return {
+						id: extractString( value.interaction_id ),
+						trigger: extractString( value.trigger ),
+						effect: extractString( animValue.effect ),
+						effectType: extractString( animValue.type ),
+						direction: extractString( animValue.direction ),
+						duration: extractSize( timingValue.duration ),
+						delay: extractSize( timingValue.delay ),
+						easing: extractString( configValue.easing ),
+						excludedBreakpoints: extractExcludedBreakpoints( value.breakpoints ),
+					};
+				} );
+
+				return JSON.stringify( {
+					elementId,
+					interactions: summary,
+					count: summary.length,
+				} );
+			}
+
+			let updatedItems = [ ...currentInteractions.items ];
+
+			switch ( action ) {
+				case 'add': {
+					if ( updatedItems.length >= MAX_INTERACTIONS_PER_ELEMENT ) {
+						throw new Error(
+							`Cannot add more than ${ MAX_INTERACTIONS_PER_ELEMENT } interactions per element. Current count: ${ updatedItems.length }. Delete an existing interaction first.`
+						);
+					}
+
+					const newItem = createInteractionItem( {
+						interactionId: generateTempInteractionId(),
+						trigger: trigger ?? 'load',
+						effect: effect ?? 'fade',
+						type: effectType ?? 'in',
+						direction: direction ?? '',
+						duration: duration ?? 600,
+						delay: delay ?? 0,
+						replay: false,
+						easing: easing ?? 'easeIn',
+						excludedBreakpoints,
+					} );
+
+					updatedItems = [ ...updatedItems, newItem ];
+					break;
+				}
+
+				case 'update': {
+					if ( ! interactionId ) {
+						throw new Error( 'interactionId is required for the update action.' );
+					}
+
+					const itemIndex = updatedItems.findIndex(
+						( item ) => extractString( item.value.interaction_id ) === interactionId
+					);
+
+					if ( itemIndex === -1 ) {
+						throw new Error( `Interaction with ID "${ interactionId }" not found on element "${ elementId }".` );
+					}
+
+					const existingItem = updatedItems[ itemIndex ];
+					const existingValue = existingItem.value;
+					const existingAnimation = existingValue.animation.value;
+					const existingTiming = existingAnimation.timing_config.value;
+					const existingConfig = existingAnimation.config.value;
+					const existingExcludedBreakpoints = extractExcludedBreakpoints( existingValue.breakpoints );
+
+					const updatedItem = createInteractionItem( {
+						interactionId,
+						trigger: trigger ?? extractString( existingValue.trigger ),
+						effect: effect ?? extractString( existingAnimation.effect ),
+						type: effectType ?? extractString( existingAnimation.type ),
+						direction: direction !== undefined ? direction : extractString( existingAnimation.direction ),
+						duration: duration !== undefined ? duration : ( extractSize( existingTiming.duration ) as number ),
+						delay: delay !== undefined ? delay : ( extractSize( existingTiming.delay ) as number ),
+						replay: existingConfig.replay?.value ?? false,
+						easing: easing ?? extractString( existingConfig.easing ),
+						excludedBreakpoints: excludedBreakpoints !== undefined ? excludedBreakpoints : existingExcludedBreakpoints,
+					} );
+
+					updatedItems = [
+						...updatedItems.slice( 0, itemIndex ),
+						updatedItem,
+						...updatedItems.slice( itemIndex + 1 ),
+					];
+					break;
+				}
+
+				case 'delete': {
+					if ( ! interactionId ) {
+						throw new Error( 'interactionId is required for the delete action.' );
+					}
+
+					const beforeCount = updatedItems.length;
+					updatedItems = updatedItems.filter(
+						( item ) => extractString( item.value.interaction_id ) !== interactionId
+					);
+
+					if ( updatedItems.length === beforeCount ) {
+						throw new Error( `Interaction with ID "${ interactionId }" not found on element "${ elementId }".` );
+					}
+					break;
+				}
+
+				case 'clear': {
+					updatedItems = [];
+					break;
+				}
+			}
+
+			const updatedInteractions: ElementInteractions = {
+				...currentInteractions,
+				items: updatedItems,
+			};
+
+			updateElementInteractions( { elementId, interactions: updatedInteractions } );
+
+			return JSON.stringify( {
+				success: true,
+				action,
+				elementId,
+				interactionCount: updatedItems.length,
+			} );
+		},
+	} );
+};


### PR DESCRIPTION
Add the basic interactions MCP tool (using core features only)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add MCP (Model Context Protocol) server integration to enable AI-powered management of element interactions and animations through natural language commands.

Main changes:
- Implemented interactions MCP domain with schema resource exposing available triggers, effects, easings, and timing constraints
- Added manage-element-interaction tool supporting CRUD operations (get, add, update, delete, clear) on element animations via MCP
- Removed direct initInteractionsRepository call from editor-canvas init and added new dependencies (@elementor/editor-mcp, @elementor/schema)

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
