### PR TITLE
Fix: Fix overridable props alignment for nested components [ED-23622]

### DIFF
--- a/modules/components/documents/component.php
+++ b/modules/components/documents/component.php
@@ -6,6 +6,7 @@ use Elementor\Core\Utils\Api\Parse_Result;
 use Elementor\Modules\Components\OverridableProps\Component_Overridable_Props_Parser;
 use Elementor\Modules\Components\PropTypes\Override_Prop_Type;
 use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+use Elementor\Modules\Components\Widgets\Component_Instance;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -176,19 +177,37 @@ class Component extends Document {
 
 	private function get_elements_origin_values_map( array $elements_data, array $overridable_props_map ) {
 		foreach ( $elements_data as $element ) {
-			foreach ( $element['settings'] as $prop_key => $prop_value ) {
-				if ( isset( $prop_value['$$type'] ) && Overridable_Prop_Type::get_key() === $prop_value['$$type'] ) {
-					$override_key = $prop_value['value']['override_key'];
-					$origin_value = $prop_value['value']['origin_value'];
+			if ( $this->is_component_instance( $element ) ) {
+				$component_instance = $element['settings']['component_instance']['value'];
+				$overrides = $component_instance['overrides']['value'] ?? [];
 
-					if (
-						isset( $origin_value['$$type'] ) &&
-						Override_Prop_Type::get_key() === $origin_value['$$type']
-					) {
-						$origin_value = $origin_value['value']['override_value'];
+				if ( empty( $overrides ) ) {
+					continue;
+				}
+
+				foreach ( $overrides as $item ) {
+					if ( $this->is_overridable_prop( $item ) ) {
+						$override_key = $item['value']['override_key'];
+						$override = $item['value']['origin_value'];
+
+						if ( ! $this->is_override_prop( $override ) ) {
+							throw new \Exception( 'Invalid override value' );
+						}
+						$overridable_props_map[ $override_key ] = $override['value']['override_value'];
 					}
+				}
 
-					$overridable_props_map[ $override_key ] = $origin_value;
+				continue;
+			}
+
+			if ( ! empty( $element['settings'] ) ) {
+				foreach ( $element['settings'] as $prop_key => $prop_value ) {
+					if ( isset( $prop_value['$$type'] ) && Overridable_Prop_Type::get_key() === $prop_value['$$type'] ) {
+						$override_key = $prop_value['value']['override_key'];
+						$origin_value = $prop_value['value']['origin_value'];
+
+						$overridable_props_map[ $override_key ] = $origin_value;
+					}
 				}
 			}
 
@@ -198,5 +217,17 @@ class Component extends Document {
 		}
 
 		return $overridable_props_map;
+	}
+
+	private function is_overridable_prop( array $prop ): bool {
+		return isset( $prop['$$type'] ) && Overridable_Prop_Type::get_key() === $prop['$$type'];
+	}
+
+	private function is_override_prop( array $prop ): bool {
+		return isset( $prop['$$type'] ) && Override_Prop_Type::get_key() === $prop['$$type'];
+	}
+
+	private function is_component_instance( array $element ): bool {
+		return $element['elType'] === 'widget' && $element['widgetType'] === Component_Instance::get_element_type();
 	}
 }

--- a/modules/components/documents/component.php
+++ b/modules/components/documents/component.php
@@ -228,6 +228,6 @@ class Component extends Document {
 	}
 
 	private function is_component_instance( array $element ): bool {
-		return $element['elType'] === 'widget' && $element['widgetType'] === Component_Instance::get_element_type();
+		return 'widget' === $element['elType'] && Component_Instance::get_element_type() === $element['widgetType'];
 	}
 }

--- a/tests/phpunit/elementor/modules/components/test-component-align-overridable-props.php
+++ b/tests/phpunit/elementor/modules/components/test-component-align-overridable-props.php
@@ -50,7 +50,10 @@ class Test_Component_Align_Overridable_Props extends Elementor_Test_Base {
 		$new_origin_value = [
 			'$$type' => 'html-v3',
 			'value'  => [
-				'content'  => [ '$$type' => 'string', 'value' => 'Migrated Title' ],
+				'content'  => [
+					'$$type' => 'string',
+					'value' => 'Migrated Title',
+				],
 				'children' => [],
 			],
 		];
@@ -117,7 +120,7 @@ class Test_Component_Align_Overridable_Props extends Elementor_Test_Base {
 		);
 	}
 
-	public function test_align__unwraps_override_prop_type_from_origin_value() {
+	public function test_align__for_nested_component_with_exposed_further_override_unwraps_override_prop_type_from_origin_value() {
 		// Arrange
 		$this->act_as_admin();
 
@@ -144,7 +147,10 @@ class Test_Component_Align_Overridable_Props extends Elementor_Test_Base {
 		$new_origin_value = [
 			'$$type' => 'html-v3',
 			'value'  => [
-				'content'  => [ '$$type' => 'string', 'value' => 'Title' ],
+				'content'  => [
+					'$$type' => 'string',
+					'value' => 'Title',
+				],
 				'children' => [],
 			],
 		];
@@ -155,17 +161,34 @@ class Test_Component_Align_Overridable_Props extends Elementor_Test_Base {
 				'elType'   => 'widget',
 				'widgetType' => 'e-component',
 				'settings' => [
-					'some_prop' => [
-						'$$type' => 'overridable',
+					'component_instance' => [
+						'$$type' => 'component-instance',
 						'value'  => [
-							'override_key' => 'prop-222',
-							'origin_value' => [
-								'$$type' => 'override',
-								'value'  => [
-									'override_key'   => 'inner-key',
-									'override_value' => $new_origin_value,
-									'schema_source' => [ 'type' => 'component', 'id' => $inner_component_id ],
-								],
+							'component_id' => [
+								'$$type' => 'number',
+								'value' => $inner_component_id,
+							],
+							'overrides' => [
+								'$$type' => 'overrides',
+								'value' => [
+									[
+										'$$type' => 'overridable',
+										'value'  => [
+											'override_key' => 'prop-222',
+											'origin_value' => [
+												'$$type' => 'override',
+												'value'  => [
+													'override_key'   => 'inner-key',
+													'override_value' => $new_origin_value,
+													'schema_source' => [
+														'type' => 'component',
+														'id' => $inner_component_id,
+													],
+												],
+											],
+										],
+									]
+								]
 							],
 						],
 					],
@@ -186,7 +209,10 @@ class Test_Component_Align_Overridable_Props extends Elementor_Test_Base {
 					'originValue' => [
 						'$$type' => 'html-v3',
 						'value'  => [
-							'content'  => [ '$$type' => 'string', 'value' => 'Old Title' ],
+							'content'  => [
+								'$$type' => 'string',
+								'value' => 'Old Title',
+							],
 							'children' => [],
 						],
 					],
@@ -285,7 +311,10 @@ class Test_Component_Align_Overridable_Props extends Elementor_Test_Base {
 		$new_origin_value = [
 			'$$type' => 'html-v3',
 			'value'  => [
-				'content'  => [ '$$type' => 'string', 'value' => 'Nested Migrated Value' ],
+				'content'  => [
+					'$$type' => 'string',
+					'value' => 'Nested Migrated Value',
+				],
 				'children' => [],
 			],
 		];
@@ -366,7 +395,10 @@ class Test_Component_Align_Overridable_Props extends Elementor_Test_Base {
 		$new_title_origin_value = [
 			'$$type' => 'html-v3',
 			'value'  => [
-				'content'  => [ '$$type' => 'string', 'value' => 'New Title' ],
+				'content'  => [
+					'$$type' => 'string',
+					'value' => 'New Title',
+				],
 				'children' => [],
 			],
 		];
@@ -383,7 +415,10 @@ class Test_Component_Align_Overridable_Props extends Elementor_Test_Base {
 					'$$type' => 'image-src',
 					'value'  => [
 						'id'  => null,
-						'url' => [ '$$type' => 'url', 'value' => 'https://new.com/img.jpg' ],
+						'url' => [
+							'$$type' => 'url',
+							'value' => 'https://new.com/img.jpg',
+						],
 					],
 				],
 			],
@@ -438,7 +473,10 @@ class Test_Component_Align_Overridable_Props extends Elementor_Test_Base {
 					'widgetType'  => 'e-heading',
 					'propKey'     => 'title',
 					'label'       => 'Title',
-					'originValue' => [ '$$type' => 'string', 'value' => 'Stale Title' ],
+					'originValue' => [
+						'$$type' => 'string',
+						'value' => 'Stale Title',
+					],
 					'groupId'     => 'group-1',
 				],
 				'prop-tag' => [
@@ -448,7 +486,10 @@ class Test_Component_Align_Overridable_Props extends Elementor_Test_Base {
 					'widgetType'  => 'e-heading',
 					'propKey'     => 'tag',
 					'label'       => 'Tag',
-					'originValue' => [ '$$type' => 'string-v0', 'value' => 'h3' ],
+					'originValue' => [
+						'$$type' => 'string-v0',
+						'value' => 'h3',
+					],
 					'groupId'     => 'group-1',
 				],
 				'prop-image' => [
@@ -465,7 +506,10 @@ class Test_Component_Align_Overridable_Props extends Elementor_Test_Base {
 								'$$type' => 'image-src-v0',
 								'value'  => [
 									'id'  => null,
-									'url' => [ '$$type' => 'url', 'value' => 'https://old.com/img.jpg' ],
+									'url' => [
+										'$$type' => 'url',
+										'value' => 'https://old.com/img.jpg',
+									],
 								],
 							],
 						],


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix overridable props alignment algorithm to correctly handle nested component instances with exposed overrides and prevent data corruption during component publishing.

Main changes:
- Added special handling for component instances in get_elements_origin_values_map() to extract overrides from component_instance settings structure
- Implemented helper methods to identify component instances, overridable props, and override props for cleaner type checking
- Updated test data structure to use proper component_instance format instead of flat settings structure for nested components

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
