### PR TITLE
Internal: Align CI workflow PR trigger path filters to reduce unnecessary runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,10 @@ on:
       - '**.md'
       - '**.txt'
       - '.github/config.json'
+      - 'bin/**'
       - '.gitignore'
       - 'docs/**'
+      - '.vscode/**'
   workflow_dispatch:
   workflow_call:
     outputs:

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -2,13 +2,10 @@ name: Jest
 
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - '.github/config.json'
-      - 'bin/**'
-      - '.gitignore'
-      - 'docs/**'
+    paths:
+      - '**/*.+(js|ts|jsx|tsx)'
+      - 'package*.json'
+      - '.github/workflows/jest.yml'
   merge_group:
 
 # This allows a subsequently queued workflow run to interrupt previous runs

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,6 +2,14 @@ name: Lighthouse
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '.github/config.json'
+      - 'bin/**'
+      - '.gitignore'
+      - 'docs/**'
+      - '.vscode/**'
   push:
     branches:
       - 'main'

--- a/.github/workflows/lint-php-changes-only.yml
+++ b/.github/workflows/lint-php-changes-only.yml
@@ -2,6 +2,9 @@ name: Lint-PHP-Changes-Only
 
 on:
   pull_request:
+    paths:
+      - '**/*.php'
+      - '.github/workflows/lint-php-changes-only.yml'
   merge_group:
 
 # This allows a subsequently queued workflow run to interrupt previous runs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ on:
       - 'bin/**'
       - '.gitignore'
       - 'docs/**'
+      - '.vscode/**'
   merge_group:
 
 # This allows a subsequently queued workflow run to interrupt previous runs

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,6 +15,8 @@ on:
       - 'bin/**'
       - '.gitignore'
       - 'docs/**'
+      - '.vscode/**'
+      - 'tests/playwright/**'
   merge_group:
 
 # This allows a subsequently queued workflow run to interrupt previous runs

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,6 +15,7 @@ on:
       - 'docs/**'
       - '.vscode/**'
       - '**/package.json'
+      - 'tests/phpunit/**'
   schedule:
     - cron: '30 08 * * 0,1,2,3,4,5'
   workflow_dispatch:

--- a/.github/workflows/pr-checks-noop.yml
+++ b/.github/workflows/pr-checks-noop.yml
@@ -9,6 +9,9 @@ on:
       - 'bin/**'
       - '.gitignore'
       - 'docs/**'
+      - '.vscode/**'
+      - 'tests/playwright/**'
+      - 'tests/phpunit/**'
 jobs:
   build-plugin:
     name: Build plugin

--- a/.github/workflows/pr-enhance-review.yml
+++ b/.github/workflows/pr-enhance-review.yml
@@ -3,6 +3,14 @@ name: Enhanced PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '.github/config.json'
+      - 'bin/**'
+      - '.gitignore'
+      - 'docs/**'
+      - '.vscode/**'
 
 jobs:
   check-label:

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -9,6 +9,7 @@ on:
       - 'bin/**'
       - '.gitignore'
       - 'docs/**'
+      - '.vscode/**'
   merge_group:
 
 # This allows a subsequently queued workflow run to interrupt previous runs


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to `lighthouse.yml` PR trigger — was completely unfiltered, causing every PR to spin up a full plugin build + Lighthouse test setup
- Switch `lint-php-changes-only.yml` from bare trigger to `paths` allowlist (`**/*.php`) — was firing on all PRs despite the name
- Add missing `bin/**` and `.vscode/**` to `build.yml` PR `paths-ignore` — aligns it with the push trigger
- Switch `jest.yml` from broad `paths-ignore` to a `paths` allowlist for JS/TS files — prevents runners starting on PHP-only PRs
- Add `paths-ignore` to `pr-enhance-review.yml` — was running AI review on every PR including doc/changelog-only PRs
- Add `.vscode/**` and `tests/playwright/**` to `phpunit.yml` `paths-ignore` — PHP tests are irrelevant to Playwright TS file changes
- Add `tests/phpunit/**` to `playwright.yml` `paths-ignore` — E2E tests don't depend on PHPUnit source changes
- Add `.vscode/**` to `lint.yml` and `pr-linter.yml` `paths-ignore`
- Expand `pr-checks-noop.yml` `paths` to include `.vscode/**`, `tests/playwright/**`, `tests/phpunit/**` — keeps required branch-protection checks passing for PRs that only touch these newly-ignored paths

## Test plan
- [ ] Open a PR that only changes `.md` / `.txt` files → only `pr-checks-noop` fires, all required checks pass
- [ ] Open a PR that only changes `.vscode/**` → only `pr-checks-noop` fires, all required checks pass
- [ ] Open a PR that only changes `tests/playwright/**` → `pr-checks-noop` fires for PHPUnit check; `lint.yml` runs (TS → JS-Lint)
- [ ] Open a PR that only changes `tests/phpunit/**` → `pr-checks-noop` fires for Playwright check; `phpunit.yml` and `lint.yml` run
- [ ] Open a PR that only changes `bin/**` → only `pr-checks-noop` fires
- [ ] Open a PR with PHP source changes → `phpunit.yml`, `lint.yml` (PHP-Lint), `playwright.yml`, `build.yml` all trigger
- [ ] Open a PR with JS/TS source changes → `jest.yml`, `lint.yml` (JS-Lint), `playwright.yml`, `build.yml` all trigger

## Dependencies
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Optimize CI pipeline efficiency by refining GitHub Actions path filters to prevent unnecessary workflow executions on non-code changes.

Main changes:
- Added `.vscode/**` to paths-ignore across all workflows to skip IDE configuration changes
- Replaced paths-ignore with explicit paths whitelist in Jest and lint-php workflows for precise triggering
- Added mutual exclusion of test directories between PHPUnit and Playwright workflows to reduce redundant runs

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
