### PR TITLE
test

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -174,7 +174,7 @@ class Frontend extends App {
 		add_filter( 'get_the_excerpt', [ $this, 'end_excerpt_flag' ], 20 );
 
 		if ( version_compare( get_bloginfo( 'version' ), '6.9', '>=' ) ) {
-			add_filter( 'wp_should_output_buffer_template_for_enhancement', '__return_false', 1 );
+			// add_filter( 'wp_should_output_buffer_template_for_enhancement', '__return_false', 1 );
 		}
 	}
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Disable WordPress 6.9+ template output buffering filter by commenting out the filter hook that prevents template enhancement buffering.
Main changes:
- Commented out `wp_should_output_buffer_template_for_enhancement` filter to allow default WordPress template buffering behavior
- Preserved version check conditional logic for WordPress 6.9+ compatibility without active filter modification

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
