### PR TITLE
Internal: Global classes (4/6) — atomic styles & design system [ED-23093]

### DIFF
--- a/app/modules/site-builder/services/design-system-service.php
+++ b/app/modules/site-builder/services/design-system-service.php
@@ -28,8 +28,7 @@ class Design_System_Service {
 			? array_values( $global_classes['order'] )
 			: [];
 
-		Global_Classes_Repository::make( $this->kit )
-			->context( Global_Classes_Repository::CONTEXT_FRONTEND )
+		Global_Classes_Repository::make( $this->get_kit() )
 			->put( $items, $order );
 
 		return [
@@ -69,7 +68,11 @@ class Design_System_Service {
 	}
 
 	private function get_kit(): ?Kit {
-		return $this->kit ?? Plugin::$instance->kits_manager->get_active_kit();
+		if ( ! $this->kit ) {
+			$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+		}
+
+		return $this->kit;
 	}
 
 	private function repository_for( Kit $kit ): Variables_Repository {

--- a/modules/design-system-sync/classes/classes-provider.php
+++ b/modules/design-system-sync/classes/classes-provider.php
@@ -21,7 +21,6 @@ class Classes_Provider {
 		}
 
 		$classes_data = Global_Classes_Repository::make()
-			->context( Global_Classes_Repository::CONTEXT_FRONTEND )
 			->all()
 			->get();
 
@@ -31,16 +30,16 @@ class Classes_Provider {
 	}
 
 	public static function get_synced_classes(): array {
-		$all_classes = self::get_all_classes();
 		$synced_classes = [];
 
-		foreach ( $all_classes as $id => $class ) {
-			if ( empty( $class['sync_to_v3'] ) ) {
-				continue;
-			}
+		Global_Classes_Repository::make()
+			->each_item( static function ( array $class ) use ( &$synced_classes ) {
+				if ( empty( $class['sync_to_v3'] ) ) {
+					return;
+				}
 
-			$synced_classes[ $id ] = $class;
-		}
+				$synced_classes[ $class['id'] ] = $class;
+			} );
 
 		return $synced_classes;
 	}

--- a/modules/global-classes/atomic-global-styles.php
+++ b/modules/global-classes/atomic-global-styles.php
@@ -8,15 +8,26 @@ use Elementor\Modules\AtomicWidgets\Styles\Atomic_Styles_Manager;
 class Atomic_Global_Styles {
 	const STYLES_KEY = 'global';
 
+	private Global_Classes_Relations $relations;
+
+	public function __construct( Global_Classes_Relations $relations ) {
+		$this->relations = $relations;
+	}
+
 	public function register_hooks() {
 		add_action(
 			'elementor/atomic-widgets/styles/register',
-			fn( Atomic_Styles_Manager $styles_manager ) => $this->register_styles( $styles_manager ),
+			fn( Atomic_Styles_Manager $styles_manager, array $post_ids ) => $this->register_styles( $styles_manager, $post_ids ),
 			20,
 			2
 		);
 
-		add_action( 'elementor/global_classes/update', fn( string $context ) => $this->invalidate_cache( $context ), 10, 1 );
+		add_action(
+			'elementor/global_classes/update',
+			fn( string $context, array $changes ) => $this->invalidate_cache_for_updated_classes( $context, $changes ),
+			10,
+			2
+		);
 
 		add_action(
 			'deleted_post',
@@ -25,39 +36,141 @@ class Atomic_Global_Styles {
 
 		add_action(
 			'elementor/core/files/clear_cache',
-			fn() => $this->invalidate_cache(),
+			fn() => $this->invalidate_all_cache(),
 		);
 
-		add_filter('elementor/atomic-widgets/settings/transformers/classes',
+		add_filter(
+			'elementor/atomic-widgets/settings/transformers/classes',
 			fn( $value ) => $this->transform_classes_names( $value )
 		);
 	}
 
-	private function register_styles( Atomic_Styles_Manager $styles_manager ) {
-		$context = Plugin::$instance->preview->is_editor_or_preview() ? Global_Classes_Repository::CONTEXT_PREVIEW : Global_Classes_Repository::CONTEXT_FRONTEND;
+	private function register_styles( Atomic_Styles_Manager $styles_manager, array $post_ids ) {
+		$context = $this->get_context();
 
-		$get_styles = function () use ( $context ) {
-			return Global_Classes_Repository::make()->context( $context )->all()->get_ordered_items()->map( function( $item ) {
-				$item['id'] = $item['label'];
-				return $item;
-			})->reverse()->all(); // we should reverse the order of the items so that the last in the original array should be rendered first (to be overridden by the previous ones)
-		};
+		foreach ( $post_ids as $post_id ) {
+			$get_styles = fn() => $this->get_document_global_styles( $post_id, $context );
 
-		$styles_manager->register(
-			[ self::STYLES_KEY, $context ],
-			$get_styles,
-		);
+			$styles_manager->register(
+				[ self::STYLES_KEY, $post_id, $context ],
+				$get_styles
+			);
+		}
+	}
+
+	private function get_document_global_styles( int $post_id, string $context ): array {
+		$is_preview = Global_Classes_Repository::CONTEXT_PREVIEW === $context;
+		$class_ids = $this->relations->set_preview( $is_preview )->get_styles_by_post( $post_id );
+
+		if ( empty( $class_ids ) ) {
+			return [];
+		}
+
+		$repository = Global_Classes_Repository::make();
+
+		if ( $is_preview ) {
+			$repository->set_preview( true );
+		}
+
+		$global_order = $repository->all_labels();
+		$ordered_class_ids = array_values( array_intersect( array_keys( $global_order ), $class_ids ) );
+
+		if ( empty( $ordered_class_ids ) ) {
+			return [];
+		}
+
+		$items = $repository->get_by_ids( $ordered_class_ids );
+		$reversed_order = array_reverse( $ordered_class_ids );
+
+		$styles = [];
+
+		foreach ( $reversed_order as $class_id ) {
+			$item = $items[ $class_id ] ?? null;
+
+			if ( ! $item ) {
+				continue;
+			}
+
+			$item['id'] = $item['label'];
+			$styles[] = $item;
+		}
+
+		return $styles;
 	}
 
 	private function on_post_delete( $post_id ) {
-		if ( ! Plugin::$instance->kits_manager->is_kit( $post_id ) ) {
+		if ( Global_Class_Post_Type::CPT === get_post_type( $post_id ) ) {
+			$class_id = get_post_meta( $post_id, Global_Class_Post::META_KEY_ID, true );
+
+			if ( $class_id ) {
+				$this->invalidate_cache_for_class( $class_id );
+			}
+
 			return;
 		}
 
-		$this->invalidate_cache();
+		if ( Plugin::$instance->kits_manager->is_kit( $post_id ) ) {
+			$this->invalidate_all_cache();
+		}
 	}
 
-	private function invalidate_cache( ?string $context = null ) {
+	private function invalidate_cache_for_updated_classes( string $context, array $changes ) {
+		if ( isset( $changes['order'] ) && $changes['order'] ) {
+			$this->invalidate_all_cache( $context );
+
+			return;
+		}
+
+		$affected = array_unique( array_merge(
+			$changes['added'] ?? [],
+			$changes['deleted'] ?? [],
+			$changes['modified'] ?? []
+		) );
+
+		if ( empty( $affected ) ) {
+			return;
+		}
+
+		$document_ids = [];
+		$is_preview = Global_Classes_Repository::CONTEXT_PREVIEW === $context;
+
+		foreach ( $affected as $class_id ) {
+			foreach ( $this->relations->set_preview( $is_preview )->get_posts_by_style( $class_id ) as $doc_id ) {
+				$document_ids[ $doc_id ] = true;
+			}
+		}
+
+		if ( empty( $document_ids ) ) {
+			$this->invalidate_all_cache( $context );
+
+			return;
+		}
+
+		foreach ( array_keys( $document_ids ) as $post_id ) {
+			$this->invalidate_document_cache( $post_id, $context );
+		}
+	}
+
+	private function invalidate_cache_for_class( string $class_id, ?string $context = null ) {
+		$document_ids = array_values( array_unique( array_merge(
+			( new Global_Classes_Relations() )->get_posts_by_style( $class_id ),
+			( new Global_Classes_Relations() )->set_preview( true )->get_posts_by_style( $class_id )
+		) ) );
+
+		foreach ( $document_ids as $doc_id ) {
+			$this->invalidate_document_cache( $doc_id, $context );
+		}
+	}
+
+	private function invalidate_document_cache( int $post_id, ?string $context = null ) {
+		if ( empty( $context ) ) {
+			do_action( 'elementor/atomic-widgets/styles/clear', [ self::STYLES_KEY, $post_id ] );
+		} else {
+			do_action( 'elementor/atomic-widgets/styles/clear', [ self::STYLES_KEY, $post_id, $context ] );
+		}
+	}
+
+	private function invalidate_all_cache( ?string $context = null ) {
 		if ( empty( $context ) || Global_Classes_Repository::CONTEXT_FRONTEND === $context ) {
 			do_action( 'elementor/atomic-widgets/styles/clear', [ self::STYLES_KEY ] );
 
@@ -68,20 +181,27 @@ class Atomic_Global_Styles {
 	}
 
 	private function transform_classes_names( $ids ) {
-		$context = Plugin::$instance->preview->is_editor_or_preview() ? Global_Classes_Repository::CONTEXT_PREVIEW : Global_Classes_Repository::CONTEXT_FRONTEND;
+		$context = $this->get_context();
 
-		$classes = Global_Classes_Repository::make()
-			->context( $context )
-			->all()
-			->get_items();
+		$repository = Global_Classes_Repository::make();
+
+		if ( Global_Classes_Repository::CONTEXT_PREVIEW === $context ) {
+			$repository->set_preview( true );
+		}
+
+		$labels = $repository->all_labels();
 
 		return array_map(
-			function( $id ) use ( $classes ) {
-				$class = $classes->get( $id );
-
-				return $class ? $class['label'] : $id;
+			static function( $id ) use ( $labels ) {
+				return $labels[ $id ] ?? $id;
 			},
 			$ids
 		);
+	}
+
+	private function get_context(): string {
+		return Plugin::$instance->preview->is_editor_or_preview()
+			? Global_Classes_Repository::CONTEXT_PREVIEW
+			: Global_Classes_Repository::CONTEXT_FRONTEND;
 	}
 }


### PR DESCRIPTION
**This slice:** wires **`Atomic_Global_Styles`** with relations (per-document style registration and invalidation), and connects **site-builder** / **design-system-sync** so deployed and synced class data stay consistent.

---

## Full feature (ED-23093)

This stacked series delivers **ED-23093**: global classes persisted as **posts** (with migration from kit metadata), **document–class relations** for usage and cache invalidation, **REST** and **import/export** behavior, **atomic global styles** plus **design-system** integration, the **`editor-global-classes`** editor package, and **tests**. Each PR is a reviewable slice; merge **1 → 6** in order so the stack matches the full integration branch against `main`.
