### PR TITLE
Internal: [V4] migrate submit button's content key from label to text

### DIFF
--- a/migrations/manifest.json
+++ b/migrations/manifest.json
@@ -1,5 +1,9 @@
 {
-  "widgetKeys": {},
+  "widgetKeys": {
+    "e-form-submit-button": [
+      { "from": "label", "to": "text" }
+    ]
+  },
   "propTypes": {
     "string-to-html": {
       "fromType": "string",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add widget key migration configuration to rename submit button's content property from 'label' to 'text' for V4 form component updates.

Main changes:
- Added widgetKeys migration entry for e-form-submit-button component to map 'label' key to 'text'
- Replaced empty widgetKeys object with structured migration configuration in manifest.json

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
