### PR TITLE
Revert "Fix: Elementor Editor Broken on WordPress 7.0 beta [ED-23138]"

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,7 +2,7 @@ name: Playwright
 
 on:
   pull_request:
-    types: [labeled, synchronize, opened, reopened, ready_for_review]
+    types: [labeled, synchronize, opened, reopened]
     branches:
       - main
       - '[0-9].[0-9][0-9]'
@@ -47,7 +47,7 @@ jobs:
   build-plugin:
     if: |
       contains(github.event.pull_request.labels.*.name, 'run-tests') ||
-      (!github.event.pull_request.draft && github.event_name == 'pull_request') ||
+      github.event_name == 'pull_request' ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     name: Build plugin
@@ -60,7 +60,7 @@ jobs:
     if: |
       github.event.inputs.tag == '' &&
       (contains(github.event.pull_request.labels.*.name, 'run-tests') ||
-      (!github.event.pull_request.draft && github.event_name == 'pull_request') ||
+      github.event_name == 'pull_request' ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch')
     strategy:
@@ -92,7 +92,7 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: |
-          npm run prepare-environment:ci
+          npm run install:ci
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
@@ -183,7 +183,7 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: |
-          npm run prepare-environment:ci
+          npm run install:ci
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
@@ -428,4 +428,3 @@ jobs:
       - name: Check Playwright matrix status
         if: ${{ (needs.Playwright.result != 'success' && needs.Playwright.result != 'skipped') || (needs.PlaywrightWithTag.result != 'success' && needs.PlaywrightWithTag.result != 'skipped') }}
         run: exit 1
-        

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,7 +2,7 @@ name: Playwright
 
 on:
   pull_request:
-    types: [labeled, synchronize, opened, reopened]
+    types: [labeled, synchronize, opened, reopened, ready_for_review]
     branches:
       - main
       - '[0-9].[0-9][0-9]'
@@ -47,7 +47,7 @@ jobs:
   build-plugin:
     if: |
       contains(github.event.pull_request.labels.*.name, 'run-tests') ||
-      github.event_name == 'pull_request' ||
+      (!github.event.pull_request.draft && github.event_name == 'pull_request') ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     name: Build plugin
@@ -60,7 +60,7 @@ jobs:
     if: |
       github.event.inputs.tag == '' &&
       (contains(github.event.pull_request.labels.*.name, 'run-tests') ||
-      github.event_name == 'pull_request' ||
+      (!github.event.pull_request.draft && github.event_name == 'pull_request') ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch')
     strategy:
@@ -92,7 +92,7 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: |
-          npm run install:ci
+          npm run prepare-environment:ci
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
@@ -113,7 +113,7 @@ jobs:
         run: |
           npm run start-local-server
       - name: Update wordpress to nightly build
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: npx wp-lite-env cli --config=./tests/playwright/.playwright-wp-lite-env.json --port=8888 --command="wp core update https://wordpress.org/nightly-builds/wordpress-latest.zip"
       - name: Setup test data
         run: npm run test:setup:playwright
@@ -183,7 +183,7 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: |
-          npm run install:ci
+          npm run prepare-environment:ci
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
@@ -203,6 +203,8 @@ jobs:
       - name: Install WordPress environment
         run: |
           npm run start-local-server
+      - name: Update wordpress to nightly build
+        run: npx wp-lite-env cli --config=./tests/playwright/.playwright-wp-lite-env.json --port=8888 --command="wp core update https://wordpress.org/nightly-builds/wordpress-latest.zip"
       - name: Setup test data
         run: npm run test:setup:playwright
       - name: WordPress debug information
@@ -426,3 +428,4 @@ jobs:
       - name: Check Playwright matrix status
         if: ${{ (needs.Playwright.result != 'success' && needs.Playwright.result != 'skipped') || (needs.PlaywrightWithTag.result != 'success' && needs.PlaywrightWithTag.result != 'skipped') }}
         run: exit 1
+        

--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -538,26 +538,6 @@ class Editor {
 		// Handle autocomplete feature for URL control.
 		add_filter( 'wp_link_query_args', [ $this, 'filter_wp_link_query_args' ] );
 		add_filter( 'wp_link_query', [ $this, 'filter_wp_link_query' ] );
-
-		add_filter( 'replace_editor', [ $this, 'filter_replace_editor' ], 10, 2 );
-	}
-
-	/**
-	 * Signals to WordPress that Elementor is replacing the block editor on its own editor page,
-	 * so that block-editor-specific behaviour (e.g. WP 7.0 COOP/COEP isolation headers) is not
-	 * applied when the Elementor editor is active.
-	 *
-	 * @param bool     $replace Whether the editor is being replaced.
-	 * @param \WP_Post $post    The post being edited.
-	 *
-	 * @return bool
-	 */
-	public function filter_replace_editor( $replace, $post ) {
-		if ( isset( $_REQUEST['action'] ) && 'elementor' === $_REQUEST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return true;
-		}
-
-		return $replace;
 	}
 
 	/**


### PR DESCRIPTION
Reverts elementor/elementor#34900
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert WordPress 7.0 beta compatibility fix that added block editor replacement filter to restore original editor initialization behavior.

Main changes:
- Removed filter_replace_editor() method and replace_editor filter hook preventing COOP/COEP isolation headers in Elementor editor
- Modified Playwright workflow to run WordPress nightly build updates on both scheduled and manual workflow dispatch triggers
- Added WordPress nightly build update step to test environment without conditional execution check

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
