### PR TITLE
Internal: Analytics for Widget Deletion

### DIFF
--- a/assets/dev/js/editor/document/elements/commands/delete.js
+++ b/assets/dev/js/editor/document/elements/commands/delete.js
@@ -48,6 +48,7 @@ export class Delete extends $e.modules.editor.document.CommandHistoryBase {
 				} );
 			}
 
+			this.dispatchDeleteEvent( container, args.callerName );
 			this.deselectRecursive( container.model.get( 'id' ) );
 
 			container.model.destroy();
@@ -59,6 +60,41 @@ export class Delete extends $e.modules.editor.document.CommandHistoryBase {
 		}
 
 		return containers;
+	}
+
+	dispatchDeleteEvent( container, callerName ) {
+		try {
+			if ( ! elementorCommon?.eventsManager?.dispatchEvent ) {
+				return;
+			}
+
+			const elType = container.model.get( 'elType' ) ?? '';
+			const widgetType = container.model.get( 'widgetType' ) ?? '';
+			const widgetName = 'widget' === elType ? widgetType : elType;
+			const parentWidgetType = container.parent?.model?.get( 'widgetType' ) ?? '';
+			const parentType = parentWidgetType || container.parent?.type || '';
+
+			const eventData = {
+				app_type: 'editor',
+				window_name: 'editor',
+				interaction_type: 'click',
+				target_type: elType,
+				target_name: 'delete',
+				interaction_result: `${ elType }_deleted`,
+				target_location: 'canvas',
+				location_l1: parentType,
+				location_l2: widgetName,
+				interaction_description: `user_deleted_${ widgetName }_from_canvas`,
+			};
+
+			if ( callerName ) {
+				eventData.trigger = callerName;
+			}
+
+			elementorCommon.eventsManager.dispatchEvent( 'delete_element', eventData );
+		} catch {
+			// Silently fail — analytics should never break production functionality.
+		}
 	}
 
 	deselectRecursive( id ) {

--- a/assets/dev/js/editor/document/ui/commands/delete.js
+++ b/assets/dev/js/editor/document/ui/commands/delete.js
@@ -5,6 +5,7 @@ export class Delete extends $e.modules.CommandBase {
 		if ( selectedElements.length ) {
 			return $e.run( 'document/elements/delete', {
 				containers: selectedElements,
+				callerName: 'keyboard',
 			} );
 		}
 

--- a/assets/dev/js/editor/elements/views/base.js
+++ b/assets/dev/js/editor/elements/views/base.js
@@ -251,7 +251,7 @@ BaseElementView = BaseContainer.extend( {
 						return __( 'Delete', 'elementor' );
 					},
 					shortcut: '⌦',
-					callback: () => $e.run( 'document/elements/delete', { containers: elementor.selection.getElements( this.getContainer() ) } ),
+					callback: () => $e.run( 'document/elements/delete', { containers: elementor.selection.getElements( this.getContainer() ), callerName: 'context_menu' } ),
 					isEnabled: () => ! this.getContainer().isLocked(),
 				},
 			],
@@ -1080,7 +1080,7 @@ BaseElementView = BaseContainer.extend( {
 		event.stopPropagation();
 		this.handleAnchorClick( event );
 
-		$e.run( 'document/elements/delete', { container: this.getContainer() } );
+		$e.run( 'document/elements/delete', { container: this.getContainer(), callerName: 'remove_button' } );
 	},
 
 	handleAnchorClick( event ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add analytics event tracking for widget deletion operations to monitor user interactions with delete functionality across different editor contexts.

Main changes:
- Implemented dispatchDeleteEvent method in Delete command to track deletion events with widget metadata and interaction context
- Added callerName parameter to delete operations identifying trigger source (keyboard, context_menu, remove_button)
- Wrapped analytics dispatch in try-catch block to prevent tracking failures from breaking deletion functionality

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
