### PR TITLE
Internal: Investigate and fix flaky test - Editing panel tabs @v4-tests [ED-23782]

### DIFF
--- a/tests/playwright/sanity/modules/v4-tests/editing-panel-tabs.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/editing-panel-tabs.test.ts
@@ -103,6 +103,11 @@ test.describe( 'Editing panel tabs @v4-tests', () => {
 	test( 'should maintain header tabs visibility during inner component scrolling', async () => {
 		await openScrollableStylePanel();
 
+		await test.step( 'Close the size section', async () => {
+			const sectionButton = editor.page.locator( '.MuiButtonBase-root', { hasText: 'Size' } );
+			await sectionButton.click();
+		} );
+
 		const panelHeader = editor.page.locator( 'button', { hasText: /^Style$/g } ).locator( '../../../..' );
 
 		await test.step( 'Open the font family control', async () => {

--- a/tests/playwright/sanity/modules/v4-tests/editing-panel-tabs.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/editing-panel-tabs.test.ts
@@ -3,6 +3,7 @@ import { parallelTest as test } from '../../../parallelTest';
 import { BrowserContext, expect } from '@playwright/test';
 import EditorPage from '../../../pages/editor-page';
 import { timeouts } from '../../../config/timeouts';
+import { FONT_FAMILIES } from './typography/typography-constants';
 
 test.describe( 'Editing panel tabs @v4-tests', () => {
 	let editor: EditorPage;
@@ -110,14 +111,14 @@ test.describe( 'Editing panel tabs @v4-tests', () => {
 			await fontFamilyControl.click();
 		} );
 
-		await test.step( 'Scroll the font family popover list to the end', async () => {
+		await test.step( 'Scroll the font family popover list slightly', async () => {
 			const scrollContainer = editor.page.locator( '[data-testid="item-list"]' ).locator( 'xpath=parent::*' );
-			await scrollContainer.evaluate( ( el: HTMLElement ) => {
-				el.scrollTop = el.scrollHeight;
-			} );
-
-			const googleFontFamilySubheaderName = editor.page.locator( '.MuiListSubheader-root', { hasText: 'Google (Early Access)' } );
-			await googleFontFamilySubheaderName.waitFor( { state: 'visible', timeout: timeouts.action } );
+			const arialFontFamilyLocator = editor.page.locator( '.MuiListItem-root', { hasText: FONT_FAMILIES.system } );
+			await expect( arialFontFamilyLocator ).toBeVisible();
+			await scrollContainer.evaluate(
+				( el: HTMLElement ) => el.scrollBy( 0, 100 ),
+			);
+			await expect( arialFontFamilyLocator ).not.toBeVisible();
 		} );
 
 		await expect.soft( panelHeader ).toHaveScreenshot( 'editing-panel-inner-scrolling.png' );

--- a/tests/playwright/sanity/modules/v4-tests/editing-panel-tabs.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/editing-panel-tabs.test.ts
@@ -103,12 +103,22 @@ test.describe( 'Editing panel tabs @v4-tests', () => {
 		await openScrollableStylePanel();
 
 		const panelHeader = editor.page.locator( 'button', { hasText: /^Style$/g } ).locator( '../../../..' );
-		const fontFamilyControl = editor.page
-			.locator( 'div.MuiGrid-container' )
-			.filter( { has: editor.page.locator( 'label', { hasText: 'Font family' } ) } );
 
-		await fontFamilyControl.scrollIntoViewIfNeeded();
-		await editor.page.waitForTimeout( timeouts.action );
+		await test.step( 'Open the font family control', async () => {
+			const fontFamilyControl = editor.page
+				.locator( '#font-family-control' ).getByRole( 'button' );
+			await fontFamilyControl.click();
+		} );
+
+		await test.step( 'Scroll the font family popover list to the end', async () => {
+			const scrollContainer = editor.page.locator( '[data-testid="item-list"]' ).locator( 'xpath=parent::*' );
+			await scrollContainer.evaluate( ( el: HTMLElement ) => {
+				el.scrollTop = el.scrollHeight;
+			} );
+
+			const googleFontFamilySubheaderName = editor.page.locator( '.MuiListSubheader-root', { hasText: 'Google (Early Access)' } );
+			await googleFontFamilySubheaderName.waitFor( { state: 'visible', timeout: timeouts.action } );
+		} );
 
 		await expect.soft( panelHeader ).toHaveScreenshot( 'editing-panel-inner-scrolling.png' );
 	} );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Test was flaky due to unreliable element selection and timing assumptions. Refactored to use explicit step-based controls with proper visibility checks and constants.

## 2. What Changed (Where)

- `editing-panel-tabs.test.ts`: Added font family constants import; rewrote font family test logic with three explicit test steps replacing fragile scroll-into-view pattern.

## 3. How It Works

Test now: closes Size section → opens font family dropdown → scrolls popover to verify header stays fixed. Uses data-testid and test.step() for clarity and debuggability.

## 4. Risks

None—improves reliability. Uses standard Playwright patterns (getByRole, test.step). Only concern: FONT_FAMILIES constant must exist and match actual UI labels.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
