### PR TITLE
Internal: Add -packages suffix to publish packages tags [ED-24092]

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -217,12 +217,12 @@ jobs:
           git config --global user.name "GitHub Actions"
           git remote set-url origin https://x-access-token:${{ secrets.MAINTAIN_TOKEN }}@github.com/${{ github.repository }}.git
 
-          TAG_NAME="v${{ steps.version.outputs.FULL_VERSION }}"
+          TAG_NAME="v${{ steps.version.outputs.FULL_VERSION }}-packages"
 
           # Check if tag exists
           if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
             echo "Tag $TAG_NAME already exists, skipping creation"
           else
-            git tag -a "$TAG_NAME" -m "Release ${{ steps.version.outputs.FULL_VERSION }}"
+            git tag -a "$TAG_NAME" -m "Packages release ${{ steps.version.outputs.FULL_VERSION }}"
             git push origin "$TAG_NAME" || echo "Warning: Failed to push tag"
           fi


### PR DESCRIPTION
## Summary
- Added `-packages` suffix to tag names created in the publish packages CI workflow (`TAG_NAME` now becomes `v{version}-packages`)
- Updated the tag message from `Release {version}` to `Packages release {version}` to make the context explicit

## Test plan
- [ ] Trigger the publish packages workflow and verify the created tag has the `-packages` suffix
- [ ] Verify no tag collision occurs with the existing version tags (e.g. `v1.0.0` vs `v1.0.0-packages`)

## Jira
[https://elementor.atlassian.net/browse/ED-24092](https://elementor.atlassian.net/browse/ED-24092)

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds `-packages` suffix to Git release tags to distinguish package publishing events from standard version releases (ED-24092). Enables clearer CI/CD tagging strategy for publish-specific workflows.

## 2. What Changed (Where)

- `.github/workflows/publish-packages.yml`: Tag naming changed from `v{VERSION}` to `v{VERSION}-packages` with updated message from "Release" to "Packages release".

## 3. How It Works

Tag creation logic unchanged—still checks existence before creating annotated tag and pushing. Only the tag suffix and message string differ to provide semantic distinction.

## 4. Risks

None identified. Non-breaking change confined to publish workflow; doesn't affect existing versioning or release mechanisms.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
