### PR TITLE
CI: Remove not needed CPicked PR title [ED-23113]

### DIFF
--- a/.github/workflows/cherry-pick-pr.yml
+++ b/.github/workflows/cherry-pick-pr.yml
@@ -104,9 +104,6 @@ jobs:
                 TYPE="Internal:"
               fi
 
-              # Remove the type from PR_TITLE for the description part
-              DESCRIPTION=$(echo "$PR_TITLE" | sed 's/^[A-Za-z]*: *//')
-
               # Push the conflict branch
               if git push --force-with-lease origin "$BRANCH:$CONFLICT_BRANCH"; then
                 # Create draft PR with conflict information
@@ -120,7 +117,7 @@ jobs:
                   gh pr create \
                     --base "$TARGET" \
                     --head "$CONFLICT_BRANCH" \
-                    --title "${TYPE} Cherry-pick PR ${PR_NUMBER} to ${TARGET} with conflicts ${DESCRIPTION}" \
+                    --title "${TYPE} Cherry-pick PR ${PR_NUMBER} to ${TARGET} with conflicts" \
                     --body "⚠️ **Manual Resolution Required**
 
                   This cherry-pick of [#${PR_NUMBER}](${ORIG_URL}) to \`${TARGET}\` branch has conflicts that need manual resolution.
@@ -164,9 +161,6 @@ jobs:
               TYPE="Internal:"
             fi
 
-                        # Remove the type from PR_TITLE for the description part
-            DESCRIPTION=$(echo "$PR_TITLE" | sed 's/^[A-Za-z]*: *//')
-
             # Create PR via gh CLI (token already in env: GH_TOKEN)
             # Check if PR already exists
             if gh pr list --head "$BRANCH" --base "$TARGET" --state open | grep -q .; then
@@ -181,7 +175,7 @@ jobs:
               PR_URL=$(gh pr create \
                 --base "$TARGET" \
                 --head "$BRANCH" \
-                --title "${TYPE} Cherry-pick PR ${PR_NUMBER} to ${TARGET} ${DESCRIPTION}" \
+                --title "${TYPE} Cherry-pick PR ${PR_NUMBER} to ${TARGET}" \
                 --body "Automatic cherry-pick of [#${PR_NUMBER}](${ORIG_URL}) to \`${TARGET}\` branch.
 
                 **Source:** ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
Naming of the PR titles on CP caused long text and really not needed as the original PR already tagged and mentioned in the description.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove redundant DESCRIPTION variable from cherry-pick workflow PR title generation to simplify PR naming logic.

Main changes:
- Removed DESCRIPTION variable extraction and sed processing from both conflict and success PR creation paths
- Simplified cherry-pick PR titles to exclude original PR description suffix, keeping only standardized format
- Updated PR title templates to use consistent format: "${TYPE} Cherry-pick PR ${PR_NUMBER} to ${TARGET}"

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
