### PR TITLE
Fix: Add interaction migration script [ED-23796]

### DIFF
--- a/migrations/manifest.json
+++ b/migrations/manifest.json
@@ -25,6 +25,11 @@
       "fromType": "image-src",
       "toType": "svg-src",
       "path": "operations/image-src-to-svg-src.json"
+    },
+    "config-to-config-v2": {
+      "fromType": "config",
+      "toType": "config-v2",
+      "path": "operations/config-to-config-v2.json"
     }
   }
 }

--- a/migrations/operations/config-to-config-v2.json
+++ b/migrations/operations/config-to-config-v2.json
@@ -1,0 +1,24 @@
+{
+  "up": [
+    {
+      "op": { "fn": "move", "src": "value.start", "dest": "value.offsetTop", "clean": false }
+    },
+    {
+      "op": { "fn": "move", "src": "value.end", "dest": "value.offsetBottom", "clean": false }
+    },
+    {
+      "op": { "fn": "set", "path": "$$type", "value": "config-v2" }
+    }
+  ],
+  "down": [
+    {
+      "op": { "fn": "move", "src": "value.offsetTop", "dest": "value.start", "clean": false }
+    },
+    {
+      "op": { "fn": "move", "src": "value.offsetBottom", "dest": "value.end", "clean": false }
+    },
+    {
+      "op": { "fn": "set", "path": "$$type", "value": "config" }
+    }
+  ]
+}

--- a/migrations/operations/config-to-config-v2.json
+++ b/migrations/operations/config-to-config-v2.json
@@ -1,10 +1,10 @@
 {
   "up": [
     {
-      "op": { "fn": "move", "src": "value.start", "dest": "value.offsetTop", "clean": false }
+      "op": { "fn": "move", "src": "value.offsetTop", "dest": "value.start", "clean": false }
     },
     {
-      "op": { "fn": "move", "src": "value.end", "dest": "value.offsetBottom", "clean": false }
+      "op": { "fn": "move", "src": "value.offsetBottom", "dest": "value.end", "clean": false }
     },
     {
       "op": { "fn": "set", "path": "$$type", "value": "config-v2" }
@@ -12,10 +12,10 @@
   ],
   "down": [
     {
-      "op": { "fn": "move", "src": "value.offsetTop", "dest": "value.start", "clean": false }
+      "op": { "fn": "move", "src": "value.start", "dest": "value.offsetTop", "clean": false }
     },
     {
-      "op": { "fn": "move", "src": "value.offsetBottom", "dest": "value.end", "clean": false }
+      "op": { "fn": "move", "src": "value.end", "dest": "value.offsetBottom", "clean": false }
     },
     {
       "op": { "fn": "set", "path": "$$type", "value": "config" }

--- a/modules/interactions/props/animation-config-prop-type.php
+++ b/modules/interactions/props/animation-config-prop-type.php
@@ -6,6 +6,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Boolean_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\Interactions\Presets;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -24,8 +25,8 @@ class Animation_Config_Prop_Type extends Object_Prop_Type {
 			'relativeTo' => String_Prop_Type::make()->meta( 'pro', true )->description( 'The container scope used by scroll-based interactions' ),
 			'repeat' => String_Prop_Type::make()->meta( 'enum', Presets::REPEAT_OPTIONS )->default( Presets::DEFAULT_REPEAT )->meta( 'pro', true )->description( 'Repeat mode for interactions that can run multiple times' ),
 			'times' => Number_Prop_Type::make()->meta( 'pro', true )->description( 'Total number of times to play when repeat mode is "times"' ),
-			'start' => Number_Prop_Type::make()->meta( 'pro', true )->description( 'The start to use for the animation' ),
-			'end' => Number_Prop_Type::make()->meta( 'pro', true )->description( 'The end to use for the animation' ),
+			'start' => Size_Prop_Type::make()->units( '%' )->default_unit( '%' )->meta( 'pro', true )->description( 'The start to use for the animation' ),
+			'end' => Size_Prop_Type::make()->units( '%' )->default_unit( '%' )->meta( 'pro', true )->description( 'The end to use for the animation' ),
 		];
 	}
 }

--- a/modules/interactions/props/animation-config-prop-type.php
+++ b/modules/interactions/props/animation-config-prop-type.php
@@ -7,7 +7,6 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Boolean_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\Interactions\Presets;
-use Elementor\Modules\Interactions\Utils\Prop_Shape_Filter_For_Pro;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -15,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Animation_Config_Prop_Type extends Object_Prop_Type {
 	public static function get_key(): string {
-		return 'config';
+		return 'config-v2';
 	}
 
 	protected function define_shape(): array {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Migrating interaction animation configs from v1 to v2 schema, changing offset-based positioning (offsetTop/offsetBottom) to percentage-based sizing (start/end) with Size_Prop_Type. Ticket ED-23796.

## 2. What Changed (Where)

- **animation-config-prop-type.php**: Config key bumped to v2, Size_Prop_Type imported, start/end fields now use Size_Prop_Type instead of Number_Prop_Type.
- **manifest.json**: New migration route config→config-v2 registered.
- **config-to-config-v2.json**: Bidirectional migration ops mapping offsetTop↔start, offsetBottom↔end.

## 3. How It Works

Up migration maps legacy numeric offsets to percentage-based start/end values, updating the config type marker. Down migration reverses the transform for rollback support.

## 4. Risks

Migration assumes 1:1 offset-to-percentage mapping without validation—legacy numeric values may need unit conversion if semantics differ. Test with existing interaction data to verify no silent data loss during migration.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
