### PR TITLE
Fix: Cherry-pick PR 35850 to 4.01: Components exposed link-in-link controls do not update in time [ED-23746]

### DIFF
--- a/packages/packages/libs/editor-controls/src/components/restricted-link-infotip.tsx
+++ b/packages/packages/libs/editor-controls/src/components/restricted-link-infotip.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { type PropsWithChildren } from 'react';
-import { type LinkInLinkRestriction, selectElement } from '@elementor/editor-elements';
+import {
+	getContainer,
+	getCurrentDocumentId,
+	type LinkInLinkRestriction,
+	selectElement,
+} from '@elementor/editor-elements';
 import { InfoCircleFilledIcon } from '@elementor/icons';
 import { Alert, AlertAction, AlertTitle, Box, Infotip, Link } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
@@ -26,12 +31,31 @@ type RestrictedLinkInfotipProps = PropsWithChildren< {
 	isVisible: boolean;
 } >;
 
+function isTargetInCurrentDocument( elementId: string | null | undefined ): boolean {
+	if ( ! elementId ) {
+		return false;
+	}
+
+	const el = getContainer( elementId )?.view?.el;
+
+	if ( ! el ) {
+		return false;
+	}
+
+	const targetDocId = el.closest( '[data-elementor-id]' )?.getAttribute( 'data-elementor-id' );
+	const currentDocId = String( getCurrentDocumentId() ?? '' );
+
+	return !! ( targetDocId && currentDocId && targetDocId === currentDocId );
+}
+
 export const RestrictedLinkInfotip: React.FC< RestrictedLinkInfotipProps > = ( {
 	linkInLinkRestriction,
 	isVisible,
 	children,
 } ) => {
 	const { shouldRestrict, reason, elementId } = linkInLinkRestriction;
+
+	const showTakeMeThereCta = !! ( elementId && isTargetInCurrentDocument( elementId ) );
 
 	const handleTakeMeClick = () => {
 		if ( elementId ) {
@@ -45,14 +69,16 @@ export const RestrictedLinkInfotip: React.FC< RestrictedLinkInfotipProps > = ( {
 			icon={ <InfoCircleFilledIcon /> }
 			size="small"
 			action={
-				<AlertAction
-					sx={ { width: 'fit-content' } }
-					variant="contained"
-					color="secondary"
-					onClick={ handleTakeMeClick }
-				>
-					{ __( 'Take me there', 'elementor' ) }
-				</AlertAction>
+				showTakeMeThereCta ? (
+					<AlertAction
+						sx={ { width: 'fit-content' } }
+						variant="contained"
+						color="secondary"
+						onClick={ handleTakeMeClick }
+					>
+						{ __( 'Take me there', 'elementor' ) }
+					</AlertAction>
+				) : undefined
 			}
 		>
 			<AlertTitle>{ __( 'Nested links', 'elementor' ) }</AlertTitle>

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/link-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/link-control.test.tsx
@@ -1,10 +1,24 @@
 import * as React from 'react';
-import { createMockPropType, renderControl } from 'test-utils';
-import { getLinkInLinkRestriction, type LinkInLinkRestriction, selectElement } from '@elementor/editor-elements';
+import { createMockPropType, dispatchCommandAfter, renderControl } from 'test-utils';
+import {
+	getContainer,
+	getCurrentDocumentId,
+	getLinkInLinkRestriction,
+	type LinkInLinkRestriction,
+	selectElement,
+} from '@elementor/editor-elements';
 import { useSessionStorage } from '@elementor/session';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 
 import { LinkControl } from '../link-control';
+
+const buildContainerWithDocId = ( docId: string ) => {
+	const root = document.createElement( 'div' );
+	root.setAttribute( 'data-elementor-id', docId );
+	const el = document.createElement( 'div' );
+	root.appendChild( el );
+	return { view: { el } } as unknown as ReturnType< typeof getContainer >;
+};
 
 const propType = createMockPropType( {
 	kind: 'object',
@@ -93,6 +107,9 @@ describe( '<LinkControl />', () => {
 		jest.mocked( getLinkInLinkRestriction ).mockReturnValue( {
 			shouldRestrict: false,
 		} );
+
+		jest.mocked( getCurrentDocumentId ).mockReturnValue( 100 );
+		jest.mocked( getContainer ).mockReturnValue( buildContainerWithDocId( '100' ) );
 	} );
 
 	afterEach( () => {
@@ -512,6 +529,96 @@ describe( '<LinkControl />', () => {
 		expect( toggleButton ).toBeDisabled();
 	} );
 
+	it( 'should re-evaluate restriction when any element settings change via V1 command', async () => {
+		// Arrange - start unrestricted (sibling LinkControl has no link yet).
+		jest.mocked( getLinkInLinkRestriction ).mockReturnValue( { shouldRestrict: false } );
+
+		renderControl( <LinkControl { ...globalProps } placeholder="test" />, baseProps );
+
+		// Wait for the on-mount restriction check to settle as unrestricted.
+		await waitFor( () => {
+			expect( screen.getByRole( 'button', { name: 'Toggle link' } ) ).toBeEnabled();
+		} );
+
+		const callCountAfterMount = jest.mocked( getLinkInLinkRestriction ).mock.calls.length;
+
+		// Settle: give the on-mount debounced check time to fire (300ms),
+		// and confirm no further calls happen on their own.
+		await new Promise( ( resolve ) => setTimeout( resolve, 400 ) );
+		const callCountAfterSettle = jest.mocked( getLinkInLinkRestriction ).mock.calls.length;
+		expect( callCountAfterSettle ).toBeGreaterThanOrEqual( callCountAfterMount );
+
+		// Act - simulate a sibling element saving a link (V1 set-settings command).
+		jest.mocked( getLinkInLinkRestriction ).mockReturnValue( {
+			shouldRestrict: true,
+			reason: 'ancestor',
+			elementId: 'sibling-element-id',
+		} );
+
+		act( () => {
+			dispatchCommandAfter( 'document/elements/set-settings' );
+		} );
+
+		// Assert - the V1 command-end event must trigger another restriction
+		// re-check on this control (which has not changed its own value or elementId).
+		await waitFor( () => {
+			expect( jest.mocked( getLinkInLinkRestriction ).mock.calls.length ).toBeGreaterThan( callCountAfterSettle );
+		} );
+
+		// And the control should become disabled.
+		await waitFor( () => {
+			expect( screen.getByRole( 'button', { name: 'Toggle link' } ) ).toBeDisabled();
+		} );
+	} );
+
+	it( 'should clear partial value when restriction forcibly closes the active control', async () => {
+		// Arrange - control is active with a non-null value, restriction is initially absent.
+		jest.mocked( getLinkInLinkRestriction ).mockReturnValue( { shouldRestrict: false } );
+
+		const setValueSpy = jest.fn();
+		const props = {
+			...baseProps,
+			setValue: setValueSpy,
+			value: {
+				$$type: 'link',
+				value: {
+					destination: {
+						$$type: 'url',
+						value: 'https://partial',
+					},
+					isTargetBlank: {
+						$$type: 'boolean',
+						value: false,
+					},
+				},
+			},
+		};
+
+		renderControl( <LinkControl { ...globalProps } />, props );
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'button', { name: 'Toggle link' } ) ).toBeEnabled();
+		} );
+
+		setValueSpy.mockClear();
+
+		// Act - sibling/ancestor gains a link, restriction becomes active.
+		jest.mocked( getLinkInLinkRestriction ).mockReturnValue( {
+			shouldRestrict: true,
+			reason: 'ancestor',
+			elementId: 'ancestor-id',
+		} );
+
+		act( () => {
+			dispatchCommandAfter( 'document/elements/set-settings' );
+		} );
+
+		// Assert - setValue(null) must be called so the partial URL is cleared.
+		await waitFor( () => {
+			expect( setValueSpy ).toHaveBeenCalledWith( null );
+		} );
+	} );
+
 	it( 'should show tooltip when inline link restriction is active', async () => {
 		// Arrange
 		const inlineLinkRestriction: LinkInLinkRestriction = {
@@ -532,5 +639,27 @@ describe( '<LinkControl />', () => {
 		await waitFor( () => {
 			expect( screen.getByText( 'from the elements inside of it', { exact: false } ) ).toBeInTheDocument();
 		} );
+	} );
+
+	it( 'should hide "Take me there" button when target element lives in a different document', async () => {
+		// Arrange - target's data-elementor-id (200) differs from current document (100).
+		jest.mocked( getLinkInLinkRestriction ).mockReturnValue( {
+			shouldRestrict: true,
+			reason: 'descendant',
+			elementId: 'inner-component-element-id',
+		} );
+		jest.mocked( getContainer ).mockReturnValue( buildContainerWithDocId( '200' ) );
+
+		// Act
+		renderControl( <LinkControl { ...globalProps } placeholder="test" />, baseProps );
+
+		const toggleButton = screen.getByRole( 'button', { name: 'Toggle link' } );
+		fireEvent.mouseOver( toggleButton );
+
+		// Assert - infotip text still shown, but the CTA button is absent.
+		await waitFor( () => {
+			expect( screen.getByText( 'from the elements inside of it', { exact: false } ) ).toBeInTheDocument();
+		} );
+		expect( screen.queryByRole( 'button', { name: 'Take me there' } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/packages/libs/editor-controls/src/controls/link-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/link-control.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { useEffect, useMemo, useState } from 'react';
-import { getLinkInLinkRestriction } from '@elementor/editor-elements';
+import { useEffect, useState } from 'react';
+import { getLinkInLinkRestriction, type LinkInLinkRestriction } from '@elementor/editor-elements';
 import { linkPropTypeUtil, type LinkPropValue } from '@elementor/editor-props';
+import { __privateUseListenTo as useListenTo, commandEndEvent } from '@elementor/editor-v1-adapters';
 import { MinusIcon, PlusIcon } from '@elementor/icons';
 import { useSessionStorage } from '@elementor/session';
 import { Collapse, Grid, IconButton, Stack } from '@elementor/ui';
-import { debounce } from '@elementor/utils';
+import { useDebouncedCallback } from '@elementor/utils';
 import { __ } from '@wordpress/i18n';
 
 import { PropKeyProvider, PropProvider, useBoundProp } from '../bound-prop-context';
@@ -62,36 +63,39 @@ export const LinkControl = createControl( ( props: Props ) => {
 
 	const shouldDisableAddingLink = ! isActive && linkInLinkRestriction.shouldRestrict;
 
-	const debouncedCheckRestriction = useMemo(
-		() =>
-			debounce( () => {
-				const newRestriction = getLinkInLinkRestriction( elementId, value ?? linkPlaceholder );
+	const debouncedCheckRestriction = useDebouncedCallback( () => {
+		const newRestriction = getLinkInLinkRestriction( elementId, value ?? linkPlaceholder );
 
-				if ( newRestriction.shouldRestrict && isActive && ! linkPlaceholder ) {
-					setIsActive( false );
-				}
+		if ( newRestriction.shouldRestrict && isActive && ! linkPlaceholder ) {
+			setIsActive( false );
 
-				setLinkInLinkRestriction( newRestriction );
-			}, 300 ),
-		[ elementId, isActive, value, linkPlaceholder ]
+			if ( value !== null ) {
+				setValue( null );
+			}
+		}
+
+		setLinkInLinkRestriction( ( prev ) => ( isSameRestriction( prev, newRestriction ) ? prev : newRestriction ) );
+	}, 300 );
+
+	useListenTo(
+		commandEndEvent( 'document/elements/set-settings' ),
+		() => {
+			debouncedCheckRestriction();
+		},
+		[ debouncedCheckRestriction ]
 	);
 
 	useEffect( () => {
 		debouncedCheckRestriction();
 
-		const handleInlineLinkChanged = ( event: Event ) => {
-			const customEvent = event as CustomEvent< { elementId: string } >;
-
-			if ( customEvent.detail.elementId === elementId ) {
-				debouncedCheckRestriction();
-			}
+		const handleInlineLinkChanged = () => {
+			debouncedCheckRestriction();
 		};
 
 		window.addEventListener( 'elementor:inline-link-changed', handleInlineLinkChanged );
 
 		return () => {
 			window.removeEventListener( 'elementor:inline-link-changed', handleInlineLinkChanged );
-			debouncedCheckRestriction.cancel();
 		};
 	}, [ elementId, debouncedCheckRestriction ] );
 
@@ -181,3 +185,7 @@ export const LinkControl = createControl( ( props: Props ) => {
 		</PropProvider>
 	);
 } );
+
+function isSameRestriction( a: LinkInLinkRestriction, b: LinkInLinkRestriction ): boolean {
+	return a.shouldRestrict === b.shouldRestrict && a.reason === b.reason && a.elementId === b.elementId;
+}

--- a/packages/packages/libs/editor-elements/src/__tests__/link-restriction.test.ts
+++ b/packages/packages/libs/editor-elements/src/__tests__/link-restriction.test.ts
@@ -5,9 +5,15 @@ import {
 	isElementAnchored,
 } from '../link-restriction';
 
+const containersWithoutView = new Set< string >();
+
 jest.mock( '../sync/get-container', () => {
 	return {
 		getContainer: jest.fn( ( elementId: string ) => {
+			if ( containersWithoutView.has( elementId ) ) {
+				return null;
+			}
+
 			const element = document.querySelector( `[data-id="${ elementId }"]` );
 			return element ? { view: { el: element } } : null;
 		} ),
@@ -19,6 +25,8 @@ const BUTTON_ACTION_LINK_ATTRIBUTE = 'data-action-link';
 describe( 'link-restriction', () => {
 	beforeEach( () => {
 		document.body.innerHTML = '';
+		containersWithoutView.clear();
+		delete ( window as unknown as { elementor?: unknown } ).elementor;
 	} );
 
 	describe( 'doesElementHaveAnchorTag', () => {
@@ -431,6 +439,48 @@ describe( 'link-restriction', () => {
 
 			// Assert
 			expect( result ).toBeNull();
+		} );
+	} );
+
+	describe( 'getElementDOM fallback for inner component elements', () => {
+		it( 'should detect ancestor anchor for an inner element that has no V1 view but exists in the preview DOM', () => {
+			// Arrange: inner heading has data-id in DOM but no registered V1 container/view
+			document.body.innerHTML = `
+				<a data-id="ancestor-div" href="#">
+					<div data-id="inner-heading">Heading</div>
+				</a>
+			`;
+			containersWithoutView.add( 'inner-heading' );
+
+			( window as unknown as { elementor: unknown } ).elementor = {
+				getPreviewContainer: () => ( { view: { el: document.body } } ),
+			};
+
+			// Act
+			const result = getAnchoredAncestorId( 'inner-heading' );
+
+			// Assert
+			expect( result ).toBe( 'ancestor-div' );
+		} );
+
+		it( 'should detect descendant anchor for an inner element that has no V1 view but exists in the preview DOM', () => {
+			// Arrange
+			document.body.innerHTML = `
+				<div data-id="inner-wrapper">
+					<a data-id="inner-link" href="#">Link</a>
+				</div>
+			`;
+			containersWithoutView.add( 'inner-wrapper' );
+
+			( window as unknown as { elementor: unknown } ).elementor = {
+				getPreviewContainer: () => ( { view: { el: document.body } } ),
+			};
+
+			// Act
+			const result = getAnchoredDescendantId( 'inner-wrapper' );
+
+			// Assert
+			expect( result ).toBe( 'inner-link' );
 		} );
 	} );
 

--- a/packages/packages/libs/editor-elements/src/link-restriction.ts
+++ b/packages/packages/libs/editor-elements/src/link-restriction.ts
@@ -2,6 +2,7 @@ import { type LinkPropValue } from '@elementor/editor-props';
 
 import { getContainer } from './sync/get-container';
 import { getElementSetting } from './sync/get-element-setting';
+import { type ExtendedWindow } from './sync/types';
 
 const ANCHOR_SELECTOR = 'a, [data-action-link]';
 
@@ -24,8 +25,8 @@ export function getLinkInLinkRestriction( elementId: string, resolvedValue?: Lin
 
 	if ( anchoredDescendantId ) {
 		return {
-			shouldRestrict: true,
-			reason: 'descendant',
+			shouldRestrict: true as const,
+			reason: 'descendant' as const,
 			elementId: anchoredDescendantId,
 		};
 	}
@@ -34,8 +35,8 @@ export function getLinkInLinkRestriction( elementId: string, resolvedValue?: Lin
 
 	if ( hasInlineLink ) {
 		return {
-			shouldRestrict: true,
-			reason: 'descendant',
+			shouldRestrict: true as const,
+			reason: 'descendant' as const,
 			elementId,
 		};
 	}
@@ -44,8 +45,8 @@ export function getLinkInLinkRestriction( elementId: string, resolvedValue?: Lin
 
 	if ( ancestor ) {
 		return {
-			shouldRestrict: true,
-			reason: 'ancestor',
+			shouldRestrict: true as const,
+			reason: 'ancestor' as const,
 			elementId: ancestor,
 		};
 	}
@@ -144,10 +145,31 @@ function checkForInlineLink( elementId: string, resolvedValue?: LinkValue ): boo
 
 function getElementDOM( id: string ) {
 	try {
-		return getContainer( id )?.view?.el || null;
+		const fromContainer = getContainer( id )?.view?.el;
+
+		if ( fromContainer ) {
+			return fromContainer;
+		}
+
+		// Inner elements of component instances are rendered from Twig and have
+		// no V1 Backbone view, so getContainer(id) returns null. Fall back to
+		// querying the preview iframe document directly so link-in-link
+		// restriction still works for those elements.
+		return queryPreviewDOMByElementId( id );
 	} catch {
 		return null;
 	}
+}
+
+function queryPreviewDOMByElementId( id: string ): HTMLElement | null {
+	const previewDocument = ( window as unknown as ExtendedWindow ).elementor?.getPreviewContainer?.()?.view?.el
+		?.ownerDocument;
+
+	if ( ! previewDocument ) {
+		return null;
+	}
+
+	return previewDocument.querySelector< HTMLElement >( `[data-id="${ id }"]` );
 }
 
 function isElementorElement( element: Element ): boolean {

--- a/packages/packages/libs/editor-elements/src/sync/types.ts
+++ b/packages/packages/libs/editor-elements/src/sync/types.ts
@@ -29,6 +29,7 @@ export type ExtendedWindow = Window & {
 			getCurrentId?: () => number;
 		};
 		getContainer?: ( id: string ) => V1Element | undefined;
+		getPreviewContainer?: () => V1Element | undefined;
 		helpers?: {
 			isAtomicWidget?: ( model: unknown ) => boolean;
 		};
@@ -150,6 +151,7 @@ export type ElementInteractions = {
 export type V1ElementModelProps = {
 	title?: string;
 	isLocked?: boolean;
+	meta?: Record< string, unknown >;
 	widgetType?: string;
 	elType: string;
 	id: string;

--- a/packages/packages/libs/utils/src/__tests__/use-debounced-callback.test.tsx
+++ b/packages/packages/libs/utils/src/__tests__/use-debounced-callback.test.tsx
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useDebouncedCallback } from '../use-debounced-callback';
+
+beforeEach( () => {
+	jest.useFakeTimers();
+} );
+
+afterEach( () => {
+	jest.runOnlyPendingTimers();
+	jest.clearAllTimers();
+	jest.clearAllMocks();
+} );
+
+describe( 'useDebouncedCallback', () => {
+	it( 'should debounce calls and run only the last one', () => {
+		const fn = jest.fn();
+		const { result } = renderHook( () => useDebouncedCallback( fn, 300 ) );
+
+		act( () => {
+			result.current( 'a' );
+			result.current( 'b' );
+			result.current( 'c' );
+		} );
+
+		expect( fn ).not.toHaveBeenCalled();
+
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+
+		expect( fn ).toHaveBeenCalledTimes( 1 );
+		expect( fn ).toHaveBeenCalledWith( 'c' );
+	} );
+
+	it( 'should keep a stable identity across renders even when callback identity changes', () => {
+		let value = 0;
+		const { result, rerender } = renderHook( () => useDebouncedCallback( () => value, 300 ) );
+		const first = result.current;
+
+		value = 1;
+		rerender();
+
+		expect( result.current ).toBe( first );
+	} );
+
+	it( 'should always invoke the latest callback closure', () => {
+		const calls: number[] = [];
+		const { result, rerender } = renderHook(
+			( { v }: { v: number } ) => useDebouncedCallback( () => calls.push( v ), 300 ),
+			{ initialProps: { v: 1 } }
+		);
+
+		act( () => {
+			result.current();
+		} );
+
+		rerender( { v: 2 } );
+
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+
+		expect( calls ).toEqual( [ 2 ] );
+	} );
+
+	it( 'should cancel pending invocation on unmount', () => {
+		const fn = jest.fn();
+		const { result, unmount } = renderHook( () => useDebouncedCallback( fn, 300 ) );
+
+		act( () => {
+			result.current();
+		} );
+
+		unmount();
+
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+
+		expect( fn ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/packages/libs/utils/src/index.ts
+++ b/packages/packages/libs/utils/src/index.ts
@@ -1,6 +1,7 @@
 export { ElementorError, createError, ensureError } from './errors';
 export type { ElementorErrorOptions, CreateErrorParams } from './errors';
 export { useDebounceState, type UseDebounceStateOptions, type UseDebounceStateResult } from './use-debounce-state';
+export { useDebouncedCallback } from './use-debounced-callback';
 export { debounce } from './debounce';
 export { throttle } from './throttle';
 export { encodeString, decodeString } from './encoding';

--- a/packages/packages/libs/utils/src/use-debounced-callback.ts
+++ b/packages/packages/libs/utils/src/use-debounced-callback.ts
@@ -1,0 +1,25 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+import { debounce } from './debounce';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useDebouncedCallback< TArgs extends any[] >( callback: ( ...args: TArgs ) => void, delay: number ) {
+	const callbackRef = useRef( callback );
+
+	useEffect( () => {
+		callbackRef.current = callback;
+	}, [ callback ] );
+
+	const debounced = useMemo(
+		() => debounce( ( ...args: TArgs ) => callbackRef.current( ...args ), delay ),
+		[ delay ]
+	);
+
+	useEffect( () => {
+		return () => {
+			debounced.cancel();
+		};
+	}, [ debounced ] );
+
+	return debounced;
+}


### PR DESCRIPTION
Cherry-pick of #35850 onto branch \`4.01\`.

## Cases covered

### 1. Cross-control reactivity on settings change
Subscribe \`LinkControl\` to \`commandEndEvent('document/elements/set-settings')\` so sibling exposed link controls disable immediately when a link is assigned elsewhere.

### 2. Partial value cleared on auto-close
When the restriction forces the control closed, \`setValue(null)\` is called to clear any partial URL.

### 3. "Take me there" CTA hidden for cross-document targets
Show the CTA only when the restriction target's nearest \`[data-elementor-id]\` DOM ancestor matches \`getCurrentDocumentId()\`.

### 4. Ancestor/descendant restriction for inner component elements
\`getElementDOM\` now falls back to querying the preview iframe by \`[data-id]\` when \`getContainer(id)?.view?.el\` is null (Twig-rendered inner elements have no V1 Backbone view).

## Files changed
- \`packages/packages/libs/editor-controls/src/controls/link-control.tsx\`
- \`packages/packages/libs/editor-controls/src/components/restricted-link-infotip.tsx\`
- \`packages/packages/libs/editor-elements/src/link-restriction.ts\`
- \`packages/packages/libs/editor-elements/src/sync/types.ts\`
- \`packages/packages/libs/utils/src/use-debounced-callback.ts\` (new)
- Tests for all of the above

Fixes [ED-23746](https://elementor.atlassian.net/browse/ED-23746)

Made with [Cursor](https://cursor.com)

[ED-23746]: https://elementor.atlassian.net/browse/ED-23746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Link-in-link restrictions weren't re-evaluating when sibling/ancestor elements changed via V1 commands, leaving stale UI state. Cherry-pick fix from 35850 to v4.01 branch (ED-23746).

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `link-control.tsx` | Replaced `useMemo(debounce())` with `useDebouncedCallback` hook; added V1 command listener for `document/elements/set-settings` |
| `restricted-link-infotip.tsx` | Conditionally render "Take me there" CTA only when target exists in current document |
| `link-restriction.ts` | Enhanced `getElementDOM()` fallback to query preview DOM for inner component elements lacking V1 views; added type safety with `const` assertions |
| `use-debounced-callback.ts` (new) | Stable-identity debounced callback hook using `useRef` to capture latest closure |
| `types.ts` | Added `getPreviewContainer()` and `meta` field to support inner component element resolution |
| Test files | Added 80+ lines of test coverage for V1 command reactivity, cross-document detection, and fallback DOM queries |

## 3. How It Works

When `document/elements/set-settings` fires, `useListenTo()` triggers `debouncedCheckRestriction()` to re-evaluate restrictions. The new `useDebouncedCallback` hook maintains a stable debounced reference across renders while always executing the latest callback closure. For inner component elements without V1 Backbone views, `getElementDOM()` falls back to `queryPreviewDOMByElementId()` scanning the preview iframe. The infotip conditionally shows the "Take me there" button only when `isTargetInCurrentDocument()` confirms both elements share the same `data-elementor-id` ancestor.

## 4. Risks

Minor: `useDebouncedCallback` replaces `useMemo(debounce())` pattern—behavior identical but changes dependency tracking (only `delay`). Fallback DOM query adds slight perf cost for inner components, but only when V1 container missing. Test mocks for `getCurrentDocumentId` and `getContainer` must stay in sync with actual implementations during future refactors.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
