### PR TITLE
Fix: Reduce edit-disabled alert duration to 2s [ED-23372]

### DIFF
--- a/packages/packages/core/editor-components/src/__tests__/create-component-type.test.ts
+++ b/packages/packages/core/editor-components/src/__tests__/create-component-type.test.ts
@@ -416,6 +416,7 @@ describe( 'createComponentType', () => {
 			expect.objectContaining( {
 				id: 'component-edit-upgrade',
 				type: 'promotion',
+				autoHideDuration: 2000,
 			} )
 		);
 	} );

--- a/packages/packages/core/editor-components/src/create-component-type.ts
+++ b/packages/packages/core/editor-components/src/create-component-type.ts
@@ -57,11 +57,14 @@ const EDIT_COMPONENT_UPGRADE_URL = 'https://go.elementor.com/go-pro-components-e
 
 const COMPONENT_EDIT_UPGRADE_NOTIFICATION_ID = 'component-edit-upgrade';
 
+const COMPONENT_EDIT_UPGRADE_AUTO_HIDE_DURATION = 2000;
+
 function notifyComponentEditUpgrade() {
 	notify( {
 		type: 'promotion',
 		id: COMPONENT_EDIT_UPGRADE_NOTIFICATION_ID,
 		message: __( 'Editing components requires an active Pro subscription.', 'elementor' ),
+		autoHideDuration: COMPONENT_EDIT_UPGRADE_AUTO_HIDE_DURATION,
 		additionalActionProps: [
 			{
 				size: 'small',


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Reduced the component edit-disabled promotion alert display time from 8 seconds to 2 seconds.

## Description

When a user double-clicks a component on the canvas and Pro is not installed, a promotion alert ("Editing components requires an active Pro subscription.") is shown. The default `autoHideDuration` for notifications is 8 seconds, which is too long for this transient feedback. This PR sets an explicit `autoHideDuration` of 2 seconds on that specific notification.

**Changes:**
- Added a `COMPONENT_EDIT_UPGRADE_AUTO_HIDE_DURATION` constant (2000ms) in `create-component-type.ts`.
- Passed `autoHideDuration` to the `notify()` call in `notifyComponentEditUpgrade()`.
- Updated the existing test to assert the `autoHideDuration` value.

## Test instructions

1. Open the editor with Pro **not** installed.
2. Add a component widget to the canvas.
3. Double-click the component.
4. Observe the promotion alert disappears after ~2 seconds (previously ~8 seconds).

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended

Fixes ED-23372

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Reduce notification display duration for component edit-disabled alerts to improve user experience by preventing alert lingering.

Main changes:
- Added COMPONENT_EDIT_UPGRADE_AUTO_HIDE_DURATION constant set to 2000ms for consistent alert timing
- Configured component edit upgrade notification to auto-hide after 2 seconds
- Updated test suite to verify 2-second auto-hide duration on upgrade notification

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
