### PR TITLE
Fix: Attributes value escaping while typing. [ED-23331]

### DIFF
--- a/modules/atomic-widgets/prop-types/key-value-prop-type.php
+++ b/modules/atomic-widgets/prop-types/key-value-prop-type.php
@@ -22,9 +22,15 @@ class Key_Value_Prop_Type extends Object_Prop_Type {
 	}
 
 	public function sanitize_value( $value ) {
-		$value['key'] = String_Prop_Type::generate( esc_attr( $value['key']['value'] ) );
-		$value['value'] = String_Prop_Type::generate( esc_attr( $value['value']['value'] ) );
-
+		$prop_type = String_Prop_Type::make();
+		if ( isset( $value['key'] ) ) {
+			$clean_key = esc_attr( $prop_type->sanitize( $value['key'] )['value'] );
+			$value['key'] = String_Prop_Type::generate( $clean_key );
+		}
+		if ( isset( $value['value'] ) ) {
+			$clean_value = esc_attr( $prop_type->sanitize( $value['value'] )['value'] );
+			$value['value'] = String_Prop_Type::generate( $clean_value );
+		}
 		return $value;
 	}
 }

--- a/modules/atomic-widgets/prop-types/key-value-prop-type.php
+++ b/modules/atomic-widgets/prop-types/key-value-prop-type.php
@@ -20,4 +20,11 @@ class Key_Value_Prop_Type extends Object_Prop_Type {
 			'value' => String_Prop_Type::make(),
 		];
 	}
+
+	public function sanitize_value( $value ) {
+		$value['key'] = String_Prop_Type::generate( esc_attr( $value['key']['value'] ) );
+		$value['value'] = String_Prop_Type::generate( esc_attr( $value['value']['value'] ) );
+
+		return $value;
+	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix attribute value escaping in key-value prop types to prevent XSS vulnerabilities and ensure proper HTML attribute sanitization during user input.

Main changes:
- Added sanitize_value() method to Key_Value_Prop_Type class with esc_attr() protection for both key and value fields
- Implemented nested sanitization using String_Prop_Type for proper value processing before HTML attribute escaping
- Applied sanitization to both 'key' and 'value' fields when present to ensure consistent security across all attribute inputs

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
