### PR TITLE
Internal: Add support for select widget in atomic form. [ED-32654]

### DIFF
--- a/modules/atomic-widgets/controls/types/repeatable-control.php
+++ b/modules/atomic-widgets/controls/types/repeatable-control.php
@@ -18,6 +18,8 @@ class Repeatable_Control extends Atomic_Control_Base {
 	private ?string $pattern_label;
 	private ?string $placeholder;
 	private ?string $prop_key = '';
+	private bool $is_sortable = false;
+	private ?object $add_item_tooltip_props = null;
 
 	public function get_type(): string {
 		return 'repeatable';
@@ -77,6 +79,18 @@ class Repeatable_Control extends Atomic_Control_Base {
 		return $this;
 	}
 
+	public function set_is_sortable( bool $is_sortable ): self {
+		$this->is_sortable = $is_sortable;
+
+		return $this;
+	}
+
+	public function set_add_item_tooltip_props( $add_item_tooltip_props ): self {
+		$this->add_item_tooltip_props = (object) $add_item_tooltip_props;
+
+		return $this;
+	}
+
 	public function get_props(): array {
 		return [
 			'childControlType'   => $this->child_control_type,
@@ -88,6 +102,8 @@ class Repeatable_Control extends Atomic_Control_Base {
 			'repeaterLabel'      => $this->repeater_label,
 			'placeholder'        => $this->placeholder,
 			'propKey'            => $this->prop_key,
+			'isSortable'         => $this->is_sortable,
+			'addItemTooltipProps' => $this->add_item_tooltip_props,
 		];
 	}
 }

--- a/modules/atomic-widgets/elements/base/has-atomic-base.php
+++ b/modules/atomic-widgets/elements/base/has-atomic-base.php
@@ -302,7 +302,10 @@ trait Has_Atomic_Base {
 
 	public static function get_props_schema(): array {
 		$schema = static::define_props_schema();
-		$schema['_cssid'] = String_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() );
+
+		if ( ! isset( $schema['_cssid'] ) ) {
+			$schema['_cssid'] = String_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() );
+		}
 
 		return apply_filters(
 			'elementor/atomic-widgets/props-schema',

--- a/modules/atomic-widgets/prop-types/options-prop-type.php
+++ b/modules/atomic-widgets/prop-types/options-prop-type.php
@@ -1,0 +1,19 @@
+<?php
+namespace Elementor\Modules\AtomicWidgets\PropTypes;
+
+use Elementor\Modules\AtomicWidgets\PropTypes\Base\Array_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Options_Prop_Type extends Array_Prop_Type {
+	public static function get_key(): string {
+		return 'options';
+	}
+
+	protected function define_item_type(): Prop_Type {
+		return Key_Value_Prop_Type::make();
+	}
+}

--- a/packages/packages/core/editor-canvas/src/form-structure/utils.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/utils.ts
@@ -40,6 +40,7 @@ export const FORM_FIELD_ELEMENT_TYPES = new Set( [
 	'e-form-label',
 	'e-form-checkbox',
 	'e-form-submit-button',
+	'e-form-select',
 ] );
 
 export function getArgsElementType( args: CreateArgs ): string | undefined {

--- a/packages/packages/libs/editor-controls/src/controls/repeatable-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/repeatable-control.tsx
@@ -33,6 +33,7 @@ type RepeatableControlProps = {
 	patternLabel?: string;
 	placeholder?: string;
 	propKey?: string;
+	isSortable?: boolean;
 	addItemTooltipProps?: TooltipAddItemActionProps;
 };
 
@@ -48,6 +49,7 @@ export const RepeatableControl = createControl(
 		patternLabel,
 		placeholder,
 		propKey,
+		isSortable,
 		addItemTooltipProps,
 	}: RepeatableControlProps ) => {
 		const { propTypeUtil: childPropTypeUtil, isItemDisabled } = childControlConfig;
@@ -71,6 +73,7 @@ export const RepeatableControl = createControl(
 		);
 
 		const { propType, value, setValue } = useBoundProp( childArrayPropTypeUtil );
+		const newItemIndex = addItemTooltipProps?.newItemIndex === null ? undefined : 0;
 
 		return (
 			<PropProvider propType={ propType } value={ value } setValue={ setValue }>
@@ -83,11 +86,11 @@ export const RepeatableControl = createControl(
 						<RepeaterHeader label={ repeaterLabel }>
 							<TooltipAddItemAction
 								{ ...addItemTooltipProps }
-								newItemIndex={ 0 }
+								newItemIndex={ newItemIndex }
 								ariaLabel={ repeaterLabel }
 							/>
 						</RepeaterHeader>
-						<ItemsContainer isSortable={ false }>
+						<ItemsContainer isSortable={ isSortable }>
 							<Item
 								Icon={ ItemIcon }
 								Label={ ItemLabel }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding select widget support to atomic forms (ED-32654). The repeatable control was rigid—hard-coded sorting off and always added items at index 0. This extends the control to support sortable items and configurable add-item behavior, unblocking select field integration and other future form controls that need ordering or custom insertion points.

## 2. What Changed (Where)

- `repeatable-control.php`: Added `is_sortable` and `add_item_tooltip_props` properties with setters/getters
- `has-atomic-base.php`: Made `_cssid` prop conditional—only injected if not already defined in schema
- `options-prop-type.php`: New prop type for handling option arrays (key-value pairs)
- `utils.ts`: Registered `e-form-select` as valid form field element type
- `repeatable-control.tsx`: Made sortable behavior and new item index configurable via props instead of hard-coded

## 3. How It Works

Repeatable control now accepts `isSortable` boolean and `addItemTooltipProps` object from parent widgets. When `addItemTooltipProps.newItemIndex` is `null`, insertion point becomes `undefined` (appends to end); otherwise defaults to 0 (prepends). The `ItemsContainer` component receives the sortable flag directly. The new `Options_Prop_Type` extends `Array_Prop_Type` with `Key_Value_Prop_Type` items, providing schema validation for select options structure.

## 4. Risks

The `_cssid` conditional check could break widgets that relied on it being auto-injected—if any widget defines `_cssid` explicitly with different metadata, behavior changes. The `newItemIndex === null` → `undefined` coercion needs testing: verify repeaters with tooltip props but no explicit index handle append behavior correctly across all usages.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
