### PR TITLE
Internal: Migrations manifest cached for 12h [ED-23823]

### DIFF
--- a/modules/atomic-widgets/prop-type-migrations/migrations-cache.php
+++ b/modules/atomic-widgets/prop-type-migrations/migrations-cache.php
@@ -70,6 +70,16 @@ class Migrations_Cache {
 		] );
 	}
 
+	public static function get_version_fingerprint(): string {
+		$fingerprint = ELEMENTOR_VERSION;
+
+		if ( defined( 'ELEMENTOR_PRO_VERSION' ) ) {
+			$fingerprint .= ':' . ELEMENTOR_PRO_VERSION;
+		}
+
+		return $fingerprint;
+	}
+
 	private static function get_cache_meta_key( string $data_identifier ): string {
 		return self::MIGRATIONS_STATE_META_KEY . '_' . substr( md5( $data_identifier ), 0, 4 );
 	}
@@ -79,12 +89,6 @@ class Migrations_Cache {
 			return '';
 		}
 
-		$state = ELEMENTOR_VERSION;
-
-		if ( defined( 'ELEMENTOR_PRO_VERSION' ) ) {
-			$state .= ':' . ELEMENTOR_PRO_VERSION;
-		}
-
-		return $state . ':' . $manifest_hash;
+		return self::get_version_fingerprint() . ':' . $manifest_hash;
 	}
 }

--- a/modules/atomic-widgets/prop-type-migrations/migrations-loader.php
+++ b/modules/atomic-widgets/prop-type-migrations/migrations-loader.php
@@ -9,6 +9,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Migrations_Loader {
+	private const TRANSIENT_KEY = 'elementor_migrations_manifest';
+	private const TRANSIENT_TTL = 12 * HOUR_IN_SECONDS;
+
 	private static ?self $instance = null;
 
 	private ?array $manifest = null;
@@ -33,6 +36,7 @@ class Migrations_Loader {
 	}
 
 	public static function destroy(): void {
+		delete_transient( self::TRANSIENT_KEY );
 		self::$instance = null;
 	}
 
@@ -265,6 +269,14 @@ class Migrations_Loader {
 
 		$manifest_path = $this->base_path . $this->manifest_file;
 
+		if ( $this->is_url( $manifest_path ) ) {
+			$this->manifest = $this->get_manifest_from_transient();
+
+			if ( null !== $this->manifest ) {
+				return $this->manifest;
+			}
+		}
+
 		$contents = $this->read_source( $manifest_path );
 
 		if ( false === $contents ) {
@@ -272,10 +284,7 @@ class Migrations_Loader {
 				'path' => $manifest_path,
 			] );
 
-			$this->manifest = [
-				'widgetKeys' => [],
-				'propTypes' => [],
-			];
+			$this->manifest = $this->empty_manifest();
 			return $this->manifest;
 		}
 
@@ -287,16 +296,46 @@ class Migrations_Loader {
 				'error' => json_last_error_msg(),
 			] );
 
-			$this->manifest = [
-				'widgetKeys' => [],
-				'propTypes' => [],
-			];
+			$this->manifest = $this->empty_manifest();
 			return $this->manifest;
 		}
 
 		$this->manifest = $manifest;
 
+		if ( $this->is_url( $manifest_path ) ) {
+			$this->save_manifest_to_transient( $manifest );
+		}
+
 		return $this->manifest;
+	}
+
+	private function get_manifest_from_transient(): ?array {
+		$cached = get_transient( self::TRANSIENT_KEY );
+
+		if ( ! is_array( $cached ) ) {
+			return null;
+		}
+
+		if ( ( $cached['version'] ?? '' ) !== Migrations_Cache::get_version_fingerprint() ) {
+			delete_transient( self::TRANSIENT_KEY );
+			return null;
+		}
+
+		return $cached['manifest'] ?? null;
+	}
+
+	private function save_manifest_to_transient( array $manifest ): void {
+		set_transient( self::TRANSIENT_KEY, [
+			'version' => Migrations_Cache::get_version_fingerprint(),
+			'manifest' => $manifest,
+		], self::TRANSIENT_TTL );
+	}
+
+	private function empty_manifest(): array {
+		return [
+			'widgetKeys' => [],
+			'propTypes' => [],
+		];
 	}
 
 	private function read_source( string $path ) {

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-loader.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-loader.php
@@ -251,5 +251,108 @@ class Test_Migrations_Loader extends Elementor_Test_Base {
 		// Assert
 		$this->assertEquals( 'svg', $result );
 	}
+
+	public function test_remote_manifest_is_cached_in_transient() {
+		// Arrange
+		$manifest = $this->get_fixture_manifest();
+		$fetch_count = 0;
+
+		add_filter( 'pre_http_request', function () use ( $manifest, &$fetch_count ) {
+			$fetch_count++;
+			return [
+				'headers' => [],
+				'response' => [ 'code' => 200, 'message' => 'OK' ],
+				'body' => wp_json_encode( $manifest ),
+			];
+		} );
+
+		$loader = Migrations_Loader::make( 'https://migrations.example.com/' );
+
+		// Act
+		$result = $loader->find_migration_path( 'string', 'string_v2' );
+
+		// Assert
+		$this->assertNotNull( $result );
+		$this->assertEquals( 1, $fetch_count );
+
+		$cached = get_transient( 'elementor_migrations_manifest' );
+		$this->assertIsArray( $cached );
+		$this->assertEquals( $manifest, $cached['manifest'] );
+	}
+
+	public function test_remote_manifest_served_from_transient_on_subsequent_instance() {
+		// Arrange
+		$manifest = $this->get_fixture_manifest();
+
+		set_transient( 'elementor_migrations_manifest', [
+			'version' => \Elementor\Modules\AtomicWidgets\PropTypeMigrations\Migrations_Cache::get_version_fingerprint(),
+			'manifest' => $manifest,
+		], HOUR_IN_SECONDS );
+
+		$fetch_count = 0;
+
+		add_filter( 'pre_http_request', function () use ( &$fetch_count ) {
+			$fetch_count++;
+			return new \WP_Error( 'should_not_be_called', 'Remote should not be called' );
+		} );
+
+		$loader = Migrations_Loader::make( 'https://migrations.example.com/' );
+
+		// Act
+		$result = $loader->find_migration_path( 'string', 'string_v2' );
+
+		// Assert
+		$this->assertNotNull( $result );
+		$this->assertEquals( 0, $fetch_count );
+	}
+
+	public function test_remote_manifest_transient_invalidated_on_version_change() {
+		// Arrange
+		$manifest = $this->get_fixture_manifest();
+
+		set_transient( 'elementor_migrations_manifest', [
+			'version' => 'outdated-version',
+			'manifest' => $manifest,
+		], HOUR_IN_SECONDS );
+
+		$fetch_count = 0;
+
+		add_filter( 'pre_http_request', function () use ( $manifest, &$fetch_count ) {
+			$fetch_count++;
+			return [
+				'headers' => [],
+				'response' => [ 'code' => 200, 'message' => 'OK' ],
+				'body' => wp_json_encode( $manifest ),
+			];
+		} );
+
+		$loader = Migrations_Loader::make( 'https://migrations.example.com/' );
+
+		// Act
+		$result = $loader->find_migration_path( 'string', 'string_v2' );
+
+		// Assert
+		$this->assertNotNull( $result );
+		$this->assertEquals( 1, $fetch_count );
+	}
+
+	public function test_failed_remote_fetch_does_not_cache_empty_manifest() {
+		// Arrange
+		add_filter( 'pre_http_request', function () {
+			return new \WP_Error( 'http_request_failed', 'Connection timed out' );
+		} );
+
+		$loader = Migrations_Loader::make( 'https://migrations.example.com/' );
+
+		// Act
+		$loader->find_migration_path( 'string', 'string_v2' );
+
+		// Assert
+		$this->assertFalse( get_transient( 'elementor_migrations_manifest' ) );
+	}
+
+	private function get_fixture_manifest(): array {
+		return json_decode( file_get_contents( $this->fixtures_path . 'manifest.json' ), true );
+	}
 }
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Remote migrations manifest was fetched on every instance creation, causing unnecessary HTTP requests. This caches it for 12 hours while invalidating on version changes to balance performance with freshness.

## 2. What Changed (Where)

- **migrations-cache.php**: Extracted version fingerprint logic into reusable `get_version_fingerprint()` method.
- **migrations-loader.php**: Added transient caching (12h TTL) for remote manifests; introduced `empty_manifest()` helper; clears cache on destroy.
- **test-migrations-loader.php**: Four new test cases validating transient caching, version invalidation, and failure handling.

## 3. How It Works

When loading a remote manifest: check transient first, validate cached version matches current Elementor + Pro version, fetch if missing/stale, then cache for 12 hours. Empty manifest structure extracted to prevent duplication. Transient cleared on `Migrations_Loader::destroy()` to prevent stale data across test runs.

## 4. Risks

Transient relies on WordPress caching layer — if transients disabled or misconfigured, fallback works but loses optimization. Version fingerprint string comparison is fragile if version format changes. No explicit migration for existing stale transients.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
