### PR TITLE
Internal: Restore styles clearing logic

### DIFF
--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -13,7 +13,6 @@ import { registerDataHook } from '@elementor/editor-v1-adapters';
 import { __registerSlice as registerSlice } from '@elementor/store';
 import { __ } from '@wordpress/i18n';
 
-import { apiClient } from './api';
 import { componentInstanceTransformer } from './component-instance-transformer';
 import { componentOverridableTransformer } from './component-overridable-transformer';
 import { componentOverrideTransformer } from './component-override-transformer';
@@ -26,6 +25,7 @@ import { COMPONENT_WIDGET_TYPE, createComponentType } from './create-component-t
 import { PopulateStore } from './populate-store';
 import { initCircularNestingPrevention } from './prevent-circular-nesting';
 import { loadComponentsAssets } from './store/actions/load-components-assets';
+import { removeComponentStyles } from './store/actions/remove-component-styles';
 import { componentsStylesProvider } from './store/components-styles-provider';
 import { slice } from './store/store';
 import { beforeSave } from './sync/before-save';
@@ -63,7 +63,7 @@ export function init() {
 		const { id, config } = getV1CurrentDocument();
 
 		if ( id ) {
-			apiClient.invalidateComponentConfigCache( id );
+			removeComponentStyles( id );
 		}
 
 		await loadComponentsAssets( ( config?.elements as V1ElementData[] ) ?? [] );

--- a/packages/packages/core/editor-components/src/store/actions/remove-component-styles.ts
+++ b/packages/packages/core/editor-components/src/store/actions/remove-component-styles.ts
@@ -1,0 +1,9 @@
+import { __dispatch as dispatch } from '@elementor/store';
+
+import { apiClient } from '../../api';
+import { slice } from '../store';
+
+export function removeComponentStyles( id: number ) {
+	apiClient.invalidateComponentConfigCache( id );
+	dispatch( slice.actions.removeStyles( { id } ) );
+}

--- a/packages/packages/core/editor-components/src/store/dispatchers.ts
+++ b/packages/packages/core/editor-components/src/store/dispatchers.ts
@@ -24,6 +24,9 @@ export const componentsActions = {
 	resetUnpublished() {
 		dispatch( slice.actions.resetUnpublished() );
 	},
+	removeStyles( id: ComponentId ) {
+		dispatch( slice.actions.removeStyles( { id } ) );
+	},
 	addStyles( styles: Record< string, unknown > ) {
 		dispatch( slice.actions.addStyles( styles ) );
 	},

--- a/packages/packages/core/editor-components/src/store/extensible-slice.ts
+++ b/packages/packages/core/editor-components/src/store/extensible-slice.ts
@@ -65,6 +65,11 @@ const baseSlice = createSlice( {
 		resetUnpublished: ( state ) => {
 			state.unpublishedData = [];
 		},
+		removeStyles( state, { payload }: PayloadAction< { id: ComponentId } > ) {
+			const { [ payload.id ]: _, ...rest } = state.styles;
+
+			state.styles = rest;
+		},
 		addStyles: ( state, { payload } ) => {
 			state.styles = { ...state.styles, ...payload };
 		},


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Previous refactor removed critical style cleanup logic tied to document lifecycle. When switching documents or attaching previews, stale component styles weren't being cleared from the store or cache, causing style bleeding across documents. This restores that clearing behavior via a dedicated action.

## 2. What Changed (Where)

- `init.ts`: Replaced direct `apiClient.invalidateComponentConfigCache()` call with new `removeComponentStyles()` action
- `remove-component-styles.ts`: New action encapsulating cache invalidation + store cleanup
- `extensible-slice.ts`: Added `removeStyles` reducer to delete component styles by ID
- `dispatchers.ts`: Exposed `removeStyles` dispatcher for external consumers

## 3. How It Works

On `editor/documents/attach-preview` hook, `removeComponentStyles(id)` now runs both cache invalidation and store cleanup atomically. The reducer uses destructuring (`{ [id]: _, ...rest }`) to omit the target ID from the styles object. This ensures no stale CSS persists when navigating between documents.

## 4. Risks

None. This restores proven logic that was inadvertently removed. The atomic action (cache + store) is safer than the previous scattered approach.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
