### PR TITLE
Tweak: Allow empty sections hide in settings, turn submit actions into sections [ED-23874]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.php
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.php
@@ -173,32 +173,34 @@ class Atomic_Form extends Atomic_Element_Base {
 				->set_meta( [ 'topDivider' => true ] ),
 		];
 
-		$content_controls = array_merge( $content_controls, $email_controls );
-
-		$content_controls = array_merge( $content_controls, [
-			Chips_Control::bind_to( 'submissions_metadata' )
-				->set_options( [
-					[
-						'label' => __( 'User IP', 'elementor' ),
-						'value' => self::METADATA_REMOTE_IP,
-					],
-					[
-						'label' => __( 'User Agent', 'elementor' ),
-						'value' => self::METADATA_USER_AGENT,
-					],
-				] )
-				->set_label( __( 'Include metadata', 'elementor' ) )
-				->set_meta( [ 'topDivider' => true ] ),
-			Text_Control::bind_to( 'webhook_url' )
-				->set_placeholder( __( 'https://your-webhook-url.com', 'elementor' ) )
-				->set_label( __( 'Webhook URL', 'elementor' ) )
-				->set_meta( [ 'topDivider' => true ] ),
-		] );
-
 		return [
 			Section::make()
 				->set_label( __( 'Content', 'elementor' ) )
 				->set_items( $content_controls ),
+			...$email_controls,
+			Section::make()
+				->set_label( __( 'Collect submissions', 'elementor' ) )
+				->set_items( [
+					Chips_Control::bind_to( 'submissions_metadata' )
+						->set_options( [
+							[
+								'label' => __( 'User IP', 'elementor' ),
+								'value' => self::METADATA_REMOTE_IP,
+							],
+							[
+								'label' => __( 'User Agent', 'elementor' ),
+								'value' => self::METADATA_USER_AGENT,
+							],
+						] )
+						->set_label( __( 'Include metadata', 'elementor' ) ),
+				] ),
+			Section::make()
+				->set_label( __( 'Webhook', 'elementor' ) )
+				->set_items( [
+					Text_Control::bind_to( 'webhook_url' )
+						->set_placeholder( __( 'https://your-webhook-url.com', 'elementor' ) )
+						->set_label( __( 'Webhook URL', 'elementor' ) ),
+				] ),
 			Section::make()
 				->set_label( __( 'Settings', 'elementor' ) )
 				->set_id( 'settings' )
@@ -427,10 +429,13 @@ class Atomic_Form extends Atomic_Element_Base {
 				'value' => $key,
 			];
 
-			$email_controls[] = Email_Form_Action_Control::bind_to( $key )
-				->set_free_chips( true )
-				->set_label( $label )
-				->set_meta( [ 'topDivider' => true ] );
+			$email_controls[] = Section::make()
+					->set_label( $label )
+					->set_items( [
+						Email_Form_Action_Control::bind_to( $key )
+							->set_free_chips( true )
+							->set_label( $label ),
+					] );
 		}
 
 		return [

--- a/packages/packages/core/editor-editing-panel/src/components/__tests__/settings-tab.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/__tests__/settings-tab.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { createMockElementType, renderWithTheme } from 'test-utils';
-import { type Control, type ControlsSection, getElementLabel } from '@elementor/editor-elements';
+import { createMockElementType, createMockPropType, renderWithTheme } from 'test-utils';
+import { type Control, type ControlsSection, type ElementControl, getElementLabel } from '@elementor/editor-elements';
 import { isExperimentActive } from '@elementor/editor-v1-adapters';
 import { screen } from '@testing-library/react';
 
@@ -16,7 +16,7 @@ jest.mock( '@elementor/editor-elements', () => ( {
 	getElementLabel: jest.fn(),
 } ) );
 
-const MockSelectComponent = ( { id }: { id?: string } ) => <select id={ id } />;
+const MockSelectComponent = ( { id }: { id?: string } ) => <select id={ id } aria-label="mock-select" />;
 
 const MockTextAreaComponent = ( { placeholder }: { placeholder?: string } ) => (
 	<input type="text" placeholder={ placeholder } />
@@ -48,11 +48,11 @@ describe( '<SettingsTab />', () => {
 			controls: [
 				mockSection( {
 					label: 'Section 1',
-					items: [],
+					items: [ mockTextAreaControl( { label: 'Section 1 Control' } ) ],
 				} ),
 				mockSection( {
 					label: 'Section 2',
-					items: [],
+					items: [ mockTextAreaControl( { label: 'Section 2 Control' } ) ],
 				} ),
 			],
 		} );
@@ -65,7 +65,7 @@ describe( '<SettingsTab />', () => {
 
 		jest.mocked( useDefaultPanelSettings ).mockReturnValue( {
 			defaultSectionsExpanded: {
-				settings: [],
+				settings: [ 'Section 1', 'Section 2' ],
 			},
 			defaultTab: 'settings',
 		} );
@@ -258,6 +258,148 @@ describe( '<SettingsTab />', () => {
 		const separator = screen.getByRole( 'separator' );
 		expect( separator ).toBeInTheDocument();
 	} );
+
+	it( 'should hide a section when all child controls are dependency-hidden', () => {
+		// Arrange.
+		const elementType = createMockElementType( {
+			propsSchema: {
+				'actions-after-submit': createMockPropType( {
+					kind: 'array',
+					item_prop_type: createMockPropType( { kind: 'plain' } ),
+				} ),
+				email: createMockPropType( {
+					kind: 'plain',
+					dependencies: {
+						relation: 'or',
+						terms: [
+							{
+								operator: 'contains',
+								path: [ 'actions-after-submit' ],
+								value: 'email',
+								effect: 'hide',
+							},
+						],
+					},
+				} ),
+			},
+			controls: [
+				mockSection( {
+					label: 'Email Section',
+					items: [ mockTextAreaControl( { bind: 'email', label: 'Email Control' } ) ],
+				} ),
+			],
+		} );
+
+		jest.mocked( useElement ).mockReturnValue( {
+			element: { type: 'mock-type', id: 'mock-id' },
+			elementType,
+			settings: {
+				'actions-after-submit': {
+					$$type: 'array',
+					value: [ { $$type: 'string', value: 'webhook' } ],
+				},
+			},
+		} );
+		jest.mocked( useDefaultPanelSettings ).mockReturnValue( {
+			defaultSectionsExpanded: {
+				settings: [ 'Mixed Section' ],
+			},
+			defaultTab: 'settings',
+		} );
+
+		// Act.
+		renderWithTheme( <SettingsTab /> );
+
+		// Assert.
+		expect( screen.queryByText( 'Email Section' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Email Control' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render section with only visible controls when mixed dependency visibility exists', () => {
+		// Arrange.
+		const elementType = createMockElementType( {
+			propsSchema: {
+				'actions-after-submit': createMockPropType( {
+					kind: 'array',
+					item_prop_type: createMockPropType( { kind: 'plain' } ),
+				} ),
+				email: createMockPropType( {
+					kind: 'plain',
+					dependencies: {
+						relation: 'or',
+						terms: [
+							{
+								operator: 'contains',
+								path: [ 'actions-after-submit' ],
+								value: 'email',
+								effect: 'hide',
+							},
+						],
+					},
+				} ),
+				title: createMockPropType( { kind: 'plain' } ),
+			},
+			controls: [
+				mockSection( {
+					label: 'Mixed Section',
+					items: [
+						mockTextAreaControl( { bind: 'email', label: 'Hidden Control' } ),
+						mockTextAreaControl( { bind: 'title', label: 'Visible Control' } ),
+					],
+				} ),
+			],
+		} );
+
+		jest.mocked( useElement ).mockReturnValue( {
+			element: { type: 'mock-type', id: 'mock-id' },
+			elementType,
+			settings: {
+				'actions-after-submit': {
+					$$type: 'array',
+					value: [ { $$type: 'string', value: 'webhook' } ],
+				},
+			},
+		} );
+
+		// Act.
+		renderWithTheme( <SettingsTab /> );
+
+		// Assert.
+		expect( screen.getByText( 'Mixed Section' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Visible Control' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Hidden Control' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should keep section visible when it contains element-control items', () => {
+		// Arrange.
+		const elementType = createMockElementType( {
+			controls: [
+				mockSection( {
+					label: 'Element Control Section',
+					items: [ mockElementControl( { label: 'Element Control' } ) ],
+				} ),
+			],
+		} );
+
+		jest.mocked( useElement ).mockReturnValue( {
+			element: { type: 'mock-type', id: 'mock-id' },
+			elementType,
+			settings: {},
+		} );
+		jest.mocked( useDefaultPanelSettings ).mockReturnValue( {
+			defaultSectionsExpanded: {
+				settings: [ 'Element Control Section' ],
+			},
+			defaultTab: 'settings',
+		} );
+
+		// Act.
+		renderWithTheme( <SettingsTab /> );
+
+		// Assert.
+		expect( screen.getByText( 'Element Control Section' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Element Control' ) ).toBeInTheDocument();
+	} );
 } );
 
 export const mockSection = ( {
@@ -294,6 +436,16 @@ const mockTextAreaControl = ( value?: Partial< Control[ 'value' ] > ): Control =
 	value: {
 		label: 'Textarea Control',
 		bind: 'title',
+		type: 'textarea',
+		props: {},
+		...value,
+	},
+} );
+
+const mockElementControl = ( value?: Partial< ElementControl[ 'value' ] > ): ElementControl => ( {
+	type: 'element-control',
+	value: {
+		label: 'Element Control',
 		type: 'textarea',
 		props: {},
 		...value,

--- a/packages/packages/core/editor-editing-panel/src/components/settings-tab.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/settings-tab.tsx
@@ -4,8 +4,8 @@ import { type Props, type PropsSchema } from '@elementor/editor-props';
 import { SessionStorageProvider } from '@elementor/session';
 
 import { useElement } from '../contexts/element-context';
-import { extractDependencyEffect } from '../utils/prop-dependency-utils';
 import { useDefaultPanelSettings } from '../hooks/use-default-panel-settings';
+import { extractDependencyEffect } from '../utils/prop-dependency-utils';
 import { Section } from './section';
 import { SectionsList } from './sections-list';
 import { SettingsControl } from './settings-control';

--- a/packages/packages/core/editor-editing-panel/src/components/settings-tab.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/settings-tab.tsx
@@ -1,16 +1,19 @@
 import * as React from 'react';
 import { type Control, type ControlItem, type Element, type ElementControl } from '@elementor/editor-elements';
+import { type Props, type PropsSchema } from '@elementor/editor-props';
 import { SessionStorageProvider } from '@elementor/session';
 
 import { useElement } from '../contexts/element-context';
+import { extractDependencyEffect } from '../utils/prop-dependency-utils';
 import { useDefaultPanelSettings } from '../hooks/use-default-panel-settings';
 import { Section } from './section';
 import { SectionsList } from './sections-list';
 import { SettingsControl } from './settings-control';
 
 export const SettingsTab = () => {
-	const { elementType, element } = useElement();
+	const { elementType, element, settings } = useElement();
 	const settingsDefault = useDefaultPanelSettings();
+	const currentSettings = settings as Props;
 
 	const isDefaultExpanded = ( sectionId: string ) =>
 		settingsDefault.defaultSectionsExpanded.settings?.includes( sectionId );
@@ -26,20 +29,24 @@ export const SettingsTab = () => {
 					const { type, value } = control;
 
 					if ( type === 'section' ) {
+						const sectionItems = renderSectionItems( {
+							items: value.items,
+							element,
+							propsSchema: elementType.propsSchema,
+							settings: currentSettings,
+						} );
+
+						if ( ! sectionItems.length ) {
+							return null;
+						}
+
 						return (
 							<Section
 								title={ value.label }
 								key={ type + '.' + index }
 								defaultExpanded={ isDefaultExpanded( value.label ) }
 							>
-								{ value.items?.map( ( item ) => {
-									if ( isControl( item ) ) {
-										return <SettingsControl key={ getKey( item, element ) } control={ item } />;
-									}
-
-									// TODO: Handle 2nd level sections
-									return null;
-								} ) }
+								{ sectionItems }
 							</Section>
 						);
 					}
@@ -61,4 +68,37 @@ function getKey( control: Control | ElementControl, element: Element ) {
 
 function isControl( control: ControlItem ): control is Control | ElementControl {
 	return control.type === 'control' || control.type === 'element-control';
+}
+
+function renderSectionItems( {
+	items,
+	element,
+	propsSchema,
+	settings,
+}: {
+	items?: ControlItem[];
+	element: Element;
+	propsSchema: PropsSchema;
+	settings: Props;
+} ) {
+	return (
+		items?.flatMap( ( item ) => {
+			if ( ! isControl( item ) ) {
+				// TODO: Handle 2nd level sections
+				return [];
+			}
+
+			if ( item.type === 'control' && isControlHiddenByDependencies( item, propsSchema, settings ) ) {
+				return [];
+			}
+
+			return [ <SettingsControl key={ getKey( item, element ) } control={ item } /> ];
+		} ) ?? []
+	);
+}
+
+function isControlHiddenByDependencies( control: Control, propsSchema: PropsSchema, settings: Props ) {
+	const { isHidden } = extractDependencyEffect( control.value.bind, propsSchema, settings );
+
+	return isHidden;
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Refactor form settings UI to render email actions as independent sections instead of flat controls, and hide empty sections based on control dependencies (ED-23874). Improves UX by grouping related controls and respecting conditional visibility rules.

## 2. What Changed (Where)

- **atomic-form.php**: Email controls now wrapped in `Section::make()` containers; spread into return array instead of merged into flat `$content_controls`.
- **settings-tab.tsx**: Added `renderSectionItems()` and `isControlHiddenByDependencies()` functions to filter controls by dependency conditions; sections render null if all children hidden.
- **settings-tab.test.tsx**: Updated mocks and added three test cases covering dependency-based hiding, mixed visibility, and element-control preservation.

## 3. How It Works

Section rendering now evaluates each control's dependencies against current settings before rendering. If a control fails its dependency check (e.g., "hide if email not in actions-after-submit"), it's filtered out. When all controls in a section are filtered, the section itself returns null and doesn't render. Non-control items (nested sections) skip dependency checks but still respect the empty-section culling logic.

## 4. Risks

Dependency evaluation could break if `extractDependencyEffect()` mishandles nested prop paths or array containment checks. Test coverage added mitigates this, but schema-based dependencies are fragile. Consider defensive null-checks on `propsSchema` access in production.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
