### PR TITLE
Internal: Enable mixpanel events for design sync [ED-22801]

### DIFF
--- a/core/common/modules/events-manager/assets/js/events-config.js
+++ b/core/common/modules/events-manager/assets/js/events-config.js
@@ -234,6 +234,7 @@ const eventsConfig = {
 			openManager: 'open_variables_manager',
 			saveChanges: 'save_variables_changes',
 			delete: 'delete_variable',
+			variableSyncToV3: 'variable_sync_to_v3',
 		},
 		components: {
 			createClicked: 'component_create_clicked',
@@ -266,6 +267,9 @@ const eventsConfig = {
 			classStateClicked: 'class_state_clicked',
 			classUsageClicked: 'class_usage_clicked',
 			classDuplicate: 'class_duplicate',
+			classSyncToV3PopupShown: 'class_sync_to_v3_popup_shown',
+			classSyncToV3: 'class_sync_to_v3',
+			classSyncToV3PopupClick: 'class_sync_to_v3_popup_click',
 		},
 		editorOne: {
 			topBarPublishDropdown: 'top_bar_publish_dropdown',
@@ -282,7 +286,7 @@ const eventsConfig = {
 		},
 		interactions: {
 			created: 'interactions_created',
-    },
+		},
 		promotions: {
 			viewPromotion: 'view_promotion',
 			upgradePromotionClick: 'upgrade_promotion_click',

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
@@ -464,4 +464,46 @@ describe( 'ClassManagerPanel', () => {
 			event: 'classManagerSearched',
 		} );
 	} );
+
+	it( 'should track syncToV3 unsync event when stopping sync via confirmation dialog', async () => {
+		// Arrange
+		act( () => {
+			__dispatch( slice.actions.update( { style: { id: 'class-2', sync_to_v3: true } } ) );
+		} );
+
+		// Act.
+		renderWithStore(
+			<ThemeProvider>
+				<QueryClientProvider client={ queryClient }>
+					<ClassManagerPanel />
+				</QueryClientProvider>
+			</ThemeProvider>,
+			store
+		);
+
+		const [ firstClass ] = screen.getAllByRole( 'listitem' );
+
+		fireEvent.click( within( firstClass ).getByRole( 'button', { name: 'More actions' } ) );
+
+		const stopSyncButton = screen.getByRole( 'menuitem', { name: /Stop syncing to Global Fonts/i } );
+
+		fireEvent.click( stopSyncButton );
+
+		// Assert - confirmation dialog should appear.
+		await waitFor( () => {
+			expect( screen.getByText( 'Un-sync typography class' ) ).toBeInTheDocument();
+		} );
+
+		// Act - confirm the dialog.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Got it' } ) );
+
+		// Assert.
+		await waitFor( () => {
+			expect( mockTracking ).toHaveBeenCalledWith( {
+				event: 'classSyncToV3',
+				classId: 'class-2',
+				action: 'unsync',
+			} );
+		} );
+	} );
 } );

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
@@ -471,7 +471,7 @@ describe( 'ClassManagerPanel', () => {
 			__dispatch( slice.actions.update( { style: { id: 'class-2', sync_to_v3: true } } ) );
 		} );
 
-		// Act.
+		// Act
 		renderWithStore(
 			<ThemeProvider>
 				<QueryClientProvider client={ queryClient }>
@@ -489,15 +489,15 @@ describe( 'ClassManagerPanel', () => {
 
 		fireEvent.click( stopSyncButton );
 
-		// Assert - confirmation dialog should appear.
+		// Assert
 		await waitFor( () => {
 			expect( screen.getByText( 'Un-sync typography class' ) ).toBeInTheDocument();
 		} );
 
-		// Act - confirm the dialog.
+		// Act
 		fireEvent.click( screen.getByRole( 'button', { name: 'Got it' } ) );
 
-		// Assert.
+		// Assert
 		await waitFor( () => {
 			expect( mockTracking ).toHaveBeenCalledWith( {
 				event: 'classSyncToV3',

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/start-sync-to-v3-modal.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/start-sync-to-v3-modal.test.tsx
@@ -84,7 +84,12 @@ describe( 'StartSyncToV3Modal', () => {
 	it( 'should track exposure again when modal is reopened', async () => {
 		const { rerender } = render(
 			<ThemeProvider>
-				<StartSyncToV3Modal externalOpen classId="class-1" onExternalClose={ jest.fn() } onConfirm={ jest.fn() } />
+				<StartSyncToV3Modal
+					externalOpen
+					classId="class-1"
+					onExternalClose={ jest.fn() }
+					onConfirm={ jest.fn() }
+				/>
 			</ThemeProvider>
 		);
 
@@ -99,13 +104,23 @@ describe( 'StartSyncToV3Modal', () => {
 
 		rerender(
 			<ThemeProvider>
-				<StartSyncToV3Modal externalOpen={ false } classId="class-1" onExternalClose={ jest.fn() } onConfirm={ jest.fn() } />
+				<StartSyncToV3Modal
+					externalOpen={ false }
+					classId="class-1"
+					onExternalClose={ jest.fn() }
+					onConfirm={ jest.fn() }
+				/>
 			</ThemeProvider>
 		);
 
 		rerender(
 			<ThemeProvider>
-				<StartSyncToV3Modal externalOpen classId="class-2" onExternalClose={ jest.fn() } onConfirm={ jest.fn() } />
+				<StartSyncToV3Modal
+					externalOpen
+					classId="class-2"
+					onExternalClose={ jest.fn() }
+					onConfirm={ jest.fn() }
+				/>
 			</ThemeProvider>
 		);
 

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/start-sync-to-v3-modal.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/start-sync-to-v3-modal.test.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { createMockTrackingModule, mockTracking } from 'test-utils';
+import { ThemeProvider } from '@elementor/ui';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { StartSyncToV3Modal } from '../start-sync-to-v3-modal';
+
+jest.mock( '../../../utils/tracking', () => createMockTrackingModule( 'trackGlobalClasses' ) );
+
+const renderModal = ( props = {} ) => {
+	const defaultProps = {
+		externalOpen: true,
+		classId: 'class-1',
+		onExternalClose: jest.fn(),
+		onConfirm: jest.fn(),
+	};
+
+	return {
+		...render(
+			<ThemeProvider>
+				<StartSyncToV3Modal { ...defaultProps } { ...props } />
+			</ThemeProvider>
+		),
+		props: { ...defaultProps, ...props },
+	};
+};
+
+describe( 'StartSyncToV3Modal', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should track popup exposure when modal opens', async () => {
+		renderModal();
+
+		await waitFor( () => {
+			expect( mockTracking ).toHaveBeenCalledWith( {
+				event: 'classSyncToV3PopupShown',
+				classId: 'class-1',
+			} );
+		} );
+	} );
+
+	it( 'should track popup click with sync action when confirming', async () => {
+		const { props } = renderModal();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Sync to Global Fonts' } ) );
+
+		await waitFor( () => {
+			expect( mockTracking ).toHaveBeenCalledWith( {
+				event: 'classSyncToV3PopupClick',
+				classId: 'class-1',
+				action: 'sync',
+			} );
+		} );
+
+		expect( props.onConfirm ).toHaveBeenCalled();
+		expect( props.onExternalClose ).toHaveBeenCalled();
+	} );
+
+	it( 'should track popup click with cancel action when cancelling', async () => {
+		const { props } = renderModal();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		await waitFor( () => {
+			expect( mockTracking ).toHaveBeenCalledWith( {
+				event: 'classSyncToV3PopupClick',
+				classId: 'class-1',
+				action: 'cancel',
+			} );
+		} );
+
+		expect( props.onExternalClose ).toHaveBeenCalled();
+		expect( props.onConfirm ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not track when modal is closed', () => {
+		renderModal( { externalOpen: false } );
+
+		expect( mockTracking ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/start-sync-to-v3-modal.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/start-sync-to-v3-modal.test.tsx
@@ -80,4 +80,40 @@ describe( 'StartSyncToV3Modal', () => {
 
 		expect( mockTracking ).not.toHaveBeenCalled();
 	} );
+
+	it( 'should track exposure again when modal is reopened', async () => {
+		const { rerender } = render(
+			<ThemeProvider>
+				<StartSyncToV3Modal externalOpen classId="class-1" onExternalClose={ jest.fn() } onConfirm={ jest.fn() } />
+			</ThemeProvider>
+		);
+
+		await waitFor( () => {
+			expect( mockTracking ).toHaveBeenCalledWith( {
+				event: 'classSyncToV3PopupShown',
+				classId: 'class-1',
+			} );
+		} );
+
+		mockTracking.mockClear();
+
+		rerender(
+			<ThemeProvider>
+				<StartSyncToV3Modal externalOpen={ false } classId="class-1" onExternalClose={ jest.fn() } onConfirm={ jest.fn() } />
+			</ThemeProvider>
+		);
+
+		rerender(
+			<ThemeProvider>
+				<StartSyncToV3Modal externalOpen classId="class-2" onExternalClose={ jest.fn() } onConfirm={ jest.fn() } />
+			</ThemeProvider>
+		);
+
+		await waitFor( () => {
+			expect( mockTracking ).toHaveBeenCalledWith( {
+				event: 'classSyncToV3PopupShown',
+				classId: 'class-2',
+			} );
+		} );
+	} );
 } );

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/class-manager-panel.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/class-manager-panel.tsx
@@ -34,6 +34,7 @@ import { useDirtyState } from '../../hooks/use-dirty-state';
 import { useFilters } from '../../hooks/use-filters';
 import { saveGlobalClasses } from '../../save-global-classes';
 import { slice } from '../../store';
+import { trackGlobalClasses } from '../../utils/tracking';
 import { ActiveFilters } from '../search-and-filter/components/filter/active-filters';
 import { CssClassFilter } from '../search-and-filter/components/filter/css-class-filter';
 import { ClassManagerSearch } from '../search-and-filter/components/search/class-manager-search';
@@ -113,6 +114,7 @@ export function ClassManagerPanel() {
 				},
 			} )
 		);
+		trackGlobalClasses( { event: 'classSyncToV3', classId, action: 'unsync' } );
 		setStopSyncConfirmation( null );
 	}, [] );
 
@@ -125,6 +127,7 @@ export function ClassManagerPanel() {
 				},
 			} )
 		);
+		trackGlobalClasses( { event: 'classSyncToV3', classId, action: 'sync' } );
 		setStartSyncConfirmation( null );
 	}, [] );
 
@@ -221,6 +224,7 @@ export function ClassManagerPanel() {
 			{ startSyncConfirmation && (
 				<StartSyncToV3Modal
 					externalOpen
+					classId={ startSyncConfirmation }
 					onExternalClose={ () => setStartSyncConfirmation( null ) }
 					onConfirm={ () => handleStartSync( startSyncConfirmation ) }
 				/>

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/start-sync-to-v3-modal.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/start-sync-to-v3-modal.tsx
@@ -32,6 +32,10 @@ export const StartSyncToV3Modal = ( { externalOpen, classId, onExternalClose, on
 			hasTrackedExposure.current = true;
 			trackGlobalClasses( { event: 'classSyncToV3PopupShown', classId } );
 		}
+
+		if ( ! externalOpen ) {
+			hasTrackedExposure.current = false;
+		}
 	}, [ externalOpen, classId ] );
 
 	const handleClose = () => {

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/start-sync-to-v3-modal.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/start-sync-to-v3-modal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
 	Box,
 	Button,
@@ -12,22 +12,39 @@ import {
 } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
+import { trackGlobalClasses } from '../../utils/tracking';
+
 const IMAGE_URL = 'https://assets.elementor.com/packages/v1/images/class-manager-sync-modal.png';
 
 type StartSyncToV3ModalProps = {
 	externalOpen?: boolean;
+	classId?: string;
 	onExternalClose?: () => void;
 	onConfirm?: () => void;
 };
 
-export const StartSyncToV3Modal = ( { externalOpen, onExternalClose, onConfirm }: StartSyncToV3ModalProps = {} ) => {
+export const StartSyncToV3Modal = ( { externalOpen, classId, onExternalClose, onConfirm }: StartSyncToV3ModalProps = {} ) => {
 	const [ shouldShowAgain, setShouldShowAgain ] = useState( true );
+	const hasTrackedExposure = useRef( false );
+
+	useEffect( () => {
+		if ( externalOpen && classId && ! hasTrackedExposure.current ) {
+			hasTrackedExposure.current = true;
+			trackGlobalClasses( { event: 'classSyncToV3PopupShown', classId } );
+		}
+	}, [ externalOpen, classId ] );
 
 	const handleClose = () => {
+		if ( classId ) {
+			trackGlobalClasses( { event: 'classSyncToV3PopupClick', classId, action: 'cancel' } );
+		}
 		onExternalClose?.();
 	};
 
 	const handleConfirm = () => {
+		if ( classId ) {
+			trackGlobalClasses( { event: 'classSyncToV3PopupClick', classId, action: 'sync' } );
+		}
 		onConfirm?.();
 		onExternalClose?.();
 	};

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/start-sync-to-v3-modal.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/start-sync-to-v3-modal.tsx
@@ -23,7 +23,12 @@ type StartSyncToV3ModalProps = {
 	onConfirm?: () => void;
 };
 
-export const StartSyncToV3Modal = ( { externalOpen, classId, onExternalClose, onConfirm }: StartSyncToV3ModalProps = {} ) => {
+export const StartSyncToV3Modal = ( {
+	externalOpen,
+	classId,
+	onExternalClose,
+	onConfirm,
+}: StartSyncToV3ModalProps = {} ) => {
 	const [ shouldShowAgain, setShouldShowAgain ] = useState( true );
 	const hasTrackedExposure = useRef( false );
 

--- a/packages/packages/core/editor-global-classes/src/utils/tracking.ts
+++ b/packages/packages/core/editor-global-classes/src/utils/tracking.ts
@@ -72,6 +72,17 @@ type EventMap = {
 		type: string;
 		source: 'global' | 'local';
 	};
+	classSyncToV3PopupShown: {
+		classId: StyleDefinitionID;
+	};
+	classSyncToV3: {
+		classId: StyleDefinitionID;
+		action: 'sync' | 'unsync';
+	};
+	classSyncToV3PopupClick: {
+		classId: StyleDefinitionID;
+		action: 'sync' | 'cancel';
+	};
 };
 
 export type TrackingEvent = {
@@ -138,6 +149,43 @@ const getSanitizedData = async ( payload: TrackingEvent ): Promise< Record< stri
 				return { ...payload, classTitle: getCssClass( payload.classId ).label };
 			}
 			break;
+		case 'classSyncToV3PopupShown':
+			return {
+				...payload,
+				interaction_type: 'popup_shown',
+				target_type: 'popup',
+				target_name: 'sync_to_v3_popup',
+				interaction_result: 'popup_viewed',
+				target_location: 'widget_panel',
+				location_l1: 'class_manager',
+			};
+		case 'classSyncToV3': {
+			const classLabel = getCssClass( payload.classId ).label;
+			const isSync = payload.action === 'sync';
+			return {
+				...payload,
+				interaction_type: 'click',
+				target_type: classLabel,
+				target_name: isSync ? 'sync_to_v3' : 'unsync_to_v3',
+				interaction_result: isSync ? 'class_is_synced_to_V3' : 'class_is_unsynced_from_V3',
+				target_location: 'widget_panel',
+				location_l1: 'class_manager',
+				interaction_description: isSync
+					? `user_synced_${ classLabel }_to_v3`
+					: `user_unsync_${ classLabel }_from_v3`,
+			};
+		}
+		case 'classSyncToV3PopupClick': {
+			const isSyncAction = payload.action === 'sync';
+			return {
+				...payload,
+				interaction_type: 'click',
+				target_type: 'button',
+				target_name: isSyncAction ? 'sync_to_v3' : 'cancel',
+				interaction_result: isSyncAction ? 'class_is_synced' : 'cancel',
+				target_location: 'sync_to_v3_popup',
+			};
+		}
 		default:
 			return payload;
 	}

--- a/packages/packages/core/editor-variables/src/components/variables-manager/variables-manager-panel.tsx
+++ b/packages/packages/core/editor-variables/src/components/variables-manager/variables-manager-panel.tsx
@@ -25,7 +25,7 @@ import {
 } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
-import { trackVariablesManagerEvent } from '../../utils/tracking';
+import { trackVariablesManagerEvent, trackVariableSyncToV3 } from '../../utils/tracking';
 import { type ErrorResponse, type MappedError, mapServerError } from '../../utils/validations';
 import { getMenuActionsForVariable, getVariableType } from '../../variables-registry/variable-type-registry';
 import { DeleteConfirmationDialog } from '../ui/delete-confirmation-dialog';
@@ -151,12 +151,34 @@ export function VariablesManagerPanel() {
 		[ handleDeleteVariable ]
 	);
 
-	const handleStopSyncWithConfirmation = useCallback(
+	const handleStartSyncWithTracking = useCallback(
+		( itemId: string ) => {
+			handleStartSync( itemId );
+			const variable = variables[ itemId ];
+			if ( variable ) {
+				trackVariableSyncToV3( { variableLabel: variable.label, action: 'sync' } );
+			}
+		},
+		[ handleStartSync, variables ]
+	);
+
+	const handleStopSyncWithTracking = useCallback(
 		( itemId: string ) => {
 			handleStopSync( itemId );
+			const variable = variables[ itemId ];
+			if ( variable ) {
+				trackVariableSyncToV3( { variableLabel: variable.label, action: 'unsync' } );
+			}
+		},
+		[ handleStopSync, variables ]
+	);
+
+	const handleStopSyncWithConfirmation = useCallback(
+		( itemId: string ) => {
+			handleStopSyncWithTracking( itemId );
 			setStopSyncConfirmation( null );
 		},
-		[ handleStopSync ]
+		[ handleStopSyncWithTracking ]
 	);
 
 	const handleShowStopSyncDialog = useCallback(
@@ -164,10 +186,10 @@ export function VariablesManagerPanel() {
 			if ( ! isStopSyncSuppressed ) {
 				setStopSyncConfirmation( itemId );
 			} else {
-				handleStopSync( itemId );
+				handleStopSyncWithTracking( itemId );
 			}
 		},
-		[ isStopSyncSuppressed, handleStopSync ]
+		[ isStopSyncSuppressed, handleStopSyncWithTracking ]
 	);
 
 	const buildMenuActions = useCallback(
@@ -181,7 +203,7 @@ export function VariablesManagerPanel() {
 				variable,
 				variableId,
 				handlers: {
-					onStartSync: handleStartSync,
+					onStartSync: handleStartSyncWithTracking,
 					onStopSync: handleShowStopSyncDialog,
 				},
 			} );
@@ -203,7 +225,7 @@ export function VariablesManagerPanel() {
 
 			return [ ...typeActions, deleteAction ];
 		},
-		[ variables, handleStartSync, handleShowStopSyncDialog ]
+		[ variables, handleStartSyncWithTracking, handleShowStopSyncDialog ]
 	);
 
 	const hasVariables = Object.keys( variables ).length > 0;

--- a/packages/packages/core/editor-variables/src/components/variables-manager/variables-manager-panel.tsx
+++ b/packages/packages/core/editor-variables/src/components/variables-manager/variables-manager-panel.tsx
@@ -76,8 +76,8 @@ export function VariablesManagerPanel() {
 		handleOnChange,
 		createVariable,
 		handleDeleteVariable,
-		handleStartSync,
-		handleStopSync,
+		handleStartSync: startSyncFromState,
+		handleStopSync: stopSyncFromState,
 		handleSave,
 		isSaving,
 		handleSearch,
@@ -151,45 +151,37 @@ export function VariablesManagerPanel() {
 		[ handleDeleteVariable ]
 	);
 
-	const handleStartSyncWithTracking = useCallback(
+	const commitStopSync = useCallback(
 		( itemId: string ) => {
-			handleStartSync( itemId );
-			const variable = variables[ itemId ];
-			if ( variable ) {
-				trackVariableSyncToV3( { variableLabel: variable.label, action: 'sync' } );
-			}
-		},
-		[ handleStartSync, variables ]
-	);
-
-	const handleStopSyncWithTracking = useCallback(
-		( itemId: string ) => {
-			handleStopSync( itemId );
+			stopSyncFromState( itemId );
 			const variable = variables[ itemId ];
 			if ( variable ) {
 				trackVariableSyncToV3( { variableLabel: variable.label, action: 'unsync' } );
 			}
 		},
-		[ handleStopSync, variables ]
+		[ stopSyncFromState, variables ]
 	);
 
-	const handleStopSyncWithConfirmation = useCallback(
+	const handleStartSync = useCallback(
 		( itemId: string ) => {
-			handleStopSyncWithTracking( itemId );
-			setStopSyncConfirmation( null );
+			startSyncFromState( itemId );
+			const variable = variables[ itemId ];
+			if ( variable ) {
+				trackVariableSyncToV3( { variableLabel: variable.label, action: 'sync' } );
+			}
 		},
-		[ handleStopSyncWithTracking ]
+		[ startSyncFromState, variables ]
 	);
 
-	const handleShowStopSyncDialog = useCallback(
+	const handleStopSync = useCallback(
 		( itemId: string ) => {
 			if ( ! isStopSyncSuppressed ) {
 				setStopSyncConfirmation( itemId );
 			} else {
-				handleStopSyncWithTracking( itemId );
+				commitStopSync( itemId );
 			}
 		},
-		[ isStopSyncSuppressed, handleStopSyncWithTracking ]
+		[ isStopSyncSuppressed, commitStopSync ]
 	);
 
 	const buildMenuActions = useCallback(
@@ -203,8 +195,8 @@ export function VariablesManagerPanel() {
 				variable,
 				variableId,
 				handlers: {
-					onStartSync: handleStartSyncWithTracking,
-					onStopSync: handleShowStopSyncDialog,
+					onStartSync: handleStartSync,
+					onStopSync: handleStopSync,
 				},
 			} );
 
@@ -225,7 +217,7 @@ export function VariablesManagerPanel() {
 
 			return [ ...typeActions, deleteAction ];
 		},
-		[ variables, handleStartSyncWithTracking, handleShowStopSyncDialog ]
+		[ variables, handleStartSync, handleStopSync ]
 	);
 
 	const hasVariables = Object.keys( variables ).length > 0;
@@ -390,7 +382,10 @@ export function VariablesManagerPanel() {
 				<StopSyncConfirmationDialog
 					open
 					onClose={ () => setStopSyncConfirmation( null ) }
-					onConfirm={ () => handleStopSyncWithConfirmation( stopSyncConfirmation ) }
+					onConfirm={ () => {
+						commitStopSync( stopSyncConfirmation );
+						setStopSyncConfirmation( null );
+					} }
 				/>
 			) }
 

--- a/packages/packages/core/editor-variables/src/utils/__tests__/tracking.test.ts
+++ b/packages/packages/core/editor-variables/src/utils/__tests__/tracking.test.ts
@@ -68,19 +68,10 @@ describe( 'trackVariableSyncToV3', () => {
 	} );
 
 	it( 'should not throw when dispatchEvent fails', () => {
-		const consoleErrorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
 		mockDispatchEvent.mockImplementation( () => {
 			throw new Error( 'dispatch failed' );
 		} );
 
 		expect( () => trackVariableSyncToV3( { variableLabel: 'Primary Color', action: 'sync' } ) ).not.toThrow();
-
-		expect( consoleErrorSpy ).toHaveBeenCalledWith( 'Failed to track variable sync to V3', {
-			variableLabel: 'Primary Color',
-			action: 'sync',
-			error: expect.any( Error ),
-		} );
-
-		consoleErrorSpy.mockRestore();
 	} );
 } );

--- a/packages/packages/core/editor-variables/src/utils/__tests__/tracking.test.ts
+++ b/packages/packages/core/editor-variables/src/utils/__tests__/tracking.test.ts
@@ -1,0 +1,69 @@
+import { getMixpanel } from '@elementor/events';
+
+import { trackVariableSyncToV3 } from '../tracking';
+
+jest.mock( '@elementor/events', () => ( {
+	getMixpanel: jest.fn(),
+} ) );
+
+describe( 'trackVariableSyncToV3', () => {
+	const mockDispatchEvent = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		jest.mocked( getMixpanel ).mockReturnValue( {
+			dispatchEvent: mockDispatchEvent,
+			config: {
+				names: {
+					variables: {
+						variableSyncToV3: 'variable_sync_to_v3',
+					},
+				},
+			},
+		} as never );
+	} );
+
+	it( 'should dispatch sync event with correct payload', () => {
+		trackVariableSyncToV3( { variableLabel: 'Primary Color', action: 'sync' } );
+
+		expect( mockDispatchEvent ).toHaveBeenCalledWith( 'variable_sync_to_v3', {
+			interaction_type: 'click',
+			target_type: 'Primary Color',
+			target_name: 'sync_to_v3',
+			interaction_result: 'var_is_synced_to_V3',
+			target_location: 'widget_panel',
+			location_l1: 'var_manager',
+			interaction_description: 'user_synced_Primary Color_to_v3',
+		} );
+	} );
+
+	it( 'should dispatch unsync event with correct payload', () => {
+		trackVariableSyncToV3( { variableLabel: 'Primary Color', action: 'unsync' } );
+
+		expect( mockDispatchEvent ).toHaveBeenCalledWith( 'variable_sync_to_v3', {
+			interaction_type: 'click',
+			target_type: 'Primary Color',
+			target_name: 'unsync_to_v3',
+			interaction_result: 'var_is_unsynced_from_V3',
+			target_location: 'widget_panel',
+			location_l1: 'var_manager',
+			interaction_description: 'user_unsync_Primary Color_from_v3',
+		} );
+	} );
+
+	it( 'should not dispatch when config is missing', () => {
+		jest.mocked( getMixpanel ).mockReturnValue( {
+			dispatchEvent: mockDispatchEvent,
+			config: {
+				names: {
+					variables: {},
+				},
+			},
+		} as never );
+
+		trackVariableSyncToV3( { variableLabel: 'Primary Color', action: 'sync' } );
+
+		expect( mockDispatchEvent ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/packages/core/editor-variables/src/utils/__tests__/tracking.test.ts
+++ b/packages/packages/core/editor-variables/src/utils/__tests__/tracking.test.ts
@@ -66,4 +66,22 @@ describe( 'trackVariableSyncToV3', () => {
 
 		expect( mockDispatchEvent ).not.toHaveBeenCalled();
 	} );
+
+	it( 'should not throw when dispatchEvent fails', () => {
+		const consoleErrorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		mockDispatchEvent.mockImplementation( () => {
+			throw new Error( 'dispatch failed' );
+		} );
+
+		expect( () =>
+			trackVariableSyncToV3( { variableLabel: 'Primary Color', action: 'sync' } )
+		).not.toThrow();
+
+		expect( consoleErrorSpy ).toHaveBeenCalledWith(
+			'Failed to track variable sync to V3:',
+			expect.any( Error )
+		);
+
+		consoleErrorSpy.mockRestore();
+	} );
 } );

--- a/packages/packages/core/editor-variables/src/utils/__tests__/tracking.test.ts
+++ b/packages/packages/core/editor-variables/src/utils/__tests__/tracking.test.ts
@@ -73,14 +73,13 @@ describe( 'trackVariableSyncToV3', () => {
 			throw new Error( 'dispatch failed' );
 		} );
 
-		expect( () =>
-			trackVariableSyncToV3( { variableLabel: 'Primary Color', action: 'sync' } )
-		).not.toThrow();
+		expect( () => trackVariableSyncToV3( { variableLabel: 'Primary Color', action: 'sync' } ) ).not.toThrow();
 
-		expect( consoleErrorSpy ).toHaveBeenCalledWith(
-			'Failed to track variable sync to V3:',
-			expect.any( Error )
-		);
+		expect( consoleErrorSpy ).toHaveBeenCalledWith( 'Failed to track variable sync to V3', {
+			variableLabel: 'Primary Color',
+			action: 'sync',
+			error: expect.any( Error ),
+		} );
 
 		consoleErrorSpy.mockRestore();
 	} );

--- a/packages/packages/core/editor-variables/src/utils/tracking.ts
+++ b/packages/packages/core/editor-variables/src/utils/tracking.ts
@@ -52,3 +52,30 @@ export const trackVariablesManagerEvent = ( { action, varType, controlPath }: Va
 
 	dispatchEvent?.( name, eventData );
 };
+
+type VariableSyncToV3Data = {
+	variableLabel: string;
+	action: 'sync' | 'unsync';
+};
+
+export const trackVariableSyncToV3 = ( { variableLabel, action }: VariableSyncToV3Data ) => {
+	const { dispatchEvent, config } = getMixpanel();
+	if ( ! config?.names?.variables?.variableSyncToV3 ) {
+		return;
+	}
+
+	const name = config.names.variables.variableSyncToV3;
+	const isSync = action === 'sync';
+
+	dispatchEvent?.( name, {
+		interaction_type: 'click',
+		target_type: variableLabel,
+		target_name: isSync ? 'sync_to_v3' : 'unsync_to_v3',
+		interaction_result: isSync ? 'var_is_synced_to_V3' : 'var_is_unsynced_from_V3',
+		target_location: 'widget_panel',
+		location_l1: 'var_manager',
+		interaction_description: isSync
+			? `user_synced_${ variableLabel }_to_v3`
+			: `user_unsync_${ variableLabel }_from_v3`,
+	} );
+};

--- a/packages/packages/core/editor-variables/src/utils/tracking.ts
+++ b/packages/packages/core/editor-variables/src/utils/tracking.ts
@@ -80,6 +80,11 @@ export const trackVariableSyncToV3 = ( { variableLabel, action }: VariableSyncTo
 				: `user_unsync_${ variableLabel }_from_v3`,
 		} );
 	} catch ( error ) {
-		console.error( 'Failed to track variable sync to V3:', error );
+		// eslint-disable-next-line no-console
+		console.error( 'Failed to track variable sync to V3', {
+			variableLabel,
+			action,
+			error,
+		} );
 	}
 };

--- a/packages/packages/core/editor-variables/src/utils/tracking.ts
+++ b/packages/packages/core/editor-variables/src/utils/tracking.ts
@@ -79,12 +79,5 @@ export const trackVariableSyncToV3 = ( { variableLabel, action }: VariableSyncTo
 				? `user_synced_${ variableLabel }_to_v3`
 				: `user_unsync_${ variableLabel }_from_v3`,
 		} );
-	} catch ( error ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Failed to track variable sync to V3', {
-			variableLabel,
-			action,
-			error,
-		} );
-	}
+	} catch {}
 };

--- a/packages/packages/core/editor-variables/src/utils/tracking.ts
+++ b/packages/packages/core/editor-variables/src/utils/tracking.ts
@@ -59,23 +59,27 @@ type VariableSyncToV3Data = {
 };
 
 export const trackVariableSyncToV3 = ( { variableLabel, action }: VariableSyncToV3Data ) => {
-	const { dispatchEvent, config } = getMixpanel();
-	if ( ! config?.names?.variables?.variableSyncToV3 ) {
-		return;
+	try {
+		const { dispatchEvent, config } = getMixpanel();
+		if ( ! config?.names?.variables?.variableSyncToV3 ) {
+			return;
+		}
+
+		const name = config.names.variables.variableSyncToV3;
+		const isSync = action === 'sync';
+
+		dispatchEvent?.( name, {
+			interaction_type: 'click',
+			target_type: variableLabel,
+			target_name: isSync ? 'sync_to_v3' : 'unsync_to_v3',
+			interaction_result: isSync ? 'var_is_synced_to_V3' : 'var_is_unsynced_from_V3',
+			target_location: 'widget_panel',
+			location_l1: 'var_manager',
+			interaction_description: isSync
+				? `user_synced_${ variableLabel }_to_v3`
+				: `user_unsync_${ variableLabel }_from_v3`,
+		} );
+	} catch ( error ) {
+		console.error( 'Failed to track variable sync to V3:', error );
 	}
-
-	const name = config.names.variables.variableSyncToV3;
-	const isSync = action === 'sync';
-
-	dispatchEvent?.( name, {
-		interaction_type: 'click',
-		target_type: variableLabel,
-		target_name: isSync ? 'sync_to_v3' : 'unsync_to_v3',
-		interaction_result: isSync ? 'var_is_synced_to_V3' : 'var_is_unsynced_from_V3',
-		target_location: 'widget_panel',
-		location_l1: 'var_manager',
-		interaction_description: isSync
-			? `user_synced_${ variableLabel }_to_v3`
-			: `user_unsync_${ variableLabel }_from_v3`,
-	} );
 };


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add Mixpanel analytics tracking for design sync operations to monitor user interactions with Global Fonts and Variables synchronization features.

Main changes:
- Implemented tracking events for class and variable sync operations including popup exposure, user actions (sync/unsync), and confirmation dialog interactions
- Added event configuration entries for variable_sync_to_v3, class_sync_to_v3_popup_shown, class_sync_to_v3, and class_sync_to_v3_popup_click in events-config.js
- Created comprehensive test coverage for tracking functionality in StartSyncToV3Modal and variable sync tracking utilities

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
