### PR TITLE
Fix: hide 'Take me there' CTA when target is in a different document [ED-23988]

### DIFF
--- a/packages/packages/libs/editor-controls/src/components/restricted-link-infotip.tsx
+++ b/packages/packages/libs/editor-controls/src/components/restricted-link-infotip.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { type PropsWithChildren } from 'react';
-import { type LinkInLinkRestriction, selectElement } from '@elementor/editor-elements';
+import {
+	getContainer,
+	getCurrentDocumentId,
+	type LinkInLinkRestriction,
+	selectElement,
+} from '@elementor/editor-elements';
 import { InfoCircleFilledIcon } from '@elementor/icons';
 import { Alert, AlertAction, AlertTitle, Box, Infotip, Link } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
@@ -26,12 +31,31 @@ type RestrictedLinkInfotipProps = PropsWithChildren< {
 	isVisible: boolean;
 } >;
 
+function isTargetInCurrentDocument( elementId: string | null | undefined ): boolean {
+	if ( ! elementId ) {
+		return false;
+	}
+
+	const el = getContainer( elementId )?.view?.el;
+
+	if ( ! el ) {
+		return false;
+	}
+
+	const targetDocId = el.closest( '[data-elementor-id]' )?.getAttribute( 'data-elementor-id' );
+	const currentDocId = String( getCurrentDocumentId() ?? '' );
+
+	return !! ( targetDocId && currentDocId && targetDocId === currentDocId );
+}
+
 export const RestrictedLinkInfotip: React.FC< RestrictedLinkInfotipProps > = ( {
 	linkInLinkRestriction,
 	isVisible,
 	children,
 } ) => {
 	const { shouldRestrict, reason, elementId } = linkInLinkRestriction;
+
+	const showTakeMeThereCta = !! ( elementId && isTargetInCurrentDocument( elementId ) );
 
 	const handleTakeMeClick = () => {
 		if ( elementId ) {
@@ -45,14 +69,16 @@ export const RestrictedLinkInfotip: React.FC< RestrictedLinkInfotipProps > = ( {
 			icon={ <InfoCircleFilledIcon /> }
 			size="small"
 			action={
-				<AlertAction
-					sx={ { width: 'fit-content' } }
-					variant="contained"
-					color="secondary"
-					onClick={ handleTakeMeClick }
-				>
-					{ __( 'Take me there', 'elementor' ) }
-				</AlertAction>
+				showTakeMeThereCta ? (
+					<AlertAction
+						sx={ { width: 'fit-content' } }
+						variant="contained"
+						color="secondary"
+						onClick={ handleTakeMeClick }
+					>
+						{ __( 'Take me there', 'elementor' ) }
+					</AlertAction>
+				) : undefined
 			}
 		>
 			<AlertTitle>{ __( 'Nested links', 'elementor' ) }</AlertTitle>

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/link-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/link-control.test.tsx
@@ -1,10 +1,24 @@
 import * as React from 'react';
 import { createMockPropType, renderControl } from 'test-utils';
-import { getLinkInLinkRestriction, type LinkInLinkRestriction, selectElement } from '@elementor/editor-elements';
+import {
+	getContainer,
+	getCurrentDocumentId,
+	getLinkInLinkRestriction,
+	type LinkInLinkRestriction,
+	selectElement,
+} from '@elementor/editor-elements';
 import { useSessionStorage } from '@elementor/session';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 
 import { LinkControl } from '../link-control';
+
+const buildContainerWithDocId = ( docId: string ) => {
+	const root = document.createElement( 'div' );
+	root.setAttribute( 'data-elementor-id', docId );
+	const el = document.createElement( 'div' );
+	root.appendChild( el );
+	return { view: { el } } as unknown as ReturnType< typeof getContainer >;
+};
 
 const propType = createMockPropType( {
 	kind: 'object',
@@ -93,6 +107,9 @@ describe( '<LinkControl />', () => {
 		jest.mocked( getLinkInLinkRestriction ).mockReturnValue( {
 			shouldRestrict: false,
 		} );
+
+		jest.mocked( getCurrentDocumentId ).mockReturnValue( 100 );
+		jest.mocked( getContainer ).mockReturnValue( buildContainerWithDocId( '100' ) );
 	} );
 
 	afterEach( () => {
@@ -532,5 +549,27 @@ describe( '<LinkControl />', () => {
 		await waitFor( () => {
 			expect( screen.getByText( 'from the elements inside of it', { exact: false } ) ).toBeInTheDocument();
 		} );
+	} );
+
+	it( 'should hide "Take me there" button when target element lives in a different document', async () => {
+		// Arrange - target's data-elementor-id (200) differs from current document (100).
+		jest.mocked( getLinkInLinkRestriction ).mockReturnValue( {
+			shouldRestrict: true,
+			reason: 'descendant',
+			elementId: 'inner-component-element-id',
+		} );
+		jest.mocked( getContainer ).mockReturnValue( buildContainerWithDocId( '200' ) );
+
+		// Act
+		renderControl( <LinkControl { ...globalProps } placeholder="test" />, baseProps );
+
+		const toggleButton = screen.getByRole( 'button', { name: 'Toggle link' } );
+		fireEvent.mouseOver( toggleButton );
+
+		// Assert - infotip text still shown, but the CTA button is absent.
+		await waitFor( () => {
+			expect( screen.getByText( 'from the elements inside of it', { exact: false } ) ).toBeInTheDocument();
+		} );
+		expect( screen.queryByRole( 'button', { name: 'Take me there' } ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Bugfix

## Summary

Hide the 'Take me there' CTA button in the link-in-link restriction infotip when the target element lives in a different Elementor document.

## Description

The `RestrictedLinkInfotip` component's 'Take me there' CTA was always shown whenever a link-in-link restriction had an `elementId`. This caused the button to appear even for inner elements of component instances, which are rendered from Twig and live in a different document — clicking the button in those cases would call `selectElement` on an element that can't be navigated to from the current document.

This fix introduces an `isTargetInCurrentDocument` check that compares the `data-elementor-id` attribute of the target element's document root with the current document ID. The CTA is only shown when the target is navigable.

**Changes:**
- `restricted-link-infotip.tsx`: Added `isTargetInCurrentDocument` helper using `getContainer` + `getCurrentDocumentId`; CTA is now conditionally rendered
- `link-control.test.tsx`: Added mocks for `getContainer`/`getCurrentDocumentId` and a test covering the cross-document CTA hiding

Relates to: ED-23988

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Hide the "Take me there" CTA button in nested link warnings when the target element resides in a different document (ED-23988). Prevents navigation attempts across document boundaries where the element context doesn't exist.

## 2. What Changed (Where)

- **restricted-link-infotip.tsx**: Added document ID validation logic; conditionally render AlertAction only when target exists in current document
- **link-control.test.tsx**: Enhanced test setup with container mocking; added regression test for cross-document scenario

## 3. How It Works

New `isTargetInCurrentDocument()` helper retrieves the target's document ID via `getContainer().view.el.closest('[data-elementor-id]')` and compares against `getCurrentDocumentId()`. The `showTakeMeThereCta` flag gates the AlertAction render—undefined action prop disables the button entirely. Test mocks fixture `buildContainerWithDocId()` to simulate document isolation.

## 4. Risks

None material. Logic is defensive (null checks on elementId, container, el). Existing "Learn More" link remains unaffected. Test coverage validates both same-document (button shown) and cross-document (button hidden) paths.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
