### PR TITLE
Fix: Cherry-pick PR 35842 to 4.01: Apply imported template global classes on insert [ED-24069]

### DIFF
--- a/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
+++ b/modules/global-classes/utils/template-library-global-classes-snapshot-builder.php
@@ -176,25 +176,31 @@ class Template_Library_Global_Classes_Snapshot_Builder extends Template_Library_
 		$new_items = $data['new_items'] ?? [];
 		$order = $data['order'] ?? [];
 
-		if ( ! empty( $new_items ) ) {
-			$repository = Global_Classes_Repository::make()->set_preview( false );
-
-			$added_ids = array_keys( $new_items );
-
-			$repository->apply_changes(
-				$new_items,
-				[
-					'added' => $added_ids,
-					'order' => true,
+		if ( empty( $new_items ) ) {
+			return [
+				'global_classes' => [
+					'added_items' => [],
+					'added_items_order' => [],
 				],
-				$order
-			);
+			];
 		}
+
+		$repository = Global_Classes_Repository::make()->set_preview( false );
+		$added_ids = array_keys( $new_items );
+
+		$repository->apply_changes(
+			$new_items,
+			[
+				'added' => $added_ids,
+				'order' => true,
+			],
+			$order
+		);
 
 		return [
 			'global_classes' => [
-				'items' => $data['updated_items'] ?? [],
-				'order' => $order,
+				'added_items_order' => $added_ids,
+				'added_items' => $new_items,
 			],
 		];
 	}

--- a/packages/packages/core/editor-canvas/src/sync/global-styles-imported-event.ts
+++ b/packages/packages/core/editor-canvas/src/sync/global-styles-imported-event.ts
@@ -4,5 +4,5 @@ export const GLOBAL_STYLES_IMPORTED_EVENT = 'elementor/global-styles/imported';
 
 export type ImportedGlobalStylesPayload = {
 	global_variables?: { data: StyleVariables };
-	global_classes?: { items: StyleDefinitionsMap; order: StyleDefinitionID[] };
+	global_classes?: { added_items: StyleDefinitionsMap; added_items_order: StyleDefinitionID[] };
 };

--- a/packages/packages/core/editor-global-classes/src/__tests__/store.test.ts
+++ b/packages/packages/core/editor-global-classes/src/__tests__/store.test.ts
@@ -6,7 +6,14 @@ import {
 	__registerSlice as registerSlice,
 } from '@elementor/store';
 
-import { selectData, selectFrontendInitialData, selectIsDirty, selectPreviewInitialData, slice } from '../store';
+import {
+	selectClassLabels,
+	selectData,
+	selectFrontendInitialData,
+	selectIsDirty,
+	selectPreviewInitialData,
+	slice,
+} from '../store';
 
 const classLabelsFor = ( order: string[], items: Record< string, ReturnType< typeof createMockStyleDefinition > > ) =>
 	Object.fromEntries( order.map( ( id ) => [ id, items[ id ]?.label ?? id ] ) );
@@ -149,6 +156,217 @@ describe( 'store', () => {
 
 			// Assert - dirty state should still be true because we added a class
 			expect( selectIsDirty( getState() ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'updateAfterTemplateImport', () => {
+		it( 'should add imported classes to all data sources without resetting existing data', () => {
+			// Arrange - simulate initial state with existing classes
+			const existingPublishedClass = createMockStyleDefinition( {
+				id: 'existing-published',
+				label: 'Existing Class',
+			} );
+			const existingDraftClass = createMockStyleDefinition( {
+				id: 'existing-draft',
+				label: 'Existing Draft Class',
+			} );
+
+			dispatch(
+				slice.actions.load( {
+					frontend: {
+						items: { 'existing-published': existingPublishedClass },
+						order: [ 'existing-published' ],
+					},
+					preview: {
+						items: { 'existing-published': existingPublishedClass, 'existing-draft': existingDraftClass },
+						order: [ 'existing-draft', 'existing-published' ],
+					},
+					classLabels: classLabelsFor( [ 'existing-draft', 'existing-published' ], {
+						'existing-draft': existingDraftClass,
+						'existing-published': existingPublishedClass,
+					} ),
+				} )
+			);
+
+			// Imported classes from template
+			const importedClass1 = createMockStyleDefinition( { id: 'g-imported-1', label: 'Imported Primary' } );
+			const importedClass2 = createMockStyleDefinition( { id: 'g-imported-2', label: 'Imported Secondary' } );
+			const importedItems = {
+				'g-imported-1': importedClass1,
+				'g-imported-2': importedClass2,
+			};
+			const importedOrder = [ 'g-imported-1', 'g-imported-2' ];
+
+			// Act
+			dispatch(
+				slice.actions.updateAfterTemplateImport( {
+					addedItems: importedItems,
+					addedIdsOrder: importedOrder,
+					addedClassLabels: {
+						'g-imported-1': 'Imported Primary',
+						'g-imported-2': 'Imported Secondary',
+					},
+				} )
+			);
+
+			// Assert - current data should contain both existing and imported
+			const data = selectData( getState() );
+			expect( data.items ).toEqual( {
+				'existing-draft': existingDraftClass,
+				'existing-published': existingPublishedClass,
+				'g-imported-1': importedClass1,
+				'g-imported-2': importedClass2,
+			} );
+			expect( data.order ).toEqual( [ 'existing-draft', 'existing-published', 'g-imported-1', 'g-imported-2' ] );
+
+			// Assert - frontend initial data should be updated
+			const frontendInitial = selectFrontendInitialData( getState() );
+			expect( frontendInitial.items ).toEqual( {
+				'existing-published': existingPublishedClass,
+				'g-imported-1': importedClass1,
+				'g-imported-2': importedClass2,
+			} );
+			expect( frontendInitial.order ).toEqual( [ 'existing-published', 'g-imported-1', 'g-imported-2' ] );
+
+			// Assert - preview initial data should be updated
+			const previewInitial = selectPreviewInitialData( getState() );
+			expect( previewInitial.items ).toEqual( {
+				'existing-published': existingPublishedClass,
+				'existing-draft': existingDraftClass,
+				'g-imported-1': importedClass1,
+				'g-imported-2': importedClass2,
+			} );
+			expect( previewInitial.order ).toEqual( [
+				'existing-draft',
+				'existing-published',
+				'g-imported-1',
+				'g-imported-2',
+			] );
+
+			// Assert - class labels should be updated
+			const classLabels = selectClassLabels( getState() );
+			expect( classLabels ).toEqual( {
+				'existing-draft': 'Existing Draft Class',
+				'existing-published': 'Existing Class',
+				'g-imported-1': 'Imported Primary',
+				'g-imported-2': 'Imported Secondary',
+			} );
+		} );
+
+		it( 'should preserve user changes made in the current session', () => {
+			// Arrange - load initial data
+			const initialClass1 = createMockStyleDefinition( { id: 'class-1', label: 'Original Label' } );
+			const initialClass2 = createMockStyleDefinition( { id: 'class-2', label: 'Original Label' } );
+			const order = [ 'class-1', 'class-2' ];
+
+			dispatch(
+				slice.actions.load( {
+					frontend: { items: { 'class-1': initialClass1, 'class-2': initialClass2 }, order },
+					preview: { items: { 'class-1': initialClass1, 'class-2': initialClass2 }, order },
+					classLabels: classLabelsFor( order, { 'class-1': initialClass1, 'class-2': initialClass2 } ),
+				} )
+			);
+
+			// User makes changes in the current session
+			// User creates a new class
+			const userCreatedClass = createMockStyleDefinition( { id: 'user-created', label: 'User Created' } );
+			dispatch( slice.actions.add( userCreatedClass ) );
+
+			// User updates an existing class
+			dispatch(
+				slice.actions.update( {
+					style: {
+						id: 'class-1',
+						label: 'User Modified Label',
+					},
+				} )
+			);
+
+			// User deletes an existing class
+			dispatch( slice.actions.delete( 'class-2' ) );
+
+			// Verify state before import
+			const stateBeforeImport = selectData( getState() );
+			expect( stateBeforeImport.items[ 'class-1' ].label ).toBe( 'User Modified Label' );
+			expect( stateBeforeImport.items[ 'user-created' ] ).toBeDefined();
+			expect( stateBeforeImport.order ).toEqual( [ 'user-created', 'class-1' ] );
+			expect( selectIsDirty( getState() ) ).toBe( true );
+
+			// Act - import new classes from template
+			const importedClass = createMockStyleDefinition( { id: 'g-imported', label: 'Imported' } );
+			dispatch(
+				slice.actions.updateAfterTemplateImport( {
+					addedItems: { 'g-imported': importedClass },
+					addedIdsOrder: [ 'g-imported' ],
+					addedClassLabels: { 'g-imported': 'Imported' },
+				} )
+			);
+
+			// Assert - user changes should be preserved
+			const data = selectData( getState() );
+			expect( data.items[ 'class-1' ].label ).toBe( 'User Modified Label' );
+			expect( data.items[ 'user-created' ] ).toBeDefined();
+			expect( data.items[ 'g-imported' ] ).toBeDefined();
+
+			// Order should include all classes: existing + user created + imported
+			expect( data.order ).toEqual( [ 'user-created', 'class-1', 'g-imported' ] );
+		} );
+
+		it( 'should append imported classes to the end of the order', () => {
+			// Arrange
+			const class1 = createMockStyleDefinition( { id: 'class-1' } );
+			const class2 = createMockStyleDefinition( { id: 'class-2' } );
+			const order = [ 'class-1', 'class-2' ];
+
+			dispatch(
+				slice.actions.load( {
+					frontend: { items: { 'class-1': class1, 'class-2': class2 }, order },
+					preview: { items: { 'class-1': class1, 'class-2': class2 }, order },
+					classLabels: classLabelsFor( order, { 'class-1': class1, 'class-2': class2 } ),
+				} )
+			);
+
+			// Act - import classes
+			const imported1 = createMockStyleDefinition( { id: 'imported-1' } );
+			const imported2 = createMockStyleDefinition( { id: 'imported-2' } );
+			dispatch(
+				slice.actions.updateAfterTemplateImport( {
+					addedItems: { 'imported-1': imported1, 'imported-2': imported2 },
+					addedIdsOrder: [ 'imported-1', 'imported-2' ],
+					addedClassLabels: { 'imported-1': 'Imported 1', 'imported-2': 'Imported 2' },
+				} )
+			);
+
+			// Assert - imported classes should be at the end
+			const data = selectData( getState() );
+			expect( data.order ).toEqual( [ 'class-1', 'class-2', 'imported-1', 'imported-2' ] );
+		} );
+
+		it( 'should not modify isDirty state', () => {
+			// Arrange - clean state
+			const existingClass = createMockStyleDefinition( { id: 'existing' } );
+			dispatch(
+				slice.actions.load( {
+					frontend: { items: { existing: existingClass }, order: [ 'existing' ] },
+					preview: { items: { existing: existingClass }, order: [ 'existing' ] },
+					classLabels: { existing: 'Existing' },
+				} )
+			);
+
+			expect( selectIsDirty( getState() ) ).toBe( false );
+
+			// Act - import classes
+			const imported = createMockStyleDefinition( { id: 'imported' } );
+			dispatch(
+				slice.actions.updateAfterTemplateImport( {
+					addedItems: { imported },
+					addedIdsOrder: [ 'imported' ],
+					addedClassLabels: { imported: 'Imported' },
+				} )
+			);
+
+			// Assert - isDirty should remain false (import doesn't mark as dirty)
+			expect( selectIsDirty( getState() ) ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/packages/core/editor-global-classes/src/components/global-styles-import-listener.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/global-styles-import-listener.tsx
@@ -1,15 +1,35 @@
 import { useEffect } from 'react';
-import { GLOBAL_STYLES_IMPORTED_EVENT } from '@elementor/editor-canvas';
+import { GLOBAL_STYLES_IMPORTED_EVENT, type ImportedGlobalStylesPayload } from '@elementor/editor-canvas';
 import { __useDispatch as useDispatch } from '@elementor/store';
 
 import { loadCurrentDocumentClasses } from '../load-document-classes';
+import { slice } from '../store';
+import { createLabelsForClasses } from '../utils/create-labels-for-classes';
 
 export function GlobalStylesImportListener() {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		const handleGlobalStylesImported = () => {
-			loadCurrentDocumentClasses();
+		const handleGlobalStylesImported = async ( event: Event ) => {
+			const customEvent = event as CustomEvent< ImportedGlobalStylesPayload >;
+			const globalClasses = customEvent.detail?.global_classes;
+
+			if (
+				! globalClasses?.added_items_order ||
+				! globalClasses?.added_items ||
+				globalClasses?.added_items_order?.length === 0
+			) {
+				loadCurrentDocumentClasses();
+				return;
+			}
+
+			dispatch(
+				slice.actions.updateAfterTemplateImport( {
+					addedItems: globalClasses.added_items,
+					addedIdsOrder: globalClasses.added_items_order,
+					addedClassLabels: createLabelsForClasses( Object.values( globalClasses.added_items ) ),
+				} )
+			);
 		};
 
 		window.addEventListener( GLOBAL_STYLES_IMPORTED_EVENT, handleGlobalStylesImported as EventListener );

--- a/packages/packages/core/editor-global-classes/src/store.ts
+++ b/packages/packages/core/editor-global-classes/src/store.ts
@@ -244,6 +244,35 @@ export const slice = createSlice( {
 				}
 			} );
 		},
+
+		setOrderWithoutHistory( state, { payload }: PayloadAction< StyleDefinitionID[] > ) {
+			state.data.order = payload;
+		},
+
+		updateAfterTemplateImport(
+			state,
+			{
+				payload,
+			}: PayloadAction< {
+				addedItems: StyleDefinitionsMap;
+				addedIdsOrder: StyleDefinitionID[];
+				addedClassLabels: Record< StyleDefinitionID, string >;
+			} >
+		) {
+			// Update initial data
+			state.initialData.frontend.items = { ...state.initialData.frontend.items, ...payload.addedItems };
+			state.initialData.frontend.order = [ ...state.initialData.frontend.order, ...payload.addedIdsOrder ];
+
+			state.initialData.preview.items = { ...state.initialData.preview.items, ...payload.addedItems };
+			state.initialData.preview.order = [ ...state.initialData.preview.order, ...payload.addedIdsOrder ];
+
+			// Update current data
+			state.data.items = { ...state.data.items, ...payload.addedItems };
+			state.data.order = [ ...state.data.order, ...payload.addedIdsOrder ];
+
+			// Update class labels
+			state.classLabels = { ...state.classLabels, ...payload.addedClassLabels };
+		},
 	},
 } );
 

--- a/packages/packages/core/editor-global-classes/src/utils/create-labels-for-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/utils/create-labels-for-classes.ts
@@ -1,7 +1,9 @@
-import { type StyleDefinitionID } from '@elementor/editor-styles';
+import { type StyleDefinition, type StyleDefinitionID } from '@elementor/editor-styles';
 
 import { type GlobalClassIndexEntry } from '../api';
 
-export function createLabelsForClasses( entries: GlobalClassIndexEntry[] ): Record< StyleDefinitionID, string > {
+export function createLabelsForClasses(
+	entries: Array< GlobalClassIndexEntry | StyleDefinition >
+): Record< StyleDefinitionID, string > {
 	return Object.fromEntries( entries.map( ( e ) => [ e.id, e.label ] ) );
 }


### PR DESCRIPTION
cherry-pick of https://github.com/elementor/elementor/pull/35842 to 4.01 branch.
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

When importing templates, global classes weren't being applied to the document. This cherry-pick fixes the template import flow to persist imported classes into the store and apply them on insert (ED-24069).

## 2. What Changed (Where)

- **template-library-global-classes-snapshot-builder.php**: Changed `save_data()` to apply imported classes via `Repository::apply_changes()` and return `added_items`/`added_items_order` instead of `items`/`order`.
- **global-styles-imported-event.ts**: Updated payload shape from `{ items, order }` to `{ added_items, added_items_order }` for global classes.
- **global-styles-import-listener.tsx**: Implemented handler to dispatch `updateAfterTemplateImport` action with imported class metadata.
- **store.ts**: Added `updateAfterTemplateImport` reducer to merge imported classes into `initialData`, current `data`, and `classLabels` without marking dirty.
- **create-labels-for-classes.ts**: Generalized type to accept `StyleDefinition | GlobalClassIndexEntry` union.
- **store.test.ts**: Added comprehensive test suite covering merge behavior, session changes preservation, ordering, and dirty state.

## 3. How It Works

Import listener receives `GLOBAL_STYLES_IMPORTED_EVENT` → extracts added classes/order from payload → dispatches `updateAfterTemplateImport` → reducer merges into all three data sources (frontend/preview initial + current) and class labels → changes persist without triggering dirty flag. Empty imports short-circuit early.

## 4. Risks

Minimal—pure additive logic that spreads imported items into existing collections. Test coverage verifies non-destructive merge and preserves user edits. Only concern: payload shape change requires event producer alignment, but covered by type definition.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
