### PR TITLE
Fix: Validate variable labels in Angie MCP tool [ED-23840]

### DIFF
--- a/packages/packages/core/editor-variables/src/mcp/__tests__/manage-variable-tool.test.ts
+++ b/packages/packages/core/editor-variables/src/mcp/__tests__/manage-variable-tool.test.ts
@@ -1,0 +1,111 @@
+import { initManageVariableTool } from '../manage-variable-tool';
+import { service } from '../../service';
+
+jest.mock( '../../service' );
+
+describe( 'manage-variable-tool validation', () => {
+	let mockRegistryEntry: any;
+	let toolHandler: any;
+
+	beforeEach( () => {
+		const mockService = {
+			create: jest.fn().mockResolvedValue( { id: '123' } ),
+			update: jest.fn().mockResolvedValue( { id: '123' } ),
+			delete: jest.fn().mockResolvedValue( undefined ),
+		};
+
+		( service as any ).create = mockService.create;
+		( service as any ).update = mockService.update;
+		( service as any ).delete = mockService.delete;
+
+		const tools: any[] = [];
+		mockRegistryEntry = {
+			addTool: ( tool: any ) => tools.push( tool ),
+		};
+
+		initManageVariableTool( mockRegistryEntry );
+		const manageTool = tools[ 0 ];
+		toolHandler = manageTool.handler;
+	} );
+
+	describe( 'create action', () => {
+		it( 'should reject label with spaces', async () => {
+			await expect(
+				toolHandler( { action: 'create', type: 'global-color-variable', label: 'Headline Primary', value: '#000' } )
+			).rejects.toThrow( 'Use letters, numbers, dashes (-), or underscores (_) for the name.' );
+
+			expect( service.create ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should reject label with special characters', async () => {
+			await expect(
+				toolHandler( { action: 'create', type: 'global-color-variable', label: 'font!@#$', value: '#000' } )
+			).rejects.toThrow( 'Use letters, numbers, dashes (-), or underscores (_) for the name.' );
+
+			expect( service.create ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should reject label with only dashes/underscores', async () => {
+			await expect(
+				toolHandler( { action: 'create', type: 'global-color-variable', label: '---', value: '#000' } )
+			).rejects.toThrow( 'Names have to include at least one non-special character.' );
+
+			expect( service.create ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should allow valid label', async () => {
+			await toolHandler( { action: 'create', type: 'global-color-variable', label: 'headline-primary', value: '#000' } );
+
+			expect( service.create ).toHaveBeenCalledWith( {
+				type: 'global-color-variable',
+				label: 'headline-primary',
+				value: '#000',
+			} );
+		} );
+
+		it( 'should allow label with underscores', async () => {
+			await toolHandler( { action: 'create', type: 'global-color-variable', label: 'headline_primary', value: '#000' } );
+
+			expect( service.create ).toHaveBeenCalledWith( {
+				type: 'global-color-variable',
+				label: 'headline_primary',
+				value: '#000',
+			} );
+		} );
+
+		it( 'should reject empty label', async () => {
+			await expect(
+				toolHandler( { action: 'create', type: 'global-color-variable', label: '', value: '#000' } )
+			).rejects.toThrow();
+
+			expect( service.create ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'update action', () => {
+		it( 'should reject label with spaces', async () => {
+			await expect(
+				toolHandler( { action: 'update', id: '123', label: 'Headline Primary', value: '#000' } )
+			).rejects.toThrow( 'Use letters, numbers, dashes (-), or underscores (_) for the name.' );
+
+			expect( service.update ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should reject label with special characters', async () => {
+			await expect(
+				toolHandler( { action: 'update', id: '123', label: 'font!@#', value: '#000' } )
+			).rejects.toThrow( 'Use letters, numbers, dashes (-), or underscores (_) for the name.' );
+
+			expect( service.update ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should allow valid label', async () => {
+			await toolHandler( { action: 'update', id: '123', label: 'headline-primary', value: '#000' } );
+
+			expect( service.update ).toHaveBeenCalledWith( '123', {
+				label: 'headline-primary',
+				value: '#000',
+			} );
+		} );
+	} );
+} );

--- a/packages/packages/core/editor-variables/src/mcp/__tests__/manage-variable-tool.test.ts
+++ b/packages/packages/core/editor-variables/src/mcp/__tests__/manage-variable-tool.test.ts
@@ -1,5 +1,6 @@
-import { initManageVariableTool } from '../manage-variable-tool';
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { service } from '../../service';
+import { initManageVariableTool } from '../manage-variable-tool';
 
 jest.mock( '../../service' );
 
@@ -31,7 +32,12 @@ describe( 'manage-variable-tool validation', () => {
 	describe( 'create action', () => {
 		it( 'should reject label with spaces', async () => {
 			await expect(
-				toolHandler( { action: 'create', type: 'global-color-variable', label: 'Headline Primary', value: '#000' } )
+				toolHandler( {
+					action: 'create',
+					type: 'global-color-variable',
+					label: 'Headline Primary',
+					value: '#000',
+				} )
 			).rejects.toThrow( 'Use letters, numbers, dashes (-), or underscores (_) for the name.' );
 
 			expect( service.create ).not.toHaveBeenCalled();
@@ -54,7 +60,12 @@ describe( 'manage-variable-tool validation', () => {
 		} );
 
 		it( 'should allow valid label', async () => {
-			await toolHandler( { action: 'create', type: 'global-color-variable', label: 'headline-primary', value: '#000' } );
+			await toolHandler( {
+				action: 'create',
+				type: 'global-color-variable',
+				label: 'headline-primary',
+				value: '#000',
+			} );
 
 			expect( service.create ).toHaveBeenCalledWith( {
 				type: 'global-color-variable',
@@ -64,7 +75,12 @@ describe( 'manage-variable-tool validation', () => {
 		} );
 
 		it( 'should allow label with underscores', async () => {
-			await toolHandler( { action: 'create', type: 'global-color-variable', label: 'headline_primary', value: '#000' } );
+			await toolHandler( {
+				action: 'create',
+				type: 'global-color-variable',
+				label: 'headline_primary',
+				value: '#000',
+			} );
 
 			expect( service.create ).toHaveBeenCalledWith( {
 				type: 'global-color-variable',

--- a/packages/packages/core/editor-variables/src/mcp/manage-variable-tool.ts
+++ b/packages/packages/core/editor-variables/src/mcp/manage-variable-tool.ts
@@ -2,6 +2,7 @@ import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 import { z } from '@elementor/schema';
 
 import { service } from '../service';
+import { validateLabel } from '../utils/validations';
 import { GLOBAL_VARIABLES_URI } from './variables-resource';
 
 export const initManageVariableTool = ( reg: MCPRegistryEntry ) => {
@@ -68,11 +69,19 @@ function getServiceActions( svc: typeof service ) {
 			if ( ! type || ! label || ! value ) {
 				throw new Error( 'Create requires type, label, and value' );
 			}
+			const labelError = validateLabel( label );
+			if ( labelError ) {
+				throw new Error( labelError );
+			}
 			return svc.create( { type, label, value } );
 		},
 		update( { id, label, value }: Opts< { id: string; label: string; value: string } > ) {
 			if ( ! id || ! label || ! value ) {
 				throw new Error( 'Update requires id, label, and value' );
+			}
+			const labelError = validateLabel( label );
+			if ( labelError ) {
+				throw new Error( labelError );
 			}
 			return svc.update( id, { label, value } );
 		},


### PR DESCRIPTION
Summary
Add label validation to the manage-global-variable MCP tool to prevent Angie from creating variables with invalid names. Invalid labels now throw a clear error message, allowing Angie to retry with a corrected value.

Bug: Angie was only instructed (in the tool description) to use lowercase-dashed names (e.g., headline-primary), but there was no programmatic enforcement. If the LLM deviated (e.g., sent "Headline Primary" or "headline_font!"), the invalid label was stored and rendered as a CSS variable name, breaking the stylesheet.

Fix: Reuse the existing validateLabel utility from validations.ts in the create and update operations. When validation fails, throw an error with a clear message that Angie can act on.

Changes
Import validateLabel from utils/validations.ts
Call validation before calling svc.create() and svc.update()
Add comprehensive test suite covering both valid and invalid labels
Test Plan
 All 279 tests in editor-variables package pass
 New test suite validates rejection of spaces, special characters, and only-dashes
 Valid labels (dashes, underscores, alphanumerics) pass through
 Error messages are clear and actionable
🤖 Generated with [Claude Code](https://claude.com/claude-code)

✨ PR Description
1. Problem & Context
Variable labels in the Angie MCP tool lacked validation, allowing invalid names (spaces, special chars, only symbols). This PR adds label validation to create and update actions to enforce naming constraints.

2. What Changed (Where)
manage-variable-tool.ts: Added validateLabel import and validation checks in create/update functions (lines 72–75, 82–85)
manage-variable-tool.test.ts: New test suite validating label rejection for spaces, special chars, symbol-only strings; accepts valid names
3. How It Works
Both create and update actions now call validateLabel(label) after basic null checks. If validation returns an error string, it throws before calling the service. Tests confirm spaces/special chars are rejected while headline-primary and headline_primary formats pass.

4. Risks
None identified. Validation is applied consistently to both mutation points, tests cover happy/sad paths, and error messages are user-facing. Assumes validateLabel exists and functions correctly in the utils module.

Generated by LinearB AI and added by gitStream.
AI-generated content may contain inaccuracies. Please verify before using.
💡 Tip: You can customize your AI Description using Guidelines [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Variable labels in the Angie MCP tool weren't validated, allowing invalid characters and malformed names. This PR adds validation to create and update operations to enforce consistent naming rules (alphanumeric, dashes, underscores only; must include at least one non-special character).

## 2. What Changed (Where)

- `manage-variable-tool.ts`: Imports `validateLabel` utility; adds validation checks in `create` and `update` handlers
- `manage-variable-tool.test.ts`: New test file covering label validation across invalid formats and edge cases

## 3. How It Works

Handler receives create/update action → `validateLabel()` checks label format → returns error message if invalid → throws before delegating to service. Valid labels pass through unchanged.

## 4. Risks

Minimal. Validation is client-side only; no schema changes. Existing valid labels unaffected. Test coverage validates rejection paths (spaces, special chars, dashes-only) and acceptance paths (dashes, underscores).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
