### PR TITLE
Fix: Properly reset close button styles across all shared modals [ED-23556]

### DIFF
--- a/assets/dev/scss/admin/_beta-tester.scss
+++ b/assets/dev/scss/admin/_beta-tester.scss
@@ -14,10 +14,6 @@
 			}
 		}
 
-		.elementor-templates-modal__header__close {
-			border: none;
-		}
-
 		.elementor-beta-tester-do-not-show-again {
 			text-transform: uppercase;
 			font-weight: bold;

--- a/assets/dev/scss/common/_dialog-templates.scss
+++ b/assets/dev/scss/common/_dialog-templates.scss
@@ -87,6 +87,7 @@
 		&__items-area {
 			display: flex;
 			flex-direction: row-reverse;
+			align-items: center;
 		}
 
 		&__item {
@@ -108,6 +109,16 @@
 		}
 
 		&__close {
+			// Reset browser button defaults when rendered as a <button> element
+			&:is(button) {
+				background: transparent;
+				margin: 0;
+				font-size: inherit;
+				font-family: inherit;
+				color: inherit;
+				border: none;
+				cursor: pointer;
+			}
 
 			&--normal {
 				width: 47px;

--- a/assets/dev/scss/editor/_templates-modal.scss
+++ b/assets/dev/scss/editor/_templates-modal.scss
@@ -34,12 +34,6 @@ $remote-templates-items-space: 30px;
 		@include focus-outline($radius: 2px);
 	}
 
-	// Reset button styles for the close button changed from div to button
-	button.elementor-templates-modal__header__close {
-		@include button-reset;
-		cursor: pointer;
-	}
-
 	a.elementor-template-library-blank-footer-link {
 		font-style: normal;
 		text-decoration: underline;


### PR DESCRIPTION
## Summary
- The modal close button was changed from a `<div>` to a `<button>` (ED-18852) for accessibility, but the browser-default button reset was only applied inside `#elementor-template-library-modal`
- All other modals sharing the same header template were broken: Finder, Hotkeys, New Template, and Beta Tester showed a box-styled button instead of a clean icon
- Moved the `button` reset into `_dialog-templates.scss` using `:is(button)` so it applies universally to every modal using `.elementor-templates-modal__header__close`
- Added `align-items: center` to `__items-area` to fix vertical misalignment between close button and adjacent items (e.g. Beta Tester's "Don't Show Again" text)
- Removed the now-redundant `button` reset from `_templates-modal.scss` and the partial `border: none` workaround from `_beta-tester.scss`

## Test plan
- [ ] Open Finder (Cmd+E) — close button should show as a clean × icon with a left border, not a box
- [ ] Open Keyboard Shortcuts modal — close button should look correct
- [ ] WP Admin > Templates > Add New — close button styled correctly
- [ ] WP Admin > Elementor > Beta Tester modal — close button and "Don't Show Again" text should be vertically aligned
- [ ] Open Template Library (Add Template in editor) — regression check, close button still looks correct

## Jira
[ED-23556](https://elementor.atlassian.net/browse/ED-23556)

[ED-23556]: https://elementor.atlassian.net/browse/ED-23556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix inconsistent close button styling in shared modal components by consolidating button reset styles into common dialog template styles.

Main changes:
- Removed duplicate button style resets from beta-tester.scss and templates-modal.scss to eliminate redundancy
- Added centralized button reset styles in dialog-templates.scss using :is(button) selector for proper rendering
- Fixed modal header items alignment by adding center alignment to items-area flexbox container

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
