### PR TITLE
Fix: Elementor Editor Broken on WordPress 7.0 beta [ED-23138]

### DIFF
--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -538,6 +538,26 @@ class Editor {
 		// Handle autocomplete feature for URL control.
 		add_filter( 'wp_link_query_args', [ $this, 'filter_wp_link_query_args' ] );
 		add_filter( 'wp_link_query', [ $this, 'filter_wp_link_query' ] );
+
+		add_filter( 'replace_editor', [ $this, 'filter_replace_editor' ], 10, 2 );
+	}
+
+	/**
+	 * Signals to WordPress that Elementor is replacing the block editor on its own editor page,
+	 * so that block-editor-specific behaviour (e.g. WP 7.0 COOP/COEP isolation headers) is not
+	 * applied when the Elementor editor is active.
+	 *
+	 * @param bool     $replace Whether the editor is being replaced.
+	 * @param \WP_Post $post    The post being edited.
+	 *
+	 * @return bool
+	 */
+	public function filter_replace_editor( $replace, $post ) {
+		if ( isset( $_REQUEST['action'] ) && 'elementor' === $_REQUEST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return true;
+		}
+
+		return $replace;
 	}
 
 	/**


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Elementor editor compatibility with WordPress 7.0 beta by preventing block editor isolation headers from breaking the Elementor editing interface.

Main changes:
- Added filter_replace_editor() hook to signal WordPress that Elementor replaces the block editor on editor pages
- Implemented action detection logic to conditionally return true when Elementor editor is active via 'elementor' action parameter
- Registered replace_editor filter callback in register_actions() to prevent WP 7.0 COOP/COEP isolation headers from interfering

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
