### PR TITLE
Internal: Show placeholders for inherited values [ED-22215]

### DIFF
--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/__tests__/override-prop-control.test.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/__tests__/override-prop-control.test.tsx
@@ -222,7 +222,9 @@ describe( '<OverridePropControl />', () => {
 
 			// Assert
 			expect( screen.getByText( 'Nested Title' ) ).toBeInTheDocument();
-			expect( screen.getByDisplayValue( 'Element 1 Original Title' ) ).toBeInTheDocument();
+			const input = screen.getByRole( 'textbox' );
+			expect( input ).toHaveValue( '' );
+			expect( input ).toHaveAttribute( 'placeholder', 'Element 1 Original Title' );
 			expect( getElementType ).toHaveBeenCalledWith( 'e-heading' );
 		} );
 	} );
@@ -277,7 +279,7 @@ describe( '<OverridePropControl />', () => {
 			},
 		} );
 
-		it( 'should show originValue when override is cleared (single level)', () => {
+		it( 'should show empty value with no placeholder when override exists with null value (single level)', () => {
 			// Arrange
 			const overridableProp: OverridableProp = {
 				overrideKey: INNER_OVERRIDE_KEY_1,
@@ -317,10 +319,49 @@ describe( '<OverridePropControl />', () => {
 
 			// Assert
 			const input = screen.getByRole( 'textbox' );
-			expect( input ).toHaveValue( 'Innermost Origin Value' );
+			expect( input ).toHaveValue( '' );
+			expect( input ).not.toHaveAttribute( 'placeholder' );
 		} );
 
-		it( 'should recursively find origin value through nested overridable structure', () => {
+		it( 'should show originValue as placeholder when no override exists (single level)', () => {
+			// Arrange
+			const overridableProp: OverridableProp = {
+				overrideKey: INNER_OVERRIDE_KEY_1,
+				label: 'Title',
+				elementId: INNER_ELEMENT_ID,
+				propKey: 'title',
+				widgetType: 'e-heading',
+				elType: 'widget',
+				groupId: 'content',
+				originValue: INNER_ORIGIN_VALUE_1,
+			};
+
+			setupElementsMocks( { [ INNER_ELEMENT_ID ]: INNER_ELEMENT } );
+			setupNestedComponents( [
+				{
+					componentId: INNER_COMPONENT_ID,
+					elementId: INNER_ELEMENT_ID,
+					props: [
+						{
+							overrideKey: INNER_OVERRIDE_KEY_1,
+							propKey: 'title',
+							label: 'Title',
+							originValue: INNER_ORIGIN_VALUE_1,
+						},
+					],
+				},
+			] );
+
+			// Act
+			renderOverridePropControl( store, overridableProp, [], INNER_COMPONENT_ID );
+
+			// Assert
+			const input = screen.getByRole( 'textbox' );
+			expect( input ).toHaveValue( '' );
+			expect( input ).toHaveAttribute( 'placeholder', 'Innermost Origin Value' );
+		} );
+
+		it( 'should show empty value with no placeholder when nested override exists with null value', () => {
 			// Arrange
 			const overridablePropWithNullOrigin: OverridableProp = {
 				overrideKey: MIDDLE_OVERRIDE_KEY_1,
@@ -395,12 +436,77 @@ describe( '<OverridePropControl />', () => {
 
 			// Assert
 			const input = screen.getByRole( 'textbox' );
-			expect( input ).toHaveValue( 'Innermost Origin Value' );
+			expect( input ).toHaveValue( '' );
+			expect( input ).not.toHaveAttribute( 'placeholder' );
 		} );
 
-		it( 'should resolve correct origin when multiple props share the same elementId', () => {
+		it( 'should recursively find origin value as placeholder when no override exists', () => {
 			// Arrange
+			const overridablePropWithNullOrigin: OverridableProp = {
+				overrideKey: MIDDLE_OVERRIDE_KEY_1,
+				label: 'Nested Title',
+				elementId: MIDDLE_ELEMENT_ID,
+				propKey: 'title',
+				widgetType: 'e-heading',
+				elType: 'widget',
+				groupId: 'content',
+				originValue: null,
+				originPropFields: {
+					propKey: 'title',
+					widgetType: 'e-heading',
+					elType: 'widget',
+					elementId: INNER_ELEMENT_ID,
+				},
+			};
 
+			setupElementsMocks( {
+				[ INNER_ELEMENT_ID ]: INNER_ELEMENT,
+				[ MIDDLE_ELEMENT_ID ]: INNER_COMPONENT_INSTANCE,
+			} );
+			setupNestedComponents( [
+				{
+					componentId: INNER_COMPONENT_ID,
+					elementId: INNER_ELEMENT_ID,
+					props: [
+						{
+							overrideKey: INNER_OVERRIDE_KEY_1,
+							propKey: 'title',
+							label: 'Title',
+							originValue: INNER_ORIGIN_VALUE_1,
+						},
+					],
+				},
+				{
+					componentId: MIDDLE_COMPONENT_ID,
+					elementId: MIDDLE_ELEMENT_ID,
+					props: [
+						{
+							overrideKey: MIDDLE_OVERRIDE_KEY_1,
+							propKey: 'title',
+							label: 'Title',
+							originValue: null,
+							originPropFields: {
+								propKey: 'title',
+								widgetType: 'e-heading',
+								elType: 'widget',
+								elementId: INNER_ELEMENT_ID,
+							},
+						},
+					],
+				},
+			] );
+
+			// Act
+			renderOverridePropControl( store, overridablePropWithNullOrigin, [], MIDDLE_COMPONENT_ID );
+
+			// Assert
+			const input = screen.getByRole( 'textbox' );
+			expect( input ).toHaveValue( '' );
+			expect( input ).toHaveAttribute( 'placeholder', 'Innermost Origin Value' );
+		} );
+
+		it( 'should show empty value with no placeholder when override exists for specific prop among multiple', () => {
+			// Arrange
 			const linkOverridableProp: OverridableProp = {
 				overrideKey: MIDDLE_OVERRIDE_KEY_2,
 				label: 'Link',
@@ -487,7 +593,91 @@ describe( '<OverridePropControl />', () => {
 
 			// Assert
 			const input = screen.getByRole( 'textbox' );
-			expect( input ).toHaveValue( 'Link Origin Value' );
+			expect( input ).toHaveValue( '' );
+			expect( input ).not.toHaveAttribute( 'placeholder' );
+		} );
+
+		it( 'should resolve correct origin as placeholder when no override exists for specific prop among multiple', () => {
+			// Arrange
+			const linkOverridableProp: OverridableProp = {
+				overrideKey: MIDDLE_OVERRIDE_KEY_2,
+				label: 'Link',
+				elementId: MIDDLE_ELEMENT_ID,
+				propKey: 'link',
+				widgetType: 'e-heading',
+				elType: 'widget',
+				groupId: 'content',
+				originValue: null,
+				originPropFields: {
+					propKey: 'link',
+					widgetType: 'e-heading',
+					elType: 'widget',
+					elementId: INNER_ELEMENT_ID,
+				},
+			};
+
+			setupNestedComponents( [
+				{
+					componentId: INNER_COMPONENT_ID,
+					elementId: INNER_ELEMENT_ID,
+					props: [
+						{
+							overrideKey: INNER_OVERRIDE_KEY_1,
+							propKey: 'title',
+							label: 'Title',
+							originValue: INNER_ORIGIN_VALUE_1,
+						},
+						{
+							overrideKey: INNER_OVERRIDE_KEY_2,
+							propKey: 'link',
+							label: 'Link',
+							originValue: INNER_ORIGIN_VALUE_2,
+						},
+					],
+				},
+				{
+					componentId: MIDDLE_COMPONENT_ID,
+					elementId: MIDDLE_ELEMENT_ID,
+					props: [
+						{
+							overrideKey: MIDDLE_OVERRIDE_KEY_1,
+							propKey: 'title',
+							label: 'Title',
+							originValue: null,
+							originPropFields: {
+								propKey: 'title',
+								widgetType: 'e-heading',
+								elType: 'widget',
+								elementId: INNER_ELEMENT_ID,
+							},
+						},
+						{
+							overrideKey: MIDDLE_OVERRIDE_KEY_2,
+							propKey: 'link',
+							label: 'Link',
+							originValue: null,
+							originPropFields: {
+								propKey: 'link',
+								widgetType: 'e-heading',
+								elType: 'widget',
+								elementId: INNER_ELEMENT_ID,
+							},
+						},
+					],
+				},
+			] );
+			setupElementsMocks( {
+				[ INNER_ELEMENT_ID ]: INNER_ELEMENT,
+				[ MIDDLE_ELEMENT_ID ]: INNER_COMPONENT_INSTANCE,
+			} );
+
+			// Act
+			renderOverridePropControl( store, linkOverridableProp, [], MIDDLE_COMPONENT_ID );
+
+			// Assert
+			const input = screen.getByRole( 'textbox' );
+			expect( input ).toHaveValue( '' );
+			expect( input ).toHaveAttribute( 'placeholder', 'Link Origin Value' );
 		} );
 	} );
 } );

--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/override-prop-control.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/override-prop-control.tsx
@@ -158,10 +158,18 @@ function OverrideControl( { overridableProp }: InternalProps ) {
 		return null;
 	}
 
-	const propValue = resolvedElementSettings[ propKey ];
+	const { propValue, placeholderValue } = resolveValueAndPlaceholder(
+		matchingOverride,
+		settingsWithInnerOverrides,
+		propKey
+	);
 
 	const value = {
 		[ overridableProp.overrideKey ]: propValue,
+	} as OverridesSchema;
+
+	const placeholder = {
+		[ overridableProp.overrideKey ]: placeholderValue,
 	} as OverridesSchema;
 
 	const setValue = ( newValue: OverridesSchema ) => {
@@ -247,6 +255,7 @@ function OverrideControl( { overridableProp }: InternalProps ) {
 						propType={ propTypeSchema }
 						value={ value }
 						setValue={ setValue }
+						placeholder={ placeholder }
 						isDisabled={ () => {
 							return false;
 						} }
@@ -270,7 +279,27 @@ function OverrideControl( { overridableProp }: InternalProps ) {
 	);
 }
 
-// temp solution to allow dynamic values to be overridden, will be removed once placeholder is implemented
+type ElementSettings = Record< string, AnyTransformable | null >;
+
+function resolveValueAndPlaceholder(
+	matchingOverride: ComponentInstanceOverride | null,
+	settingsWithInnerOverrides: ElementSettings,
+	propKey: string
+) {
+	const overrideValue = matchingOverride ? resolveOverridePropValue( matchingOverride ) : null;
+
+	const placeholderSettings = unwrapOverridableSettings( settingsWithInnerOverrides );
+	const inheritedValue = placeholderSettings[ propKey ] ?? null;
+	const isInheritedDynamic = isDynamicPropValue( inheritedValue );
+
+	const propValue = isInheritedDynamic && ! matchingOverride ? inheritedValue : overrideValue;
+	const placeholderValue = matchingOverride || isInheritedDynamic ? null : inheritedValue;
+
+	return { propValue, placeholderValue };
+}
+
+// Temp solution: when removing an override on a dynamic value, fall back to propType.default
+// instead of null, since we don't have placeholder support for dynamics yet.
 function getTempNewValueForDynamicProp( propType: PropType, propValue: PropValue, newPropValue: PropValue ) {
 	const isRemovingOverride = newPropValue === null;
 

--- a/packages/packages/libs/editor-controls/src/bound-prop-context/prop-key-context.tsx
+++ b/packages/packages/libs/editor-controls/src/bound-prop-context/prop-key-context.tsx
@@ -89,12 +89,21 @@ const ArrayPropKeyProvider = ( { children, bind }: PropKeyProviderProps ) => {
 	};
 
 	const value = context.value?.[ Number( bind ) ];
+	const placeholder = context.placeholder?.[ Number( bind ) ];
 
 	const propType = context.propType.item_prop_type;
 
 	return (
 		<PropKeyContext.Provider
-			value={ { ...context, value, setValue, bind, propType, path: [ ...( path ?? [] ), bind ] } }
+			value={ {
+				...context,
+				value,
+				setValue,
+				bind,
+				propType,
+				path: [ ...( path ?? [] ), bind ],
+				placeholder: placeholder ?? undefined,
+			} }
 		>
 			{ children }
 		</PropKeyContext.Provider>

--- a/packages/packages/libs/editor-controls/src/bound-prop-context/use-bound-prop.ts
+++ b/packages/packages/libs/editor-controls/src/bound-prop-context/use-bound-prop.ts
@@ -73,7 +73,10 @@ export function useBoundProp< TKey extends string, TValue extends PropValue >(
 
 	const propType = resolveUnionPropType( propKeyContext.propType, propTypeUtil.key );
 
-	const value = propTypeUtil.extract( propKeyContext.value ?? propType.default ?? null );
+	const hasPlaceholder = propKeyContext.placeholder !== undefined && propKeyContext.placeholder !== null;
+	const fallbackValue = hasPlaceholder ? null : propType.default;
+
+	const value = propTypeUtil.extract( propKeyContext.value ?? fallbackValue ?? null );
 	const placeholder = propTypeUtil.extract( propKeyContext.placeholder ?? null );
 
 	return {

--- a/packages/packages/libs/editor-controls/src/components/inline-editor.tsx
+++ b/packages/packages/libs/editor-controls/src/components/inline-editor.tsx
@@ -25,6 +25,7 @@ const UNDERLINE_KEYBOARD_SHORTCUT = 'u';
 type InlineEditorProps = {
 	value: string | null;
 	setValue: ( value: string | null ) => void;
+	placeholder?: string | null;
 	editorProps?: EditorProps;
 	elementClasses?: string;
 	sx?: SxProps< Theme >;
@@ -41,6 +42,7 @@ export const InlineEditor = React.forwardRef( ( props: InlineEditorProps, ref ) 
 	const {
 		value,
 		setValue,
+		placeholder = null,
 		editorProps = {},
 		elementClasses = '',
 		autofocus = false,
@@ -139,6 +141,8 @@ export const InlineEditor = React.forwardRef( ( props: InlineEditorProps, ref ) 
 			attributes: {
 				...( editorProps.attributes ?? {} ),
 				role: 'textbox',
+				...( placeholder ? { 'data-placeholder': placeholder } : {} ),
+				...( value === null || value === '' ? { class: 'is-empty' } : {} ),
 			},
 		},
 		onCreate: onEditorCreate ? ( { editor: mountedEditor } ) => onEditorCreate( mountedEditor ) : undefined,

--- a/packages/packages/libs/editor-controls/src/controls/image-media-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/image-media-control.tsx
@@ -14,11 +14,12 @@ type ImageMediaControlProps = {
 };
 
 export const ImageMediaControl = createControl( ( { mediaTypes = [ 'image' ] }: ImageMediaControlProps ) => {
-	const { value, setValue, propType } = useBoundProp( imageSrcPropTypeUtil );
+	const { value, setValue, propType, placeholder } = useBoundProp( imageSrcPropTypeUtil );
 	const { id, url } = value ?? {};
 
 	const { data: attachment, isFetching } = useWpMediaAttachment( id?.value || null );
-	const src = attachment?.url ?? url?.value ?? null;
+	const { data: placeholderAttachment } = useWpMediaAttachment( placeholder?.id?.value || null );
+	const src = attachment?.url ?? url?.value ?? placeholderAttachment?.url ?? null;
 
 	const { open } = useWpMediaFrame( {
 		mediaTypes,

--- a/packages/packages/libs/editor-controls/src/controls/inline-editing-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/inline-editing-control.tsx
@@ -21,7 +21,7 @@ export const InlineEditingControl = createControl(
 		attributes?: Record< string, string >;
 		props?: ComponentProps< 'div' >;
 	} ) => {
-		const { value, setValue } = useBoundProp( htmlV3PropTypeUtil );
+		const { value, setValue, placeholder } = useBoundProp( htmlV3PropTypeUtil );
 		const content = stringPropTypeUtil.extract( value?.content ?? null ) ?? '';
 
 		const debouncedParse = useMemo(
@@ -82,6 +82,13 @@ export const InlineEditingControl = createControl(
 								margin: 0,
 								padding: 0,
 							},
+							'&.is-empty::before': {
+								content: 'attr(data-placeholder)',
+								color: 'text.tertiary',
+								pointerEvents: 'none',
+								position: 'absolute',
+								opacity: 0.6,
+							},
 						},
 						'.strip-styles *': {
 							all: 'unset',
@@ -91,7 +98,11 @@ export const InlineEditingControl = createControl(
 					{ ...attributes }
 					{ ...props }
 				>
-					<InlineEditor value={ content } setValue={ handleChange } />
+					<InlineEditor
+						value={ content }
+						setValue={ handleChange }
+						placeholder={ placeholder?.content?.value ?? null }
+					/>
 				</Box>
 			</ControlActions>
 		);

--- a/packages/packages/libs/editor-controls/src/controls/link-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/link-control.tsx
@@ -42,8 +42,9 @@ const SIZE = 'tiny';
 
 export const LinkControl = createControl( ( props: Props ) => {
 	const { value, path, setValue, ...propContext } = useBoundProp( linkPropTypeUtil );
+	const linkPlaceholder = propContext.placeholder;
 	const [ linkSessionValue, setLinkSessionValue ] = useSessionStorage< LinkSessionValue >( path.join( '/' ) );
-	const [ isActive, setIsActive ] = useState( !! value );
+	const [ isActive, setIsActive ] = useState( !! value || !! linkPlaceholder );
 
 	const {
 		allowCustomValues = true,
@@ -56,22 +57,23 @@ export const LinkControl = createControl( ( props: Props ) => {
 	} = props || {};
 
 	const [ linkInLinkRestriction, setLinkInLinkRestriction ] = useState(
-		getLinkInLinkRestriction( elementId, value )
+		getLinkInLinkRestriction( elementId, value ?? linkPlaceholder )
 	);
+
 	const shouldDisableAddingLink = ! isActive && linkInLinkRestriction.shouldRestrict;
 
 	const debouncedCheckRestriction = useMemo(
 		() =>
 			debounce( () => {
-				const newRestriction = getLinkInLinkRestriction( elementId, value );
+				const newRestriction = getLinkInLinkRestriction( elementId, value ?? linkPlaceholder );
 
-				if ( newRestriction.shouldRestrict && isActive ) {
+				if ( newRestriction.shouldRestrict && isActive && ! linkPlaceholder ) {
 					setIsActive( false );
 				}
 
 				setLinkInLinkRestriction( newRestriction );
 			}, 300 ),
-		[ elementId, isActive, value ]
+		[ elementId, isActive, value, linkPlaceholder ]
 	);
 
 	useEffect( () => {
@@ -94,7 +96,7 @@ export const LinkControl = createControl( ( props: Props ) => {
 	}, [ elementId, debouncedCheckRestriction ] );
 
 	const onEnabledChange = () => {
-		setLinkInLinkRestriction( getLinkInLinkRestriction( elementId, value ) );
+		setLinkInLinkRestriction( getLinkInLinkRestriction( elementId, value ?? linkPlaceholder ) );
 
 		if ( linkInLinkRestriction.shouldRestrict && ! isActive ) {
 			return;
@@ -141,12 +143,14 @@ export const LinkControl = createControl( ( props: Props ) => {
 				>
 					<ControlLabel>{ label }</ControlLabel>
 					<RestrictedLinkInfotip isVisible={ ! isActive } linkInLinkRestriction={ linkInLinkRestriction }>
-						<ToggleIconControl
+						<IconButton
+							size={ SIZE }
+							onClick={ onEnabledChange }
+							aria-label={ __( 'Toggle link', 'elementor' ) }
 							disabled={ shouldDisableAddingLink }
-							active={ isActive }
-							onIconClick={ onEnabledChange }
-							label={ __( 'Toggle link', 'elementor' ) }
-						/>
+						>
+							{ isActive ? <MinusIcon fontSize={ SIZE } /> : <PlusIcon fontSize={ SIZE } /> }
+						</IconButton>
 					</RestrictedLinkInfotip>
 				</Stack>
 				<Collapse in={ isActive } timeout="auto" unmountOnExit>
@@ -177,18 +181,3 @@ export const LinkControl = createControl( ( props: Props ) => {
 		</PropProvider>
 	);
 } );
-
-type ToggleIconControlProps = {
-	disabled: boolean;
-	active: boolean;
-	onIconClick: () => void;
-	label?: string;
-};
-
-const ToggleIconControl = ( { disabled, active, onIconClick, label }: ToggleIconControlProps ) => {
-	return (
-		<IconButton size={ SIZE } onClick={ onIconClick } aria-label={ label } disabled={ disabled }>
-			{ active ? <MinusIcon fontSize={ SIZE } /> : <PlusIcon fontSize={ SIZE } /> }
-		</IconButton>
-	);
-};

--- a/packages/packages/libs/editor-controls/src/controls/query-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/query-control.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { useMemo, useState } from 'react';
-import { numberPropTypeUtil, stringPropTypeUtil, urlPropTypeUtil } from '@elementor/editor-props';
+import {
+	numberPropTypeUtil,
+	queryPropTypeUtil,
+	type QueryPropValue,
+	stringPropTypeUtil,
+	urlPropTypeUtil,
+} from '@elementor/editor-props';
 import { type HttpResponse, httpService } from '@elementor/http-client';
 import { SearchIcon } from '@elementor/icons';
 import { debounce } from '@elementor/utils';
@@ -35,56 +41,51 @@ type Response = HttpResponse< { value: FlatOption[] | CategorizedOption[] } >;
 type FetchOptionsParams = Record< string, unknown > & { term: string };
 
 export const QueryControl = createControl( ( props: Props ) => {
-	const { value, setValue } = useBoundProp< DestinationProp >();
+	const { value: queryValue, setValue: setQueryValue } = useBoundProp( queryPropTypeUtil );
+	const { value: urlValue, setValue: setUrlValue, placeholder: urlPlaceholder } = useBoundProp( urlPropTypeUtil );
 
 	const {
 		allowCustomValues = true,
 		queryOptions: { url, params = {} },
-		placeholder,
+		placeholder = __( 'Search', 'elementor' ),
 		minInputLength = 2,
 		onSetValue,
 		ariaLabel,
 	} = props || {};
 
-	const normalizedPlaceholder = placeholder || __( 'Search', 'elementor' );
-
 	const [ options, setOptions ] = useState< FlatOption[] | CategorizedOption[] >(
-		generateFirstLoadedOption( value?.value )
+		generateFirstLoadedOption( queryValue )
 	);
 
 	const onOptionChange = ( newValue: number | null ) => {
 		if ( newValue === null ) {
-			setValue( null );
+			setQueryValue( null );
 			onSetValue?.( null );
 
 			return;
 		}
 
-		const valueToSave = {
-			$$type: 'query',
-			value: {
-				id: numberPropTypeUtil.create( newValue ),
-				label: stringPropTypeUtil.create( findMatchingOption( options, newValue )?.label || null ),
-			},
+		const newQueryValue = {
+			id: numberPropTypeUtil.create( newValue ),
+			label: stringPropTypeUtil.create( findMatchingOption( options, newValue )?.label || null ),
 		};
 
-		setValue( valueToSave );
-		onSetValue?.( valueToSave );
+		setQueryValue( newQueryValue );
+		onSetValue?.( queryPropTypeUtil.create( newQueryValue ) );
 	};
 
 	const onTextChange = ( newValue: string | null ) => {
-		if ( ! newValue ) {
-			setValue( null );
+		const trimmedValue = newValue?.trim() || '';
+
+		if ( ! trimmedValue ) {
+			setUrlValue( null );
 			onSetValue?.( null );
 
 			return;
 		}
 
-		const newLinkValue = newValue?.trim() || '';
-		const valueToSave = newLinkValue ? urlPropTypeUtil.create( newLinkValue ) : null;
-
-		setValue( valueToSave );
-		onSetValue?.( valueToSave );
+		setUrlValue( trimmedValue );
+		onSetValue?.( urlPropTypeUtil.create( trimmedValue ) );
 		updateOptions( newValue );
 	};
 
@@ -110,14 +111,16 @@ export const QueryControl = createControl( ( props: Props ) => {
 		[ url ]
 	);
 
+	const displayValue = queryValue?.id?.value ?? urlValue;
+
 	return (
 		<ControlActions>
 			<Autocomplete
 				options={ options }
 				allowCustomValues={ allowCustomValues }
-				placeholder={ normalizedPlaceholder }
+				placeholder={ urlPlaceholder ?? placeholder }
 				startAdornment={ <SearchIcon fontSize="tiny" /> }
-				value={ value?.value?.id?.value || value?.value }
+				value={ displayValue }
 				onOptionChange={ onOptionChange }
 				onTextChange={ onTextChange }
 				minInputLength={ minInputLength }
@@ -152,17 +155,15 @@ function formatOptions( options: FlatOption[] | CategorizedOption[] ): FlatOptio
 	);
 }
 
-function generateFirstLoadedOption( unionValue: DestinationProp | null ): FlatOption[] {
-	const value = unionValue?.id?.value;
-	const label = unionValue?.label?.value;
-	const type = unionValue?.id?.$$type || 'url';
+function generateFirstLoadedOption( queryValue: QueryPropValue[ 'value' ] | null ): FlatOption[] {
+	const id = queryValue?.id?.value;
+	const label = queryValue?.label?.value;
 
-	return value && label && type === 'number'
-		? [
-				{
-					id: value.toString(),
-					label,
-				},
-		  ]
-		: [];
+	const option = [];
+
+	if ( id && label ) {
+		option.push( { id: id.toString(), label } );
+	}
+
+	return option;
 }

--- a/packages/packages/libs/editor-controls/src/controls/switch-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/switch-control.tsx
@@ -6,7 +6,7 @@ import { useBoundProp } from '../bound-prop-context/use-bound-prop';
 import { createControl } from '../create-control';
 
 export const SwitchControl = createControl( () => {
-	const { value, setValue, disabled } = useBoundProp( booleanPropTypeUtil );
+	const { value, setValue, disabled, placeholder } = useBoundProp( booleanPropTypeUtil );
 
 	const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		setValue( event.target.checked );
@@ -15,7 +15,7 @@ export const SwitchControl = createControl( () => {
 	return (
 		<Box sx={ { display: 'flex', justifyContent: 'flex-end' } }>
 			<Switch
-				checked={ !! value }
+				checked={ !! ( value || placeholder ) }
 				onChange={ handleChange }
 				size="small"
 				disabled={ disabled }

--- a/packages/packages/libs/editor-controls/src/controls/text-area-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/text-area-control.tsx
@@ -11,12 +11,14 @@ type Props = {
 	ariaLabel?: string;
 };
 
-export const TextAreaControl = createControl( ( { placeholder, ariaLabel }: Props ) => {
-	const { value, setValue, disabled } = useBoundProp( stringPropTypeUtil );
+export const TextAreaControl = createControl( ( { placeholder: propPlaceholder, ariaLabel }: Props ) => {
+	const { value, setValue, disabled, placeholder: boundPlaceholder } = useBoundProp( stringPropTypeUtil );
 
 	const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		setValue( event.target.value );
 	};
+
+	const placeholder = propPlaceholder ?? boundPlaceholder ?? undefined;
 
 	return (
 		<ControlActions>

--- a/packages/packages/libs/editor-controls/src/controls/text-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/text-control.tsx
@@ -8,7 +8,7 @@ import { createControl } from '../create-control';
 
 export const TextControl = createControl(
 	( {
-		placeholder,
+		placeholder: propPlaceholder,
 		error,
 		inputValue,
 		inputDisabled,
@@ -24,8 +24,10 @@ export const TextControl = createControl(
 		sx?: SxProps;
 		ariaLabel?: string;
 	} ) => {
-		const { value, setValue, disabled } = useBoundProp( stringPropTypeUtil );
+		const { value, setValue, disabled, placeholder: boundPlaceholder } = useBoundProp( stringPropTypeUtil );
 		const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => setValue( event.target.value );
+
+		const placeholder = propPlaceholder ?? boundPlaceholder ?? undefined;
 
 		return (
 			<ControlActions>

--- a/packages/packages/libs/editor-controls/src/controls/url-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/url-control.tsx
@@ -7,9 +7,11 @@ import ControlActions from '../control-actions/control-actions';
 import { createControl } from '../create-control';
 
 export const UrlControl = createControl(
-	( { placeholder, ariaLabel }: { placeholder?: string; ariaLabel?: string } ) => {
-		const { value, setValue, disabled } = useBoundProp( urlPropTypeUtil );
+	( { placeholder: propPlaceholder, ariaLabel }: { placeholder?: string; ariaLabel?: string } ) => {
+		const { value, setValue, disabled, placeholder: boundPlaceholder } = useBoundProp( urlPropTypeUtil );
 		const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => setValue( event.target.value );
+
+		const placeholder = propPlaceholder ?? boundPlaceholder ?? undefined;
 
 		return (
 			<ControlActions>


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add placeholder support for inherited component instance values to improve UX by showing inherited values when overrides are not set.

Main changes:
- Implemented resolveValueAndPlaceholder() function to separate actual override values from inherited placeholder values
- Extended PropProvider and control components to accept and display placeholder values from inherited settings
- Updated placeholder resolution logic to show inherited values only when no override exists, with special handling for dynamic values

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
