### PR TITLE
Fix: Replace keyboard shortcut text with "New" pill badge  [ED-23309]

### DIFF
--- a/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.js
+++ b/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.js
@@ -1,4 +1,3 @@
-import environment from 'elementor-common/utils/environment';
 import { getAllElementTypes } from 'elementor-editor/utils/element-types';
 import AtomicElementEmptyView from './container/atomic-element-empty-view';
 
@@ -450,15 +449,14 @@ export default function createAtomicElementBaseView( type ) {
 				const isProOutdated = hasProInstalled && ! ( window.elementorV2?.utils?.isProAtLeast?.( '4.0' ) ?? false );
 				const showPromoBadge = ! isProActive && ! isProOutdated;
 
-				const controlSign = environment.mac ? '&#8984;' : '^';
-				const shortcutLabel = controlSign + '+⇧+K';
+				const newBadge = `<span class="elementor-context-menu-list__item__shortcut__new-badge">${ __( 'New', 'elementor' ) }</span>`;
 				const badgeClass = 'elementor-context-menu-list__item__shortcut__promotion-badge';
 				const proBadge = `<a href="https://go.elementor.com/go-pro-components-Instance-create-context-menu/" target="_blank" onclick="event.stopPropagation()" class="${ badgeClass }"><i class="eicon-upgrade-crown"></i></a>`;
 
 				saveActions.unshift( {
 					name: 'save-component',
 					title: __( 'Create component', 'elementor' ),
-					shortcut: ( isProActive || isProOutdated ) ? shortcutLabel : proBadge,
+					shortcut: ( isProActive || isProOutdated ) ? newBadge : proBadge,
 					hasShortcutAction: showPromoBadge,
 					callback: this.saveAsComponent.bind( this ),
 					isEnabled: () => ( isProActive || isProOutdated ) && ! this.getContainer().isLocked(),

--- a/tests/jest/unit/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.test.js
+++ b/tests/jest/unit/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.test.js
@@ -1213,7 +1213,7 @@ describe( 'createAtomicElementBaseView - components Pro gating', () => {
 		return saveGroup?.actions?.find( ( a ) => 'save-component' === a.name );
 	};
 
-	it( 'should show keyboard shortcut and enable create-component when Pro is active', () => {
+	it( 'should show new badge and enable create-component when Pro is active', () => {
 		// Arrange
 		setProState( { isActive: true, hasInstalled: true, isAtLeast: true } );
 
@@ -1222,8 +1222,8 @@ describe( 'createAtomicElementBaseView - components Pro gating', () => {
 
 		// Assert
 		expect( action ).toBeDefined();
-		expect( action.shortcut ).toContain( '+⇧+K' );
-		expect( action.shortcut ).not.toContain( 'PRO' );
+		expect( action.shortcut ).toContain( 'new-badge' );
+		expect( action.shortcut ).toContain( 'New' );
 		expect( action.isEnabled() ).toBe( true );
 	} );
 
@@ -1250,7 +1250,7 @@ describe( 'createAtomicElementBaseView - components Pro gating', () => {
 
 		// Assert
 		expect( action ).toBeDefined();
-		expect( action.shortcut ).toContain( '+⇧+K' );
+		expect( action.shortcut ).toContain( 'new-badge' );
 		expect( action.isEnabled() ).toBe( true );
 	} );
 
@@ -1318,7 +1318,7 @@ describe( 'createAtomicElementBaseView - components Pro gating', () => {
 		);
 	} );
 
-	it( 'should show keyboard shortcut and enable create-component when Pro is outdated', () => {
+	it( 'should show new badge and enable create-component when Pro is outdated', () => {
 		// Arrange
 		setProState( { isActive: false, hasInstalled: true, isAtLeast: false } );
 
@@ -1327,7 +1327,7 @@ describe( 'createAtomicElementBaseView - components Pro gating', () => {
 
 		// Assert
 		expect( action ).toBeDefined();
-		expect( action.shortcut ).toContain( '+⇧+K' );
+		expect( action.shortcut ).toContain( 'new-badge' );
 		expect( action.shortcut ).not.toContain( 'eicon-upgrade-crown' );
 		expect( action.isEnabled() ).toBe( true );
 	} );


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Replace the keyboard shortcut label (`⌘+⇧+K`) with the "New" pill badge in the "Create Component" context menu item.

## Description

PR #34935 introduced a keyboard shortcut (Ctrl+Shift+K) for the "Create Component" action and simultaneously replaced the "New" pill badge in the context menu with the shortcut label text. This PR reverts the visual indicator change — replacing the shortcut text back with the "New" badge — while keeping the keyboard shortcut functionality intact.

**Changes:**
- Removed the `environment` import (only used for platform-specific shortcut label)
- Replaced `shortcutLabel` (`⌘+⇧+K` / `^+⇧+K`) with the "New" badge `<span>` for Pro users
- Non-Pro users still see the crown/promotion badge (unchanged)
- Updated tests to assert "New" badge instead of shortcut text


<img width="422" height="510" alt="image" src="https://github.com/user-attachments/assets/7ea2bc20-3de3-4ac9-9b4d-993a07ca4cb4" />


## Test instructions
This PR can be tested by following these steps:

1. Open the editor with an atomic element on the canvas
2. Right-click the element → open context menu
3. Look at the "Create component" item in the "Save" group
4. **Pro active:** Should show a "New" pill badge (not keyboard shortcut text)
5. **Pro inactive:** Should show the crown/upgrade badge (unchanged)
6. Verify the keyboard shortcut (`Ctrl+Shift+K` / `⌘+⇧+K`) still works when pressing it

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes ED-23309

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace platform-specific keyboard shortcut text (Ctrl/Cmd+Shift+K) with localized "New" pill badge in component creation context menu to improve UI consistency.

Main changes:
- Removed environment utility import and platform-specific shortcut label generation logic (Ctrl/Cmd+Shift+K)
- Added newBadge HTML span element with localized "New" text for Pro active/outdated users
- Updated unit tests to verify new-badge class and "New" text instead of keyboard shortcut symbols

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
