### PR TITLE
Fix: Overridable props not applying for unpublished components [ED-23372]

### DIFF
--- a/packages/packages/core/editor-components/src/index.ts
+++ b/packages/packages/core/editor-components/src/index.ts
@@ -82,6 +82,7 @@ export type {
 	UpdatedComponentName,
 } from './types';
 
+export { applyOverridablesToElements } from './utils/apply-overridables-to-elements';
 export { filterValidOverridableProps } from './utils/filter-valid-overridable-props';
 export { getContainerByOriginId } from './utils/get-container-by-origin-id';
 export { getOverridableProp } from './utils/get-overridable-prop';

--- a/packages/packages/core/editor-components/src/utils/__tests__/apply-overridables-to-elements.test.ts
+++ b/packages/packages/core/editor-components/src/utils/__tests__/apply-overridables-to-elements.test.ts
@@ -1,0 +1,241 @@
+import { type V1ElementData } from '@elementor/editor-elements';
+
+import { type OverridableProps } from '../../types';
+import { applyOverridablesToElements } from '../apply-overridables-to-elements';
+
+describe( 'applyOverridablesToElements', () => {
+	it( 'should wrap matching element settings with $$type overridable', () => {
+		// Arrange
+		const elements: V1ElementData[] = [
+			{
+				id: 'root-1',
+				elType: 'container',
+				settings: {},
+				elements: [
+					{
+						id: 'heading-1',
+						elType: 'widget',
+						widgetType: 'e-heading',
+						settings: { title: 'Hello World' },
+						elements: [],
+					},
+				],
+			},
+		];
+
+		const overridableProps: OverridableProps = {
+			props: {
+				'prop-abc': {
+					overrideKey: 'prop-abc',
+					label: 'Heading Text',
+					elementId: 'heading-1',
+					propKey: 'title',
+					elType: 'widget',
+					widgetType: 'e-heading',
+					originValue: 'Hello World',
+					groupId: 'group-1',
+				},
+			},
+			groups: {
+				items: { 'group-1': { id: 'group-1', label: 'Default', props: [ 'prop-abc' ] } },
+				order: [ 'group-1' ],
+			},
+		};
+
+		// Act
+		applyOverridablesToElements( elements, overridableProps );
+
+		// Assert
+		const heading = elements[ 0 ]?.elements?.[ 0 ];
+		expect( heading?.settings?.title ).toEqual( {
+			$$type: 'overridable',
+			value: {
+				override_key: 'prop-abc',
+				origin_value: 'Hello World',
+			},
+		} );
+	} );
+
+	it( 'should handle multiple overridable props across different elements', () => {
+		// Arrange
+		const elements: V1ElementData[] = [
+			{
+				id: 'root-1',
+				elType: 'container',
+				settings: {},
+				elements: [
+					{
+						id: 'heading-1',
+						elType: 'widget',
+						widgetType: 'e-heading',
+						settings: { title: 'Title' },
+						elements: [],
+					},
+					{
+						id: 'button-1',
+						elType: 'widget',
+						widgetType: 'e-button',
+						settings: { text: 'Click me' },
+						elements: [],
+					},
+				],
+			},
+		];
+
+		const overridableProps: OverridableProps = {
+			props: {
+				'prop-1': {
+					overrideKey: 'prop-1',
+					label: 'Heading',
+					elementId: 'heading-1',
+					propKey: 'title',
+					elType: 'widget',
+					widgetType: 'e-heading',
+					originValue: 'Title',
+					groupId: 'group-1',
+				},
+				'prop-2': {
+					overrideKey: 'prop-2',
+					label: 'Button',
+					elementId: 'button-1',
+					propKey: 'text',
+					elType: 'widget',
+					widgetType: 'e-button',
+					originValue: 'Click me',
+					groupId: 'group-1',
+				},
+			},
+			groups: {
+				items: { 'group-1': { id: 'group-1', label: 'Default', props: [ 'prop-1', 'prop-2' ] } },
+				order: [ 'group-1' ],
+			},
+		};
+
+		// Act
+		applyOverridablesToElements( elements, overridableProps );
+
+		// Assert
+		expect( elements[ 0 ]?.elements?.[ 0 ]?.settings?.title ).toEqual( {
+			$$type: 'overridable',
+			value: { override_key: 'prop-1', origin_value: 'Title' },
+		} );
+		expect( elements[ 0 ]?.elements?.[ 1 ]?.settings?.text ).toEqual( {
+			$$type: 'overridable',
+			value: { override_key: 'prop-2', origin_value: 'Click me' },
+		} );
+	} );
+
+	it( 'should skip props whose element is not found in the tree', () => {
+		// Arrange
+		const elements: V1ElementData[] = [
+			{
+				id: 'root-1',
+				elType: 'container',
+				settings: {},
+				elements: [],
+			},
+		];
+
+		const overridableProps: OverridableProps = {
+			props: {
+				'prop-1': {
+					overrideKey: 'prop-1',
+					label: 'Missing Element',
+					elementId: 'nonexistent',
+					propKey: 'title',
+					elType: 'widget',
+					widgetType: 'e-heading',
+					originValue: 'test',
+					groupId: 'group-1',
+				},
+			},
+			groups: {
+				items: { 'group-1': { id: 'group-1', label: 'Default', props: [ 'prop-1' ] } },
+				order: [ 'group-1' ],
+			},
+		};
+
+		// Act & Assert - should not throw
+		applyOverridablesToElements( elements, overridableProps );
+	} );
+
+	it( 'should not modify elements when overridableProps has no props', () => {
+		// Arrange
+		const elements: V1ElementData[] = [
+			{
+				id: 'heading-1',
+				elType: 'widget',
+				widgetType: 'e-heading',
+				settings: { title: 'Original' },
+				elements: [],
+			},
+		];
+
+		const overridableProps: OverridableProps = {
+			props: {},
+			groups: { items: {}, order: [] },
+		};
+
+		// Act
+		applyOverridablesToElements( elements, overridableProps );
+
+		// Assert
+		expect( elements[ 0 ]?.settings?.title ).toBe( 'Original' );
+	} );
+
+	it( 'should handle deeply nested elements', () => {
+		// Arrange
+		const elements: V1ElementData[] = [
+			{
+				id: 'root',
+				elType: 'container',
+				settings: {},
+				elements: [
+					{
+						id: 'level-1',
+						elType: 'container',
+						settings: {},
+						elements: [
+							{
+								id: 'deep-heading',
+								elType: 'widget',
+								widgetType: 'e-heading',
+								settings: { title: 'Deep' },
+								elements: [],
+							},
+						],
+					},
+				],
+			},
+		];
+
+		const overridableProps: OverridableProps = {
+			props: {
+				'prop-deep': {
+					overrideKey: 'prop-deep',
+					label: 'Deep Heading',
+					elementId: 'deep-heading',
+					propKey: 'title',
+					elType: 'widget',
+					widgetType: 'e-heading',
+					originValue: 'Deep',
+					groupId: 'group-1',
+				},
+			},
+			groups: {
+				items: { 'group-1': { id: 'group-1', label: 'Default', props: [ 'prop-deep' ] } },
+				order: [ 'group-1' ],
+			},
+		};
+
+		// Act
+		applyOverridablesToElements( elements, overridableProps );
+
+		// Assert
+		const deepHeading = elements[ 0 ]?.elements?.[ 0 ]?.elements?.[ 0 ];
+		expect( deepHeading?.settings?.title ).toEqual( {
+			$$type: 'overridable',
+			value: { override_key: 'prop-deep', origin_value: 'Deep' },
+		} );
+	} );
+} );

--- a/packages/packages/core/editor-components/src/utils/apply-overridables-to-elements.ts
+++ b/packages/packages/core/editor-components/src/utils/apply-overridables-to-elements.ts
@@ -1,0 +1,24 @@
+import { findElementById, type V1ElementData } from '@elementor/editor-elements';
+
+import { type OverridableProps } from '../types';
+
+export function applyOverridablesToElements(
+	elements: V1ElementData[],
+	overridableProps: OverridableProps
+): void {
+	Object.values( overridableProps.props ).forEach( ( prop ) => {
+		const element = findElementById( elements, prop.elementId );
+
+		if ( ! element?.settings ) {
+			return;
+		}
+
+		element.settings[ prop.propKey ] = {
+			$$type: 'overridable',
+			value: {
+				override_key: prop.overrideKey,
+				origin_value: element.settings[ prop.propKey ],
+			},
+		};
+	} );
+}

--- a/packages/packages/libs/editor-elements/src/index.ts
+++ b/packages/packages/libs/editor-elements/src/index.ts
@@ -36,6 +36,7 @@ export {
 	getElementChildren as getElementChildrenWithFallback,
 	type ModelResult,
 } from './sync/model-utils';
+export { findElementById } from './sync/find-element-by-id';
 export { getElements } from './sync/get-elements';
 export { getSelectedElements } from './sync/get-selected-elements';
 export { getWidgetsCache } from './sync/get-widgets-cache';

--- a/packages/packages/libs/editor-elements/src/sync/find-element-by-id.ts
+++ b/packages/packages/libs/editor-elements/src/sync/find-element-by-id.ts
@@ -1,0 +1,19 @@
+import { type V1ElementData } from './types';
+
+export function findElementById( elements: V1ElementData[], targetId: string ): V1ElementData | null {
+	for ( const element of elements ) {
+		if ( element.id === targetId ) {
+			return element;
+		}
+
+		if ( element.elements ) {
+			const found = findElementById( element.elements, targetId );
+
+			if ( found ) {
+				return found;
+			}
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
## Summary

When MCP-created components have overridable props, the `createUnpublishedComponent` action strips all `$$type: 'overridable'` wrappers (to prevent inheriting wrappers from parent components). This left elements in Redux without wrappers, so the `componentOverridableTransformer` couldn't resolve overrides at render time.

This PR adds shared utilities (`applyOverridablesToElements` and `findElementById`) that allow downstream code (Pro) to re-apply the correct wrappers after stripping inherited ones.

### Changes
- **New utility**: `applyOverridablesToElements` in `editor-components` — re-applies `$$type: 'overridable'` wrappers to elements based on `overridableProps` metadata
- **New utility**: `findElementById` in `editor-elements` — recursively finds an element by ID in a `V1ElementData` tree
- **Tests**: Unit tests for `applyOverridablesToElements`

### How the fix works (with companion Pro PR #6595)

The fix consolidates wrapper re-application at the source — in `createUnpublishedComponent` (Pro). After stripping inherited wrappers, the component's own wrappers are immediately re-applied. Elements enter Redux WITH correct wrappers, so no downstream patching is needed.

```mermaid
flowchart TD
    A["MCP: save-as-component\n(with overridable props)"] --> B["updateElementDataWithOverridableProps\n✅ Wraps settings with $$type: 'overridable'"]
    B --> C["createUnpublishedComponent"]
    C --> D["revertAllOverridablesInElementData\nStrips ALL wrappers (prevents inheritance)"]
    D --> E["applyOverridablesToElements\n✅ Re-applies THIS component's wrappers"]
    E --> F["Redux store:\nelements WITH correct wrappers\n+ overridableProps metadata"]
    F --> G["componentInstanceTransformer\nloads from unpublished store"]
    G --> H["Returns elements WITH wrappers\n(already correct from Redux)"]
    H --> I["componentOverridableTransformer\n✅ Finds wrappers → applies overrides"]
    I --> J["✅ Prop changes update canvas"]
    F --> K["createComponentsBeforeSave\nsends elements to backend"]
    K --> L["Backend stores elements\nWITH wrappers (already correct)"]
    L --> M["After edit mode exit:\n✅ Overrides keep working"]

    style E fill:#51cf66,color:#fff
    style F fill:#51cf66,color:#fff
    style J fill:#51cf66,color:#fff
    style M fill:#51cf66,color:#fff
```

### Why stripping + re-applying (not just keeping wrappers)

The stripping in `revertAllOverridablesInElementData` prevents inheriting `$$type: 'overridable'` wrappers from a parent component when creating a new component from elements inside an existing one. This is a valid safety measure. The re-application step only adds back wrappers that belong to THIS component (based on its `overridableProps` metadata), keeping copy/paste safe.

## Test plan
- [ ] Create a component via MCP with overridable props
- [ ] Verify overridable props update the canvas when changed in the panel
- [ ] Enter component edit mode, then exit — verify overrides still work
- [ ] Create a component from elements inside an existing component — verify inherited wrappers don't leak

## Companion PR
- Pro: https://github.com/elementor/elementor-pro/pull/6595
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix overridable props not applying correctly to unpublished component instances by implementing element tree traversal and settings transformation logic.

Main changes:
- Added applyOverridablesToElements utility to wrap element settings with $$type overridable structure for proper override handling
- Implemented findElementById recursive search function to locate elements by ID in nested component trees
- Exported new utilities from core packages to enable overridable prop application across component lifecycle

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
