### PR TITLE
Internal: Remove hardcoded browser targets from webpack config [ED-23768]

### DIFF
--- a/.grunt-config/webpack.js
+++ b/.grunt-config/webpack.js
@@ -68,19 +68,6 @@ const moduleRules = getModuleRules( [ '@wordpress/default' ] );
 const frontendRulesPresets = [ [
 	'@babel/preset-env',
 	{
-		targets: {
-			browsers: [
-				'last 3 versions',
-				'Chrome >= 111',
-				'Firefox >= 111',
-				'Edge >= 111',
-				'Safari >= 16.4',
-				'iOS >= 16.4',
-				'Android >= 111',
-				'ChromeAndroid >= 111',
-				'not dead',
-			],
-		},
 		"useBuiltIns": "usage",
 		"corejs": "3.23",
 	}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Removes hardcoded browser targets from Babel config (ED-23768). Browser compatibility now sourced from `.browserslistrc` instead of duplicated webpack config—single source of truth pattern.

## 2. What Changed (Where)

`.grunt-config/webpack.js`: Deleted 13-line `targets.browsers` array from `frontendRulesPresets` Babel preset options. Babel will now auto-discover targets via standard browserslist resolution.

## 3. How It Works

Babel's `@babel/preset-env` automatically consults `.browserslistrc` when no explicit `targets` config exists. This eliminates redundancy and ensures webpack, eslint, and other tools read identical browser support definitions.

## 4. Risks

Low—assumes `.browserslistrc` exists and defines appropriate targets. If missing or misconfigured, Babel defaults to modern browsers, potentially skipping needed polyfills. Verify `.browserslistrc` is committed and CI/build pipeline regenerates properly.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
