### PR TITLE
Tweak: Improve IE media functionality [ED-23882]

### DIFF
--- a/app/modules/import-export-customization/data/routes/process-media.php
+++ b/app/modules/import-export-customization/data/routes/process-media.php
@@ -31,6 +31,10 @@ class Process_Media extends Base_Route {
 
 		$cloud_kit_library_app = $this->get_cloud_kit_library_app();
 
+		if ( $cloud_kit_library_app && ! $cloud_kit_library_app->is_connected() ) {
+			return Response::error( ImportExportCustomizationModule::MEDIA_PROCESSING_ERROR, 'Cloud Library is not connected' );
+		}
+
 		$media_urls = $request->get_param( 'media_urls' );
 		$kit = $request->get_param( 'kit' );
 		$quota = null;

--- a/tests/phpunit/elementor/app/import-export-customization/data/routes/test-process-media.php
+++ b/tests/phpunit/elementor/app/import-export-customization/data/routes/test-process-media.php
@@ -110,16 +110,19 @@ class Test_Process_Media extends Elementor_Test_Base {
     public function test_empty_array() {
         $this->init_rest_api();
         $this->act_as_admin();
+        $this->add_mock_http_filter();
 
         $response = $this->send_request( [] );
 
         $status = $response->get_status();
         $this->assertEquals( 500, $status );
+        $this->remove_mock_http_filter();
     }
 
     public function test_invalid_urls() {
         $this->init_rest_api();
         $this->act_as_admin();
+        $this->add_mock_http_filter();
 
         $response = $this->send_request( [
             'not-a-url',
@@ -129,6 +132,7 @@ class Test_Process_Media extends Elementor_Test_Base {
         $status = $response->get_status();
 
         $this->assertEquals( 500, $status );
+        $this->remove_mock_http_filter();
     }
 
     private function add_mock_http_filter() {
@@ -140,17 +144,21 @@ class Test_Process_Media extends Elementor_Test_Base {
     }
 
     public function mock_http_filter( $preempt, $args, $url ) {
-        if ( strpos( $url, 'example.com' ) === false ) {
-            return $preempt;
+        $mocked_hosts = [ 'example.com', 'cloud-library.prod.builder.elementor.red' ];
+
+        foreach ( $mocked_hosts as $host ) {
+            if ( strpos( $url, $host ) !== false ) {
+                return [
+                    'response' => [
+                        'code' => 200,
+                        'message' => 'OK',
+                    ],
+                    'body' => 'fake-image-content',
+                ];
+            }
         }
 
-        return [
-            'response' => [
-                'code' => 200,
-                'message' => 'OK',
-            ],
-            'body' => 'fake-image-content',
-        ];
+        return $preempt;
     }
 
     private function send_request( $media_urls ) {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cloud Library connectivity validation was missing from media processing, and HTTP mocking in tests didn't cover the cloud-library host. This ensures media import/export fails gracefully when Cloud Library is unavailable.

## 2. What Changed (Where)

- **process-media.php**: Added Cloud Library connection check before processing media URLs
- **test-process-media.php**: Enhanced mock HTTP filter to handle both example.com and cloud-library.prod.builder.elementor.red; added filter setup/teardown to existing tests

## 3. How It Works

Route now validates `$cloud_kit_library_app->is_connected()` early and returns error (MEDIA_PROCESSING_ERROR) if disconnected. Test mock filter expanded to intercept multiple hosts, returning fake image content for both production cloud-library domain and test domains.

## 4. Risks

Mock filter logic inversion (was "if not example.com, early return") could mask integration issues if cloud-library host mocking fails silently. Verify test assertions still catch actual connectivity failures post-merge.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
