### PR TITLE
New: Add Playground live preview comment on PRs

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -1,0 +1,67 @@
+name: Playground PR Preview
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+permissions:
+  contents: write      # upload to ci-artifacts release
+  pull-requests: write # post PR comment
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    # Guard: only for PRs (not pushes to main), only for non-forks, only on successful builds
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prs = context.payload.workflow_run.pull_requests;
+            if (!prs.length) {
+              core.setFailed('No pull request found for this workflow run');
+              return;
+            }
+            core.setOutput('number', prs[0].number);
+
+      - name: Download plugin artifact
+        id: artifact
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const hit = artifacts.find(a => a.name.startsWith('elementor-'));
+            if (!hit) {
+              core.setFailed('No elementor artifact found in triggering workflow run');
+              return;
+            }
+            const dl = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: hit.id,
+              archive_format: 'zip',
+            });
+            require('fs').writeFileSync('plugin.zip', Buffer.from(dl.data));
+            core.setOutput('artifact-name', hit.name);
+
+      - name: Post Playground Preview comment
+        uses: WordPress/action-wp-playground-pr-preview@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.pr.outputs.number }}
+          plugin-zip-path: plugin.zip
+          blueprint: tests/playwright/blueprints/pr-preview.json
+          comment-header: "## Live Playground Preview"

--- a/tests/playwright/blueprints/pr-preview.json
+++ b/tests/playwright/blueprints/pr-preview.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+    "landingPage": "/wp-admin",
+    "preferredVersions": { "php": "7.4", "wp": "latest" },
+    "features": {
+        "networking": true
+    },
+    "extraLibraries": [ "wp-cli" ],
+    "steps": [
+        { "step": "login", "username": "admin", "password": "password" },
+        {
+            "step": "defineWpConfigConsts",
+            "consts": {
+                "ELEMENTOR_SHOW_HIDDEN_EXPERIMENTS": true
+            }
+        },
+        {
+            "step": "installPlugin",
+            "pluginData": {
+                "resource": "url",
+                "url": "$PLUGIN_ZIP_URL"
+            }
+        },
+        {
+            "step": "installTheme",
+            "themeData": {
+                "resource": "wordpress.org/themes",
+                "slug": "hello-elementor"
+            }
+        },
+        { "step": "activateTheme", "themeFolderName": "hello-elementor" },
+        { "step": "wp-cli", "command": "wp option add 'elementor_onboarded' 1" },
+        { "step": "wp-cli", "command": "wp elementor experiments activate e_atomic_elements,container,e_opt_in_v4,e_classes" },
+        { "step": "updateUserMeta", "meta": { "announcements_user_counter": 999, "elementor_enable_ai": 0, "_e_welcome_popover_displayed": 1 }, "userId": 1 }
+    ]
+}


### PR DESCRIPTION
## Summary
- Adds a new `playground-preview.yml` workflow that triggers via `workflow_run` after the Build workflow completes
- Fork-safe: the job is guarded by a three-condition `if:` that skips fork PRs, failed builds, and non-PR events
- Finds the `elementor-*` artifact from the triggering build run, downloads it as a ZIP, uploads it to a `ci-artifacts` GitHub Release, and posts a PR comment with a live Playground link
- Adds `tests/playwright/blueprints/pr-preview.json` — a Playground blueprint that installs the plugin from a URL (vs. the existing CI blueprint which mounts from the filesystem)

## Test plan
- [ ] Open a non-fork PR and push a commit; wait for "Build" to succeed — "Playground PR Preview" workflow should trigger automatically
- [ ] Verify a PR comment appears with a live Playground link; clicking it should open WP with Elementor installed and all experiments active
- [ ] Open or simulate a fork PR — confirm the preview job is skipped (not failed)
- [ ] Create the one-time `ci-artifacts` GitHub Release before first run: `gh release create ci-artifacts --title "CI Artifacts" --prerelease`

## Jira
N/A
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds automated Playground live preview for PRs, enabling developers to test plugin changes directly in a WordPress environment without manual setup.

## 2. What Changed (Where)

- `.github/workflows/playground-preview.yml`: New workflow triggered on successful builds to post interactive Playground preview comments on PRs
- `tests/playwright/blueprints/pr-preview.json`: Blueprint configuring Playground environment with Elementor plugin, theme, and experimental features enabled

## 3. How It Works

Workflow triggers post-build → extracts PR number from workflow context → downloads plugin artifact from Build workflow → calls WordPress/action-wp-playground-pr-preview action with plugin zip and blueprint → posts preview link as PR comment. Blueprint pre-configures WordPress with hello-elementor theme, enables Elementor experiments, and sets up WP-CLI for additional configuration.

## 4. Risks

- Artifact lookup assumes naming convention (`elementor-*`); workflow fails silently if artifact missing or renamed
- Fork detection prevents preview on community PRs (intentional security boundary but limits external contributor feedback)
- Blueprint hardcodes PHP 7.4; version drift from production environments could cause compatibility blind spots

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
