### PR TITLE
Internal: Cherry Pick PR 35692 to 4.01: Improve AI Integration by extraction of texts [ED-23921]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ coverage/
 !.cursor/rules/
 .claude/
 
+# PHPunit and PHPlint cache files
+*.cache
+
 # playwright
 test-results/
 **/storageState-*.json

--- a/packages/apps/elementor-capabilities-mcp/src/elementor-capabilities-mcp-server.ts
+++ b/packages/apps/elementor-capabilities-mcp/src/elementor-capabilities-mcp-server.ts
@@ -3,6 +3,7 @@ import { callWpApi } from '@elementor/elementor-mcp-common';
 import { z } from '@elementor/schema';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
+import { addCapabilitiesDescriptionResource, CAPABILITIES_DESCRIPTION_URI } from './mcp-description-resource';
 import { addPagesListResource, PAGES_LIST_RESOURCE_URI } from './pages-list-resource';
 
 type McpToolResult = {
@@ -66,111 +67,7 @@ export function createElementorCapabilitiesServer() {
 			title: 'Elementor Capabilities',
 		},
 		{
-			instructions: `## Elementor Page Builder - Available When In Editor
-
-This MCP provides information about Elementor's page building capabilities. When users ask about Elementor features, you should navigate them to the Elementor editor where full capabilities are available.
-
-### Available Resources:
-**Pages List Resource** (\`${ PAGES_LIST_RESOURCE_URI }\`):
-- Lists all WordPress pages with IDs, titles, status, and metadata
-- Use this to see what pages are available before navigation
-- Updated automatically when pages are created or modified
-- Useful for suggesting pages to edit or checking if a page exists
-
-### Elementor Capabilities (Available In Editor):
-
-**Page Management:**
-- Manage page settings, saving and routing pages
-- Control the editor UI, including switching between desktop, tablet, and mobile views
-
-**Global Styles:**
-- Work with global styles, helping manage shared design settings like colors and fonts across the site
-
-**Element Management:**
-- Create, edit, delete, duplicate, and move individual Elementor widgets and containers
-- Update widget and container settings
-- Insert text content with AI-powered text generation
-- Create image widgets and assign images to elements
-
-**AI-Powered Content Creation:**
-- Generate and edit text and insert it into the page
-- Generate images and place them on the canvas
-
-**Custom Styling & Code:**
-- Apply custom CSS to elements
-- Generate supported code snippets
-
-### Elementor Limitations (What Cannot Be Done):
-
-**Element Management Limitations:**
-- Cannot apply motion effects
-- Cannot create fully designed or polished pages in a single step
-- Cannot fully resolve responsiveness issues
-- Layout generation (Copilot) is not currently available
-
-**Theme Builder:**
-- Cannot create or manage Theme Builder templates, including headers, footers, single posts, archives, products, loop items, or 404 pages
-- Cannot set display conditions for templates
-- Cannot configure popup triggers and advanced rules
-
-**System Settings:**
-- Cannot change Elementor system-level settings
-- Cannot activate or work with Editor V4
-- Cannot manage form submissions
-- Cannot add custom fonts or icons
-- Cannot manage user roles
-- Cannot roll back Elementor versions
-- Cannot place the site in maintenance mode
-- Cannot export the website
-- Cannot apply full website templates
-
-**Code & Widgets:**
-- Cannot register PHP code or create new custom widgets, though Angie may provide guidance, code snippets, or plugin suggestions where helpful
-
-**Note**: While page names can include terms like "header" or "footer", these won't function as actual theme parts without Theme Builder access.
-
-### How to Help Users:
-
-**When users ask about Elementor features:**
-1. Confirm what they want to accomplish
-2. Check if it's a supported capability (see lists above)
-3. **Get the page to edit:**
-   - If user says "create new page" → Use createNew=true
-   - Otherwise → Call tool with no parameters to get page list
-   - Show pages to user: "Which page? Homepage, About, Contact..."
-   - User chooses → Call tool again with that pageId
-4. Once in editor, full Elementor MCP tools will be available
-
-**Examples:**
-- User: "Edit homepage" → Get page list → Find "Homepage" → Ask to confirm → Navigate
-- User: "Create new page" → createNew=true → Navigate
-
-**Examples of when to navigate to editor:**
-- "Edit my homepage with Elementor"
-- "Apply custom CSS to my page"
-- "Generate text content for my page"
-- "Work with dynamic content"
-
-**Examples of when to navigate to editor (element management now supported):**
-- "Add a heading widget" (Navigate to editor - element management supported)
-- "Create a new section with containers" (Navigate to editor - container creation supported)
-- "Change the color of a button" (Navigate to editor - widget settings supported)
-
-**Examples of what Elementor CANNOT do (don't navigate):**
-- "Add motion effects to my page" (Motion effects not supported)
-- "Create a header template" (Theme Builder not available)
-- "Set up a popup trigger" (Popup triggers and advanced rules not supported)
-- "Change Elementor settings" (System-level settings restricted)
-- "Add custom fonts" (Custom fonts not supported)
-- "Create a custom widget" (Cannot register PHP code or custom widgets)
-
-### Important Notes:
-- Elementor tools are ONLY available when inside the Elementor editor
-- This MCP server is for navigation and capability awareness
-- Once in editor, the full 'elementor' MCP server with all tools becomes available
-- Always verify if the requested feature is supported before navigating
-
-**Important**: When users ask "What can Angie do?" or similar questions about Angie's general capabilities, use the \`what-can-angie-do\` tool from the knowledge MCP server instead of generating your own response.`,
+			instructions: `Provides Elementor page-building capabilities and navigates users to the editor.`,
 			capabilities: {
 				resources: {
 					subscribe: true,
@@ -180,17 +77,14 @@ This MCP provides information about Elementor's page building capabilities. When
 	);
 
 	addPagesListResource( server );
+	addCapabilitiesDescriptionResource( server );
 
 	server.registerTool(
 		'navigate-to-elementor-editor',
 		{
-			description:
-				'Navigate the user to the Elementor editor to use Elementor page building capabilities. ' +
-				'WORKFLOW: ' +
-				'1. Check the wp-pages-list resource (automatically loaded) to see available pages. ' +
-				'2. If user asks to create new → set createNew=true with confirmationMessage. ' +
-				'3. If editing existing page → set pageId (from resource) with confirmationMessage. ' +
-				'Once in editor, full Elementor MCP capabilities become available.',
+			description: `Navigate the user to the Elementor editor. Causes a full page reload — editor-related tools become available afterward.
+
+Workflow: choose from the pages list resource → set pageId (edit) OR createNew=true (new page) with confirmationMessage.`,
 			inputSchema: {
 				pageId: z
 					.number()
@@ -223,6 +117,10 @@ This MCP provides information about Elementor's page building capabilities. When
 			},
 			_meta: {
 				[ ANGIE_REQUIRED_RESOURCES ]: [
+					{
+						uri: CAPABILITIES_DESCRIPTION_URI,
+						whenToUse: 'Read first for full capabilities and limitations guide',
+					},
 					{
 						uri: PAGES_LIST_RESOURCE_URI,
 						whenToUse:

--- a/packages/apps/elementor-capabilities-mcp/src/mcp-description-resource.ts
+++ b/packages/apps/elementor-capabilities-mcp/src/mcp-description-resource.ts
@@ -1,0 +1,126 @@
+import { type McpServer } from '@elementor/editor-mcp';
+
+import { PAGES_LIST_RESOURCE_URI } from './pages-list-resource';
+
+export const CAPABILITIES_DESCRIPTION_URI = 'elementor://capabilities/server-description';
+
+export const CAPABILITIES_DESCRIPTION = `## Elementor Page Builder - Available When In Editor
+
+This MCP provides information about Elementor's page building capabilities. When users ask about Elementor features, you should navigate them to the Elementor editor where full capabilities are available.
+
+### Available Resources:
+**Pages List Resource** (\`${ PAGES_LIST_RESOURCE_URI }\`):
+- Lists all WordPress pages with IDs, titles, status, and metadata
+- Use this to see what pages are available before navigation
+- Updated automatically when pages are created or modified
+- Useful for suggesting pages to edit or checking if a page exists
+
+### Elementor Capabilities (Available In Editor):
+
+**Page Management:**
+- Manage page settings, saving and routing pages
+- Control the editor UI, including switching between desktop, tablet, and mobile views
+
+**Global Styles:**
+- Work with global styles, helping manage shared design settings like colors and fonts across the site
+
+**Element Management:**
+- Create, edit, delete, duplicate, and move individual Elementor widgets and containers
+- Update widget and container settings
+- Insert text content with AI-powered text generation
+- Create image widgets and assign images to elements
+
+**AI-Powered Content Creation:**
+- Generate and edit text and insert it into the page
+- Generate images and place them on the canvas
+
+**Custom Styling & Code:**
+- Apply custom CSS to elements
+- Generate supported code snippets
+
+### Elementor Limitations (What Cannot Be Done):
+
+**Element Management Limitations:**
+- Cannot apply motion effects
+- Cannot create fully designed or polished pages in a single step
+- Cannot fully resolve responsiveness issues
+- Layout generation (Copilot) is not currently available
+
+**Theme Builder:**
+- Cannot create or manage Theme Builder templates, including headers, footers, single posts, archives, products, loop items, or 404 pages
+- Cannot set display conditions for templates
+- Cannot configure popup triggers and advanced rules
+
+**System Settings:**
+- Cannot change Elementor system-level settings
+- Cannot activate or work with Editor V4
+- Cannot manage form submissions
+- Cannot add custom fonts or icons
+- Cannot manage user roles
+- Cannot roll back Elementor versions
+- Cannot place the site in maintenance mode
+- Cannot export the website
+- Cannot apply full website templates
+
+**Code & Widgets:**
+- Cannot register PHP code or create new custom widgets, though Angie may provide guidance, code snippets, or plugin suggestions where helpful
+
+**Note**: While page names can include terms like "header" or "footer", these won't function as actual theme parts without Theme Builder access.
+
+### How to Help Users:
+
+**When users ask about Elementor features:**
+1. Confirm what they want to accomplish
+2. Check if it's a supported capability (see lists above)
+3. **Get the page to edit:**
+   - If user says "create new page" → Use createNew=true
+   - Otherwise → Call tool with no parameters to get page list
+   - Show pages to user: "Which page? Homepage, About, Contact..."
+   - User chooses → Call tool again with that pageId
+4. Once in editor, full Elementor MCP tools will be available
+
+**Examples:**
+- User: "Edit homepage" → Get page list → Find "Homepage" → Ask to confirm → Navigate
+- User: "Create new page" → createNew=true → Navigate
+
+**Examples of when to navigate to editor:**
+- "Edit my homepage with Elementor"
+- "Apply custom CSS to my page"
+- "Generate text content for my page"
+- "Work with dynamic content"
+
+**Examples of when to navigate to editor (element management now supported):**
+- "Add a heading widget" (Navigate to editor - element management supported)
+- "Create a new section with containers" (Navigate to editor - container creation supported)
+- "Change the color of a button" (Navigate to editor - widget settings supported)
+
+**Examples of what Elementor CANNOT do (don't navigate):**
+- "Add motion effects to my page" (Motion effects not supported)
+- "Create a header template" (Theme Builder not available)
+- "Set up a popup trigger" (Popup triggers and advanced rules not supported)
+- "Change Elementor settings" (System-level settings restricted)
+- "Add custom fonts" (Custom fonts not supported)
+- "Create a custom widget" (Cannot register PHP code or custom widgets)
+
+### Important Notes:
+- Elementor tools are ONLY available when inside the Elementor editor
+- This MCP server is for navigation and capability awareness
+- Once in editor, the full 'elementor' MCP server with all tools becomes available
+- Always verify if the requested feature is supported before navigating
+
+**Important**: When users ask "What can Angie do?" or similar questions about Angie's general capabilities, use the \`what-can-angie-do\` tool from the knowledge MCP server instead of generating your own response.`;
+
+export function addCapabilitiesDescriptionResource( server: McpServer ) {
+	server.registerResource(
+		'elementor-capabilities-server-description',
+		CAPABILITIES_DESCRIPTION_URI,
+		{
+			title: 'Elementor capabilities and limitations',
+			description:
+				'Full guide to Elementor MCP capabilities, limitations, workflows, and when to navigate to the editor.',
+		},
+		async ( uri ) => ( {
+			contents: [ { uri: uri.href, mimeType: 'text/plain', text: CAPABILITIES_DESCRIPTION } ],
+		} )
+	);
+}

--- a/packages/packages/core/editor-canvas/src/init.tsx
+++ b/packages/packages/core/editor-canvas/src/init.tsx
@@ -53,7 +53,13 @@ export function init() {
 
 	initCanvasMcp(
 		getMCPByDomain( 'canvas', {
-			instructions: mcpDescription,
+			instructions: `Everything related to V4 ( Atomic ) canvas.
+# Canvas workflow for new compositions
+- Configure elements settings and styles
+- Build compositions/sections out of V4 atomic elements using context aware designs using the website resources
+- Get and retrieve element configuration values
+`,
+			docs: mcpDescription,
 		} )
 	);
 

--- a/packages/packages/core/editor-canvas/src/mcp/canvas-mcp.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/canvas-mcp.ts
@@ -12,15 +12,6 @@ import { initConfigureElementTool } from './tools/configure-element/tool';
 import { initGetElementConfigTool } from './tools/get-element-config/tool';
 
 export const initCanvasMcp = ( reg: MCPRegistryEntry ) => {
-	const { setMCPDescription } = reg;
-	setMCPDescription(
-		`Everything related to V4 ( Atomic ) canvas.
-# Canvas workflow for new compositions
-- Configure elements settings and styles
-- Build compositions/sections out of V4 atomic elements using context aware designs using the website resources
-- Get and retrieve element configuration values
-`
-	);
 	initWidgetsSchemaResource( reg );
 	initAvailableWidgetsResource( reg );
 	initDocumentStructureResource( reg );

--- a/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/prompt.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/prompt.ts
@@ -2,6 +2,8 @@ import { toolPrompts } from '@elementor/editor-mcp';
 
 import { AVAILABLE_WIDGETS_URI } from '../../resources/available-widgets-resource';
 
+export const BUILD_COMPOSITIONS_GUIDE_URI = 'elementor://canvas/tools/build-compositions-guide';
+
 export const generatePrompt = () => {
 	const buildCompositionsToolPrompt = toolPrompts( 'build-compositions' );
 

--- a/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/tool.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/tool.ts
@@ -13,17 +13,31 @@ import { AVAILABLE_WIDGETS_URI_V4 } from '../../resources/available-widgets-reso
 import { BEST_PRACTICES_URI, STYLE_SCHEMA_URI, WIDGET_SCHEMA_URI } from '../../resources/widgets-schema-resource';
 import { doUpdateElementProperty } from '../../utils/do-update-element-property';
 import { getCompositionTargetContainer } from '../../utils/get-composition-target-container';
-import { generatePrompt } from './prompt';
+import { BUILD_COMPOSITIONS_GUIDE_URI, generatePrompt } from './prompt';
 import { inputSchema as schema, outputSchema } from './schema';
 
 export const initBuildCompositionsTool = ( reg: MCPRegistryEntry ) => {
-	const { addTool } = reg;
+	const { addTool, resource } = reg;
+
+	resource(
+		'build-compositions-guide',
+		BUILD_COMPOSITIONS_GUIDE_URI,
+		{
+			title: 'Build Compositions Guide',
+			description: 'Detailed guide for using the build-compositions tool',
+			mimeType: 'text/plain',
+		},
+		async ( uri: URL ) => ( {
+			contents: [ { uri: uri.href, mimeType: 'text/plain', text: generatePrompt() } ],
+		} )
+	);
 
 	addTool( {
 		name: 'build-compositions',
-		description: generatePrompt(),
+		description: 'Build V4 element compositions on the Elementor canvas. Read the guide resource before use.',
 		schema,
 		requiredResources: [
+			{ description: 'Build compositions guide', uri: BUILD_COMPOSITIONS_GUIDE_URI },
 			{ description: 'Widgets schema', uri: WIDGET_SCHEMA_URI },
 			{ description: 'Styles schema', uri: STYLE_SCHEMA_URI },
 			{ description: 'Global Classes', uri: 'elementor://global-classes' },

--- a/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/prompt.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/prompt.ts
@@ -1,6 +1,14 @@
+import { toolPrompts } from '@elementor/editor-mcp';
+
 import { STYLE_SCHEMA_URI, WIDGET_SCHEMA_URI } from '../../resources/widgets-schema-resource';
 
-export const configureElementToolPrompt = `Configure an existing element on the page.
+export const CONFIGURE_ELEMENT_GUIDE_URI = 'elementor://canvas/tools/configure-element-guide';
+
+export const generatePrompt = () => {
+	const configureElementToolPrompt = toolPrompts( 'configure-element' );
+
+	configureElementToolPrompt.description( `
+Configure an existing element on the page.
 
 # **CRITICAL - REQUIRED INFORMATION (Must read before using this tool)**
 1. [${ WIDGET_SCHEMA_URI }]
@@ -14,12 +22,6 @@ export const configureElementToolPrompt = `Configure an existing element on the 
 Before using this tool, check the definitions of the elements PropTypes at the resource "widget-schema-by-type" at editor-canvas__elementor://widgets/schema/{widgetType}
 All widgets share a common _style property for styling, which uses the common styles schema.
 Retrieve and check the common styles schema at the resource list "styles-schema" at editor-canvas__elementor://styles/schema/{category}
-
-# Parameters
-- propertiesToChange: An object containing the properties to change, with their new values. MANDATORY. When updating a style only, provide an empty object.
-- stylePropertiesToChange: An object containing the style properties to change, with their new values. OPTIONAL
-- elementId: The ID of the element to configure. MANDATORY
-- elementType: The type of the element to configure (i.e. e-heading, e-button). MANDATORY
 
 # When to use this tool
 When a user requires to change anything in an element, such as updating text, colors, sizes, or other configurable properties.
@@ -49,7 +51,7 @@ You can use multiple property changes at once by providing multiple entries in t
 Some properties are nested, use the root property name, then objects with nested values inside, as the complete schema suggests.
 
 Make sure you have the "widget-schema-by-type" resource available to retrieve the PropType schema for the element type you are configuring.
-Make sure you have to "styles-schema" resources available to retrieve the common styles schema.
+Make sure you have the "styles-schema" resources available to retrieve the common styles schema.
 
 # How to configure elements
 We use a dedicated PropType Schema for configuring elements, including styles. When you configure an element, you must use the EXACT PropType Value as defined in the schema.
@@ -57,8 +59,26 @@ For styleProperties, use the style schema provided, as it also uses the PropType
 For all non-primitive types, provide the key property as defined in the schema as $$type in the generated object, as it is MANDATORY for parsing.
 
 Use the EXACT "PROP-TYPE" Schema given, and ALWAYS include the "key" property from the original configuration for every property you are changing.
+` );
 
-# Example
+	configureElementToolPrompt.parameter( 'elementId', 'The ID of the element to configure. MANDATORY.' );
+
+	configureElementToolPrompt.parameter(
+		'elementType',
+		'The type of the element to configure (i.e. e-heading, e-button). MANDATORY.'
+	);
+
+	configureElementToolPrompt.parameter(
+		'propertiesToChange',
+		'An object containing the properties to change, with their new values. MANDATORY. When updating a style only, provide an empty object.'
+	);
+
+	configureElementToolPrompt.parameter(
+		'stylePropertiesToChange',
+		'An object containing the style properties to change, with their new values. OPTIONAL.'
+	);
+
+	configureElementToolPrompt.example( `
 \`\`\`json
 {
   propertiesToChange: {
@@ -74,7 +94,7 @@ Use the EXACT "PROP-TYPE" Schema given, and ALWAYS include the "key" property fr
   },
   stylePropertiesToChange: {
     'line-height': {
-      $$type: 'size', // MANDATORY do not forget to include the correct $$type for every property
+      $$type: 'size',
       value: {
         size: {
           $$type: 'number',
@@ -91,8 +111,13 @@ Use the EXACT "PROP-TYPE" Schema given, and ALWAYS include the "key" property fr
   elementType: 'element-type'
 };
 \`\`\`
+` );
 
-<IMPORTANT>
-The $$type property is MANDATORY for every value, it is required to parse the value and apply application-level effects.
-</IMPORTANT>
-`;
+	configureElementToolPrompt.instruction(
+		'The $$type property is MANDATORY for every value; it is required to parse the value and apply application-level effects.'
+	);
+
+	return configureElementToolPrompt.prompt();
+};
+
+export const CONFIGURE_ELEMENT_GUIDE_TEXT = generatePrompt();

--- a/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/tool.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/tool.ts
@@ -4,20 +4,34 @@ import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 import { STYLE_SCHEMA_URI, WIDGET_SCHEMA_URI } from '../../resources/widgets-schema-resource';
 import { doUpdateElementProperty } from '../../utils/do-update-element-property';
 import { validateInput } from '../../utils/validate-input';
-import { configureElementToolPrompt } from './prompt';
+import { CONFIGURE_ELEMENT_GUIDE_URI, generatePrompt } from './prompt';
 import { inputSchema as schema, outputSchema } from './schema';
 
 export const initConfigureElementTool = ( reg: MCPRegistryEntry ) => {
-	const { addTool } = reg;
+	const { addTool, resource } = reg;
+
+	resource(
+		'configure-element-guide',
+		CONFIGURE_ELEMENT_GUIDE_URI,
+		{
+			title: 'Configure Element Guide',
+			description: 'Detailed guide for using the configure-element tool',
+			mimeType: 'text/plain',
+		},
+		async ( uri: URL ) => ( {
+			contents: [ { uri: uri.href, mimeType: 'text/plain', text: generatePrompt() } ],
+		} )
+	);
 
 	addTool( {
 		name: 'configure-element',
-		description: configureElementToolPrompt,
+		description: "Configure an existing V4 element's properties and styles. Read the guide resource before use.",
 		schema,
 		outputSchema,
 		requiredResources: [
 			{ description: 'Widgets schema', uri: WIDGET_SCHEMA_URI },
 			{ description: 'Styles schema', uri: STYLE_SCHEMA_URI },
+			{ description: 'Configure element guide', uri: CONFIGURE_ELEMENT_GUIDE_URI },
 		],
 		modelPreferences: {
 			hints: [ { name: 'claude-sonnet-4-5' } ],

--- a/packages/packages/core/editor-components/src/components/__tests__/components-tab.test.tsx
+++ b/packages/packages/core/editor-components/src/components/__tests__/components-tab.test.tsx
@@ -36,12 +36,18 @@ jest.mock( '@elementor/editor-documents', () => ( {
 	setDocumentModifiedStatus: jest.fn(),
 } ) );
 
-jest.mock( '@elementor/editor-mcp', () => ( {
-	getAngieSdk: jest.fn().mockImplementation( () => ( {
-		isAngieReady: jest.fn( () => false ),
-		triggerAngie: jest.fn(),
-	} ) ),
-} ) );
+jest.mock( '@elementor/editor-mcp', () => {
+	const { toolPrompts } = jest.requireActual( '@elementor/editor-mcp' ) as {
+		toolPrompts: ( name: string ) => unknown;
+	};
+	return {
+		toolPrompts,
+		getAngieSdk: jest.fn().mockImplementation( () => ( {
+			isAngieReady: jest.fn( () => false ),
+			triggerAngie: jest.fn(),
+		} ) ),
+	};
+} );
 
 jest.mock( '@elementor/editor-current-user' );
 

--- a/packages/packages/core/editor-global-classes/src/init.ts
+++ b/packages/packages/core/editor-global-classes/src/init.ts
@@ -74,7 +74,15 @@ export function init() {
 	} );
 
 	initMcpIntegration(
-		getMCPByDomain( 'classes', { instructions: 'MCP server for management of Elementor global classes' } ),
+		getMCPByDomain( 'classes', {
+			instructions: 'MCP server for management of Elementor global classes',
+			docs: `Everything related to V4 ( Atomic ) global classes.
+# Global classes
+- Create/update/delete global classes
+- Get list of global classes
+- Get details of a global class
+`,
+		} ),
 		getMCPByDomain( 'canvas' )
 	);
 }

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/apply-global-class-guide-prompt.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/apply-global-class-guide-prompt.ts
@@ -1,0 +1,39 @@
+import { toolPrompts } from '@elementor/editor-mcp';
+
+export const APPLY_GLOBAL_CLASS_GUIDE_URI = 'elementor://global-classes/tools/apply-global-class-guide';
+
+export const generateApplyGlobalClassGuidePrompt = () => {
+	const prompt = toolPrompts( 'apply-global-class' );
+
+	prompt.description( 'Apply a global class to an element, enabling consistent styling through your design system.' );
+
+	prompt.instruction(
+		`## When to use this tool:
+**ALWAYS use this IMMEDIATELY AFTER building compositions** to apply the global classes you created beforehand:
+- After using "build-compositions" tool, apply semantic classes to the created elements
+- When applying consistent typography styles (heading-primary, text-body, etc.)
+- When applying theme colors or brand styles (bg-brand, button-cta, etc.)
+- When ensuring spacing consistency (spacing-section-large, etc.)
+
+**DO NOT use this tool** for:
+- Elements that don't share styles with other elements (use inline styles instead)
+- Layout-specific properties (those should remain inline in stylesConfig)`
+	);
+
+	prompt.instruction(
+		`## Prerequisites:
+- **REQUIRED**: Get the list of available global classes from 'elementor://global-classes' resource
+- **REQUIRED**: Get element IDs from the composition XML returned by "build-compositions" tool
+- Ensure you have the most up-to-date list of classes applied to the element to avoid duplicates
+- Make sure you have the correct class ID that you want to apply`
+	);
+
+	prompt.instruction(
+		`## Best Practices:
+1. Apply multiple classes to a single element if needed (typography + color + spacing)
+2. After applying, the tool will remind you to remove duplicate inline styles from elementConfig
+3. Classes should describe purpose, not implementation (e.g., "heading-primary" not "big-red-text")`
+	);
+
+	return prompt.prompt();
+};

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/index.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/index.ts
@@ -6,16 +6,6 @@ import initMcpApplyGetGlobalClassUsages from './mcp-get-global-class-usages';
 import { initManageGlobalClasses } from './mcp-manage-global-classes';
 
 export const initMcpIntegration = ( reg: MCPRegistryEntry, canvasMcpEntry: MCPRegistryEntry ) => {
-	const { setMCPDescription } = reg;
-	setMCPDescription(
-		`Everything related to V4 ( Atomic ) global classes.
-# Global classes
-- Create/update/delete global classes
-- Get list of global classes
-- Get details of a global class
-- Get details of a global class
-`
-	);
 	initMcpApplyUnapplyGlobalClasses( reg );
 	initMcpApplyGetGlobalClassUsages( reg );
 	initManageGlobalClasses( reg );

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-apply-unapply-global-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-apply-unapply-global-classes.ts
@@ -2,8 +2,27 @@ import { doApplyClasses, doGetAppliedClasses, doUnapplyClass } from '@elementor/
 import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 import { z } from '@elementor/schema';
 
+import { APPLY_GLOBAL_CLASS_GUIDE_URI, generateApplyGlobalClassGuidePrompt } from './apply-global-class-guide-prompt';
+import { GLOBAL_CLASSES_URI } from './classes-resource';
+
 export default function initMcpApplyUnapplyGlobalClasses( server: MCPRegistryEntry ) {
-	server.addTool( {
+	const { addTool, resource } = server;
+	const applyGlobalClassGuideText = generateApplyGlobalClassGuidePrompt();
+
+	resource(
+		'apply-global-class-guide',
+		APPLY_GLOBAL_CLASS_GUIDE_URI,
+		{
+			description: 'Workflow, prerequisites, and best practices for apply-global-class',
+			mimeType: 'text/plain',
+			title: 'Apply global class tool guide',
+		},
+		async ( uri ) => ( {
+			contents: [ { mimeType: 'text/plain', text: applyGlobalClassGuideText, uri: uri.href } ],
+		} )
+	);
+
+	addTool( {
 		schema: {
 			classId: z.string().describe( 'The ID of the class to apply' ),
 			elementId: z.string().describe( 'The ID of the element to which the class will be applied' ),
@@ -19,29 +38,11 @@ export default function initMcpApplyUnapplyGlobalClasses( server: MCPRegistryEnt
 			intelligencePriority: 0.7,
 			speedPriority: 0.8,
 		},
-		description: `Apply a global class to an element, enabling consistent styling through your design system.
-
-## When to use this tool:
-**ALWAYS use this IMMEDIATELY AFTER building compositions** to apply the global classes you created beforehand:
-- After using "build-compositions" tool, apply semantic classes to the created elements
-- When applying consistent typography styles (heading-primary, text-body, etc.)
-- When applying theme colors or brand styles (bg-brand, button-cta, etc.)
-- When ensuring spacing consistency (spacing-section-large, etc.)
-
-**DO NOT use this tool** for:
-- Elements that don't share styles with other elements (use inline styles instead)
-- Layout-specific properties (those should remain inline in stylesConfig)
-
-## Prerequisites:
-- **REQUIRED**: Get the list of available global classes from 'elementor://global-classes' resource
-- **REQUIRED**: Get element IDs from the composition XML returned by "build-compositions" tool
-- Ensure you have the most up-to-date list of classes applied to the element to avoid duplicates
-- Make sure you have the correct class ID that you want to apply
-
-## Best Practices:
-1. Apply multiple classes to a single element if needed (typography + color + spacing)
-2. After applying, the tool will remind you to remove duplicate inline styles from elementConfig
-3. Classes should describe purpose, not implementation (e.g., "heading-primary" not "big-red-text")`,
+		description: `Apply a global class to an element for shared design-system styling. Read the full guide at [${ APPLY_GLOBAL_CLASS_GUIDE_URI }].`,
+		requiredResources: [
+			{ description: 'Apply global class tool guide', uri: APPLY_GLOBAL_CLASS_GUIDE_URI },
+			{ description: 'Global classes list', uri: GLOBAL_CLASSES_URI },
+		],
 		handler: async ( params ) => {
 			const { classId, elementId } = params;
 			const appliedClasses = doGetAppliedClasses( elementId );
@@ -54,7 +55,7 @@ export default function initMcpApplyUnapplyGlobalClasses( server: MCPRegistryEnt
 		},
 	} );
 
-	server.addTool( {
+	addTool( {
 		name: 'unapply-global-class',
 		schema: {
 			classId: z.string().describe( 'The ID of the class to unapply' ),
@@ -67,21 +68,8 @@ export default function initMcpApplyUnapplyGlobalClasses( server: MCPRegistryEnt
 			intelligencePriority: 0.7,
 			speedPriority: 0.8,
 		},
-		description: `Unapply a (global) class from the current element
-
-## When to use this tool:
-- When a user requests to unapply a global class or a class from an element in the Elementor editor.
-- When you need to remove a specific class from an element's applied classes.
-
-## Prerequisites:
-- Ensure you have the most up-to-date list of classes applied to the element to avoid errors.
-  The list is available at always up-to-date resource 'elementor://global-classes'.
-- Make sure you have the correct class ID that you want to unapply.
-
-<note>
-If the user want to unapply a class by it's name and not ID, retrieve the id from the list, available at uri elementor://global-classes
-</note>
-`,
+		description: `Unapply a global class from an element by class ID. Resolve class names to IDs via [${ GLOBAL_CLASSES_URI }].`,
+		requiredResources: [ { description: 'Global classes list', uri: GLOBAL_CLASSES_URI } ],
 		handler: async ( params ) => {
 			const { classId, elementId } = params;
 			const ok = doUnapplyClass( elementId, classId );

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-get-global-class-usages.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-get-global-class-usages.ts
@@ -3,6 +3,7 @@ import { z } from '@elementor/schema';
 
 import { fetchCssClassUsage } from '../../service/css-class-usage-service';
 import { type CssClassUsageContent, type EnhancedCssClassUsageContent } from '../components/css-class-usage/types';
+import { GLOBAL_CLASSES_URI } from './classes-resource';
 
 export default function initMcpApplyGetGlobalClassUsages( reg: MCPRegistryEntry ) {
 	const { addTool } = reg;
@@ -32,19 +33,15 @@ export default function initMcpApplyGetGlobalClassUsages( reg: MCPRegistryEntry 
 			intelligencePriority: 0.6,
 			speedPriority: 0.8,
 		},
-		description: `Retrieve the usages of global-classes ACROSS PAGES designed by Elementor editor.
+		description: `Retrieve usages of global classes across all Elementor pages. Heavy operation — scans every page in the site.
 
-## Prerequisites: CRITICAL
-- The list of global classes and their applid values is available at resource uri elementor://global-classes
+## When to use:
+- Before deleting or radically changing a class — to understand cross-page side effects and decide whether to consult the user.
+- To identify unused global classes for cleanup.
 
-## When to use this tool:
-- When a user requests to see where a specific global class is being used across the site.
-- When you need to manage or clean up unused global classes.
-- Before deleting a global class, to ensure it is not in use in any other pages.
-
-## When NOT to use this tool:
-- For getting the list of global classes, refer to the resource at uri elementor://global-classes
-`,
+## When NOT to use:
+- To list global classes themselves — use the global-classes resource instead (this tool returns usages, not the class list).`,
+		requiredResources: [ { description: 'Global classes list', uri: GLOBAL_CLASSES_URI } ],
 		outputSchema: globalClassesUsageSchema,
 		handler: async () => {
 			const data = await fetchCssClassUsage();

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-manage-global-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-manage-global-classes.ts
@@ -213,15 +213,7 @@ export const initManageGlobalClasses = ( reg: MCPRegistryEntry ) => {
 			intelligencePriority: 0.85,
 			speedPriority: 0.6,
 		},
-		description: `Manages global classes (create/modify) in Elementor editor. Check [elementor://global-classes] and style schemas first.
-
-CREATE: Requires globalClassName, props. Use semantic naming (heading-primary, button-cta, text-muted). Check existing classes to avoid duplicates. ALWAYS create global classes BEFORE compositions for reusable styles.
-MODIFY: Requires classId, props. Get classId from [elementor://global-classes] resource.
-
-Naming pattern: [element-type]-[purpose/variant]-[modifier]
-DO NOT create global classes for: one-off styles, layout-specific properties.
-
-Use style schema at [elementor://styles/schema/{category}] for valid props. Errors include exact schema mismatch details.`,
+		description: `Create or modify global classes for reusable design-system styling. Class names must reflect purpose (e.g. heading-primary, button-cta). Create classes BEFORE compositions. Do NOT create classes for one-off styles or layout-specific properties.`,
 		schema,
 		outputSchema,
 		handler,

--- a/packages/packages/core/editor-interactions/src/init.ts
+++ b/packages/packages/core/editor-interactions/src/init.ts
@@ -11,7 +11,11 @@ import { Trigger } from './components/controls/trigger';
 import { initCleanInteractionIdsOnDuplicate } from './hooks/on-duplicate';
 import { registerInteractionsControl } from './interactions-controls-registry';
 import { interactionsRepository } from './interactions-repository';
-import { EDITOR_INTERACTIONS_MCP_INSTRUCTIONS, initMcpInteractions } from './mcp';
+import {
+	EDITOR_INTERACTIONS_MCP_DESCRIPTION,
+	EDITOR_INTERACTIONS_MCP_SHORT_DESCRIPTION,
+	initMcpInteractions,
+} from './mcp';
 import { documentElementsInteractionsProvider } from './providers/document-elements-interactions-provider';
 
 export function init() {
@@ -62,7 +66,12 @@ export function init() {
 			component: Repeat,
 		} );
 
-		initMcpInteractions( getMCPByDomain( 'interactions', { instructions: EDITOR_INTERACTIONS_MCP_INSTRUCTIONS } ) );
+		initMcpInteractions(
+			getMCPByDomain( 'interactions', {
+				docs: EDITOR_INTERACTIONS_MCP_DESCRIPTION,
+				instructions: EDITOR_INTERACTIONS_MCP_SHORT_DESCRIPTION,
+			} )
+		);
 	} catch ( error ) {
 		throw error;
 	}

--- a/packages/packages/core/editor-interactions/src/mcp/constants.ts
+++ b/packages/packages/core/editor-interactions/src/mcp/constants.ts
@@ -1,5 +1,11 @@
 export const MAX_INTERACTIONS_PER_ELEMENT = 5;
-export const EDITOR_INTERACTIONS_MCP_INSTRUCTIONS = `MCP server for managing element interactions and animations. Use this to add, modify, or remove animations and motion effects triggered by user events such as page load or scroll-into-view.
+export const EDITOR_INTERACTIONS_MCP_SHORT_DESCRIPTION = `Everything related to V4 ( Atomic ) interactions.
+# Interactions
+- Create/update/delete interactions
+- Get list of interactions
+- Get details of an interaction
+`;
+export const EDITOR_INTERACTIONS_MCP_DESCRIPTION = `MCP server for managing element interactions and animations. Use this to add, modify, or remove animations and motion effects triggered by user events such as page load or scroll-into-view.
 		** IMPORTANT **
 		Use the "interactions-schema" resource to get the schema of the interactions.
 		Actions:
@@ -8,7 +14,7 @@ export const EDITOR_INTERACTIONS_MCP_INSTRUCTIONS = `MCP server for managing ele
 		- update: Update an existing interaction by its interactionId.
 		- delete: Remove a specific interaction by its interactionId.
 		- clear: Remove all interactions from the element.
-		
+
 		For add/update, provide: trigger, effect, effectType, direction (required for slide effect), duration, delay, easing.
 		Use excludedBreakpoints to disable the animation on specific responsive breakpoints (e.g. ["mobile", "tablet"]).
 		Example Get Request:

--- a/packages/packages/core/editor-variables/src/init.ts
+++ b/packages/packages/core/editor-variables/src/init.ts
@@ -47,7 +47,15 @@ export function init() {
 	} );
 
 	variablesService.init().then( () => {
-		initMcp( getMCPByDomain( 'variables' ), getMCPByDomain( 'canvas' ) );
+		const variablesMcpRegistry = getMCPByDomain( 'variables', {
+			instructions: `Everything related to V4 ( Atomic ) variables.
+# Global variables
+- Create/update/delete global variables
+- Get list of global variables
+- Get details of a global variable
+`,
+		} );
+		initMcp( variablesMcpRegistry, getMCPByDomain( 'canvas' ) );
 	} );
 
 	injectIntoTop( {

--- a/packages/packages/core/editor-variables/src/mcp/index.ts
+++ b/packages/packages/core/editor-variables/src/mcp/index.ts
@@ -4,15 +4,6 @@ import { initManageVariableTool } from './manage-variable-tool';
 import { initVariablesResource } from './variables-resource';
 
 export function initMcp( reg: MCPRegistryEntry, canvasMcpEntry: MCPRegistryEntry ) {
-	const { setMCPDescription } = reg;
-	setMCPDescription(
-		`Everything related to V4 ( Atomic ) variables.
-# Global variables
-- Create/update/delete global variables
-- Get list of global variables
-- Get details of a global variable
-`
-	);
 	initManageVariableTool( reg );
 	initVariablesResource( reg, canvasMcpEntry );
 }

--- a/packages/packages/core/editor-variables/src/mcp/manage-variable-tool.ts
+++ b/packages/packages/core/editor-variables/src/mcp/manage-variable-tool.ts
@@ -20,7 +20,12 @@ export const initManageVariableTool = ( reg: MCPRegistryEntry ) => {
 				.optional()
 				.describe( 'Variable type: "global-color-variable" or "global-font-variable" (required for create)' ),
 			label: z.string().optional().describe( 'Variable label (required for create/update)' ),
-			value: z.string().optional().describe( 'Variable value (required for create/update)' ),
+			value: z
+				.string()
+				.optional()
+				.describe(
+					'The variable value (required for create/update). Provide a plain CSS value matching the variable type (font: family name; color: CSS color; size: value with unit). Never JSON.'
+				),
 		},
 		outputSchema: {
 			status: z.enum( [ 'ok' ] ).describe( 'Operation status' ),
@@ -36,14 +41,11 @@ export const initManageVariableTool = ( reg: MCPRegistryEntry ) => {
 				description: 'Global variables',
 			},
 		],
-		description: `Manages global variables (create/update/delete). Existing variables available in resources.
-CREATE: requires type, label, value. Ensure label is unique.
-UPDATE: requires id, label, value. When renaming: keep existing value. When updating value: keep exact label.
-DELETE: requires id. DESTRUCTIVE - confirm with user first.
-
-# NAMING - IMPORTANT
-the variables names should ALWAYS be lowercased and dashed spaced. example: "Headline Primary" should be "headline-primary"
-`,
+		description: `Create, update, or delete V4 global variables (distinct from legacy "globals").
+- Values: any valid CSS value, inserted as-is (1:1 with \`--css-var: VALUE\`). Do NOT pass JSON or legacy-globals object structures.
+- Names: lowercase, dash-separated (e.g. "Headline Primary" → "headline-primary").
+- Update: when renaming, keep the existing value; when updating value, keep the exact label.
+- Delete: destructive — confirm with user first.`,
 		handler: async ( params ) => {
 			const operations = getServiceActions( service );
 			const op = operations[ params.action ];

--- a/packages/packages/core/elementor-kit-mcp/src/elementor-kit-mcp-server.ts
+++ b/packages/packages/core/elementor-kit-mcp/src/elementor-kit-mcp-server.ts
@@ -2,6 +2,8 @@ import { getAngieSdk, McpServer, ResourceTemplate } from '@elementor/editor-mcp'
 import { callWpApi, requireConfirmationMessage, waitForElementorEditor } from '@elementor/elementor-mcp-common';
 import { z } from '@elementor/schema';
 
+import { addKitDescriptionResource, KIT_DESCRIPTION, KIT_DESCRIPTION_URI } from './mcp-description-resource';
+
 const RESOURCE_NAME_KIT_FONTS = 'elementor-kit-fonts';
 const RESOURCE_URI_KIT_FONTS = 'elementor://kit/fonts';
 const RESOURCE_NAME_KIT_SCHEMA = 'elementor-kit-schema';
@@ -141,30 +143,6 @@ const generalPatchSchema = z
 		'General patch object for any other Elementor kit settings like spacing, buttons, forms, layout settings, etc.'
 	);
 
-const SERVER_INSTRUCTIONS = `## Elementor Kit Settings Management
-
-### Capabilities:
-**Global Design System:**
-- Create, update, name, and delete global colors (both system and custom)
-- Create, update, name, and delete global fonts (both system and custom)
-
-**Site Identity:**
-- Insert site logo
-- Set site favicon
-- Update site name
-- Modify site description
-
-### Limitations:
-**Theme Style Settings:**
-- Cannot set or update Elementor Theme Style settings including typography, buttons, images, form fields, Hello Theme header, or Hello Theme footer that affect the entire website appearance
-
-**Site-Wide Settings:**
-- Cannot set site-wide background (color or image)
-- Cannot configure mobile browser background
-- Cannot modify global layout settings such as content width, container padding, and widget gaps (the default space between widgets)
-
-**Note**: Angie can adjust all of these layout properties at the container or page level - just not site-wide.`;
-
 export async function createElementorKitServer(): Promise< McpServer > {
 	await waitForElementorEditor();
 	const server = new McpServer(
@@ -174,7 +152,7 @@ export async function createElementorKitServer(): Promise< McpServer > {
 			title: 'Elementor Kit',
 		},
 		{
-			instructions: SERVER_INSTRUCTIONS,
+			instructions: 'Manages Elementor global design system: colors, typography, and site identity.',
 			capabilities: {
 				resources: {
 					subscribe: true,
@@ -182,6 +160,8 @@ export async function createElementorKitServer(): Promise< McpServer > {
 			},
 		}
 	);
+
+	addKitDescriptionResource( server );
 
 	const getAvailableTabs = async (): Promise< string[] > => {
 		const kitSchema = await fetchKitSchema();
@@ -331,6 +311,14 @@ The tool will permanently update the site's global design settings and return a 
 				title: 'Update Elementor Kit Settings',
 				destructiveHint: true,
 			},
+			_meta: {
+				'angie/requiredResources': [
+					{
+						uri: KIT_DESCRIPTION_URI,
+						whenToUse: 'Read first for kit capabilities and limitations',
+					},
+				],
+			},
 		},
 		async ( {
 			systemColors,
@@ -388,7 +376,7 @@ The tool will permanently update the site's global design settings and return a 
 	sdk.registerLocalServer( {
 		server,
 		version: VERSION,
-		description: SERVER_INSTRUCTIONS,
+		description: KIT_DESCRIPTION,
 		name: 'elementor-kit-server',
 	} );
 	return server;

--- a/packages/packages/core/elementor-kit-mcp/src/mcp-description-resource.ts
+++ b/packages/packages/core/elementor-kit-mcp/src/mcp-description-resource.ts
@@ -1,0 +1,42 @@
+import { type McpServer } from '@elementor/editor-mcp';
+
+export const KIT_DESCRIPTION_URI = 'elementor://kit/server-description';
+
+export const KIT_DESCRIPTION = `## Elementor Kit Settings Management
+
+### Capabilities:
+**Global Design System:**
+- Create, update, name, and delete global colors (both system and custom)
+- Create, update, name, and delete global fonts (both system and custom)
+
+**Site Identity:**
+- Insert site logo
+- Set site favicon
+- Update site name
+- Modify site description
+
+### Limitations:
+**Theme Style Settings:**
+- Cannot set or update Elementor Theme Style settings including typography, buttons, images, form fields, Hello Theme header, or Hello Theme footer that affect the entire website appearance
+
+**Site-Wide Settings:**
+- Cannot set site-wide background (color or image)
+- Cannot configure mobile browser background
+- Cannot modify global layout settings such as content width, container padding, and widget gaps (the default space between widgets)
+
+**Note**: Angie can adjust all of these layout properties at the container or page level - just not site-wide.`;
+
+export function addKitDescriptionResource( server: McpServer ) {
+	server.registerResource(
+		'elementor-kit-server-description',
+		KIT_DESCRIPTION_URI,
+		{
+			title: 'Elementor Kit Server Description',
+			description: 'Elementor Kit capabilities and limitations',
+			mimeType: 'text/plain',
+		},
+		async ( uri ) => ( {
+			contents: [ { uri: uri.href, mimeType: 'text/plain', text: KIT_DESCRIPTION } ],
+		} )
+	);
+}

--- a/packages/packages/core/elementor-v3-mcp/src/elementor-mcp-server.ts
+++ b/packages/packages/core/elementor-v3-mcp/src/elementor-mcp-server.ts
@@ -2,60 +2,9 @@ import { getAngieSdk } from '@elementor/editor-mcp';
 import { waitForElementorEditor } from '@elementor/elementor-mcp-common';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
+import { addV3DescriptionResource, V3_DESCRIPTION } from './mcp-description-resource';
 import { addElementorResources } from './resources';
 import { addAiTool, addDynamicTool, addPageTool, addRoutesTool, addStylingTool, addUiTool } from './tools';
-
-const SERVER_INSTRUCTIONS = `## Elementor Page Builder
-
-### Capabilities:
-**Page Management:**
-- Manage page settings, saving and routing pages
-- Control the editor UI, including switching between desktop, tablet, and mobile views
-
-**Global Styles:**
-- Work with global styles, helping manage shared design settings like colors and fonts across the site
-
-**AI-Powered Content Creation:**
-- Generate and edit text and insert it into the page
-- Generate images and place them on the canvas
-
-**Custom Styling & Code:**
-- Apply custom CSS to elements
-- Generate supported code snippets
-
-### Limitations:
-**Element Management (Not Supported):**
-- Cannot create or edit individual Elementor elements such as widgets or containers
-- Cannot build page layouts or create containers
-- Cannot modify widget-level settings
-- Cannot apply motion effects
-- Cannot reorder sections or perform detailed canvas-level edits
-- Cannot create fully designed or polished pages
-- Cannot fully resolve responsiveness issues
-- Support for these editor-level capabilities is planned for Editor V4
-
-**Theme Builder:**
-- Cannot create or manage Theme Builder templates, including headers, footers, single posts, archives, products, loop items, or 404 pages
-- Cannot set display conditions for templates
-- Cannot configure popup triggers and advanced rules
-
-**System Settings:**
-- Cannot change Elementor system-level settings
-- Cannot activate or work with Editor V4
-- Cannot manage form submissions
-- Cannot add custom fonts or icons
-- Cannot manage user roles
-- Cannot roll back Elementor versions
-- Cannot place the site in maintenance mode
-- Cannot export the website
-- Cannot apply full website templates
-
-**Code & Widgets:**
-- Cannot register PHP code or create new custom widgets, though Angie may provide guidance, code snippets, or plugin suggestions where helpful
-
-**Note**: While page names can include terms like "header" or "footer", these won't function as actual theme parts without Theme Builder access.
-
-**Important**: When users ask "What can Angie do?" or similar questions about Angie's general capabilities, use the \`what-can-angie-do\` tool from the knowledge MCP server instead of generating your own response.`;
 
 const VERSION = '2.0.0';
 
@@ -69,7 +18,7 @@ export async function createElementorServer(): Promise< McpServer > {
 			title: 'Elementor',
 		},
 		{
-			instructions: SERVER_INSTRUCTIONS,
+			instructions: `Controls the Elementor editor: page settings, UI, global styles, AI content, and custom CSS.`,
 			capabilities: {
 				resources: {
 					subscribe: true,
@@ -78,6 +27,7 @@ export async function createElementorServer(): Promise< McpServer > {
 		}
 	);
 
+	addV3DescriptionResource( server );
 	addElementorResources( server );
 
 	addPageTool( server );
@@ -89,7 +39,7 @@ export async function createElementorServer(): Promise< McpServer > {
 
 	const sdk = getAngieSdk();
 	await sdk.waitForReady();
-	sdk.registerLocalServer( { server, version: VERSION, description: SERVER_INSTRUCTIONS, name: 'Elementor' } );
+	sdk.registerLocalServer( { server, version: VERSION, description: V3_DESCRIPTION, name: 'Elementor' } );
 
 	return server;
 }

--- a/packages/packages/core/elementor-v3-mcp/src/mcp-description-resource.ts
+++ b/packages/packages/core/elementor-v3-mcp/src/mcp-description-resource.ts
@@ -1,0 +1,70 @@
+import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export const V3_DESCRIPTION_URI = 'elementor://elementor/server-description';
+
+export const V3_DESCRIPTION = `## Elementor Page Builder
+
+### Capabilities:
+**Page Management:**
+- Manage page settings, saving and routing pages
+- Control the editor UI, including switching between desktop, tablet, and mobile views
+
+**Global Styles:**
+- Work with global styles, helping manage shared design settings like colors and fonts across the site
+
+**AI-Powered Content Creation:**
+- Generate and edit text and insert it into the page
+- Generate images and place them on the canvas
+
+**Custom Styling & Code:**
+- Apply custom CSS to elements
+- Generate supported code snippets
+
+### Limitations:
+**Element Management (Not Supported):**
+- Cannot create or edit individual Elementor elements such as widgets or containers
+- Cannot build page layouts or create containers
+- Cannot modify widget-level settings
+- Cannot apply motion effects
+- Cannot reorder sections or perform detailed canvas-level edits
+- Cannot create fully designed or polished pages
+- Cannot fully resolve responsiveness issues
+- Support for these editor-level capabilities is planned for Editor V4
+
+**Theme Builder:**
+- Cannot create or manage Theme Builder templates, including headers, footers, single posts, archives, products, loop items, or 404 pages
+- Cannot set display conditions for templates
+- Cannot configure popup triggers and advanced rules
+
+**System Settings:**
+- Cannot change Elementor system-level settings
+- Cannot activate or work with Editor V4
+- Cannot manage form submissions
+- Cannot add custom fonts or icons
+- Cannot manage user roles
+- Cannot roll back Elementor versions
+- Cannot place the site in maintenance mode
+- Cannot export the website
+- Cannot apply full website templates
+
+**Code & Widgets:**
+- Cannot register PHP code or create new custom widgets, though Angie may provide guidance, code snippets, or plugin suggestions where helpful
+
+**Note**: While page names can include terms like "header" or "footer", these won't function as actual theme parts without Theme Builder access.
+
+**Important**: When users ask "What can Angie do?" or similar questions about Angie's general capabilities, use the \`what-can-angie-do\` tool from the knowledge MCP server instead of generating your own response.`;
+
+export function addV3DescriptionResource( server: McpServer ) {
+	server.registerResource(
+		'elementor-v3-server-description',
+		V3_DESCRIPTION_URI,
+		{
+			title: 'Elementor V3 Server Description',
+			description: 'Elementor V3 MCP capabilities and limitations',
+			mimeType: 'text/plain',
+		},
+		async ( uri ) => ( {
+			contents: [ { uri: uri.href, mimeType: 'text/plain', text: V3_DESCRIPTION } ],
+		} )
+	);
+}

--- a/packages/packages/core/elementor-v3-mcp/src/tools/ai-tool.ts
+++ b/packages/packages/core/elementor-v3-mcp/src/tools/ai-tool.ts
@@ -1,6 +1,7 @@
 import { z } from '@elementor/schema';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
+import { V3_DESCRIPTION_URI } from '../mcp-description-resource';
 import type { McpToolResult } from '../types';
 import { get$e } from '../utils';
 
@@ -16,6 +17,14 @@ export function addAiTool( server: McpServer ): void {
 			},
 			annotations: {
 				title: 'Manage AI Integration',
+			},
+			_meta: {
+				'angie/requiredResources': [
+					{
+						uri: V3_DESCRIPTION_URI,
+						whenToUse: 'Read to understand Elementor capabilities and limitations before using this tool.',
+					},
+				],
 			},
 		},
 		async ( params ) => {

--- a/packages/packages/core/elementor-v3-mcp/src/tools/dynamic-tool.ts
+++ b/packages/packages/core/elementor-v3-mcp/src/tools/dynamic-tool.ts
@@ -1,6 +1,7 @@
 import { z } from '@elementor/schema';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
+import { V3_DESCRIPTION_URI } from '../mcp-description-resource';
 import type { ElementorContainer, McpToolResult, ToolParams } from '../types';
 import { get$e, getElementor, getElementorCommon } from '../utils';
 import { validateDynamicTagDisabled, validateDynamicTagEnabled } from '../validation-helpers';
@@ -39,6 +40,14 @@ export function addDynamicTool( server: McpServer ): void {
 			},
 			annotations: {
 				title: 'Manage Dynamic Content',
+			},
+			_meta: {
+				'angie/requiredResources': [
+					{
+						uri: V3_DESCRIPTION_URI,
+						whenToUse: 'Read to understand Elementor capabilities and limitations before using this tool.',
+					},
+				],
 			},
 		},
 		async ( params: ToolParams ) => {

--- a/packages/packages/core/elementor-v3-mcp/src/tools/page-tool.ts
+++ b/packages/packages/core/elementor-v3-mcp/src/tools/page-tool.ts
@@ -1,6 +1,7 @@
 import { z } from '@elementor/schema';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
+import { V3_DESCRIPTION_URI } from '../mcp-description-resource';
 import { RESOURCE_URI_PAGE_SETTINGS } from '../resources';
 import type { ElementorContainer, McpToolResult, ToolParams } from '../types';
 import { encodeToolJson, get$e, getElementor } from '../utils';
@@ -10,12 +11,7 @@ export function addPageTool( server: McpServer ): void {
 	server.registerTool(
 		'page',
 		{
-			description: `Manage page and document operations including undo/redo, saving, page settings, and page information. Use this tool when you need to: 
-		- Undo or redo changes (history-undo, history-redo, history-undo-all) - Use these when user asks to undo, revert, or redo recent changes
-		- Save page changes (save-draft, save-publish, save-update, save-discard)
-		- Get or update page settings like page title, description, keywords, styling (get-settings, update-settings)
-		- Open or preview pages (open, preview)
-		This tool handles document-level operations and change history.`,
+			description: `Manage page and document operations: history, save, settings, and open/preview.`,
 			inputSchema: {
 				action: z
 					.enum( [
@@ -46,7 +42,11 @@ export function addPageTool( server: McpServer ): void {
 				title: 'Manage Page',
 			},
 			_meta: {
-				'angie:required-resources': [
+				'angie/requiredResources': [
+					{
+						uri: V3_DESCRIPTION_URI,
+						whenToUse: 'Read to understand Elementor capabilities and limitations before using this tool.',
+					},
 					{
 						uri: RESOURCE_URI_PAGE_SETTINGS,
 						whenToUse:

--- a/packages/packages/core/elementor-v3-mcp/src/tools/routes-tool.ts
+++ b/packages/packages/core/elementor-v3-mcp/src/tools/routes-tool.ts
@@ -1,6 +1,7 @@
 import { z } from '@elementor/schema';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
+import { V3_DESCRIPTION_URI } from '../mcp-description-resource';
 import type { McpToolResult, ToolParams } from '../types';
 import { get$e } from '../utils';
 
@@ -40,6 +41,14 @@ export function addRoutesTool( server: McpServer ): void {
 			},
 			annotations: {
 				title: 'Manage Routes',
+			},
+			_meta: {
+				'angie/requiredResources': [
+					{
+						uri: V3_DESCRIPTION_URI,
+						whenToUse: 'Read to understand Elementor capabilities and limitations before using this tool.',
+					},
+				],
 			},
 		},
 		async ( params: ToolParams ) => {

--- a/packages/packages/core/elementor-v3-mcp/src/tools/styling-tool.ts
+++ b/packages/packages/core/elementor-v3-mcp/src/tools/styling-tool.ts
@@ -2,6 +2,7 @@ import { z } from '@elementor/schema';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { SamplingMessageSchema } from '@modelcontextprotocol/sdk/types.js';
 
+import { V3_DESCRIPTION_URI } from '../mcp-description-resource';
 import type { McpToolResult } from '../types';
 import { getElementor } from '../utils';
 
@@ -9,28 +10,10 @@ export function addStylingTool( server: McpServer ): void {
 	server.registerTool(
 		'styling',
 		{
-			description: `This tool provides AI-powered custom CSS styling for Elementor elements. Use this when users want advanced styling that goes beyond Elementor capabilities and can't be targeted using the element settings.
-
-**When to use this tool:**
-- Visual effects: shadows, filters, pseudo-elements, advanced selectors
-- Complex animations with custom keyframes or CSS transitions
-- Styling that requires media queries or complex CSS rules
-- Click-triggered effects or other non-motion triggers
-- Custom hover effects that don't involve motion (color changes, opacity, etc.)
-
-**When NOT to use this tool:**
-- Basic styling achievable through Elementor settings (colors, typography, spacing, borders, simple hover effects) -> use the elementor__elements with "update-settings" action.
-
-**Do NOT use this tool if the user mentions motion effects with supported triggers:**
-- "on hover" with motion (movement, rotation, scaling) → use motion-effects tool
-- "on scroll" with motion effects → use motion-effects tool  
-- "mouse move" / "follow mouse" → use motion-effects tool
-- "entrance" / "fade in" / "slide in" animations → use motion-effects tool
-
-**Actions available:**
-- **custom-css**: Generate and apply AI-powered custom CSS to elements
-
-This tool generates CSS code using AI, provides preview functionality, and handles user approval workflow for applying custom styles.`,
+			description: `Apply custom CSS to legacy/V3 elements.
+- Do NOT use for V4 elements — V4 has its own MCP and tools.
+- Do NOT use for animations or motion — use the interactions tools.
+- Do NOT use for basic styling — V3 elements support basic styling via the V3 settings tool.`,
 			inputSchema: {
 				action: z
 					.enum( [ 'custom-css' ] )
@@ -50,6 +33,14 @@ This tool generates CSS code using AI, provides preview functionality, and handl
 			},
 			annotations: {
 				title: 'Apply Custom Styling',
+			},
+			_meta: {
+				'angie/requiredResources': [
+					{
+						uri: V3_DESCRIPTION_URI,
+						whenToUse: 'Read to understand Elementor capabilities and limitations before using this tool.',
+					},
+				],
 			},
 		},
 		async ( params ) => {

--- a/packages/packages/core/elementor-v3-mcp/src/tools/ui-tool.ts
+++ b/packages/packages/core/elementor-v3-mcp/src/tools/ui-tool.ts
@@ -1,6 +1,7 @@
 import { z } from '@elementor/schema';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
+import { V3_DESCRIPTION_URI } from '../mcp-description-resource';
 import type { McpToolResult, ToolParams } from '../types';
 import { get$e, getElementor } from '../utils';
 
@@ -35,6 +36,14 @@ export function addUiTool( server: McpServer ): void {
 			},
 			annotations: {
 				title: 'Manage UI',
+			},
+			_meta: {
+				'angie/requiredResources': [
+					{
+						uri: V3_DESCRIPTION_URI,
+						whenToUse: 'Read to understand Elementor capabilities and limitations before using this tool.',
+					},
+				],
 			},
 		},
 		async ( params: ToolParams ) => {

--- a/packages/packages/libs/editor-mcp/src/index.ts
+++ b/packages/packages/libs/editor-mcp/src/index.ts
@@ -13,7 +13,7 @@ export { isAngieSidebarOpen } from './utils/is-angie-sidebar-open';
 export * from './mcp-registry';
 export { createSampler } from './sampler';
 export { toolPrompts } from './utils/prompt-builder';
-export { ANGIE_MODEL_PREFERENCES, type AngieModelPreferences } from './angie-annotations';
+export { ANGIE_MODEL_PREFERENCES, ANGIE_REQUIRED_RESOURCES, type AngieModelPreferences } from './angie-annotations';
 export { getActiveChatInfo, type ActiveChatInfo } from './utils/get-active-chat-info';
 export { sendPromptToAngie } from './utils/send-prompt-to-angie';
 export { redirectToInstallation } from './utils/redirect-to-installation';

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -1,7 +1,6 @@
 import { z, type z3 } from '@elementor/schema';
 import { McpServer, type ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { type RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
-import { UriTemplate } from '@modelcontextprotocol/sdk/shared/uriTemplate.js';
 import { type ServerNotification, type ServerRequest } from '@modelcontextprotocol/sdk/types.js';
 
 import { type IMcpRegistrationAdapter, type McpResourceHandler, type McpResourceUriOrTemplate } from './adapters/types';
@@ -12,6 +11,8 @@ import {
 	createDefaultModelPreferences,
 } from './angie-annotations';
 import { mockMcpRegistry } from './test-utils/mock-mcp-registry';
+import { mergeRequiredResources, type ResourceList } from './utils/merge-required-resources';
+import { registerServerDocsResource } from './utils/register-server-docs-resource';
 
 type ZodRawShape = z3.ZodRawShape;
 
@@ -84,12 +85,17 @@ export const toMCPTitle = ( namespace: string ): string => {
 };
 
 /**
- *
  * @param namespace            The namespace of the MCP server. It should contain only lowercase alphabetic characters.
  * @param options
- * @param options.instructions
+ * @param options.instructions Short hint about the MCP and its toolset (MCP SDK `instructions`; keeps payload small).
+ * @param options.docs         Full documentation registered as a lazy-loaded resource.
+ *                             When provided, it is registered at elementor://{namespace}/server-docs
+ *                             and auto-injected into every tool's requiredResources.
  */
-export const getMCPByDomain = ( namespace: string, options?: { instructions?: string } ): MCPRegistryEntry => {
+export const getMCPByDomain = (
+	namespace: string,
+	options?: { docs?: string; instructions?: string }
+): MCPRegistryEntry => {
 	const mcpName = `editor-${ isAlphabet( namespace ) }`;
 	const title = toMCPTitle( namespace );
 	// @ts-ignore - QUnit fails this
@@ -98,26 +104,19 @@ export const getMCPByDomain = ( namespace: string, options?: { instructions?: st
 	}
 	if ( ! mcpRegistry[ namespace ] ) {
 		mcpRegistry[ namespace ] = new McpServer(
-			{
-				name: mcpName,
-				title,
-				version: '1.0.0',
-			},
-			{
-				instructions: options?.instructions,
-				capabilities: { resources: { subscribe: true } },
-			}
+			{ name: mcpName, title, version: '1.0.0' },
+			{ instructions: options?.instructions, capabilities: { resources: { subscribe: true } } }
 		);
-		if ( !! options?.instructions ) {
-			callAdapters( ( adapter ) =>
-				adapter.onResourceRegistered( `${ mcpName }`, { uriTemplate: new UriTemplate( mcpName ) }, () =>
-					Promise.resolve( { contents: [ { text: options.instructions ?? '' } ] } )
-				)
-			);
+		if ( options?.docs ) {
+			registerServerDocsResource( mcpRegistry[ namespace ], namespace, title, options.docs, ( ...args ) => {
+				bufferedResources.push( args );
+				callAdapters( ( adapter ) => adapter.onResourceRegistered( ...args ) );
+			} );
 		}
 	}
 	const mcpServer = mcpRegistry[ namespace ];
-	const { addTool } = createToolRegistry( mcpServer, mcpName );
+	const serverDocsUri = options?.docs ? `elementor://${ namespace }/server-docs` : undefined;
+	const { addTool } = createToolRegistry( mcpServer, mcpName, serverDocsUri );
 	return {
 		waitForReady: () => readyPromise,
 		// @ts-expect-error: TS is unable to infer the type here
@@ -162,11 +161,6 @@ export interface MCPRegistryEntry {
 	waitForReady: () => Promise< void >;
 }
 
-type ResourceList = {
-	uri: string;
-	description: string;
-}[];
-
 type ToolRegistrationOptions<
 	InputArgs extends undefined | z.ZodRawShape = undefined,
 	OutputSchema extends undefined | z.ZodRawShape = undefined,
@@ -194,7 +188,7 @@ type ToolRegistrationOptions<
 	modelPreferences?: AngieModelPreferences;
 };
 
-function createToolRegistry( server: McpServer, serverName: string ) {
+function createToolRegistry( server: McpServer, serverName: string, serverDocsUri?: string ) {
 	function addTool<
 		T extends undefined | z.ZodRawShape = undefined,
 		O extends undefined | z.ZodRawShape = undefined,
@@ -245,9 +239,10 @@ function createToolRegistry( server: McpServer, serverName: string ) {
 			readOnlyHint: opts.isDestructive ? false : undefined,
 			title: opts.name,
 		};
+		const mergedResources = mergeRequiredResources( opts.requiredResources, serverDocsUri );
 		const angieAnnotations = {
 			[ ANGIE_MODEL_PREFERENCES ]: opts.modelPreferences ?? createDefaultModelPreferences(),
-			[ ANGIE_REQUIRED_RESOURCES ]: opts.requiredResources ?? undefined,
+			[ ANGIE_REQUIRED_RESOURCES ]: mergedResources,
 		};
 		server.registerTool(
 			opts.name,
@@ -277,7 +272,7 @@ function createToolRegistry( server: McpServer, serverName: string ) {
 		};
 		const extraData = {
 			resources: [ `Server resource name: ${ serverName }, Required to fetch!` ],
-			requiredResources: opts.requiredResources?.map( ( resource ) => resource.uri ) ?? [],
+			requiredResources: mergedResources?.map( ( resource ) => resource.uri ) ?? [],
 		};
 		bufferedTools.push( [ toolDescriptor, extraData ] );
 		callAdapters( ( adapter ) => adapter.onToolRegistered( toolDescriptor, extraData ) );

--- a/packages/packages/libs/editor-mcp/src/utils/create-simple-resource-handler.ts
+++ b/packages/packages/libs/editor-mcp/src/utils/create-simple-resource-handler.ts
@@ -1,0 +1,3 @@
+export const createSimpleResourceHandler = ( text: string ) => async ( uri: URL ) => ( {
+	contents: [ { uri: uri.href, mimeType: 'text/plain', text } ],
+} );

--- a/packages/packages/libs/editor-mcp/src/utils/merge-required-resources.ts
+++ b/packages/packages/libs/editor-mcp/src/utils/merge-required-resources.ts
@@ -1,0 +1,17 @@
+export type ResourceList = {
+	uri: string;
+	description: string;
+}[];
+
+export const mergeRequiredResources = (
+	toolResources: ResourceList | undefined,
+	serverDocsUri: string | undefined
+): ResourceList | undefined => {
+	if ( ! serverDocsUri ) {
+		return toolResources;
+	}
+	if ( toolResources?.some( ( r ) => r.uri === serverDocsUri ) ) {
+		return toolResources;
+	}
+	return [ ...( toolResources ?? [] ), { uri: serverDocsUri, description: 'Server docs' } ];
+};

--- a/packages/packages/libs/editor-mcp/src/utils/prompt-builder.ts
+++ b/packages/packages/libs/editor-mcp/src/utils/prompt-builder.ts
@@ -44,15 +44,9 @@ class ToolPrompts {
 		return `# ${ this.name }
 # Description
 ${ this._description }
-
-${ this._parameters.length ? '# Parameters' : '' }
-${ Object.values( this._parameters ).join( '\n\n' ) }
-
-${ this._examples.length ? '# Examples' : '' }
-${ this.examples }
-
-${ this._furtherInstructions.length ? '# Further Instructions' : '' }
-${ this._furtherInstructions.join( '\n\n' ) }
+${ this._parameters.length ? '# Parameters\n' + Object.values( this._parameters ).join( '\n\n' ) : '' }
+${ this._examples.length ? '# Examples\n' + this.examples : '' }
+${ this._furtherInstructions.length ? '# Further Instructions\n' + this._furtherInstructions.join( '\n\n' ) : '' }
 `.trim();
 	}
 }

--- a/packages/packages/libs/editor-mcp/src/utils/register-server-docs-resource.ts
+++ b/packages/packages/libs/editor-mcp/src/utils/register-server-docs-resource.ts
@@ -1,0 +1,29 @@
+import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { type IMcpRegistrationAdapter } from '../adapters/types';
+import { createSimpleResourceHandler } from './create-simple-resource-handler';
+
+type OnResourceRegistered = ( ...args: Parameters< IMcpRegistrationAdapter[ 'onResourceRegistered' ] > ) => void;
+
+export const registerServerDocsResource = (
+	server: McpServer,
+	namespace: string,
+	title: string,
+	docs: string,
+	onRegistered: OnResourceRegistered
+): void => {
+	const uri = `elementor://${ namespace }/server-docs`;
+	const name = `${ namespace }-server-docs`;
+	const handler = createSimpleResourceHandler( docs );
+	server.registerResource(
+		name,
+		uri,
+		{
+			title: `${ title } server docs`,
+			description: 'Full MCP documentation (lazy-loaded)',
+			mimeType: 'text/plain',
+		},
+		handler
+	);
+	onRegistered( name, uri, handler );
+};

--- a/packages/tests/setup.ts
+++ b/packages/tests/setup.ts
@@ -11,7 +11,12 @@ import { __deleteStore } from '@elementor/store';
 import { TextEncoder, TextDecoder } from 'util';
 
 jest.mock( '@elementor/http-client' );
-jest.mock( '@elementor/editor-mcp', () => ( {} ) );
+jest.mock( '@elementor/editor-mcp', () => {
+	const { toolPrompts } = jest.requireActual< typeof import( '@elementor/editor-mcp' ) >(
+		'@elementor/editor-mcp'
+	);
+	return { toolPrompts };
+} );
 globalThis.structuredClone = ( value ) => JSON.parse( JSON.stringify( value ) );
 globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
 globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;


### PR DESCRIPTION
…ources [Ed 23921] (#35692)

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements: **Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no
spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

---------

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Extracted inline AI integration descriptions/prompts into dedicated lazy-loaded resources to reduce MCP server payload size and enable dynamic updates without server re-registration. Improves scalability for complex documentation strings.

## 2. What Changed (Where)

| Module | Change |
|--------|--------|
| elementor-capabilities-mcp | Extracted server instructions to `mcp-description-resource.ts`; added resource reference to tool metadata |
| editor-canvas | Moved MCP description from `initCanvasMcp()` call to `getMCPByDomain()` `docs` parameter; created `build-compositions-guide` and `configure-element-guide` resources |
| editor-global-classes | Extracted tool descriptions to `apply-global-class-guide-prompt.ts`; moved descriptions from `initMcpIntegration()` to `getMCPByDomain()` `docs` |
| editor-interactions, editor-variables | Moved description strings from `setMCPDescription()` to `getMCPByDomain()` `docs` parameter |
| elementor-kit-mcp, elementor-v3-mcp | Created `mcp-description-resource.ts`; registered as lazy resource; simplified server initialization |
| editor-mcp lib | Enhanced `getMCPByDomain()` to accept `docs` option; auto-registers `elementor://{namespace}/server-docs` resource; added `mergeRequiredResources()` to inject server-docs into all tool requiredResources |
| Test mocks | Updated to preserve `toolPrompts` export; removed stubs that broke import chains |

## 3. How It Works

`getMCPByDomain(namespace, { instructions, docs })` now creates a resource handler via `registerServerDocsResource()` that serves docs at `elementor://{namespace}/server-docs`. `createToolRegistry()` receives `serverDocsUri` and `mergeRequiredResources()` auto-injects it into every tool's `requiredResources` (avoiding duplicates). Descriptions moved from inline strings to `ToolPrompts` builder chain (`.description()`, `.parameter()`, `.instruction()`, `.example()`, `.prompt()`), enabling structured formatting without bloating tool definitions.

## 4. Risks

**Import exposure**: Added `ANGIE_REQUIRED_RESOURCES` to export index; verify downstream consumers don't misuse. **Resource URI collisions**: No validation that custom `docs` URIs don't collide with tool-registered ones; unlikely but possible if tool defines `elementor://{ns}/server-docs`. **Mock brittleness**: Test setup now mocks `toolPrompts` selectively; future `toolPrompts` enhancements need mock updates.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
