### PR TITLE
Internal: Disable WP pointers for test setup [ED-23761]

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -11,7 +11,8 @@
 		"elementor-templates": "./tests/playwright/templates",
 		"elementor-config": "./tests/wp-env/config",
 		"elementor-playwright-templates": "./templates/playwright",
-		"elementor-playwright": "./tests/playwright"
+		"elementor-playwright": "./tests/playwright",
+		"wp-content/mu-plugins": "./tests/playwright/mu-plugins"
 	},
 	"config": {
 		"ELEMENTOR_SHOW_HIDDEN_EXPERIMENTS": true,

--- a/tests/playwright/.playwright-wp-lite-env.json
+++ b/tests/playwright/.playwright-wp-lite-env.json
@@ -11,7 +11,8 @@
 		"elementor-templates": "./tests/playwright/templates",
 		"elementor-config": "./tests/wp-env/config",
 		"elementor-playwright-templates": "./templates/playwright",
-		"elementor-playwright": "./tests/playwright"
+		"elementor-playwright": "./tests/playwright",
+		"wp-content/mu-plugins": "./tests/playwright/mu-plugins"
 	},
 	"config": {
 		"ELEMENTOR_SHOW_HIDDEN_EXPERIMENTS": true,

--- a/tests/playwright/mu-plugins/disable-pointers.php
+++ b/tests/playwright/mu-plugins/disable-pointers.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Plugin Name: Disable WP Pointers for Testing
+ * Description: Prevents WordPress pointers and feature tours from loading to ensure a stable testing environment.
+ */
+
+add_action('admin_enqueue_scripts', function() {
+    remove_action('admin_enqueue_scripts', array('WP_Internal_Pointers', 'enqueue_scripts'));
+}, 1);

--- a/tests/playwright/upgrade-test/.upgrade-test-wp-lite-env.json
+++ b/tests/playwright/upgrade-test/.upgrade-test-wp-lite-env.json
@@ -10,7 +10,8 @@
 		"elementor-templates": "./tests/playwright/templates",
 		"elementor-config": "./tests/wp-env/config",
 		"elementor-playwright-templates": "./templates/playwright",
-		"elementor-playwright": "./tests/playwright"
+		"elementor-playwright": "./tests/playwright",
+		"wp-content/mu-plugins": "./tests/playwright/mu-plugins"
 	},
 	"config": {
 		"ELEMENTOR_SHOW_HIDDEN_EXPERIMENTS": true,


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

WordPress admin pointers and feature tours interfere with Playwright test reliability by creating unpredictable UI overlays. This disables them via mu-plugin to stabilize the test environment (ED-23761).

## 2. What Changed (Where)

- Created `disable-pointers.php` mu-plugin that removes WP_Internal_Pointers enqueue hook at priority 1
- Updated three wp-env config files to map mu-plugins directory, enabling auto-loading of the new plugin

## 3. How It Works

The mu-plugin hooks into `admin_enqueue_scripts` at priority 1 (before default 10) and removes WP's pointer enqueue callback, preventing pointer assets from loading during test runs.

## 4. Risks

None identified — mu-plugin only affects test environments (isolated via wp-env mappings) and safely removes a non-essential admin feature without touching core test logic.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
