### PR TITLE
Internal: UI fixes [ED-23855]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/__tests__/display-flex.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/__tests__/display-flex.test.tsx
@@ -127,13 +127,16 @@ describe( '<DisplayField />', () => {
 			expect( screen.getByRole( 'button', { name: label } ) ).toHaveAttribute( 'aria-pressed', 'false' );
 		} );
 
-		const overflowMenuButton = screen
+		const overflowMenuButtons = screen
 			.getAllByRole( 'button' )
-			.find( ( btn ) => btn.getAttribute( 'aria-haspopup' ) === 'menu' );
-		expect( overflowMenuButton ).toBeDefined();
-		fireEvent.click( overflowMenuButton! );
+			.filter( ( btn ) => btn.getAttribute( 'aria-haspopup' ) === 'menu' );
+		expect( overflowMenuButtons ).toHaveLength( 1 );
+		fireEvent.click( overflowMenuButtons[ 0 ] );
 
-		expect( screen.getByRole( 'menuitem', { name: 'Inline-flex' } ) ).not.toHaveAttribute( 'aria-selected', 'true' );
+		expect( screen.getByRole( 'menuitem', { name: 'Inline-flex' } ) ).not.toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
 	} );
 } );
 

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/__tests__/display-flex.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/__tests__/display-flex.test.tsx
@@ -122,7 +122,7 @@ describe( '<DisplayField />', () => {
 		// Act.
 		renderDisplayField();
 
-		// Assert — toolbar toggles (includes `None`); overflow holds `Inline-flex` when grid experiment is off.
+		// Assert.
 		[ 'Block', 'Flex', 'None', 'Inline-block' ].forEach( ( label ) => {
 			expect( screen.getByRole( 'button', { name: label } ) ).toHaveAttribute( 'aria-pressed', 'false' );
 		} );

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/__tests__/display-flex.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/__tests__/display-flex.test.tsx
@@ -13,7 +13,7 @@ import { getStylesSchema, type StyleDefinition } from '@elementor/editor-styles'
 import { stylesRepository } from '@elementor/editor-styles-repository';
 import { ThemeProvider } from '@elementor/editor-ui';
 import { isExperimentActive } from '@elementor/editor-v1-adapters';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { mockElement } from '../../../../__tests__/utils';
 import { ClassesPropProvider } from '../../../../contexts/classes-prop-context';
@@ -122,10 +122,18 @@ describe( '<DisplayField />', () => {
 		// Act.
 		renderDisplayField();
 
-		// Assert.
-		[ 'Block', 'Flex', 'Inline-block', 'Inline-flex' ].forEach( ( label ) => {
+		// Assert — toolbar toggles (includes `None`); overflow holds `Inline-flex` when grid experiment is off.
+		[ 'Block', 'Flex', 'None', 'Inline-block' ].forEach( ( label ) => {
 			expect( screen.getByRole( 'button', { name: label } ) ).toHaveAttribute( 'aria-pressed', 'false' );
 		} );
+
+		const overflowMenuButton = screen
+			.getAllByRole( 'button' )
+			.find( ( btn ) => btn.getAttribute( 'aria-haspopup' ) === 'menu' );
+		expect( overflowMenuButton ).toBeDefined();
+		fireEvent.click( overflowMenuButton! );
+
+		expect( screen.getByRole( 'menuitem', { name: 'Inline-flex' } ) ).not.toHaveAttribute( 'aria-selected', 'true' );
 	} );
 } );
 

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/display-field.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/display-field.tsx
@@ -8,7 +8,13 @@ import { useStylesInheritanceChain } from '../../../contexts/styles-inheritance-
 import { StylesField } from '../../../controls-registry/styles-field';
 import { StylesFieldLayout } from '../../styles-field-layout';
 
-type Displays = 'block' | 'flex' | 'grid' | 'inline-block' | 'inline-flex' | 'none';
+type Displays =
+	| 'block'
+	| 'flex'
+	| 'grid'
+	| 'inline-block'
+	| 'inline-flex'
+	| 'none';
 
 const DISPLAY_LABEL = __( 'Display', 'elementor' );
 
@@ -32,6 +38,12 @@ const displayFieldItems: ToggleButtonGroupItem< Displays >[] = [
 		showTooltip: true,
 	},
 	{
+		value: 'none',
+		renderContent: () => __( 'None', 'elementor' ),
+		label: __( 'None', 'elementor' ),
+		showTooltip: true,
+	},
+	{
 		value: 'inline-block',
 		renderContent: () => __( 'In-blk', 'elementor' ),
 		label: __( 'Inline-block', 'elementor' ),
@@ -41,12 +53,6 @@ const displayFieldItems: ToggleButtonGroupItem< Displays >[] = [
 		value: 'inline-flex',
 		renderContent: () => __( 'In-flx', 'elementor' ),
 		label: __( 'Inline-flex', 'elementor' ),
-		showTooltip: true,
-	},
-	{
-		value: 'none',
-		renderContent: () => __( 'None', 'elementor' ),
-		label: __( 'None', 'elementor' ),
 		showTooltip: true,
 	},
 ];

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/display-field.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/display-field.tsx
@@ -8,13 +8,7 @@ import { useStylesInheritanceChain } from '../../../contexts/styles-inheritance-
 import { StylesField } from '../../../controls-registry/styles-field';
 import { StylesFieldLayout } from '../../styles-field-layout';
 
-type Displays =
-	| 'block'
-	| 'flex'
-	| 'grid'
-	| 'inline-block'
-	| 'inline-flex'
-	| 'none';
+type Displays = 'block' | 'flex' | 'grid' | 'inline-block' | 'inline-flex' | 'none';
 
 const DISPLAY_LABEL = __( 'Display', 'elementor' );
 

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/grid-auto-flow-field.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/grid-auto-flow-field.tsx
@@ -76,7 +76,7 @@ const GridAutoFlowFieldContent = () => {
 					/>
 				</Grid>
 				<Grid item>
-					<Tooltip title={ DENSE_LABEL }>
+					<Tooltip title={ DENSE_LABEL } placement="top">
 						<ToggleButton
 							value="dense"
 							selected={ dense }

--- a/packages/packages/libs/editor-controls/src/__tests__/control-toggle-button-group.test.tsx
+++ b/packages/packages/libs/editor-controls/src/__tests__/control-toggle-button-group.test.tsx
@@ -244,12 +244,18 @@ describe( 'ControlToggleButtonGroup', () => {
 		expect( getCurrentSplitButton() ).toHaveTextContent( mockSplitItems[ Math.max( 0, initIndexInSplit ) ].label );
 
 		// Act.
+		const previewSplitValue = mockSplitItems[ Math.max( 0, initIndexInSplit ) ].value;
+
 		if ( targetIndexInSplit !== -1 ) {
-			fireEvent.click( getSplitTriggerButton() );
+			if ( targetValue === previewSplitValue ) {
+				fireEvent.click( getCurrentSplitButton() );
+			} else {
+				fireEvent.click( getSplitTriggerButton() );
 
-			const splitItem = getItem( mockSplitItems[ targetIndexInSplit ].label );
+				const splitItem = getItem( mockSplitItems[ targetIndexInSplit ].label );
 
-			fireEvent.click( splitItem );
+				fireEvent.click( splitItem );
+			}
 		} else {
 			const targetItem = mockBaseItems.find(
 				( { value } ) => value === targetValue
@@ -261,6 +267,29 @@ describe( 'ControlToggleButtonGroup', () => {
 		// Assert.
 		expect( onChange ).toHaveBeenCalledWith( initValue === targetValue ? null : targetValue );
 		expect( getCurrentSplitButton() ).toHaveTextContent( expectedSplitItem.label );
+	} );
+
+	it( 'should exclude the currently previewed split item from the dropdown', () => {
+		// Arrange.
+		const onChange = jest.fn();
+
+		// Act.
+		renderControlToggleButtonGroup(
+			<ControlToggleButtonGroup
+				value={ 6 }
+				items={ [ ...mockBaseItems, ...mockSplitItems ] }
+				maxItems={ 5 }
+				onChange={ onChange }
+				exclusive
+			/>
+		);
+
+		fireEvent.click( getSplitTriggerButton() );
+
+		// Assert.
+		const menu = screen.getByRole( 'menu' );
+		expect( within( menu ).queryByText( 'Six' ) ).not.toBeInTheDocument();
+		expect( within( menu ).getByText( 'Five' ) ).toBeInTheDocument();
 	} );
 } );
 

--- a/packages/packages/libs/editor-controls/src/components/control-toggle-button-group.tsx
+++ b/packages/packages/libs/editor-controls/src/components/control-toggle-button-group.tsx
@@ -303,17 +303,19 @@ const SplitButtonGroup = < TValue, >( {
 					mt: 0.5,
 				} }
 			>
-				{ items.map( ( { label, value: buttonValue } ) => (
-					<MenuItem
-						key={ buttonValue }
-						selected={ buttonValue === value }
-						onClick={ () => onMenuItemClick( buttonValue ) }
-					>
-						<ListItemText>
-							<Typography sx={ { fontSize: '14px' } }>{ label }</Typography>
-						</ListItemText>
-					</MenuItem>
-				) ) }
+				{ items
+					.filter( ( item ) => item.value !== previewButton.value )
+					.map( ( { label, value: buttonValue } ) => (
+						<MenuItem
+							key={ buttonValue }
+							selected={ buttonValue === value }
+							onClick={ () => onMenuItemClick( buttonValue ) }
+						>
+							<ListItemText>
+								<Typography sx={ { fontSize: '14px' } }>{ label }</Typography>
+							</ListItemText>
+						</MenuItem>
+					) ) }
 			</Menu>
 		</>
 	);


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

UI refinements for display/layout controls: reorder "None" display option, add tooltip to dense toggle, exclude currently-selected split items from dropdown menu, and improve test coverage.

## 2. What Changed (Where)

- **display-field.tsx**: Moved "None" display option from end to after "Grid" in toggle button group
- **grid-auto-flow-field.tsx**: Added `placement="top"` prop to Tooltip wrapping dense toggle button
- **control-toggle-button-group.tsx**: Filter out preview button value from split menu items
- **display-flex.test.tsx**: Added `fireEvent` import; updated test to verify "None" visibility and "Inline-flex" in overflow menu
- **control-toggle-button-group.test.tsx**: Refactored split button test logic with conditional branching; added test verifying currently-previewed item excluded from dropdown

## 3. How It Works

Split button menu now filters items using `.filter((item) => item.value !== previewButton.value)` before rendering—prevents duplicate display of the currently-shown split item in the dropdown. Test updates validate this filtering and verify correct interaction paths when target equals preview value.

## 4. Risks

Low. Changes are isolated UI fixes with corresponding test coverage. Filter addition has clear intent (no functional side effects). Only risk: tooltip placement default differs from new explicit "top" setting—verify design intent across breakpoints if needed.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
