### PR TITLE
Fix: Update package-lock.json after replacing in onboarding [ED-22737]

### DIFF
--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -20962,7 +20962,7 @@
         "@elementor/query": "4.0.0",
         "@elementor/store": "4.0.0",
         "@elementor/ui": "1.36.17",
-        "@wordpress/i18n": "^5.13.0"
+        "@elementor/utils": "4.0.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -21244,6 +21244,7 @@
       "version": "4.0.0-524",
       "resolved": "https://registry.npmjs.org/@elementor/editor-v1-adapters/-/editor-v1-adapters-4.0.0-524.tgz",
       "integrity": "sha512-Uqe/W8nOBYqckWrCd8TypHuVqlxOeD+O8eJye6XTzQB+I7le5J5RFBUGcvFT3+2O9nLgVpDtKwiu9gWKTifNBw==",
+      "extraneous": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/utils": "4.0.0-524"
@@ -21256,6 +21257,7 @@
       "version": "4.0.0-524",
       "resolved": "https://registry.npmjs.org/@elementor/utils/-/utils-4.0.0-524.tgz",
       "integrity": "sha512-YPexHyxS1wsIz5LaNOB9HEqygBGUNLwIYU8oubj7DwW/8vtp3PvQPtPtom2hhpR36VcWMzRg+NxVNDLGikuRfg==",
+      "extraneous": true,
       "license": "GPL-3.0-or-later",
       "peerDependencies": {
         "react": "^18.3.1"


### PR DESCRIPTION
## Summary
- The commit for ED-22737 replaced `@wordpress/i18n` with `@elementor/utils` in `packages/apps/onboarding/package.json`, but `npm install` was never run afterward
- This left `package-lock.json` out of sync — it still listed `@wordpress/i18n` instead of `@elementor/utils` for the onboarding package
- Running `npm install` in the `packages/` directory regenerates the lock file with the correct dependency

## Test plan
- [ ] Verify `packages/apps/onboarding` entry in `package-lock.json` now lists `@elementor/utils: 4.0.0` instead of `@wordpress/i18n`
- [ ] Run `npm ci` in the `packages/` directory and confirm it completes without errors

## Jira
[ED-22737](https://elementor.atlassian.net/browse/ED-22737)

[ED-22737]: https://elementor.atlassian.net/browse/ED-22737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ