### PR TITLE
Fix: Import template: adjust to new classes architecture [ED-24013]

### DIFF
--- a/core/utils/template-library-snapshot-processor.php
+++ b/core/utils/template-library-snapshot-processor.php
@@ -15,7 +15,15 @@ abstract class Template_Library_Snapshot_Processor {
 	abstract protected function parse_incoming_snapshot( array $snapshot ): ?array;
 	abstract protected function get_incoming_items( array $parsed_snapshot ): array;
 	abstract protected function count_current_items( array $items ): int;
-	abstract protected function save_data( array $items, array $metadata ): array;
+	/**
+	 * @param array $data {
+	 *     @type array $updated_items All items (existing + new) after processing.
+	 *     @type array $new_items     Only the newly added items.
+	 *     @type array $order         The updated order of all items.
+	 * }
+	 * @param array $metadata The original data from load_current_data().
+	 */
+	abstract protected function save_data( array $data, array $metadata ): array;
 
 	protected function normalize_for_comparison( array $item ): array {
 		return $item;
@@ -53,6 +61,7 @@ abstract class Template_Library_Snapshot_Processor {
 
 		$id_map = [];
 		$ids_to_flatten = [];
+		$new_items = [];
 		$updated_items = $current_items;
 		$existing_ids = array_fill_keys( array_keys( $updated_items ), true );
 		$updated_order = $current['order'] ?? [];
@@ -106,7 +115,8 @@ abstract class Template_Library_Snapshot_Processor {
 				$updated_items,
 				$existing_ids,
 				$existing_labels,
-				$updated_order
+				$updated_order,
+				$new_items
 			);
 
 			$new_label = $updated_items[ $target_id ]['label'] ?? null;
@@ -115,7 +125,11 @@ abstract class Template_Library_Snapshot_Processor {
 			}
 		}
 
-		$saved_result = $this->save_data( $updated_items, array_merge( $current, [ 'order' => $updated_order ] ) );
+		$saved_result = $this->save_data( [
+			'updated_items' => $updated_items,
+			'new_items' => $new_items,
+			'order' => $updated_order,
+		], $current );
 
 		return array_merge($this->get_empty_result(), [
 			'id_map' => $id_map,
@@ -145,6 +159,7 @@ abstract class Template_Library_Snapshot_Processor {
 
 		$id_map = [];
 		$ids_to_flatten = [];
+		$new_items = [];
 		$updated_items = $current_items;
 		$existing_ids = array_fill_keys( array_keys( $updated_items ), true );
 		$updated_order = $current['order'] ?? [];
@@ -177,11 +192,16 @@ abstract class Template_Library_Snapshot_Processor {
 				$updated_items,
 				$existing_ids,
 				$existing_labels,
-				$updated_order
+				$updated_order,
+				$new_items
 			);
 		}
 
-		$saved_result = $this->save_data( $updated_items, array_merge( $current, [ 'order' => $updated_order ] ) );
+		$saved_result = $this->save_data( [
+			'updated_items' => $updated_items,
+			'new_items' => $new_items,
+			'order' => $updated_order,
+		], $current );
 
 		return array_merge($this->get_empty_result(), [
 			'id_map' => $id_map,
@@ -189,10 +209,11 @@ abstract class Template_Library_Snapshot_Processor {
 		], $saved_result);
 	}
 
-	protected function add_item_with_label( array $item, string $target_id, array &$updated_items, array &$existing_ids, array &$existing_labels, array &$updated_order ): void {
+	protected function add_item_with_label( array $item, string $target_id, array &$updated_items, array &$existing_ids, array &$existing_labels, array &$updated_order, array &$new_items ): void {
 		$item = $this->prepare_item_for_save( $item, $target_id );
 		$item = Template_Library_Import_Export_Utils::apply_unique_label( $item, $existing_labels );
 		$updated_items[ $target_id ] = $item;
+		$new_items[ $target_id ] = $item;
 		$existing_ids[ $target_id ] = true;
 
 		if ( ! in_array( $target_id, $updated_order, true ) ) {

--- a/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
+++ b/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
@@ -63,9 +63,9 @@ class Template_Library_Global_Classes_Snapshot_Builder extends Template_Library_
 			return null;
 		}
 
-		$repository = Global_Classes_Repository::make()->set_preview( true );
-		$global_order = array_keys( $repository->all_labels() );
-		$filtered_order = array_values( array_intersect( $global_order, $ids ) );
+		$repository = Global_Classes_Repository::make()->set_preview( false );
+		$order = $repository->get_order();
+		$filtered_order = array_values( array_filter( $order, fn( $id ) => in_array( $id, $ids, true ) ) );
 		$filtered_items = $repository->get_by_ids( $ids );
 
 		if ( empty( $filtered_items ) ) {

--- a/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
+++ b/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
@@ -63,14 +63,14 @@ class Template_Library_Global_Classes_Snapshot_Builder extends Template_Library_
 			return null;
 		}
 
-		$current = self::make()->load_current_data();
-		$filtered_items = Template_Library_Import_Export_Utils::filter_items_by_ids( $current['items'], $ids );
+		$repository = Global_Classes_Repository::make()->set_preview( true );
+		$global_order = array_keys( $repository->all_labels() );
+		$filtered_order = array_values( array_intersect( $global_order, $ids ) );
+		$filtered_items = $repository->get_by_ids( $ids );
 
 		if ( empty( $filtered_items ) ) {
 			return null;
 		}
-
-		$filtered_order = Template_Library_Import_Export_Utils::build_filtered_order( $current['order'], $filtered_items );
 
 		return self::parse_snapshot_or_null( [
 			'items' => $filtered_items,
@@ -134,11 +134,17 @@ class Template_Library_Global_Classes_Snapshot_Builder extends Template_Library_
 	}
 
 	protected function load_current_data(): array {
-		$current = Global_Classes_Repository::make()->set_preview( true )->all()->get();
+		$repository = Global_Classes_Repository::make()->set_preview( true );
+		$labels = $repository->all_labels();
+
+		$items = [];
+		foreach ( $labels as $id => $label ) {
+			$items[ $id ] = [ 'id' => $id, 'label' => $label ];
+		}
 
 		return [
-			'items' => $current['items'] ?? [],
-			'order' => $current['order'] ?? [],
+			'items' => $items,
+			'order' => $repository->get_order(),
 		];
 	}
 
@@ -165,8 +171,18 @@ class Template_Library_Global_Classes_Snapshot_Builder extends Template_Library_
 
 	protected function save_data( array $items, array $metadata ): array {
 		$order = $metadata['order'] ?? [];
+		$existing_items = $metadata['items'] ?? [];
+		$existing_ids = array_flip( array_keys( $existing_items ) );
 
-		Global_Classes_Repository::make()->put( $items, $order );
+		$new_items = array_filter(
+			$items,
+			fn( $item, $id ) => ! isset( $existing_ids[ $id ] ),
+			ARRAY_FILTER_USE_BOTH
+		);
+
+		if ( ! empty( $new_items ) ) {
+			Global_Classes_Repository::make()->put( $new_items, $order );
+		}
 
 		return [
 			'global_classes' => [

--- a/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
+++ b/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
@@ -169,16 +169,9 @@ class Template_Library_Global_Classes_Snapshot_Builder extends Template_Library_
 		return count( $items );
 	}
 
-	protected function save_data( array $items, array $metadata ): array {
-		$order = $metadata['order'] ?? [];
-		$existing_items = $metadata['items'] ?? [];
-		$existing_ids = array_flip( array_keys( $existing_items ) );
-
-		$new_items = array_filter(
-			$items,
-			fn( $item, $id ) => ! isset( $existing_ids[ $id ] ),
-			ARRAY_FILTER_USE_BOTH
-		);
+	protected function save_data( array $data, array $metadata ): array {
+		$new_items = $data['new_items'] ?? [];
+		$order = $data['order'] ?? [];
 
 		if ( ! empty( $new_items ) ) {
 			Global_Classes_Repository::make()->put( $new_items, $order );
@@ -186,7 +179,7 @@ class Template_Library_Global_Classes_Snapshot_Builder extends Template_Library_
 
 		return [
 			'global_classes' => [
-				'items' => $items,
+				'items' => $data['updated_items'] ?? [],
 				'order' => $order,
 			],
 		];

--- a/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
+++ b/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
@@ -139,7 +139,10 @@ class Template_Library_Global_Classes_Snapshot_Builder extends Template_Library_
 
 		$items = [];
 		foreach ( $labels as $id => $label ) {
-			$items[ $id ] = [ 'id' => $id, 'label' => $label ];
+			$items[ $id ] = [
+				'id' => $id,
+				'label' => $label,
+			];
 		}
 
 		return [
@@ -180,7 +183,7 @@ class Template_Library_Global_Classes_Snapshot_Builder extends Template_Library_
 
 			$repository->apply_changes(
 				$new_items,
-				[ 
+				[
 					'added' => $added_ids,
 					'order' => true,
 				],

--- a/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
+++ b/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
@@ -174,7 +174,18 @@ class Template_Library_Global_Classes_Snapshot_Builder extends Template_Library_
 		$order = $data['order'] ?? [];
 
 		if ( ! empty( $new_items ) ) {
-			Global_Classes_Repository::make()->put( $new_items, $order );
+			$repository = Global_Classes_Repository::make()->set_preview( false );
+
+			$added_ids = array_keys( $new_items );
+
+			$repository->apply_changes(
+				$new_items,
+				[ 
+					'added' => $added_ids,
+					'order' => true,
+				],
+				$order
+			);
 		}
 
 		return [

--- a/modules/variables/utils/template-library-variables-snapshot-builder.php
+++ b/modules/variables/utils/template-library-variables-snapshot-builder.php
@@ -168,12 +168,14 @@ class Template_Library_Variables_Snapshot_Builder extends Template_Library_Snaps
 		return $count;
 	}
 
-	protected function save_data( array $items, array $metadata ): array {
+	protected function save_data( array $data, array $metadata ): array {
 		$repository = $this->get_repository_or_null();
 
 		if ( ! $repository ) {
 			return [];
 		}
+
+		$items = $data['updated_items'] ?? [];
 
 		$updated_collection = Variables_Collection::hydrate( [
 			'data' => $items,


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The Global Classes Repository refactored how items are stored and accessed — it now separates labels from full class data and uses `apply_changes()` instead of `put()`. The old template import code assumed items were always complete objects, causing imports to fail. **Ticket: ED-24013**

## 2. What Changed (Where)

- **`template-library-snapshot-processor.php`**: Refactored `save_data()` signature to accept structured data (`updated_items`, `new_items`, `order`) instead of flat items array; added `$new_items` tracking throughout import flows
- **`template-library-global-classes-snapshot-builder.php`**: Rewrote `load_current_data()` to fetch labels-only via repository; changed `save_data()` to call `apply_changes()` with only new items; fixed `build_snapshot_by_ids()` to use repository methods directly
- **`template-library-variables-snapshot-builder.php`**: Updated `save_data()` to extract `updated_items` from new data structure

## 3. How It Works

The processor now distinguishes between all items (`updated_items`) and newly imported ones (`new_items`). During import, `add_item_with_label()` populates both arrays. At save time, Global Classes only persists `new_items` via `apply_changes()` — existing items remain untouched since the repository now manages them separately. The `load_current_data()` rebuild constructs lightweight items from `all_labels()` instead of fetching full class definitions, avoiding the mismatch between label-only storage and the import system's expectations.

## 4. Risks

The Global Classes `save_data()` silently skips persistence if `$new_items` is empty, which could mask import failures when all items matched existing ones. The old `put()` would've rewritten everything, surfacing issues. Consider logging when no new items are added but imports were attempted.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-24013]: https://elementor.atlassian.net/browse/ED-24013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ