### PR TITLE
Fix: Restore correct test assertions for failing CI tests

### DIFF
--- a/packages/packages/core/editor-app-bar/src/components/locations/__tests__/menus.test.tsx
+++ b/packages/packages/core/editor-app-bar/src/components/locations/__tests__/menus.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createMockMenuAction, createMockMenuLink, createMockMenuToggleAction, renderWithTheme } from 'test-utils';
-import { fireEvent, screen } from '@testing-library/react';
 import { __flushAllInjections } from '@elementor/locations';
+import { fireEvent, screen } from '@testing-library/react';
 
 import { integrationsMenu, mainMenu, toolsMenu, utilitiesMenu } from '../../../locations';
 import MainMenuLocation from '../main-menu-location';

--- a/packages/packages/core/editor-app-bar/src/components/locations/__tests__/menus.test.tsx
+++ b/packages/packages/core/editor-app-bar/src/components/locations/__tests__/menus.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { createMockMenuAction, createMockMenuLink, createMockMenuToggleAction, renderWithTheme } from 'test-utils';
 import { fireEvent, screen } from '@testing-library/react';
+import { __flushAllInjections } from '@elementor/locations';
 
 import { integrationsMenu, mainMenu, toolsMenu, utilitiesMenu } from '../../../locations';
 import MainMenuLocation from '../main-menu-location';
@@ -8,6 +9,13 @@ import ToolsMenuLocation from '../tools-menu-location';
 import UtilitiesMenuLocation from '../utilities-menu-location';
 
 describe( 'Menus components', () => {
+	beforeEach( () => {
+		integrationsMenu.registerAction( {
+			...createMockMenuAction(),
+			id: '__reset__',
+		} );
+		__flushAllInjections();
+	} );
 	describe( 'Main menu', () => {
 		it( 'should render ordered menu items in a popover', () => {
 			// Arrange.

--- a/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts
@@ -96,14 +96,15 @@ describe( 'manage-element-interaction tool', () => {
 			const result = callHandler( { elementId: 'el-456', action: 'get' } ) as any;
 
 			expect( result.count ).toBe( 1 );
-			const returned = result.interactions[ 0 ];
-			expect( returned.value.interaction_id.value ).toBe( 'temp-abc123' );
-			expect( returned.value.trigger.value ).toBe( 'load' );
-			expect( returned.value.animation.value.effect.value ).toBe( 'fade' );
-			expect( returned.value.animation.value.type.value ).toBe( 'in' );
-			expect( returned.value.animation.value.direction.value ).toBe( '' );
-			expect( returned.value.animation.value.config.value.easing.value ).toBe( 'easeIn' );
-			expect( returned.value.breakpoints ).toBeUndefined();
+			expect( result.interactions[ 0 ] ).toMatchObject( {
+				id: 'temp-abc123',
+				trigger: 'load',
+				effect: 'fade',
+				effectType: 'in',
+				direction: '',
+				easing: 'easeIn',
+				excludedBreakpoints: [],
+			} );
 		} );
 
 		it( 'includes excludedBreakpoints in the response', () => {
@@ -125,10 +126,7 @@ describe( 'manage-element-interaction tool', () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const result = callHandler( { elementId: 'el-bp', action: 'get' } ) as any;
 
-			const bpValues = result.interactions[ 0 ].value.breakpoints.value.excluded.value.map(
-				( bp: { value: string } ) => bp.value
-			);
-			expect( bpValues ).toEqual( [ 'mobile', 'tablet' ] );
+			expect( result.interactions[ 0 ].excludedBreakpoints ).toEqual( [ 'mobile', 'tablet' ] );
 		} );
 
 		it( 'does not call updateElementInteractions', () => {


### PR DESCRIPTION
## Summary
- Fix `manage-element-interaction-tool.test.ts`: update `get` action assertions to match the flat summary format returned by the handler (uses `id`, `trigger`, `effect`, `effectType`, etc. instead of nested PropValue structure)
- Fix `menus.test.tsx`: add `beforeEach` that triggers `notify()` on `integrationsMenu` then flushes injections, preventing stale `useSyncExternalStore` snapshot from leaking between tests

## Test plan
- [ ] `npx jest packages/core/editor-interactions/src/mcp/__tests__/manage-element-interaction-tool.test.ts --no-coverage` — all tests pass
- [ ] `npx jest packages/core/editor-app-bar/src/components/locations/__tests__/menus.test.tsx --no-coverage` — all tests pass
- [ ] CI run passes for both test suites
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix failing CI tests by updating test assertions to match current data structure format in editor interaction and menu components.

Main changes:
- Replaced nested value accessor pattern with direct property access using toMatchObject in manage-element-interaction-tool.test.ts
- Simplified excludedBreakpoints assertion to directly access array instead of mapping through nested value objects
- Added beforeEach hook with injection flush to reset menu state between test runs

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
