### PR TITLE
Fix: New websites should not see the top bar notice [ED-23252]

### DIFF
--- a/modules/editor-app-bar/module.php
+++ b/modules/editor-app-bar/module.php
@@ -84,15 +84,11 @@ class Module extends BaseModule {
 	}
 
 	private function is_existing_user_upgraded_to_target_version( string $target_version ): bool {
-
 		if ( version_compare( ELEMENTOR_VERSION, $target_version, '<' ) ) {
 			return false;
 		}
 
-		$installs_history = \Elementor\Core\Upgrade\Manager::get_installs_history();
-
-		return ! empty( $installs_history ) &&
-			version_compare( array_key_first( $installs_history ), $target_version, '<' );
+		return \Elementor\Core\Upgrade\Manager::had_install_prior_to( $target_version );
 	}
 
 	private function add_packages( $packages ) {


### PR DESCRIPTION
## Summary
- Fixed `is_existing_user_upgraded_to_target_version()` in `modules/editor-app-bar/module.php` incorrectly showing the top bar structure popup notice to new/fresh installations
- The bug: `array_key_first($installs_history)` was called without first sorting by version, so on installs where history is stored newest-first, the check would return a wrong "oldest" version
- Fix: replaced the unsafe inline logic with a delegation to `Manager::had_install_prior_to()`, which correctly sorts history with `uksort()` before checking the oldest version, and returns `false` for empty history (new sites)

## Test plan
- [ ] On a brand new Elementor installation (no prior install history): the top bar structure popup notice should **not** appear
- [ ] On a site upgraded from a version prior to 3.32.0: the notice **should** appear
- [ ] After dismissing the notice, it should **not** appear again

## Jira
[ED-23252](https://elementor.atlassian.net/browse/ED-23252)

[ED-23252]: https://elementor.atlassian.net/browse/ED-23252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix top bar notice incorrectly appearing for new website installations by correcting the user upgrade detection logic in editor app bar module.

Main changes:
- Replaced manual installs history check with Manager::had_install_prior_to() method for accurate upgrade detection
- Simplified is_existing_user_upgraded_to_target_version() logic by removing redundant empty check and version comparison
- Fixed bug where new installations were incorrectly identified as upgraded users triggering unwanted notices

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
