### PR TITLE
Internal: Design system experiment test fix [ED-23993]

### DIFF
--- a/tests/playwright/sanity/modules/v4-tests/editor-variables/utils.ts
+++ b/tests/playwright/sanity/modules/v4-tests/editor-variables/utils.ts
@@ -4,7 +4,11 @@ import ApiRequests from '../../../../assets/api-requests';
 
 export const initTemplate = async ( page: Page, testInfo: TestInfo, apiRequests: ApiRequests ) => {
 	const wpAdminPage = new WpAdminPage( page, testInfo, apiRequests );
-	await wpAdminPage.setExperiments( { e_variables: 'active', e_atomic_elements: 'active' } );
+	await wpAdminPage.setExperiments( {
+		e_variables: 'active',
+		e_atomic_elements: 'active',
+		e_editor_design_system_panel: 'inactive',
+	} );
 	await wpAdminPage.setExperiments( { e_variables_manager: 'active' } );
 	const editorPage = await wpAdminPage.openNewPage();
 	await editorPage.loadTemplate( 'tests/playwright/sanity/modules/v4-tests/editor-variables/variables-manager-template.json' );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Fixes test instability by explicitly disabling the `e_editor_design_system_panel` experiment. Tests were failing intermittently when this experiment was active, interfering with variables manager functionality. This ensures a consistent baseline state for editor variable tests.

## 2. What Changed (Where)

- `tests/playwright/sanity/modules/v4-tests/editor-variables/utils.ts`: Split experiment activation into two calls—first sets foundational experiments with design system explicitly off, second activates variables manager.

## 3. How It Works

Before test execution, `initTemplate` now sets three experiments (`e_variables`, `e_atomic_elements`, `e_editor_design_system_panel`) in one batch, then activates `e_variables_manager` separately. The design system panel is force-disabled to prevent UI conflicts with the variables manager being tested.

## 4. Risks

None—this is additive configuration that reduces flakiness. If design system panel was meant to be tested alongside variables, we'd need separate test coverage, but that's tracked in ED-23993.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
