### PR TITLE
Fix: [V4] Atomic Image with a link - The link HTML is broken [ED-23795]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-image/atomic-image.html.twig
+++ b/modules/atomic-widgets/elements/atomic-image/atomic-image.html.twig
@@ -1,6 +1,7 @@
 {% if settings.image.src is not empty %}
 	{% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}	
-	{% if settings.link and settings.link.attributes is not empty %}
+	{% set has_link = settings.link and settings.link.attributes is not empty %}
+	{% if has_link %}
 		<{{ settings.link.tag | e('html_tag') }}
 			{{ settings.link.attributes | raw }}
 			class="{{ base_styles['link-base'] }}"
@@ -20,7 +21,7 @@
 			{% endif %}
 		{% endfor %}
 	/>
-	{% if settings.link.href %}
+	{% if has_link %}
 		</{{ settings.link.tag | e('html_tag') }}>
 	{% endif %}
 {% endif %}

--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/__snapshots__/Test_Has_Template__test_render with data set Atomic Image default__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/__snapshots__/Test_Has_Template__test_render with data set Atomic Image default__1.txt
@@ -1,5 +1,5 @@
 					
-		<img class="e-image-base " 
+			<img class="e-image-base " 
 					data-interaction-id="e8e55a1" 
 		 
 		 

--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/__snapshots__/Test_Has_Template__test_render with data set Atomic Image linked__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/__snapshots__/Test_Has_Template__test_render with data set Atomic Image linked__1.txt
@@ -1,5 +1,5 @@
 					
-			<a
+				<a
 			href="https://example.com" target="_blank"
 			class="e-image-link-base"
 			data-interaction-id="e8e55a1"
@@ -11,4 +11,5 @@
 									id="123"
 												src="https://example.com/image.jpg"
 						/>
+			</a>
 			


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Image wrapping with links rendered broken HTML because the closing tag condition checked `settings.link.href` (which could exist even without attributes), while the opening tag conditionally rendered based on link attributes. Now both use consistent logic.

## 2. What Changed (Where)

`atomic-image.html.twig`: Extracted link existence check into reusable `has_link` variable (line 3) applied to both opening (line 4) and closing (line 24) tag conditions.

## 3. How It Works

Opens link tag only if `settings.link` and its attributes exist; closes only if opened. Eliminates asymmetric conditions that caused orphaned closing tags.

## 4. Risks

None — change is defensive and fixes a logic bug. Template renders fewer links now (safer), only when fully configured.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
