### PR TITLE
Internal: Add support for time picker form widget and time range prop type [ED-23656]

### DIFF
--- a/modules/atomic-widgets/controls/types/time-range-control.php
+++ b/modules/atomic-widgets/controls/types/time-range-control.php
@@ -8,7 +8,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Time_Range_Control extends Atomic_Control_Base {
-
 	public function get_type(): string {
 		return 'time-range';
 	}

--- a/modules/atomic-widgets/controls/types/time-range-control.php
+++ b/modules/atomic-widgets/controls/types/time-range-control.php
@@ -1,0 +1,19 @@
+<?php
+namespace Elementor\Modules\AtomicWidgets\Controls\Types;
+
+use Elementor\Modules\AtomicWidgets\Controls\Base\Atomic_Control_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Time_Range_Control extends Atomic_Control_Base {
+
+	public function get_type(): string {
+		return 'time-range';
+	}
+
+	public function get_props(): array {
+		return [];
+	}
+}

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -73,6 +73,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Border_Width_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Color_Stop_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Date_Time_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Date_Range_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Time_Range_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Backdrop_Filter_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Filter_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Gradient_Color_Stop_Prop_Type;
@@ -115,6 +116,7 @@ use Elementor\Widgets_Manager;
 use Elementor\Modules\AtomicWidgets\Library\Atomic_Widgets_Library;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Settings\Query_Transformer;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Settings\Date_Range_Transformer;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Settings\Time_Range_Transformer;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Styles\Perspective_Origin_Transformer;
 use Elementor\Modules\AtomicWidgets\PropTypes\Query_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Transform\Perspective_Origin_Prop_Type;
@@ -334,6 +336,7 @@ class Module extends BaseModule {
 		$transformers->register( Attributes_Prop_Type::get_key(), new Attributes_Transformer() );
 		$transformers->register( Date_Time_Prop_Type::get_key(), new Date_Time_Transformer() );
 		$transformers->register( Date_Range_Prop_Type::get_key(), new Date_Range_Transformer() );
+		$transformers->register( Time_Range_Prop_Type::get_key(), new Time_Range_Transformer() );
 		$transformers->register( Html_V2_Prop_Type::get_key(), new Html_V2_Transformer() );
 		$transformers->register( Html_V3_Prop_Type::get_key(), new Html_V3_Transformer() );
 	}

--- a/modules/atomic-widgets/prop-types/time-range-prop-type.php
+++ b/modules/atomic-widgets/prop-types/time-range-prop-type.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\PropTypes;
+
+use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Time_String_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Time_Range_Prop_Type extends Object_Prop_Type {
+	public static function get_key(): string {
+		return 'time-range';
+	}
+
+	protected function define_shape(): array {
+		return [
+			'min' => Time_String_Prop_Type::make(),
+			'max' => Time_String_Prop_Type::make(),
+		];
+	}
+}

--- a/modules/atomic-widgets/prop-types/time-string-prop-type.php
+++ b/modules/atomic-widgets/prop-types/time-string-prop-type.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\PropTypes;
+
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Time_String_Prop_Type extends String_Prop_Type {
+	const ISO_TIME_REGEX = '/^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/';
+
+	public static function get_key(): string {
+		return 'time-string';
+	}
+
+	protected function validate_value( $value ): bool {
+		if ( ! parent::validate_value( $value ) ) {
+			return false;
+		}
+
+		return 1 === preg_match( self::ISO_TIME_REGEX, $value );
+	}
+}

--- a/modules/atomic-widgets/props-resolver/transformers/settings/date-range-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/settings/date-range-transformer.php
@@ -13,7 +13,6 @@ const INVALID_DATE = 'Invalid Date';
 
 class Date_Range_Transformer extends Transformer_Base {
 	public function transform( $value, Props_Resolver_Context $context ) {
-
 		if ( empty( $value ) ) {
 			return null;
 		}

--- a/modules/atomic-widgets/props-resolver/transformers/settings/date-range-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/settings/date-range-transformer.php
@@ -9,24 +9,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-const INVALID_DATE = 'Invalid Date';
-
 class Date_Range_Transformer extends Transformer_Base {
 	public function transform( $value, Props_Resolver_Context $context ) {
 		if ( empty( $value ) ) {
 			return null;
 		}
 
-		$result = [];
-
-		if ( isset( $value['min'] ) ) {
-			$result['min'] = INVALID_DATE !== $value['min'] ? $value['min'] : '';
-		}
-
-		if ( isset( $value['max'] ) ) {
-			$result['max'] = INVALID_DATE !== $value['max'] ? $value['max'] : '';
-		}
-
-		return $result;
+		return [
+			'min' => empty( $value['min'] ) ? null : $value['min'],
+			'max' => empty( $value['max'] ) ? null : $value['max'],
+		];
 	}
 }

--- a/modules/atomic-widgets/props-resolver/transformers/settings/time-range-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/settings/time-range-transformer.php
@@ -10,23 +10,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Time_Range_Transformer extends Transformer_Base {
-	const INVALID_DATE = 'Invalid Date';
-
 	public function transform( $value, Props_Resolver_Context $context ) {
 		if ( empty( $value ) ) {
 			return null;
 		}
 
-		$result = [];
-
-		if ( isset( $value['min'] ) ) {
-			$result['min'] = self::INVALID_DATE !== $value['min'] ? $value['min'] : '';
-		}
-
-		if ( isset( $value['max'] ) ) {
-			$result['max'] = self::INVALID_DATE !== $value['max'] ? $value['max'] : '';
-		}
-
-		return $result;
+		return [
+			'min' => empty( $value['min'] ) ? null : $value['min'],
+			'max' => empty( $value['max'] ) ? null : $value['max'],
+		];
 	}
 }

--- a/modules/atomic-widgets/props-resolver/transformers/settings/time-range-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/settings/time-range-transformer.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Settings;
+
+use Elementor\Modules\AtomicWidgets\PropsResolver\Props_Resolver_Context;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Transformer_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Time_Range_Transformer extends Transformer_Base {
+	const INVALID_DATE = 'Invalid Date';
+
+	public function transform( $value, Props_Resolver_Context $context ) {
+
+		if ( empty( $value ) ) {
+			return null;
+		}
+
+		$result = [];
+
+		if ( isset( $value['min'] ) ) {
+			$result['min'] = self::INVALID_DATE !== $value['min'] ? $value['min'] : '';
+		}
+
+		if ( isset( $value['max'] ) ) {
+			$result['max'] = self::INVALID_DATE !== $value['max'] ? $value['max'] : '';
+		}
+
+		return $result;
+	}
+}

--- a/modules/atomic-widgets/props-resolver/transformers/settings/time-range-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/settings/time-range-transformer.php
@@ -13,7 +13,6 @@ class Time_Range_Transformer extends Transformer_Base {
 	const INVALID_DATE = 'Invalid Date';
 
 	public function transform( $value, Props_Resolver_Context $context ) {
-
 		if ( empty( $value ) ) {
 			return null;
 		}

--- a/packages/packages/core/editor-canvas/src/form-structure/utils.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/utils.ts
@@ -44,6 +44,7 @@ export const FORM_FIELD_ELEMENT_TYPES = new Set( [
 	'e-form-radio-button',
 	'e-form-file-upload',
 	'e-form-date-picker',
+	'e-form-time-picker',
 ] );
 
 export function getArgsElementType( args: CreateArgs ): string | undefined {

--- a/packages/packages/core/editor-canvas/src/init-settings-transformers.ts
+++ b/packages/packages/core/editor-canvas/src/init-settings-transformers.ts
@@ -7,6 +7,7 @@ import { htmlV2Transformer } from './transformers/settings/html-v2-transformer';
 import { htmlV3Transformer } from './transformers/settings/html-v3-transformer';
 import { linkTransformer } from './transformers/settings/link-transformer';
 import { queryTransformer } from './transformers/settings/query-transformer';
+import { timeRangeTransformer } from './transformers/settings/time-range-transformer';
 import { imageSrcTransformer } from './transformers/shared/image-src-transformer';
 import { imageTransformer } from './transformers/shared/image-transformer';
 import { plainTransformer } from './transformers/shared/plain-transformer';
@@ -27,5 +28,6 @@ export function initSettingsTransformers() {
 		.register( 'html-v2', htmlV2Transformer )
 		.register( 'html-v3', htmlV3Transformer )
 		.register( 'date-range', dateRangeTransformer )
+		.register( 'time-range', timeRangeTransformer )
 		.registerFallback( plainTransformer );
 }

--- a/packages/packages/core/editor-canvas/src/transformers/settings/date-range-transformer.ts
+++ b/packages/packages/core/editor-canvas/src/transformers/settings/date-range-transformer.ts
@@ -1,13 +1,12 @@
 import { createTransformer } from '../create-transformer';
 
-const INVALID_DATE = 'Invalid Date';
-export const dateRangeTransformer = createTransformer< { min?: string; max?: string } >( ( value ) => {
+export const dateRangeTransformer = createTransformer< { min?: string | null; max?: string | null } >( ( value ) => {
 	if ( ! value || Object.keys( value ).length === 0 ) {
 		return null;
 	}
 
 	return {
-		min: value.min && value.min !== INVALID_DATE ? value.min : '',
-		max: value.max && value.max !== INVALID_DATE ? value.max : '',
+		min: value.min || null,
+		max: value.max || null,
 	};
 } );

--- a/packages/packages/core/editor-canvas/src/transformers/settings/time-range-transformer.ts
+++ b/packages/packages/core/editor-canvas/src/transformers/settings/time-range-transformer.ts
@@ -1,13 +1,12 @@
 import { createTransformer } from '../create-transformer';
 
-const INVALID_DATE = 'Invalid Date';
-export const timeRangeTransformer = createTransformer< { min?: string; max?: string } >( ( value ) => {
+export const timeRangeTransformer = createTransformer< { min?: string | null; max?: string | null } >( ( value ) => {
 	if ( ! value || Object.keys( value ).length === 0 ) {
 		return null;
 	}
 
 	return {
-		min: value.min && value.min !== INVALID_DATE ? value.min : '',
-		max: value.max && value.max !== INVALID_DATE ? value.max : '',
+		min: value.min || null,
+		max: value.max || null,
 	};
 } );

--- a/packages/packages/core/editor-canvas/src/transformers/settings/time-range-transformer.ts
+++ b/packages/packages/core/editor-canvas/src/transformers/settings/time-range-transformer.ts
@@ -1,0 +1,13 @@
+import { createTransformer } from '../create-transformer';
+
+const INVALID_DATE = 'Invalid Date';
+export const timeRangeTransformer = createTransformer< { min?: string; max?: string } >( ( value ) => {
+	if ( ! value || Object.keys( value ).length === 0 ) {
+		return null;
+	}
+
+	return {
+		min: value.min && value.min !== INVALID_DATE ? value.min : '',
+		max: value.max && value.max !== INVALID_DATE ? value.max : '',
+	};
+} );

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/controls-registry.tsx
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/controls-registry.tsx
@@ -78,7 +78,7 @@ const controlTypes = {
 		component: DateRangeControl,
 		layout: 'custom',
 		propTypeUtil: dateRangePropTypeUtil,
-	},	
+	},
 	'time-range': {
 		component: TimeRangeControl,
 		layout: 'custom',

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/controls-registry.tsx
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/controls-registry.tsx
@@ -19,6 +19,7 @@ import {
 	SwitchControl,
 	TextAreaControl,
 	TextControl,
+	TimeRangeControl,
 	ToggleControl,
 	UrlControl,
 	VideoMediaControl,
@@ -40,6 +41,7 @@ import {
 	stringArrayPropTypeUtil,
 	stringPropTypeUtil,
 	svgSrcPropTypeUtil,
+	timeRangePropTypeUtil,
 	videoSrcPropTypeUtil,
 } from '@elementor/editor-props';
 
@@ -76,6 +78,11 @@ const controlTypes = {
 		component: DateRangeControl,
 		layout: 'custom',
 		propTypeUtil: dateRangePropTypeUtil,
+	},	
+	'time-range': {
+		component: TimeRangeControl,
+		layout: 'custom',
+		propTypeUtil: timeRangePropTypeUtil,
 	},
 	'attachment-type': { component: AttachmentTypeControl, layout: 'custom', propTypeUtil: stringPropTypeUtil },
 } as const satisfies ControlRegistry;

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/time-range-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/time-range-control.test.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import { createMockPropType, renderControl } from 'test-utils';
+import { fireEvent, screen } from '@testing-library/react';
+
+import { TimeRangeControl } from '../time-range-control';
+
+const propType = createMockPropType( {
+	kind: 'object',
+	key: 'time-range',
+	shape: {
+		min: createMockPropType( { kind: 'plain', key: 'time-string' } ),
+		max: createMockPropType( { kind: 'plain', key: 'time-string' } ),
+	},
+} );
+
+const createValue = ( min: string | null, max: string | null ) => ( {
+	$$type: 'time-range',
+	value: {
+		min: min === null ? null : { $$type: 'time-string', value: min },
+		max: max === null ? null : { $$type: 'time-string', value: max },
+	},
+} );
+
+describe( 'TimeRangeControl', () => {
+	it( 'should render Start time and End time labels', () => {
+		// Arrange.
+		const props = {
+			setValue: jest.fn(),
+			value: createValue( null, null ),
+			bind: 'time_range',
+			propType,
+		};
+
+		// Act.
+		renderControl( <TimeRangeControl />, props );
+
+		// Assert.
+		expect( screen.getByText( 'Start time' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'End time' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render existing min and max time values', () => {
+		// Arrange.
+		const props = {
+			setValue: jest.fn(),
+			value: createValue( '09:00', '17:30' ),
+			bind: 'time_range',
+			propType,
+		};
+
+		// Act.
+		renderControl( <TimeRangeControl />, props );
+
+		// Assert.
+		expect( ( screen.getByLabelText( 'Start time' ) as HTMLInputElement ).value ).toBe( '09:00 AM' );
+		expect( ( screen.getByLabelText( 'End time' ) as HTMLInputElement ).value ).toBe( '05:30 PM' );
+	} );
+
+	it( 'should accept end time earlier than start time without showing an error', () => {
+		// Arrange.
+		const props = {
+			setValue: jest.fn(),
+			value: createValue( '22:00', '13:00' ),
+			bind: 'time_range',
+			propType,
+		};
+
+		// Act.
+		renderControl( <TimeRangeControl />, props );
+
+		// Assert.
+		expect( screen.getByLabelText( 'Start time' ) ).toHaveAttribute( 'aria-invalid', 'false' );
+		expect( screen.getByLabelText( 'End time' ) ).toHaveAttribute( 'aria-invalid', 'false' );
+	} );
+
+	it( 'should call setValue with merged min when start input changes', () => {
+		// Arrange.
+		const setValue = jest.fn();
+		const props = {
+			setValue,
+			value: createValue( '09:00', '17:30' ),
+			bind: 'time_range',
+			propType,
+		};
+
+		renderControl( <TimeRangeControl />, props );
+
+		// Act.
+		fireEvent.change( screen.getByLabelText( 'Start time' ), { target: { value: '10:15 AM' } } );
+
+		// Assert.
+		expect( setValue ).toHaveBeenCalledWith( {
+			$$type: 'time-range',
+			value: {
+				min: { $$type: 'time-string', value: '10:15' },
+				max: { $$type: 'time-string', value: '17:30' },
+			},
+		} );
+	} );
+
+	it( 'should call setValue with merged max when end input changes', () => {
+		// Arrange.
+		const setValue = jest.fn();
+		const props = {
+			setValue,
+			value: createValue( '09:00', '17:30' ),
+			bind: 'time_range',
+			propType,
+		};
+
+		renderControl( <TimeRangeControl />, props );
+
+		// Act.
+		fireEvent.change( screen.getByLabelText( 'End time' ), { target: { value: '06:45 PM' } } );
+
+		// Assert.
+		expect( setValue ).toHaveBeenCalledWith( {
+			$$type: 'time-range',
+			value: {
+				min: { $$type: 'time-string', value: '09:00' },
+				max: { $$type: 'time-string', value: '18:45' },
+			},
+		} );
+	} );
+} );

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/time-string-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/time-string-control.test.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import { createMockPropType, renderControl } from 'test-utils';
+import { fireEvent, screen } from '@testing-library/react';
+
+import { TimeStringControl } from '../time-string-control';
+
+const propType = createMockPropType( { kind: 'plain' } );
+
+describe( 'TimeStringControl', () => {
+	it( 'should render the formatted time value in the input', () => {
+		// Arrange.
+		const setValue = jest.fn();
+		const props = {
+			setValue,
+			value: { $$type: 'time-string', value: '14:30' },
+			bind: 'time',
+			propType,
+		};
+
+		// Act.
+		renderControl( <TimeStringControl ariaLabel="Min time" />, props );
+
+		// Assert.
+		const input = screen.getByLabelText( 'Min time' ) as HTMLInputElement;
+		expect( input.value ).toBe( '02:30 PM' );
+	} );
+
+	it( 'should call setValue with formatted time when input changes', () => {
+		// Arrange.
+		const setValue = jest.fn();
+		const props = {
+			setValue,
+			value: { $$type: 'time-string', value: '' },
+			bind: 'time',
+			propType,
+		};
+
+		renderControl( <TimeStringControl ariaLabel="Min time" />, props );
+
+		const input = screen.getByLabelText( 'Min time' );
+
+		// Act.
+		fireEvent.change( input, { target: { value: '02:30 PM' } } );
+
+		// Assert.
+		expect( setValue ).toHaveBeenCalledWith( {
+			$$type: 'time-string',
+			value: '14:30',
+		} );
+	} );
+
+	it( 'should call setValue with null when the input is cleared', () => {
+		// Arrange.
+		const setValue = jest.fn();
+		const props = {
+			setValue,
+			value: { $$type: 'time-string', value: '14:30' },
+			bind: 'time',
+			propType,
+		};
+
+		renderControl( <TimeStringControl ariaLabel="Min time" />, props );
+
+		const input = screen.getByLabelText( 'Min time' );
+
+		// Act.
+		fireEvent.change( input, { target: { value: '' } } );
+
+		// Assert.
+		expect( setValue ).toHaveBeenCalledWith( null );
+	} );
+
+	it( 'should render an empty input when the value is null', () => {
+		// Arrange.
+		const setValue = jest.fn();
+		const props = {
+			setValue,
+			value: { $$type: 'time-string', value: null },
+			bind: 'time',
+			propType,
+		};
+
+		// Act.
+		renderControl( <TimeStringControl ariaLabel="Min time" />, props );
+
+		// Assert.
+		const input = screen.getByLabelText( 'Min time' ) as HTMLInputElement;
+		expect( input.value ).toBe( '' );
+	} );
+
+	it( 'should disable the input when inputDisabled is true', () => {
+		// Arrange.
+		const setValue = jest.fn();
+		const props = {
+			setValue,
+			value: { $$type: 'time-string', value: '14:30' },
+			bind: 'time',
+			propType,
+		};
+
+		// Act.
+		renderControl( <TimeStringControl ariaLabel="Min time" inputDisabled />, props );
+
+		// Assert.
+		expect( screen.getByLabelText( 'Min time' ) ).toBeDisabled();
+	} );
+
+	it( 'should mark the input as invalid when error is true', () => {
+		// Arrange.
+		const setValue = jest.fn();
+		const props = {
+			setValue,
+			value: { $$type: 'time-string', value: '14:30' },
+			bind: 'time',
+			propType,
+		};
+
+		// Act.
+		renderControl( <TimeStringControl ariaLabel="Min time" error />, props );
+
+		// Assert.
+		expect( screen.getByLabelText( 'Min time' ) ).toHaveAttribute( 'aria-invalid', 'true' );
+	} );
+} );

--- a/packages/packages/libs/editor-controls/src/controls/date-range-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/date-range-control.tsx
@@ -14,7 +14,7 @@ const RANGE_LABELS = {
 };
 
 const isMaxBeforeMin = ( minIso?: string | null, maxIso?: string | null ): boolean => {
-	if ( ! minIso || ! maxIso || [ minIso, maxIso ].some( ( v ) => v === 'Invalid Date' ) ) {
+	if ( ! minIso || ! maxIso ) {
 		return false;
 	}
 
@@ -77,7 +77,7 @@ const BoundDateStringControl = ( {
 } ) => {
 	return (
 		<PropKeyProvider bind={ bind }>
-			<DateStringControl ariaLabel={ ariaLabel } error={ error } coerceInvalidToEmpty />
+			<DateStringControl ariaLabel={ ariaLabel } error={ error } coerceInvalidToNull />
 		</PropKeyProvider>
 	);
 };

--- a/packages/packages/libs/editor-controls/src/controls/date-range-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/date-range-control.tsx
@@ -77,7 +77,7 @@ const BoundDateStringControl = ( {
 } ) => {
 	return (
 		<PropKeyProvider bind={ bind }>
-			<DateStringControl ariaLabel={ ariaLabel } error={ error } />
+			<DateStringControl ariaLabel={ ariaLabel } error={ error } coerceInvalidToEmpty />
 		</PropKeyProvider>
 	);
 };

--- a/packages/packages/libs/editor-controls/src/controls/date-string-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/date-string-control.tsx
@@ -6,17 +6,17 @@ import { DatePicker, LocalizationProvider } from '@elementor/ui';
 import { useBoundProp } from '../bound-prop-context';
 import ControlActions from '../control-actions/control-actions';
 import { createControl } from '../create-control';
-import { DATE_FORMAT, INVALID_DATE, parseDateString } from '../utils/date-time';
+import { DATE_FORMAT, isValidDayjs, parseDateString } from '../utils/date-time';
 
 type DateStringControlProps = {
 	inputDisabled?: boolean;
 	ariaLabel?: string;
 	error?: boolean;
-	coerceInvalidToEmpty?: boolean;
+	coerceInvalidToNull?: boolean;
 };
 
 export const DateStringControl = createControl(
-	( { inputDisabled, ariaLabel, error, coerceInvalidToEmpty = false }: DateStringControlProps ) => {
+	( { inputDisabled, ariaLabel, error, coerceInvalidToNull = false }: DateStringControlProps ) => {
 		const { value, setValue, disabled } = useBoundProp( dateStringPropTypeUtil );
 
 		const isDisabled = inputDisabled ?? disabled;
@@ -38,14 +38,12 @@ export const DateStringControl = createControl(
 				return;
 			}
 
-			const formatted = newValue.format( format );
-
-			if ( coerceInvalidToEmpty && formatted === INVALID_DATE ) {
-				setValue( '' );
+			if ( coerceInvalidToNull && ! isValidDayjs( newValue ) ) {
+				setValue( null );
 				return;
 			}
 
-			setValue( formatted );
+			setValue( newValue.format( format ) );
 		};
 
 		return (

--- a/packages/packages/libs/editor-controls/src/controls/date-string-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/date-string-control.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import type { Dayjs } from 'dayjs';
-import * as dayjs from 'dayjs';
 import { dateStringPropTypeUtil } from '@elementor/editor-props';
 import { DatePicker, LocalizationProvider } from '@elementor/ui';
 
 import { useBoundProp } from '../bound-prop-context';
 import ControlActions from '../control-actions/control-actions';
 import { createControl } from '../create-control';
+import { DATE_FORMAT, INVALID_DATE, parseDateString } from '../utils/date-time';
 
 type DateStringControlProps = {
 	inputDisabled?: boolean;
@@ -14,9 +14,6 @@ type DateStringControlProps = {
 	error?: boolean;
 	coerceInvalidToEmpty?: boolean;
 };
-
-const DATE_FORMAT = 'YYYY-MM-DD';
-const INVALID_DATE = 'Invalid Date';
 
 export const DateStringControl = createControl(
 	( { inputDisabled, ariaLabel, error, coerceInvalidToEmpty = false }: DateStringControlProps ) => {
@@ -65,17 +62,3 @@ export const DateStringControl = createControl(
 		);
 	}
 );
-
-function parseDateString( raw: string ): Dayjs | null {
-	if ( ! raw ) {
-		return null;
-	}
-
-	const parsed = ( dayjs as unknown as { default: ( s?: string | number | Date ) => Dayjs } ).default( raw );
-
-	return isValidDayjs( parsed ) ? parsed : null;
-}
-
-function isValidDayjs( value: Dayjs | null ): value is Dayjs {
-	return !! value && typeof value.isValid === 'function' && value.isValid();
-}

--- a/packages/packages/libs/editor-controls/src/controls/time-range-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/time-range-control.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { type PropKey, timeRangePropTypeUtil } from '@elementor/editor-props';
+import { Grid, Stack } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import { PropKeyProvider, PropProvider, useBoundProp } from '../bound-prop-context';
+import { ControlFormLabel } from '../components/control-form-label';
+import { createControl } from '../create-control';
+import { TimeStringControl } from './time-string-control';
+
+const RANGE_LABELS = {
+	min: __( 'Start time', 'elementor' ),
+	max: __( 'End time', 'elementor' ),
+};
+
+export const TimeRangeControl = createControl( () => {
+	const { value, setValue, ...propContext } = useBoundProp( timeRangePropTypeUtil );
+
+	return (
+		<PropProvider { ...propContext } value={ value } setValue={ setValue }>
+			<Stack direction="row" gap={ 2 } flexWrap="nowrap">
+				<Grid container gap={ 0.75 } alignItems="center">
+					<Grid item xs={ 12 }>
+						<ControlFormLabel>{ RANGE_LABELS.min }</ControlFormLabel>
+					</Grid>
+					<Grid item xs={ 12 }>
+						<BoundTimeStringControl bind={ 'min' } ariaLabel={ RANGE_LABELS.min } />
+					</Grid>
+				</Grid>
+				<Grid container gap={ 0.75 } alignItems="center">
+					<Grid item xs={ 12 }>
+						<ControlFormLabel>{ RANGE_LABELS.max }</ControlFormLabel>
+					</Grid>
+					<Grid item xs={ 12 }>
+						<BoundTimeStringControl bind={ 'max' } ariaLabel={ RANGE_LABELS.max } />
+					</Grid>
+				</Grid>
+			</Stack>
+		</PropProvider>
+	);
+} );
+
+const BoundTimeStringControl = ( { bind, ariaLabel }: { bind: PropKey; ariaLabel?: string } ) => {
+	return (
+		<PropKeyProvider bind={ bind }>
+			<TimeStringControl ariaLabel={ ariaLabel } coerceInvalidToEmpty />
+		</PropKeyProvider>
+	);
+};

--- a/packages/packages/libs/editor-controls/src/controls/time-range-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/time-range-control.tsx
@@ -43,7 +43,7 @@ export const TimeRangeControl = createControl( () => {
 const BoundTimeStringControl = ( { bind, ariaLabel }: { bind: PropKey; ariaLabel?: string } ) => {
 	return (
 		<PropKeyProvider bind={ bind }>
-			<TimeStringControl ariaLabel={ ariaLabel } coerceInvalidToEmpty />
+			<TimeStringControl ariaLabel={ ariaLabel } coerceInvalidToNull />
 		</PropKeyProvider>
 	);
 };

--- a/packages/packages/libs/editor-controls/src/controls/time-string-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/time-string-control.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import type { Dayjs } from 'dayjs';
-import * as dayjs from 'dayjs';
 import { timeStringPropTypeUtil } from '@elementor/editor-props';
 import { LocalizationProvider, TimePicker } from '@elementor/ui';
 
 import { useBoundProp } from '../bound-prop-context';
 import ControlActions from '../control-actions/control-actions';
 import { createControl } from '../create-control';
+import { INVALID_DATE, parseTimeString, TIME_FORMAT } from '../utils/date-time';
 
 type TimeStringControlProps = {
 	inputDisabled?: boolean;
@@ -14,9 +14,6 @@ type TimeStringControlProps = {
 	error?: boolean;
 	coerceInvalidToEmpty?: boolean;
 };
-
-const TIME_FORMAT = 'HH:mm';
-const INVALID_DATE = 'Invalid Date';
 
 export const TimeStringControl = createControl(
 	( { inputDisabled, ariaLabel, error, coerceInvalidToEmpty = false }: TimeStringControlProps ) => {
@@ -65,25 +62,3 @@ export const TimeStringControl = createControl(
 		);
 	}
 );
-
-function parseTimeString( raw: string ): Dayjs | null {
-	if ( ! raw ) {
-		return null;
-	}
-
-	const [ hours, minutes, seconds ] = raw.split( ':' );
-	const h = Number.parseInt( hours ?? '', 10 );
-	const m = Number.parseInt( minutes ?? '', 10 );
-	const s = Number.parseInt( seconds ?? '0', 10 );
-
-	if ( Number.isNaN( h ) || Number.isNaN( m ) ) {
-		return null;
-	}
-
-	const base = ( dayjs as unknown as { default: () => Dayjs } ).default();
-	return base
-		.hour( h )
-		.minute( m )
-		.second( Number.isNaN( s ) ? 0 : s )
-		.millisecond( 0 );
-}

--- a/packages/packages/libs/editor-controls/src/controls/time-string-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/time-string-control.tsx
@@ -1,26 +1,26 @@
 import * as React from 'react';
 import type { Dayjs } from 'dayjs';
 import * as dayjs from 'dayjs';
-import { dateStringPropTypeUtil } from '@elementor/editor-props';
-import { DatePicker, LocalizationProvider } from '@elementor/ui';
+import { timeStringPropTypeUtil } from '@elementor/editor-props';
+import { LocalizationProvider, TimePicker } from '@elementor/ui';
 
 import { useBoundProp } from '../bound-prop-context';
 import ControlActions from '../control-actions/control-actions';
 import { createControl } from '../create-control';
 
-type DateStringControlProps = {
+type TimeStringControlProps = {
 	inputDisabled?: boolean;
 	ariaLabel?: string;
 	error?: boolean;
 	coerceInvalidToEmpty?: boolean;
 };
 
-const DATE_FORMAT = 'YYYY-MM-DD';
+const TIME_FORMAT = 'HH:mm';
 const INVALID_DATE = 'Invalid Date';
 
-export const DateStringControl = createControl(
-	( { inputDisabled, ariaLabel, error, coerceInvalidToEmpty = false }: DateStringControlProps ) => {
-		const { value, setValue, disabled } = useBoundProp( dateStringPropTypeUtil );
+export const TimeStringControl = createControl(
+	( { inputDisabled, ariaLabel, error, coerceInvalidToEmpty = false }: TimeStringControlProps ) => {
+		const { value, setValue, disabled } = useBoundProp( timeStringPropTypeUtil );
 
 		const isDisabled = inputDisabled ?? disabled;
 
@@ -54,9 +54,9 @@ export const DateStringControl = createControl(
 		return (
 			<LocalizationProvider>
 				<ControlActions>
-					<DatePicker
-						value={ parseDateString( value ?? '' ) }
-						onChange={ ( newValue: Dayjs | null ) => handleChange( newValue, DATE_FORMAT ) }
+					<TimePicker
+						value={ parseTimeString( value ?? '' ) }
+						onChange={ ( newValue: Dayjs | null ) => handleChange( newValue, TIME_FORMAT ) }
 						disabled={ isDisabled }
 						slotProps={ slotProps }
 					/>
@@ -66,16 +66,24 @@ export const DateStringControl = createControl(
 	}
 );
 
-function parseDateString( raw: string ): Dayjs | null {
+function parseTimeString( raw: string ): Dayjs | null {
 	if ( ! raw ) {
 		return null;
 	}
 
-	const parsed = ( dayjs as unknown as { default: ( s?: string | number | Date ) => Dayjs } ).default( raw );
+	const [ hours, minutes, seconds ] = raw.split( ':' );
+	const h = Number.parseInt( hours ?? '', 10 );
+	const m = Number.parseInt( minutes ?? '', 10 );
+	const s = Number.parseInt( seconds ?? '0', 10 );
 
-	return isValidDayjs( parsed ) ? parsed : null;
-}
+	if ( Number.isNaN( h ) || Number.isNaN( m ) ) {
+		return null;
+	}
 
-function isValidDayjs( value: Dayjs | null ): value is Dayjs {
-	return !! value && typeof value.isValid === 'function' && value.isValid();
+	const base = ( dayjs as unknown as { default: () => Dayjs } ).default();
+	return base
+		.hour( h )
+		.minute( m )
+		.second( Number.isNaN( s ) ? 0 : s )
+		.millisecond( 0 );
 }

--- a/packages/packages/libs/editor-controls/src/controls/time-string-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/time-string-control.tsx
@@ -6,17 +6,17 @@ import { LocalizationProvider, TimePicker } from '@elementor/ui';
 import { useBoundProp } from '../bound-prop-context';
 import ControlActions from '../control-actions/control-actions';
 import { createControl } from '../create-control';
-import { INVALID_DATE, parseTimeString, TIME_FORMAT } from '../utils/date-time';
+import { isValidDayjs, parseTimeString, TIME_FORMAT } from '../utils/date-time';
 
 type TimeStringControlProps = {
 	inputDisabled?: boolean;
 	ariaLabel?: string;
 	error?: boolean;
-	coerceInvalidToEmpty?: boolean;
+	coerceInvalidToNull?: boolean;
 };
 
 export const TimeStringControl = createControl(
-	( { inputDisabled, ariaLabel, error, coerceInvalidToEmpty = false }: TimeStringControlProps ) => {
+	( { inputDisabled, ariaLabel, error, coerceInvalidToNull = false }: TimeStringControlProps ) => {
 		const { value, setValue, disabled } = useBoundProp( timeStringPropTypeUtil );
 
 		const isDisabled = inputDisabled ?? disabled;
@@ -38,14 +38,12 @@ export const TimeStringControl = createControl(
 				return;
 			}
 
-			const formatted = newValue.format( format );
-
-			if ( coerceInvalidToEmpty && formatted === INVALID_DATE ) {
-				setValue( '' );
+			if ( coerceInvalidToNull && ! isValidDayjs( newValue ) ) {
+				setValue( null );
 				return;
 			}
 
-			setValue( formatted );
+			setValue( newValue.format( format ) );
 		};
 
 		return (

--- a/packages/packages/libs/editor-controls/src/hooks/use-form-field-suggestions.ts
+++ b/packages/packages/libs/editor-controls/src/hooks/use-form-field-suggestions.ts
@@ -13,6 +13,8 @@ const FORM_FIELD_WIDGET_TYPES = [
 	'e-form-checkbox',
 	'e-form-radio-button',
 	'e-form-select',
+	'e-form-date-picker',
+	'e-form-time-picker',
 ];
 
 type Options = {

--- a/packages/packages/libs/editor-controls/src/index.ts
+++ b/packages/packages/libs/editor-controls/src/index.ts
@@ -38,6 +38,8 @@ export { enqueueFont } from './controls/font-family-control/enqueue-font';
 export { transitionProperties, transitionsItemsList } from './controls/transition-control/data';
 export { DateTimeControl } from './controls/date-time-control';
 export { DateRangeControl } from './controls/date-range-control';
+export { TimeStringControl } from './controls/time-string-control';
+export { TimeRangeControl } from './controls/time-range-control';
 export { InlineEditingControl } from './controls/inline-editing-control';
 export { EmailFormActionControl } from './controls/email-form-action-control';
 export { AttachmentTypeControl } from './controls/attachment-type-control';

--- a/packages/packages/libs/editor-controls/src/utils/date-time.ts
+++ b/packages/packages/libs/editor-controls/src/utils/date-time.ts
@@ -1,0 +1,42 @@
+import type { Dayjs } from 'dayjs';
+import * as dayjs from 'dayjs';
+
+export const DATE_FORMAT = 'YYYY-MM-DD';
+export const TIME_FORMAT = 'HH:mm';
+export const INVALID_DATE = 'Invalid Date';
+
+export function isValidDayjs( value: Dayjs | null ): value is Dayjs {
+	return !! value && typeof value.isValid === 'function' && value.isValid();
+}
+
+export function parseDateString( raw: string ): Dayjs | null {
+	if ( ! raw ) {
+		return null;
+	}
+
+	const parsed = ( dayjs as unknown as { default: ( s?: string | number | Date ) => Dayjs } ).default( raw );
+
+	return isValidDayjs( parsed ) ? parsed : null;
+}
+
+export function parseTimeString( raw: string ): Dayjs | null {
+	if ( ! raw ) {
+		return null;
+	}
+
+	const [ hours, minutes, seconds ] = raw.split( ':' );
+	const h = Number.parseInt( hours ?? '', 10 );
+	const m = Number.parseInt( minutes ?? '', 10 );
+	const s = Number.parseInt( seconds ?? '0', 10 );
+
+	if ( Number.isNaN( h ) || Number.isNaN( m ) ) {
+		return null;
+	}
+
+	const base = ( dayjs as unknown as { default: () => Dayjs } ).default();
+	return base
+		.hour( h )
+		.minute( m )
+		.second( Number.isNaN( s ) ? 0 : s )
+		.millisecond( 0 );
+}

--- a/packages/packages/libs/editor-controls/src/utils/date-time.ts
+++ b/packages/packages/libs/editor-controls/src/utils/date-time.ts
@@ -3,7 +3,6 @@ import * as dayjs from 'dayjs';
 
 export const DATE_FORMAT = 'YYYY-MM-DD';
 export const TIME_FORMAT = 'HH:mm';
-export const INVALID_DATE = 'Invalid Date';
 
 export function isValidDayjs( value: Dayjs | null ): value is Dayjs {
 	return !! value && typeof value.isValid === 'function' && value.isValid();

--- a/packages/packages/libs/editor-props/src/prop-types/index.ts
+++ b/packages/packages/libs/editor-props/src/prop-types/index.ts
@@ -58,3 +58,5 @@ export * from './filter-prop-types/filter-functions/color-tone-filter';
 export * from './filter-prop-types/filter-functions/hue-rotate-filter';
 export * from './date-range';
 export * from './date-string';
+export * from './time-range';
+export * from './time-string';

--- a/packages/packages/libs/editor-props/src/prop-types/time-range.ts
+++ b/packages/packages/libs/editor-props/src/prop-types/time-range.ts
@@ -1,0 +1,14 @@
+import { z } from '@elementor/schema';
+
+import { createPropUtils } from '../utils/create-prop-utils';
+import { unknownChildrenSchema } from './utils';
+
+export const timeRangePropTypeUtil = createPropUtils(
+	'time-range',
+	z.strictObject( {
+		min: unknownChildrenSchema,
+		max: unknownChildrenSchema,
+	} )
+);
+
+export type TimeRangePropValue = z.infer< typeof timeRangePropTypeUtil.schema >;

--- a/packages/packages/libs/editor-props/src/prop-types/time-string.ts
+++ b/packages/packages/libs/editor-props/src/prop-types/time-string.ts
@@ -1,0 +1,7 @@
+import { z } from '@elementor/schema';
+
+import { createPropUtils } from '../utils/create-prop-utils';
+
+export const timeStringPropTypeUtil = createPropUtils( 'time-string', z.string() );
+
+export type TimeStringPropValue = z.infer< typeof timeStringPropTypeUtil.schema >;


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding time picker widget and time-range prop type support to atomic widgets system, mirroring existing date-range infrastructure.

## 2. What Changed (Where)

| Category | Changes |
|----------|---------|
| **Prop Types** | New `Time_String_Prop_Type` (ISO time validation) and `Time_Range_Prop_Type` (min/max object) in PHP |
| **Controls** | New `TimeStringControl` and `TimeRangeControl` in TypeScript; added to form element registry |
| **Transformers** | New `Time_Range_Transformer` (PHP/TS); refactored `Date_Range_Transformer` to use null coercion instead of 'Invalid Date' strings |
| **Form Elements** | Added `e-form-time-picker` to form field types |
| **Utils** | Extracted date/time parsing logic to shared `date-time.ts` utilities; added `parseTimeString()` for HH:mm format |

## 3. How It Works

Time inputs flow through `TimeStringControl` → `parseTimeString()` (parse HH:mm to Dayjs) → `TimePicker` UI → format back to HH:mm on change. `TimeRangeControl` wraps two `TimeStringControl` instances (min/max) within shared prop context. Backend transformers normalize null/empty values consistently. Unlike dates, time range doesn't validate ordering (accepts end < start).

## 4. Risks

**Coercion logic change**: `Date_Range_Transformer` now coerces empty values to `null` instead of empty strings—verify consumers handle null correctly. **Format assumption**: Time format hardcoded to HH:mm; localization/seconds handling not exposed. **No validation**: Time range accepts invalid orderings silently (by design per test).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
