### PR TITLE
Internal: Add atomic-form webhook into actions after submit [ED-23166]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.php
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.php
@@ -40,6 +40,7 @@ class Atomic_Form extends Atomic_Element_Base {
 	public static $widget_description = 'A form container that holds form field widgets (labels, inputs, textareas, checkboxes, submit button) and status messages.';
 
 	public const ACTION_COLLECT_SUBMISSIONS = 'collect-submissions';
+	public const ACTION_WEBHOOK = 'webhook';
 	public const METADATA_REMOTE_IP = 'remote_ip';
 	public const METADATA_USER_AGENT = 'user_agent';
 
@@ -97,6 +98,15 @@ class Atomic_Form extends Atomic_Element_Base {
 			] )
 			->get();
 
+		$webhook_dependencies = Dependency_Manager::make()
+			->where( [
+				'operator' => 'contains',
+				'path' => [ 'actions-after-submit' ],
+				'value' => self::ACTION_WEBHOOK,
+				'effect' => 'hide',
+			] )
+			->get();
+
 		return [
 			'classes' => Classes_Prop_Type::make()
 				->default( [] ),
@@ -121,6 +131,10 @@ class Atomic_Form extends Atomic_Element_Base {
 					'to' => String_Prop_Type::generate( self::get_default_recipient_email() ),
 					'from' => String_Prop_Type::generate( self::get_default_sender_email() ),
 				] ),
+			'webhook_url' => String_Prop_Type::make()
+				->set_dependencies( $webhook_dependencies )
+				->meta( Overridable_Prop_Type::ignore() )
+				->default( String_Prop_Type::generate( '' ) ),
 			'attributes' => Attributes_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() ),
 		];
 	}
@@ -168,7 +182,15 @@ class Atomic_Form extends Atomic_Element_Base {
 								'label' => __( 'Email', 'elementor' ),
 								'value' => 'email',
 							],
+							[
+								'label' => __( 'Webhook', 'elementor' ),
+								'value' => self::ACTION_WEBHOOK,
+							],
 						] ),
+					Text_Control::bind_to( 'webhook_url' )
+						->set_label( __( 'Webhook URL', 'elementor' ) )
+						->set_placeholder( __( 'https://your-webhook-url.com', 'elementor' ) )
+						->set_meta( [ 'topDivider' => true ] ),
 					Chips_Control::bind_to( 'submissions_metadata' )
 						->set_label( __( 'Include metadata', 'elementor' ) )
 						->set_meta( [ 'topDivider' => true ] )

--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-form.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-form.php
@@ -44,9 +44,6 @@ class Test_Atomic_Form extends Elementor_Test_Base {
 		$this->assertSame( 'text', $url_control->get_type() );
 	}
 
-	/**
-	 * @param Section[]|Atomic_Control_Base[] $controls
-	 */
 	private function find_control_by_bind( array $controls, string $bind ): ?Atomic_Control_Base {
 		foreach ( $controls as $control ) {
 			if ( $control instanceof Section ) {

--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-form.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-form.php
@@ -1,0 +1,76 @@
+<?php
+
+use Elementor\Modules\AtomicWidgets\Controls\Base\Atomic_Control_Base;
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Chips_Control;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Form\Atomic_Form;
+use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Atomic_Form extends Elementor_Test_Base {
+
+	public function test_action_webhook_constant_matches_expected_slug() {
+		$this->assertSame( 'webhook', Atomic_Form::ACTION_WEBHOOK );
+	}
+
+	public function test_props_schema_includes_webhook_url_string_prop() {
+		$schema = Atomic_Form::get_props_schema();
+
+		$this->assertArrayHasKey( 'webhook_url', $schema );
+		$this->assertInstanceOf( Prop_Type::class, $schema['webhook_url'] );
+		$this->assertArrayHasKey( 'actions-after-submit', $schema );
+	}
+
+	public function test_actions_after_submit_control_includes_webhook_chip() {
+		$form = $this->make_atomic_form_instance();
+
+		$chips = $this->find_control_by_bind( $form->get_atomic_controls(), 'actions-after-submit' );
+		$this->assertInstanceOf( Chips_Control::class, $chips );
+
+		$values = array_column( $chips->get_props()['options'] ?? [], 'value' );
+		$this->assertContains( Atomic_Form::ACTION_WEBHOOK, $values );
+	}
+
+	public function test_webhook_url_text_control_is_registered() {
+		$form = $this->make_atomic_form_instance();
+
+		$url_control = $this->find_control_by_bind( $form->get_atomic_controls(), 'webhook_url' );
+		$this->assertInstanceOf( Text_Control::class, $url_control );
+		$this->assertSame( 'text', $url_control->get_type() );
+	}
+
+	/**
+	 * @param Section[]|Atomic_Control_Base[] $controls
+	 */
+	private function find_control_by_bind( array $controls, string $bind ): ?Atomic_Control_Base {
+		foreach ( $controls as $control ) {
+			if ( $control instanceof Section ) {
+				$found = $this->find_control_by_bind( $control->get_items(), $bind );
+				if ( null !== $found ) {
+					return $found;
+				}
+				continue;
+			}
+
+			if ( $control instanceof Atomic_Control_Base && $control->get_bind() === $bind ) {
+				return $control;
+			}
+		}
+
+		return null;
+	}
+
+	private function make_atomic_form_instance(): Atomic_Form {
+		return new Atomic_Form( [
+			'id' => 'test_atomic_form_instance',
+			'elType' => 'widget',
+			'widgetType' => Atomic_Form::get_element_type(),
+			'settings' => [],
+		], null );
+	}
+}


### PR DESCRIPTION
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding webhook support to atomic forms as a post-submit action, tracked in ED-23166. This extends the existing actions framework (email, collect-submissions) to allow sending form data to external endpoints. Likely needed for third-party integrations without requiring custom server-side code.

## 2. What Changed (Where)

- **atomic-form.php**: Added `ACTION_WEBHOOK` constant, `webhook_url` prop with dependency management, and webhook option in actions-after-submit control
- **test-atomic-form.php**: New test file covering constant value, prop schema, control registration, and recursive control finding utility

## 3. How It Works

Webhook follows the same conditional visibility pattern as email. When user selects "Webhook" in `actions-after-submit` chips control, the `webhook_url` text input appears via dependency manager. The prop defaults to empty string and is ignored in overrides (same meta as email config). No actual webhook execution logic in this PR — this is purely the UI/schema layer.

## 4. Risks

None. This is config/UI only with no runtime behavior. The actual webhook POST logic isn't implemented here, so there's no security surface yet. Tests cover the structural changes adequately.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-23166]: https://elementor.atlassian.net/browse/ED-23166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ