### PR TITLE
Internal: Auto-update open PRs from main only when approved [ED-24137]

### DIFF
--- a/.github/scripts/update-latest-pull-requests.js
+++ b/.github/scripts/update-latest-pull-requests.js
@@ -5,7 +5,7 @@ const updatePullRequests = async () => {
 	lastDays.setDate( lastDays.getDate() - DAYS_TO_UPDATE );
 	const lastDaysString = lastDays.toISOString().split( 'T' )[0];
 
-	const url = `https://api.github.com/search/issues?q=repo:${GITHUB_REPOSITORY}+type:pr+is:open+draft:false+base:main+created:>=${lastDaysString}`;
+	const url = `https://api.github.com/search/issues?q=repo:${GITHUB_REPOSITORY}+type:pr+is:open+draft:false+base:main+review:approved+created:>=${lastDaysString}`;
 	const headers = {
 		Authorization: `token ${GITHUB_TOKEN}`,
 		Accept: 'application/vnd.github.v3+json',


### PR DESCRIPTION
## Summary
- Restrict the `Update Latest Pull Requests` script so it only calls GitHub’s `update-branch` API for PRs that already match `review:approved` in issue search (in addition to existing filters: open, non-draft, `base:main`, recent window).
- Default branch for this repository is `main` (there is no `master` branch); this PR targets `main` accordingly.

## Jira
ED-24137

## Test Plan
- [ ] PHP unit tests pass: `composer test`
- [ ] Jest tests pass: `npm test`
- [ ] Manual: open editor, add widget, verify render in preview and frontend
- [ ] Accessibility: keyboard nav and screen reader verified
- [ ] No `console.log` or `var_dump` left in code
- [ ] PHPCS clean: `./vendor/bin/phpcs`
- [ ] After merge: confirm workflow still runs on `main` push and only approved PRs (per GitHub search semantics) get branch updates

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Auto-update workflow was triggering on all open PRs against main; now restricted to approved PRs only to reduce unnecessary CI runs and noise (ED-24137).

## 2. What Changed (Where)

`.github/scripts/update-latest-pull-requests.js`: GitHub API search query now includes `+review:approved` filter in the URL construction.

## 3. How It Works

The script queries GitHub's search API with an additional `review:approved` parameter, ensuring only approved pull requests matching the other criteria (open, non-draft, base:main, recent) are returned for auto-update processing.

## 4. Risks

None identified—additive filter is backward compatible and reduces scope safely.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
