### PR TITLE
Fix: Remove broken unfiltered uploads setup in AI image sideload [ED-23530]

### DIFF
--- a/modules/ai/module.php
+++ b/modules/ai/module.php
@@ -1313,16 +1313,6 @@ class Module extends BaseModule {
 			throw new \Exception( 'Not Allowed to Upload images' );
 		}
 
-		$uploads_manager = new \Elementor\Core\Files\Uploads_Manager();
-		if ( $uploads_manager::are_unfiltered_uploads_enabled() ) {
-			Plugin::$instance->uploads_manager->set_elementor_upload_state( true );
-			add_filter( 'wp_handle_sideload_prefilter', [ Plugin::$instance->uploads_manager, 'handle_elementor_upload' ] );
-			add_filter( 'image_sideload_extensions', function( $extensions ) {
-				$extensions[] = 'svg';
-				return $extensions;
-			});
-		}
-
 		$attachment_id = media_sideload_image( $image_url, $parent_post_id, $image_title, 'id' );
 
 		if ( is_wp_error( $attachment_id ) ) {


### PR DESCRIPTION
## Summary
- Removes the conditional block that set up unfiltered upload state and SVG extension support before calling `media_sideload_image` in the AI module
- This code was introduced in a prior security fix and caused a PHP Fatal error (`Cannot use object of type WP_Error as array`) when "Enable Unfiltered File Uploads" was enabled in Elementor settings
- The `media_sideload_image` function handles sideloading internally; the extra setup was interfering and producing a `WP_Error` that was then treated as an array

## Test plan
- [ ] Enable "Enable Unfiltered File Uploads" in Elementor → Settings → Advanced
- [ ] Use "Generate with AI" to generate and insert an image in the editor
- [ ] Verify the image is sideloaded successfully without a PHP Fatal error
- [ ] Verify the fix also works when "Enable Unfiltered File Uploads" is **disabled**

## Jira
[https://elementor.atlassian.net/browse/ED-23530](https://elementor.atlassian.net/browse/ED-23530)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix broken unfiltered uploads configuration by removing non-functional SVG upload setup in AI image sideloading process to prevent potential errors.

Main changes:
- Removed unused unfiltered uploads manager initialization and Elementor upload state configuration that was not working
- Deleted broken SVG file extension filter and sideload handler that were never properly executed
- Simplified upload_image method by keeping only essential media_sideload_image call with proper error handling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
