### PR TITLE
Fix: Name input does not auto-focus when creating a new variable [ED-23375]

### DIFF
--- a/modules/variables/services/variables-service.php
+++ b/modules/variables/services/variables-service.php
@@ -167,9 +167,15 @@ class Variables_Service {
 		$collection = $this->repo->load();
 		$variable = $collection->find_or_fail( $id );
 
+		$label = $variable->label();
+
+		if ( isset( $overrides['label'] ) ) {
+			$label = $overrides['label'];
+		}
+
 		$collection->assert_limit_not_reached();
 
-		$collection->assert_label_is_unique( $overrides['label'], $variable->id() );
+		$collection->assert_label_is_unique( $label, $variable->id() );
 
 		$variable->apply_changes( $overrides );
 		$variable->validate();

--- a/modules/variables/services/variables-service.php
+++ b/modules/variables/services/variables-service.php
@@ -169,9 +169,7 @@ class Variables_Service {
 
 		$collection->assert_limit_not_reached();
 
-		if ( isset( $overrides['label'] ) ) {
-			$collection->assert_label_is_unique( $overrides['label'], $variable->id() );
-		}
+		$collection->assert_label_is_unique( $overrides['label'], $variable->id() );
 
 		$variable->apply_changes( $overrides );
 		$variable->validate();

--- a/packages/packages/core/editor-variables/src/components/variable-creation.tsx
+++ b/packages/packages/core/editor-variables/src/components/variable-creation.tsx
@@ -147,6 +147,7 @@ export const VariableCreation = ( { onGoBack, onClose }: Props ) => {
 							} );
 						} }
 						onKeyDown={ handleKeyDown }
+						focusOnShow
 					/>
 				</FormField>
 				{ ValueField && (

--- a/packages/packages/core/editor-variables/src/components/variable-edit.tsx
+++ b/packages/packages/core/editor-variables/src/components/variable-edit.tsx
@@ -213,6 +213,7 @@ export const VariableEdit = ( { onClose, onGoBack, onSubmit, editId }: Props ) =
 								} );
 							} }
 							onKeyDown={ handleKeyDown }
+							focusOnShow
 						/>
 					</FormField>
 					{ ValueField && (

--- a/packages/packages/core/editor-variables/src/components/variable-restore.tsx
+++ b/packages/packages/core/editor-variables/src/components/variable-restore.tsx
@@ -132,6 +132,7 @@ export const VariableRestore = ( { variableId, onClose, onSubmit }: Props ) => {
 								} );
 							} }
 							onKeyDown={ handleKeyDown }
+							focusOnShow
 						/>
 					</FormField>
 					{ ValueField && (


### PR DESCRIPTION
## Summary
- Added `focusOnShow` prop to `LabelField` in `variable-creation.tsx` so the Name input automatically receives focus when the variable creation popover opens
- `LabelField` already supported auto-focus via `focusOnShow` → `autoFocus` — it simply wasn't being passed at the call site

## Test plan
- [ ] Open the variable creation popover from a control panel
- [ ] Verify the Name input field is focused immediately without needing to click
- [ ] Verify typing works right away after the popover opens

## Jira
[ED-23375](https://elementor.atlassian.net/browse/ED-23375)

[ED-23375]: https://elementor.atlassian.net/browse/ED-23375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix name input auto-focus issue in variable creation, edit, and restore dialogs to improve user experience and workflow efficiency.

Main changes:
- Added focusOnShow prop to name input fields across variable creation, edit, and restore components
- Refactored validation logic in restore method to check label uniqueness before applying changes
- Moved collection limit and label uniqueness assertions earlier in restore flow for better error handling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
