### PR TITLE
Internal: Adding more keys

### DIFF
--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elementor;
 
 use Elementor\Core\Admin\Menu\Admin_Menu_Manager;
@@ -39,7 +40,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 class Plugin {
+
 	const ELEMENTOR_DEFAULT_POST_TYPES = [ 'page', 'post' ];
+
+	private const SANITIZABLE_META_KEYS = [
+		'_elementor_data',
+		'_elementor_page_settings',
+	];
 
 	/**
 	 * Instance.
@@ -835,24 +842,32 @@ class Plugin {
 		if ( current_user_can( 'unfiltered_html' ) ) {
 			return $post;
 		}
-		$request_body = json_decode( $request->get_body(), true );
-		$meta = $request_body['meta'];
-		if ( is_null( $meta ) ) {
-			return $post;
-		}
-		$elementor_data = $meta['_elementor_data'] ?? [];
-		if ( is_string( $elementor_data ) ) {
-			$elementor_data = json_decode( $elementor_data );
-		}
-		if ( is_null( $elementor_data ) ) {
+
+		$meta = $request->get_param( 'meta' );
+		if ( empty( $meta ) || ! is_array( $meta ) ) {
 			return $post;
 		}
 
-		$elementor_data = map_deep( $elementor_data, function ( $value ) {
-			return is_bool( $value ) || is_null( $value ) ? $value : wp_kses_post( $value );
-		} );
-		$request_body['meta']['_elementor_data'] = json_encode( $elementor_data );
-		$request->set_body( json_encode( $request_body ) );
+		foreach ( self::SANITIZABLE_META_KEYS as $meta_key ) {
+			$elementor_data = $meta[ $meta_key ] ?? null;
+			if ( is_null( $elementor_data ) ) {
+				continue;
+			}
+			if ( is_string( $elementor_data ) ) {
+				$elementor_data = json_decode( $elementor_data, true );
+			}
+			if ( empty( $elementor_data ) ) {
+				continue;
+			}
+
+			$elementor_data = map_deep($elementor_data, function ( $value ) {
+				return is_bool( $value ) || is_null( $value ) ? $value : wp_kses_post( $value );
+			});
+
+			$meta[ $meta_key ] = wp_json_encode( $elementor_data );
+		}
+
+		$request->set_param( 'meta', $meta );
 		return $post;
 	}
 }


### PR DESCRIPTION
- Replaced json_decode($request->get_body()) with $request->get_param('meta') to handle form-encoded and multipart requests, preventing sanitization bypass for non-privileged users.
- Extended sanitization to cover both _elementor_data and _elementor_page_settings  meta keys.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
