### PR TITLE
Fix: [V4] Registering handlers after DOMContentLoaded is done [ED-23643]

### DIFF
--- a/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.js
+++ b/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.js
@@ -29,15 +29,19 @@ export default function createAtomicElementBaseView( type ) {
 
 		_resolveTag() {
 			const renderContext = this.getResolverRenderContext?.();
+
 			const tagSetting = this.model.getSetting( 'tag' );
 			const resolvedTag = this._resolvePropValue( tagSetting, renderContext );
-			const tagValue = resolvedTag?.value ?? resolvedTag;
 
-			if ( this._hasLink( renderContext ) ) {
-				return 'a';
-			}
+			const linkSetting = this.model.getSetting( 'link' );
+			const resolvedLinkTag = this._resolvePropValue( linkSetting?.value?.tag, renderContext );
 
-			return tagValue || this.model.config.default_html_tag || 'div';
+			const linkTag = resolvedLinkTag?.value ?? resolvedLinkTag;
+			const baseTag = resolvedTag?.value ?? resolvedTag;
+
+			const resultTag = linkTag ?? baseTag;
+
+			return resultTag || this.model.config.default_html_tag || 'div';
 		},
 
 		getChildViewContainer() {
@@ -326,11 +330,15 @@ export default function createAtomicElementBaseView( type ) {
 			this.$el.removeAttr( 'href' );
 			this.$el.removeAttr( 'data-action-link' );
 
-			const link = this.getLink();
+			const link = this.getLinkAttributes();
 
-			if ( link ) {
-				this.$el.attr( link.attr, link.value );
+			if ( ! link ) {
+				return;
 			}
+
+			Object.entries( link ).forEach( ( [ key, value ] ) => {
+				this.$el.attr( key, value );
+			} );
 		},
 
 		async _waitForChildrenToComplete() {
@@ -402,7 +410,7 @@ export default function createAtomicElementBaseView( type ) {
 			return !! destination?.value;
 		},
 
-		getLink() {
+		getLinkAttributes() {
 			const renderContext = this.getResolverRenderContext?.();
 			const linkSetting = this.model.getSetting( 'link' );
 			const resolvedLink = this._resolvePropValue( linkSetting, renderContext );
@@ -426,9 +434,10 @@ export default function createAtomicElementBaseView( type ) {
 					return null;
 				}
 
+				const attributeKey = 'action' === value?.group ? 'data-action-link' : 'href';
+
 				return {
-					attr: 'action' === value.settings?.group ? 'data-action-link' : 'href',
-					value: resolvedValue,
+					[ attributeKey ]: resolvedValue,
 				};
 			}
 
@@ -436,8 +445,7 @@ export default function createAtomicElementBaseView( type ) {
 			const hrefPrefix = isPostId ? elementor.config.home_url + '/?p=' : '';
 
 			return {
-				attr: 'href',
-				value: hrefPrefix + value,
+				href: hrefPrefix + value,
 			};
 		},
 

--- a/modules/atomic-widgets/assets/js/frontend/handlers.js
+++ b/modules/atomic-widgets/assets/js/frontend/handlers.js
@@ -4,9 +4,10 @@ import { Alpine } from '@elementor/alpinejs';
 const LINK_ACTIONS_EDITOR_WHITELIST = [ 'off_canvas', 'lightbox' ];
 const WHITELIST_FILTER = 'frontend/handlers/atomic-widgets/link-actions-whitelist';
 const ACTION_LINK_SELECTOR = '[data-action-link]';
-const REGISTRATION_SELECTOR = `${ ACTION_LINK_SELECTOR }, :has(> ${ ACTION_LINK_SELECTOR })`;
+const REGISTRATION_SELECTOR = `${ ACTION_LINK_SELECTOR }, :has(${ ACTION_LINK_SELECTOR })`;
 const ATOMIC_FORM_SELECTOR = '[data-element_type="e-form"]';
 const ATOMIC_FORM_FIELD_SELECTOR = 'input[data-interaction-id], textarea[data-interaction-id]';
+const ELEMENTOR_DOCUMENT_SELECTOR = '[data-elementor-id]';
 
 registerBySelector( {
 	id: 'atomic-link-action-handler',
@@ -20,21 +21,29 @@ registerBySelector( {
 	callback: ( { element } ) => handleAtomicFormSubmit( element ),
 } );
 
-function handleLinkActions( element ) {
-	const actionLinkElement = element.matches( ACTION_LINK_SELECTOR )
-		? element
-		: element.querySelector( ACTION_LINK_SELECTOR );
-	const url = actionLinkElement?.dataset.actionLink;
+function handleLinkActions( registrationElement ) {
+	if ( ! registrationElement ) {
+		return;
+	}
+
+	const actionLinkElement = registrationElement.matches( ACTION_LINK_SELECTOR )
+		? registrationElement
+		: registrationElement.querySelector( ACTION_LINK_SELECTOR );
+
+	if ( ! actionLinkElement ) {
+		return;
+	}
+
+	const url =
+		actionLinkElement.dataset.actionLink ||
+		actionLinkElement.getAttribute( 'href' ) ||
+		'';
 
 	if ( ! url ) {
 		return;
 	}
 
-	const handler = ( event ) => {
-		if ( actionLinkElement && actionLinkElement !== element && ! actionLinkElement.contains( event.target ) ) {
-			return;
-		}
-
+	const onClick = ( event ) => {
 		if ( ! shouldFireLinkActionHandler( url ) ) {
 			return;
 		}
@@ -47,19 +56,23 @@ function handleLinkActions( element ) {
 		elementorFrontend.utils.urlActions.runAction( url, event );
 	};
 
-	element.addEventListener( 'click', handler );
+	actionLinkElement.addEventListener( 'click', onClick );
 
-	return () => element.removeEventListener( 'click', handler );
+	return () => {
+		actionLinkElement.removeEventListener( 'click', onClick );
+	};
 }
 
-function handleAtomicFormSubmit( element ) {
-	const form = element;
-
+function registerAtomicFormAlpineData( form ) {
 	if ( ! form || ! Alpine?.data ) {
 		return;
 	}
 
-	const alpineId = getFormAlpineId( form );
+	const alpineId = getAlpineId( form );
+
+	if ( ! alpineId ) {
+		return;
+	}
 
 	Alpine.data( alpineId, () => ( {
 		async submit( event ) {
@@ -88,34 +101,36 @@ function handleAtomicFormSubmit( element ) {
 					const response = await submitAtomicForm( payload );
 					const state = response?.success ? 'success' : 'error';
 
-					setFormState( element, state );
+					setFormState( form, state );
 
 					if ( response?.success ) {
 						form.reset();
 
 						form.addEventListener( 'input', () => {
-							setFormState( element, 'default' );
+							setFormState( form, 'default' );
 						}, { once: true } );
 					}
 				} catch ( error ) {
-					setFormState( element, 'error' );
+					setFormState( form, 'error' );
 				} finally {
 					clearAtomicFormSubmittingState( form, submitButtons );
 				}
 			} else {
-				setFormState( element, 'error' );
+				setFormState( form, 'error' );
 				clearAtomicFormSubmittingState( form, submitButtons );
 			}
 		},
 	} ) );
-
-	return () => {
-		Alpine.destroyTree( form );
-	};
 }
 
-function getFormAlpineId( form ) {
-	return form.getAttribute( 'x-data' );
+function handleAtomicFormSubmit( form ) {
+	registerAtomicFormAlpineData( form );
+
+	return refreshDom( form );
+}
+
+function getAlpineId( element ) {
+	return element.getAttribute( 'x-data' );
 }
 
 function clearAtomicFormSubmittingState( form, submitButtons ) {
@@ -127,7 +142,7 @@ function clearAtomicFormSubmittingState( form, submitButtons ) {
 }
 
 function buildAtomicFormPayload( form ) {
-	const postId = getPostId();
+	const postId = getPostId( form );
 	const formId = form.dataset.id;
 	const formName = form.dataset.formName || '';
 	const formFields = getAtomicFormFields( form );
@@ -259,8 +274,11 @@ function setFormState( element, state ) {
 	element.classList.add( `form-state-${ state }` );
 }
 
-function getPostId() {
-	return elementorFrontend?.config?.post?.id || null;
+function getPostId( form ) {
+	const innerDocumentId = form?.closest?.( ELEMENTOR_DOCUMENT_SELECTOR )?.dataset?.elementorId;
+	const ownerDocument = elementorFrontend?.config?.post?.id;
+
+	return innerDocumentId || ownerDocument || null;
 }
 
 function shouldFireLinkActionHandler( url ) {
@@ -286,4 +304,17 @@ function shouldFireLinkActionHandler( url ) {
 
 function isEditorContext() {
 	return !! window.elementor || !! window.parent?.elementor;
+}
+
+function refreshDom( element ) {
+	if ( ! Alpine?.nextTick || ! Alpine?.destroyTree || ! Alpine?.initTree ) {
+		return;
+	}
+
+	Alpine.nextTick( () => {
+		Alpine.destroyTree( element );
+		Alpine.initTree( element );
+	} );
+
+	return () => Alpine.destroyTree( element );
 }

--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.html.twig
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.html.twig
@@ -2,11 +2,9 @@
     {%- set allowed_tags = '<b><strong><sup><sub><s><em><i><u><del><span><br>' %}
     {% set classes = settings.classes | merge( [ base_styles.base ] ) | join(' ') %}
 	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
-    {% if settings.link.href %}
+    {% if settings.link and settings.link.attributes is not empty %}
         <{{ settings.link.tag | e('html_tag') }}
-            {% set linkAttr = settings.link.tag == 'a' ? 'href' : 'data-action-link' %}
-			{{ linkAttr }}="{{ settings.link.href | raw }}"
-        target="{{ settings.link.target }}"
+            {{ settings.link.attributes | raw }}
             class="{{ classes }}"
             data-interaction-id="{{ interaction_id }}"
             {{ id_attribute }} {{ settings.attributes | raw }}

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -8,11 +8,9 @@
 	>
 	{% set allowed_tags = '<b><strong><sup><sub><s><em><i><u><a><del><span><br>' %}
 
-	{% if settings.link.href %}
+	{% if settings.link and settings.link.attributes is not empty %}
 		<{{ settings.link.tag | e('html_tag') }} 
-			{% set linkAttr = settings.link.tag == 'a' ? 'href' : 'data-action-link' %}
-			{{ linkAttr }}="{{ settings.link.href | raw }}"
-			target="{{ settings.link.target }}" 
+			{{ settings.link.attributes | raw }}
 			class="{{ base_styles['link-base'] }}">
 			{{ settings.title | striptags(allowed_tags) | raw }}
 		</{{ settings.link.tag | e('html_tag') }}>

--- a/modules/atomic-widgets/elements/atomic-image/atomic-image.html.twig
+++ b/modules/atomic-widgets/elements/atomic-image/atomic-image.html.twig
@@ -1,11 +1,9 @@
 {% if settings.image.src is not empty %}
 	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}	
-	{% if settings.link.href %}
+	{% if settings.link and settings.link.attributes is not empty %}
 		<{{ settings.link.tag | e('html_tag') }}
-			{% set linkAttr = settings.link.tag == 'a' ? 'href' : 'data-action-link' %}
-			{{ linkAttr }}="{{ settings.link.href | raw }}"
+			{{ settings.link.attributes | raw }}
 			class="{{ base_styles['link-base'] }}"
-			target="{{ settings.link.target }}"
 			data-interaction-id="{{ interaction_id }}"
 		>
 	{% endif %}

--- a/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.html.twig
+++ b/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.html.twig
@@ -1,11 +1,9 @@
 {% if settings.paragraph is not empty %}
 	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
 		<{{ settings.tag | e('html_tag') }} class="{{ settings.classes | merge( [ base_styles.base ] ) | join(' ') }}" data-interaction-id="{{ interaction_id }}" {{ id_attribute }} {{ settings.attributes | raw }}>
-			{% if settings.link.href %}
+			{% if settings.link and settings.link.attributes is not empty %}
 				<{{ settings.link.tag | e('html_tag') }}
-					{% set linkAttr = settings.link.tag == 'a' ? 'href' : 'data-action-link' %}
-					{{ linkAttr }}="{{ settings.link.href | raw }}"
-					target="{{ settings.link.target }}"
+					{{ settings.link.attributes | raw }}
 					class="{{ base_styles['link-base'] }}"
 				>
 						{{ settings.paragraph | striptags(allowed_tags) | raw }}

--- a/modules/atomic-widgets/elements/atomic-svg/atomic-svg.html.twig
+++ b/modules/atomic-widgets/elements/atomic-svg/atomic-svg.html.twig
@@ -1,9 +1,8 @@
 {%- if settings.svg.html is defined and settings.svg.html is not empty -%}
     {%- set classes = settings.classes | merge([base_styles.base]) | join(' ') -%}
     {%- set id_attribute = settings._cssid is not empty ? 'id="' ~ settings._cssid | e('html_attr') ~ '"' : '' -%}
-    {%- if settings.link.href is defined and settings.link.href is not empty -%}
-        {%- set linkAttr = settings.link.tag == 'a' ? 'href' : 'data-action-link' -%}
-        <{{ settings.link.tag | e('html_tag') }} {{ linkAttr }}="{{ settings.link.href | raw }}" target="{{ settings.link.target }}" class="{{ classes }}" data-interaction-id="{{ interaction_id }}"
+    {%- if settings.link is defined  and settings.link.attributes is not empty -%}
+        <{{ settings.link.tag | e('html_tag') }} {{ settings.link.attributes | raw }} class="{{ classes }}" data-interaction-id="{{ interaction_id }}"
             {%- if id_attribute is not empty %} {{ id_attribute }}{% endif -%}
             {%- if settings.attributes is defined and settings.attributes is not empty %} {{ settings.attributes | raw }}{% endif -%}
         >{{ settings.svg.html | raw }}</{{ settings.link.tag | e('html_tag') }}>

--- a/modules/atomic-widgets/elements/base/atomic-element-base.php
+++ b/modules/atomic-widgets/elements/base/atomic-element-base.php
@@ -163,7 +163,11 @@ abstract class Atomic_Element_Base extends Element_Base {
 		$settings = $this->get_atomic_settings();
 		$default_html_tag = $this->define_default_html_tag();
 
-		return ! empty( $settings['link']['href'] ) ? $settings['link']['tag'] : ( $settings['tag'] ?? $default_html_tag );
+		if ( ! empty( $settings['link']['tag'] ) ) {
+			return $settings['link']['tag'];
+		}
+
+		return $settings['tag'] ?? $default_html_tag;
 	}
 
 	/**
@@ -184,6 +188,11 @@ abstract class Atomic_Element_Base extends Element_Base {
 	protected function print_custom_attributes() {
 		$settings = $this->get_atomic_settings();
 		$attributes = $settings['attributes'] ?? '';
+
+		if ( isset( $settings['link']['attributes'] ) ) {
+			$attributes .= ' ' . ( $settings['link']['attributes'] ?? '' );
+		}
+
 		if ( ! empty( $attributes ) && is_string( $attributes ) ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo ' ' . $attributes;

--- a/modules/atomic-widgets/elements/base/has-atomic-base.php
+++ b/modules/atomic-widgets/elements/base/has-atomic-base.php
@@ -241,14 +241,22 @@ trait Has_Atomic_Base {
 	public function get_atomic_settings(): array {
 		$schema = static::get_props_schema();
 		$props = $this->get_settings();
-		$initial_attributes = $this->get_initial_attributes();
 
-		$props['attributes'] = Attributes_Prop_Type::generate( array_merge(
-			$initial_attributes['value'] ?? [],
+		$merged_attribute_values = array_merge(
+			$this->get_initial_attributes()['value'] ?? [],
 			$props['attributes']['value'] ?? []
-		) );
+		);
+		$props['attributes'] = Attributes_Prop_Type::generate( $merged_attribute_values );
 
-		return Render_Props_Resolver::for_settings()->resolve( $schema, $props );
+		$parsed = Render_Props_Resolver::for_settings()->resolve( $schema, $props );
+		$link_attributes = isset( $parsed['link'] ) ? $this->get_link_attributes_string( $parsed['link'] ) : '';
+
+		$parsed['link'] = ! empty( $link_attributes ) ? [
+			'tag' => $parsed['link']['tag'],
+			'attributes' => $link_attributes,
+		] : null;
+
+		return $parsed;
 	}
 
 	protected function get_initial_attributes() {
@@ -353,23 +361,40 @@ trait Has_Atomic_Base {
 		return [];
 	}
 
-	protected function get_link_attributes( $link_settings, $add_key_to_result = false ) {
-		$tag = $link_settings['tag'] ?? Link_Prop_Type::DEFAULT_TAG;
-		$href = $link_settings['href'];
-		$target = $link_settings['target'] ?? '_self';
-
-		$is_button = 'button' === $tag;
-		$href_attribute_key = $is_button ? 'data-action-link' : 'href';
-
-		$result = [
-			$href_attribute_key => $href,
-			'target' => $target,
-		];
-
-		if ( $add_key_to_result ) {
-			$result['key'] = $href_attribute_key;
+	protected function get_link_attributes( $link_settings ) {
+		if ( empty( $link_settings['href'] ) ) {
+			return [];
 		}
 
-		return $result;
+		$tag = $link_settings['tag'] ?? Link_Prop_Type::DEFAULT_TAG;
+		$url = $link_settings['href'];
+		$target = $link_settings['target'] ?? '_self';
+		$is_action_link = 'button' === $tag;
+		$url_attr_key = $is_action_link ? 'data-action-link' : 'href';
+
+		return [
+			$url_attr_key => $url,
+			'target' => $target,
+		];
+	}
+
+	private function get_link_attributes_string( $link_settings ) {
+		$link_attributes = $this->get_link_attributes( $link_settings );
+
+		if ( empty( $link_attributes ) ) {
+			return '';
+		}
+
+		$parts = [];
+
+		foreach ( $link_attributes as $key => $value ) {
+			if ( 'tag' === $key ) {
+				continue;
+			}
+
+			$parts[] = sprintf( '%s="%s"', $key, esc_attr( $value ) );
+		}
+
+		return implode( ' ', $parts );
 	}
 }

--- a/packages/packages/core/editor-canvas/src/legacy/create-templated-element-type.ts
+++ b/packages/packages/core/editor-canvas/src/legacy/create-templated-element-type.ts
@@ -186,7 +186,7 @@ export function createTemplatedElementView( {
 		}
 
 		afterSettingsResolve( settings: { [ key: string ]: unknown } ) {
-			return settings;
+			return this._getLinkAttributes( settings );
 		}
 
 		_beforeRender() {
@@ -213,6 +213,38 @@ export function createTemplatedElementView( {
 			const id = this.model.get( 'id' );
 
 			return originId ?? id;
+		}
+
+		_getLinkAttributes( settings: { [ key: string ]: unknown } ) {
+			const linkAttributes = Object.entries( this._handleActionLinkAttributes( settings ) )
+				.map( ( [ key, value ] ) => `${ key }="${ value }"` )
+				.join( ' ' );
+
+			return {
+				...settings,
+				link: linkAttributes
+					? {
+							tag: ( settings?.link as { tag?: string } )?.tag,
+							attributes: linkAttributes,
+					  }
+					: null,
+			};
+		}
+
+		_handleActionLinkAttributes( settings: { [ key: string ]: unknown } ) {
+			const link = settings.link;
+
+			if ( ! link || typeof link !== 'object' || ! ( 'href' in link ) || ! link.href ) {
+				return {};
+			}
+
+			const isActionLink = 'tag' in link && link.tag === 'button';
+			const urlAttrKey = isActionLink ? 'data-action-link' : 'href';
+
+			return {
+				[ urlAttrKey ]: link.href,
+				target: ( 'target' in link && link.target ) ?? '_self',
+			};
 		}
 	};
 }

--- a/packages/packages/core/frontend-handlers/src/init.ts
+++ b/packages/packages/core/frontend-handlers/src/init.ts
@@ -1,5 +1,11 @@
 import { onElementDestroy, onElementRender } from './lifecycle-events';
 
+const ATOMIC_SELECTOR = '[data-e-type]';
+
+let domMutationObserverStarted = false;
+const pendingMutationNodes = new Set< Node >();
+let pendingMutationsRafId = 0;
+
 export function init() {
 	window.addEventListener( 'elementor/element/render', ( _event ) => {
 		const event = _event as CustomEvent< { id: string; type: string; element: Element } >;
@@ -15,17 +21,102 @@ export function init() {
 		onElementDestroy( { elementType: type, elementId: id, element } );
 	} );
 
-	// 'elementor/element/render' doesn't fire on the frontend
-	document.addEventListener( 'DOMContentLoaded', () => {
-		document.querySelectorAll( '[data-e-type]' ).forEach( ( element ) => {
-			const el = element as HTMLElement;
-			const { eType, id } = el.dataset;
+	const bootDomHandlers = () => {
+		scanDocumentForAtomicElements();
+		startObservingDomForNewAtomicElements();
+	};
 
-			if ( ! eType || ! id ) {
-				return;
+	document.addEventListener( 'DOMContentLoaded', bootDomHandlers );
+
+	if ( 'loading' !== document.readyState ) {
+		bootDomHandlers();
+	}
+}
+
+function triggerAtomicRender( atom: HTMLElement ) {
+	const eType = atom.dataset.eType;
+	const id = atom.dataset.id;
+
+	if ( ! eType || ! id ) {
+		return;
+	}
+
+	onElementRender( { element: atom, elementType: eType, elementId: id } );
+}
+
+function collectAtomicElementsInSubtree( root: Element ): HTMLElement[] {
+	const found: HTMLElement[] = [];
+
+	if ( root.matches( ATOMIC_SELECTOR ) ) {
+		found.push( root as HTMLElement );
+	}
+
+	root.querySelectorAll( ATOMIC_SELECTOR ).forEach( ( el ) => {
+		found.push( el as HTMLElement );
+	} );
+
+	return found;
+}
+
+function scanDocumentForAtomicElements() {
+	document.querySelectorAll( ATOMIC_SELECTOR ).forEach( ( el ) => {
+		const atom = el as HTMLElement;
+		const { eType, id } = atom.dataset;
+
+		if ( ! eType || ! id ) {
+			return;
+		}
+
+		triggerAtomicRender( atom );
+	} );
+}
+
+function startObservingDomForNewAtomicElements() {
+	if ( domMutationObserverStarted || 'undefined' === typeof MutationObserver ) {
+		return;
+	}
+
+	domMutationObserverStarted = true;
+
+	const observer = new MutationObserver( ( mutations ) => {
+		for ( const mutation of mutations ) {
+			mutation.addedNodes.forEach( ( node ) => {
+				pendingMutationNodes.add( node );
+			} );
+		}
+
+		queueProcessPendingMutationNodes();
+	} );
+
+	observer.observe( document.documentElement, {
+		childList: true,
+		subtree: true,
+	} );
+}
+
+function queueProcessPendingMutationNodes() {
+	if ( pendingMutationsRafId || ! pendingMutationNodes.size ) {
+		return;
+	}
+
+	pendingMutationsRafId = requestAnimationFrame( () => {
+		pendingMutationsRafId = 0;
+
+		const roots = Array.from( pendingMutationNodes );
+		pendingMutationNodes.clear();
+
+		const atoms = new Set< HTMLElement >();
+
+		for ( const node of roots ) {
+			if ( Node.ELEMENT_NODE !== node.nodeType ) {
+				continue;
 			}
 
-			onElementRender( { element: el, elementType: eType, elementId: id } );
-		} );
+			collectAtomicElementsInSubtree( node as Element ).forEach( ( atom ) => {
+				atoms.add( atom );
+			} );
+		}
+
+		atoms.forEach( ( atom ) => triggerAtomicRender( atom ) );
 	} );
 }

--- a/tests/jest/unit/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.test.js
+++ b/tests/jest/unit/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.test.js
@@ -30,6 +30,7 @@ const createLinkProp = ( destination ) => ( {
 	$$type: 'link',
 	value: {
 		destination,
+		tag: 'a',
 	},
 } );
 
@@ -684,7 +685,7 @@ describe( 'createAtomicElementBaseView - getLink with overridable props', () => 
 		mockModel.getSetting.mockReturnValue( undefined );
 
 		// Act
-		const result = viewInstance.getLink();
+		const result = viewInstance.getLinkAttributes();
 
 		// Assert
 		expect( result ).toBeNull();
@@ -700,12 +701,11 @@ describe( 'createAtomicElementBaseView - getLink with overridable props', () => 
 		} );
 
 		// Act
-		const result = viewInstance.getLink();
+		const result = viewInstance.getLinkAttributes();
 
 		// Assert
 		expect( result ).toEqual( {
-			attr: 'href',
-			value: 'https://example.com',
+			href: 'https://example.com',
 		} );
 	} );
 
@@ -719,12 +719,11 @@ describe( 'createAtomicElementBaseView - getLink with overridable props', () => 
 		} );
 
 		// Act
-		const result = viewInstance.getLink();
+		const result = viewInstance.getLinkAttributes();
 
 		// Assert
 		expect( result ).toEqual( {
-			attr: 'href',
-			value: 'https://example.com/?p=123',
+			href: 'https://example.com/?p=123',
 		} );
 	} );
 
@@ -738,12 +737,11 @@ describe( 'createAtomicElementBaseView - getLink with overridable props', () => 
 		} );
 
 		// Act
-		const result = viewInstance.getLink();
+		const result = viewInstance.getLinkAttributes();
 
 		// Assert
 		expect( result ).toEqual( {
-			attr: 'data-action-link',
-			value: DYNAMIC_LINK_VALUE,
+			'data-action-link': DYNAMIC_LINK_VALUE,
 		} );
 	} );
 
@@ -759,12 +757,11 @@ describe( 'createAtomicElementBaseView - getLink with overridable props', () => 
 		} );
 
 		// Act
-		const result = viewInstance.getLink();
+		const result = viewInstance.getLinkAttributes();
 
 		// Assert
 		expect( result ).toEqual( {
-			attr: 'href',
-			value: 'https://dynamic-url.com',
+			href: 'https://dynamic-url.com',
 		} );
 	} );
 
@@ -780,12 +777,11 @@ describe( 'createAtomicElementBaseView - getLink with overridable props', () => 
 		} );
 
 		// Act
-		const result = viewInstance.getLink();
+		const result = viewInstance.getLinkAttributes();
 
 		// Assert
 		expect( result ).toEqual( {
-			attr: 'href',
-			value: originUrl,
+			href: originUrl,
 		} );
 	} );
 
@@ -808,12 +804,11 @@ describe( 'createAtomicElementBaseView - getLink with overridable props', () => 
 		} ) );
 
 		// Act
-		const result = viewInstance.getLink();
+		const result = viewInstance.getLinkAttributes();
 
 		// Assert
 		expect( result ).toEqual( {
-			attr: 'href',
-			value: overrideUrl,
+			href: overrideUrl,
 		} );
 	} );
 } );

--- a/tests/jest/unit/modules/atomic-widgets/assets/js/frontend/handlers.test.js
+++ b/tests/jest/unit/modules/atomic-widgets/assets/js/frontend/handlers.test.js
@@ -59,18 +59,25 @@ describe( 'Atomic Widgets frontend handlers', () => {
 	} );
 
 	it( 'registers link and form handlers by selector', async () => {
+		// Arrange
 		const { registration, registerBySelector, getRegistration } = await importHandlers();
 
+		// Act
+		const { id, selector, callback } = registration;
+
+		// Assert
 		expect( registerBySelector ).toHaveBeenCalledTimes( REGISTRATIONS.length );
-		expect( { id: registration.id, selector: registration.selector } ).toEqual( { id: HANDLER_ID, selector: SELECTOR } );
-		expect( typeof registration.callback ).toBe( 'function' );
-		expect( getRegistration( ATOMIC_FORM_HANDLER_ID ).selector ).toBe( '[data-element_type="e-form"]' );
+		expect( { id, selector } ).toEqual( { id: HANDLER_ID, selector: SELECTOR } );
+		expect( typeof callback ).toBe( 'function' );
+		expect( getRegistration( ATOMIC_FORM_HANDLER_ID ) ).toBe( '[data-element_type="e-form"]' );
 	} );
 
 	it( 'does not attach listeners when action link is missing', async () => {
+		// Arrange
 		const { registration } = await importHandlers();
 		const element = document.createElement( 'button' );
 
+		// Act
 		const cleanup = registration.callback( { element } );
 		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
@@ -81,6 +88,7 @@ describe( 'Atomic Widgets frontend handlers', () => {
 	} );
 
 	it( 'runs whitelisted editor link actions and cleans up listeners', async () => {
+		// Arrange
 		global.elementor = {};
 		const { registration } = await importHandlers();
 		const element = document.createElement( 'button' );
@@ -90,6 +98,7 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		const cleanup = registration.callback( { element } );
 		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
+		// Act
 		element.dispatchEvent( event );
 		cleanup?.();
 
@@ -97,6 +106,7 @@ describe( 'Atomic Widgets frontend handlers', () => {
 
 		element.dispatchEvent( secondEvent );
 
+		// Assert
 		expect( event.defaultPrevented ).toBe( true );
 		expect( runAction ).toHaveBeenCalledTimes( 1 );
 		expect( runAction ).toHaveBeenCalledWith( ALLOWED_ACTION_URL, event );
@@ -104,6 +114,7 @@ describe( 'Atomic Widgets frontend handlers', () => {
 	} );
 
 	it( 'skips non-whitelisted editor link actions', async () => {
+		// Arrange
 		global.elementor = {};
 		const { registration } = await importHandlers();
 		const element = document.createElement( 'button' );
@@ -111,13 +122,16 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		registration.callback( { element } );
 		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
+		// Act
 		element.dispatchEvent( event );
 
+		// Assert
 		expect( runAction ).not.toHaveBeenCalled();
 		expect( event.defaultPrevented ).toBe( false );
 	} );
 
 	it( 'runs link actions outside editor context regardless of whitelist', async () => {
+		// Arrange
 		const { registration } = await importHandlers();
 		const element = document.createElement( 'button' );
 
@@ -126,18 +140,26 @@ describe( 'Atomic Widgets frontend handlers', () => {
 
 		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
+		// Act
 		element.dispatchEvent( event );
 
+		// Assert
 		expect( runAction ).toHaveBeenCalledTimes( 1 );
 		expect( runAction ).toHaveBeenCalledWith( ANY_CONTEXT_URL, event );
 		expect( event.defaultPrevented ).toBe( true );
 	} );
 
 	it( 'runs nested link actions only when clicking inside the nested element', async () => {
+		// Arrange
 		const { registration } = await importHandlers();
 		const element = document.createElement( 'h2' );
 		const nestedLink = document.createElement( 'a' );
 
+		// Act
+		nestedLink.dispatchEvent( linkEvent );
+		element.dispatchEvent( elementEvent );
+
+		// Assert
 		nestedLink.dataset.actionLink = ANY_CONTEXT_URL;
 		element.appendChild( nestedLink );
 		registration.callback( { element } );
@@ -145,9 +167,11 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		const linkEvent = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 		const elementEvent = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
+		// Act
 		nestedLink.dispatchEvent( linkEvent );
 		element.dispatchEvent( elementEvent );
 
+		// Assert
 		expect( runAction ).toHaveBeenCalledTimes( 1 );
 		expect( runAction ).toHaveBeenCalledWith( ANY_CONTEXT_URL, linkEvent );
 		expect( linkEvent.defaultPrevented ).toBe( true );
@@ -353,6 +377,7 @@ describe( 'Atomic Widgets frontend handlers', () => {
 	} );
 
 	it( 'adds non-whitelisted editor link actions via filter', async () => {
+		// Arrange
 		global.elementor = {};
 		global.elementorFrontend = { ...global.elementorFrontend, hooks: { applyFilters: () => [ BLOCKED_ACTION ] } };
 		const { registration } = await importHandlers();
@@ -364,8 +389,10 @@ describe( 'Atomic Widgets frontend handlers', () => {
 
 		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
+		// Act
 		element.dispatchEvent( event );
 
+		// Assert
 		expect( event.defaultPrevented ).toBe( true );
 		expect( runAction ).toHaveBeenCalledTimes( 1 );
 		expect( runAction ).toHaveBeenCalledWith( BLOCKED_ACTION_URL, event );

--- a/tests/jest/unit/modules/atomic-widgets/assets/js/frontend/handlers.test.js
+++ b/tests/jest/unit/modules/atomic-widgets/assets/js/frontend/handlers.test.js
@@ -387,35 +387,6 @@ describe( 'Atomic Widgets frontend handlers', () => {
 			expect( form.classList.contains( 'form-state-default' ) ).toBe( true );
 			expect( form.classList.contains( 'form-state-success' ) ).toBe( false );
 		} );
-
-		it( 'sends referer_title and referrer in FormData (atomic form / admin-ajax contract)', async () => {
-			// Arrange
-			const { form, input } = createFormWithInput();
-			input.value = 'Test value';
-			document.title = 'Submission Contract Page';
-
-			const instance = await setupFormHandler( form );
-
-			global.fetch = jest.fn().mockResolvedValue( {
-				ok: true,
-				json: () => Promise.resolve( { success: true } ),
-			} );
-
-			// Act
-			await instance.submit( new Event( 'submit', { cancelable: true } ) );
-
-			// Assert
-			expect( global.fetch ).toHaveBeenCalledTimes( 1 );
-			const fetchOptions = global.fetch.mock.calls[ 0 ][ 1 ];
-			expect( fetchOptions.method ).toBe( 'POST' );
-			expect( fetchOptions.body ).toBeInstanceOf( FormData );
-
-			const body = fetchOptions.body;
-			expect( body.has( 'referer_title' ) ).toBe( true );
-			expect( body.has( 'referrer' ) ).toBe( true );
-			expect( body.get( 'referer_title' ) ).toBe( 'Submission Contract Page' );
-			expect( body.get( 'referrer' ) ).toBe( window.location.href );
-		} );
 	} );
 
 	it( 'adds non-whitelisted editor link actions via filter', async () => {

--- a/tests/jest/unit/modules/atomic-widgets/assets/js/frontend/handlers.test.js
+++ b/tests/jest/unit/modules/atomic-widgets/assets/js/frontend/handlers.test.js
@@ -59,11 +59,8 @@ describe( 'Atomic Widgets frontend handlers', () => {
 	} );
 
 	it( 'registers link and form handlers by selector', async () => {
-		// Arrange
-		// Act
 		const { registration, registerBySelector, getRegistration } = await importHandlers();
 
-		// Assert
 		expect( registerBySelector ).toHaveBeenCalledTimes( REGISTRATIONS.length );
 		expect( { id: registration.id, selector: registration.selector } ).toEqual( { id: HANDLER_ID, selector: SELECTOR } );
 		expect( typeof registration.callback ).toBe( 'function' );
@@ -71,23 +68,19 @@ describe( 'Atomic Widgets frontend handlers', () => {
 	} );
 
 	it( 'does not attach listeners when action link is missing', async () => {
-		// Arrange
 		const { registration } = await importHandlers();
 		const element = document.createElement( 'button' );
 
-		// Act
 		const cleanup = registration.callback( { element } );
 		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
 		element.dispatchEvent( event );
 
-		// Assert
 		expect( cleanup ).toBeUndefined();
 		expect( event.defaultPrevented ).toBe( false );
 	} );
 
 	it( 'runs whitelisted editor link actions and cleans up listeners', async () => {
-		// Arrange
 		global.elementor = {};
 		const { registration } = await importHandlers();
 		const element = document.createElement( 'button' );
@@ -97,7 +90,6 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		const cleanup = registration.callback( { element } );
 		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
-		// Act
 		element.dispatchEvent( event );
 		cleanup?.();
 
@@ -105,7 +97,6 @@ describe( 'Atomic Widgets frontend handlers', () => {
 
 		element.dispatchEvent( secondEvent );
 
-		// Assert
 		expect( event.defaultPrevented ).toBe( true );
 		expect( runAction ).toHaveBeenCalledTimes( 1 );
 		expect( runAction ).toHaveBeenCalledWith( ALLOWED_ACTION_URL, event );
@@ -113,7 +104,6 @@ describe( 'Atomic Widgets frontend handlers', () => {
 	} );
 
 	it( 'skips non-whitelisted editor link actions', async () => {
-		// Arrange
 		global.elementor = {};
 		const { registration } = await importHandlers();
 		const element = document.createElement( 'button' );
@@ -121,16 +111,13 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		registration.callback( { element } );
 		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
-		// Act
 		element.dispatchEvent( event );
 
-		// Assert
 		expect( runAction ).not.toHaveBeenCalled();
 		expect( event.defaultPrevented ).toBe( false );
 	} );
 
 	it( 'runs link actions outside editor context regardless of whitelist', async () => {
-		// Arrange
 		const { registration } = await importHandlers();
 		const element = document.createElement( 'button' );
 
@@ -139,17 +126,14 @@ describe( 'Atomic Widgets frontend handlers', () => {
 
 		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
-		// Act
 		element.dispatchEvent( event );
 
-		// Assert
 		expect( runAction ).toHaveBeenCalledTimes( 1 );
 		expect( runAction ).toHaveBeenCalledWith( ANY_CONTEXT_URL, event );
 		expect( event.defaultPrevented ).toBe( true );
 	} );
 
 	it( 'runs nested link actions only when clicking inside the nested element', async () => {
-		// Arrange
 		const { registration } = await importHandlers();
 		const element = document.createElement( 'h2' );
 		const nestedLink = document.createElement( 'a' );
@@ -161,11 +145,9 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		const linkEvent = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 		const elementEvent = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
-		// Act
 		nestedLink.dispatchEvent( linkEvent );
 		element.dispatchEvent( elementEvent );
 
-		// Assert
 		expect( runAction ).toHaveBeenCalledTimes( 1 );
 		expect( runAction ).toHaveBeenCalledWith( ANY_CONTEXT_URL, linkEvent );
 		expect( linkEvent.defaultPrevented ).toBe( true );
@@ -191,7 +173,6 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		};
 
 		it( 'prefers aria-label over everything else', async () => {
-			// Arrange
 			await importHandlers();
 			const form = createForm();
 			const input = createInput( {
@@ -212,12 +193,10 @@ describe( 'Atomic Widgets frontend handlers', () => {
 				fields.push( ariaLabel );
 			} );
 
-			// Assert
 			expect( fields[ 0 ] ).toBe( 'Aria Label' );
 		} );
 
 		it( 'prefers label[for] over placeholder', async () => {
-			// Arrange
 			await importHandlers();
 			const form = createForm();
 			const input = createInput( {
@@ -234,12 +213,10 @@ describe( 'Atomic Widgets frontend handlers', () => {
 			const fieldId = input.getAttribute( 'id' );
 			const labelElement = form.querySelector( `label[for="${ fieldId }"]` );
 
-			// Assert
 			expect( labelElement.textContent.trim() ).toBe( 'Email' );
 		} );
 
 		it( 'uses placeholder as last resort', async () => {
-			// Arrange
 			await importHandlers();
 			const form = createForm();
 			const input = createInput( {
@@ -253,14 +230,12 @@ describe( 'Atomic Widgets frontend handlers', () => {
 			const labelElement = fieldId ? form.querySelector( `label[for="${ fieldId }"]` ) : null;
 			const placeholder = input.getAttribute( 'placeholder' );
 
-			// Assert
 			expect( ariaLabel ).toBeNull();
 			expect( labelElement ).toBeNull();
 			expect( placeholder ).toBe( 'Enter your name' );
 		} );
 
 		it( 'uses parent label when no aria-label, for-label, or placeholder', async () => {
-			// Arrange
 			await importHandlers();
 			const form = createForm();
 			const parentLabel = document.createElement( 'label' );
@@ -273,7 +248,6 @@ describe( 'Atomic Widgets frontend handlers', () => {
 			const fieldId = input.getAttribute( 'id' );
 			const closestLabel = input.closest( 'label' );
 
-			// Assert
 			expect( ariaLabel ).toBeNull();
 			expect( fieldId ).toBeNull();
 			expect( closestLabel.textContent.trim() ).toBe( 'Parent Label' );
@@ -328,7 +302,6 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		} );
 
 		it( 'clears form fields on successful submission', async () => {
-			// Arrange
 			const { form, input } = createFormWithInput();
 			input.value = 'Test value';
 
@@ -339,15 +312,12 @@ describe( 'Atomic Widgets frontend handlers', () => {
 				json: () => Promise.resolve( { success: true } ),
 			} );
 
-			// Act
 			await instance.submit( new Event( 'submit', { cancelable: true } ) );
 
-			// Assert
 			expect( input.value ).toBe( '' );
 		} );
 
 		it( 'does not clear form fields on failed submission', async () => {
-			// Arrange
 			const { form, input } = createFormWithInput();
 			input.value = 'Test value';
 
@@ -355,15 +325,12 @@ describe( 'Atomic Widgets frontend handlers', () => {
 
 			global.fetch = jest.fn().mockResolvedValue( { ok: false } );
 
-			// Act
 			await instance.submit( new Event( 'submit', { cancelable: true } ) );
 
-			// Assert
 			expect( input.value ).toBe( 'Test value' );
 		} );
 
 		it( 'dismisses success message when user starts typing', async () => {
-			// Arrange
 			const { form, input } = createFormWithInput();
 			input.value = 'Test value';
 
@@ -374,23 +341,18 @@ describe( 'Atomic Widgets frontend handlers', () => {
 				json: () => Promise.resolve( { success: true } ),
 			} );
 
-			// Act
 			await instance.submit( new Event( 'submit', { cancelable: true } ) );
 
-			// Assert
 			expect( form.classList.contains( 'form-state-success' ) ).toBe( true );
 
-			// Act
 			input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
 
-			// Assert
 			expect( form.classList.contains( 'form-state-default' ) ).toBe( true );
 			expect( form.classList.contains( 'form-state-success' ) ).toBe( false );
 		} );
 	} );
 
 	it( 'adds non-whitelisted editor link actions via filter', async () => {
-		// Arrange
 		global.elementor = {};
 		global.elementorFrontend = { ...global.elementorFrontend, hooks: { applyFilters: () => [ BLOCKED_ACTION ] } };
 		const { registration } = await importHandlers();
@@ -402,10 +364,8 @@ describe( 'Atomic Widgets frontend handlers', () => {
 
 		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
-		// Act
 		element.dispatchEvent( event );
 
-		// Assert
 		expect( event.defaultPrevented ).toBe( true );
 		expect( runAction ).toHaveBeenCalledTimes( 1 );
 		expect( runAction ).toHaveBeenCalledWith( BLOCKED_ACTION_URL, event );

--- a/tests/jest/unit/modules/atomic-widgets/assets/js/frontend/handlers.test.js
+++ b/tests/jest/unit/modules/atomic-widgets/assets/js/frontend/handlers.test.js
@@ -6,11 +6,13 @@ jest.mock( '@elementor/alpinejs', () => ( {
 	Alpine: {
 		data: jest.fn(),
 		destroyTree: jest.fn(),
+		initTree: jest.fn(),
+		nextTick: jest.fn( ( callback ) => callback() ),
 	},
 } ), { virtual: true } );
 
 const HANDLER_ID = 'atomic-link-action-handler';
-const SELECTOR = '[data-action-link], :has(> [data-action-link])';
+const SELECTOR = '[data-action-link], :has([data-action-link])';
 const ATOMIC_FORM_HANDLER_ID = 'atomic-form-submit-handler';
 const REGISTRATIONS = [ 'action-link', 'form-prevention' ];
 
@@ -35,6 +37,7 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		const registration = getRegistration( HANDLER_ID );
 
 		expect( registration ).toBeDefined();
+		expect( getRegistration( ATOMIC_FORM_HANDLER_ID ) ).toBeDefined();
 
 		return {
 			registration,
@@ -55,18 +58,16 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		global.elementorFrontend = { utils: { urlActions: { runAction } } };
 	} );
 
-	it( 'registers link action handler by selector', async () => {
+	it( 'registers link and form handlers by selector', async () => {
 		// Arrange
-		const { registration, registerBySelector, getRegistration } = await importHandlers();
-
 		// Act
-		const { id, selector, callback } = registration;
+		const { registration, registerBySelector, getRegistration } = await importHandlers();
 
 		// Assert
 		expect( registerBySelector ).toHaveBeenCalledTimes( REGISTRATIONS.length );
-		expect( { id, selector } ).toEqual( { id: HANDLER_ID, selector: SELECTOR } );
-		expect( typeof callback ).toBe( 'function' );
-		expect( getRegistration( ATOMIC_FORM_HANDLER_ID ) ).toBeDefined();
+		expect( { id: registration.id, selector: registration.selector } ).toEqual( { id: HANDLER_ID, selector: SELECTOR } );
+		expect( typeof registration.callback ).toBe( 'function' );
+		expect( getRegistration( ATOMIC_FORM_HANDLER_ID ).selector ).toBe( '[data-element_type="e-form"]' );
 	} );
 
 	it( 'does not attach listeners when action link is missing', async () => {
@@ -190,6 +191,7 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		};
 
 		it( 'prefers aria-label over everything else', async () => {
+			// Arrange
 			await importHandlers();
 			const form = createForm();
 			const input = createInput( {
@@ -210,10 +212,12 @@ describe( 'Atomic Widgets frontend handlers', () => {
 				fields.push( ariaLabel );
 			} );
 
+			// Assert
 			expect( fields[ 0 ] ).toBe( 'Aria Label' );
 		} );
 
 		it( 'prefers label[for] over placeholder', async () => {
+			// Arrange
 			await importHandlers();
 			const form = createForm();
 			const input = createInput( {
@@ -230,10 +234,12 @@ describe( 'Atomic Widgets frontend handlers', () => {
 			const fieldId = input.getAttribute( 'id' );
 			const labelElement = form.querySelector( `label[for="${ fieldId }"]` );
 
+			// Assert
 			expect( labelElement.textContent.trim() ).toBe( 'Email' );
 		} );
 
 		it( 'uses placeholder as last resort', async () => {
+			// Arrange
 			await importHandlers();
 			const form = createForm();
 			const input = createInput( {
@@ -247,12 +253,14 @@ describe( 'Atomic Widgets frontend handlers', () => {
 			const labelElement = fieldId ? form.querySelector( `label[for="${ fieldId }"]` ) : null;
 			const placeholder = input.getAttribute( 'placeholder' );
 
+			// Assert
 			expect( ariaLabel ).toBeNull();
 			expect( labelElement ).toBeNull();
 			expect( placeholder ).toBe( 'Enter your name' );
 		} );
 
 		it( 'uses parent label when no aria-label, for-label, or placeholder', async () => {
+			// Arrange
 			await importHandlers();
 			const form = createForm();
 			const parentLabel = document.createElement( 'label' );
@@ -265,6 +273,7 @@ describe( 'Atomic Widgets frontend handlers', () => {
 			const fieldId = input.getAttribute( 'id' );
 			const closestLabel = input.closest( 'label' );
 
+			// Assert
 			expect( ariaLabel ).toBeNull();
 			expect( fieldId ).toBeNull();
 			expect( closestLabel.textContent.trim() ).toBe( 'Parent Label' );
@@ -319,6 +328,7 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		} );
 
 		it( 'clears form fields on successful submission', async () => {
+			// Arrange
 			const { form, input } = createFormWithInput();
 			input.value = 'Test value';
 
@@ -329,12 +339,15 @@ describe( 'Atomic Widgets frontend handlers', () => {
 				json: () => Promise.resolve( { success: true } ),
 			} );
 
+			// Act
 			await instance.submit( new Event( 'submit', { cancelable: true } ) );
 
+			// Assert
 			expect( input.value ).toBe( '' );
 		} );
 
 		it( 'does not clear form fields on failed submission', async () => {
+			// Arrange
 			const { form, input } = createFormWithInput();
 			input.value = 'Test value';
 
@@ -342,12 +355,15 @@ describe( 'Atomic Widgets frontend handlers', () => {
 
 			global.fetch = jest.fn().mockResolvedValue( { ok: false } );
 
+			// Act
 			await instance.submit( new Event( 'submit', { cancelable: true } ) );
 
+			// Assert
 			expect( input.value ).toBe( 'Test value' );
 		} );
 
 		it( 'dismisses success message when user starts typing', async () => {
+			// Arrange
 			const { form, input } = createFormWithInput();
 			input.value = 'Test value';
 
@@ -358,18 +374,51 @@ describe( 'Atomic Widgets frontend handlers', () => {
 				json: () => Promise.resolve( { success: true } ),
 			} );
 
+			// Act
 			await instance.submit( new Event( 'submit', { cancelable: true } ) );
 
+			// Assert
 			expect( form.classList.contains( 'form-state-success' ) ).toBe( true );
 
+			// Act
 			input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
 
+			// Assert
 			expect( form.classList.contains( 'form-state-default' ) ).toBe( true );
 			expect( form.classList.contains( 'form-state-success' ) ).toBe( false );
 		} );
+
+		it( 'sends referer_title and referrer in FormData (atomic form / admin-ajax contract)', async () => {
+			// Arrange
+			const { form, input } = createFormWithInput();
+			input.value = 'Test value';
+			document.title = 'Submission Contract Page';
+
+			const instance = await setupFormHandler( form );
+
+			global.fetch = jest.fn().mockResolvedValue( {
+				ok: true,
+				json: () => Promise.resolve( { success: true } ),
+			} );
+
+			// Act
+			await instance.submit( new Event( 'submit', { cancelable: true } ) );
+
+			// Assert
+			expect( global.fetch ).toHaveBeenCalledTimes( 1 );
+			const fetchOptions = global.fetch.mock.calls[ 0 ][ 1 ];
+			expect( fetchOptions.method ).toBe( 'POST' );
+			expect( fetchOptions.body ).toBeInstanceOf( FormData );
+
+			const body = fetchOptions.body;
+			expect( body.has( 'referer_title' ) ).toBe( true );
+			expect( body.has( 'referrer' ) ).toBe( true );
+			expect( body.get( 'referer_title' ) ).toBe( 'Submission Contract Page' );
+			expect( body.get( 'referrer' ) ).toBe( window.location.href );
+		} );
 	} );
 
-	it( 'adds non-whitelisted editor link actions', async () => {
+	it( 'adds non-whitelisted editor link actions via filter', async () => {
 		// Arrange
 		global.elementor = {};
 		global.elementorFrontend = { ...global.elementorFrontend, hooks: { applyFilters: () => [ BLOCKED_ACTION ] } };

--- a/tests/jest/unit/modules/atomic-widgets/assets/js/frontend/handlers.test.js
+++ b/tests/jest/unit/modules/atomic-widgets/assets/js/frontend/handlers.test.js
@@ -155,12 +155,15 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		const element = document.createElement( 'h2' );
 		const nestedLink = document.createElement( 'a' );
 
+		nestedLink.dataset.actionLink = ANY_CONTEXT_URL;
+		element.appendChild( nestedLink );
+		registration.callback( { element } );
+
 		const linkEvent = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 		const elementEvent = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
 		// Act
 		nestedLink.dispatchEvent( linkEvent );
-		registration.callback( { element } );
 		element.dispatchEvent( elementEvent );
 
 		// Assert

--- a/tests/jest/unit/modules/atomic-widgets/assets/js/frontend/handlers.test.js
+++ b/tests/jest/unit/modules/atomic-widgets/assets/js/frontend/handlers.test.js
@@ -69,7 +69,7 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		expect( registerBySelector ).toHaveBeenCalledTimes( REGISTRATIONS.length );
 		expect( { id, selector } ).toEqual( { id: HANDLER_ID, selector: SELECTOR } );
 		expect( typeof callback ).toBe( 'function' );
-		expect( getRegistration( ATOMIC_FORM_HANDLER_ID ) ).toBe( '[data-element_type="e-form"]' );
+		expect( getRegistration( ATOMIC_FORM_HANDLER_ID ).selector ).toBe( '[data-element_type="e-form"]' );
 	} );
 
 	it( 'does not attach listeners when action link is missing', async () => {
@@ -155,20 +155,12 @@ describe( 'Atomic Widgets frontend handlers', () => {
 		const element = document.createElement( 'h2' );
 		const nestedLink = document.createElement( 'a' );
 
-		// Act
-		nestedLink.dispatchEvent( linkEvent );
-		element.dispatchEvent( elementEvent );
-
-		// Assert
-		nestedLink.dataset.actionLink = ANY_CONTEXT_URL;
-		element.appendChild( nestedLink );
-		registration.callback( { element } );
-
 		const linkEvent = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 		const elementEvent = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
 
 		// Act
 		nestedLink.dispatchEvent( linkEvent );
+		registration.callback( { element } );
 		element.dispatchEvent( elementEvent );
 
 		// Assert

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Button__test__render_button_with_action_link__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Button__test__render_button_with_action_link__1.txt
@@ -1,6 +1,5 @@
 			    	            <button
-            			data-action-link="https://very.dynamic.content.elementor"
-        target="_blank"
+            data-action-link="https://very.dynamic.content.elementor" target="_blank"
             class="e-button-base"
             data-interaction-id="e8e55a1"
              

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Button__test__render_linked_button__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Button__test__render_linked_button__1.txt
@@ -1,6 +1,5 @@
 			    	            <a
-            			href="https://example.com"
-        target="_blank"
+            href="https://example.com" target="_blank"
             class="e-button-base"
             data-interaction-id="e8e55a1"
              

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Button__test__render_linked_button_target_self__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Button__test__render_linked_button_target_self__1.txt
@@ -1,6 +1,5 @@
 			    	            <a
-            			href="https://example.com"
-        target="_self"
+            href="https://example.com" target="_self"
             class="e-button-base"
             data-interaction-id="e8e55a1"
              

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Heading__test__render_heading_with_action_link__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Heading__test__render_heading_with_action_link__1.txt
@@ -6,8 +6,7 @@
 	>
 	
 			<button 
-						data-action-link="https://very.dynamic.content.elementor"
-			target="_blank" 
+			data-action-link="https://very.dynamic.content.elementor" target="_blank"
 			class="e-heading-link-base">
 			This is a title
 		</button>

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Heading__test__render_linked_heading__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Heading__test__render_linked_heading__1.txt
@@ -6,8 +6,7 @@
 	>
 	
 			<a 
-						href="https://example.com"
-			target="_blank" 
+			href="https://example.com" target="_blank"
 			class="e-heading-link-base">
 			This is a title
 		</a>

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Heading__test__render_linked_heading_target_self__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Heading__test__render_linked_heading_target_self__1.txt
@@ -6,8 +6,7 @@
 	>
 	
 			<a 
-						href="https://example.com"
-			target="_self" 
+			href="https://example.com" target="_self"
 			class="e-heading-link-base">
 			This is a title
 		</a>

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Paragraph__test__render_linked_paragraph__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Paragraph__test__render_linked_paragraph__1.txt
@@ -1,7 +1,6 @@
 						<p class="e-paragraph-base" data-interaction-id="e8e55a1"  >
 							<a
-										href="https://example.com"
-					target="_blank"
+					href="https://example.com" target="_blank"
 					class="e-paragraph-link-base"
 				>
 						Type your paragraph here

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Paragraph__test__render_linked_paragraph_target_self__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Paragraph__test__render_linked_paragraph_target_self__1.txt
@@ -1,7 +1,6 @@
 						<p class="e-paragraph-base" data-interaction-id="e8e55a1"  >
 							<a
-										href="https://example.com"
-					target="_self"
+					href="https://example.com" target="_self"
 					class="e-paragraph-link-base"
 				>
 						Type your paragraph here

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Paragraph__test__render_paragraph_with_action_link__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Atomic_Paragraph__test__render_paragraph_with_action_link__1.txt
@@ -1,7 +1,6 @@
 						<p class="e-paragraph-base" data-interaction-id="e8e55a1"  >
 							<button
-										data-action-link="https://very.dynamic.content.elementor"
-					target="_blank"
+					data-action-link="https://very.dynamic.content.elementor" target="_blank"
 					class="e-paragraph-link-base"
 				>
 						Type your paragraph here

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Div_Block__test__render_div_block_with_action_link__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Div_Block__test__render_div_block_with_action_link__1.txt
@@ -1,4 +1,4 @@
-		<button class="elementor-element elementor-element-e8e55a1 e-con e-atomic-element e-div-block-base" data-id="e8e55a1" data-element_type="e-div-block" data-e-type="e-div-block" data-interaction-id="e8e55a1" data-action-link="https://very.dynamic.content.elementor" target="_blank">
+		<button class="elementor-element elementor-element-e8e55a1 e-con e-atomic-element e-div-block-base" data-id="e8e55a1" data-element_type="e-div-block" data-e-type="e-div-block" data-interaction-id="e8e55a1"  data-action-link="https://very.dynamic.content.elementor" target="_blank">
 								<p class="e-paragraph-base" data-interaction-id="e8e55a1"  >
 								Type your paragraph here
 					</p>

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Div_Block__test__render_div_block_with_link_control__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Div_Block__test__render_div_block_with_link_control__1.txt
@@ -1,4 +1,4 @@
-		<a class="elementor-element elementor-element-e8e55a1 e-con e-atomic-element e-div-block-base" data-id="e8e55a1" data-element_type="e-div-block" data-e-type="e-div-block" data-interaction-id="e8e55a1" href="https://example.com" target="_blank">
+		<a class="elementor-element elementor-element-e8e55a1 e-con e-atomic-element e-div-block-base" data-id="e8e55a1" data-element_type="e-div-block" data-e-type="e-div-block" data-interaction-id="e8e55a1"  href="https://example.com" target="_blank">
 								<p class="e-paragraph-base" data-interaction-id="e8e55a1"  >
 								Type your paragraph here
 					</p>

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Flexbox__test__render_flexbox_with_action_link__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Flexbox__test__render_flexbox_with_action_link__1.txt
@@ -1,4 +1,4 @@
-		<button class="elementor-element elementor-element-e8e55a1 e-con e-atomic-element e-flexbox-base" data-id="e8e55a1" data-element_type="e-flexbox" data-e-type="e-flexbox" data-interaction-id="e8e55a1" data-action-link="https://very.dynamic.content.elementor" target="_blank">
+		<button class="elementor-element elementor-element-e8e55a1 e-con e-atomic-element e-flexbox-base" data-id="e8e55a1" data-element_type="e-flexbox" data-e-type="e-flexbox" data-interaction-id="e8e55a1"  data-action-link="https://very.dynamic.content.elementor" target="_blank">
 				<div class="elementor-element elementor-element-a3v23u9 e-con e-atomic-element e-flexbox-base" data-id="a3v23u9" data-element_type="e-flexbox" data-e-type="e-flexbox" data-interaction-id="a3v23u9">
 				</div>
 				</button>

--- a/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Flexbox__test__render_flexbox_with_link_control__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/__snapshots__/Test_Flexbox__test__render_flexbox_with_link_control__1.txt
@@ -1,4 +1,4 @@
-		<a class="elementor-element elementor-element-e8e55a1 e-con e-atomic-element e-flexbox-base" data-id="e8e55a1" data-element_type="e-flexbox" data-e-type="e-flexbox" data-interaction-id="e8e55a1" href="https://example.com" target="_blank">
+		<a class="elementor-element elementor-element-e8e55a1 e-con e-atomic-element e-flexbox-base" data-id="e8e55a1" data-element_type="e-flexbox" data-e-type="e-flexbox" data-interaction-id="e8e55a1"  href="https://example.com" target="_blank">
 								<p class="e-paragraph-base" data-interaction-id="e8e55a1"  >
 								Type your paragraph here
 					</p>

--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/__snapshots__/Test_Has_Template__test_render with data set Atomic Image linked__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/__snapshots__/Test_Has_Template__test_render with data set Atomic Image linked__1.txt
@@ -1,15 +1,14 @@
 					
 			<a
-						href="https://example.com"
+			href="https://example.com" target="_blank"
 			class="e-image-link-base"
-			target="_blank"
 			data-interaction-id="e8e55a1"
 		>
 		<img class="e-image-base " 
+					data-interaction-id="e8e55a1" 
 		 
 		 
 									id="123"
 												src="https://example.com/image.jpg"
 						/>
-			</a>
 			

--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/__snapshots__/Test_Has_Template__test_render with data set Atomic Paragraph linked__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/__snapshots__/Test_Has_Template__test_render with data set Atomic Paragraph linked__1.txt
@@ -1,7 +1,6 @@
 						<p class="e-paragraph-base" data-interaction-id="e8e55a1"  >
 							<a
-										href="https://example.com"
-					target="_blank"
+					href="https://example.com" target="_blank"
 					class="e-paragraph-link-base"
 				>
 						Type your paragraph here

--- a/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-widget-base.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-widget-base.php
@@ -77,9 +77,8 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 						'text' => 'This text is more great than the greatest text',
 						'tag' => 'h2',
 						'link' => [
-							'href' => 'https://elementor.com',
-							'target' => '_blank',
 							'tag' => 'a',
+							'attributes' => 'href="https://elementor.com" target="_blank"',
 						],
 					],
 				]

--- a/tests/playwright/sanity/modules/v4-tests/interactions-tab.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/interactions-tab.test.ts
@@ -185,6 +185,11 @@ test.describe( 'Interactions Tab @v4-tests', () => {
 
 			// Change effect type to "Out"
 			const effectTypeButton = popover.getByLabel( 'Out', { exact: true } );
+
+			// Done to avoid tooltip blocking mouse actions
+			const label = effectTypeButton.locator( '../../..' ).locator( 'label' );
+			await label.hover();
+
 			await expect( effectTypeButton ).toBeVisible();
 			await effectTypeButton.click();
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

**[ED-23643]** Handlers registered via `registerBySelector()` weren't firing for elements added to the DOM after `DOMContentLoaded`. This broke link actions and form handlers when atomic widgets were dynamically inserted (e.g., inside loops, conditionally rendered, or lazy-loaded). The fix adds a `MutationObserver` to scan for new `[data-e-type]` elements post-boot, plus refactors link attribute handling from template-time checks (`settings.link.href`) to pre-serialized attribute strings.

## 2. What Changed (Where)

- **Frontend handler init** (`frontend-handlers/src/init.ts`): Added `MutationObserver` to scan DOM for new atomic elements post-`DOMContentLoaded`, throttled via `requestAnimationFrame`.
- **Link attribute serialization** (PHP: `has-atomic-base.php`, `atomic-element-base.php`; JS: `create-atomic-element-base-view.js`, `create-templated-element-type.ts`): Moved link attribute logic from templates to element base classes—now returns `{tag, attributes: "href=\"...\" target=\"...\""}`instead of raw `{href, target}`.
- **Template logic** (5 Twig files: button, heading, image, paragraph, svg): Changed from `{% if settings.link.href %}` to `{% if settings.link.attributes %}`, rendering `{{ settings.link.attributes | raw }}`.
- **Handler selectors** (`handlers.js`): Changed `REGISTRATION_SELECTOR` from `:has(> [data-action-link])` to `:has([data-action-link])` (removed direct-child constraint); added `refreshDom()` to re-initialize Alpine for forms.
- **Test updates**: Updated assertions to expect `{href: "...", target: "..."}` instead of `{attr, value}` in JS tests; added Alpine mocks for `initTree`/`nextTick`.

## 3. How It Works

**Boot sequence:**  
On page load, `init()` fires `bootDomHandlers()` (listens for `DOMContentLoaded` or runs immediately if document already loaded). This scans existing `[data-e-type]` elements and starts a `MutationObserver` watching `document.documentElement` for additions. New nodes are batched via `requestAnimationFrame`, de-duped, then trigger `onElementRender()` for each discovered atomic element.

**Link attributes flow:**  
PHP: `get_atomic_settings()` calls `get_link_attributes_string()` → checks if link tag is `button` → sets `data-action-link` or `href` → escapes/joins into a single string. Templates now check `settings.link.attributes` (truthy if non-empty) and render the pre-escaped string. JS editor mirrors this in `afterSettingsResolve()` and `getLinkAttributes()` (returns object with `href` or `data-action-link` key).

**Form handler refresh:**  
`handleAtomicFormSubmit()` now calls `refreshDom(form)`, which uses Alpine's `destroyTree`/`initTree` to re-mount reactive handlers for forms inserted dynamically.

```mermaid
graph LR
    A[DOMContentLoaded] --> B[scanDocumentForAtomicElements]
    A --> C[startObservingDomForNewAtomicElements]
    C --> D[MutationObserver]
    D --> E[queueProcessPendingMutationNodes RAF]
    E --> F[collectAtomicElementsInSubtree]
    F --> G[triggerAtomicRender]
    G --> H[onElementRender]
    H --> I[registerBySelector callbacks]
    I --> J{Element type?}
    J -->|Link action| K[handleLinkActions]
    J -->|Form| L[registerAtomicFormAlpineData + refreshDom]
```

## 4. Risks

- **Performance:** `MutationObserver` on `documentElement` with `subtree: true` can fire frequently on DOM-heavy pages. RAF batching mitigates but doesn't prevent handler re-registration on already-handled elements—handlers don't check if previously attached (could cause duplicate listeners if `onElementRender` isn't idempotent).
- **Race condition:** If Alpine form data is registered before Alpine itself loads, `Alpine.data()` silently fails (no-op if `!Alpine?.data`). Forms rendered pre-Alpine boot won't have handlers unless Alpine is guaranteed synchronous.
- **Breaking change:** CSS selector `:has([data-action-link])` (no direct-child constraint) now matches *any* ancestor, widening event delegation scope. If nested widgets both have action links, both handlers attach to the parent—likely intended but untested in diff.
- **Post-ID resolution:** `getPostId(form)` prefers `closest('[data-elementor-id]')` over global config—correct for nested documents but could break if inner document ID doesn't match expected post context (e.g., global widgets).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-23643]: https://elementor.atlassian.net/browse/ED-23643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ