### PR TITLE
 Internal: Update interaction trigger and effect flow [ED-23659]

### DIFF
--- a/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interactions-list.tsx
@@ -31,6 +31,7 @@ export function InteractionsList( props: InteractionListProps ) {
 	const { elementId } = useInteractionsContext();
 
 	const hasInitializedRef = useRef( false );
+	const newlyCreatedIdsRef = useRef< Set< string > >( new Set() );
 
 	const handleUpdateInteractions = useCallback(
 		( newInteractions: ElementInteractions ) => {
@@ -46,9 +47,11 @@ export function InteractionsList( props: InteractionListProps ) {
 			( ! interactions.items || interactions.items?.length === 0 )
 		) {
 			hasInitializedRef.current = true;
+			const newItem = createDefaultInteractionItem();
+			newlyCreatedIdsRef.current.add( extractString( newItem.value.interaction_id ) );
 			const newState: ElementInteractions = {
 				version: 1,
-				items: [ createDefaultInteractionItem() ],
+				items: [ newItem ],
 			};
 			handleUpdateInteractions( newState );
 		}
@@ -83,7 +86,7 @@ export function InteractionsList( props: InteractionListProps ) {
 			if ( meta?.action?.type === 'add' ) {
 				const addedItem = meta.action.payload[ 0 ]?.item;
 				if ( addedItem ) {
-					trackInteractionCreated( elementId, addedItem );
+					newlyCreatedIdsRef.current.add( extractString( addedItem.value.interaction_id ) );
 				}
 			}
 		},
@@ -138,7 +141,14 @@ export function InteractionsList( props: InteractionListProps ) {
 						);
 						syncGridOverlay( trigger, start, end, relativeTo );
 					},
-					onPopoverClose: () => dispatchScrollInteraction( null ),
+					onPopoverClose: ( value: InteractionItemPropValue ) => {
+						dispatchScrollInteraction( null );
+						const id = extractString( value.value.interaction_id );
+						if ( newlyCreatedIdsRef.current.has( id ) ) {
+							newlyCreatedIdsRef.current.delete( id );
+							trackInteractionCreated( elementId, value );
+						}
+					},
 					actions: ( value: InteractionItemPropValue ) => (
 						<Tooltip key="preview" placement="top" title={ __( 'Preview', 'elementor' ) }>
 							<IconButton

--- a/packages/packages/core/editor-interactions/src/components/interactions-tab.tsx
+++ b/packages/packages/core/editor-interactions/src/components/interactions-tab.tsx
@@ -7,8 +7,6 @@ import { InteractionsProvider, useInteractionsContext } from '../contexts/intera
 import { PopupStateProvider } from '../contexts/popup-state-context';
 import { useElementInteractions } from '../hooks/use-element-interactions';
 import type { ElementInteractions } from '../types';
-import { createDefaultInteractionItem } from '../utils/prop-value-utils';
-import { trackInteractionCreated } from '../utils/tracking';
 import { EmptyState } from './empty-state';
 import { InteractionsList } from './interactions-list';
 
@@ -35,7 +33,6 @@ function InteractionsTabContent( { elementId }: { elementId: string } ) {
 				<EmptyState
 					onCreateInteraction={ () => {
 						firstInteractionState[ 1 ]( true );
-						trackInteractionCreated( elementId, createDefaultInteractionItem() );
 					} }
 				/>
 			) }

--- a/packages/packages/libs/editor-controls/src/components/repeater/repeater.tsx
+++ b/packages/packages/libs/editor-controls/src/components/repeater/repeater.tsx
@@ -81,7 +81,7 @@ type BaseItemSettings< T > = {
 	Content: RepeaterItemContent< T >;
 	actions?: ( value: T ) => React.ReactNode;
 	onPopoverOpen?: ( value: T ) => void;
-	onPopoverClose?: () => void;
+	onPopoverClose?: ( value: T ) => void;
 };
 
 type SortableItemSettings< T > = BaseItemSettings< T > & {
@@ -313,7 +313,7 @@ type RepeaterItemProps< T > = {
 	openOnMount: boolean;
 	onOpen: () => void;
 	onPopoverOpen?: ( value: T ) => void;
-	onPopoverClose?: () => void;
+	onPopoverClose?: ( value: T ) => void;
 	showDuplicate: boolean;
 	showToggle: boolean;
 	showRemove: boolean;
@@ -341,13 +341,14 @@ const RepeaterItem = < T, >( {
 	actions,
 	value,
 }: RepeaterItemProps< T > ) => {
+	const wrappedOnPopoverClose = onPopoverClose ? () => onPopoverClose( value ) : undefined;
 	const { popoverState, popoverProps, ref, setRef } = usePopover(
 		openOnMount,
 		() => {
 			onOpen();
 			onPopoverOpen?.( value );
 		},
-		onPopoverClose
+		wrappedOnPopoverClose
 	);
 	const triggerProps = bindTrigger( popoverState );
 


### PR DESCRIPTION
## Summary
- Mixpanel interaction events were always reporting `interaction_trigger: "On page load"` and `interaction_effect: "Fade In"` regardless of user configuration
- Root cause: `trackInteractionCreated` fired at creation time (with hardcoded defaults), before the user could configure the trigger and effect via the popover
- Fixed by deferring tracking to when the interaction popover **closes** — at which point the item holds the user's actual configured values
- Added a `newlyCreatedIdsRef` set in `InteractionsList` to distinguish first-time creations from edits to existing interactions (only new items trigger the Mixpanel event on popover close)
- Extended `Repeater`'s `onPopoverClose` callback to receive the current item value (consistent with how `onPopoverOpen` already works)
- Removed the premature `trackInteractionCreated` call from the empty-state "Create Interaction" handler in `InteractionsTab`

## Test plan
- [ ] Add a new interaction from the empty state — verify Mixpanel event fires **after** closing the popover, with the trigger/effect you configured (not the defaults)
- [ ] Add a new interaction via the repeater "+" button, change the trigger to "Scroll into view" and effect to "Slide In", close the popover — verify Mixpanel reports those values
- [ ] Open and close the popover for an **existing** interaction without changing anything — verify no Mixpanel event is fired
- [ ] Verify default case still works: add interaction, close popover without changing anything — verify Mixpanel reports "On page load" / "Fade In"

## Jira
[ED-23659](https://elementor.atlassian.net/browse/ED-23659)

[ED-23659]: https://elementor.atlassian.net/browse/ED-23659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Mixpanel interaction tracking to send actual interaction trigger and effect data instead of default values when interactions are created.

Main changes:
- Deferred Mixpanel tracking from interaction creation to popover close, ensuring complete interaction configuration is captured
- Added Set-based tracking of newly created interaction IDs to prevent duplicate events and track only new interactions
- Updated onPopoverClose callback signature to receive interaction value for accurate event tracking with configured data

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
