### PR TITLE
Fix: Align overridable props to element settings after prop migration [ED-23622]

### DIFF
--- a/core/base/document.php
+++ b/core/base/document.php
@@ -2109,4 +2109,8 @@ abstract class Document extends Controls_Stack {
 
 		return $this->elements_iteration_actions;
 	}
+
+	public function get_elementor_version() {
+		return $this->get_main_meta( '_elementor_version' );
+	}
 }

--- a/modules/atomic-widgets/prop-type-migrations/migrations-orchestrator.php
+++ b/modules/atomic-widgets/prop-type-migrations/migrations-orchestrator.php
@@ -311,6 +311,8 @@ class Migrations_Orchestrator {
 					Document::ELEMENTOR_DATA_META_KEY,
 					$migrated_data
 				);
+
+				do_action( 'elementor/document/after_migrate', $document, $migrated_data );
 			}
 		);
 

--- a/modules/components/components-rest-api.php
+++ b/modules/components/components-rest-api.php
@@ -320,6 +320,7 @@ class Components_REST_API {
 				->build();
 		}
 
+		/** @var Component $document */
 		$document = $this->get_repository()->get( $component_id );
 
 		if ( ! $document ) {
@@ -327,6 +328,16 @@ class Components_REST_API {
 				->set_status( 404 )
 				->set_message( __( 'Component not found', 'elementor' ) )
 				->build();
+		}
+
+		// This is a fix for the case where overridable props in element settings where migrated
+		// but the overridable props metadata were not aligned with the new origin values.
+		// In version 4.0.1, we fixed this by running the align_overridable_props_with_elements method after the migration.
+		$document_version = $document->get_elementor_version();
+		$overridable_props_migration_fix_version = '4.0.1';
+		$should_align_overridable_props = version_compare( $document_version, $overridable_props_migration_fix_version, '<=' );
+		if ( $should_align_overridable_props ) {
+			$document->align_overridable_props_with_elements();
 		}
 
 		$overridable = $document->get_json_meta( Component::OVERRIDABLE_PROPS_META_KEY ) ?? null;

--- a/modules/components/documents/component-overridable-prop.php
+++ b/modules/components/documents/component-overridable-prop.php
@@ -56,4 +56,28 @@ class Component_Overridable_Prop {
 	public static function make( array $overridable_prop ): self {
 		return new self( $overridable_prop );
 	}
+
+	public function to_associative_array(): array {
+		$result = [
+			'overrideKey' => $this->override_key,
+			'elementId'   => $this->element_id,
+			'elType'      => $this->el_type,
+			'widgetType'  => $this->widget_type,
+			'propKey'     => $this->prop_key,
+			'label'       => $this->label,
+			'originValue' => $this->origin_value,
+			'groupId'     => $this->group_id,
+		];
+
+		if ( $this->origin_prop_fields ) {
+			$result['originPropFields'] = [
+				'elType'     => $this->origin_prop_fields['el_type'],
+				'widgetType' => $this->origin_prop_fields['widget_type'],
+				'propKey'    => $this->origin_prop_fields['prop_key'],
+				'elementId'  => $this->origin_prop_fields['element_id'],
+			];
+		}
+
+		return $result;
+	}
 }

--- a/modules/components/documents/component-overridable-props.php
+++ b/modules/components/documents/component-overridable-props.php
@@ -33,4 +33,16 @@ class Component_Overridable_Props {
 	public static function make( array $overridable_props_meta ): self {
 		return new self( $overridable_props_meta );
 	}
+
+	public function to_associative_array(): array {
+		$props_map = [];
+		foreach ( $this->props as $prop ) {
+			$props_map[ $prop->override_key ] = $prop->to_associative_array();
+		}
+
+		return [
+			'props'  => $props_map,
+			'groups' => $this->groups,
+		];
+	}
 }

--- a/modules/components/documents/component.php
+++ b/modules/components/documents/component.php
@@ -177,7 +177,7 @@ class Component extends Document {
 	private function get_elements_origin_values_map( array $elements_data, array $overridable_props_map ) {
 		foreach ( $elements_data as $element ) {
 			foreach ( $element['settings'] as $prop_key => $prop_value ) {
-				if ( isset( $prop_value['$$type'] ) && $prop_value['$$type'] === Overridable_Prop_Type::get_key() ) {
+				if ( isset( $prop_value['$$type'] ) && Overridable_Prop_Type::get_key() === $prop_value['$$type'] ) {
 					$override_key = $prop_value['value']['override_key'];
 					$origin_value = $prop_value['value']['origin_value'];
 

--- a/modules/components/documents/component.php
+++ b/modules/components/documents/component.php
@@ -4,6 +4,7 @@ namespace Elementor\Modules\Components\Documents;
 use Elementor\Core\Base\Document;
 use Elementor\Core\Utils\Api\Parse_Result;
 use Elementor\Modules\Components\OverridableProps\Component_Overridable_Props_Parser;
+use Elementor\Modules\Components\PropTypes\Override_Prop_Type;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -147,5 +148,54 @@ class Component extends Document {
 
 	public function print_elements_without_cache( array $elements_data ) {
 		$this->do_print_elements( $elements_data );
+	}
+
+	public function align_overridable_props_with_elements() {
+		$elements_data = $this->get_elements_data();
+		// format elements data to flat map of overridable prop key -> new origin value
+		$overridable_props_map = $this->get_elements_origin_values_map( $elements_data, [] );
+
+		if ( empty( $overridable_props_map ) ) {
+			return;
+		}
+
+		$updated_overridable_props = $this->get_overridable_props();
+
+		foreach ( $updated_overridable_props->props as $prop ) {
+
+			$new_origin_value = $overridable_props_map[ $prop->override_key ];
+
+			if ( isset( $new_origin_value ) ) {
+				$prop->origin_value = $new_origin_value;
+			}
+		}
+
+		$this->update_overridable_props( $updated_overridable_props->to_associative_array() );
+	}
+
+	private function get_elements_origin_values_map( array $elements_data, array $overridable_props_map ) {
+		foreach ( $elements_data as $element ) {
+			foreach ( $element['settings'] as $prop_key => $prop_value ) {
+				if ( isset( $prop_value['$$type'] ) && $prop_value['$$type'] === 'overridable' ) {
+					$override_key = $prop_value['value']['override_key'];
+					$origin_value = $prop_value['value']['origin_value'];
+
+					if (
+						isset( $origin_value['$$type'] ) &&
+						Override_Prop_Type::get_key() === $origin_value['$$type']
+					) {
+						$origin_value = $origin_value['value']['override_value'];
+					}
+
+					$overridable_props_map[ $override_key ] = $origin_value;
+				}
+			}
+		}
+
+		if ( is_array( $element['elements'] ) ) {
+			$overridable_props_map = array_merge( $overridable_props_map, $this->get_elements_origin_values_map( $element['elements'], $overridable_props_map ) );
+		}
+
+		return $overridable_props_map;
 	}
 }

--- a/modules/components/documents/component.php
+++ b/modules/components/documents/component.php
@@ -189,11 +189,11 @@ class Component extends Document {
 
 					$overridable_props_map[ $override_key ] = $origin_value;
 				}
-			}
-		}
 
-		if ( is_array( $element['elements'] ) ) {
-			$overridable_props_map = array_merge( $overridable_props_map, $this->get_elements_origin_values_map( $element['elements'], $overridable_props_map ) );
+				if ( is_array( $element['elements'] ) ) {
+					$overridable_props_map = array_merge( $overridable_props_map, $this->get_elements_origin_values_map( $element['elements'], $overridable_props_map ) );
+				}
+			}
 		}
 
 		return $overridable_props_map;

--- a/modules/components/documents/component.php
+++ b/modules/components/documents/component.php
@@ -189,10 +189,10 @@ class Component extends Document {
 
 					$overridable_props_map[ $override_key ] = $origin_value;
 				}
+			}
 
-				if ( is_array( $element['elements'] ) ) {
-					$overridable_props_map = array_merge( $overridable_props_map, $this->get_elements_origin_values_map( $element['elements'], $overridable_props_map ) );
-				}
+			if ( is_array( $element['elements'] ) ) {
+				$overridable_props_map = $this->get_elements_origin_values_map( $element['elements'], $overridable_props_map );
 			}
 		}
 

--- a/modules/components/documents/component.php
+++ b/modules/components/documents/component.php
@@ -5,6 +5,7 @@ use Elementor\Core\Base\Document;
 use Elementor\Core\Utils\Api\Parse_Result;
 use Elementor\Modules\Components\OverridableProps\Component_Overridable_Props_Parser;
 use Elementor\Modules\Components\PropTypes\Override_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -176,7 +177,7 @@ class Component extends Document {
 	private function get_elements_origin_values_map( array $elements_data, array $overridable_props_map ) {
 		foreach ( $elements_data as $element ) {
 			foreach ( $element['settings'] as $prop_key => $prop_value ) {
-				if ( isset( $prop_value['$$type'] ) && $prop_value['$$type'] === 'overridable' ) {
+				if ( isset( $prop_value['$$type'] ) && $prop_value['$$type'] === Overridable_Prop_Type::get_key() ) {
 					$override_key = $prop_value['value']['override_key'];
 					$origin_value = $prop_value['value']['origin_value'];
 

--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -46,6 +46,7 @@ class Module extends BaseModule {
 		add_filter( 'elementor/global_classes/additional_post_types', fn( $post_types ) => array_merge( $post_types, [ Component_Document::TYPE ] ) );
 
 		add_action( 'elementor/atomic-widgets/settings/transformers/register', fn ( $transformers ) => $this->register_settings_transformers( $transformers ) );
+		add_action( 'elementor/document/after_migrate', fn( Document $document, array $data ) => $this->after_component_migrate( $document, $data ), 10, 2 );
 
 		( Component_Lock_Manager::get_instance()->register_hooks() );
 		( new Component_Styles() )->register_hooks();
@@ -143,5 +144,13 @@ class Module extends BaseModule {
 		$transformers->register( Component_Instance_Prop_Type::get_key(), new Component_Instance_Transformer() );
 		$transformers->register( Overridable_Prop_Type::get_key(), new Overridable_Transformer() );
 		$transformers->register( Override_Prop_Type::get_key(), new Override_Transformer() );
+	}
+
+	private function after_component_migrate( Document $document, array $data ) {
+		if ( ! $document instanceof Component_Document ) {
+			return;
+		}
+
+		$document->align_overridable_props_with_elements();
 	}
 }

--- a/tests/phpunit/elementor/modules/components/test-component-align-overridable-props.php
+++ b/tests/phpunit/elementor/modules/components/test-component-align-overridable-props.php
@@ -1,0 +1,550 @@
+<?php
+
+namespace Elementor\Testing\Modules\Components;
+
+use Elementor\Core\Base\Document;
+use Elementor\Modules\Components\Documents\Component as Component_Document;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Component_Align_Overridable_Props extends Elementor_Test_Base {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		Plugin::$instance->documents->register_document_type(
+			Component_Document::TYPE,
+			Component_Document::get_class_full_name()
+		);
+
+		register_post_type( Component_Document::TYPE, [
+			'label'    => Component_Document::get_title(),
+			'labels'   => Component_Document::get_labels(),
+			'public'   => false,
+			'supports' => Component_Document::get_supported_features(),
+		] );
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		$components = get_posts( [
+			'post_type'      => Component_Document::TYPE,
+			'post_status'    => 'any',
+			'posts_per_page' => -1,
+		] );
+
+		foreach ( $components as $component ) {
+			wp_delete_post( $component->ID, true );
+		}
+	}
+
+	public function test_align__updates_stale_origin_values_from_elements() {
+		// Arrange
+		$this->act_as_admin();
+
+		$new_origin_value = [
+			'$$type' => 'html-v3',
+			'value'  => [
+				'content'  => [ '$$type' => 'string', 'value' => 'Migrated Title' ],
+				'children' => [],
+			],
+		];
+
+		$elements_data = [
+			[
+				'id'       => 'heading-el',
+				'elType'   => 'widget',
+				'widgetType' => 'e-heading',
+				'settings' => [
+					'title' => [
+						'$$type' => 'overridable',
+						'value'  => [
+							'override_key' => 'prop-111',
+							'origin_value' => $new_origin_value,
+						],
+					],
+				],
+				'elements' => [],
+			],
+		];
+
+		$stale_overridable_props = [
+			'props' => [
+				'prop-111' => [
+					'overrideKey' => 'prop-111',
+					'elementId'   => 'heading-el',
+					'elType'      => 'widget',
+					'widgetType'  => 'e-heading',
+					'propKey'     => 'title',
+					'label'       => 'Title',
+					'originValue' => [
+						'$$type' => 'string',
+						'value'  => 'Old Stale Title',
+					],
+					'groupId' => 'group-1',
+				],
+			],
+			'groups' => [
+				'items' => [
+					'group-1' => [
+						'id'    => 'group-1',
+						'label' => 'Default',
+						'props' => [ 'prop-111' ],
+					],
+				],
+				'order' => [ 'group-1' ],
+			],
+		];
+
+		$component_id = $this->create_test_component_with_data( $elements_data, $stale_overridable_props );
+		$document = Plugin::$instance->documents->get( $component_id, false );
+
+		// Act
+		/** @var Component_Document $document */
+		$document->align_overridable_props_with_elements();
+
+		// Assert
+		$updated_meta = $this->get_stored_overridable_props( $component_id );
+
+		$this->assertEquals(
+			$new_origin_value,
+			$updated_meta['props']['prop-111']['originValue']
+		);
+	}
+
+	public function test_align__unwraps_override_prop_type_from_origin_value() {
+		// Arrange
+		$this->act_as_admin();
+
+		$inner_component_overridable_props = [
+			'props' => [
+				'inner-key' => [
+					'overrideKey' => 'inner-key',
+					'elementId'   => 'inner-el',
+					'elType'      => 'widget',
+					'widgetType'  => 'e-heading',
+					'propKey'     => 'title',
+					'label'       => 'Title',
+					'originValue' => [
+						'$$type' => 'string',
+						'value'  => 'Inner Title',
+					],
+					'groupId' => 'group-1',
+				],
+			],
+		];
+
+		$inner_component_id = $this->create_test_component_with_data( [], $inner_component_overridable_props );
+
+		$new_origin_value = [
+			'$$type' => 'html-v3',
+			'value'  => [
+				'content'  => [ '$$type' => 'string', 'value' => 'Title' ],
+				'children' => [],
+			],
+		];
+
+		$elements_data = [
+			[
+				'id'       => 'comp-instance-el',
+				'elType'   => 'widget',
+				'widgetType' => 'e-component',
+				'settings' => [
+					'some_prop' => [
+						'$$type' => 'overridable',
+						'value'  => [
+							'override_key' => 'prop-222',
+							'origin_value' => [
+								'$$type' => 'override',
+								'value'  => [
+									'override_key'   => 'inner-key',
+									'override_value' => $new_origin_value,
+									'schema_source' => [ 'type' => 'component', 'id' => $inner_component_id ],
+								],
+							],
+						],
+					],
+				],
+				'elements' => [],
+			],
+		];
+
+		$stale_overridable_props = [
+			'props' => [
+				'prop-222' => [
+					'overrideKey' => 'prop-222',
+					'elementId'   => 'comp-instance-el',
+					'elType'      => 'widget',
+					'widgetType'  => 'e-heading',
+					'propKey'     => 'title',
+					'label'       => 'Title',
+					'originValue' => [
+						'$$type' => 'html-v3',
+						'value'  => [
+							'content'  => [ '$$type' => 'string', 'value' => 'Old Title' ],
+							'children' => [],
+						],
+					],
+					'groupId' => 'group-1',
+				],
+			],
+			'groups' => [
+				'items' => [
+					'group-1' => [
+						'id'    => 'group-1',
+						'label' => 'Default',
+						'props' => [ 'prop-222' ],
+					],
+				],
+				'order' => [ 'group-1' ],
+			],
+		];
+
+		$component_id = $this->create_test_component_with_data( $elements_data, $stale_overridable_props );
+		$document = Plugin::$instance->documents->get( $component_id, false );
+
+		// Act
+		/** @var Component_Document $document */
+		$document->align_overridable_props_with_elements();
+
+		// Assert
+		$updated_meta = $this->get_stored_overridable_props( $component_id );
+
+		$this->assertEquals( $new_origin_value, $updated_meta['props']['prop-222']['originValue'] );
+	}
+
+	public function test_align__no_op_when_elements_have_no_overridable_settings() {
+		// Arrange
+		$this->act_as_admin();
+
+		$elements_data = [
+			[
+				'id'       => 'heading-el',
+				'elType'   => 'widget',
+				'widgetType' => 'e-heading',
+				'settings' => [
+					'title' => [
+						'$$type' => 'string',
+						'value'  => 'Regular non-overridable title',
+					],
+				],
+				'elements' => [],
+			],
+		];
+
+		$original_overridable_props = [
+			'props' => [
+				'prop-333' => [
+					'overrideKey' => 'prop-333',
+					'elementId'   => 'heading-el',
+					'elType'      => 'widget',
+					'widgetType'  => 'e-heading',
+					'propKey'     => 'title',
+					'label'       => 'Title',
+					'originValue' => [
+						'$$type' => 'string',
+						'value'  => 'Should Not Change',
+					],
+					'groupId' => 'group-1',
+				],
+			],
+			'groups' => [
+				'items' => [
+					'group-1' => [
+						'id'    => 'group-1',
+						'label' => 'Default',
+						'props' => [ 'prop-333' ],
+					],
+				],
+				'order' => [ 'group-1' ],
+			],
+		];
+
+		$component_id = $this->create_test_component_with_data( $elements_data, $original_overridable_props );
+		$document = Plugin::$instance->documents->get( $component_id, false );
+
+		// Act
+		/** @var Component_Document $document */
+		$document->align_overridable_props_with_elements();
+
+		// Assert
+		$stored_meta = $this->get_stored_overridable_props( $component_id );
+
+		$this->assertEquals( $original_overridable_props, $stored_meta );
+	}
+
+	public function test_align__traverses_nested_child_elements() {
+		// Arrange
+		$this->act_as_admin();
+
+		$new_origin_value = [
+			'$$type' => 'html-v3',
+			'value'  => [
+				'content'  => [ '$$type' => 'string', 'value' => 'Nested Migrated Value' ],
+				'children' => [],
+			],
+		];
+
+		$elements_data = [
+			[
+				'id'       => 'flexbox-wrapper',
+				'elType'   => 'e-flexbox',
+				'settings' => [],
+				'elements' => [
+					[
+						'id'       => 'nested-heading',
+						'elType'   => 'widget',
+						'widgetType' => 'e-heading',
+						'settings' => [
+							'title' => [
+								'$$type' => 'overridable',
+								'value'  => [
+									'override_key' => 'prop-nested',
+									'origin_value' => $new_origin_value,
+								],
+							],
+						],
+						'elements' => [],
+					],
+				],
+			],
+		];
+
+		$stale_overridable_props = [
+			'props' => [
+				'prop-nested' => [
+					'overrideKey' => 'prop-nested',
+					'elementId'   => 'nested-heading',
+					'elType'      => 'widget',
+					'widgetType'  => 'e-heading',
+					'propKey'     => 'title',
+					'label'       => 'Nested Title',
+					'originValue' => [
+						'$$type' => 'string',
+						'value'  => 'Old Nested Value',
+					],
+					'groupId' => 'group-1',
+				],
+			],
+			'groups' => [
+				'items' => [
+					'group-1' => [
+						'id'    => 'group-1',
+						'label' => 'Default',
+						'props' => [ 'prop-nested' ],
+					],
+				],
+				'order' => [ 'group-1' ],
+			],
+		];
+
+		$component_id = $this->create_test_component_with_data( $elements_data, $stale_overridable_props );
+		$document = Plugin::$instance->documents->get( $component_id, false );
+
+		// Act
+		/** @var Component_Document $document */
+		$document->align_overridable_props_with_elements();
+
+		// Assert
+		$updated_meta = $this->get_stored_overridable_props( $component_id );
+
+		$this->assertEquals(
+			$new_origin_value,
+			$updated_meta['props']['prop-nested']['originValue']
+		);
+	}
+
+	public function test_align__handles_multiple_overridable_props_across_elements() {
+		// Arrange
+		$this->act_as_admin();
+
+		$new_title_origin_value = [
+			'$$type' => 'html-v3',
+			'value'  => [
+				'content'  => [ '$$type' => 'string', 'value' => 'New Title' ],
+				'children' => [],
+			],
+		];
+
+		$new_tag_origin_value = [
+			'$$type' => 'string',
+			'value'  => 'h1',
+		];
+
+		$new_image_origin_value = [
+			'$$type' => 'image',
+			'value'  => [
+				'src' => [
+					'$$type' => 'image-src',
+					'value'  => [
+						'id'  => null,
+						'url' => [ '$$type' => 'url', 'value' => 'https://new.com/img.jpg' ],
+					],
+				],
+			],
+		];
+
+		$elements_data = [
+			[
+				'id'       => 'heading-el',
+				'elType'   => 'widget',
+				'widgetType' => 'e-heading',
+				'settings' => [
+					'title' => [
+						'$$type' => 'overridable',
+						'value'  => [
+							'override_key' => 'prop-title',
+							'origin_value' => $new_title_origin_value,
+						],
+					],
+					'tag' => [
+						'$$type' => 'overridable',
+						'value'  => [
+							'override_key' => 'prop-tag',
+							'origin_value' => $new_tag_origin_value,
+						],
+					],
+				],
+				'elements' => [],
+			],
+			[
+				'id'       => 'image-el',
+				'elType'   => 'widget',
+				'widgetType' => 'e-image',
+				'settings' => [
+					'image' => [
+						'$$type' => 'overridable',
+						'value'  => [
+							'override_key' => 'prop-image',
+							'origin_value' => $new_image_origin_value,
+						],
+					],
+				],
+				'elements' => [],
+			],
+		];
+
+		$stale_props = [
+			'props' => [
+				'prop-title' => [
+					'overrideKey' => 'prop-title',
+					'elementId'   => 'heading-el',
+					'elType'      => 'widget',
+					'widgetType'  => 'e-heading',
+					'propKey'     => 'title',
+					'label'       => 'Title',
+					'originValue' => [ '$$type' => 'string', 'value' => 'Stale Title' ],
+					'groupId'     => 'group-1',
+				],
+				'prop-tag' => [
+					'overrideKey' => 'prop-tag',
+					'elementId'   => 'heading-el',
+					'elType'      => 'widget',
+					'widgetType'  => 'e-heading',
+					'propKey'     => 'tag',
+					'label'       => 'Tag',
+					'originValue' => [ '$$type' => 'string-v0', 'value' => 'h3' ],
+					'groupId'     => 'group-1',
+				],
+				'prop-image' => [
+					'overrideKey' => 'prop-image',
+					'elementId'   => 'image-el',
+					'elType'      => 'widget',
+					'widgetType'  => 'e-image',
+					'propKey'     => 'image',
+					'label'       => 'Image',
+					'originValue' => [
+						'$$type' => 'image',
+						'value'  => [
+							'src' => [
+								'$$type' => 'image-src-v0',
+								'value'  => [
+									'id'  => null,
+									'url' => [ '$$type' => 'url', 'value' => 'https://old.com/img.jpg' ],
+								],
+							],
+						],
+					],
+					'groupId'     => 'group-2',
+				],
+			],
+			'groups' => [
+				'items' => [
+					'group-1' => [
+						'id'    => 'group-1',
+						'label' => 'Heading',
+						'props' => [ 'prop-title', 'prop-tag' ],
+					],
+					'group-2' => [
+						'id'    => 'group-2',
+						'label' => 'Media',
+						'props' => [ 'prop-image' ],
+					],
+				],
+				'order' => [ 'group-1', 'group-2' ],
+			],
+		];
+
+		$component_id = $this->create_test_component_with_data( $elements_data, $stale_props );
+		$document = Plugin::$instance->documents->get( $component_id, false );
+
+		// Act
+		/** @var Component_Document $document */
+		$document->align_overridable_props_with_elements();
+
+		// Assert
+		$updated_meta = $this->get_stored_overridable_props( $component_id );
+
+		$this->assertEquals(
+			$new_title_origin_value,
+			$updated_meta['props']['prop-title']['originValue']
+		);
+
+		$this->assertEquals(
+			$new_tag_origin_value,
+			$updated_meta['props']['prop-tag']['originValue']
+		);
+
+		$this->assertEquals(
+			$new_image_origin_value,
+			$updated_meta['props']['prop-image']['originValue']
+		);
+	}
+
+	private function create_test_component_with_data( array $elements_data, array $overridable_props ): int {
+		$document = Plugin::$instance->documents->create(
+			Component_Document::get_type(),
+			[
+				'post_title'  => 'Test Component',
+				'post_status' => 'publish',
+			]
+		);
+
+		$component_id = $document->get_main_id();
+
+		update_post_meta(
+			$component_id,
+			Document::ELEMENTOR_DATA_META_KEY,
+			wp_slash( wp_json_encode( $elements_data ) )
+		);
+
+		update_post_meta(
+			$component_id,
+			Component_Document::OVERRIDABLE_PROPS_META_KEY,
+			wp_slash( wp_json_encode( $overridable_props ) )
+		);
+
+		return $component_id;
+	}
+
+	private function get_stored_overridable_props( int $component_id ): array {
+		$raw = get_post_meta( $component_id, Component_Document::OVERRIDABLE_PROPS_META_KEY, true );
+
+		return json_decode( $raw, true );
+	}
+}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix migration issue where overridable component props stored stale origin values after prop type migrations in versions prior to 4.0.1.

Main changes:
- Added align_overridable_props_with_elements method to synchronize overridable props metadata with current element settings post-migration
- Implemented version check in REST API to trigger alignment for components created before v4.0.1
- Added after_migrate hook to automatically align overridable props when component documents undergo migration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
