### PR TITLE
Internal: Cherry-pick PR 35819 to 4.01: Adding tests + extend error checking [ED-24036]

### DIFF
--- a/packages/packages/core/editor-canvas/src/composition-builder/__tests__/composition-builder.test.ts
+++ b/packages/packages/core/editor-canvas/src/composition-builder/__tests__/composition-builder.test.ts
@@ -67,7 +67,7 @@ describe( 'CompositionBuilder.build createElement failure cleanup', () => {
 		// Assert
 		expect( getContainer ).toHaveBeenCalledWith( GENERATED_ELEMENT_ID );
 		expect( deleteElement ).toHaveBeenCalledTimes( 1 );
-		expect( deleteElement ).toHaveBeenCalledWith( { container: partialContainer } );
+		expect( deleteElement ).toHaveBeenCalledWith( { container: partialContainer, options: { useHistory: false } } );
 		expect( doUpdateElementProperty ).not.toHaveBeenCalled();
 	} );
 
@@ -125,7 +125,7 @@ describe( 'CompositionBuilder.build createElement failure cleanup', () => {
 		// Assert
 		expect( getContainer ).toHaveBeenCalledWith( GENERATED_ELEMENT_ID );
 		expect( deleteElement ).toHaveBeenCalledTimes( 1 );
-		expect( deleteElement ).toHaveBeenCalledWith( { container: partialContainer } );
+		expect( deleteElement ).toHaveBeenCalledWith( { container: partialContainer, options: { useHistory: false } } );
 		expect( doUpdateElementProperty ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/packages/core/editor-canvas/src/composition-builder/__tests__/composition-builder.test.ts
+++ b/packages/packages/core/editor-canvas/src/composition-builder/__tests__/composition-builder.test.ts
@@ -1,0 +1,190 @@
+import { type V1Element } from '@elementor/editor-elements';
+
+import { CompositionBuilder } from '../composition-builder';
+
+const ROOT_CHILD_TAG = 'column';
+const GENERATED_ELEMENT_ID = 'generated-element-id';
+const CONFIG_ID = 'cfg-a';
+const ELEMENT_CONFIG_PROPERTY = 'title';
+const ELEMENT_CONFIG_VALUE = 'configured-value';
+
+const xmlStringWithConfiguration = `<${ ROOT_CHILD_TAG } configuration-id="${ CONFIG_ID }" />`;
+
+const createElementConfigPayload = () => ( {
+	[ CONFIG_ID ]: {
+		[ ELEMENT_CONFIG_PROPERTY ]: ELEMENT_CONFIG_VALUE,
+	},
+} );
+
+const createMinimalWidgetsCache = () =>
+	( {
+		[ ROOT_CHILD_TAG ]: {
+			elType: 'column',
+		},
+	} ) as Record< string, { elType: string } >;
+
+const createMockRootContainer = (): V1Element =>
+	( {
+		id: 'root',
+		model: { get: jest.fn(), set: jest.fn(), toJSON: jest.fn() },
+		settings: { get: jest.fn(), set: jest.fn(), toJSON: jest.fn() },
+		children: [],
+	} ) as unknown as V1Element;
+
+const createMockPartialContainer = ( id: string ): V1Element =>
+	( {
+		id,
+		model: { get: jest.fn(), set: jest.fn(), toJSON: jest.fn() },
+		settings: { get: jest.fn(), set: jest.fn(), toJSON: jest.fn() },
+		children: [],
+	} ) as unknown as V1Element;
+
+describe( 'CompositionBuilder.build createElement failure cleanup', () => {
+	it( 'calls deleteElement when createElement fails and getContainer returns a container', async () => {
+		// Arrange
+		const partialContainer = createMockPartialContainer( GENERATED_ELEMENT_ID );
+		const deleteElement = jest.fn();
+		const doUpdateElementProperty = jest.fn();
+		const createElement = jest.fn().mockImplementation( () => {
+			throw new Error( 'create failed' );
+		} );
+		const getContainer = jest
+			.fn()
+			.mockImplementation( ( id: string ) => ( id === GENERATED_ELEMENT_ID ? partialContainer : undefined ) );
+		const builder = CompositionBuilder.fromXMLString( xmlStringWithConfiguration, {
+			createElement,
+			deleteElement,
+			getContainer,
+			generateElementId: jest.fn().mockReturnValue( GENERATED_ELEMENT_ID ),
+			getWidgetsCache: jest.fn().mockReturnValue( createMinimalWidgetsCache() ),
+			doUpdateElementProperty,
+		} );
+		builder.setElementConfig( createElementConfigPayload() );
+
+		// Act
+		await expect( builder.build( createMockRootContainer() ) ).rejects.toThrow( 'create failed' );
+
+		// Assert
+		expect( getContainer ).toHaveBeenCalledWith( GENERATED_ELEMENT_ID );
+		expect( deleteElement ).toHaveBeenCalledTimes( 1 );
+		expect( deleteElement ).toHaveBeenCalledWith( { container: partialContainer } );
+		expect( doUpdateElementProperty ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not call deleteElement when createElement fails and getContainer returns undefined', async () => {
+		// Arrange
+		const deleteElement = jest.fn();
+		const doUpdateElementProperty = jest.fn();
+		const createElement = jest.fn().mockImplementation( () => {
+			throw new Error( 'create failed' );
+		} );
+		const getContainer = jest.fn().mockReturnValue( undefined );
+		const builder = CompositionBuilder.fromXMLString( xmlStringWithConfiguration, {
+			createElement,
+			deleteElement,
+			getContainer,
+			generateElementId: jest.fn().mockReturnValue( GENERATED_ELEMENT_ID ),
+			getWidgetsCache: jest.fn().mockReturnValue( createMinimalWidgetsCache() ),
+			doUpdateElementProperty,
+		} );
+		builder.setElementConfig( createElementConfigPayload() );
+
+		// Act
+		await expect( builder.build( createMockRootContainer() ) ).rejects.toThrow( 'create failed' );
+
+		// Assert
+		expect( getContainer ).toHaveBeenCalledWith( GENERATED_ELEMENT_ID );
+		expect( deleteElement ).not.toHaveBeenCalled();
+		expect( doUpdateElementProperty ).not.toHaveBeenCalled();
+	} );
+
+	it( 'calls deleteElement when createElement returns without a model', async () => {
+		// Arrange
+		const partialContainer = createMockPartialContainer( GENERATED_ELEMENT_ID );
+		const deleteElement = jest.fn();
+		const doUpdateElementProperty = jest.fn();
+		const createElement = jest.fn().mockReturnValue( {} as V1Element );
+		const getContainer = jest
+			.fn()
+			.mockImplementation( ( id: string ) => ( id === GENERATED_ELEMENT_ID ? partialContainer : undefined ) );
+		const builder = CompositionBuilder.fromXMLString( xmlStringWithConfiguration, {
+			createElement,
+			deleteElement,
+			getContainer,
+			generateElementId: jest.fn().mockReturnValue( GENERATED_ELEMENT_ID ),
+			getWidgetsCache: jest.fn().mockReturnValue( createMinimalWidgetsCache() ),
+			doUpdateElementProperty,
+		} );
+		builder.setElementConfig( createElementConfigPayload() );
+
+		// Act
+		await expect( builder.build( createMockRootContainer() ) ).rejects.toThrow(
+			'createElement did not return an element container with a model.'
+		);
+
+		// Assert
+		expect( getContainer ).toHaveBeenCalledWith( GENERATED_ELEMENT_ID );
+		expect( deleteElement ).toHaveBeenCalledTimes( 1 );
+		expect( deleteElement ).toHaveBeenCalledWith( { container: partialContainer } );
+		expect( doUpdateElementProperty ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'CompositionBuilder.build applyProperties after create', () => {
+	it( 'calls doUpdateElementProperty when create succeeds with element config', async () => {
+		// Arrange
+		const deleteElement = jest.fn();
+		const doUpdateElementProperty = jest.fn();
+		const createdElement = createMockPartialContainer( GENERATED_ELEMENT_ID );
+		const createElement = jest.fn().mockReturnValue( createdElement );
+		const getContainer = jest
+			.fn()
+			.mockImplementation( ( id: string ) => ( id === GENERATED_ELEMENT_ID ? createdElement : undefined ) );
+		const builder = CompositionBuilder.fromXMLString( xmlStringWithConfiguration, {
+			createElement,
+			deleteElement,
+			getContainer,
+			generateElementId: jest.fn().mockReturnValue( GENERATED_ELEMENT_ID ),
+			getWidgetsCache: jest.fn().mockReturnValue( createMinimalWidgetsCache() ),
+			doUpdateElementProperty,
+		} );
+		builder.setElementConfig( createElementConfigPayload() );
+
+		// Act
+		await builder.build( createMockRootContainer() );
+
+		// Assert
+		expect( deleteElement ).not.toHaveBeenCalled();
+		expect( createElement ).toHaveBeenCalledTimes( 1 );
+		expect( doUpdateElementProperty ).toHaveBeenCalledTimes( 1 );
+		expect( doUpdateElementProperty ).toHaveBeenCalledWith( {
+			elementId: GENERATED_ELEMENT_ID,
+			propertyName: ELEMENT_CONFIG_PROPERTY,
+			propertyValue: ELEMENT_CONFIG_VALUE,
+			elementType: ROOT_CHILD_TAG,
+		} );
+	} );
+
+	it( 'does not call doUpdateElementProperty when create succeeds without element config', async () => {
+		// Arrange
+		const deleteElement = jest.fn();
+		const doUpdateElementProperty = jest.fn();
+		const createdElement = createMockPartialContainer( GENERATED_ELEMENT_ID );
+		const createElement = jest.fn().mockReturnValue( createdElement );
+		const builder = CompositionBuilder.fromXMLString( `<${ ROOT_CHILD_TAG } />`, {
+			createElement,
+			deleteElement,
+			getContainer: jest.fn(),
+			generateElementId: jest.fn().mockReturnValue( GENERATED_ELEMENT_ID ),
+			getWidgetsCache: jest.fn().mockReturnValue( createMinimalWidgetsCache() ),
+			doUpdateElementProperty,
+		} );
+
+		// Act
+		await builder.build( createMockRootContainer() );
+
+		// Assert
+		expect( deleteElement ).not.toHaveBeenCalled();
+		expect( doUpdateElementProperty ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
+++ b/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
@@ -17,6 +17,8 @@ import { validateInput } from '../mcp/utils/validate-input';
 type AnyValue = z.infer< z.ZodTypeAny >;
 type AnyConfig = Record< string, Record< string, AnyValue > >;
 
+const CREATE_ELEMENT_INVALID_CONTAINER_MESSAGE = 'createElement did not return an element container with a model.';
+
 type API = {
 	createElement: typeof createElement;
 	deleteElement: typeof deleteElement;
@@ -296,6 +298,9 @@ export class CompositionBuilder {
 					model: modelTree as CreateElementParams[ 'model' ],
 					options: { useHistory: false },
 				} );
+				if ( ! newElement?.model ) {
+					throw new Error( CREATE_ELEMENT_INVALID_CONTAINER_MESSAGE );
+				}
 				this.rootContainers.push( newElement );
 				await this.awaitViewRender( newElement );
 			} catch ( e: unknown ) {


### PR DESCRIPTION
Cherry-pick of #35819 to the 4.01 release branch.

## Changes
- Added validation after `createElement` to ensure the response includes a model before proceeding
- Added `composition-builder.test.ts` covering createElement failure scenarios and element config application

## Original PR
#35819

## Jira
[ED-24036](https://elementor.atlassian.net/browse/ED-24036)


Made with [Cursor](https://cursor.com)

[ED-24036]: https://elementor.atlassian.net/browse/ED-24036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick of PR 35819 to 4.01 branch adding validation and test coverage for createElement failure scenarios. Ticket: ED-24036.

## 2. What Changed (Where)

- **composition-builder.ts**: Added error message constant and validation check that throws when `createElement` returns without a model property (lines 20, 301-303).
- **composition-builder.test.ts**: New 190-line test suite covering createElement failures, cleanup behavior, and property application flows.

## 3. How It Works

When `createElement` completes, the code now validates that the returned element has a `model` property. If missing, it throws with a descriptive error message, triggering the existing catch-block cleanup (deleteElement + getContainer check). Tests verify three scenarios: exception during creation, missing model on successful return, and successful creation with/without config application.

## 4. Risks

None identified. Error check is defensive and non-breaking; existing exception handling already manages the thrown error. Tests validate both success and failure paths comprehensively.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
