### PR TITLE
Internal: Allow negative values for box-shadow offset and spread [ED-23498]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/box-shadow-repeater-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/box-shadow-repeater-control.tsx
@@ -90,7 +90,7 @@ const Content = () => {
 				</PopoverGridContainer>
 				<PopoverGridContainer ref={ rowRef[ 1 ] }>
 					<Control bind="blur" label={ __( 'Blur', 'elementor' ) }>
-						<SizeControl anchorRef={ rowRef[ 1 ] }/>
+						<SizeControl anchorRef={ rowRef[ 1 ] } />
 					</Control>
 					<Control bind="spread" label={ __( 'Spread', 'elementor' ) }>
 						<SizeControl anchorRef={ rowRef[ 1 ] } min={ -Number.MAX_SAFE_INTEGER } />

--- a/packages/packages/libs/editor-controls/src/controls/box-shadow-repeater-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/box-shadow-repeater-control.tsx
@@ -82,18 +82,18 @@ const Content = () => {
 				</PopoverGridContainer>
 				<PopoverGridContainer ref={ rowRef[ 0 ] }>
 					<Control bind="hOffset" label={ __( 'Horizontal', 'elementor' ) }>
-						<SizeControl anchorRef={ rowRef[ 0 ] } />
+						<SizeControl anchorRef={ rowRef[ 0 ] } min={ -Number.MAX_SAFE_INTEGER } />
 					</Control>
 					<Control bind="vOffset" label={ __( 'Vertical', 'elementor' ) }>
-						<SizeControl anchorRef={ rowRef[ 0 ] } />
+						<SizeControl anchorRef={ rowRef[ 0 ] } min={ -Number.MAX_SAFE_INTEGER } />
 					</Control>
 				</PopoverGridContainer>
 				<PopoverGridContainer ref={ rowRef[ 1 ] }>
 					<Control bind="blur" label={ __( 'Blur', 'elementor' ) }>
-						<SizeControl anchorRef={ rowRef[ 1 ] } />
+						<SizeControl anchorRef={ rowRef[ 1 ] }/>
 					</Control>
 					<Control bind="spread" label={ __( 'Spread', 'elementor' ) }>
-						<SizeControl anchorRef={ rowRef[ 1 ] } />
+						<SizeControl anchorRef={ rowRef[ 1 ] } min={ -Number.MAX_SAFE_INTEGER } />
 					</Control>
 				</PopoverGridContainer>
 			</PopoverContent>


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Box shadow controls were artificially constrained to non-negative values, preventing users from creating valid CSS effects that require negative offsets (e.g., reversed shadows, inset effects). ED-23498 removes this limitation by allowing negative values for horizontal offset, vertical offset, and spread properties to match standard CSS box-shadow behavior.

## 2. What Changed (Where)

- `box-shadow-repeater-control.tsx`: Added `min={ -Number.MAX_SAFE_INTEGER }` to three SizeControl components (hOffset, vOffset, spread)

## 3. How It Works

Three SizeControl instances now explicitly set minimum bounds to JavaScript's most negative safe integer (~-9 quadrillion). This removes the default lower bound that was preventing negative input. Blur remains constrained to positive values (no min prop) since negative blur is invalid in CSS.

## 4. Risks

None. This aligns the UI with CSS spec — negative values were always valid in the underlying CSS, just blocked by the control. No breaking changes to existing shadow configurations since previously saved values remain unchanged.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
