### PR TITLE
Internal: Move custom Angie annotations to _meta in MCP tools [ED-23433]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4357,20 +4357,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@elementor-external/angie-sdk": {
-      "name": "@elementor/angie-sdk",
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@elementor/angie-sdk/-/angie-sdk-1.4.1.tgz",
-      "integrity": "sha512-0joCJV+R28CfPU577iEY2qtPbA+vutPGJhqkOvhutBY4kniJe8PXyWPiYgBjvHII1aSOV59j+xiXMBceoShjMA==",
-      "license": "MIT",
-      "dependencies": {
-        "@elementor/angie-logger": "^0.3.1",
-        "@elementor/oidc-auth": "^0.1.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": ">=1.27.0"
-      }
-    },
     "node_modules/@elementor/alpinejs": {
       "resolved": "packages/packages/core/alpinejs",
       "link": true
@@ -45027,6 +45013,20 @@
       "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
       "license": "MIT"
     },
+    "packages/node_modules/@elementor-external/angie-sdk": {
+      "name": "@elementor/angie-sdk",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@elementor/angie-sdk/-/angie-sdk-1.4.5.tgz",
+      "integrity": "sha512-5ZvpEAl2V0VkeU0NxqrTUsC/wOWRkcxVK4JeMREJ4PcDo60h5mHgJhh3LlYk/rY0ldv5KSmnewpq3WNcC7vNSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@elementor/angie-logger": "^0.3.1",
+        "@elementor/oidc-auth": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": ">=1.27.0"
+      }
+    },
     "packages/node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
@@ -46868,7 +46868,7 @@
       "version": "4.1.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor-external/angie-sdk": "npm:@elementor/angie-sdk@^1.3.1",
+        "@elementor-external/angie-sdk": "npm:@elementor/angie-sdk@^1.4.5",
         "@elementor/editor-v1-adapters": "4.1.0",
         "@elementor/schema": "4.1.0",
         "@elementor/store": "4.1.0",

--- a/packages/packages/core/editor-canvas/src/mcp/resources/breakpoints-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/breakpoints-resource.ts
@@ -39,9 +39,11 @@ export const initBreakpointsResource = ( reg: MCPRegistryEntry ) => {
 	} );
 
 	window.addEventListener( v1ReadyEvent().name, () => {
-		waitForReady().then( () => sendResourceUpdated( {
-			uri: BREAKPOINTS_SCHEMA_URI,
-			...buildResourceResponse(),
-		} ) );
+		waitForReady().then( () =>
+			sendResourceUpdated( {
+				uri: BREAKPOINTS_SCHEMA_URI,
+				...buildResourceResponse(),
+			} )
+		);
 	} );
 };

--- a/packages/packages/core/editor-canvas/src/mcp/resources/breakpoints-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/breakpoints-resource.ts
@@ -5,7 +5,7 @@ import { v1ReadyEvent } from '@elementor/editor-v1-adapters';
 export const BREAKPOINTS_SCHEMA_URI = 'elementor://breakpoints/list';
 
 export const initBreakpointsResource = ( reg: MCPRegistryEntry ) => {
-	const { mcpServer, sendResourceUpdated } = reg;
+	const { mcpServer, waitForReady, sendResourceUpdated } = reg;
 
 	const getBreakpointsList = () => {
 		const { breakpoints } = ( window as unknown as ExtendedWindow ).elementor?.config?.responsive || {};
@@ -39,9 +39,9 @@ export const initBreakpointsResource = ( reg: MCPRegistryEntry ) => {
 	} );
 
 	window.addEventListener( v1ReadyEvent().name, () => {
-		sendResourceUpdated( {
+		waitForReady().then( () => sendResourceUpdated( {
 			uri: BREAKPOINTS_SCHEMA_URI,
 			...buildResourceResponse(),
-		} );
+		} ) );
 	} );
 };

--- a/packages/packages/core/editor-canvas/src/mcp/resources/breakpoints-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/breakpoints-resource.ts
@@ -34,11 +34,16 @@ export const initBreakpointsResource = ( reg: MCPRegistryEntry ) => {
 		],
 	} );
 
-	resource( 'breakpoints ', BREAKPOINTS_SCHEMA_URI, {
-		description: 'Breakpoints list.',
-	}, () => {
-		return buildResourceResponse();
-	} );
+	resource(
+		'breakpoints ',
+		BREAKPOINTS_SCHEMA_URI,
+		{
+			description: 'Breakpoints list.',
+		},
+		() => {
+			return buildResourceResponse();
+		}
+	);
 
 	window.addEventListener( v1ReadyEvent().name, () => {
 		sendResourceUpdated( {

--- a/packages/packages/core/editor-canvas/src/mcp/resources/breakpoints-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/breakpoints-resource.ts
@@ -5,7 +5,7 @@ import { v1ReadyEvent } from '@elementor/editor-v1-adapters';
 export const BREAKPOINTS_SCHEMA_URI = 'elementor://breakpoints/list';
 
 export const initBreakpointsResource = ( reg: MCPRegistryEntry ) => {
-	const { mcpServer, waitForReady, sendResourceUpdated } = reg;
+	const { resource, sendResourceUpdated } = reg;
 
 	const getBreakpointsList = () => {
 		const { breakpoints } = ( window as unknown as ExtendedWindow ).elementor?.config?.responsive || {};
@@ -34,16 +34,16 @@ export const initBreakpointsResource = ( reg: MCPRegistryEntry ) => {
 		],
 	} );
 
-	mcpServer.resource( 'breakpoints ', BREAKPOINTS_SCHEMA_URI, () => {
+	resource( 'breakpoints ', BREAKPOINTS_SCHEMA_URI, {
+		description: 'Breakpoints list.',
+	}, () => {
 		return buildResourceResponse();
 	} );
 
 	window.addEventListener( v1ReadyEvent().name, () => {
-		waitForReady().then( () =>
-			sendResourceUpdated( {
-				uri: BREAKPOINTS_SCHEMA_URI,
-				...buildResourceResponse(),
-			} )
-		);
+		sendResourceUpdated( {
+			uri: BREAKPOINTS_SCHEMA_URI,
+			...buildResourceResponse(),
+		} );
 	} );
 };

--- a/packages/packages/core/editor-canvas/src/mcp/resources/document-structure-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/document-structure-resource.ts
@@ -39,7 +39,7 @@ type ElementorContainer = {
 export const DOCUMENT_STRUCTURE_URI = 'elementor://document/structure';
 
 export const initDocumentStructureResource = ( reg: MCPRegistryEntry ) => {
-	const { resource, waitForReady, sendResourceUpdated } = reg;
+	const { resource, sendResourceUpdated } = reg;
 
 	let currentDocumentStructure: string | null = null;
 
@@ -49,7 +49,7 @@ export const initDocumentStructureResource = ( reg: MCPRegistryEntry ) => {
 
 		if ( newStructure !== currentDocumentStructure ) {
 			currentDocumentStructure = newStructure;
-			waitForReady().then( () => sendResourceUpdated( { uri: DOCUMENT_STRUCTURE_URI } ) );
+			sendResourceUpdated( { uri: DOCUMENT_STRUCTURE_URI } );
 		}
 	};
 

--- a/packages/packages/core/editor-canvas/src/mcp/resources/document-structure-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/document-structure-resource.ts
@@ -39,7 +39,7 @@ type ElementorContainer = {
 export const DOCUMENT_STRUCTURE_URI = 'elementor://document/structure';
 
 export const initDocumentStructureResource = ( reg: MCPRegistryEntry ) => {
-	const { mcpServer, sendResourceUpdated } = reg;
+		const { resource, waitForReady, sendResourceUpdated } = reg;
 
 	let currentDocumentStructure: string | null = null;
 
@@ -49,7 +49,7 @@ export const initDocumentStructureResource = ( reg: MCPRegistryEntry ) => {
 
 		if ( newStructure !== currentDocumentStructure ) {
 			currentDocumentStructure = newStructure;
-			sendResourceUpdated( { uri: DOCUMENT_STRUCTURE_URI } );
+			waitForReady().then( () => sendResourceUpdated( { uri: DOCUMENT_STRUCTURE_URI } ) );
 		}
 	};
 
@@ -69,14 +69,14 @@ export const initDocumentStructureResource = ( reg: MCPRegistryEntry ) => {
 	// Initialize on load
 	updateDocumentStructure();
 
-	mcpServer.resource( 'document-structure', DOCUMENT_STRUCTURE_URI, async () => {
-		const structure = getDocumentStructure();
-
+	resource( 'document-structure', DOCUMENT_STRUCTURE_URI, {
+		description: 'Document structure.',
+	}, async () => {
 		return {
 			contents: [
 				{
 					uri: DOCUMENT_STRUCTURE_URI,
-					text: JSON.stringify( structure, null, 2 ),
+					text: JSON.stringify( getDocumentStructure(), null, 2 ),
 				},
 			],
 		};

--- a/packages/packages/core/editor-canvas/src/mcp/resources/document-structure-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/document-structure-resource.ts
@@ -39,7 +39,7 @@ type ElementorContainer = {
 export const DOCUMENT_STRUCTURE_URI = 'elementor://document/structure';
 
 export const initDocumentStructureResource = ( reg: MCPRegistryEntry ) => {
-		const { resource, waitForReady, sendResourceUpdated } = reg;
+	const { resource, waitForReady, sendResourceUpdated } = reg;
 
 	let currentDocumentStructure: string | null = null;
 
@@ -69,18 +69,23 @@ export const initDocumentStructureResource = ( reg: MCPRegistryEntry ) => {
 	// Initialize on load
 	updateDocumentStructure();
 
-	resource( 'document-structure', DOCUMENT_STRUCTURE_URI, {
-		description: 'Document structure.',
-	}, async () => {
-		return {
-			contents: [
-				{
-					uri: DOCUMENT_STRUCTURE_URI,
-					text: JSON.stringify( getDocumentStructure(), null, 2 ),
-				},
-			],
-		};
-	} );
+	resource(
+		'document-structure',
+		DOCUMENT_STRUCTURE_URI,
+		{
+			description: 'Document structure.',
+		},
+		async () => {
+			return {
+				contents: [
+					{
+						uri: DOCUMENT_STRUCTURE_URI,
+						text: JSON.stringify( getDocumentStructure(), null, 2 ),
+					},
+				],
+			};
+		}
+	);
 };
 
 function getDocumentStructure() {

--- a/packages/packages/libs/editor-mcp/package.json
+++ b/packages/packages/libs/editor-mcp/package.json
@@ -42,7 +42,7 @@
     "tsup": "^8.3.5"
   },
   "dependencies": {
-    "@elementor-external/angie-sdk": "npm:@elementor/angie-sdk@^1.3.1",
+    "@elementor-external/angie-sdk": "npm:@elementor/angie-sdk@^1.4.5",
     "@elementor/editor-v1-adapters": "4.1.0",
     "@elementor/schema": "4.1.0",
     "@elementor/store": "4.1.0",

--- a/packages/packages/libs/editor-mcp/src/angie-annotations.ts
+++ b/packages/packages/libs/editor-mcp/src/angie-annotations.ts
@@ -1,4 +1,5 @@
 export const ANGIE_MODEL_PREFERENCES = 'angie/modelPreferences' as const;
+export const ANGIE_REQUIRED_RESOURCES = 'angie/requiredResources' as const;
 
 export interface AngieModelPreferences {
 	hints?: Array< { name: string } >;

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -8,6 +8,7 @@ import {
 	ANGIE_MODEL_PREFERENCES,
 	type AngieModelPreferences,
 	createDefaultModelPreferences,
+	ANGIE_REQUIRED_RESOURCES,
 } from './angie-annotations';
 import { mockMcpRegistry } from './test-utils/mock-mcp-registry';
 import { getSDK } from './utils/get-sdk';
@@ -77,15 +78,18 @@ export const getMCPByDomain = ( namespace: string, options?: { instructions?: st
 	return {
 		waitForReady: () => getSDK().waitForReady(),
 		// @ts-expect-error: TS is unable to infer the type here
-		resource: async ( ...args: Parameters< McpServer[ 'resource' ] > ) => {
+		resource: async ( ...args: Parameters< McpServer[ 'registerResource' ] > ) => {
 			await getSDK().waitForReady();
-			return mcpServer.resource( ...args );
+			return mcpServer.registerResource( ...args );
 		},
 		sendResourceUpdated: ( ...args: Parameters< McpServer[ 'server' ][ 'sendResourceUpdated' ] > ) => {
-			return new Promise( async () => {
-				await getSDK().waitForReady();
-				mcpServer.server.sendResourceUpdated( ...args );
-			} );
+			return getSDK().waitForReady().then( () => mcpServer.server.sendResourceUpdated( ...args ) )
+				.catch( ( error: Error ) => {
+					if ( error?.message?.includes( 'Not connected' ) ) {
+						return; // Expected when no MCP client is connected yet
+					}
+					throw error;
+				} );
 		},
 		mcpServer,
 		addTool,
@@ -116,7 +120,7 @@ export interface MCPRegistryEntry {
 	setMCPDescription: ( description: string ) => void;
 	getActiveChatInfo: () => { sessionId: string; expiresAt: number };
 	sendResourceUpdated: McpServer[ 'server' ][ 'sendResourceUpdated' ];
-	resource: McpServer[ 'resource' ];
+	resource: McpServer[ 'registerResource' ];
 	mcpServer: McpServer;
 	waitForReady: () => Promise< void >;
 }
@@ -173,7 +177,6 @@ function createToolRegistry( server: McpServer ) {
 			try {
 				const invocationResult = await opts.handler( opts.schema ? args : {}, extra );
 				return {
-					// TODO: Uncomment this when the outputSchema is stable
 					// structuredContent: typeof invocationResult === 'string' ? undefined : invocationResult,
 					content: [
 						{
@@ -205,19 +208,19 @@ function createToolRegistry( server: McpServer ) {
 			readOnlyHint: opts.isDestructive ? false : undefined,
 			title: opts.name,
 		};
-		if ( opts.requiredResources ) {
-			annotations[ 'angie/requiredResources' ] = opts.requiredResources;
+		const angieAnnotations = {
+			[ANGIE_MODEL_PREFERENCES]: opts.modelPreferences ?? createDefaultModelPreferences(),
+			[ANGIE_REQUIRED_RESOURCES]: opts.requiredResources ?? undefined
 		}
-		annotations[ ANGIE_MODEL_PREFERENCES ] = opts.modelPreferences ?? createDefaultModelPreferences();
 		server.registerTool(
 			opts.name,
 			{
 				description: opts.description,
 				inputSchema,
-				// TODO: Uncomment this when the outputSchema is stable
 				// outputSchema,
 				title: opts.name,
 				annotations,
+				_meta: angieAnnotations
 			},
 			toolCallback
 		);

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -6,9 +6,9 @@ import { type ServerNotification, type ServerRequest } from '@modelcontextprotoc
 
 import {
 	ANGIE_MODEL_PREFERENCES,
+	ANGIE_REQUIRED_RESOURCES,
 	type AngieModelPreferences,
 	createDefaultModelPreferences,
-	ANGIE_REQUIRED_RESOURCES,
 } from './angie-annotations';
 import { mockMcpRegistry } from './test-utils/mock-mcp-registry';
 import { getSDK } from './utils/get-sdk';
@@ -83,7 +83,9 @@ export const getMCPByDomain = ( namespace: string, options?: { instructions?: st
 			return mcpServer.registerResource( ...args );
 		},
 		sendResourceUpdated: ( ...args: Parameters< McpServer[ 'server' ][ 'sendResourceUpdated' ] > ) => {
-			return getSDK().waitForReady().then( () => mcpServer.server.sendResourceUpdated( ...args ) )
+			return getSDK()
+				.waitForReady()
+				.then( () => mcpServer.server.sendResourceUpdated( ...args ) )
 				.catch( ( error: Error ) => {
 					if ( error?.message?.includes( 'Not connected' ) ) {
 						return; // Expected when no MCP client is connected yet
@@ -209,18 +211,19 @@ function createToolRegistry( server: McpServer ) {
 			title: opts.name,
 		};
 		const angieAnnotations = {
-			[ANGIE_MODEL_PREFERENCES]: opts.modelPreferences ?? createDefaultModelPreferences(),
-			[ANGIE_REQUIRED_RESOURCES]: opts.requiredResources ?? undefined
-		}
+			[ ANGIE_MODEL_PREFERENCES ]: opts.modelPreferences ?? createDefaultModelPreferences(),
+			[ ANGIE_REQUIRED_RESOURCES ]: opts.requiredResources ?? undefined,
+		};
 		server.registerTool(
 			opts.name,
 			{
 				description: opts.description,
 				inputSchema,
+				// TODO: Uncomment this when the outputSchema is stable
 				// outputSchema,
 				title: opts.name,
 				annotations,
-				_meta: angieAnnotations
+				_meta: angieAnnotations,
 			},
 			toolCallback
 		);


### PR DESCRIPTION
## Summary
- Upgrade `@elementor-external/angie-sdk` from `^1.3.1` to `^1.4.5` to align with MCP SDK v1.27
- Move custom Angie tool annotations (`angie/modelPreferences`, `angie/requiredResources`) from `ToolAnnotations` to `_meta`, as MCP SDK v1.27 now strictly types `ToolAnnotations` and strips unknown keys
- Add `ANGIE_REQUIRED_RESOURCES` constant to `angie-annotations.ts`
- Fix `resource()` → `registerResource()` following MCP SDK API rename
- Fix `sendResourceUpdated` promise handling and suppress expected `Not connected` errors on startup (before any MCP client connects)
- Add `waitForReady()` guard in `breakpoints-resource` and `document-structure-resource` before sending resource update notifications
- Add description to document-structure resource registration

## Test plan
- [ ] Open the Elementor editor and verify no console errors related to MCP tool registration
- [ ] Verify Angie can list and call MCP tools correctly (model preferences applied)
- [ ] Verify `angie/requiredResources` annotation is passed through correctly when set on a tool
- [ ] Confirm no `Uncaught (in promise) Error: Not connected` errors appear on editor startup
- [ ] Confirm breakpoints resource and document structure resource update correctly when changes occur

## Jira
[ED-23433](https://elementor.atlassian.net/browse/ED-23433)

[ED-23433]: https://elementor.atlassian.net/browse/ED-23433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor MCP tool registration to move custom Angie annotations from top-level annotations object to _meta property for better API compliance and separation of concerns.

Main changes:
- Moved angie/modelPreferences and angie/requiredResources from annotations to _meta object in tool registration
- Replaced deprecated McpServer.resource() method with registerResource() for MCP resources registration
- Updated sendResourceUpdated error handling to gracefully ignore 'Not connected' errors during initialization

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
