### PR TITLE
Internal: Remove BC for Custom CSS injection [ED-23822]

### DIFF
--- a/modules/promotions/module.php
+++ b/modules/promotions/module.php
@@ -70,6 +70,8 @@ class Module extends Base_Module {
 			new Black_Friday();
 		}
 
+		add_filter( 'elementor/editor/localize_settings', [ $this, 'add_v4_promotions_data' ] );
+
 		if ( Utils::has_pro() ) {
 			return;
 		}
@@ -80,7 +82,6 @@ class Module extends Base_Module {
 
 		add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'enqueue_react_data' ] );
 		add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'enqueue_editor_v4_alphachip' ] );
-		add_filter( 'elementor/editor/localize_settings', [ $this, 'add_v4_promotions_data' ] );
 
 		// Add Ally promo
 		Ally_Dashboard_Widget::init();

--- a/packages/packages/core/editor-editing-panel/src/components/promotions/init.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/promotions/init.tsx
@@ -5,14 +5,13 @@ import { injectIntoStyleTab } from '../style-tab';
 import { CustomCssSection } from './custom-css';
 
 export const init = () => {
-	//Todo: Remove when v3.37 will released
-	if ( ! window.elementorPro ) {
-		injectIntoStyleTab( {
-			id: 'custom-css',
-			component: CustomCssSection,
-			options: { overwrite: true },
-		} );
+	injectIntoStyleTab( {
+		id: 'custom-css',
+		component: CustomCssSection,
+		options: { overwrite: true },
+	} );
 
+	if ( ! window.elementorPro ) {
 		controlsRegistry.register( 'attributes', AttributesControl, 'two-columns' );
 
 		controlsRegistry.register( 'display-conditions', DisplayConditionsControl, 'two-columns' );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Removes backward compatibility check that gated custom CSS injection behind `window.elementorPro`. Custom CSS section now injects unconditionally into editor, enabling promotion for Essential tier. Changes triggered by v3.37 release milestone (TODO now actionable).

## 2. What Changed (Where)

- **modules/promotions/module.php**: Moved `add_v4_promotions_data` filter registration outside pro-check guard, executes for all tiers now.
- **editor-editing-panel/init.tsx**: Removed `window.elementorPro` condition wrapping custom CSS injection; always injects, conditionally gates other controls.

## 3. How It Works

Custom CSS section now injects into style tab immediately on init, then attributes/display-conditions controls register only when Elementor Pro absent. Previously both injection and controls were blocked behind pro-check, now decoupled.

## 4. Risks

None noted—BC removal is intentional and scoped. Verify Essential tier users see custom CSS section without breaking existing Pro behavior; the unconditional injection may conflict if plugin loads multiple times.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
