### PR TITLE
Internal: Update branchout script to handle 4.0x branches [ED-23982]

### DIFF
--- a/.github/workflows/create-version-change.yml
+++ b/.github/workflows/create-version-change.yml
@@ -72,7 +72,7 @@ jobs:
             MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
           fi
           
-          BRANCH_NAME="${MAJOR}.${MINOR}"
+          BRANCH_NAME="${MAJOR}.$(printf '%02d' $MINOR)"
           DEV_BRANCH="version-${NEXT_VERSION}-to-main"
           
           echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT

--- a/scripts/create-version-change.js
+++ b/scripts/create-version-change.js
@@ -161,7 +161,7 @@ async function main() {
       skipBranches = /^[Yy]$/.test(skipBranchesInput);
     }
 
-    const branchName = `${major}.${minor}`;
+    const branchName = `${major}.${String(minor).padStart(2, '0')}`;
 
     // Get current git branch
     const currentBranch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();


### PR DESCRIPTION
## Summary
- Zero-pad the minor version in the generated release branch name so that branches `4.00`–`4.10` sort correctly lexicographically
- Updated `scripts/create-version-change.js`: use `String(minor).padStart(2, '0')` instead of bare `minor`
- Updated `.github/workflows/create-version-change.yml`: use `printf '%02d' $MINOR` instead of bare `$MINOR`

## Test plan
- [ ] Run `node scripts/create-version-change.js` when `package.json` version is `4.2.0` and verify the branch name shown is `4.02` (not `4.2`)
- [ ] Confirm branches sort correctly: `echo -e "4.02\n4.10\n4.09" | sort -V` should output `4.02 → 4.09 → 4.10`
- [ ] Verify that versions >= `4.10` remain unaffected (no triple-padding)

## Jira
[ED-23982](https://elementor.atlassian.net/browse/ED-23982)

[ED-23982]: https://elementor.atlassian.net/browse/ED-23982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Branch names need zero-padded minor versions (e.g., `4.01` instead of `4.1`) to maintain consistent lexicographic sorting as versions increment into double digits. Without padding, `4.10` would sort before `4.2`. Related to ED-23982.

## 2. What Changed (Where)

- `scripts/create-version-change.js`: Updated branch name formatting with padStart
- `.github/workflows/create-version-change.yml`: Updated shell script branch name with printf formatting

## 3. How It Works

Both implementations now pad the minor version to 2 digits. JavaScript uses `String(minor).padStart(2, '0')`, shell uses `printf '%02d' $MINOR`. When creating a branch for version 4.1, the script now generates `4.01` instead of `4.1`. This ensures `4.01` < `4.02` < ... < `4.09` < `4.10` in both Git and filesystem listings.

## 4. Risks

None. This is a formatting change that only affects new branch names going forward. Existing branches are unaffected, and the change is backward-compatible since version comparison logic should handle both formats.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
