### PR TITLE
Internal: Redirect categories page to saved templates page [ED-22981]

### DIFF
--- a/includes/template-library/sources/local.php
+++ b/includes/template-library/sources/local.php
@@ -1081,9 +1081,9 @@ class Source_Local extends Source_Base {
 
 	public function redirect_categories_page_to_saved_templates_page() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$taxonomy = $_GET['taxonomy'] ?? '';
+		$taxonomy = sanitize_key( wp_unslash( $_GET['taxonomy'] ?? '' ) );
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$post_type = $_GET['post_type'] ?? '';
+		$post_type = sanitize_key( wp_unslash( $_GET['post_type'] ?? '' ) );
 		$is_categories_page = 'edit-tags.php' === $GLOBALS['pagenow']
 			&& self::TAXONOMY_CATEGORY_SLUG === $taxonomy
 			&& self::CPT === $post_type;

--- a/includes/template-library/sources/local.php
+++ b/includes/template-library/sources/local.php
@@ -1079,6 +1079,21 @@ class Source_Local extends Source_Base {
 		}
 	}
 
+	public function redirect_categories_page_to_saved_templates_page() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$taxonomy = $_GET['taxonomy'] ?? '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$post_type = $_GET['post_type'] ?? '';
+		$is_categories_page = 'edit-tags.php' === $GLOBALS['pagenow']
+			&& self::TAXONOMY_CATEGORY_SLUG === $taxonomy
+			&& self::CPT === $post_type;
+
+		if ( $is_categories_page ) {
+			wp_safe_redirect( admin_url( 'edit.php?post_type=' . self::CPT . '&tabs_group=library' ) );
+			die;
+		}
+	}
+
 	/**
 	 * Is template library supports export.
 	 *
@@ -1717,6 +1732,8 @@ class Source_Local extends Source_Base {
 	 */
 	private function add_actions() {
 		if ( is_admin() ) {
+			add_action( 'admin_init', [ $this, 'redirect_categories_page_to_saved_templates_page' ] );
+
 			add_action( 'elementor/editor-one/menu/register', function ( Menu_Data_Provider $menu_data_provider ) {
 				$this->register_editor_one_menu( $menu_data_provider );
 			} );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Redirect users from the template library categories page to the saved templates page to consolidate template management navigation.

Main changes:
- Added redirect_categories_page_to_saved_templates_page() method detecting categories page access via taxonomy and post_type query parameters
- Hooked new method to admin_init action to execute redirect logic during admin initialization

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
