### PR TITLE
Internal: Fix failing onboarding test [ED-23159]

### DIFF
--- a/tests/playwright/sanity/core/app/modules/onboarding/onboarding.test.ts
+++ b/tests/playwright/sanity/core/app/modules/onboarding/onboarding.test.ts
@@ -29,7 +29,7 @@ test.describe( 'On boarding @onBoarding', async () => {
 	/**
 	 *  Test that the "Upgrade" popover appears when overing over the "Upgrade" button.
 	 */
-	test.skip( 'Onboarding Upgrade Popover', async ( { page } ) => {
+	test( 'Onboarding Upgrade Popover', async ( { page } ) => {
 		await page.goto( '/wp-admin/admin.php?page=elementor-app#onboarding' );
 
 		const goProHeaderButton = page.locator( '#eps-app-header-btn-go-pro' );
@@ -41,7 +41,7 @@ test.describe( 'On boarding @onBoarding', async () => {
 		await expect( goProPopover ).toBeVisible();
 	} );
 
-	test.skip( 'Onboarding Create Account Popup Open', async ( { page } ) => {
+	test( 'Onboarding Create Account Popup Open', async ( { page } ) => {
 		await page.goto( '/wp-admin/admin.php?page=elementor-app#onboarding' );
 
 		const variantA = page.locator( 'a.e-onboarding__button-action' );
@@ -76,7 +76,7 @@ test.describe( 'On boarding @onBoarding', async () => {
 	/**
 	 * Test the "Skip" button - to make sure it skips to the next step.
 	 */
-	test.skip( 'Onboarding Skip to Hello Theme Page', async ( { page } ) => {
+	test( 'Onboarding Skip to Hello Theme Page', async ( { page } ) => {
 		await page.goto( '/wp-admin/admin.php?page=elementor-app#onboarding' );
 
 		const variantASkip = page.locator( 'text=Skip' );
@@ -96,7 +96,7 @@ test.describe( 'On boarding @onBoarding', async () => {
 	 * filled.
 	 * 2. Clicking on 'Skip' should take the user to the Site Logo screen
 	 */
-	test.skip( 'Onboarding Site Name Page', async ( { page } ) => {
+	test( 'Onboarding Site Name Page', async ( { page } ) => {
 		await page.goto( '/wp-admin/admin.php?page=elementor-app#onboarding/siteName' );
 
 		await page.fill( 'input[type="text"]', '' );
@@ -109,7 +109,7 @@ test.describe( 'On boarding @onBoarding', async () => {
 
 		await expect( nextButton ).toHaveClass( BUTTON_CLASSES.active );
 
-		await page.locator( EditorSelectors.onboarding.skipButton ).click();
+		await page.locator( EditorSelectors.onboardingButton ).click();
 
 		const pageTitle = page.locator( EditorSelectors.onboarding.screenTitle );
 		await expect( pageTitle ).toHaveText( 'Have a logo? Add it here.' );
@@ -123,12 +123,12 @@ test.describe( 'On boarding @onBoarding', async () => {
 	 * 2. Clicking on 'Skip' should take the user to the Good to Go screen
 	 */
 
-	test.skip( 'Onboarding Site Logo Page', async ( { page } ) => {
+	test( 'Onboarding Site Logo Page', async ( { page } ) => {
 		await page.goto( '/wp-admin/admin.php?page=elementor-app#onboarding/siteLogo' );
 
 		const nextButton = page.locator( 'text=Next' );
 		const removeButton = page.locator( EditorSelectors.onboarding.removeLogoButton );
-		const skipButton = page.locator( EditorSelectors.onboarding.skipButton );
+		const skipButton = page.locator( EditorSelectors.onboardingButton );
 
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-expect-error
@@ -148,7 +148,7 @@ test.describe( 'On boarding @onBoarding', async () => {
 	/**
 	 * In the Good to Go page - tests that clicking on the Kit Library card/button navigates the user to the Kit Library.
 	 */
-	test.skip( 'Onboarding Good to Go Page - Open Kit Library', async ( { page } ) => {
+	test( 'Onboarding Good to Go Page - Open Kit Library', async ( { page } ) => {
 		await page.goto( '/wp-admin/admin.php?page=elementor-app#onboarding/goodToGo' );
 
 		const nextButton = page.locator( '.e-onboarding__cards-grid > a:nth-child(2)' );
@@ -164,7 +164,7 @@ test.describe( 'On boarding @onBoarding', async () => {
 test.describe( 'Onboarding @onBoarding', async () => {
 	const chooseFeaturesUrl = '/wp-admin/admin.php?page=elementor-app#onboarding/chooseFeatures';
 
-	test.skip( 'Onboarding Choose Features page', async ( { page } ) => {
+	test( 'Onboarding Choose Features page', async ( { page } ) => {
 		await page.goto( chooseFeaturesUrl );
 
 		const chooseFeaturesScreen = page.locator( '.e-onboarding__page-chooseFeatures' ),
@@ -220,7 +220,7 @@ test.describe( 'Onboarding @onBoarding', async () => {
 		} );
 	} );
 
-	test.skip( 'Onboarding Choose Features page - Upgrade button', async ( { page } ) => {
+	test( 'Onboarding Choose Features page - Upgrade button', async ( { page } ) => {
 		await page.goto( chooseFeaturesUrl );
 
 		const upgradeNowBtn = page.locator( EditorSelectors.onboarding.upgradeButton );
@@ -244,21 +244,24 @@ test.describe( 'Onboarding @onBoarding', async () => {
 		await test.step( 'Check that step was changed to Good to Go', async () => {
 			expect( page.url() ).toContain( 'onboarding/goodToGo' );
 			await expect( page.locator( EditorSelectors.onboarding.progressBar.completedItem ) ).toContainText( 'Choose Features' );
-			await expect( page.locator( EditorSelectors.onboarding.screenTitle ) ).toHaveText( 'Welcome aboard! What\'s next?' );
+
+			await expect(
+				page.locator( EditorSelectors.onboarding.screenTitle ),
+			).toHaveText( /Welcome aboard! What's next\?|How would you like to create your website?|All set! Choose how to start/ );
 		} );
 	} );
 
-	test.skip( 'Onboarding Choose Features page - Skip button', async ( { page } ) => {
+	test( 'Onboarding Choose Features page - Skip button', async ( { page } ) => {
 		await page.goto( chooseFeaturesUrl );
 
-		const skipButton = page.locator( EditorSelectors.onboarding.skipButton );
+		const skipButton = page.locator( EditorSelectors.onboardingButton );
 
 		await skipButton.waitFor();
 
 		await test.step( 'Check that Skip button leads to the Good to Go screen', async () => {
 			await skipButton.click();
 			expect( page.url() ).toContain( 'onboarding/goodToGo' );
-			await expect( page.locator( EditorSelectors.onboarding.progressBar.skippedItem ) ).toContainText( 'Choose Features' );
+			await expect( page.locator( EditorSelectors.onboarding.progressBarpedItem ) ).toContainText( 'Choose Features' );
 			await expect( page.locator( EditorSelectors.onboarding.screenTitle ) ).toHaveText( 'Welcome aboard! What\'s next?' );
 		} );
 	} );

--- a/tests/playwright/sanity/core/app/modules/onboarding/onboarding.test.ts
+++ b/tests/playwright/sanity/core/app/modules/onboarding/onboarding.test.ts
@@ -254,7 +254,7 @@ test.describe( 'Onboarding @onBoarding', async () => {
 	test( 'Onboarding Choose Features page - Skip button', async ( { page } ) => {
 		await page.goto( chooseFeaturesUrl );
 
-		const skipButton = page.locator( EditorSelectors.onboardingButton );
+		const skipButton = page.locator( EditorSelectors.onboarding.skipButton );
 
 		await skipButton.waitFor();
 

--- a/tests/playwright/sanity/core/app/modules/onboarding/onboarding.test.ts
+++ b/tests/playwright/sanity/core/app/modules/onboarding/onboarding.test.ts
@@ -261,7 +261,7 @@ test.describe( 'Onboarding @onBoarding', async () => {
 		await test.step( 'Check that Skip button leads to the Good to Go screen', async () => {
 			await skipButton.click();
 			expect( page.url() ).toContain( 'onboarding/goodToGo' );
-			await expect( page.locator( EditorSelectors.onboarding.progressBarpedItem ) ).toContainText( 'Choose Features' );
+			await expect( page.locator( EditorSelectors.onboarding.progressBar.skippedItem ) ).toContainText( 'Choose Features' );
 			await expect( page.locator( EditorSelectors.onboarding.screenTitle ) ).toHaveText( 'Welcome aboard! What\'s next?' );
 		} );
 	} );

--- a/tests/playwright/sanity/core/app/modules/onboarding/onboarding.test.ts
+++ b/tests/playwright/sanity/core/app/modules/onboarding/onboarding.test.ts
@@ -109,7 +109,7 @@ test.describe( 'On boarding @onBoarding', async () => {
 
 		await expect( nextButton ).toHaveClass( BUTTON_CLASSES.active );
 
-		await page.locator( EditorSelectors.onboardingButton ).click();
+		await page.locator( EditorSelectors.onboarding.skipButton ).click();
 
 		const pageTitle = page.locator( EditorSelectors.onboarding.screenTitle );
 		await expect( pageTitle ).toHaveText( 'Have a logo? Add it here.' );
@@ -128,7 +128,7 @@ test.describe( 'On boarding @onBoarding', async () => {
 
 		const nextButton = page.locator( 'text=Next' );
 		const removeButton = page.locator( EditorSelectors.onboarding.removeLogoButton );
-		const skipButton = page.locator( EditorSelectors.onboardingButton );
+		const skipButton = page.locator( EditorSelectors.onboarding.skipButton );
 
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-expect-error


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Re-enable skipped Playwright onboarding tests and update assertions to handle multiple onboarding flow variants.

Main changes:
- Removed test.skip() from eight onboarding e2e tests to restore test coverage for upgrade popover, account creation, and feature selection flows
- Updated "Good to Go" screen title assertion to accept three possible text variants using regex pattern matching
- Added whitespace and formatting adjustments to improve test step readability in Choose Features upgrade button test

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
