### PR TITLE
Internal: Migrate all getMCPByDomain call sites to getAsyncMCPByDomain

### DIFF
--- a/packages/packages/core/editor-canvas/src/init.tsx
+++ b/packages/packages/core/editor-canvas/src/init.tsx
@@ -1,5 +1,5 @@
 import { injectIntoLogic, injectIntoTop } from '@elementor/editor';
-import { getMCPByDomain } from '@elementor/editor-mcp';
+import { getAsyncMCPByDomain } from '@elementor/editor-mcp';
 
 import { ClassesRename } from './components/classes-rename';
 import { ElementsOverlays } from './components/elements-overlays';
@@ -51,11 +51,11 @@ export function init() {
 		component: ClassesRename,
 	} );
 
-	initCanvasMcp(
-		getMCPByDomain( 'canvas', {
-			instructions: mcpDescription,
-		} )
-	);
+	getAsyncMCPByDomain( 'canvas', {
+		instructions: mcpDescription,
+	} ).then( ( reg ) => {
+		initCanvasMcp( reg );
+	} );
 
 	initTabsModelExtensions();
 }

--- a/packages/packages/core/editor-global-classes/src/init.ts
+++ b/packages/packages/core/editor-global-classes/src/init.ts
@@ -19,6 +19,7 @@ import { PrefetchCssClassUsage } from './hooks/use-prefetch-css-class-usage';
 import { initMcpIntegration } from './mcp-integration';
 import { slice } from './store';
 import { SyncWithDocumentSave } from './sync-with-document';
+import { getAsyncMCPByDomain } from '@elementor/editor-mcp';
 
 export function init() {
 	registerSlice( slice );
@@ -66,5 +67,10 @@ export function init() {
 		getThemeColor: ( theme ) => theme.palette.global.dark,
 	} );
 
-	initMcpIntegration();
+	Promise.all([
+		getAsyncMCPByDomain( 'classes' ),
+		getAsyncMCPByDomain( 'canvas' ),
+	]).then(([classesMcpEntry, canvasMcpEntry]) => {
+		initMcpIntegration( classesMcpEntry, canvasMcpEntry);
+	});
 }

--- a/packages/packages/core/editor-interactions/src/init.ts
+++ b/packages/packages/core/editor-interactions/src/init.ts
@@ -1,3 +1,5 @@
+import { getAsyncMCPByDomain } from '@elementor/editor-mcp';
+
 import { initPasteInteractionsCommand } from './commands/paste-interactions';
 import { Direction } from './components/controls/direction';
 import { Easing } from './components/controls/easing';
@@ -60,7 +62,9 @@ export function init() {
 			component: Repeat,
 		} );
 
-		initMcpInteractions();
+		getAsyncMCPByDomain( 'interactions' ).then( ( reg ) => {
+			initMcpInteractions( reg );
+		} );
 	} catch ( error ) {
 		throw error;
 	}

--- a/packages/packages/core/editor-variables/src/init.ts
+++ b/packages/packages/core/editor-variables/src/init.ts
@@ -16,6 +16,7 @@ import { StyleVariablesRenderer } from './renderers/style-variables-renderer';
 import { registerRepeaterInjections } from './repeater-injections';
 import { service as variablesService } from './service';
 import { hasVariableType } from './variables-registry/variable-type-registry';
+import { getAsyncMCPByDomain } from '@elementor/editor-mcp';
 
 const { registerPopoverAction } = controlActionsMenu;
 
@@ -44,8 +45,12 @@ export function init() {
 		useProps: usePropVariableAction,
 	} );
 
-	variablesService.init().then( () => {
-		initMcp();
+	variablesService.init().then( async () => {
+		const [canvasMcpEntry, variablesMcpEntry] = await Promise.all([
+			getAsyncMCPByDomain( 'canvas' ),
+			getAsyncMCPByDomain( 'variables' ),
+		]);
+		initMcp(variablesMcpEntry, canvasMcpEntry);
 	} );
 
 	injectIntoTop( {


### PR DESCRIPTION
## Summary
- Replace `getMCPByDomain` with `getAsyncMCPByDomain` in all consumers
- Affected files: `editor-canvas`, `editor-interactions`, `editor-variables`, `editor-global-classes`

> **Depends on #35233** — merge that PR first so `getAsyncMCPByDomain` is available.

## Test plan
- [ ] TypeScript compiles without errors after #35233 is merged
- [ ] All MCP integrations continue to work (canvas, interactions, variables, global classes)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Migrate synchronous getMCPByDomain calls to asynchronous getAsyncMCPByDomain across editor packages to enable non-blocking MCP initialization.
Main changes:
- Replaced getMCPByDomain with getAsyncMCPByDomain and wrapped MCP initialization in promise handlers across four packages
- Updated editor-global-classes and editor-variables to fetch multiple MCP domains concurrently using Promise.all
- Restructured initialization flow to handle asynchronous MCP registration with then callbacks instead of synchronous calls

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
