### PR TITLE
Internal: Add prop base value support [ED-23616]

### DIFF
--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/override-prop-control.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/override-prop-control.tsx
@@ -119,7 +119,7 @@ function OverrideControl( { overridableProp }: InternalProps ) {
 		propValue,
 		baseValue: resolvedBaseValue,
 		placeholderValue,
-	} = resolveValueAndBaseValue( matchingOverride, overrideValue, resolvedOriginValues, propKey );
+	} = resolveOverrideValues( matchingOverride, overrideValue, resolvedOriginValues, propKey );
 
 	const value = {
 		[ overridableProp.overrideKey ]: propValue,
@@ -224,7 +224,7 @@ function OverrideControl( { overridableProp }: InternalProps ) {
 	);
 }
 
-function resolveValueAndBaseValue(
+function resolveOverrideValues(
 	matchingOverride: ComponentInstanceOverride | null,
 	overrideValue: AnyTransformable | null,
 	resolvedOriginValues: ElementSettings,

--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/override-prop-control.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/override-prop-control.tsx
@@ -115,11 +115,12 @@ function OverrideControl( { overridableProp }: InternalProps ) {
 		return null;
 	}
 
-	const {
-		propValue,
-		baseValue: resolvedBaseValue,
-		placeholderValue,
-	} = resolveOverrideValues( matchingOverride, overrideValue, resolvedOriginValues, propKey );
+	const { propValue, baseValue: resolvedBaseValue } = resolveOverrideValues(
+		matchingOverride,
+		overrideValue,
+		resolvedOriginValues,
+		propKey
+	);
 
 	const value = {
 		[ overridableProp.overrideKey ]: propValue,
@@ -127,10 +128,6 @@ function OverrideControl( { overridableProp }: InternalProps ) {
 
 	const baseValue = {
 		[ overridableProp.overrideKey ]: resolvedBaseValue,
-	} as OverridesSchema;
-
-	const placeholder = {
-		[ overridableProp.overrideKey ]: placeholderValue,
 	} as OverridesSchema;
 
 	const { control, controlProps, layout } = getControlParams(
@@ -205,7 +202,6 @@ function OverrideControl( { overridableProp }: InternalProps ) {
 					value={ value }
 					setValue={ setValue }
 					baseValue={ baseValue }
-					placeholder={ placeholder }
 					isDisabled={ isDisabled }
 				>
 					<PropKeyProvider bind={ overridableProp.overrideKey }>
@@ -237,10 +233,9 @@ function resolveOverrideValues(
 	const shouldUseInheritedAsValue = isInheritedDynamic && ! matchingOverride;
 
 	const propValue = shouldUseInheritedAsValue ? inheritedValue : overrideValue;
-	const baseValue = isInheritedDynamic ? null : inheritedValue;
-	const placeholderValue = matchingOverride || isInheritedDynamic ? null : inheritedValue;
+	const baseValue = matchingOverride || isInheritedDynamic ? null : inheritedValue;
 
-	return { propValue, baseValue, placeholderValue };
+	return { propValue, baseValue };
 }
 
 // Temp solution: when removing an override on a dynamic value, fall back to propType.default

--- a/packages/packages/core/editor-components/src/components/instance-editing-panel/override-prop-control.tsx
+++ b/packages/packages/core/editor-components/src/components/instance-editing-panel/override-prop-control.tsx
@@ -158,14 +158,18 @@ function OverrideControl( { overridableProp }: InternalProps ) {
 		return null;
 	}
 
-	const { propValue, placeholderValue } = resolveValueAndPlaceholder(
-		matchingOverride,
-		settingsWithInnerOverrides,
-		propKey
-	);
+	const {
+		propValue,
+		baseValue: resolvedBaseValue,
+		placeholderValue,
+	} = resolveValueAndBaseValue( matchingOverride, settingsWithInnerOverrides, propKey );
 
 	const value = {
 		[ overridableProp.overrideKey ]: propValue,
+	} as OverridesSchema;
+
+	const baseValue = {
+		[ overridableProp.overrideKey ]: resolvedBaseValue,
 	} as OverridesSchema;
 
 	const placeholder = {
@@ -255,6 +259,7 @@ function OverrideControl( { overridableProp }: InternalProps ) {
 						propType={ propTypeSchema }
 						value={ value }
 						setValue={ setValue }
+						baseValue={ baseValue }
 						placeholder={ placeholder }
 						isDisabled={ () => {
 							return false;
@@ -281,21 +286,22 @@ function OverrideControl( { overridableProp }: InternalProps ) {
 
 type ElementSettings = Record< string, AnyTransformable | null >;
 
-function resolveValueAndPlaceholder(
+function resolveValueAndBaseValue(
 	matchingOverride: ComponentInstanceOverride | null,
 	settingsWithInnerOverrides: ElementSettings,
 	propKey: string
 ) {
 	const overrideValue = matchingOverride ? resolveOverridePropValue( matchingOverride ) : null;
 
-	const placeholderSettings = unwrapOverridableSettings( settingsWithInnerOverrides );
-	const inheritedValue = placeholderSettings[ propKey ] ?? null;
+	const unwrappedSettings = unwrapOverridableSettings( settingsWithInnerOverrides );
+	const inheritedValue = unwrappedSettings[ propKey ] ?? null;
 	const isInheritedDynamic = isDynamicPropValue( inheritedValue );
 
 	const propValue = isInheritedDynamic && ! matchingOverride ? inheritedValue : overrideValue;
+	const baseValue = isInheritedDynamic ? null : inheritedValue;
 	const placeholderValue = matchingOverride || isInheritedDynamic ? null : inheritedValue;
 
-	return { propValue, placeholderValue };
+	return { propValue, baseValue, placeholderValue };
 }
 
 // Temp solution: when removing an override on a dynamic value, fall back to propType.default

--- a/packages/packages/libs/editor-controls/src/__tests__/bound-prop-context.test.tsx
+++ b/packages/packages/libs/editor-controls/src/__tests__/bound-prop-context.test.tsx
@@ -461,7 +461,7 @@ describe( 'useBoundProp', () => {
 		expect( setValue ).toHaveBeenCalledWith( { key: null }, undefined, { bind: 'key' } );
 	} );
 
-	it( 'should return baseValue sliced by bind from PropProvider', () => {
+	it( 'should return baseValue sliced by bind and derive placeholder from it', () => {
 		// Arrange
 		const propType = createMockPropType( {
 			kind: 'object',
@@ -485,6 +485,7 @@ describe( 'useBoundProp', () => {
 
 		// Assert
 		expect( result.current.baseValue ).toBe( 'inherited' );
+		expect( result.current.placeholder ).toBe( 'inherited' );
 		expect( result.current.value ).toBe( null );
 	} );
 
@@ -575,7 +576,7 @@ describe( 'useBoundProp', () => {
 		);
 	} );
 
-	it( 'should return placeholder independently from baseValue', () => {
+	it( 'should prefer explicit placeholder over baseValue when both are provided', () => {
 		// Arrange
 		const propType = createMockPropType( {
 			kind: 'object',

--- a/packages/packages/libs/editor-controls/src/__tests__/bound-prop-context.test.tsx
+++ b/packages/packages/libs/editor-controls/src/__tests__/bound-prop-context.test.tsx
@@ -461,6 +461,187 @@ describe( 'useBoundProp', () => {
 		expect( setValue ).toHaveBeenCalledWith( { key: null }, undefined, { bind: 'key' } );
 	} );
 
+	it( 'should return baseValue sliced by bind from PropProvider', () => {
+		// Arrange
+		const propType = createMockPropType( {
+			kind: 'object',
+			shape: {
+				key: createMockPropType( { kind: 'plain' } ),
+			},
+		} );
+
+		const baseValue = {
+			key: stringPropTypeUtil.create( 'inherited' ),
+		};
+
+		// Act
+		const { result } = renderHook( () => useBoundProp( stringPropTypeUtil ), {
+			wrapper: ( { children } ) => (
+				<PropProvider value={ null } setValue={ jest.fn() } propType={ propType } baseValue={ baseValue }>
+					<PropKeyProvider bind="key">{ children }</PropKeyProvider>
+				</PropProvider>
+			),
+		} );
+
+		// Assert
+		expect( result.current.baseValue ).toBe( 'inherited' );
+		expect( result.current.value ).toBe( null );
+	} );
+
+	it( 'should merge siblings from baseValue when value is null and setValue is called', () => {
+		// Arrange
+		const nestedPropType = createMockPropType( { kind: 'plain' } );
+
+		const propType = createMockPropType( {
+			kind: 'object',
+			shape: {
+				'key-1': nestedPropType,
+				'key-2': nestedPropType,
+			},
+		} );
+
+		const baseValue = {
+			'key-1': stringPropTypeUtil.create( 'sibling-value' ),
+			'key-2': stringPropTypeUtil.create( 'other-sibling' ),
+		};
+
+		const parentSetValue = jest.fn();
+
+		// Act
+		const { result } = renderHook( () => useBoundProp( stringPropTypeUtil ), {
+			wrapper: ( { children } ) => (
+				<PropProvider value={ null } setValue={ parentSetValue } propType={ propType } baseValue={ baseValue }>
+					<PropKeyProvider bind="key-1">{ children }</PropKeyProvider>
+				</PropProvider>
+			),
+		} );
+
+		result.current.setValue( 'new value' );
+
+		// Assert
+		expect( parentSetValue ).toHaveBeenCalledWith(
+			{
+				'key-1': stringPropTypeUtil.create( 'new value' ),
+				'key-2': stringPropTypeUtil.create( 'other-sibling' ),
+			},
+			{},
+			{ bind: 'key-1' }
+		);
+	} );
+
+	it( 'should prefer value over baseValue for sibling merging when both exist', () => {
+		// Arrange
+		const nestedPropType = createMockPropType( { kind: 'plain' } );
+
+		const propType = createMockPropType( {
+			kind: 'object',
+			shape: {
+				'key-1': nestedPropType,
+				'key-2': nestedPropType,
+			},
+		} );
+
+		const value = {
+			'key-1': stringPropTypeUtil.create( 'override-1' ),
+			'key-2': stringPropTypeUtil.create( 'override-2' ),
+		};
+
+		const baseValue = {
+			'key-1': stringPropTypeUtil.create( 'base-1' ),
+			'key-2': stringPropTypeUtil.create( 'base-2' ),
+		};
+
+		const parentSetValue = jest.fn();
+
+		// Act
+		const { result } = renderHook( () => useBoundProp( stringPropTypeUtil ), {
+			wrapper: ( { children } ) => (
+				<PropProvider value={ value } setValue={ parentSetValue } propType={ propType } baseValue={ baseValue }>
+					<PropKeyProvider bind="key-1">{ children }</PropKeyProvider>
+				</PropProvider>
+			),
+		} );
+
+		result.current.setValue( 'changed' );
+
+		// Assert
+		expect( parentSetValue ).toHaveBeenCalledWith(
+			{
+				'key-1': stringPropTypeUtil.create( 'changed' ),
+				'key-2': stringPropTypeUtil.create( 'override-2' ),
+			},
+			{},
+			{ bind: 'key-1' }
+		);
+	} );
+
+	it( 'should return placeholder independently from baseValue', () => {
+		// Arrange
+		const propType = createMockPropType( {
+			kind: 'object',
+			shape: {
+				key: createMockPropType( { kind: 'plain' } ),
+			},
+		} );
+
+		const baseValue = {
+			key: stringPropTypeUtil.create( 'base' ),
+		};
+
+		const placeholder = {
+			key: stringPropTypeUtil.create( 'hint' ),
+		};
+
+		// Act
+		const { result } = renderHook( () => useBoundProp( stringPropTypeUtil ), {
+			wrapper: ( { children } ) => (
+				<PropProvider
+					value={ null }
+					setValue={ jest.fn() }
+					propType={ propType }
+					baseValue={ baseValue }
+					placeholder={ placeholder }
+				>
+					<PropKeyProvider bind="key">{ children }</PropKeyProvider>
+				</PropProvider>
+			),
+		} );
+
+		// Assert
+		expect( result.current.baseValue ).toBe( 'base' );
+		expect( result.current.placeholder ).toBe( 'hint' );
+		expect( result.current.value ).toBe( null );
+	} );
+
+	it( 'should not use propType default when baseValue is provided', () => {
+		// Arrange
+		const defaultValue = stringPropTypeUtil.create( 'default-text' );
+
+		const propType = createMockPropType( {
+			kind: 'object',
+			shape: {
+				key: createMockPropType( { kind: 'plain', key: 'string', default: defaultValue } ),
+			},
+		} );
+
+		const baseValue = {
+			key: stringPropTypeUtil.create( 'inherited' ),
+		};
+
+		// Act
+		const { result } = renderHook( () => useBoundProp( stringPropTypeUtil ), {
+			wrapper: ( { children } ) => (
+				<PropProvider value={ null } setValue={ jest.fn() } propType={ propType } baseValue={ baseValue }>
+					<PropKeyProvider bind="key">{ children }</PropKeyProvider>
+				</PropProvider>
+			),
+		} );
+
+		// Assert
+		expect( result.current.value ).toBe( null );
+		expect( result.current.baseValue ).toBe( 'inherited' );
+	} );
+
 	it( 'should resetValue to initial_value when initial_value is set', () => {
 		// Arrange.
 		const initialValue = sizePropTypeUtil.create( { size: 201, unit: 'rem' } );

--- a/packages/packages/libs/editor-controls/src/bound-prop-context/prop-context.tsx
+++ b/packages/packages/libs/editor-controls/src/bound-prop-context/prop-context.tsx
@@ -23,6 +23,7 @@ type PropContext< T extends PropValue, P extends PropType > = {
 	value: T | null;
 	propType: P;
 	placeholder?: T;
+	baseValue?: T;
 	isDisabled?: ( propType: PropType ) => boolean | undefined;
 };
 
@@ -38,6 +39,7 @@ export const PropProvider = < T extends PropValue, P extends PropType >( {
 	setValue,
 	propType,
 	placeholder,
+	baseValue,
 	isDisabled,
 }: PropProviderProps< T, P > ) => {
 	return (
@@ -47,6 +49,7 @@ export const PropProvider = < T extends PropValue, P extends PropType >( {
 				propType,
 				setValue: setValue as SetValue< PropValue >,
 				placeholder,
+				baseValue,
 				isDisabled,
 			} }
 		>

--- a/packages/packages/libs/editor-controls/src/bound-prop-context/prop-key-context.tsx
+++ b/packages/packages/libs/editor-controls/src/bound-prop-context/prop-key-context.tsx
@@ -20,6 +20,7 @@ export type PropKeyContextValue< T, P > = {
 	value: T;
 	propType: P;
 	placeholder?: T;
+	baseValue?: T;
 	path: PropKey[];
 	isDisabled?: ( propType: PropType ) => boolean | undefined;
 	disabled?: boolean;
@@ -55,7 +56,7 @@ const ObjectPropKeyProvider = ( { children, bind }: PropKeyProviderProps ) => {
 
 	const setValue: SetValue< PropValue > = ( value, options, meta ) => {
 		const newValue = {
-			...context.value,
+			...( context.value ?? context.baseValue ),
 			[ bind ]: value,
 		};
 
@@ -64,12 +65,22 @@ const ObjectPropKeyProvider = ( { children, bind }: PropKeyProviderProps ) => {
 
 	const value = context.value?.[ bind ];
 	const placeholder = context.placeholder?.[ bind ];
+	const baseValue = context.baseValue?.[ bind ];
 
 	const propType = context.propType.shape[ bind ];
 
 	return (
 		<PropKeyContext.Provider
-			value={ { ...context, value, setValue, placeholder, bind, propType, path: [ ...( path ?? [] ), bind ] } }
+			value={ {
+				...context,
+				value,
+				setValue,
+				placeholder,
+				baseValue,
+				bind,
+				propType,
+				path: [ ...( path ?? [] ), bind ],
+			} }
 		>
 			{ children }
 		</PropKeyContext.Provider>
@@ -81,7 +92,7 @@ const ArrayPropKeyProvider = ( { children, bind }: PropKeyProviderProps ) => {
 	const { path } = useContext( PropKeyContext ) ?? {};
 
 	const setValue = ( value: PropValue, options?: CreateOptions ) => {
-		const newValue = [ ...( context.value ?? [] ) ];
+		const newValue = [ ...( context.value ?? context.baseValue ?? [] ) ];
 
 		newValue[ Number( bind ) ] = value;
 
@@ -90,6 +101,7 @@ const ArrayPropKeyProvider = ( { children, bind }: PropKeyProviderProps ) => {
 
 	const value = context.value?.[ Number( bind ) ];
 	const placeholder = context.placeholder?.[ Number( bind ) ];
+	const baseValue = context.baseValue?.[ Number( bind ) ];
 
 	const propType = context.propType.item_prop_type;
 
@@ -103,6 +115,7 @@ const ArrayPropKeyProvider = ( { children, bind }: PropKeyProviderProps ) => {
 				propType,
 				path: [ ...( path ?? [] ), bind ],
 				placeholder: placeholder ?? undefined,
+				baseValue: baseValue ?? undefined,
 			} }
 		>
 			{ children }

--- a/packages/packages/libs/editor-controls/src/bound-prop-context/use-bound-prop.ts
+++ b/packages/packages/libs/editor-controls/src/bound-prop-context/use-bound-prop.ts
@@ -75,12 +75,11 @@ export function useBoundProp< TKey extends string, TValue extends PropValue >(
 	const propType = resolveUnionPropType( propKeyContext.propType, propTypeUtil.key );
 
 	const hasBaseValue = propKeyContext.baseValue !== undefined && propKeyContext.baseValue !== null;
-	const hasPlaceholder = propKeyContext.placeholder !== undefined && propKeyContext.placeholder !== null;
-	const fallbackValue = hasBaseValue || hasPlaceholder ? null : propType.default;
+	const fallbackValue = hasBaseValue ? null : propType.default;
 
 	const value = propTypeUtil.extract( propKeyContext.value ?? fallbackValue ?? null );
 	const baseValue = propTypeUtil.extract( propKeyContext.baseValue ?? null );
-	const placeholder = propTypeUtil.extract( propKeyContext.placeholder ?? null );
+	const placeholder = propTypeUtil.extract( propKeyContext.placeholder ?? propKeyContext.baseValue ?? null );
 
 	return {
 		...propKeyContext,

--- a/packages/packages/libs/editor-controls/src/bound-prop-context/use-bound-prop.ts
+++ b/packages/packages/libs/editor-controls/src/bound-prop-context/use-bound-prop.ts
@@ -17,6 +17,7 @@ type UseBoundProp< TValue extends PropValue > = {
 	value: TValue;
 	propType: PropType;
 	placeholder?: TValue;
+	baseValue?: TValue;
 	path: PropKey[];
 	restoreValue: () => void;
 	resetValue: () => void;
@@ -73,10 +74,12 @@ export function useBoundProp< TKey extends string, TValue extends PropValue >(
 
 	const propType = resolveUnionPropType( propKeyContext.propType, propTypeUtil.key );
 
+	const hasBaseValue = propKeyContext.baseValue !== undefined && propKeyContext.baseValue !== null;
 	const hasPlaceholder = propKeyContext.placeholder !== undefined && propKeyContext.placeholder !== null;
-	const fallbackValue = hasPlaceholder ? null : propType.default;
+	const fallbackValue = hasBaseValue || hasPlaceholder ? null : propType.default;
 
 	const value = propTypeUtil.extract( propKeyContext.value ?? fallbackValue ?? null );
+	const baseValue = propTypeUtil.extract( propKeyContext.baseValue ?? null );
 	const placeholder = propTypeUtil.extract( propKeyContext.placeholder ?? null );
 
 	return {
@@ -86,6 +89,7 @@ export function useBoundProp< TKey extends string, TValue extends PropValue >(
 		value: isValid ? value : null,
 		restoreValue,
 		placeholder,
+		baseValue,
 		disabled,
 		resetValue,
 	};

--- a/packages/packages/libs/editor-controls/src/controls/select-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/select-control.tsx
@@ -39,6 +39,12 @@ export const SelectControl = createControl(
 		};
 		const isDisabled = disabled || options.length === 0;
 
+		const normalizeSelectValue = ( v: string | null | undefined ) =>
+			v === null || v === undefined || v === '' ? null : v;
+
+		const findOptionByValue = ( searchValue: string | null | undefined ) =>
+			options.find( ( opt ) => normalizeSelectValue( opt.value ) === normalizeSelectValue( searchValue ) );
+
 		return (
 			<ControlActions>
 				<Select
@@ -48,24 +54,30 @@ export const SelectControl = createControl(
 					MenuProps={ MenuProps }
 					aria-label={ ariaLabel || placeholder }
 					renderValue={ ( selectedValue: string | null ) => {
-						const findOptionByValue = ( searchValue: string | null ) =>
-							options.find( ( opt ) => opt.value === searchValue );
+						const isEmpty = ! selectedValue || selectedValue === '';
 
-						if ( ! selectedValue || selectedValue === '' ) {
-							if ( placeholder ) {
-								const placeholderOption = findOptionByValue( placeholder );
-								const displayText = placeholderOption?.label || placeholder;
+						if ( isEmpty && placeholder ) {
+							const placeholderOption = findOptionByValue( placeholder );
+							const displayText = placeholderOption?.label || placeholder;
 
-								return (
-									<Typography component="span" variant="caption" color="text.tertiary">
-										{ displayText }
-									</Typography>
-								);
-							}
+							return (
+								<Typography component="span" variant="caption" color="text.tertiary">
+									{ displayText }
+								</Typography>
+							);
+						}
+
+						const option = findOptionByValue( selectedValue );
+
+						if ( option ) {
+							return option.label;
+						}
+
+						if ( isEmpty ) {
 							return '';
 						}
-						const option = findOptionByValue( selectedValue );
-						return option?.label || selectedValue;
+
+						return selectedValue;
 					} }
 					value={ value ?? '' }
 					onChange={ handleChange }

--- a/packages/packages/libs/editor-controls/src/controls/select-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/select-control.tsx
@@ -39,12 +39,6 @@ export const SelectControl = createControl(
 		};
 		const isDisabled = disabled || options.length === 0;
 
-		const normalizeSelectValue = ( v: string | null | undefined ) =>
-			v === null || v === undefined || v === '' ? null : v;
-
-		const findOptionByValue = ( searchValue: string | null | undefined ) =>
-			options.find( ( opt ) => normalizeSelectValue( opt.value ) === normalizeSelectValue( searchValue ) );
-
 		return (
 			<ControlActions>
 				<Select
@@ -54,30 +48,24 @@ export const SelectControl = createControl(
 					MenuProps={ MenuProps }
 					aria-label={ ariaLabel || placeholder }
 					renderValue={ ( selectedValue: string | null ) => {
-						const isEmpty = ! selectedValue || selectedValue === '';
+						const findOptionByValue = ( searchValue: string | null ) =>
+							options.find( ( opt ) => opt.value === searchValue );
 
-						if ( isEmpty && placeholder ) {
-							const placeholderOption = findOptionByValue( placeholder );
-							const displayText = placeholderOption?.label || placeholder;
+						if ( ! selectedValue || selectedValue === '' ) {
+							if ( placeholder ) {
+								const placeholderOption = findOptionByValue( placeholder );
+								const displayText = placeholderOption?.label || placeholder;
 
-							return (
-								<Typography component="span" variant="caption" color="text.tertiary">
-									{ displayText }
-								</Typography>
-							);
-						}
-
-						const option = findOptionByValue( selectedValue );
-
-						if ( option ) {
-							return option.label;
-						}
-
-						if ( isEmpty ) {
+								return (
+									<Typography component="span" variant="caption" color="text.tertiary">
+										{ displayText }
+									</Typography>
+								);
+							}
 							return '';
 						}
-
-						return selectedValue;
+						const option = findOptionByValue( selectedValue );
+						return option?.label || selectedValue;
 					} }
 					value={ value ?? '' }
 					onChange={ handleChange }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add base value support to prop control system to enable proper inheritance of component instance property values from parent components.

Main changes:
- Replaced placeholder-based inheritance with baseValue property throughout PropProvider, PropKeyProvider, and useBoundProp hook
- Modified ObjectPropKeyProvider and ArrayPropKeyProvider to merge sibling properties from baseValue when value is null
- Updated OverrideControl component to resolve and pass baseValue instead of placeholder for component override properties

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
