### PR TITLE
Internal: Bump packages [ED-23219]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "elementor/wp-one-package": "1.0.55"
+        "elementor/wp-one-package": "1.0.56"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53017212cf884e4c8ec7f90756eae70b",
+    "content-hash": "ac5529de4a1ef5266428d05d467296aa",
     "packages": [
         {
             "name": "elementor/wp-notifications-package",
@@ -39,10 +39,10 @@
         },
         {
             "name": "elementor/wp-one-package",
-            "version": "1.0.55",
+            "version": "1.0.56",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.55"
+                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.56"
             },
             "require": {
                 "elementor/wp-notifications-package": "^1.2"
@@ -69,7 +69,7 @@
                     "vendor/bin/phpcbf ."
                 ]
             },
-            "time": "2026-03-02T13:09:20+00:00"
+            "time": "2026-03-03T14:11:28+00:00"
         }
     ],
     "packages-dev": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "elementor",
       "version": "3.35.0",
       "dependencies": {
-        "@elementor/elementor-one-assets": "0.4.26",
+        "@elementor/elementor-one-assets": "0.4.28",
         "@elementor/icons": "1.63.0",
         "@elementor/ui": "1.36.17",
         "@reach/router": "1.3.4",
@@ -3550,9 +3550,9 @@
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@elementor/elementor-one-assets": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.26.tgz",
-      "integrity": "sha512-d4zROC+dxrMU0wRzJ51sqkuxgbZGFwLHuMg3W0sAvhMufCpJr6arrI/OsNdOA0aQHEgUUV7Be/p2X+Di/TVFIg==",
+      "version": "0.4.28",
+      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.28.tgz",
+      "integrity": "sha512-MTqVbUQOLIWEBI6DRCOGYbh738h01llUbtsWQvrAsICTaF/tdiddMDhDURLD/8ILI1k/yC/RklafQX7UTK7/Sg==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/icons": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "write": "^2.0.0"
   },
   "dependencies": {
-    "@elementor/elementor-one-assets": "0.4.26",
+    "@elementor/elementor-one-assets": "0.4.28",
     "@elementor/icons": "1.63.0",
     "@elementor/ui": "1.36.17",
     "@reach/router": "1.3.4",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update internal Elementor package dependencies to latest versions for improved compatibility and feature support.

Main changes:
- Upgraded elementor/wp-one-package from version 1.0.55 to 1.0.56 in composer.json
- Upgraded @elementor/elementor-one-assets from version 0.4.26 to 0.4.28 in package.json

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
