### PR TITLE
Fix: Component instance editing panel crashes on first load for nested components [ED-23660]

### DIFF
--- a/modules/components/components-rest-api.php
+++ b/modules/components/components-rest-api.php
@@ -148,10 +148,13 @@ class Components_REST_API {
 				'callback' => fn( $request ) => $this->route_wrapper( fn() => $this->get_overridable_props( $request ) ),
 				'permission_callback' => fn() => current_user_can( 'edit_posts' ),
 				'args' => [
-					'componentId' => [
-						'type' => 'integer',
+					'componentIds' => [
+						'type' => 'array',
+						'items' => [
+							'type' => 'integer',
+						],
 						'required' => true,
-						'description' => 'The component ID to get overridable props for',
+						'description' => 'The component IDs to get overridable props for',
 					],
 				],
 			],
@@ -311,42 +314,40 @@ class Components_REST_API {
 	}
 
 	private function get_overridable_props( \WP_REST_Request $request ) {
-		$component_id = (int) $request->get_param( 'componentId' );
+		$component_ids = $request->get_param( 'componentIds' );
 
-		if ( ! $component_id ) {
-			return Error_Builder::make( 'invalid_component_id' )
-				->set_status( 400 )
-				->set_message( __( 'Invalid component ID', 'elementor' ) )
-				->build();
+		$data = [];
+		$errors = [];
+
+		foreach ( $component_ids as $component_id ) {
+			$component_id = (int) $component_id;
+
+			/** @var Component $document */
+			$document = $this->get_repository()->get( $component_id );
+
+			if ( ! $document ) {
+				$errors[ $component_id ] = 'component_not_found';
+				continue;
+			}
+
+			// This is a fix for the case where overridable props in element settings where migrated
+			// but the overridable props metadata were not aligned with the new origin values.
+			// In version 4.0.1, we fixed this by running the align_overridable_props_with_elements method after the migration.
+			$document_version = $document->get_elementor_version();
+			$overridable_props_migration_fix_version = '4.0.1';
+			$should_align_overridable_props = version_compare( $document_version, $overridable_props_migration_fix_version, '<=' );
+			if ( $should_align_overridable_props ) {
+				$document->align_overridable_props_with_elements();
+			}
+
+			$overridable = $document->get_json_meta( Component::OVERRIDABLE_PROPS_META_KEY );
+
+			$data[ $component_id ] = empty( $overridable ) ? null : $overridable;
 		}
 
-		/** @var Component $document */
-		$document = $this->get_repository()->get( $component_id );
-
-		if ( ! $document ) {
-			return Error_Builder::make( 'component_not_found' )
-				->set_status( 404 )
-				->set_message( __( 'Component not found', 'elementor' ) )
-				->build();
-		}
-
-		// This is a fix for the case where overridable props in element settings where migrated
-		// but the overridable props metadata were not aligned with the new origin values.
-		// In version 4.0.1, we fixed this by running the align_overridable_props_with_elements method after the migration.
-		$document_version = $document->get_elementor_version();
-		$overridable_props_migration_fix_version = '4.0.1';
-		$should_align_overridable_props = version_compare( $document_version, $overridable_props_migration_fix_version, '<=' );
-		if ( $should_align_overridable_props ) {
-			$document->align_overridable_props_with_elements();
-		}
-
-		$overridable = $document->get_json_meta( Component::OVERRIDABLE_PROPS_META_KEY ) ?? null;
-
-		if ( empty( $overridable ) ) {
-			$overridable = null;
-		}
-
-		return Response_Builder::make( $overridable )->build();
+		return Response_Builder::make( $data )
+			->set_meta( [ 'errors' => $errors ] )
+			->build();
 	}
 
 	private function create_components( \WP_REST_Request $request ) {

--- a/packages/packages/core/editor-components/src/api.ts
+++ b/packages/packages/core/editor-components/src/api.ts
@@ -92,14 +92,15 @@ export const apiClient = {
 				componentId,
 			} )
 			.then( ( res ) => res.data ),
-	getOverridableProps: async ( componentId: number ) =>
+	getOverridableProps: async ( componentIds: number[] ) =>
 		await httpService()
-			.get< HttpResponse< OverridableProps > >( `${ BASE_URL }/overridable-props`, {
-				params: {
-					componentId: componentId.toString(),
-				},
-			} )
-			.then( ( res ) => res.data.data ),
+			.get< HttpResponse< Record< number, OverridableProps | null >, { errors: Record< number, string > } > >(
+				`${ BASE_URL }/overridable-props`,
+				{
+					params: { 'componentIds[]': componentIds },
+				}
+			)
+			.then( ( res ) => res.data ),
 	updateArchivedComponents: async ( componentIds: number[], status: DocumentSaveStatus ) =>
 		await httpService()
 			.post< { data: { failedIds: number[]; successIds: number[]; success: boolean } } >(

--- a/packages/packages/core/editor-components/src/store/actions/load-components-overridable-props.ts
+++ b/packages/packages/core/editor-components/src/store/actions/load-components-overridable-props.ts
@@ -10,22 +10,18 @@ export async function loadComponentsOverridableProps( componentIds: number[] ) {
 		return;
 	}
 
-	const { data, meta } = await apiClient.getOverridableProps( unloadedIds );
+	const { data } = await apiClient.getOverridableProps( unloadedIds );
 
-	for ( const [ componentId, overridableProps ] of Object.entries( data ) ) {
-		if ( ! overridableProps ) {
-			continue;
+	componentIds.forEach( ( componentId ) => {
+		if ( ! data[ componentId ] ) {
+			return;
 		}
 
 		dispatch(
 			slice.actions.setOverridableProps( {
-				componentId: Number( componentId ),
-				overridableProps,
+				componentId,
+				overridableProps: data[ componentId ],
 			} )
 		);
-	}
-
-	if ( meta?.errors && Object.keys( meta.errors ).length ) {
-		throw new Error( `Failed to load overridable props for some components: ${ JSON.stringify( meta.errors ) }` );
-	}
+	} );
 }

--- a/packages/packages/core/editor-components/src/store/actions/load-components-overridable-props.ts
+++ b/packages/packages/core/editor-components/src/store/actions/load-components-overridable-props.ts
@@ -3,31 +3,29 @@ import { __dispatch as dispatch, __getState as getState } from '@elementor/store
 import { apiClient } from '../../api';
 import { selectIsOverridablePropsLoaded, slice } from '../store';
 
-export function loadComponentsOverridableProps( componentIds: number[] ) {
-	if ( ! componentIds.length ) {
+export async function loadComponentsOverridableProps( componentIds: number[] ) {
+	const unloadedIds = componentIds.filter( ( id ) => ! selectIsOverridablePropsLoaded( getState(), id ) );
+
+	if ( ! unloadedIds.length ) {
 		return;
 	}
 
-	return Promise.all( componentIds.map( loadComponentOverrides ) );
-}
+	const { data, meta } = await apiClient.getOverridableProps( unloadedIds );
 
-async function loadComponentOverrides( componentId: number ) {
-	const isOverridablePropsLoaded = selectIsOverridablePropsLoaded( getState(), componentId );
+	for ( const [ componentId, overridableProps ] of Object.entries( data ) ) {
+		if ( ! overridableProps ) {
+			continue;
+		}
 
-	if ( isOverridablePropsLoaded ) {
-		return;
+		dispatch(
+			slice.actions.setOverridableProps( {
+				componentId: Number( componentId ),
+				overridableProps,
+			} )
+		);
 	}
 
-	const overridableProps = await apiClient.getOverridableProps( componentId );
-
-	if ( ! overridableProps ) {
-		return;
+	if ( meta?.errors && Object.keys( meta.errors ).length ) {
+		throw new Error( `Failed to load overridable props for some components: ${ JSON.stringify( meta.errors ) }` );
 	}
-
-	dispatch(
-		slice.actions.setOverridableProps( {
-			componentId,
-			overridableProps,
-		} )
-	);
 }

--- a/packages/packages/core/editor-components/src/store/actions/load-components-overridable-props.ts
+++ b/packages/packages/core/editor-components/src/store/actions/load-components-overridable-props.ts
@@ -12,16 +12,5 @@ export async function loadComponentsOverridableProps( componentIds: number[] ) {
 
 	const { data } = await apiClient.getOverridableProps( unloadedIds );
 
-	componentIds.forEach( ( componentId ) => {
-		if ( ! data[ componentId ] ) {
-			return;
-		}
-
-		dispatch(
-			slice.actions.setOverridableProps( {
-				componentId,
-				overridableProps: data[ componentId ],
-			} )
-		);
-	} );
+	dispatch( slice.actions.loadOverridableProps( data ) );
 }

--- a/packages/packages/core/editor-components/src/store/extensible-slice.ts
+++ b/packages/packages/core/editor-components/src/store/extensible-slice.ts
@@ -105,6 +105,25 @@ const baseSlice = createSlice( {
 
 			component.overridableProps = payload.overridableProps;
 		},
+		loadOverridableProps: (
+			state,
+			{ payload }: PayloadAction< Record< ComponentId, OverridableProps | null > >
+		) => {
+			const componentIds = Object.keys( payload );
+
+			componentIds.forEach( ( id ) => {
+				const componentId = Number( id );
+				const overridableProps = payload[ componentId ];
+
+				const component = state.data.find( ( comp ) => comp.id === componentId );
+
+				if ( ! component || ! overridableProps ) {
+					return;
+				}
+
+				component.overridableProps = overridableProps;
+			} );
+		},
 		rename: ( state, { payload }: PayloadAction< { componentUid: string; name: string } > ) => {
 			const component = state.data.find( ( comp ) => comp.uid === payload.componentUid );
 

--- a/tests/phpunit/elementor/modules/components/test-components-rest-api.php
+++ b/tests/phpunit/elementor/modules/components/test-components-rest-api.php
@@ -1038,7 +1038,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 			'GET overridable-props' => [
 				'method' => 'GET',
 				'endpoint' => '/elementor/v1/components/overridable-props',
-				'params' => [ 'componentId' => 123 ],
+				'params' => [ 'componentIds' => [ 123 ] ],
 			],
 			'POST validate' => [
 				'method' => 'POST',
@@ -1091,7 +1091,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 			'GET overridable-props' => [
 				'method' => 'GET',
 				'endpoint' => '/elementor/v1/components/overridable-props',
-				'params' => [ 'componentId' => 123 ],
+				'params' => [ 'componentIds' => [ 123 ] ],
 			],
 		];
 	}
@@ -1338,25 +1338,28 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$this->assertEquals( 'rest_forbidden', $response->get_data()['code'] );
 	}
 
-	public function test_get_overridable_props__returns_props_for_existing_component() {
+	public function test_get_overridable_props__returns_props_for_existing_components() {
 		// Arrange
 		$this->act_as_admin();
-		$component_id = $this->create_test_component( 'Component With Overrides', $this->mock_component_1_content );
+		$component_id_1 = $this->create_test_component( 'Component With Overrides 1', $this->mock_component_1_content );
+		$component_id_2 = $this->create_test_component( 'Component With Overrides 2', $this->mock_component_2_content );
 
 		$mocks = new Component_Overrides_Mocks();
 		$overridable_props = $mocks->get_mock_component_overridable_props();
 
-		update_post_meta( $component_id, Component_Document::OVERRIDABLE_PROPS_META_KEY, json_encode( $overridable_props ) );
+		update_post_meta( $component_id_1, Component_Document::OVERRIDABLE_PROPS_META_KEY, json_encode( $overridable_props ) );
+		update_post_meta( $component_id_2, Component_Document::OVERRIDABLE_PROPS_META_KEY, json_encode( $overridable_props ) );
 
 		// Act
 		$request = new \WP_REST_Request( 'GET', '/elementor/v1/components/overridable-props' );
-		$request->set_param( 'componentId', $component_id );
+		$request->set_param( 'componentIds', [ $component_id_1, $component_id_2 ] );
 		$response = rest_do_request( $request );
 
 		// Assert
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data()['data'];
-		$this->assertEquals( $overridable_props, $data );
+		$this->assertEquals( $overridable_props, $data[ $component_id_1 ] );
+		$this->assertEquals( $overridable_props, $data[ $component_id_2 ] );
 	}
 
 	public function test_get_overridable_props__returns_null_when_no_overridable_props() {
@@ -1366,15 +1369,15 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 
 		// Act
 		$request = new \WP_REST_Request( 'GET', '/elementor/v1/components/overridable-props' );
-		$request->set_param( 'componentId', $component_id );
+		$request->set_param( 'componentIds', [ $component_id ] );
 		$response = rest_do_request( $request );
 
 		// Assert
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertNull( $response->get_data()['data'] );
+		$this->assertNull( $response->get_data()['data'][ $component_id ] );
 	}
 
-	public function test_get_overridable_props__fails_without_component_id() {
+	public function test_get_overridable_props__fails_without_component_ids() {
 		// Arrange
 		$this->act_as_admin();
 
@@ -1387,19 +1390,27 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 		$this->assertEquals( 'rest_missing_callback_param', $response->get_data()['code'] );
 	}
 
-	public function test_get_overridable_props__fails_for_non_existing_component() {
+	public function test_get_overridable_props__returns_error_in_meta_for_non_existing_component() {
 		// Arrange
 		$this->act_as_admin();
+		$existing_component_id = $this->create_test_component( 'Existing Component', $this->mock_component_1_content );
 		$non_existing_component_id = 999999;
+
+		$mocks = new Component_Overrides_Mocks();
+		$overridable_props = $mocks->get_mock_component_overridable_props();
+		update_post_meta( $existing_component_id, Component_Document::OVERRIDABLE_PROPS_META_KEY, json_encode( $overridable_props ) );
 
 		// Act
 		$request = new \WP_REST_Request( 'GET', '/elementor/v1/components/overridable-props' );
-		$request->set_param( 'componentId', $non_existing_component_id );
+		$request->set_param( 'componentIds', [ $existing_component_id, $non_existing_component_id ] );
 		$response = rest_do_request( $request );
 
 		// Assert
-		$this->assertEquals( 404, $response->get_status() );
-		$this->assertEquals( 'component_not_found', $response->get_data()['code'] );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data()['data'];
+		$errors = $response->get_data()['meta']['errors'];
+		$this->assertEquals( $overridable_props, $data[ $existing_component_id ] );
+		$this->assertEquals( 'component_not_found', $errors[ $non_existing_component_id ] );
 	}
 
 	public function test_get_overridable_props__succeeds_for_editor() {
@@ -1415,13 +1426,13 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 
 		// Act
 		$request = new \WP_REST_Request( 'GET', '/elementor/v1/components/overridable-props' );
-		$request->set_param( 'componentId', $component_id );
+		$request->set_param( 'componentIds', [ $component_id ] );
 		$response = rest_do_request( $request );
 
 		// Assert
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data()['data'];
-		$this->assertEquals( $overridable_props, $data );
+		$this->assertEquals( $overridable_props, $data[ $component_id ] );
 	}
 
 	public function test_post_validate_components__passes_with_valid_data() {
@@ -1832,14 +1843,14 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 
 		// Act
 		$request = new \WP_REST_Request( 'GET', '/elementor/v1/components/overridable-props' );
-		$request->set_param( 'componentId', $component_id );
+		$request->set_param( 'componentIds', [ $component_id ] );
 		$response = rest_do_request( $request );
 
 		// Assert
 		$this->assertEquals( 200, $response->get_status() );
 
 		$data = $response->get_data()['data'];
-		$this->assertEquals( $autosave_props, $data );
+		$this->assertEquals( $autosave_props, $data[ $component_id ] );
 	}
 
 	// =====================================================
@@ -2460,7 +2471,7 @@ class Test_Components_Rest_Api extends Elementor_Test_Base {
 
 		// Act
 		$request = new \WP_REST_Request( 'GET', '/elementor/v1/components/overridable-props' );
-		$request->set_param( 'componentId', $component_id );
+		$request->set_param( 'componentIds', [ $component_id ] );
 		$response = rest_do_request( $request );
 
 		// Assert


### PR DESCRIPTION
### The Bug 
When adding to the page a component that has a nested inner component with exposed-further props, the instance editing panel crashes on first load. 
On subsequent loads, or when the component was already in page,  it works correctly.

### Root cause 
We sent a separate request to get each component's overridable props. The outer component's data loaded first, and the panel tried to resolve the overrides chain before the inner component's data was loaded to the store, causing `resolveOverridesChain` to throw.
This crash was introduced by [a recent change](https://github.com/elementor/elementor/pull/35294) in `filterValidOverridableProps`, which now throws error when a nested component's overridable props are not found in the store. Before that change, the same situation caused a silent bug: the exposed-further props were filtered out and not shown in the panel.

### Fix
Changed the `GET /overridable-props` endpoint to accept an array of component IDs and return a map of results, instead of supporting a single component ID only.
All components' overridable props are now fetched in a single request - (whether on initial page load or when a new component is added to the page), guaranteeing that a component and its nested components' data are loaded to the store together before the instance editing panel renders.

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix crash in component instance editing panel by refactoring overridable-props REST API endpoint to support batch fetching of multiple component IDs instead of single component requests.

Main changes:
- Refactored REST API endpoint from single componentId to componentIds array parameter with batch processing and error handling in response metadata
- Updated TypeScript API client to fetch multiple component overridable props in single request with typed error responses
- Consolidated component overridable props loading logic to eliminate sequential API calls and filter already-loaded components

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
