### PR TITLE
Internal: Add getMCPByDomain async function

### DIFF
--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -50,6 +50,11 @@ const isAlphabet = ( str: string ): string | never => {
 	return str;
 };
 
+const toMCPTitle = ( namespace: string ): string => {
+	const capitalized = namespace.charAt( 0 ).toUpperCase() + namespace.slice( 1 );
+	return `Editor${ capitalized }`;
+};
+
 /**
  *
  * @param namespace            The namespace of the MCP server. It should contain only lowercase alphabetic characters.
@@ -76,6 +81,7 @@ export const getMCPByDomain = ( namespace: string, options?: { instructions?: st
 	const mcpServer = mcpRegistry[ namespace ];
 	const { addTool } = createToolRegistry( mcpServer );
 	return {
+		title: toMCPTitle( namespace ),
 		waitForReady: () => getSDK().waitForReady(),
 		// @ts-expect-error: TS is unable to infer the type here
 		resource: async ( ...args: Parameters< McpServer[ 'registerResource' ] > ) => {
@@ -115,7 +121,20 @@ export const getMCPByDomain = ( namespace: string, options?: { instructions?: st
 	};
 };
 
+/**
+ * Async version of getMCPByDomain that waits for the SDK to load before returning the registry entry.
+ *
+ * @param namespace            The namespace of the MCP server. It should contain only lowercase alphabetic characters.
+ * @param options
+ * @param options.instructions
+ */
+export const getAsyncMCPByDomain = async ( namespace: string, options?: { instructions?: string } ): Promise< MCPRegistryEntry > => {
+	await getSDK().waitForReady();
+	return getMCPByDomain( namespace, options );
+};
+
 export interface MCPRegistryEntry {
+	title: string;
 	addTool: < T extends undefined | z.ZodRawShape = undefined, O extends undefined | z.ZodRawShape = undefined >(
 		opts: ToolRegistrationOptions< T, O >
 	) => void;

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -52,7 +52,7 @@ const isAlphabet = ( str: string ): string | never => {
 
 const toMCPTitle = ( namespace: string ): string => {
 	const capitalized = namespace.charAt( 0 ).toUpperCase() + namespace.slice( 1 );
-	return `Editor${ capitalized }`;
+	return `Editor ${ capitalized }`;
 };
 
 /**

--- a/packages/packages/libs/editor-mcp/src/test-utils/mock-mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/test-utils/mock-mcp-registry.ts
@@ -15,6 +15,7 @@ const mock = new Proxy(
 
 export const mockMcpRegistry = (): MCPRegistryEntry => {
 	return {
+		title: 'EditorMock',
 		// @ts-ignore
 		resource: async () => {},
 		// @ts-ignore
@@ -25,5 +26,6 @@ export const mockMcpRegistry = (): MCPRegistryEntry => {
 			return { sessionId: 'mock-session-id', expiresAt: Date.now() + 3600000 };
 		},
 		mcpServer: mock as McpServer,
+		waitForReady: async () => {},
 	};
 };


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add async MCP registry initialization function to support deferred SDK loading and improve registry entry structure with title metadata.

Main changes:
- Created getAsyncMCPByDomain function that waits for SDK initialization before returning MCP registry entry
- Added title field to MCPRegistryEntry interface with dynamic generation from namespace using toMCPTitle helper
- Updated mock registry implementation to include new title and waitForReady fields for test compatibility

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
