### PR TITLE
Internal: CP Learn more link in Import Design System dialog [ED-24022]

### DIFF
--- a/packages/packages/core/editor-design-system/src/import/__tests__/import-design-system-dialog.test.tsx
+++ b/packages/packages/core/editor-design-system/src/import/__tests__/import-design-system-dialog.test.tsx
@@ -104,6 +104,16 @@ describe( '<ImportDesignSystemDialog />', () => {
 		sharedQueryClient.clear();
 	} );
 
+	it( 'renders a "Learn more" link to the design system imports docs', () => {
+		setupHttpServiceMock();
+
+		renderWithQuery( <ImportDesignSystemDialog onClose={ jest.fn() } /> );
+
+		const link = screen.getByRole( 'link', { name: 'Learn how design system imports work' } );
+		expect( link ).toHaveAttribute( 'href', 'https://go.elementor.com/wp-dash-import-export-design-system/' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+	} );
+
 	it( 'disables the import button until a file and conflict strategy are selected', async () => {
 		setupHttpServiceMock();
 

--- a/packages/packages/core/editor-design-system/src/import/import-design-system-dialog.tsx
+++ b/packages/packages/core/editor-design-system/src/import/import-design-system-dialog.tsx
@@ -90,7 +90,7 @@ export const ImportDesignSystemDialog = ( { onClose }: Props ) => {
 						/>
 					) }
 					<ConflictOptions value={ conflictStrategy } onChange={ handleConflictChange } />
-					<Stack direction="row" spacing={ 0.5 } alignItems="center" justifyContent="center">
+					<Stack direction="row" spacing={ 0.5 } alignItems="center" justifyContent="flex-start">
 						<HelpIcon sx={ { fontSize: 16, color: 'text.tertiary' } } />
 						<Link
 							href={ LEARN_MORE_URL }

--- a/packages/packages/core/editor-design-system/src/import/import-design-system-dialog.tsx
+++ b/packages/packages/core/editor-design-system/src/import/import-design-system-dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { closeDialog, FileUploadDropzone, FileUploadRow, openDialog } from '@elementor/editor-ui';
-import { Button, DialogActions, DialogContent, DialogHeader, DialogTitle, Stack } from '@elementor/ui';
+import { HelpIcon } from '@elementor/icons';
+import { Button, DialogActions, DialogContent, DialogHeader, DialogTitle, Link, Stack } from '@elementor/ui';
 import { __, sprintf } from '@wordpress/i18n';
 
 import { ConflictOptions } from './components/conflict-options';
@@ -14,6 +15,7 @@ const ALLOWED_FILE_TYPES: `${ string }/${ string }`[] = [ 'application/zip' ];
 const FILE_INPUT_ACCEPT = 'application/zip,.zip';
 // TODO: Replace with the actual server-enforced limit once finalized.
 const MAX_FILE_SIZE_MB = 3;
+const LEARN_MORE_URL = 'https://go.elementor.com/wp-dash-import-export-design-system/';
 
 type Props = {
 	onClose: () => void;
@@ -88,6 +90,19 @@ export const ImportDesignSystemDialog = ( { onClose }: Props ) => {
 						/>
 					) }
 					<ConflictOptions value={ conflictStrategy } onChange={ handleConflictChange } />
+					<Stack direction="row" spacing={ 0.5 } alignItems="center" justifyContent="center">
+						<HelpIcon sx={ { fontSize: 16, color: 'text.tertiary' } } />
+						<Link
+							href={ LEARN_MORE_URL }
+							target="_blank"
+							rel="noopener noreferrer"
+							underline="always"
+							variant="caption"
+							color="text.tertiary"
+						>
+							{ __( 'Learn how design system imports work', 'elementor' ) }
+						</Link>
+					</Stack>
 				</Stack>
 			</DialogContent>
 			<DialogActions>


### PR DESCRIPTION
## Summary

Cherry-picks [ED-24022](https://elementor.atlassian.net/browse/ED-24022) onto the **`4.01`** version branch: adds the “Learn how design system imports work” help link (with icon) in the Import Design System dialog, plus left-aligned layout for that row (`justifyContent="flex-start"`).

## Source

- Original PR: https://github.com/elementor/elementor/pull/35849 (target `main`)
- Cherry-picked commits (in order):
  1. `bcd61553ba` — Feature: Add Learn more link to Import Design System dialog [ED-24022]
  2. `bee6943e11` — Style: Left-align learn-more row in Import Design System dialog [ED-24022]

## Files

- `packages/packages/core/editor-design-system/src/import/import-design-system-dialog.tsx`
- `packages/packages/core/editor-design-system/src/import/__tests__/import-design-system-dialog.test.tsx`

## Test instructions

Same as main PR: open Design System → Import Design System; confirm link + `href` / `target="_blank"`; run package tests for the dialog if needed.

Refs ED-24022

Made with [Cursor](https://cursor.com)

[ED-24022]: https://elementor.atlassian.net/browse/ED-24022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ED-24022]: https://elementor.atlassian.net/browse/ED-24022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ED-24022]: https://elementor.atlassian.net/browse/ED-24022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Adding a contextual "Learn more" link in the Import Design System dialog to guide users to documentation (ED-24022).

## 2. What Changed (Where)
- **import-design-system-dialog.tsx**: Added `HelpIcon` import, `Link` component to UI imports, `LEARN_MORE_URL` constant, and rendered help link with icon in dialog content.
- **import-design-system-dialog.test.tsx**: Added test verifying link renders with correct href and target attributes.

## 3. How It Works
New Stack component houses a HelpIcon and Link pointing to design system import docs, positioned inline with existing dialog content. Link opens in new tab with proper security attributes.

## 4. Risks
None. Low-risk UI addition with full test coverage; no breaking changes or dependency shifts.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
