### PR TITLE
Internal: From automatically stretches to the wrapper height  > Add align content [ED-23242]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.php
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.php
@@ -194,6 +194,7 @@ class Atomic_Form extends Atomic_Element_Base {
 						->add_prop( 'flex-direction', String_Prop_Type::generate( 'row' ) )
 						->add_prop( 'flex-wrap', String_Prop_Type::generate( 'wrap' ) )
 						->add_prop( 'align-items', String_Prop_Type::generate( 'flex-start' ) )
+						->add_prop( 'align-content', String_Prop_Type::generate( 'start' ) )
 						->add_prop( 'gap', Size_Prop_Type::generate( [
 							'size' => 10,
 							'unit' => 'px',


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix form layout stretching issue by adding align-content CSS property to prevent automatic height expansion in flex containers.

Main changes:
- Added align-content CSS property with 'start' value to Atomic Form desktop breakpoint flex container
- Prevents form wrapper from automatically stretching to full available height in flexbox layout
- Maintains existing flex-start alignment for items while controlling content distribution behavior

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
