### PR TITLE
Fix: Fix events logs name [ED-24149]

### DIFF
--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -31,9 +31,7 @@ export default class extends elementorModules.Module {
 					persistence: 'localStorage',
 					autocapture: false,
 					flags: true,
-					api_hosts: {
-						flags: 'https://api-eu.mixpanel.com',
-					},
+					api_hosts: 'https://api-eu.mixpanel.com',
 					loaded: onLoaded,
 					record_sessions_percent: 0,
 					record_idle_timeout_ms: 60 * 1000, // 60 Seconds

--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -31,7 +31,7 @@ export default class extends elementorModules.Module {
 					persistence: 'localStorage',
 					autocapture: false,
 					flags: true,
-					api_hosts: 'https://api-eu.mixpanel.com',
+					api_host: 'https://api-eu.mixpanel.com',
 					loaded: onLoaded,
 					record_sessions_percent: 0,
 					record_idle_timeout_ms: 60 * 1000, // 60 Seconds


### PR DESCRIPTION
## Jira
ED-24149

## Test Plan
- [ ] PHP unit tests pass: `composer test`
- [ ] Jest tests pass: `npm test`
- [ ] Manual: open editor, add widget, verify render in preview and frontend
- [ ] Accessibility: keyboard nav and screen reader verified
- [ ] No `console.log` or `var_dump` left in code
- [ ] PHPCS clean: `./vendor/bin/phpcs`

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Mixpanel EU endpoint configuration was incorrectly nested under `api_hosts.flags`. This change simplifies it to use the standard `api_host` parameter for proper EU region routing (ED-24149).

## 2. What Changed (Where)

events-manager/assets/js/module.js: Replaced nested `api_hosts` object with single `api_host` string pointing to EU endpoint.

## 3. How It Works

Mixpanel SDK accepts `api_host` in config to override default US endpoint. This routes all events to EU infrastructure without additional nesting.

## 4. Risks

None. This aligns with Mixpanel SDK API; incorrect nesting likely broke EU routing entirely, so this is a fix not a breaking change.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
