### PR TITLE
Internal: Update browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,9 +1,11 @@
 last 3 versions
-Chrome >= 111
-Firefox >= 111
-Edge >= 111
-Safari >= 16.4
-iOS >= 16.4
-Android >= 111
-ChromeAndroid >= 111
 not dead
+
+# Minimum versions (updated 2026-05-05)
+Chrome >= 145
+Firefox >= 148
+Edge >= 145
+Safari >= 26.2
+iOS >= 26.2
+Android >= 147
+ChromeAndroid >= 147

--- a/package-lock.json
+++ b/package-lock.json
@@ -21598,9 +21598,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001754",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
-      "integrity": "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
Automated monthly browserslist update.

**Changes:**
- Updated `caniuse-lite` database in `package-lock.json`
- Auto-resolved minimum browser version floors in `.browserslistrc`

**Created by:** GitHub Actions (`browserslist-update` workflow)
**Branch:** `chore/update-browserslist-2026-05-05`
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Routine browserslist update to reflect current minimum browser version support as of May 2026. Bumps all major browsers significantly (Chrome/Firefox/Edge ~34 versions, Safari/iOS ~10 versions).

## 2. What Changed (Where)

.browserslistrc: Replaced hardcoded minimum versions with updated constraints for Chrome, Firefox, Edge, Safari, iOS, Android, and ChromeAndroid.

## 3. How It Works

This configuration file drives transpilation and polyfill decisions in the build pipeline. Newer minimums will reduce bundle size by requiring fewer legacy fallbacks.

## 4. Risks

Large version jump may surface untested browser-specific bugs if targeting users on outdated clients. Validate against actual analytics before shipping if available.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
