### PR TITLE
Internal: Skip onboarding test conditionally [ED-23159]

### DIFF
--- a/tests/playwright/sanity/core/app/modules/onboarding/onboarding.test.ts
+++ b/tests/playwright/sanity/core/app/modules/onboarding/onboarding.test.ts
@@ -153,6 +153,14 @@ test.describe( 'On boarding @onBoarding', async () => {
 	test( 'Onboarding Good to Go Page - Open Kit Library', async ( { page } ) => {
 		await page.goto( '/wp-admin/admin.php?page=elementor-app#onboarding/goodToGo' );
 
+		const isExperiment402B = await page.evaluate( () => {
+			return 'B' === localStorage.getItem( 'elementor_onboarding_experiment402_variant' );
+		} );
+
+		if ( isExperiment402B ) {
+			test.skip( true, 'Skipping Kit Library navigation test in Experiment 402 Variant B' );
+		}
+
 		const nextButton = page.locator( '.e-onboarding__cards-grid > a:nth-child(2)' );
 
 		await nextButton.click();


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add conditional test skipping for onboarding Kit Library navigation based on experiment variant to prevent false test failures in A/B testing scenarios.

Main changes:
- Added experiment variant detection by checking localStorage for 'elementor_onboarding_experiment402_variant' value
- Implemented conditional test.skip() when variant B is detected to avoid testing incompatible UI flow
- Preserved existing Kit Library navigation test logic for non-experiment and variant A users

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
