### PR TITLE
Internal: Global classes (1/6) — posts, migration & repository [ED-23093]

### DIFF
--- a/modules/global-classes/concerns/has-kit-dependency.php
+++ b/modules/global-classes/concerns/has-kit-dependency.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Elementor\Modules\GlobalClasses\Concerns;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+trait Has_Kit_Dependency {
+	private ?Kit $kit = null;
+
+	public function set_kit( Kit $kit ): self {
+		$this->kit = $kit;
+
+		return $this;
+	}
+
+	protected function get_kit(): ?Kit {
+		if ( ! $this->kit ) {
+			$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+		}
+
+		return $this->kit;
+	}
+}

--- a/modules/global-classes/concerns/has-preview-context.php
+++ b/modules/global-classes/concerns/has-preview-context.php
@@ -28,7 +28,7 @@ trait Has_Preview_Context {
 		$map = $this->get_context_keys()[ $key ] ?? null;
 
 		if ( null === $map ) {
-			throw new \InvalidArgumentException( "Unknown context key: {$key}" );
+			throw new \InvalidArgumentException( sprintf( 'Unknown context key: %s', $key ) );
 		}
 
 		return $this->is_preview ? $map['preview'] : $map['frontend'];

--- a/modules/global-classes/concerns/has-preview-context.php
+++ b/modules/global-classes/concerns/has-preview-context.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Elementor\Modules\GlobalClasses\Concerns;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+trait Has_Preview_Context {
+	private bool $is_preview = false;
+
+	public function set_preview( bool $is_preview = true ): self {
+		if ( $is_preview === $this->is_preview ) {
+			return $this;
+		}
+
+		$this->is_preview = $is_preview;
+		$this->on_preview_change();
+
+		return $this;
+	}
+
+	protected function is_preview(): bool {
+		return $this->is_preview;
+	}
+
+	protected function get_context_key( string $key ): string {
+		$map = $this->get_context_keys()[ $key ] ?? null;
+
+		if ( null === $map ) {
+			throw new \InvalidArgumentException( "Unknown context key: {$key}" );
+		}
+
+		return $this->is_preview ? $map['preview'] : $map['frontend'];
+	}
+
+	protected function get_context_keys(): array {
+		if ( empty( $this->context_keys ) ) {
+			return [];
+		}
+
+		return $this->context_keys;
+	}
+
+	protected function on_preview_change(): void {
+	}
+}

--- a/modules/global-classes/concerns/has-preview-context.php
+++ b/modules/global-classes/concerns/has-preview-context.php
@@ -28,7 +28,7 @@ trait Has_Preview_Context {
 		$map = $this->get_context_keys()[ $key ] ?? null;
 
 		if ( null === $map ) {
-			throw new \InvalidArgumentException( sprintf( 'Unknown context key: %s', $key ) );
+			throw new \InvalidArgumentException( sprintf( 'Unknown context key: %s', esc_html( $key ) ) );
 		}
 
 		return $this->is_preview ? $map['preview'] : $map['frontend'];

--- a/modules/global-classes/database/global-classes-database-updater.php
+++ b/modules/global-classes/database/global-classes-database-updater.php
@@ -4,14 +4,16 @@ namespace Elementor\Modules\GlobalClasses\Database;
 
 use Elementor\Core\Database\Base_Database_Updater;
 use Elementor\Modules\GlobalClasses\Database\Migrations\Add_Capabilities;
+use Elementor\Modules\GlobalClasses\Database\Migrations\Migrate_To_Posts;
 
 class Global_Classes_Database_Updater extends Base_Database_Updater {
-	const DB_VERSION = 1;
+	const DB_VERSION = 2;
 	const OPTION_NAME = 'elementor_global_classes_db_version';
 
 	protected function get_migrations(): array {
 		return [
 			1 => new Add_Capabilities(),
+			2 => new Migrate_To_Posts(),
 		];
 	}
 

--- a/modules/global-classes/database/migrations/migrate-to-posts.php
+++ b/modules/global-classes/database/migrations/migrate-to-posts.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Elementor\Modules\GlobalClasses\Database\Migrations;
+
+use Elementor\Core\Database\Base_Migration;
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\GlobalClasses\Global_Class_Post;
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use Elementor\Modules\GlobalClasses\Global_Classes_Order;
+use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
+use Elementor\Modules\GlobalClasses\Global_Classes_Relations;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Migrate_To_Posts extends Base_Migration {
+	private ?Kit $kit = null;
+
+	public function up() {
+		$this->ensure_cpt_registered();
+
+		$kit = $this->get_kit();
+		if ( ! $kit ) {
+			return;
+		}
+
+		$migrated = $this->migrate_global_classes_to_posts();
+
+		if ( ! $migrated ) {
+			return;
+		}
+
+		$this->update_document_tracking( $kit );
+
+		// We'll comment it out for now as we may prefer to avoid data restoration upon downgrading
+		// $this->cleanup_kit_meta();
+	}
+
+	private function ensure_cpt_registered(): void {
+		if ( ! post_type_exists( Global_Class_Post_Type::CPT ) ) {
+			( new Global_Class_Post_Type() )->register_post_type();
+		}
+	}
+
+	private function migrate_global_classes_to_posts(): bool {
+		$kit = $this->get_kit();
+
+		if ( ! $kit ) {
+			return false;
+		}
+
+		$global_classes = $kit->get_json_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+
+		if ( empty( $global_classes ) || empty( $global_classes['items'] ) ) {
+			return false;
+		}
+
+		$existing_posts = $this->get_existing_class_posts();
+
+		if ( ! empty( $existing_posts ) ) {
+			return false;
+		}
+
+		$items = $global_classes['items'] ?? [];
+		$order = $global_classes['order'] ?? array_keys( $items );
+
+		$order_index = array_flip( $order );
+		$created_order = [];
+
+		foreach ( $items as $class_id => $class_data ) {
+			$index = $order_index[ $class_id ] ?? 0;
+
+			$stored = [
+				'type' => $class_data['type'] ?? 'class',
+				'variants' => $class_data['variants'] ?? [],
+			];
+
+			if ( array_key_exists( 'sync_to_v3', $class_data ) ) {
+				$stored['sync_to_v3'] = (bool) $class_data['sync_to_v3'];
+			}
+
+			$post = Global_Class_Post::create(
+				$class_id,
+				$class_data['label'] ?? $class_id,
+				$stored,
+				$index
+			);
+
+			if ( $post ) {
+				$created_order[ $index ] = $class_id;
+			}
+		}
+
+		ksort( $created_order );
+		Global_Classes_Order::make( $kit )->set_order( array_values( $created_order ) );
+
+		return true;
+	}
+
+	private function get_existing_class_posts(): array {
+		return get_posts( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_status' => 'publish',
+			'posts_per_page' => -1,
+			'fields' => 'ids',
+		] );
+	}
+
+	private function update_document_tracking( Kit $kit ): void {
+		$valid_class_ids = Global_Classes_Order::make( $kit )->get_order();
+
+		if ( empty( $valid_class_ids ) ) {
+			return;
+		}
+
+		$relations = new Global_Classes_Relations();
+
+		Plugin::$instance->db->iterate_elementor_documents(
+			function ( $document ) use ( $relations, $valid_class_ids ) {
+				$post_id = $document->get_main_id();
+				$used_class_ids = $relations->collect_class_ids_from_post( $post_id, $valid_class_ids );
+
+				if ( ! empty( $used_class_ids ) ) {
+					$relations->set_styles_for_post( $post_id, $used_class_ids );
+				}
+			}
+		);
+	}
+
+	private function cleanup_kit_meta(): void {
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+
+		if ( ! $kit ) {
+			return;
+		}
+
+		$kit->delete_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+		$kit->delete_meta( Global_Classes_Repository::META_KEY_PREVIEW );
+	}
+
+	private function get_kit(): ?Kit {
+		if ( null !== $this->kit ) {
+			return $this->kit;
+		}
+
+		$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+
+		return $this->kit;
+	}
+}

--- a/modules/global-classes/global-class-post-type.php
+++ b/modules/global-classes/global-class-post-type.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Elementor\Modules\GlobalClasses;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Global_Class_Post_Type {
+	const CPT = 'e_global_class';
+
+	public function register() {
+		add_action( 'init', [ $this, 'register_post_type' ] );
+	}
+
+	public function register_post_type() {
+		register_post_type( self::CPT, [
+			'label' => esc_html__( 'Global Class', 'elementor' ),
+			'labels' => [
+				'name' => esc_html__( 'Global Classes', 'elementor' ),
+				'singular_name' => esc_html__( 'Global Class', 'elementor' ),
+			],
+			'public' => false,
+			'supports' => [ 'title' ],
+		] );
+	}
+}

--- a/modules/global-classes/global-class-post.php
+++ b/modules/global-classes/global-class-post.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Elementor\Modules\GlobalClasses;
+
+use Elementor\Modules\AtomicWidgets\PropTypeMigrations\Migrations_Orchestrator;
+use Elementor\Modules\GlobalClasses\Concerns\Has_Preview_Context;
+use WP_Post;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Global_Class_Post {
+	use Has_Preview_Context;
+
+	const META_KEY_ID = '_elementor_global_class_id';
+	const META_KEY_DATA = '_elementor_global_class_data';
+	const META_KEY_DATA_PREVIEW = '_elementor_global_class_data_preview';
+
+	protected array $context_keys = [
+		'data' => [
+			'frontend' => self::META_KEY_DATA,
+			'preview' => self::META_KEY_DATA_PREVIEW,
+		],
+	];
+
+	private WP_Post $post;
+
+	private function __construct( WP_Post $post, bool $is_preview = false ) {
+		$this->post = $post;
+		$this->is_preview = $is_preview;
+	}
+
+	public static function from_post( WP_Post $post, bool $is_preview = false ): self {
+		return new self( $post, $is_preview );
+	}
+
+	public static function from_post_id( int $post_id, bool $is_preview = false ): ?self {
+		$post = get_post( $post_id );
+
+		if ( ! $post || Global_Class_Post_Type::CPT !== $post->post_type ) {
+			return null;
+		}
+
+		return new self( $post, $is_preview );
+	}
+
+	public static function find_by_class_id( string $class_id, bool $is_preview = false ): ?self {
+		$posts = get_posts( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_status' => 'publish',
+			'posts_per_page' => 1,
+			'meta_key' => self::META_KEY_ID,
+			'meta_value' => $class_id,
+		] );
+
+		if ( empty( $posts ) ) {
+			return null;
+		}
+
+		return new self( $posts[0], $is_preview );
+	}
+
+	public function get_post_id(): int {
+		return $this->post->ID;
+	}
+
+	public function get_class_id(): string {
+		$class_id = get_post_meta( $this->post->ID, self::META_KEY_ID, true );
+
+		if ( ! $class_id ) {
+			return '';
+		}
+
+		return $class_id;
+	}
+
+	public function get_label(): string {
+		return $this->post->post_title;
+	}
+
+	public function get_order(): int {
+		return (int) $this->post->menu_order;
+	}
+
+	public function get_data(): array {
+		$data = $this->get_context_data();
+		$meta_key = $this->get_data_meta_key();
+
+		if ( empty( $data ) && $this->is_preview() ) {
+			$data = $this->get_frontend_data();
+			$meta_key = self::META_KEY_DATA;
+		}
+
+		if ( ! empty( $data ) ) {
+			$this->migrate_data( $data, $meta_key );
+		}
+
+		return $data;
+	}
+
+	private function migrate_data( array &$data, string $meta_key ): void {
+		if ( ! Migrations_Orchestrator::is_active() ) {
+			return;
+		}
+
+		$post_id = $this->post->ID;
+
+		Migrations_Orchestrator::make()->migrate(
+			$data,
+			$post_id,
+			$meta_key,
+			function ( $migrated ) use ( $post_id, $meta_key ) {
+				update_post_meta( $post_id, $meta_key, $migrated );
+				clean_post_cache( $post_id );
+			}
+		);
+	}
+
+	public function to_array(): array {
+		$data = $this->get_data();
+
+		$result = [
+			'id' => $this->get_class_id(),
+			'label' => $this->get_label(),
+			'type' => $data['type'] ?? 'class',
+			'variants' => $data['variants'] ?? [],
+		];
+
+		if ( array_key_exists( 'sync_to_v3', $data ) ) {
+			$result['sync_to_v3'] = (bool) $data['sync_to_v3'];
+		}
+
+		return $result;
+	}
+
+	private function get_context_data(): array {
+		$data = get_post_meta( $this->post->ID, $this->get_data_meta_key(), true );
+
+		return is_array( $data ) ? $data : [];
+	}
+
+	private function get_data_meta_key(): string {
+		return $this->get_context_key( 'data' );
+	}
+
+	private function get_frontend_data(): array {
+		$data = get_post_meta( $this->post->ID, self::META_KEY_DATA, true );
+
+		return is_array( $data ) ? $data : [];
+	}
+
+	public function update_data( array $data, bool $is_preview_update = false ): bool {
+		$meta_key = $is_preview_update ? self::META_KEY_DATA_PREVIEW : self::META_KEY_DATA;
+
+		$result = update_post_meta( $this->post->ID, $meta_key, $data );
+
+		if ( ! $is_preview_update ) {
+			delete_post_meta( $this->post->ID, self::META_KEY_DATA_PREVIEW );
+		}
+
+		return false !== $result;
+	}
+
+	public function update_label( string $label ): bool {
+		$result = wp_update_post( [
+			'ID' => $this->post->ID,
+			'post_title' => $label,
+		] );
+
+		return ! is_wp_error( $result );
+	}
+
+	public function update_order( int $order ): bool {
+		$result = wp_update_post( [
+			'ID' => $this->post->ID,
+			'menu_order' => $order,
+		] );
+
+		return ! is_wp_error( $result );
+	}
+
+	public static function create( string $class_id, string $label, array $data, int $order = 0 ): ?self {
+		$post_id = wp_insert_post( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_title' => $label,
+			'post_status' => 'publish',
+			'menu_order' => $order,
+		] );
+
+		if ( is_wp_error( $post_id ) || ! $post_id ) {
+			return null;
+		}
+
+		update_post_meta( $post_id, self::META_KEY_ID, $class_id );
+		update_post_meta( $post_id, self::META_KEY_DATA, $data );
+
+		return self::from_post_id( $post_id );
+	}
+
+	public function delete(): bool {
+		$result = wp_delete_post( $this->post->ID, true );
+
+		return false !== $result;
+	}
+}

--- a/modules/global-classes/global-classes-labels.php
+++ b/modules/global-classes/global-classes-labels.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Elementor\Modules\GlobalClasses;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\GlobalClasses\Concerns\Has_Kit_Dependency;
+use Elementor\Modules\GlobalClasses\Concerns\Has_Preview_Context;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Global_Classes_Labels {
+	use Has_Kit_Dependency;
+	use Has_Preview_Context;
+
+	const META_KEY_FRONTEND = '_elementor_global_classes_labels';
+	const META_KEY_PREVIEW = '_elementor_global_classes_labels_preview';
+
+	const META_KEY = self::META_KEY_FRONTEND;
+
+	protected array $context_keys = [
+		'labels' => [
+			'frontend' => self::META_KEY_FRONTEND,
+			'preview' => self::META_KEY_PREVIEW,
+		],
+	];
+
+	private ?array $cache = null;
+
+	private function __construct() {
+	}
+
+	public static function make( Kit $kit ): self {
+		return ( new self() )->set_kit( $kit );
+	}
+
+	protected function on_preview_change(): void {
+		$this->cache = null;
+	}
+
+	public function get_labels(): array {
+		$stored = $this->read_stored();
+
+		if ( empty( $stored ) ) {
+			return [];
+		}
+
+		return $stored;
+	}
+
+	public function get_ordered_labels(): array {
+		$order = Global_Classes_Order::make( $this->get_kit() )->get_order();
+		$map = $this->get_labels();
+
+		if ( $this->is_preview() ) {
+			$frontend_map = self::make( $this->get_kit() )->get_labels();
+			foreach ( $order as $id ) {
+				if ( ! isset( $map[ $id ] ) && isset( $frontend_map[ $id ] ) ) {
+					$map[ $id ] = $frontend_map[ $id ];
+				}
+			}
+		}
+
+		$result = [];
+
+		foreach ( $order as $id ) {
+			if ( isset( $map[ $id ] ) ) {
+				$result[ $id ] = $map[ $id ];
+			}
+		}
+
+		return $result;
+	}
+
+	public function set_labels( array $id_to_label ): bool {
+		$kit = $this->get_kit();
+
+		if ( ! $kit ) {
+			return false;
+		}
+
+		$result = $kit->update_meta( $this->get_context_key( 'labels' ), $id_to_label );
+		$this->cache = $id_to_label;
+
+		return false !== $result;
+	}
+
+	private function read_stored(): array {
+		if ( null !== $this->cache ) {
+			return $this->cache;
+		}
+
+		$kit = $this->get_kit();
+
+		if ( ! $kit ) {
+			$this->cache = [];
+
+			return [];
+		}
+
+		$raw = $kit->get_meta( $this->get_context_key( 'labels' ) );
+		$this->cache = is_array( $raw ) ? $raw : [];
+
+		return $this->cache;
+	}
+}

--- a/modules/global-classes/global-classes-order.php
+++ b/modules/global-classes/global-classes-order.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Elementor\Modules\GlobalClasses;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\GlobalClasses\Concerns\Has_Kit_Dependency;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Global_Classes_Order {
+	use Has_Kit_Dependency;
+
+	const META_KEY = '_elementor_global_classes_order';
+
+	private ?array $cache = null;
+
+	private function __construct() {
+	}
+
+	public static function make( Kit $kit ): self {
+		return ( new self() )->set_kit( $kit );
+	}
+
+	public function get_order(): array {
+		$payload = $this->read_kit_meta_payload();
+
+		return $payload['order'] ?? [];
+	}
+
+	public function set_order( array $ids ): bool {
+		$kit = $this->get_kit();
+
+		if ( ! $kit ) {
+			return false;
+		}
+
+		$payload = [
+			'order' => array_values( $ids ),
+		];
+
+		$result = $kit->update_meta( self::META_KEY, $payload );
+		$this->cache = null;
+
+		return false !== $result;
+	}
+
+	public function remove_class_id( string $id ): bool {
+		$order = $this->get_order();
+
+		if ( ! in_array( $id, $order, true ) ) {
+			return true;
+		}
+
+		$order = array_filter( $order, fn( $item ) => $item !== $id );
+
+		return $this->set_order( $order );
+	}
+
+	private function read_kit_meta_payload(): array {
+		if ( null !== $this->cache ) {
+			return $this->cache;
+		}
+
+		$kit = $this->get_kit();
+
+		if ( ! $kit ) {
+			return [];
+		}
+
+		$payload = $kit->get_meta( self::META_KEY );
+		$this->cache = is_array( $payload ) ? $payload : [];
+
+		return $this->cache;
+	}
+}

--- a/modules/global-classes/global-classes-parser.php
+++ b/modules/global-classes/global-classes-parser.php
@@ -2,9 +2,6 @@
 
 namespace Elementor\Modules\GlobalClasses;
 
-use Elementor\Core\Utils\Collection;
-use Elementor\Modules\AtomicWidgets\Module;
-use Elementor\Modules\AtomicWidgets\OptIn\Opt_In;
 use Elementor\Core\Utils\Api\Parse_Result;
 use Elementor\Modules\AtomicWidgets\Parsers\Style_Parser;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
@@ -52,7 +49,9 @@ class Global_Classes_Parser {
 			return $result;
 		}
 
-		$order_result = $this->parse_order( $order, $items_result->unwrap() );
+		$sanitized_items = $items_result->unwrap();
+
+		$order_result = $this->parse_order( $order, array_keys( $sanitized_items ) );
 
 		if ( ! $order_result->is_valid() ) {
 			$result->errors()->merge( $order_result->errors(), 'order' );
@@ -60,9 +59,11 @@ class Global_Classes_Parser {
 			return $result;
 		}
 
+		$sanitized_order = $order_result->unwrap();
+
 		return $result->wrap( [
-			'items' => $items_result->unwrap(),
-			'order' => $order_result->unwrap(),
+			'items' => $sanitized_items,
+			'order' => $sanitized_order,
 		] );
 	}
 
@@ -70,7 +71,6 @@ class Global_Classes_Parser {
 		$sanitized_items = [];
 		$result = Parse_Result::make();
 		$style_parser = Style_Parser::make( Style_Schema::get() );
-		$existing_labels = [];
 
 		foreach ( $items as $item_id => $item ) {
 			$item_result = $style_parser->parse( $item );
@@ -90,51 +90,72 @@ class Global_Classes_Parser {
 			}
 
 			$sanitized_items[ $sanitized_item['id'] ] = $sanitized_item;
-			$existing_labels[] = $sanitized_item['label'];
 		}
 
 		return $result->wrap( $sanitized_items );
 	}
 
-	public function parse_order( array $order, array $items ): Parse_Result {
+	public function parse_order( array $order, array $final_item_ids ) {
 		$result = Parse_Result::make();
 
-		$items = Collection::make( $items );
+		$expected_ids = array_values( $final_item_ids );
+		$order_unique = array_values( array_unique( array_filter( $order, 'is_string' ) ) );
 
-		$order = Collection::make( $order )
-			->filter( fn( $item ) => is_string( $item ) )
-			->unique();
+		$missing_ids = array_diff( $expected_ids, $order_unique );
+		$excess_ids = array_diff( $order_unique, $expected_ids );
 
-		$existing_ids = $items->keys();
-
-		$excess_ids = $order->diff( $existing_ids );
-		$missing_ids = $existing_ids->diff( $order );
-
-		$excess_ids->each( fn( $id ) => $result->errors()->add( $id, 'excess' ) );
-		$missing_ids->each( fn( $id ) => $result->errors()->add( $id, 'missing' ) );
+		foreach ( $missing_ids as $id ) {
+			$result->errors()->add( $id, 'missing' );
+		}
+		foreach ( $excess_ids as $id ) {
+			$result->errors()->add( $id, 'excess' );
+		}
 
 		return $result->is_valid()
-			? $result->wrap( $order->values() )
+			? $result->wrap( $order_unique )
 			: $result;
 	}
 
-	public static function check_for_duplicate_labels( array $existing_labels, array $items, array $new_items_ids ) {
-
+	public static function check_for_duplicate_labels(
+		array $label_by_id,
+		array $deleted_ids,
+		array $items,
+		array $new_items_ids
+	) {
 		if ( empty( $new_items_ids ) ) {
-			return false;
+			return [];
 		}
-		$new_added_items = array_filter( $items, fn( $item ) => in_array( $item['id'], $new_items_ids, true ) );
+
+		$new_added_items = array_filter(
+			$items,
+			fn( $item ) => in_array( $item['id'], $new_items_ids, true )
+		);
 
 		$duplicates = [];
 
-		foreach ( $new_added_items as $item_id => $item ) {
-			if ( in_array( $item['label'], $existing_labels, true ) ) {
-				$duplicates[] = [
-					'item_id' => $item_id,
-					'label' => $item['label'],
-				];
+		foreach ( $new_added_items as $item ) {
+			$item_id = $item['id'];
+			$label = $item['label'];
+
+			foreach ( $label_by_id as $other_id => $other_label ) {
+				if ( in_array( $other_id, $deleted_ids, true ) ) {
+					continue;
+				}
+
+				if ( $other_id === $item_id ) {
+					continue;
+				}
+
+				if ( $other_label === $label ) {
+					$duplicates[] = [
+						'item_id' => $item_id,
+						'label' => $label,
+					];
+					break;
+				}
 			}
 		}
+
 		return $duplicates;
 	}
 

--- a/modules/global-classes/global-classes-repository.php
+++ b/modules/global-classes/global-classes-repository.php
@@ -2,15 +2,16 @@
 namespace Elementor\Modules\GlobalClasses;
 
 use Elementor\Core\Kits\Documents\Kit;
-use Elementor\Modules\AtomicWidgets\PropTypeMigrations\Migrations_Orchestrator;
-use Elementor\Modules\GlobalClasses\Global_Classes_Parser;
-use Elementor\Plugin;
+use Elementor\Modules\GlobalClasses\Concerns\Has_Kit_Dependency;
+use Elementor\Modules\GlobalClasses\Concerns\Has_Preview_Context;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
 class Global_Classes_Repository {
+	use Has_Kit_Dependency;
+	use Has_Preview_Context;
 
 	const META_KEY_FRONTEND = '_elementor_global_classes';
 	const META_KEY_PREVIEW = '_elementor_global_classes_preview';
@@ -18,25 +19,34 @@ class Global_Classes_Repository {
 	const CONTEXT_FRONTEND = 'frontend';
 	const CONTEXT_PREVIEW = 'preview';
 
-	private string $context = self::CONTEXT_FRONTEND;
+	const READ_BATCH_SIZE = 100;
+	const PERSIST_BATCH_SIZE = 100;
+
+	protected array $context_keys = [
+		'event' => [
+			'frontend' => self::CONTEXT_FRONTEND,
+			'preview' => self::CONTEXT_PREVIEW,
+		],
+		'meta_key' => [
+			'frontend' => self::META_KEY_FRONTEND,
+			'preview' => self::META_KEY_PREVIEW,
+		],
+	];
 
 	private ?Global_Classes $cache = null;
 
-	private ?Kit $kit = null;
-
 	public function __construct( ?Kit $kit = null ) {
-		$this->kit = $kit;
+		if ( null !== $kit ) {
+			$this->set_kit( $kit );
+		}
 	}
 
 	public static function make( ?Kit $kit = null ): Global_Classes_Repository {
 		return new self( $kit );
 	}
 
-	public function context( string $context ): self {
-		$this->context = $context;
+	protected function on_preview_change(): void {
 		$this->cache = null;
-
-		return $this;
 	}
 
 	public function all( bool $force = false ): Global_Classes {
@@ -44,31 +54,98 @@ class Global_Classes_Repository {
 			return $this->cache;
 		}
 
-		$meta_key = $this->get_meta_key();
-		$kit = $this->get_kit();
-		$all = $kit->get_json_meta( $meta_key );
-
-		$is_preview = static::META_KEY_PREVIEW === $meta_key;
-		$is_empty = empty( $all );
-
-		if ( $is_preview && $is_empty ) {
-			$all = $kit->get_json_meta( static::META_KEY_FRONTEND );
-		}
-
-		$all['order'] = Global_Classes_Parser::sanitize_order( $all['items'] ?? [], $all['order'] ?? [] );
-
-		Migrations_Orchestrator::make()->migrate(
-			$all,
-			$kit->get_id(),
-			$meta_key,
-			function( $migrated_data ) use ( $kit, $meta_key ) {
-				$kit->update_json_meta( $meta_key, $migrated_data );
-			}
-		);
-
-		$this->cache = Global_Classes::make( $all['items'] ?? [], $all['order'] ?? [] );
+		$this->cache = $this->all_from_posts();
 
 		return $this->cache;
+	}
+
+	public function all_labels(): array {
+		return $this->labels()->get_ordered_labels();
+	}
+
+	private function labels(): Global_Classes_Labels {
+		return Global_Classes_Labels::make( $this->get_kit() )->set_preview( $this->is_preview() );
+	}
+
+	public function get( string $class_id ): ?array {
+		$post = Global_Class_Post::find_by_class_id( $class_id, $this->is_preview() );
+
+		return $post ? $post->to_array() : null;
+	}
+
+	public function get_by_ids( array $class_ids ): array {
+		if ( empty( $class_ids ) ) {
+			return [];
+		}
+
+		$items = [];
+
+		foreach ( $this->iterate_class_posts_for_ids( $class_ids ) as $class_post ) {
+			$class_data = $class_post->to_array();
+			$items[ $class_data['id'] ] = $class_data;
+		}
+
+		return $items;
+	}
+
+	public function apply_changes( array $touched_items, array $changes, array $order ): void {
+		$labels = $this->labels();
+		$before = $labels->get_labels();
+		$is_preview = $this->is_preview();
+		$to_delete = $changes['deleted'] ?? [];
+		$to_create = $changes['added'] ?? [];
+		$to_update = $changes['modified'] ?? [];
+		$order_changed = isset( $changes['order'] ) && $changes['order'];
+
+		$final_label_map = [];
+		foreach ( $order as $id ) {
+			if ( isset( $touched_items[ $id ] ) ) {
+				$final_label_map[ $id ] = $touched_items[ $id ]['label'];
+			} elseif ( isset( $before[ $id ] ) ) {
+				$final_label_map[ $id ] = $before[ $id ];
+			}
+		}
+
+		$this->persist_class_batch_mutations( $to_delete, $to_create, $to_update, $touched_items, $is_preview );
+
+		$classes_order = Global_Classes_Order::make( $this->get_kit() );
+		$classes_order->set_order( $order );
+		$labels->set_labels( $final_label_map );
+
+		if ( ! $is_preview ) {
+			$ids_to_clear_preview = array_values( array_diff( $order, $to_create ) );
+			$this->each_class_id_batch( $ids_to_clear_preview, function ( string $class_id ) {
+				$post = Global_Class_Post::find_by_class_id( $class_id, false );
+				if ( $post ) {
+					delete_post_meta( $post->get_post_id(), Global_Class_Post::META_KEY_DATA_PREVIEW );
+					clean_post_cache( $post->get_post_id() );
+				}
+			} );
+		}
+
+		$this->cache = null;
+		$this->flush_runtime_cache();
+
+		do_action( 'elementor/global_classes/update', $this->get_context_key( 'event' ), [
+			'added' => $to_create,
+			'deleted' => $to_delete,
+			'modified' => $to_update,
+			'order' => $order_changed,
+		] );
+	}
+
+	public function each_item( callable $cb, int $batch_size = self::READ_BATCH_SIZE ): void {
+		$order = Global_Classes_Order::make( $this->get_kit() )->get_order();
+
+		if ( empty( $order ) ) {
+			return;
+		}
+
+		foreach ( array_chunk( $order, $batch_size ) as $chunk ) {
+			foreach ( $this->iterate_class_posts_for_ids( $chunk ) as $class_post ) {
+				$cb( $class_post->to_array() );
+			}
+		}
 	}
 
 	public function put( array $items, array $order ) {
@@ -79,36 +156,202 @@ class Global_Classes_Repository {
 			'order' => $order,
 		];
 
-		// `update_metadata` fails for identical data, so we skip it.
 		if ( $current_value === $updated_value ) {
 			return;
 		}
 
-		$meta_key = $this->get_meta_key();
-		$value = $this->get_kit()->update_json_meta( $meta_key, $updated_value );
+		$current_ids = array_keys( $current_value['items'] );
+		$new_ids = array_keys( $items );
 
-		$should_delete_preview = static::META_KEY_FRONTEND === $meta_key;
+		$changes = [
+			'added' => array_values( array_diff( $new_ids, $current_ids ) ),
+			'deleted' => array_values( array_diff( $current_ids, $new_ids ) ),
+			'modified' => array_values( array_filter(
+				array_intersect( $new_ids, $current_ids ),
+				fn( $id ) => $items[ $id ] !== $current_value['items'][ $id ]
+			) ),
+			'order' => implode( ';', $current_value['order'] ?? [] ) !== implode( ';', $order ),
+		];
 
-		if ( $should_delete_preview ) {
-			$this->get_kit()->delete_meta( static::META_KEY_PREVIEW );
-		}
-
-		if ( ! $value ) {
-			throw new \Exception( 'Failed to update global classes' );
-		}
+		$this->put_to_posts( $items, $order, $current_value );
 
 		$this->cache = null;
 
-		do_action( 'elementor/global_classes/update', $this->context, $updated_value, $current_value );
+		do_action( 'elementor/global_classes/update', $this->get_context_key( 'event' ), $changes );
 	}
 
-	private function get_meta_key(): string {
-		return static::CONTEXT_FRONTEND === $this->context
-			? static::META_KEY_FRONTEND
-			: static::META_KEY_PREVIEW;
+	private function all_from_posts(): Global_Classes {
+		$classes_order = Global_Classes_Order::make( $this->get_kit() );
+		$order = $classes_order->get_order();
+
+		if ( empty( $order ) ) {
+			return Global_Classes::make( [], [] );
+		}
+
+		$items = [];
+
+		foreach ( $this->iterate_class_posts_for_ids( $order ) as $class_post ) {
+			$class_data = $class_post->to_array();
+			$items[ $class_data['id'] ] = $class_data;
+		}
+
+		$order = Global_Classes_Parser::sanitize_order( $items, $order );
+
+		return Global_Classes::make( $items, $order );
 	}
 
-	private function get_kit(): Kit {
-		return $this->kit ?? Plugin::$instance->kits_manager->get_active_kit();
+	private function put_to_posts( array $items, array $order, array $current_value ): void {
+		$is_preview = $this->is_preview();
+		$current_ids = array_keys( $current_value['items'] );
+		$new_ids = array_keys( $items );
+
+		$to_delete = array_diff( $current_ids, $new_ids );
+		$to_create = array_diff( $new_ids, $current_ids );
+		$to_update = array_intersect( $new_ids, $current_ids );
+
+		$this->persist_class_batch_mutations( $to_delete, $to_create, $to_update, $items, $is_preview );
+
+		$classes_order = Global_Classes_Order::make( $this->get_kit() );
+		$classes_order->set_order( $order );
+
+		$label_map = [];
+		foreach ( $order as $id ) {
+			if ( isset( $items[ $id ]['label'] ) ) {
+				$label_map[ $id ] = $items[ $id ]['label'];
+			}
+		}
+		$this->labels()->set_labels( $label_map );
+
+		if ( ! $is_preview ) {
+			$existing_ids_to_clear = array_values( array_intersect( $new_ids, $current_ids ) );
+			$this->each_class_id_batch( $existing_ids_to_clear, function ( string $class_id ) {
+				$post = Global_Class_Post::find_by_class_id( $class_id, false );
+				if ( $post ) {
+					delete_post_meta( $post->get_post_id(), Global_Class_Post::META_KEY_DATA_PREVIEW );
+					clean_post_cache( $post->get_post_id() );
+				}
+			} );
+		}
+	}
+
+	private function iterate_class_posts_for_ids( array $class_ids ): \Generator {
+		foreach ( array_chunk( $class_ids, self::READ_BATCH_SIZE ) as $chunk ) {
+			$posts = get_posts( [
+				'post_type' => Global_Class_Post_Type::CPT,
+				'post_status' => 'publish',
+				'posts_per_page' => -1,
+				'meta_query' => [
+					[
+						'key' => Global_Class_Post::META_KEY_ID,
+						'value' => $chunk,
+						'compare' => 'IN',
+					],
+				],
+			] );
+
+			foreach ( $posts as $post ) {
+				yield Global_Class_Post::from_post( $post, $this->is_preview() );
+				clean_post_cache( $post->ID );
+			}
+			unset( $posts );
+			$this->flush_runtime_cache();
+		}
+	}
+
+	private function persist_class_batch_mutations(
+		array $to_delete,
+		array $to_create,
+		array $to_update,
+		array $items_by_id,
+		bool $is_preview
+	): void {
+		$this->each_class_id_batch( $to_delete, function ( string $class_id ) use ( $is_preview ) {
+			$post = Global_Class_Post::find_by_class_id( $class_id, false );
+
+			if ( $post ) {
+				if ( $is_preview ) {
+					$post->update_data( [], true );
+					clean_post_cache( $post->get_post_id() );
+				} else {
+					$post->delete();
+				}
+			}
+		} );
+
+		$this->each_class_id_batch( $to_create, function ( string $class_id ) use ( $items_by_id, $is_preview ) {
+			if ( ! isset( $items_by_id[ $class_id ] ) ) {
+				return;
+			}
+
+			$item = $items_by_id[ $class_id ];
+			$data = $this->build_class_data_for_storage( $item );
+
+			if ( $is_preview ) {
+				$post = Global_Class_Post::find_by_class_id( $class_id, true );
+
+				if ( $post ) {
+					$post->update_data( $data, true );
+					$post->update_label( $item['label'] );
+					clean_post_cache( $post->get_post_id() );
+				} else {
+					$created = Global_Class_Post::create( $class_id, $item['label'], $data );
+					if ( $created ) {
+						clean_post_cache( $created->get_post_id() );
+					}
+				}
+			} else {
+				$created = Global_Class_Post::create( $class_id, $item['label'], $data );
+				if ( $created ) {
+					clean_post_cache( $created->get_post_id() );
+				}
+			}
+		} );
+
+		$this->each_class_id_batch( $to_update, function ( string $class_id ) use ( $items_by_id, $is_preview ) {
+			if ( ! isset( $items_by_id[ $class_id ] ) ) {
+				return;
+			}
+
+			$item = $items_by_id[ $class_id ];
+			$post = Global_Class_Post::find_by_class_id( $class_id, $is_preview );
+
+			if ( ! $post ) {
+				return;
+			}
+
+			$data = $this->build_class_data_for_storage( $item );
+			$post->update_data( $data, $is_preview );
+			$post->update_label( $item['label'] );
+			clean_post_cache( $post->get_post_id() );
+		} );
+	}
+
+	private function each_class_id_batch( $class_ids, callable $callback, int $batch_size = self::PERSIST_BATCH_SIZE ): void {
+		$class_ids = is_array( $class_ids ) ? $class_ids : iterator_to_array( $class_ids, false );
+		foreach ( array_chunk( array_values( $class_ids ), $batch_size ) as $batch ) {
+			foreach ( $batch as $class_id ) {
+				$callback( $class_id );
+			}
+			$this->flush_runtime_cache();
+		}
+	}
+
+	private function flush_runtime_cache(): void {
+		if ( function_exists( 'wp_cache_flush_runtime' ) ) {
+			wp_cache_flush_runtime();
+		}
+	}
+
+	private function build_class_data_for_storage( array $item ): array {
+		$data = [
+			'type' => $item['type'] ?? 'class',
+			'variants' => $item['variants'] ?? [],
+		];
+
+		if ( array_key_exists( 'sync_to_v3', $item ) ) {
+			$data['sync_to_v3'] = (bool) $item['sync_to_v3'];
+		}
+
+		return $data;
 	}
 }

--- a/modules/global-classes/module.php
+++ b/modules/global-classes/module.php
@@ -39,11 +39,16 @@ class Module extends BaseModule {
 
 		// TODO: When the `e_atomic_elements` feature is not hidden, add it as a dependency
 		if ( $is_feature_active && $is_atomic_widgets_active ) {
+			( new Global_Class_Post_Type() )->register();
+
+			$relations = new Global_Classes_Relations();
+			$relations->register_hooks();
+
 			add_filter( 'elementor/editor/v2/packages', fn( $packages ) => $this->add_packages( $packages ) );
 
 			( new Global_Classes_Usage() )->register_hooks();
 			( new Global_Classes_REST_API() )->register_hooks();
-			( new Atomic_Global_Styles() )->register_hooks();
+			( new Atomic_Global_Styles( $relations ) )->register_hooks();
 			( new Global_Classes_Cleanup() )->register_hooks();
 			( new Import_Export() )->register_hooks();
 			( new Import_Export_Customization() )->register_hooks();

--- a/modules/global-classes/utils/atomic-elements-utils.php
+++ b/modules/global-classes/utils/atomic-elements-utils.php
@@ -2,10 +2,10 @@
 
 namespace Elementor\Modules\GlobalClasses\Utils;
 
-use Elementor\Core\Base\Document;
-use Elementor\Core\Utils\Collection;
 use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
 use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Widget_Base;
+use Elementor\Modules\AtomicWidgets\Utils\Utils as Atomic_Utils;
+use Elementor\Modules\AtomicWidgets\PropTypeMigrations\Schema_Resolver;
 use Elementor\Plugin;
 
 class Atomic_Elements_Utils {
@@ -13,6 +13,39 @@ class Atomic_Elements_Utils {
 	public static function is_classes_prop( $prop ) {
 		// phpcs:ignore
 		return 'plain' === $prop::$KIND && 'classes' === $prop->get_key();
+	}
+
+	public static function collect_class_ids_from_element_data( array $element_data ): array {
+		$element_type = self::get_element_type( $element_data );
+		$element_instance = self::get_element_instance( $element_type );
+
+		if ( ! Atomic_Utils::is_atomic( $element_instance ) ) {
+			return [];
+		}
+
+		$schema = Schema_Resolver::get_widget_schema( $element_type );
+		$settings = $element_data['settings'] ?? [];
+		$class_ids = [];
+
+		foreach ( $schema as $settings_key => $prop ) {
+			if ( ! self::is_classes_prop( $prop ) ) {
+				continue;
+			}
+
+			$values = $settings[ $settings_key ]['value'] ?? [];
+
+			if ( ! is_array( $values ) ) {
+				continue;
+			}
+
+			foreach ( $values as $class_id ) {
+				if ( is_string( $class_id ) && '' !== $class_id ) {
+					$class_ids[] = $class_id;
+				}
+			}
+		}
+
+		return $class_ids;
 	}
 
 	public static function get_element_type( $element ) {

--- a/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
+++ b/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
@@ -134,7 +134,7 @@ class Template_Library_Global_Classes_Snapshot_Builder extends Template_Library_
 	}
 
 	protected function load_current_data(): array {
-		$current = Global_Classes_Repository::make()->context( Global_Classes_Repository::CONTEXT_PREVIEW )->all()->get();
+		$current = Global_Classes_Repository::make()->set_preview( true )->all()->get();
 
 		return [
 			'items' => $current['items'] ?? [],

--- a/tests/phpunit/elementor/modules/global-classes/database/test-migrate-to-posts.php
+++ b/tests/phpunit/elementor/modules/global-classes/database/test-migrate-to-posts.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\GlobalClasses\Database;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\GlobalClasses\Database\Migrations\Migrate_To_Posts;
+use Elementor\Modules\GlobalClasses\Global_Class_Post;
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use Elementor\Modules\GlobalClasses\Global_Classes_Order;
+use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Migrate_To_Posts extends Elementor_Test_Base {
+	private Kit $kit;
+	private array $created_post_ids = [];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		( new Global_Class_Post_Type() )->register_post_type();
+
+		$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+	}
+
+	public function tearDown(): void {
+		$this->kit->delete_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+		$this->kit->delete_meta( Global_Classes_Repository::META_KEY_PREVIEW );
+		$this->kit->delete_meta( Global_Classes_Order::META_KEY );
+
+		$posts = get_posts( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_status' => 'any',
+			'posts_per_page' => -1,
+			'fields' => 'ids',
+		] );
+
+		foreach ( $posts as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+
+		foreach ( $this->created_post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+
+		$this->created_post_ids = [];
+
+		parent::tearDown();
+	}
+
+	public function test_migration__creates_posts_from_kit_meta() {
+		// Arrange
+		$global_classes = [
+			'items' => [
+				'g-1' => [
+					'id' => 'g-1',
+					'label' => 'button-primary',
+					'type' => 'class',
+					'variants' => [
+						[
+							'meta' => [ 'breakpoint' => 'desktop', 'state' => null ],
+							'props' => [ 'color' => [ '$$type' => 'color', 'value' => 'blue' ] ],
+						],
+					],
+				],
+				'g-2' => [
+					'id' => 'g-2',
+					'label' => 'card-shadow',
+					'type' => 'class',
+					'variants' => [],
+				],
+			],
+			'order' => [ 'g-2', 'g-1' ],
+		];
+
+		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $global_classes );
+
+		// Act
+		$migration = new Migrate_To_Posts();
+		$migration->up();
+
+		// Assert
+		$post1 = Global_Class_Post::find_by_class_id( 'g-1' );
+		$post2 = Global_Class_Post::find_by_class_id( 'g-2' );
+
+		$this->assertNotNull( $post1 );
+		$this->assertNotNull( $post2 );
+		$this->assertSame( 'button-primary', $post1->get_label() );
+		$this->assertSame( 'card-shadow', $post2->get_label() );
+
+		$classes_order = Global_Classes_Order::make( $this->kit );
+		$this->assertSame( [ 'g-2', 'g-1' ], $classes_order->get_order() );
+	}
+
+	public function test_migration__preserves_variants() {
+		// Arrange
+		$variants = [
+			[
+				'meta' => [ 'breakpoint' => 'desktop', 'state' => null ],
+				'props' => [ 'color' => [ '$$type' => 'color', 'value' => 'red' ] ],
+			],
+			[
+				'meta' => [ 'breakpoint' => 'mobile', 'state' => 'hover' ],
+				'props' => [ 'color' => [ '$$type' => 'color', 'value' => 'blue' ] ],
+			],
+		];
+
+		$global_classes = [
+			'items' => [
+				'g-1' => [
+					'id' => 'g-1',
+					'label' => 'test-class',
+					'type' => 'class',
+					'variants' => $variants,
+				],
+			],
+			'order' => [ 'g-1' ],
+		];
+
+		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $global_classes );
+
+		// Act
+		$migration = new Migrate_To_Posts();
+		$migration->up();
+
+		// Assert
+		$post = Global_Class_Post::find_by_class_id( 'g-1' );
+		$data = $post->get_data();
+
+		$this->assertSame( $variants, $data['variants'] );
+	}
+
+	public function test_migration__skips_when_no_global_classes() {
+		// Arrange - no global classes in kit meta
+
+		// Act
+		$migration = new Migrate_To_Posts();
+		$migration->up();
+
+		// Assert
+		$posts = get_posts( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_status' => 'publish',
+			'posts_per_page' => -1,
+		] );
+
+		$this->assertEmpty( $posts );
+	}
+
+	public function test_migration__skips_when_posts_already_exist() {
+		// Arrange
+		$global_classes = [
+			'items' => [
+				'g-1' => [ 'id' => 'g-1', 'label' => 'test', 'type' => 'class', 'variants' => [] ],
+			],
+			'order' => [ 'g-1' ],
+		];
+
+		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $global_classes );
+
+		$existing_post = Global_Class_Post::create( 'g-existing', 'existing-class', [ 'type' => 'class', 'variants' => [] ] );
+
+		// Act
+		$migration = new Migrate_To_Posts();
+		$migration->up();
+
+		// Assert - only the pre-existing post should exist
+		$posts = get_posts( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_status' => 'publish',
+			'posts_per_page' => -1,
+		] );
+
+		$this->assertCount( 1, $posts );
+		$this->assertSame( $existing_post->get_post_id(), $posts[0]->ID );
+
+		$this->assertNotEmpty( $this->kit->get_json_meta( Global_Classes_Repository::META_KEY_FRONTEND ) );
+	}
+}

--- a/tests/phpunit/elementor/modules/global-classes/test-global-class-post-type.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-global-class-post-type.php
@@ -1,0 +1,45 @@
+<?php
+namespace Elementor\Tests\Phpunit\Modules\GlobalClasses;
+
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Global_Class_Post_Type extends Elementor_Test_Base {
+	public function setUp(): void {
+		parent::setUp();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	public function test_register_post_type__should_register_e_global_class_cpt() {
+		// Arrange
+		$post_type = new Global_Class_Post_Type();
+
+		// Act
+		$post_type->register_post_type();
+
+		// Assert
+		$this->assertTrue( post_type_exists( Global_Class_Post_Type::CPT ) );
+	}
+
+	public function test_register_post_type__should_not_be_public() {
+		// Arrange
+		$post_type = new Global_Class_Post_Type();
+
+		// Act
+		$post_type->register_post_type();
+		$post_type_obj = get_post_type_object( Global_Class_Post_Type::CPT );
+
+		// Assert
+		$this->assertFalse( $post_type_obj->public );
+		$this->assertFalse( $post_type_obj->publicly_queryable );
+		$this->assertFalse( $post_type_obj->show_ui );
+		$this->assertFalse( $post_type_obj->show_in_menu );
+	}
+}

--- a/tests/phpunit/elementor/modules/global-classes/test-global-class-post.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-global-class-post.php
@@ -1,0 +1,223 @@
+<?php
+namespace Elementor\Tests\Phpunit\Modules\GlobalClasses;
+
+use Elementor\Modules\GlobalClasses\Global_Class_Post;
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Global_Class_Post extends Elementor_Test_Base {
+	private array $created_post_ids = [];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		( new Global_Class_Post_Type() )->register_post_type();
+	}
+
+	public function tearDown(): void {
+		foreach ( $this->created_post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+
+		$this->created_post_ids = [];
+
+		parent::tearDown();
+	}
+
+	public function test_create__should_create_post_with_correct_data() {
+		// Arrange
+		$class_id = 'g-123';
+		$label = 'my-button';
+		$data = [
+			'type' => 'class',
+			'variants' => [
+				[
+					'meta' => [ 'breakpoint' => 'desktop', 'state' => null ],
+					'props' => [ 'color' => [ '$$type' => 'color', 'value' => 'red' ] ],
+				],
+			],
+		];
+
+		// Act
+		$post = Global_Class_Post::create( $class_id, $label, $data, 5 );
+		$this->created_post_ids[] = $post->get_post_id();
+
+		// Assert
+		$this->assertNotNull( $post );
+		$this->assertSame( $class_id, $post->get_class_id() );
+		$this->assertSame( $label, $post->get_label() );
+		$this->assertSame( 5, $post->get_order() );
+		$this->assertSame( $data, $post->get_data() );
+	}
+
+	public function test_find_by_class_id__should_find_existing_post() {
+		// Arrange
+		$class_id = 'g-456';
+		$post = Global_Class_Post::create( $class_id, 'test-class', [ 'type' => 'class', 'variants' => [] ] );
+		$this->created_post_ids[] = $post->get_post_id();
+
+		// Act
+		$found = Global_Class_Post::find_by_class_id( $class_id );
+
+		// Assert
+		$this->assertNotNull( $found );
+		$this->assertSame( $class_id, $found->get_class_id() );
+		$this->assertSame( $post->get_post_id(), $found->get_post_id() );
+	}
+
+	public function test_find_by_class_id__should_return_null_for_non_existing() {
+		// Act
+		$found = Global_Class_Post::find_by_class_id( 'non-existing-id' );
+
+		// Assert
+		$this->assertNull( $found );
+	}
+
+	public function test_from_post_id__should_return_post_for_valid_id() {
+		// Arrange
+		$post = Global_Class_Post::create( 'g-789', 'test-class', [ 'type' => 'class', 'variants' => [] ] );
+		$this->created_post_ids[] = $post->get_post_id();
+
+		// Act
+		$found = Global_Class_Post::from_post_id( $post->get_post_id() );
+
+		// Assert
+		$this->assertNotNull( $found );
+		$this->assertSame( 'g-789', $found->get_class_id() );
+	}
+
+	public function test_from_post_id__should_return_null_for_invalid_id() {
+		// Act
+		$found = Global_Class_Post::from_post_id( 99999 );
+
+		// Assert
+		$this->assertNull( $found );
+	}
+
+	public function test_to_array__should_return_correct_structure() {
+		// Arrange
+		$class_id = 'g-abc';
+		$label = 'button-primary';
+		$data = [
+			'type' => 'class',
+			'variants' => [
+				[
+					'meta' => [ 'breakpoint' => 'desktop', 'state' => null ],
+					'props' => [ 'background' => [ '$$type' => 'color', 'value' => 'blue' ] ],
+				],
+			],
+		];
+		$post = Global_Class_Post::create( $class_id, $label, $data );
+		$this->created_post_ids[] = $post->get_post_id();
+
+		// Act
+		$array = $post->to_array();
+
+		// Assert
+		$this->assertSame( [
+			'id' => $class_id,
+			'label' => $label,
+			'type' => 'class',
+			'variants' => $data['variants'],
+		], $array );
+	}
+
+	public function test_update_data__should_update_frontend_data() {
+		// Arrange
+		$post = Global_Class_Post::create( 'g-update', 'update-test', [ 'type' => 'class', 'variants' => [] ] );
+		$this->created_post_ids[] = $post->get_post_id();
+
+		$new_data = [
+			'type' => 'class',
+			'variants' => [
+				[
+					'meta' => [ 'breakpoint' => 'desktop', 'state' => 'hover' ],
+					'props' => [ 'color' => [ '$$type' => 'color', 'value' => 'green' ] ],
+				],
+			],
+		];
+
+		// Act
+		$result = $post->update_data( $new_data, false );
+
+		// Assert
+		$this->assertTrue( $result );
+		$this->assertSame( $new_data, $post->get_data() );
+	}
+
+	public function test_update_data__preview_should_not_affect_frontend() {
+		// Arrange
+		$frontend_data = [ 'type' => 'class', 'variants' => [] ];
+		$post = Global_Class_Post::create( 'g-preview', 'preview-test', $frontend_data );
+		$this->created_post_ids[] = $post->get_post_id();
+
+		$preview_data = [
+			'type' => 'class',
+			'variants' => [
+				[
+					'meta' => [ 'breakpoint' => 'desktop', 'state' => null ],
+					'props' => [ 'color' => [ '$$type' => 'color', 'value' => 'purple' ] ],
+				],
+			],
+		];
+
+		// Act
+		$post->update_data( $preview_data, true );
+
+		// Assert - frontend context should still return frontend data
+		$frontend_post = Global_Class_Post::from_post_id( $post->get_post_id(), false );
+		$this->assertSame( $frontend_data, $frontend_post->get_data() );
+
+		// Assert - preview context should return preview data
+		$preview_post = Global_Class_Post::from_post_id( $post->get_post_id(), true );
+		$this->assertSame( $preview_data, $preview_post->get_data() );
+	}
+
+	public function test_update_label__should_update_post_title() {
+		// Arrange
+		$post = Global_Class_Post::create( 'g-label', 'old-label', [ 'type' => 'class', 'variants' => [] ] );
+		$this->created_post_ids[] = $post->get_post_id();
+
+		// Act
+		$result = $post->update_label( 'new-label' );
+
+		// Assert
+		$this->assertTrue( $result );
+
+		$updated = Global_Class_Post::from_post_id( $post->get_post_id() );
+		$this->assertSame( 'new-label', $updated->get_label() );
+	}
+
+	public function test_update_order__should_update_menu_order() {
+		// Arrange
+		$post = Global_Class_Post::create( 'g-order', 'order-test', [ 'type' => 'class', 'variants' => [] ], 0 );
+		$this->created_post_ids[] = $post->get_post_id();
+
+		// Act
+		$result = $post->update_order( 10 );
+
+		// Assert
+		$this->assertTrue( $result );
+
+		$updated = Global_Class_Post::from_post_id( $post->get_post_id() );
+		$this->assertSame( 10, $updated->get_order() );
+	}
+
+	public function test_delete__should_remove_post() {
+		// Arrange
+		$post = Global_Class_Post::create( 'g-delete', 'delete-test', [ 'type' => 'class', 'variants' => [] ] );
+		$post_id = $post->get_post_id();
+
+		// Act
+		$result = $post->delete();
+
+		// Assert
+		$this->assertTrue( $result );
+		$this->assertNull( Global_Class_Post::from_post_id( $post_id ) );
+	}
+}

--- a/tests/phpunit/elementor/modules/global-classes/test-global-classes-repository-posts.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-global-classes-repository-posts.php
@@ -1,0 +1,255 @@
+<?php
+namespace Elementor\Tests\Phpunit\Modules\GlobalClasses;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\GlobalClasses\Global_Class_Post;
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use Elementor\Modules\GlobalClasses\Global_Classes_Labels;
+use Elementor\Modules\GlobalClasses\Global_Classes_Order;
+use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Global_Classes_Repository_Posts extends Elementor_Test_Base {
+	private Kit $kit;
+	private array $created_post_ids = [];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		( new Global_Class_Post_Type() )->register_post_type();
+
+		$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+	}
+
+	public function tearDown(): void {
+		$this->kit->delete_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+		$this->kit->delete_meta( Global_Classes_Repository::META_KEY_PREVIEW );
+		$this->kit->delete_meta( Global_Classes_Labels::META_KEY_FRONTEND );
+		$this->kit->delete_meta( Global_Classes_Labels::META_KEY_PREVIEW );
+
+		foreach ( $this->created_post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+
+		$this->created_post_ids = [];
+
+		parent::tearDown();
+	}
+
+	public function test_all__returns_from_posts_when_posts_exist() {
+		// Arrange
+		$post1 = Global_Class_Post::create( 'g-1', 'button-primary', [
+			'type' => 'class',
+			'variants' => [ [ 'meta' => [ 'breakpoint' => 'desktop', 'state' => null ], 'props' => [] ] ],
+		] );
+		$post2 = Global_Class_Post::create( 'g-2', 'card-shadow', [
+			'type' => 'class',
+			'variants' => [],
+		] );
+		$this->created_post_ids[] = $post1->get_post_id();
+		$this->created_post_ids[] = $post2->get_post_id();
+
+		Global_Classes_Order::make( $this->kit )->set_order( [ 'g-2', 'g-1' ] );
+
+		// Act
+		$result = Global_Classes_Repository::make()->all();
+
+		// Assert
+		$this->assertSame( [ 'g-2', 'g-1' ], $result->get_order()->all() );
+		$this->assertSame( 'button-primary', $result->get_items()->get( 'g-1' )['label'] );
+		$this->assertSame( 'card-shadow', $result->get_items()->get( 'g-2' )['label'] );
+	}
+
+	public function test_get__returns_class_from_posts() {
+		// Arrange
+		$post = Global_Class_Post::create( 'g-123', 'my-class', [
+			'type' => 'class',
+			'variants' => [ [ 'meta' => [ 'breakpoint' => 'desktop', 'state' => null ], 'props' => [] ] ],
+		] );
+		$this->created_post_ids[] = $post->get_post_id();
+
+		Global_Classes_Order::make( $this->kit )->set_order( [ 'g-123' ] );
+
+		// Act
+		$result = Global_Classes_Repository::make()->get( 'g-123' );
+
+		// Assert
+		$this->assertNotNull( $result );
+		$this->assertSame( 'g-123', $result['id'] );
+		$this->assertSame( 'my-class', $result['label'] );
+	}
+
+	public function test_get__returns_null_for_non_existing() {
+		// Arrange
+		$post = Global_Class_Post::create( 'g-1', 'exists', [ 'type' => 'class', 'variants' => [] ] );
+		$this->created_post_ids[] = $post->get_post_id();
+
+		Global_Classes_Order::make( $this->kit )->set_order( [ 'g-1' ] );
+
+		// Act
+		$result = Global_Classes_Repository::make()->get( 'g-non-existing' );
+
+		// Assert
+		$this->assertNull( $result );
+	}
+
+	public function test_put__creates_new_posts() {
+		// Arrange
+		$post = Global_Class_Post::create( 'g-existing', 'existing', [ 'type' => 'class', 'variants' => [] ] );
+		$this->created_post_ids[] = $post->get_post_id();
+
+		Global_Classes_Order::make( $this->kit )->set_order( [ 'g-existing' ] );
+
+		$new_items = [
+			'g-existing' => [ 'id' => 'g-existing', 'label' => 'existing', 'type' => 'class', 'variants' => [] ],
+			'g-new' => [ 'id' => 'g-new', 'label' => 'new-class', 'type' => 'class', 'variants' => [] ],
+		];
+
+		// Act
+		Global_Classes_Repository::make()->put( $new_items, [ 'g-new', 'g-existing' ] );
+
+		// Assert
+		$new_post = Global_Class_Post::find_by_class_id( 'g-new' );
+		$this->assertNotNull( $new_post );
+		$this->created_post_ids[] = $new_post->get_post_id();
+		$this->assertSame( 'new-class', $new_post->get_label() );
+
+		$classes_order = Global_Classes_Order::make( $this->kit );
+		$this->assertSame( [ 'g-new', 'g-existing' ], $classes_order->get_order() );
+	}
+
+	public function test_put__deletes_removed_posts() {
+		// Arrange
+		$post1 = Global_Class_Post::create( 'g-keep', 'keep', [ 'type' => 'class', 'variants' => [] ] );
+		$post2 = Global_Class_Post::create( 'g-delete', 'delete', [ 'type' => 'class', 'variants' => [] ] );
+		$this->created_post_ids[] = $post1->get_post_id();
+
+		Global_Classes_Order::make( $this->kit )->set_order( [ 'g-keep', 'g-delete' ] );
+
+		$new_items = [
+			'g-keep' => [ 'id' => 'g-keep', 'label' => 'keep', 'type' => 'class', 'variants' => [] ],
+		];
+
+		// Act
+		Global_Classes_Repository::make()->put( $new_items, [ 'g-keep' ] );
+
+		// Assert
+		$deleted_post = Global_Class_Post::find_by_class_id( 'g-delete' );
+		$this->assertNull( $deleted_post );
+
+		$kept_post = Global_Class_Post::find_by_class_id( 'g-keep' );
+		$this->assertNotNull( $kept_post );
+	}
+
+	public function test_put__updates_existing_posts() {
+		// Arrange
+		$post = Global_Class_Post::create( 'g-update', 'old-label', [
+			'type' => 'class',
+			'variants' => [],
+		] );
+		$this->created_post_ids[] = $post->get_post_id();
+
+		Global_Classes_Order::make( $this->kit )->set_order( [ 'g-update' ] );
+
+		$updated_items = [
+			'g-update' => [
+				'id' => 'g-update',
+				'label' => 'new-label',
+				'type' => 'class',
+				'variants' => [ [ 'meta' => [ 'breakpoint' => 'desktop', 'state' => null ], 'props' => [ 'color' => 'red' ] ] ],
+			],
+		];
+
+		// Act
+		Global_Classes_Repository::make()->put( $updated_items, [ 'g-update' ] );
+
+		// Assert
+		$updated_post = Global_Class_Post::find_by_class_id( 'g-update' );
+		$this->assertSame( 'new-label', $updated_post->get_label() );
+
+		$data = $updated_post->get_data();
+		$this->assertCount( 1, $data['variants'] );
+	}
+
+	public function test_put__merges_with_stored_state() {
+		$style_def = [
+			'type' => 'class',
+			'variants' => [ [ 'meta' => [ 'breakpoint' => 'desktop', 'state' => null ], 'props' => [] ] ],
+		];
+		$post1 = Global_Class_Post::create( 'g-keep', 'keep', $style_def );
+		$this->created_post_ids[] = $post1->get_post_id();
+		$post2 = Global_Class_Post::create( 'g-removed', 'gone', $style_def );
+		$this->created_post_ids[] = $post2->get_post_id();
+
+		Global_Classes_Order::make( $this->kit )->set_order( [ 'g-keep', 'g-removed' ] );
+
+		Global_Classes_Repository::make()->put(
+			[
+				'g-keep' => [
+					'id' => 'g-keep',
+					'label' => 'keep',
+					'type' => 'class',
+					'variants' => [ [ 'meta' => [ 'breakpoint' => 'desktop', 'state' => null ], 'props' => [] ] ],
+				],
+				'g-new' => [ 'id' => 'g-new', 'label' => 'n', 'type' => 'class', 'variants' => [] ],
+			],
+			[ 'g-keep', 'g-new' ]
+		);
+
+		$keep = Global_Class_Post::find_by_class_id( 'g-keep' );
+		$this->assertNotNull( $keep );
+		$this->assertNull( Global_Class_Post::find_by_class_id( 'g-removed' ) );
+
+		$this->assertNotNull( Global_Class_Post::find_by_class_id( 'g-new' ) );
+		$this->created_post_ids[] = Global_Class_Post::find_by_class_id( 'g-new' )->get_post_id();
+
+		$all = Global_Classes_Repository::make()->all( true );
+		$this->assertArrayHasKey( 'g-keep', $all->get_items()->all() );
+		$this->assertArrayNotHasKey( 'g-removed', $all->get_items()->all() );
+		$this->assertArrayHasKey( 'g-new', $all->get_items()->all() );
+	}
+
+	public function test_all_labels__is_ordered_by_kit_labels_meta() {
+		$post = Global_Class_Post::create( 'gl-1', 'Label-One', [ 'type' => 'class', 'variants' => [] ] );
+		$this->created_post_ids[] = $post->get_post_id();
+		Global_Classes_Order::make( $this->kit )->set_order( [ 'gl-1' ] );
+		Global_Classes_Labels::make( $this->kit )->set_labels( [ 'gl-1' => 'Label-One' ] );
+
+		$this->assertSame( [ 'gl-1' => 'Label-One' ], Global_Classes_Repository::make()->all_labels() );
+	}
+
+	public function test_apply_changes__replaces_set_and_syncs_label_meta() {
+		$p1 = Global_Class_Post::create( 'ac-1', 'A', [ 'type' => 'class', 'variants' => [] ] );
+		$this->created_post_ids[] = $p1->get_post_id();
+		Global_Classes_Order::make( $this->kit )->set_order( [ 'ac-1' ] );
+		Global_Classes_Repository::make()->all_labels();
+
+		Global_Classes_Repository::make()->apply_changes(
+			[
+				'ac-2' => [
+					'id' => 'ac-2',
+					'label' => 'B',
+					'type' => 'class',
+					'variants' => [],
+				],
+			],
+			[
+				'added' => [ 'ac-2' ],
+				'deleted' => [ 'ac-1' ],
+				'modified' => [],
+			],
+			[ 'ac-2' ]
+		);
+
+		$ac2 = Global_Class_Post::find_by_class_id( 'ac-2' );
+		$this->assertNotNull( $ac2 );
+		$this->created_post_ids[] = $ac2->get_post_id();
+		$this->assertNull( Global_Class_Post::find_by_class_id( 'ac-1' ) );
+		$this->assertSame( [ 'ac-2' => 'B' ], Global_Classes_Repository::make()->all_labels() );
+	}
+}


### PR DESCRIPTION
**This slice:** introduces the global-class CPT and post model, the DB updater and **migrate-to-posts** migration, the **repository** with parser/labels/order plus **atomic-elements** utils, removes the obsolete **changes resolver** class, and registers the CPT in `module.php` (relations and atomic constructor wiring follow in later PRs).

---

## Full feature (ED-23093)

This stacked series delivers **ED-23093**: global classes persisted as **posts** (with migration from kit metadata), **document–class relations** for usage and cache invalidation, **REST** and **import/export** behavior, **atomic global styles** plus **design-system** integration, the **`editor-global-classes`** editor package, and **tests**. Each PR is a reviewable slice; merge **1 → 6** in order so the stack matches the full integration branch against `main`.

---

Made with [Cursor](https://cursor.com)