### PR TITLE
Fix: Harden global classes endpoint against migration fetch timeouts [ED-23544]

### DIFF
--- a/modules/atomic-widgets/prop-type-migrations/migrations-loader.php
+++ b/modules/atomic-widgets/prop-type-migrations/migrations-loader.php
@@ -9,6 +9,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Migrations_Loader {
+	const MANIFEST_TRANSIENT_KEY = 'elementor_migrations_manifest';
+	const MANIFEST_TRANSIENT_TTL = 12 * HOUR_IN_SECONDS;
+
 	private static ?self $instance = null;
 
 	private ?array $manifest = null;
@@ -265,17 +268,16 @@ class Migrations_Loader {
 
 		$manifest_path = $this->base_path . $this->manifest_file;
 
-		$contents = $this->read_source( $manifest_path );
+		$contents = $this->is_url( $manifest_path )
+			? $this->read_remote_manifest( $manifest_path )
+			: $this->read_source( $manifest_path );
 
 		if ( false === $contents ) {
 			Logger::warning( 'Migrations manifest not found', [
 				'path' => $manifest_path,
 			] );
 
-			$this->manifest = [
-				'widgetKeys' => [],
-				'propTypes' => [],
-			];
+			$this->manifest = self::empty_manifest();
 			return $this->manifest;
 		}
 
@@ -287,10 +289,7 @@ class Migrations_Loader {
 				'error' => json_last_error_msg(),
 			] );
 
-			$this->manifest = [
-				'widgetKeys' => [],
-				'propTypes' => [],
-			];
+			$this->manifest = self::empty_manifest();
 			return $this->manifest;
 		}
 
@@ -299,9 +298,43 @@ class Migrations_Loader {
 		return $this->manifest;
 	}
 
+	private function read_remote_manifest( string $url ) {
+		$transient_key = self::MANIFEST_TRANSIENT_KEY;
+		$stale_key = self::MANIFEST_TRANSIENT_KEY . '_stale';
+
+		$cached = get_transient( $transient_key );
+
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		$body = $this->read_source( $url );
+
+		if ( false !== $body ) {
+			set_transient( $transient_key, $body, self::MANIFEST_TRANSIENT_TTL );
+			update_option( $stale_key, $body, false );
+			return $body;
+		}
+
+		$stale = get_option( $stale_key );
+
+		if ( false !== $stale ) {
+			return $stale;
+		}
+
+		return false;
+	}
+
+	private static function empty_manifest(): array {
+		return [
+			'widgetKeys' => [],
+			'propTypes' => [],
+		];
+	}
+
 	private function read_source( string $path ) {
 		if ( $this->is_url( $path ) ) {
-			$response = wp_remote_get( $path, [ 'timeout' => 10 ] );
+			$response = wp_remote_get( $path, [ 'timeout' => 3 ] );
 
 			if ( is_wp_error( $response ) ) {
 				return false;

--- a/modules/global-classes/global-classes-repository.php
+++ b/modules/global-classes/global-classes-repository.php
@@ -54,14 +54,16 @@ class Global_Classes_Repository {
 			$all = $kit->get_json_meta( static::META_KEY_FRONTEND );
 		}
 
-		Migrations_Orchestrator::make()->migrate(
-			$all,
-			$kit->get_id(),
-			$meta_key,
-			function( $migrated_data ) use ( $kit, $meta_key ) {
-				$kit->update_json_meta( $meta_key, $migrated_data );
-			}
-		);
+		if ( Migrations_Orchestrator::is_active() ) {
+			Migrations_Orchestrator::make()->migrate(
+				$all,
+				$kit->get_id(),
+				$meta_key,
+				function( $migrated_data ) use ( $kit, $meta_key ) {
+					$kit->update_json_meta( $meta_key, $migrated_data );
+				}
+			);
+		}
 
 		$this->cache = Global_Classes::make( $all['items'] ?? [], $all['order'] ?? [] );
 

--- a/modules/global-classes/global-classes-rest-api.php
+++ b/modules/global-classes/global-classes-rest-api.php
@@ -259,7 +259,7 @@ class Global_Classes_REST_API {
 	private function route_wrapper( callable $cb ) {
 		try {
 			$response = $cb();
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			return Error_Builder::make( 'unexpected_error' )
 				->set_message( __( 'Something went wrong', 'elementor' ) )
 				->build();

--- a/packages/packages/core/editor-global-classes/src/components/populate-store.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/populate-store.tsx
@@ -8,8 +8,8 @@ export function PopulateStore() {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		Promise.all( [ apiClient.all( 'preview' ), apiClient.all( 'frontend' ) ] ).then(
-			( [ previewRes, frontendRes ] ) => {
+		Promise.all( [ apiClient.all( 'preview' ), apiClient.all( 'frontend' ) ] )
+			.then( ( [ previewRes, frontendRes ] ) => {
 				const { data: previewData } = previewRes;
 				const { data: frontendData } = frontendRes;
 
@@ -25,8 +25,11 @@ export function PopulateStore() {
 						},
 					} )
 				);
-			}
-		);
+			} )
+			.catch( ( error ) => {
+				// eslint-disable-next-line no-console
+				console.error( error );
+			} );
 	}, [ dispatch ] );
 
 	return null;

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-loader.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-loader.php
@@ -23,6 +23,9 @@ class Test_Migrations_Loader extends Elementor_Test_Base {
 
 	public function tearDown(): void {
 		Migrations_Loader::destroy();
+		delete_transient( Migrations_Loader::MANIFEST_TRANSIENT_KEY );
+		delete_option( Migrations_Loader::MANIFEST_TRANSIENT_KEY . '_stale' );
+		remove_all_filters( 'pre_http_request' );
 		parent::tearDown();
 	}
 
@@ -250,6 +253,91 @@ class Test_Migrations_Loader extends Elementor_Test_Base {
 
 		// Assert
 		$this->assertEquals( 'svg', $result );
+	}
+
+	public function test_remote_manifest_returns_cached_transient() {
+		// Arrange
+		$manifest_json = wp_json_encode( [ 'propTypes' => [], 'widgetKeys' => [] ] );
+		set_transient( Migrations_Loader::MANIFEST_TRANSIENT_KEY, $manifest_json, HOUR_IN_SECONDS );
+
+		$loader = Migrations_Loader::make( 'https://migrations.elementor.com/' );
+
+		// Act
+		$hash = $loader->get_manifest_hash();
+
+		// Assert
+		$this->assertNotEmpty( $hash );
+	}
+
+	public function test_remote_manifest_fetches_and_caches_on_transient_miss() {
+		// Arrange
+		$manifest = [ 'propTypes' => [], 'widgetKeys' => [] ];
+		$manifest_json = wp_json_encode( $manifest );
+
+		delete_transient( Migrations_Loader::MANIFEST_TRANSIENT_KEY );
+		delete_option( Migrations_Loader::MANIFEST_TRANSIENT_KEY . '_stale' );
+
+		add_filter( 'pre_http_request', function ( $pre, $args, $url ) use ( $manifest_json ) {
+			if ( false !== strpos( $url, 'migrations.elementor.com' ) ) {
+				return [ 'response' => [ 'code' => 200 ], 'body' => $manifest_json ];
+			}
+			return $pre;
+		}, 10, 3 );
+
+		$loader = Migrations_Loader::make( 'https://migrations.elementor.com/' );
+
+		// Act
+		$hash = $loader->get_manifest_hash();
+
+		// Assert
+		$this->assertNotEmpty( $hash );
+		$this->assertEquals( $manifest_json, get_transient( Migrations_Loader::MANIFEST_TRANSIENT_KEY ) );
+		$this->assertEquals( $manifest_json, get_option( Migrations_Loader::MANIFEST_TRANSIENT_KEY . '_stale' ) );
+	}
+
+	public function test_remote_manifest_falls_back_to_stale_on_fetch_failure() {
+		// Arrange
+		$stale_manifest = wp_json_encode( [ 'propTypes' => [], 'widgetKeys' => [] ] );
+
+		delete_transient( Migrations_Loader::MANIFEST_TRANSIENT_KEY );
+		update_option( Migrations_Loader::MANIFEST_TRANSIENT_KEY . '_stale', $stale_manifest, false );
+
+		add_filter( 'pre_http_request', function ( $pre, $args, $url ) {
+			if ( false !== strpos( $url, 'migrations.elementor.com' ) ) {
+				return new \WP_Error( 'http_request_failed', 'Connection timed out' );
+			}
+			return $pre;
+		}, 10, 3 );
+
+		$loader = Migrations_Loader::make( 'https://migrations.elementor.com/' );
+
+		// Act
+		$hash = $loader->get_manifest_hash();
+
+		// Assert
+		$this->assertNotEmpty( $hash );
+		$this->assertEquals( md5( $stale_manifest ), $hash );
+	}
+
+	public function test_remote_manifest_returns_empty_when_no_cache_and_fetch_fails() {
+		// Arrange
+		delete_transient( Migrations_Loader::MANIFEST_TRANSIENT_KEY );
+		delete_option( Migrations_Loader::MANIFEST_TRANSIENT_KEY . '_stale' );
+
+		add_filter( 'pre_http_request', function ( $pre, $args, $url ) {
+			if ( false !== strpos( $url, 'migrations.elementor.com' ) ) {
+				return new \WP_Error( 'http_request_failed', 'Connection timed out' );
+			}
+			return $pre;
+		}, 10, 3 );
+
+		$loader = Migrations_Loader::make( 'https://migrations.elementor.com/' );
+
+		// Act
+		$hash = $loader->get_manifest_hash();
+
+		// Assert
+		$this->assertEmpty( $hash );
 	}
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type

- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Prevent global classes from disappearing when the remote migration manifest fetch times out or fails

## Description

**Problem:** The `GET /global-classes` endpoint could hang for up to 10 seconds (or until PHP `max_execution_time`) when `migrations.elementor.com` was slow or unreachable. This caused the client-side store to remain empty, making all global classes appear to vanish. The client-side `PopulateStore` component also lacked error handling, silently swallowing fetch failures.

**Solution — 5 layers of resilience:**

1. **Gate migration with `is_active()` check** — Skip the migration orchestrator entirely when the `e_bc_migrations` experiment is inactive, avoiding the remote fetch altogether in most cases.

2. **Cache remote manifest via WordPress transients** — Cache the manifest with a 12-hour TTL. On transient miss, attempt a remote fetch and persist a stale copy via `wp_option`. On fetch failure, fall back to the stale copy. This ensures that even if the remote server is down, previously-fetched manifests are reused.

3. **Reduce `wp_remote_get` timeout** — Lowered from 10s to 3s to fail fast on unreachable hosts instead of blocking the entire request.

4. **Catch `\Throwable` in `route_wrapper`** — Changed from `\Exception` to `\Throwable` to also catch PHP `\Error` (e.g., `Maximum execution time exceeded`), returning a proper REST API error response instead of a raw 500.

5. **Add `.catch()` to client-side `PopulateStore`** — Prevents silent promise rejections so errors are logged and the Redux store state is predictable.

### Key decisions

- **Show classes without migration over showing nothing** — If the manifest can't be fetched and no cache exists, classes are returned unmigrated rather than failing the entire endpoint. This trades off potential stale prop-type formats for guaranteed class visibility.
- **Stale-while-revalidate pattern** — The `wp_option`-based stale fallback ensures that even after the transient expires and a fresh fetch fails, the last known good manifest is used.

## Test instructions

This PR can be tested by following these steps:

1. Enable the `e_bc_migrations` experiment
2. Block network access to `migrations.elementor.com` (e.g. via hosts file or firewall rule)
3. Open the editor and verify global classes load correctly (using cached/stale manifest)
4. Disable the `e_bc_migrations` experiment
5. Verify global classes still load (migration is skipped entirely)

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes ED-23544

Made with [Cursor](https://cursor.com)