### PR TITLE
Internal:  Cherry pick - Variables MCP tool race condition on initialization to 4.01 [ED-24131]

### DIFF
--- a/packages/packages/core/editor-variables/src/init.ts
+++ b/packages/packages/core/editor-variables/src/init.ts
@@ -46,17 +46,18 @@ export function init() {
 		useProps: usePropVariableAction,
 	} );
 
-	variablesService.init().then( () => {
-		const variablesMcpRegistry = getMCPByDomain( 'variables', {
-			instructions: `Everything related to V4 ( Atomic ) variables.
+	variablesService.init();
+
+	const variablesMcpRegistry = getMCPByDomain( 'variables', {
+		instructions: `Everything related to V4 ( Atomic ) variables.
 # Global variables
 - Create/update/delete global variables
 - Get list of global variables
 - Get details of a global variable
 `,
-		} );
-		initMcp( variablesMcpRegistry, getMCPByDomain( 'canvas' ) );
 	} );
+
+	initMcp( variablesMcpRegistry, getMCPByDomain( 'canvas' ) );
 
 	injectIntoTop( {
 		id: 'canvas-style-variables-render',


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Race condition in Variables MCP tool initialization (ED-24131): moving `variablesService.init()` and MCP setup outside the async `.then()` callback eliminates the ordering guarantee that was suppressing concurrent initialization hazards.

## 2. What Changed (Where)

`packages/core/editor-variables/src/init.ts`: Removed `.then()` wrapper around `variablesService.init()` and hoisted `variablesMcpRegistry` setup to synchronous execution.

## 3. How It Works

Previously, MCP registry initialization was gated behind `variablesService.init()` promise completion. Now both execute immediately in sequence, relying on `variablesService.init()` to internally handle any async setup without blocking downstream code.

## 4. Risks

Potential issue if `variablesService.init()` has side effects that must complete before MCP registry access. Mitigation: verify `variablesService.init()` is idempotent and any async work is self-contained (doesn't block required state for MCP setup).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
