### PR TITLE
Internal: Include ticket number in cherry-pick PR titles [ED-23189]

### DIFF
--- a/.github/workflows/cherry-pick-pr.yml
+++ b/.github/workflows/cherry-pick-pr.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
       USING_PAT: ${{ secrets.GH_PAT != '' }}
+      JIRA_TICKET_PATTERN: '[A-Z]{2,10}-[0-9]+'
 
     steps:
       - name: Checkout repository
@@ -104,6 +105,14 @@ jobs:
                 TYPE="Internal:"
               fi
 
+              # Extract ticket from original PR title (e.g. [ED-22962], [PROJ-123])
+              TICKET=$(echo "$PR_TITLE" | grep -oE "$JIRA_TICKET_PATTERN" | head -1)
+              if [ -n "$TICKET" ]; then
+                TICKET_SUFFIX=" [${TICKET}]"
+              else
+                TICKET_SUFFIX=" [NO-TICKET]"
+              fi
+
               # Push the conflict branch
               if git push --force-with-lease origin "$BRANCH:$CONFLICT_BRANCH"; then
                 # Create draft PR with conflict information
@@ -117,7 +126,7 @@ jobs:
                   gh pr create \
                     --base "$TARGET" \
                     --head "$CONFLICT_BRANCH" \
-                    --title "${TYPE} Cherry-pick PR ${PR_NUMBER} to ${TARGET} with conflicts" \
+                    --title "${TYPE} Cherry-pick PR ${PR_NUMBER} to ${TARGET} with conflicts${TICKET_SUFFIX}" \
                     --body "⚠️ **Manual Resolution Required**
 
                   This cherry-pick of [#${PR_NUMBER}](${ORIG_URL}) to \`${TARGET}\` branch has conflicts that need manual resolution.
@@ -161,6 +170,14 @@ jobs:
               TYPE="Internal:"
             fi
 
+            # Extract ticket from original PR title (e.g. [ED-22962], [PROJ-123])
+            TICKET=$(echo "$PR_TITLE" | grep -oE "$JIRA_TICKET_PATTERN" | head -1)
+            if [ -n "$TICKET" ]; then
+              TICKET_SUFFIX=" [${TICKET}]"
+            else
+              TICKET_SUFFIX=" [NO-TICKET]"
+            fi
+
             # Create PR via gh CLI (token already in env: GH_TOKEN)
             # Check if PR already exists
             if gh pr list --head "$BRANCH" --base "$TARGET" --state open | grep -q .; then
@@ -175,7 +192,7 @@ jobs:
               PR_URL=$(gh pr create \
                 --base "$TARGET" \
                 --head "$BRANCH" \
-                --title "${TYPE} Cherry-pick PR ${PR_NUMBER} to ${TARGET}" \
+                --title "${TYPE} Cherry-pick PR ${PR_NUMBER} to ${TARGET}${TICKET_SUFFIX}" \
                 --body "Automatic cherry-pick of [#${PR_NUMBER}](${ORIG_URL}) to \`${TARGET}\` branch.
 
                 **Source:** ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
## Summary
- Added `JIRA_TICKET_PATTERN` env var (`[A-Z]{2,10}-[0-9]+`) to the cherry-pick job, making the pattern configurable without script changes
- After extracting `TYPE` in both the conflict path and success path, the script now extracts the Jira ticket from the original PR title
- Appends `[ED-XXXXX]` (or `[PROJ-456]` for any project) to cherry-pick PR titles when a ticket is found
- Falls back to `[NO-TICKET]` when no ticket is found, so the indicator is always present

## Test plan
- [ ] Merge a PR with `[ED-XXXXX]` in its title and a `cp_` label → cherry-pick PR title should end with `[ED-XXXXX]`
- [ ] Merge a PR without any ticket number and a `cp_` label → cherry-pick PR title should end with `[NO-TICKET]`
- [ ] Trigger a cherry-pick that produces conflicts → conflict draft PR title should also include the ticket suffix
- [ ] Verify a PR with a non-ED ticket (e.g. `[PROJ-456]`) is also picked up correctly

## Jira
[ED-23189](https://elementor.atlassian.net/browse/ED-23189)

[ED-23189]: https://elementor.atlassian.net/browse/ED-23189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update cherry-pick automation workflow to include Jira ticket numbers from original PR titles in generated cherry-pick PR titles for better traceability.

Main changes:
- Added JIRA_TICKET_PATTERN environment variable to match ticket format [PROJECT-NUMBER] across workflow
- Implemented ticket extraction logic that appends found ticket or [NO-TICKET] suffix to cherry-pick PR titles
- Updated both conflict and clean cherry-pick PR title templates to include ticket suffix

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
