### PR TITLE
Fix: CP Global classes search uses contains matching  [ED-23973]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/components/creatable-autocomplete/__tests__/creatable-autocomplete.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/creatable-autocomplete/__tests__/creatable-autocomplete.test.tsx
@@ -4,9 +4,9 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { CreatableAutocomplete } from '../creatable-autocomplete';
 
 const options = [
-	{ label: 'Option 1', value: '1' },
-	{ label: 'Option 2', value: '2' },
-	{ label: 'Option 3', value: '3' },
+	{ label: 'option-1', value: '1' },
+	{ label: 'option-2', value: '2' },
+	{ label: 'option-3', value: '3' },
 ];
 
 const entityName = {
@@ -42,28 +42,28 @@ describe( 'CreatableAutocomplete', () => {
 
 	it( 'should render options properly, before and after filter', async () => {
 		// Arrange
-		setup( { selected: [ { label: 'Option 2', value: '2' } ], placeholder, entityName } );
+		setup( { selected: [ { label: 'option-2', value: '2' } ], placeholder, entityName } );
 
 		// Assert
 		const dropdown = screen.getAllByRole( 'listbox' )[ 0 ];
 		expect( dropdown ).toBeInTheDocument();
 
 		// Selected options should not be displayed in the dropdown, but as chips above
-		expect( screen.getByText( 'Option 2' ) ).toBeInTheDocument();
-		expect( within( dropdown ).queryByText( 'Option 2' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'option-2' ) ).toBeInTheDocument();
+		expect( within( dropdown ).queryByText( 'option-2' ) ).not.toBeInTheDocument();
 
 		// The dropdown should display all available options
-		expect( within( dropdown ).getByRole( 'option', { name: 'Option 1' } ) ).toBeInTheDocument();
-		expect( within( dropdown ).getByRole( 'option', { name: 'Option 3' } ) ).toBeInTheDocument();
+		expect( within( dropdown ).getByRole( 'option', { name: 'option-1' } ) ).toBeInTheDocument();
+		expect( within( dropdown ).getByRole( 'option', { name: 'option-3' } ) ).toBeInTheDocument();
 
 		// Act
 		const input = screen.getByPlaceholderText( 'Type to search/add test option' );
-		fireEvent.change( input, { target: { value: 'Option 1' } } );
+		fireEvent.change( input, { target: { value: 'option-1' } } );
 
 		// Assert
 		// The dropdown should filter options based on user input
-		expect( within( dropdown ).getByRole( 'option', { name: 'Option 1' } ) ).toBeInTheDocument();
-		expect( within( dropdown ).queryByText( 'Option 3' ) ).not.toBeInTheDocument();
+		expect( within( dropdown ).getByRole( 'option', { name: 'option-1' } ) ).toBeInTheDocument();
+		expect( within( dropdown ).queryByText( 'option-3' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should show create option button when user typing', async () => {
@@ -87,28 +87,28 @@ describe( 'CreatableAutocomplete', () => {
 
 	it( 'should call onSelect when an existing option is selected', async () => {
 		// Arrange.
-		const { onSelect } = setup( { selected: [ { label: 'Option 1', value: '1' } ] } );
+		const { onSelect } = setup( { selected: [ { label: 'option-1', value: '1' } ] } );
 
 		// Act.
 		const input = screen.getByRole( 'combobox' );
-		fireEvent.change( input, { target: { value: 'Option 2' } } );
+		fireEvent.change( input, { target: { value: 'option-2' } } );
 		fireEvent.keyDown( input, { key: 'Enter' } );
 
 		// Assert.
 		expect( onSelect ).toHaveBeenCalledTimes( 1 );
 		expect( onSelect ).toHaveBeenCalledWith(
 			[
-				{ label: 'Option 1', value: '1' },
-				{ label: 'Option 2', value: '2' },
+				{ label: 'option-1', value: '1' },
+				{ label: 'option-2', value: '2' },
 			],
 			'selectOption',
-			{ label: 'Option 2', value: '2' }
+			{ label: 'option-2', value: '2' }
 		);
 	} );
 
 	it( 'should call onCreate when a new option is created', async () => {
 		// Arrange.
-		const { onCreate } = setup( { selected: [ { label: 'Option 1', value: '1' } ] } );
+		const { onCreate } = setup( { selected: [ { label: 'option-1', value: '1' } ] } );
 
 		// Act.
 		const input = screen.getByRole( 'combobox' );

--- a/packages/packages/core/editor-editing-panel/src/components/creatable-autocomplete/use-filter-options.ts
+++ b/packages/packages/core/editor-editing-panel/src/components/creatable-autocomplete/use-filter-options.ts
@@ -2,6 +2,12 @@ import { createFilterOptions } from '@elementor/ui';
 
 import { type InternalOption, type Option } from './types';
 
+const STRIP_NON_CLASS_CHARS = /[^a-zA-Z0-9_-]/g;
+
+function normalizeClassSearch( value: string ) {
+	return value.replace( STRIP_NON_CLASS_CHARS, '' ).toLowerCase();
+}
+
 export function useFilterOptions< TOption extends Option >( parameters: {
 	options: TOption[];
 	selected: TOption[];
@@ -10,7 +16,9 @@ export function useFilterOptions< TOption extends Option >( parameters: {
 } ) {
 	const { options, selected, onCreate, entityName } = parameters;
 
-	const filter = createFilterOptions< InternalOption< TOption > >();
+	const filter = createFilterOptions< InternalOption< TOption > >( {
+		matchFrom: 'any',
+	} );
 
 	const filterOptions = (
 		optionList: InternalOption< TOption >[],
@@ -23,7 +31,7 @@ export function useFilterOptions< TOption extends Option >( parameters: {
 
 		const filteredOptions = filter(
 			optionList.filter( ( option ) => ! selectedValues.includes( option.value ) ),
-			params
+			{ ...params, inputValue: normalizeClassSearch( params.inputValue ) }
 		);
 
 		const isExisting = options.some( ( option ) => params.inputValue === option.label );

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/__tests__/css-class-selector.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/__tests__/css-class-selector.test.tsx
@@ -400,6 +400,39 @@ describe( '<CssClassSelector />', () => {
 		expect( screen.queryByRole( 'option', { name: 'Create "Provider-1-a"' } ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'should show existing classes in the dropdown when typing at the max classes limit', () => {
+		// Arrange.
+		jest.mocked( useGetStylesRepositoryCreateAction ).mockReturnValue( [ { ...provider1, limit: 0 }, jest.fn() ] );
+
+		renderComponent( { active: 'provider-1-b', appliedClasses: [ 'local' ] } );
+
+		// Act.
+		const input = screen.getByRole( 'combobox', { hidden: true } );
+
+		fireEvent.change( input, { target: { value: 'Provider-1-a' } } );
+
+		// Assert - existing class is visible in dropdown.
+		expect( screen.getByRole( 'option', { name: 'Provider-1-a' } ) ).toBeInTheDocument();
+		// Assert - no "Create" option shown when at limit.
+		expect( screen.queryByRole( 'option', { name: 'Create "Provider-1-a"' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should validate the input when typing an invalid class name at the max classes limit', () => {
+		// Arrange.
+		jest.mocked( useGetStylesRepositoryCreateAction ).mockReturnValue( [ { ...provider1, limit: 0 }, jest.fn() ] );
+		jest.mocked( validateStyleLabel ).mockReturnValue( { isValid: false, errorMessage: 'Test error' } );
+
+		renderComponent( { active: 'provider-1-b', appliedClasses: [ 'local' ] } );
+
+		// Act.
+		const input = screen.getByRole( 'combobox', { hidden: true } );
+
+		fireEvent.change( input, { target: { value: '1invalid' } } );
+
+		// Assert - validateStyleLabel is invoked even when at limit, so format errors still surface.
+		expect( validateStyleLabel ).toHaveBeenCalledWith( '1invalid', 'inputChange' );
+	} );
+
 	it( 'should create, apply, and activate a class on click', async () => {
 		// Arrange.
 		const appliedIds = [ 'local', 'provider-1-b' ];

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-selector.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-selector.tsx
@@ -11,11 +11,13 @@ import {
 	validateStyleLabel,
 } from '@elementor/editor-styles-repository';
 import { InfoAlert, WarningInfotip } from '@elementor/editor-ui';
+import { isExperimentActive } from '@elementor/editor-v1-adapters';
 import { ColorSwatchIcon, MapPinIcon } from '@elementor/icons';
 import { createLocation } from '@elementor/locations';
 import {
 	type AutocompleteChangeReason,
 	Box,
+	Button,
 	Chip,
 	type ChipOwnProps,
 	FormLabel,
@@ -42,6 +44,22 @@ import { useApplyClass, useCreateAndApplyClass, useUnapplyClass } from './use-ap
 
 const ID = 'elementor-css-class-selector';
 const TAGS_LIMIT = 50;
+
+const EVENT_OPEN_GLOBAL_CLASSES_MANAGER = 'elementor/open-global-classes-manager';
+const EVENT_TOGGLE_DESIGN_SYSTEM = 'elementor/toggle-design-system';
+
+function openClassManagerPanel() {
+	if ( isExperimentActive( 'e_editor_design_system_panel' ) ) {
+		window.dispatchEvent(
+			new CustomEvent( EVENT_TOGGLE_DESIGN_SYSTEM, {
+				detail: { tab: 'classes' as const },
+			} )
+		);
+		return;
+	}
+
+	window.dispatchEvent( new CustomEvent( EVENT_OPEN_GLOBAL_CLASSES_MANAGER ) );
+}
 
 type StyleDefOption = Option & {
 	color: ChipOwnProps[ 'color' ];
@@ -74,7 +92,7 @@ export function CssClassSelector() {
 	const [ renameError, setRenameError ] = useState< string | null >( null );
 
 	const handleSelect = useHandleSelect();
-	const { create, validate, entityName } = useCreateAction();
+	const { create, validate, entityName, isAtLimit, limitCount } = useCreateAction();
 
 	const appliedOptions = useAppliedOptions( options );
 	const active = appliedOptions.find( ( option ) => option.value === activeId ) ?? EMPTY_OPTION;
@@ -114,7 +132,13 @@ export function CssClassSelector() {
 					onCreate={ create ?? undefined }
 					validate={ validate ?? undefined }
 					limitTags={ TAGS_LIMIT }
-					renderEmptyState={ EmptyState }
+					renderEmptyState={
+						isAtLimit && typeof limitCount === 'number'
+							? ( props ) => (
+									<LimitReachedEmptyState limitCount={ limitCount } onClear={ props.onClear } />
+							  )
+							: EmptyState
+					}
 					getLimitTagsText={ ( more ) => (
 						<Chip size="tiny" variant="standard" label={ `+${ more }` } clickable />
 					) }
@@ -166,7 +190,9 @@ export function CssClassSelector() {
 	);
 }
 
-const EmptyState = ( { searchValue, onClear }: { searchValue: string; onClear: () => void } ) => (
+type EmptyStateProps = { searchValue: string; onClear: () => void };
+
+const EmptyStateLayout = ( { searchValue, onClear, children }: EmptyStateProps & { children: React.ReactNode } ) => (
 	<Box sx={ { py: 4 } }>
 		<Stack
 			gap={ 1 }
@@ -181,14 +207,66 @@ const EmptyState = ( { searchValue, onClear }: { searchValue: string; onClear: (
 				<br />
 				&ldquo;{ searchValue }&rdquo;.
 			</Typography>
-			<Typography align="center" variant="caption" sx={ { mb: 2 } }>
-				{ __( 'With your current role,', 'elementor' ) }
-				<br />
-				{ __( 'you can only use existing classes.', 'elementor' ) }
-			</Typography>
+			{ children }
 			<Link color="text.secondary" variant="caption" component="button" onClick={ onClear }>
 				{ __( 'Clear & try again', 'elementor' ) }
 			</Link>
+		</Stack>
+	</Box>
+);
+
+const EmptyState = ( props: EmptyStateProps ) => (
+	<EmptyStateLayout { ...props }>
+		<Typography align="center" variant="caption" sx={ { mb: 2 } }>
+			{ __( 'With your current role,', 'elementor' ) }
+			<br />
+			{ __( 'you can only use existing classes.', 'elementor' ) }
+		</Typography>
+	</EmptyStateLayout>
+);
+
+const LimitReachedEmptyState = ( {
+	limitCount,
+	onClear,
+}: Pick< EmptyStateProps, 'onClear' > & { limitCount: number } ) => (
+	<Box sx={ { py: 4 } }>
+		<Stack
+			gap={ 1 }
+			alignItems="center"
+			color="text.secondary"
+			justifyContent="center"
+			sx={ { px: 1, m: 'auto', maxWidth: '260px' } }
+		>
+			<ColorSwatchIcon sx={ { transform: 'rotate(90deg)' } } fontSize="large" />
+			<Typography align="center" variant="subtitle2">
+				{
+					/* translators: %s is the maximum number of classes */
+					__( 'Limit of %s classes reached', 'elementor' ).replace( '%s', String( limitCount ) )
+				}
+			</Typography>
+			<Typography align="center" variant="caption" component="div">
+				{ __( 'Remove a class to create a new one.', 'elementor' ) }{ ' ' }
+				<Link
+					color="inherit"
+					variant="caption"
+					component="button"
+					onClick={ onClear }
+					sx={ { verticalAlign: 'baseline' } }
+				>
+					{ __( 'Clear', 'elementor' ) }
+				</Link>
+			</Typography>
+			<Button
+				variant="outlined"
+				color="secondary"
+				size="small"
+				onClick={ () => {
+					openClassManagerPanel();
+					onClear();
+				} }
+			>
+				{ __( 'Class Manager', 'elementor' ) }
+			</Button>
 		</Stack>
 	</Box>
 );
@@ -250,6 +328,18 @@ function useCreateAction() {
 		return {};
 	}
 
+	const entityName =
+		provider.labels.singular && provider.labels.plural
+			? ( provider.labels as CreatableAutocompleteProps< StyleDefOption >[ 'entityName' ] )
+			: undefined;
+
+	const validate = ( newClassLabel: string, event: ValidationEvent ): ValidationResult =>
+		validateStyleLabel( newClassLabel, event );
+
+	if ( hasReachedLimit( provider ) ) {
+		return { entityName, isAtLimit: true as const, limitCount: provider.limit, validate };
+	}
+
 	const create = ( classLabel: string ) => {
 		const { createdId } = createAction( { classLabel } );
 		trackStyles( provider.getKey() ?? '', 'classCreated', {
@@ -259,26 +349,7 @@ function useCreateAction() {
 		} );
 	};
 
-	const validate = ( newClassLabel: string, event: ValidationEvent ): ValidationResult => {
-		if ( hasReachedLimit( provider ) ) {
-			return {
-				isValid: false,
-				/* translators: %s is the maximum number of classes */
-				errorMessage: __(
-					'You’ve reached the limit of %s classes. Please remove an existing one to create a new class.',
-					'elementor'
-				).replace( '%s', provider.limit.toString() ),
-			};
-		}
-		return validateStyleLabel( newClassLabel, event );
-	};
-
-	const entityName =
-		provider.labels.singular && provider.labels.plural
-			? ( provider.labels as CreatableAutocompleteProps< StyleDefOption >[ 'entityName' ] )
-			: undefined;
-
-	return { create, validate, entityName };
+	return { create, validate, entityName, isAtLimit: false as const };
 }
 
 function hasReachedLimit( provider: StylesProvider ) {

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/global-classes-list.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/global-classes-list.tsx
@@ -248,8 +248,9 @@ const useFilteredCssClasses = (): StyleDefinition[] => {
 	);
 
 	const filteredClasses = useMemo( () => {
-		if ( searchValue.length > 1 ) {
-			return lowercaseLabels.filter( ( cssClass ) => cssClass.lowerLabel.includes( searchValue.toLowerCase() ) );
+		const normalizedSearch = searchValue.replace( /[^a-zA-Z0-9_-]/g, '' ).toLowerCase();
+		if ( normalizedSearch.length > 1 ) {
+			return lowercaseLabels.filter( ( cssClass ) => cssClass.lowerLabel.includes( normalizedSearch ) );
 		}
 		return cssClasses;
 	}, [ searchValue, cssClasses, lowercaseLabels ] );

--- a/packages/packages/core/editor-global-classes/src/components/open-panel-from-event.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/open-panel-from-event.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+import { usePanelActions } from './class-manager/class-manager-panel';
+
+const EVENT_OPEN_GLOBAL_CLASSES_MANAGER = 'elementor/open-global-classes-manager';
+
+export function OpenPanelFromEvent() {
+	const { open } = usePanelActions();
+
+	useEffect( () => {
+		const handler = () => open();
+
+		window.addEventListener( EVENT_OPEN_GLOBAL_CLASSES_MANAGER, handler );
+
+		return () => window.removeEventListener( EVENT_OPEN_GLOBAL_CLASSES_MANAGER, handler );
+	}, [ open ] );
+
+	return null;
+}

--- a/packages/packages/core/editor-global-classes/src/global-classes-styles-provider.ts
+++ b/packages/packages/core/editor-global-classes/src/global-classes-styles-provider.ts
@@ -27,7 +27,7 @@ import {
 } from './store';
 import { trackGlobalClasses, type TrackingEvent } from './utils/tracking';
 
-const MAX_CLASSES = 5000;
+const MAX_CLASSES = 1000;
 
 export const GLOBAL_CLASSES_PROVIDER_KEY = 'global-classes';
 const PREGENERATED_LINK_PATTERN = /^global-([0-9]+-)?(preview|frontend)-[a-zA-Z_-]+-css$/;

--- a/packages/packages/core/editor-global-classes/src/init.ts
+++ b/packages/packages/core/editor-global-classes/src/init.ts
@@ -14,6 +14,7 @@ import { ClassManagerButton } from './components/class-manager/class-manager-but
 import { panel } from './components/class-manager/class-manager-panel';
 import { ConvertLocalClassToGlobalClass } from './components/convert-local-class-to-global-class';
 import { GlobalStylesImportListener } from './components/global-styles-import-listener';
+import { OpenPanelFromEvent } from './components/open-panel-from-event';
 import { OpenPanelFromUrl } from './components/open-panel-from-url';
 import { PopulateStore } from './components/populate-store';
 import { GLOBAL_CLASSES_PROVIDER_KEY, globalClassesStylesProvider } from './global-classes-styles-provider';
@@ -55,6 +56,11 @@ export function init() {
 		injectIntoLogic( {
 			id: 'global-classes-open-panel-from-url',
 			component: OpenPanelFromUrl,
+		} );
+
+		injectIntoLogic( {
+			id: 'global-classes-open-panel-from-event',
+			component: OpenPanelFromEvent,
 		} );
 	}
 


### PR DESCRIPTION
Cherry pick of #35826 into `4.01`.

## Summary

- Fixed: typing in the CSS class selector while at the class limit now shows existing classes in the autocomplete dropdown instead of replacing the dropdown with an error message.
- Fixed: clicking "Class Manager" in the limit-reached empty state now correctly opens the panel when the Design System experiment is off.
- Improved: global class search normalizes the query (strips non-alphanumeric characters like leading dots) before matching, so searching `.btn` or `btn` both find `btn-primary`.

## Original PR

#35826

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Global class search was using exact matching (case-sensitive) instead of contains matching, and hitting the class limit prevented autocomplete entirely rather than showing existing classes. ED-23973 fixes both by normalizing search input and decoupling limit validation from filtering logic.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `use-filter-options.ts` | Added `normalizeClassSearch()` to strip non-class chars; configured filter with `matchFrom: 'any'` for contains matching |
| `css-class-selector.tsx` | Split `useCreateAction()` to return `isAtLimit` flag separately; added `LimitReachedEmptyState` component with Class Manager button; refactored `EmptyState` as composable layout |
| `global-classes-list.tsx` | Applied same normalization logic to search filtering |
| `global-classes-styles-provider.ts` | Reduced `MAX_CLASSES` from 5000 to 1000 |
| `init.ts` | Added `OpenPanelFromEvent` listener for design system panel integration |
| Test files | Updated test fixtures and assertions to match new class naming convention |

## 3. How It Works

Search normalizes input by stripping non-alphanumeric chars (`[^a-zA-Z0-9_-]`) and lowercasing before filtering. `useCreateAction()` now checks limit upfront and returns `{ isAtLimit, limitCount }` flag. When at limit, `LimitReachedEmptyState` renders instead of blocking—users can still browse existing classes and access Class Manager. Validation still runs to surface format errors. Event listener (`OpenPanelFromEvent`) allows CSS class selector to trigger design system panel via custom events.

## 4. Risks

Normalization might match unintended results if users search with special chars (e.g., `my-class` and `my_class` now match identically)—acceptable trade-off for UX. Reduced class limit (5000→1000) may impact existing large installations. New event-based panel trigger adds implicit coupling between modules—mitigated by constant namespacing.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
