### PR TITLE
Update logic for working around CSS cascade issue in WP 6.9

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -173,8 +173,15 @@ class Frontend extends App {
 		add_filter( 'get_the_excerpt', [ $this, 'start_excerpt_flag' ], 1 );
 		add_filter( 'get_the_excerpt', [ $this, 'end_excerpt_flag' ], 20 );
 
-		if ( version_compare( get_bloginfo( 'version' ), '6.9', '>=' ) ) {
-			add_filter( 'wp_should_output_buffer_template_for_enhancement', '__return_false', 1 );
+		/* 
+		 * Work around bugs in CSS cascade introduced in 6.9 but fixed in 7.0:
+		 * - https://core.trac.wordpress.org/ticket/64389
+		 * - https://core.trac.wordpress.org/ticket/64354
+		 *
+		 * For more on this, see <https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/#load-block-styles-on-demand-in-classic-themes>.
+		 */
+		if ( version_compare( get_bloginfo( 'version' ), '6.9', '>=' ) && version_compare( get_bloginfo( 'version' ), '7.0-beta5', '<' ) ) {
+			add_filter( 'should_load_separate_core_block_assets', '__return_false', 1 );
 		}
 	}
 


### PR DESCRIPTION
This is a follow-up to https://github.com/elementor/elementor/pull/33728.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Remove workaround from WP 6.9 which disabled the template enhancement output buffer.

## Description
An explanation of what is done in this PR

* Stop applying the workaround in 7.0-beta5.
* Replace workaround disabling template enhancement output buffer with forcing combined core assets.
* Add comments explaining the workaround for CSS cascade bugs introduced in version 6.9 and fixed in 7.0.

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
