### PR TITLE
Fix: Version replacement in create-version-change script

### DIFF
--- a/scripts/create-version-change.js
+++ b/scripts/create-version-change.js
@@ -51,7 +51,7 @@ function updateVersionInFile(filePath, version, patterns, dryRun) {
   let content = fs.readFileSync(filePath, 'utf8');
   
   patterns.forEach(pattern => {
-    content = content.replace(pattern.regex, pattern.replacement(version));
+    content = content.replace(pattern.regex, (...args) => pattern.replacement(version, ...args));
   });
 
   fs.writeFileSync(filePath, content);
@@ -207,11 +207,11 @@ async function main() {
       updateVersionInFile('elementor.php', versionToUse, [
         {
           regex: /(\* Version: )[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9]+)?/,
-          replacement: (version) => `$1${version}`
+          replacement: (version, match, prefix) => `${prefix}${version}`
         },
         {
           regex: /(define\( 'ELEMENTOR_VERSION', ')[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9]+)?'( \);)/,
-          replacement: (version) => `$1${version}'$3`
+          replacement: (version, match, prefix, _preRelease, suffix) => `${prefix}${version}'${suffix}`
         }
       ], dryRun);
     } else {


### PR DESCRIPTION
## Summary
- Fixed `$n` backreference misinterpretation in `String.prototype.replace` — when the replacement was a string like `$14.1.0`, JavaScript could ambiguously parse `$14` as a reference to capture group 14 (which doesn't exist) instead of group 1 followed by the literal `4`
- Changed `updateVersionInFile` to pass replacement as a proper function via `(...args) => pattern.replacement(version, ...args)` so capture groups are passed as named arguments
- Updated pattern `replacement` functions to use template literal interpolation with named params (`prefix`, `suffix`) instead of `$n` syntax

## Test plan
- [ ] Run `node scripts/create-version-change.js <version> --skip-branches --dry-run` and verify no errors
- [ ] Run with a real version and confirm `elementor.php` `* Version:` comment and `ELEMENTOR_VERSION` define are both updated correctly
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix version replacement logic in create-version-change script to correctly handle regex capture groups and prevent incorrect string substitutions.

Main changes:
- Updated replacement function to accept full regex match arguments instead of just version parameter
- Modified replacement callbacks to use explicit capture group parameters (prefix, suffix) instead of ### ✨ PR Description
Purpose: Fix version replacement logic in create-version-change script to correctly handle regex capture groups and prevent backreference errors in string replacements.

Main changes:
- Modified updateVersionInFile to pass all regex match arguments to replacement function using spread operator
- Updated elementor.php version patterns to use explicit capture group parameters instead of numbered backreferences
- Fixed replacement functions to reconstruct strings using captured prefix/suffix groups rather than $1/$3 placeholders

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>/$3 backreferences
- Fixed regex replacement pattern to properly reconstruct matched strings with correct capture group ordering

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
