### PR TITLE
Fix: Fix popovers position when Angie is active [ED-23465]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/styles-inheritance/components/styles-inheritance-infotip.tsx
+++ b/packages/packages/core/editor-editing-panel/src/styles-inheritance/components/styles-inheritance-infotip.tsx
@@ -21,7 +21,6 @@ import {
 } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
-import { useDirection } from '../../hooks/use-direction';
 import { useNormalizedInheritanceChainItems } from '../hooks/use-normalized-inheritance-chain-items';
 import { type SnapshotPropValue } from '../types';
 import { ActionIcons, BreakpointIcon, LabelChip, ValueComponent } from './infotip';
@@ -169,8 +168,6 @@ export const StylesInheritanceInfotip = ( {
 				onClose={ closeInfotip }
 				infotipContent={ infotipContent }
 				isDisabled={ isDisabled }
-				triggerRef={ triggerRef }
-				sectionWidth={ sectionWidth }
 			>
 				<IconButton
 					onClick={ toggleInfotip }
@@ -191,29 +188,18 @@ function TooltipOrInfotip( {
 	onClose,
 	infotipContent,
 	isDisabled,
-	triggerRef,
-	sectionWidth,
 }: {
 	children: React.ReactNode;
 	showInfotip: boolean;
 	onClose: () => void;
 	infotipContent: React.ReactNode;
 	isDisabled?: boolean;
-	triggerRef: React.RefObject< HTMLDivElement >;
-	sectionWidth: number;
 } ) {
-	const direction = useDirection();
-	const isSiteRtl = direction.isSiteRtl;
-
 	if ( isDisabled ) {
 		return <Box sx={ { display: 'inline-flex' } }>{ children }</Box>;
 	}
 
 	if ( showInfotip ) {
-		const triggerRect = triggerRef.current?.getBoundingClientRect();
-		const cardWidth = Math.min( sectionWidth - SECTION_PADDING_INLINE, INFOTIP_MAX_WIDTH );
-		const offsetX = calculatePopoverOffset( triggerRect, cardWidth, isSiteRtl );
-
 		return (
 			<>
 				<Backdrop
@@ -225,7 +211,7 @@ function TooltipOrInfotip( {
 					} }
 				/>
 				<Infotip
-					placement="top"
+					placement="top-end"
 					content={ infotipContent }
 					open={ showInfotip }
 					onClose={ onClose }

--- a/packages/packages/core/editor-editing-panel/src/styles-inheritance/components/styles-inheritance-infotip.tsx
+++ b/packages/packages/core/editor-editing-panel/src/styles-inheritance/components/styles-inheritance-infotip.tsx
@@ -230,19 +230,6 @@ function TooltipOrInfotip( {
 					open={ showInfotip }
 					onClose={ onClose }
 					disableHoverListener
-					componentsProps={ {
-						tooltip: {
-							sx: { mx: 2 },
-						},
-					} }
-					PopperProps={ {
-						modifiers: [
-							{
-								name: 'offset',
-								options: { offset: [ offsetX, 0 ] },
-							},
-						],
-					} }
 				>
 					{ children }
 				</Infotip>


### PR DESCRIPTION
<img width="373" height="179" alt="image" src="https://github.com/user-attachments/assets/2f2c744e-e570-4ce6-96d6-ae8f4c8dc206" />

## Summary
- Remove `componentsProps` tooltip margin and `PopperProps` offset modifier from `Infotip` in styles-inheritance-infotip
- Fixes popover/inheritance popover positioning so they appear above the editor panel instead of over Angie
- Fixes the small triangle indicator
- Prevents popovers from stacking on top of each other

## Test plan
- [ ] Open Elementor editor with Angie active
- [ ] Trigger styles inheritance infotip/popover
- [ ] Verify popover appears above the editor panel, not over Angie
- [ ] Verify the triangle indicator renders correctly
- [ ] Verify multiple popovers don't stack on top of each other

## Jira
[ED-23465](https://elementor.atlassian.net/browse/ED-23465)

[ED-23465]: https://elementor.atlassian.net/browse/ED-23465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix popover positioning logic in styles inheritance infotip to correctly handle RTL layouts when Angie (AI assistant) is active.

Main changes:
- Removed custom popover offset calculation logic that was causing incorrect positioning in RTL layouts
- Changed Infotip placement from "top" to "top-end" for consistent anchor positioning across different UI states
- Eliminated unused triggerRef and sectionWidth props from TooltipOrInfotip component to simplify implementation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
