### PR TITLE
Internal: Parse inline editor placeholder [ED-22215]

### DIFF
--- a/packages/packages/libs/editor-controls/src/components/__tests__/inline-editor.test.tsx
+++ b/packages/packages/libs/editor-controls/src/components/__tests__/inline-editor.test.tsx
@@ -87,4 +87,44 @@ describe( 'InlineEditor', () => {
 		expect( paragraph ).toHaveClass( 'custom-padding' );
 		expect( paragraph ).toHaveClass( 'custom-margin' );
 	} );
+
+	it.each( [
+		[ null, true ],
+		[ '', true ],
+		[ 'Some content', false ],
+	] )( 'should toggle is-empty class based on value (%s)', ( value, shouldBeEmpty ) => {
+		// Arrange & Act.
+		setup( { value } );
+
+		// Assert.
+		const editor = screen.getByRole( 'textbox' );
+
+		if ( shouldBeEmpty ) {
+			expect( editor ).toHaveClass( 'is-empty' );
+		} else {
+			expect( editor ).not.toHaveClass( 'is-empty' );
+		}
+	} );
+
+	it.each( [
+		[ 'Enter text here', 'Enter text here' ],
+		[ 'hello<br>world', 'hello\nworld' ],
+		[ '<strong>Bold</strong> text', 'Bold text' ],
+	] )( 'should convert placeholder HTML to plain text (%s)', ( placeholder, expected ) => {
+		// Arrange & Act.
+		setup( { value: null, placeholder } );
+
+		// Assert.
+		const editor = screen.getByRole( 'textbox' );
+		expect( editor ).toHaveAttribute( 'data-placeholder', expected );
+	} );
+
+	it( 'should not set data-placeholder when placeholder is null', () => {
+		// Arrange & Act.
+		setup( { value: null, placeholder: null } );
+
+		// Assert.
+		const editor = screen.getByRole( 'textbox' );
+		expect( editor ).not.toHaveAttribute( 'data-placeholder' );
+	} );
 } );

--- a/packages/packages/libs/editor-controls/src/components/inline-editor.tsx
+++ b/packages/packages/libs/editor-controls/src/components/inline-editor.tsx
@@ -16,7 +16,7 @@ import Underline from '@tiptap/extension-underline';
 import { type EditorProps, type EditorView } from '@tiptap/pm/view';
 import { type Editor, EditorContent, useEditor } from '@tiptap/react';
 
-import { isEmpty } from '../utils/inline-editing';
+import { htmlToPlainText, isEmpty } from '../utils/inline-editing';
 
 const ITALIC_KEYBOARD_SHORTCUT = 'i';
 const BOLD_KEYBOARD_SHORTCUT = 'b';
@@ -139,6 +139,8 @@ export const InlineEditor = React.forwardRef( ( props: InlineEditorProps, ref ) 
 			attributes: {
 				...( editorProps.attributes ?? {} ),
 				role: 'textbox',
+				...( placeholder ? { 'data-placeholder': htmlToPlainText( placeholder ) } : {} ),
+				...( value === null || value === '' ? { class: 'is-empty' } : {} ),
 			},
 		},
 		onCreate: onEditorCreate ? ( { editor: mountedEditor } ) => onEditorCreate( mountedEditor ) : undefined,

--- a/packages/packages/libs/editor-controls/src/utils/inline-editing.ts
+++ b/packages/packages/libs/editor-controls/src/utils/inline-editing.ts
@@ -9,3 +9,15 @@ export function isEmpty( value: string | null = '' ) {
 
 	return ! pseudoElement.textContent?.length;
 }
+
+export function htmlToPlainText( html: string | null ): string {
+	if ( ! html ) {
+		return '';
+	}
+
+	const div = document.createElement( 'div' );
+
+	div.innerHTML = html.replace( /<br\s*\/?>/gi, '\n' ).replace( /<\/p>\s*<p[^>]*>/gi, '\n' );
+
+	return div.textContent ?? '';
+}

--- a/packages/packages/libs/editor-controls/src/utils/inline-editing.ts
+++ b/packages/packages/libs/editor-controls/src/utils/inline-editing.ts
@@ -15,9 +15,8 @@ export function htmlToPlainText( html: string | null ): string {
 		return '';
 	}
 
-	const div = document.createElement( 'div' );
+	const normalizedHtml = html.replace( /<br\s*\/?>/gi, '\n' ).replace( /<\/p>\s*<p[^>]*>/gi, '\n' );
+	const doc = new DOMParser().parseFromString( normalizedHtml, 'text/html' );
 
-	div.innerHTML = html.replace( /<br\s*\/?>/gi, '\n' ).replace( /<\/p>\s*<p[^>]*>/gi, '\n' );
-
-	return div.textContent ?? '';
+	return doc.body.textContent ?? '';
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix inline editor placeholder rendering by converting HTML content to plain text to prevent HTML markup display in placeholder attribute.

Main changes:
- Added htmlToPlainText utility function to parse HTML placeholders and convert them to plain text with preserved line breaks
- Updated inline-editor component to apply htmlToPlainText transformation on placeholder attribute before rendering
- Added comprehensive test coverage for placeholder HTML parsing and is-empty class toggling scenarios

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
