### PR TITLE
Fix: Activate new-site experiments on first installation request [ED-23474]

### DIFF
--- a/core/experiments/manager.php
+++ b/core/experiments/manager.php
@@ -121,7 +121,9 @@ class Manager extends Base_Object {
 		$installs_history = Upgrade_Manager::get_installs_history();
 
 		if ( empty( $installs_history ) ) {
-			return false;
+			// Fresh installation: upgrade manager hasn't written history yet on this first request.
+			// Use the current plugin version as the effective first-install version.
+			return version_compare( ELEMENTOR_VERSION, $version, '>=' );
 		}
 
 		$cleaned_version = preg_replace( '/-(beta|cloud|dev)\d*$/', '', key( $installs_history ) );

--- a/tests/phpunit/elementor/core/experiments/test-manager.php
+++ b/tests/phpunit/elementor/core/experiments/test-manager.php
@@ -466,6 +466,16 @@ class Test_Manager extends Elementor_Test_Base {
                 'minimum_installation_version' => '3.1.0',
                 'expected' => false,
             ],
+            'empty_history_current_version_meets_minimum' => [
+                'versions_history' => [],
+                'minimum_installation_version' => '3.1.0',
+                'expected' => true,
+            ],
+            'empty_history_current_version_below_minimum' => [
+                'versions_history' => [],
+                'minimum_installation_version' => '999.0.0',
+                'expected' => false,
+            ],
             'new_site_with_beta_active' => [
                 'versions_history' => [
                     '3.1.0-beta1' => time(),


### PR DESCRIPTION
## Summary
- Fixed a race condition where `e_opt_in_v4` and `e_atomic_elements` experiments were not activated on the very first page load of a fresh Elementor installation
- Root cause: `Modules_Manager` (which registers experiments) is instantiated before `Core\Upgrade\Manager` (which writes `installs_history`) in `plugin.php::init_components()`. On first load, `install_compare()` found empty history and returned `false`, leaving experiment defaults as `STATE_INACTIVE`
- Fix: when `installs_history` is empty, `install_compare()` now falls back to comparing `ELEMENTOR_VERSION` against the minimum — the current version IS the effective first-install version on that first request
- Existing sites and upgrades are completely unaffected (their history is always populated before experiments are registered)
- Added two test cases to `test-manager.php` covering the empty-history scenarios

## Test plan
- [ ] Fresh install: verify `e_opt_in_v4` and `e_atomic_elements` experiments are active on the very first page load (before any subsequent requests)
- [ ] Simulate by clearing the `elementor_install_history` DB option and reloading the admin — experiments should be active
- [ ] Verify existing sites (non-empty history) are unaffected — experiments activate/deactivate as before
- [ ] Run PHPUnit: `vendor/bin/phpunit tests/phpunit/elementor/core/experiments/test-manager.php --filter="test_is_feature_active__new_site"` — all 6 data-provider cases should pass, including the 2 new empty-history cases

## Jira
[https://elementor.atlassian.net/browse/ED-23474](https://elementor.atlassian.net/browse/ED-23474)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix new-site experiments activation by properly handling first installation requests before upgrade manager writes installation history.

Main changes:
- Modified install_compare() to use current plugin version when installation history is empty on first request
- Added fallback logic comparing ELEMENTOR_VERSION against minimum version for fresh installations before history initialization
- Added test cases validating experiment activation behavior with empty installation history scenarios

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
