### PR TITLE
New: Virtualize Class Manager panel list [ED-23898]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10827,33 +10827,6 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.19",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.19.tgz",
-      "integrity": "sha512-KzwmU1IbE0IvCZSm6OXkS+kRdrgW2c2P3Ho3NC+zZXWK6oObv/L+lcV/2VuJ+snVESRlMJ+w/fg4WXI/JzoNGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/virtual-core": "3.13.19"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.19",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.19.tgz",
-      "integrity": "sha512-/BMP7kNhzKOd7wnDeB8NrIRNLwkf5AhCYCvtfZV2GXWbBieFm/el0n6LOAXlTi6ZwHICSNnQcIxRCWHrLzDY+g==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -45000,6 +44973,33 @@
       "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
       "license": "MIT"
     },
+    "packages/node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "packages/node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "packages/node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
@@ -45830,6 +45830,7 @@
         "@elementor/store": "4.1.0",
         "@elementor/ui": "1.37.5",
         "@elementor/utils": "4.1.0",
+        "@tanstack/react-virtual": "^3.13.24",
         "@wordpress/i18n": "^5.13.0"
       },
       "devDependencies": {

--- a/packages/packages/core/editor-global-classes/package.json
+++ b/packages/packages/core/editor-global-classes/package.json
@@ -59,6 +59,7 @@
     "@elementor/store": "4.1.0",
     "@elementor/ui": "1.37.5",
     "@elementor/utils": "4.1.0",
+    "@tanstack/react-virtual": "^3.13.24",
     "@wordpress/i18n": "^5.13.0",
     "@elementor/events": "4.1.0"
   },

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
@@ -12,11 +12,40 @@ import { __privateRunCommand } from '@elementor/editor-v1-adapters';
 import { QueryClient, QueryClientProvider } from '@elementor/query';
 import { __createStore, __dispatch, __registerSlice, type SliceState, type Store } from '@elementor/store';
 import { ThemeProvider } from '@elementor/ui';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 
 import { apiClient } from '../../../api';
 import { slice } from '../../../store';
 import { ClassManagerPanel, usePanelActions } from '../class-manager-panel';
+
+jest.mock( '@tanstack/react-virtual', () => {
+	const actual = jest.requireActual( '@tanstack/react-virtual' );
+	return {
+		...actual,
+		useVirtualizer: jest.fn(),
+	};
+} );
+
+const PANEL_TEST_ROW_HEIGHT = 40;
+
+const mockVirtualizerWithAllItemsForPanel = () => {
+	jest.mocked( useVirtualizer ).mockImplementation( ( options ) => {
+		const indices = Array.from( { length: options.count }, ( _, i ) => i );
+		return {
+			getTotalSize: () => options.count * PANEL_TEST_ROW_HEIGHT,
+			getVirtualItems: () =>
+				indices.map( ( index ) => ( {
+					index,
+					key: options.getItemKey ? options.getItemKey( index ) : index,
+					start: index * PANEL_TEST_ROW_HEIGHT,
+					end: ( index + 1 ) * PANEL_TEST_ROW_HEIGHT,
+					size: PANEL_TEST_ROW_HEIGHT,
+					lane: 0,
+				} ) ),
+		} as unknown as ReturnType< typeof useVirtualizer >;
+	} );
+};
 
 jest.mock( '@elementor/editor-documents' );
 jest.mock( '../class-manager-introduction' );
@@ -83,6 +112,8 @@ describe( 'ClassManagerPanel', () => {
 		);
 
 		jest.mocked( getCurrentDocument ).mockReturnValue( createMockDocument( { id: 1 } ) );
+
+		mockVirtualizerWithAllItemsForPanel();
 	} );
 
 	it( 'should have a disabled "save changes" button when dirty state is false', () => {
@@ -463,6 +494,26 @@ describe( 'ClassManagerPanel', () => {
 		expect( mockTracking ).toHaveBeenCalledWith( {
 			event: 'classManagerSearched',
 		} );
+	} );
+
+	it( 'should wire a real scroll element to the virtualized list', async () => {
+		renderWithStore(
+			<ThemeProvider>
+				<QueryClientProvider client={ queryClient }>
+					<ClassManagerPanel />
+				</QueryClientProvider>
+			</ThemeProvider>,
+			store
+		);
+
+		await waitFor( () => {
+			expect( useVirtualizer ).toHaveBeenCalled();
+		} );
+
+		const lastCall = jest.mocked( useVirtualizer ).mock.calls.at( -1 );
+		const options = lastCall?.[ 0 ];
+
+		expect( options?.getScrollElement?.() ).toBeInstanceOf( HTMLElement );
 	} );
 
 	it( 'should track syncToV3 unsync event when stopping sync via confirmation dialog', async () => {

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
@@ -12,40 +12,34 @@ import { __privateRunCommand } from '@elementor/editor-v1-adapters';
 import { QueryClient, QueryClientProvider } from '@elementor/query';
 import { __createStore, __dispatch, __registerSlice, type SliceState, type Store } from '@elementor/store';
 import { ThemeProvider } from '@elementor/ui';
-import { useVirtualizer } from '@tanstack/react-virtual';
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 
 import { apiClient } from '../../../api';
 import { slice } from '../../../store';
 import { ClassManagerPanel, usePanelActions } from '../class-manager-panel';
 
-jest.mock( '@tanstack/react-virtual', () => {
-	const actual = jest.requireActual( '@tanstack/react-virtual' );
-	return {
-		...actual,
-		useVirtualizer: jest.fn(),
-	};
-} );
-
 const PANEL_TEST_ROW_HEIGHT = 40;
 
-const mockVirtualizerWithAllItemsForPanel = () => {
-	jest.mocked( useVirtualizer ).mockImplementation( ( options ) => {
-		const indices = Array.from( { length: options.count }, ( _, i ) => i );
+jest.mock( '@tanstack/react-virtual', () => ( {
+	useVirtualizer: jest.fn().mockImplementation( ( config ) => {
+		const { count, getItemKey } = config;
+		const indices = Array.from( { length: count }, ( _, i ) => i );
+
 		return {
-			getTotalSize: () => options.count * PANEL_TEST_ROW_HEIGHT,
-			getVirtualItems: () =>
+			getTotalSize: jest.fn().mockReturnValue( count * PANEL_TEST_ROW_HEIGHT ),
+			getVirtualItems: jest.fn().mockReturnValue(
 				indices.map( ( index ) => ( {
 					index,
-					key: options.getItemKey ? options.getItemKey( index ) : index,
+					key: getItemKey ? getItemKey( index ) : index,
 					start: index * PANEL_TEST_ROW_HEIGHT,
 					end: ( index + 1 ) * PANEL_TEST_ROW_HEIGHT,
 					size: PANEL_TEST_ROW_HEIGHT,
 					lane: 0,
-				} ) ),
-		} as unknown as ReturnType< typeof useVirtualizer >;
-	} );
-};
+				} ) )
+			),
+		};
+	} ),
+} ) );
 
 jest.mock( '@elementor/editor-documents' );
 jest.mock( '../class-manager-introduction' );
@@ -112,8 +106,6 @@ describe( 'ClassManagerPanel', () => {
 		);
 
 		jest.mocked( getCurrentDocument ).mockReturnValue( createMockDocument( { id: 1 } ) );
-
-		mockVirtualizerWithAllItemsForPanel();
 	} );
 
 	it( 'should have a disabled "save changes" button when dirty state is false', () => {
@@ -494,26 +486,6 @@ describe( 'ClassManagerPanel', () => {
 		expect( mockTracking ).toHaveBeenCalledWith( {
 			event: 'classManagerSearched',
 		} );
-	} );
-
-	it( 'should wire a real scroll element to the virtualized list', async () => {
-		renderWithStore(
-			<ThemeProvider>
-				<QueryClientProvider client={ queryClient }>
-					<ClassManagerPanel />
-				</QueryClientProvider>
-			</ThemeProvider>,
-			store
-		);
-
-		await waitFor( () => {
-			expect( useVirtualizer ).toHaveBeenCalled();
-		} );
-
-		const lastCall = jest.mocked( useVirtualizer ).mock.calls.at( -1 );
-		const options = lastCall?.[ 0 ];
-
-		expect( options?.getScrollElement?.() ).toBeInstanceOf( HTMLElement );
 	} );
 
 	it( 'should track syncToV3 unsync event when stopping sync via confirmation dialog', async () => {

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/global-classes-list.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/global-classes-list.test.tsx
@@ -14,7 +14,6 @@ import {
 	__dispatch as dispatch,
 	__registerSlice as registerSlice,
 } from '@elementor/store';
-import { useVirtualizer } from '@tanstack/react-virtual';
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 
 import { useFilters } from '../../../hooks/use-filters';
@@ -22,33 +21,28 @@ import { slice } from '../../../store';
 import { type SearchAndFilterContextType, useSearchAndFilters } from '../../search-and-filter/context';
 import { GlobalClassesList } from '../global-classes-list';
 
-jest.mock( '@tanstack/react-virtual', () => {
-	const actual = jest.requireActual( '@tanstack/react-virtual' );
-	return {
-		...actual,
-		useVirtualizer: jest.fn(),
-	};
-} );
-
 const ROW_HEIGHT = 40;
 
-const mockVirtualizerWithAllItems = () => {
-	jest.mocked( useVirtualizer ).mockImplementation( ( options ) => {
-		const indices = Array.from( { length: options.count }, ( _, i ) => i );
+jest.mock( '@tanstack/react-virtual', () => ( {
+	useVirtualizer: jest.fn().mockImplementation( ( config ) => {
+		const { count, getItemKey } = config;
+		const indices = Array.from( { length: count }, ( _, i ) => i );
+
 		return {
-			getTotalSize: () => options.count * ROW_HEIGHT,
-			getVirtualItems: () =>
+			getTotalSize: jest.fn().mockReturnValue( count * ROW_HEIGHT ),
+			getVirtualItems: jest.fn().mockReturnValue(
 				indices.map( ( index ) => ( {
 					index,
-					key: options.getItemKey ? options.getItemKey( index ) : index,
+					key: getItemKey ? getItemKey( index ) : index,
 					start: index * ROW_HEIGHT,
 					end: ( index + 1 ) * ROW_HEIGHT,
 					size: ROW_HEIGHT,
 					lane: 0,
-				} ) ),
-		} as unknown as ReturnType< typeof useVirtualizer >;
-	} );
-};
+				} ) )
+			),
+		};
+	} ),
+} ) );
 
 jest.mock( '@elementor/editor-v1-adapters', () => ( {
 	...jest.requireActual( '@elementor/editor-v1-adapters' ),
@@ -102,8 +96,6 @@ describe( 'GlobalClassesList', () => {
 
 		store = createStore();
 		jest.mocked( useSearchAndFilters ).mockReturnValue( { ...mockUseSearchAndFiltersProps } );
-
-		mockVirtualizerWithAllItems();
 	} );
 
 	it( 'should render the list of classes with its order', async () => {
@@ -642,28 +634,9 @@ describe( 'GlobalClassesList', () => {
 		expect( mockTracking ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should render only the windowed subset for large lists', () => {
-		const totalCount = 50;
-		const windowSize = 10;
-
-		jest.mocked( useVirtualizer ).mockImplementation( ( options ) => {
-			const indices = Array.from( { length: Math.min( windowSize, options.count ) }, ( _, i ) => i );
-			return {
-				getTotalSize: () => options.count * ROW_HEIGHT,
-				getVirtualItems: () =>
-					indices.map( ( index ) => ( {
-						index,
-						key: options.getItemKey ? options.getItemKey( index ) : index,
-						start: index * ROW_HEIGHT,
-						end: ( index + 1 ) * ROW_HEIGHT,
-						size: ROW_HEIGHT,
-						lane: 0,
-					} ) ),
-			} as unknown as ReturnType< typeof useVirtualizer >;
-		} );
-
+	it( 'should keep sortable triggers wired on classes rendered while virtualized', () => {
 		mockClasses(
-			Array.from( { length: totalCount }, ( _, i ) => ( {
+			Array.from( { length: 50 }, ( _, i ) => ( {
 				id: `class-${ i + 1 }`,
 				label: `ClassLabel${ i + 1 }`,
 			} ) )
@@ -671,10 +644,10 @@ describe( 'GlobalClassesList', () => {
 
 		renderWithStore( <GlobalClassesList />, store );
 
-		expect( screen.getByText( 'ClassLabel1' ) ).toBeInTheDocument();
-		expect( screen.getByText( `ClassLabel${ windowSize }` ) ).toBeInTheDocument();
-		expect( screen.queryByText( `ClassLabel${ windowSize + 1 }` ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( `ClassLabel${ totalCount }` ) ).not.toBeInTheDocument();
+		const renderedRows = screen.getAllByRole( 'listitem' );
+		const sortTriggers = screen.getAllByRole( 'button', { name: 'sort' } );
+
+		expect( sortTriggers ).toHaveLength( renderedRows.length );
 	} );
 } );
 

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/global-classes-list.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/global-classes-list.test.tsx
@@ -14,12 +14,41 @@ import {
 	__dispatch as dispatch,
 	__registerSlice as registerSlice,
 } from '@elementor/store';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 
 import { useFilters } from '../../../hooks/use-filters';
 import { slice } from '../../../store';
 import { type SearchAndFilterContextType, useSearchAndFilters } from '../../search-and-filter/context';
 import { GlobalClassesList } from '../global-classes-list';
+
+jest.mock( '@tanstack/react-virtual', () => {
+	const actual = jest.requireActual( '@tanstack/react-virtual' );
+	return {
+		...actual,
+		useVirtualizer: jest.fn(),
+	};
+} );
+
+const ROW_HEIGHT = 40;
+
+const mockVirtualizerWithAllItems = () => {
+	jest.mocked( useVirtualizer ).mockImplementation( ( options ) => {
+		const indices = Array.from( { length: options.count }, ( _, i ) => i );
+		return {
+			getTotalSize: () => options.count * ROW_HEIGHT,
+			getVirtualItems: () =>
+				indices.map( ( index ) => ( {
+					index,
+					key: options.getItemKey ? options.getItemKey( index ) : index,
+					start: index * ROW_HEIGHT,
+					end: ( index + 1 ) * ROW_HEIGHT,
+					size: ROW_HEIGHT,
+					lane: 0,
+				} ) ),
+		} as unknown as ReturnType< typeof useVirtualizer >;
+	} );
+};
 
 jest.mock( '@elementor/editor-v1-adapters', () => ( {
 	...jest.requireActual( '@elementor/editor-v1-adapters' ),
@@ -67,11 +96,14 @@ describe( 'GlobalClassesList', () => {
 		jest.mocked( getCurrentDocument ).mockReturnValue( createMockDocument( { id: 1 } ) );
 
 		jest.mocked( validateStyleLabel ).mockReturnValue( { isValid: true, errorMessage: null } );
+		jest.mocked( useFilters ).mockReturnValue( null );
 
 		registerSlice( slice );
 
 		store = createStore();
 		jest.mocked( useSearchAndFilters ).mockReturnValue( { ...mockUseSearchAndFiltersProps } );
+
+		mockVirtualizerWithAllItems();
 	} );
 
 	it( 'should render the list of classes with its order', async () => {
@@ -608,6 +640,41 @@ describe( 'GlobalClassesList', () => {
 
 		expect( triggers ).toHaveLength( 0 );
 		expect( mockTracking ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should render only the windowed subset for large lists', () => {
+		const totalCount = 50;
+		const windowSize = 10;
+
+		jest.mocked( useVirtualizer ).mockImplementation( ( options ) => {
+			const indices = Array.from( { length: Math.min( windowSize, options.count ) }, ( _, i ) => i );
+			return {
+				getTotalSize: () => options.count * ROW_HEIGHT,
+				getVirtualItems: () =>
+					indices.map( ( index ) => ( {
+						index,
+						key: options.getItemKey ? options.getItemKey( index ) : index,
+						start: index * ROW_HEIGHT,
+						end: ( index + 1 ) * ROW_HEIGHT,
+						size: ROW_HEIGHT,
+						lane: 0,
+					} ) ),
+			} as unknown as ReturnType< typeof useVirtualizer >;
+		} );
+
+		mockClasses(
+			Array.from( { length: totalCount }, ( _, i ) => ( {
+				id: `class-${ i + 1 }`,
+				label: `ClassLabel${ i + 1 }`,
+			} ) )
+		);
+
+		renderWithStore( <GlobalClassesList />, store );
+
+		expect( screen.getByText( 'ClassLabel1' ) ).toBeInTheDocument();
+		expect( screen.getByText( `ClassLabel${ windowSize }` ) ).toBeInTheDocument();
+		expect( screen.queryByText( `ClassLabel${ windowSize + 1 }` ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( `ClassLabel${ totalCount }` ) ).not.toBeInTheDocument();
 	} );
 } );
 

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/class-manager-panel.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/class-manager-panel.tsx
@@ -97,6 +97,7 @@ export function ClassManagerPanel() {
 	const [ stopSyncConfirmation, setStopSyncConfirmation ] = useState< string | null >( null );
 	const [ startSyncConfirmation, setStartSyncConfirmation ] = useState< string | null >( null );
 	const [ isStopSyncSuppressed ] = useSuppressedMessage( STOP_SYNC_MESSAGE_KEY );
+	const [ scrollElement, setScrollElement ] = useState< HTMLElement | null >( null );
 
 	const { mutateAsync: publish, isPending: isPublishing } = usePublish();
 
@@ -190,6 +191,7 @@ export function ClassManagerPanel() {
 							</Box>
 							<Divider />
 							<Box
+								ref={ setScrollElement }
 								px={ 2 }
 								sx={ {
 									flexGrow: 1,
@@ -198,6 +200,7 @@ export function ClassManagerPanel() {
 							>
 								<GlobalClassesList
 									disabled={ isPublishing }
+									scrollElement={ scrollElement }
 									onStopSyncRequest={ handleStopSyncRequest }
 									onStartSyncRequest={ ( classId ) => setStartSyncConfirmation( classId ) }
 								/>

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/global-classes-list.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/global-classes-list.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { type StyleDefinition, type StyleDefinitionID } from '@elementor/editor-styles';
 import { __useDispatch as useDispatch } from '@elementor/store';
 import { List, Stack, styled, Typography, type TypographyProps } from '@elementor/ui';
-import { defaultRangeExtractor, type Range, useVirtualizer } from '@tanstack/react-virtual';
+import { defaultRangeExtractor, useVirtualizer } from '@tanstack/react-virtual';
 import { __ } from '@wordpress/i18n';
 
 import { useClassesOrder } from '../../hooks/use-classes-order';
@@ -45,23 +45,9 @@ export const GlobalClassesList = ( {
 	const [ classesOrder, reorderClasses ] = useReorder( draggedItemId, setDraggedItemId, draggedItemLabel ?? '' );
 	const filteredCssClasses = useFilteredCssClasses();
 
-	const draggedItemIndex = useMemo( () => {
-		if ( ! draggedItemId ) {
-			return -1;
-		}
-		return filteredCssClasses.findIndex( ( cssClass ) => cssClass.id === draggedItemId );
-	}, [ draggedItemId, filteredCssClasses ] );
-
-	const rangeExtractor = useCallback(
-		( range: Range ) => {
-			const indices = new Set( defaultRangeExtractor( range ) );
-			if ( draggedItemIndex >= 0 ) {
-				indices.add( draggedItemIndex );
-			}
-			return [ ...indices ].sort( ( a, b ) => a - b );
-		},
-		[ draggedItemIndex ]
-	);
+	const draggedItemIndex = draggedItemId
+		? filteredCssClasses.findIndex( ( cssClass ) => cssClass.id === draggedItemId )
+		: -1;
 
 	const virtualizer = useVirtualizer( {
 		count: filteredCssClasses.length,
@@ -69,7 +55,16 @@ export const GlobalClassesList = ( {
 		estimateSize: () => ROW_HEIGHT,
 		overscan: OVERSCAN,
 		getItemKey: ( index ) => filteredCssClasses[ index ].id,
-		rangeExtractor,
+		// Keep the actively dragged row mounted even when scrolled out of view.
+		// SortableItem unregisters its render on unmount, which would make the
+		// DragOverlay clone disappear mid-drag.
+		rangeExtractor: ( range ) => {
+			const indices = new Set( defaultRangeExtractor( range ) );
+			if ( draggedItemIndex >= 0 ) {
+				indices.add( draggedItemIndex );
+			}
+			return [ ...indices ].sort( ( a, b ) => a - b );
+		},
 	} );
 
 	useEffect( () => {

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/global-classes-list.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/global-classes-list.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { type StyleDefinition, type StyleDefinitionID } from '@elementor/editor-styles';
 import { __useDispatch as useDispatch } from '@elementor/store';
 import { List, Stack, styled, Typography, type TypographyProps } from '@elementor/ui';
+import { defaultRangeExtractor, type Range, useVirtualizer } from '@tanstack/react-virtual';
 import { __ } from '@wordpress/i18n';
 
 import { useClassesOrder } from '../../hooks/use-classes-order';
@@ -17,13 +18,22 @@ import { FlippedColorSwatchIcon } from './flipped-color-swatch-icon';
 import { getNotFoundType, NotFound } from './not-found';
 import { SortableItem, SortableProvider } from './sortable';
 
+const ROW_HEIGHT = 40;
+const OVERSCAN = 6;
+
 type GlobalClassesListProps = {
 	disabled?: boolean;
+	scrollElement?: HTMLElement | null;
 	onStopSyncRequest?: ( id: string ) => void;
 	onStartSyncRequest?: ( id: string ) => void;
 };
 
-export const GlobalClassesList = ( { disabled, onStopSyncRequest, onStartSyncRequest }: GlobalClassesListProps ) => {
+export const GlobalClassesList = ( {
+	disabled,
+	scrollElement,
+	onStopSyncRequest,
+	onStartSyncRequest,
+}: GlobalClassesListProps ) => {
 	const {
 		search: { debouncedValue: searchValue },
 	} = useSearchAndFilters();
@@ -34,6 +44,33 @@ export const GlobalClassesList = ( { disabled, onStopSyncRequest, onStartSyncReq
 	const draggedItemLabel = cssClasses.find( ( cssClass ) => cssClass.id === draggedItemId )?.label ?? '';
 	const [ classesOrder, reorderClasses ] = useReorder( draggedItemId, setDraggedItemId, draggedItemLabel ?? '' );
 	const filteredCssClasses = useFilteredCssClasses();
+
+	const draggedItemIndex = useMemo( () => {
+		if ( ! draggedItemId ) {
+			return -1;
+		}
+		return filteredCssClasses.findIndex( ( cssClass ) => cssClass.id === draggedItemId );
+	}, [ draggedItemId, filteredCssClasses ] );
+
+	const rangeExtractor = useCallback(
+		( range: Range ) => {
+			const indices = new Set( defaultRangeExtractor( range ) );
+			if ( draggedItemIndex >= 0 ) {
+				indices.add( draggedItemIndex );
+			}
+			return [ ...indices ].sort( ( a, b ) => a - b );
+		},
+		[ draggedItemIndex ]
+	);
+
+	const virtualizer = useVirtualizer( {
+		count: filteredCssClasses.length,
+		getScrollElement: () => scrollElement ?? null,
+		estimateSize: () => ROW_HEIGHT,
+		overscan: OVERSCAN,
+		getItemKey: ( index ) => filteredCssClasses[ index ].id,
+		rangeExtractor,
+	} );
 
 	useEffect( () => {
 		const handler = ( event: KeyboardEvent ) => {
@@ -69,19 +106,36 @@ export const GlobalClassesList = ( { disabled, onStopSyncRequest, onStartSyncReq
 
 	return (
 		<DeleteConfirmationProvider>
-			<List sx={ { display: 'flex', flexDirection: 'column', gap: 0.5 } }>
+			<List
+				sx={ {
+					position: 'relative',
+					display: 'block',
+					height: virtualizer.getTotalSize(),
+					padding: 0,
+				} }
+			>
 				<SortableProvider
 					value={ classesOrder }
 					onChange={ reorderClasses }
+					onDragStart={ ( event ) => setDraggedItemId( event.active.id as StyleDefinitionID ) }
+					onDragEnd={ () => setDraggedItemId( null ) }
+					onDragCancel={ () => setDraggedItemId( null ) }
 					disableDragOverlay={ ! allowSorting }
 				>
-					{ filteredCssClasses?.map( ( cssClass ) => (
-						<SortableItem key={ cssClass.id } id={ cssClass.id }>
-							{ ( { isDragged, isDragPlaceholder, triggerProps, triggerStyle } ) => {
-								if ( isDragged && ! draggedItemId ) {
-									setDraggedItemId( cssClass.id );
-								}
-								return (
+					{ virtualizer.getVirtualItems().map( ( virtualRow ) => {
+						const cssClass = filteredCssClasses[ virtualRow.index ];
+						return (
+							<SortableItem
+								key={ virtualRow.key }
+								id={ cssClass.id }
+								style={ {
+									position: 'absolute',
+									top: virtualRow.start,
+									left: 0,
+									width: '100%',
+								} }
+							>
+								{ ( { isDragged, isDragPlaceholder, triggerProps, triggerStyle } ) => (
 									<ClassItem
 										id={ cssClass.id }
 										label={ cssClass.label }
@@ -127,10 +181,10 @@ export const GlobalClassesList = ( { disabled, onStopSyncRequest, onStartSyncReq
 											}
 										} }
 									/>
-								);
-							} }
-						</SortableItem>
-					) ) }
+								) }
+							</SortableItem>
+						);
+					} ) }
 				</SortableProvider>
 			</List>
 		</DeleteConfirmationProvider>
@@ -176,7 +230,7 @@ const useReorder = (
 				classId: draggedItemId,
 				classTitle: draggedItemLabel,
 			} );
-			setDraggedItemId( null ); // Reset after tracking
+			setDraggedItemId( null );
 		}
 	};
 

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/global-classes-list.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/global-classes-list.tsx
@@ -45,10 +45,6 @@ export const GlobalClassesList = ( {
 	const [ classesOrder, reorderClasses ] = useReorder( draggedItemId, setDraggedItemId, draggedItemLabel ?? '' );
 	const filteredCssClasses = useFilteredCssClasses();
 
-	const draggedItemIndex = draggedItemId
-		? filteredCssClasses.findIndex( ( cssClass ) => cssClass.id === draggedItemId )
-		: -1;
-
 	const virtualizer = useVirtualizer( {
 		count: filteredCssClasses.length,
 		getScrollElement: () => scrollElement ?? null,
@@ -60,8 +56,11 @@ export const GlobalClassesList = ( {
 		// DragOverlay clone disappear mid-drag.
 		rangeExtractor: ( range ) => {
 			const indices = new Set( defaultRangeExtractor( range ) );
-			if ( draggedItemIndex >= 0 ) {
-				indices.add( draggedItemIndex );
+			if ( draggedItemId ) {
+				const draggedItemIndex = filteredCssClasses.findIndex( ( cssClass ) => cssClass.id === draggedItemId );
+				if ( draggedItemIndex >= 0 ) {
+					indices.add( draggedItemIndex );
+				}
 			}
 			return [ ...indices ].sort( ( a, b ) => a - b );
 		},

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/sortable.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/sortable.tsx
@@ -11,7 +11,12 @@ import {
 } from '@elementor/ui';
 
 export const SortableProvider = < T extends string >( props: UnstableSortableProviderProps< T > ) => (
-	<UnstableSortableProvider restrictAxis variant="static" dragPlaceholderStyle={ { opacity: '1' } } { ...props } />
+	<UnstableSortableProvider
+		restrictAxis
+		variant="static"
+		dragPlaceholderStyle={ { visibility: 'hidden' } }
+		{ ...props }
+	/>
 );
 
 export type SortableTriggerProps = React.HTMLAttributes< HTMLDivElement >;
@@ -24,10 +29,11 @@ export const SortableTrigger = ( props: SortableTriggerProps ) => (
 
 type SortableItemProps = {
 	id: UnstableSortableItemProps[ 'id' ];
+	style?: React.CSSProperties;
 	children: ( props: Partial< UnstableSortableItemRenderProps > ) => React.ReactNode;
 };
 
-export const SortableItem = ( { children, id, ...props }: SortableItemProps ) => {
+export const SortableItem = ( { children, id, style, ...props }: SortableItemProps ) => {
 	return (
 		<UnstableSortableItem
 			{ ...props }
@@ -46,7 +52,7 @@ export const SortableItem = ( { children, id, ...props }: SortableItemProps ) =>
 				return (
 					<Box
 						{ ...itemProps }
-						style={ itemStyle }
+						style={ { ...itemStyle, ...( ! isDragOverlay ? style : null ) } }
 						component={ 'li' }
 						role="listitem"
 						sx={ {


### PR DESCRIPTION
## PR Type
- [x] Feature

## Summary

Virtualize the Class Manager classes list using `@tanstack/react-virtual`, keeping drag-and-drop intact. Performance scales with viewport size, not with the number of saved classes.

## Description

The Class Manager rendered every class as a DOM node. With hundreds of classes the panel became sluggish on open, scroll and drag. This PR mounts only the visible window plus a small overscan via `useVirtualizer`, while preserving the existing `@dnd-kit` reorder behavior.

Key implementation points:

- `class-manager-panel.tsx` exposes the scroll element via a `useState` callback ref so `useVirtualizer` always gets a stable, valid element.
- `global-classes-list.tsx` switches to a virtualized list of `SortableItem`s. Items are absolutely positioned at `top: virtualRow.start`; the container takes `height: virtualizer.getTotalSize()`.
- A custom `rangeExtractor` pins the actively dragged item in the rendered window so dnd-kit never loses it during scroll.
- `sortable.tsx` applies the virtualization style only when `! isDragOverlay` so the cloned `DragOverlay` is positioned by dnd-kit (cursor follow) instead of being pushed off-screen by `top: <large>px`.
- The dragged-item placeholder is hidden via `dragPlaceholderStyle: { visibility: 'hidden' }` to avoid a visual gap-plus-ghost flicker.
- New unit tests cover: only the windowed subset is rendered for large lists, and the real scroll element is wired into the virtualizer.

## Test instructions

1. Open the Class Manager with a large number of classes (hundreds).
2. Scroll: only ~10 rows should be in the DOM at any time, scrolling stays smooth.
3. Drag a row by its handle: the ghost should follow the cursor; the original row's slot is hidden during the drag; native dnd-kit auto-scroll engages near the panel edges; releasing reorders the list and enables Save changes.
4. Search/filter: filtered subset still renders virtualized.
5. Existing flows (rename, delete, save, discard) continue to work.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended

Fixes ED-23898

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Virtualizing the class manager panel list to handle potentially large numbers of CSS classes without performance degradation. The panel was rendering all classes at once; now only visible rows render.

## 2. What Changed (Where)

- **global-classes-list.tsx**: Integrated `@tanstack/react-virtual` with custom `rangeExtractor` to keep dragged items mounted during virtualization.
- **class-manager-panel.tsx**: Added scroll container ref passed to virtualized list component.
- **sortable.tsx**: Added `style` prop to `SortableItem` for absolute positioning; changed placeholder visibility style.
- **Tests**: Mocked `useVirtualizer` to simulate full list rendering in test environment.
- **package.json**: Added `@tanstack/react-virtual` dependency.

## 3. How It Works

Parent panel captures scroll container ref → passes to `GlobalClassesList` → `useVirtualizer` computes visible range based on 40px row height with 6-item overscan → renders only virtual items with absolute positioning. Custom `rangeExtractor` keeps actively dragged item mounted even when scrolled out of view, preserving DragOverlay during reorder operations. Tests mock virtualizer to render all rows, ensuring sort triggers remain wired.

## 4. Risks

Drag-and-drop during scroll could flicker if overscan too small (mitigated: 6-item buffer). Test mocks render full list—real virtualization untested in CI. If scroll container unmounts before virtualizer initializes, `getTotalSize()` returns 0 (mitigated: ref set before render). Custom `rangeExtractor` adds complexity; verify dragged items don't cause layout shifts on edge boundaries.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
