### PR TITLE
Fix: Overridden components migration [ED-23607]

### DIFF
--- a/modules/atomic-widgets/prop-type-migrations/migrations-cache.php
+++ b/modules/atomic-widgets/prop-type-migrations/migrations-cache.php
@@ -20,7 +20,6 @@ class Migrations_Cache {
 	 * @return bool
 	 */
 	public static function is_migrated( int $id, string $data_identifier, string $manifest_hash ): bool {
-		return false;
 		$cache_meta_key = self::get_cache_meta_key( $data_identifier );
 		$current_state = self::get_migration_state( $manifest_hash );
 

--- a/modules/atomic-widgets/prop-type-migrations/migrations-cache.php
+++ b/modules/atomic-widgets/prop-type-migrations/migrations-cache.php
@@ -20,6 +20,7 @@ class Migrations_Cache {
 	 * @return bool
 	 */
 	public static function is_migrated( int $id, string $data_identifier, string $manifest_hash ): bool {
+		return false;
 		$cache_meta_key = self::get_cache_meta_key( $data_identifier );
 		$current_state = self::get_migration_state( $manifest_hash );
 

--- a/modules/atomic-widgets/prop-type-migrations/migrations-orchestrator.php
+++ b/modules/atomic-widgets/prop-type-migrations/migrations-orchestrator.php
@@ -8,7 +8,9 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Base\Array_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Component_Override_Parser;
 use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Override_Prop_Type;
 use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -234,6 +236,10 @@ class Migrations_Orchestrator {
 					$has_changes = true;
 				}
 			}
+		} elseif ( $actual_prop_type instanceof Override_Prop_Type && is_array( $value['value'] ) ) {
+			if ( $this->migrate_override_value( $value['value'] ) ) {
+				$has_changes = true;
+			}
 		}
 
 		$found_type = $value['$$type'];
@@ -271,6 +277,30 @@ class Migrations_Orchestrator {
 		}
 
 		return null;
+	}
+
+	private function migrate_override_value( array &$data ): bool {
+		$override_key = $data['override_key'] ?? null;
+		$override_value = $data['override_value'] ?? null;
+		$schema_source = $data['schema_source'] ?? null;
+
+		if ( ! $override_key || ! is_array( $override_value ) || ! isset( $override_value['$$type'] ) || ! is_array( $schema_source ) ) {
+			return false;
+		}
+
+		$component_id = $schema_source['id'] ?? null;
+
+		if ( ! $component_id ) {
+			return false;
+		}
+
+		$prop_type = Component_Override_Parser::make()->resolve_override_value_prop_type( $override_key, (int) $component_id );
+
+		if ( ! ( $prop_type instanceof Prop_Type ) ) {
+			return false;
+		}
+
+		return $this->migrate_prop( $data['override_value'], $prop_type );
 	}
 
 	private function execute_prop_migration( $prop_value, array $migrations, string $direction ) {

--- a/modules/components/prop-types/component-override-parser.php
+++ b/modules/components/prop-types/component-override-parser.php
@@ -25,6 +25,21 @@ class Component_Override_Parser extends Override_Parser {
 		return new static();
 	}
 
+	public function resolve_override_value_prop_type( string $override_key, int $component_id ): ?Prop_Type {
+		$component_overridable_props = $this->get_component_overridable_props( $component_id );
+		$matching = $this->get_matching_component_overridable_prop( $override_key, $component_overridable_props );
+
+		if ( ! $matching ) {
+			return null;
+		}
+
+		try {
+			return $this->get_overridable_prop_type( $matching );
+		} catch ( \Exception $e ) {
+			return null;
+		}
+	}
+
 	public function validate_override( string $override_key, ?array $override_value, array $schema_source ): bool {
 		if ( ! isset( $schema_source['id'] ) ) {
 			return false;

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/fixtures/document-migrations/overridable-migration-data.json
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/fixtures/document-migrations/overridable-migration-data.json
@@ -1,19 +1,117 @@
 [
-  {
-    "id": "element_1",
-    "elType": "widget",
-    "widgetType": "e-heading",
-    "settings": {
-      "title": {
-        "$$type": "overridable",
-        "value": {
-          "override_key": "prop-123",
-          "origin_value": {
-            "$$type": "html",
-            "value": "Overridable Title"
-          }
-        }
-      }
-    }
-  }
+	{
+		"id": "element_1",
+		"elType": "widget",
+		"widgetType": "e-heading",
+		"settings": {
+			"title": {
+				"$$type": "overridable",
+				"value": {
+					"override_key": "prop-123",
+					"origin_value": {
+						"$$type": "html",
+						"value": "Overridable Title"
+					}
+				}
+			}
+		}
+	},
+	{
+		"id": "flexbox-element-overrides",
+		"elType": "widget",
+		"settings": {
+			"component_instance": {
+				"$$type": "component-instance",
+				"value": {
+					"component_id": {
+						"$$type": "number",
+						"value": 1530
+					},
+					"overrides": {
+						"$$type": "overrides",
+						"value": [
+							{
+								"$$type": "override",
+								"value": {
+									"override_key": "prop-1774948276142-hbvo1d6",
+									"override_value": {
+										"$$type": "html",
+										"value": "This is a title1"
+									},
+									"schema_source": {
+										"type": "component",
+										"id": 1530
+									}
+								}
+							}
+						]
+					}
+				}
+			}
+		},
+		"interactions": [],
+		"elements": [],
+		"widgetType": "e-component",
+		"styles": [],
+		"componentId": 1530,
+		"isGlobal": true
+	},
+	{
+		"id": "flexbox-element-overrides-nested",
+		"elType": "e-flexbox",
+		"settings": {},
+		"interactions": [],
+		"elements": [
+			{
+				"id": "fd78ee2",
+				"elType": "widget",
+				"settings": {
+					"component_instance": {
+						"$$type": "component-instance",
+						"value": {
+							"component_id": {
+								"$$type": "number",
+								"value": 1530
+							},
+							"overrides": {
+								"$$type": "overrides",
+								"value": [
+									{
+										"$$type": "overridable",
+										"value": {
+											"override_key": "prop-1774949015125-0ez30mb",
+											"origin_value": {
+												"$$type": "override",
+												"value": {
+													"override_key": "prop-1774948276142-hbvo1d6",
+													"override_value": {
+														"$$type": "html",
+														"value": "This is a title2"
+													},
+													"schema_source": {
+														"type": "component",
+														"id": 1530
+													}
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					}
+				},
+				"defaultEditSettings": {
+					"defaultEditRoute": "content"
+				},
+				"interactions": [],
+				"elements": [],
+				"widgetType": "e-component",
+				"styles": [],
+				"componentId": 1530
+			}
+		],
+		"styles": [],
+		"editor_settings": []
+	}
 ]

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-document-migration-integration.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-document-migration-integration.php
@@ -2,12 +2,16 @@
 
 namespace Elementor\Tests\Phpunit\Elementor\Modules\AtomicWidgets\PropTypeMigrations;
 
+use Elementor\Core\Documents_Manager;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Heading\Atomic_Heading;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Image\Atomic_Image;
 use Elementor\Modules\AtomicWidgets\Elements\Div_Block\Div_Block;
 use Elementor\Modules\AtomicWidgets\Elements\Flexbox\Flexbox;
 use Elementor\Modules\AtomicWidgets\PropTypeMigrations\Migrations_Orchestrator;
+use Elementor\Modules\Components\Documents\Component as Component_Document;
+use Elementor\Modules\Components\Documents\Component_Overridable_Props;
 use Elementor\Modules\Components\Overridable_Schema_Extender;
+use Elementor\Modules\Components\Widgets\Component_Instance;
 use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
 use Spatie\Snapshots\MatchesSnapshots;
@@ -22,6 +26,18 @@ class Mock_String_V2_Integration_Prop_Type extends \Elementor\Modules\AtomicWidg
 	}
 }
 
+class Mock_Migration_Component_Document extends Component_Document {
+	private array $mock_overridable_props;
+
+	public function __construct( array $overridable_props ) {
+		$this->mock_overridable_props = $overridable_props;
+	}
+
+	public function get_overridable_props(): Component_Overridable_Props {
+		return Component_Overridable_Props::make( $this->mock_overridable_props );
+	}
+}
+
 /**
  * @group prop-type-migrations
  * @group integration
@@ -29,11 +45,15 @@ class Mock_String_V2_Integration_Prop_Type extends \Elementor\Modules\AtomicWidg
 class Test_Document_Migration_Integration extends Elementor_Test_Base {
 	use MatchesSnapshots;
 
+	const COMPONENT_ID = 1530;
+
 	private string $fixtures_path = __DIR__ . '/fixtures/document-migrations/';
 
 	private array $registered_widgets = [];
 
 	private array $registered_elements = [];
+
+	private ?Documents_Manager $original_documents_manager = null;
 
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
@@ -66,6 +86,11 @@ class Test_Document_Migration_Integration extends Elementor_Test_Base {
 			$this->registered_elements[] = 'e-div-block';
 		}
 
+		if ( ! $widgets_manager->get_widget_types( 'e-component' ) ) {
+			$widgets_manager->register( new Component_Instance( [], [] ) );
+			$this->registered_widgets[] = 'e-component';
+		}
+
 		Migrations_Orchestrator::clear_migration_cache();
 	}
 
@@ -83,6 +108,11 @@ class Test_Document_Migration_Integration extends Elementor_Test_Base {
 
 		$this->registered_widgets = [];
 		$this->registered_elements = [];
+
+		if ( $this->original_documents_manager ) {
+			Plugin::$instance->documents = $this->original_documents_manager;
+			$this->original_documents_manager = null;
+		}
 
 		Migrations_Orchestrator::destroy();
 
@@ -272,6 +302,120 @@ class Test_Document_Migration_Integration extends Elementor_Test_Base {
 		$this->assertEquals( 'prop-123', $document_data[0]['settings']['title']['value']['override_key'] );
 
 		remove_filter( 'elementor/atomic-widgets/props-schema', [ $this, 'extend_schema_with_overridable' ], 999999 );
+	}
+
+	public function test_migrate_override_value_inside_component_instance() {
+		// Arrange
+		add_filter( 'elementor/atomic-widgets/props-schema', [ $this, 'extend_schema_with_overridable' ], 999999 );
+		$this->mock_component_documents_manager();
+
+		$document_data = json_decode(
+			file_get_contents( $this->fixtures_path . 'overridable-migration-data.json' ),
+			true
+		);
+
+		$element_data = [ $document_data[1] ];
+
+		$orchestrator = Migrations_Orchestrator::make( $this->fixtures_path );
+		$post_id = 1003;
+
+		// Act
+		$orchestrator->migrate(
+			$element_data,
+			$post_id,
+			'_elementor_data',
+			function() {}
+		);
+
+		// Assert
+		$override = $element_data[0]['settings']['component_instance']['value']['overrides']['value'][0];
+		$this->assertEquals( 'override', $override['$$type'] );
+		$this->assertEquals( 'html-v3', $override['value']['override_value']['$$type'], 'override_value should be migrated from html to html-v3' );
+
+		remove_filter( 'elementor/atomic-widgets/props-schema', [ $this, 'extend_schema_with_overridable' ], 999999 );
+	}
+
+	public function test_migrate_override_value_nested_inside_overridable_and_override() {
+		// Arrange
+		add_filter( 'elementor/atomic-widgets/props-schema', [ $this, 'extend_schema_with_overridable' ], 999999 );
+		$this->mock_component_documents_manager();
+
+		$document_data = json_decode(
+			file_get_contents( $this->fixtures_path . 'overridable-migration-data.json' ),
+			true
+		);
+
+		$element_data = [ $document_data[2] ];
+
+		$orchestrator = Migrations_Orchestrator::make( $this->fixtures_path );
+		$post_id = 1004;
+
+		// Act
+		$orchestrator->migrate(
+			$element_data,
+			$post_id,
+			'_elementor_data',
+			function() {}
+		);
+
+		// Assert
+		$overridable_item = $element_data[0]['elements'][0]['settings']['component_instance']['value']['overrides']['value'][0];
+		$this->assertEquals( 'overridable', $overridable_item['$$type'] );
+
+		$inner_override = $overridable_item['value']['origin_value'];
+		$this->assertEquals( 'override', $inner_override['$$type'] );
+		$this->assertEquals( 'html-v3', $inner_override['value']['override_value']['$$type'], 'nested override_value should be migrated from html to html-v3' );
+
+		remove_filter( 'elementor/atomic-widgets/props-schema', [ $this, 'extend_schema_with_overridable' ], 999999 );
+	}
+
+	private function mock_component_documents_manager(): void {
+		$this->original_documents_manager = Plugin::$instance->documents;
+
+		$overridable_props = [
+			'props' => [
+				'prop-1774948276142-hbvo1d6' => [
+					'overrideKey' => 'prop-1774948276142-hbvo1d6',
+					'label' => 'Heading Title',
+					'elementId' => 'heading-123',
+					'elType' => 'widget',
+					'widgetType' => 'e-heading',
+					'propKey' => 'title',
+					'originValue' => [
+						'$$type' => 'html-v3',
+						'value' => 'Original Title',
+					],
+				],
+			],
+			'groups' => [],
+		];
+
+		$mock_doc = new Mock_Migration_Component_Document( $overridable_props );
+
+		$documents_mock = $this->getMockBuilder( Documents_Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get', 'get_doc_or_auto_save' ] )
+			->getMock();
+
+		$documents_mock->method( 'get_doc_or_auto_save' )->willReturnCallback(
+			function ( $post_id ) use ( $mock_doc ) {
+				if ( $post_id === self::COMPONENT_ID ) {
+					return $mock_doc;
+				}
+				return $this->original_documents_manager->get_doc_or_auto_save( $post_id );
+			}
+		);
+
+		$documents_mock->method( 'get' )->willReturnCallback(
+			function ( $post_id ) use ( $mock_doc ) {
+				if ( $post_id === self::COMPONENT_ID ) {
+					return $mock_doc;
+				}
+				return $this->original_documents_manager->get( $post_id );
+			}
+		);
+
+		Plugin::$instance->documents = $documents_mock;
 	}
 
 	public function test_widget_migration_edge_cases() {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix migration handling for overridden component props by adding support for Override_Prop_Type traversal in the migrations orchestrator.

Main changes:
- Added migrate_override_value() method to handle Override_Prop_Type migration by resolving prop types from component schemas
- Implemented resolve_override_value_prop_type() in Component_Override_Parser to extract correct prop types for override values
- Extended migration logic to recursively process override values nested within overridable props and component instances

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
