### PR TITLE
Tweak: Update experiments metadata for markdown-render and MCP modules [ED-24020] [ED-24021]

### DIFF
--- a/modules/markdown-render/module.php
+++ b/modules/markdown-render/module.php
@@ -22,8 +22,12 @@ class Module extends BaseModule {
 	public static function get_experimental_data() {
 		return [
 			'name' => self::EXPERIMENT_NAME,
-			'title' => esc_html__( 'Markdown Rendering', 'elementor' ),
-			'description' => esc_html__( 'Serve page content as Markdown when AI crawlers request it via the Accept: text/markdown header, or when ?format=markdown is appended to the URL.', 'elementor' ),
+			'title' => esc_html__( 'Generate website markdown', 'elementor' ),
+			'description' => sprintf(
+				'%1$s <a href="https://go.elementor.com/wp-dash-generate-website-markdown-article/" target="_blank">%2$s</a>',
+				esc_html__( 'Serve your pages as Markdown files so AI agents can ingest and understand your content more efficiently.', 'elementor' ),
+				esc_html__( 'Learn more', 'elementor' )
+			),
 			'default' => Experiments_Manager::STATE_INACTIVE,
 			'release_status' => Experiments_Manager::RELEASE_STATUS_ALPHA,
 		];

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -29,7 +29,7 @@ class Module extends BaseModule {
 			'name' => self::EXPERIMENT_NAME,
 			'title' => __( 'Elementor MCP WP Abilities API', 'elementor' ),
 			'description' => __( 'Enable Elementor MCP WP Abilities API. Requirements: 1. WordPress 7.0 or higher. 2. Create an application password for your agent user. 3. Add to your MCP config: {url: "https://<your-site-url>/wp-json/elementor/mcp", headers: {Authorization: "Basic <base64(user:application-password)>"}}', 'elementor' ),
-			'hidden' => false,
+			'hidden' => true,
 			'default' => ExperimentsManager::STATE_INACTIVE,
 		];
 	}


### PR DESCRIPTION
## Summary
- Updated `markdown-render` experiment title to "Generate website markdown" and revised its description to be clearer — now explains that pages are served as Markdown files for AI agent ingestion, with a "Learn more" link.
- Changed the `mcp` (Elementor MCP WP Abilities API) experiment to `hidden: true`, hiding it from the experiments UI.

## Test plan
- [ ] Verify the `markdown-render` experiment appears with the updated title "Generate website markdown" and new description in the Elementor experiments panel.
- [ ] Verify the "Learn more" link in the description points to the correct URL.
- [ ] Verify the `mcp` experiment is no longer visible in the experiments panel.

## Jira
[ED-24020](https://elementor.atlassian.net/browse/ED-24020) — Merge Markdown generation to Editor 4.01
[ED-24021](https://elementor.atlassian.net/browse/ED-24021) — Make the Abilities feature as Hidden experiment

Made with [Cursor](https://cursor.com)

[ED-24020]: https://elementor.atlassian.net/browse/ED-24020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ED-24021]: https://elementor.atlassian.net/browse/ED-24021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Updates experimental feature metadata for two AI-related modules. The markdown-render experiment needed clearer user-facing copy emphasizing its value for AI agent content ingestion, while the MCP module was made hidden to reduce dashboard clutter during alpha testing. Tickets: ED-24020, ED-24021.

## 2. What Changed (Where)

- **modules/markdown-render/module.php**: Replaced experiment title/description with AI-focused messaging and added external documentation link
- **modules/mcp/module.php**: Changed `hidden` flag from `false` to `true` to hide experiment from UI

## 3. How It Works

Both changes affect metadata returned by `get_experimental_data()` which the Experiments Manager uses to render feature toggles in the admin dashboard. The markdown-render change improves discovery and comprehension; the MCP change prevents the experiment from appearing in the UI while keeping it programmatically accessible for testing.

## 4. Risks

None. Pure metadata changes with no logic modifications. The `sprintf()` in markdown-render properly escapes output and the hidden flag is a standard experiment property.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
