### PR TITLE
Internal: Block latest tag from workflow_dispatch runs

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -136,6 +136,12 @@ jobs:
             fi
           fi
 
+          # Disallow "latest" tag in manual (workflow_dispatch) runs
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ "${{ inputs.tag }}" == "latest" ]; then
+            echo "Error: 'latest' tag is not allowed for manual workflow_dispatch runs. Use the release workflow to publish as latest."
+            exit 1
+          fi
+
       - name: Determine Tag Strategy
         id: tag-strategy
         run: |


### PR DESCRIPTION
## Summary
- Added validation in the **Validate Inputs** step of `publish-packages.yml` to reject the `latest` tag when the workflow is triggered via `workflow_dispatch`
- Publishing as `latest` must go through the designated release workflow, not manual runs

## Test plan
- [ ] Trigger `publish-packages` via `workflow_dispatch` with `tag=latest` → expect the workflow to fail with a clear error message
- [ ] Trigger with any other tag (e.g. `beta`, `manual`) → expect no change in behavior
- [ ] Trigger via `workflow_call` with `tag=latest` → expect it to still work (restriction is `workflow_dispatch` only)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Manual `workflow_dispatch` runs were allowing the `latest` tag, which should only be published through the official release workflow to maintain tag integrity and prevent accidental overwrites. This adds a validation gate to block `latest` on manual runs while preserving existing push-based automation.

## 2. What Changed (Where)

- `.github/workflows/publish-packages.yml`: Added validation step blocking `latest` tag when `github.event_name == workflow_dispatch`

## 3. How It Works

Validation runs after the existing tag character check. If both conditions are true (`workflow_dispatch` trigger AND tag equals "latest"), the workflow exits with error message directing users to the release workflow. Push-based triggers remain unaffected.

## 4. Risks

None. This is purely restrictive — removes a footgun without affecting legitimate workflows.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
