### PR TITLE
Fix: Cherry-pick PR 35257 to 4.00: Activate new-site experiments on first installation request [ED-23474]

### DIFF
--- a/core/experiments/manager.php
+++ b/core/experiments/manager.php
@@ -121,7 +121,9 @@ class Manager extends Base_Object {
 		$installs_history = Upgrade_Manager::get_installs_history();
 
 		if ( empty( $installs_history ) ) {
-			return false;
+			// Fresh installation: upgrade manager hasn't written history yet on this first request.
+			// Use the current plugin version as the effective first-install version.
+			return version_compare( ELEMENTOR_VERSION, $version, '>=' );
 		}
 
 		$cleaned_version = preg_replace( '/-(beta|cloud|dev)\d*$/', '', key( $installs_history ) );

--- a/tests/phpunit/elementor/core/experiments/test-manager.php
+++ b/tests/phpunit/elementor/core/experiments/test-manager.php
@@ -466,6 +466,16 @@ class Test_Manager extends Elementor_Test_Base {
                 'minimum_installation_version' => '3.1.0',
                 'expected' => false,
             ],
+            'empty_history_current_version_meets_minimum' => [
+                'versions_history' => [],
+                'minimum_installation_version' => '3.1.0',
+                'expected' => true,
+            ],
+            'empty_history_current_version_below_minimum' => [
+                'versions_history' => [],
+                'minimum_installation_version' => '999.0.0',
+                'expected' => false,
+            ],
             'new_site_with_beta_active' => [
                 'versions_history' => [
                     '3.1.0-beta1' => time(),


### PR DESCRIPTION
## Summary
- Cherry-pick of PR #35257 targeting the `4.00` release branch
- Fixed a race condition where `e_opt_in_v4` and `e_atomic_elements` experiments were not activated on the very first page load of a fresh Elementor installation
- Root cause: `Modules_Manager` (which registers experiments) is instantiated before `Core\Upgrade\Manager` (which writes `installs_history`) in `plugin.php::init_components()`. On first load, `install_compare()` found empty history and returned `false`, leaving experiment defaults as `STATE_INACTIVE`
- Fix: when `installs_history` is empty, `install_compare()` now falls back to comparing `ELEMENTOR_VERSION` against the minimum — the current version IS the effective first-install version on that first request
- Added two PHPUnit test cases covering the empty-history scenarios

## Test plan
- [ ] Fresh install on 4.0: verify `e_opt_in_v4` and `e_atomic_elements` experiments are active on the very first page load (before any subsequent requests)
- [ ] Simulate by clearing the `elementor_install_history` DB option and reloading the admin — experiments should be active
- [ ] Verify existing sites (non-empty history) are unaffected — experiments activate/deactivate as before
- [ ] Run PHPUnit: `vendor/bin/phpunit tests/phpunit/elementor/core/experiments/test-manager.php --filter="test_is_feature_active__new_site"` — all cases should pass, including the 2 new empty-history cases

## Jira
[ED-23474](https://elementor.atlassian.net/browse/ED-23474)

[ED-23474]: https://elementor.atlassian.net/browse/ED-23474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix experiment activation logic to properly handle first-time installations by comparing current plugin version against experiment requirements when install history is empty.

Main changes:
- Modified install_compare() to return version comparison using ELEMENTOR_VERSION instead of false when installs_history is empty
- Added test coverage for empty history scenarios validating both above and below minimum version thresholds
- Enables new-site experiments to activate correctly on first installation request before upgrade manager writes history

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
