### PR TITLE
Internal: Add getMCPByDomainAsync and refactor MCP init to accept registry entries [ED-23472]

### DIFF
--- a/packages/packages/core/editor-canvas/src/mcp/canvas-mcp.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/canvas-mcp.ts
@@ -10,14 +10,12 @@ import { initGetElementConfigTool } from './tools/get-element-config/tool';
 export const initCanvasMcp = ( reg: MCPRegistryEntry ) => {
 	const { setMCPDescription } = reg;
 	setMCPDescription(
-		`Everything related to creative design, layout, styling and building the pages, specifically element of type "widget".
+		`Everything related to V4 ( Atomic ) canvas.
 # Canvas workflow for new compositions
-- Check existing global variables
-- Check existing global classes
-- Create missing global variables
-- Create reusable global classes
-- Build valid XML with minimal inline styles (layout/positioning only)
-- Apply global classes to elements`
+- Configure elements settings and styles
+- Build compositions/sections out of V4 atomic elements using context aware designs using the website resources
+- Get and retrieve element configuration values
+`
 	);
 	initWidgetsSchemaResource( reg );
 	initDocumentStructureResource( reg );

--- a/packages/packages/core/editor-global-classes/src/init.ts
+++ b/packages/packages/core/editor-global-classes/src/init.ts
@@ -4,6 +4,7 @@ import {
 	injectIntoCssClassConvert,
 	registerStyleProviderToColors,
 } from '@elementor/editor-editing-panel';
+import { getMCPByDomain } from '@elementor/editor-mcp';
 import { __registerPanel as registerPanel } from '@elementor/editor-panels';
 import { stylesRepository } from '@elementor/editor-styles-repository';
 import { __registerSlice as registerSlice } from '@elementor/store';
@@ -66,5 +67,5 @@ export function init() {
 		getThemeColor: ( theme ) => theme.palette.global.dark,
 	} );
 
-	initMcpIntegration();
+	initMcpIntegration( getMCPByDomain( 'classes' ), getMCPByDomain( 'canvas' ) );
 }

--- a/packages/packages/core/editor-global-classes/src/init.ts
+++ b/packages/packages/core/editor-global-classes/src/init.ts
@@ -67,5 +67,8 @@ export function init() {
 		getThemeColor: ( theme ) => theme.palette.global.dark,
 	} );
 
-	initMcpIntegration( getMCPByDomain( 'classes' ), getMCPByDomain( 'canvas' ) );
+	initMcpIntegration(
+		getMCPByDomain( 'classes', { instructions: 'MCP server for management of Elementor global classes' } ),
+		getMCPByDomain( 'canvas' )
+	);
 }

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/classes-resource.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/classes-resource.ts
@@ -1,4 +1,4 @@
-import { getMCPByDomain } from '@elementor/editor-mcp';
+import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 
 import { globalClassesStylesProvider } from '../global-classes-styles-provider';
 
@@ -12,10 +12,7 @@ const updateLocalStorageCache = () => {
 	localStorage.setItem( STORAGE_KEY, JSON.stringify( classes ) );
 };
 
-export const initClassesResource = () => {
-	const canvasMcpEntry = getMCPByDomain( 'canvas' );
-	const classesMcpEntry = getMCPByDomain( 'classes' );
-
+export const initClassesResource = ( classesMcpEntry: MCPRegistryEntry, canvasMcpEntry: MCPRegistryEntry ) => {
 	[ canvasMcpEntry, classesMcpEntry ].forEach( ( entry ) => {
 		const { mcpServer, resource, waitForReady } = entry;
 		resource(

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/index.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/index.ts
@@ -1,16 +1,15 @@
-import { getMCPByDomain } from '@elementor/editor-mcp';
+import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 
 import { initClassesResource } from './classes-resource';
 import initMcpApplyUnapplyGlobalClasses from './mcp-apply-unapply-global-classes';
 import initMcpApplyGetGlobalClassUsages from './mcp-get-global-class-usages';
 import { initManageGlobalClasses } from './mcp-manage-global-classes';
 
-export const initMcpIntegration = () => {
-	const reg = getMCPByDomain( 'classes', {
-		instructions: 'MCP server for management of Elementor global classes',
-	} );
+export const initMcpIntegration = ( reg: MCPRegistryEntry, canvasMcpEntry: MCPRegistryEntry ) => {
+	const { setMCPDescription } = reg;
+	setMCPDescription( 'MCP server for management of Elementor global classes' );
 	initMcpApplyUnapplyGlobalClasses( reg );
 	initMcpApplyGetGlobalClassUsages( reg );
 	initManageGlobalClasses( reg );
-	initClassesResource();
+	initClassesResource( reg, canvasMcpEntry );
 };

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/index.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/index.ts
@@ -14,7 +14,8 @@ export const initMcpIntegration = ( reg: MCPRegistryEntry, canvasMcpEntry: MCPRe
 - Get list of global classes
 - Get details of a global class
 - Get details of a global class
-` );
+`
+	);
 	initMcpApplyUnapplyGlobalClasses( reg );
 	initMcpApplyGetGlobalClassUsages( reg );
 	initManageGlobalClasses( reg );

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/index.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/index.ts
@@ -6,6 +6,15 @@ import initMcpApplyGetGlobalClassUsages from './mcp-get-global-class-usages';
 import { initManageGlobalClasses } from './mcp-manage-global-classes';
 
 export const initMcpIntegration = ( reg: MCPRegistryEntry, canvasMcpEntry: MCPRegistryEntry ) => {
+	const { setMCPDescription } = reg;
+	setMCPDescription(
+		`Everything related to V4 ( Atomic ) global classes.
+# Global classes
+- Create/update/delete global classes
+- Get list of global classes
+- Get details of a global class
+- Get details of a global class
+` );
 	initMcpApplyUnapplyGlobalClasses( reg );
 	initMcpApplyGetGlobalClassUsages( reg );
 	initManageGlobalClasses( reg );

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/index.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/index.ts
@@ -6,8 +6,6 @@ import initMcpApplyGetGlobalClassUsages from './mcp-get-global-class-usages';
 import { initManageGlobalClasses } from './mcp-manage-global-classes';
 
 export const initMcpIntegration = ( reg: MCPRegistryEntry, canvasMcpEntry: MCPRegistryEntry ) => {
-	const { setMCPDescription } = reg;
-	setMCPDescription( 'MCP server for management of Elementor global classes' );
 	initMcpApplyUnapplyGlobalClasses( reg );
 	initMcpApplyGetGlobalClassUsages( reg );
 	initManageGlobalClasses( reg );

--- a/packages/packages/core/editor-interactions/src/init.ts
+++ b/packages/packages/core/editor-interactions/src/init.ts
@@ -1,3 +1,5 @@
+import { getMCPByDomain } from '@elementor/editor-mcp';
+
 import { initPasteInteractionsCommand } from './commands/paste-interactions';
 import { Direction } from './components/controls/direction';
 import { Easing } from './components/controls/easing';
@@ -60,7 +62,7 @@ export function init() {
 			component: Repeat,
 		} );
 
-		initMcpInteractions();
+		initMcpInteractions( getMCPByDomain( 'interactions' ) );
 	} catch ( error ) {
 		throw error;
 	}

--- a/packages/packages/core/editor-interactions/src/init.ts
+++ b/packages/packages/core/editor-interactions/src/init.ts
@@ -11,7 +11,7 @@ import { Trigger } from './components/controls/trigger';
 import { initCleanInteractionIdsOnDuplicate } from './hooks/on-duplicate';
 import { registerInteractionsControl } from './interactions-controls-registry';
 import { interactionsRepository } from './interactions-repository';
-import { initMcpInteractions } from './mcp';
+import { EDITOR_INTERACTIONS_MCP_INSTRUCTIONS, initMcpInteractions } from './mcp';
 import { documentElementsInteractionsProvider } from './providers/document-elements-interactions-provider';
 
 export function init() {
@@ -62,7 +62,7 @@ export function init() {
 			component: Repeat,
 		} );
 
-		initMcpInteractions( getMCPByDomain( 'interactions' ) );
+		initMcpInteractions( getMCPByDomain( 'interactions', { instructions: EDITOR_INTERACTIONS_MCP_INSTRUCTIONS } ) );
 	} catch ( error ) {
 		throw error;
 	}

--- a/packages/packages/core/editor-interactions/src/mcp/constants.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/constants.ts
@@ -1,1 +1,59 @@
 export const MAX_INTERACTIONS_PER_ELEMENT = 5;
+export const EDITOR_INTERACTIONS_MCP_INSTRUCTIONS = `MCP server for managing element interactions and animations. Use this to add, modify, or remove animations and motion effects triggered by user events such as page load or scroll-into-view.
+		** IMPORTANT **
+		Use the "interactions-schema" resource to get the schema of the interactions.
+		Actions:
+		- get: Read the current interactions on the element.
+		- add: Add a new interaction (max ${ MAX_INTERACTIONS_PER_ELEMENT } per element).
+		- update: Update an existing interaction by its interactionId.
+		- delete: Remove a specific interaction by its interactionId.
+		- clear: Remove all interactions from the element.
+		
+		For add/update, provide: trigger, effect, effectType, direction (required for slide effect), duration, delay, easing.
+		Use excludedBreakpoints to disable the animation on specific responsive breakpoints (e.g. ["mobile", "tablet"]).
+		Example Get Request:
+		{
+			"elementId": "123",
+			"action": "get",
+			"interactionId": "123",
+			"animationData": {
+				"trigger": "click",
+				"effect": "fade",
+			}
+		}
+		Example Add Request:
+		{
+			"elementId": "123",
+			"action": "add",
+			"animationData": {
+				"effectType": "in",
+				"direction": "top",
+				"trigger": "click",
+				"effect": "fade",
+				"duration": 1000,
+				"delay": 0,
+				"easing": "easeIn",
+				"excludedBreakpoints": ["mobile", "tablet"],
+			}
+		}
+		Example Update Request:
+		{
+			"elementId": "123",
+			"action": "update",
+			"interactionId": "123",
+			"animationData": {
+				"trigger": "click",
+				"effect": "fade",
+			}
+		}
+		Example Delete Request:
+		{
+			"elementId": "123",
+			"action": "delete",
+			"interactionId": "123",
+		}
+		Example Clear Request:
+		{
+			"elementId": "123",
+			"action": "clear",
+		}`;

--- a/packages/packages/core/editor-interactions/src/mcp/index.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/index.ts
@@ -1,12 +1,12 @@
-import { getMCPByDomain } from '@elementor/editor-mcp';
+import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 
 import { MAX_INTERACTIONS_PER_ELEMENT } from './constants';
 import { initInteractionsSchemaResource } from './resources/interactions-schema-resource';
 import { initManageElementInteractionTool } from './tools/manage-element-interaction-tool';
 
-export const initMcpInteractions = () => {
-	const reg = getMCPByDomain( 'interactions', {
-		instructions: `
+export const initMcpInteractions = ( reg: MCPRegistryEntry ) => {
+	const { setMCPDescription } = reg;
+	setMCPDescription( `
 		MCP server for managing element interactions and animations. Use this to add, modify, or remove animations and motion effects triggered by user events such as page load or scroll-into-view.
 		** IMPORTANT **
 		Use the "interactions-schema" resource to get the schema of the interactions.
@@ -64,11 +64,8 @@ export const initMcpInteractions = () => {
 		{
 			"elementId": "123",
 			"action": "clear",
-		}
-		`,
-	} );
-	reg.waitForReady().then( () => {
-		initInteractionsSchemaResource( reg );
-		initManageElementInteractionTool( reg );
-	} );
+		}` );
+
+	initInteractionsSchemaResource( reg );
+	initManageElementInteractionTool( reg );
 };

--- a/packages/packages/core/editor-interactions/src/mcp/index.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/index.ts
@@ -6,6 +6,14 @@ import { initManageElementInteractionTool } from './tools/manage-element-interac
 export * from './constants';
 
 export const initMcpInteractions = ( reg: MCPRegistryEntry ) => {
+	const { setMCPDescription } = reg;
+	setMCPDescription(
+		`Everything related to V4 ( Atomic ) interactions.
+# Interactions
+- Create/update/delete interactions
+- Get list of interactions
+- Get details of an interaction
+` );
 	initInteractionsSchemaResource( reg );
 	initManageElementInteractionTool( reg );
 };

--- a/packages/packages/core/editor-interactions/src/mcp/index.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/index.ts
@@ -1,71 +1,11 @@
 import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 
-import { MAX_INTERACTIONS_PER_ELEMENT } from './constants';
 import { initInteractionsSchemaResource } from './resources/interactions-schema-resource';
 import { initManageElementInteractionTool } from './tools/manage-element-interaction-tool';
 
-export const initMcpInteractions = ( reg: MCPRegistryEntry ) => {
-	const { setMCPDescription } = reg;
-	setMCPDescription( `
-		MCP server for managing element interactions and animations. Use this to add, modify, or remove animations and motion effects triggered by user events such as page load or scroll-into-view.
-		** IMPORTANT **
-		Use the "interactions-schema" resource to get the schema of the interactions.
-		Actions:
-		- get: Read the current interactions on the element.
-		- add: Add a new interaction (max ${ MAX_INTERACTIONS_PER_ELEMENT } per element).
-		- update: Update an existing interaction by its interactionId.
-		- delete: Remove a specific interaction by its interactionId.
-		- clear: Remove all interactions from the element.
-		
-		For add/update, provide: trigger, effect, effectType, direction (required for slide effect), duration, delay, easing.
-		Use excludedBreakpoints to disable the animation on specific responsive breakpoints (e.g. ["mobile", "tablet"]).
-		Example Get Request:
-		{
-			"elementId": "123",
-			"action": "get",
-			"interactionId": "123",
-			"animationData": {
-				"trigger": "click",
-				"effect": "fade",
-			}
-		}
-		Example Add Request:
-		{
-			"elementId": "123",
-			"action": "add",
-			"animationData": {
-				"effectType": "in",
-				"direction": "top",
-				"trigger": "click",
-				"effect": "fade",
-				"duration": 1000,
-				"delay": 0,
-				"easing": "easeIn",
-				"excludedBreakpoints": ["mobile", "tablet"],
-			}
-		}
-		Example Update Request:
-		{
-			"elementId": "123",
-			"action": "update",
-			"interactionId": "123",
-			"animationData": {
-				"trigger": "click",
-				"effect": "fade",
-			}
-		}
-		Example Delete Request:
-		{
-			"elementId": "123",
-			"action": "delete",
-			"interactionId": "123",
-		}
-		Example Clear Request:
-		{
-			"elementId": "123",
-			"action": "clear",
-		}` );
+export * from './constants';
 
+export const initMcpInteractions = ( reg: MCPRegistryEntry ) => {
 	initInteractionsSchemaResource( reg );
 	initManageElementInteractionTool( reg );
 };

--- a/packages/packages/core/editor-interactions/src/mcp/index.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/index.ts
@@ -13,7 +13,8 @@ export const initMcpInteractions = ( reg: MCPRegistryEntry ) => {
 - Create/update/delete interactions
 - Get list of interactions
 - Get details of an interaction
-` );
+`
+	);
 	initInteractionsSchemaResource( reg );
 	initManageElementInteractionTool( reg );
 };

--- a/packages/packages/core/editor-variables/src/init.ts
+++ b/packages/packages/core/editor-variables/src/init.ts
@@ -1,5 +1,6 @@
 import { injectIntoLogic, injectIntoTop } from '@elementor/editor';
 import { registerControlReplacement } from '@elementor/editor-controls';
+import { getMCPByDomain } from '@elementor/editor-mcp';
 import { __registerPanel as registerPanel } from '@elementor/editor-panels';
 import { isTransformable, type PropValue } from '@elementor/editor-props';
 import { controlActionsMenu } from '@elementor/menus';
@@ -45,7 +46,7 @@ export function init() {
 	} );
 
 	variablesService.init().then( () => {
-		initMcp();
+		initMcp( getMCPByDomain( 'variables' ), getMCPByDomain( 'canvas' ) );
 	} );
 
 	injectIntoTop( {

--- a/packages/packages/core/editor-variables/src/mcp/index.ts
+++ b/packages/packages/core/editor-variables/src/mcp/index.ts
@@ -1,12 +1,12 @@
-import { isAngieAvailable } from '@elementor/editor-mcp';
+import { isAngieAvailable, type MCPRegistryEntry } from '@elementor/editor-mcp';
 
 import { initManageVariableTool } from './manage-variable-tool';
 import { initVariablesResource } from './variables-resource';
 
-export function initMcp() {
+export function initMcp( reg: MCPRegistryEntry, canvasMcpEntry: MCPRegistryEntry ) {
 	if ( ! isAngieAvailable() ) {
 		return;
 	}
-	initManageVariableTool();
-	initVariablesResource();
+	initManageVariableTool( reg );
+	initVariablesResource( reg, canvasMcpEntry );
 }

--- a/packages/packages/core/editor-variables/src/mcp/index.ts
+++ b/packages/packages/core/editor-variables/src/mcp/index.ts
@@ -1,4 +1,4 @@
-import { isAngieAvailable, type MCPRegistryEntry } from '@elementor/editor-mcp';
+import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 
 import { initManageVariableTool } from './manage-variable-tool';
 import { initVariablesResource } from './variables-resource';
@@ -11,7 +11,8 @@ export function initMcp( reg: MCPRegistryEntry, canvasMcpEntry: MCPRegistryEntry
 - Create/update/delete global variables
 - Get list of global variables
 - Get details of a global variable
-` );
+`
+	);
 	initManageVariableTool( reg );
 	initVariablesResource( reg, canvasMcpEntry );
 }

--- a/packages/packages/core/editor-variables/src/mcp/index.ts
+++ b/packages/packages/core/editor-variables/src/mcp/index.ts
@@ -4,9 +4,14 @@ import { initManageVariableTool } from './manage-variable-tool';
 import { initVariablesResource } from './variables-resource';
 
 export function initMcp( reg: MCPRegistryEntry, canvasMcpEntry: MCPRegistryEntry ) {
-	if ( ! isAngieAvailable() ) {
-		return;
-	}
+	const { setMCPDescription } = reg;
+	setMCPDescription(
+		`Everything related to V4 ( Atomic ) variables.
+# Global variables
+- Create/update/delete global variables
+- Get list of global variables
+- Get details of a global variable
+` );
 	initManageVariableTool( reg );
 	initVariablesResource( reg, canvasMcpEntry );
 }

--- a/packages/packages/core/editor-variables/src/mcp/manage-variable-tool.ts
+++ b/packages/packages/core/editor-variables/src/mcp/manage-variable-tool.ts
@@ -1,11 +1,12 @@
-import { getMCPByDomain } from '@elementor/editor-mcp';
+import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 import { z } from '@elementor/schema';
 
 import { service } from '../service';
 import { GLOBAL_VARIABLES_URI } from './variables-resource';
 
-export const initManageVariableTool = () => {
-	getMCPByDomain( 'variables' ).addTool( {
+export const initManageVariableTool = ( reg: MCPRegistryEntry ) => {
+	const { addTool } = reg;
+	addTool( {
 		name: 'manage-global-variable',
 		schema: {
 			action: z.enum( [ 'create', 'update', 'delete' ] ).describe( 'Operation to perform' ),

--- a/packages/packages/core/editor-variables/src/mcp/variables-resource.ts
+++ b/packages/packages/core/editor-variables/src/mcp/variables-resource.ts
@@ -1,17 +1,14 @@
-import { getMCPByDomain } from '@elementor/editor-mcp';
+import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 
 import { service } from '../service';
 import { type TVariable } from '../storage';
 
 export const GLOBAL_VARIABLES_URI = 'elementor://global-variables';
 
-export const initVariablesResource = () => {
-	const canvasMcpEntry = getMCPByDomain( 'canvas' );
-	const variablesMcpEntry = getMCPByDomain( 'variables' );
-
+export const initVariablesResource = ( variablesMcpEntry: MCPRegistryEntry, canvasMcpEntry: MCPRegistryEntry ) => {
 	[ canvasMcpEntry, variablesMcpEntry ].forEach( ( entry ) => {
-		const { mcpServer } = entry;
-		mcpServer.resource(
+		const { resource, sendResourceUpdated } = entry;
+		resource(
 			'global-variables',
 			GLOBAL_VARIABLES_URI,
 			{
@@ -33,7 +30,7 @@ export const initVariablesResource = () => {
 		);
 
 		window.addEventListener( 'variables:updated', () => {
-			mcpServer.server.sendResourceUpdated( {
+			sendResourceUpdated( {
 				uri: GLOBAL_VARIABLES_URI,
 			} );
 		} );

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -50,6 +50,19 @@ const isAlphabet = ( str: string ): string | never => {
 	return str;
 };
 
+export const toMCPTitle = ( namespace: string ): string => {
+	const capitalized = namespace.charAt( 0 ).toUpperCase() + namespace.slice( 1 );
+	return `Editor ${ capitalized }`;
+};
+
+export const getMCPByDomainAsync = async (
+	namespace: string,
+	options?: { instructions?: string }
+): Promise< MCPRegistryEntry > => {
+	await getSDK().waitForReady();
+	return getMCPByDomain( namespace, options );
+};
+
 /**
  *
  * @param namespace            The namespace of the MCP server. It should contain only lowercase alphabetic characters.
@@ -58,6 +71,7 @@ const isAlphabet = ( str: string ): string | never => {
  */
 export const getMCPByDomain = ( namespace: string, options?: { instructions?: string } ): MCPRegistryEntry => {
 	const mcpName = `editor-${ isAlphabet( namespace ) }`;
+	const title = toMCPTitle( namespace );
 	// @ts-ignore - QUnit fails this
 	if ( typeof globalThis.jest !== 'undefined' ) {
 		return mockMcpRegistry();
@@ -66,6 +80,7 @@ export const getMCPByDomain = ( namespace: string, options?: { instructions?: st
 		mcpRegistry[ namespace ] = new McpServer(
 			{
 				name: mcpName,
+				title,
 				version: '1.0.0',
 			},
 			{

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -18,7 +18,7 @@ type ZodRawShape = z3.ZodRawShape;
 const mcpRegistry: { [ namespace: string ]: McpServer } = {};
 const mcpDescriptions: { [ namespace: string ]: string } = {};
 // @ts-ignore - QUnit fails this
-let isMcpRegistrationActivated = false || typeof globalThis.jest !== 'undefined';
+const isMcpRegistrationActivated = false || typeof globalThis.jest !== 'undefined';
 
 export const registerMcp = ( mcp: McpServer, name: string ) => {
 	const mcpName = isAlphabet( name );
@@ -27,6 +27,7 @@ export const registerMcp = ( mcp: McpServer, name: string ) => {
 
 export async function activateMcpRegistration( sdk: AngieMcpSdk, entries = Object.entries( mcpRegistry ), retry = 3 ) {
 	if ( retry === 0 ) {
+		/* eslint-disable-next-line no-console */
 		console.error( 'Failed to register MCP after 3 retries. failed entries: ', entries );
 		return;
 	}

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -25,20 +25,31 @@ export const registerMcp = ( mcp: McpServer, name: string ) => {
 	mcpRegistry[ mcpName ] = mcp;
 };
 
-export async function activateMcpRegistration( sdk: AngieMcpSdk ) {
-	if ( isMcpRegistrationActivated ) {
+export async function activateMcpRegistration( sdk: AngieMcpSdk, entries = Object.entries( mcpRegistry ), retry = 3 ) {
+	if ( retry === 0 ) {
+		console.error( 'Failed to register MCP after 3 retries. failed entries: ', entries );
 		return;
 	}
-	isMcpRegistrationActivated = true;
-	const mcpServerList = Object.entries( mcpRegistry );
-	for await ( const entry of mcpServerList ) {
+	if ( entries.length === 0 ) {
+		return;
+	}
+	const failed = [];
+	for await ( const entry of entries ) {
 		const [ key, mcpServer ] = entry;
-		await sdk.registerLocalServer( {
-			name: `editor-${ key }`,
-			server: mcpServer,
-			version: '1.0.0',
-			description: mcpDescriptions[ key ] || key,
-		} );
+		try {
+			await sdk.registerLocalServer( {
+				title: toMCPTitle( key ),
+				name: `editor-${ key }`,
+				server: mcpServer,
+				version: '1.0.0',
+				description: mcpDescriptions[ key ] || key,
+			} );
+		} catch {
+			failed.push( entry );
+		}
+	}
+	if ( failed.length > 0 ) {
+		return activateMcpRegistration( sdk, failed, retry - 1 );
 	}
 }
 
@@ -53,14 +64,6 @@ const isAlphabet = ( str: string ): string | never => {
 export const toMCPTitle = ( namespace: string ): string => {
 	const capitalized = namespace.charAt( 0 ).toUpperCase() + namespace.slice( 1 );
 	return `Editor ${ capitalized }`;
-};
-
-export const getMCPByDomainAsync = async (
-	namespace: string,
-	options?: { instructions?: string }
-): Promise< MCPRegistryEntry > => {
-	await getSDK().waitForReady();
-	return getMCPByDomain( namespace, options );
 };
 
 /**


### PR DESCRIPTION
## Summary
- Added `getMCPByDomainAsync` function to `mcp-registry.ts` that waits for SDK to load before returning the MCP registry entry
- Added `toMCPTitle` helper to generate consistent MCP server titles from namespace names
- Added `title` field to MCP server initialization
- Refactored MCP init functions across `editor-variables`, `editor-interactions`, and `editor-global-classes` to accept `MCPRegistryEntry` as parameters (dependency injection) instead of calling `getMCPByDomain` internally
- Removed `waitForReady().then()` wrapper from interactions MCP init since initialization is now handled at the call site

## Test plan
- [ ] Verify MCP tools and resources still initialize correctly for variables, interactions, and global classes
- [ ] Verify `getMCPByDomainAsync` properly waits for SDK readiness before returning
- [ ] Verify MCP server title appears correctly with the new `toMCPTitle` helper

## Jira
[ED-23472](https://elementor.atlassian.net/browse/ED-23472)

[ED-23472]: https://elementor.atlassian.net/browse/ED-23472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor MCP initialization architecture to accept MCPRegistryEntry parameters instead of internally calling getMCPByDomain, improving testability and dependency injection across editor modules.

Main changes:
- Modified initMcp functions across canvas, classes, interactions, and variables modules to accept MCPRegistryEntry parameters
- Added getMCPByDomainAsync function with retry mechanism for MCP server registration and failure handling
- Extracted MCP instructions to constants and updated server descriptions to use V4 Atomic terminology

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
