### PR TITLE
Internal: Restore transition core functionality [ED-22964]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/transition-control/__tests__/conditional-properties.test.ts
+++ b/packages/packages/libs/editor-controls/src/controls/transition-control/__tests__/conditional-properties.test.ts
@@ -1,12 +1,18 @@
 type TransitionCategory = { label: string };
 
+const mockHasProInstalled = jest.fn( () => false );
+
+jest.mock( '@elementor/utils', () => ( {
+	...jest.requireActual( '@elementor/utils' ),
+	hasProInstalled: () => mockHasProInstalled(),
+} ) );
+
 describe( 'transition properties conditional loading', () => {
 	const originalElementorPro = window.elementorPro;
-	const originalElementor = window.elementor;
 
 	afterEach( () => {
 		window.elementorPro = originalElementorPro;
-		window.elementor = originalElementor;
+		mockHasProInstalled.mockReturnValue( false );
 		jest.resetModules();
 	} );
 
@@ -14,29 +20,22 @@ describe( 'transition properties conditional loading', () => {
 		{
 			scenario: 'Pro not installed',
 			proConfig: undefined,
-			hasProHelper: false,
+			hasPro: false,
 			expectedLength: 10,
 			expectedHasMargin: true,
 		},
 		{
 			scenario: 'Pro version below 3.35',
 			proConfig: { config: { version: '3.34.0' } },
-			hasProHelper: true,
+			hasPro: true,
 			expectedLength: 1,
 			expectedHasMargin: false,
 		},
 	] )(
 		'should load correct properties when $scenario',
-		( { proConfig, hasProHelper, expectedLength, expectedHasMargin } ) => {
+		( { proConfig, hasPro, expectedLength, expectedHasMargin } ) => {
 			window.elementorPro = proConfig;
-			if ( hasProHelper ) {
-				window.elementor = {
-					...window.elementor,
-					helpers: { hasPro: () => true },
-				};
-			} else {
-				delete window.elementor;
-			}
+			mockHasProInstalled.mockReturnValue( hasPro );
 
 			const { transitionProperties: props } = require( '../data' );
 

--- a/packages/packages/libs/editor-controls/src/controls/transition-control/__tests__/conditional-properties.test.ts
+++ b/packages/packages/libs/editor-controls/src/controls/transition-control/__tests__/conditional-properties.test.ts
@@ -2,9 +2,11 @@ type TransitionCategory = { label: string };
 
 describe( 'transition properties conditional loading', () => {
 	const originalElementorPro = window.elementorPro;
+	const originalElementor = window.elementor;
 
 	afterEach( () => {
 		window.elementorPro = originalElementorPro;
+		window.elementor = originalElementor;
 		jest.resetModules();
 	} );
 
@@ -12,23 +14,36 @@ describe( 'transition properties conditional loading', () => {
 		{
 			scenario: 'Pro not installed',
 			proConfig: undefined,
-			expectedLength: 1,
-			expectedHasMargin: false,
+			hasProHelper: false,
+			expectedLength: 10,
+			expectedHasMargin: true,
 		},
 		{
 			scenario: 'Pro version below 3.35',
 			proConfig: { config: { version: '3.34.0' } },
+			hasProHelper: true,
 			expectedLength: 1,
 			expectedHasMargin: false,
 		},
-	] )( 'should load correct properties when $scenario', ( { proConfig, expectedLength, expectedHasMargin } ) => {
-		window.elementorPro = proConfig;
+	] )(
+		'should load correct properties when $scenario',
+		( { proConfig, hasProHelper, expectedLength, expectedHasMargin } ) => {
+			window.elementorPro = proConfig;
+			if ( hasProHelper ) {
+				window.elementor = {
+					...window.elementor,
+					helpers: { hasPro: () => true },
+				};
+			} else {
+				delete window.elementor;
+			}
 
-		const { transitionProperties: props } = require( '../data' );
+			const { transitionProperties: props } = require( '../data' );
 
-		expect( props.length ).toBe( expectedLength );
-		expect( props.some( ( cat: TransitionCategory ) => cat.label === 'Margin' ) ).toBe( expectedHasMargin );
-	} );
+			expect( props.length ).toBe( expectedLength );
+			expect( props.some( ( cat: TransitionCategory ) => cat.label === 'Margin' ) ).toBe( expectedHasMargin );
+		}
+	);
 
 	// TODO: Pro version detection (3.35+) does not load extra properties in test env
 	it.skip( 'should load correct properties when Pro version 3.35 or higher', () => {} );

--- a/packages/packages/libs/editor-controls/src/controls/transition-control/__tests__/data.test.ts
+++ b/packages/packages/libs/editor-controls/src/controls/transition-control/__tests__/data.test.ts
@@ -4,6 +4,13 @@ jest.mock( '@wordpress/i18n', () => ( {
 	__: ( label: string ) => label,
 } ) );
 
+const mockHasProInstalled = jest.fn( () => false );
+
+jest.mock( '@elementor/utils', () => ( {
+	...jest.requireActual( '@elementor/utils' ),
+	hasProInstalled: () => mockHasProInstalled(),
+} ) );
+
 const setSiteDirection = ( isRtl: boolean ) => {
 	window.elementorFrontend = {
 		config: {
@@ -19,13 +26,10 @@ const setProInstalled = ( version?: string ) => {
 				version,
 			},
 		};
-		window.elementor = {
-			...window.elementor,
-			helpers: { hasPro: () => true },
-		};
+		mockHasProInstalled.mockReturnValue( true );
 	} else {
 		delete window.elementorPro;
-		delete window.elementor;
+		mockHasProInstalled.mockReturnValue( false );
 	}
 };
 
@@ -45,7 +49,7 @@ describe( 'transitionProperties RTL support', () => {
 	beforeEach( () => {
 		delete window.elementorFrontend;
 		delete window.elementorPro;
-		delete window.elementor;
+		mockHasProInstalled.mockReturnValue( false );
 		jest.resetModules();
 	} );
 
@@ -97,7 +101,7 @@ describe( 'transitionProperties Pro version handling', () => {
 	beforeEach( () => {
 		delete window.elementorFrontend;
 		delete window.elementorPro;
-		delete window.elementor;
+		mockHasProInstalled.mockReturnValue( false );
 		jest.resetModules();
 	} );
 
@@ -154,12 +158,9 @@ describe( 'transitionProperties Pro version handling', () => {
 	} );
 
 	it( 'should show only Default category when Pro is installed but version is undefined', () => {
+		mockHasProInstalled.mockReturnValue( true );
 		window.elementorPro = {
 			config: {},
-		};
-		window.elementor = {
-			...window.elementor,
-			helpers: { hasPro: () => true },
 		};
 
 		const props = getTransitionProperties();

--- a/packages/packages/libs/editor-controls/src/controls/transition-control/__tests__/data.test.ts
+++ b/packages/packages/libs/editor-controls/src/controls/transition-control/__tests__/data.test.ts
@@ -19,8 +19,13 @@ const setProInstalled = ( version?: string ) => {
 				version,
 			},
 		};
+		window.elementor = {
+			...window.elementor,
+			helpers: { hasPro: () => true },
+		};
 	} else {
 		delete window.elementorPro;
+		delete window.elementor;
 	}
 };
 
@@ -40,6 +45,7 @@ describe( 'transitionProperties RTL support', () => {
 	beforeEach( () => {
 		delete window.elementorFrontend;
 		delete window.elementorPro;
+		delete window.elementor;
 		jest.resetModules();
 	} );
 
@@ -91,6 +97,7 @@ describe( 'transitionProperties Pro version handling', () => {
 	beforeEach( () => {
 		delete window.elementorFrontend;
 		delete window.elementorPro;
+		delete window.elementor;
 		jest.resetModules();
 	} );
 
@@ -99,15 +106,19 @@ describe( 'transitionProperties Pro version handling', () => {
 		return props;
 	};
 
-	it( 'should show only Default category when Pro is not installed', () => {
+	it( 'should show all categories with disabled properties when Pro is not installed', () => {
 		setProInstalled();
 
 		const props = getTransitionProperties();
 
-		expect( props ).toHaveLength( 1 );
+		expect( props.length ).toBeGreaterThan( 1 );
 		expect( props[ 0 ].label ).toBe( 'Default' );
-		expect( props[ 0 ].properties ).toHaveLength( 1 );
-		expect( props[ 0 ].properties[ 0 ].value ).toBe( 'all' );
+
+		props.slice( 1 ).forEach( ( cat: TransitionCategory ) => {
+			cat.properties.forEach( ( prop: TransitionProperty ) => {
+				expect( prop.isDisabled ).toBe( true );
+			} );
+		} );
 	} );
 
 	it( 'should show only Default category when Pro version is below 3.35', () => {
@@ -145,6 +156,10 @@ describe( 'transitionProperties Pro version handling', () => {
 	it( 'should show only Default category when Pro is installed but version is undefined', () => {
 		window.elementorPro = {
 			config: {},
+		};
+		window.elementor = {
+			...window.elementor,
+			helpers: { hasPro: () => true },
 		};
 
 		const props = getTransitionProperties();

--- a/packages/packages/libs/editor-controls/src/controls/transition-control/data.ts
+++ b/packages/packages/libs/editor-controls/src/controls/transition-control/data.ts
@@ -46,9 +46,9 @@ const getIsSiteRtl = () => {
 };
 
 // TODO: Remove this after version 4.01 is released
-const shouldExtendTransitionProperties = (): boolean => {
+const shouldShowAllTransitionProperties = (): boolean => {
 	if ( ! hasProInstalled() ) {
-		return false;
+		return true;
 	}
 
 	const proVersion = window.elementorPro?.config?.version;
@@ -191,7 +191,7 @@ const createTransitionPropertiesList = (): TransitionCategory[] => {
 		},
 	];
 
-	return shouldExtendTransitionProperties() ? baseProperties : [ baseProperties[ 0 ] ];
+	return shouldShowAllTransitionProperties() ? baseProperties : [ baseProperties[ 0 ] ];
 };
 
 export const transitionProperties: TransitionCategory[] = createTransitionPropertiesList();

--- a/packages/packages/libs/editor-controls/src/controls/transition-control/transition-repeater-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/transition-control/transition-repeater-control.tsx
@@ -9,6 +9,7 @@ import {
 import { type StyleDefinitionState } from '@elementor/editor-styles';
 import { InfoCircleFilledIcon } from '@elementor/icons';
 import { Alert, AlertTitle, Box, Typography } from '@elementor/ui';
+import { hasProInstalled } from '@elementor/utils';
 import { __ } from '@wordpress/i18n';
 
 import { useBoundProp } from '../../bound-prop-context';
@@ -181,6 +182,7 @@ export const TransitionRepeaterControl = createControl(
 	} ) => {
 		const currentStyleIsNormal = currentStyleState === null;
 		const [ recentlyUsedList, setRecentlyUsedList ] = useState< string[] >( [] );
+		const proInstalled = hasProInstalled();
 
 		const { value, setValue } = useBoundProp( childArrayPropTypeUtil );
 		const { allDisabled: disabledItems, proDisabled: proDisabledItems } = useMemo(
@@ -191,10 +193,14 @@ export const TransitionRepeaterControl = createControl(
 		const allowedTransitionSet = useMemo( () => {
 			const set = new Set< string >();
 			transitionProperties.forEach( ( category ) => {
-				category.properties.forEach( ( prop ) => set.add( prop.value ) );
+				category.properties.forEach( ( prop ) => {
+					if ( ! prop.isDisabled || proInstalled ) {
+						set.add( prop.value );
+					}
+				} );
 			} );
 			return set;
-		}, [] );
+		}, [ proInstalled ] );
 
 		useEffect( () => {
 			if ( ! value || value.length === 0 ) {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Restore transition control functionality to show all property categories when Pro is not installed, fixing broken feature availability for free users.

Main changes:
- Inverted shouldExtendTransitionProperties logic to shouldShowAllTransitionProperties, returning true when Pro is not installed instead of false
- Updated allowedTransitionSet to filter properties based on Pro installation status, enabling disabled properties only for Pro users
- Added comprehensive test coverage for Pro/non-Pro scenarios with proper mocking of hasProInstalled utility

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
