### PR TITLE
Internal: Global classes (5/6) — editor package [ED-23093]

### DIFF
--- a/packages/packages/core/editor-global-classes/src/api.ts
+++ b/packages/packages/core/editor-global-classes/src/api.ts
@@ -1,4 +1,4 @@
-import { type StyleDefinition, type StyleDefinitionID, type StyleDefinitionsMap } from '@elementor/editor-styles';
+import { type StyleDefinition, type StyleDefinitionID } from '@elementor/editor-styles';
 import { type HttpResponse, httpService } from '@elementor/http-client';
 
 import { type CssClassUsage } from './components/css-class-usage/types';
@@ -7,13 +7,24 @@ import { type GlobalClasses } from './store';
 const RESOURCE_URL = '/global-classes';
 const BASE_URL = 'elementor/v1';
 const RESOURCE_USAGE_URL = `${ RESOURCE_URL }/usage`;
+const RESOURCE_POST_URL = `${ RESOURCE_URL }/post`;
+const RESOURCE_STYLES_URL = `${ RESOURCE_URL }/styles`;
 
 type GlobalClassesUsageResponse = HttpResponse< CssClassUsage >;
 
-export type GlobalClassesGetAllResponse = HttpResponse<
-	StyleDefinitionsMap,
+export type GlobalClassIndexEntry = {
+	id: StyleDefinitionID;
+	label: string;
+};
+
+export type GlobalClassesIndexHttpResponse = HttpResponse< GlobalClassIndexEntry[], Record< string, never > >;
+
+export type StyleDefinitionsNullableMap = Record< StyleDefinitionID, StyleDefinition | null >;
+
+export type GlobalClassesStylesHttpResponse = HttpResponse<
+	StyleDefinitionsNullableMap,
 	{
-		order: StyleDefinition[ 'id' ][];
+		order: StyleDefinitionID[];
 	}
 >;
 
@@ -27,27 +38,33 @@ type UpdatePayload = GlobalClasses & {
 
 export type ApiContext = 'preview' | 'frontend';
 
+function saveGlobalClasses( context: ApiContext, payload: UpdatePayload ) {
+	return httpService().put( `${ BASE_URL }${ RESOURCE_URL }`, payload, {
+		params: { context },
+	} );
+}
+
 export const apiClient = {
 	usage: () => httpService().get< GlobalClassesUsageResponse >( `${ BASE_URL }${ RESOURCE_USAGE_URL }` ),
 
 	all: ( context: ApiContext = 'preview' ) =>
-		httpService().get< GlobalClassesGetAllResponse >( `${ BASE_URL }${ RESOURCE_URL }`, {
+		httpService().get< GlobalClassesIndexHttpResponse >( `${ BASE_URL }${ RESOURCE_URL }`, {
 			params: { context },
 		} ),
 
-	publish: ( payload: UpdatePayload ) =>
-		httpService().put( 'elementor/v1' + RESOURCE_URL, payload, {
-			params: {
-				context: 'frontend' satisfies ApiContext,
-			},
+	getStylesForPost: ( postId: number, context: ApiContext = 'preview' ) =>
+		httpService().get< GlobalClassesStylesHttpResponse >( `${ BASE_URL }${ RESOURCE_POST_URL }`, {
+			params: { context, post_id: postId },
 		} ),
 
-	saveDraft: ( payload: UpdatePayload ) =>
-		httpService().put( 'elementor/v1' + RESOURCE_URL, payload, {
-			params: {
-				context: 'preview' satisfies ApiContext,
-			},
+	getStylesByIds: ( ids: StyleDefinitionID[], context: ApiContext = 'preview' ) =>
+		httpService().get< GlobalClassesStylesHttpResponse >( `${ BASE_URL }${ RESOURCE_STYLES_URL }`, {
+			params: { context, ids: ids.join( ',' ) },
 		} ),
+
+	publish: ( payload: UpdatePayload ) => saveGlobalClasses( 'frontend', payload ),
+
+	saveDraft: ( payload: UpdatePayload ) => saveGlobalClasses( 'preview', payload ),
 };
 
 export const API_ERROR_CODES = {

--- a/packages/packages/core/editor-global-classes/src/components/global-styles-import-listener.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/global-styles-import-listener.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
+import { getCurrentDocument } from '@elementor/editor-documents';
 import { __useDispatch as useDispatch } from '@elementor/store';
 
-import { apiClient } from '../api';
+import { fetchAndDispatchGlobalClasses } from '../load-global-classes-state';
 import { slice } from '../store';
 
 export function GlobalStylesImportListener() {
@@ -12,6 +13,8 @@ export function GlobalStylesImportListener() {
 			const importedClasses = event.detail?.global_classes;
 
 			if ( importedClasses?.items && importedClasses?.order ) {
+				const items = importedClasses.items as Record< string, { id: string; label: string } >;
+
 				dispatch(
 					slice.actions.load( {
 						preview: {
@@ -22,29 +25,14 @@ export function GlobalStylesImportListener() {
 							items: importedClasses.items,
 							order: importedClasses.order,
 						},
+						classLabels: Object.fromEntries(
+							Object.entries( items ).map( ( [ id, item ] ) => [ id, item.label ] )
+						),
 					} )
 				);
 			}
 
-			Promise.all( [ apiClient.all( 'preview' ), apiClient.all( 'frontend' ) ] )
-				.then( ( [ previewRes, frontendRes ] ) => {
-					const { data: previewData } = previewRes;
-					const { data: frontendData } = frontendRes;
-
-					dispatch(
-						slice.actions.load( {
-							preview: {
-								items: previewData.data,
-								order: previewData.meta.order,
-							},
-							frontend: {
-								items: frontendData.data,
-								order: frontendData.meta.order,
-							},
-						} )
-					);
-				} )
-				.catch( () => {} );
+			fetchAndDispatchGlobalClasses( getCurrentDocument()?.id ).catch( () => {} );
 		};
 
 		window.addEventListener( 'elementor/global-styles/imported', handleGlobalStylesImported as EventListener );

--- a/packages/packages/core/editor-global-classes/src/components/populate-store.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/populate-store.tsx
@@ -1,33 +1,17 @@
 import { useEffect } from 'react';
-import { __useDispatch as useDispatch } from '@elementor/store';
+import { getCurrentDocument } from '@elementor/editor-documents';
+import { registerDataHook } from '@elementor/editor-v1-adapters';
 
-import { apiClient } from '../api';
-import { slice } from '../store';
+import { fetchAndDispatchGlobalClasses } from '../load-global-classes-state';
 
 export function PopulateStore() {
-	const dispatch = useDispatch();
-
 	useEffect( () => {
-		Promise.all( [ apiClient.all( 'preview' ), apiClient.all( 'frontend' ) ] ).then(
-			( [ previewRes, frontendRes ] ) => {
-				const { data: previewData } = previewRes;
-				const { data: frontendData } = frontendRes;
+		fetchAndDispatchGlobalClasses( getCurrentDocument()?.id );
 
-				dispatch(
-					slice.actions.load( {
-						preview: {
-							items: previewData.data,
-							order: previewData.meta.order,
-						},
-						frontend: {
-							items: frontendData.data,
-							order: frontendData.meta.order,
-						},
-					} )
-				);
-			}
-		);
-	}, [ dispatch ] );
+		registerDataHook( 'after', 'editor/documents/attach-preview', async () => {
+			await fetchAndDispatchGlobalClasses( getCurrentDocument()?.id );
+		} );
+	}, [] );
 
 	return null;
 }

--- a/packages/packages/core/editor-global-classes/src/global-classes-styles-provider.ts
+++ b/packages/packages/core/editor-global-classes/src/global-classes-styles-provider.ts
@@ -14,20 +14,23 @@ import { __ } from '@wordpress/i18n';
 
 import { getCapabilities } from './capabilities';
 import { GlobalClassLabelAlreadyExistsError, GlobalClassTrackingError } from './errors';
+import { loadExistingClasses } from './load-existing-classes';
 import {
+	placeholderDefinition,
 	selectClass,
+	selectClassLabels,
 	selectData,
-	selectGlobalClasses,
+	selectIsClassFetched,
 	selectOrderedClasses,
 	slice,
 	type StateWithGlobalClasses,
 } from './store';
 import { trackGlobalClasses, type TrackingEvent } from './utils/tracking';
 
-const MAX_CLASSES = 100;
+const MAX_CLASSES = 1000;
 
 export const GLOBAL_CLASSES_PROVIDER_KEY = 'global-classes';
-const PREGENERATED_LINK_PATTERN = /^global-(preview|frontend)-[a-zA-Z_-]+-css$/;
+const PREGENERATED_LINK_PATTERN = /^global-([0-9]+-)?(preview|frontend)-[a-zA-Z_-]+-css$/;
 
 export const globalClassesStylesProvider = createStylesProvider( {
 	key: GLOBAL_CLASSES_PROVIDER_KEY,
@@ -42,21 +45,44 @@ export const globalClassesStylesProvider = createStylesProvider( {
 	capabilities: getCapabilities(),
 	actions: {
 		all: () => selectOrderedClasses( getState() ),
-		get: ( id ) => selectClass( getState(), id ),
+		get: ( id ) => {
+			const state = getState();
+
+			const isFetched = selectIsClassFetched( state, id );
+			const style = selectClass( state, id );
+
+			// the isFetched flag is based on the existence of the style in the initial data
+			// so if the style is created during the same session - it won't be stored as part of the initial data
+			if ( isFetched || style ) {
+				return style;
+			}
+
+			loadExistingClasses( [ id ] );
+
+			const label = selectClassLabels( state )[ id ] ?? id;
+			return placeholderDefinition( id, label );
+		},
 		resolveCssName: ( id: string ) => {
-			return selectClass( getState(), id )?.label ?? id;
+			const state = getState();
+			const loaded = selectClass( state, id );
+			if ( loaded ) {
+				return loaded.label;
+			}
+			const fromIndex = selectClassLabels( state )[ id ];
+			return fromIndex ?? id;
 		},
 		create: ( label, variants: StyleDefinitionVariant[] = [], id?: StyleDefinitionID ) => {
-			const classes = selectGlobalClasses( getState() );
-
-			const existingLabels = Object.values( classes ).map( ( style ) => style.label );
+			const existingClasses = Object.entries( selectClassLabels( getState() ) );
+			const existingLabels = existingClasses.map( ( [ , classLabel ] ) => classLabel );
 
 			if ( existingLabels.includes( label ) ) {
 				throw new GlobalClassLabelAlreadyExistsError( { context: { label } } );
 			}
 
+			const existingIds = existingClasses.map( ( [ existingId ] ) => existingId );
+
 			if ( ! id ) {
-				id = generateId( 'g-', Object.keys( classes ) );
+				id = generateId( 'g-', existingIds );
 			}
 
 			dispatch(
@@ -114,10 +140,10 @@ const subscribeWithStates = (
 	let previousState = selectData( getState() );
 
 	return subscribeWithSelector(
-		( state: StateWithGlobalClasses ) => state.globalClasses,
+		( state: StateWithGlobalClasses ) => selectData( state ),
 		( currentState ) => {
-			cb( previousState.items, currentState.data.items );
-			previousState = currentState.data;
+			cb( previousState.items, currentState.items );
+			previousState = currentState;
 		}
 	);
 };

--- a/packages/packages/core/editor-global-classes/src/index.ts
+++ b/packages/packages/core/editor-global-classes/src/index.ts
@@ -1,3 +1,7 @@
 export { GLOBAL_CLASSES_URI } from './mcp-integration/classes-resource';
 
 export { init } from './init';
+
+export { loadExistingClasses } from './load-existing-classes';
+export { fetchAndDispatchGlobalClasses, indexEntriesToClassLabels } from './load-global-classes-state';
+export type { GlobalClassIndexEntry } from './api';

--- a/packages/packages/core/editor-global-classes/src/load-existing-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/load-existing-classes.ts
@@ -1,0 +1,49 @@
+import { type StyleDefinitionID } from '@elementor/editor-styles';
+import { __dispatch as dispatch, __getState as getState } from '@elementor/store';
+
+import { apiClient } from './api';
+import { styleDefinitionsMapWithoutNull } from './load-global-classes-state';
+import { selectGlobalClasses, slice } from './store';
+
+let pendingLoad: Promise< void > | null = null;
+const pendingIds = new Set< StyleDefinitionID >();
+
+export async function loadExistingClasses( classIds: StyleDefinitionID[] ): Promise< void > {
+	const existingClasses = selectGlobalClasses( getState() );
+	const missingIds = classIds.filter( ( id ) => ! ( id in existingClasses ) );
+
+	if ( missingIds.length === 0 ) {
+		return;
+	}
+
+	missingIds.forEach( ( id ) => pendingIds.add( id ) );
+
+	if ( pendingLoad ) {
+		await pendingLoad;
+		return loadExistingClasses( classIds );
+	}
+
+	pendingLoad = fetchAndMergeClasses();
+
+	try {
+		await pendingLoad;
+	} finally {
+		pendingLoad = null;
+	}
+}
+
+async function fetchAndMergeClasses(): Promise< void > {
+	const idsToFetch = Array.from( pendingIds );
+	pendingIds.clear();
+
+	if ( idsToFetch.length === 0 ) {
+		return;
+	}
+
+	const previewResponse = await apiClient.getStylesByIds( idsToFetch, 'preview' );
+	const frontendResponse = await apiClient.getStylesByIds( idsToFetch, 'frontend' );
+	const previewItems = styleDefinitionsMapWithoutNull( previewResponse.data.data );
+	const frontendItems = styleDefinitionsMapWithoutNull( frontendResponse.data.data );
+
+	dispatch( slice.actions.mergeExistingClasses( { preview: previewItems, frontend: frontendItems } ) );
+}

--- a/packages/packages/core/editor-global-classes/src/load-global-classes-state.ts
+++ b/packages/packages/core/editor-global-classes/src/load-global-classes-state.ts
@@ -1,0 +1,56 @@
+import { type StyleDefinition, type StyleDefinitionID } from '@elementor/editor-styles';
+import { __dispatch as dispatch } from '@elementor/store';
+
+import { apiClient, type GlobalClassIndexEntry, type StyleDefinitionsNullableMap } from './api';
+import { slice } from './store';
+
+export function indexEntriesToClassLabels( entries: GlobalClassIndexEntry[] ): Record< StyleDefinitionID, string > {
+	return Object.fromEntries( entries.map( ( e ) => [ e.id, e.label ] ) );
+}
+
+export function styleDefinitionsMapWithoutNull(
+	map: StyleDefinitionsNullableMap
+): Record< StyleDefinitionID, StyleDefinition > {
+	return Object.fromEntries(
+		Object.entries( map ).filter(
+			( entry ): entry is [ StyleDefinitionID, StyleDefinition ] => entry[ 1 ] !== null
+		)
+	) as Record< StyleDefinitionID, StyleDefinition >;
+}
+
+export async function fetchAndDispatchGlobalClasses( postId?: number ) {
+	const previewIndexRes = await apiClient.all( 'preview' );
+	const previewIndex = previewIndexRes.data.data;
+	const classLabels = indexEntriesToClassLabels( previewIndex );
+	const globalOrder = previewIndex.map( ( e ) => e.id );
+
+	if ( ! postId ) {
+		dispatch(
+			slice.actions.load( {
+				preview: { items: {}, order: globalOrder },
+				frontend: { items: {}, order: globalOrder },
+				classLabels,
+			} )
+		);
+		return;
+	}
+
+	const [ frontendIndexRes, previewPostRes, frontendPostRes ] = await Promise.all( [
+		apiClient.all( 'frontend' ),
+		apiClient.getStylesForPost( postId, 'preview' ),
+		apiClient.getStylesForPost( postId, 'frontend' ),
+	] );
+
+	void frontendIndexRes;
+
+	const previewItems = styleDefinitionsMapWithoutNull( previewPostRes.data.data );
+	const frontendItems = styleDefinitionsMapWithoutNull( frontendPostRes.data.data );
+
+	dispatch(
+		slice.actions.load( {
+			preview: { items: previewItems, order: globalOrder },
+			frontend: { items: frontendItems, order: globalOrder },
+			classLabels,
+		} )
+	);
+}

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/classes-resource.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/classes-resource.ts
@@ -1,13 +1,15 @@
 import { type MCPRegistryEntry } from '@elementor/editor-mcp';
+import { __getState as getState } from '@elementor/store';
 
 import { globalClassesStylesProvider } from '../global-classes-styles-provider';
+import { selectOrderedClasses } from '../store';
 
 export const GLOBAL_CLASSES_URI = 'elementor://global-classes';
 
 const STORAGE_KEY = 'elementor-global-classes';
 
 const updateLocalStorageCache = () => {
-	const classes = globalClassesStylesProvider.actions.all();
+	const classes = selectOrderedClasses( getState() );
 
 	localStorage.setItem( STORAGE_KEY, JSON.stringify( classes ) );
 };

--- a/packages/packages/core/editor-global-classes/src/save-global-classes.tsx
+++ b/packages/packages/core/editor-global-classes/src/save-global-classes.tsx
@@ -17,10 +17,17 @@ export async function saveGlobalClasses( { context, onApprove }: Options ) {
 	const state = selectData( getState() );
 	const apiAction = context === 'preview' ? apiClient.saveDraft : apiClient.publish;
 	const currentContext = context === 'preview' ? selectPreviewInitialData : selectFrontendInitialData;
+	const changes = calculateChanges( state, currentContext( getState() ) );
+
+	const touchedIds = [ ...changes.added, ...changes.modified ];
+	const touchedItems = Object.fromEntries(
+		touchedIds.map( ( id ) => [ id, state.items[ id ] ] ).filter( ( [ , v ] ) => v )
+	);
+
 	const response = await apiAction( {
-		items: state.items,
+		items: touchedItems,
 		order: state.order,
-		changes: calculateChanges( state, currentContext( getState() ) ),
+		changes,
 	} );
 
 	dispatch( slice.actions.reset( { context } ) );
@@ -29,10 +36,12 @@ export async function saveGlobalClasses( { context, onApprove }: Options ) {
 
 	if ( response?.data?.data?.code === API_ERROR_CODES.DUPLICATED_LABEL ) {
 		dispatch( slice.actions.updateMultiple( response.data.data.modifiedLabels ) );
+
 		trackGlobalClasses( {
 			event: 'classPublishConflict',
 			numOfConflicts: Object.keys( response.data.data.modifiedLabels ).length,
 		} );
+
 		openDialog( {
 			component: (
 				<DuplicateLabelDialog
@@ -48,11 +57,17 @@ function calculateChanges( state: GlobalClasses, initialData: GlobalClasses ) {
 	const stateIds = Object.keys( state.items );
 	const initialDataIds = Object.keys( initialData.items );
 
+	const { order: stateOrder } = state;
+	const { order: initialDataOrder } = initialData;
+
+	const order = stateOrder.join( ';' ) !== initialDataOrder.join( ';' );
+
 	return {
 		added: stateIds.filter( ( id ) => ! initialDataIds.includes( id ) ),
 		deleted: initialDataIds.filter( ( id ) => ! stateIds.includes( id ) ),
 		modified: stateIds.filter( ( id ) => {
 			return id in initialData.items && hash( state.items[ id ] ) !== hash( initialData.items[ id ] );
 		} ),
+		order,
 	};
 }

--- a/packages/packages/core/editor-global-classes/src/store.ts
+++ b/packages/packages/core/editor-global-classes/src/store.ts
@@ -25,6 +25,7 @@ export type GlobalClasses = {
 
 type GlobalClassesState = {
 	data: GlobalClasses;
+	classLabels: Record< StyleDefinitionID, string >;
 	initialData: {
 		frontend: GlobalClasses;
 		preview: GlobalClasses;
@@ -43,6 +44,7 @@ const localHistory = SnapshotHistory.get< GlobalClasses >( 'global-classes' );
 
 const initialState: GlobalClassesState = {
 	data: { items: {}, order: [] },
+	classLabels: {},
 	initialData: {
 		frontend: { items: {}, order: [] },
 		preview: { items: {}, order: [] },
@@ -62,15 +64,17 @@ export const slice = createSlice( {
 		load(
 			state,
 			{
-				payload: { frontend, preview },
+				payload: { frontend, preview, classLabels },
 			}: PayloadAction< {
 				frontend: GlobalClasses;
 				preview: GlobalClasses;
+				classLabels: Record< StyleDefinitionID, string >;
 			} >
 		) {
 			state.initialData.frontend = frontend;
 			state.initialData.preview = preview;
 			state.data = preview;
+			state.classLabels = classLabels;
 
 			state.isDirty = false;
 		},
@@ -79,6 +83,7 @@ export const slice = createSlice( {
 			localHistory.next( state.data );
 			state.data.items[ payload.id ] = payload;
 			state.data.order.unshift( payload.id );
+			state.classLabels[ payload.id ] = payload.label;
 
 			state.isDirty = true;
 		},
@@ -90,6 +95,8 @@ export const slice = createSlice( {
 			);
 
 			state.data.order = state.data.order.filter( ( id ) => id !== payload );
+			// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+			delete state.classLabels[ payload ];
 
 			state.isDirty = true;
 		},
@@ -119,6 +126,7 @@ export const slice = createSlice( {
 			localHistory.next( state.data );
 			Object.entries( payload ).forEach( ( [ id, { modified } ] ) => {
 				state.data.items[ id ].label = modified;
+				state.classLabels[ id ] = modified;
 			} );
 
 			state.isDirty = false;
@@ -208,6 +216,33 @@ export const slice = createSlice( {
 				state.isDirty = true;
 			}
 		},
+
+		mergeExistingClasses(
+			state,
+			{
+				payload: { preview, frontend },
+			}: PayloadAction< { preview: GlobalClasses[ 'items' ]; frontend: GlobalClasses[ 'items' ] } >
+		) {
+			Object.entries( preview ).forEach( ( [ id, previewClassData ] ) => {
+				const frontendClassData = frontend[ id ];
+
+				if ( previewClassData === null || previewClassData === undefined ) {
+					return;
+				}
+				if ( ! ( id in state.data.items ) ) {
+					state.data.items[ id ] = previewClassData;
+				}
+				if ( ! ( id in state.initialData.frontend.items ) ) {
+					state.initialData.frontend.items[ id ] = frontendClassData;
+				}
+				if ( ! ( id in state.initialData.preview.items ) ) {
+					state.initialData.preview.items[ id ] = previewClassData;
+				}
+				if ( ! ( id in state.classLabels ) ) {
+					state.classLabels[ id ] = previewClassData.label;
+				}
+			} );
+		},
 	},
 } );
 
@@ -233,8 +268,17 @@ const getNonEmptyVariants = ( style: StyleDefinition ) => {
 	);
 };
 
+export const placeholderDefinition = ( id: StyleDefinitionID, label: string ): StyleDefinition => ( {
+	id,
+	type: 'class',
+	label,
+	variants: [],
+} );
+
 // Selectors
 export const selectData = ( state: SliceState< typeof slice > ) => state[ SLICE_NAME ].data;
+
+export const selectClassLabels = ( state: SliceState< typeof slice > ) => state[ SLICE_NAME ].classLabels;
 
 export const selectFrontendInitialData = ( state: SliceState< typeof slice > ) =>
 	state[ SLICE_NAME ].initialData.frontend;
@@ -248,8 +292,17 @@ export const selectGlobalClasses = createSelector( selectData, ( { items } ) => 
 
 export const selectIsDirty = ( state: SliceState< typeof slice > ) => state[ SLICE_NAME ].isDirty;
 
-export const selectOrderedClasses = createSelector( selectGlobalClasses, selectOrder, ( items, order ) =>
-	order.map( ( id ) => items[ id ] )
+export const selectOrderedClasses = createSelector( selectData, selectClassLabels, ( { items, order }, classLabels ) =>
+	order
+		.map( ( id ) => {
+			const loaded = items[ id ];
+			if ( loaded ) {
+				return loaded;
+			}
+			const label = classLabels[ id ];
+			return label !== undefined ? placeholderDefinition( id, label ) : null;
+		} )
+		.filter( ( s ): s is StyleDefinition => s !== null )
 );
 
 export const selectClass = ( state: SliceState< typeof slice >, id: StyleDefinitionID ) =>
@@ -258,3 +311,8 @@ export const selectClass = ( state: SliceState< typeof slice >, id: StyleDefinit
 export const selectEmptyCssClass = createSelector( selectData, ( { items } ) =>
 	Object.values( items ).filter( ( cssClass ) => cssClass.variants.length === 0 )
 );
+
+export const selectIsClassFetched = ( state: SliceState< typeof slice >, id: StyleDefinitionID ) =>
+	!! state[ SLICE_NAME ].initialData.preview.items[ id ] ||
+	!! state[ SLICE_NAME ].initialData.frontend.items[ id ] ||
+	false;

--- a/packages/packages/core/editor-global-classes/src/utils/tracking.ts
+++ b/packages/packages/core/editor-global-classes/src/utils/tracking.ts
@@ -5,7 +5,7 @@ import { __getState as getState } from '@elementor/store';
 import { fetchCssClassUsage } from '../../service/css-class-usage-service';
 import { GlobalClassTrackingError } from '../errors';
 import { type FilterKey } from '../hooks/use-filtered-css-class-usage';
-import { selectClass } from '../store';
+import { placeholderDefinition, selectClass, selectClassLabels } from '../store';
 
 type EventMap = {
 	classCreated: {
@@ -220,16 +220,24 @@ const extractCssClassData = ( classId: StyleDefinitionID ) => {
 };
 
 const getCssClass = ( classId: StyleDefinitionID ) => {
-	const cssClass = selectClass( getState(), classId );
-	if ( ! cssClass ) {
-		throw new Error( `CSS class with ID ${ classId } not found` );
+	const state = getState();
+	const cssClass = selectClass( state, classId );
+
+	if ( cssClass ) {
+		return cssClass;
 	}
-	return cssClass;
+
+	const label = selectClassLabels( state )[ classId ];
+	if ( label !== undefined ) {
+		return placeholderDefinition( classId, label );
+	}
+
+	throw new Error( `CSS class with ID ${ classId } not found` );
 };
 
 const trackDeleteClass = async ( classId: StyleDefinitionID ) => {
-	const totalInstances = await getTotalInstancesByCssClassID( classId );
 	const classTitle = getCssClass( classId ).label;
+	const totalInstances = await getTotalInstancesByCssClassID( classId );
 	return { totalInstances, classTitle };
 };
 


### PR DESCRIPTION
**This slice:** ships the **`editor-global-classes`** package—store, API, load/save flows, MCP resource, and UI glue—without the Jest tests (those are in PR 6).

---

## Full feature (ED-23093)

This stacked series delivers **ED-23093**: global classes persisted as **posts** (with migration from kit metadata), **document–class relations** for usage and cache invalidation, **REST** and **import/export** behavior, **atomic global styles** plus **design-system** integration, the **`editor-global-classes`** editor package, and **tests**. Each PR is a reviewable slice; merge **1 → 6** in order so the stack matches the full integration branch against `main`.
