### PR TITLE
Internal: Make submit button optional for atomic-form [ED-23207]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.php
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.php
@@ -235,7 +235,6 @@ class Atomic_Form extends Atomic_Element_Base {
 						'children' => [],
 					] ),
 				] )
-				->is_locked( true )
 				->build(),
 			$this->build_status_message(
 				__( 'Great! We’ve received your information.', 'elementor' ),


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove submit button lock constraint in atomic-form component to allow developers to configure or remove the button as needed.
Main changes:
- Removed `is_locked(true)` method call from submit button configuration in Atomic_Form element builder
- Submit button can now be modified or hidden by developers through configuration settings

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
