### PR TITLE
Fix: Run autosave before design system import to prevent data loss of unsaved classes [ED-24072]

### DIFF
--- a/packages/packages/core/editor-design-system/src/import/__tests__/import-design-system-dialog.test.tsx
+++ b/packages/packages/core/editor-design-system/src/import/__tests__/import-design-system-dialog.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { renderWithTheme } from 'test-utils';
 import { GLOBAL_STYLES_IMPORTED_EVENT } from '@elementor/editor-canvas';
 import { useCurrentUserCapabilities } from '@elementor/editor-current-user';
-import { reloadCurrentDocument } from '@elementor/editor-documents';
 import { dismissNotification, notify } from '@elementor/editor-notifications';
 import { closeDialog, openDialog } from '@elementor/editor-ui';
 import { httpService } from '@elementor/http-client';
@@ -14,6 +13,7 @@ import { downloadBlob } from '../../export/download';
 import { IMPORT_DESIGN_SYSTEM_MUTATION_KEY } from '../hooks/use-import-request';
 import { ImportDesignSystemDialog } from '../import-design-system-dialog';
 import { trackDesignSystem } from '../tracking';
+import { __privateRunCommand } from '@elementor/editor-v1-adapters';
 
 jest.mock( '@elementor/http-client', () => ( {
 	httpService: jest.fn(),
@@ -24,9 +24,9 @@ jest.mock( '@elementor/editor-notifications', () => ( {
 	notify: jest.fn(),
 } ) );
 
-jest.mock( '@elementor/editor-documents', () => ( {
-	...jest.requireActual( '@elementor/editor-documents' ),
-	reloadCurrentDocument: jest.fn().mockResolvedValue( undefined ),
+jest.mock( '@elementor/editor-v1-adapters', () => ( {
+	...jest.requireActual( '@elementor/editor-v1-adapters' ),
+	__privateRunCommand: jest.fn(),
 } ) );
 
 jest.mock( '@elementor/editor-ui', () => ( {
@@ -123,13 +123,15 @@ describe( '<ImportDesignSystemDialog />', () => {
 		await waitFor( () => expect( importButton ).toBeEnabled() );
 	} );
 
-	it( 'fires the in-progress notification, calls onClose and triggers the upload→import→runner flow', async () => {
+	it( 'runs auto save, fires the in-progress notification, calls onClose and triggers the upload→import→runner flow', async () => {
 		const { post } = setupHttpServiceMock();
 		const onClose = jest.fn();
 
 		renderWithQuery( <ImportDesignSystemDialog onClose={ onClose } /> );
 
 		const file = submitImport();
+
+		await waitFor( () => expect( __privateRunCommand ).toHaveBeenCalledWith( 'document/save/auto', { force: true } ) );
 
 		const inProgressCall = ( notify as jest.Mock ).mock.calls.find(
 			( [ payload ] ) => payload.id === 'design-system-import-started'
@@ -185,7 +187,6 @@ describe( '<ImportDesignSystemDialog />', () => {
 
 		expect( dismissNotification ).toHaveBeenCalledWith( 'design-system-import-started' );
 		expect( eventListener ).toHaveBeenCalledTimes( 1 );
-		expect( reloadCurrentDocument ).toHaveBeenCalledTimes( 1 );
 
 		await waitFor( () => expect( isImporting() ).toBe( false ) );
 
@@ -200,6 +201,8 @@ describe( '<ImportDesignSystemDialog />', () => {
 
 		submitImport();
 
+		await waitFor( () => expect( __privateRunCommand ).toHaveBeenCalledWith( 'document/save/auto', { force: true } ) );
+
 		const errorCall = await waitFor(
 			() => {
 				const call = ( notify as jest.Mock ).mock.calls.find(
@@ -212,7 +215,6 @@ describe( '<ImportDesignSystemDialog />', () => {
 		);
 
 		expect( dismissNotification ).toHaveBeenCalledWith( 'design-system-import-started' );
-		expect( reloadCurrentDocument ).not.toHaveBeenCalled();
 
 		await waitFor( () => expect( isImporting() ).toBe( false ) );
 

--- a/packages/packages/core/editor-design-system/src/import/__tests__/import-design-system-dialog.test.tsx
+++ b/packages/packages/core/editor-design-system/src/import/__tests__/import-design-system-dialog.test.tsx
@@ -4,6 +4,7 @@ import { GLOBAL_STYLES_IMPORTED_EVENT } from '@elementor/editor-canvas';
 import { useCurrentUserCapabilities } from '@elementor/editor-current-user';
 import { dismissNotification, notify } from '@elementor/editor-notifications';
 import { closeDialog, openDialog } from '@elementor/editor-ui';
+import { __privateRunCommand } from '@elementor/editor-v1-adapters';
 import { httpService } from '@elementor/http-client';
 import { type QueryClient, QueryClientProvider } from '@elementor/query';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
@@ -13,7 +14,6 @@ import { downloadBlob } from '../../export/download';
 import { IMPORT_DESIGN_SYSTEM_MUTATION_KEY } from '../hooks/use-import-request';
 import { ImportDesignSystemDialog } from '../import-design-system-dialog';
 import { trackDesignSystem } from '../tracking';
-import { __privateRunCommand } from '@elementor/editor-v1-adapters';
 
 jest.mock( '@elementor/http-client', () => ( {
 	httpService: jest.fn(),
@@ -131,7 +131,9 @@ describe( '<ImportDesignSystemDialog />', () => {
 
 		const file = submitImport();
 
-		await waitFor( () => expect( __privateRunCommand ).toHaveBeenCalledWith( 'document/save/auto', { force: true } ) );
+		await waitFor( () =>
+			expect( __privateRunCommand ).toHaveBeenCalledWith( 'document/save/auto', { force: true } )
+		);
 
 		const inProgressCall = ( notify as jest.Mock ).mock.calls.find(
 			( [ payload ] ) => payload.id === 'design-system-import-started'
@@ -201,7 +203,9 @@ describe( '<ImportDesignSystemDialog />', () => {
 
 		submitImport();
 
-		await waitFor( () => expect( __privateRunCommand ).toHaveBeenCalledWith( 'document/save/auto', { force: true } ) );
+		await waitFor( () =>
+			expect( __privateRunCommand ).toHaveBeenCalledWith( 'document/save/auto', { force: true } )
+		);
 
 		const errorCall = await waitFor(
 			() => {

--- a/packages/packages/core/editor-design-system/src/import/hooks/use-import-request.ts
+++ b/packages/packages/core/editor-design-system/src/import/hooks/use-import-request.ts
@@ -1,5 +1,5 @@
 import { GLOBAL_STYLES_IMPORTED_EVENT } from '@elementor/editor-canvas';
-import { reloadCurrentDocument } from '@elementor/editor-documents';
+import { __privateRunCommand as runCommand } from '@elementor/editor-v1-adapters';
 import { type HttpResponse, httpService } from '@elementor/http-client';
 import { useMutation } from '@elementor/query';
 
@@ -33,12 +33,12 @@ export const useImportRequest = () => {
 	return useMutation( {
 		mutationKey: [ IMPORT_DESIGN_SYSTEM_MUTATION_KEY ],
 		mutationFn: async ( { file, conflictStrategy }: ImportRequestArgs ): Promise< void > => {
+			await runCommand( 'document/save/auto', { force: true } );
+
 			const session = await uploadKit( file );
 			const runners = await startImport( session, conflictStrategy );
 
 			await runRunners( session, runners );
-
-			await reloadCurrentDocument();
 
 			window.dispatchEvent( new CustomEvent( GLOBAL_STYLES_IMPORTED_EVENT ) );
 		},


### PR DESCRIPTION
### Before
https://www.loom.com/share/92c5658592614a84939e937543efbc0c
### After
https://www.loom.com/share/e79131695c9341b4893572064f369d47

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Design system imports were discarding unsaved class changes because document reload happened without prior autosave. This PR adds autosave before import to prevent data loss (ED-24072).

## 2. What Changed (Where)

- `use-import-request.ts`: Replaced `reloadCurrentDocument()` call with `runCommand('document/save/auto', { force: true })` before import flow
- `import-design-system-dialog.test.tsx`: Updated mocks and test assertions to verify autosave executes before import, removed stale reload verification

## 3. How It Works

Import mutation now autosaves first (forcing save even if unchanged), then proceeds with upload→import→runners flow. Autosave executes synchronously before any import operations touch the document state, eliminating the race condition that caused data loss.

## 4. Risks

Command execution assumes `runCommand('document/save/auto')` is idempotent and won't trigger side effects. Verify autosave doesn't fire redundant notifications or conflict with concurrent user saves during large imports.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
