### PR TITLE
CI: Fix publish packages

### DIFF
--- a/.github/workflows/one-click-release.yml
+++ b/.github/workflows/one-click-release.yml
@@ -34,6 +34,9 @@ jobs:
     outputs:
       PACKAGE_VERSION: ${{ steps.output-data.outputs.PACKAGE_VERSION }}
       PACKAGE_TAG: ${{ steps.output-data.outputs.PACKAGE_TAG }}
+      CLEAN_PACKAGE_VERSION: ${{ steps.output-data.outputs.CLEAN_PACKAGE_VERSION }}
+      VERSION_SUFFIX: ${{ steps.output-data.outputs.VERSION_SUFFIX }}
+      NPM_TAG: ${{ steps.output-data.outputs.NPM_TAG }}
     steps:
       - name: Check if Custom Core was executed
         if: github.event.inputs.custom_core_executed == 'false'
@@ -210,14 +213,26 @@ jobs:
         run: |
           echo "PACKAGE_VERSION=${{ env.PACKAGE_VERSION }}" >> $GITHUB_OUTPUT
           echo "PACKAGE_TAG=${{ steps.package-tag.outputs.tag }}" >> $GITHUB_OUTPUT
+          echo "CLEAN_PACKAGE_VERSION=${{ env.CLEAN_PACKAGE_VERSION }}" >> $GITHUB_OUTPUT
+
+          if [ "${{ env.CHANNEL }}" == "ga" ]; then
+            echo "VERSION_SUFFIX=" >> $GITHUB_OUTPUT
+            echo "NPM_TAG=latest" >> $GITHUB_OUTPUT
+          else
+            VERSION_SUFFIX="${{ env.PACKAGE_VERSION }}"
+            VERSION_SUFFIX="${VERSION_SUFFIX#${{ env.CLEAN_PACKAGE_VERSION }}-}"
+            echo "VERSION_SUFFIX=${VERSION_SUFFIX}" >> $GITHUB_OUTPUT
+            echo "NPM_TAG=${{ env.CHANNEL }}" >> $GITHUB_OUTPUT
+          fi
 
   publish-packages:
     needs: release
     if: github.event.inputs.dry_run == 'false'
     uses: ./.github/workflows/publish-packages.yml
     with:
-      version: ${{ needs.release.outputs.PACKAGE_VERSION }}
-      tag: ${{ needs.release.outputs.PACKAGE_TAG }}
+      version: ${{ needs.release.outputs.CLEAN_PACKAGE_VERSION }}
+      version_suffix: ${{ needs.release.outputs.VERSION_SUFFIX }}
+      tag: ${{ needs.release.outputs.NPM_TAG }}
     secrets:
       NPMJS_CLOUD_DEVOPS_TOKEN: ${{ secrets.NPMJS_CLOUD_DEVOPS_TOKEN }}
       MAINTAIN_TOKEN: ${{ secrets.MAINTAIN_TOKEN }}


### PR DESCRIPTION
## Summary
- Fix `one-click-release.yml` passing `PACKAGE_VERSION` (e.g. `3.30.0-beta1`) directly to `publish-packages.yml`'s `version` input, which fails the strict `^X.Y.Z$` semver validation
- For **beta**: passes `version=3.30.0`, `version_suffix=beta1`, `tag=beta`
- For **GA**: passes `version=3.30.0`, `version_suffix=` (empty), `tag=latest`

## Test plan
- [ ] Trigger `one-click-release` with `channel=beta`, `dry_run=true` — `Validate Inputs` step should pass
- [ ] Trigger `one-click-release` with `channel=ga`, `dry_run=true` — `Validate Inputs` step should pass
- [ ] Confirm beta packages publish as `X.Y.Z-betaN` under dist-tag `beta`
- [ ] Confirm GA packages publish as `X.Y.Z` under dist-tag `latest`
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix package publishing workflow by correcting version and tag parameter passing to ensure proper NPM package release with appropriate version suffixes and distribution tags.

Main changes:
- Added three new job outputs (CLEAN_PACKAGE_VERSION, VERSION_SUFFIX, NPM_TAG) to release job for downstream workflow consumption
- Implemented channel-based logic to compute VERSION_SUFFIX from package version and set NPM_TAG (latest for GA, channel name otherwise)
- Updated publish-packages workflow inputs to use corrected version parameters instead of full PACKAGE_VERSION and PACKAGE_TAG

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
