### PR TITLE
Internal: Fix for v4 flex in wizard [ED-24004]

### DIFF
--- a/assets/dev/js/editor/utils/v4-flexbox-preset.js
+++ b/assets/dev/js/editor/utils/v4-flexbox-preset.js
@@ -68,7 +68,11 @@ function getPresetDefinition( preset ) {
 }
 
 function buildModel( cssProps, mobileProps ) {
-	const model = { elType: V4_ELEMENT_TYPE };
+	const model = {
+		id: elementorCommon.helpers.getUniqueId(),
+		elType: V4_ELEMENT_TYPE,
+		elements: [],
+	};
 
 	const hasBase = cssProps && Object.keys( cssProps ).length > 0;
 	const hasMobile = mobileProps && Object.keys( mobileProps ).length > 0;
@@ -80,7 +84,7 @@ function buildModel( cssProps, mobileProps ) {
 	const styleId = `e-${ elementorCommon.helpers.getUniqueId() }`;
 	const variants = [
 		{
-			meta: { breakpoint: null, state: null },
+			meta: { breakpoint: 'desktop', state: null },
 			props: cssProps ?? {},
 			custom_css: null,
 		},
@@ -110,22 +114,98 @@ function buildModel( cssProps, mobileProps ) {
 	return model;
 }
 
+function buildTreeModel( definition ) {
+	const { parent: parentProps, parentMobile, children = [] } = definition;
+	const model = buildModel( parentProps, parentMobile );
+
+	model.elements = children.map( ( childDef ) => buildTreeModel( childDef ) );
+
+	return model;
+}
+
 function createFlexboxElement( target, model, options ) {
-	return $e.run( 'document/elements/create', {
-		container: target,
+	const containerClass = elementorModules?.editor?.Container;
+	const getDocumentUtils = () => $e?.components?.get?.( 'document' )?.utils;
+	const getContainerById = ( id ) => getDocumentUtils()?.findContainerById?.( id ) ?? null;
+	const isContainerInstance = ( candidate ) => {
+		if ( ! containerClass || ! candidate ) {
+			return false;
+		}
+
+		return candidate instanceof containerClass ||
+			candidate.constructor?.name === containerClass.prototype?.[ Symbol.toStringTag ];
+	};
+	const resolveContainer = ( candidate ) => {
+		if ( ! containerClass ) {
+			return candidate;
+		}
+
+		if ( isContainerInstance( candidate ) ) {
+			return candidate;
+		}
+
+		const lookedUp = candidate?.lookup?.();
+		if ( isContainerInstance( lookedUp ) ) {
+			return lookedUp;
+		}
+
+		const byId = candidate?.id ? getContainerById( candidate.id ) : null;
+		if ( isContainerInstance( byId ) ) {
+			return byId;
+		}
+
+		return null;
+	};
+
+	const resolvedTarget = resolveContainer( target );
+
+	if ( ! resolvedTarget && containerClass && target?.id ) {
+		getDocumentUtils()?.addModelToParent?.( target.id, model, options );
+
+		const inserted = getContainerById( model.id );
+		if ( inserted ) {
+			return inserted;
+		}
+
+		return {
+			id: model.id,
+			lookup: () => getContainerById( model.id ),
+		};
+	}
+
+	const created = $e.run( 'document/elements/create', {
+		container: resolvedTarget ?? target,
 		model,
 		...options,
 	} );
+
+	const resolvedCreated = resolveContainer( created );
+
+	if ( resolvedCreated || ! containerClass ) {
+		return resolvedCreated ?? created;
+	}
+
+	return {
+		id: model.id,
+		lookup: () => getContainerById( model.id ),
+	};
 }
 
 function buildNode( definition, target, options, isRoot ) {
 	const { parent: parentProps, parentMobile, children } = definition;
 	const reuseTarget = isRoot && false === options.createWrapper;
 	const node = reuseTarget
-		? target
+		? ( target?.lookup?.() ?? target )
 		: createFlexboxElement( target, buildModel( parentProps, parentMobile ), isRoot ? options : { edit: false } );
 
 	children.forEach( ( childDef ) => {
+		const hasNestedChildren = ( childDef.children?.length ?? 0 ) > 0;
+
+		if ( hasNestedChildren ) {
+			createFlexboxElement( node, buildTreeModel( childDef ), { edit: false } );
+			return;
+		}
+
 		buildNode( childDef, node, options, false );
 	} );
 

--- a/assets/dev/js/editor/utils/v4-flexbox-preset.js
+++ b/assets/dev/js/editor/utils/v4-flexbox-preset.js
@@ -199,7 +199,7 @@ function buildNode( definition, target, options, isRoot ) {
 		: createFlexboxElement( target, buildModel( parentProps, parentMobile ), isRoot ? options : { edit: false } );
 
 	children.forEach( ( childDef ) => {
-		const hasNestedChildren = ( childDef.children?.length ?? 0 ) > 0;
+		const hasNestedChildren = !! childDef.children?.length;
 
 		if ( hasNestedChildren ) {
 			createFlexboxElement( node, buildTreeModel( childDef ), { edit: false } );

--- a/tests/jest/unit/assets/dev/js/editor/utils/v4-flexbox-preset.test.js
+++ b/tests/jest/unit/assets/dev/js/editor/utils/v4-flexbox-preset.test.js
@@ -90,6 +90,10 @@ describe( 'createV4FlexboxFromPreset', () => {
 		return model.styles?.[ lastId ]?.variants;
 	}
 
+	function getChildModels( model ) {
+		return model.elements ?? [];
+	}
+
 	test( 'c100 → 1 e-flexbox with flex-direction:column overriding the row base style', () => {
 		const target = makeFakeContainer( 'target' );
 
@@ -155,9 +159,8 @@ describe( 'createV4FlexboxFromPreset', () => {
 	test( 'c100-c50-50 → row parent + left child + right wrapper + 2 grandchildren', () => {
 		createV4FlexboxFromPreset( 'c100-c50-50', makeFakeContainer( 'target' ), {} );
 
-		expect( createCalls ).toHaveLength( 5 );
-
-		const [ parent, , rightCol ] = createdContainers;
+		expect( createCalls ).toHaveLength( 3 );
+		const [ parent ] = createdContainers;
 
 		expect( getProps( getModel( 0 ) ) ).toEqual( { 'flex-direction': ROW } );
 		expect( getProps( getModel( 1 ) ) ).toEqual( { 'flex-direction': COLUMN, width: sizeProp( 50, '%' ) } );
@@ -166,13 +169,12 @@ describe( 'createV4FlexboxFromPreset', () => {
 			width: sizeProp( 50, '%' ),
 			padding: ZERO_PX,
 		} );
-		expect( getProps( getModel( 3 ) ) ).toEqual( { 'flex-direction': COLUMN } );
-		expect( getProps( getModel( 4 ) ) ).toEqual( { 'flex-direction': COLUMN } );
+		expect( getChildModels( getModel( 2 ) ) ).toHaveLength( 2 );
+		expect( getProps( getChildModels( getModel( 2 ) )[ 0 ] ) ).toEqual( { 'flex-direction': COLUMN } );
+		expect( getProps( getChildModels( getModel( 2 ) )[ 1 ] ) ).toEqual( { 'flex-direction': COLUMN } );
 
 		expect( createCalls[ 1 ].target ).toBe( parent );
 		expect( createCalls[ 2 ].target ).toBe( parent );
-		expect( createCalls[ 3 ].target ).toBe( rightCol );
-		expect( createCalls[ 4 ].target ).toBe( rightCol );
 	} );
 
 	test( 'createWrapper:false → reuses target as parent, only children are created', () => {
@@ -194,7 +196,7 @@ describe( 'createV4FlexboxFromPreset', () => {
 		for ( let i = 1; i <= 4; i++ ) {
 			const variants = getVariants( getModel( i ) );
 			expect( variants ).toHaveLength( 2 );
-			expect( variants[ 0 ].meta ).toEqual( { breakpoint: null, state: null } );
+			expect( variants[ 0 ].meta ).toEqual( { breakpoint: 'desktop', state: null } );
 			expect( variants[ 0 ].props ).toEqual( { 'flex-direction': COLUMN, width: sizeProp( 50, '%' ) } );
 			expect( variants[ 1 ].meta ).toEqual( { breakpoint: 'mobile', state: null } );
 			expect( variants[ 1 ].props ).toEqual( { width: sizeProp( 100, '%' ) } );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

V4 flexbox wizard was failing because model initialization was incomplete (missing `id` and `elements` fields) and nested structures weren't being created correctly. Breakpoint metadata had `null` instead of `'desktop'`, breaking responsive behavior. Ticket: **ED-24004**.

## 2. What Changed (Where)

- **`v4-flexbox-preset.js`**: Fixed model initialization, added recursive tree builder, robust container resolution with fallback strategies, optimized nested child creation
- **`v4-flexbox-preset.test.js`**: Updated assertions to match new nested model structure (3 creates instead of 5, children in-model vs separate)

## 3. How It Works

**Model initialization**: Now ensures every model has unique `id`, `elType`, and empty `elements` array upfront. Base variant uses `breakpoint: 'desktop'` instead of `null` for proper responsive handling.

**Nested structure optimization**: `buildTreeModel()` recursively creates the full model tree in-memory first, then `createFlexboxElement()` does a single insert operation. Previous approach created 5 separate containers for `c100-c50-50`; now creates 3 containers with nested children embedded in the third container's model.

**Container resolution chain**: For wizard context where containers may not be immediately available, implements 3-tier lookup: direct instanceof check → `lookup()` method → `getContainerById()`. Returns proxy object with deferred `lookup()` when container isn't immediately resolvable, handling async initialization race conditions.

## 4. Risks

Container resolution fallbacks assume `elementorModules`, `$e.components`, and document utils exist. If wizard runs before these globals initialize, the proxy pattern mitigates but doesn't eliminate timing issues. Nested model structure changes serialization format — verify import/export and undo/redo still work with embedded `elements` arrays.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-24004]: https://elementor.atlassian.net/browse/ED-24004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ