### PR TITLE
Fix: Show label for empty select control values [ED-23524]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/__tests__/select-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/select-control.test.tsx
@@ -248,6 +248,25 @@ describe( 'SelectControl', () => {
 		expect( screen.getByText( 'Default text' ) ).toBeInTheDocument();
 	} );
 
+	it( 'should display label for option with null value when there is no placeholder', () => {
+		const optionsWithNullOutset = [
+			{ label: 'Inset', value: 'inset' },
+			{ label: 'Outset', value: null },
+		];
+
+		const propsOutsetSelected = {
+			setValue: jest.fn(),
+			value: { $$type: 'string', value: null },
+			placeholder: undefined,
+			bind: 'tag',
+			propType,
+		};
+
+		renderControl( <SelectControl options={ optionsWithNullOutset } />, propsOutsetSelected );
+
+		expect( screen.getByRole( 'combobox' ) ).toHaveTextContent( 'Outset' );
+	} );
+
 	it( 'should handle options with null values correctly with placeholder', () => {
 		// Arrange.
 		const optionsWithNull = [

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/select-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/select-control.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { createMockPropType, renderControl } from 'test-utils';
+import { stringPropTypeUtil } from '@elementor/editor-props';
 import { fireEvent, screen } from '@testing-library/react';
 
 import { SelectControl } from '../select-control';
@@ -250,13 +251,13 @@ describe( 'SelectControl', () => {
 
 	it( 'should display label for option with null value when there is no placeholder', () => {
 		const optionsWithNullOutset = [
-			{ label: 'Inset', value: 'inset' },
-			{ label: 'Outset', value: null },
+			{ label: 'With value', value: 'some-value' },
+			{ label: 'Without value', value: null },
 		];
 
 		const propsOutsetSelected = {
 			setValue: jest.fn(),
-			value: { $$type: 'string', value: null },
+			value: stringPropTypeUtil.create( null ),
 			placeholder: undefined,
 			bind: 'tag',
 			propType,
@@ -264,7 +265,7 @@ describe( 'SelectControl', () => {
 
 		renderControl( <SelectControl options={ optionsWithNullOutset } />, propsOutsetSelected );
 
-		expect( screen.getByRole( 'combobox' ) ).toHaveTextContent( 'Outset' );
+		expect( screen.getByRole( 'combobox' ) ).toHaveTextContent( 'Without value' );
 	} );
 
 	it( 'should handle options with null values correctly with placeholder', () => {

--- a/packages/packages/libs/editor-controls/src/controls/select-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/select-control.tsx
@@ -47,26 +47,9 @@ export const SelectControl = createControl(
 					size="tiny"
 					MenuProps={ MenuProps }
 					aria-label={ ariaLabel || placeholder }
-					renderValue={ ( selectedValue: string | null ) => {
-						const findOptionByValue = ( searchValue: string | null ) =>
-							options.find( ( opt ) => opt.value === searchValue );
-
-						if ( ! selectedValue || selectedValue === '' ) {
-							if ( placeholder ) {
-								const placeholderOption = findOptionByValue( placeholder );
-								const displayText = placeholderOption?.label || placeholder;
-
-								return (
-									<Typography component="span" variant="caption" color="text.tertiary">
-										{ displayText }
-									</Typography>
-								);
-							}
-							return '';
-						}
-						const option = findOptionByValue( selectedValue );
-						return option?.label || selectedValue;
-					} }
+					renderValue={ ( selectedValue: string | null ) =>
+						getSelectRenderValue( options, placeholder, selectedValue )
+					}
 					value={ value ?? '' }
 					onChange={ handleChange }
 					disabled={ isDisabled }
@@ -82,3 +65,30 @@ export const SelectControl = createControl(
 		);
 	}
 );
+
+function getSelectRenderValue(
+	options: SelectOption[],
+	placeholder: string | null | undefined,
+	selectedValue: string | null
+): React.ReactNode {
+	const optionWithValue = ( v: string | null ) => options.find( ( { value } ) => value === v );
+
+	if ( ! isUnsetSelectValue( selectedValue ) ) {
+		return optionWithValue( selectedValue )?.label ?? selectedValue;
+	}
+
+	if ( placeholder ) {
+		const text = optionWithValue( placeholder )?.label ?? placeholder;
+		return (
+			<Typography component="span" variant="inherit" color="text.tertiary">
+				{ text }
+			</Typography>
+		);
+	}
+
+	return options.find( ( { value } ) => isUnsetSelectValue( value ) )?.label ?? '';
+}
+
+function isUnsetSelectValue( value: string | null | undefined ): boolean {
+	return value === null || value === undefined || value === '';
+}


### PR DESCRIPTION
- Fixes UI issue when placeholder is shown with different size than the actual value.
- Fixes SelectControl so a selected “empty” value (null / '') still resolves to an option whose value is null or empty (e.g. Box shadow Outset), instead of rendering blank.
- When a placeholder is set, behavior is unchanged: the placeholder still wins over a null-valued option.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix select control to properly display labels for options with null/empty values when no placeholder is provided, resolving ED-23524.
Main changes:
- Extracted renderValue logic into getSelectRenderValue function with improved handling for unset values
- Added isUnsetSelectValue utility to consistently check for null, undefined, or empty string values
- Implemented fallback to display label of first unset option when no placeholder exists

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
