### PR TITLE
Internal: Global classes (6/6) — tests [ED-23093]

### DIFF
--- a/packages/packages/core/editor-global-classes/src/__tests__/global-classes-styles-provider.test.ts
+++ b/packages/packages/core/editor-global-classes/src/__tests__/global-classes-styles-provider.test.ts
@@ -2,12 +2,13 @@ import { type StyleDefinition } from '@elementor/editor-styles';
 import {
 	__createStore as createStore,
 	__dispatch as dispatch,
+	__getState as getState,
 	__registerSlice as registerSlice,
 } from '@elementor/store';
 
 import { GlobalClassNotFoundError } from '../errors';
 import { globalClassesStylesProvider } from '../global-classes-styles-provider';
-import { type GlobalClasses, slice } from '../store';
+import { type GlobalClasses, selectClass, slice } from '../store';
 
 describe( 'globalClassesStylesProvider', () => {
 	beforeEach( () => {
@@ -37,10 +38,16 @@ describe( 'globalClassesStylesProvider', () => {
 			order: [ 'style-1', 'style-2' ],
 		};
 
+		const classLabels = {
+			'style-1': 'Style 1',
+			'style-2': 'Style 2',
+		};
+
 		dispatch(
 			slice.actions.load( {
 				preview: data,
 				frontend: data,
+				classLabels,
 			} )
 		);
 
@@ -73,10 +80,16 @@ describe( 'globalClassesStylesProvider', () => {
 			order: [ 'style-1', 'style-2' ],
 		};
 
+		const classLabels = {
+			'style-1': 'Style 1',
+			'style-2': 'Style 2',
+		};
+
 		dispatch(
 			slice.actions.load( {
 				preview: data,
 				frontend: data,
+				classLabels,
 			} )
 		);
 
@@ -103,10 +116,15 @@ describe( 'globalClassesStylesProvider', () => {
 			order: [ existingClass.id ],
 		};
 
+		const classLabels = {
+			[ existingClass.id ]: existingClass.label,
+		};
+
 		dispatch(
 			slice.actions.load( {
 				preview: data,
 				frontend: data,
+				classLabels,
 			} )
 		);
 
@@ -129,6 +147,50 @@ describe( 'globalClassesStylesProvider', () => {
 		] );
 	} );
 
+	it( 'should return live store rows from get for newly created unsaved classes', () => {
+		const existingClass: StyleDefinition = {
+			id: 'g-123',
+			type: 'class',
+			label: 'Existing class',
+			variants: [],
+		};
+
+		const data = {
+			items: {
+				[ existingClass.id ]: existingClass,
+			},
+			order: [ existingClass.id ],
+		};
+
+		const classLabels = {
+			[ existingClass.id ]: existingClass.label,
+		};
+
+		dispatch(
+			slice.actions.load( {
+				preview: data,
+				frontend: data,
+				classLabels,
+			} )
+		);
+
+		const createdId = globalClassesStylesProvider.actions?.create?.( 'Session class', [] );
+
+		globalClassesStylesProvider.actions?.updateProps?.( {
+			id: createdId ?? '',
+			meta: { state: null, breakpoint: null },
+			props: {
+				editorHint: 'regression-session-class',
+			},
+		} );
+
+		expect( createdId ).toMatch( /^g-[a-z0-9]{7}$/ );
+
+		expect( globalClassesStylesProvider.actions.get( createdId ?? '' ) ).toStrictEqual(
+			selectClass( getState(), createdId ?? '' )
+		);
+	} );
+
 	it( 'should throw when trying to update a non-existing global class', () => {
 		// Arrange.
 		const data: GlobalClasses = {
@@ -143,10 +205,15 @@ describe( 'globalClassesStylesProvider', () => {
 			order: [],
 		};
 
+		const classLabels = {
+			'style-1': 'Style 1',
+		};
+
 		dispatch(
 			slice.actions.load( {
 				preview: data,
 				frontend: data,
+				classLabels,
 			} )
 		);
 

--- a/packages/packages/core/editor-global-classes/src/__tests__/save-global-classes.test.ts
+++ b/packages/packages/core/editor-global-classes/src/__tests__/save-global-classes.test.ts
@@ -1,0 +1,175 @@
+import { createMockStyleDefinition } from 'test-utils';
+import { getCurrentUser } from '@elementor/editor-current-user';
+import {
+	__createStore as createStore,
+	__dispatch as dispatch,
+	__registerSlice as registerSlice,
+} from '@elementor/store';
+
+import { apiClient } from '../api';
+import { UPDATE_CLASS_CAPABILITY_KEY } from '../capabilities';
+import { saveGlobalClasses } from '../save-global-classes';
+import { slice } from '../store';
+
+jest.mock( '../api' );
+jest.mock( '@elementor/editor-current-user' );
+
+const classLabelsFor = ( order: string[], items: Record< string, ReturnType< typeof createMockStyleDefinition > > ) =>
+	Object.fromEntries( order.map( ( id ) => [ id, items[ id ]?.label ?? id ] ) );
+
+describe( 'saveGlobalClasses', () => {
+	beforeEach( () => {
+		registerSlice( slice );
+		createStore();
+
+		jest.mocked( getCurrentUser ).mockReturnValue( {
+			capabilities: [ UPDATE_CLASS_CAPABILITY_KEY ],
+		} as never );
+
+		jest.mocked( apiClient.publish ).mockResolvedValue( {} as never );
+		jest.mocked( apiClient.saveDraft ).mockResolvedValue( {} as never );
+	} );
+
+	it( 'should not mark lazily loaded classes as added', async () => {
+		// Arrange
+		const initialClass = createMockStyleDefinition( { id: 'initial-class' } );
+		const lazyLoadedClass = createMockStyleDefinition( { id: 'lazy-class' } );
+		const order = [ 'initial-class', 'lazy-class' ];
+
+		dispatch(
+			slice.actions.load( {
+				frontend: { items: { 'initial-class': initialClass }, order },
+				preview: { items: { 'initial-class': initialClass }, order },
+				classLabels: classLabelsFor( order, {
+					'initial-class': initialClass,
+					'lazy-class': lazyLoadedClass,
+				} ),
+			} )
+		);
+
+		dispatch(
+			slice.actions.mergeExistingClasses( {
+				preview: { 'lazy-class': lazyLoadedClass },
+				frontend: { 'lazy-class': lazyLoadedClass },
+			} )
+		);
+
+		// Act
+		await saveGlobalClasses( { context: 'frontend' } );
+
+		// Assert
+		expect( apiClient.publish ).toHaveBeenCalledWith( {
+			items: {},
+			order,
+			changes: {
+				added: [],
+				deleted: [],
+				modified: [],
+				order: false,
+			},
+		} );
+	} );
+
+	it( 'should correctly mark newly created classes as added', async () => {
+		// Arrange
+		const initialClass = createMockStyleDefinition( { id: 'initial-class' } );
+		const newClass = createMockStyleDefinition( { id: 'new-class' } );
+
+		dispatch(
+			slice.actions.load( {
+				frontend: { items: { 'initial-class': initialClass }, order: [ 'initial-class' ] },
+				preview: { items: { 'initial-class': initialClass }, order: [ 'initial-class' ] },
+				classLabels: classLabelsFor( [ 'initial-class' ], { 'initial-class': initialClass } ),
+			} )
+		);
+
+		dispatch( slice.actions.add( newClass ) );
+
+		// Act
+		await saveGlobalClasses( { context: 'frontend' } );
+
+		// Assert
+		expect( apiClient.publish ).toHaveBeenCalledWith( {
+			items: { 'new-class': newClass },
+			order: [ 'new-class', 'initial-class' ],
+			changes: {
+				added: [ 'new-class' ],
+				deleted: [],
+				modified: [],
+				order: true,
+			},
+		} );
+	} );
+
+	it( 'should correctly detect modified classes', async () => {
+		// Arrange
+		const originalClass = createMockStyleDefinition( { id: 'class-1', label: 'Original' } );
+
+		dispatch(
+			slice.actions.load( {
+				frontend: { items: { 'class-1': originalClass }, order: [ 'class-1' ] },
+				preview: { items: { 'class-1': originalClass }, order: [ 'class-1' ] },
+				classLabels: classLabelsFor( [ 'class-1' ], { 'class-1': originalClass } ),
+			} )
+		);
+
+		dispatch( slice.actions.update( { style: { id: 'class-1', label: 'Modified' } } ) );
+
+		// Act
+		await saveGlobalClasses( { context: 'frontend' } );
+
+		// Assert
+		expect( apiClient.publish ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				changes: {
+					added: [],
+					deleted: [],
+					modified: [ 'class-1' ],
+					order: false,
+				},
+			} )
+		);
+	} );
+
+	it( 'should handle mixed scenario: lazy load + create + modify', async () => {
+		// Arrange
+		const initialClass = createMockStyleDefinition( { id: 'initial' } );
+		const lazyClass = createMockStyleDefinition( { id: 'lazy' } );
+		const createdClass = createMockStyleDefinition( { id: 'created' } );
+		const orderBeforeCreate = [ 'initial', 'lazy' ];
+
+		dispatch(
+			slice.actions.load( {
+				frontend: { items: { initial: initialClass }, order: orderBeforeCreate },
+				preview: { items: { initial: initialClass }, order: orderBeforeCreate },
+				classLabels: classLabelsFor( orderBeforeCreate, { initial: initialClass, lazy: lazyClass } ),
+			} )
+		);
+
+		dispatch(
+			slice.actions.mergeExistingClasses( {
+				preview: { lazy: lazyClass },
+				frontend: { lazy: lazyClass },
+			} )
+		);
+
+		dispatch( slice.actions.add( createdClass ) );
+
+		dispatch( slice.actions.update( { style: { id: 'initial', label: 'Modified Initial' } } ) );
+
+		// Act
+		await saveGlobalClasses( { context: 'frontend' } );
+
+		// Assert
+		expect( apiClient.publish ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				changes: {
+					added: [ 'created' ],
+					deleted: [],
+					modified: [ 'initial' ],
+					order: true,
+				},
+			} )
+		);
+	} );
+} );

--- a/packages/packages/core/editor-global-classes/src/__tests__/store.test.ts
+++ b/packages/packages/core/editor-global-classes/src/__tests__/store.test.ts
@@ -1,0 +1,154 @@
+import { createMockStyleDefinition } from 'test-utils';
+import {
+	__createStore as createStore,
+	__dispatch as dispatch,
+	__getState as getState,
+	__registerSlice as registerSlice,
+} from '@elementor/store';
+
+import { selectData, selectFrontendInitialData, selectIsDirty, selectPreviewInitialData, slice } from '../store';
+
+const classLabelsFor = ( order: string[], items: Record< string, ReturnType< typeof createMockStyleDefinition > > ) =>
+	Object.fromEntries( order.map( ( id ) => [ id, items[ id ]?.label ?? id ] ) );
+
+describe( 'store', () => {
+	beforeEach( () => {
+		registerSlice( slice );
+		createStore();
+	} );
+
+	describe( 'mergeExistingClasses', () => {
+		it( 'should merge classes into data and initialData without marking as dirty', () => {
+			// Arrange
+			const initialClass = createMockStyleDefinition( { id: 'initial-class' } );
+			const newClass = createMockStyleDefinition( { id: 'new-class' } );
+			const order = [ 'initial-class', 'new-class' ];
+
+			dispatch(
+				slice.actions.load( {
+					frontend: { items: { 'initial-class': initialClass }, order },
+					preview: { items: { 'initial-class': initialClass }, order },
+					classLabels: classLabelsFor( order, { 'initial-class': initialClass, 'new-class': newClass } ),
+				} )
+			);
+
+			// Act
+			dispatch(
+				slice.actions.mergeExistingClasses( {
+					preview: { 'new-class': newClass },
+					frontend: { 'new-class': newClass },
+				} )
+			);
+
+			// Assert
+			const data = selectData( getState() );
+			const frontendInitial = selectFrontendInitialData( getState() );
+			const previewInitial = selectPreviewInitialData( getState() );
+			const isDirty = selectIsDirty( getState() );
+
+			expect( data.items ).toEqual( {
+				'initial-class': initialClass,
+				'new-class': newClass,
+			} );
+			expect( data.order ).toEqual( order );
+
+			expect( frontendInitial.items ).toEqual( {
+				'initial-class': initialClass,
+				'new-class': newClass,
+			} );
+
+			expect( previewInitial.items ).toEqual( {
+				'initial-class': initialClass,
+				'new-class': newClass,
+			} );
+
+			expect( isDirty ).toBe( false );
+		} );
+
+		it( 'should not overwrite existing classes', () => {
+			// Arrange
+			const existingClass = createMockStyleDefinition( { id: 'existing', label: 'Original' } );
+			const duplicateClass = createMockStyleDefinition( { id: 'existing', label: 'Duplicate' } );
+			const order = [ 'existing' ];
+
+			dispatch(
+				slice.actions.load( {
+					frontend: { items: { existing: existingClass }, order },
+					preview: { items: { existing: existingClass }, order },
+					classLabels: classLabelsFor( order, { existing: existingClass } ),
+				} )
+			);
+
+			// Act
+			dispatch(
+				slice.actions.mergeExistingClasses( {
+					preview: { existing: duplicateClass },
+					frontend: { existing: duplicateClass },
+				} )
+			);
+
+			// Assert
+			const data = selectData( getState() );
+			expect( data.items.existing.label ).toBe( 'Original' );
+		} );
+
+		it( 'should not change order array length when merging', () => {
+			// Arrange
+			const existingClass = createMockStyleDefinition( { id: 'existing' } );
+			const order = [ 'existing' ];
+
+			dispatch(
+				slice.actions.load( {
+					frontend: { items: { existing: existingClass }, order },
+					preview: { items: { existing: existingClass }, order },
+					classLabels: classLabelsFor( order, { existing: existingClass } ),
+				} )
+			);
+
+			// Act
+			dispatch(
+				slice.actions.mergeExistingClasses( {
+					preview: { existing: existingClass },
+					frontend: { existing: existingClass },
+				} )
+			);
+
+			// Assert
+			const data = selectData( getState() );
+			expect( data.order ).toEqual( order );
+		} );
+
+		it( 'should preserve dirty state when set before merge', () => {
+			// Arrange
+			const initialClass = createMockStyleDefinition( { id: 'initial' } );
+			const newClass = createMockStyleDefinition( { id: 'new' } );
+			const createdClass = createMockStyleDefinition( { id: 'created' } );
+			const order = [ 'initial', 'new' ];
+
+			dispatch(
+				slice.actions.load( {
+					frontend: { items: { initial: initialClass }, order },
+					preview: { items: { initial: initialClass }, order },
+					classLabels: classLabelsFor( order, {
+						initial: initialClass,
+						new: newClass,
+					} ),
+				} )
+			);
+
+			dispatch( slice.actions.add( createdClass ) );
+			expect( selectIsDirty( getState() ) ).toBe( true );
+
+			// Act
+			dispatch(
+				slice.actions.mergeExistingClasses( {
+					preview: { new: newClass },
+					frontend: { new: newClass },
+				} )
+			);
+
+			// Assert - dirty state should still be true because we added a class
+			expect( selectIsDirty( getState() ) ).toBe( true );
+		} );
+	} );
+} );

--- a/packages/packages/core/editor-global-classes/src/__tests__/sync-with-document-save.test.ts
+++ b/packages/packages/core/editor-global-classes/src/__tests__/sync-with-document-save.test.ts
@@ -78,11 +78,11 @@ describe( 'syncWithDocumentSave', () => {
 					[ styleDefinition.id ]: styleDefinition,
 				},
 				order: [ styleDefinition.id ],
-				changes: {
+				changes: expect.objectContaining( {
 					added: [ styleDefinition.id ],
 					deleted: [],
 					modified: [],
-				},
+				} ),
 			} );
 
 			const isPublish = status === 'publish';

--- a/packages/packages/core/editor-global-classes/src/components/__tests__/logic-hooks.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/__tests__/logic-hooks.test.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { createMockHttpResponse, createMockStyleDefinition, renderWithStore } from 'test-utils';
+import { getCurrentDocument } from '@elementor/editor-documents';
+import { type HttpResponse } from '@elementor/http-client';
 import { __createStore as createStore, __registerSlice as registerSlice } from '@elementor/store';
 import { waitFor } from '@testing-library/react';
 
-import { apiClient, type GlobalClassesGetAllResponse } from '../../api';
+import { apiClient, type GlobalClassIndexEntry } from '../../api';
 import { globalClassesStylesProvider } from '../../global-classes-styles-provider';
 import { slice } from '../../store';
 import { PopulateStore } from '../populate-store';
@@ -11,7 +13,17 @@ import { PopulateStore } from '../populate-store';
 jest.mock( '../../api', () => ( {
 	apiClient: {
 		all: jest.fn(),
+		getStylesForPost: jest.fn(),
 	},
+} ) );
+
+jest.mock( '@elementor/editor-documents', () => ( {
+	getCurrentDocument: jest.fn(),
+} ) );
+
+jest.mock( '@elementor/editor-v1-adapters', () => ( {
+	...jest.requireActual( '@elementor/editor-v1-adapters' ),
+	registerDataHook: jest.fn(),
 } ) );
 
 describe( '<LogicHooks />', () => {
@@ -20,9 +32,10 @@ describe( '<LogicHooks />', () => {
 	beforeEach( () => {
 		registerSlice( slice );
 		store = createStore();
+		jest.mocked( getCurrentDocument ).mockReturnValue( { id: 1 } as never );
 	} );
 
-	it( 'should load all classes on mount', async () => {
+	it( 'should load document classes on mount', async () => {
 		// Arrange
 		const subscriber = jest.fn();
 
@@ -31,15 +44,32 @@ describe( '<LogicHooks />', () => {
 		const globalClass1 = createMockStyleDefinition( { id: 'global-1' } );
 		const globalClass2 = createMockStyleDefinition( { id: 'global-2' } );
 
-		const mockResponse = createMockHttpResponse< GlobalClassesGetAllResponse >( {
+		const indexPayload: HttpResponse< GlobalClassIndexEntry[], Record< string, never > > = {
+			data: [
+				{ id: 'global-2', label: 'Class 2' },
+				{ id: 'global-1', label: 'Class 1' },
+			],
+			meta: {},
+		};
+
+		const stylesPayload: HttpResponse<
+			Record< string, ReturnType< typeof createMockStyleDefinition > >,
+			{ order: string[] }
+		> = {
 			data: {
 				'global-1': globalClass1,
 				'global-2': globalClass2,
 			},
 			meta: { order: [ 'global-2', 'global-1' ] },
-		} );
+		};
 
-		jest.mocked( apiClient.all ).mockResolvedValue( mockResponse );
+		jest.mocked( apiClient.all ).mockResolvedValue( createMockHttpResponse( indexPayload ) );
+		jest.mocked( apiClient.getStylesForPost ).mockResolvedValue( createMockHttpResponse( stylesPayload ) );
+
+		const loadedItems = {
+			'global-1': globalClass1,
+			'global-2': globalClass2,
+		};
 
 		// Act
 		renderWithStore( <PopulateStore />, store );
@@ -48,6 +78,8 @@ describe( '<LogicHooks />', () => {
 		await waitFor( () => {
 			expect( subscriber ).toHaveBeenCalledTimes( 1 );
 		} );
+
+		expect( subscriber ).toHaveBeenNthCalledWith( 1, {}, loadedItems );
 
 		expect( globalClassesStylesProvider.actions.all() ).toEqual( [ globalClass2, globalClass1 ] );
 	} );

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
@@ -79,6 +79,10 @@ describe( 'ClassManagerPanel', () => {
 			slice.actions.load( {
 				frontend: data,
 				preview: data,
+				classLabels: {
+					'class-1': 'Class 1',
+					'class-2': 'Class 2',
+				},
 			} )
 		);
 
@@ -119,12 +123,9 @@ describe( 'ClassManagerPanel', () => {
 		// Assert.
 		await waitFor( () => {
 			expect( apiClient.publish ).toHaveBeenCalledWith( {
-				items: {
-					'class-1': createMockStyleDefinition( { id: 'class-1', label: 'Class 1' } ),
-					'class-2': createMockStyleDefinition( { id: 'class-2', label: 'Class 2' } ),
-				},
+				items: {},
 				order: [ 'class-1', 'class-2' ],
-				changes: { added: [], deleted: [], modified: [] },
+				changes: { added: [], deleted: [], modified: [], order: true },
 			} );
 		} );
 	} );
@@ -149,11 +150,9 @@ describe( 'ClassManagerPanel', () => {
 		// Assert.
 		await waitFor( () => {
 			expect( apiClient.publish ).toHaveBeenCalledWith( {
-				items: {
-					'class-2': createMockStyleDefinition( { id: 'class-2', label: 'Class 2' } ),
-				},
+				items: {},
 				order: [ 'class-2' ],
-				changes: { added: [], deleted: [ 'class-1' ], modified: [] },
+				changes: { added: [], deleted: [ 'class-1' ], modified: [], order: true },
 			} );
 		} );
 	} );
@@ -180,10 +179,9 @@ describe( 'ClassManagerPanel', () => {
 			expect( apiClient.publish ).toHaveBeenCalledWith( {
 				items: {
 					'class-1': createMockStyleDefinition( { id: 'class-1', label: 'New label' } ),
-					'class-2': createMockStyleDefinition( { id: 'class-2', label: 'Class 2' } ),
 				},
 				order: [ 'class-2', 'class-1' ],
-				changes: { added: [], deleted: [], modified: [ 'class-1' ] },
+				changes: { added: [], deleted: [], modified: [ 'class-1' ], order: false },
 			} );
 		} );
 	} );
@@ -253,12 +251,9 @@ describe( 'ClassManagerPanel', () => {
 		// Assert.
 		await waitFor( () => {
 			expect( apiClient.publish ).toHaveBeenCalledWith( {
-				items: {
-					'class-1': createMockStyleDefinition( { id: 'class-1', label: 'Class 1' } ),
-					'class-2': createMockStyleDefinition( { id: 'class-2', label: 'Class 2' } ),
-				},
+				items: {},
 				order: [ 'class-1', 'class-2' ],
-				changes: { added: [], deleted: [], modified: [] },
+				changes: { added: [], deleted: [], modified: [], order: true },
 			} );
 		} );
 
@@ -359,11 +354,9 @@ describe( 'ClassManagerPanel', () => {
 		// Assert - Verify that publish was called with deleted class
 		await waitFor( () => {
 			expect( apiClient.publish ).toHaveBeenCalledWith( {
-				items: {
-					'class-1': createMockStyleDefinition( { id: 'class-1', label: 'Class 1' } ),
-				},
+				items: {},
 				order: [ 'class-1' ],
-				changes: { added: [], deleted: [ 'class-2' ], modified: [] },
+				changes: { added: [], deleted: [ 'class-2' ], modified: [], order: true },
 			} );
 		} );
 	} );

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/global-classes-list.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/global-classes-list.test.tsx
@@ -619,11 +619,14 @@ const mockClasses = ( classes: Pick< StyleDefinition, 'id' | 'label' >[] ) => {
 		order: classes.map( ( { id } ) => id ),
 	};
 
+	const classLabels = Object.fromEntries( classes.map( ( { id, label } ) => [ id, label ] ) );
+
 	act( () =>
 		dispatch(
 			slice.actions.load( {
 				preview: data,
 				frontend: data,
+				classLabels,
 			} )
 		)
 	);

--- a/tests/phpunit/elementor/app/modules/site-builder/services/test-design-system-service.php
+++ b/tests/phpunit/elementor/app/modules/site-builder/services/test-design-system-service.php
@@ -24,11 +24,13 @@ class Test_Design_System_Service extends Elementor_Test_Base {
 			'g-1' => [
 				'id' => 'g-1',
 				'label' => 'heading',
+				'type' => 'class',
 				'variants' => [],
 			],
 			'g-2' => [
 				'id' => 'g-2',
 				'label' => 'subheading',
+				'type' => 'class',
 				'variants' => [],
 			],
 		],
@@ -76,7 +78,6 @@ class Test_Design_System_Service extends Elementor_Test_Base {
 		], $result );
 
 		$stored = Global_Classes_Repository::make( $this->kit )
-			->context( Global_Classes_Repository::CONTEXT_FRONTEND )
 			->all( true )
 			->get();
 
@@ -94,7 +95,6 @@ class Test_Design_System_Service extends Elementor_Test_Base {
 		], $result );
 
 		$stored = Global_Classes_Repository::make( $this->kit )
-			->context( Global_Classes_Repository::CONTEXT_FRONTEND )
 			->all( true )
 			->get();
 

--- a/tests/phpunit/elementor/includes/template-library/test-manager-cloud.php
+++ b/tests/phpunit/elementor/includes/template-library/test-manager-cloud.php
@@ -227,8 +227,8 @@ class Elementor_Test_Manager_Cloud extends Elementor_Test_Base {
 			'items' => [
 				'g-123' => [
 					'id' => 'g-123',
-					'type' => 'class',
 					'label' => 'Used',
+					'type' => 'class',
 					'variants' => [],
 				],
 			],

--- a/tests/phpunit/elementor/modules/design-system-sync/classes/test-global-typography-extension.php
+++ b/tests/phpunit/elementor/modules/design-system-sync/classes/test-global-typography-extension.php
@@ -2,6 +2,9 @@
 
 namespace Elementor\Modules\DesignSystemSync\Classes;
 
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use Elementor\Modules\GlobalClasses\Global_Classes_Order;
+use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
 use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
 
@@ -17,6 +20,8 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 
 	public function setUp(): void {
 		parent::setUp();
+
+		( new Global_Class_Post_Type() )->register_post_type();
 
 		$this->extension = new Global_Typography_Extension();
 		Classes_Provider::clear_cache();
@@ -34,17 +39,25 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 		$kit = Plugin::$instance->kits_manager->get_active_kit();
 
 		if ( $kit ) {
-			$kit->delete_meta( '_elementor_global_classes' );
+			$kit->delete_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+			$kit->delete_meta( Global_Classes_Repository::META_KEY_PREVIEW );
+			$kit->delete_meta( Global_Classes_Order::META_KEY );
+		}
+
+		$posts = get_posts( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_status' => 'any',
+			'posts_per_page' => -1,
+			'fields' => 'ids',
+		] );
+
+		foreach ( $posts as $post_id ) {
+			wp_delete_post( $post_id, true );
 		}
 	}
 
 	public function test_add_v4_classes_to_typography_selector__returns_items_unchanged_when_no_classes() {
 		// Arrange
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-		$kit->update_json_meta( '_elementor_global_classes', [
-			'items' => [],
-		] );
-
 		$items = [
 			'existing-1' => [
 				'id' => 'existing-1',
@@ -62,37 +75,34 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 
 	public function test_add_v4_classes_to_typography_selector__skips_classes_without_sync_to_v3() {
 		// Arrange
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-		$kit->update_json_meta( '_elementor_global_classes', [
-			'items' => [
-				'class-1' => [
-					'label' => 'Heading',
-					'type' => 'class',
-					'variants' => [
-						[
-							'meta' => [
-								'breakpoint' => 'desktop',
-								'state' => 'normal',
+		$this->create_kit_with_classes( [
+			'class-1' => [
+				'label' => 'Heading',
+				'type' => 'class',
+				'variants' => [
+					[
+						'meta' => [
+							'breakpoint' => 'desktop',
+							'state' => 'normal',
+						],
+						'props' => [
+							'font-family' => [
+								'$$type' => 'string',
+								'value' => 'Roboto',
 							],
-							'props' => [
-								'font-family' => [
-									'$$type' => 'string',
-									'value' => 'Roboto',
-								],
-								'font-size' => [
-									'$$type' => 'size',
-									'value' => [
-										'size' => 24,
-										'unit' => 'px',
-									],
+							'font-size' => [
+								'$$type' => 'size',
+								'value' => [
+									'size' => 24,
+									'unit' => 'px',
 								],
 							],
 						],
 					],
-					'sync_to_v3' => false,
 				],
+				'sync_to_v3' => false,
 			],
-		] );
+		], [ 'class-1' ] );
 
 		$items = [];
 
@@ -105,28 +115,25 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 
 	public function test_add_v4_classes_to_typography_selector__skips_classes_without_typography_props() {
 		// Arrange
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-		$kit->update_json_meta( '_elementor_global_classes', [
-			'items' => [
-				'class-1' => [
-					'label' => 'Color Only',
-					'type' => 'class',
-					'variants' => [
-						[
-							'meta' => [
-								'breakpoint' => 'desktop',
-								'state' => 'normal',
-							],
-							'props' => [
-								'color' => '#ff0000',
-								'background-color' => '#000000',
-							],
+		$this->create_kit_with_classes( [
+			'class-1' => [
+				'label' => 'Color Only',
+				'type' => 'class',
+				'variants' => [
+					[
+						'meta' => [
+							'breakpoint' => 'desktop',
+							'state' => 'normal',
+						],
+						'props' => [
+							'color' => '#ff0000',
+							'background-color' => '#000000',
 						],
 					],
-					'sync_to_v3' => true,
 				],
+				'sync_to_v3' => true,
 			],
-		] );
+		], [ 'class-1' ] );
 
 		$items = [];
 
@@ -139,48 +146,45 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 
 	public function test_add_v4_classes_to_typography_selector__injects_v4_classes_with_correct_format() {
 		// Arrange
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-		$kit->update_json_meta( '_elementor_global_classes', [
-			'items' => [
-				'class-1' => [
-					'label' => 'Heading',
-					'type' => 'class',
-					'variants' => [
-						[
-							'meta' => [
-								'breakpoint' => 'desktop',
-								'state' => 'normal',
+		$this->create_kit_with_classes( [
+			'class-1' => [
+				'label' => 'Heading',
+				'type' => 'class',
+				'variants' => [
+					[
+						'meta' => [
+							'breakpoint' => 'desktop',
+							'state' => 'normal',
+						],
+						'props' => [
+							'font-family' => [
+								'$$type' => 'string',
+								'value' => 'Roboto',
 							],
-							'props' => [
-								'font-family' => [
-									'$$type' => 'string',
-									'value' => 'Roboto',
+							'font-size' => [
+								'$$type' => 'size',
+								'value' => [
+									'size' => 24,
+									'unit' => 'px',
 								],
-								'font-size' => [
-									'$$type' => 'size',
-									'value' => [
-										'size' => 24,
-										'unit' => 'px',
-									],
-								],
-								'font-weight' => [
-									'$$type' => 'string',
-									'value' => 'bold',
-								],
-								'line-height' => [
-									'$$type' => 'size',
-									'value' => [
-										'size' => 1.5,
-										'unit' => 'em',
-									],
+							],
+							'font-weight' => [
+								'$$type' => 'string',
+								'value' => 'bold',
+							],
+							'line-height' => [
+								'$$type' => 'size',
+								'value' => [
+									'size' => 1.5,
+									'unit' => 'em',
 								],
 							],
 						],
 					],
-					'sync_to_v3' => true,
 				],
+				'sync_to_v3' => true,
 			],
-		] );
+		], [ 'class-1' ] );
 
 		$items = [];
 
@@ -197,45 +201,42 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 
 	public function test_add_v4_classes_to_typography_selector__converts_props_to_v3_format() {
 		// Arrange
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-		$kit->update_json_meta( '_elementor_global_classes', [
-			'items' => [
-				'class-1' => [
-					'label' => 'Body',
-					'type' => 'class',
-					'variants' => [
-						[
-							'meta' => [
-								'breakpoint' => 'desktop',
-								'state' => 'normal',
+		$this->create_kit_with_classes( [
+			'class-1' => [
+				'label' => 'Body',
+				'type' => 'class',
+				'variants' => [
+					[
+						'meta' => [
+							'breakpoint' => 'desktop',
+							'state' => 'normal',
+						],
+						'props' => [
+							'font-family' => [
+								'$$type' => 'string',
+								'value' => 'Arial',
 							],
-							'props' => [
-								'font-family' => [
-									'$$type' => 'string',
-									'value' => 'Arial',
+							'font-size' => [
+								'$$type' => 'size',
+								'value' => [
+									'size' => 16,
+									'unit' => 'px',
 								],
-								'font-size' => [
-									'$$type' => 'size',
-									'value' => [
-										'size' => 16,
-										'unit' => 'px',
-									],
-								],
-								'font-weight' => [
-									'$$type' => 'string',
-									'value' => '400',
-								],
-								'font-style' => [
-									'$$type' => 'string',
-									'value' => 'italic',
-								],
+							],
+							'font-weight' => [
+								'$$type' => 'string',
+								'value' => '400',
+							],
+							'font-style' => [
+								'$$type' => 'string',
+								'value' => 'italic',
 							],
 						],
 					],
-					'sync_to_v3' => true,
 				],
+				'sync_to_v3' => true,
 			],
-		] );
+		], [ 'class-1' ] );
 
 		$items = [];
 
@@ -253,30 +254,27 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 
 	public function test_add_v4_classes_to_typography_selector__prepends_v4_items() {
 		// Arrange
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-		$kit->update_json_meta( '_elementor_global_classes', [
-			'items' => [
-				'class-1' => [
-					'label' => 'V4Class',
-					'type' => 'class',
-					'variants' => [
-						[
-							'meta' => [
-								'breakpoint' => 'desktop',
-								'state' => 'normal',
-							],
-							'props' => [
-								'font-family' => [
-									'$$type' => 'string',
-									'value' => 'Roboto',
-								],
+		$this->create_kit_with_classes( [
+			'class-1' => [
+				'label' => 'V4Class',
+				'type' => 'class',
+				'variants' => [
+					[
+						'meta' => [
+							'breakpoint' => 'desktop',
+							'state' => 'normal',
+						],
+						'props' => [
+							'font-family' => [
+								'$$type' => 'string',
+								'value' => 'Roboto',
 							],
 						],
 					],
-					'sync_to_v3' => true,
 				],
+				'sync_to_v3' => true,
 			],
-		] );
+		], [ 'class-1' ] );
 
 		$items = [
 			'v3-item' => [
@@ -297,9 +295,7 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 
 	public function test_add_v4_classes_to_typography_selector__skips_empty_props() {
 		// Arrange
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-		$kit->update_json_meta( '_elementor_global_classes', [
-			'items' => [
+		$this->create_kit_with_classes( [
 				'class-1' => [
 					'label' => 'EmptyProps',
 					'type' => 'class',
@@ -314,8 +310,7 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 					],
 					'sync_to_v3' => true,
 				],
-			],
-		] );
+			], [ 'class-1' ] );
 
 		$items = [];
 
@@ -328,30 +323,27 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 
 	public function test_add_v4_classes_to_typography_selector__skips_empty_label() {
 		// Arrange
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-		$kit->update_json_meta( '_elementor_global_classes', [
-			'items' => [
-				'class-1' => [
-					'label' => '',
-					'type' => 'class',
-					'variants' => [
-						[
-							'meta' => [
-								'breakpoint' => 'desktop',
-								'state' => 'normal',
-							],
-							'props' => [
-								'font-family' => [
-									'$$type' => 'string',
-									'value' => 'Roboto',
-								],
+		$this->create_kit_with_classes( [
+			'class-1' => [
+				'label' => '',
+				'type' => 'class',
+				'variants' => [
+					[
+						'meta' => [
+							'breakpoint' => 'desktop',
+							'state' => 'normal',
+						],
+						'props' => [
+							'font-family' => [
+								'$$type' => 'string',
+								'value' => 'Roboto',
 							],
 						],
 					],
-					'sync_to_v3' => true,
 				],
+				'sync_to_v3' => true,
 			],
-		] );
+		], [ 'class-1' ] );
 
 		$items = [];
 
@@ -364,67 +356,64 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 
 	public function test_add_v4_classes_to_typography_selector__includes_responsive_breakpoint_values() {
 		// Arrange
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-		$kit->update_json_meta( '_elementor_global_classes', [
-			'items' => [
-				'class-1' => [
-					'label' => 'Heading',
-					'type' => 'class',
-					'variants' => [
-						[
-							'meta' => [
-								'breakpoint' => 'desktop',
-								'state' => 'normal',
-							],
-							'props' => [
-								'font-family' => [
-									'$$type' => 'string',
-									'value' => 'Roboto',
-								],
-								'font-size' => [
-									'$$type' => 'size',
-									'value' => [
-										'size' => 24,
-										'unit' => 'px',
-									],
-								],
-							],
+		$this->create_kit_with_classes( [
+			'class-1' => [
+				'label' => 'Heading',
+				'type' => 'class',
+				'variants' => [
+					[
+						'meta' => [
+							'breakpoint' => 'desktop',
+							'state' => 'normal',
 						],
-						[
-							'meta' => [
-								'breakpoint' => 'tablet',
-								'state' => null,
+						'props' => [
+							'font-family' => [
+								'$$type' => 'string',
+								'value' => 'Roboto',
 							],
-							'props' => [
-								'font-size' => [
-									'$$type' => 'size',
-									'value' => [
-										'size' => 20,
-										'unit' => 'px',
-									],
-								],
-							],
-						],
-						[
-							'meta' => [
-								'breakpoint' => 'mobile',
-								'state' => null,
-							],
-							'props' => [
-								'font-size' => [
-									'$$type' => 'size',
-									'value' => [
-										'size' => 16,
-										'unit' => 'px',
-									],
+							'font-size' => [
+								'$$type' => 'size',
+								'value' => [
+									'size' => 24,
+									'unit' => 'px',
 								],
 							],
 						],
 					],
-					'sync_to_v3' => true,
+					[
+						'meta' => [
+							'breakpoint' => 'tablet',
+							'state' => null,
+						],
+						'props' => [
+							'font-size' => [
+								'$$type' => 'size',
+								'value' => [
+									'size' => 20,
+									'unit' => 'px',
+								],
+							],
+						],
+					],
+					[
+						'meta' => [
+							'breakpoint' => 'mobile',
+							'state' => null,
+						],
+						'props' => [
+							'font-size' => [
+								'$$type' => 'size',
+								'value' => [
+									'size' => 16,
+									'unit' => 'px',
+								],
+							],
+						],
+					],
 				],
+				'sync_to_v3' => true,
 			],
-		] );
+		], [ 'class-1' ] );
 
 		$items = [];
 
@@ -440,56 +429,53 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 
 	public function test_add_v4_classes_to_typography_selector__only_adds_responsive_suffix_to_responsive_props() {
 		// Arrange
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-		$kit->update_json_meta( '_elementor_global_classes', [
-			'items' => [
-				'class-1' => [
-					'label' => 'Heading',
-					'type' => 'class',
-					'variants' => [
-						[
-							'meta' => [
-								'breakpoint' => 'desktop',
-								'state' => 'normal',
-							],
-							'props' => [
-								'font-family' => [
-									'$$type' => 'string',
-									'value' => 'Roboto',
-								],
-								'font-size' => [
-									'$$type' => 'size',
-									'value' => [
-										'size' => 24,
-										'unit' => 'px',
-									],
-								],
-							],
+		$this->create_kit_with_classes( [
+			'class-1' => [
+				'label' => 'Heading',
+				'type' => 'class',
+				'variants' => [
+					[
+						'meta' => [
+							'breakpoint' => 'desktop',
+							'state' => 'normal',
 						],
-						[
-							'meta' => [
-								'breakpoint' => 'tablet',
-								'state' => null,
+						'props' => [
+							'font-family' => [
+								'$$type' => 'string',
+								'value' => 'Roboto',
 							],
-							'props' => [
-								'font-family' => [
-									'$$type' => 'string',
-									'value' => 'Arial',
-								],
-								'font-size' => [
-									'$$type' => 'size',
-									'value' => [
-										'size' => 20,
-										'unit' => 'px',
-									],
+							'font-size' => [
+								'$$type' => 'size',
+								'value' => [
+									'size' => 24,
+									'unit' => 'px',
 								],
 							],
 						],
 					],
-					'sync_to_v3' => true,
+					[
+						'meta' => [
+							'breakpoint' => 'tablet',
+							'state' => null,
+						],
+						'props' => [
+							'font-family' => [
+								'$$type' => 'string',
+								'value' => 'Arial',
+							],
+							'font-size' => [
+								'$$type' => 'size',
+								'value' => [
+									'size' => 20,
+									'unit' => 'px',
+								],
+							],
+						],
+					],
 				],
+				'sync_to_v3' => true,
 			],
-		] );
+		], [ 'class-1' ] );
 
 		$items = [];
 
@@ -504,49 +490,46 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 
 	public function test_add_v4_classes_to_typography_selector__handles_multiple_classes() {
 		// Arrange
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-		$kit->update_json_meta( '_elementor_global_classes', [
-			'items' => [
-				'class-1' => [
-					'label' => 'Heading',
-					'type' => 'class',
-					'variants' => [
-						[
-							'meta' => [
-								'breakpoint' => 'desktop',
-								'state' => 'normal',
-							],
-							'props' => [
-								'font-family' => [
-									'$$type' => 'string',
-									'value' => 'Roboto',
-								],
+		$this->create_kit_with_classes( [
+			'class-1' => [
+				'label' => 'Heading',
+				'type' => 'class',
+				'variants' => [
+					[
+						'meta' => [
+							'breakpoint' => 'desktop',
+							'state' => 'normal',
+						],
+						'props' => [
+							'font-family' => [
+								'$$type' => 'string',
+								'value' => 'Roboto',
 							],
 						],
 					],
-					'sync_to_v3' => true,
 				],
-				'class-2' => [
-					'label' => 'Body',
-					'type' => 'class',
-					'variants' => [
-						[
-							'meta' => [
-								'breakpoint' => 'desktop',
-								'state' => 'normal',
-							],
-							'props' => [
-								'font-family' => [
-									'$$type' => 'string',
-									'value' => 'Arial',
-								],
-							],
-						],
-					],
-					'sync_to_v3' => true,
-				],
+				'sync_to_v3' => true,
 			],
-		] );
+			'class-2' => [
+				'label' => 'Body',
+				'type' => 'class',
+				'variants' => [
+					[
+						'meta' => [
+							'breakpoint' => 'desktop',
+							'state' => 'normal',
+						],
+						'props' => [
+							'font-family' => [
+								'$$type' => 'string',
+								'value' => 'Arial',
+							],
+						],
+					],
+				],
+				'sync_to_v3' => true,
+			],
+		], [ 'class-1', 'class-2' ] );
 
 		$items = [];
 
@@ -557,5 +540,11 @@ class Test_Global_Typography_Extension extends Elementor_Test_Base {
 		$this->assertCount( 2, $result );
 		$this->assertArrayHasKey( 'v4-heading', $result );
 		$this->assertArrayHasKey( 'v4-body', $result );
+	}
+
+	private function create_kit_with_classes( array $classes, array $order ) {
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+		
+		Global_Classes_Repository::make( $kit )->put( $classes, $order );
 	}
 }

--- a/tests/phpunit/elementor/modules/design-system-sync/classes/test-stylesheet-manager.php
+++ b/tests/phpunit/elementor/modules/design-system-sync/classes/test-stylesheet-manager.php
@@ -3,6 +3,9 @@
 namespace Elementor\Modules\DesignSystemSync\Classes;
 
 use Elementor\Core\Files\Base as Base_File;
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use Elementor\Modules\GlobalClasses\Global_Classes_Order;
+use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
 use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
 
@@ -18,6 +21,8 @@ class Test_Stylesheet_Manager extends Elementor_Test_Base {
 
 	public function setUp(): void {
 		parent::setUp();
+
+		( new Global_Class_Post_Type() )->register_post_type();
 
 		Variables_Provider::clear_cache();
 		Classes_Provider::clear_cache();
@@ -470,13 +475,9 @@ class Test_Stylesheet_Manager extends Elementor_Test_Base {
 	}
 
 	private function set_kit_classes( array $classes ): void {
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-
-		$kit->update_json_meta( '_elementor_global_classes', [
-			'items' => $classes,
-			'order' => array_keys( $classes ),
-		] );
 		Classes_Provider::clear_cache();
+
+		Global_Classes_Repository::make()->put( $classes, array_keys( $classes ) );
 	}
 
 	private function clear_kit_variables(): void {
@@ -491,7 +492,20 @@ class Test_Stylesheet_Manager extends Elementor_Test_Base {
 		$kit = Plugin::$instance->kits_manager->get_active_kit();
 
 		if ( $kit ) {
-			$kit->delete_meta( '_elementor_global_classes' );
+			$kit->delete_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+			$kit->delete_meta( Global_Classes_Repository::META_KEY_PREVIEW );
+			$kit->delete_meta( Global_Classes_Order::META_KEY );
+		}
+
+		$posts = get_posts( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_status' => 'any',
+			'posts_per_page' => -1,
+			'fields' => 'ids',
+		] );
+
+		foreach ( $posts as $post_id ) {
+			wp_delete_post( $post_id, true );
 		}
 	}
 

--- a/tests/phpunit/elementor/modules/global-classes/import-export-customization/test-export-runner.php
+++ b/tests/phpunit/elementor/modules/global-classes/import-export-customization/test-export-runner.php
@@ -95,7 +95,7 @@ class Test_Export_Runner extends Elementor_Test_Base {
 
 		$sanitized_order = [ 'g-123', 'g-456' ];
 
-		$this->assertSame( [
+		$this->assertEquals( [
 			'files' => [
 				'path' => 'global-classes',
 				'data' => [
@@ -112,6 +112,9 @@ class Test_Export_Runner extends Elementor_Test_Base {
 		$items = [
 			'g-123' => [
 				'id' => 'g-123',
+				'label' => 'invalid-export-style',
+				'type' => '__not_a_valid_style_type__',
+				'variants' => [],
 			],
 		];
 
@@ -123,7 +126,7 @@ class Test_Export_Runner extends Elementor_Test_Base {
 		$result = ( new Export_Runner() )->export( [] );
 
 		// Assert.
-		$this->assertSame( [
+		$this->assertEquals( [
 			'manifest' => [],
 			'files' => [],
 		], $result );

--- a/tests/phpunit/elementor/modules/global-classes/import-export-customization/test-imort-runner.php
+++ b/tests/phpunit/elementor/modules/global-classes/import-export-customization/test-imort-runner.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Testing\Modules\GlobalClasses\ImportExportCustomization;
 
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
 use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
 use Elementor\Modules\GlobalClasses\ImportExportCustomization\Runners\Import as Import_Runner;
 use Elementor\Plugin;
@@ -11,7 +12,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-class ç extends Elementor_Test_Base {
+class Test_Import_Runner extends Elementor_Test_Base {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		( new Global_Class_Post_Type() )->register_post_type();
+	}
 
 	public function test_import() {
 		// Act.
@@ -54,7 +61,7 @@ class ç extends Elementor_Test_Base {
 				'id' => 'g-456',
 				'type' => 'class',
 				'label' => 'Test2',
-				"variants" => [],
+				'variants' => [],
 			],
 		];
 
@@ -65,8 +72,8 @@ class ç extends Elementor_Test_Base {
 			'order' => $sanitized_order,
 		];
 
-		$this->assertSame( $sanitized_global_classes, $result );
-		$this->assertSame( $sanitized_global_classes, Global_Classes_Repository::make()->all()->get() );
+		$this->assertEquals( $sanitized_global_classes, $result );
+		$this->assertEquals( $sanitized_global_classes, Global_Classes_Repository::make()->all()->get() );
 	}
 
 	public function test_import__invalid_style() {
@@ -97,7 +104,10 @@ class ç extends Elementor_Test_Base {
 		];
 
 		$old_kit = Plugin::$instance->kits_manager->get_active_kit();
-		$old_kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $existing_classes );
+		Global_Classes_Repository::make( $old_kit )->put(
+			$existing_classes['items'],
+			$existing_classes['order']
+		);
 
 		// Simulate what site-settings runner does: create a new empty active kit.
 		$new_kit_id = Plugin::$instance->kits_manager->create_new_kit( 'Imported Kit' );
@@ -132,7 +142,10 @@ class ç extends Elementor_Test_Base {
 		];
 
 		$old_kit = Plugin::$instance->kits_manager->get_active_kit();
-		$old_kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $existing_classes );
+		Global_Classes_Repository::make( $old_kit )->put(
+			$existing_classes['items'],
+			$existing_classes['order']
+		);
 
 		$new_kit_id = Plugin::$instance->kits_manager->create_new_kit( 'Imported Kit' );
 

--- a/tests/phpunit/elementor/modules/global-classes/import-export/test-export-runner.php
+++ b/tests/phpunit/elementor/modules/global-classes/import-export/test-export-runner.php
@@ -60,8 +60,8 @@ class Test_Export_Runner extends Elementor_Test_Base {
 		$sanitized_items = [
 			'g-123' => [
 				'id' => 'g-123',
-				'type' => 'class',
 				'label' => 'Test',
+				'type' => 'class',
 				'variants' => [
 					[
 						'meta' => [
@@ -87,15 +87,15 @@ class Test_Export_Runner extends Elementor_Test_Base {
 			],
 			'g-456' => [
 				'id' => 'g-456',
-				'type' => 'class',
 				'label' => 'test-2',
+				'type' => 'class',
 				'variants' => [],
 			],
 		];
 
 		$sanitized_order = [ 'g-123', 'g-456' ];
 
-		$this->assertSame( [
+		$this->assertEquals( [
 			'files' => [
 				'path' => 'global-classes',
 				'data' => [
@@ -111,6 +111,9 @@ class Test_Export_Runner extends Elementor_Test_Base {
 		$items = [
 			'g-123' => [
 				'id' => 'g-123',
+				'label' => 'invalid-export-style',
+				'type' => '__not_a_valid_style_type__',
+				'variants' => [],
 			],
 		];
 
@@ -122,7 +125,7 @@ class Test_Export_Runner extends Elementor_Test_Base {
 		$result = ( new Export_Runner() )->export( [] );
 
 		// Assert.
-		$this->assertSame( [
+		$this->assertEquals( [
 			'manifest' => [],
 			'files' => [],
 		], $result );

--- a/tests/phpunit/elementor/modules/global-classes/import-export/test-imort-runner.php
+++ b/tests/phpunit/elementor/modules/global-classes/import-export/test-imort-runner.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-class ç extends Elementor_Test_Base {
+class Test_Import_Runner extends Elementor_Test_Base {
 
 	public function test_import() {
 		// Act.
@@ -65,8 +65,8 @@ class ç extends Elementor_Test_Base {
 			'order' => $sanitized_order,
 		];
 
-		$this->assertSame( $sanitized_global_classes, $result );
-		$this->assertSame( $sanitized_global_classes, Global_Classes_Repository::make()->all()->get() );
+		$this->assertEquals( $sanitized_global_classes, $result );
+		$this->assertEquals( $sanitized_global_classes, Global_Classes_Repository::make()->all()->get() );
 	}
 
 	public function test_import__invalid_style() {

--- a/tests/phpunit/elementor/modules/global-classes/test-atomic-global-styles.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-atomic-global-styles.php
@@ -6,6 +6,10 @@ use Elementor\Core\Utils\Collection;
 use Elementor\Modules\AtomicWidgets\Styles\CacheValidity\Cache_Validity;
 use Elementor\Modules\AtomicWidgets\Styles\Atomic_Styles_Manager;
 use Elementor\Modules\GlobalClasses\Atomic_Global_Styles;
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use Elementor\Modules\GlobalClasses\Global_Classes_Labels;
+use Elementor\Modules\GlobalClasses\Global_Classes_Order;
+use Elementor\Modules\GlobalClasses\Global_Classes_Relations;
 use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
 use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
@@ -64,24 +68,55 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 	public function setUp(): void {
 		parent::setUp();
 
+		( new Global_Class_Post_Type() )->register_post_type();
+
 		$this->mock_atomic_styles_manager = $this->createMock( Atomic_Styles_Manager::class );
 
 		remove_all_actions( 'elementor/atomic-widgets/styles/register' );
 		remove_all_actions( 'elementor/atomic-widgets/settings/transformers/classes' );
 	}
 
-	public function test_register_styles() {
+	public function tearDown(): void {
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+
+		if ( $kit ) {
+			$kit->delete_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+			$kit->delete_meta( Global_Classes_Repository::META_KEY_PREVIEW );
+			$kit->delete_meta( Global_Classes_Labels::META_KEY_FRONTEND );
+			$kit->delete_meta( Global_Classes_Labels::META_KEY_PREVIEW );
+			$kit->delete_meta( Global_Classes_Order::META_KEY );
+		}
+
+		$post_ids = get_posts( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_status' => 'any',
+			'posts_per_page' => -1,
+			'fields' => 'ids',
+		] );
+
+		foreach ( $post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+
+		parent::tearDown();
+	}
+
+	public function test_register_styles__for_document_with_tracked_classes() {
 		// Arrange.
-		$global_classes = new Atomic_Global_Styles();
+		$relations = new Global_Classes_Relations();
+		$global_classes = new Atomic_Global_Styles( $relations );
 		$global_classes->register_hooks();
-		$context = Plugin::$instance->preview->is_editor_or_preview() ? Global_Classes_Repository::CONTEXT_PREVIEW : Global_Classes_Repository::CONTEXT_FRONTEND;
+
+		$post_id = $this->factory()->post->create();
+		$context = Global_Classes_Repository::CONTEXT_FRONTEND;
+
+		$relations->set_styles_for_post( $post_id, [ 'g-4-123', 'g-4-124' ] );
 
 		Global_Classes_Repository::make()->put(
 			$this->mock_global_classes['items'],
 			$this->mock_global_classes['order']
 		);
 
-		// Assert.
 		$expected = Collection::make( $this->mock_global_classes['order'] )
 			->map( fn( $id ) => $this->mock_global_classes['items'][ $id ] ?? null )
 			->filter( fn( $item ) => null !== $item )
@@ -96,21 +131,84 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 			->expects( $this->once() )
 			->method( 'register' )
 			->with(
-				[ Atomic_Global_Styles::STYLES_KEY, $context ],
+				[ Atomic_Global_Styles::STYLES_KEY, $post_id, $context ],
 				$this->callback( function ( $callback ) use ( $expected ) {
-					$styles = $callback( [ 1, 2 ] );
+					$styles = $callback();
 					$this->assertEquals( $expected, $styles );
 					return true;
 				} )
 			);
 
 		// Act.
-		do_action( 'elementor/atomic-widgets/styles/register', $this->mock_atomic_styles_manager, [ 0 ] );
+		do_action( 'elementor/atomic-widgets/styles/register', $this->mock_atomic_styles_manager, [ $post_id ] );
+	}
+
+	public function test_register_styles__returns_only_document_classes() {
+		// Arrange.
+		$relations = new Global_Classes_Relations();
+		$global_classes = new Atomic_Global_Styles( $relations );
+		$global_classes->register_hooks();
+
+		$post_id = $this->factory()->post->create();
+		$context = Global_Classes_Repository::CONTEXT_FRONTEND;
+
+		$relations->set_styles_for_post( $post_id, [ 'g-4-123' ] );
+
+		Global_Classes_Repository::make()->put(
+			$this->mock_global_classes['items'],
+			$this->mock_global_classes['order']
+		);
+
+		$this->mock_atomic_styles_manager
+			->expects( $this->once() )
+			->method( 'register' )
+			->with(
+				[ Atomic_Global_Styles::STYLES_KEY, $post_id, $context ],
+				$this->callback( function ( $callback ) {
+					$styles = $callback();
+					$this->assertCount( 1, $styles );
+					$this->assertEquals( 'pinky', $styles[0]['label'] );
+					return true;
+				} )
+			);
+
+		// Act.
+		do_action( 'elementor/atomic-widgets/styles/register', $this->mock_atomic_styles_manager, [ $post_id ] );
+	}
+
+	public function test_register_styles__returns_empty_for_document_without_classes() {
+		// Arrange.
+		$relations = new Global_Classes_Relations();
+		$global_classes = new Atomic_Global_Styles( $relations );
+		$global_classes->register_hooks();
+
+		$post_id = $this->factory()->post->create();
+		$context = Global_Classes_Repository::CONTEXT_FRONTEND;
+
+		Global_Classes_Repository::make()->put(
+			$this->mock_global_classes['items'],
+			$this->mock_global_classes['order']
+		);
+
+		$this->mock_atomic_styles_manager
+			->expects( $this->once() )
+			->method( 'register' )
+			->with(
+				[ Atomic_Global_Styles::STYLES_KEY, $post_id, $context ],
+				$this->callback( function ( $callback ) {
+					$styles = $callback();
+					$this->assertEmpty( $styles );
+					return true;
+				} )
+			);
+
+		// Act.
+		do_action( 'elementor/atomic-widgets/styles/register', $this->mock_atomic_styles_manager, [ $post_id ] );
 	}
 
 	public function test_register_styles_ignores_order_entries_without_matching_items() {
 		// Arrange.
-		$global_classes = new Atomic_Global_Styles();
+		$global_classes = $this->create_atomic_global_styles();
 		$global_classes->register_hooks();
 		$context = Plugin::$instance->preview->is_editor_or_preview() ? Global_Classes_Repository::CONTEXT_PREVIEW : Global_Classes_Repository::CONTEXT_FRONTEND;
 
@@ -128,15 +226,15 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 
 	public function test_transform_classes_names() {
 		// Arrange.
-		$global_classes = new Atomic_Global_Styles();
+		$global_classes = $this->create_atomic_global_styles();
 		$global_classes->register_hooks();
 
 		Global_Classes_Repository::make()->put(
 			[
-				'g-2' => [ 'id' => 'g-2', 'label' => 'pinky' ],
-				'g-3' => [ 'id' => 'g-3', 'label' => 'bluey' ],
+				'g-2' => $this->minimal_global_class_item( 'g-2', 'pinky' ),
+				'g-3' => $this->minimal_global_class_item( 'g-3', 'bluey' ),
 			],
-			[],
+			[ 'g-2', 'g-3' ],
 		);
 
 		// Act.
@@ -148,7 +246,7 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 
 	public function test_transform_classes_names__for_preview_mode() {
 		// Arrange.
-		$global_classes = new Atomic_Global_Styles();
+		$global_classes = $this->create_atomic_global_styles();
 		$global_classes->register_hooks();
 
 		global $wp_query;
@@ -157,18 +255,18 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 
 		Global_Classes_Repository::make()->put(
 			[
-				'g-only-frontend' => [ 'id' => 'g-only-frontend', 'label' => 'frontend' ],
-				'g-both' => [ 'id' => 'g-both', 'label' => 'both' ],
+				'g-only-frontend' => $this->minimal_global_class_item( 'g-only-frontend', 'frontend' ),
+				'g-both' => $this->minimal_global_class_item( 'g-both', 'both' ),
 			],
-			[],
+			[ 'g-only-frontend', 'g-both' ],
 		);
 
-		Global_Classes_Repository::make()->context( Global_Classes_Repository::CONTEXT_PREVIEW )->put(
+		Global_Classes_Repository::make()->set_preview( true )->put(
 			[
-				'g-both' => [ 'id' => 'g-both', 'label' => 'both' ],
-				'g-only-preview' => [ 'id' => 'g-only-preview', 'label' => 'preview' ],
+				'g-both' => $this->minimal_global_class_item( 'g-both', 'both' ),
+				'g-only-preview' => $this->minimal_global_class_item( 'g-only-preview', 'preview' ),
 			],
-			[],
+			[ 'g-only-frontend', 'g-both', 'g-only-preview' ],
 		);
 
 		// Act.
@@ -178,12 +276,12 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 		);
 
 		// Assert.
-		$this->assertEquals( [ 'g-only-frontend', 'both', 'preview' ], $result );
+		$this->assertEquals( [ 'frontend', 'both', 'preview' ], $result );
 	}
 
 	public function test_cache_invalidation_on_frontend_update() {
 		// Arrange.
-		$global_classes = new Atomic_Global_Styles();
+		$global_classes = $this->create_atomic_global_styles();
 		$global_classes->register_hooks();
 		$cache_validity = new Cache_Validity();
 
@@ -201,11 +299,9 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 
 		// Act.
 		do_action( 'elementor/global_classes/update', Global_Classes_Repository::CONTEXT_FRONTEND, [
-			'items' => [],
-			'order' => [],
-		], [
-			'items' => [],
-			'order' => [],
+			'added' => [],
+			'deleted' => [],
+			'modified' => [ 'g-invalidate-cache' ],
 		] );
 
 		// Assert.
@@ -220,7 +316,7 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 
 	public function test_cache_invalidation_on_preview_update() {
 		// Arrange.
-		$global_classes = new Atomic_Global_Styles();
+		$global_classes = $this->create_atomic_global_styles();
 		$global_classes->register_hooks();
 		$cache_validity = new Cache_Validity();
 
@@ -238,11 +334,9 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 
 		// Act.
 		do_action( 'elementor/global_classes/update', Global_Classes_Repository::CONTEXT_PREVIEW, [
-			'items' => [],
-			'order' => [],
-		], [
-			'items' => [],
-			'order' => [],
+			'added' => [],
+			'deleted' => [],
+			'modified' => [ 'g-invalidate-cache' ],
 		] );
 
 		// Assert.
@@ -257,7 +351,7 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 
 	public function test_cache_invalidation_on_global_cache_clear() {
 		// Arrange.
-		$global_classes = new Atomic_Global_Styles();
+		$global_classes = $this->create_atomic_global_styles();
 		$global_classes->register_hooks();
 
 		$cache_validity = new Cache_Validity();
@@ -275,5 +369,20 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 		$this->assertFalse( $cache_validity->is_valid(
 			[ Atomic_Global_Styles::STYLES_KEY, Global_Classes_Repository::CONTEXT_PREVIEW ]
 		) );
+	}
+
+	private function create_atomic_global_styles(): Atomic_Global_Styles {
+		$relations = new Global_Classes_Relations();
+
+		return new Atomic_Global_Styles( $relations );
+	}
+
+	private function minimal_global_class_item( string $id, string $label ): array {
+		return [
+			'id' => $id,
+			'label' => $label,
+			'type' => 'class',
+			'variants' => [],
+		];
 	}
 }

--- a/tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php
@@ -2,6 +2,11 @@
 namespace Elementor\Testing\Modules\GlobalClasses;
 
 use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\GlobalClasses\Global_Class_Post;
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use Elementor\Modules\GlobalClasses\Global_Classes_Labels;
+use Elementor\Modules\GlobalClasses\Global_Classes_Order;
+use Elementor\Modules\GlobalClasses\Global_Classes_Relations;
 use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
 use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
@@ -73,6 +78,8 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		do_action( 'rest_api_init' );
 
+		( new Global_Class_Post_Type() )->register_post_type();
+
 		$this->kit = Plugin::$instance->kits_manager->get_active_kit();
 	}
 
@@ -84,21 +91,36 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		$this->kit->delete_meta( Global_Classes_Repository::META_KEY_FRONTEND );
 		$this->kit->delete_meta( Global_Classes_Repository::META_KEY_PREVIEW );
+		$this->kit->delete_meta( Global_Classes_Labels::META_KEY_FRONTEND );
+		$this->kit->delete_meta( Global_Classes_Labels::META_KEY_PREVIEW );
+		$this->kit->delete_meta( Global_Classes_Order::META_KEY );
+		$this->delete_all_global_class_posts();
 	}
 
 	public function test_all__returns_all_global_classes() {
 		// Arrange
 		$this->act_as_admin();
 
-		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $this->mock_global_classes );
+		$this->seed_global_classes_posts($this->mock_global_classes );
 
 		// Act
 		$request = new \WP_REST_Request( 'GET', '/elementor/v1/global-classes' );
 		$response = rest_do_request( $request );
 
 		// Assert
-		$this->assertEquals( (object) $this->mock_global_classes['items'], $response->get_data()['data'] );
-		$this->assertEquals( $this->mock_global_classes['order'], $response->get_data()['meta']['order'] );
+		$expected_list = [
+			[
+				'id' => 'g-4-123',
+				'label' => 'pinky',
+			],
+			[
+				'id' => 'g-4-124',
+				'label' => 'bluey',
+			],
+		];
+
+		$this->assertEquals( $expected_list, $response->get_data()['data'] );
+		$this->assertEquals( [], $response->get_data()['meta'] );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
@@ -106,7 +128,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		// Arrange.
 		$this->act_as_admin();
 
-		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_PREVIEW, $this->mock_global_classes );
+		$this->seed_global_classes_posts( $this->mock_global_classes );
 
 		// Act.
 		$request = new \WP_REST_Request( 'GET', '/elementor/v1/global-classes' );
@@ -115,8 +137,19 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request( $request );
 
 		// Assert.
-		$this->assertEquals( (object) $this->mock_global_classes['items'], $response->get_data()['data'] );
-		$this->assertEquals( $this->mock_global_classes['order'], $response->get_data()['meta']['order'] );
+		$expected_list = [
+			[
+				'id' => 'g-4-123',
+				'label' => 'pinky',
+			],
+			[
+				'id' => 'g-4-124',
+				'label' => 'bluey',
+			],
+		];
+
+		$this->assertEquals( $expected_list, $response->get_data()['data'] );
+		$this->assertEquals( [], $response->get_data()['meta'] );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
@@ -129,8 +162,8 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request( $request );
 
 		// Assert
-		$this->assertEquals( (object) [], $response->get_data()['data'] );
-		$this->assertEquals( [], $response->get_data()['meta']['order'] );
+		$this->assertEquals( [], $response->get_data()['data'] );
+		$this->assertEquals( [], $response->get_data()['meta'] );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
@@ -165,7 +198,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 			'order' => [ 'g-1', 'g-2' ],
 		];
 
-		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $initial );
+		$this->seed_global_classes_posts($initial );
 
 		// Act.
 		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
@@ -174,7 +207,6 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		$updated = [
 			'items' => [
-				'g-1' => $class_1,
 				'g-3' => $class_3,
 			],
 			'order' => [ 'g-3', 'g-1' ],
@@ -190,12 +222,12 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request( $request );
 
 		// Assert.
-		$classes = $this->kit->get_json_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
 
 		$this->assertSame( 204, $response->get_status() );
 		$this->assertNull( $response->get_data() );
 
-		$this->assertSame( [
+		$this->assertEquals( [
 			'items' => [
 				'g-1' => $class_1,
 				'g-3' => $this->create_global_class( 'g-3', 'should-be-sanitized' ),
@@ -223,22 +255,19 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 			'order' => [ 'unchanged', 'removed', 'modified', 'not-in-payload' ],
 		];
 
-		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $initial );
+		$this->seed_global_classes_posts($initial );
 
 		// Act.
 		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
 
 		$new = $this->create_global_class( 'new' );
-		$unchanged_removed_in_server = $this->create_global_class( 'unchanged-removed-in-server' );
 
 		$payload = [
 			'items' => [
-				'unchanged' => $unchanged,
 				'modified' => $this->create_global_class( 'modified', 'yellow' ),
 				'new' => $new,
-				'unchanged-removed-in-server' => $unchanged_removed_in_server,
 			],
-			'order' => [ 'unchanged-removed-in-server', 'modified', 'unchanged', 'new' ],
+			'order' => [ 'not-in-payload', 'modified', 'unchanged', 'new' ],
 			'changes' => [
 				'added' => [ 'new' ],
 				'deleted' => [ 'removed' ],
@@ -251,12 +280,12 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request( $request );
 
 		// Assert.
-		$classes = $this->kit->get_json_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
 
 		$this->assertSame( 204, $response->get_status() );
 		$this->assertNull( $response->get_data() );
 
-		$this->assertSame( [
+		$this->assertEquals( [
 			'items' => [
 				'unchanged' => $unchanged,
 				'modified' => $this->create_global_class( 'modified', 'yellow' ),
@@ -282,7 +311,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 			'order' => [ 'g-1', 'g-2' ],
 		];
 
-		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_PREVIEW, $initial );
+		$this->seed_global_classes_posts( $initial, true );
 
 		// Act.
 		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
@@ -291,7 +320,6 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		$params = [
 			'items' => [
-				'g-1' => $class_1,
 				'g-3' => $class_3,
 			],
 			'order' => [ 'g-3', 'g-1' ],
@@ -308,18 +336,81 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request( $request );
 
 		// Assert.
-		$classes = $this->kit->get_json_meta( Global_Classes_Repository::META_KEY_PREVIEW );
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_PREVIEW );
 
 		$this->assertSame( 204, $response->get_status() );
 		$this->assertNull( $response->get_data() );
 
-		$this->assertSame( [
+		$this->assertEquals( [
 			'items' => [
 				'g-1' => $class_1,
 				'g-3' => $this->create_global_class( 'g-3', 'should-be-sanitized' ),
 			],
 			'order' => [ 'g-3', 'g-1' ],
 		], $classes );
+	}
+
+	public function test_put__frontend_publish_after_preview_save_does_not_false_positive_duplicate_same_id() {
+		$this->act_as_admin();
+
+		$class_1 = $this->create_global_class( 'g-1' );
+
+		$this->seed_global_classes_posts( [
+			'items' => [
+				'g-1' => $class_1,
+			],
+			'order' => [ 'g-1' ],
+		] );
+
+		Global_Classes_Labels::make( $this->kit )->set_labels( [
+			'g-1' => $class_1['label'],
+		] );
+
+		$g_new = $this->create_global_class( 'g-new', 'green', 'NewClassLabel' );
+
+		$preview_request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
+		$preview_request->set_body_params( [
+			'items' => [
+				'g-new' => $g_new,
+			],
+			'order' => [ 'g-new', 'g-1' ],
+			'changes' => [
+				'added' => [ 'g-new' ],
+				'deleted' => [],
+				'modified' => [],
+				'order' => true,
+			],
+			'context' => Global_Classes_Repository::CONTEXT_PREVIEW,
+		] );
+
+		$preview_response = rest_do_request( $preview_request );
+
+		$this->assertSame( 204, $preview_response->get_status() );
+		$this->assertNull( $preview_response->get_data() );
+
+		$frontend_request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
+		$frontend_request->set_body_params( [
+			'items' => [
+				'g-new' => $g_new,
+			],
+			'order' => [ 'g-new', 'g-1' ],
+			'changes' => [
+				'added' => [ 'g-new' ],
+				'deleted' => [],
+				'modified' => [],
+				'order' => false,
+			],
+			'context' => Global_Classes_Repository::CONTEXT_FRONTEND,
+		] );
+
+		$frontend_response = rest_do_request( $frontend_request );
+
+		$this->assertSame( 204, $frontend_response->get_status() );
+		$this->assertNull( $frontend_response->get_data() );
+
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
+
+		$this->assertSame( 'NewClassLabel', $classes['items']['g-new']['label'] );
 	}
 
 	public function test_put__fails_when_unauthorized() {
@@ -501,7 +592,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
 
 		$items = [];
-		for ( $i = 0; $i < 100; $i++ ) {
+		for ( $i = 0; $i < 1000; $i++ ) {
 			$items[ "g-$i" ] = $this->create_global_class( "g-$i" );
 		}
 
@@ -520,14 +611,16 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		// Assert - should succeed.
 		$this->assertSame( 204, $response->get_status() );
 
-		// Act - send the 101st item.
-		$items[ "g-101" ] = $this->create_global_class( "g-101" );
+		// Act - send the 101st item (only the new item, not all items).
+		$new_item = $this->create_global_class( "g-100" );
+		$all_order = array_keys( $items );
+		$all_order[] = "g-100";
 
 		$request->set_body_params( [
-			'items' => $items,
-			'order' => array_keys( $items ),
+			'items' => [ 'g-100' => $new_item ],
+			'order' => $all_order,
 			'changes' => [
-				'added' => [ 'g-101' ],
+				'added' => [ 'g-100' ],
 				'deleted' => [],
 				'modified' => [],
 			]
@@ -594,7 +687,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request( $request );
 
 		// Assert.
-		$classes = $this->kit->get_json_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
 
 		$this->assertSame( 204, $response->get_status() );
 		$this->assertNull( $response->get_data() );
@@ -652,7 +745,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 			'order' => [ 'existing' ],
 		];
 
-		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $initial );
+		$this->seed_global_classes_posts($initial );
 
 		// Act - Try to add a new class with the same label (duplicate)
 		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
@@ -661,7 +754,6 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		$payload = [
 			'items' => [
-				'existing' => $existing_class,
 				'new' => $new_class,
 			],
 			'order' => [ 'existing', 'new' ],
@@ -677,7 +769,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request( $request );
 
 		// Assert.
-		$classes = $this->kit->get_json_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
 
 		// Should return 200 with content when duplicates are resolved
 		$this->assertSame( 200, $response->get_status() );
@@ -713,7 +805,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 			'order' => ['existing'],
 		];
 
-		$this->kit->update_json_meta(Global_Classes_Repository::META_KEY_FRONTEND, $initial);
+		$this->seed_global_classes_posts($initial);
 
 		// Act - Try to add a new class with the same label (duplicate)
 		$request = new \WP_REST_Request('PUT', '/elementor/v1/global-classes');
@@ -722,7 +814,6 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		$payload = [
 			'items' => [
-				'existing' => $existing_class,
 				'new' => $new_class,
 			],
 			'order' => ['existing', 'new'],
@@ -738,7 +829,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request($request);
 
 		// Assert.
-		$classes = $this->kit->get_json_meta(Global_Classes_Repository::META_KEY_FRONTEND);
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
 
 		// Should return 200 with content when duplicates are resolved
 		$this->assertSame(200, $response->get_status());
@@ -774,7 +865,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 			'order' => ['existing'],
 		];
 
-		$this->kit->update_json_meta(Global_Classes_Repository::META_KEY_FRONTEND, $initial);
+		$this->seed_global_classes_posts($initial);
 
 		// Act - Try to add a new class with the same label that already has DUP_ prefix
 		$request = new \WP_REST_Request('PUT', '/elementor/v1/global-classes');
@@ -783,7 +874,6 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		$payload = [
 			'items' => [
-				'existing' => $existing_class,
 				'new' => $new_class,
 			],
 			'order' => ['existing', 'new'],
@@ -798,7 +888,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request($request);
 
 		// Assert
-		$classes = $this->kit->get_json_meta(Global_Classes_Repository::META_KEY_FRONTEND);
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
 
 		// Should return 200 with content when duplicates are resolved
 		$this->assertSame(200, $response->get_status());
@@ -834,7 +924,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 			'order' => ['existing'],
 		];
 
-		$this->kit->update_json_meta(Global_Classes_Repository::META_KEY_FRONTEND, $initial);
+		$this->seed_global_classes_posts($initial);
 
 		// Act - Try to add a new class with the same very long label
 		$request = new \WP_REST_Request('PUT', '/elementor/v1/global-classes');
@@ -843,7 +933,6 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		$payload = [
 			'items' => [
-				'existing' => $existing_class,
 				'new' => $new_class,
 			],
 			'order' => ['existing', 'new'],
@@ -858,7 +947,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request($request);
 
 		// Assert
-		$classes = $this->kit->get_json_meta(Global_Classes_Repository::META_KEY_FRONTEND);
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
 
 		// Should return 400 when labels are too long (validation error)
 		$this->assertSame(400, $response->get_status());
@@ -883,7 +972,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 			'order' => ['existing'],
 		];
 
-		$this->kit->update_json_meta(Global_Classes_Repository::META_KEY_FRONTEND, $initial);
+		$this->seed_global_classes_posts($initial);
 
 		// Act - First modify the existing class label
 		$modified_class = $this->create_global_class('existing', 'blue', 'NewClass');
@@ -907,7 +996,6 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$new_class = $this->create_global_class('new', 'red', 'MyClass');
 		$second_payload = [
 			'items' => [
-				'existing' => $modified_class,
 				'new' => $new_class,
 			],
 			'order' => ['existing', 'new'],
@@ -923,7 +1011,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request($request);
 
 		// Assert
-		$classes = $this->kit->get_json_meta(Global_Classes_Repository::META_KEY_FRONTEND);
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
 
 		// Should return 204 when no duplicates are found (no content)
 		$this->assertSame(204, $response->get_status());
@@ -949,7 +1037,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 			'order' => ['existing'],
 		];
 
-		$this->kit->update_json_meta(Global_Classes_Repository::META_KEY_FRONTEND, $initial);
+		$this->seed_global_classes_posts($initial);
 
 		// Act - Add multiple classes where some have duplicate labels
 		$request = new \WP_REST_Request('PUT', '/elementor/v1/global-classes');
@@ -961,7 +1049,6 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		$payload = [
 			'items' => [
-				'existing' => $existing_class,
 				'duplicate1' => $duplicate_class_1,
 				'duplicate2' => $duplicate_class_2,
 				'unique1' => $unique_class_1,
@@ -979,7 +1066,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request($request);
 
 		// Assert
-		$classes = $this->kit->get_json_meta(Global_Classes_Repository::META_KEY_FRONTEND);
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
 
 		// Should return 200 with content when duplicates are resolved
 		$this->assertSame(200, $response->get_status());
@@ -1018,7 +1105,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 			'order' => ['existing'],
 		];
 
-		$this->kit->update_json_meta(Global_Classes_Repository::META_KEY_FRONTEND, $initial);
+		$this->seed_global_classes_posts($initial);
 
 		// Act - Add classes where some labels are duplicates and others are unique
 		$request = new \WP_REST_Request('PUT', '/elementor/v1/global-classes');
@@ -1029,7 +1116,6 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		$payload = [
 			'items' => [
-				'existing' => $existing_class,
 				'duplicate' => $duplicate_class,
 				'unique1' => $unique_class_1,
 				'unique2' => $unique_class_2,
@@ -1046,7 +1132,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request($request);
 
 		// Assert
-		$classes = $this->kit->get_json_meta(Global_Classes_Repository::META_KEY_FRONTEND);
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
 
 		// Should return 200 with content when duplicates are resolved
 		$this->assertSame(200, $response->get_status());
@@ -1089,7 +1175,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 			'order' => $order,
 		];
 
-		$this->kit->update_json_meta(Global_Classes_Repository::META_KEY_FRONTEND, $initial);
+		$this->seed_global_classes_posts($initial);
 
 		// Act - Try to add a class with a duplicate label
 		$request = new \WP_REST_Request('PUT', '/elementor/v1/global-classes');
@@ -1097,7 +1183,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$duplicate_class = $this->create_global_class('duplicate', 'red', 'Class0'); // Duplicate of first class
 
 		$payload = [
-			'items' => array_merge($items, ['duplicate' => $duplicate_class]),
+			'items' => ['duplicate' => $duplicate_class],
 			'order' => array_merge($order, ['duplicate']),
 			'changes' => [
 				'added' => ['duplicate'],
@@ -1110,7 +1196,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$response = rest_do_request($request);
 
 		// Assert
-		$classes = $this->kit->get_json_meta(Global_Classes_Repository::META_KEY_FRONTEND);
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
 
 		// Should return 200 with content when duplicates are resolved
 		$this->assertSame(200, $response->get_status());
@@ -1162,15 +1248,26 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		// Arrange
 		$this->act_as_editor();
 
-		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $this->mock_global_classes );
+		$this->seed_global_classes_posts($this->mock_global_classes );
 
 		// Act
 		$request = new \WP_REST_Request( 'GET', '/elementor/v1/global-classes' );
 		$response = rest_do_request( $request );
 
 		// Assert
-		$this->assertEquals( (object) $this->mock_global_classes['items'], $response->get_data()['data'] );
-		$this->assertEquals( $this->mock_global_classes['order'], $response->get_data()['meta']['order'] );
+		$expected_list = [
+			[
+				'id' => 'g-4-123',
+				'label' => 'pinky',
+			],
+			[
+				'id' => 'g-4-124',
+				'label' => 'bluey',
+			],
+		];
+
+		$this->assertEquals( $expected_list, $response->get_data()['data'] );
+		$this->assertEquals( [], $response->get_data()['meta'] );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
@@ -1178,7 +1275,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		// Arrange
 		wp_set_current_user( 0 );
 
-		$this->kit->update_json_meta( Global_Classes_Repository::META_KEY_FRONTEND, $this->mock_global_classes );
+		$this->seed_global_classes_posts($this->mock_global_classes );
 
 		// Act
 		$request = new \WP_REST_Request( 'GET', '/elementor/v1/global-classes' );
@@ -1188,11 +1285,164 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 401, $response->get_status() );
 	}
 
+	public function test_post__returns_styles_for_document() {
+		// Arrange
+		$this->act_as_admin();
+
+		$this->seed_global_classes_posts($this->mock_global_classes );
+
+		$post_id = $this->factory()->post->create();
+
+		add_post_meta( $post_id, '_elementor_used_global_class', 'g-4-123' );
+
+		// Act
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/global-classes/post' );
+		$request->set_param( 'post_id', $post_id );
+		$response = rest_do_request( $request );
+
+		// Assert
+		$data = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, (array) $data['data'] );
+		$this->assertArrayHasKey( 'g-4-123', (array) $data['data'] );
+		$this->assertArrayNotHasKey( 'g-4-124', (array) $data['data'] );
+		$this->assertEquals( [ 'g-4-123' ], $data['meta']['order'] );
+	}
+
+	public function test_post__returns_empty_when_document_has_no_classes() {
+		// Arrange
+		$this->act_as_admin();
+
+		$this->seed_global_classes_posts($this->mock_global_classes );
+
+		$post_id = $this->factory()->post->create();
+
+		// Act
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/global-classes/post' );
+		$request->set_param( 'post_id', $post_id );
+		$response = rest_do_request( $request );
+
+		// Assert
+		$data = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['data'] );
+		$this->assertEquals( [], $data['meta']['order'] );
+	}
+
+	public function test_styles__returns_definitions_by_ids() {
+		// Arrange
+		$this->act_as_admin();
+
+		$this->seed_global_classes_posts($this->mock_global_classes );
+
+		// Act
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/global-classes/styles' );
+		$request->set_param( 'ids', 'g-4-123' );
+		$response = rest_do_request( $request );
+
+		// Assert
+		$data = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, (array) $data['data'] );
+		$this->assertArrayHasKey( 'g-4-123', (array) $data['data'] );
+		$this->assertEquals( [ 'g-4-123' ], $data['meta']['order'] );
+	}
+
+	public function test_styles__returns_explicit_null_for_missing_ids() {
+		$this->act_as_admin();
+
+		$this->seed_global_classes_posts($this->mock_global_classes );
+
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/global-classes/styles' );
+		$request->set_param( 'ids', 'g-4-123,g-missing' );
+		$response = rest_do_request( $request );
+
+		$data = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertNotNull( $data['data']->{'g-4-123'} );
+		$this->assertTrue( property_exists( $data['data'], 'g-missing' ) );
+		$this->assertNull( $data['data']->{'g-missing'} );
+		$this->assertEquals( [ 'g-4-123' ], $data['meta']['order'] );
+	}
+
+	public function test_post__returns_explicit_null_for_missing_classes() {
+		$this->act_as_admin();
+
+		$this->seed_global_classes_posts($this->mock_global_classes );
+
+		$post_id = $this->factory()->post->create();
+
+		add_post_meta( $post_id, Global_Classes_Relations::META_KEY_FRONTEND, 'g-4-123' );
+		add_post_meta( $post_id, Global_Classes_Relations::META_KEY_FRONTEND, 'g-missing' );
+
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/global-classes/post' );
+		$request->set_param( 'post_id', $post_id );
+		$response = rest_do_request( $request );
+
+		$data = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertNotNull( $data['data']->{'g-4-123'} );
+		$this->assertTrue( property_exists( $data['data'], 'g-missing' ) );
+		$this->assertNull( $data['data']->{'g-missing'} );
+	}
+
 	public function test_register_routes__endpoints_exist() {
 		global $wp_rest_server;
 		$routes = $wp_rest_server->get_routes();
 		$this->assertArrayHasKey( '/elementor/v1/global-classes', $routes );
 		$this->assertArrayHasKey( '/elementor/v1/global-classes/usage', $routes );
+		$this->assertArrayHasKey( '/elementor/v1/global-classes/post', $routes );
+		$this->assertArrayHasKey( '/elementor/v1/global-classes/styles', $routes );
+	}
+
+	private function delete_all_global_class_posts(): void {
+		$post_ids = get_posts( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_status' => 'any',
+			'posts_per_page' => -1,
+			'fields' => 'ids',
+		] );
+
+		foreach ( $post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+	}
+
+	private function seed_global_classes_posts( array $payload, bool $duplicate_to_preview_meta = false ): void {
+		$this->delete_all_global_class_posts();
+		$this->kit->delete_meta( Global_Classes_Labels::META_KEY_FRONTEND );
+		$this->kit->delete_meta( Global_Classes_Labels::META_KEY_PREVIEW );
+		$this->kit->delete_meta( Global_Classes_Order::META_KEY );
+
+		$labels = [];
+
+		foreach ( $payload['items'] ?? [] as $class_id => $item ) {
+			$data = [
+				'type' => $item['type'] ?? 'class',
+				'variants' => $item['variants'] ?? [],
+			];
+
+			$post_object = Global_Class_Post::create( $class_id, $item['label'], $data );
+
+			if ( $duplicate_to_preview_meta && $post_object ) {
+				$post_object->update_data( $data, true );
+			}
+
+			$labels[ $class_id ] = $item['label'];
+		}
+
+		Global_Classes_Order::make( $this->kit )->set_order( $payload['order'] ?? [] );
+		Global_Classes_Labels::make( $this->kit )->set_labels( $labels );
+	}
+
+	private function get_repository_snapshot( string $context ): array {
+		$repository = Global_Classes_Repository::make();
+
+		if ( Global_Classes_Repository::CONTEXT_PREVIEW === $context ) {
+			$repository->set_preview( true );
+		}
+
+		return $repository->all()->get();
 	}
 
 	private function create_global_class( string $id, ?string $color = null, ?string $label = null ) {

--- a/tests/phpunit/elementor/modules/global-classes/test-template-library-global-classes-utils.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-template-library-global-classes-utils.php
@@ -3,9 +3,12 @@
 namespace Elementor\Testing\Modules\GlobalClasses;
 
 use Elementor\Core\Utils\Template_Library_Import_Export_Utils;
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use Elementor\Modules\GlobalClasses\Global_Classes_Order;
 use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
 use Elementor\Modules\GlobalClasses\Utils\Template_Library_Global_Classes_Element_Transformer;
 use Elementor\Modules\GlobalClasses\Utils\Template_Library_Global_Classes_Snapshot_Builder;
+use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,6 +16,35 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Test_Template_Library_Global_Classes_Utils extends Elementor_Test_Base {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		( new Global_Class_Post_Type() )->register_post_type();
+	}
+
+	public function tearDown(): void {
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+
+		if ( $kit ) {
+			$kit->delete_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+			$kit->delete_meta( Global_Classes_Repository::META_KEY_PREVIEW );
+			$kit->delete_meta( Global_Classes_Order::META_KEY );
+		}
+
+		$post_ids = get_posts( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_status' => 'any',
+			'posts_per_page' => -1,
+			'fields' => 'ids',
+		] );
+
+		foreach ( $post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+
+		parent::tearDown();
+	}
 
 	private function seed_global_classes( array $items, array $order ): void {
 		Global_Classes_Repository::make()->put( $items, $order );
@@ -75,7 +107,7 @@ class Test_Template_Library_Global_Classes_Utils extends Elementor_Test_Base {
 			],
 		];
 
-		$this->seed_global_classes( $items, [ 'g-2' ] );
+		$this->seed_global_classes( $items, [ 'g-2', 'g-1' ] );
 
 		$snapshot = Template_Library_Global_Classes_Snapshot_Builder::build_snapshot_for_ids( [ 'g-1', 'g-2', 'g-missing', '' ] );
 

--- a/tests/phpunit/elementor/modules/wp-rest/test-design-system-rest-api.php
+++ b/tests/phpunit/elementor/modules/wp-rest/test-design-system-rest-api.php
@@ -2,6 +2,8 @@
 
 namespace Elementor\Testing\Modules\WpRest;
 
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use Elementor\Modules\GlobalClasses\Global_Classes_Order;
 use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
 use Elementor\Modules\Variables\Storage\Constants as Variables_Constants;
 use Elementor\Modules\Variables\Storage\Variables_Repository;
@@ -26,11 +28,13 @@ class Test_Design_System_Rest_Api extends Elementor_Test_Base {
 		'items' => [
 			'g-1' => [
 				'id' => 'g-1',
+				'type' => 'class',
 				'label' => 'heading',
 				'variants' => [],
 			],
 			'g-2' => [
 				'id' => 'g-2',
+				'type' => 'class',
 				'label' => 'subheading',
 				'variants' => [],
 			],
@@ -61,13 +65,27 @@ class Test_Design_System_Rest_Api extends Elementor_Test_Base {
 		} );
 		do_action( 'rest_api_init' );
 
+		( new Global_Class_Post_Type() )->register_post_type();
+
 		$this->kit = Plugin::$instance->kits_manager->get_active_kit();
 	}
 
 	public function tearDown(): void {
 		$this->kit->delete_meta( Global_Classes_Repository::META_KEY_FRONTEND );
 		$this->kit->delete_meta( Global_Classes_Repository::META_KEY_PREVIEW );
+		$this->kit->delete_meta( Global_Classes_Order::META_KEY );
 		$this->kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
+
+		$post_ids = get_posts( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_status' => 'any',
+			'posts_per_page' => -1,
+			'fields' => 'ids',
+		] );
+
+		foreach ( $post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
 
 		parent::tearDown();
 	}
@@ -83,7 +101,6 @@ class Test_Design_System_Rest_Api extends Elementor_Test_Base {
 		$this->assertEquals( 200, $response->get_status() );
 
 		$stored = Global_Classes_Repository::make()
-			->context( Global_Classes_Repository::CONTEXT_FRONTEND )
 			->all( true )
 			->get();
 
@@ -121,10 +138,13 @@ class Test_Design_System_Rest_Api extends Elementor_Test_Base {
 
 		$this->assertEquals( 200, $response->get_status() );
 
-		$classes_meta = $this->kit->get_json_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+		$stored_classes = Global_Classes_Repository::make()
+			->all()
+			->get();
+
 		$collection = ( new Variables_Repository( $this->kit ) )->load();
 
-		$this->assertEquals( $this->mock_global_classes['order'], $classes_meta['order'] );
+		$this->assertEquals( $this->mock_global_classes['order'], $stored_classes['order'] );
 		$this->assertCount( count( $this->mock_global_variables['data'] ), $collection->all() );
 		$this->assertEquals( 'Primary', $collection->get( 'e-gv-1' )->label() );
 	}

--- a/tests/playwright/sanity/modules/v4-tests/global-classes/global-classes-api-stress.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/global-classes/global-classes-api-stress.test.ts
@@ -4,15 +4,15 @@ import type EditorPage from '../../../../pages/editor-page';
 import { type Device } from '../../../../types/types';
 import WpAdminPage from '../../../../pages/wp-admin-page';
 
-import { deleteAllGlobalClasses, createGlobalClasses, getGlobalClasses } from './utils';
+import { createGlobalClasses, deleteAllGlobalClasses, getGlobalClasses } from './utils';
 
 /**
  * This is an initial set of stress tests, currently meant to be executed manually+locally (against a valid .env file)
  *
- * This test adds 100 global styles via REST API
+ * Adds many global classes via REST API (above the legacy 100 cap after post-based storage).
  */
 
-const CLASS_COUNT = 100;
+const CLASS_COUNT = 1000;
 const BASIC_BREAKPOINTS: Device[] = [ 'desktop', 'tablet', 'mobile' ];
 const ALL_BREAKPOINTS: Device[] = [ 'widescreen', 'desktop', 'tablet', 'mobile', 'widescreen', 'laptop', 'tablet_extra', 'mobile_extra' ];
 const STATES = [ 'normal', 'hover', 'focus', 'active' ] as const;
@@ -128,7 +128,7 @@ function buildGlobalClassData( count: number ): { items: Record<string, GlobalCl
 test.describe.skip( 'Global Classes API Stress Test @stress', () => {
 	test.setTimeout( 600000 );
 
-	test( 'Create 100 global classes via REST API and verify CSS generation', async ( { page, apiRequests }, testInfo ) => {
+	test( `Create ${ CLASS_COUNT } global classes via REST API and verify CSS generation`, async ( { page, apiRequests }, testInfo ) => {
 		logProgress( 'Starting API-based stress test...' );
 
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
@@ -167,10 +167,15 @@ test.describe.skip( 'Global Classes API Stress Test @stress', () => {
 		logProgress( `Found ${ existingIds.length } classes in storage` );
 
 		expect( existingIds.length ).toBe( CLASS_COUNT );
+		expect( new Set( existingIds ).size ).toBe( CLASS_COUNT );
 
-		logProgress( 'Opening editor...' );
+		let publishTime = 0;
+		let viewTime = 0;
+
+		logProgress( 'Opening editor (STRESS_TEST_INCLUDE_EDITOR=1)...' );
 		const editor = await wpAdmin.openNewPage() as EditorPage;
 		await editor.waitForPanelToLoad();
+		await page.waitForSelector( '#elementor-panel', { timeout: 60000 } );
 
 		logProgress( 'Adding div block widget...' );
 		const divBlockId = await editor.addElement( { elType: 'e-div-block' }, 'document' );
@@ -179,14 +184,14 @@ test.describe.skip( 'Global Classes API Stress Test @stress', () => {
 		logProgress( 'Publishing page...' );
 		const startPublish = Date.now();
 		await editor.publishPage();
-		const publishTime = Date.now() - startPublish;
+		publishTime = Date.now() - startPublish;
 		logProgress( `Page published in ${ publishTime }ms` );
 
 		logProgress( 'Navigating to frontend...' );
 		const startView = Date.now();
 		await editor.viewPage();
-		await page.waitForLoadState( 'networkidle' );
-		const viewTime = Date.now() - startView;
+		await page.waitForLoadState( 'domcontentloaded' );
+		viewTime = Date.now() - startView;
 		logProgress( `Frontend loaded in ${ viewTime }ms` );
 
 		const stylesheets = await page.evaluate( () => {

--- a/tests/playwright/sanity/modules/v4-tests/global-classes/utils.ts
+++ b/tests/playwright/sanity/modules/v4-tests/global-classes/utils.ts
@@ -16,13 +16,27 @@ type GlobalClassItem = {
 	sync_to_v3?: boolean;
 };
 
-export async function getGlobalClasses( apiRequests: ApiRequests, request: APIRequestContext ): Promise<{ items: Record<string, GlobalClassItem>; order: string[] }> {
+export async function getGlobalClasses( apiRequests: ApiRequests, request: APIRequestContext ): Promise<{ items: Record<string, Pick<GlobalClassItem, 'id' | 'label'>>; order: string[] }> {
 	try {
-		const data = await apiRequests.customGet( request, 'index.php?rest_route=/elementor/v1/global-classes' );
-		return {
-			items: data.data || {},
-			order: data.meta?.order || [],
-		};
+		const response = await apiRequests.customGet( request, 'index.php?rest_route=/elementor/v1/global-classes' );
+
+		const list: Array<{ id: string; label: string }> = Array.isArray( response?.data )
+			? response.data
+			: [];
+
+		const items: Record<string, Pick<GlobalClassItem, 'id' | 'label'>> = {};
+		const order: string[] = [];
+
+		for ( const entry of list ) {
+			if ( ! entry?.id ) {
+				continue;
+			}
+
+			items[ entry.id ] = { id: entry.id, label: entry.label };
+			order.push( entry.id );
+		}
+
+		return { items, order };
 	} catch {
 		return { items: {}, order: [] };
 	}
@@ -39,7 +53,7 @@ export async function deleteAllGlobalClasses( apiRequests: ApiRequests, request:
 		await apiRequests.customPut( request, 'index.php?rest_route=/elementor/v1/global-classes', {
 			items: {},
 			order: [],
-			changes: { added: [], deleted: order, modified: [] },
+			changes: { added: [], deleted: order, modified: [], order: false },
 		} );
 
 		return { success: true, deleted: order.length };
@@ -48,6 +62,8 @@ export async function deleteAllGlobalClasses( apiRequests: ApiRequests, request:
 	}
 }
 
+const CREATE_BATCH_SIZE = 100;
+
 export async function createGlobalClasses(
 	apiRequests: ApiRequests,
 	request: APIRequestContext,
@@ -55,11 +71,29 @@ export async function createGlobalClasses(
 	order: string[],
 ): Promise<{ success: boolean; error?: string }> {
 	try {
-		await apiRequests.customPut( request, 'index.php?rest_route=/elementor/v1/global-classes', {
-			items,
-			order,
-			changes: { added: order, deleted: [], modified: [] },
-		} );
+		const totalBatches = Math.ceil( order.length / CREATE_BATCH_SIZE );
+
+		for ( let i = 0; i < order.length; i += CREATE_BATCH_SIZE ) {
+			const batchIds = order.slice( i, i + CREATE_BATCH_SIZE );
+			const batchItems: Record<string, GlobalClassItem> = {};
+
+			for ( const id of batchIds ) {
+				batchItems[ id ] = items[ id ];
+			}
+
+			const cumulativeOrder = order.slice( 0, i + batchIds.length );
+			const batchNumber = Math.floor( i / CREATE_BATCH_SIZE ) + 1;
+
+			// eslint-disable-next-line no-console
+			console.log( `[createGlobalClasses] Batch ${ batchNumber }/${ totalBatches } (${ batchIds.length } classes)` );
+
+			await apiRequests.customPut( request, 'index.php?rest_route=/elementor/v1/global-classes', {
+				items: batchItems,
+				order: cumulativeOrder,
+				changes: { added: batchIds, deleted: [], modified: [], order: false },
+			} );
+		}
+
 		return { success: true };
 	} catch ( error ) {
 		return { success: false, error: String( error ) };


### PR DESCRIPTION
**This slice:** adds **PHPUnit**, **Playwright**, and **package unit tests** covering migration, REST, import/export, atomic styles, design-system REST, and editor-global-classes behavior—intended to pass once PRs 1–5 are in place.

---

## Full feature (ED-23093)

This stacked series delivers **ED-23093**: global classes persisted as **posts** (with migration from kit metadata), **document–class relations** for usage and cache invalidation, **REST** and **import/export** behavior, **atomic global styles** plus **design-system** integration, the **`editor-global-classes`** editor package, and **tests**. Each PR is a reviewable slice; merge **1 → 6** in order so the stack matches the full integration branch against `main`.
