### PR TITLE
Internal: Improve global design settings handling [ED-23596]

### DIFF
--- a/core/editor/data/globals/controller.php
+++ b/core/editor/data/globals/controller.php
@@ -28,14 +28,14 @@ class Controller extends Controller_Base {
 			if ( Plugin::$instance->data_manager_v2->is_internal() ) {
 				return true;
 			}
-	
+
 			return current_user_can( 'edit_posts' );
 		}
-	
+
 		if ( \WP_REST_Server::CREATABLE === $method_type || \WP_REST_Server::DELETABLE === $method_type ) {
 			return current_user_can( 'manage_options' );
 		}
-	
+
 		return false;
 	}
 

--- a/core/editor/data/globals/controller.php
+++ b/core/editor/data/globals/controller.php
@@ -22,12 +22,21 @@ class Controller extends Controller_Base {
 	}
 
 	public function get_permission_callback( $request ) {
-		// Allow internal get global values. (e.g render global.css for a visitor)
-		if ( 'GET' === $request->get_method() && Plugin::$instance->data_manager_v2->is_internal() ) {
-			return true;
+		$method_type = $request->get_method();
+		if ( \WP_REST_Server::READABLE === $method_type ) {
+			// Allow internal get global values. (e.g render global.css for a visitor)
+			if ( Plugin::$instance->data_manager_v2->is_internal() ) {
+				return true;
+			}
+	
+			return current_user_can( 'edit_posts' );
 		}
-
-		return current_user_can( 'edit_posts' );
+	
+		if ( \WP_REST_Server::CREATABLE === $method_type || \WP_REST_Server::DELETABLE === $method_type ) {
+			return current_user_can( 'manage_options' );
+		}
+	
+		return false;
 	}
 
 	protected function register_index_endpoint() {

--- a/tests/phpunit/elementor/core/editor/data/globals/test-controller.php
+++ b/tests/phpunit/elementor/core/editor/data/globals/test-controller.php
@@ -7,23 +7,45 @@ use Elementor\Tests\Phpunit\Elementor\Data\V2\Base\Data_Test_Base;
 class Test_Controller extends Data_Test_Base  {
 	public function test_get_permission_callback() {
 		$controller = new Globals\Controller();
-		$methods = explode( ', ', \WP_REST_Server::ALLMETHODS );
 
-		// Set Editor.
+		$expected_by_method = [
+			\WP_REST_Server::READABLE  => true,
+			\WP_REST_Server::CREATABLE => false,
+			\WP_REST_Server::DELETABLE => false,
+			'PUT'                      => false,
+			'PATCH'                    => false,
+		];
+
+		// Set Editor — can only read globals, not modify them.
 		wp_set_current_user( $this->factory()->get_editor_user()->ID );
 
-		foreach ( $methods as $method ) {
+		foreach ( $expected_by_method as $method => $expected ) {
 			$request = new \WP_REST_Request( $method );
-			$this->assertEquals( true, $controller->get_permission_callback( $request ) );
+			$this->assertEquals( $expected, $controller->get_permission_callback( $request ), "Method: $method" );
 		}
 
-		// Set subscriber.
+		// Set subscriber — no access at all.
 		wp_set_current_user( $this->factory()->get_subscriber_user()->ID );
 
-		foreach ( $methods as $method ) {
+		foreach ( array_keys( $expected_by_method ) as $method ) {
 			$request = new \WP_REST_Request( $method );
+			$this->assertEquals( false, $controller->get_permission_callback( $request ), "Method: $method" );
+		}
 
-			$this->assertEquals( false, $controller->get_permission_callback( $request ) );
+		// Set admin — can read and write globals, but PUT/PATCH are not supported.
+		wp_set_current_user( $this->factory()->get_administrator_user()->ID );
+
+		$admin_expected_by_method = [
+			\WP_REST_Server::READABLE  => true,
+			\WP_REST_Server::CREATABLE => true,
+			\WP_REST_Server::DELETABLE => true,
+			'PUT'                      => false,
+			'PATCH'                    => false,
+		];
+
+		foreach ( $admin_expected_by_method as $method => $expected ) {
+			$request = new \WP_REST_Request( $method );
+			$this->assertEquals( $expected, $controller->get_permission_callback( $request ), "Method: $method" );
 		}
 	}
 }


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor global design settings API permission handling to enforce proper access control based on HTTP methods and user capabilities.

Main changes:
- Implemented granular permission checks distinguishing GET (edit_posts), POST/DELETE (manage_options), and unsupported methods (denied)
- Replaced simple edit_posts check with method-specific authorization using WP_REST_Server constants
- Added comprehensive test coverage for editor, subscriber, and administrator roles across all HTTP methods

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
