### PR TITLE
Fix: Styling issues in Repeater Indications Popovers [ED-21321]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/styles-inheritance/components/infotip/value-component.tsx
+++ b/packages/packages/core/editor-editing-panel/src/styles-inheritance/components/infotip/value-component.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Typography } from '@elementor/ui';
+import { Tooltip, Typography } from '@elementor/ui';
 
 type Props = {
 	index: number;
@@ -8,21 +8,24 @@ type Props = {
 
 export const ValueComponent = ( { index, value }: Props ) => {
 	return (
-		<Typography
-			variant="caption"
-			color="text.tertiary"
-			sx={ {
-				mt: '1px',
-				textDecoration: index === 0 ? 'none' : 'line-through',
-				overflow: 'hidden',
-				textOverflow: 'ellipsis',
-				whiteSpace: 'nowrap',
-				pl: 2.5,
-				minWidth: 0,
-				maxWidth: '100%',
-			} }
-		>
-			{ value }
-		</Typography>
+		<Tooltip title={ value } placement="top">
+			<Typography
+				variant="caption"
+				color="text.tertiary"
+				sx={ {
+					mt: '1px',
+					textDecoration: index === 0 ? 'none' : 'line-through',
+					overflow: 'hidden',
+					display: '-webkit-box',
+					WebkitLineClamp: 1,
+					WebkitBoxOrient: 'vertical',
+					pl: 2.5,
+					minWidth: 0,
+					maxWidth: '100%',
+				} }
+			>
+				{ value }
+			</Typography>
+		</Tooltip>
 	);
 };

--- a/packages/packages/core/editor-editing-panel/src/styles-inheritance/components/styles-inheritance-infotip.tsx
+++ b/packages/packages/core/editor-editing-panel/src/styles-inheritance/components/styles-inheritance-infotip.tsx
@@ -125,7 +125,7 @@ export const StylesInheritanceInfotip = ( {
 						},
 					} }
 				>
-					<Stack gap={ 1.5 } sx={ { pl: 3, pr: 1, pb: 2 } } role="list">
+					<Stack gap={ 1.5 } sx={ { pl: 2, pr: 1, pt: 1.5, pb: 1.5 } } role="list">
 						{ items.map( ( item, index ) => {
 							return (
 								<Box
@@ -235,15 +235,13 @@ function TooltipOrInfotip( {
 							sx: { mx: 2 },
 						},
 					} }
-					slotProps={ {
-						popper: {
-							modifiers: [
-								{
-									name: 'offset',
-									options: { offset: [ offsetX, 0 ] },
-								},
-							],
-						},
+					PopperProps={ {
+						modifiers: [
+							{
+								name: 'offset',
+								options: { offset: [ offsetX, 0 ] },
+							},
+						],
 					} }
 				>
 					{ children }

--- a/packages/packages/core/editor-editing-panel/src/styles-inheritance/init-styles-inheritance-transformers.ts
+++ b/packages/packages/core/editor-editing-panel/src/styles-inheritance/init-styles-inheritance-transformers.ts
@@ -53,7 +53,7 @@ function registerCustomTransformers( originalStyleTransformers: ReturnType< type
 	);
 	stylesInheritanceTransformersRegistry.register(
 		'transition',
-		createRepeaterToItemsTransformer( originalStyleTransformers.transition, ', ' )
+		createRepeaterToItemsTransformer( originalStyleTransformers.transition )
 	);
 
 	[ 'background-overlay', 'box-shadow', 'transform-functions' ].forEach( ( propType ) =>

--- a/packages/packages/core/editor-editing-panel/src/styles-inheritance/transformers/array-transformer.tsx
+++ b/packages/packages/core/editor-editing-panel/src/styles-inheritance/transformers/array-transformer.tsx
@@ -9,9 +9,7 @@ export const arrayTransformer = createTransformer( ( values: ArrayValues[] ) => 
 		return null;
 	}
 
-	const allStrings = values.every(
-		( item ) => typeof item === 'string' || typeof item === 'number'
-	);
+	const allStrings = values.every( ( item ) => typeof item === 'string' || typeof item === 'number' );
 
 	if ( allStrings ) {
 		return ( values as ( string | number )[] ).join( ' ' );

--- a/packages/packages/core/editor-editing-panel/src/styles-inheritance/transformers/array-transformer.tsx
+++ b/packages/packages/core/editor-editing-panel/src/styles-inheritance/transformers/array-transformer.tsx
@@ -1,20 +1,30 @@
 import * as React from 'react';
 import { type ReactNode } from 'react';
 import { createTransformer } from '@elementor/editor-canvas';
-import { Stack } from '@elementor/ui';
 
-type ArrayValues = ReactNode[];
+type ArrayValues = ReactNode | ReactNode[];
 
 export const arrayTransformer = createTransformer( ( values: ArrayValues[] ) => {
 	if ( ! values || values.length === 0 ) {
 		return null;
 	}
 
+	const allStrings = values.every(
+		( item ) => typeof item === 'string' || typeof item === 'number'
+	);
+
+	if ( allStrings ) {
+		return ( values as ( string | number )[] ).join( ' ' );
+	}
+
 	return (
-		<Stack direction="column">
+		<>
 			{ values.map( ( item, index ) => (
-				<Stack key={ index }>{ item }</Stack>
+				<React.Fragment key={ index }>
+					{ index > 0 && ' ' }
+					{ item }
+				</React.Fragment>
 			) ) }
-		</Stack>
+		</>
 	);
 } );

--- a/packages/packages/core/editor-editing-panel/src/styles-inheritance/transformers/box-shadow-transformer.tsx
+++ b/packages/packages/core/editor-editing-panel/src/styles-inheritance/transformers/box-shadow-transformer.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
+import { type ReactNode } from 'react';
 import { createTransformer } from '@elementor/editor-canvas';
-import { Stack } from '@elementor/ui';
 
 type Shadow = {
 	hOffset?: string;
 	vOffset?: string;
 	blur?: string;
 	spread?: string;
-	color?: string;
+	color?: ReactNode;
 	position?: string | null;
 };
 
@@ -23,10 +23,8 @@ export const boxShadowTransformer = createTransformer( ( value: Shadow ) => {
 	const positionValue = position || 'outset';
 
 	return (
-		<Stack direction="column" gap={ 0.5 } pb={ 1 }>
-			<span>
-				{ colorValue } { positionValue }, { sizes }
-			</span>
-		</Stack>
+		<>
+			{ colorValue } { positionValue }, { sizes }
+		</>
 	);
 } );

--- a/packages/packages/core/editor-editing-panel/src/styles-inheritance/transformers/repeater-to-items-transformer.tsx
+++ b/packages/packages/core/editor-editing-panel/src/styles-inheritance/transformers/repeater-to-items-transformer.tsx
@@ -1,6 +1,6 @@
 import { type AnyTransformer, createTransformer } from '@elementor/editor-canvas';
 
-export const createRepeaterToItemsTransformer = ( originalTransformer: AnyTransformer, _separator: string = ' ' ) => {
+export const createRepeaterToItemsTransformer = ( originalTransformer: AnyTransformer ) => {
 	return createTransformer( ( value: string, options: { key: string; signal?: AbortSignal } ) => {
 		const stringResult = originalTransformer( value, options );
 

--- a/packages/packages/core/editor-editing-panel/src/styles-inheritance/transformers/repeater-to-items-transformer.tsx
+++ b/packages/packages/core/editor-editing-panel/src/styles-inheritance/transformers/repeater-to-items-transformer.tsx
@@ -1,8 +1,6 @@
-import * as React from 'react';
 import { type AnyTransformer, createTransformer } from '@elementor/editor-canvas';
-import { Stack } from '@elementor/ui';
 
-export const createRepeaterToItemsTransformer = ( originalTransformer: AnyTransformer, separator: string = ' ' ) => {
+export const createRepeaterToItemsTransformer = ( originalTransformer: AnyTransformer, _separator: string = ' ' ) => {
 	return createTransformer( ( value: string, options: { key: string; signal?: AbortSignal } ) => {
 		const stringResult = originalTransformer( value, options );
 
@@ -10,18 +8,6 @@ export const createRepeaterToItemsTransformer = ( originalTransformer: AnyTransf
 			return stringResult;
 		}
 
-		const parts = stringResult.split( separator ).filter( Boolean );
-
-		if ( parts.length <= 1 ) {
-			return stringResult;
-		}
-
-		return (
-			<Stack direction="column" gap={ 0.5 }>
-				{ parts.map( ( part, index ) => (
-					<Stack key={ index }>{ part.trim() }</Stack>
-				) ) }
-			</Stack>
-		);
+		return stringResult;
 	} );
 };


### PR DESCRIPTION
## Summary
- Add `Tooltip` wrapper to value component with `-webkit-line-clamp` for proper multi-line ellipsis truncation
- Fix consistent spacing/padding across all indication list items (`pt: 1.5`, `pb: 1.5`, `pl: 2` instead of uneven `pl: 3`, `pb: 2`)
- Simplify `box-shadow-transformer` and `repeater-to-items-transformer` to return flat content instead of nested `Stack` wrappers, eliminating extra spacing artifacts
- Fix `array-transformer` to handle both single and array `ReactNode` values
- Fix Infotip popover positioning by switching from `slotProps.popper.modifiers` to `PopperProps.modifiers` so the offset modifier reliably reaches the custom `StyledPopper` component

## Test plan
- [ ] Open the style origin popover for a repeater property (e.g. box-shadow, background) and verify text is truncated with ellipsis when it overflows
- [ ] Hover over a truncated value to confirm the full value is shown in a tooltip
- [ ] Verify all indication items have consistent vertical and horizontal spacing
- [ ] Verify the popover arrow aligns correctly with the trigger indicator (no horizontal shift)
- [ ] Check RTL layout for correct popover positioning

## Jira
[ED-21321](https://elementor.atlassian.net/browse/ED-21321)

[ED-21321]: https://elementor.atlassian.net/browse/ED-21321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix styling and layout issues in Repeater Indications Popovers by improving text overflow handling, spacing adjustments, and component prop configurations.

Main changes:
- Added Tooltip wrapper with text truncation using WebkitLineClamp to ValueComponent for better overflow handling
- Adjusted popover spacing and padding, replacing slotProps with PopperProps for proper offset positioning
- Simplified array and box-shadow transformers by removing unnecessary Stack wrappers and separator logic

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
