### PR TITLE
Internal: Interactions module constants — single source of truth [ED-22824]

### DIFF
--- a/modules/interactions/assets/js/interactions-shared-utils.js
+++ b/modules/interactions/assets/js/interactions-shared-utils.js
@@ -2,16 +2,7 @@
 
 import { getActiveBreakpoint } from './interactions-breakpoints.js';
 
-export const config = window.ElementorInteractionsConfig?.constants || {
-	defaultDuration: 600,
-	defaultDelay: 0,
-	slideDistance: 100,
-	scaleStart: 0,
-	defaultEasing: 'easeIn',
-	relativeTo: 'viewport',
-	start: 85,
-	end: 15,
-};
+export const config = window.ElementorInteractionsConfig?.constants ?? {};
 
 export function skipInteraction( interaction ) {
 	const breakpoint = getActiveBreakpoint();

--- a/modules/interactions/interactions-frontend-handler.php
+++ b/modules/interactions/interactions-frontend-handler.php
@@ -161,7 +161,7 @@ class Interactions_Frontend_Handler {
 		$json_data = wp_json_encode( $elements_with_interactions, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON data is already encoded
-		echo '<script type="application/json" id="elementor-interactions-data">' . $json_data . '</script>';
+		echo '<script type="application/json" id="' . Module::SCRIPT_ID_INTERACTIONS_DATA . '">' . $json_data . '</script>';
 	}
 
 	/**
@@ -202,14 +202,14 @@ class Interactions_Frontend_Handler {
 	}
 
 	private function enqueue_interactions_assets() {
-		wp_enqueue_script( 'motion-js' );
-		wp_enqueue_script( 'elementor-interactions' );
+		wp_enqueue_script( Module::HANDLE_MOTION_JS );
+		wp_enqueue_script( Module::HANDLE_FRONTEND );
 
 		$config = $this->config_provider ? call_user_func( $this->config_provider ) : [];
 
 		wp_localize_script(
-			'elementor-interactions',
-			'ElementorInteractionsConfig',
+			Module::HANDLE_FRONTEND,
+			Module::JS_CONFIG_OBJECT,
 			$config
 		);
 	}

--- a/modules/interactions/module.php
+++ b/modules/interactions/module.php
@@ -16,6 +16,13 @@ class Module extends BaseModule {
 	const MODULE_NAME = 'e-interactions';
 	const EXPERIMENT_NAME = 'e_interactions';
 
+	const HANDLE_MOTION_JS            = 'motion-js';
+	const HANDLE_SHARED_UTILS         = 'elementor-interactions-shared-utils';
+	const HANDLE_FRONTEND             = 'elementor-interactions';
+	const HANDLE_EDITOR               = 'elementor-editor-interactions';
+	const JS_CONFIG_OBJECT            = 'ElementorInteractionsConfig';
+	const SCRIPT_ID_INTERACTIONS_DATA = 'elementor-interactions-data';
+
 	public function get_name() {
 		return self::MODULE_NAME;
 	}
@@ -116,7 +123,7 @@ class Module extends BaseModule {
 		$suffix = ( Utils::is_script_debug() || Utils::is_elementor_tests() ) ? '' : '.min';
 
 		wp_register_script(
-			'motion-js',
+			self::HANDLE_MOTION_JS,
 			ELEMENTOR_ASSETS_URL . 'lib/motion/motion' . $suffix . '.js',
 			[],
 			'11.13.5',
@@ -124,25 +131,25 @@ class Module extends BaseModule {
 		);
 
 		wp_register_script(
-			'elementor-interactions-shared-utils',
+			self::HANDLE_SHARED_UTILS,
 			$this->get_js_assets_url( 'interactions-shared-utils' ),
-			[ 'motion-js' ],
+			[ self::HANDLE_MOTION_JS ],
 			'1.0.0',
 			true
 		);
 
 		wp_register_script(
-			'elementor-interactions',
+			self::HANDLE_FRONTEND,
 			$this->get_js_assets_url( 'interactions' ),
-			[ 'motion-js', 'elementor-interactions-shared-utils' ],
+			[ self::HANDLE_MOTION_JS, self::HANDLE_SHARED_UTILS ],
 			'1.0.0',
 			true
 		);
 
 		wp_register_script(
-			'elementor-editor-interactions',
+			self::HANDLE_EDITOR,
 			$this->get_js_assets_url( 'editor-interactions' ),
-			[ 'motion-js', 'elementor-interactions-shared-utils' ],
+			[ self::HANDLE_MOTION_JS, self::HANDLE_SHARED_UTILS ],
 			'1.0.0',
 			true
 		);
@@ -151,20 +158,20 @@ class Module extends BaseModule {
 	public function enqueue_editor_scripts() {
 		wp_add_inline_script(
 			'elementor-common',
-			'window.ElementorInteractionsConfig = ' . wp_json_encode( $this->get_config() ) . ';',
+			'window.' . self::JS_CONFIG_OBJECT . ' = ' . wp_json_encode( $this->get_config() ) . ';',
 			'before'
 		);
 	}
 
 	public function enqueue_preview_scripts() {
-		wp_enqueue_script( 'elementor-interactions-shared-utils' );
+		wp_enqueue_script( self::HANDLE_SHARED_UTILS );
 		// Ensure motion-js and editor-interactions handler are available in preview iframe
-		wp_enqueue_script( 'motion-js' );
-		wp_enqueue_script( 'elementor-editor-interactions' );
+		wp_enqueue_script( self::HANDLE_MOTION_JS );
+		wp_enqueue_script( self::HANDLE_EDITOR );
 
 		wp_localize_script(
-			'elementor-editor-interactions',
-			'ElementorInteractionsConfig',
+			self::HANDLE_EDITOR,
+			self::JS_CONFIG_OBJECT,
 			$this->get_config()
 		);
 	}

--- a/packages/packages/core/editor-interactions/src/utils/get-interactions-config.ts
+++ b/packages/packages/core/editor-interactions/src/utils/get-interactions-config.ts
@@ -1,18 +1,5 @@
 import { type InteractionsConfig } from '../types';
 
-const DEFAULT_CONFIG: InteractionsConfig = {
-	constants: {
-		defaultDuration: 600,
-		defaultDelay: 0,
-		slideDistance: 100,
-		scaleStart: 0,
-		defaultEasing: 'easeIn',
-		relativeTo: 'viewport',
-		end: 15,
-		start: 85,
-	},
-};
-
 export function getInteractionsConfig(): InteractionsConfig {
-	return window.ElementorInteractionsConfig || DEFAULT_CONFIG;
+	return window.ElementorInteractionsConfig ?? ( {} as InteractionsConfig );
 }


### PR DESCRIPTION
## Summary
- Add 6 named constants to core `Module` class (`HANDLE_MOTION_JS`, `HANDLE_SHARED_UTILS`, `HANDLE_FRONTEND`, `HANDLE_EDITOR`, `JS_CONFIG_OBJECT`, `SCRIPT_ID_INTERACTIONS_DATA`) so all shared string values live in one place
- Update `module.php`, `interactions-frontend-handler.php` to reference `self::*` / `Module::*` instead of hardcoded literals
- Remove hardcoded default config object from `interactions-shared-utils.js` — trust PHP-provided `window.ElementorInteractionsConfig`
- Remove `DEFAULT_CONFIG` fallback from `get-interactions-config.ts` — PHP always provides the config via `wp_localize_script`

## Test plan
- [ ] Load a page with interactions → animations fire correctly
- [ ] Edit an interaction in the editor preview → preview updates correctly
- [ ] `grep -n 'elementor-interactions\|ElementorInteractionsConfig\|motion-js' modules/interactions/module.php` shows only constant definitions, no bare literals in usage sites
- [ ] `grep -n 'defaultDuration' modules/interactions/assets/js/interactions-shared-utils.js` → zero results
- [ ] `grep -n 'DEFAULT_CONFIG\|defaultDuration' packages/packages/core/editor-interactions/src/utils/get-interactions-config.ts` → zero results

## Jira
[ED-22824](https://elementor.atlassian.net/browse/ED-22824)

[ED-22824]: https://elementor.atlassian.net/browse/ED-22824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor interactions module to centralize all configuration constants and script identifiers in Module class, eliminating hardcoded strings and duplicate default values across codebase.

Main changes:
- Added six class constants (HANDLE_MOTION_JS, HANDLE_FRONTEND, HANDLE_EDITOR, etc.) to Module class as single source of truth
- Replaced all hardcoded script handles and identifiers with Module class constants throughout frontend handler and registration methods
- Removed duplicate default configuration objects from JavaScript files, now relying solely on server-side PHP configuration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
