### PR TITLE
Internal: V3/4 Design Sync > Merge experiment [ED-23063]

### DIFF
--- a/modules/design-system-sync/module.php
+++ b/modules/design-system-sync/module.php
@@ -3,7 +3,6 @@
 namespace Elementor\Modules\DesignSystemSync;
 
 use Elementor\Core\Base\Module as BaseModule;
-use Elementor\Core\Experiments\Manager as ExperimentsManager;
 use Elementor\Modules\DesignSystemSync\Classes\Stylesheet_Manager;
 use Elementor\Modules\DesignSystemSync\Classes\Controller;
 
@@ -13,25 +12,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Module extends BaseModule {
 	const MODULE_NAME = 'design-system-sync';
-	const EXPERIMENT_NAME = 'e_design_system_sync';
-
 	public static function get_v3_sync_id( string $label ): string {
 		return 'v4-' . strtolower( $label );
 	}
 
 	public function get_name() {
 		return self::MODULE_NAME;
-	}
-
-	public static function get_experimental_data(): array {
-		return [
-			'name' => self::EXPERIMENT_NAME,
-			'title' => esc_html__( 'Design System Sync', 'elementor' ),
-			'description' => esc_html__( 'Sync V4 design system (variables, classes) to V3 Global Styles.', 'elementor' ),
-			'hidden' => true,
-			'default' => ExperimentsManager::STATE_INACTIVE,
-			'release_status' => ExperimentsManager::RELEASE_STATUS_ALPHA,
-		];
 	}
 
 	public function __construct() {

--- a/modules/design-system-sync/module.php
+++ b/modules/design-system-sync/module.php
@@ -23,15 +23,7 @@ class Module extends BaseModule {
 	public function __construct() {
 		parent::__construct();
 
-		if ( ! $this->is_experiment_active() ) {
-			return;
-		}
-
 		$this->register_hooks();
-	}
-
-	private function is_experiment_active(): bool {
-		return \Elementor\Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME );
 	}
 
 	private function register_hooks() {

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/class-item.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/class-item.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useRef, useState } from 'react';
 import { validateStyleLabel } from '@elementor/editor-styles-repository';
 import { EditableField, EllipsisWithTooltip, MenuListItem, useEditable, WarningInfotip } from '@elementor/editor-ui';
-import { isExperimentActive } from '@elementor/editor-v1-adapters';
 import { DotsVerticalIcon } from '@elementor/icons';
 import {
 	bindMenu,
@@ -142,7 +141,7 @@ export const ClassItem = ( {
 						{ __( 'Rename', 'elementor' ) }
 					</Typography>
 				</MenuListItem>
-				{ isExperimentActive( 'e_design_system_sync' ) && onToggleSync && (
+				{ onToggleSync && (
 					<MenuListItem
 						onClick={ () => {
 							popupState.close();

--- a/packages/packages/core/editor-variables/src/register-variable-types.tsx
+++ b/packages/packages/core/editor-variables/src/register-variable-types.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { trackUpgradePromotionClick } from '@elementor/editor-controls';
 import { colorPropTypeUtil, sizePropTypeUtil, stringPropTypeUtil } from '@elementor/editor-props';
 import { CtaButton } from '@elementor/editor-ui';
-import { isExperimentActive } from '@elementor/editor-v1-adapters';
 import { BrushIcon, ExpandDiagonalIcon, ResetIcon, TextIcon } from '@elementor/icons';
 import { __ } from '@wordpress/i18n';
 
@@ -27,10 +26,6 @@ export function registerVariableTypes() {
 		defaultValue: '#ffffff',
 		menuActionsFactory: ( { variable, variableId, handlers } ) => {
 			const actions = [];
-
-			if ( ! isExperimentActive( 'e_design_system_sync' ) ) {
-				return [];
-			}
 
 			if ( variable.sync_to_v3 ) {
 				actions.push( {

--- a/tests/playwright/sanity/modules/v4-tests/design-sync/design-system-sync-typography.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/design-sync/design-system-sync-typography.test.ts
@@ -21,7 +21,6 @@ test.describe.skip( 'Design System Sync - Typography V4 - V3 @v4-tests', () => {
 		await wpAdmin.setExperiments( {
 			e_atomic_elements: 'active',
 			e_classes: 'active',
-			e_design_system_sync: 'active',
 		} );
 
 		const { request } = page.context();

--- a/tests/playwright/sanity/modules/v4-tests/editor-variables/variable-v3-sync.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/editor-variables/variable-v3-sync.test.ts
@@ -9,7 +9,7 @@ import { createVariableWithSync, deleteAllVariablesViaApi } from './variables-ap
 const initTemplate = async ( page: Page, testInfo: TestInfo, apiRequests: ApiRequests ) => {
 	const wpAdminPage = new WpAdminPage( page, testInfo, apiRequests );
 	await wpAdminPage.setExperiments( { e_variables: 'active', e_atomic_elements: 'active' } );
-	await wpAdminPage.setExperiments( { e_variables_manager: 'active', e_design_system_sync: 'active' } );
+	await wpAdminPage.setExperiments( { e_variables_manager: 'active' } );
 	const editorPage = await wpAdminPage.openNewPage();
 	await editorPage.loadTemplate( 'tests/playwright/sanity/modules/v4-tests/editor-variables/variables-manager-template.json' );
 	return { wpAdminPage, editorPage };


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove experimental feature flag for Design System Sync module and enable V3/V4 design synchronization functionality by default across Elementor editor.

Main changes:
- Removed experiment gate checks and configuration for e_design_system_sync feature flag from PHP module
- Eliminated conditional rendering based on experiment status in global classes and variables UI components
- Updated test configurations to remove e_design_system_sync experiment activation requirement

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
