### PR TITLE
Internal: Cover session by editor assets config [ED-23684]

### DIFF
--- a/core/common/modules/events-manager/module.php
+++ b/core/common/modules/events-manager/module.php
@@ -32,12 +32,32 @@ class Module extends BaseModule {
 			Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME );
 
 		$is_flags_enabled = false;
+		$session_recording_events = [];
 
 		if ( $can_send_events ) {
 			$mixpanel_config = self::get_remote_mixpanel_config();
-			$is_flags_enabled = EditorAssetsAPI::has_valid_nested_array( $mixpanel_config, [ 0 ] )
-				? (bool) ( $mixpanel_config[0]['flags'] ?? false )
-				: false;
+			$has_config = EditorAssetsAPI::has_valid_nested_array( $mixpanel_config, [ 0 ] );
+
+			if ( $has_config ) {
+				$is_flags_enabled = (bool) ( $mixpanel_config[0]['flags'] ?? false );
+
+				$session_replays = $mixpanel_config[0]['sessionReplays'] ?? [];
+				$is_session_replays_enabled = (bool) ( $session_replays['enabled'] ?? false );
+				$raw_events = $session_replays['events'] ?? null;
+				$events_map = is_array( $raw_events ) ? $raw_events : [];
+
+				if ( $is_session_replays_enabled ) {
+					$session_recording_events = array_values( array_filter(
+						self::get_session_recording_events(),
+						function ( $pair ) use ( $events_map ) {
+							if ( ! isset( $pair['start'] ) ) {
+								return false;
+							}
+							return (bool) ( $events_map[ $pair['start'] ] ?? false );
+						}
+					) );
+				}
+			}
 		}
 
 		$settings = [
@@ -53,7 +73,7 @@ class Module extends BaseModule {
 			'token' => ELEMENTOR_EDITOR_EVENTS_MIXPANEL_TOKEN,
 			'flags_enabled' => $is_flags_enabled,
 			'user_id' => self::get_user_id(),
-			'session_recording_events' => self::get_session_recording_events(),
+			'session_recording_events' => $session_recording_events,
 		];
 
 		return $settings;


### PR DESCRIPTION
## Summary
- Gate `session_recording_events` population behind remote editor assets config flags (`sessionReplays.enabled`)
- Add `is_array()` guard on `events_map` from remote payload to prevent silent failures when the remote config delivers an unexpected type
- Add `isset( $pair['start'] )` guard in the filter callback for defensive future-proofing
- `session_recording_events` now returns `[]` unless the user can send events and the remote config explicitly enables session replays

## Test plan
- [ ] Verify session recording events are populated when `sessionReplays.enabled` is `true` in the remote config and event keys match
- [ ] Verify `session_recording_events` is `[]` when `sessionReplays.enabled` is `false`
- [ ] Verify `session_recording_events` is `[]` when the user cannot send events (`can_send_events = false`)
- [ ] Verify `session_recording_events` is `[]` when remote config is unavailable/malformed
- [ ] Verify no PHP warnings when `sessionReplays.events` is `null` or a non-array value

## Jira
[ED-23684](https://elementor.atlassian.net/browse/ED-23684)

[ED-23684]: https://elementor.atlassian.net/browse/ED-23684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Session recording events were previously sent unconditionally based on `get_session_recording_events()`. This change gates them by the remote editor assets config, allowing server-side control over which session replay events are actually captured. This aligns session recording behavior with the existing flags pattern and provides deployment-time flexibility without code changes.

**Ticket**: ED-23684

## 2. What Changed (Where)

- `core/common/modules/events-manager/module.php`: Moved session recording events from always-included to conditionally filtered based on remote config's `sessionReplays` settings.

## 3. How It Works

When `$can_send_events` is true, the code now:
1. Validates mixpanel config structure via `has_valid_nested_array`
2. Checks `sessionReplays.enabled` flag in config
3. Filters local `get_session_recording_events()` against the remote `events` map (keyed by `start` event name)
4. Only includes event pairs where the remote config has `events[pair.start] === true`
5. Passes filtered array to frontend settings instead of the full list

If config is missing, malformed, or `sessionReplays.enabled` is false, `session_recording_events` becomes an empty array.

## 4. Risks

**Data Loss**: If the remote config is stale or the `events` map is incomplete, legitimate session recordings won't be captured. Ensure config deployment is tested before rolling out.

**Performance**: `array_filter` over all events on every editor load. If `get_session_recording_events()` returns hundreds of items, consider caching the filtered result.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
