### PR TITLE
Internal: Export getComponentDocumentData for async MCP resource usage [ED-23473]

### DIFF
--- a/packages/packages/core/editor-components/src/index.ts
+++ b/packages/packages/core/editor-components/src/index.ts
@@ -91,3 +91,4 @@ export { resolveOverridePropValue } from './utils/resolve-override-prop-value';
 export { switchToComponent } from './utils/switch-to-component';
 export { onElementDrop, trackComponentEvent } from './utils/tracking';
 export type { Source } from './utils/tracking';
+export { getComponentDocumentData } from './utils/component-document-data';


### PR DESCRIPTION
## Summary
- Export `getComponentDocumentData` from `editor-components` public index
- This export is needed by the components MCP tool to use async domain + resources instead of the synchronous list-components approach

## Test plan
- [ ] Verify `getComponentDocumentData` is importable from `@elementor/editor-components`
- [ ] Verify the components MCP tool works correctly with the async domain/resource implementation

## Jira
[ED-23473](https://elementor.atlassian.net/browse/ED-23473)

[ED-23473]: https://elementor.atlassian.net/browse/ED-23473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Export getComponentDocumentData utility function to enable async MCP resource integration for component document data retrieval in external modules.

Main changes:
- Added public export of getComponentDocumentData from component-document-data utils module to package API surface
- Enables external async MCP resource consumers to access component document metadata without internal imports

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
