### PR TITLE
Fix: Playground Preview action to use PR Build artifact [ED-24114]

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -4,8 +4,8 @@ on:
     workflows: ["Build"]
     types: [completed]
 permissions:
-  contents: write      # upload to ci-artifacts release
-  pull-requests: write # post PR comment
+  contents: read
+  pull-requests: write
   actions: read
   deployments: write
 
@@ -63,7 +63,7 @@ jobs:
             require('fs').writeFileSync('build-artifact.zip', Buffer.from(dl.data));
             core.setOutput('artifact-name', hit.name);
 
-      - name: Repack build artifact as plugin zip
+      - name: Repack build artifact for Playground
         run: |
           unzip -oq build-artifact.zip -d build-artifact
           ls -la build-artifact
@@ -74,54 +74,34 @@ jobs:
           rm -rf plugin-root
           mkdir -p plugin-root/elementor
           cp -a build-artifact/. plugin-root/elementor/
-          (
-            cd plugin-root
-            zip -rq "$GITHUB_WORKSPACE/plugin.zip" elementor
-          )
-
-      - name: Upload plugin zip artifact
+          test -f plugin-root/elementor/elementor.php
+      - name: Upload playground plugin artifact
         uses: actions/upload-artifact@v4
         with:
           name: playground-plugin-pr${{ steps.runctx.outputs.pr-number }}-${{ steps.runctx.outputs.head-sha }}
-          path: plugin.zip
+          path: plugin-root.zip
           if-no-files-found: error
           retention-days: 3
-
-      - name: Expose plugin zip on public URL
-        id: expose
-        uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
-        with:
-          artifact-name: playground-plugin-pr${{ steps.runctx.outputs.pr-number }}-${{ steps.runctx.outputs.head-sha }}
-          artifact-filename: plugin.zip
-          pr-number: ${{ steps.runctx.outputs.pr-number }}
-          commit-sha: ${{ steps.runctx.outputs.head-sha }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish ci-artifacts release
-        run: |
-          gh release edit ci-artifacts --draft=false
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          
       - name: Prepare blueprint JSON
         id: blueprint
         env:
-          PLUGIN_ZIP_URL: ${{ steps.expose.outputs.artifact-url }}
+          ARTIFACT_NAME: playground-plugin-pr${{ steps.runctx.outputs.pr-number }}-${{ steps.runctx.outputs.head-sha }}
         run: |
           node <<'NODE'
           const fs = require('fs');
-          const url = process.env.PLUGIN_ZIP_URL;
-          if (!url) {
-            throw new Error('Missing PLUGIN_ZIP_URL from expose step');
-          }
+          const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+          const artifactName = process.env.ARTIFACT_NAME;
+          const runId = process.env.GITHUB_RUN_ID;
+          const url = `https://nightly.link/${owner}/${repo}/actions/runs/${runId}/${artifactName}.zip`;
           const template = fs.readFileSync('tests/playwright/blueprints/pr-preview.json', 'utf8');
           const blueprint = template.replace(/\$PLUGIN_ZIP_URL/g, url);
           JSON.parse(blueprint);
           const playgroundUrl = `https://playground.wordpress.net/?blueprint-url=data:application/json,${encodeURIComponent(blueprint)}`;
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `plugin-zip-url=${url}\n`);
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `json<<BLUEPRINT_JSON_EOF\n${blueprint}\nBLUEPRINT_JSON_EOF\n`);
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `playground-url=${playgroundUrl}\n`);
           NODE
-
       - name: Create PR deployment
         uses: actions/github-script@v7
         env:

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -75,7 +75,9 @@ jobs:
           mkdir -p plugin-root/elementor
           cp -a build-artifact/. plugin-root/elementor/
           test -f plugin-root/elementor/elementor.php
+
       - name: Upload playground plugin artifact
+        id: playground-artifact
         uses: actions/upload-artifact@v4
         with:
           name: playground-plugin-pr${{ steps.runctx.outputs.pr-number }}-${{ steps.runctx.outputs.head-sha }}

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playground-plugin-pr${{ steps.runctx.outputs.pr-number }}-${{ steps.runctx.outputs.head-sha }}
-          path: plugin-root.zip
+          path: plugin-root
           if-no-files-found: error
           retention-days: 3
           


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Workflow was using a custom action to expose artifacts publicly; switching to GitHub's native nightly.link endpoint eliminates custom infrastructure and reduces permissions (contents: write → read).

## 2. What Changed (Where)

- `.github/workflows/playground-preview.yml`: Removed custom expose-artifact action and ci-artifacts release logic; now generates nightly.link URL directly in blueprint step. Upload artifact unchanged but without zip compression step.

## 3. How It Works

Blueprint step now constructs URL via `https://nightly.link/{owner}/{repo}/actions/runs/{runId}/{artifactName}.zip` using environment variables instead of relying on custom action output. Artifact uploaded as directory (plugin-root) rather than pre-zipped file—nightly.link handles compression on download.

## 4. Risks

nightly.link availability dependency; if service degrades, previews fail. Validate artifact directory structure survives repacking without zip intermediate (line 77 assertion mitigates). Permissions reduced but should remain sufficient for read/write operations.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
