### PR TITLE
Feature: Add Learn more link to Import Design System dialog [ED-24022]

### DIFF
--- a/packages/packages/core/editor-design-system/src/import/__tests__/import-design-system-dialog.test.tsx
+++ b/packages/packages/core/editor-design-system/src/import/__tests__/import-design-system-dialog.test.tsx
@@ -104,6 +104,16 @@ describe( '<ImportDesignSystemDialog />', () => {
 		sharedQueryClient.clear();
 	} );
 
+	it( 'renders a "Learn more" link to the design system imports docs', () => {
+		setupHttpServiceMock();
+
+		renderWithQuery( <ImportDesignSystemDialog onClose={ jest.fn() } /> );
+
+		const link = screen.getByRole( 'link', { name: 'Learn how design system imports work' } );
+		expect( link ).toHaveAttribute( 'href', 'https://go.elementor.com/wp-dash-import-export-design-system/' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+	} );
+
 	it( 'disables the import button until a file and conflict strategy are selected', async () => {
 		setupHttpServiceMock();
 

--- a/packages/packages/core/editor-design-system/src/import/import-design-system-dialog.tsx
+++ b/packages/packages/core/editor-design-system/src/import/import-design-system-dialog.tsx
@@ -90,7 +90,7 @@ export const ImportDesignSystemDialog = ( { onClose }: Props ) => {
 						/>
 					) }
 					<ConflictOptions value={ conflictStrategy } onChange={ handleConflictChange } />
-					<Stack direction="row" spacing={ 0.5 } alignItems="center" justifyContent="center">
+					<Stack direction="row" spacing={ 0.5 } alignItems="center" justifyContent="flex-start">
 						<HelpIcon sx={ { fontSize: 16, color: 'text.tertiary' } } />
 						<Link
 							href={ LEARN_MORE_URL }

--- a/packages/packages/core/editor-design-system/src/import/import-design-system-dialog.tsx
+++ b/packages/packages/core/editor-design-system/src/import/import-design-system-dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { closeDialog, FileUploadDropzone, FileUploadRow, openDialog } from '@elementor/editor-ui';
-import { Button, DialogActions, DialogContent, DialogHeader, DialogTitle, Stack } from '@elementor/ui';
+import { HelpIcon } from '@elementor/icons';
+import { Button, DialogActions, DialogContent, DialogHeader, DialogTitle, Link, Stack } from '@elementor/ui';
 import { __, sprintf } from '@wordpress/i18n';
 
 import { ConflictOptions } from './components/conflict-options';
@@ -14,6 +15,7 @@ const ALLOWED_FILE_TYPES: `${ string }/${ string }`[] = [ 'application/zip' ];
 const FILE_INPUT_ACCEPT = 'application/zip,.zip';
 // TODO: Replace with the actual server-enforced limit once finalized.
 const MAX_FILE_SIZE_MB = 3;
+const LEARN_MORE_URL = 'https://go.elementor.com/wp-dash-import-export-design-system/';
 
 type Props = {
 	onClose: () => void;
@@ -88,6 +90,19 @@ export const ImportDesignSystemDialog = ( { onClose }: Props ) => {
 						/>
 					) }
 					<ConflictOptions value={ conflictStrategy } onChange={ handleConflictChange } />
+					<Stack direction="row" spacing={ 0.5 } alignItems="center" justifyContent="center">
+						<HelpIcon sx={ { fontSize: 16, color: 'text.tertiary' } } />
+						<Link
+							href={ LEARN_MORE_URL }
+							target="_blank"
+							rel="noopener noreferrer"
+							underline="always"
+							variant="caption"
+							color="text.tertiary"
+						>
+							{ __( 'Learn how design system imports work', 'elementor' ) }
+						</Link>
+					</Stack>
 				</Stack>
 			</DialogContent>
 			<DialogActions>


### PR DESCRIPTION
## Summary

The Import Design System dialog had no in-product way to learn more about how imports work; this PR adds a help icon and a "Learn how design system imports work" link below the conflict-resolution options that opens the docs page in a new tab.

Closes [ED-24022](https://elementor.atlassian.net/browse/ED-24022).

## PR Type

- [x] Feature

## Description

- New centered row inside `<DialogContent>` of `ImportDesignSystemDialog`, rendered after `<ConflictOptions>`:
  - `HelpIcon` (16px, `text.tertiary`) + MUI `Link` (`variant="caption"`, `text.tertiary`, underlined) with `target="_blank"` and `rel="noopener noreferrer"`.
  - `href`: `https://go.elementor.com/wp-dash-import-export-design-system/` (extracted to a module-level `LEARN_MORE_URL` constant — no magic strings).
- No new files, no new abstractions, no changes to tracking/hooks/notifications — minimal diff matching the Figma node from the ticket.

### Decisions
- **No tracking event** for the link click (confirmed during planning) — keeps the change scoped and avoids touching the Mixpanel event schema.
- **Reused existing patterns** from the codebase (`Link` from `@elementor/ui` with `target="_blank"`, e.g. [`error-state.tsx`](packages/packages/core/editor-site-navigation/src/components/panel/posts-list/error-state.tsx)) instead of introducing a new component.
- **Used `HelpIcon` from `@elementor/icons`** because the Figma node's icon is named "Help" (question-mark in a circle), matching `HelpIcon` exactly.

## Test instructions

1. Open the Elementor v4 editor on any page.
2. Open the **Design System** panel and click **Import Design System**.
3. In the dialog, scroll to the bottom of the dialog content (above Cancel/Import).
4. Verify a centered row showing a small help icon and the underlined text **"Learn how design system imports work"**.
5. Click the link — a new tab opens at `https://go.elementor.com/wp-dash-import-export-design-system/`.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Added a unit test in `import-design-system-dialog.test.tsx` asserting the link is rendered with the correct `href` and `target="_blank"`. All 13 tests in the suite pass; ESLint passes for the changed files.

Fixes #

Made with [Cursor](https://cursor.com)

[ED-24022]: https://elementor.atlassian.net/browse/ED-24022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Users need guidance on design system import workflows. This adds a "Learn more" link to the import dialog directing users to documentation (ED-24022).

## 2. What Changed (Where)

- `import-design-system-dialog.tsx`: Added `HelpIcon` import, `Link` component import, constant `LEARN_MORE_URL`, and rendered help section with icon + link below conflict options
- `import-design-system-dialog.test.tsx`: Added test case verifying link renders with correct href and target attributes

## 3. How It Works

Dialog renders a `Stack` row containing a help icon + externally-linked `Link` component positioned below the conflict strategy selector. Link opens documentation in new tab with security attributes (`rel="noopener noreferrer"`).

## 4. Risks

None—straightforward UI addition with hardcoded URL and comprehensive test coverage.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
