### PR TITLE
Fix: Playground Preview action to use PR Build artifact [ED-24114]

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -117,29 +117,17 @@ jobs:
           const template = fs.readFileSync('tests/playwright/blueprints/pr-preview.json', 'utf8');
           const blueprint = template.replace(/\$PLUGIN_ZIP_URL/g, url);
           JSON.parse(blueprint);
+          const playgroundUrl = `https://playground.wordpress.net/?blueprint-url=data:application/json,${encodeURIComponent(blueprint)}`;
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `json<<BLUEPRINT_JSON_EOF\n${blueprint}\nBLUEPRINT_JSON_EOF\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `playground-url=${playgroundUrl}\n`);
           NODE
-
-      - name: Post Playground Preview comment
-        id: post-preview
-        uses: WordPress/action-wp-playground-pr-preview@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-number: ${{ steps.runctx.outputs.pr-number }}
-          blueprint: ${{ steps.blueprint.outputs.json }}
-          mode: append-to-description
-          restore-button-if-removed: true
-          playground-host: https://playground.wordpress.net
-          description-template: |
-            ## Live Playground Preview
-            {{PLAYGROUND_BUTTON}}
 
       - name: Create PR deployment
         uses: actions/github-script@v7
         env:
           HEAD_SHA: ${{ steps.runctx.outputs.head-sha }}
           PR_NUMBER: ${{ steps.runctx.outputs.pr-number }}
-          PREVIEW_URL: ${{ steps.post-preview.outputs.preview-url }}
+          PREVIEW_URL: ${{ steps.blueprint.outputs.playground-url }}
         with:
           script: |
             const { data: deployment } = await github.rest.repos.createDeployment({

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            console.log('context: ${JSON.stringify(context)}');
+            console.log('context:${JSON.stringify(context)}');
             const run = context.payload.workflow_run;
             const prs = run.pull_requests || [];
             if (!prs.length) {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Replace the deprecated WordPress Playground PR Preview action with inline blueprint URL generation, eliminating the external action dependency while maintaining deployment preview functionality.

## 2. What Changed (Where)

`.github/workflows/playground-preview.yml`: Generate playground URL directly in blueprint step; remove WordPress action; pass URL to deployment step; fix template literal syntax in debug log.

## 3. How It Works

Blueprint step now constructs the playground URL by encoding the blueprint JSON as a data URI (`data:application/json,${encodeURIComponent(blueprint)}`), then writes it to `GITHUB_OUTPUT` for the deployment step to consume. Removed the separate "Post Playground Preview comment" action that previously handled this.

## 4. Risks

URL encoding edge cases in blueprint JSON (quotes, special chars) could break the data URI—validate against complex plugin configs. Removed action may have had undocumented side effects (comments, checks); verify deployment step fully replaces that behavior.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

<!-- wp-playground-preview:start -->
## Live Playground Preview
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%0A%20%20%20%20%22%24schema%22%3A%20%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%0A%20%20%20%20%22landingPage%22%3A%20%22%2Fwp-admin%22%2C%0A%20%20%20%20%22preferredVersions%22%3A%20%7B%20%22php%22%3A%20%227.4%22%2C%20%22wp%22%3A%20%22latest%22%20%7D%2C%0A%20%20%20%20%22features%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22networking%22%3A%20true%0A%20%20%20%20%7D%2C%0A%20%20%20%20%22extraLibraries%22%3A%20%5B%20%22wp-cli%22%20%5D%2C%0A%20%20%20%20%22steps%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%7B%20%22step%22%3A%20%22login%22%2C%20%22username%22%3A%20%22admin%22%2C%20%22password%22%3A%20%22password%22%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22step%22%3A%20%22defineWpConfigConsts%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22consts%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22ELEMENTOR_SHOW_HIDDEN_EXPERIMENTS%22%3A%20true%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22step%22%3A%20%22installPlugin%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22pluginData%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22resource%22%3A%20%22url%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22url%22%3A%20%22https%3A%2F%2Fgithub.com%2Felementor%2Felementor%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-35914-6f0a7eab19c0c54644ca10a6e0b60642607c1801.zip%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22step%22%3A%20%22installTheme%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22themeData%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22resource%22%3A%20%22wordpress.org%2Fthemes%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22slug%22%3A%20%22hello-elementor%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%20%22step%22%3A%20%22activateTheme%22%2C%20%22themeFolderName%22%3A%20%22hello-elementor%22%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%20%22step%22%3A%20%22wp-cli%22%2C%20%22command%22%3A%20%22wp%20option%20add%20&#039;elementor_onboarded&#039;%201%22%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%20%22step%22%3A%20%22wp-cli%22%2C%20%22command%22%3A%20%22wp%20elementor%20experiments%20activate%20e_atomic_elements%2Ccontainer%2Ce_opt_in_v4%2Ce_classes%22%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%20%22step%22%3A%20%22updateUserMeta%22%2C%20%22meta%22%3A%20%7B%20%22announcements_user_counter%22%3A%20999%2C%20%22elementor_enable_ai%22%3A%200%2C%20%22_e_welcome_popover_displayed%22%3A%201%20%7D%2C%20%22userId%22%3A%201%20%7D%0A%20%20%20%20%5D%0A%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->