### PR TITLE
Research: Create an atomic list element

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -42,9 +42,12 @@ class Utils {
 		'header',
 		'main',
 		'nav',
+		'ol',
 		'p',
 		'section',
 		'span',
+		'ul',
+		'li',
 	];
 
 	const EXTENDED_ALLOWED_HTML_TAGS = [

--- a/modules/atomic-widgets/controls/types/elements/list-items-control.php
+++ b/modules/atomic-widgets/controls/types/elements/list-items-control.php
@@ -1,0 +1,18 @@
+<?php
+namespace Elementor\Modules\AtomicWidgets\Controls\Types\Elements;
+
+use Elementor\Modules\AtomicWidgets\Controls\Base\Element_Control_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class List_Items_Control extends Element_Control_Base {
+	public function get_type(): string {
+		return 'list-items';
+	}
+
+	public function get_props(): array {
+		return [];
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.html.twig
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.html.twig
@@ -1,5 +1,5 @@
 {% import 'elementor/macros' as m %}
-{%- set allowed_tags = '<b><strong><sup><sub><s><em><i><u><del><span><br>' -%}
+{%- set allowed_tags = '<b><strong><sup><sub><s><em><i><u><del><span><ul><ol><li><br>' -%}
 {%- set classes = settings.classes | merge( [ base_styles.base ] ) | join(' ') -%}
 {%- set id_attribute = settings._cssid is not empty ? 'id="' ~ settings._cssid | e('html_attr') ~ '"' : '' -%}
 {%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -5,7 +5,7 @@
 	{%- if id_attribute is not empty %} {{ id_attribute }}{% endif -%}
 	{%- if settings.attributes is defined and settings.attributes is not empty %} {{ settings.attributes | raw }}{% endif -%}
 >
-{%- set allowed_tags = '<b><strong><sup><sub><s><em><i><u><a><del><span><br>' -%}
+{%- set allowed_tags = '<b><strong><sup><sub><s><em><i><u><a><del><span><ul><ol><li><br>' -%}
 {%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
 	<{{ settings.link.tag | default('a') | e('html_tag') }}
 		{{- m.render_link_attributes(settings.link) }} class="{{ base_styles['link-base'] }}">

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list-item/atomic-list-item.html.twig
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list-item/atomic-list-item.html.twig
@@ -1,0 +1,2 @@
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+<li class="{{ classes }} {{ editor_classes | default('') }}" data-id="{{ id }}" data-element_type="{{ type }}" data-e-type="{{ type }}" data-interaction-id="{{ id }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" {{ settings.attributes | raw }} {{ editor_attributes | default('') | raw }}><!-- elementor-children-placeholder --></li>

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list-item/atomic-list-item.php
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list-item/atomic-list-item.php
@@ -1,0 +1,117 @@
+<?php
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item;
+
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Paragraph\Atomic_Paragraph;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Html_V3_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_States;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Atomic_List_Item extends Atomic_Element_Base {
+	use Has_Element_Template;
+
+	const BASE_STYLE_KEY = 'base';
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'llm_support', false );
+		$this->meta( 'is_container', true );
+	}
+
+	public static function get_type() {
+		return 'e-list-item';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-list-item';
+	}
+
+	public function get_title() {
+		return esc_html__( 'List item', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'list', 'item' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-list';
+	}
+
+	public function should_show_in_panel() {
+		return false;
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()
+				->default( [] ),
+			'attributes' => Attributes_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [] ),
+		];
+	}
+
+	protected function define_atomic_pseudo_states(): array {
+		return [
+			Style_States::get_custom_states_map()['list-item-marker'],
+		];
+	}
+
+	protected function define_base_styles(): array {
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+				),
+		];
+	}
+
+	protected function define_default_html_tag() {
+		return 'li';
+	}
+
+	protected function define_default_children() {
+		$position = $this->editor_settings['initial_position'] ?? 1;
+
+		return [
+			Atomic_Paragraph::generate()
+				->settings( [
+					'paragraph' => Html_V3_Prop_Type::generate( [
+						'content' => String_Prop_Type::generate( "Item #{$position}" ),
+						'children' => [],
+					] ),
+					'tag' => String_Prop_Type::generate( 'span' ),
+				] )
+				->build(),
+		];
+	}
+
+	protected function define_allowed_child_types() {
+		return [ Atomic_Paragraph::get_element_type() ];
+	}
+
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-list-item' => __DIR__ . '/atomic-list-item.html.twig',
+		];
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.html.twig
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.html.twig
@@ -1,2 +1,3 @@
 {% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{% set tag = (settings['list-type'] | default('unordered')) == 'ordered' ? 'ol' : 'ul' %}
 <{{ tag | e('html_tag') }} class="{{ classes }} {{ editor_classes | default('') }}" data-id="{{ id }}" data-element_type="{{ type }}" data-e-type="{{ type }}" data-interaction-id="{{ id }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" {{ settings.attributes | raw }} {{ editor_attributes | default('') | raw }}><!-- elementor-children-placeholder --></{{ tag | e('html_tag') }}>

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.html.twig
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.html.twig
@@ -1,0 +1,2 @@
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+<{{ tag | e('html_tag') }} class="{{ classes }} {{ editor_classes | default('') }}" data-id="{{ id }}" data-element_type="{{ type }}" data-e-type="{{ type }}" data-interaction-id="{{ id }}" data-interactions="{{ interactions | json_encode | e('html_attr') }}" {{ settings.attributes | raw }} {{ editor_attributes | default('') | raw }}><!-- elementor-children-placeholder --></{{ tag | e('html_tag') }}>

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.php
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.php
@@ -73,13 +73,17 @@ class Atomic_List extends Atomic_Element_Base {
 						->add_options( [
 							'unordered' => [
 								'title' => __( 'Unordered', 'elementor' ),
-								'atomic-icon' => 'eicon-bullet-list',
+								'atomic-icon' => 'ListIcon',
 							],
 							'ordered' => [
 								'title' => __( 'Ordered', 'elementor' ),
-								'atomic-icon' => 'eicon-number-field',
+								'atomic-icon' => 'Number123Icon',
 							],
 						] )
+						->set_exclusive( true )
+						->set_convert_options( true )
+						->set_size( 'tiny' )
+						->set_full_width( true )
 						->set_label( __( 'List Type', 'elementor' ) ),
 					List_Items_Control::make()
 						->set_label( __( 'List Items', 'elementor' ) )
@@ -142,14 +146,6 @@ class Atomic_List extends Atomic_Element_Base {
 
 	protected function define_allowed_child_types() {
 		return [ Atomic_List_Item::get_element_type() ];
-	}
-
-	protected function build_template_context(): array {
-		$settings = $this->get_atomic_settings();
-
-		return array_merge( $this->build_base_template_context(), [
-			'tag' => 'ordered' === ( $settings['list-type'] ?? 'unordered' ) ? 'ol' : 'ul',
-		] );
 	}
 
 	protected function get_templates(): array {

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.php
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.php
@@ -1,0 +1,160 @@
+<?php
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List;
+
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Elements\List_Items_Control;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Toggle_Control;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Paragraph\Atomic_Paragraph;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item\Atomic_List_Item;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Html_V3_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_States;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Atomic_List extends Atomic_Element_Base {
+	use Has_Element_Template;
+
+	const BASE_STYLE_KEY = 'base';
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'is_container', true );
+	}
+
+	public static function get_type() {
+		return 'e-list';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-list';
+	}
+
+	public function get_title() {
+		return esc_html__( 'List', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'list' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-bullet-list';
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()
+				->default( [] ),
+			'list-type' => String_Prop_Type::make()
+				->enum( [ 'unordered', 'ordered' ] )
+				->default( 'unordered' ),
+			'attributes' => Attributes_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Content', 'elementor' ) )
+				->set_id( 'content' )
+				->set_items( [
+					Toggle_Control::bind_to( 'list-type' )
+						->add_options( [
+							'unordered' => [
+								'title' => __( 'Unordered', 'elementor' ),
+								'atomic-icon' => 'eicon-bullet-list',
+							],
+							'ordered' => [
+								'title' => __( 'Ordered', 'elementor' ),
+								'atomic-icon' => 'eicon-number-field',
+							],
+						] )
+						->set_label( __( 'List Type', 'elementor' ) ),
+					List_Items_Control::make()
+						->set_label( __( 'List Items', 'elementor' ) )
+						->set_meta( [
+							'layout' => 'custom',
+						] ),
+				] ),
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [
+					Text_Control::bind_to( '_cssid' )
+						->set_label( __( 'ID', 'elementor' ) )
+						->set_meta( [
+							'layout' => 'two-columns',
+						] ),
+				] ),
+		];
+	}
+
+	protected function define_atomic_pseudo_states(): array {
+		return [
+			Style_States::get_custom_states_map()['list-markers'],
+		];
+	}
+
+	protected function define_base_styles(): array {
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+						->add_prop( 'display', String_Prop_Type::generate( 'block' ) )
+				),
+		];
+	}
+
+	protected function define_default_children() {
+		return array_map(
+			fn ( $index ) => Atomic_List_Item::generate()
+				->children( [
+					Atomic_Paragraph::generate()
+						->settings( [
+							'paragraph' => Html_V3_Prop_Type::generate( [
+								'content' => String_Prop_Type::generate( "Item #{$index}" ),
+								'children' => [],
+							] ),
+							'tag' => String_Prop_Type::generate( 'span' ),
+						] )
+						->build(),
+				] )
+				->editor_settings( [
+					'title' => "Item #{$index}",
+					'initial_position' => $index,
+				] )
+				->is_locked( true )
+				->build(),
+			range( 1, 3 )
+		);
+	}
+
+	protected function define_allowed_child_types() {
+		return [ Atomic_List_Item::get_element_type() ];
+	}
+
+	protected function build_template_context(): array {
+		$settings = $this->get_atomic_settings();
+
+		return array_merge( $this->build_base_template_context(), [
+			'tag' => 'ordered' === ( $settings['list-type'] ?? 'unordered' ) ? 'ol' : 'ul',
+		] );
+	}
+
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-list' => __DIR__ . '/atomic-list.html.twig',
+		];
+	}
+}

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -21,6 +21,8 @@ use Elementor\Modules\AtomicWidgets\Elements\Atomic_Tabs\Atomic_Tabs\Atomic_Tabs
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Tabs\Atomic_Tabs_Menu\Atomic_Tabs_Menu;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Tabs\Atomic_Tab\Atomic_Tab;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Tabs\Atomic_Tabs_Content_Area\Atomic_Tabs_Content_Area;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List\Atomic_List;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item\Atomic_List_Item;
 use Elementor\Modules\AtomicWidgets\ImportExport\Atomic_Import_Export;
 use Elementor\Modules\AtomicWidgets\Elements\Loader\Frontend_Assets_Loader;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Combine_Array_Transformer;
@@ -301,6 +303,9 @@ class Module extends BaseModule {
 		$elements_manager->register_element_type( new Atomic_Tab() );
 		$elements_manager->register_element_type( new Atomic_Tabs_Content_Area() );
 		$elements_manager->register_element_type( new Atomic_Tab_Content() );
+
+		$elements_manager->register_element_type( new Atomic_List() );
+		$elements_manager->register_element_type( new Atomic_List_Item() );
 
 		if ( \Elementor\Utils::has_pro() && Plugin::$instance->experiments->is_feature_active( 'e_pro_atomic_form' ) ) {
 			$elements_manager->register_element_type( new Atomic_Form() );

--- a/modules/atomic-widgets/props-resolver/transformers/image-src-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/image-src-transformer.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Image_Src_Transformer extends Transformer_Base {
+	const LIST_STYLE_IMAGE_KEY = 'list-style-image';
 
 	/**
 	 * This transformer (or rather this prop type) exists only to support dynamic images.
@@ -17,9 +18,27 @@ class Image_Src_Transformer extends Transformer_Base {
 	 * what, so we need to keep the same structure in the props.
 	 */
 	public function transform( $value, Props_Resolver_Context $context ) {
+		if ( self::LIST_STYLE_IMAGE_KEY === $context->get_key() ) {
+			$image_url = $this->get_image_url( $value );
+
+			return $image_url ? 'url("' . esc_url( $image_url ) . '")' : null;
+		}
+
 		return [
 			'id' => isset( $value['id'] ) ? (int) $value['id'] : null,
 			'url' => $value['url'] ?? null,
 		];
+	}
+
+	private function get_image_url( array $value ): ?string {
+		if ( ! empty( $value['id'] ) ) {
+			$image = wp_get_attachment_image_src( (int) $value['id'], 'full' );
+
+			if ( $image ) {
+				return $image[0];
+			}
+		}
+
+		return $value['url'] ?? null;
 	}
 }

--- a/modules/atomic-widgets/styles/style-schema.php
+++ b/modules/atomic-widgets/styles/style-schema.php
@@ -13,6 +13,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Dimensions_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Backdrop_Filter_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Filter_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Image_Src_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Layout_Direction_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Position_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
@@ -44,6 +45,7 @@ class Style_Schema {
 			self::get_background_props(),
 			self::get_effects_props(),
 			self::get_layout_props(),
+			self::get_list_props(),
 			self::get_alignment_props(),
 			self::get_special_props(),
 		);
@@ -392,6 +394,21 @@ class Style_Schema {
 				'stretch',
 			] )->description( 'Allows the default alignment (or the one specified by align-items) to be overridden for individual flex items. CSS values: auto, normal, center, start, end, self-start, self-end, flex-start, flex-end, anchor-center, baseline, first baseline, last baseline, stretch' ),
 			'order' => Number_Prop_Type::make()->description( 'Specifies the order of the flex items. Items with lower order values are displayed first.' ),
+		];
+	}
+
+	private static function get_list_props() {
+		return [
+			'list-style-type' => String_Prop_Type::make()
+				->description( 'The list-style-type CSS property.' ),
+			'list-style-position' => String_Prop_Type::make()
+				->enum( [
+					'inside',
+					'outside',
+				] )
+				->description( 'The list-style-position CSS property.' ),
+			'list-style-image' => Image_Src_Prop_Type::make()
+				->description( 'The list-style-image CSS property.' ),
 		];
 	}
 

--- a/modules/atomic-widgets/styles/style-states.php
+++ b/modules/atomic-widgets/styles/style-states.php
@@ -10,6 +10,8 @@ class Style_States {
 	const CHECKED = 'checked';
 
 	const SELECTED = 'e--selected';
+	const LIST_MARKERS = ' > li::marker';
+	const LIST_ITEM_MARKER = '::marker';
 
 	private static function get_pseudo_states(): array {
 		return [
@@ -24,6 +26,13 @@ class Style_States {
 	private static function get_class_states(): array {
 		return [
 			self::SELECTED,
+		];
+	}
+
+	private static function get_custom_states(): array {
+		return [
+			self::LIST_MARKERS,
+			self::LIST_ITEM_MARKER,
 		];
 	}
 
@@ -67,6 +76,7 @@ class Style_States {
 				return ! in_array( $state, self::get_additional_states_map()[ $state ] ?? [], true );
 			} ),
 			...self::get_class_states(),
+			...self::get_custom_states(),
 			null,
 		];
 	}
@@ -101,6 +111,19 @@ class Style_States {
 			'checked' => [
 				'name' => 'checked',
 				'value' => self::CHECKED,
+			],
+		];
+	}
+
+	public static function get_custom_states_map(): array {
+		return [
+			'list-markers' => [
+				'name' => 'List Markers',
+				'value' => self::LIST_MARKERS,
+			],
+			'list-item-marker' => [
+				'name' => 'List Item Marker',
+				'value' => self::LIST_ITEM_MARKER,
 			],
 		];
 	}

--- a/packages/packages/core/editor-canvas/src/__tests__/styles-prop-resolver.test.ts
+++ b/packages/packages/core/editor-canvas/src/__tests__/styles-prop-resolver.test.ts
@@ -271,6 +271,18 @@ describe( 'styles prop resolver', () => {
 			},
 		},
 		{
+			name: 'list style image url',
+			props: {
+				'list-style-image': imageSrcPropTypeUtil.create( {
+					id: null,
+					url: 'https://localhost.test/list-marker.png',
+				} ),
+			},
+			expected: {
+				'list-style-image': 'url("https://localhost.test/list-marker.png")',
+			},
+		},
+		{
 			name: 'background (only color)',
 			props: {
 				background: backgroundPropTypeUtil.create( {

--- a/packages/packages/core/editor-canvas/src/renderers/__tests__/create-dom-renderer.test.ts
+++ b/packages/packages/core/editor-canvas/src/renderers/__tests__/create-dom-renderer.test.ts
@@ -10,10 +10,22 @@ describe( 'createDomRenderer', () => {
 			expected: 'Hello StyleShit',
 		},
 		{
-			title: 'allowed html tags',
+			title: 'allowed html tag ul',
 			template: `<{{ tag | e( 'html_tag' ) }}></{{ tag | e( 'html_tag' ) }}>`,
-			context: { tag: 'a' },
-			expected: '<a></a>',
+			context: { tag: 'ul' },
+			expected: '<ul></ul>',
+		},
+		{
+			title: 'allowed html tag ol',
+			template: `<{{ tag | e( 'html_tag' ) }}></{{ tag | e( 'html_tag' ) }}>`,
+			context: { tag: 'ol' },
+			expected: '<ol></ol>',
+		},
+		{
+			title: 'allowed html tag li',
+			template: `<{{ tag | e( 'html_tag' ) }}></{{ tag | e( 'html_tag' ) }}>`,
+			context: { tag: 'li' },
+			expected: '<li></li>',
 		},
 		{
 			title: 'disallowed html tags',

--- a/packages/packages/core/editor-canvas/src/renderers/create-dom-renderer.ts
+++ b/packages/packages/core/editor-canvas/src/renderers/create-dom-renderer.ts
@@ -33,11 +33,14 @@ function escapeHtmlTag( value: string ) {
 		'h5',
 		'h6',
 		'header',
+		'li',
 		'main',
 		'nav',
+		'ol',
 		'p',
 		'section',
 		'span',
+		'ul',
 	];
 
 	return allowedTags.includes( value ) ? value : 'div';

--- a/packages/packages/core/editor-canvas/src/transformers/shared/image-src-transformer.ts
+++ b/packages/packages/core/editor-canvas/src/transformers/shared/image-src-transformer.ts
@@ -1,3 +1,5 @@
+import { getMediaAttachment } from '@elementor/wp-media';
+
 import { createTransformer } from '../create-transformer';
 
 type ImageSrc = {
@@ -5,7 +7,27 @@ type ImageSrc = {
 	url?: unknown;
 };
 
-export const imageSrcTransformer = createTransformer( ( value: ImageSrc ) => ( {
-	id: value.id ?? null,
-	url: value.url ?? null,
-} ) );
+export const imageSrcTransformer = createTransformer( async ( value: ImageSrc, { key } ) => {
+	if ( key === 'list-style-image' ) {
+		const imageUrl = await getImageUrl( value );
+
+		return imageUrl ? `url("${ imageUrl }")` : null;
+	}
+
+	return {
+		id: value.id ?? null,
+		url: value.url ?? null,
+	};
+} );
+
+async function getImageUrl( value: ImageSrc ) {
+	if ( typeof value.id === 'number' ) {
+		const attachment = await getMediaAttachment( { id: value.id } );
+
+		if ( attachment?.url ) {
+			return attachment.url;
+		}
+	}
+
+	return typeof value.url === 'string' ? value.url : null;
+}

--- a/packages/packages/core/editor-canvas/src/transformers/shared/image-src-transformer.ts
+++ b/packages/packages/core/editor-canvas/src/transformers/shared/image-src-transformer.ts
@@ -1,13 +1,14 @@
 import { getMediaAttachment } from '@elementor/wp-media';
 
 import { createTransformer } from '../create-transformer';
+import type { TransformerOptions } from '../types';
 
 type ImageSrc = {
 	id?: unknown;
 	url?: unknown;
 };
 
-export const imageSrcTransformer = createTransformer( async ( value: ImageSrc, { key } ) => {
+export const imageSrcTransformer = createTransformer( async ( value: ImageSrc, { key }: TransformerOptions ) => {
 	if ( key === 'list-style-image' ) {
 		const imageUrl = await getImageUrl( value );
 

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/list-section/list-section.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/list-section/list-section.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { ImageMediaControl, SelectControl } from '@elementor/editor-controls';
+import { __ } from '@wordpress/i18n';
+
+import { StylesField } from '../../../controls-registry/styles-field';
+import { SectionContent } from '../../section-content';
+import { StylesFieldLayout } from '../../styles-field-layout';
+
+const LIST_STYLE_TYPE_LABEL = __( 'Marker type', 'elementor' );
+const LIST_STYLE_POSITION_LABEL = __( 'Marker position', 'elementor' );
+const LIST_STYLE_IMAGE_LABEL = __( 'Marker image', 'elementor' );
+
+const listStyleTypeOptions = [
+	{ label: __( 'Disc', 'elementor' ), value: 'disc' },
+	{ label: __( 'Circle', 'elementor' ), value: 'circle' },
+	{ label: __( 'Square', 'elementor' ), value: 'square' },
+	{ label: __( 'Decimal', 'elementor' ), value: 'decimal' },
+	{ label: __( 'Lower alpha', 'elementor' ), value: 'lower-alpha' },
+	{ label: __( 'Upper alpha', 'elementor' ), value: 'upper-alpha' },
+	{ label: __( 'Lower roman', 'elementor' ), value: 'lower-roman' },
+	{ label: __( 'Upper roman', 'elementor' ), value: 'upper-roman' },
+];
+
+const listStylePositionOptions = [
+	{ label: __( 'Outside', 'elementor' ), value: 'outside' },
+	{ label: __( 'Inside', 'elementor' ), value: 'inside' },
+];
+
+export const ListSection = () => {
+	return (
+		<SectionContent>
+			<StylesField bind="list-style-type" propDisplayName={ LIST_STYLE_TYPE_LABEL }>
+				<StylesFieldLayout label={ LIST_STYLE_TYPE_LABEL }>
+					<SelectControl options={ listStyleTypeOptions } />
+				</StylesFieldLayout>
+			</StylesField>
+			<StylesField bind="list-style-position" propDisplayName={ LIST_STYLE_POSITION_LABEL }>
+				<StylesFieldLayout label={ LIST_STYLE_POSITION_LABEL }>
+					<SelectControl options={ listStylePositionOptions } />
+				</StylesFieldLayout>
+			</StylesField>
+			<StylesField bind="list-style-image" propDisplayName={ LIST_STYLE_IMAGE_LABEL }>
+				<StylesFieldLayout label={ LIST_STYLE_IMAGE_LABEL }>
+					<ImageMediaControl />
+				</StylesFieldLayout>
+			</StylesField>
+		</SectionContent>
+	);
+};

--- a/packages/packages/core/editor-editing-panel/src/components/style-tab.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-tab.tsx
@@ -20,6 +20,7 @@ import { BackgroundSection } from './style-sections/background-section/backgroun
 import { BorderSection } from './style-sections/border-section/border-section';
 import { EffectsSection } from './style-sections/effects-section/effects-section';
 import { LayoutSection } from './style-sections/layout-section/layout-section';
+import { ListSection } from './style-sections/list-section/list-section';
 import { PositionSection } from './style-sections/position-section/position-section';
 import { SizeSection } from './style-sections/size-section/size-section';
 import { SpacingSection } from './style-sections/spacing-section/spacing-section';
@@ -40,6 +41,7 @@ export const stickyHeaderStyles = {
 
 export const StyleTab = () => {
 	const currentClassesProp = useCurrentClassesProp();
+	const { element } = useElement();
 	const [ activeStyleDefId, setActiveStyleDefId ] = useActiveStyleDefId( currentClassesProp ?? '' );
 	const [ activeStyleState, setActiveStyleState ] = useState< StyleDefinitionState | null >( null );
 	const breakpoint = useActiveBreakpoint();
@@ -140,6 +142,16 @@ export const StyleTab = () => {
 									'stroke',
 								] }
 							/>
+							{ isListElement( element.type ) && (
+								<StyleTabSection
+									section={ {
+										component: ListSection,
+										name: 'List',
+										title: __( 'List', 'elementor' ),
+									} }
+									fields={ [ 'list-style-type', 'list-style-position', 'list-style-image' ] }
+								/>
+							) }
 							<StyleTabSection
 								section={ {
 									component: BackgroundSection,
@@ -191,6 +203,10 @@ function ClassesHeader( { children }: { children: React.ReactNode } ) {
 			{ children }
 		</Stack>
 	);
+}
+
+function isListElement( elementType: string ) {
+	return [ 'e-list', 'e-list-item' ].includes( elementType );
 }
 
 function useCurrentClassesProp(): string | null {

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/list-items-control.tsx
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/list-items-control.tsx
@@ -1,0 +1,222 @@
+import * as React from 'react';
+import {
+	ControlFormLabel,
+	Repeater,
+	type RepeaterItem,
+	type SetRepeaterValuesMeta,
+} from '@elementor/editor-controls';
+import {
+	createElements,
+	type CreateElementParams,
+	duplicateElements,
+	getContainer,
+	moveElements,
+	removeElements,
+	updateElementEditorSettings,
+	useElementEditorSettings,
+	type V1Element,
+	type V1ElementModelProps,
+} from '@elementor/editor-elements';
+import { type CreateOptions } from '@elementor/editor-props';
+import { __privateUseListenTo as useListenTo, commandEndEvent, v1ReadyEvent } from '@elementor/editor-v1-adapters';
+import { Stack, TextField } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import { useElement } from '../../../contexts/element-context';
+
+const LIST_ITEM_ELEMENT_TYPE = 'e-list-item';
+
+type ListItem = {
+	id: string;
+	title?: string;
+};
+
+export const ListItemsControl = ( { label }: { label: string } ) => {
+	const { element } = useElement();
+	const listItems = useListItems( element.id );
+
+	const repeaterValues: RepeaterItem< ListItem >[] = listItems.map( ( item, index ) => ( {
+		id: item.id,
+		title: item.editorSettings?.title,
+		index,
+	} ) );
+
+	const setValue = (
+		_newValues: RepeaterItem< ListItem >[],
+		_options: CreateOptions,
+		meta?: SetRepeaterValuesMeta< RepeaterItem< ListItem > >
+	) => {
+		if ( meta?.action?.type === 'add' ) {
+			meta.action.payload.forEach( ( { index } ) => addItem( element.id, index ) );
+		}
+
+		if ( meta?.action?.type === 'remove' ) {
+			removeElements( {
+				title: __( 'List Items', 'elementor' ),
+				elementIds: meta.action.payload.map( ( { item } ) => item.id ),
+			} );
+		}
+
+		if ( meta?.action?.type === 'duplicate' ) {
+			meta.action.payload.forEach( ( { item } ) => {
+				duplicateElements( {
+					title: __( 'Duplicate List Item', 'elementor' ),
+					elementIds: [ item.id ],
+				} );
+			} );
+		}
+
+		if ( meta?.action?.type === 'reorder' ) {
+			const { from, to } = meta.action.payload;
+			const movedElement = getContainer( listItems[ from ]?.id );
+			const targetContainer = getContainer( element.id );
+
+			if ( movedElement && targetContainer ) {
+				moveElements( {
+					title: __( 'Reorder List Items', 'elementor' ),
+					moves: [
+						{
+							element: movedElement,
+							targetContainer,
+							options: { at: to },
+						},
+					],
+				} );
+			}
+		}
+	};
+
+	return (
+		<Repeater
+			showToggle={ false }
+			values={ repeaterValues }
+			setValues={ setValue }
+			showRemove={ repeaterValues.length > 1 }
+			label={ label }
+			itemSettings={ {
+				getId: ( { item } ) => item.id,
+				initialValues: { id: '', title: __( 'Item', 'elementor' ) },
+				Label: ItemLabel,
+				Content: ItemContent,
+				Icon: () => null,
+			} }
+		/>
+	);
+};
+
+function useListItems( elementId: string ) {
+	return useListenTo(
+		[
+			v1ReadyEvent(),
+			commandEndEvent( 'document/elements/create' ),
+			commandEndEvent( 'document/elements/delete' ),
+			commandEndEvent( 'document/elements/update' ),
+			commandEndEvent( 'document/elements/set-settings' ),
+		],
+		() => {
+			const container = getContainer( elementId );
+
+			return ( container?.children ?? [] )
+				.filter( ( child: V1Element ) => child.model.get( 'elType' ) === LIST_ITEM_ELEMENT_TYPE )
+				.map( ( child: V1Element ) => ( {
+					id: child.id,
+					editorSettings: child.model.get( 'editor_settings' ) ?? {},
+				} ) );
+		},
+		[ elementId ]
+	);
+}
+
+function addItem( elementId: string, index: number ) {
+	const container = getContainer( elementId );
+
+	if ( ! container ) {
+		return;
+	}
+
+	const position = index + 1;
+
+	createElements( {
+		title: __( 'List Items', 'elementor' ),
+		elements: [
+			{
+				container,
+				model: createListItemModel( position ),
+				options: { at: index },
+			},
+		],
+	} );
+}
+
+function createListItemModel( position: number ): CreateElementParams[ 'model' ] {
+	const paragraph = `Item #${ position }`;
+	const paragraphChild = {
+		elType: 'widget',
+		widgetType: 'e-paragraph',
+		settings: {
+			paragraph: {
+				$$type: 'html-v3',
+				value: {
+					content: {
+						$$type: 'string',
+						value: paragraph,
+					},
+					children: [],
+				},
+			},
+			tag: {
+				$$type: 'string',
+				value: 'span',
+			},
+		},
+	};
+
+	return {
+		elType: LIST_ITEM_ELEMENT_TYPE,
+		isLocked: true,
+		editor_settings: {
+			title: paragraph,
+			initial_position: position,
+		},
+		elements: [ paragraphChild ] as unknown as V1ElementModelProps[ 'elements' ],
+	};
+}
+
+const ItemLabel = ( { value }: { value: ListItem } ) => {
+	const editorSettings = useElementEditorSettings( value.id );
+
+	return <span>{ editorSettings?.title || value?.title || __( 'Item', 'elementor' ) }</span>;
+};
+
+const ItemContent = ( { value }: { value: ListItem } ) => {
+	if ( ! value.id ) {
+		return null;
+	}
+
+	return (
+		<Stack p={ 2 } gap={ 1 }>
+			<ListItemTitleControl elementId={ value.id } />
+		</Stack>
+	);
+};
+
+const ListItemTitleControl = ( { elementId }: { elementId: string } ) => {
+	const editorSettings = useElementEditorSettings( elementId );
+	const title = editorSettings?.title ?? '';
+
+	return (
+		<>
+			<ControlFormLabel>{ __( 'Item name', 'elementor' ) }</ControlFormLabel>
+			<TextField
+				size="tiny"
+				value={ title }
+				onChange={ ( { target }: React.ChangeEvent< HTMLInputElement > ) => {
+					updateElementEditorSettings( {
+						elementId,
+						settings: { title: target.value },
+					} );
+				} }
+			/>
+		</>
+	);
+};

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/list-items-control.tsx
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/list-items-control.tsx
@@ -180,6 +180,7 @@ function createListItemModel( position: number ): CreateElementParams[ 'model' ]
 				value: 'span',
 			},
 		},
+		elements: [],
 	};
 
 	return {

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/list-items-control.tsx
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/list-items-control.tsx
@@ -23,6 +23,7 @@ import { Stack, TextField } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { useElement } from '../../../contexts/element-context';
+import { SettingsField } from '../../settings-field';
 
 const LIST_ITEM_ELEMENT_TYPE = 'e-list-item';
 
@@ -32,6 +33,14 @@ type ListItem = {
 };
 
 export const ListItemsControl = ( { label }: { label: string } ) => {
+	return (
+		<SettingsField bind="list-type" propDisplayName={ __( 'List Items', 'elementor' ) }>
+			<ListItemsControlContent label={ label } />
+		</SettingsField>
+	);
+};
+
+const ListItemsControlContent = ( { label }: { label: string } ) => {
 	const { element } = useElement();
 	const listItems = useListItems( element.id );
 
@@ -202,7 +211,11 @@ const ItemContent = ( { value }: { value: ListItem } ) => {
 
 const ListItemTitleControl = ( { elementId }: { elementId: string } ) => {
 	const editorSettings = useElementEditorSettings( elementId );
-	const title = editorSettings?.title ?? '';
+	const [ title, setTitle ] = React.useState( editorSettings?.title ?? '' );
+
+	React.useEffect( () => {
+		setTitle( editorSettings?.title ?? '' );
+	}, [ editorSettings?.title ] );
 
 	return (
 		<>
@@ -211,6 +224,7 @@ const ListItemTitleControl = ( { elementId }: { elementId: string } ) => {
 				size="tiny"
 				value={ title }
 				onChange={ ( { target }: React.ChangeEvent< HTMLInputElement > ) => {
+					setTitle( target.value );
 					updateElementEditorSettings( {
 						elementId,
 						settings: { title: target.value },

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/list-items-control.tsx
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/list-items-control.tsx
@@ -9,6 +9,7 @@ import {
 	createElements,
 	type CreateElementParams,
 	duplicateElements,
+	generateElementId,
 	getContainer,
 	moveElements,
 	removeElements,
@@ -160,6 +161,7 @@ function addItem( elementId: string, index: number ) {
 function createListItemModel( position: number ): CreateElementParams[ 'model' ] {
 	const paragraph = `Item #${ position }`;
 	const paragraphChild = {
+		id: generateElementId(),
 		elType: 'widget',
 		widgetType: 'e-paragraph',
 		settings: {

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/registry.ts
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/registry.ts
@@ -1,9 +1,11 @@
 import { type ControlComponent } from '@elementor/editor-controls';
 
 import { type ControlRegistry, controlsRegistry } from '../controls-registry';
+import { ListItemsControl } from './list-items-control/list-items-control';
 import { TabsControl } from './tabs-control/tabs-control';
 
 const controlTypes = {
+	'list-items': { component: ListItemsControl as ControlComponent, layout: 'full' },
 	tabs: { component: TabsControl as ControlComponent, layout: 'full' },
 } as const satisfies ControlRegistry;
 

--- a/packages/packages/libs/editor-controls/src/index.ts
+++ b/packages/packages/libs/editor-controls/src/index.ts
@@ -1,5 +1,6 @@
 // control types
 export { ImageControl } from './controls/image-control';
+export { ImageMediaControl } from './controls/image-media-control';
 export { TextControl } from './controls/text-control';
 export { TextAreaControl } from './controls/text-area-control';
 export { MentionTextAreaControl } from './controls/mention-text-area-control';

--- a/packages/packages/libs/editor-styles/src/types.ts
+++ b/packages/packages/libs/editor-styles/src/types.ts
@@ -8,6 +8,8 @@ export type ClassState = {
 
 export type StyleDefinitionAdditionalPseudoState = 'focus-visible';
 
+export type StyleDefinitionCustomSelectorState = ' > li::marker' | '::marker';
+
 export type StyleDefinitionPseudoState =
 	| 'hover'
 	| 'focus'
@@ -17,7 +19,10 @@ export type StyleDefinitionPseudoState =
 
 export type StyleDefinitionClassState = ClassState[ 'value' ];
 
-export type StyleDefinitionStateType = StyleDefinitionPseudoState | StyleDefinitionClassState;
+export type StyleDefinitionStateType =
+	| StyleDefinitionPseudoState
+	| StyleDefinitionClassState
+	| StyleDefinitionCustomSelectorState;
 
 export type StyleDefinitionState = null | Exclude< StyleDefinitionStateType, StyleDefinitionAdditionalPseudoState >;
 

--- a/packages/packages/libs/editor-styles/src/utils/state-utils.ts
+++ b/packages/packages/libs/editor-styles/src/utils/state-utils.ts
@@ -1,6 +1,7 @@
 import {
 	type StyleDefinitionAdditionalPseudoState,
 	type StyleDefinitionClassState,
+	type StyleDefinitionCustomSelectorState,
 	type StyleDefinitionPseudoState,
 	type StyleDefinitionState,
 	type StyleDefinitionStateType,
@@ -18,7 +19,9 @@ function getAdditionalStates( state: StyleDefinitionState ): StyleDefinitionAddi
 	return [];
 }
 
-function getStateSelector( state: StyleDefinitionPseudoState | StyleDefinitionClassState ) {
+function getStateSelector(
+	state: StyleDefinitionPseudoState | StyleDefinitionClassState | StyleDefinitionCustomSelectorState
+) {
 	if ( isClassState( state ) ) {
 		return `.${ state }`;
 	}

--- a/packages/tests/test-utils/mock-styles-schema.ts
+++ b/packages/tests/test-utils/mock-styles-schema.ts
@@ -3,6 +3,29 @@ import { type PropsSchema } from '@elementor/editor-props';
 import { createMockSingleSizeFilterPropType } from './create-mock-filter-schema';
 
 export const mockStylesSchema = {
+	'list-style-image': {
+		kind: 'object',
+		key: 'image-src',
+		default: null,
+		meta: {},
+		settings: {},
+		shape: {
+			id: {
+				kind: 'plain',
+				key: 'image-attachment-id',
+				default: null,
+				meta: {},
+				settings: {},
+			},
+			url: {
+				kind: 'plain',
+				key: 'url',
+				default: null,
+				meta: {},
+				settings: {},
+			},
+		},
+	},
 	'font-size': {
 		kind: 'object',
 		key: 'size',

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/test-styles-renderer.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/test-styles-renderer.php
@@ -5,6 +5,7 @@ namespace Elementor\Testing\Modules\AtomicWidgets\Styles;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Render_Props_Resolver;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformer_Base;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Image_Src_Prop_Type;
 use Elementor\Testing\Modules\AtomicWidgets\Props_Factory;
 use Elementor\Utils;
 use Spatie\Snapshots\MatchesSnapshots;
@@ -145,6 +146,72 @@ class Test_Styles_Renderer extends Elementor_Test_Base {
 
 		// Assert.
 		$this->assertMatchesSnapshot( $css );
+	}
+
+	public function test_render__list_style_props_and_marker_states() {
+		// Arrange.
+		add_filter( 'wp_get_attachment_image_src', function () {
+			return [
+				'https://example.com/marker.png',
+				20,
+				20,
+			];
+		} );
+
+		$styles = [
+			[
+				'id' => 'test-list',
+				'type' => 'class',
+				'variants' => [
+					[
+						'props' => [
+							'list-style-type' => 'square',
+							'list-style-position' => 'inside',
+						],
+						'meta' => [],
+					],
+					[
+						'props' => [
+							'color' => 'red',
+							'list-style-image' => Image_Src_Prop_Type::generate( [
+								'id' => [
+									'$$type' => 'image-attachment-id',
+									'value' => 3,
+								],
+								'url' => null,
+							] ),
+						],
+						'meta' => [
+							'state' => ' > li::marker',
+						],
+					],
+				],
+			],
+			[
+				'id' => 'test-list-item',
+				'type' => 'class',
+				'variants' => [
+					[
+						'props' => [
+							'color' => 'blue',
+						],
+						'meta' => [
+							'state' => '::marker',
+						],
+					],
+				],
+			],
+		];
+
+		$stylesRenderer = Styles_Renderer::make( [], '' );
+
+		// Act.
+		$css = $stylesRenderer->render( $styles );
+
+		// Assert.
+		$this->assertStringContainsString( '.test-list{list-style-type:square;list-style-position:inside;}', $css );
+		$this->assertStringContainsString( '.test-list > li::marker{color:red;list-style-image:url("https://example.com/marker.png");}', $css );
+		$this->assertStringContainsString( '.test-list-item::marker{color:blue;}', $css );
 	}
 
 	public function test_render__style_variant_with_breakpoint() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-list.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-list.php
@@ -1,0 +1,136 @@
+<?php
+
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List\Atomic_List;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item\Atomic_List_Item;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Paragraph\Atomic_Paragraph;
+use Elementor\Modules\AtomicWidgets\PropTypes\Html_V3_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+class Test_Atomic_List extends Elementor_Test_Base {
+	public function test__render_unordered_list(): void {
+		// Arrange.
+		$instance = $this->create_list_instance( 'unordered' );
+
+		// Act.
+		ob_start();
+		$instance->print_element();
+		$rendered_output = ob_get_clean();
+
+		// Assert.
+		$this->assertStringContainsString( '<ul ', $rendered_output );
+		$this->assertStringContainsString( '</ul>', $rendered_output );
+		$this->assertStringNotContainsString( '<ol ', $rendered_output );
+		$this->assertSame( 3, substr_count( $rendered_output, '<li ' ) );
+		$this->assertStringContainsString( 'Item #1', $rendered_output );
+		$this->assertStringContainsString( 'Item #2', $rendered_output );
+		$this->assertStringContainsString( 'Item #3', $rendered_output );
+	}
+
+	public function test__render_ordered_list(): void {
+		// Arrange.
+		$instance = $this->create_list_instance( 'ordered' );
+
+		// Act.
+		ob_start();
+		$instance->print_element();
+		$rendered_output = ob_get_clean();
+
+		// Assert.
+		$this->assertStringContainsString( '<ol ', $rendered_output );
+		$this->assertStringContainsString( '</ol>', $rendered_output );
+		$this->assertStringNotContainsString( '<ul ', $rendered_output );
+		$this->assertSame( 3, substr_count( $rendered_output, '<li ' ) );
+	}
+
+	public function test__list_config_contains_default_locked_items(): void {
+		// Arrange.
+		$instance = Plugin::$instance->elements_manager->create_element_instance( [
+			'id' => 'list',
+			'elType' => Atomic_List::get_element_type(),
+			'settings' => [],
+			'widgetType' => Atomic_List::get_element_type(),
+		] );
+
+		// Act.
+		$config = $instance->get_config();
+		$children = $config['default_children'];
+
+		// Assert.
+		$this->assertTrue( $config['show_in_panel'] );
+		$this->assertSame( [ Atomic_List_Item::get_element_type() ], $config['allowed_child_types'] );
+		$this->assertSame( 'List Markers', $config['atomic_pseudo_states'][0]['name'] );
+		$this->assertSame( ' > li::marker', $config['atomic_pseudo_states'][0]['value'] );
+		$this->assertCount( 3, $children );
+
+		foreach ( $children as $index => $child ) {
+			$item_number = $index + 1;
+
+			$this->assertSame( Atomic_List_Item::get_element_type(), $child['elType'] );
+			$this->assertTrue( $child['isLocked'] );
+			$this->assertSame( "Item #{$item_number}", $child['editor_settings']['title'] );
+			$this->assertCount( 1, $child['elements'] );
+			$this->assertSame( Atomic_Paragraph::get_element_type(), $child['elements'][0]['elType'] );
+			$this->assertSame( 'span', $child['elements'][0]['settings']['tag']['value'] );
+			$this->assertSame( "Item #{$item_number}", $child['elements'][0]['settings']['paragraph']['value']['content']['value'] );
+		}
+	}
+
+	public function test__list_item_config_is_internal_and_semantic(): void {
+		// Arrange.
+		$instance = Plugin::$instance->elements_manager->create_element_instance( [
+			'id' => 'list-item',
+			'elType' => Atomic_List_Item::get_element_type(),
+			'settings' => [],
+			'widgetType' => Atomic_List_Item::get_element_type(),
+		] );
+
+		// Act.
+		$config = $instance->get_config();
+
+		// Assert.
+		$this->assertFalse( $config['show_in_panel'] );
+		$this->assertSame( 'li', $config['default_html_tag'] );
+		$this->assertSame( [ Atomic_Paragraph::get_element_type() ], $config['allowed_child_types'] );
+		$this->assertSame( 'List Item Marker', $config['atomic_pseudo_states'][0]['name'] );
+		$this->assertSame( '::marker', $config['atomic_pseudo_states'][0]['value'] );
+	}
+
+	private function create_list_instance( string $list_type ): object {
+		$children = [];
+
+		foreach ( range( 1, 3 ) as $index ) {
+			$children[] = [
+				'id' => "item-{$index}",
+				'elType' => Atomic_List_Item::get_element_type(),
+				'settings' => [],
+				'widgetType' => Atomic_List_Item::get_element_type(),
+				'elements' => [
+					[
+						'id' => "paragraph-{$index}",
+						'elType' => 'widget',
+						'widgetType' => Atomic_Paragraph::get_element_type(),
+						'settings' => [
+							'paragraph' => Html_V3_Prop_Type::generate( [
+								'content' => String_Prop_Type::generate( "Item #{$index}" ),
+								'children' => [],
+							] ),
+							'tag' => String_Prop_Type::generate( 'span' ),
+						],
+					],
+				],
+			];
+		}
+
+		return Plugin::$instance->elements_manager->create_element_instance( [
+			'id' => 'list',
+			'elType' => Atomic_List::get_element_type(),
+			'settings' => [
+				'list-type' => String_Prop_Type::generate( $list_type ),
+			],
+			'widgetType' => Atomic_List::get_element_type(),
+			'elements' => $children,
+		] );
+	}
+}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Implements atomic list and list-item elements with full styling support (markers, positions, custom images) for the new atomic widgets system. Research branch preparing foundational list component infrastructure.

## 2. What Changed (Where)

| Component | Changes |
|-----------|---------|
| **Backend** | New `Atomic_List` / `Atomic_List_Item` classes; `List_Items_Control`; list-style props (type, position, image) in style schema; custom pseudo-states for `::marker` |
| **Frontend (Canvas)** | `imageSrcTransformer` enhanced to handle `list-style-image` URLs; allowed HTML tags include `<ul>`, `<ol>`, `<li>` |
| **UI (Editing Panel)** | New `ListSection` component; `ListItemsControl` repeater for managing items; conditional rendering for list elements |
| **Utils & Config** | Allowlisted `ol`/`ul`/`li` tags in PHP/TS sanitizers; `Style_States` extended with custom selector states |
| **Tests** | PHPUnit tests validating ordered/unordered rendering; snapshot test for marker CSS output; DOM renderer tests for list tags |

## 3. How It Works

**List setup**: `Atomic_List` renders `<ul>` or `<ol>` dynamically based on `list-type` prop; enforces 3 locked default items via `define_default_children()`. **Items**: `Atomic_List_Item` renders `<li>` with mandatory `Atomic_Paragraph` child; hides from panel (`should_show_in_panel=false`). **Styling**: New pseudo-states ` > li::marker` (list-level) and `::marker` (item-level) allow independent marker styling. **Image markers**: `Image_Src_Transformer` detects `list-style-image` key, fetches attachment URL, returns CSS `url()` format. Frontend mirrors logic via `imageSrcTransformer`. **Item management**: `ListItemsControl` repeater syncs add/remove/reorder/duplicate ops via existing element commands.

## 4. Risks

**Minor**: Custom pseudo-state selectors (` > li::marker`) are non-standard in type system—only used for `e-list`/`e-list-item`, validate no cross-element pollution. **Possible**: Image transformer assumes `wp_get_attachment_image_src` availability; gracefully falls back to URL field if attachment missing.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
