### PR TITLE
Fix: Default effectType to 'in' for fade/slide interactions created via MCP [ED-23218]

### DIFF
--- a/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
@@ -230,6 +230,24 @@ describe( 'manage-element-interaction tool', () => {
 			expect( result.count ).toBe( 2 );
 		} );
 
+		it( 'defaults effectType to "in" when not provided for fade effect', () => {
+			mockAll.mockReturnValue( [] );
+			const callHandler = createRegistryAndGetHandler();
+			callHandler( { elementId: 'el-default-type', action: 'add', trigger: 'load', effect: 'fade' } );
+
+			const createdItem = mockUpdateElementInteractions.mock.calls[ 0 ][ 0 ].interactions.items[ 0 ];
+			expect( createdItem.value.animation.value.type.value ).toBe( 'in' );
+		} );
+
+		it( 'uses provided effectType when given', () => {
+			mockAll.mockReturnValue( [] );
+			const callHandler = createRegistryAndGetHandler();
+			callHandler( { elementId: 'el-explicit-type', action: 'add', trigger: 'load', effect: 'fade', effectType: 'out' } );
+
+			const createdItem = mockUpdateElementInteractions.mock.calls[ 0 ][ 0 ].interactions.items[ 0 ];
+			expect( createdItem.value.animation.value.type.value ).toBe( 'out' );
+		} );
+
 		it( `throws when element already has ${ MAX_INTERACTIONS_PER_ELEMENT } interactions`, () => {
 			const items = Array.from( { length: MAX_INTERACTIONS_PER_ELEMENT }, ( _, i ) =>
 				createInteractionItem( {

--- a/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
@@ -242,7 +242,13 @@ describe( 'manage-element-interaction tool', () => {
 		it( 'uses provided effectType when given', () => {
 			mockAll.mockReturnValue( [] );
 			const callHandler = createRegistryAndGetHandler();
-			callHandler( { elementId: 'el-explicit-type', action: 'add', trigger: 'load', effect: 'fade', effectType: 'out' } );
+			callHandler( {
+				elementId: 'el-explicit-type',
+				action: 'add',
+				trigger: 'load',
+				effect: 'fade',
+				effectType: 'out',
+			} );
 
 			const createdItem = mockUpdateElementInteractions.mock.calls[ 0 ][ 0 ].interactions.items[ 0 ];
 			expect( createdItem.value.animation.value.type.value ).toBe( 'out' );

--- a/packages/packages/core/editor-interactions/src/mcp/tools/manage-element-interaction-tool.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/tools/manage-element-interaction-tool.ts
@@ -62,9 +62,13 @@ export const initManageElementInteractionTool = ( reg: MCPRegistryEntry ) => {
 			[ key: string ]: unknown;
 		} ) => {
 			const { elementId, action, interactionId, ...animationData } = input;
-			const { effectType, ...restAnimationData } = animationData as { effectType?: string; [ key: string ]: unknown };
+			const { effectType, ...restAnimationData } = animationData as {
+				effectType?: string;
+				[ key: string ]: unknown;
+			};
 			const effect = restAnimationData.effect as string | undefined;
-			const resolvedType = effectType ?? ( effect && ! EFFECTS_WITHOUT_TYPE.includes( effect ) ? 'in' : undefined );
+			const resolvedType =
+				effectType ?? ( effect && ! EFFECTS_WITHOUT_TYPE.includes( effect ) ? 'in' : undefined );
 
 			const allInteractions = interactionsRepository.all();
 			const elementData = allInteractions.find( ( data ) => data.elementId === elementId );

--- a/packages/packages/core/editor-interactions/src/mcp/tools/manage-element-interaction-tool.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/tools/manage-element-interaction-tool.ts
@@ -21,6 +21,8 @@ const EMPTY_INTERACTIONS: ElementInteractions = {
 	items: [],
 };
 
+const EFFECTS_WITHOUT_TYPE = [ 'custom' ];
+
 export const initManageElementInteractionTool = ( reg: MCPRegistryEntry ) => {
 	const { addTool } = reg;
 	const extendedSchema = isProActive() ? { ...baseSchema, ...proSchema } : baseSchema;
@@ -60,6 +62,9 @@ export const initManageElementInteractionTool = ( reg: MCPRegistryEntry ) => {
 			[ key: string ]: unknown;
 		} ) => {
 			const { elementId, action, interactionId, ...animationData } = input;
+			const { effectType, ...restAnimationData } = animationData as { effectType?: string; [ key: string ]: unknown };
+			const effect = restAnimationData.effect as string | undefined;
+			const resolvedType = effectType ?? ( effect && ! EFFECTS_WITHOUT_TYPE.includes( effect ) ? 'in' : undefined );
 
 			const allInteractions = interactionsRepository.all();
 			const elementData = allInteractions.find( ( data ) => data.elementId === elementId );
@@ -106,7 +111,8 @@ export const initManageElementInteractionTool = ( reg: MCPRegistryEntry ) => {
 
 					const newItem = createInteractionItem( {
 						interactionId: generateTempInteractionId(),
-						...animationData,
+						...restAnimationData,
+						type: resolvedType,
 					} );
 
 					updatedItems = [ ...updatedItems, newItem ];
@@ -130,7 +136,8 @@ export const initManageElementInteractionTool = ( reg: MCPRegistryEntry ) => {
 
 					const updatedItem = createInteractionItem( {
 						interactionId,
-						...animationData,
+						...restAnimationData,
+						type: resolvedType,
 					} );
 
 					updatedItems = [


### PR DESCRIPTION
## Summary
- Fixed field name mismatch where MCP schema uses `effectType` but `createInteractionItem()` expects `type` — previously `effectType` was spread as an unrecognized prop and `type` was always `undefined`
- Added default: when `effectType` is omitted and the effect requires a type (any effect except `'custom'`), `type` now defaults to `'in'`
- Extracted `EFFECTS_WITHOUT_TYPE` constant to file level for clarity and reuse
- Both `add` and `update` cases now correctly pass `type` to `createInteractionItem()`

## Test plan
- [ ] Create an interaction via MCP with a fade effect and no `effectType` — verify `type` is `'in'` in the resulting interaction
- [ ] Create an interaction via MCP with `effectType: 'out'` — verify `type` is `'out'`
- [ ] Create an interaction via MCP with effect `'custom'` — verify no `type` is set
- [ ] Update an existing interaction via MCP — verify same `effectType` → `type` resolution applies
- [ ] Run unit tests: `cd packages && npx jest packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts --no-coverage`

## Jira
[ED-23218](https://elementor.atlassian.net/browse/ED-23218)

[ED-23218]: https://elementor.atlassian.net/browse/ED-23218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix missing effectType property for fade and slide interaction effects created via MCP by defaulting to 'in' when not explicitly provided.
Main changes:
- Added automatic effectType defaulting logic to set 'in' for effects requiring type (fade/slide) when effectType is omitted
- Extracted effectType from animationData and applied resolved type to both add and update interaction operations
- Added unit tests validating default 'in' type assignment and explicit type override functionality

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
