### PR TITLE
Fix: Use ControlTypeContainer for instance panel override controls [ED-23368]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46830,7 +46830,6 @@
       "dependencies": {
         "@elementor/editor": "4.1.0",
         "@elementor/editor-v1-adapters": "4.1.0",
-        "@elementor/icons": "1.68.0",
         "@elementor/ui": "1.36.17",
         "@wordpress/api-fetch": "^7.12.0",
         "@wordpress/i18n": "^5.13.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -46830,6 +46830,7 @@
       "dependencies": {
         "@elementor/editor": "4.1.0",
         "@elementor/editor-v1-adapters": "4.1.0",
+        "@elementor/icons": "1.68.0",
         "@elementor/ui": "1.36.17",
         "@wordpress/api-fetch": "^7.12.0",
         "@wordpress/i18n": "^5.13.0"

--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/override-prop-control.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/override-prop-control.tsx
@@ -10,6 +10,7 @@ import {
 	BaseControl,
 	controlsRegistry,
 	type ControlType,
+	ControlTypeContainer,
 	createTopLevelObjectType,
 	ElementProvider,
 	isDynamicPropValue,
@@ -18,7 +19,7 @@ import {
 } from '@elementor/editor-editing-panel';
 import { type Control, getElementSettings, getElementType } from '@elementor/editor-elements';
 import { type AnyTransformable, type PropType, type PropValue } from '@elementor/editor-props';
-import { Stack } from '@elementor/ui';
+import { Box } from '@elementor/ui';
 
 import { useControlsByWidgetType } from '../../hooks/use-controls-by-widget-type';
 import {
@@ -214,10 +215,14 @@ function OverrideControl( { overridableProp }: InternalProps ) {
 					>
 						<PropKeyProvider bind={ overridableProp.overrideKey }>
 							<ControlReplacementsProvider replacements={ controlReplacements }>
-								<Stack direction="column" gap={ 1 } mb={ 1.5 }>
-									{ layout !== 'custom' && <ControlLabel>{ overridableProp.label }</ControlLabel> }
-									<OriginalControl control={ control } controlProps={ controlProps } />
-								</Stack>
+								<Box mb={ 1.5 }>
+									<ControlTypeContainer layout={ layout }>
+										{ layout !== 'custom' && (
+											<ControlLabel>{ overridableProp.label }</ControlLabel>
+										) }
+										<OriginalControl control={ control } controlProps={ controlProps } />
+									</ControlTypeContainer>
+								</Box>
 							</ControlReplacementsProvider>
 						</PropKeyProvider>
 					</PropProvider>

--- a/packages/packages/core/editor-editing-panel/src/index.ts
+++ b/packages/packages/core/editor-editing-panel/src/index.ts
@@ -13,6 +13,7 @@ export { useClassesProp } from './contexts/classes-prop-context';
 export { ElementProvider, useElement } from './contexts/element-context';
 export { useStyle } from './contexts/style-context';
 export { Control as BaseControl } from './controls-registry/control';
+export { ControlTypeContainer } from './controls-registry/control-type-container';
 export { controlsRegistry, type ControlType } from './controls-registry/controls-registry';
 export { StylesProviderCannotUpdatePropsError } from './errors';
 export { createTopLevelObjectType } from './controls-registry/create-top-level-object-type';


### PR DESCRIPTION
## Summary
- Instance panel override controls were using a plain `Stack` for layout, which didn't respect control layout types (e.g., `two-columns` for toggle controls).
- Replaced with the existing `ControlTypeContainer` component (already used in the regular editing panel) which applies the correct grid layout based on each control's layout type.
- Exported `ControlTypeContainer` from `@elementor/editor-editing-panel` so it can be reused by `@elementor/editor-components`.

## Test plan
- [ ] Open an instance panel for a component that has toggle/switch overridable props
- [ ] Verify toggle controls render with two-column layout (label + control side by side)
- [ ] Verify text controls still render with full-width layout
- [ ] Verify custom-layout controls still render without a label wrapper

<img width="270" height="477" alt="image" src="https://github.com/user-attachments/assets/055cc9cc-bede-4b4a-a928-203021766030" />



Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix instance panel override controls rendering by replacing Stack component with ControlTypeContainer to ensure consistent control layout and styling across the editor.

Main changes:
- Replaced Stack with ControlTypeContainer wrapper and Box spacing for override controls rendering
- Added ControlTypeContainer export to editor-editing-panel public API for external component access
- Updated import from Stack to Box component and added ControlTypeContainer import

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
