### PR TITLE
Fix: Video Timing Should Not Be Dynamic [ED-23315]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-self-hosted-video/atomic-self-hosted-video.php
+++ b/modules/atomic-widgets/elements/atomic-self-hosted-video/atomic-self-hosted-video.php
@@ -9,6 +9,7 @@ use Elementor\Modules\AtomicWidgets\Controls\Types\Select_Control;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Switch_Control;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Video_Control;
+use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Widget_Base;
 use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Template;
 use Elementor\Modules\AtomicWidgets\PropDependencies\Manager as Dependency_Manager;
@@ -73,6 +74,7 @@ class Atomic_Self_Hosted_Video extends Atomic_Widget_Base {
 			])
 			->get();
 
+		// NOTE: restore the dependency when dependencies works in overridables
 		$poster_dependencies = Dependency_Manager::make()
 			->where([
 				'operator' => 'eq',
@@ -108,8 +110,14 @@ class Atomic_Self_Hosted_Video extends Atomic_Widget_Base {
 				->enum( array_keys( self::get_preload_options() ) ),
 			'download' => Boolean_Prop_Type::make()->default( false )
 				->set_dependencies( $allow_download_dependencies ),
-			'start_time' => Number_Prop_Type::make()->default( null )->meta( 'suffix', 'SEC' ),
-			'end_time' => Number_Prop_Type::make()->default( null )->meta( 'suffix', 'SEC' ),
+			'start_time' => Number_Prop_Type::make()
+				->default( null )
+				->meta( Dynamic_Prop_Type::ignore() )
+				->meta( 'suffix', 'SEC' ),
+			'end_time' => Number_Prop_Type::make()
+				->default( null )
+				->meta( 'suffix', 'SEC' )
+				->meta( Dynamic_Prop_Type::ignore() ),
 			'poster_enabled' => Boolean_Prop_Type::make()->default( false ),
 			'poster' => Image_Prop_Type::make()
 				->default_size( 'medium_large' )


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix video timing configuration by disabling dynamic tag support for start_time and end_time properties in atomic self-hosted video widget.

Main changes:
- Added Dynamic_Prop_Type import and applied ignore() meta to start_time and end_time properties
- Reorganized start_time and end_time property definitions with explicit dynamic tag exclusion metadata
- Added comment noting poster_dependencies restoration needed when dependencies work with overridables

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
