### PR TITLE
Internal: Add elementor-capabilities-mcp module [ED-23723]

### DIFF
--- a/core/modules-manager.php
+++ b/core/modules-manager.php
@@ -138,6 +138,7 @@ class Modules_Manager {
 			'feedback',
 			'widget-creation',
 			'editor-one',
+			'elementor-capabilities-mcp',
 		];
 	}
 

--- a/modules/elementor-capabilities-mcp/module.php
+++ b/modules/elementor-capabilities-mcp/module.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Elementor\Modules\ElementorCapabilitiesMcp;
+
+use Elementor\Core\Base\Module as BaseModule;
+use Elementor\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Module extends BaseModule {
+
+	private const PACKAGE_NAME = 'elementor-capabilities-mcp';
+
+	private const REQUIRED_PACKAGES = [
+		'utils',
+		'schema',
+		'elementor-mcp-common',
+		'editor-v1-adapters',
+		'editor-mcp',
+		'elementor-capabilities-mcp',
+	];
+
+	public function get_name(): string {
+		return self::PACKAGE_NAME;
+	}
+
+	public static function is_active(): bool {
+		return is_admin();
+	}
+
+	public function __construct() {
+		parent::__construct();
+
+		add_action( 'admin_enqueue_scripts', [ $this, 'register_packages' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ], 20 );
+
+		add_filter( 'elementor/editor/v2/packages', [ $this, 'add_editor_packages' ] );
+	}
+
+	public function add_editor_packages( array $packages ): array {
+		$packages[] = self::PACKAGE_NAME;
+
+		return $packages;
+	}
+
+	public function register_packages(): void {
+		$suffix = Utils::is_script_debug() ? '' : '.min';
+
+		foreach ( self::REQUIRED_PACKAGES as $package ) {
+			$asset_file = ELEMENTOR_ASSETS_PATH . "js/packages/{$package}/{$package}.asset.php";
+
+			if ( ! file_exists( $asset_file ) ) {
+				continue;
+			}
+
+			$asset = require $asset_file;
+			$handle = $asset['handle'] ?? "elementor-v2-{$package}";
+
+			if ( wp_script_is( $handle, 'registered' ) ) {
+				continue;
+			}
+
+			wp_register_script(
+				$handle,
+				ELEMENTOR_ASSETS_URL . "js/packages/{$package}/{$package}{$suffix}.js",
+				$asset['deps'] ?? [],
+				ELEMENTOR_VERSION,
+				true
+			);
+		}
+	}
+
+	public function enqueue_scripts(): void {
+		wp_enqueue_script( 'elementor-v2-' . self::PACKAGE_NAME );
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "elementor-packages",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
-        "@types/jest": "^29.5.14",
         "@typescript-eslint/eslint-plugin": "^8.6.0",
         "@typescript-eslint/parser": "^8.6.0",
         "@wordpress/eslint-plugin": "^21.1.0",
@@ -4487,6 +4486,10 @@
     },
     "node_modules/@elementor/editor-widget-creation": {
       "resolved": "packages/packages/core/editor-widget-creation",
+      "link": true
+    },
+    "node_modules/@elementor/elementor-capabilities-mcp": {
+      "resolved": "packages/apps/elementor-capabilities-mcp",
       "link": true
     },
     "node_modules/@elementor/elementor-mcp-common": {
@@ -44815,6 +44818,20 @@
       },
       "peerDependencies": {
         "zod": "^3.24.4"
+      }
+    },
+    "packages/apps/elementor-capabilities-mcp": {
+      "name": "@elementor/elementor-capabilities-mcp",
+      "version": "4.1.0",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@elementor/editor-mcp": "*",
+        "@elementor/elementor-mcp-common": "*",
+        "@elementor/schema": "*",
+        "@modelcontextprotocol/sdk": "1.27.1"
+      },
+      "devDependencies": {
+        "tsup": "^8.3.5"
       }
     },
     "packages/apps/onboarding": {

--- a/packages/apps/elementor-capabilities-mcp/package.json
+++ b/packages/apps/elementor-capabilities-mcp/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@elementor/elementor-capabilities-mcp",
+  "description": "Elementor Capabilities MCP module",
+  "version": "4.1.0",
+  "private": true,
+  "author": "Elementor Team",
+  "homepage": "https://elementor.com/",
+  "license": "GPL-3.0-or-later",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elementor/elementor.git",
+    "directory": "packages/apps/elementor-capabilities-mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/elementor/elementor/issues"
+  },
+	"dependencies": {
+		"@elementor/editor-mcp": "4.1.0",
+		"@elementor/elementor-mcp-common": "4.1.0",
+		"@elementor/schema": "4.1.0",
+		"@modelcontextprotocol/sdk": "1.27.1"
+	},
+  "files": [
+    "README.md",
+    "CHANGELOG.md",
+    "/dist",
+    "/src",
+    "!**/__tests__"
+  ],
+  "scripts": {
+    "build": "tsup --config=../../tsup.build.ts",
+    "dev": "tsup --config=../../tsup.dev.ts"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5"
+  }
+}

--- a/packages/apps/elementor-capabilities-mcp/src/elementor-capabilities-mcp-server.ts
+++ b/packages/apps/elementor-capabilities-mcp/src/elementor-capabilities-mcp-server.ts
@@ -1,0 +1,327 @@
+import { AngieMessageEvenetType as MessageEventType, getAngieIframe } from '@elementor/editor-mcp';
+import { callWpApi } from '@elementor/elementor-mcp-common';
+import { z } from '@elementor/schema';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { addPagesListResource, PAGES_LIST_RESOURCE_URI } from './pages-list-resource';
+
+type McpToolResult = {
+	content: {
+		type: 'text';
+		text: string;
+	}[];
+};
+// Constants
+const ANGIE_REQUIRED_RESOURCES = 'angie/requiredResources';
+const WP_PAGES_ENDPOINT = '/wp/v2/pages';
+const ELEMENTOR_EDIT_MODE = 'builder';
+const DEFAULT_PAGE_TITLE = 'New Page';
+const ELEMENTOR_EDIT_ACTION = 'elementor';
+
+type WPPost = {
+	id: number;
+	title: { rendered: string };
+	link: string;
+	type: string;
+	status: string;
+};
+
+export const getSafeOrigin = () => {
+	if ( typeof window === 'undefined' ) {
+		return '';
+	}
+	const url = new URL( window.location.href );
+	const originParam = `${ url.protocol }://${ url.host }`;
+	return originParam || '';
+};
+
+export function safeNavigateAfterResponse( url: string ) {
+	try {
+		const angieIframe = getAngieIframe();
+
+		// @ts-ignore: It's not null
+		angieIframe.contentWindow.postMessage(
+			{
+				type: MessageEventType.ANGIE_NAVIGATE_AFTER_RESPONSE,
+				payload: { url },
+			},
+			getSafeOrigin()
+		);
+	} finally {
+		setTimeout( () => {
+			window.location.replace( url );
+		}, 50 );
+	}
+}
+
+/**
+ * Creates an MCP server that exposes Elementor capabilities when NOT in the editor
+ * This helps Angie understand what Elementor can do and navigate users to the editor
+ */
+export function createElementorCapabilitiesServer() {
+	const server = new McpServer(
+		{
+			name: 'elementor-capabilities-server',
+			version: '1.0.0',
+			title: 'Elementor Capabilities',
+		},
+		{
+			instructions: `## Elementor Page Builder - Available When In Editor
+
+This MCP provides information about Elementor's page building capabilities. When users ask about Elementor features, you should navigate them to the Elementor editor where full capabilities are available.
+
+### Available Resources:
+**Pages List Resource** (\`${ PAGES_LIST_RESOURCE_URI }\`):
+- Lists all WordPress pages with IDs, titles, status, and metadata
+- Use this to see what pages are available before navigation
+- Updated automatically when pages are created or modified
+- Useful for suggesting pages to edit or checking if a page exists
+
+### Elementor Capabilities (Available In Editor):
+
+**Page Management:**
+- Manage page settings, saving and routing pages
+- Control the editor UI, including switching between desktop, tablet, and mobile views
+
+**Global Styles:**
+- Work with global styles, helping manage shared design settings like colors and fonts across the site
+
+**Element Management:**
+- Create, edit, delete, duplicate, and move individual Elementor widgets and containers
+- Update widget and container settings
+- Insert text content with AI-powered text generation
+- Create image widgets and assign images to elements
+
+**AI-Powered Content Creation:**
+- Generate and edit text and insert it into the page
+- Generate images and place them on the canvas
+
+**Custom Styling & Code:**
+- Apply custom CSS to elements
+- Generate supported code snippets
+
+### Elementor Limitations (What Cannot Be Done):
+
+**Element Management Limitations:**
+- Cannot apply motion effects
+- Cannot create fully designed or polished pages in a single step
+- Cannot fully resolve responsiveness issues
+- Layout generation (Copilot) is not currently available
+
+**Theme Builder:**
+- Cannot create or manage Theme Builder templates, including headers, footers, single posts, archives, products, loop items, or 404 pages
+- Cannot set display conditions for templates
+- Cannot configure popup triggers and advanced rules
+
+**System Settings:**
+- Cannot change Elementor system-level settings
+- Cannot activate or work with Editor V4
+- Cannot manage form submissions
+- Cannot add custom fonts or icons
+- Cannot manage user roles
+- Cannot roll back Elementor versions
+- Cannot place the site in maintenance mode
+- Cannot export the website
+- Cannot apply full website templates
+
+**Code & Widgets:**
+- Cannot register PHP code or create new custom widgets, though Angie may provide guidance, code snippets, or plugin suggestions where helpful
+
+**Note**: While page names can include terms like "header" or "footer", these won't function as actual theme parts without Theme Builder access.
+
+### How to Help Users:
+
+**When users ask about Elementor features:**
+1. Confirm what they want to accomplish
+2. Check if it's a supported capability (see lists above)
+3. **Get the page to edit:**
+   - If user says "create new page" → Use createNew=true
+   - Otherwise → Call tool with no parameters to get page list
+   - Show pages to user: "Which page? Homepage, About, Contact..."
+   - User chooses → Call tool again with that pageId
+4. Once in editor, full Elementor MCP tools will be available
+
+**Examples:**
+- User: "Edit homepage" → Get page list → Find "Homepage" → Ask to confirm → Navigate
+- User: "Create new page" → createNew=true → Navigate
+
+**Examples of when to navigate to editor:**
+- "Edit my homepage with Elementor"
+- "Apply custom CSS to my page"
+- "Generate text content for my page"
+- "Work with dynamic content"
+
+**Examples of when to navigate to editor (element management now supported):**
+- "Add a heading widget" (Navigate to editor - element management supported)
+- "Create a new section with containers" (Navigate to editor - container creation supported)
+- "Change the color of a button" (Navigate to editor - widget settings supported)
+
+**Examples of what Elementor CANNOT do (don't navigate):**
+- "Add motion effects to my page" (Motion effects not supported)
+- "Create a header template" (Theme Builder not available)
+- "Set up a popup trigger" (Popup triggers and advanced rules not supported)
+- "Change Elementor settings" (System-level settings restricted)
+- "Add custom fonts" (Custom fonts not supported)
+- "Create a custom widget" (Cannot register PHP code or custom widgets)
+
+### Important Notes:
+- Elementor tools are ONLY available when inside the Elementor editor
+- This MCP server is for navigation and capability awareness
+- Once in editor, the full 'elementor' MCP server with all tools becomes available
+- Always verify if the requested feature is supported before navigating
+
+**Important**: When users ask "What can Angie do?" or similar questions about Angie's general capabilities, use the \`what-can-angie-do\` tool from the knowledge MCP server instead of generating your own response.`,
+			capabilities: {
+				resources: {
+					subscribe: true,
+				},
+			},
+		}
+	);
+
+	addPagesListResource( server );
+
+	server.registerTool(
+		'navigate-to-elementor-editor',
+		{
+			description:
+				'Navigate the user to the Elementor editor to use Elementor page building capabilities. ' +
+				'WORKFLOW: ' +
+				'1. Check the wp-pages-list resource (automatically loaded) to see available pages. ' +
+				'2. If user asks to create new → set createNew=true with confirmationMessage. ' +
+				'3. If editing existing page → set pageId (from resource) with confirmationMessage. ' +
+				'Once in editor, full Elementor MCP capabilities become available.',
+			inputSchema: {
+				pageId: z
+					.number()
+					.optional()
+					.describe(
+						'The ID of the page to navigate to. Only provide after user has explicitly selected a page from the available pages list. When provided, confirmationMessage is REQUIRED.'
+					),
+				createNew: z
+					.boolean()
+					.optional()
+					.describe(
+						'Set to true ONLY when user explicitly requests to create a new page. When true, confirmationMessage is REQUIRED. Default is false.'
+					),
+				newPageTitle: z
+					.string()
+					.optional()
+					.describe(
+						'Title for the new page when createNew is true. Use what the user specified or default to "New Page".'
+					),
+				confirmationMessage: z
+					.string()
+					.optional()
+					.describe(
+						"REQUIRED when pageId or createNew is provided. A clear message shown to user before navigation. Example: \"I'll open the 'Homepage' in Elementor editor so you can add a form widget. Ready to proceed?\" Omit when just fetching available pages."
+					),
+			},
+			annotations: {
+				title: 'Navigate to Elementor Editor',
+				destructiveHint: true,
+			},
+			_meta: {
+				[ ANGIE_REQUIRED_RESOURCES ]: [
+					{
+						uri: PAGES_LIST_RESOURCE_URI,
+						whenToUse:
+							'Always use this resource first to understand what pages are available before asking the user which page to edit',
+					},
+				],
+			},
+		},
+		async ( params ) => {
+			try {
+				if ( ( params.pageId || params.createNew ) && ! params.confirmationMessage ) {
+					throw new Error(
+						'confirmationMessage is required when navigating to a page (pageId or createNew provided)'
+					);
+				}
+
+				if ( params.createNew ) {
+					return await handleCreateAndNavigate( params );
+				}
+
+				if ( params.pageId ) {
+					return await handleNavigateToPage( params.pageId );
+				}
+
+				throw new Error(
+					'Either pageId or createNew must be provided. The pages list is available in the wp-pages-list resource.'
+				);
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( '[Elementor Capabilities Server] navigation error:', error );
+				throw new Error( `Error navigating to Elementor editor: ${ ( error as Error ).message }` );
+			}
+		}
+	);
+
+	return server;
+}
+
+async function handleCreateAndNavigate( params: { newPageTitle?: string } ): Promise< McpToolResult > {
+	const title = params.newPageTitle || DEFAULT_PAGE_TITLE;
+
+	const response = await callWpApi( WP_PAGES_ENDPOINT, 'POST', {
+		title,
+		status: 'draft',
+		meta: {
+			_elementor_edit_mode: ELEMENTOR_EDIT_MODE,
+		},
+	} );
+	const newPage = response.data;
+
+	if ( ! newPage || typeof newPage !== 'object' || ! ( 'id' in newPage ) ) {
+		throw new Error( 'Invalid response from page creation API' );
+	}
+
+	return await handleNavigateToPage( newPage.id as number );
+}
+
+async function handleNavigateToPage( pageId: number ): Promise< McpToolResult > {
+	if ( ! pageId || pageId <= 0 ) {
+		throw new Error( 'Invalid page ID' );
+	}
+
+	const response = await callWpApi< WPPost >( `${ WP_PAGES_ENDPOINT }/${ pageId }`, 'GET' );
+	const page = response.data;
+	if ( ! page || typeof page !== 'object' || ! ( 'id' in page ) || ! ( 'title' in page ) ) {
+		throw new Error( `Invalid page data received for page ID ${ pageId }` );
+	}
+
+	const editUrl = generateElementorEditUrl( pageId );
+
+	if ( ! editUrl.startsWith( window.location.origin ) ) {
+		throw new Error( 'Invalid navigation URL' );
+	}
+
+	safeNavigateAfterResponse( editUrl );
+
+	return {
+		content: [
+			{
+				type: 'text',
+				text: JSON.stringify(
+					{
+						success: true,
+						message: `Navigating to Elementor editor for page: ${ page.title.rendered }`,
+						pageId: page.id,
+						pageTitle: page.title.rendered,
+						editUrl,
+						nextSteps:
+							'Once in the Elementor editor, you can use Elementor MCP tools for page settings, UI navigation, AI content generation, custom styling, and dynamic content.',
+					},
+					null,
+					2
+				),
+			},
+		],
+	};
+}
+
+function generateElementorEditUrl( pageId: number ): string {
+	const baseUrl = window.location.origin;
+	return `${ baseUrl }/wp-admin/post.php?post=${ pageId }&action=${ ELEMENTOR_EDIT_ACTION }`;
+}

--- a/packages/apps/elementor-capabilities-mcp/src/index.ts
+++ b/packages/apps/elementor-capabilities-mcp/src/index.ts
@@ -1,0 +1,21 @@
+import { getAngieSdk } from '@elementor/editor-mcp';
+
+import { createElementorCapabilitiesServer } from './elementor-capabilities-mcp-server';
+
+export function init() {
+	const sdk = getAngieSdk();
+	sdk.waitForReady().then( () => {
+		const capabilitiesServer = createElementorCapabilitiesServer();
+		sdk.registerServer( {
+			name: 'elementor-capabilities',
+			version: '2.0.0',
+			description: 'Elementor Capabilities Gateway',
+			server: capabilitiesServer,
+			capabilities: {
+				tools: {},
+			},
+		} );
+		// eslint-disable-next-line no-console
+		console.log( '[Elementor Capabilities MCP] Module initialized' );
+	} );
+}

--- a/packages/apps/elementor-capabilities-mcp/src/pages-list-resource.ts
+++ b/packages/apps/elementor-capabilities-mcp/src/pages-list-resource.ts
@@ -1,0 +1,64 @@
+import { type McpServer } from '@elementor/editor-mcp';
+import { callWpApi } from '@elementor/elementor-mcp-common';
+
+type WPPage = {
+	id: number;
+	title: { rendered: string };
+	link: string;
+	status: string;
+	modified: string;
+	type: string;
+};
+
+export const PAGES_LIST_RESOURCE_URI = 'wp://pages/list';
+
+export function addPagesListResource( server: McpServer ) {
+	server.registerResource(
+		'wp-pages-list',
+		PAGES_LIST_RESOURCE_URI,
+		{
+			title: 'List of wordpress pages',
+			description:
+				'List of all WordPress pages with their IDs, titles, status, and metadata. Use this to get available pages before navigation or editing.',
+		},
+		async ( uri ) => {
+			try {
+				const response = await callWpApi< WPPage[] >(
+					'/wp/v2/pages?per_page=100&orderby=modified&order=desc',
+					'GET'
+				);
+				const pages = response.data;
+				if ( ! Array.isArray( pages ) ) {
+					throw new Error( 'Invalid response format from wordpress pages API' );
+				}
+				const pagesList = pages.map( ( page ) => ( {
+					id: page.id,
+					title: page.title.rendered,
+					status: page.status,
+					link: page.link,
+					modified: page.modified,
+					type: page.type,
+				} ) );
+				return {
+					contents: [
+						{
+							uri: uri.href,
+							mimeType: 'application/json',
+							text: JSON.stringify(
+								{
+									pages: pagesList,
+									total: pagesList.length,
+									message: 'List of all available wordpress pages',
+								},
+								null,
+								2
+							),
+						},
+					],
+				};
+			} catch ( error ) {
+				throw new Error( `Failed to fetch pages list: ${ ( error as Error ).message }` );
+			}
+		}
+	);
+}

--- a/packages/packages/libs/editor-mcp/src/index.ts
+++ b/packages/packages/libs/editor-mcp/src/index.ts
@@ -1,4 +1,5 @@
 import { getSDK } from './utils/get-sdk';
+export { getAngieIframe, MessageEventType as AngieMessageEvenetType } from './utils/get-sdk';
 
 export {
 	McpServer,

--- a/packages/packages/libs/editor-mcp/src/utils/get-sdk.ts
+++ b/packages/packages/libs/editor-mcp/src/utils/get-sdk.ts
@@ -1,4 +1,5 @@
 import { AngieMcpSdk } from '@elementor-external/angie-sdk';
+export { getAngieIframe, MessageEventType } from '@elementor-external/angie-sdk';
 
 let sdk: AngieMcpSdk;
 


### PR DESCRIPTION
MCP server exposing Elementor capabilities. Loads on wp-admin pages and V2 editor. Implementation ported from external Angie repository.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Porting the capabilities MCP (Model Context Protocol) module to expose Elementor's feature set when users are outside the editor. This enables Angie (AI assistant) to understand what Elementor can/cannot do and navigate users to the editor context where full capabilities are available. Bridges the gap between admin context and editor context by providing a navigation layer with page management.

**Ticket**: ED-23723

## 2. What Changed (Where)

- `core/modules-manager.php` – Registered `elementor-capabilities-mcp` in modules list
- `modules/elementor-capabilities-mcp/module.php` – New PHP module bootstrapping script registration and enqueuing
- `packages/apps/elementor-capabilities-mcp/src/` – New TypeScript MCP server implementation with navigation tool and pages resource
- `packages/packages/libs/editor-mcp/src/` – Exported `getAngieIframe` and `MessageEventType` for cross-context messaging
- `packages/apps/elementor-capabilities-mcp/package.json` – Package manifest with dependencies on editor-mcp, schema, and MCP SDK

## 3. How It Works

**Entry Point**: PHP module registers and enqueues 6 JS packages (utils, schema, elementor-mcp-common, editor-v1-adapters, editor-mcp, elementor-capabilities-mcp) in admin context. The `init()` function waits for Angie SDK ready state, then registers an MCP server with the Angie iframe.

**Core Flow**: Server exposes two capabilities:
1. **`wp-pages-list` resource** – Fetches up to 100 pages via `/wp/v2/pages` REST API, returns JSON with id/title/status/link/modified metadata
2. **`navigate-to-elementor-editor` tool** – Two modes:
   - `createNew=true` → POST to `/wp/v2/pages` with title/draft status → navigate to `post.php?post={id}&action=elementor`
   - `pageId={n}` → GET page data → validate → navigate to edit URL

**Navigation Safety**: `safeNavigateAfterResponse()` posts message to Angie iframe (`ANGIE_NAVIGATE_AFTER_RESPONSE`) and falls back to `window.location.replace()` after 50ms timeout. Origin validation prevents navigation outside current domain.

**Edge Cases**: Tool requires `confirmationMessage` when `pageId` or `createNew` provided (enforced via schema and runtime check). Invalid page IDs, malformed API responses, and origin mismatches throw errors that bubble to MCP client.

## 4. Risks

**Security**: Origin validation in `generateElementorEditUrl()` only checks `window.location.origin` prefix, but doesn't validate protocol or prevent path traversal. If admin URL differs from site URL, navigation could fail silently.

**Race Condition**: 50ms fallback timeout in `safeNavigateAfterResponse()` may execute before Angie processes the message, causing duplicate navigation or state desync if Angie handles the message asynchronously.

**API Limits**: Pages resource hardcoded to `per_page=100` with no pagination — sites with 100+ pages will have incomplete lists, breaking navigation for older pages.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
