### PR TITLE
Internal: Change actions after submit order [ED-23750]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.php
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.php
@@ -39,6 +39,7 @@ class Atomic_Form extends Atomic_Element_Base {
 
 	public static $widget_description = 'A form container that holds form field widgets (labels, inputs, textareas, checkboxes, submit button) and status messages.';
 
+	public const ACTION_EMAIL = 'email';
 	public const ACTION_COLLECT_SUBMISSIONS = 'collect-submissions';
 	public const ACTION_WEBHOOK = 'webhook';
 	public const METADATA_REMOTE_IP = 'remote_ip';
@@ -84,7 +85,7 @@ class Atomic_Form extends Atomic_Element_Base {
 			->where( [
 				'operator' => 'contains',
 				'path' => [ 'actions-after-submit' ],
-				'value' => 'email',
+				'value' => self::ACTION_EMAIL,
 				'effect' => 'hide',
 			] )
 			->get();
@@ -117,7 +118,7 @@ class Atomic_Form extends Atomic_Element_Base {
 				->default( 'default' )
 				->meta( 'generates_class', 'form-state-{value}' ),
 			'actions-after-submit' => String_Array_Prop_Type::make()
-				->default( [ String_Prop_Type::generate( 'email' ) ] ),
+				->default( [ String_Prop_Type::generate( self::ACTION_EMAIL ) ] ),
 			'submissions_metadata' => String_Array_Prop_Type::make()
 				->set_dependencies( $submissions_metadata_dependencies )
 				->default( [
@@ -175,22 +176,22 @@ class Atomic_Form extends Atomic_Element_Base {
 						->set_meta( [ 'topDivider' => true ] )
 						->set_options( [
 							[
-								'label' => __( 'Collect submissions', 'elementor' ),
-								'value' => self::ACTION_COLLECT_SUBMISSIONS,
+								'label' => __( 'Email', 'elementor' ),
+								'value' => self::ACTION_EMAIL,
 							],
 							[
-								'label' => __( 'Email', 'elementor' ),
-								'value' => 'email',
+								'label' => __( 'Collect submissions', 'elementor' ),
+								'value' => self::ACTION_COLLECT_SUBMISSIONS,
 							],
 							[
 								'label' => __( 'Webhook', 'elementor' ),
 								'value' => self::ACTION_WEBHOOK,
 							],
 						] ),
-					Text_Control::bind_to( 'webhook_url' )
-						->set_label( __( 'Webhook URL', 'elementor' ) )
-						->set_placeholder( __( 'https://your-webhook-url.com', 'elementor' ) )
-						->set_meta( [ 'topDivider' => true ] ),
+					Email_Form_Action_Control::bind_to( 'email' )
+						->set_meta( [
+							'topDivider' => true,
+						] ),
 					Chips_Control::bind_to( 'submissions_metadata' )
 						->set_label( __( 'Include metadata', 'elementor' ) )
 						->set_meta( [ 'topDivider' => true ] )
@@ -204,10 +205,10 @@ class Atomic_Form extends Atomic_Element_Base {
 								'value' => self::METADATA_USER_AGENT,
 							],
 						] ),
-					Email_Form_Action_Control::bind_to( 'email' )
-						->set_meta( [
-							'topDivider' => true,
-						] ),
+					Text_Control::bind_to( 'webhook_url' )
+						->set_label( __( 'Webhook URL', 'elementor' ) )
+						->set_placeholder( __( 'https://your-webhook-url.com', 'elementor' ) )
+						->set_meta( [ 'topDivider' => true ] ),
 				] ),
 			Section::make()
 				->set_label( __( 'Settings', 'elementor' ) )


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Reordering form action controls to prioritize Email over Collect Submissions as the default action. Fixes hardcoded string literal 'email' by introducing `ACTION_EMAIL` constant for consistency. Ticket: ED-23750.

## 2. What Changed (Where)

- `modules/atomic-widgets/elements/atomic-form/atomic-form.php`: Added `ACTION_EMAIL` constant, reordered actions-after-submit options (Email now first), moved Email_Form_Action_Control above submissions_metadata, moved webhook_url control below metadata

## 3. How It Works

String literal replacement: `'email'` → `self::ACTION_EMAIL` in dependency manager and default value. Control rendering order changed from [Collect Submissions, Email, Webhook] to [Email, Collect Submissions, Webhook]. Email configuration control moved earlier in the form schema to match the new action priority. Default action remains Email but now uses the constant.

## 4. Risks

None — pure refactor with cosmetic reordering. No behavior changes, just constant extraction and UI reordering.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-23750]: https://elementor.atlassian.net/browse/ED-23750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ