### PR TITLE
CI: Playground Preview action to use PR Build artifact [ED-24114]

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -1,0 +1,150 @@
+name: Playground PR Preview Deployments
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+permissions:
+  contents: write      # upload to ci-artifacts release
+  pull-requests: write # post PR comment
+  actions: read
+  deployments: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve PR context and Build run
+        id: runctx
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('context:${JSON.stringify(context)}');
+            const run = context.payload.workflow_run;
+            const prs = run.pull_requests || [];
+            if (!prs.length) {
+              core.setFailed('No pull request found for this workflow run');
+              return;
+            }
+
+            const prNumber = prs[0].number;
+            const headSha = run.head_sha;
+            const buildRunId = run.id;
+
+            core.setOutput('pr-number', String(prNumber));
+            core.setOutput('head-sha', headSha);
+            core.setOutput('build-run-id', String(buildRunId));
+
+      - name: Download plugin artifact
+        id: artifact
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: Number('${{ steps.runctx.outputs.build-run-id }}'),
+            });
+            const hit = artifacts.find(a => a.name.startsWith('elementor-'));
+            if (!hit) {
+              core.setFailed('No elementor artifact found in resolved Build workflow run');
+              return;
+            }
+            const dl = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: hit.id,
+              archive_format: 'zip',
+            });
+            require('fs').writeFileSync('build-artifact.zip', Buffer.from(dl.data));
+            core.setOutput('artifact-name', hit.name);
+
+      - name: Repack build artifact as plugin zip
+        run: |
+          unzip -oq build-artifact.zip -d build-artifact
+          ls -la build-artifact
+          if [ ! -f build-artifact/elementor.php ]; then
+            echo "Downloaded artifact does not look like Elementor plugin root (missing elementor.php)"
+            exit 1
+          fi
+          rm -rf plugin-root
+          mkdir -p plugin-root/elementor
+          cp -a build-artifact/. plugin-root/elementor/
+          (
+            cd plugin-root
+            zip -rq "$GITHUB_WORKSPACE/plugin.zip" elementor
+          )
+
+      - name: Upload plugin zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: playground-plugin-pr${{ steps.runctx.outputs.pr-number }}-${{ steps.runctx.outputs.head-sha }}
+          path: plugin.zip
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Expose plugin zip on public URL
+        id: expose
+        uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
+        with:
+          artifact-name: playground-plugin-pr${{ steps.runctx.outputs.pr-number }}-${{ steps.runctx.outputs.head-sha }}
+          artifact-filename: plugin.zip
+          pr-number: ${{ steps.runctx.outputs.pr-number }}
+          commit-sha: ${{ steps.runctx.outputs.head-sha }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish ci-artifacts release
+        run: |
+          gh release edit ci-artifacts --draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare blueprint JSON
+        id: blueprint
+        env:
+          PLUGIN_ZIP_URL: ${{ steps.expose.outputs.artifact-url }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const url = process.env.PLUGIN_ZIP_URL;
+          if (!url) {
+            throw new Error('Missing PLUGIN_ZIP_URL from expose step');
+          }
+          const template = fs.readFileSync('tests/playwright/blueprints/pr-preview.json', 'utf8');
+          const blueprint = template.replace(/\$PLUGIN_ZIP_URL/g, url);
+          JSON.parse(blueprint);
+          const playgroundUrl = `https://playground.wordpress.net/?blueprint-url=data:application/json,${encodeURIComponent(blueprint)}`;
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `json<<BLUEPRINT_JSON_EOF\n${blueprint}\nBLUEPRINT_JSON_EOF\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `playground-url=${playgroundUrl}\n`);
+          NODE
+
+      - name: Create PR deployment
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ steps.runctx.outputs.head-sha }}
+          PR_NUMBER: ${{ steps.runctx.outputs.pr-number }}
+          PREVIEW_URL: ${{ steps.blueprint.outputs.playground-url }}
+        with:
+          script: |
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: process.env.HEAD_SHA,
+              environment: 'playground-preview',
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              description: `WP Playground preview for PR #${process.env.PR_NUMBER}`,
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.id,
+              state: 'success',
+              environment_url: process.env.PREVIEW_URL,
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/playground-preview.yml` — the Playground PR Preview Deployments workflow (did not previously exist on `4.00`)
- Includes full artifact download, repack, expose, blueprint preparation, and GitHub deployment status steps

## Test plan
- [ ] Verify the workflow triggers correctly on a PR build completion
- [ ] Confirm the plugin zip is created and uploaded as an artifact
- [ ] Check that the playground preview URL is posted to the PR deployment


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds automated preview deployments for Elementor PRs to WordPress Playground, enabling reviewers to test changes without local setup. Triggered on successful Build workflow completion.

## 2. What Changed (Where)

- `.github/workflows/playground-preview.yml`: New 150-line workflow orchestrating artifact download, repacking, exposure, and Playground preview deployment.

## 3. How It Works

Build workflow completes → workflow_run trigger fires → extract PR context and build run ID → download Elementor artifact from Build job → repack as plugin zip → expose via public URL → generate Playground blueprint with plugin URL → create deployment with preview link. Exits early if PR context missing or artifact not found.

## 4. Risks

- Artifact download fails silently if naming convention changes; `artifact.find()` returns undefined without fallback diagnostics.
- Blueprint template path hardcoded (`tests/playwright/blueprints/pr-preview.json`); workflow breaks if file moves.
- No validation that exposed URL is actually accessible before creating deployment; preview may appear broken.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
