### PR TITLE
Fix: 'Publish' button isn't enabled when editing an element by Angie[ED-22371]

### DIFF
--- a/packages/packages/core/editor-canvas/src/mcp/utils/do-update-element-property.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/utils/do-update-element-property.ts
@@ -7,8 +7,8 @@ import {
 } from '@elementor/editor-elements';
 import { getPropSchemaFromCache, type PropValue, Schema, type TransformablePropValue } from '@elementor/editor-props';
 import { type CustomCss, getStylesSchema } from '@elementor/editor-styles';
-import { type Utils as IUtils } from '@elementor/editor-variables';
 import { __privateRunCommandSync as runCommandSync } from '@elementor/editor-v1-adapters';
+import { type Utils as IUtils } from '@elementor/editor-variables';
 import { type z } from '@elementor/schema';
 
 // TODO: see https://elementor.atlassian.net/browse/ED-22513 for better cross-module access

--- a/packages/packages/core/editor-canvas/src/mcp/utils/do-update-element-property.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/utils/do-update-element-property.ts
@@ -8,6 +8,7 @@ import {
 import { getPropSchemaFromCache, type PropValue, Schema, type TransformablePropValue } from '@elementor/editor-props';
 import { type CustomCss, getStylesSchema } from '@elementor/editor-styles';
 import { type Utils as IUtils } from '@elementor/editor-variables';
+import { __privateRunCommandSync as runCommandSync } from '@elementor/editor-v1-adapters';
 import { type z } from '@elementor/schema';
 
 // TODO: see https://elementor.atlassian.net/browse/ED-22513 for better cross-module access
@@ -135,4 +136,5 @@ export const doUpdateElementProperty = ( params: OwnParams ) => {
 		},
 		withHistory: false,
 	} );
+	runCommandSync( 'document/save/set-is-modified', { status: true }, { internal: true } );
 };


### PR DESCRIPTION
…t [ED-22371]

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #


[ED-22371]: https://elementor.atlassian.net/browse/ED-22371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

ED-22371: The Publish button wasn't enabled after editing element properties because the document's modified state wasn't being set. `doUpdateElementProperty` updates elements with `withHistory: false`, bypassing the normal save state tracking. This adds an explicit call to mark the document as modified so the UI reflects unsaved changes.

## 2. What Changed (Where)

- `packages/core/editor-canvas/src/mcp/utils/do-update-element-property.ts`: Added `runCommandSync` call to set document modified state after updating element properties

## 3. How It Works

After `dispatchAction` updates the element settings (line 127-138), we now immediately invoke `runCommandSync('document/save/set-is-modified', { status: true })` to mark the document as dirty. This triggers the v1 adapter's save state tracking, enabling the Publish button. The `{ internal: true }` flag indicates this is a system-level state change.

## 4. Risks

None significant. The command is synchronous and side-effect only (UI state). If `runCommandSync` fails silently, worst case is the Publish button stays disabled until another tracked change occurs.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
