### PR TITLE
Internal: Add permanently_locked meta to prevent elements from save as components [ED-23589]

### DIFF
--- a/modules/atomic-widgets/assets/js/editor/atomic-element-base-model.js
+++ b/modules/atomic-widgets/assets/js/editor/atomic-element-base-model.js
@@ -14,6 +14,10 @@ export default class AtomicElementBaseModel extends elementor.modules.elements.m
 		const elementType = this.get( 'elType' );
 		this.config = elementor.config.elements[ elementType ];
 
+		if ( this.config?.meta?.permanently_locked ) {
+			this.set( 'isLocked', true );
+		}
+
 		const isNewElementCreate = 0 === this.get( 'elements' ).length &&
 			$e.commands.currentTrace.includes( 'document/elements/create' );
 

--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.php
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.php
@@ -358,7 +358,6 @@ class Atomic_Form extends Atomic_Element_Base {
 					] )
 					->build(),
 			] )
-			->is_locked( true )
 			->build();
 	}
 

--- a/modules/atomic-widgets/elements/atomic-form/form-message/form-message.php
+++ b/modules/atomic-widgets/elements/atomic-form/form-message/form-message.php
@@ -33,6 +33,7 @@ abstract class Form_Message extends Atomic_Element_Base {
 	public function __construct( $data = [], $args = null ) {
 		parent::__construct( $data, $args );
 		$this->meta( 'is_container', true );
+		$this->meta( 'permanently_locked', true );
 	}
 
 	public function get_icon() {

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tab-content/atomic-tab-content.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tab-content/atomic-tab-content.php
@@ -29,6 +29,7 @@ class Atomic_Tab_Content extends Atomic_Element_Base {
 
 	public function __construct( $data = [], $args = null ) {
 		parent::__construct( $data, $args );
+		$this->meta( 'permanently_locked', true );
 	}
 
 	public static function get_type() {

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tab/atomic-tab.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tab/atomic-tab.php
@@ -32,6 +32,7 @@ class Atomic_Tab extends Atomic_Element_Base {
 
 	public function __construct( $data = [], $args = null ) {
 		parent::__construct( $data, $args );
+		$this->meta( 'permanently_locked', true );
 	}
 
 	public static function get_type() {

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-content-area/atomic-tabs-content-area.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-content-area/atomic-tabs-content-area.php
@@ -25,6 +25,7 @@ class Atomic_Tabs_Content_Area extends Atomic_Element_Base {
 
 	public function __construct( $data = [], $args = null ) {
 		parent::__construct( $data, $args );
+		$this->meta( 'permanently_locked', true );
 	}
 
 	public static function get_type() {

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-menu/atomic-tabs-menu.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-menu/atomic-tabs-menu.php
@@ -23,6 +23,7 @@ class Atomic_Tabs_Menu extends Atomic_Element_Base {
 
 	public function __construct( $data = [], $args = null ) {
 		parent::__construct( $data, $args );
+		$this->meta( 'permanently_locked', true );
 	}
 
 	public static function get_type() {

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs/atomic-tabs.php
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs/atomic-tabs.php
@@ -138,11 +138,9 @@ class Atomic_Tabs extends Atomic_Element_Base {
 					'title' => "Tab {$i} trigger",
 					'initial_position' => $i,
 				] )
-				->is_locked( true )
 				->build();
 
 			$tab_content_elements[] = Atomic_Tab_Content::generate()
-				->is_locked( true )
 				->editor_settings( [
 					'title' => "Tab {$i} content",
 					'initial_position' => $i,
@@ -152,12 +150,10 @@ class Atomic_Tabs extends Atomic_Element_Base {
 
 		$tabs_menu = Atomic_Tabs_Menu::generate()
 			->children( $tab_elements )
-			->is_locked( true )
 			->build();
 
 		$tabs_content_area = Atomic_Tabs_Content_Area::generate()
 			->children( $tab_content_elements )
-			->is_locked( true )
 			->build();
 
 		return [


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Feature

## Summary

This PR can be summarized in the following changelog entry:

* Introduce `permanently_locked` element meta to prevent nested structural elements from being saved as standalone components or templates

## Description

**Problem:** Nested structural elements (tab, tab-content, tabs-menu, tabs-content-area, form messages) could be saved as standalone components. When instantiated, they render without parent context, causing PHP fatal errors.

**Root cause:** The `isLocked` flag was set at the instance level via `define_default_children()`, but could become stale across save/reload cycles since it depends on persisted data.

**Solution:** Replace instance-level `isLocked` with a type-level `permanently_locked` meta on the element class using the existing `Has_Meta` trait.

### Changes:
- **PHP meta**: Add `$this->meta('permanently_locked', true)` to constructors of `Atomic_Tab`, `Atomic_Tab_Content`, `Atomic_Tabs_Menu`, `Atomic_Tabs_Content_Area`, and `Form_Message`
- **Remove instance locks**: Remove `->is_locked(true)` from `Atomic_Tabs::define_default_children()` and `Atomic_Form::build_status_message()`
- **JS model**: Force `isLocked=true` in `AtomicElementBaseModel.initialize()` when the element config meta has `permanently_locked` — runs on both new creates and loads
- **Context menu**: Check type-level `permanently_locked` meta instead of instance-level `isLocked` for "Save as template" and "Create component" actions
- **Server-side validation**: New `Permanently_Locked_Validator` rejects REST API requests that attempt to save permanently locked elements as components (defense-in-depth)

### Key decisions:
- **Meta over dedicated method**: Uses the existing `Has_Meta` trait rather than introducing a new PHP method — keeps the API surface small and leverages a pattern already in use (`llm_support`, `is_container`)
- **Type-level over instance-level**: The lock derives from the class, not persisted data — impossible to lose through serialization/deserialization
- **`isLocked` still set on model**: Downstream checks (keyboard shortcuts, drag, edit buttons) continue working without changes

## Test Instructions

1. Open the Elementor editor with V4 editor and components experiment enabled
2. Add a Tabs element to the page
3. Right-click on a tab or tab content area
4. Verify "Save as a component" and "Save as a template" are **disabled** (grayed out)
5. Right-click on the parent Tabs element — these options should be **enabled**
6. Try creating a component via the REST API directly with a tab element as root — should return a 422 error

Made with Cursor

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace runtime element locking with permanent metadata flag to prevent components from being saved as reusable components.

Main changes:
- Add `permanently_locked` meta to Form_Message, Atomic_Tab, Atomic_Tab_Content, and tabs container constructors
- Remove `is_locked()` builder calls from Atomic_Form and Atomic_Tabs element generation
- Implement metadata-based lock enforcement in AtomicElementBaseModel initialization logic

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
