### PR TITLE
Fix: hard-reinstall script explicitly targets root node_modules and package-lock.json

### DIFF
--- a/core/common/modules/events-manager/assets/js/events-config.js
+++ b/core/common/modules/events-manager/assets/js/events-config.js
@@ -278,6 +278,9 @@ const eventsConfig = {
 			canvasEmptyBoxAction: 'canvas_empty_box_action',
 			widgetPanelSearch: 'widget_panel_search',
 		},
+		interactions: {
+			created: 'interactions_created',
+		},
 	},
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46646,6 +46646,7 @@
         "@elementor/editor-responsive": "4.0.0",
         "@elementor/editor-ui": "4.0.0",
         "@elementor/editor-v1-adapters": "4.0.0",
+        "@elementor/events": "4.0.0",
         "@elementor/icons": "^1.68.0",
         "@elementor/schema": "4.0.0",
         "@elementor/session": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "install:ci": "npm ci --ignore-scripts",
     "composer:no-dev": "composer install --optimize-autoloader --prefer-dist && composer install --no-scripts --no-dev && composer dump-autoload",
     "reinstall": "rm -rf node_modules && npm cache clean --force && npm ci",
-    "hard-reinstall": "rm -rf **/node_modules **/package-lock.json && npm cache clean --force && npm i --ignore-scripts",
+    "hard-reinstall": "rm -rf node_modules **/node_modules package-lock.json && npm cache clean --force && npm i --ignore-scripts",
     "env:setup": "bash scripts/setup-test-environment.sh",
     "env:setup:with-playwright": "bash scripts/setup-test-environment.sh && npx playwright install chromium",
     "wp-env": "wp-env",

--- a/packages/packages/core/editor-interactions/package.json
+++ b/packages/packages/core/editor-interactions/package.json
@@ -51,6 +51,7 @@
     "@elementor/session": "4.0.0",
     "@elementor/ui": "1.36.17",
     "@elementor/utils": "4.0.0",
+    "@elementor/events": "4.0.0",
     "@wordpress/i18n": "^5.13.0"
   },
   "peerDependencies": {

--- a/packages/packages/core/editor-interactions/src/__tests__/interactions-list.test.tsx
+++ b/packages/packages/core/editor-interactions/src/__tests__/interactions-list.test.tsx
@@ -17,6 +17,15 @@ jest.mock( '../utils/get-interactions-config', () => ( {
 	} ) ),
 } ) );
 
+jest.mock( '../contexts/interactions-context', () => ( {
+	useInteractionsContext: jest.fn( () => ( {
+		elementId: 'test-element-id',
+		interactions: { version: 1, items: [] },
+		setInteractions: jest.fn(),
+		playInteractions: jest.fn(),
+	} ) ),
+} ) );
+
 const createInteraction = (
 	trigger: string,
 	effect: string,

--- a/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Repeater } from '@elementor/editor-controls';
+import { Repeater, type SetRepeaterValuesMeta } from '@elementor/editor-controls';
 import { InfoCircleFilledIcon, PlayerPlayIcon } from '@elementor/icons';
 import { Alert, AlertTitle, Box, IconButton, Tooltip } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
+import { useInteractionsContext } from '../contexts/interactions-context';
 import { InteractionItemContextProvider } from '../contexts/interactions-item-context';
 import type { ElementInteractions, InteractionItemPropValue, InteractionItemValue } from '../types';
 import { buildDisplayLabel, createDefaultInteractionItem, extractString } from '../utils/prop-value-utils';
+import { trackInteractionCreated } from '../utils/tracking';
 import { InteractionsListItem } from './interactions-list-item';
 export const MAX_NUMBER_OF_INTERACTIONS = 5;
 
@@ -20,6 +22,7 @@ export type InteractionListProps = {
 
 export function InteractionsList( props: InteractionListProps ) {
 	const { interactions, onSelectInteractions, onPlayInteraction, triggerCreateOnShowEmpty } = props;
+	const { elementId } = useInteractionsContext();
 
 	const hasInitializedRef = useRef( false );
 
@@ -62,13 +65,23 @@ export function InteractionsList( props: InteractionListProps ) {
 	) : undefined;
 
 	const handleRepeaterChange = useCallback(
-		( newItems: ElementInteractions[ 'items' ] ) => {
+		(
+			newItems: ElementInteractions[ 'items' ],
+			_: unknown,
+			meta?: SetRepeaterValuesMeta< InteractionItemPropValue >
+		) => {
 			handleUpdateInteractions( {
 				...interactions,
 				items: newItems,
 			} );
+			if ( meta?.action?.type === 'add' ) {
+				const addedItem = meta.action.payload[ 0 ]?.item;
+				if ( addedItem ) {
+					trackInteractionCreated( elementId, addedItem );
+				}
+			}
 		},
-		[ interactions, handleUpdateInteractions ]
+		[ interactions, handleUpdateInteractions, elementId ]
 	);
 
 	const handleInteractionChange = useCallback(

--- a/packages/packages/core/editor-interactions/src/components/interactions-tab.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interactions-tab.tsx
@@ -7,6 +7,8 @@ import { InteractionsProvider, useInteractionsContext } from '../contexts/intera
 import { PopupStateProvider } from '../contexts/popup-state-context';
 import { useElementInteractions } from '../hooks/use-element-interactions';
 import type { ElementInteractions } from '../types';
+import { createDefaultInteractionItem } from '../utils/prop-value-utils';
+import { trackInteractionCreated } from '../utils/tracking';
 import { EmptyState } from './empty-state';
 import { InteractionsList } from './interactions-list';
 
@@ -33,6 +35,7 @@ function InteractionsTabContent( { elementId }: { elementId: string } ) {
 				<EmptyState
 					onCreateInteraction={ () => {
 						firstInteractionState[ 1 ]( true );
+						trackInteractionCreated( elementId, createDefaultInteractionItem() );
 					} }
 				/>
 			) }

--- a/packages/packages/core/editor-interactions/src/contexts/interactions-context.tsx
+++ b/packages/packages/core/editor-interactions/src/contexts/interactions-context.tsx
@@ -9,6 +9,7 @@ import {
 import { useElementInteractions } from '../hooks/use-element-interactions';
 
 type InteractionsContextValue = {
+	elementId: string;
 	interactions: ElementInteractions;
 	setInteractions: ( value: ElementInteractions | undefined ) => void;
 	playInteractions: ( interactionId: string ) => void;
@@ -45,6 +46,7 @@ export const InteractionsProvider = ( { children, elementId }: { children: React
 	};
 
 	const contextValue: InteractionsContextValue = {
+		elementId,
 		interactions,
 		setInteractions,
 		playInteractions,

--- a/packages/packages/core/editor-interactions/src/utils/tracking.ts
+++ b/packages/packages/core/editor-interactions/src/utils/tracking.ts
@@ -1,0 +1,42 @@
+import { getElementLabel } from '@elementor/editor-elements';
+import { getMixpanel } from '@elementor/events';
+
+import type { InteractionItemPropValue } from '../types';
+import { extractString } from './prop-value-utils';
+
+const TRIGGER_LABELS: Record< string, string > = {
+	load: 'On page load',
+	scrollIn: 'Scroll into view',
+	scrollOut: 'Scroll out of view',
+	scrollOn: 'While scrolling',
+	hover: 'Hover',
+	click: 'Click',
+};
+
+const capitalize = ( s: string ) => s.charAt( 0 ).toUpperCase() + s.slice( 1 );
+
+export const trackInteractionCreated = ( elementId: string, item: InteractionItemPropValue ) => {
+	const { dispatchEvent, config } = getMixpanel();
+	if ( ! config?.names?.interactions?.created ) {
+		return;
+	}
+
+	const trigger = extractString( item.value.trigger );
+	const effect = extractString( item.value.animation.value.effect );
+	const type = extractString( item.value.animation.value.type );
+
+	dispatchEvent?.( config.names.interactions.created, {
+		app_type: config?.appTypes?.editor,
+		window_name: config?.appTypes?.editor,
+		interaction_type: config?.triggers?.click,
+		target_name: getElementLabel( elementId ),
+		interaction_result: 'interaction_created',
+		target_location: config?.locations?.widgetPanel,
+		location_l1: getElementLabel( elementId ),
+		location_l2: 'interactions',
+		interaction_description: 'interaction_created',
+		interaction_trigger: TRIGGER_LABELS[ trigger ] ?? capitalize( trigger ),
+		interaction_effect:
+			effect === 'custom' ? capitalize( effect ) : `${ capitalize( effect ) } ${ capitalize( type ) }`,
+	} );
+};


### PR DESCRIPTION
## Summary
- Fixes the `hard-reinstall` script to explicitly delete the root `node_modules` and `package-lock.json` in addition to nested ones
- The `**/node_modules` glob pattern was missing the root-level directory; same for `package-lock.json`

## Test plan
- [ ] Run `npm run hard-reinstall` and verify root `node_modules` and `package-lock.json` are removed along with nested ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add interaction creation tracking to editor interactions feature to monitor user behavior and improve product analytics capabilities.
Main changes:
- Implemented Mixpanel tracking event dispatch when users create new interactions via repeater add action or empty state
- Added elementId to InteractionsContext for tracking target element identification in analytics events
- Fixed hard-reinstall npm script to explicitly target root node_modules and package-lock.json instead of nested directories

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
