### PR TITLE
Fix: Gate Angie install promotions on plugin active or admin [ED-23546] cp

### DIFF
--- a/assets/dev/js/editor/regions/panel/pages/elements/elements.js
+++ b/assets/dev/js/editor/regions/panel/pages/elements/elements.js
@@ -7,6 +7,10 @@ var PanelElementsCategoriesCollection = require( './collections/categories' ),
 	PanelElementsWidgetCreationView = require( './views/widget-creation' ),
 	PanelElementsLayoutView;
 
+function elementorIsAngieIframeInDocument() {
+	return !! document.querySelector( 'iframe[src*="angie/"]' );
+}
+
 PanelElementsLayoutView = Marionette.LayoutView.extend( {
 	template: '#tmpl-elementor-panel-elements',
 
@@ -276,6 +280,14 @@ PanelElementsLayoutView = Marionette.LayoutView.extend( {
 		const filterValue = elementor.channels.panelElements.request( 'filter:value' );
 
 		if ( ! filterValue ) {
+			this.widgetCreation.empty();
+			return;
+		}
+
+		const isAngiePresent = elementorIsAngieIframeInDocument();
+		const isAdministrator = elementor.config.user.is_administrator;
+
+		if ( ! isAngiePresent && ! isAdministrator ) {
 			this.widgetCreation.empty();
 			return;
 		}


### PR DESCRIPTION
Cherry-pick of #35280 to 4.00.

**Original PR:** https://github.com/elementor/elementor/pull/35280

**Summary:** Hide Angie widget-creation install promotions for non-administrators when the Angie plugin is not active; keep promotions for all users when Angie is active, and for administrators when it is not.

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Angie install promotion visibility by restricting widget creation prompts to active plugin sessions or administrator users to prevent unauthorized display.

Main changes:
- Added elementorIsAngieIframeInDocument() utility function to detect Angie plugin iframe presence in DOM
- Implemented access control check combining Angie iframe detection and administrator role verification
- Early return prevents widget creation view rendering when neither condition is met

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
