### PR TITLE
Fix: Angie fails to generate classes since Global Classes refactor [ED-24140]

### DIFF
--- a/packages/packages/core/editor-canvas/src/index.ts
+++ b/packages/packages/core/editor-canvas/src/index.ts
@@ -1,5 +1,5 @@
-export { BREAKPOINTS_SCHEMA_URI } from './mcp/resources/breakpoints-resource';
-export { STYLE_SCHEMA_URI } from './mcp/resources/widgets-schema-resource';
+export { BREAKPOINTS_SCHEMA_URI, BREAKPOINTS_SCHEMA_FULL_URI } from './mcp/resources/breakpoints-resource';
+export { STYLE_SCHEMA_URI, STYLE_SCHEMA_FULL_URI } from './mcp/resources/widgets-schema-resource';
 
 export { init } from './init';
 export { isAtomicWidget } from './utils/command-utils';
@@ -24,7 +24,7 @@ export { styleTransformersRegistry } from './style-transformers-registry';
 export { endDragElementFromPanel, startDragElementFromPanel } from './sync/drag-element-from-panel';
 export { GLOBAL_STYLES_IMPORTED_EVENT, type ImportedGlobalStylesPayload } from './sync/global-styles-imported-event';
 export { DOCUMENT_STRUCTURE_URI } from './mcp/resources/document-structure-resource';
-export { WIDGET_SCHEMA_URI } from './mcp/resources/widgets-schema-resource';
+export { WIDGET_SCHEMA_URI, WIDGET_SCHEMA_FULL_URI } from './mcp/resources/widgets-schema-resource';
 export * from './legacy/types';
 export { SpotlightBackdrop } from './components/spotlight-backdrop';
 export { createTransformer } from './transformers/create-transformer';

--- a/packages/packages/core/editor-canvas/src/mcp/resources/breakpoints-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/breakpoints-resource.ts
@@ -1,10 +1,11 @@
 import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 import { type ExtendedWindow } from '@elementor/editor-responsive';
 import { v1ReadyEvent } from '@elementor/editor-v1-adapters';
+
 import { CANVAS_SERVER_NAME } from './widgets-schema-resource';
 
 export const BREAKPOINTS_SCHEMA_URI = 'elementor://breakpoints/list';
-export const BREAKPOINTS_SCHEMA_FULL_URI = `${CANVAS_SERVER_NAME}_${BREAKPOINTS_SCHEMA_URI}`;
+export const BREAKPOINTS_SCHEMA_FULL_URI = `${ CANVAS_SERVER_NAME }_${ BREAKPOINTS_SCHEMA_URI }`;
 
 export const initBreakpointsResource = ( reg: MCPRegistryEntry ) => {
 	const { resource, sendResourceUpdated } = reg;

--- a/packages/packages/core/editor-canvas/src/mcp/resources/breakpoints-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/breakpoints-resource.ts
@@ -1,8 +1,10 @@
 import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 import { type ExtendedWindow } from '@elementor/editor-responsive';
 import { v1ReadyEvent } from '@elementor/editor-v1-adapters';
+import { CANVAS_SERVER_NAME } from './widgets-schema-resource';
 
 export const BREAKPOINTS_SCHEMA_URI = 'elementor://breakpoints/list';
+export const BREAKPOINTS_SCHEMA_FULL_URI = `${CANVAS_SERVER_NAME}_${BREAKPOINTS_SCHEMA_URI}`;
 
 export const initBreakpointsResource = ( reg: MCPRegistryEntry ) => {
 	const { resource, sendResourceUpdated } = reg;

--- a/packages/packages/core/editor-canvas/src/mcp/resources/widgets-schema-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/widgets-schema-resource.ts
@@ -59,11 +59,11 @@ function extractV3ControlsMetadata( controls: unknown ): Record< string, V3Contr
 export const CANVAS_SERVER_NAME = 'editor-canvas';
 
 export const WIDGET_SCHEMA_URI = 'elementor://widgets/schema/{widgetType}';
-export const WIDGET_SCHEMA_FULL_URI = `${CANVAS_SERVER_NAME}_${WIDGET_SCHEMA_URI}`;
+export const WIDGET_SCHEMA_FULL_URI = `${ CANVAS_SERVER_NAME }_${ WIDGET_SCHEMA_URI }`;
 export const STYLE_SCHEMA_URI = 'elementor://styles/schema/{category}';
-export const STYLE_SCHEMA_FULL_URI = `${CANVAS_SERVER_NAME}_${STYLE_SCHEMA_URI}`;
+export const STYLE_SCHEMA_FULL_URI = `${ CANVAS_SERVER_NAME }_${ STYLE_SCHEMA_URI }`;
 export const BEST_PRACTICES_URI = 'elementor://styles/best-practices';
-export const BEST_PRACTICES_FULL_URI = `${CANVAS_SERVER_NAME}_${BEST_PRACTICES_URI}`;
+export const BEST_PRACTICES_FULL_URI = `${ CANVAS_SERVER_NAME }_${ BEST_PRACTICES_URI }`;
 
 export const initWidgetsSchemaResource = ( reg: MCPRegistryEntry ) => {
 	const { resource } = reg;

--- a/packages/packages/core/editor-canvas/src/mcp/resources/widgets-schema-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/widgets-schema-resource.ts
@@ -56,9 +56,14 @@ function extractV3ControlsMetadata( controls: unknown ): Record< string, V3Contr
 	return result;
 }
 
+export const CANVAS_SERVER_NAME = 'editor-canvas';
+
 export const WIDGET_SCHEMA_URI = 'elementor://widgets/schema/{widgetType}';
+export const WIDGET_SCHEMA_FULL_URI = `${CANVAS_SERVER_NAME}_${WIDGET_SCHEMA_URI}`;
 export const STYLE_SCHEMA_URI = 'elementor://styles/schema/{category}';
+export const STYLE_SCHEMA_FULL_URI = `${CANVAS_SERVER_NAME}_${STYLE_SCHEMA_URI}`;
 export const BEST_PRACTICES_URI = 'elementor://styles/best-practices';
+export const BEST_PRACTICES_FULL_URI = `${CANVAS_SERVER_NAME}_${BEST_PRACTICES_URI}`;
 
 export const initWidgetsSchemaResource = ( reg: MCPRegistryEntry ) => {
 	const { resource } = reg;

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-manage-global-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-manage-global-classes.ts
@@ -26,25 +26,37 @@ const schema = {
 		default: z
 			.record(
 				z.string().describe( 'The style property name' ),
-				z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` ),
-				z.any()
+				z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` )
 			)
-			.describe( 'An object record containing style property names and their new values. MUST contain at least one property — empty objects are rejected.' ),
+			.describe(
+				'An object record containing style property names and their new values. MUST contain at least one property — empty objects are rejected.'
+			),
 		hover: z
-		.record(
-			z.string().describe( 'The style property name' ),
-			z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` ),
-			z.any()
-		)
-		.describe( 'An object record containing style property names and their new values to be set on the element. for :hover css state. optional' )
-		.optional(),
+			.record(
+				z.string().describe( 'The style property name' ),
+				z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` )
+			)
+			.describe(
+				'An object record containing style property names and their new values to be set on the element. for :hover css state. optional'
+			)
+			.optional(),
 		focus: z
-			.record( z.string().describe( 'The style property name' ), z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` ), z.any() )
-			.describe( 'An object record containing style property names and their new values to be set on the element. for :focus css state. optional' )
+			.record(
+				z.string().describe( 'The style property name' ),
+				z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` )
+			)
+			.describe(
+				'An object record containing style property names and their new values to be set on the element. for :focus css state. optional'
+			)
 			.optional(),
 		active: z
-			.record( z.string().describe( 'The style property name' ), z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` ), z.any() )
-			.describe( 'An object record containing style property names and their new values to be set on the element. for :active css state. optional' )
+			.record(
+				z.string().describe( 'The style property name' ),
+				z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` )
+			)
+			.describe(
+				'An object record containing style property names and their new values to be set on the element. for :active css state. optional'
+			)
 			.optional(),
 	} ),
 	breakpoint: z
@@ -117,14 +129,20 @@ const handler = async ( input: InputSchema ): Promise< OutputSchema > => {
 			( stateProps ) => Object.keys( stateProps ).length > 0
 		);
 		if ( ! hasAnyProps ) {
-			throw new Error( `Props must not be empty. Each prop must be a PropValue object from the style schema.\n\nExample: { "display": { "$$type": "string", "value": "flex" }, "flex-direction": { "$$type": "string", "value": "column" } }\n\n${STYLE_SCHEMA_FULL_URI} to get the allowed values (look at the "value" enum in the schema response), then construct { "$$type": "string", "value": "<chosen value>" } for each property.\nAvailable Properties: ${ validProps.join( ', ' ) }` );
+			throw new Error(
+				`Props must not be empty. Each prop must be a PropValue object from the style schema.\n\nExample: { "display": { "$$type": "string", "value": "flex" }, "flex-direction": { "$$type": "string", "value": "column" } }\n\n${ STYLE_SCHEMA_FULL_URI } to get the allowed values (look at the "value" enum in the schema response), then construct { "$$type": "string", "value": "<chosen value>" } for each property.\nAvailable Properties: ${ validProps.join(
+					', '
+				) }`
+			);
 		}
 	}
 
 	if ( errors.length > 0 ) {
-		throw new Error( `Validation errors:\n${ errors.join( '\n' ) }\nAvailable Properties: ${ validProps.join(
-			', '
-		) }\nUpdate your input and try again.` );
+		throw new Error(
+			`Validation errors:\n${ errors.join( '\n' ) }\nAvailable Properties: ${ validProps.join(
+				', '
+			) }\nUpdate your input and try again.`
+		);
 	}
 
 	// TODO: see https://elementor.atlassian.net/browse/ED-22513 for better cross-module access
@@ -146,6 +164,17 @@ const handler = async ( input: InputSchema ): Promise< OutputSchema > => {
 	} as { status: 'error' | 'ok'; message?: string; classId?: string };
 
 	try {
+		if ( action === 'delete' ) {
+			const deleted = await attemptDelete( {
+				classId,
+				stylesProvider: globalClassesStylesProvider,
+			} );
+			if ( deleted ) {
+				return { status: 'ok', message: `deleted global class with ID ${ classId }` };
+			}
+			throw new Error( 'error deleting class' );
+		}
+
 		let currentAction = action;
 		for await ( const [ state, props ] of Object.entries( propsWithStates ) ) {
 			switch ( currentAction ) {
@@ -183,17 +212,6 @@ const handler = async ( input: InputSchema ): Promise< OutputSchema > => {
 						throw new Error( 'error modifying class' );
 					}
 					break;
-				case 'delete':
-					const deleted = await attemptDelete( {
-						classId,
-						stylesProvider: globalClassesStylesProvider,
-					} );
-					if ( deleted ) {
-						result = { status: 'ok', message: `deleted global class with ID ${ classId }` };
-					} else {
-						throw new Error( 'error deleting class' );
-					}
-					break;
 				default:
 					throw new Error( `Unsupported action ${ action }` );
 			}
@@ -220,7 +238,7 @@ export const initManageGlobalClasses = ( reg: MCPRegistryEntry ) => {
 		description: `Create or modify global classes for reusable design-system styling. Class names must reflect purpose (e.g. heading-primary, button-cta). Create classes BEFORE applying them. Do NOT create classes for one-off styles.
 
 IMPORTANT: props must contain actual CSS property values — never pass empty objects.
-Fetch ${STYLE_SCHEMA_FULL_URI} to get the allowed values for each property, then use them to build the props object.
+Fetch ${ STYLE_SCHEMA_FULL_URI } to get the allowed values for each property, then use them to build the props object.
 
 Example — creating a flex column class:
 props.default = {

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-manage-global-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-manage-global-classes.ts
@@ -1,4 +1,4 @@
-import { BREAKPOINTS_SCHEMA_URI, STYLE_SCHEMA_URI } from '@elementor/editor-canvas';
+import { BREAKPOINTS_SCHEMA_FULL_URI, STYLE_SCHEMA_FULL_URI } from '@elementor/editor-canvas';
 import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 import { type Props, Schema } from '@elementor/editor-props';
 import { type BreakpointId } from '@elementor/editor-responsive';
@@ -8,6 +8,7 @@ import { type Utils as IUtils } from '@elementor/editor-variables';
 import { z } from '@elementor/schema';
 
 import { globalClassesStylesProvider } from '../global-classes-styles-provider';
+import { loadExistingClasses } from '../load-existing-classes';
 import { saveGlobalClasses } from '../save-global-classes';
 import { GLOBAL_CLASSES_URI } from './classes-resource';
 
@@ -23,21 +24,27 @@ const schema = {
 	globalClassName: z.string().optional().describe( 'Global class name (required for create)' ),
 	props: z.object( {
 		default: z
-			.record( z.any() )
-			.describe(
-				'key-value of style-schema PropValues. Available properties at dynamic resource "elementor://styles/schema/{property-name}"'
-			),
+			.record(
+				z.string().describe( 'The style property name' ),
+				z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` ),
+				z.any()
+			)
+			.describe( 'An object record containing style property names and their new values. MUST contain at least one property — empty objects are rejected.' ),
 		hover: z
-			.record( z.any() )
-			.describe( 'key-value of style-schema PropValues, for :hover css state. optional' )
-			.optional(),
+		.record(
+			z.string().describe( 'The style property name' ),
+			z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` ),
+			z.any()
+		)
+		.describe( 'An object record containing style property names and their new values to be set on the element. for :hover css state. optional' )
+		.optional(),
 		focus: z
-			.record( z.any() )
-			.describe( 'key-value of style-schema PropValues, for :focus css state. optional' )
+			.record( z.string().describe( 'The style property name' ), z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` ), z.any() )
+			.describe( 'An object record containing style property names and their new values to be set on the element. for :focus css state. optional' )
 			.optional(),
 		active: z
-			.record( z.any() )
-			.describe( 'key-value of style-schema PropValues, for :active css state. optional' )
+			.record( z.string().describe( 'The style property name' ), z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` ), z.any() )
+			.describe( 'An object record containing style property names and their new values to be set on the element. for :active css state. optional' )
 			.optional(),
 	} ),
 	breakpoint: z
@@ -105,13 +112,19 @@ const handler = async ( input: InputSchema ): Promise< OutputSchema > => {
 		} );
 	} );
 
+	if ( action !== 'delete' ) {
+		const hasAnyProps = Object.values( propsWithStates ).some(
+			( stateProps ) => Object.keys( stateProps ).length > 0
+		);
+		if ( ! hasAnyProps ) {
+			throw new Error( `Props must not be empty. Each prop must be a PropValue object from the style schema.\n\nExample: { "display": { "$$type": "string", "value": "flex" }, "flex-direction": { "$$type": "string", "value": "column" } }\n\n${STYLE_SCHEMA_FULL_URI} to get the allowed values (look at the "value" enum in the schema response), then construct { "$$type": "string", "value": "<chosen value>" } for each property.\nAvailable Properties: ${ validProps.join( ', ' ) }` );
+		}
+	}
+
 	if ( errors.length > 0 ) {
-		return {
-			status: 'error',
-			message: `Validation errors:\n${ errors.join( '\n' ) }\nAvailable Properties: ${ validProps.join(
-				', '
-			) }\nUpdate your input and try again.`,
-		};
+		throw new Error( `Validation errors:\n${ errors.join( '\n' ) }\nAvailable Properties: ${ validProps.join(
+			', '
+		) }\nUpdate your input and try again.` );
 	}
 
 	// TODO: see https://elementor.atlassian.net/browse/ED-22513 for better cross-module access
@@ -148,16 +161,13 @@ const handler = async ( input: InputSchema ): Promise< OutputSchema > => {
 						// NOTE: for multiple iterations as the state changes, the next execution would be update an existing class
 						currentAction = 'modify';
 						classId = newClassId;
+						result = {
+							status: 'ok',
+							message: `created global class with ID ${ newClassId }`,
+						};
+					} else {
+						throw new Error( 'error creating class' );
 					}
-					result = newClassId
-						? {
-								status: 'ok',
-								message: `created global class with ID ${ newClassId }`,
-						  }
-						: {
-								status: 'error',
-								message: 'error creating class',
-						  };
 					break;
 				case 'modify':
 					const updated = await attemptUpdate( {
@@ -167,24 +177,22 @@ const handler = async ( input: InputSchema ): Promise< OutputSchema > => {
 						breakpoint: breakpointValue as BreakpointId,
 						state: state as StyleDefinitionState,
 					} );
-					result = updated
-						? { status: 'ok', classId }
-						: {
-								status: 'error',
-								message: 'error modifying class',
-						  };
+					if ( updated ) {
+						result = { status: 'ok', classId };
+					} else {
+						throw new Error( 'error modifying class' );
+					}
 					break;
 				case 'delete':
 					const deleted = await attemptDelete( {
 						classId,
 						stylesProvider: globalClassesStylesProvider,
 					} );
-					result = deleted
-						? { status: 'ok', message: `deleted global class with ID ${ classId }` }
-						: {
-								status: 'error',
-								message: 'error deleting class',
-						  };
+					if ( deleted ) {
+						result = { status: 'ok', message: `deleted global class with ID ${ classId }` };
+					} else {
+						throw new Error( 'error deleting class' );
+					}
 					break;
 				default:
 					throw new Error( `Unsupported action ${ action }` );
@@ -206,10 +214,21 @@ export const initManageGlobalClasses = ( reg: MCPRegistryEntry ) => {
 		name: 'manage-global-classes',
 		requiredResources: [
 			{ uri: GLOBAL_CLASSES_URI, description: 'Global classes list' },
-			{ uri: STYLE_SCHEMA_URI, description: 'Style schema resources' },
-			{ uri: BREAKPOINTS_SCHEMA_URI, description: 'Breakpoints list' },
+			{ uri: STYLE_SCHEMA_FULL_URI, description: 'Style schema resources' },
+			{ uri: BREAKPOINTS_SCHEMA_FULL_URI, description: 'Breakpoints list' },
 		],
-		description: `Create or modify global classes for reusable design-system styling. Class names must reflect purpose (e.g. heading-primary, button-cta). Create classes BEFORE compositions. Do NOT create classes for one-off styles or layout-specific properties.`,
+		description: `Create or modify global classes for reusable design-system styling. Class names must reflect purpose (e.g. heading-primary, button-cta). Create classes BEFORE applying them. Do NOT create classes for one-off styles.
+
+IMPORTANT: props must contain actual CSS property values — never pass empty objects.
+Fetch ${STYLE_SCHEMA_FULL_URI} to get the allowed values for each property, then use them to build the props object.
+
+Example — creating a flex column class:
+props.default = {
+  "display": { "$$type": "string", "value": "flex" },
+  "flex-direction": { "$$type": "string", "value": "column" }
+}
+
+The style schema returns a JSON Schema. Extract the "value" enum to pick the right value, then construct { "$$type": "string", "value": "<picked value>" }.`,
 		schema,
 		outputSchema,
 		handler,
@@ -249,7 +268,7 @@ async function attemptCreate( opts: Opts ) {
 		return newClassId;
 	} catch {
 		deleteClass( newClassId );
-		return null;
+		throw new Error( 'error creating class' );
 	}
 }
 
@@ -262,6 +281,7 @@ async function attemptUpdate( opts: Opts ) {
 	if ( ! updateProps || ! update ) {
 		throw new Error( 'User is unable to update global classes' );
 	}
+	await loadExistingClasses( [ classId ] );
 	const snapshot = structuredClone( stylesProvider.actions.all() );
 	try {
 		updateProps( {
@@ -269,7 +289,7 @@ async function attemptUpdate( opts: Opts ) {
 			props,
 			meta: {
 				breakpoint,
-				state,
+				state: ( state as string ) === 'default' ? null : state,
 			},
 		} );
 		await saveGlobalClasses( { context: 'frontend' } );
@@ -282,7 +302,7 @@ async function attemptUpdate( opts: Opts ) {
 			} );
 		} );
 		await saveGlobalClasses( { context: 'frontend' } );
-		return false;
+		throw new Error( 'error updating class' );
 	}
 }
 
@@ -300,11 +320,7 @@ async function attemptDelete( opts: Pick< Opts, 'classId' | 'stylesProvider' > )
 	if ( ! targetClass ) {
 		throw new Error( `Class with ID "${ classId }" not found` );
 	}
-	try {
-		deleteClass( classId );
-		await saveGlobalClasses( { context: 'frontend' } );
-		return true;
-	} catch {
-		return false;
-	}
+	deleteClass( classId );
+	await saveGlobalClasses( { context: 'frontend' } );
+	return true;
 }


### PR DESCRIPTION
## Summary
- Fix Angie's MCP tool for managing global classes after the Global Classes refactor (1000 classes support)
- Export full URIs (`BREAKPOINTS_SCHEMA_FULL_URI`, `STYLE_SCHEMA_FULL_URI`, `WIDGET_SCHEMA_FULL_URI`) from `editor-canvas` to properly prefix resource URIs with the server name
- Update `manage-global-classes` tool to reference full URIs in `requiredResources` and schema descriptions, giving Angie direct links to fetch the correct resources
- Improve schema descriptions with concrete examples so Angie constructs valid `PropValue` objects
- Validate that `props` is non-empty before attempting create/modify operations, with a helpful error message and style schema link
- Refactor error handling to use `throw` instead of returning `{ status: 'error' }`, so errors propagate correctly through the MCP tool pipeline
- Fix `attemptUpdate` to correctly pass `null` (instead of the string `"default"`) for the default state
- Add `loadExistingClasses` call before updating to ensure class data is in memory

## Test plan
- [ ] Verify Angie can create a new global class with valid props (e.g. `display: flex`)
- [ ] Verify Angie can modify an existing global class
- [ ] Verify Angie can delete an existing global class
- [ ] Verify Angie receives a clear error when attempting to create/modify a class with empty props
- [ ] Verify Angie can read the style schema resource when prompted
- [ ] Verify breakpoint-specific class modifications work correctly

## Jira
[ED-24140](https://elementor.atlassian.net/browse/ED-24140)

Made with [Cursor](https://cursor.com)

[ED-24140]: https://elementor.atlassian.net/browse/ED-24140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The Global Classes refactor broke Angie's ability to generate classes because schema URIs changed from simple identifiers to fully-qualified resource names. This PR fixes integration by exporting full URIs and updating handler logic to use them and properly validate/handle errors.

## 2. What Changed (Where)

- **editor-canvas**: Export `*_FULL_URI` constants alongside base URIs for breakpoints, styles, and widgets schemas
- **mcp-manage-global-classes**: Import full URIs, add `loadExistingClasses()` call, refactor error handling from early returns to throws, validate non-empty props, improve tool description with usage examples

## 3. How It Works

Handler now validates props aren't empty upfront, then routes delete action before the create/modify loop. Failed operations throw errors (caught by try-catch) instead of returning error objects early, simplifying control flow. State normalization converts `'default'` to `null` in metadata. Schema descriptions reference full URIs for LLM guidance on fetching allowed property values.

## 4. Risks

None significant. Error handling refactor from returns to throws is isolated to handler and helper functions. `loadExistingClasses()` adds a fetch but only during modify operations. Breaking change for callers expecting error response objects instead of exceptions, but this is internal tooling.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
