### PR TITLE
Fix: Cherry-pick PR 35854 to 4.01: Adding PropValue validation in automated doUpdateElementProperty [ED-24097]

### DIFF
--- a/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/tool.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/tool.ts
@@ -68,27 +68,34 @@ export const initBuildCompositionsTool = ( reg: MCPRegistryEntry ) => {
 				compositionBuilder.setStylesConfig( stylesConfig );
 				compositionBuilder.setCustomCSS( customCSS );
 
-				const { invalidStyles, rootContainers: generatedRootContainers } =
-					await compositionBuilder.build( targetContainer );
+				const {
+					invalidStyles,
+					configErrors,
+					rootContainers: generatedRootContainers,
+				} = await compositionBuilder.build( targetContainer );
 
 				rootContainers.push( ...generatedRootContainers );
 				generatedXML = new XMLSerializer().serializeToString( compositionBuilder.getXML() );
 
-				Object.entries( invalidStyles ).forEach( ( [ elementId, rawCssRules ] ) => {
-					const customCss = {
-						value: rawCssRules.join( ';\n' ),
-					};
-					doUpdateElementProperty( {
-						elementId,
-						propertyName: '_styles',
-						propertyValue: {
-							_styles: {
-								custom_css: customCss,
+				if ( configErrors.length ) {
+					errors.push( ...configErrors.map( ( msg ) => new Error( msg ) ) );
+				} else {
+					Object.entries( invalidStyles ).forEach( ( [ elementId, rawCssRules ] ) => {
+						const customCss = {
+							value: rawCssRules.join( ';\n' ),
+						};
+						doUpdateElementProperty( {
+							elementId,
+							propertyName: '_styles',
+							propertyValue: {
+								_styles: {
+									custom_css: customCss,
+								},
 							},
-						},
-						elementType: 'widget',
+							elementType: 'widget',
+						} );
 					} );
-				} );
+				}
 			} catch ( error ) {
 				errors.push( error as Error );
 			}

--- a/packages/packages/core/editor-canvas/src/mcp/utils/__tests__/do-update-element-property.test.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/utils/__tests__/do-update-element-property.test.ts
@@ -1,0 +1,135 @@
+import { getWidgetsCache, updateElementSettings } from '@elementor/editor-elements';
+import { Schema } from '@elementor/editor-props';
+import { __privateRunCommandSync } from '@elementor/editor-v1-adapters';
+
+import { doUpdateElementProperty } from '../do-update-element-property';
+
+jest.mock( '@elementor/editor-elements', () => ( {
+	createElementStyle: jest.fn(),
+	getElementStyles: jest.fn(),
+	getWidgetsCache: jest.fn(),
+	updateElementSettings: jest.fn(),
+	updateElementStyle: jest.fn(),
+} ) );
+
+jest.mock( '@elementor/editor-props', () => ( {
+	getPropSchemaFromCache: jest.fn(),
+	Schema: {
+		adjustLlmPropValueSchema: jest.fn( ( value: unknown ) => value ),
+		validatePropValue: jest.fn(),
+	},
+} ) );
+
+jest.mock( '@elementor/editor-styles', () => ( {
+	getStylesSchema: jest.fn( () => ( {} ) ),
+} ) );
+
+jest.mock( '@elementor/editor-v1-adapters', () => ( {
+	__privateRunCommandSync: jest.fn(),
+} ) );
+
+const ELEMENT_ID = 'test-element-id';
+const ELEMENT_TYPE = 'atomic-heading';
+const EXPECTED_JSON_SCHEMA_SNIPPET = '{"type":"object"}';
+const PROPERTY_NAME = 'title';
+const PROP_SCHEMA_ENTRY = { key: 'titlePropKey' };
+
+const widgetsCacheFixture = {
+	[ ELEMENT_TYPE ]: {
+		atomic_props_schema: {
+			[ PROPERTY_NAME ]: PROP_SCHEMA_ENTRY,
+		},
+	},
+};
+
+describe( 'doUpdateElementProperty', () => {
+	beforeEach( () => {
+		Object.assign( window, {
+			elementorV2: {
+				editorVariables: {
+					Utils: {
+						globalVariablesLLMResolvers: [],
+					},
+				},
+			},
+		} );
+		// @ts-ignore: Mock values for test
+		jest.mocked( getWidgetsCache ).mockReturnValue( widgetsCacheFixture );
+		// @ts-ignore: Mock values for test
+		jest.mocked( Schema.adjustLlmPropValueSchema ).mockImplementation( ( value: unknown ) => value );
+		jest.mocked( Schema.validatePropValue ).mockReset();
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'throws when Schema.validatePropValue reports invalid PropValue and does not persist', () => {
+		// Arrange
+		const propertyValue = { invalid: true };
+		jest.mocked( Schema.validatePropValue ).mockReturnValue( {
+			jsonSchema: EXPECTED_JSON_SCHEMA_SNIPPET,
+			valid: false,
+			errorMessages: 'error',
+			errors: [],
+		} );
+
+		// Act
+		let thrown: unknown;
+		try {
+			doUpdateElementProperty( {
+				elementId: ELEMENT_ID,
+				elementType: ELEMENT_TYPE,
+				propertyName: PROPERTY_NAME,
+				propertyValue,
+			} );
+		} catch ( error ) {
+			thrown = error;
+		}
+
+		// Assert
+		expect( thrown ).toBeInstanceOf( Error );
+		expect( ( thrown as Error ).message ).toMatch( /Invalid PropValue/ );
+		expect( ( thrown as Error ).message ).toContain( ELEMENT_ID );
+		expect( ( thrown as Error ).message ).toContain( PROP_SCHEMA_ENTRY.key );
+		expect( ( thrown as Error ).message ).toContain( EXPECTED_JSON_SCHEMA_SNIPPET );
+		expect( Schema.validatePropValue ).toHaveBeenCalledWith( PROP_SCHEMA_ENTRY, propertyValue );
+		expect( updateElementSettings ).not.toHaveBeenCalled();
+		expect( __privateRunCommandSync ).not.toHaveBeenCalled();
+	} );
+
+	it( 'updates settings when Schema.validatePropValue reports valid PropValue', () => {
+		// Arrange
+		const propertyValue = 'resolved-title';
+		jest.mocked( Schema.validatePropValue ).mockReturnValue( {
+			jsonSchema: EXPECTED_JSON_SCHEMA_SNIPPET,
+			valid: true,
+			errorMessages: [],
+			errors: [],
+		} );
+
+		// Act
+		doUpdateElementProperty( {
+			elementId: ELEMENT_ID,
+			elementType: ELEMENT_TYPE,
+			propertyName: PROPERTY_NAME,
+			propertyValue,
+		} );
+
+		// Assert
+		expect( Schema.validatePropValue ).toHaveBeenCalledWith( PROP_SCHEMA_ENTRY, propertyValue );
+		expect( updateElementSettings ).toHaveBeenCalledTimes( 1 );
+		expect( updateElementSettings ).toHaveBeenCalledWith( {
+			id: ELEMENT_ID,
+			props: {
+				[ PROPERTY_NAME ]: propertyValue,
+			},
+			withHistory: false,
+		} );
+		expect( __privateRunCommandSync ).toHaveBeenCalledWith(
+			'document/save/set-is-modified',
+			{ status: true },
+			{ internal: true }
+		);
+	} );
+} );

--- a/packages/packages/core/editor-canvas/src/mcp/utils/do-update-element-property.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/utils/do-update-element-property.ts
@@ -129,6 +129,14 @@ export const doUpdateElementProperty = ( params: OwnParams ) => {
 	}
 	const propKey = elementPropSchema[ propertyName ].key;
 	const value = resolvePropValue( propertyValue, propKey );
+	const { valid, jsonSchema } = Schema.validatePropValue( elementPropSchema[ propertyName ], propertyValue );
+	if ( ! valid ) {
+		throw new Error(
+			`Invalid PropValue for elementId: ${ elementId }. PropKey: ${ propKey }, PropValue: ${ JSON.stringify(
+				propertyValue
+			) }\nExpected Schema: ${ jsonSchema }`
+		);
+	}
 	updateElementSettings( {
 		id: elementId,
 		props: {


### PR DESCRIPTION
Cherry-pick of #35854 to the 4.01 release branch.

## Changes
- Added `Schema.validatePropValue()` check in `doUpdateElementProperty` before persisting element properties
- Refactored build result handling in `build-composition/tool.ts` with error-handling for invalid PropValues
- Added unit tests for valid/invalid PropValue scenarios

## Original PR
#35854

## Jira
[ED-24097](https://elementor.atlassian.net/browse/ED-24097)

Made with [Cursor](https://cursor.com)

[ED-24097]: https://elementor.atlassian.net/browse/ED-24097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick from main adds PropValue validation to `doUpdateElementProperty` to catch invalid prop assignments early. ED-24097 tracks the original work; refactors build composition error handling to distinguish config errors from style validation failures.

## 2. What Changed (Where)

- `do-update-element-property.ts`: Added `Schema.validatePropValue()` check before persisting; throws descriptive error on invalid props.
- `tool.ts`: Refactored to destructure `configErrors` from build result; conditionally routes through validation or error handling.
- `do-update-element-property.test.ts`: New test file with 135 lines covering validation failure and success paths.

## 3. How It Works

Build composition now captures both config errors and invalid styles. If config errors exist, they're surfaced immediately. Otherwise, invalid styles trigger `doUpdateElementProperty` calls with newly-validated props. Validation runs synchronously before `updateElementSettings`—throws with schema context if invalid.

## 4. Risks

Prop validation could reject previously-accepted values if schema stricter than before; mitigate via test coverage (done). Error messages now expose internal schema details—acceptable for logging, not user-facing yet.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
