### PR TITLE
Fix: Prevent styles order mutation [ED-23246]

### DIFF
--- a/packages/packages/core/editor-canvas/src/hooks/__tests__/use-style-items.test.ts
+++ b/packages/packages/core/editor-canvas/src/hooks/__tests__/use-style-items.test.ts
@@ -128,6 +128,9 @@ describe( 'useStyleItems', () => {
 
 		jest.mocked( stylesRepository ).getProviders.mockReturnValue( [ mockProvider1, mockProvider2 ] );
 
+		const provider1OriginalOrder = mockProvider1.actions.all().map( ( s ) => s.id );
+		const provider2OriginalOrder = mockProvider2.actions.all().map( ( s ) => s.id );
+
 		let attachPreviewCallback: () => Promise< void >;
 
 		jest.mocked( registerDataHook ).mockImplementation( ( position, command, callback ) => {
@@ -156,6 +159,9 @@ describe( 'useStyleItems', () => {
 			{ id: 'style2', breakpoint: 'desktop' },
 			{ id: 'style1', breakpoint: 'desktop' },
 		] );
+
+		expect( mockProvider1.actions.all().map( ( s ) => s.id ) ).toEqual( provider1OriginalOrder );
+		expect( mockProvider2.actions.all().map( ( s ) => s.id ) ).toEqual( provider2OriginalOrder );
 	} );
 
 	it( 'should return style items ordered by provider priority and breakpoint', async () => {

--- a/packages/packages/core/editor-canvas/src/hooks/use-style-items.ts
+++ b/packages/packages/core/editor-canvas/src/hooks/use-style-items.ts
@@ -181,7 +181,7 @@ function createProviderSubscriber( { provider, renderStyles, setStyleItems, cach
 	async function createItems( signal: AbortSignal ) {
 		const allStyles = provider.actions.all();
 
-		const styles = allStyles.reverse().map( ( style ) => {
+		const styles = [ ...allStyles ].reverse().map( ( style ) => {
 			return {
 				...style,
 				cssName: provider.actions.resolveCssName( style.id ),


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix array mutation bug in style provider processing that was causing unintended side effects by reversing the original styles array.

Main changes:
- Added array spread operator to create copy before reversing in createItems() to prevent mutation of provider.actions.all()
- Added unit test assertions to verify style provider arrays maintain original order after processing
- Prevented potential race conditions and unexpected behavior from mutating shared state across multiple components

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
