### PR TITLE
POC MEGA

### DIFF
--- a/.grunt-config/webpack.js
+++ b/.grunt-config/webpack.js
@@ -163,6 +163,8 @@ const frontendEntries = {
 	'youtube-handler': path.resolve( __dirname, '../modules/atomic-widgets/elements/atomic-youtube/youtube-handler.js' ),
 	'tabs-handler': path.resolve( __dirname, '../modules/atomic-widgets/elements/atomic-tabs/handlers/atomic-tabs-handler.js' ),
 	'tabs-preview-handler': path.resolve( __dirname, '../modules/atomic-widgets/elements/atomic-tabs/handlers/atomic-tabs-preview-handler.js' ),
+	'mega-menu-handler': path.resolve( __dirname, '../modules/atomic-widgets/elements/atomic-mega-menu/handlers/atomic-mega-menu-handler.js' ),
+	'mega-menu-preview-handler': path.resolve( __dirname, '../modules/atomic-widgets/elements/atomic-mega-menu/handlers/atomic-mega-menu-preview-handler.js' ),
 	'atomic-widgets-frontend-handler': path.resolve( __dirname, '../modules/atomic-widgets/assets/js/frontend/handlers.js' ),
 };
 

--- a/modules/atomic-widgets/controls/types/elements/mega-menu-control.php
+++ b/modules/atomic-widgets/controls/types/elements/mega-menu-control.php
@@ -1,0 +1,18 @@
+<?php
+namespace Elementor\Modules\AtomicWidgets\Controls\Types\Elements;
+
+use Elementor\Modules\AtomicWidgets\Controls\Base\Element_Control_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Mega_Menu_Control extends Element_Control_Base {
+	public function get_type(): string {
+		return 'mega-menu';
+	}
+
+	public function get_props(): array {
+		return [];
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-content-area/atomic-mega-menu-content-area.html.twig
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-content-area/atomic-mega-menu-content-area.html.twig
@@ -1,0 +1,2 @@
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+<div class="{{ classes }} {{ editor_classes | default('') }}" data-id="{{ id }}" data-element_type="{{ type }}" data-e-type="{{ type }}" data-interaction-id="{{ id }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" x-bind="contentArea" {{ editor_attributes | default('') | raw }}><!-- elementor-children-placeholder --></div>

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-content-area/atomic-mega-menu-content-area.php
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-content-area/atomic-mega-menu-content-area.php
@@ -1,0 +1,110 @@
+<?php
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Content_Area;
+
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Atomic_Mega_Menu_Content_Area extends Atomic_Element_Base {
+	const BASE_STYLE_KEY = 'base';
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'llm_support', false );
+	}
+
+	public static function get_type() {
+		return 'e-mega-menu-content-area';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-mega-menu-content-area';
+	}
+
+	public function get_title() {
+		return esc_html__( 'Mega Menu Content Area', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-inner-section';
+	}
+
+	public function should_show_in_panel() {
+		return false;
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()
+				->default( [] ),
+			'attributes' => Attributes_Prop_Type::make()
+				->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [
+					Text_Control::bind_to( '_cssid' )
+						->set_label( __( 'ID', 'elementor' ) )
+						->set_meta( [
+							'layout' => 'two-columns',
+						] ),
+				] ),
+		];
+	}
+
+	protected function define_base_styles(): array {
+		$styles = [
+			'display' => String_Prop_Type::generate( 'block' ),
+			'position' => String_Prop_Type::generate( 'relative' ),
+		];
+
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+						->add_props( $styles )
+				),
+		];
+	}
+
+	protected function add_render_attributes() {
+		parent::add_render_attributes();
+		$settings = $this->get_atomic_settings();
+		$base_style_class = $this->get_base_styles_dictionary()[ static::BASE_STYLE_KEY ];
+		$initial_attributes = $this->define_initial_attributes();
+
+		$attributes = [
+			'class' => [
+				'e-con',
+				'e-atomic-element',
+				$base_style_class,
+				...( $settings['classes'] ?? [] ),
+			],
+		];
+
+		if ( ! empty( $settings['_cssid'] ) ) {
+			$attributes['id'] = esc_attr( $settings['_cssid'] );
+		}
+
+		$this->add_render_attribute( '_wrapper', array_merge( $initial_attributes, $attributes ) );
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-content-area/atomic-mega-menu-content-area.php
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-content-area/atomic-mega-menu-content-area.php
@@ -2,6 +2,7 @@
 namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Content_Area;
 
 use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
@@ -16,6 +17,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Atomic_Mega_Menu_Content_Area extends Atomic_Element_Base {
+	use Has_Element_Template;
+
 	const BASE_STYLE_KEY = 'base';
 
 	public function __construct( $data = [], $args = null ) {
@@ -86,25 +89,13 @@ class Atomic_Mega_Menu_Content_Area extends Atomic_Element_Base {
 		];
 	}
 
-	protected function add_render_attributes() {
-		parent::add_render_attributes();
-		$settings = $this->get_atomic_settings();
-		$base_style_class = $this->get_base_styles_dictionary()[ static::BASE_STYLE_KEY ];
-		$initial_attributes = $this->define_initial_attributes();
-
-		$attributes = [
-			'class' => [
-				'e-con',
-				'e-atomic-element',
-				$base_style_class,
-				...( $settings['classes'] ?? [] ),
-			],
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-mega-menu-content-area' => __DIR__ . '/atomic-mega-menu-content-area.html.twig',
 		];
+	}
 
-		if ( ! empty( $settings['_cssid'] ) ) {
-			$attributes['id'] = esc_attr( $settings['_cssid'] );
-		}
-
-		$this->add_render_attribute( '_wrapper', array_merge( $initial_attributes, $attributes ) );
+	protected function define_allowed_child_types() {
+		return [ 'e-mega-menu-panel', 'container' ];
 	}
 }

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-item/atomic-mega-menu-item.html.twig
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-item/atomic-mega-menu-item.html.twig
@@ -1,0 +1,2 @@
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+<li class="{{ classes }} {{ editor_classes | default('') }}" data-id="{{ id }}" data-element_type="{{ type }}" data-e-type="{{ type }}" data-interaction-id="{{ id }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" role="none" x-bind="menuItem" x-ref="{{ id }}" {{ editor_attributes | default('') | raw }}><!-- elementor-children-placeholder --></li>

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-item/atomic-mega-menu-item.php
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-item/atomic-mega-menu-item.php
@@ -2,6 +2,7 @@
 namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Item;
 
 use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
 use Elementor\Modules\AtomicWidgets\Elements\Base\Render_Context;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu\Atomic_Mega_Menu;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Paragraph\Atomic_Paragraph;
@@ -23,6 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Atomic_Mega_Menu_Item extends Atomic_Element_Base {
+	use Has_Element_Template;
+
 	const BASE_STYLE_KEY = 'base';
 
 	public function __construct( $data = [], $args = null ) {
@@ -93,25 +96,32 @@ class Atomic_Mega_Menu_Item extends Atomic_Element_Base {
 			'display' => String_Prop_Type::generate( 'flex' ),
 			'align-items' => String_Prop_Type::generate( 'center' ),
 			'cursor' => String_Prop_Type::generate( 'pointer' ),
-			'color' => Color_Prop_Type::generate( '#0C0D0E' ),
+			'color' => Color_Prop_Type::generate( '#3B3B3B' ),
+			'font-size' => Size_Prop_Type::generate( [
+				'size' => 15,
+				'unit' => 'px',
+			] ),
+			'font-weight' => String_Prop_Type::generate( '500' ),
 			'padding' => Size_Prop_Type::generate( [
-				'size' => 12,
+				'size' => 14,
 				'unit' => 'px',
 			] ),
 			'background' => Background_Prop_Type::generate( [
-				'color' => Color_Prop_Type::generate( '#FFFFFF' ),
+				'color' => Color_Prop_Type::generate( 'transparent' ),
 			] ),
 		];
 
 		$selected_styles = [
+			'color' => Color_Prop_Type::generate( '#0C0D0E' ),
 			'background' => Background_Prop_Type::generate( [
 				'color' => Color_Prop_Type::generate( '#F0F0F0' ),
 			] ),
 		];
 
 		$hover_styles = [
+			'color' => Color_Prop_Type::generate( '#0C0D0E' ),
 			'background' => Background_Prop_Type::generate( [
-				'color' => Color_Prop_Type::generate( '#E0E0E0' ),
+				'color' => Color_Prop_Type::generate( '#F5F5F5' ),
 			] ),
 		];
 
@@ -148,32 +158,22 @@ class Atomic_Mega_Menu_Item extends Atomic_Element_Base {
 		];
 	}
 
-	protected function add_render_attributes() {
-		parent::add_render_attributes();
-		$settings = $this->get_atomic_settings();
-		$base_style_class = $this->get_base_styles_dictionary()[ static::BASE_STYLE_KEY ];
-		$initial_attributes = $this->define_initial_attributes();
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-mega-menu-item' => __DIR__ . '/atomic-mega-menu-item.html.twig',
+		];
+	}
 
+	protected function build_template_context(): array {
 		$menu_context = Render_Context::get( Atomic_Mega_Menu::class );
 		$get_item_index = $menu_context['get-item-index'];
 		$mega_menu_id = $menu_context['mega-menu-id'];
 
 		$index = $get_item_index( $this->get_id() );
 
-		$attributes = [
-			'class' => [
-				'e-con',
-				'e-atomic-element',
-				$base_style_class,
-				...( $settings['classes'] ?? [] ),
-			],
-			'x-bind' => 'menuItem',
-			'x-ref' => $this->get_id(),
-			'id' => Atomic_Mega_Menu::get_item_id( $mega_menu_id, $index ),
-			'aria-expanded' => 'false',
-			'aria-controls' => Atomic_Mega_Menu::get_panel_id( $mega_menu_id, $index ),
-		];
-
-		$this->add_render_attribute( '_wrapper', array_merge( $initial_attributes, $attributes ) );
+		return array_merge( $this->build_base_template_context(), [
+			'item_id' => Atomic_Mega_Menu::get_item_id( $mega_menu_id, $index ),
+			'panel_id' => Atomic_Mega_Menu::get_panel_id( $mega_menu_id, $index ),
+		] );
 	}
 }

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-item/atomic-mega-menu-item.php
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-item/atomic-mega-menu-item.php
@@ -1,0 +1,179 @@
+<?php
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Item;
+
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Render_Context;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu\Atomic_Mega_Menu;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Paragraph\Atomic_Paragraph;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Html_V3_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\AtomicWidgets\Styles\Style_States;
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Atomic_Mega_Menu_Item extends Atomic_Element_Base {
+	const BASE_STYLE_KEY = 'base';
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'llm_support', false );
+	}
+
+	public static function get_type() {
+		return 'e-mega-menu-item';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-mega-menu-item';
+	}
+
+	public function get_title() {
+		return esc_html__( 'Menu Item', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'menu', 'item' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-nav-menu';
+	}
+
+	public function should_show_in_panel() {
+		return false;
+	}
+
+	protected function define_default_html_tag() {
+		return 'li';
+	}
+
+	protected function define_initial_attributes() {
+		return [
+			'role' => 'none',
+		];
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()
+				->default( [] ),
+			'attributes' => Attributes_Prop_Type::make()
+				->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [] ),
+		];
+	}
+
+	protected function define_atomic_style_states(): array {
+		$selected_state = Style_States::get_class_states_map()['selected'];
+
+		return [ $selected_state ];
+	}
+
+	protected function define_base_styles(): array {
+		$styles = [
+			'display' => String_Prop_Type::generate( 'flex' ),
+			'align-items' => String_Prop_Type::generate( 'center' ),
+			'cursor' => String_Prop_Type::generate( 'pointer' ),
+			'color' => Color_Prop_Type::generate( '#0C0D0E' ),
+			'padding' => Size_Prop_Type::generate( [
+				'size' => 12,
+				'unit' => 'px',
+			] ),
+			'background' => Background_Prop_Type::generate( [
+				'color' => Color_Prop_Type::generate( '#FFFFFF' ),
+			] ),
+		];
+
+		$selected_styles = [
+			'background' => Background_Prop_Type::generate( [
+				'color' => Color_Prop_Type::generate( '#F0F0F0' ),
+			] ),
+		];
+
+		$hover_styles = [
+			'background' => Background_Prop_Type::generate( [
+				'color' => Color_Prop_Type::generate( '#E0E0E0' ),
+			] ),
+		];
+
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+						->add_props( $styles )
+				)
+				->add_variant(
+					Style_Variant::make()
+						->set_state( Style_States::SELECTED )
+						->add_props( $selected_styles )
+				)
+				->add_variant(
+					Style_Variant::make()
+						->set_state( Style_States::HOVER )
+						->add_props( $hover_styles )
+				),
+		];
+	}
+
+	protected function define_default_children() {
+		return [
+			Atomic_Paragraph::generate()
+				->settings( [
+					'paragraph' => Html_V3_Prop_Type::generate( [
+						'content'  => String_Prop_Type::generate( 'Menu Item' ),
+						'children' => [],
+					] ),
+					'tag' => String_Prop_Type::generate( 'span' ),
+				] )
+				->build(),
+		];
+	}
+
+	protected function add_render_attributes() {
+		parent::add_render_attributes();
+		$settings = $this->get_atomic_settings();
+		$base_style_class = $this->get_base_styles_dictionary()[ static::BASE_STYLE_KEY ];
+		$initial_attributes = $this->define_initial_attributes();
+
+		$menu_context = Render_Context::get( Atomic_Mega_Menu::class );
+		$get_item_index = $menu_context['get-item-index'];
+		$mega_menu_id = $menu_context['mega-menu-id'];
+
+		$index = $get_item_index( $this->get_id() );
+
+		$attributes = [
+			'class' => [
+				'e-con',
+				'e-atomic-element',
+				$base_style_class,
+				...( $settings['classes'] ?? [] ),
+			],
+			'x-bind' => 'menuItem',
+			'x-ref' => $this->get_id(),
+			'id' => Atomic_Mega_Menu::get_item_id( $mega_menu_id, $index ),
+			'aria-expanded' => 'false',
+			'aria-controls' => Atomic_Mega_Menu::get_panel_id( $mega_menu_id, $index ),
+		];
+
+		$this->add_render_attribute( '_wrapper', array_merge( $initial_attributes, $attributes ) );
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-nav/atomic-mega-menu-nav.html.twig
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-nav/atomic-mega-menu-nav.html.twig
@@ -1,0 +1,2 @@
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+<ul class="{{ classes }} {{ editor_classes | default('') }}" data-id="{{ id }}" data-element_type="{{ type }}" data-e-type="{{ type }}" data-interaction-id="{{ id }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" role="menubar" x-bind="nav" {{ editor_attributes | default('') | raw }}><!-- elementor-children-placeholder --></ul>

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-nav/atomic-mega-menu-nav.php
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-nav/atomic-mega-menu-nav.php
@@ -1,0 +1,122 @@
+<?php
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Nav;
+
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Atomic_Mega_Menu_Nav extends Atomic_Element_Base {
+	const BASE_STYLE_KEY = 'base';
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'llm_support', false );
+	}
+
+	public static function get_type() {
+		return 'e-mega-menu-nav';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-mega-menu-nav';
+	}
+
+	public function get_title() {
+		return esc_html__( 'Mega Menu Nav', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-nav-menu';
+	}
+
+	public function should_show_in_panel() {
+		return false;
+	}
+
+	protected function define_default_html_tag() {
+		return 'ul';
+	}
+
+	public function define_initial_attributes(): array {
+		return [
+			'role' => 'menubar',
+		];
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()
+				->default( [] ),
+			'attributes' => Attributes_Prop_Type::make()
+				->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [
+					Text_Control::bind_to( '_cssid' )
+						->set_label( __( 'ID', 'elementor' ) )
+						->set_meta( [
+							'layout' => 'two-columns',
+						] ),
+				] ),
+		];
+	}
+
+	protected function define_base_styles(): array {
+		$styles = [
+			'display' => String_Prop_Type::generate( 'flex' ),
+			'list-style' => String_Prop_Type::generate( 'none' ),
+			'margin' => String_Prop_Type::generate( '0' ),
+			'padding' => String_Prop_Type::generate( '0' ),
+		];
+
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+						->add_props( $styles )
+				),
+		];
+	}
+
+	protected function add_render_attributes() {
+		parent::add_render_attributes();
+		$settings = $this->get_atomic_settings();
+		$base_style_class = $this->get_base_styles_dictionary()[ static::BASE_STYLE_KEY ];
+		$initial_attributes = $this->define_initial_attributes();
+
+		$attributes = [
+			'class' => [
+				'e-con',
+				'e-atomic-element',
+				$base_style_class,
+				...( $settings['classes'] ?? [] ),
+			],
+		];
+
+		if ( ! empty( $settings['_cssid'] ) ) {
+			$attributes['id'] = esc_attr( $settings['_cssid'] );
+		}
+
+		$this->add_render_attribute( '_wrapper', array_merge( $initial_attributes, $attributes ) );
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-panel/atomic-mega-menu-panel.html.twig
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-panel/atomic-mega-menu-panel.html.twig
@@ -1,0 +1,2 @@
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+<div class="{{ classes }} {{ editor_classes | default('') }}" data-id="{{ id }}" data-element_type="{{ type }}" data-e-type="{{ type }}" data-interaction-id="{{ id }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" x-bind="panel" x-ref="{{ id }}" hidden="true" style="display: none;" {{ editor_attributes | default('') | raw }}><!-- elementor-children-placeholder --></div>

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-panel/atomic-mega-menu-panel.php
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-panel/atomic-mega-menu-panel.php
@@ -2,8 +2,10 @@
 namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Panel;
 
 use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
 use Elementor\Modules\AtomicWidgets\Elements\Base\Render_Context;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu\Atomic_Mega_Menu;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
@@ -21,6 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Atomic_Mega_Menu_Panel extends Atomic_Element_Base {
+	use Has_Element_Template;
+
 	const BASE_STYLE_KEY = 'base';
 
 	public function __construct( $data = [], $args = null ) {
@@ -80,6 +84,7 @@ class Atomic_Mega_Menu_Panel extends Atomic_Element_Base {
 		$styles = [
 			'display' => String_Prop_Type::generate( 'block' ),
 			'position' => String_Prop_Type::generate( 'absolute' ),
+			'z-index' => Number_Prop_Type::generate( 1000 ),
 			'min-width' => Size_Prop_Type::generate( [
 				'size' => 200,
 				'unit' => 'px',
@@ -102,36 +107,22 @@ class Atomic_Mega_Menu_Panel extends Atomic_Element_Base {
 		];
 	}
 
-	protected function add_render_attributes() {
-		parent::add_render_attributes();
-		$settings = $this->get_atomic_settings();
-		$base_style_class = $this->get_base_styles_dictionary()[ static::BASE_STYLE_KEY ];
-		$initial_attributes = $this->define_initial_attributes();
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-mega-menu-panel' => __DIR__ . '/atomic-mega-menu-panel.html.twig',
+		];
+	}
 
+	protected function build_template_context(): array {
 		$menu_context = Render_Context::get( Atomic_Mega_Menu::class );
 		$get_panel_index = $menu_context['get-panel-index'];
 		$mega_menu_id = $menu_context['mega-menu-id'];
 
 		$index = $get_panel_index( $this->get_id() );
 
-		$attributes = [
-			'class' => [
-				'e-con',
-				'e-atomic-element',
-				$base_style_class,
-				...( $settings['classes'] ?? [] ),
-			],
-			'x-bind' => 'panel',
-			'id' => Atomic_Mega_Menu::get_panel_id( $mega_menu_id, $index ),
-			'aria-labelledby' => Atomic_Mega_Menu::get_item_id( $mega_menu_id, $index ),
-			'hidden' => 'true',
-			'style' => 'display: none;',
-		];
-
-		if ( ! empty( $settings['_cssid'] ) ) {
-			$attributes['id'] = esc_attr( $settings['_cssid'] );
-		}
-
-		$this->add_render_attribute( '_wrapper', array_merge( $initial_attributes, $attributes ) );
+		return array_merge( $this->build_base_template_context(), [
+			'panel_id' => Atomic_Mega_Menu::get_panel_id( $mega_menu_id, $index ),
+			'item_id' => Atomic_Mega_Menu::get_item_id( $mega_menu_id, $index ),
+		] );
 	}
 }

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-panel/atomic-mega-menu-panel.php
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-panel/atomic-mega-menu-panel.php
@@ -1,0 +1,137 @@
+<?php
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Panel;
+
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Render_Context;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu\Atomic_Mega_Menu;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\AtomicWidgets\Styles\Style_States;
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Atomic_Mega_Menu_Panel extends Atomic_Element_Base {
+	const BASE_STYLE_KEY = 'base';
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'llm_support', false );
+	}
+
+	public static function get_type() {
+		return 'e-mega-menu-panel';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-mega-menu-panel';
+	}
+
+	public function get_title() {
+		return esc_html__( 'Mega Menu Panel', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'menu', 'panel', 'dropdown' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-inner-section';
+	}
+
+	public function should_show_in_panel() {
+		return false;
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()
+				->default( [] ),
+			'attributes' => Attributes_Prop_Type::make()
+				->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [] ),
+		];
+	}
+
+	protected function define_atomic_style_states(): array {
+		$selected_state = Style_States::get_class_states_map()['selected'];
+
+		return [ $selected_state ];
+	}
+
+	protected function define_base_styles(): array {
+		$styles = [
+			'display' => String_Prop_Type::generate( 'block' ),
+			'position' => String_Prop_Type::generate( 'absolute' ),
+			'min-width' => Size_Prop_Type::generate( [
+				'size' => 200,
+				'unit' => 'px',
+			] ),
+			'padding' => Size_Prop_Type::generate( [
+				'size' => 16,
+				'unit' => 'px',
+			] ),
+			'background' => Background_Prop_Type::generate( [
+				'color' => Color_Prop_Type::generate( '#FFFFFF' ),
+			] ),
+		];
+
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+						->add_props( $styles )
+				),
+		];
+	}
+
+	protected function add_render_attributes() {
+		parent::add_render_attributes();
+		$settings = $this->get_atomic_settings();
+		$base_style_class = $this->get_base_styles_dictionary()[ static::BASE_STYLE_KEY ];
+		$initial_attributes = $this->define_initial_attributes();
+
+		$menu_context = Render_Context::get( Atomic_Mega_Menu::class );
+		$get_panel_index = $menu_context['get-panel-index'];
+		$mega_menu_id = $menu_context['mega-menu-id'];
+
+		$index = $get_panel_index( $this->get_id() );
+
+		$attributes = [
+			'class' => [
+				'e-con',
+				'e-atomic-element',
+				$base_style_class,
+				...( $settings['classes'] ?? [] ),
+			],
+			'x-bind' => 'panel',
+			'id' => Atomic_Mega_Menu::get_panel_id( $mega_menu_id, $index ),
+			'aria-labelledby' => Atomic_Mega_Menu::get_item_id( $mega_menu_id, $index ),
+			'hidden' => 'true',
+			'style' => 'display: none;',
+		];
+
+		if ( ! empty( $settings['_cssid'] ) ) {
+			$attributes['id'] = esc_attr( $settings['_cssid'] );
+		}
+
+		$this->add_render_attribute( '_wrapper', array_merge( $initial_attributes, $attributes ) );
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-toggle/atomic-mega-menu-toggle.html.twig
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-toggle/atomic-mega-menu-toggle.html.twig
@@ -1,0 +1,8 @@
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+<button class="{{ classes }} {{ editor_classes | default('') }}" data-id="{{ id }}" data-element_type="{{ type }}" data-e-type="{{ type }}" data-interaction-id="{{ id }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" type="button" x-bind="toggle" aria-label="Toggle navigation menu" {{ editor_attributes | default('') | raw }}>
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <line x1="3" y1="6" x2="21" y2="6"/>
+        <line x1="3" y1="12" x2="21" y2="12"/>
+        <line x1="3" y1="18" x2="21" y2="18"/>
+    </svg>
+</button>

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-toggle/atomic-mega-menu-toggle.php
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu-toggle/atomic-mega-menu-toggle.php
@@ -1,5 +1,5 @@
 <?php
-namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Nav;
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Toggle;
 
 use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
 use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
@@ -8,9 +8,9 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_States;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
 use Elementor\Modules\AtomicWidgets\Controls\Section;
-use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
 use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class Atomic_Mega_Menu_Nav extends Atomic_Element_Base {
+class Atomic_Mega_Menu_Toggle extends Atomic_Element_Base {
 	use Has_Element_Template;
 
 	const BASE_STYLE_KEY = 'base';
@@ -30,33 +30,31 @@ class Atomic_Mega_Menu_Nav extends Atomic_Element_Base {
 	}
 
 	public static function get_type() {
-		return 'e-mega-menu-nav';
+		return 'e-mega-menu-toggle';
 	}
 
 	public static function get_element_type(): string {
-		return 'e-mega-menu-nav';
+		return 'e-mega-menu-toggle';
 	}
 
 	public function get_title() {
-		return esc_html__( 'Mega Menu Nav', 'elementor' );
+		return esc_html__( 'Menu Toggle', 'elementor' );
 	}
 
 	public function get_keywords() {
-		return [ 'ato', 'atom', 'atoms', 'atomic' ];
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'menu', 'toggle', 'hamburger' ];
 	}
 
 	public function get_icon() {
-		return 'eicon-nav-menu';
+		return 'eicon-menu-bar';
 	}
 
 	public function should_show_in_panel() {
 		return false;
 	}
 
-	public function define_initial_attributes(): array {
-		return [
-			'role' => 'menubar',
-		];
+	protected function define_default_html_tag() {
+		return 'button';
 	}
 
 	protected static function define_props_schema(): array {
@@ -73,32 +71,37 @@ class Atomic_Mega_Menu_Nav extends Atomic_Element_Base {
 			Section::make()
 				->set_label( __( 'Settings', 'elementor' ) )
 				->set_id( 'settings' )
-				->set_items( [
-					Text_Control::bind_to( '_cssid' )
-						->set_label( __( 'ID', 'elementor' ) )
-						->set_meta( [
-							'layout' => 'two-columns',
-						] ),
-				] ),
+				->set_items( [] ),
 		];
 	}
 
 	protected function define_base_styles(): array {
 		$styles = [
 			'display' => String_Prop_Type::generate( 'flex' ),
-			'flex-wrap' => String_Prop_Type::generate( 'wrap' ),
-			'align-items' => String_Prop_Type::generate( 'stretch' ),
-			'gap' => Size_Prop_Type::generate( [
-				'size' => 0,
-				'unit' => 'px',
+			'align-items' => String_Prop_Type::generate( 'center' ),
+			'justify-content' => String_Prop_Type::generate( 'center' ),
+			'cursor' => String_Prop_Type::generate( 'pointer' ),
+			'background' => Background_Prop_Type::generate( [
+				'color' => Color_Prop_Type::generate( '#FFFFFF' ),
 			] ),
-			'margin' => Size_Prop_Type::generate( [
-				'size' => 0,
-				'unit' => 'px',
-			] ),
+			'color' => Color_Prop_Type::generate( '#0C0D0E' ),
 			'padding' => Size_Prop_Type::generate( [
-				'size' => 0,
+				'size' => 12,
 				'unit' => 'px',
+			] ),
+			'font-size' => Size_Prop_Type::generate( [
+				'size' => 24,
+				'unit' => 'px',
+			] ),
+			'border-radius' => Size_Prop_Type::generate( [
+				'size' => 4,
+				'unit' => 'px',
+			] ),
+		];
+
+		$hover_styles = [
+			'background' => Background_Prop_Type::generate( [
+				'color' => Color_Prop_Type::generate( '#F5F5F5' ),
 			] ),
 		];
 
@@ -107,17 +110,18 @@ class Atomic_Mega_Menu_Nav extends Atomic_Element_Base {
 				->add_variant(
 					Style_Variant::make()
 						->add_props( $styles )
+				)
+				->add_variant(
+					Style_Variant::make()
+						->set_state( Style_States::HOVER )
+						->add_props( $hover_styles )
 				),
 		];
 	}
 
 	protected function get_templates(): array {
 		return [
-			'elementor/elements/atomic-mega-menu-nav' => __DIR__ . '/atomic-mega-menu-nav.html.twig',
+			'elementor/elements/atomic-mega-menu-toggle' => __DIR__ . '/atomic-mega-menu-toggle.html.twig',
 		];
-	}
-
-	protected function define_allowed_child_types() {
-		return [ 'e-mega-menu-item', 'container' ];
 	}
 }

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu/atomic-mega-menu.html.twig
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu/atomic-mega-menu.html.twig
@@ -1,0 +1,10 @@
+{% set e_settings = {
+    'trigger-mode': settings['trigger-mode'] | default('hover'),
+    'content-width': settings['content-width'] | default('full-width'),
+    'content-position': settings['content-position'] | default('center'),
+    'dropdown-breakpoint': settings['dropdown-breakpoint'] | default('tablet'),
+} %}
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+<nav class="{{ classes }} {{ editor_classes | default('') }}" data-id="{{ id }}" data-element_type="{{ type }}" data-e-type="{{ type }}" data-interaction-id="{{ id }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" role="navigation" x-data="eMegaMenu{{ id }}" data-e-settings="{{ e_settings | json_encode | e('html_attr') }}" {{ editor_attributes | default('') | raw }}>
+    <!-- elementor-children-placeholder -->
+</nav>

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu/atomic-mega-menu.php
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu/atomic-mega-menu.php
@@ -1,0 +1,249 @@
+<?php
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu;
+
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Nav\Atomic_Mega_Menu_Nav;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Item\Atomic_Mega_Menu_Item;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Content_Area\Atomic_Mega_Menu_Content_Area;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Panel\Atomic_Mega_Menu_Panel;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Elements\Loader\Frontend_Assets_Loader;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+use Elementor\Core\Utils\Collection;
+use Elementor\Utils;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Atomic_Mega_Menu extends Atomic_Element_Base {
+	const BASE_STYLE_KEY = 'base';
+	const ELEMENT_TYPE_NAV = 'e-mega-menu-nav';
+	const ELEMENT_TYPE_CONTENT_AREA = 'e-mega-menu-content-area';
+	const ELEMENT_TYPE_ITEM = 'e-mega-menu-item';
+	const ELEMENT_TYPE_PANEL = 'e-mega-menu-panel';
+
+	const DEFAULT_ITEM_COUNT = 3;
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'is_container', true );
+	}
+
+	public static function get_type() {
+		return 'e-mega-menu';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-mega-menu';
+	}
+
+	public function get_title() {
+		return esc_html__( 'Mega Menu', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'menu', 'mega', 'nav', 'navigation' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-nav-menu';
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()
+				->default( [] ),
+			'attributes' => Attributes_Prop_Type::make()
+				->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Content', 'elementor' ) )
+				->set_id( 'content' )
+				->set_items( [] ),
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [
+					Text_Control::bind_to( '_cssid' )
+						->set_label( __( 'ID', 'elementor' ) )
+						->set_meta( [
+							'layout' => 'two-columns',
+						] ),
+				] ),
+		];
+	}
+
+	protected function define_default_html_tag() {
+		return 'nav';
+	}
+
+	protected function define_base_styles(): array {
+		$styles = [
+			'display' => String_Prop_Type::generate( 'flex' ),
+			'flex-direction' => String_Prop_Type::generate( 'column' ),
+			'position' => String_Prop_Type::generate( 'relative' ),
+		];
+
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+						->add_props( $styles )
+				),
+		];
+	}
+
+	protected function define_default_children() {
+		$item_elements = [];
+		$panel_elements = [];
+
+		foreach ( range( 1, self::DEFAULT_ITEM_COUNT ) as $i ) {
+			$item_elements[] = Atomic_Mega_Menu_Item::generate()
+				->editor_settings( [
+					'title' => "Menu Item {$i}",
+					'initial_position' => $i,
+				] )
+				->is_locked( true )
+				->build();
+
+			$panel_elements[] = Atomic_Mega_Menu_Panel::generate()
+				->is_locked( true )
+				->editor_settings( [
+					'title' => "Panel {$i}",
+					'initial_position' => $i,
+				] )
+				->build();
+		}
+
+		$nav = Atomic_Mega_Menu_Nav::generate()
+			->children( $item_elements )
+			->is_locked( true )
+			->build();
+
+		$content_area = Atomic_Mega_Menu_Content_Area::generate()
+			->children( $panel_elements )
+			->is_locked( true )
+			->build();
+
+		return [
+			$nav,
+			$content_area,
+		];
+	}
+
+	public function get_script_depends() {
+		$global_depends = parent::get_script_depends();
+
+		if ( Plugin::$instance->preview->is_preview_mode() ) {
+			return array_merge( $global_depends, [ 'elementor-mega-menu-handler', 'elementor-mega-menu-preview-handler' ] );
+		}
+
+		return array_merge( $global_depends, [ 'elementor-mega-menu-handler' ] );
+	}
+
+	public function register_frontend_handlers() {
+		$assets_url = ELEMENTOR_ASSETS_URL;
+		$min_suffix = ( Utils::is_script_debug() || Utils::is_elementor_tests() ) ? '' : '.min';
+
+		wp_register_script(
+			'elementor-mega-menu-handler',
+			"{$assets_url}js/mega-menu-handler{$min_suffix}.js",
+			[ Frontend_Assets_Loader::FRONTEND_HANDLERS_HANDLE, Frontend_Assets_Loader::ALPINEJS_HANDLE ],
+			ELEMENTOR_VERSION,
+			true
+		);
+
+		wp_register_script(
+			'elementor-mega-menu-preview-handler',
+			"{$assets_url}js/mega-menu-preview-handler{$min_suffix}.js",
+			[ Frontend_Assets_Loader::FRONTEND_HANDLERS_HANDLE, Frontend_Assets_Loader::ALPINEJS_HANDLE ],
+			ELEMENTOR_VERSION,
+			true
+		);
+	}
+
+	private function get_filtered_children_ids( $parent_element, $child_type ) {
+		if ( ! $parent_element ) {
+			return [];
+		}
+
+		return Collection::make( $parent_element->get_children() )
+			->filter( fn( $element ) => $element->get_type() === $child_type )
+			->map( fn( $element ) => $element->get_id() )
+			->flip()
+			->all();
+	}
+
+	private function get_item_index( $item_id ) {
+		$direct_children = Collection::make( $this->get_children() );
+		$nav = $direct_children->filter( fn( $child ) => $child->get_type() === self::ELEMENT_TYPE_NAV )->first();
+
+		$item_ids = $this->get_filtered_children_ids( $nav, self::ELEMENT_TYPE_ITEM );
+
+		return $item_ids[ $item_id ];
+	}
+
+	private function get_panel_index( $panel_id ) {
+		$direct_children = Collection::make( $this->get_children() );
+		$content_area = $direct_children->filter( fn( $child ) => $child->get_type() === self::ELEMENT_TYPE_CONTENT_AREA )->first();
+
+		$panel_ids = $this->get_filtered_children_ids( $content_area, self::ELEMENT_TYPE_PANEL );
+
+		return $panel_ids[ $panel_id ];
+	}
+
+	protected function define_render_context(): array {
+		return [
+			'context' => [
+				'get-item-index' => fn( $item_id ) => $this->get_item_index( $item_id ),
+				'get-panel-index' => fn( $panel_id ) => $this->get_panel_index( $panel_id ),
+				'mega-menu-id' => $this->get_id(),
+			],
+		];
+	}
+
+	protected function add_render_attributes() {
+		parent::add_render_attributes();
+		$settings = $this->get_atomic_settings();
+		$base_style_class = $this->get_base_styles_dictionary()[ static::BASE_STYLE_KEY ];
+		$initial_attributes = $this->define_initial_attributes();
+
+		$attributes = [
+			'class' => [
+				'e-con',
+				'e-atomic-element',
+				$base_style_class,
+				...( $settings['classes'] ?? [] ),
+			],
+			'role' => 'navigation',
+			'x-data' => 'eMegaMenu' . $this->get_id(),
+			'data-e-settings' => wp_json_encode( [] ),
+		];
+
+		if ( ! empty( $settings['_cssid'] ) ) {
+			$attributes['id'] = esc_attr( $settings['_cssid'] );
+		}
+
+		$this->add_render_attribute( '_wrapper', array_merge( $initial_attributes, $attributes ) );
+	}
+
+	public static function get_item_id( $mega_menu_id, $index ) {
+		return "{$mega_menu_id}-item-{$index}";
+	}
+
+	public static function get_panel_id( $mega_menu_id, $index ) {
+		return "{$mega_menu_id}-panel-{$index}";
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu/atomic-mega-menu.php
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/atomic-mega-menu/atomic-mega-menu.php
@@ -2,15 +2,21 @@
 namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu;
 
 use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Nav\Atomic_Mega_Menu_Nav;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Item\Atomic_Mega_Menu_Item;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Content_Area\Atomic_Mega_Menu_Content_Area;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Panel\Atomic_Mega_Menu_Panel;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Toggle\Atomic_Mega_Menu_Toggle;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
 use Elementor\Modules\AtomicWidgets\Controls\Section;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Select_Control;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Elements\Mega_Menu_Control;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Elements\Loader\Frontend_Assets_Loader;
@@ -24,7 +30,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Atomic_Mega_Menu extends Atomic_Element_Base {
+	use Has_Element_Template;
+
 	const BASE_STYLE_KEY = 'base';
+	const ELEMENT_TYPE_TOGGLE = 'e-mega-menu-toggle';
 	const ELEMENT_TYPE_NAV = 'e-mega-menu-nav';
 	const ELEMENT_TYPE_CONTENT_AREA = 'e-mega-menu-content-area';
 	const ELEMENT_TYPE_ITEM = 'e-mega-menu-item';
@@ -63,7 +72,12 @@ class Atomic_Mega_Menu extends Atomic_Element_Base {
 				->default( [] ),
 			'attributes' => Attributes_Prop_Type::make()
 				->meta( Overridable_Prop_Type::ignore() ),
-		];
+			'trigger-mode' => String_Prop_Type::make()
+			->default( 'hover' )
+			->enum( [ 'hover', 'click' ] ),
+		'default-active-item' => Number_Prop_Type::make()
+			->default( null ),
+	];
 	}
 
 	protected function define_atomic_controls(): array {
@@ -71,11 +85,23 @@ class Atomic_Mega_Menu extends Atomic_Element_Base {
 			Section::make()
 				->set_label( __( 'Content', 'elementor' ) )
 				->set_id( 'content' )
-				->set_items( [] ),
+				->set_items( [
+					Mega_Menu_Control::make()
+						->set_label( __( 'Menu Items', 'elementor' ) )
+						->set_meta( [
+							'layout' => 'custom',
+						] ),
+				] ),
 			Section::make()
 				->set_label( __( 'Settings', 'elementor' ) )
 				->set_id( 'settings' )
 				->set_items( [
+					Select_Control::bind_to( 'trigger-mode' )
+						->set_label( __( 'Open On', 'elementor' ) )
+						->set_options( [
+							[ 'value' => 'hover', 'label' => __( 'Hover', 'elementor' ) ],
+							[ 'value' => 'click', 'label' => __( 'Click', 'elementor' ) ],
+						] ),
 					Text_Control::bind_to( '_cssid' )
 						->set_label( __( 'ID', 'elementor' ) )
 						->set_meta( [
@@ -127,6 +153,13 @@ class Atomic_Mega_Menu extends Atomic_Element_Base {
 				->build();
 		}
 
+		$toggle = Atomic_Mega_Menu_Toggle::generate()
+			->is_locked( true )
+			->editor_settings( [
+				'title' => 'Menu Toggle',
+			] )
+			->build();
+
 		$nav = Atomic_Mega_Menu_Nav::generate()
 			->children( $item_elements )
 			->is_locked( true )
@@ -138,6 +171,7 @@ class Atomic_Mega_Menu extends Atomic_Element_Base {
 			->build();
 
 		return [
+			$toggle,
 			$nav,
 			$content_area,
 		];
@@ -206,37 +240,20 @@ class Atomic_Mega_Menu extends Atomic_Element_Base {
 
 	protected function define_render_context(): array {
 		return [
-			'context' => [
-				'get-item-index' => fn( $item_id ) => $this->get_item_index( $item_id ),
-				'get-panel-index' => fn( $panel_id ) => $this->get_panel_index( $panel_id ),
-				'mega-menu-id' => $this->get_id(),
+			[
+				'context' => [
+					'get-item-index' => fn( $item_id ) => $this->get_item_index( $item_id ),
+					'get-panel-index' => fn( $panel_id ) => $this->get_panel_index( $panel_id ),
+					'mega-menu-id' => $this->get_id(),
+				],
 			],
 		];
 	}
 
-	protected function add_render_attributes() {
-		parent::add_render_attributes();
-		$settings = $this->get_atomic_settings();
-		$base_style_class = $this->get_base_styles_dictionary()[ static::BASE_STYLE_KEY ];
-		$initial_attributes = $this->define_initial_attributes();
-
-		$attributes = [
-			'class' => [
-				'e-con',
-				'e-atomic-element',
-				$base_style_class,
-				...( $settings['classes'] ?? [] ),
-			],
-			'role' => 'navigation',
-			'x-data' => 'eMegaMenu' . $this->get_id(),
-			'data-e-settings' => wp_json_encode( [] ),
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-mega-menu' => __DIR__ . '/atomic-mega-menu.html.twig',
 		];
-
-		if ( ! empty( $settings['_cssid'] ) ) {
-			$attributes['id'] = esc_attr( $settings['_cssid'] );
-		}
-
-		$this->add_render_attribute( '_wrapper', array_merge( $initial_attributes, $attributes ) );
 	}
 
 	public static function get_item_id( $mega_menu_id, $index ) {

--- a/modules/atomic-widgets/elements/atomic-mega-menu/handlers/atomic-mega-menu-handler.js
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/handlers/atomic-mega-menu-handler.js
@@ -1,77 +1,525 @@
 import { register } from '@elementor/frontend-handlers';
 import { Alpine } from '@elementor/alpinejs';
-import { ITEM_ELEMENT_TYPE, PANEL_ELEMENT_TYPE, getItemId, getPanelId, getIndex } from './utils';
+import {
+	ITEM_ELEMENT_TYPE,
+	PANEL_ELEMENT_TYPE,
+	TOGGLE_ELEMENT_TYPE,
+	SELECTED_CLASS,
+	getItemId,
+	getPanelId,
+	getIndex,
+	getItems,
+	getPanels,
+	isRtl,
+} from './utils';
 
-const SELECTED_CLASS = 'e--selected';
+const HOVER_CLOSE_DELAY_MS = 150;
+const DIAGONAL_TOLERANCE_PX = 50;
+
+const BREAKPOINT_WIDTHS = {
+	mobile: 767,
+	tablet: 1024,
+	none: 0,
+};
+
+function isDropdownMode( menuElement ) {
+	const breakpoint = menuElement.dataset.breakpoint || 'tablet';
+
+	if ( 'none' === breakpoint ) {
+		return false;
+	}
+
+	const maxWidth = BREAKPOINT_WIDTHS[ breakpoint ] || BREAKPOINT_WIDTHS.tablet;
+
+	return window.innerWidth <= maxWidth;
+}
+
+function positionPanel( panelEl, itemEl, menuElement, contentWidth, contentPosition ) {
+	panelEl.style.left = '';
+	panelEl.style.right = '';
+	panelEl.style.bottom = '';
+	panelEl.style.top = '';
+	panelEl.style.width = '';
+
+	if ( 'full-width' === contentWidth ) {
+		panelEl.style.width = menuElement.offsetWidth + 'px';
+		const navEl = itemEl.closest( '[data-element_type="e-mega-menu-nav"]' );
+
+		if ( navEl ) {
+			const navRect = navEl.getBoundingClientRect();
+			const menuRect = menuElement.getBoundingClientRect();
+			const rtl = isRtl();
+			const prop = rtl ? 'right' : 'left';
+			const offset = rtl ? navRect.right - menuRect.right : menuRect.left - navRect.left;
+			panelEl.style[ prop ] = offset + 'px';
+		}
+
+		return;
+	}
+
+	const navEl = itemEl.closest( '[data-element_type="e-mega-menu-nav"]' );
+
+	if ( ! navEl ) {
+		return;
+	}
+
+	const itemRect = itemEl.getBoundingClientRect();
+	const panelRect = panelEl.getBoundingClientRect();
+	const bodyWidth = document.documentElement.clientWidth;
+	const rtl = isRtl();
+	const navRect = navEl.getBoundingClientRect();
+
+	let offset = rtl
+		? bodyWidth - itemRect.right
+		: itemRect.left;
+
+	const position = contentPosition || 'start';
+
+	if ( 'center' === position ) {
+		offset = rtl
+			? bodyWidth - ( itemRect.left + ( itemRect.width / 2 ) + ( panelRect.width / 2 ) )
+			: ( itemRect.left + ( itemRect.width / 2 ) ) - ( panelRect.width / 2 );
+	} else if ( 'end' === position ) {
+		offset = rtl
+			? bodyWidth - itemRect.left
+			: itemRect.right - panelRect.width;
+	}
+
+	if ( offset + panelRect.width > bodyWidth ) {
+		offset = bodyWidth - panelRect.width;
+	}
+
+	if ( offset < 0 ) {
+		offset = 0;
+	}
+
+	const prop = rtl ? 'right' : 'left';
+	const navOffset = rtl ? bodyWidth - navRect.right : navRect.left;
+
+	panelEl.style[ prop ] = `${ offset - navOffset }px`;
+
+	const spaceBelow = window.innerHeight - navRect.bottom;
+
+	if ( panelRect.height > spaceBelow && panelRect.height < navRect.top ) {
+		panelEl.style.bottom = `${ navRect.height }px`;
+		panelEl.style.top = 'auto';
+	}
+}
+
+function getItemForPanel( menuElement, megaMenuId, panelEl ) {
+	const panelIndex = getIndex( panelEl, PANEL_ELEMENT_TYPE );
+	const itemId = getItemId( megaMenuId, panelIndex );
+
+	return menuElement.querySelector( `#${ CSS.escape( itemId ) }` );
+}
+
+function isCursorBetweenItemAndPanel( event, itemEl, panelEl ) {
+	if ( ! itemEl || ! panelEl ) {
+		return false;
+	}
+
+	const itemRect = itemEl.getBoundingClientRect();
+	const panelRect = panelEl.getBoundingClientRect();
+	const mouseY = event.clientY;
+	const mouseX = event.clientX;
+
+	const isBelowItem = mouseY >= itemRect.bottom - DIAGONAL_TOLERANCE_PX;
+	const isAbovePanel = mouseY <= panelRect.top + DIAGONAL_TOLERANCE_PX;
+	const isWithinHorizontalBounds =
+		mouseX >= Math.min( itemRect.left, panelRect.left ) - DIAGONAL_TOLERANCE_PX &&
+		mouseX <= Math.max( itemRect.right, panelRect.right ) + DIAGONAL_TOLERANCE_PX;
+
+	return isBelowItem && isAbovePanel && isWithinHorizontalBounds;
+}
 
 register( {
 	elementType: 'e-mega-menu',
 	id: 'e-mega-menu-handler',
-	callback: ( { element } ) => {
+	callback: ( { element, settings, signal } ) => {
+		const triggerMode = settings?.[ 'trigger-mode' ];
+
+		// Always use tablet breakpoint for responsive behavior
+		element.setAttribute( 'data-breakpoint', 'tablet' );
+
 		const megaMenuId = element.dataset.id;
+		let closeTimeout = null;
+
+		const clearCloseTimeout = () => {
+			if ( closeTimeout ) {
+				clearTimeout( closeTimeout );
+				closeTimeout = null;
+			}
+		};
+
+		const scheduleClose = ( context ) => {
+			clearCloseTimeout();
+			closeTimeout = setTimeout( () => {
+				context.activeItem = null;
+			}, HOVER_CLOSE_DELAY_MS );
+		};
+
+		const handleOutsideClick = ( event ) => {
+			if ( element.contains( event.target ) ) {
+				return;
+			}
+
+			const data = Alpine.$data( element );
+
+			if ( data?.activeItem ) {
+				data.activeItem = null;
+			}
+
+			if ( data?.menuOpen ) {
+				data.menuOpen = false;
+			}
+		};
+
+		document.addEventListener( 'click', handleOutsideClick );
+
+		signal.addEventListener( 'abort', () => {
+			document.removeEventListener( 'click', handleOutsideClick );
+			clearCloseTimeout();
+		} );
 
 		Alpine.data( `eMegaMenu${ megaMenuId }`, () => ( {
 			activeItem: null,
+			menuOpen: false,
+			isDropdown: isDropdownMode( element ),
+
+			nav: {
+				'x-show'() {
+					return ! this.isDropdown || this.menuOpen;
+				},
+
+				':style'() {
+					if ( this.isDropdown ) {
+						return { 'flex-direction': 'column' };
+					}
+
+					return { 'flex-direction': '' };
+				},
+			},
+
+			contentArea: {
+				'x-show'() {
+					return ! this.isDropdown || this.menuOpen;
+				},
+			},
+
+			toggle: {
+				'x-show'() {
+					return this.isDropdown;
+				},
+
+				'@click'() {
+					this.menuOpen = ! this.menuOpen;
+
+					if ( ! this.menuOpen ) {
+						this.activeItem = null;
+					}
+				},
+
+				':aria-expanded'() {
+					return this.menuOpen ? 'true' : 'false';
+				},
+			},
 
 			menuItem: {
 				':id'() {
 					const index = getIndex( this.$el, ITEM_ELEMENT_TYPE );
-
 					return getItemId( megaMenuId, index );
 				},
-				'@click'() {
-					const id = this.$el.id;
 
+				'@click'() {
+					clearCloseTimeout();
+					const id = this.$el.id;
 					this.activeItem = this.activeItem === id ? null : id;
 				},
+
 				'@mouseenter'() {
-					const id = this.$el.id;
+					if ( 'click' === triggerMode ) {
+						return;
+					}
 
-					this.activeItem = id;
+					if ( this.isDropdown ) {
+						return;
+					}
+
+					clearCloseTimeout();
+					this.activeItem = this.$el.id;
 				},
+
+				'@mouseleave'( event ) {
+					if ( 'click' === triggerMode ) {
+						return;
+					}
+
+					if ( this.isDropdown ) {
+						return;
+					}
+
+					const items = getItems( element );
+					const itemIndex = items.indexOf( this.$el );
+					const panels = getPanels( element );
+					const panelEl = panels[ itemIndex ];
+
+					if ( panelEl && isCursorBetweenItemAndPanel( event, this.$el, panelEl ) ) {
+						return;
+					}
+
+					scheduleClose( this );
+				},
+
 				':class'() {
-					const id = this.$el.id;
-
-					return this.activeItem === id ? SELECTED_CLASS : '';
+					return this.activeItem === this.$el.id ? SELECTED_CLASS : '';
 				},
+
 				':aria-expanded'() {
-					const id = this.$el.id;
-
-					return this.activeItem === id ? 'true' : 'false';
+					return this.activeItem === this.$el.id ? 'true' : 'false';
 				},
+
 				':aria-controls'() {
 					const index = getIndex( this.$el, ITEM_ELEMENT_TYPE );
-
 					return getPanelId( megaMenuId, index );
+				},
+
+				'@keydown'( event ) {
+					const items = getItems( element );
+					const currentIndex = items.indexOf( this.$el );
+					const dropdown = this.isDropdown;
+
+					let prevKey;
+					let nextKey;
+
+					if ( dropdown ) {
+						prevKey = 'ArrowUp';
+						nextKey = 'ArrowDown';
+					} else {
+						prevKey = isRtl() ? 'ArrowRight' : 'ArrowLeft';
+						nextKey = isRtl() ? 'ArrowLeft' : 'ArrowRight';
+					}
+
+					const openKey = dropdown ? null : 'ArrowDown';
+
+					switch ( event.key ) {
+						case nextKey: {
+							event.preventDefault();
+							const nextIndex = ( currentIndex + 1 ) % items.length;
+							items[ nextIndex ].focus();
+							break;
+						}
+
+						case prevKey: {
+							event.preventDefault();
+							const prevIndex = ( currentIndex - 1 + items.length ) % items.length;
+							items[ prevIndex ].focus();
+							break;
+						}
+
+						case 'Home': {
+							event.preventDefault();
+							items[ 0 ]?.focus();
+							break;
+						}
+
+						case 'End': {
+							event.preventDefault();
+							items[ items.length - 1 ]?.focus();
+							break;
+						}
+
+						case 'Enter':
+						case ' ': {
+							event.preventDefault();
+							const id = this.$el.id;
+							this.activeItem = this.activeItem === id ? null : id;
+							break;
+						}
+
+						case 'Escape': {
+							event.preventDefault();
+
+							if ( dropdown ) {
+								if ( this.activeItem ) {
+									this.activeItem = null;
+									this.$el.trigger( 'focus' );
+								} else {
+									const toggleEl = element.querySelector(
+										`[data-element_type="${ TOGGLE_ELEMENT_TYPE }"]`,
+									);
+									this.menuOpen = false;
+									toggleEl?.focus();
+								}
+							} else {
+								this.activeItem = null;
+								this.$el.trigger( 'focus' );
+							}
+							break;
+						}
+
+						case 'Tab': {
+							if ( this.activeItem !== this.$el.id ) {
+								break;
+							}
+
+							const panels = getPanels( element );
+							const panelEl = panels[ currentIndex ];
+
+							if ( ! panelEl || event.shiftKey ) {
+								break;
+							}
+
+							const focusable = panelEl.querySelector(
+								'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])',
+							);
+
+							if ( focusable ) {
+								event.preventDefault();
+								focusable.focus();
+							}
+							break;
+						}
+					}
+
+					if ( openKey && event.key === openKey && openKey !== nextKey ) {
+						event.preventDefault();
+						const id = this.$el.id;
+						this.activeItem = id;
+
+						this.$nextTick( () => {
+							const panels = getPanels( element );
+							const panelEl = panels[ currentIndex ];
+
+							if ( ! panelEl ) {
+								return;
+							}
+
+							const focusable = panelEl.querySelector(
+								'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])',
+							);
+
+							focusable?.focus();
+						} );
+					}
+				},
+
+				':tabindex'() {
+					const items = getItems( element );
+					const isFirst = items[ 0 ] === this.$el;
+					const isActive = this.activeItem === this.$el.id;
+
+					return ( isFirst || isActive ) ? '0' : '-1';
+				},
+
+				':role'() {
+					return 'menuitem';
 				},
 			},
 
 			panel: {
 				':id'() {
 					const index = getIndex( this.$el, PANEL_ELEMENT_TYPE );
-
 					return getPanelId( megaMenuId, index );
 				},
+
 				':aria-labelledby'() {
 					const index = getIndex( this.$el, PANEL_ELEMENT_TYPE );
-
 					return getItemId( megaMenuId, index );
 				},
+
 				'x-show'() {
 					const index = getIndex( this.$el, PANEL_ELEMENT_TYPE );
 					const itemId = getItemId( megaMenuId, index );
 					const isActive = this.activeItem === itemId;
+					const dropdown = this.isDropdown;
 
 					this.$nextTick( () => {
 						this.$el.classList.toggle( SELECTED_CLASS, isActive );
+
+						if ( dropdown ) {
+							this.$el.style.position = 'relative';
+							this.$el.style.left = '';
+							this.$el.style.right = '';
+							this.$el.style.bottom = '';
+							this.$el.style.top = '';
+							return;
+						}
+
+						this.$el.style.position = '';
+
+						if ( isActive ) {
+							const itemEl = getItemForPanel( element, megaMenuId, this.$el );
+
+							if ( itemEl ) {
+								positionPanel( this.$el, itemEl, element, 'full-width', 'center' );
+							}
+						}
 					} );
 
 					return isActive;
 				},
+
+				'@mouseenter'() {
+					if ( 'click' === triggerMode ) {
+						return;
+					}
+
+					if ( this.isDropdown ) {
+						return;
+					}
+
+					clearCloseTimeout();
+				},
+
 				'@mouseleave'() {
+					if ( 'click' === triggerMode ) {
+						return;
+					}
+
+					if ( this.isDropdown ) {
+						return;
+					}
+
+					scheduleClose( this );
+				},
+
+				'@keydown.escape'() {
+					const itemEl = getItemForPanel( element, megaMenuId, this.$el );
 					this.activeItem = null;
+					itemEl?.focus();
+				},
+
+				':role'() {
+					return 'menu';
 				},
 			},
 		} ) );
+
+		const updateLayout = () => {
+			const dropdown = isDropdownMode( element );
+			element.setAttribute( 'data-layout', dropdown ? 'dropdown' : 'horizontal' );
+
+			try {
+				const data = Alpine.$data( element );
+
+				if ( data ) {
+					data.isDropdown = dropdown;
+					data.activeItem = null;
+					data.menuOpen = false;
+				}
+			} catch ( e ) {
+				// Alpine may not have processed the element yet
+			}
+		};
+
+		requestAnimationFrame( () => {
+			updateLayout();
+		} );
+
+		window.addEventListener( 'resize', updateLayout );
+
+		signal.addEventListener( 'abort', () => {
+			window.removeEventListener( 'resize', updateLayout );
+		} );
 	},
 } );

--- a/modules/atomic-widgets/elements/atomic-mega-menu/handlers/atomic-mega-menu-handler.js
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/handlers/atomic-mega-menu-handler.js
@@ -1,0 +1,77 @@
+import { register } from '@elementor/frontend-handlers';
+import { Alpine } from '@elementor/alpinejs';
+import { ITEM_ELEMENT_TYPE, PANEL_ELEMENT_TYPE, getItemId, getPanelId, getIndex } from './utils';
+
+const SELECTED_CLASS = 'e--selected';
+
+register( {
+	elementType: 'e-mega-menu',
+	id: 'e-mega-menu-handler',
+	callback: ( { element } ) => {
+		const megaMenuId = element.dataset.id;
+
+		Alpine.data( `eMegaMenu${ megaMenuId }`, () => ( {
+			activeItem: null,
+
+			menuItem: {
+				':id'() {
+					const index = getIndex( this.$el, ITEM_ELEMENT_TYPE );
+
+					return getItemId( megaMenuId, index );
+				},
+				'@click'() {
+					const id = this.$el.id;
+
+					this.activeItem = this.activeItem === id ? null : id;
+				},
+				'@mouseenter'() {
+					const id = this.$el.id;
+
+					this.activeItem = id;
+				},
+				':class'() {
+					const id = this.$el.id;
+
+					return this.activeItem === id ? SELECTED_CLASS : '';
+				},
+				':aria-expanded'() {
+					const id = this.$el.id;
+
+					return this.activeItem === id ? 'true' : 'false';
+				},
+				':aria-controls'() {
+					const index = getIndex( this.$el, ITEM_ELEMENT_TYPE );
+
+					return getPanelId( megaMenuId, index );
+				},
+			},
+
+			panel: {
+				':id'() {
+					const index = getIndex( this.$el, PANEL_ELEMENT_TYPE );
+
+					return getPanelId( megaMenuId, index );
+				},
+				':aria-labelledby'() {
+					const index = getIndex( this.$el, PANEL_ELEMENT_TYPE );
+
+					return getItemId( megaMenuId, index );
+				},
+				'x-show'() {
+					const index = getIndex( this.$el, PANEL_ELEMENT_TYPE );
+					const itemId = getItemId( megaMenuId, index );
+					const isActive = this.activeItem === itemId;
+
+					this.$nextTick( () => {
+						this.$el.classList.toggle( SELECTED_CLASS, isActive );
+					} );
+
+					return isActive;
+				},
+				'@mouseleave'() {
+					this.activeItem = null;
+				},
+			},
+		} ) );
+	},
+} );

--- a/modules/atomic-widgets/elements/atomic-mega-menu/handlers/atomic-mega-menu-preview-handler.js
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/handlers/atomic-mega-menu-preview-handler.js
@@ -1,0 +1,29 @@
+import { register } from '@elementor/frontend-handlers';
+import { Alpine, refreshTree } from '@elementor/alpinejs';
+import { ITEM_ELEMENT_TYPE, PANEL_ELEMENT_TYPE, getItemId, getIndex } from './utils';
+
+register( {
+	elementType: 'e-mega-menu',
+	id: 'e-mega-menu-preview-handler',
+	callback: ( { element, signal, listenToChildren } ) => {
+		window?.parent.addEventListener( 'elementor/navigator/item/click', ( event ) => {
+			const { id, type } = event.detail;
+
+			if ( type !== ITEM_ELEMENT_TYPE && type !== PANEL_ELEMENT_TYPE ) {
+				return;
+			}
+
+			const targetElement = Alpine.$data( element ).$refs[ id ];
+
+			if ( ! targetElement ) {
+				return;
+			}
+
+			const targetIndex = getIndex( targetElement, type );
+			Alpine.$data( element ).activeItem = getItemId( element.dataset.id, targetIndex );
+		}, { signal } );
+
+		listenToChildren( [ ITEM_ELEMENT_TYPE, PANEL_ELEMENT_TYPE ] )
+			.render( () => refreshTree( element ) );
+	},
+} );

--- a/modules/atomic-widgets/elements/atomic-mega-menu/handlers/atomic-mega-menu-preview-handler.js
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/handlers/atomic-mega-menu-preview-handler.js
@@ -1,6 +1,12 @@
 import { register } from '@elementor/frontend-handlers';
 import { Alpine, refreshTree } from '@elementor/alpinejs';
-import { ITEM_ELEMENT_TYPE, PANEL_ELEMENT_TYPE, getItemId, getIndex } from './utils';
+import {
+	ITEM_ELEMENT_TYPE,
+	PANEL_ELEMENT_TYPE,
+	TOGGLE_ELEMENT_TYPE,
+	getItemId,
+	getIndex,
+} from './utils';
 
 register( {
 	elementType: 'e-mega-menu',
@@ -23,7 +29,7 @@ register( {
 			Alpine.$data( element ).activeItem = getItemId( element.dataset.id, targetIndex );
 		}, { signal } );
 
-		listenToChildren( [ ITEM_ELEMENT_TYPE, PANEL_ELEMENT_TYPE ] )
+		listenToChildren( [ ITEM_ELEMENT_TYPE, PANEL_ELEMENT_TYPE, TOGGLE_ELEMENT_TYPE ] )
 			.render( () => refreshTree( element ) );
 	},
 } );

--- a/modules/atomic-widgets/elements/atomic-mega-menu/handlers/utils.js
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/handlers/utils.js
@@ -1,0 +1,26 @@
+export const ITEM_ELEMENT_TYPE = 'e-mega-menu-item';
+export const PANEL_ELEMENT_TYPE = 'e-mega-menu-panel';
+export const NAV_ELEMENT_TYPE = 'e-mega-menu-nav';
+export const CONTENT_AREA_ELEMENT_TYPE = 'e-mega-menu-content-area';
+
+export const getItemId = ( megaMenuId, index ) => {
+	return `${ megaMenuId }-item-${ index }`;
+};
+
+export const getPanelId = ( megaMenuId, index ) => {
+	return `${ megaMenuId }-panel-${ index }`;
+};
+
+export const getChildren = ( el, elementType ) => {
+	const parent = el.parentElement;
+
+	return Array.from( parent.children ).filter( ( child ) => {
+		return child.dataset.element_type === elementType;
+	} );
+};
+
+export const getIndex = ( el, elementType ) => {
+	const children = getChildren( el, elementType );
+
+	return children.indexOf( el );
+};

--- a/modules/atomic-widgets/elements/atomic-mega-menu/handlers/utils.js
+++ b/modules/atomic-widgets/elements/atomic-mega-menu/handlers/utils.js
@@ -2,6 +2,9 @@ export const ITEM_ELEMENT_TYPE = 'e-mega-menu-item';
 export const PANEL_ELEMENT_TYPE = 'e-mega-menu-panel';
 export const NAV_ELEMENT_TYPE = 'e-mega-menu-nav';
 export const CONTENT_AREA_ELEMENT_TYPE = 'e-mega-menu-content-area';
+export const TOGGLE_ELEMENT_TYPE = 'e-mega-menu-toggle';
+
+export const SELECTED_CLASS = 'e--selected';
 
 export const getItemId = ( megaMenuId, index ) => {
 	return `${ megaMenuId }-item-${ index }`;
@@ -23,4 +26,20 @@ export const getIndex = ( el, elementType ) => {
 	const children = getChildren( el, elementType );
 
 	return children.indexOf( el );
+};
+
+export const getItems = ( menuElement ) => {
+	return Array.from(
+		menuElement.querySelectorAll( `[data-element_type="${ ITEM_ELEMENT_TYPE }"]` ),
+	);
+};
+
+export const getPanels = ( menuElement ) => {
+	return Array.from(
+		menuElement.querySelectorAll( `[data-element_type="${ PANEL_ELEMENT_TYPE }"]` ),
+	);
+};
+
+export const isRtl = () => {
+	return 'rtl' === document.documentElement.dir;
 };

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -105,6 +105,7 @@ use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_N
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Item\Atomic_Mega_Menu_Item;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Content_Area\Atomic_Mega_Menu_Content_Area;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Panel\Atomic_Mega_Menu_Panel;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Toggle\Atomic_Mega_Menu_Toggle;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Form\Atomic_Form;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Form\Form_Success_Message\Form_Success_Message;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Form\Form_Error_Message\Form_Error_Message;
@@ -289,6 +290,7 @@ class Module extends BaseModule {
 		$elements_manager->register_element_type( new Atomic_Mega_Menu_Item() );
 		$elements_manager->register_element_type( new Atomic_Mega_Menu_Content_Area() );
 		$elements_manager->register_element_type( new Atomic_Mega_Menu_Panel() );
+		$elements_manager->register_element_type( new Atomic_Mega_Menu_Toggle() );
 
 		if ( \Elementor\Utils::has_pro() && Plugin::$instance->experiments->is_feature_active( 'e_pro_atomic_form' ) ) {
 			$elements_manager->register_element_type( new Atomic_Form() );

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -100,6 +100,11 @@ use Elementor\Modules\AtomicWidgets\Styles\Size_Constants;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 use Elementor\Modules\AtomicWidgets\Database\Atomic_Widgets_Database_Updater;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Tabs\Atomic_Tab_Content\Atomic_Tab_Content;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu\Atomic_Mega_Menu;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Nav\Atomic_Mega_Menu_Nav;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Item\Atomic_Mega_Menu_Item;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Content_Area\Atomic_Mega_Menu_Content_Area;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Mega_Menu\Atomic_Mega_Menu_Panel\Atomic_Mega_Menu_Panel;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Form\Atomic_Form;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Form\Form_Success_Message\Form_Success_Message;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Form\Form_Error_Message\Form_Error_Message;
@@ -278,6 +283,12 @@ class Module extends BaseModule {
 		$elements_manager->register_element_type( new Atomic_Tab() );
 		$elements_manager->register_element_type( new Atomic_Tabs_Content_Area() );
 		$elements_manager->register_element_type( new Atomic_Tab_Content() );
+
+		$elements_manager->register_element_type( new Atomic_Mega_Menu() );
+		$elements_manager->register_element_type( new Atomic_Mega_Menu_Nav() );
+		$elements_manager->register_element_type( new Atomic_Mega_Menu_Item() );
+		$elements_manager->register_element_type( new Atomic_Mega_Menu_Content_Area() );
+		$elements_manager->register_element_type( new Atomic_Mega_Menu_Panel() );
 
 		if ( \Elementor\Utils::has_pro() && Plugin::$instance->experiments->is_feature_active( 'e_pro_atomic_form' ) ) {
 			$elements_manager->register_element_type( new Atomic_Form() );

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/mega-menu-control/mega-menu-control.tsx
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/mega-menu-control/mega-menu-control.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import {
+	ControlFormLabel,
+	Repeater,
+	type RepeaterItem,
+	type SetRepeaterValuesMeta,
+} from '@elementor/editor-controls';
+import {
+	updateElementEditorSettings,
+	useElementChildren,
+	useElementEditorSettings,
+	type V1Element,
+} from '@elementor/editor-elements';
+import { type CreateOptions } from '@elementor/editor-props';
+import { Stack, TextField } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import { useElement } from '../../../contexts/element-context';
+import { SettingsField } from '../../settings-field';
+import { getElementByType } from '../get-element-by-type';
+import { MENU_ITEM_ELEMENT_TYPE, type MenuItemData, useActions } from './use-actions';
+
+const NAV_ELEMENT_TYPE = 'e-mega-menu-nav';
+const CONTENT_AREA_ELEMENT_TYPE = 'e-mega-menu-content-area';
+
+export const MegaMenuControl = ( { label }: { label: string } ) => {
+	return (
+		<SettingsField bind="default-active-item" propDisplayName={ __( 'Menu Items', 'elementor' ) }>
+			<MegaMenuControlContent label={ label } />
+		</SettingsField>
+	);
+};
+
+const MegaMenuControlContent = ( { label }: { label: string } ) => {
+	const { element } = useElement();
+	const { addItem, duplicateItem, moveItem, removeItem } = useActions();
+
+	const { [ MENU_ITEM_ELEMENT_TYPE ]: menuItems } = useElementChildren( element.id, {
+		[ NAV_ELEMENT_TYPE ]: MENU_ITEM_ELEMENT_TYPE,
+	} );
+
+	const nav = getElementByType( element.id, NAV_ELEMENT_TYPE ) as V1Element;
+	const contentArea = getElementByType( element.id, CONTENT_AREA_ELEMENT_TYPE ) as V1Element;
+
+	const repeaterValues: RepeaterItem< MenuItemData >[] = ( menuItems ?? [] ).map( ( menuItem, index ) => ( {
+		id: menuItem.id,
+		title: menuItem.editorSettings?.title,
+		index,
+	} ) );
+
+	const setValue = (
+		_newValues: RepeaterItem< MenuItemData >[],
+		_options: CreateOptions,
+		meta?: SetRepeaterValuesMeta< RepeaterItem< MenuItemData > >
+	) => {
+		if ( ! nav || ! contentArea ) {
+			return;
+		}
+
+		if ( meta?.action?.type === 'add' ) {
+			const items = meta.action.payload;
+
+			return addItem( { contentAreaId: contentArea.id, items, navId: nav.id } );
+		}
+
+		if ( meta?.action?.type === 'remove' ) {
+			const items = meta.action.payload;
+
+			return removeItem( {
+				contentAreaId: contentArea.id,
+				items,
+			} );
+		}
+
+		if ( meta?.action?.type === 'duplicate' ) {
+			const items = meta.action.payload;
+
+			return duplicateItem( { contentAreaId: contentArea.id, items } );
+		}
+
+		if ( meta?.action?.type === 'reorder' ) {
+			const { from, to } = meta.action.payload;
+
+			return moveItem( {
+				contentAreaId: contentArea.id,
+				movedElementId: menuItems[ from ].id,
+				movedElementIndex: from,
+				navId: nav.id,
+				toIndex: to,
+			} );
+		}
+	};
+
+	return (
+		<Repeater
+			itemSettings={ {
+				Content: ItemContent,
+				Icon: () => null,
+				Label: ItemLabel,
+				getId: ( { item } ) => item.id,
+				initialValues: { id: '', title: 'Menu Item' },
+			} }
+			label={ label }
+			setValues={ setValue }
+			showRemove={ repeaterValues.length > 1 }
+			showToggle={ false }
+			values={ repeaterValues }
+		/>
+	);
+};
+
+const ItemLabel = ( { value }: { value: MenuItemData; index: number } ) => {
+	const elementTitle = value?.title;
+
+	return (
+		<Stack sx={ { minHeight: 20 } } direction="row" alignItems="center" gap={ 1.5 }>
+			<span>{ elementTitle }</span>
+		</Stack>
+	);
+};
+
+const ItemContent = ( { value }: { value: MenuItemData; index: number } ) => {
+	if ( ! value.id ) {
+		return null;
+	}
+
+	return (
+		<Stack p={ 2 } gap={ 1.5 }>
+			<MenuItemLabelControl elementId={ value.id } />
+		</Stack>
+	);
+};
+
+const MenuItemLabelControl = ( { elementId }: { elementId: string } ) => {
+	const editorSettings = useElementEditorSettings( elementId );
+
+	const label = editorSettings?.title ?? '';
+
+	return (
+		<Stack gap={ 1 }>
+			<ControlFormLabel>{ __( 'Menu Item', 'elementor' ) }</ControlFormLabel>
+			<TextField
+				size="tiny"
+				value={ label }
+				onChange={ ( { target }: React.ChangeEvent< HTMLInputElement > ) => {
+					updateElementEditorSettings( {
+						elementId,
+						settings: { title: target.value },
+					} );
+				} }
+			/>
+		</Stack>
+	);
+};

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/mega-menu-control/use-actions.ts
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/mega-menu-control/use-actions.ts
@@ -1,0 +1,156 @@
+import { type ItemsActionPayload } from '@elementor/editor-controls';
+import {
+	createElements,
+	duplicateElements,
+	getContainer,
+	moveElements,
+	removeElements,
+} from '@elementor/editor-elements';
+import { __ } from '@wordpress/i18n';
+
+export type MenuItemData = {
+	id: string;
+	title?: string;
+};
+
+export const MENU_ITEM_ELEMENT_TYPE = 'e-mega-menu-item';
+export const MENU_PANEL_ELEMENT_TYPE = 'e-mega-menu-panel';
+
+export const useActions = () => {
+	const duplicateItem = ( {
+		items,
+		contentAreaId,
+	}: {
+		items: ItemsActionPayload< MenuItemData >;
+		contentAreaId: string;
+	} ) => {
+		items.forEach( ( { item, index } ) => {
+			const menuItemId = item.id as string;
+			const contentAreaContainer = getContainer( contentAreaId );
+			const panelId = contentAreaContainer?.children?.[ index ]?.id;
+
+			if ( ! panelId ) {
+				throw new Error( 'Original panel ID is required for duplication' );
+			}
+
+			duplicateElements( {
+				elementIds: [ menuItemId, panelId ],
+				title: __( 'Duplicate Menu Item', 'elementor' ),
+			} );
+		} );
+	};
+
+	const moveItem = ( {
+		toIndex,
+		navId,
+		contentAreaId,
+		movedElementId,
+		movedElementIndex,
+	}: {
+		toIndex: number;
+		navId: string;
+		contentAreaId: string;
+		movedElementId: string;
+		movedElementIndex: number;
+	} ) => {
+		const contentAreaContainer = getContainer( contentAreaId );
+		const panel = contentAreaContainer?.children?.[ movedElementIndex ];
+		const movedElement = getContainer( movedElementId );
+		const nav = getContainer( navId );
+
+		if ( ! panel ) {
+			throw new Error( 'Panel element is required' );
+		}
+
+		if ( ! movedElement || ! nav ) {
+			throw new Error( 'Menu item or nav not found' );
+		}
+
+		moveElements( {
+			title: __( 'Reorder Menu Items', 'elementor' ),
+			moves: [
+				{
+					element: movedElement,
+					targetContainer: nav,
+					options: { at: toIndex },
+				},
+				{
+					element: panel,
+					targetContainer: contentAreaContainer,
+					options: { at: toIndex },
+				},
+			],
+		} );
+	};
+
+	const removeItem = ( {
+		items,
+		contentAreaId,
+	}: {
+		items: ItemsActionPayload< MenuItemData >;
+		contentAreaId: string;
+	} ) => {
+		removeElements( {
+			title: __( 'Menu Item', 'elementor' ),
+			elementIds: items.flatMap( ( { item, index } ) => {
+				const menuItemId = item.id as string;
+				const contentAreaContainer = getContainer( contentAreaId );
+				const panelId = contentAreaContainer?.children?.[ index ]?.id;
+
+				if ( ! panelId ) {
+					throw new Error( 'Panel ID is required' );
+				}
+
+				return [ menuItemId, panelId ];
+			} ),
+		} );
+	};
+
+	const addItem = ( {
+		contentAreaId,
+		navId,
+		items,
+	}: {
+		contentAreaId: string;
+		navId: string;
+		items: ItemsActionPayload< MenuItemData >;
+	} ) => {
+		const contentArea = getContainer( contentAreaId );
+		const nav = getContainer( navId );
+
+		if ( ! contentArea || ! nav ) {
+			throw new Error( 'Menu containers not found' );
+		}
+
+		items.forEach( ( { index } ) => {
+			const position = index + 1;
+
+			createElements( {
+				title: __( 'Menu Item', 'elementor' ),
+				elements: [
+					{
+						container: contentArea,
+						model: {
+							elType: MENU_PANEL_ELEMENT_TYPE,
+							editor_settings: { title: `Panel ${ position }`, initial_position: position },
+						},
+					},
+					{
+						container: nav,
+						model: {
+							elType: MENU_ITEM_ELEMENT_TYPE,
+							editor_settings: { title: `Menu Item ${ position }`, initial_position: position },
+						},
+					},
+				],
+			} );
+		} );
+	};
+
+	return {
+		duplicateItem,
+		moveItem,
+		removeItem,
+		addItem,
+	};
+};

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/registry.ts
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/registry.ts
@@ -1,9 +1,11 @@
 import { type ControlComponent } from '@elementor/editor-controls';
 
 import { type ControlRegistry, controlsRegistry } from '../controls-registry';
+import { MegaMenuControl } from './mega-menu-control/mega-menu-control';
 import { TabsControl } from './tabs-control/tabs-control';
 
 const controlTypes = {
+	'mega-menu': { component: MegaMenuControl as ControlComponent, layout: 'full' },
 	tabs: { component: TabsControl as ControlComponent, layout: 'full' },
 } as const satisfies ControlRegistry;
 

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,156 @@
+# Atomic Mega Menu V3 - Progress & DX Findings
+
+## Status
+
+| Task | Status |
+|------|--------|
+| progress.md | Done |
+| atomic-mega-menu.php (parent) | Done |
+| atomic-mega-menu-nav.php | Done |
+| atomic-mega-menu-item.php | Done |
+| atomic-mega-menu-content-area.php | Done |
+| atomic-mega-menu-panel.php | Done |
+| handlers/utils.js | Done |
+| handlers/atomic-mega-menu-handler.js | Done |
+| handlers/atomic-mega-menu-preview-handler.js | Done |
+| module.php registration | Done |
+| webpack.js entries | Done |
+
+## DX Findings & Infra Gaps
+
+### 1. Namespace / Directory Convention is Inconsistent (Friction: Medium)
+
+The tabs elements on `main` use a nested directory convention where each element lives in its own subdirectory with its own namespace segment:
+```
+atomic-tabs/atomic-tab/atomic-tab.php
+  → namespace ...Atomic_Tabs\Atomic_Tab;
+```
+
+But other atomic elements (like `atomic-paragraph`) use a flat structure:
+```
+atomic-paragraph/atomic-paragraph.php
+  → namespace ...Atomic_Paragraph;
+```
+
+This inconsistency meant I initially created flat files following the simpler pattern, then had to restructure. The skill doc doesn't mention the sub-namespace pattern at all.
+
+**Suggestion:** Document the sub-namespace convention explicitly in the skill. Or better, pick one convention and standardize.
+
+### 2. Render_Context Key Uses FQCN (Friction: Low, Risk: Medium)
+
+`Render_Context::get()` uses the class FQCN as the lookup key:
+```php
+Render_Context::get( Atomic_Mega_Menu::class );
+```
+
+This creates a tight coupling between child and parent namespaces. If the parent class is renamed or moved, all children break silently (the context array will just be empty). There's no error or warning.
+
+**Suggestion:** Consider using the element type string (`'e-mega-menu'`) as the context key instead, or add a validation that warns when `Render_Context::get()` returns empty.
+
+### 3. No "Default Inactive" Pattern in Render Context (Friction: Low)
+
+Tabs always have an active tab. The mega menu starts with nothing active (all panels hidden). The `define_render_context` pattern doesn't need any change to support this - we simply don't include a `default-active-*` key. But the skill doc and reference assume there's always an active item.
+
+The `data-e-settings` on the parent currently passes an empty JSON object `{}` since there's no default active item. This works but feels like a gap - the handler convention expects `settings['some-key']` to exist.
+
+**Suggestion:** Document that `data-e-settings` can be empty and handlers should handle `null` active states.
+
+### 4. define_default_children Builder API is Ergonomic (Finding: Positive)
+
+The builder pattern (`::generate()->editor_settings()->is_locked()->build()`) works well. The composition of items + panels into nav + content-area containers is clean and readable. No issues here.
+
+### 5. Html_V3_Prop_Type Signature Not Obvious (Friction: Medium)
+
+The default children for tabs use:
+```php
+Html_V3_Prop_Type::generate([
+    'content' => String_Prop_Type::generate('Tab'),
+    'children' => [],
+])
+```
+
+This nested structure wasn't obvious from the skill doc, which showed the simpler `Html_Prop_Type::generate('text')`. The V3 version requires wrapping in a `content` + `children` structure. I initially used the wrong API.
+
+**Suggestion:** Update the skill doc to show `Html_V3_Prop_Type` with the correct structure.
+
+### 6. Alpine.js x-bind Doesn't Natively Support "Toggle" + "Hover" Dual Modes (Friction: Medium)
+
+The tabs handler only has click behavior. The mega menu needs both click (for mobile/accessibility) and hover (for desktop). Alpine's `x-bind` object pattern handles this cleanly enough:
+```js
+'@click'() { this.activeItem = this.activeItem === id ? null : id; },
+'@mouseenter'() { this.activeItem = id; },
+```
+
+But there's no built-in way to switch between modes (hover vs click) based on viewport or settings. The v2 mega menu had `isNeedToOpenOnClick()` logic. For V3, this would need to be handled either:
+- Via a setting passed through `data-e-settings`
+- Via Alpine's `$screen` or a custom directive
+
+**Suggestion:** Consider adding a viewport-aware utility to `@elementor/alpinejs` for switching interaction modes.
+
+### 7. "Close on Click Outside" Requires Extra Pattern (Friction: Low)
+
+Alpine has `@click.outside` but it needs to be on the Alpine root component element. Since `x-data` is on the `<nav>` wrapper, clicking outside closes correctly. But the mouseleave is on individual panels, not the whole nav - this means the hover close behavior might feel inconsistent.
+
+In the v2 widget, this was handled with `document.addEventListener('click', ...)` and a complex `onMouseLeave` that checked cursor position between title and content. The Alpine binding pattern doesn't naturally handle "cursor moved between item and panel" scenarios.
+
+**Suggestion:** Document the hover gap pattern. Consider providing a shared Alpine plugin/directive for dropdown menus.
+
+### 8. Boilerplate in add_render_attributes (Friction: High)
+
+Every element repeats this exact pattern:
+```php
+parent::add_render_attributes();
+$settings = $this->get_atomic_settings();
+$base_style_class = $this->get_base_styles_dictionary()[ static::BASE_STYLE_KEY ];
+$initial_attributes = $this->define_initial_attributes();
+
+$attributes = [
+    'class' => [
+        'e-con',
+        'e-atomic-element',
+        $base_style_class,
+        ...( $settings['classes'] ?? [] ),
+    ],
+];
+
+// ...custom attributes...
+
+$this->add_render_attribute( '_wrapper', array_merge( $initial_attributes, $attributes ) );
+```
+
+This is ~15 lines of identical code in every element. The `e-con`, `e-atomic-element`, base style class, and classes prop are always there.
+
+**Suggestion:** Extract this into a base class method that returns the common attributes array, letting children just add their custom ones. Something like:
+```php
+protected function add_render_attributes() {
+    $common = $this->get_common_wrapper_attributes();
+    $custom = ['x-bind' => 'menuItem', ...];
+    $this->add_render_attribute('_wrapper', array_merge($common, $custom));
+}
+```
+
+### 9. Script Registration is Manual and Repetitive (Friction: Medium)
+
+Each nested element parent must manually implement both `register_frontend_handlers()` and `get_script_depends()`. The handler names, paths, and dependency arrays follow a predictable pattern. This could be convention-based.
+
+**Suggestion:** Consider a declarative approach:
+```php
+protected function define_frontend_handlers(): array {
+    return [
+        'handler' => 'atomic-mega-menu-handler.js',
+        'preview-handler' => 'atomic-mega-menu-preview-handler.js',
+    ];
+}
+```
+
+### 10. Webpack Entry Requires Manual Modification (Friction: Low)
+
+Adding handlers requires editing `.grunt-config/webpack.js` manually. This is expected for now but could become a maintenance burden as more nested elements are added.
+
+## Summary
+
+The nested elements infra is solid and the tabs pattern translates well to a mega menu. The main pain points are:
+1. **Boilerplate** in `add_render_attributes` (every element repeats ~15 lines)
+2. **Namespace/directory convention** inconsistency between flat and nested patterns
+3. **Skill doc accuracy** - `Html_V3_Prop_Type` signature and directory conventions not documented
+4. **Hover behavior** - no built-in Alpine utility for viewport-aware interaction mode switching


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add proof-of-concept Mega Menu atomic widget with keyboard navigation, responsive dropdown, and multi-panel content support to extend Elementor's nested atomic elements framework.

Main changes:
- Implemented six new atomic elements (Mega Menu, Nav, Item, Panel, Content Area, Toggle) with Alpine.js handlers for hover/click triggers and ARIA-compliant keyboard navigation
- Created custom Mega Menu control with repeater interface for managing menu items and panels through drag-and-drop reordering and duplication
- Added responsive layout system with automatic dropdown mode at tablet breakpoint and full-width panel positioning relative to navigation container

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
