### PR TITLE
Internal: Refactor test to use navigation request instead of variable [ED-22746]

### DIFF
--- a/tests/playwright/sanity/core/app/modules/e-onboarding/e-onboarding.test.ts
+++ b/tests/playwright/sanity/core/app/modules/e-onboarding/e-onboarding.test.ts
@@ -9,7 +9,7 @@ import {
 	navigateToSiteFeaturesStep,
 } from './e-onboarding-utils';
 
-test.describe.skip( 'E-Onboarding @e-onboarding', () => {
+test.describe( 'E-Onboarding @e-onboarding', () => {
 	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
 		const context = await browser.newContext();
 		const page = await context.newPage();

--- a/tests/playwright/sanity/core/app/modules/e-onboarding/e-onboarding.test.ts
+++ b/tests/playwright/sanity/core/app/modules/e-onboarding/e-onboarding.test.ts
@@ -215,15 +215,14 @@ test.describe( 'E-Onboarding @e-onboarding', () => {
 				page.getByText( /Based on the features you chose, we recommend the/ ),
 			).toContainText( 'Pro' );
 
-			// Intercept the createNewPage navigation so the test environment doesn't
-			// actually create a post.
-			let redirectedUrl = '';
-			await page.route( '**/edit.php**', async ( route ) => {
-				redirectedUrl = route.request().url();
-				await route.fulfill( { status: 200, contentType: 'text/html', body: '<html></html>' } );
-			} );
+			await page.route( '**/edit.php**', ( route ) =>
+				route.fulfill( { status: 200, contentType: 'text/html', body: '<html></html>' } ),
+			);
 
-			await doAndWaitForProgress( page, () => continueWithFreeBtn.click() );
+			const [ navigationRequest ] = await Promise.all( [
+				page.waitForRequest( ( req ) => req.url().includes( 'edit.php' ) ),
+				doAndWaitForProgress( page, () => continueWithFreeBtn.click() ),
+			] );
 
 			expect( choicesRequests[ 4 ] ).toMatchObject( { site_features: [ 'theme_builder' ] } );
 			expect( progressRequests.at( -1 ) ).toMatchObject( {
@@ -231,7 +230,7 @@ test.describe( 'E-Onboarding @e-onboarding', () => {
 				complete: true,
 			} );
 
-			expect( redirectedUrl ).toContain( 'action=elementor_new_post' );
+			expect( navigationRequest.url() ).toContain( 'action=elementor_new_post' );
 		} );
 	} );
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor E-Onboarding test suite to use Playwright's native request interception pattern instead of mutable variables for URL validation.

Main changes:
- Replaced string variable `redirectedUrl` with `page.waitForRequest()` to capture navigation requests using Promise.all pattern
- Removed `.skip` modifier from test suite to re-enable E-Onboarding test execution
- Simplified route handler by removing async/await and direct URL extraction from intercepted routes

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
