### PR TITLE
Internal: Refines button styles for Unboxing v4 flow [ED-23191]

### DIFF
--- a/modules/atomic-opt-in/assets/js/panel-chip/components/popover-card.js
+++ b/modules/atomic-opt-in/assets/js/panel-chip/components/popover-card.js
@@ -62,9 +62,9 @@ const PopoverCard = ( { doClose } ) => {
 					<Button
 						variant="contained"
 						size="small"
-						color="accent"
+						color="inherit"
 						onClick={ redirectHandler }
-						sx={ { ml: 'auto' } }
+						sx={ { ml: 'auto', bgcolor: 'text.primary', color: 'background.paper', '&:hover': { bgcolor: 'text.secondary', color: 'background.paper' } } }
 					>{ ctaText }</Button>
 				</Stack>
 			</Box>

--- a/packages/apps/unlock-v4-promo/src/components/atomic-elements-promo.tsx
+++ b/packages/apps/unlock-v4-promo/src/components/atomic-elements-promo.tsx
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { usePromoSuppressedMessage } from '../hooks/use-promo-suppressed-message';
 
 const PROMO_IMAGE = 'https://assets.elementor.com/v4-promotion/v1/images/v4_chip_new.png';
+const LEARN_MORE_URL = 'https://go.elementor.com/wp-dash-opt-in-v4-help-center/';
 
 export function AtomicElementsPromo() {
 	const [ suppressed, toggleSuppressMessage ] = usePromoSuppressedMessage();
@@ -102,16 +103,20 @@ export function AtomicElementsPromo() {
 						pt: 1,
 					} }
 				>
-					<Button
-						variant="text"
-						size="small"
-						color="secondary"
-						href="https://go.elementor.com/wp-dash-opt-in-v4-help-center/"
-						target="_blank"
-					>
+					<Button variant="text" size="small" color="secondary" href={ LEARN_MORE_URL } target="_blank">
 						{ __( 'Learn more', 'elementor' ) }
 					</Button>
-					<Button variant="contained" size="small" color="primary" onClick={ activateAtomicElements }>
+					<Button
+						variant="contained"
+						size="small"
+						color="inherit"
+						sx={ {
+							bgcolor: 'text.primary',
+							color: 'background.paper',
+							'&:hover': { bgcolor: 'text.secondary', color: 'background.paper' },
+						} }
+						onClick={ activateAtomicElements }
+					>
 						{ __( 'Unlock for free', 'elementor' ) }
 					</Button>
 				</Box>


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Visual styling update

## Summary

This PR can be summarized in the following changelog entry:

* Refines the styling of Call-to-Action buttons within the Unboxing v4 flow.
<img width="298" height="352" alt="image" src="https://github.com/user-attachments/assets/6bd6ee91-0d81-48fe-a10c-8ebc0590e7f3" />


## Description
An explanation of what is done in this PR

* Updates the visual appearance of key buttons in the Unboxing v4 user experience. Specifically, it applies a new contained button style using `text.primary` as the background and `background.paper` as the text color, including a distinct hover effect, to the "Unlock for free" button in the Atomic Elements Promo and the main CTA button in the Popover Card. Additionally, it adjusts the order of the "Learn more" and "Unlock for free" buttons in the Atomic Elements Promo to place "Learn more" first. These changes ensure consistency with current design guidelines for the v4 flow.

## Test instructions
This PR can be tested by following these steps:

* Navigate to the relevant Unboxing v4 promotion area (e.g., WordPress dashboard where the Atomic Elements Promo or the Opt-in panel chip appears).
* Observe the "Unlock for free" button within the Atomic Elements Promo.
* Observe the main CTA button within the Popover Card component (if visible).
* Verify that both buttons display the new contained style: dark background, light text, and a distinct hover effect on hover.
* Confirm that the "Learn more" button now appears before the "Unlock for free" button in the Atomic Elements Promo.

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #ED-23191