### PR TITLE
Fix: Cherry-pick PR 35871 to 4.01: Atomic Forms not working inside Components [ED-23721]

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -730,11 +730,17 @@ class Utils {
 				return $element;
 			}
 
-			if ( ! empty( $element['elements'] ) ) {
-				$element = self::find_element_recursive( $element['elements'], $id );
+			$inner_elements = apply_filters(
+				'elementor/utils/find_element_recursive/inner_elements',
+				$element['elements'] ?? [],
+				$element
+			);
 
-				if ( $element ) {
-					return $element;
+			if ( ! empty( $inner_elements ) ) {
+				$found = self::find_element_recursive( $inner_elements, $id );
+
+				if ( $found ) {
+					return $found;
 				}
 			}
 		}

--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -16,6 +16,7 @@ use Elementor\Modules\Components\Transformers\Overridable_Transformer;
 use Elementor\Core\Base\Document;
 use Elementor\Modules\Components\PropTypes\Override_Prop_Type;
 use Elementor\Modules\Components\Transformers\Override_Transformer;
+use Elementor\Modules\Components\Widgets\Component_Instance;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -44,6 +45,7 @@ class Module extends BaseModule {
 		add_action( 'elementor/document/before_save', fn( Document $document, array $data ) => $this->validate_circular_dependencies( $document, $data ), 10, 2 );
 		add_action( 'elementor/document/after_save', fn( Document $document, array $data ) => $this->set_component_overridable_props( $document, $data ), 10, 2 );
 		add_filter( 'elementor/global_classes/additional_post_types', fn( $post_types ) => array_merge( $post_types, [ Component_Document::TYPE ] ) );
+		add_filter( 'elementor/utils/find_element_recursive/inner_elements', fn( array $inner_elements, array $element_data ) => $this->get_inner_elements_for_search( $inner_elements, $element_data ), 10, 2 );
 
 		add_action( 'elementor/atomic-widgets/settings/transformers/register', fn ( $transformers ) => $this->register_settings_transformers( $transformers ) );
 		add_action( 'elementor/document/after_migrate', fn( Document $document, array $data ) => $this->after_component_migrate( $document, $data ), 10, 2 );
@@ -152,5 +154,25 @@ class Module extends BaseModule {
 		}
 
 		$document->align_overridable_props_with_elements();
+	}
+
+	private function get_inner_elements_for_search( array $inner_elements, array $element_data ): array {
+		if ( ! $this->is_component_instance( $element_data ) ) {
+			return $inner_elements;
+		}
+
+		$element_instance = Plugin::$instance->elements_manager->create_element_instance( $element_data );
+
+		if ( ! $element_instance instanceof Component_Instance ) {
+			return [];
+		}
+
+		return $element_instance->get_inner_elements_data_for_search();
+	}
+
+	private function is_component_instance( array $element_data ): bool {
+		return isset( $element_data['elType'], $element_data['widgetType'] )
+			&& 'widget' === $element_data['elType']
+			&& Component_Instance::get_element_type() === $element_data['widgetType'];
 	}
 }

--- a/modules/components/widgets/component-instance.php
+++ b/modules/components/widgets/component-instance.php
@@ -4,9 +4,11 @@ namespace Elementor\Modules\Components\Widgets;
 use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Widget_Base;
 use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Template;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Render_Props_Resolver;
+use Elementor\Modules\Components\Components_Repository;
 use Elementor\Modules\Components\PropTypes\Component_Instance_Prop_Type;
 use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
 use Elementor\Modules\Components\Transformers\Overridable_Transformer;
+use Elementor\Modules\Components\Utils\Format_Component_Elements_Id;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -99,5 +101,34 @@ class Component_Instance extends Atomic_Widget_Base {
 		}
 
 		return $overrides;
+	}
+
+	public function get_inner_elements_data_for_search(): array {
+		$component_id = $this->get_component_id();
+
+		if ( null === $component_id ) {
+			return [];
+		}
+
+		$repository = new Components_Repository();
+		$component = $repository->get( $component_id );
+
+		if ( ! $component ) {
+			return [];
+		}
+
+		$elements_data = $component->get_elements_data();
+
+		return Format_Component_Elements_Id::format( $elements_data, [ $this->get_id() ] );
+	}
+
+	private function get_component_id(): ?int {
+		$settings = $this->get_settings();
+
+		if ( ! isset( $settings['component_instance']['value']['component_id']['value'] ) ) {
+			return null;
+		}
+
+		return (int) $settings['component_instance']['value']['component_id']['value'];
 	}
 }

--- a/tests/phpunit/elementor/modules/components/test-find-element-recursive.php
+++ b/tests/phpunit/elementor/modules/components/test-find-element-recursive.php
@@ -1,0 +1,176 @@
+<?php
+namespace Elementor\Testing\Modules\Components;
+
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
+use Elementor\Modules\Components\Documents\Component as Component_Document;
+use Elementor\Modules\Components\Module as Components_Module;
+use Elementor\Modules\Components\Utils\Format_Component_Elements_Id;
+use Elementor\Modules\Components\Widgets\Component_Instance;
+use Elementor\Plugin;
+use Elementor\Utils;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Find_Element_Recursive extends Elementor_Test_Base {
+
+	const COMPONENT_INSTANCE_ID = 'component-instance';
+
+	private bool $registered_component_widget = false;
+
+	private string $original_atomic_widgets_experiment_state;
+
+	private string $original_components_experiment_state;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->act_as_admin();
+
+		$this->original_atomic_widgets_experiment_state = Plugin::$instance->experiments
+			->get_features( Atomic_Widgets_Module::EXPERIMENT_NAME )['default'];
+		$this->original_components_experiment_state = Plugin::$instance->experiments
+			->get_features( Components_Module::EXPERIMENT_NAME )['default'];
+
+		Plugin::$instance->experiments->set_feature_default_state(
+			Atomic_Widgets_Module::EXPERIMENT_NAME,
+			Experiments_Manager::STATE_ACTIVE
+		);
+		Plugin::$instance->experiments->set_feature_default_state(
+			Components_Module::EXPERIMENT_NAME,
+			Experiments_Manager::STATE_ACTIVE
+		);
+
+		new Components_Module();
+
+		if ( ! Plugin::$instance->widgets_manager->get_widget_types( Component_Instance::get_element_type() ) ) {
+			Plugin::$instance->widgets_manager->register( new Component_Instance( [], [] ) );
+			$this->registered_component_widget = true;
+		}
+	}
+
+	public function tearDown(): void {
+		$this->clean_up_components();
+
+		if ( $this->registered_component_widget ) {
+			Plugin::$instance->widgets_manager->unregister( Component_Instance::get_element_type() );
+		}
+
+		remove_all_filters( 'elementor/utils/find_element_recursive/inner_elements' );
+
+		Plugin::$instance->experiments->set_feature_default_state(
+			Atomic_Widgets_Module::EXPERIMENT_NAME,
+			$this->original_atomic_widgets_experiment_state
+		);
+		Plugin::$instance->experiments->set_feature_default_state(
+			Components_Module::EXPERIMENT_NAME,
+			$this->original_components_experiment_state
+		);
+
+		parent::tearDown();
+	}
+
+	public function test_find_element_recursive_searches_raw_child_elements_without_instantiation() {
+		$target = [
+			'id' => 'target-element',
+			'elType' => 'unknown-element',
+			'elements' => [],
+		];
+
+		$elements = [
+			[
+				'id' => 'parent-element',
+				'elType' => 'unknown-parent',
+				'elements' => [
+					$target,
+				],
+			],
+		];
+
+		$result = Utils::find_element_recursive( $elements, $target['id'] );
+
+		$this->assertSame( $target, $result );
+	}
+
+	public function test_find_element_recursive_searches_component_origin_elements() {
+		$component_elements = [
+			[
+				'id' => 'component-parent',
+				'elType' => 'e-flexbox',
+				'settings' => [],
+				'elements' => [
+					[
+						'id' => 'component-target',
+						'elType' => 'widget',
+						'widgetType' => 'e-heading',
+						'settings' => [],
+						'elements' => [],
+					],
+				],
+			],
+		];
+
+		$component_id = $this->create_test_component( $component_elements );
+		$formatted_elements = Format_Component_Elements_Id::format( $component_elements, [ self::COMPONENT_INSTANCE_ID ] );
+		$expected = $formatted_elements[0]['elements'][0];
+
+		$elements = [
+			[
+				'id' => self::COMPONENT_INSTANCE_ID,
+				'elType' => 'widget',
+				'widgetType' => Component_Instance::get_element_type(),
+				'elements' => [],
+				'settings' => [
+					'component_instance' => [
+						'$$type' => 'component-instance',
+						'value' => [
+							'component_id' => [
+								'$$type' => 'number',
+								'value' => $component_id,
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$result = Utils::find_element_recursive( $elements, $expected['id'] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $expected['id'], $result['id'] );
+		$this->assertSame( $expected['origin_id'], $result['origin_id'] );
+		$this->assertSame( $expected['widgetType'], $result['widgetType'] );
+	}
+
+	private function create_test_component( array $elements ): int {
+		$document = Plugin::$instance->documents->create(
+			Component_Document::get_type(),
+			[
+				'post_title' => 'Test Component',
+				'post_status' => 'publish',
+			]
+		);
+
+		$document->save( [
+			'elements' => $elements,
+			'settings' => [],
+		] );
+
+		return $document->get_main_id();
+	}
+
+	private function clean_up_components(): void {
+		$components = get_posts( [
+			'post_type' => Component_Document::TYPE,
+			'post_status' => 'any',
+			'posts_per_page' => -1,
+		] );
+
+		foreach ( $components as $component ) {
+			wp_delete_post( $component->ID, true );
+		}
+	}
+}


### PR DESCRIPTION
Cherry-pick of #35871 to `4.01` branch.

## Original PR

#35871

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Atomic Forms (Component_Instance widgets) weren't searchable via `find_element_recursive` because the function only traversed explicitly-stored child elements, not component internals. ED-23721.

## 2. What Changed (Where)

- **includes/utils.php**: Added filter hook to `find_element_recursive`, allowing modules to inject virtual children for search
- **modules/components/module.php**: Registers filter hook; hooks into search to expose component's internal elements
- **modules/components/widgets/component-instance.php**: Implements methods to retrieve formatted inner elements with parent context
- **tests/phpunit/**: New test suite covering recursive search with component instances

## 3. How It Works

When `find_element_recursive` traverses elements, it applies `elementor/utils/find_element_recursive/inner_elements` filter on each element's children. Components module detects `Component_Instance` widgets via this filter, instantiates them, retrieves their stored component's element tree, and returns it with IDs formatted to include the component instance as ancestor. This allows searching nested elements inside component instances transparently.

## 4. Risks

Minimal. Filter-based approach is non-breaking; component instantiation only triggers for `Component_Instance` widgets (narrow scope). Test coverage validates both raw element traversal and component search paths.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
