### PR TITLE
Fix: Editor style changes issues [ED-23613]

### DIFF
--- a/packages/packages/core/editor-canvas/src/components/__tests__/style-renderer.test.tsx
+++ b/packages/packages/core/editor-canvas/src/components/__tests__/style-renderer.test.tsx
@@ -13,6 +13,10 @@ jest.mock( '@elementor/editor-v1-adapters', () => ( {
 	commandEndEvent: jest.fn(),
 } ) );
 
+jest.mock( '@elementor/editor-documents', () => ( {
+	getCurrentDocument: jest.fn().mockReturnValue( { id: 1 } ),
+} ) );
+
 jest.mock( '@elementor/ui', () => ( {
 	Portal: jest.fn( ( { children } ) => <div data-testid="portal">{ children }</div> ),
 } ) );

--- a/packages/packages/core/editor-canvas/src/components/style-renderer.tsx
+++ b/packages/packages/core/editor-canvas/src/components/style-renderer.tsx
@@ -13,21 +13,12 @@ import { type StyleItem } from '../renderers/create-styles-renderer';
 
 export function StyleRenderer() {
 	const container = usePortalContainer();
+	const styleItems = useStyleItems();
+	const linksAttrs = useDocumentsCssLinks();
 
 	if ( ! container ) {
 		return null;
 	}
-
-	return <StyleRendererWithContainer container={ container } />;
-}
-
-type Props = {
-	container: HTMLElement;
-};
-
-function StyleRendererWithContainer( { container }: Props ) {
-	const styleItems = useStyleItems();
-	const linksAttrs = useDocumentsCssLinks();
 
 	return (
 		<Portal container={ container }>
@@ -46,8 +37,6 @@ function usePortalContainer() {
 	 * Firefox's JS scheduler dispatches React's pending render microtasks earlier within the initialization macrotask boundary —
 	 * before Load.apply() → setCurrent() has completed.
 	 * Chrome processes these in the opposite order, so when React's mountMemo runs, currentDocument is already populated.
-	 *
-	 * In this listener - I'll first check if the currentDocument is available, and if it is, I'll return the canvasIframeDocument.head.
 	 */
 	return useListenTo( commandEndEvent( 'editor/documents/attach-preview' ), () =>
 		getCurrentDocument() ? getCanvasIframeDocument()?.head : null

--- a/packages/packages/core/editor-canvas/src/components/style-renderer.tsx
+++ b/packages/packages/core/editor-canvas/src/components/style-renderer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { getCurrentDocument } from '@elementor/editor-documents';
 import {
 	__privateUseListenTo as useListenTo,
 	commandEndEvent,
@@ -13,12 +14,20 @@ import { type StyleItem } from '../renderers/create-styles-renderer';
 export function StyleRenderer() {
 	const container = usePortalContainer();
 
-	const styleItems = useStyleItems();
-	const linksAttrs = useDocumentsCssLinks();
-
 	if ( ! container ) {
 		return null;
 	}
+
+	return <StyleRendererWithContainer container={ container } />;
+}
+
+type Props = {
+	container: HTMLElement;
+};
+
+function StyleRendererWithContainer( { container }: Props ) {
+	const styleItems = useStyleItems();
+	const linksAttrs = useDocumentsCssLinks();
 
 	return (
 		<Portal container={ container }>
@@ -33,7 +42,16 @@ export function StyleRenderer() {
 }
 
 function usePortalContainer() {
-	return useListenTo( commandEndEvent( 'editor/documents/attach-preview' ), () => getCanvasIframeDocument()?.head );
+	/**
+	 * Firefox's JS scheduler dispatches React's pending render microtasks earlier within the initialization macrotask boundary —
+	 * before Load.apply() → setCurrent() has completed.
+	 * Chrome processes these in the opposite order, so when React's mountMemo runs, currentDocument is already populated.
+	 *
+	 * In this listener - I'll first check if the currentDocument is available, and if it is, I'll return the canvasIframeDocument.head.
+	 */
+	return useListenTo( commandEndEvent( 'editor/documents/attach-preview' ), () =>
+		getCurrentDocument() ? getCanvasIframeDocument()?.head : null
+	);
 }
 
 // we load local styles also from components, which are handled differently

--- a/packages/packages/core/editor-canvas/src/components/style-renderer.tsx
+++ b/packages/packages/core/editor-canvas/src/components/style-renderer.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { getCurrentDocument } from '@elementor/editor-documents';
 import {
 	__privateUseListenTo as useListenTo,
 	commandEndEvent,
@@ -13,6 +12,7 @@ import { type StyleItem } from '../renderers/create-styles-renderer';
 
 export function StyleRenderer() {
 	const container = usePortalContainer();
+
 	const styleItems = useStyleItems();
 	const linksAttrs = useDocumentsCssLinks();
 
@@ -33,14 +33,7 @@ export function StyleRenderer() {
 }
 
 function usePortalContainer() {
-	/**
-	 * Firefox's JS scheduler dispatches React's pending render microtasks earlier within the initialization macrotask boundary —
-	 * before Load.apply() → setCurrent() has completed.
-	 * Chrome processes these in the opposite order, so when React's mountMemo runs, currentDocument is already populated.
-	 */
-	return useListenTo( commandEndEvent( 'editor/documents/attach-preview' ), () =>
-		getCurrentDocument() ? getCanvasIframeDocument()?.head : null
-	);
+	return useListenTo( commandEndEvent( 'editor/documents/attach-preview' ), () => getCanvasIframeDocument()?.head );
 }
 
 // we load local styles also from components, which are handled differently

--- a/packages/packages/core/editor-canvas/src/hooks/__tests__/use-style-items.test.ts
+++ b/packages/packages/core/editor-canvas/src/hooks/__tests__/use-style-items.test.ts
@@ -340,6 +340,74 @@ describe( 'useStyleItems', () => {
 		expect( breakpointOrderAfterUpdate ).toEqual( [ 'desktop', 'tablet', 'mobile' ] );
 	} );
 
+	it( 'should recover and render styles when a provider key becomes available after initial failure', async () => {
+		// Arrange.
+		let shouldThrow = true;
+
+		const dynamicKey: () => string = () => {
+			if ( shouldThrow ) {
+				throw new Error( 'Document not ready' );
+			}
+
+			return 'late-provider';
+		};
+
+		const failingThenSucceedingProvider = createMockStylesProvider(
+			{
+				key: dynamicKey,
+				priority: 2,
+			},
+			[ createMockStyleDefinition( { id: 'late-style1' } ), createMockStyleDefinition( { id: 'late-style2' } ) ]
+		);
+
+		const stableProvider = createMockStylesProvider(
+			{
+				key: 'stable-provider',
+				priority: 1,
+			},
+			[
+				createMockStyleDefinition( { id: 'stable-style1' } ),
+				createMockStyleDefinition( { id: 'stable-style2' } ),
+			]
+		);
+
+		jest.mocked( stylesRepository ).getProviders.mockReturnValue( [
+			failingThenSucceedingProvider,
+			stableProvider,
+		] );
+
+		let attachPreviewCallback: () => Promise< void >;
+
+		jest.mocked( registerDataHook ).mockImplementation( ( position, command, callback ) => {
+			if ( command === 'editor/documents/attach-preview' && position === 'after' ) {
+				attachPreviewCallback = callback as never;
+			}
+
+			return null as never;
+		} );
+
+		// Act.
+		const { result } = renderHook( () => useStyleItems() );
+
+		// Assert - hook should not crash, should return empty initially.
+		expect( result.current ).toEqual( [] );
+
+		// Act - simulate document becoming ready, then trigger attach-preview.
+		shouldThrow = false;
+
+		await act( async () => {
+			await attachPreviewCallback?.();
+		} );
+
+		// Assert - both providers' styles should render in correct priority order.
+		expect( result.current ).toEqual( [
+			{ id: 'stable-style2', breakpoint: 'desktop' },
+			{ id: 'stable-style1', breakpoint: 'desktop' },
+			{ id: 'late-style2', breakpoint: 'desktop' },
+			{ id: 'late-style1', breakpoint: 'desktop' },
+		] );
+	} );
+
 	it( 'should only re-render changed styles on differential update', async () => {
 		// Arrange.
 		const renderStylesMock = jest.fn().mockImplementation( ( { styles } ) =>

--- a/packages/packages/core/editor-canvas/src/hooks/use-style-items.ts
+++ b/packages/packages/core/editor-canvas/src/hooks/use-style-items.ts
@@ -37,27 +37,31 @@ export function useStyleItems() {
 	const styleItemsCacheRef = useRef< Map< string, StyleItemsCache > >( new Map() );
 
 	const providerAndSubscribers = useMemo( () => {
-		return stylesRepository.getProviders().map( ( provider ): ProviderAndSubscriber => {
+		const getCache = ( provider: StylesProvider ): StyleItemsCache => {
 			const providerKey = safeGetKey( provider );
 
-			if ( providerKey && ! styleItemsCacheRef.current.has( providerKey ) ) {
+			if ( ! providerKey ) {
+				return { orderedIds: [], itemsById: new Map() };
+			}
+
+			if ( ! styleItemsCacheRef.current.has( providerKey ) ) {
 				styleItemsCacheRef.current.set( providerKey, { orderedIds: [], itemsById: new Map() } );
 			}
 
-			const cache = providerKey
-				? ( styleItemsCacheRef.current.get( providerKey ) as StyleItemsCache )
-				: { orderedIds: [], itemsById: new Map() };
+			return styleItemsCacheRef.current.get( providerKey ) as StyleItemsCache;
+		};
 
-			return {
+		return stylesRepository.getProviders().map(
+			( provider ): ProviderAndSubscriber => ( {
 				provider,
 				subscriber: createProviderSubscriber( {
 					provider,
 					renderStyles,
 					setStyleItems,
-					cache,
+					getCache: () => getCache( provider ),
 				} ),
-			};
-		} );
+			} )
+		);
 	}, [ renderStyles ] );
 
 	useEffect( () => {
@@ -139,13 +143,14 @@ type CreateProviderSubscriberArgs = {
 	provider: StylesProvider;
 	renderStyles: StyleRenderer;
 	setStyleItems: Dispatch< SetStateAction< ProviderAndStyleItemsMap > >;
-	cache: StyleItemsCache;
+	getCache: () => StyleItemsCache;
 };
 
-function createProviderSubscriber( { provider, renderStyles, setStyleItems, cache }: CreateProviderSubscriberArgs ) {
+function createProviderSubscriber( { provider, renderStyles, setStyleItems, getCache }: CreateProviderSubscriberArgs ) {
 	return abortPreviousRuns( ( abortController, previous?: StylesCollection, current?: StylesCollection ) =>
 		signalizedProcess( abortController.signal )
 			.then( ( _, signal ) => {
+				const cache = getCache();
 				const hasDiffInfo = current !== undefined && previous !== undefined;
 				const hasCache = cache.orderedIds.length > 0;
 
@@ -155,10 +160,10 @@ function createProviderSubscriber( { provider, renderStyles, setStyleItems, cach
 				}
 
 				if ( hasDiffInfo && hasCache ) {
-					return updateItems( previous, current, signal );
+					return updateItems( cache, previous, current, signal );
 				}
 
-				return createItems( signal );
+				return createItems( cache, signal );
 			} )
 			.then( ( items ) => {
 				setStyleItems( ( prev ) => ( {
@@ -169,7 +174,12 @@ function createProviderSubscriber( { provider, renderStyles, setStyleItems, cach
 			.execute()
 	);
 
-	async function updateItems( previous: StylesCollection, current: StylesCollection, signal: AbortSignal ) {
+	async function updateItems(
+		cache: StyleItemsCache,
+		previous: StylesCollection,
+		current: StylesCollection,
+		signal: AbortSignal
+	) {
 		const changedIds = getChangedStyleIds( previous, current );
 
 		cache.orderedIds = provider.actions
@@ -196,7 +206,7 @@ function createProviderSubscriber( { provider, renderStyles, setStyleItems, cach
 		return getOrderedItems( cache );
 	}
 
-	async function createItems( signal: AbortSignal ) {
+	async function createItems( cache: StyleItemsCache, signal: AbortSignal ) {
 		const allStyles = provider.actions.all();
 
 		const styles = [ ...allStyles ].reverse().map( ( style ) => {

--- a/packages/packages/core/editor-canvas/src/hooks/use-style-items.ts
+++ b/packages/packages/core/editor-canvas/src/hooks/use-style-items.ts
@@ -150,6 +150,7 @@ function createProviderSubscriber( { provider, renderStyles, setStyleItems, cach
 				const hasCache = cache.orderedIds.length > 0;
 
 				if ( hasCache && provider.isPregeneratedLink ) {
+					// if styles were rendered already (i.e. hasCache = true), we can safely remove the pregenerated css rules imported via <link /> tags
 					removeProviderPregeneratedLinks( provider.getKey(), provider.isPregeneratedLink );
 				}
 

--- a/packages/packages/core/editor-canvas/src/hooks/use-style-items.ts
+++ b/packages/packages/core/editor-canvas/src/hooks/use-style-items.ts
@@ -37,15 +37,19 @@ export function useStyleItems() {
 	const styleItemsCacheRef = useRef< Map< string, StyleItemsCache > >( new Map() );
 
 	const providerAndSubscribers = useMemo( () => {
+		const createEmptyCache = () => {
+			return { orderedIds: [], itemsById: new Map() };
+		};
+
 		const getCache = ( provider: StylesProvider ): StyleItemsCache => {
 			const providerKey = safeGetKey( provider );
 
 			if ( ! providerKey ) {
-				return { orderedIds: [], itemsById: new Map() };
+				return createEmptyCache();
 			}
 
 			if ( ! styleItemsCacheRef.current.has( providerKey ) ) {
-				styleItemsCacheRef.current.set( providerKey, { orderedIds: [], itemsById: new Map() } );
+				styleItemsCacheRef.current.set( providerKey, createEmptyCache() );
 			}
 
 			return styleItemsCacheRef.current.get( providerKey ) as StyleItemsCache;

--- a/packages/packages/core/editor-canvas/src/hooks/use-style-items.ts
+++ b/packages/packages/core/editor-canvas/src/hooks/use-style-items.ts
@@ -38,13 +38,15 @@ export function useStyleItems() {
 
 	const providerAndSubscribers = useMemo( () => {
 		return stylesRepository.getProviders().map( ( provider ): ProviderAndSubscriber => {
-			const providerKey = provider.getKey();
+			const providerKey = safeGetKey( provider );
 
-			if ( ! styleItemsCacheRef.current.has( providerKey ) ) {
+			if ( providerKey && ! styleItemsCacheRef.current.has( providerKey ) ) {
 				styleItemsCacheRef.current.set( providerKey, { orderedIds: [], itemsById: new Map() } );
 			}
 
-			const cache = styleItemsCacheRef.current.get( providerKey ) as StyleItemsCache;
+			const cache = providerKey
+				? ( styleItemsCacheRef.current.get( providerKey ) as StyleItemsCache )
+				: { orderedIds: [], itemsById: new Map() };
 
 			return {
 				provider,
@@ -125,6 +127,14 @@ function createBreakpointSorter( breakpointsOrder: BreakpointId[] ) {
 		breakpointsOrder.indexOf( breakpointB as BreakpointId );
 }
 
+function safeGetKey( provider: StylesProvider ): string | null {
+	try {
+		return provider.getKey();
+	} catch {
+		return null;
+	}
+}
+
 type CreateProviderSubscriberArgs = {
 	provider: StylesProvider;
 	renderStyles: StyleRenderer;
@@ -140,7 +150,6 @@ function createProviderSubscriber( { provider, renderStyles, setStyleItems, cach
 				const hasCache = cache.orderedIds.length > 0;
 
 				if ( hasCache && provider.isPregeneratedLink ) {
-					// if styles were rendered already (i.e. hasCache = true), we can safely remove the pregenerated css rules imported via <link /> tags
 					removeProviderPregeneratedLinks( provider.getKey(), provider.isPregeneratedLink );
 				}
 

--- a/packages/packages/libs/editor-elements/src/sync/get-current-document-id.ts
+++ b/packages/packages/libs/editor-elements/src/sync/get-current-document-id.ts
@@ -3,5 +3,9 @@ import { type ExtendedWindow } from './types';
 export function getCurrentDocumentId() {
 	const extendedWindow = window as unknown as ExtendedWindow;
 
-	return extendedWindow.elementor?.documents?.getCurrentId?.() ?? null;
+	try {
+		return extendedWindow.elementor?.documents?.getCurrentId?.() ?? null;
+	} catch {
+		return null;
+	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix cache reference and error handling issues in editor style management to prevent crashes when provider keys are unavailable during initialization.

Main changes:
- Refactored cache initialization from direct reference to lazy getter function to ensure fresh cache per provider
- Added safeGetKey error handler and try-catch in getCurrentDocumentId to gracefully handle unavailable providers
- Fixed cache parameter passing by making getCache a closure instead of passing stale cache reference

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
