### PR TITLE
Fix: Cherry-pick PR 35844 to 4.01: Autosave before design system import: prevent data loss[ED-24072]

### DIFF
--- a/packages/packages/core/editor-design-system/src/import/__tests__/import-design-system-dialog.test.tsx
+++ b/packages/packages/core/editor-design-system/src/import/__tests__/import-design-system-dialog.test.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { renderWithTheme } from 'test-utils';
 import { GLOBAL_STYLES_IMPORTED_EVENT } from '@elementor/editor-canvas';
 import { useCurrentUserCapabilities } from '@elementor/editor-current-user';
-import { reloadCurrentDocument } from '@elementor/editor-documents';
 import { dismissNotification, notify } from '@elementor/editor-notifications';
 import { closeDialog, openDialog } from '@elementor/editor-ui';
+import { __privateRunCommand } from '@elementor/editor-v1-adapters';
 import { httpService } from '@elementor/http-client';
 import { type QueryClient, QueryClientProvider } from '@elementor/query';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
@@ -24,9 +24,9 @@ jest.mock( '@elementor/editor-notifications', () => ( {
 	notify: jest.fn(),
 } ) );
 
-jest.mock( '@elementor/editor-documents', () => ( {
-	...jest.requireActual( '@elementor/editor-documents' ),
-	reloadCurrentDocument: jest.fn().mockResolvedValue( undefined ),
+jest.mock( '@elementor/editor-v1-adapters', () => ( {
+	...jest.requireActual( '@elementor/editor-v1-adapters' ),
+	__privateRunCommand: jest.fn(),
 } ) );
 
 jest.mock( '@elementor/editor-ui', () => ( {
@@ -123,13 +123,17 @@ describe( '<ImportDesignSystemDialog />', () => {
 		await waitFor( () => expect( importButton ).toBeEnabled() );
 	} );
 
-	it( 'fires the in-progress notification, calls onClose and triggers the upload→import→runner flow', async () => {
+	it( 'runs auto save, fires the in-progress notification, calls onClose and triggers the upload→import→runner flow', async () => {
 		const { post } = setupHttpServiceMock();
 		const onClose = jest.fn();
 
 		renderWithQuery( <ImportDesignSystemDialog onClose={ onClose } /> );
 
 		const file = submitImport();
+
+		await waitFor( () =>
+			expect( __privateRunCommand ).toHaveBeenCalledWith( 'document/save/auto', { force: true } )
+		);
 
 		const inProgressCall = ( notify as jest.Mock ).mock.calls.find(
 			( [ payload ] ) => payload.id === 'design-system-import-started'
@@ -185,7 +189,6 @@ describe( '<ImportDesignSystemDialog />', () => {
 
 		expect( dismissNotification ).toHaveBeenCalledWith( 'design-system-import-started' );
 		expect( eventListener ).toHaveBeenCalledTimes( 1 );
-		expect( reloadCurrentDocument ).toHaveBeenCalledTimes( 1 );
 
 		await waitFor( () => expect( isImporting() ).toBe( false ) );
 
@@ -200,6 +203,10 @@ describe( '<ImportDesignSystemDialog />', () => {
 
 		submitImport();
 
+		await waitFor( () =>
+			expect( __privateRunCommand ).toHaveBeenCalledWith( 'document/save/auto', { force: true } )
+		);
+
 		const errorCall = await waitFor(
 			() => {
 				const call = ( notify as jest.Mock ).mock.calls.find(
@@ -212,7 +219,6 @@ describe( '<ImportDesignSystemDialog />', () => {
 		);
 
 		expect( dismissNotification ).toHaveBeenCalledWith( 'design-system-import-started' );
-		expect( reloadCurrentDocument ).not.toHaveBeenCalled();
 
 		await waitFor( () => expect( isImporting() ).toBe( false ) );
 

--- a/packages/packages/core/editor-design-system/src/import/hooks/use-import-request.ts
+++ b/packages/packages/core/editor-design-system/src/import/hooks/use-import-request.ts
@@ -1,5 +1,5 @@
 import { GLOBAL_STYLES_IMPORTED_EVENT } from '@elementor/editor-canvas';
-import { reloadCurrentDocument } from '@elementor/editor-documents';
+import { __privateRunCommand as runCommand } from '@elementor/editor-v1-adapters';
 import { type HttpResponse, httpService } from '@elementor/http-client';
 import { useMutation } from '@elementor/query';
 
@@ -33,12 +33,12 @@ export const useImportRequest = () => {
 	return useMutation( {
 		mutationKey: [ IMPORT_DESIGN_SYSTEM_MUTATION_KEY ],
 		mutationFn: async ( { file, conflictStrategy }: ImportRequestArgs ): Promise< void > => {
+			await runCommand( 'document/save/auto', { force: true } );
+
 			const session = await uploadKit( file );
 			const runners = await startImport( session, conflictStrategy );
 
 			await runRunners( session, runners );
-
-			await reloadCurrentDocument();
 
 			window.dispatchEvent( new CustomEvent( GLOBAL_STYLES_IMPORTED_EVENT ) );
 		},


### PR DESCRIPTION
cherry-pick of https://github.com/elementor/elementor/pull/35844 to 4.01 branch.
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick addressing ED-24072: autosave document before design system import to prevent data loss when replacing design system settings. Replaces document reload with pre-import autosave to preserve unsaved changes.

## 2. What Changed (Where)

- `use-import-request.ts`: Swapped `reloadCurrentDocument()` call with `runCommand('document/save/auto', { force: true })` before import flow
- `import-design-system-dialog.test.tsx`: Updated mocks and test assertions to verify autosave invoked instead of reload

## 3. How It Works

Import mutation now calls autosave command (force flag bypasses dirty-check) before uploading/importing design system, ensuring uncommitted changes persist. Reload removed—state maintained through autosave.

## 4. Risks

Minor: Command abstraction layer (`__privateRunCommand`) could mask save failures. Mitigate by monitoring autosave command error handling in integration tests. Force flag prevents user-initiated saves from blocking—acceptable for this safety-critical flow.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
