### PR TITLE
Fix: Resolve stale element references in undo/redo for atomic widgets [ED-22825]

### DIFF
--- a/packages/packages/libs/editor-elements/src/sync/__tests__/duplicate-elements.test.ts
+++ b/packages/packages/libs/editor-elements/src/sync/__tests__/duplicate-elements.test.ts
@@ -246,7 +246,7 @@ function setupMockElementsForDuplication( mockGetContainer: jest.Mock ) {
 		widgetType: 'button',
 	} );
 	mockDuplicatedElement1.parent = mockParent;
-	mockDuplicatedElement1.view = { _index: 1 };
+	mockDuplicatedElement1.view = { ...mockDuplicatedElement1.view, _index: 1 };
 
 	const mockElement1ToJSON = jest.spyOn( mockDuplicatedElement1.model, 'toJSON' );
 	mockElement1ToJSON.mockReturnValue( {
@@ -263,7 +263,7 @@ function setupMockElementsForDuplication( mockGetContainer: jest.Mock ) {
 	} );
 
 	mockDuplicatedElement2.parent = mockParent;
-	mockDuplicatedElement2.view = { _index: 2 };
+	mockDuplicatedElement2.view = { ...mockDuplicatedElement2.view, _index: 2 };
 
 	const mockElement2ToJSON = jest.spyOn( mockDuplicatedElement2.model, 'toJSON' );
 	mockElement2ToJSON.mockReturnValue( {

--- a/packages/packages/libs/editor-elements/src/sync/__tests__/remove-elements.test.ts
+++ b/packages/packages/libs/editor-elements/src/sync/__tests__/remove-elements.test.ts
@@ -40,7 +40,7 @@ describe( 'removeElements', () => {
 			settings: { text: 'Button 1' },
 		} as unknown as V1ElementModelProps );
 		mockElement1.parent = mockParent;
-		mockElement1.view = { _index: 0 };
+		mockElement1.view = { ...mockElement1.view, _index: 0 };
 
 		const mockElement2 = createMockContainer( 'element-2', [] );
 		const mockElement2ToJSON = jest.spyOn( mockElement2.model, 'toJSON' );
@@ -51,7 +51,7 @@ describe( 'removeElements', () => {
 			settings: { content: 'Text content' },
 		} as unknown as V1ElementModelProps );
 		mockElement2.parent = mockParent;
-		mockElement2.view = { _index: 1 };
+		mockElement2.view = { ...mockElement2.view, _index: 1 };
 
 		mockGetContainer.mockImplementation( ( id ) => {
 			if ( id === 'element-1' ) {
@@ -192,7 +192,7 @@ describe( 'removeElements', () => {
 			settings: { text: 'Button 1' },
 		} as unknown as V1ElementModelProps );
 		mockElement.parent = undefined;
-		mockElement.view = { _index: 0 };
+		mockElement.view = { ...mockElement.view, _index: 0 };
 
 		mockGetContainer.mockReturnValue( mockElement );
 
@@ -220,7 +220,7 @@ describe( 'removeElements', () => {
 			settings: { text: 'Button 1' },
 		} as unknown as V1ElementModelProps );
 		mockElement.parent = mockParent;
-		mockElement.view = {};
+		mockElement.view = { ...mockElement.view, _index: undefined };
 
 		mockGetContainer.mockReturnValue( mockElement );
 
@@ -301,11 +301,75 @@ describe( 'removeElements', () => {
 		} );
 	} );
 
-	it( 'should skip undo when parent container lookup returns null', () => {
+	it( 'should skip undo when parent lookup and getContainer both return null', () => {
 		// Arrange.
 		const { mockParent } = setupMockElementsForRemoval();
 
+		const mockRestoredElement = createMockChild( { id: 'element-1', elType: 'widget', widgetType: 'button' } );
+		mockCreateElement.mockReturnValue( mockRestoredElement );
+
+		// Act.
+		removeElements( {
+			elementIds: [ 'element-1' ],
+			title: 'Remove Element',
+		} );
+
 		mockParent.lookup = jest.fn().mockReturnValue( null );
+		mockGetContainer.mockReturnValue( null );
+
+		act( () => {
+			historyMock.instance.undo();
+		} );
+
+		// Assert.
+		expect( mockDeleteElement ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateElement ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should fallback to getContainer by ID on undo when parent lookup returns null', () => {
+		// Arrange.
+		const { mockParent } = setupMockElementsForRemoval();
+
+		const mockRestoredElement = createMockChild( { id: 'element-1', elType: 'widget', widgetType: 'button' } );
+		mockCreateElement.mockReturnValue( mockRestoredElement );
+
+		// Act.
+		removeElements( {
+			elementIds: [ 'element-1' ],
+			title: 'Remove Element',
+		} );
+
+		const freshParent = createMockContainer( 'parent-1', [] );
+		mockParent.lookup = jest.fn().mockReturnValue( null );
+
+		mockGetContainer.mockImplementation( ( id ) => {
+			if ( id === 'parent-1' ) {
+				return freshParent;
+			}
+			return null;
+		} );
+
+		act( () => {
+			historyMock.instance.undo();
+		} );
+
+		// Assert.
+		expect( mockCreateElement ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateElement ).toHaveBeenCalledWith( {
+			container: freshParent,
+			model: {
+				id: 'element-1',
+				elType: 'widget',
+				widgetType: 'button',
+				settings: { text: 'Button 1' },
+			},
+			options: { useHistory: false, at: 0 },
+		} );
+	} );
+
+	it( 'should fallback to getContainer by ID on redo when container lookup returns null', () => {
+		// Arrange.
+		const { mockElement1, mockParent } = setupMockElementsForRemoval();
 
 		const mockRestoredElement = createMockChild( { id: 'element-1', elType: 'widget', widgetType: 'button' } );
 		mockCreateElement.mockReturnValue( mockRestoredElement );
@@ -320,12 +384,32 @@ describe( 'removeElements', () => {
 			historyMock.instance.undo();
 		} );
 
+		const freshContainer = createMockContainer( 'element-1', [] );
+		mockElement1.lookup = jest.fn().mockReturnValue( null );
+
+		mockGetContainer.mockImplementation( ( id ) => {
+			if ( id === 'element-1' ) {
+				return freshContainer;
+			}
+			if ( id === 'parent-1' ) {
+				return mockParent;
+			}
+			return null;
+		} );
+
+		act( () => {
+			historyMock.instance.redo();
+		} );
+
 		// Assert.
-		expect( mockDeleteElement ).toHaveBeenCalledTimes( 1 );
-		expect( mockCreateElement ).not.toHaveBeenCalled();
+		expect( mockDeleteElement ).toHaveBeenCalledTimes( 2 );
+		expect( mockDeleteElement ).toHaveBeenNthCalledWith( 2, {
+			container: freshContainer,
+			options: { useHistory: false },
+		} );
 	} );
 
-	it( 'should skip redo when container lookup returns null', () => {
+	it( 'should skip redo when container lookup and getContainer both return null', () => {
 		// Arrange.
 		const { mockElement1 } = setupMockElementsForRemoval();
 
@@ -343,6 +427,7 @@ describe( 'removeElements', () => {
 		} );
 
 		mockElement1.lookup = jest.fn().mockReturnValue( null );
+		mockGetContainer.mockReturnValue( null );
 
 		act( () => {
 			historyMock.instance.redo();
@@ -353,7 +438,7 @@ describe( 'removeElements', () => {
 		expect( mockCreateElement ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'should skip redo when parent lookup returns null', () => {
+	it( 'should skip redo when parent lookup and getContainer both return null', () => {
 		// Arrange.
 		const { mockParent } = setupMockElementsForRemoval();
 
@@ -371,6 +456,7 @@ describe( 'removeElements', () => {
 		} );
 
 		mockParent.lookup = jest.fn().mockReturnValue( null );
+		mockGetContainer.mockReturnValue( null );
 
 		act( () => {
 			historyMock.instance.redo();

--- a/packages/packages/libs/editor-elements/src/sync/create-elements.ts
+++ b/packages/packages/libs/editor-elements/src/sync/create-elements.ts
@@ -3,7 +3,8 @@ import { __ } from '@wordpress/i18n';
 
 import { createElement, type CreateElementParams } from './create-element';
 import { deleteElement } from './delete-element';
-import { type V1Element, type V1ElementModelProps } from './types';
+import { getContainer } from './get-container';
+import { type ExtendedWindow, type V1Element, type V1ElementModelProps } from './types';
 
 type CreateElementsParams = {
 	elements: CreateElementParams[];
@@ -13,7 +14,9 @@ type CreateElementsParams = {
 
 type CreatedElement = {
 	container: V1Element;
+	containerId: string;
 	parentContainer: V1Element;
+	parentContainerId: string;
 	model: V1ElementModelProps;
 	options?: CreateElementParams[ 'options' ];
 };
@@ -23,6 +26,92 @@ type CreatedElementsResult = {
 };
 
 export type { CreateElementsParams, CreatedElement, CreatedElementsResult };
+
+function getDocumentContainer(): V1Element | null {
+	const extendedWindow = window as unknown as ExtendedWindow;
+
+	return extendedWindow.elementor?.documents?.getCurrent?.()?.container ?? null;
+}
+
+function findModelById(
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	elements: any,
+	id: string
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any | null {
+	if ( ! elements ) {
+		return null;
+	}
+
+	const models = elements.models ?? elements;
+
+	if ( ! Array.isArray( models ) ) {
+		return null;
+	}
+
+	for ( const model of models ) {
+		const modelId = typeof model.get === 'function' ? model.get( 'id' ) : model.id;
+
+		if ( modelId === id ) {
+			return model;
+		}
+
+		const childElements = typeof model.get === 'function' ? model.get( 'elements' ) : model.elements;
+		const found = findModelById( childElements, id );
+
+		if ( found ) {
+			return found;
+		}
+	}
+
+	return null;
+}
+
+function addModelToParent(
+	parentModelId: string,
+	childModelData: V1ElementModelProps,
+	options?: CreateElementParams[ 'options' ]
+): boolean {
+	const doc = getDocumentContainer();
+
+	if ( ! doc?.model ) {
+		return false;
+	}
+
+	const elements = doc.model.get( 'elements' as never );
+	const parentModel = findModelById( elements, parentModelId );
+
+	if ( ! parentModel ) {
+		return false;
+	}
+
+	const parentElements = typeof parentModel.get === 'function' ? parentModel.get( 'elements' ) : null;
+
+	if ( ! parentElements ) {
+		return false;
+	}
+
+	const addOptions: Record< string, unknown > = { silent: true };
+
+	if ( options?.at !== undefined ) {
+		addOptions.at = options.at;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	( parentElements as any ).add( childModelData, addOptions, true );
+
+	return true;
+}
+
+function resolveContainer( container: V1Element, id: string ): V1Element | null {
+	const looked = container.lookup?.();
+
+	if ( looked?.view?.el?.isConnected ) {
+		return looked;
+	}
+
+	return getContainer( id );
+}
 
 export const createElements = ( {
 	elements,
@@ -49,7 +138,9 @@ export const createElements = ( {
 
 					createdElements.push( {
 						container: element,
+						containerId: element.id,
 						parentContainer,
+						parentContainerId: parentContainer.id,
 						model: element.model?.toJSON() || {},
 						options,
 					} );
@@ -58,8 +149,8 @@ export const createElements = ( {
 				return { createdElements };
 			},
 			undo: ( _: { elements: CreateElementParams[] }, { createdElements }: CreatedElementsResult ) => {
-				[ ...createdElements ].reverse().forEach( ( { container } ) => {
-					const freshContainer = container.lookup?.();
+				[ ...createdElements ].reverse().forEach( ( { container, containerId } ) => {
+					const freshContainer = resolveContainer( container, containerId );
 
 					if ( freshContainer ) {
 						deleteElement( {
@@ -75,25 +166,38 @@ export const createElements = ( {
 			): CreatedElementsResult => {
 				const newElements: CreatedElement[] = [];
 
-				createdElements.forEach( ( { parentContainer, model, options } ) => {
-					const freshParent = parentContainer.lookup?.();
+				createdElements.forEach( ( { parentContainer, parentContainerId, model, options } ) => {
+					const freshParent = resolveContainer( parentContainer, parentContainerId );
 
-					if ( ! freshParent ) {
+					if ( freshParent ) {
+						const element = createElement( {
+							container: freshParent,
+							model,
+							options: { ...options, useHistory: false },
+						} );
+
+						newElements.push( {
+							container: element,
+							containerId: element.id,
+							parentContainer: freshParent,
+							parentContainerId,
+							model: element.model.toJSON(),
+							options,
+						} );
+
 						return;
 					}
 
-					const element = createElement( {
-						container: freshParent,
-						model,
-						options: { ...options, useHistory: false },
-					} );
-
-					newElements.push( {
-						container: element,
-						parentContainer: freshParent,
-						model: element.model.toJSON(),
-						options,
-					} );
+					if ( addModelToParent( parentContainerId, model, options ) ) {
+						newElements.push( {
+							container: parentContainer,
+							containerId: model.id,
+							parentContainer,
+							parentContainerId,
+							model,
+							options,
+						} );
+					}
 				} );
 
 				return { createdElements: newElements };

--- a/packages/packages/libs/editor-elements/src/sync/duplicate-elements.ts
+++ b/packages/packages/libs/editor-elements/src/sync/duplicate-elements.ts
@@ -17,7 +17,9 @@ type DuplicateElementsParams = {
 
 type DuplicatedElement = {
 	container: V1Element;
+	containerId: string;
 	parentContainer: V1Element;
+	parentContainerId: string;
 	model: V1ElementModelProps;
 	at?: number;
 };
@@ -27,6 +29,16 @@ type DuplicatedElementsResult = {
 };
 
 export type { DuplicateElementsParams, DuplicatedElement, DuplicatedElementsResult };
+
+function resolveContainer( container: V1Element, id: string ): V1Element | null {
+	const looked = container.lookup?.();
+
+	if ( looked?.view?.el?.isConnected ) {
+		return looked;
+	}
+
+	return getContainer( id );
+}
 
 export const duplicateElements = ( {
 	elementIds,
@@ -59,7 +71,9 @@ export const duplicateElements = ( {
 
 					duplicatedElements.push( {
 						container: duplicatedElement,
+						containerId: duplicatedElement.id,
 						parentContainer: duplicatedElement.parent,
+						parentContainerId: duplicatedElement.parent.id,
 						model: duplicatedElement.model.toJSON(),
 						at: duplicatedElement.view?._index,
 					} );
@@ -69,11 +83,15 @@ export const duplicateElements = ( {
 			},
 			undo: ( _: { elementIds: string[] }, { duplicatedElements }: DuplicatedElementsResult ) => {
 				onRestoreElements?.();
-				[ ...duplicatedElements ].reverse().forEach( ( { container } ) => {
-					deleteElement( {
-						container,
-						options: { useHistory: false },
-					} );
+				[ ...duplicatedElements ].reverse().forEach( ( { container, containerId } ) => {
+					const freshContainer = resolveContainer( container, containerId );
+
+					if ( freshContainer ) {
+						deleteElement( {
+							container: freshContainer,
+							options: { useHistory: false },
+						} );
+					}
 				} );
 			},
 			redo: (
@@ -83,8 +101,8 @@ export const duplicateElements = ( {
 				onDuplicateElements?.();
 				const duplicatedElements: DuplicatedElement[] = [];
 
-				previousElements.forEach( ( { parentContainer, model, at } ) => {
-					const freshParent = parentContainer.lookup?.();
+				previousElements.forEach( ( { parentContainer, parentContainerId, model, at } ) => {
+					const freshParent = resolveContainer( parentContainer, parentContainerId );
 
 					if ( freshParent ) {
 						const createdElement = createElement( {
@@ -95,7 +113,9 @@ export const duplicateElements = ( {
 
 						duplicatedElements.push( {
 							container: createdElement,
+							containerId: createdElement.id,
 							parentContainer: freshParent,
+							parentContainerId,
 							model,
 							at,
 						} );

--- a/packages/packages/libs/editor-elements/src/sync/move-elements.ts
+++ b/packages/packages/libs/editor-elements/src/sync/move-elements.ts
@@ -1,6 +1,7 @@
 import { undoable } from '@elementor/editor-v1-adapters';
 import { __ } from '@wordpress/i18n';
 
+import { getContainer } from './get-container';
 import { moveElement } from './move-element';
 import { type V1Element } from './types';
 
@@ -26,9 +27,12 @@ type MoveElementsParams = {
 
 type MovedElement = {
 	element: V1Element;
+	elementId: string;
 	originalContainer: V1Element;
+	originalContainerId: string;
 	originalIndex: number;
 	targetContainer: V1Element;
+	targetContainerId: string;
 	options?: MoveOptions;
 };
 
@@ -37,6 +41,16 @@ type MovedElementsResult = {
 };
 
 export type { MoveElementsParams, MoveInput, MovedElement, MovedElementsResult };
+
+function resolveContainer( container: V1Element, id: string ): V1Element | null {
+	const looked = container.lookup?.();
+
+	if ( looked?.view?.el?.isConnected ) {
+		return looked;
+	}
+
+	return getContainer( id );
+}
 
 export const moveElements = ( {
 	moves: movesToMake,
@@ -78,9 +92,12 @@ export const moveElements = ( {
 
 					movedElements.push( {
 						element: newElement,
+						elementId: newElement.id,
 						originalContainer,
+						originalContainerId: originalContainer.id,
 						originalIndex,
 						targetContainer: target,
+						targetContainerId: target.id,
 						options,
 					} );
 				} );
@@ -90,51 +107,67 @@ export const moveElements = ( {
 			undo: ( _: { moves: MoveInput[] }, { movedElements }: MovedElementsResult ) => {
 				onRestoreElements?.();
 
-				[ ...movedElements ].reverse().forEach( ( { element, originalContainer, originalIndex } ) => {
-					const freshElement = element.lookup?.();
-					const freshOriginalContainer = originalContainer.lookup?.();
+				[ ...movedElements ]
+					.reverse()
+					.forEach( ( { element, elementId, originalContainer, originalContainerId, originalIndex } ) => {
+						const freshElement = resolveContainer( element, elementId );
+						const freshOriginalContainer = resolveContainer( originalContainer, originalContainerId );
 
-					if ( ! freshElement || ! freshOriginalContainer ) {
-						return;
-					}
+						if ( ! freshElement || ! freshOriginalContainer ) {
+							return;
+						}
 
-					moveElement( {
-						element: freshElement,
-						targetContainer: freshOriginalContainer,
-						options: {
-							useHistory: false,
-							at: originalIndex >= 0 ? originalIndex : undefined,
-						},
+						moveElement( {
+							element: freshElement,
+							targetContainer: freshOriginalContainer,
+							options: {
+								useHistory: false,
+								at: originalIndex >= 0 ? originalIndex : undefined,
+							},
+						} );
 					} );
-				} );
 			},
 			redo: ( _: { moves: MoveInput[] }, { movedElements }: MovedElementsResult ): MovedElementsResult => {
 				const newMovedElements: MovedElement[] = [];
 				onMoveElements?.();
 
-				movedElements.forEach( ( { element, originalContainer, originalIndex, targetContainer, options } ) => {
-					const freshElement = element.lookup?.();
-					const freshOriginalContainer = originalContainer.lookup?.();
-					const freshTarget = targetContainer.lookup?.();
-
-					if ( ! freshElement || ! freshOriginalContainer || ! freshTarget ) {
-						return;
-					}
-
-					const newElement = moveElement( {
-						element: freshElement,
-						targetContainer: freshTarget,
-						options: { ...options, useHistory: false },
-					} );
-
-					newMovedElements.push( {
-						element: newElement,
-						originalContainer: freshOriginalContainer,
+				movedElements.forEach(
+					( {
+						element,
+						elementId,
+						originalContainer,
+						originalContainerId,
 						originalIndex,
-						targetContainer: freshTarget,
+						targetContainer,
+						targetContainerId,
 						options,
-					} );
-				} );
+					} ) => {
+						const freshElement = resolveContainer( element, elementId );
+						const freshOriginalContainer = resolveContainer( originalContainer, originalContainerId );
+						const freshTarget = resolveContainer( targetContainer, targetContainerId );
+
+						if ( ! freshElement || ! freshOriginalContainer || ! freshTarget ) {
+							return;
+						}
+
+						const newElement = moveElement( {
+							element: freshElement,
+							targetContainer: freshTarget,
+							options: { ...options, useHistory: false },
+						} );
+
+						newMovedElements.push( {
+							element: newElement,
+							elementId: newElement.id,
+							originalContainer: freshOriginalContainer,
+							originalContainerId,
+							originalIndex,
+							targetContainer: freshTarget,
+							targetContainerId,
+							options,
+						} );
+					}
+				);
 
 				return { movedElements: newMovedElements };
 			},

--- a/packages/packages/libs/editor-elements/src/sync/remove-elements.ts
+++ b/packages/packages/libs/editor-elements/src/sync/remove-elements.ts
@@ -16,7 +16,9 @@ type RemoveElementsParams = {
 
 type RemovedElement = {
 	container: V1Element;
+	containerId: string;
 	parent: V1Element;
+	parentId: string;
 	model: V1ElementModelProps;
 	at: number;
 };
@@ -24,6 +26,16 @@ type RemovedElement = {
 type RemovedElementsResult = {
 	removedElements: RemovedElement[];
 };
+
+function resolveContainer( container: V1Element, id: string ): V1Element | null {
+	const looked = container.lookup?.();
+
+	if ( looked?.view?.el?.isConnected ) {
+		return looked;
+	}
+
+	return getContainer( id );
+}
 
 export const removeElements = ( {
 	elementIds,
@@ -43,7 +55,9 @@ export const removeElements = ( {
 					if ( container?.parent ) {
 						removedElements.push( {
 							container,
+							containerId: container.id,
 							parent: container.parent,
+							parentId: container.parent.id,
 							model: container.model.toJSON(),
 							at: container.view?._index ?? 0,
 						} );
@@ -64,8 +78,8 @@ export const removeElements = ( {
 			undo: ( _: { elementIds: string[] }, { removedElements }: RemovedElementsResult ) => {
 				onRestoreElements?.();
 
-				[ ...removedElements ].reverse().forEach( ( { parent, model, at } ) => {
-					const freshParent = parent.lookup?.();
+				[ ...removedElements ].reverse().forEach( ( { parent, parentId, model, at } ) => {
+					const freshParent = resolveContainer( parent, parentId );
 
 					if ( freshParent ) {
 						createElement( {
@@ -84,9 +98,9 @@ export const removeElements = ( {
 
 				const newRemovedElements: RemovedElement[] = [];
 
-				removedElements.forEach( ( { container, parent, model, at } ) => {
-					const freshContainer = container.lookup?.();
-					const freshParent = parent.lookup?.();
+				removedElements.forEach( ( { container, containerId, parent, parentId, model, at } ) => {
+					const freshContainer = resolveContainer( container, containerId );
+					const freshParent = resolveContainer( parent, parentId );
 
 					if ( ! freshContainer || ! freshParent ) {
 						return;
@@ -99,7 +113,9 @@ export const removeElements = ( {
 
 					newRemovedElements.push( {
 						container: freshContainer,
+						containerId,
 						parent: freshParent,
+						parentId,
 						model,
 						at,
 					} );

--- a/packages/tests/test-utils/create-mock-element-with-children.ts
+++ b/packages/tests/test-utils/create-mock-element-with-children.ts
@@ -25,11 +25,19 @@ function createMockSettings( data: V1ElementSettingsProps = {} ): V1Settings {
 	} as V1Settings;
 }
 
+function createConnectedView( index = 0 ): V1Element[ 'view' ] {
+	const el = document.createElement( 'div' );
+	document.body.appendChild( el );
+
+	return { el, _index: index };
+}
+
 export function createMockChild( modelData: V1ElementModelProps ): V1Element {
 	const mockChild: Partial< V1Element > = {
 		id: modelData.id,
 		model: createMockModel( modelData ),
 		settings: createMockSettings(),
+		view: createConnectedView(),
 	};
 
 	mockChild.lookup = jest.fn( () => mockChild as V1Element );
@@ -84,6 +92,7 @@ export function createMockContainer( id: string, children: V1Element[] = [], elT
 		model: createMockModel( modelData ),
 		settings: createMockSettings(),
 		children: createMockChildren( children ),
+		view: createConnectedView(),
 	};
 
 	mockContainer.lookup = jest.fn( () => mockContainer as V1Element );


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Resolve stale element references during undo/redo operations on atomic nested widgets (e.g., Tabs)

## Description

When a grandparent element (e.g., a Tabs widget) is deleted and then restored via undo, element references stored in undoable closures become stale. The legacy history system recreates parent views **asynchronously** (Marionette renders children after the parent view is attached), so view-based lookups (`container.lookup()`, `getContainer()`) fail for child elements during redo.

### Root Cause

The `undoable` wrapper stores `V1Element` references in closures. When a parent widget is deleted and recreated, these references point to destroyed Backbone views. The existing `container.lookup()` method returns stale objects (with disconnected DOM elements), causing redo operations on children to silently fail.

### Solution

1. **`resolveContainer(container, id)`** — A new helper used across all four undoable sync operations (`createElements`, `removeElements`, `duplicateElements`, `moveElements`). It first tries `container.lookup()` and validates the result via `view.el.isConnected`. If stale, it falls back to `getContainer(id)` which searches the live DOM tree.

2. **ID tracking** — Each stored element reference now also stores its `id` (e.g., `containerId`, `parentContainerId`) alongside the `V1Element` reference, enabling the ID-based fallback.

3. **Model-level injection (`addModelToParent`)** — For the specific case where parent views haven't rendered yet (atomic widgets like Tabs whose children render asynchronously), a fallback directly inserts child model data into the parent's Backbone `elements` collection. Marionette then picks up and renders these children when it processes the parent view.

### Key Decision: Model-level injection

View-based approaches (traversing `container.view.children`, `findViewRecursive`, etc.) all fail because Marionette hasn't rendered the child views yet at the time redo runs. The model-level injection bypasses this timing issue by working at the data layer, letting Marionette's normal rendering pipeline handle the rest.

## Test instructions

1. Open the Elementor editor
2. Add a Tabs widget to the page
3. Add a new tab to the Tabs widget
4. Delete the entire Tabs widget
5. Press Ctrl+Z (undo) — the Tabs widget should reappear
6. Press Ctrl+Z again — the added tab should be restored
7. Press Ctrl+Y (redo) — the tab should be removed again
8. Press Ctrl+Y again — the Tabs widget should be deleted again
9. Press Ctrl+Z twice — everything should restore correctly

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended (53 tests passing across 12 test suites)
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes ED-22825

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix stale element reference errors in undo/redo operations for atomic widgets by implementing robust container resolution with ID-based fallback mechanism.

Main changes:
- Added resolveContainer helper and ID tracking to prevent stale references during undo/redo operations across all element lifecycle methods
- Implemented addModelToParent fallback in createElements redo to handle cases where container lookup fails for atomic widgets
- Enhanced test coverage with view.el.isConnected validation and getContainer fallback scenarios for remove/duplicate operations

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
