### PR TITLE
Internal: Fix release stable tag fetching process [ED-24088]

### DIFF
--- a/.github/workflows/update-readme-txt/action.yml
+++ b/.github/workflows/update-readme-txt/action.yml
@@ -21,15 +21,18 @@ runs:
               README_TXT_PATH=${{ inputs.README_TXT_PATH }}
               if [[ "${{ inputs.CHANNEL }}" == "cloud" || "${{ inputs.CHANNEL }}" == "beta" || "${{ inputs.CHANNEL }}" == "dev" ]]; then
 
-                # git ls-remote --tags: This command lists all the tags in the remote repository along with their corresponding commit hash.
-                # grep -v "\-rc" | grep -v "\-cloud" | grep -v "\-dev" | grep -v "\-beta": This series of commands excludes tags that contain the specified substrings "-rc", "-cloud", "-dev", and "-beta".
-                # awk '{print $2}': This command prints the second field (i.e., the tag name) from the output of the previous command.
-                # grep -E 'v[0-9]+\.[0-9]+\.[0-9]+$': This command uses a regular expression to match tags that follow the semantic versioning pattern "vX.Y.Z", where X, Y, and Z are numbers.
-                # sort -V: This command sorts the matched tags in ascending order based on their version numbers.
-                # tail -n 1: This command selects the last (i.e., the highest) version number among the matched tags.
-                # sed 's/^refs\/tags\/v//': This command removes the leading "refs/tags/v" prefix from the selected tag name.
+                # Source of truth for the last published GA release: WordPress.org plugin directory.
+                # Using git tags here is unsafe — a stray/experimental tag in the repo would silently
+                # become the Stable tag in readme.txt. The WP.org API reflects what is actually live.
+                api_response=$(curl -sS --fail --max-time 15 "https://api.wordpress.org/plugins/info/1.0/elementor.json") \
+                  || { echo "Failed to fetch plugin info from WordPress.org"; exit 1; }
 
-                latest_tag=$(git ls-remote --tags | awk '{print $2}' | sed 's/^refs\/tags\/v//' | sed 's/^refs\/tags\///' | sort -V | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
+                latest_tag=$(echo "$api_response" | jq -r '.version // empty')
+
+                if [[ ! "$latest_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "WordPress.org returned an unexpected version: '${latest_tag}'"
+                  exit 1
+                fi
 
               elif [[ "${{ inputs.CHANNEL }}" == "ga" ]]; then
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Git tag-based stable version detection is unsafe—stray/experimental tags silently corrupt the stable version. Switching to WordPress.org plugin API uses the source-of-truth for published releases.

## 2. What Changed (Where)

`.github/workflows/update-readme-txt/action.yml`: Replaced git tag parsing with WP.org API call for non-GA channels (cloud/beta/dev).

## 3. How It Works

Fetches plugin metadata from `api.wordpress.org/plugins/info/1.0/elementor.json`, extracts `.version` field, validates semantic versioning format (X.Y.Z), exits if malformed or API fails (15s timeout).

## 4. Risks

API dependency/latency added; WP.org outage blocks CI. Mitigated by 15s timeout and explicit error handling. JSON parsing requires `jq` availability (standard in GH Actions).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
