### PR TITLE
Fix: Minor changes to atomic form text [ED-23241]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.php
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.php
@@ -54,7 +54,7 @@ class Atomic_Form extends Atomic_Element_Base {
 	}
 
 	public function get_title() {
-		return esc_html__( 'Atomic Form', 'elementor' );
+		return esc_html__( 'Atomic form', 'elementor' );
 	}
 
 	public function get_keywords() {
@@ -137,7 +137,7 @@ class Atomic_Form extends Atomic_Element_Base {
 				->set_label( __( 'Content', 'elementor' ) )
 				->set_items( [
 					Text_Control::bind_to( 'form-name' )
-						->set_label( __( 'Form Name', 'elementor' ) ),
+						->set_label( __( 'Form name', 'elementor' ) ),
 					$state_control,
 					Chips_Control::bind_to( 'actions-after-submit' )
 						->set_label( __( 'Actions after submit', 'elementor' ) )

--- a/modules/atomic-widgets/elements/atomic-form/form-error-message/form-error-message.php
+++ b/modules/atomic-widgets/elements/atomic-form/form-error-message/form-error-message.php
@@ -18,7 +18,7 @@ class Form_Error_Message extends Form_Message {
 	}
 
 	public function get_title() {
-		return esc_html__( 'Form error message', 'elementor' );
+		return esc_html__( 'Error message', 'elementor' );
 	}
 
 	protected static function get_background_color(): string {
@@ -27,5 +27,12 @@ class Form_Error_Message extends Form_Message {
 
 	protected static function get_text_color(): string {
 		return '#870000';
+	}
+
+	protected function get_css_id_control_meta(): array {
+		return [
+			'layout' => 'two-columns',
+			'topDivider' => false,
+		];
 	}
 }

--- a/modules/atomic-widgets/elements/atomic-form/form-success-message/form-success-message.php
+++ b/modules/atomic-widgets/elements/atomic-form/form-success-message/form-success-message.php
@@ -18,7 +18,7 @@ class Form_Success_Message extends Form_Message {
 	}
 
 	public function get_title() {
-		return esc_html__( 'Form success message', 'elementor' );
+		return esc_html__( 'Success message', 'elementor' );
 	}
 
 	protected static function get_background_color(): string {
@@ -27,5 +27,12 @@ class Form_Success_Message extends Form_Message {
 
 	protected static function get_text_color(): string {
 		return '#2F532E';
+	}
+
+	protected function get_css_id_control_meta(): array {
+		return [
+			'layout' => 'two-columns',
+			'topDivider' => false,
+		];
 	}
 }

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/email-form-action-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/email-form-action-control.test.tsx
@@ -174,6 +174,6 @@ describe( 'EmailFormActionControl', () => {
 		// Assert
 		expect( screen.getByText( /from name/i ) ).toBeInTheDocument();
 		expect( screen.getByText( /reply-to/i ) ).toBeInTheDocument();
-		expect( screen.getByText( /meta data/i ) ).toBeInTheDocument();
+		expect( screen.getByText( /metadata/i ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control.tsx
@@ -64,7 +64,7 @@ const FromEmailField = () => (
 	<EmailField
 		bind="from"
 		label={ __( 'From email', 'elementor' ) }
-		placeholder={ __( 'What email address should appear as the sender?', 'elementor' ) }
+		placeholder={ __( 'What email should appear as the sender?', 'elementor' ) }
 	/>
 );
 

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control.tsx
@@ -29,7 +29,7 @@ const EmailField = ( { bind, label, placeholder }: { bind: string; label: string
 const SendToField = () => (
 	<EmailField
 		bind="to"
-		label={ __( 'Send To', 'elementor' ) }
+		label={ __( 'Send to', 'elementor' ) }
 		placeholder={ __( 'Where should we send new submissions?', 'elementor' ) }
 	/>
 );
@@ -37,7 +37,7 @@ const SendToField = () => (
 const SubjectField = () => (
 	<EmailField
 		bind="subject"
-		label={ __( 'Email Subject', 'elementor' ) }
+		label={ __( 'Email subject', 'elementor' ) }
 		placeholder={ __( 'New form submission', 'elementor' ) }
 	/>
 );
@@ -85,7 +85,7 @@ const BccField = () => <EmailField bind="bcc" label={ __( 'Bcc', 'elementor' ) }
 const MetaDataField = () => (
 	<PropKeyProvider bind="meta-data">
 		<Stack gap={ 0.5 }>
-			<ControlLabel>{ __( 'Meta data', 'elementor' ) }</ControlLabel>
+			<ControlLabel>{ __( 'Metadata', 'elementor' ) }</ControlLabel>
 			<ChipsControl
 				options={ [
 					{ label: __( 'Date', 'elementor' ), value: 'date' },


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Standardize UI text capitalization and formatting across atomic form components to improve consistency in the Elementor form builder interface.

Main changes:
- Updated form element titles to use sentence case instead of title case (e.g., "Atomic form" vs "Atomic Form")
- Modified form control labels to follow sentence case convention across email and metadata fields
- Added CSS ID control metadata configuration to error and success message components for layout consistency

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
