### PR TITLE
Fix: Clear CSS cache after importing global variables [ED-24047]

### DIFF
--- a/modules/variables/import-export-customization/runners/import.php
+++ b/modules/variables/import-export-customization/runners/import.php
@@ -211,6 +211,8 @@ class Import extends Import_Runner_Base {
 		if ( false === $result ) {
 			throw new \RuntimeException( 'Failed to save global variables during import.' );
 		}
+
+		Plugin::$instance->files_manager->clear_cache();
 	}
 
 	private function format_variable_as_entry( Variable $variable ): array {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Global variables imported via the import mechanism weren't applying style changes until manual cache clear (ED-24047). CSS cache must be invalidated after saving variables to reflect updates immediately.

## 2. What Changed (Where)

`modules/variables/import-export-customization/runners/import.php` — Added `Plugin::$instance->files_manager->clear_cache()` call in `save_collection()` method post-save.

## 3. How It Works

After `$repository->save()` succeeds, cache invalidation triggers CSS recompilation with new variable values before import completes.

## 4. Risks

None — cache clearing is idempotent and follows existing patterns in the codebase for variable persistence.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
