### PR TITLE
Internal: Cherry pick - Restrict Font Creation Outside WordPress by Angie t0 4.01 [ED-24126]

### DIFF
--- a/packages/packages/core/editor-variables/src/mcp/__tests__/manage-variable-tool.test.ts
+++ b/packages/packages/core/editor-variables/src/mcp/__tests__/manage-variable-tool.test.ts
@@ -6,6 +6,12 @@ import { initManageVariableTool } from '../manage-variable-tool';
 import { generateVariablesPrompt } from '../variable-tool-prompt';
 
 jest.mock( '../../service' );
+jest.mock( '../../sync/get-font-configs', () => ( {
+	getFontConfigs: jest.fn( () => ( {
+		Inter: 'google-font',
+		Roboto: 'google-font',
+	} ) ),
+} ) );
 jest.mock( '@elementor/utils', () => ( {
 	...jest.requireActual( '@elementor/utils' ),
 	isProActive: jest.fn( () => true ),
@@ -223,6 +229,21 @@ describe( 'manage-variable-tool validation', () => {
 			} );
 		} );
 
+		it( 'should reject unsupported font family on create', async () => {
+			await expect(
+				toolHandler( {
+					action: 'create',
+					type: 'global-font-variable',
+					label: 'heading-font',
+					value: 'NonExistentFont',
+				} )
+			).rejects.toThrow(
+				'Font "NonExistentFont" is not supported in WordPress. Please choose one of the available font families.'
+			);
+
+			expect( service.create ).not.toHaveBeenCalled();
+		} );
+
 		it( 'should allow px value for a size variable', async () => {
 			await toolHandler( {
 				action: 'create',
@@ -282,6 +303,18 @@ describe( 'manage-variable-tool validation', () => {
 			await toolHandler( { action: 'update', id: '123', label: 'heading-font', value: 'Inter' } );
 
 			expect( service.update ).toHaveBeenCalledWith( '123', { label: 'heading-font', value: 'Inter' } );
+		} );
+
+		it( 'should reject unsupported font family on update', async () => {
+			mockVariables[ '123' ] = { type: 'global-font-variable', label: 'heading-font', value: 'Roboto' };
+
+			await expect(
+				toolHandler( { action: 'update', id: '123', label: 'heading-font', value: 'NonExistentFont' } )
+			).rejects.toThrow(
+				'Font "NonExistentFont" is not supported in WordPress. Please choose one of the available font families.'
+			);
+
+			expect( service.update ).not.toHaveBeenCalled();
 		} );
 	} );
 

--- a/packages/packages/core/editor-variables/src/mcp/manage-variable-tool.ts
+++ b/packages/packages/core/editor-variables/src/mcp/manage-variable-tool.ts
@@ -38,10 +38,11 @@ function validateValueForType( type: string, value: string ): string | null {
 	return null;
 }
 
-function isFontAvailable( value: string ) {
+function isFontAvailable( font: string ) {
 	const fonts = getFontConfigs();
+	const key = font.trim();
 
-	return !! fonts?.[ value ];
+	return !! fonts?.[ key ];
 }
 
 export const initManageVariableTool = ( reg: MCPRegistryEntry ) => {

--- a/packages/packages/core/editor-variables/src/mcp/manage-variable-tool.ts
+++ b/packages/packages/core/editor-variables/src/mcp/manage-variable-tool.ts
@@ -3,6 +3,7 @@ import { z } from '@elementor/schema';
 import { isProActive } from '@elementor/utils';
 
 import { service } from '../service';
+import { getFontConfigs } from '../sync/get-font-configs';
 import { validateLabel } from '../utils/validations';
 import { generateVariablesPrompt, MANAGE_VARIABLES_GUIDE_URI } from './variable-tool-prompt';
 import { GLOBAL_VARIABLES_URI } from './variables-resource';
@@ -30,7 +31,17 @@ function validateValueForType( type: string, value: string ): string | null {
 		return `Size variable value should include a CSS unit (e.g. "16px") or be "auto", got "${ value }".`;
 	}
 
+	if ( type === VARIABLE_TYPES.FONT && ! isFontAvailable( value ) ) {
+		return `Font "${ value }" is not supported in WordPress. Please choose one of the available font families.`;
+	}
+
 	return null;
+}
+
+function isFontAvailable( value: string ) {
+	const fonts = getFontConfigs();
+
+	return !! fonts?.[ value ];
 }
 
 export const initManageVariableTool = ( reg: MCPRegistryEntry ) => {

--- a/packages/packages/core/editor-variables/src/sync/get-font-configs.ts
+++ b/packages/packages/core/editor-variables/src/sync/get-font-configs.ts
@@ -1,0 +1,3 @@
+export const getFontConfigs = () => {
+	return window.elementor?.config?.controls?.font?.options ?? {};
+};


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick restricting font variable creation to WordPress-supported fonts only (ED-24126). Prevents invalid font assignments that would fail at runtime.

## 2. What Changed (Where)

- `manage-variable-tool.ts`: Added font validation via new `isFontAvailable()` function that checks against WordPress font registry
- `get-font-configs.ts`: New utility extracting font options from `window.elementor.config.controls.font.options`
- `manage-variable-tool.test.ts`: Added mocks and two test cases for unsupported fonts on create/update actions

## 3. How It Works

When a font variable is created or updated, `validateValueForType()` now calls `isFontAvailable()` to verify the font exists in WordPress config. If missing, validation fails with user-friendly error message before service layer is invoked.

## 4. Risks

Dependency on `window.elementor.config.controls.font.options` existing; gracefully defaults to empty object but font validation silently passes if config unavailable—consider explicit null-check or fallback strategy.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
