### PR TITLE
Fix: Unit resets to default when a property value is zeroed [ED-23490]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/__tests__/size-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/size-control.test.tsx
@@ -430,6 +430,74 @@ describe( 'SizeControl', () => {
 		expect( options.slice( -1 )[ 0 ] ).toContainHTML( customOptionElement );
 	} );
 
+	it( 'should preserve the selected unit when the value is cleared while input is focused', () => {
+		// Arrange.
+		const setValue = jest.fn();
+
+		const props = {
+			setValue,
+			value: mockSizeProp( { size: 10, unit: 'px' } ),
+			bind: 'select',
+			propType,
+		};
+
+		renderControl(
+			<ControlActionsProvider items={ [] }>
+				<SizeControl units={ mockLengthUnits() } />
+			</ControlActionsProvider>,
+			props
+		);
+
+		const select = screen.getByRole( 'button' );
+		const sizeInput = screen.getByRole( 'spinbutton' );
+
+		// Act.
+		fireEvent.click( select );
+		fireEvent.click( screen.getByText( 'REM' ) );
+
+		fireEvent.input( sizeInput, { target: { value: '' } } );
+
+		// Assert.
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'rem' );
+	} );
+
+	it( 'should reset the unit to default on blur after the value is cleared', () => {
+		// Arrange.
+		const setValue = jest.fn();
+
+		const props = {
+			setValue,
+			value: mockSizeProp( { size: 10, unit: 'px' } ),
+			bind: 'select',
+			propType,
+		};
+
+		renderControl(
+			<ControlActionsProvider items={ [] }>
+				<SizeControl units={ mockLengthUnits() } />
+			</ControlActionsProvider>,
+			props
+		);
+
+		const select = screen.getByRole( 'button' );
+		const sizeInput = screen.getByRole( 'spinbutton' );
+
+		// Act.
+		fireEvent.click( select );
+		fireEvent.click( screen.getByText( 'REM' ) );
+
+		fireEvent.input( sizeInput, { target: { value: '' } } );
+
+		// Assert.
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'rem' );
+
+		// Act.
+		fireEvent.blur( sizeInput );
+
+		// Assert.
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'px' );
+	} );
+
 	describe( 'Units', () => {
 		it( 'should use external units when enablePropTypeUnits is false', () => {
 			// Arrange.

--- a/packages/packages/libs/editor-controls/src/controls/size-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/size-control.tsx
@@ -114,7 +114,7 @@ export const SizeControl = createControl(
 		const popupState = usePopupState( { variant: 'popover' } );
 
 		const memorizedExternalState = useMemo(
-			() => createStateFromSizeProp( sizeValue, actualDefaultUnit ),
+			() => ( sizeValue ? createStateFromSizeProp( sizeValue, actualDefaultUnit ) : null ),
 			[ sizeValue, actualDefaultUnit ]
 		);
 
@@ -132,6 +132,14 @@ export const SizeControl = createControl(
 
 		const { size: controlSize = DEFAULT_SIZE, unit: controlUnit = actualDefaultUnit } =
 			extractValueFromState( state, true ) || {};
+
+		const handleBlur = () => {
+			if ( ! extractValueFromState( state ) ) {
+				setState( ( prev ) => ( { ...prev, unit: actualDefaultUnit } ) );
+			}
+
+			restoreValue();
+		};
 
 		const handleUnitChange = ( newUnit: Unit | ExtendedOption ) => {
 			if ( newUnit === 'custom' ) {
@@ -190,7 +198,7 @@ export const SizeControl = createControl(
 					startIcon={ startIcon }
 					handleSizeChange={ handleSizeChange }
 					handleUnitChange={ handleUnitChange }
-					onBlur={ restoreValue }
+					onBlur={ handleBlur }
 					onClick={ onInputClick }
 					popupState={ popupState }
 					min={ min }


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

**Ticket:** ED-23490

Unit selector was resetting to default (px) prematurely when users cleared the input value, even while still editing. The control's external state was being created unconditionally, forcing unit resets before users finished their edits. This broke the expected UX: keep the selected unit while focused, only reset to default on blur if empty.

## 2. What Changed (Where)

- `size-control.tsx`: Added conditional state initialization and custom blur handler to preserve unit during editing
- `size-control.test.tsx`: Added two test cases covering focus-time unit preservation and blur-time reset behavior

## 3. How It Works

**State initialization**: `memorizedExternalState` now returns `null` when `sizeValue` is falsy instead of always creating state. This prevents the control from forcing a unit reset when the value is cleared while editing.

**Blur handler**: New `handleBlur` checks if state has no value, then resets unit to `actualDefaultUnit` before calling `restoreValue()`. This defers the unit reset until the user finishes editing (blur), while preserving the selected unit during active editing (focus).

**Flow**: User selects rem → clears input (unit stays rem while focused) → blurs input → unit resets to px if value still empty.

## 4. Risks

None significant. The state sync logic change is localized and both behaviors (preserve on focus, reset on blur) are explicitly tested. The conditional initialization might affect other consumers of `useSyncExternalState`, but the fallback to `null` is a standard pattern for empty states.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
