### PR TITLE
Internal: Export isAngieSidebarOpen from editor-mcp [ED-23127]

### DIFF
--- a/packages/packages/libs/editor-mcp/src/index.ts
+++ b/packages/packages/libs/editor-mcp/src/index.ts
@@ -9,6 +9,7 @@ export {
 export { SamplingMessageSchema } from '@modelcontextprotocol/sdk/types.js';
 export { init } from './init';
 export { isAngieAvailable } from './utils/is-angie-available';
+export { isAngieSidebarOpen } from './utils/is-angie-sidebar-open';
 export * from './mcp-registry';
 export { createSampler } from './sampler';
 export { toolPrompts } from './utils/prompt-builder';

--- a/packages/packages/libs/editor-mcp/src/utils/is-angie-sidebar-open.ts
+++ b/packages/packages/libs/editor-mcp/src/utils/is-angie-sidebar-open.ts
@@ -1,0 +1,5 @@
+import { ANGIE_SIDEBAR_STATE_OPEN, getAngieSidebarSavedState } from '@elementor-external/angie-sdk';
+
+export const isAngieSidebarOpen = (): boolean => {
+	return getAngieSidebarSavedState() === ANGIE_SIDEBAR_STATE_OPEN;
+};


### PR DESCRIPTION
## Summary

- Adds `isAngieSidebarOpen` utility to `@elementor/editor-mcp` that checks whether the Angie sidebar is currently open using `angie-sdk`'s saved state
- Exports it from the package's public API

This is needed by Pro's `editor-components-extended` package for the Angie AI integration in the Components empty state (three-state flow: sidebar open → send prompt, sidebar closed → show intro, not installed → show install dialog).

## Test plan

- Verify `isAngieSidebarOpen` is exported from `@elementor/editor-mcp`
- Verify package builds successfully


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Export isAngieSidebarOpen utility function from editor-mcp package to enable external modules to check Angie sidebar state.

Main changes:
- Added new isAngieSidebarOpen utility function that checks if Angie sidebar is currently open using saved state
- Exported isAngieSidebarOpen from editor-mcp package index for external consumption
- Integrated @elementor-external/angie-sdk dependency to access sidebar state constants and retrieval methods

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
