### PR TITLE
Revert "Fix: Properly reset close button styles across all shared modals [ED-23556]"

### DIFF
--- a/assets/dev/scss/admin/_beta-tester.scss
+++ b/assets/dev/scss/admin/_beta-tester.scss
@@ -14,6 +14,10 @@
 			}
 		}
 
+		.elementor-templates-modal__header__close {
+			border: none;
+		}
+
 		.elementor-beta-tester-do-not-show-again {
 			text-transform: uppercase;
 			font-weight: bold;

--- a/assets/dev/scss/common/_dialog-templates.scss
+++ b/assets/dev/scss/common/_dialog-templates.scss
@@ -87,7 +87,6 @@
 		&__items-area {
 			display: flex;
 			flex-direction: row-reverse;
-			align-items: center;
 		}
 
 		&__item {
@@ -109,16 +108,6 @@
 		}
 
 		&__close {
-			// Reset browser button defaults when rendered as a <button> element
-			&:is(button) {
-				background: transparent;
-				margin: 0;
-				font-size: inherit;
-				font-family: inherit;
-				color: inherit;
-				border: none;
-				cursor: pointer;
-			}
 
 			&--normal {
 				width: 47px;

--- a/assets/dev/scss/editor/_templates-modal.scss
+++ b/assets/dev/scss/editor/_templates-modal.scss
@@ -34,6 +34,12 @@ $remote-templates-items-space: 30px;
 		@include focus-outline($radius: 2px);
 	}
 
+	// Reset button styles for the close button changed from div to button
+	button.elementor-templates-modal__header__close {
+		@include button-reset;
+		cursor: pointer;
+	}
+
 	a.elementor-template-library-blank-footer-link {
 		font-style: normal;
 		text-decoration: underline;


### PR DESCRIPTION
Reverts elementor/elementor#35305
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert previous modal close button styling changes that normalized button element appearance across shared modal components.

Main changes:
- Removed generic button element style resets from dialog-templates.scss __close selector affecting all modal instances
- Restored specific button-reset mixin and cursor styling only in templates-modal.scss for targeted component
- Removed align-items center property from modal header items-area and added border-none to beta-tester close button

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
