### PR TITLE
Fix: Local styles of component widgets in templates [ED-23670]

### DIFF
--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -13,6 +13,7 @@ import { registerDataHook } from '@elementor/editor-v1-adapters';
 import { __registerSlice as registerSlice } from '@elementor/store';
 import { __ } from '@wordpress/i18n';
 
+import { apiClient } from './api';
 import { componentInstanceTransformer } from './component-instance-transformer';
 import { componentOverridableTransformer } from './component-overridable-transformer';
 import { componentOverrideTransformer } from './component-override-transformer';
@@ -25,7 +26,6 @@ import { COMPONENT_WIDGET_TYPE, createComponentType } from './create-component-t
 import { PopulateStore } from './populate-store';
 import { initCircularNestingPrevention } from './prevent-circular-nesting';
 import { loadComponentsAssets } from './store/actions/load-components-assets';
-import { removeComponentStyles } from './store/actions/remove-component-styles';
 import { componentsStylesProvider } from './store/components-styles-provider';
 import { slice } from './store/store';
 import { beforeSave } from './sync/before-save';
@@ -63,7 +63,7 @@ export function init() {
 		const { id, config } = getV1CurrentDocument();
 
 		if ( id ) {
-			removeComponentStyles( id );
+			apiClient.invalidateComponentConfigCache( id );
 		}
 
 		await loadComponentsAssets( ( config?.elements as V1ElementData[] ) ?? [] );

--- a/packages/packages/core/editor-components/src/store/__tests__/components-styles-provider.test.ts
+++ b/packages/packages/core/editor-components/src/store/__tests__/components-styles-provider.test.ts
@@ -1,8 +1,11 @@
 import { createMockStyleDefinition } from 'test-utils';
+import { getCurrentDocumentId } from '@elementor/editor-elements';
 import { __getState as getState } from '@elementor/store';
 
 import { componentsStylesProvider } from '../components-styles-provider';
 import { SLICE_NAME } from '../store';
+
+jest.mock( '@elementor/editor-elements' );
 
 jest.mock( '@elementor/store', () => {
 	const actual = jest.requireActual( '@elementor/store' );
@@ -45,6 +48,23 @@ describe( 'componentsStylesProvider', () => {
 		// Assert.
 		expect( style ).toStrictEqual( expected );
 	} );
+
+	it.each( [
+		{ excludedDocumentId: DOC_ID_1, expectedStyles: [ STYLE_3 ] },
+		{ excludedDocumentId: DOC_ID_2, expectedStyles: [ STYLE_1, STYLE_2 ] },
+	] )(
+		'should exclude styles for document $excludedDocumentId when listing all',
+		( { excludedDocumentId, expectedStyles } ) => {
+			// Arrange.
+			jest.mocked( getCurrentDocumentId ).mockReturnValue( excludedDocumentId );
+
+			// Act.
+			const styles = componentsStylesProvider.actions.all();
+
+			// Assert.
+			expect( styles ).toStrictEqual( expectedStyles );
+		}
+	);
 
 	it( 'should expose the static key', () => {
 		// Act.

--- a/packages/packages/core/editor-components/src/store/actions/remove-component-styles.ts
+++ b/packages/packages/core/editor-components/src/store/actions/remove-component-styles.ts
@@ -1,9 +1,0 @@
-import { __dispatch as dispatch } from '@elementor/store';
-
-import { apiClient } from '../../api';
-import { slice } from '../store';
-
-export function removeComponentStyles( id: number ) {
-	apiClient.invalidateComponentConfigCache( id );
-	dispatch( slice.actions.removeStyles( { id } ) );
-}

--- a/packages/packages/core/editor-components/src/store/components-styles-provider.ts
+++ b/packages/packages/core/editor-components/src/store/components-styles-provider.ts
@@ -1,3 +1,4 @@
+import { getCurrentDocumentId } from '@elementor/editor-elements';
 import { createStylesProvider } from '@elementor/editor-styles-repository';
 import { __getState as getState, __subscribeWithSelector as subscribeWithSelector } from '@elementor/store';
 
@@ -15,7 +16,8 @@ export const componentsStylesProvider = createStylesProvider( {
 		),
 	actions: {
 		all: () => {
-			return selectFlatStyles( getState() );
+			const currentDocumentId = getCurrentDocumentId();
+			return selectFlatStyles( getState(), currentDocumentId );
 		},
 		get: ( id ) => {
 			return selectFlatStyles( getState() ).find( ( style ) => style.id === id ) ?? null;

--- a/packages/packages/core/editor-components/src/store/dispatchers.ts
+++ b/packages/packages/core/editor-components/src/store/dispatchers.ts
@@ -24,9 +24,6 @@ export const componentsActions = {
 	resetUnpublished() {
 		dispatch( slice.actions.resetUnpublished() );
 	},
-	removeStyles( id: ComponentId ) {
-		dispatch( slice.actions.removeStyles( { id } ) );
-	},
 	addStyles( styles: Record< string, unknown > ) {
 		dispatch( slice.actions.addStyles( styles ) );
 	},

--- a/packages/packages/core/editor-components/src/store/extensible-slice.ts
+++ b/packages/packages/core/editor-components/src/store/extensible-slice.ts
@@ -65,11 +65,6 @@ const baseSlice = createSlice( {
 		resetUnpublished: ( state ) => {
 			state.unpublishedData = [];
 		},
-		removeStyles( state, { payload }: PayloadAction< { id: ComponentId } > ) {
-			const { [ payload.id ]: _, ...rest } = state.styles;
-
-			state.styles = rest;
-		},
 		addStyles: ( state, { payload } ) => {
 			state.styles = { ...state.styles, ...payload };
 		},

--- a/packages/packages/core/editor-components/src/store/store.ts
+++ b/packages/packages/core/editor-components/src/store/store.ts
@@ -47,7 +47,20 @@ export const selectUnpublishedComponents = createSelector(
 export const selectLoadIsPending = createSelector( selectLoadStatus, ( status ) => status === 'pending' );
 export const selectLoadIsError = createSelector( selectLoadStatus, ( status ) => status === 'error' );
 export const selectStyles = ( state: ComponentsSlice ) => state[ SLICE_NAME ].styles ?? {};
-export const selectFlatStyles = createSelector( selectStylesDefinitions, ( data ) => Object.values( data ).flat() );
+export const selectFlatStyles = createSelector(
+	selectStylesDefinitions,
+	( _state: ComponentsSlice, excludeComponentId: ComponentId | null = null ) => excludeComponentId,
+	( data, excludeComponentId ) => {
+		if ( excludeComponentId === null ) {
+			return Object.values( data ).flat();
+		}
+
+		return Object.entries( data )
+			.filter( ( [ id ] ) => id !== String( excludeComponentId ) )
+			.map( ( [ , styles ] ) => styles )
+			.flat();
+	}
+);
 export const selectCreatedThisSession = createSelector(
 	getCreatedThisSession,
 	( createdThisSession ) => createdThisSession


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix styles repository to exclude current document's component styles when rendering templates, preventing style conflicts in the editor.

Main changes:
- Modified selectFlatStyles selector to accept optional excludeComponentId parameter for filtering component styles by document
- Replaced removeComponentStyles action with apiClient.invalidateComponentConfigCache call to simplify style cache management
- Updated componentsStylesProvider.actions.all() to filter styles based on getCurrentDocumentId to prevent local style leakage

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
