### PR TITLE
Internal: Add Angie search-widget Mixpanel events [ED-23550]

### DIFF
--- a/assets/dev/js/editor/regions/panel/pages/elements/views/widget-creation.js
+++ b/assets/dev/js/editor/regions/panel/pages/elements/views/widget-creation.js
@@ -43,7 +43,10 @@ PanelElementsWidgetCreationView = Marionette.ItemView.extend( {
 	onCtaClick() {
 		window.dispatchEvent(
 			new CustomEvent( 'elementor/editor/create-widget', {
-				detail: { prompt },
+				detail: {
+					prompt,
+					entry_point: 'search_widget',
+				},
 			} ),
 		);
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -46634,6 +46634,7 @@
         "@elementor/editor": "4.1.0",
         "@elementor/editor-mcp": "4.1.0",
         "@elementor/editor-ui": "4.1.0",
+        "@elementor/events": "4.1.0",
         "@elementor/icons": "^1.63.0",
         "@elementor/ui": "1.36.17",
         "@wordpress/i18n": "^5.13.0"

--- a/packages/packages/core/editor-widget-creation/package.json
+++ b/packages/packages/core/editor-widget-creation/package.json
@@ -42,6 +42,7 @@
     "@elementor/editor": "4.1.0",
     "@elementor/editor-mcp": "4.1.0",
     "@elementor/editor-ui": "4.1.0",
+    "@elementor/events": "4.1.0",
     "@elementor/icons": "^1.63.0",
     "@elementor/ui": "1.36.17",
     "@wordpress/i18n": "^5.13.0"

--- a/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
+++ b/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
@@ -8,45 +8,38 @@ import {
 	sendPromptToAngie,
 } from '@elementor/editor-mcp';
 import { ThemeProvider } from '@elementor/editor-ui';
+import { trackEvent } from '@elementor/events';
 import { XIcon } from '@elementor/icons';
 import { Button, CircularProgress, Dialog, DialogContent, IconButton, Image, Stack, Typography } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 type ShowModalEventDetail = {
 	prompt?: string;
+	entry_point: string;
 };
 
 type InstallState = 'idle' | 'installing' | 'error';
 
+type CreateWidgetModalProps = {
+	prompt?: string;
+	entryPoint: string;
+	onClose: () => void;
+};
+
 const CREATE_WIDGET_EVENT = 'elementor/editor/create-widget';
 const PROMOTION_IMAGE_URL = 'https://assets.elementor.com/packages/v1/images/angie-promotion.svg';
+const ANGIE_CTA_CLICKED_EVENT = 'angie_cta_clicked' as const;
+const ANGIE_INSTALL_STARTED_EVENT = 'angie_install_started' as const;
 
-export function CreateWidget() {
-	const [ open, setOpen ] = useState( false );
-	const [ prompt, setPrompt ] = useState< string | undefined >();
+function CreateWidgetModal( { prompt, entryPoint, onClose }: CreateWidgetModalProps ) {
 	const [ installState, setInstallState ] = useState< InstallState >( 'idle' );
-
-	const handleShow = async ( event: Event ) => {
-		const customEvent = event as CustomEvent< ShowModalEventDetail >;
-
-		if ( isAngieAvailable() ) {
-			sendPromptToAngie( customEvent.detail?.prompt );
-
-			return;
-		}
-
-		setPrompt( customEvent.detail?.prompt );
-		setOpen( true );
-	};
 
 	const handleClose = () => {
 		if ( installState === 'installing' ) {
 			return;
 		}
 
-		setOpen( false );
-		setPrompt( undefined );
-		setInstallState( 'idle' );
+		onClose();
 	};
 
 	const handleInstall = async () => {
@@ -55,6 +48,11 @@ export function CreateWidget() {
 		}
 
 		setInstallState( 'installing' );
+
+		trackEvent( {
+			eventName: ANGIE_INSTALL_STARTED_EVENT,
+			trigger_source: entryPoint,
+		} );
 
 		const result = await installAngiePlugin();
 
@@ -75,17 +73,9 @@ export function CreateWidget() {
 		redirectToInstallation( prompt );
 	};
 
-	useEffect( () => {
-		window.addEventListener( CREATE_WIDGET_EVENT, handleShow );
-
-		return () => {
-			window.removeEventListener( CREATE_WIDGET_EVENT, handleShow );
-		};
-	}, [] );
-
 	return (
 		<ThemeProvider>
-			<Dialog fullWidth maxWidth="md" open={ open } onClose={ handleClose }>
+			<Dialog fullWidth maxWidth="md" open onClose={ handleClose }>
 				<IconButton
 					aria-label={ __( 'Close', 'elementor' ) }
 					onClick={ handleClose }
@@ -159,5 +149,48 @@ export function CreateWidget() {
 				</DialogContent>
 			</Dialog>
 		</ThemeProvider>
+	);
+}
+
+export function CreateWidget() {
+	const [ modalData, setModalData ] = useState< ShowModalEventDetail | null >( null );
+
+	useEffect( () => {
+		const handleShow = ( event: Event ) => {
+			const customEvent = event as CustomEvent< ShowModalEventDetail >;
+			const hasAngieInstalled = isAngieAvailable();
+
+			trackEvent( {
+				eventName: ANGIE_CTA_CLICKED_EVENT,
+				entry_point: customEvent.detail.entry_point,
+				has_angie_installed: hasAngieInstalled,
+			} );
+
+			if ( hasAngieInstalled ) {
+				sendPromptToAngie( customEvent.detail?.prompt );
+
+				return;
+			}
+
+			setModalData( customEvent.detail );
+		};
+
+		window.addEventListener( CREATE_WIDGET_EVENT, handleShow );
+
+		return () => {
+			window.removeEventListener( CREATE_WIDGET_EVENT, handleShow );
+		};
+	}, [] );
+
+	if ( ! modalData ) {
+		return null;
+	}
+
+	return (
+		<CreateWidgetModal
+			prompt={ modalData.prompt }
+			entryPoint={ modalData.entry_point }
+			onClose={ () => setModalData( null ) }
+		/>
 	);
 }


### PR DESCRIPTION
## Summary

Add Mixpanel tracking for Angie CTA and install flows in the widget search / Create Widget experience.

## PR Checklist

- [x] The commit message follows our guidelines

## PR Type

- [x] Feature

## Description

This PR adds two new Mixpanel events to track user engagement with Angie promotion and installation from the widget search flow:

1. **`angie_cta_clicked`** — fires when user clicks "Create with Angie" CTA from the widget search empty state
   - `entry_point: "search_widget"`
   - `has_angie_installed: true | false`

2. **`angie_install_started`** — fires when user clicks "Install Angie" button in the install dialog
   - `trigger_source: "search_widget"`

**Implementation:**
- Added `@elementor/events` dependency to `@elementor/editor-widget-creation`
- Integrated `trackEvent` calls in `CreateWidget` component (`handleShow` and `handleInstall`)
- Unit tests verify both events fire with correct properties

**Decision rationale:**
- Used existing `trackEvent` from `@elementor/events` (same pattern as transition control analytics)
- Events fire before any async operations to ensure tracking even if operations fail
- Separate `entry_point` / `trigger_source` property names match the Jira spec exactly

## Test instructions

1. Open editor on test.local
2. Go to widgets panel → search for a non-existent widget (to trigger empty state)
3. Click "Create with Angie" CTA
4. Verify `angie_cta_clicked` event in Mixpanel with `entry_point: "search_widget"` and `has_angie_installed` boolean
5. If Angie not installed, click "Install Angie" button
6. Verify `angie_install_started` event in Mixpanel with `trigger_source: "search_widget"`

Unit tests:
```bash
npm run test:packages -- packages/core/editor-widget-creation/src/components/__tests__/create-widget.test.tsx
```

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features) — not applicable for internal analytics

Fixes https://elementor.atlassian.net/browse/ED-23550

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add Mixpanel analytics tracking to Angie search-widget CTA interactions to monitor user engagement and installation flow.

Main changes:
- Added 'angie_cta_clicked' and 'angie_install_started' event tracking with entry_point and installation status metadata
- Refactored CreateWidget component to extract modal logic and properly manage event tracking lifecycle
- Updated widget creation event detail to include entry_point parameter for analytics context propagation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
