### PR TITLE
Fix: Align user identifier source and include experiments in editor events payload [ED-23725]

### DIFF
--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -8,6 +8,7 @@ let mixpanelInstance = null;
 
 export default class extends elementorModules.Module {
 	trackingEnabled = false;
+	availableExperiments = [];
 
 	onInit() {
 		this.config = eventsConfig;
@@ -51,7 +52,7 @@ export default class extends elementorModules.Module {
 			return;
 		}
 
-		const userId = elementorCommon.config.library_connect?.user_id;
+		const userId = elementorCommon.config.editor_events?.user_id;
 
 		mixpanelInstance.register( {
 			appType: 'Editor',
@@ -68,6 +69,8 @@ export default class extends elementorModules.Module {
 		}
 
 		this.trackingEnabled = true;
+
+		this.availableExperiments = Object.keys( elementorCommon.config.experimentalFeatures || {} );
 	}
 
 	dispatchEvent( name, data, options = {} ) {
@@ -80,7 +83,7 @@ export default class extends elementorModules.Module {
 		}
 
 		const eventData = {
-			user_id: elementorCommon.config.library_connect?.user_id || null,
+			user_id: elementorCommon.config.editor_events?.user_id || null,
 			user_roles: elementorCommon.config.library_connect?.user_roles || [],
 			subscription_id: elementorCommon.config.editor_events?.subscription_id || null,
 			user_tier: elementorCommon.config.library_connect?.current_access_tier || null,
@@ -89,6 +92,7 @@ export default class extends elementorModules.Module {
 			client_id: elementorCommon.config.editor_events?.site_key,
 			app_version: elementorCommon.config.editor_events?.elementor_version,
 			site_language: elementorCommon.config.editor_events?.site_language,
+			experiments: this.availableExperiments,
 			...data,
 		};
 


### PR DESCRIPTION
## Summary
- Read `user_id` from `elementorCommon.config.editor_events` when registering the client and when building dispatched payloads (instead of `library_connect`).
- Capture enabled experiment keys once initialization succeeds and attach them as `experiments` on every dispatched event payload.

## Test plan
- [ ] Open the editor with editor events enabled and confirm the client registers without console errors.
- [ ] Trigger a representative editor event and verify the payload includes `user_id` consistent with `editor_events` configuration.
- [ ] With one or more experiments active, confirm the payload includes a non-empty `experiments` array listing experiment keys from `experimentalFeatures`.

## Jira
[ED-23725](https://elementor.atlassian.net/browse/ED-23725)

_Note: Jira details could not be retrieved from this environment (Atlassian MCP not fully available; GitKraken Jira not connected). Please confirm the summary matches the ticket scope and adjust the PR description if needed._

Made with [Cursor](https://cursor.com)

[ED-23725]: https://elementor.atlassian.net/browse/ED-23725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

User identification was incorrectly sourced from `library_connect.user_id` instead of `editor_events.user_id`, causing inconsistent tracking across the analytics pipeline. Additionally, experimental feature flags weren't included in event payloads, limiting A/B test analysis capabilities. Ticket: ED-23725.

## 2. What Changed (Where)

- `core/common/modules/events-manager/assets/js/module.js`: Aligned user ID source to `editor_events` config, added experiments tracking to event payloads

## 3. How It Works

On tracking initialization (`enableTracking()`), the module now captures available experiments from `elementorCommon.config.experimentalFeatures` as an array of keys. Every `dispatchEvent()` call injects this experiments array into the payload alongside the corrected user ID source (`editor_events.user_id` vs. `library_connect.user_id`). User ID now consistently pulled from the same config namespace as other event metadata.

## 4. Risks

If `editor_events.user_id` is undefined while `library_connect.user_id` exists, previously tracked users will appear as new/anonymous sessions. Verify both config sources are populated identically in production before deploying. Experiments array could grow large if many feature flags exist—monitor payload size if flag count exceeds ~50.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
