### PR TITLE
Fix: Avoid creating empty containers for ancestor blocked form widgets. [ED-22991]

### DIFF
--- a/assets/dev/js/editor/views/base-container.js
+++ b/assets/dev/js/editor/views/base-container.js
@@ -160,7 +160,7 @@ module.exports = Marionette.CompositeView.extend( {
 
 	getWrappingContainer( container, model, settings ) {
 		const isAtomic = elementor.helpers.isAtomicWidget( model );
-		const options = { at: settings.at, scrollIntoView: settings.scrollIntoView, useHistory: settings?.useHistory ?? true };
+		const options = { at: settings.at, scrollIntoView: settings.scrollIntoView, useHistory: settings?.useHistory ?? true, wrapperForModel: model };
 
 		if ( isAtomic ) {
 			return ContainerHelper.createContainerFromModel(

--- a/assets/dev/js/editor/views/base-container.js
+++ b/assets/dev/js/editor/views/base-container.js
@@ -160,7 +160,7 @@ module.exports = Marionette.CompositeView.extend( {
 
 	getWrappingContainer( container, model, settings ) {
 		const isAtomic = elementor.helpers.isAtomicWidget( model );
-		const options = { at: settings.at, scrollIntoView: settings.scrollIntoView, useHistory: settings?.useHistory ?? true, wrapperForModel: model };
+		const options = { at: settings.at, scrollIntoView: settings.scrollIntoView, useHistory: settings?.useHistory ?? true };
 
 		if ( isAtomic ) {
 			return ContainerHelper.createContainerFromModel(

--- a/assets/dev/js/editor/views/preview.js
+++ b/assets/dev/js/editor/views/preview.js
@@ -84,7 +84,7 @@ const Preview = BaseSectionsContainerView.extend( {
 		return BaseSectionsContainerView.prototype.createElementFromModel.call(
 			this,
 			model,
-			{ ...options, shouldWrap: wrappedElementTypes.includes( model.elType ) && ! model.widgetType?.startsWith( 'e-form-' ) },
+			{ ...options, shouldWrap: wrappedElementTypes.includes( model.elType ) },
 		);
 	},
 

--- a/assets/dev/js/editor/views/preview.js
+++ b/assets/dev/js/editor/views/preview.js
@@ -84,7 +84,7 @@ const Preview = BaseSectionsContainerView.extend( {
 		return BaseSectionsContainerView.prototype.createElementFromModel.call(
 			this,
 			model,
-			{ ...options, shouldWrap: wrappedElementTypes.includes( model.elType ) },
+			{ ...options, shouldWrap: wrappedElementTypes.includes( model.elType ) && ! model.widgetType?.startsWith( 'e-form-' ) },
 		);
 	},
 

--- a/packages/packages/core/editor-canvas/src/form-structure/enforce-form-ancestor-commands.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/enforce-form-ancestor-commands.ts
@@ -52,8 +52,7 @@ function isContainerForFormField( args: CreateArgs ): boolean {
 	return false;
 }
 
-function blockFormFieldCreate( args: CreateArgs ): boolean {	
-
+function blockFormFieldCreate( args: CreateArgs ): boolean {
 	if ( isContainerForFormField( args ) ) {
 		handleBlockedFormField();
 
@@ -66,7 +65,7 @@ function blockFormFieldCreate( args: CreateArgs ): boolean {
 		return false;
 	}
 
-	if ( ! isWithinForm( args.container )  || isContainerForFormField( args ) ) {
+	if ( ! isWithinForm( args.container ) || isContainerForFormField( args ) ) {
 		handleBlockedFormField();
 
 		return true;

--- a/packages/packages/core/editor-canvas/src/form-structure/enforce-form-ancestor-commands.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/enforce-form-ancestor-commands.ts
@@ -6,7 +6,6 @@ import {
 	type CreateArgs,
 	FORM_FIELD_ELEMENT_TYPES,
 	getArgsElementType,
-	getElementTypeFromModel,
 	hasClipboardElementTypes,
 	hasElementTypes,
 	isWithinForm,
@@ -38,27 +37,7 @@ export function initFormAncestorEnforcement() {
 	} );
 }
 
-function isContainerForFormField( args: CreateArgs ): boolean {
-	const wrapperForModel = args?.options?.wrapperForModel;
-
-	if ( wrapperForModel ) {
-		const elementType = getElementTypeFromModel( wrapperForModel );
-
-		if ( ! elementType || FORM_FIELD_ELEMENT_TYPES.has( elementType ) ) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 function blockFormFieldCreate( args: CreateArgs ): boolean {
-	if ( isContainerForFormField( args ) ) {
-		handleBlockedFormField();
-
-		return true;
-	}
-
 	const elementType = getArgsElementType( args );
 
 	if ( ! elementType || ! FORM_FIELD_ELEMENT_TYPES.has( elementType ) ) {

--- a/packages/packages/core/editor-canvas/src/form-structure/enforce-form-ancestor-commands.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/enforce-form-ancestor-commands.ts
@@ -6,6 +6,7 @@ import {
 	type CreateArgs,
 	FORM_FIELD_ELEMENT_TYPES,
 	getArgsElementType,
+	getElementTypeFromModel,
 	hasClipboardElementTypes,
 	hasElementTypes,
 	isWithinForm,
@@ -37,14 +38,35 @@ export function initFormAncestorEnforcement() {
 	} );
 }
 
-function blockFormFieldCreate( args: CreateArgs ): boolean {
+function isContainerForFormField( args: CreateArgs ): boolean {
+	const wrapperForModel = args?.options?.wrapperForModel;
+
+	if ( wrapperForModel ) {
+		const elementType = getElementTypeFromModel( wrapperForModel );
+
+		if ( ! elementType || ( elementType && FORM_FIELD_ELEMENT_TYPES.has( elementType ) ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function blockFormFieldCreate( args: CreateArgs ): boolean {	
+
+	if ( isContainerForFormField( args ) ) {
+		handleBlockedFormField();
+
+		return true;
+	}
+
 	const elementType = getArgsElementType( args );
 
 	if ( ! elementType || ! FORM_FIELD_ELEMENT_TYPES.has( elementType ) ) {
 		return false;
 	}
 
-	if ( ! isWithinForm( args.container ) ) {
+	if ( ! isWithinForm( args.container )  || isContainerForFormField( args ) ) {
 		handleBlockedFormField();
 
 		return true;

--- a/packages/packages/core/editor-canvas/src/form-structure/enforce-form-ancestor-commands.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/enforce-form-ancestor-commands.ts
@@ -44,7 +44,7 @@ function isContainerForFormField( args: CreateArgs ): boolean {
 	if ( wrapperForModel ) {
 		const elementType = getElementTypeFromModel( wrapperForModel );
 
-		if ( ! elementType || ( elementType && FORM_FIELD_ELEMENT_TYPES.has( elementType ) ) ) {
+		if ( ! elementType || FORM_FIELD_ELEMENT_TYPES.has( elementType ) ) {
 			return true;
 		}
 	}
@@ -65,7 +65,7 @@ function blockFormFieldCreate( args: CreateArgs ): boolean {
 		return false;
 	}
 
-	if ( ! isWithinForm( args.container ) || isContainerForFormField( args ) ) {
+	if ( ! isWithinForm( args.container ) ) {
 		handleBlockedFormField();
 
 		return true;

--- a/packages/packages/core/editor-canvas/src/form-structure/enforce-form-ancestor-commands.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/enforce-form-ancestor-commands.ts
@@ -16,7 +16,7 @@ import {
 
 const FORM_FIELDS_OUTSIDE_ALERT: NotificationData = {
 	type: 'default',
-	message: __( 'Form fields must be placed inside a form.', 'elementor' ),
+	message: __( 'Form elements must be placed inside a form.', 'elementor' ),
 	id: 'form-fields-outside-form-blocked',
 };
 

--- a/packages/packages/core/editor-canvas/src/form-structure/utils.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/utils.ts
@@ -1,16 +1,15 @@
 import { getAllDescendants, type V1Element } from '@elementor/editor-elements';
 
+type Model = {
+	elType?: string;
+	widgetType?: string;
+};
+
 export type CreateArgs = {
 	container?: V1Element;
-	model?: {
-		elType?: string;
-		widgetType?: string;
-	};
+	model?: Model;
 	options?: {
-		wrapperForModel?: {
-			elType?: string;
-			widgetType?: string;
-		};
+		wrapperForModel?: Model;
 	};
 };
 
@@ -50,7 +49,7 @@ export function getArgsElementType( args: CreateArgs ): string | undefined {
 	return args.model?.widgetType || args.model?.elType;
 }
 
-export function getElementTypeFromModel( { elType, widgetType }: { elType?: string, widgetType?: string } ): string | undefined {
+export function getElementTypeFromModel( { elType, widgetType }: Model ): string | undefined {
 	return widgetType || elType;
 }
 

--- a/packages/packages/core/editor-canvas/src/form-structure/utils.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/utils.ts
@@ -8,9 +8,6 @@ type Model = {
 export type CreateArgs = {
 	container?: V1Element;
 	model?: Model;
-	options?: {
-		wrapperForModel?: Model;
-	};
 };
 
 export type MoveArgs = {
@@ -47,10 +44,6 @@ export const FORM_FIELD_ELEMENT_TYPES = new Set( [
 
 export function getArgsElementType( args: CreateArgs ): string | undefined {
 	return args.model?.widgetType || args.model?.elType;
-}
-
-export function getElementTypeFromModel( { elType, widgetType }: Model ): string | undefined {
-	return widgetType || elType;
 }
 
 export function getElementType( element?: V1Element ): string | undefined {

--- a/packages/packages/core/editor-canvas/src/form-structure/utils.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/utils.ts
@@ -6,6 +6,12 @@ export type CreateArgs = {
 		elType?: string;
 		widgetType?: string;
 	};
+	options?: {
+		wrapperForModel?: {
+			elType?: string;
+			widgetType?: string;
+		};
+	};
 };
 
 export type MoveArgs = {
@@ -42,6 +48,10 @@ export const FORM_FIELD_ELEMENT_TYPES = new Set( [
 
 export function getArgsElementType( args: CreateArgs ): string | undefined {
 	return args.model?.widgetType || args.model?.elType;
+}
+
+export function getElementTypeFromModel( { elType, widgetType }: { elType?: string, widgetType?: string } ): string | undefined {
+	return widgetType || elType;
 }
 
 export function getElementType( element?: V1Element ): string | undefined {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix ancestor validation to prevent creating empty containers when form widgets are blocked from placement outside form elements.

Main changes:
- Modified shouldWrap logic in Preview.createElementFromModel to exclude form widgets (e-form-*) from container wrapping
- Updated notification message from "Form fields" to "Form elements" for broader widget type coverage
- Extracted Model type definition to separate interface for improved type reusability

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
