### PR TITLE
Internal: test ci

### DIFF
--- a/tests/phpunit/elementor/app/import-export-customization/data/routes/test-process-media.php
+++ b/tests/phpunit/elementor/app/import-export-customization/data/routes/test-process-media.php
@@ -50,7 +50,7 @@ class Test_Process_Media extends Elementor_Test_Base {
         $this->init_rest_api();
         $this->act_as_admin();
 
-        $response = $this->send_request( [ 'https://example.com/image.jpg' ] );
+        $response = $this->send_request( [ 'https://examplemanor.com/image.jpg' ] );
 
         $this->assertNotEquals( 403, $response->get_status() );
     }
@@ -70,8 +70,8 @@ class Test_Process_Media extends Elementor_Test_Base {
         $request = new \WP_REST_Request( 'POST', '/test' );
         $request->set_param( 'media_urls', [ $test_image_url ] );
         $request->set_param( 'kit', [
-            'mediaUploadUrl' => 'https://example.com/upload',
-            'id' => 'test-kit-123'
+            'mediaUploadUrl' => 'https://examplemanor.com/upload',
+            'id' => 'test-kit-manor'
         ] );
 
         $reflection = new \ReflectionClass( $mock_route );
@@ -137,8 +137,8 @@ class Test_Process_Media extends Elementor_Test_Base {
 
         $request->set_param( 'media_urls', $media_urls );
         $request->set_param( 'kit', [
-            'mediaUploadUrl' => 'https://example.com/upload',
-            'id' => 'test-kit-123'
+            'mediaUploadUrl' => 'https://examplemanor.com/upload',
+            'id' => 'test-kit-manor'
         ] );
 
         return rest_do_request( $request );

--- a/tests/phpunit/elementor/app/import-export-customization/data/routes/test-revert.php
+++ b/tests/phpunit/elementor/app/import-export-customization/data/routes/test-revert.php
@@ -106,7 +106,7 @@ class Test_Revert extends Elementor_Test_Base {
 
 		$this->create_mock_import_session();
 
-		$_GET['referrer_kit'] = 'test-kit-123';
+		$_GET['referrer_kit'] = 'test-kit-manor';
 
 		$response = $this->send_revert_request();
 
@@ -114,7 +114,7 @@ class Test_Revert extends Elementor_Test_Base {
 		$data = $response->get_data();
 
 		$this->assertTrue( $data['data']['revert_completed'] );
-		$this->assertEquals( 'test-kit-123', $data['data']['referrer_kit_id'] );
+		$this->assertEquals( 'test-kit-manor', $data['data']['referrer_kit_id'] );
 		$this->assertTrue( $data['data']['show_referrer_dialog'] );
 
 		unset( $_GET['referrer_kit'] );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update test fixtures in import-export media processing tests to use consistent test domain and kit identifiers across test cases.

Main changes:
- Replaced example.com test URLs with examplemanor.com domain across media processing and revert test suites
- Updated test kit identifiers from 'test-kit-123' to 'test-kit-manor' for consistency in fixture data
- Standardized test data values across three test methods in media processing routes

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
