### PR TITLE
Tweak: Cherry-pick PR 35699 to 4.00: Angie CTA label in panel empty/search widget creation [ED-23900]

### DIFF
--- a/assets/dev/scss/editor/panel/_elements.scss
+++ b/assets/dev/scss/editor/panel/_elements.scss
@@ -319,7 +319,7 @@
 		padding: 0;
 		border: none;
 		background: none;
-		color: var(--e-a-color-accent-promotion, #{$e-accent-promotion});
+		color: var(--e-pink-900);
 		font-size: 14px;
 		font-weight: 500;
 		cursor: pointer;

--- a/assets/dev/scss/editor/panel/_elements.scss
+++ b/assets/dev/scss/editor/panel/_elements.scss
@@ -319,7 +319,7 @@
 		padding: 0;
 		border: none;
 		background: none;
-		color: var(--e-pink-900);
+		color: #{$e-pink-900};
 		font-size: 14px;
 		font-weight: 500;
 		cursor: pointer;

--- a/includes/editor-templates/panel-elements.php
+++ b/includes/editor-templates/panel-elements.php
@@ -1,8 +1,9 @@
 <?php
 namespace Elementor;
 
-use Elementor\Utils;
+use Elementor\Core\Utils\Hints;
 use Elementor\Core\Utils\Promotions\Filtered_Promotions_Manager;
+use Elementor\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -103,22 +104,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 </script>
 
 <?php if ( Plugin::$instance->experiments->is_feature_active( Modules\WidgetCreation\Module::EXPERIMENT_NAME ) ) : ?>
+	<?php
+	$widget_creation_cta_text = Hints::is_plugin_active( 'angie' )
+		? __( 'Create custom widget', 'elementor' )
+		: __( 'Install Angie', 'elementor' );
+	?>
 <script type="text/template" id="tmpl-elementor-panel-elements-widget-creation-empty-state">
 	<div class="elementor-panel-elements-widget-creation__title"><?php echo esc_html__( 'No widget found for', 'elementor' ); ?> "{{{ searchTerm }}}"</div>
 	<div class="elementor-panel-elements-widget-creation__message"><?php echo esc_html__( 'Build a custom widget with Angie by describing what you need.', 'elementor' ); ?></div>
-	<button type="button" class="elementor-panel-elements-widget-creation__cta">
-		<i class="eicon-ai" aria-hidden="true"></i>
-		<?php echo esc_html__( 'Create custom widget', 'elementor' ); ?>
-	</button>
+	<button type="button" class="elementor-panel-elements-widget-creation__cta"><?php echo esc_html( $widget_creation_cta_text ); ?></button>
 </script>
 
 <script type="text/template" id="tmpl-elementor-panel-elements-widget-creation-search-footer">
 	<div class="elementor-panel-elements-widget-creation__title"><?php echo esc_html__( "Couldn't find what you're looking for?", 'elementor' ); ?></div>
 	<div class="elementor-panel-elements-widget-creation__message"><?php echo esc_html__( 'Build a custom widget with Angie by describing what you need.', 'elementor' ); ?></div>
-	<button type="button" class="elementor-panel-elements-widget-creation__cta">
-		<i class="eicon-ai" aria-hidden="true"></i>
-		<?php echo esc_html__( 'Create custom widget', 'elementor' ); ?>
-	</button>
+	<button type="button" class="elementor-panel-elements-widget-creation__cta"><?php echo esc_html( $widget_creation_cta_text ); ?></button>
 </script>
 <?php endif; ?>
 

--- a/tests/playwright/sanity/modules/widget-creation/widget-creation.test.ts
+++ b/tests/playwright/sanity/modules/widget-creation/widget-creation.test.ts
@@ -4,7 +4,7 @@ import EditorPage from '../../../pages/editor-page';
 import WpAdminPage from '../../../pages/wp-admin-page';
 
 type ExtendedWindow = Window & {
-	__createWidgetPrompt: string;
+  __createWidgetPrompt: string;
 };
 
 test.describe( 'Widget Creation @widget-creation', () => {
@@ -62,7 +62,7 @@ test.describe( 'Widget Creation @widget-creation', () => {
 				const cta = page.locator( WIDGET_CREATION_CTA );
 				await cta.scrollIntoViewIfNeeded();
 				await expect( cta ).toBeVisible();
-				await expect( cta ).toContainText( 'Create custom widget' );
+				await expect( cta ).toContainText( 'Install Angie' );
 
 				const title = page.locator( WIDGET_CREATION_TITLE );
 				await expect( title ).toHaveText( "Couldn't find what you're looking for?" );
@@ -81,6 +81,7 @@ test.describe( 'Widget Creation @widget-creation', () => {
 				const cta = page.locator( WIDGET_CREATION_CTA );
 				await cta.scrollIntoViewIfNeeded();
 				await expect( cta ).toBeVisible();
+				await expect( cta ).toContainText( 'Install Angie' );
 
 				const title = page.locator( WIDGET_CREATION_TITLE );
 				await expect( title ).toContainText( 'No widget found for' );


### PR DESCRIPTION
Cherry-pick of #35699 to the 4.00 release branch.

## Changes
- CTA label shows **Create custom widget** when Angie is active, **Install Angie** when not
- CTA uses `--e-pink-900` color; AI icon removed from button markup
- Playwright test expectations updated accordingly

## Original PR
#35699

## Jira
[ED-23900](https://elementor.atlassian.net/browse/ED-23900)

## Note on 4.01
4.01 already contains this change (merge commit `45dbd5e2a4` is in the 4.01 log directly).

[ED-23900]: https://elementor.atlassian.net/browse/ED-23900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick from PR #35699 to 4.00 branch (ED-23900). CTA button behavior needs to be contextual: show "Install Angie" when Angie plugin is inactive, "Create custom widget" when active. Previously hardcoded to "Create custom widget" regardless of plugin state, causing misleading UX.

## 2. What Changed (Where)

- **includes/editor-templates/panel-elements.php**: Added dynamic CTA text logic using `Hints::is_plugin_active()` check
- **assets/dev/scss/editor/_elements.scss**: Changed CTA button color from promotion accent to pink-900
- **tests/playwright/.../widget-creation.test.ts**: Updated test assertions to expect "Install Angie" text (test environment without Angie)

## 3. How It Works

PHP template checks Angie plugin status at render time via `Hints::is_plugin_active('angie')`. Ternary returns appropriate localized string. Both empty-state and search-footer templates share the same `$widget_creation_cta_text` variable. Icon markup removed from button—text-only CTA now. Color change to pink-900 ensures visual consistency with new promotion styling.

## 4. Risks

None. Simple conditional string swap with existing infrastructure. Test suite updated to match new behavior. No breaking changes to widget creation flow.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
