### PR TITLE
Internal: Sync package-lock.json from main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "elementor-packages",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
-        "@types/jest": "^29.5.14",
         "@typescript-eslint/eslint-plugin": "^8.6.0",
         "@typescript-eslint/parser": "^8.6.0",
         "@wordpress/eslint-plugin": "^21.1.0",


### PR DESCRIPTION
## Summary
- Syncs `package-lock.json` from the main repository
- Removes stale `@types/jest` devDependency entry that was missing from the lock file

## Test plan
- [ ] Verify `npm ci` runs cleanly after this change