### PR TITLE
Tweak: Update `Requires at least` to WordPress 6.8 [ED-23932]

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -59,7 +59,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     with:
       job_name: PHPUnit (Nightly)
-      wordpress_versions: '["latest", "6.8", "nightly"]'
+      wordpress_versions: '["latest", "6.9", "6.8", "nightly"]'
       php_versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
 
   test-result:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -51,7 +51,7 @@ jobs:
     if: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && (github.event.pull_request.title == null || needs.file-diff.outputs.php_diff) }}
     with:
       job_name: PHPUnit (PR/Merge)
-      wordpress_versions: '["latest", "6.8", "6.7"]'
+      wordpress_versions: '["latest", "6.8"]'
       php_versions: '["7.4", "8.0", "8.1", "8.2", "8.3"]'
 
   test_schedule:
@@ -59,7 +59,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     with:
       job_name: PHPUnit (Nightly)
-      wordpress_versions: '["latest", "6.8", "6.7", "nightly"]'
+      wordpress_versions: '["latest", "6.8", "nightly"]'
       php_versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
 
   test-result:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -51,7 +51,7 @@ jobs:
     if: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && (github.event.pull_request.title == null || needs.file-diff.outputs.php_diff) }}
     with:
       job_name: PHPUnit (PR/Merge)
-      wordpress_versions: '["latest", "6.8"]'
+      wordpress_versions: '["latest", "6.9", "6.8"]'
       php_versions: '["7.4", "8.0", "8.1", "8.2", "8.3"]'
 
   test_schedule:

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Elementor Website Builder - more than just a page builder ===
 Contributors: elemntor
 Tags: page builder, editor, landing page, drag-and-drop, elementor,
-Requires at least: 6.7
+Requires at least: 6.8
 Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 3.34.2

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: elemntor
 Tags: page builder, editor, landing page, drag-and-drop, elementor,
 Requires at least: 6.8
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
 Stable tag: 3.34.2
 Beta tag: 3.34.0-beta3


### PR DESCRIPTION
## Description
Bumps the minimum required WordPress version from **6.7** to **6.8** per ED-23932.

## What changed
- `readme.txt`: `Requires at least: 6.7` → `6.8`
- `.github/workflows/phpunit.yml`: dropped `"6.7"` from the `wordpress_versions` matrices for both the PR/Merge job and the Nightly job, since 6.7 is no longer a supported minimum.

## Jira
[ED-23932](https://elementor.atlassian.net/browse/ED-23932)

Made with [Cursor](https://cursor.com)

[ED-23932]: https://elementor.atlassian.net/browse/ED-23932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Bumping WordPress minimum version from 6.7 to 6.8 across CI testing to align with updated project requirements.

## 2. What Changed (Where)

`.github/workflows/phpunit.yml`: Updated WordPress version matrix for PR/merge tests (`["latest", "6.9", "6.8"]`) and nightly tests (`["latest", "6.9", "6.8", "nightly"]`), dropping 6.7 support.

## 3. How It Works

PHPUnit runner workflows now test against WordPress 6.8+ instead of 6.7+, ensuring CI validates compatibility with the new minimum version floor.

## 4. Risks

None — straightforward version bump in test matrix with no code logic changes or dependency modifications.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
