### PR TITLE
Internal: Skip video related tests [ED-23584]

### DIFF
--- a/tests/elements-regression/tests/elements-regression.test.ts
+++ b/tests/elements-regression/tests/elements-regression.test.ts
@@ -33,7 +33,8 @@ test.describe( 'Elementor regression tests with templates for CORE', () => {
 		'image_box',
 		'image_carousel',
 		'tabs',
-		'video',
+		// TODO: to be fixed in ED-23584
+		// 'video',
 		'spacer',
 		'text_path',
 		'social_icons',

--- a/tests/playwright/sanity/modules/container/container-1.test.ts
+++ b/tests/playwright/sanity/modules/container/container-1.test.ts
@@ -64,7 +64,8 @@ test.describe( 'Container tests #1 @container', () => {
 		expect.soft( elBeforeButton ).toEqual( elAfterHeading );
 	} );
 
-	test( 'Test widgets display inside the container using various directions and content width', async ( { page, apiRequests }, testInfo ) => {
+	// TODO: to be fixed in ED-23584
+	test.skip( 'Test widgets display inside the container using various directions and content width', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
 		const editor = await wpAdmin.openNewPage();

--- a/tests/playwright/sanity/modules/container/container-3.test.ts
+++ b/tests/playwright/sanity/modules/container/container-3.test.ts
@@ -5,7 +5,8 @@ import EditorPage from '../../../pages/editor-page';
 import ContextMenu from '../../../pages/widgets/context-menu';
 
 test.describe( 'Container tests #3 @container', () => {
-	test( 'Widget display inside container flex wrap', async ( { page, apiRequests }, testInfo ) => {
+	// TODO: to be fixed in ED-23584
+	test.skip( 'Widget display inside container flex wrap', async ( { page, apiRequests }, testInfo ) => {
 		// Arrange.
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
 		const contextMenu = new ContextMenu( page, testInfo );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Temporarily disable video widget tests in regression and container test suites to unblock CI pipeline while video-related functionality is being fixed.

Main changes:
- Commented out 'video' widget from elements regression test suite template list
- Skipped container test for widgets display with various directions and content width
- Skipped container flex wrap widget display test with TODO references to ED-23584

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
