### PR TITLE
Fix: Use i18n best practice to simplify translations [ED-24200]

### DIFF
--- a/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
+++ b/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
@@ -20,11 +20,12 @@ import {
 	FormControlLabel,
 	IconButton,
 	Image,
-	Link,
 	Stack,
 	Typography,
 } from '@elementor/ui';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+
+import { interpolateLinks } from '../interpolate-links';
 
 type ShowModalEventDetail = {
 	prompt?: string;
@@ -150,24 +151,24 @@ function CreateWidgetModal( { prompt, entryPoint, onClose }: CreateWidgetModalPr
 										}
 										label={
 											<Typography variant="body2" color="text.secondary">
-												{ __( 'I agree to the', 'elementor' ) }
-												<Link
-													sx={ { px: 0.5 } }
-													href="https://elementor.com/terms/angie-terms-conditions/"
-													target="_blank"
-													rel="noopener noreferrer"
-												>
-													{ __( 'Terms', 'elementor' ) }
-												</Link>
-												{ __( '&', 'elementor' ) }
-												<Link
-													sx={ { px: 0.5 } }
-													href="https://elementor.com/about/privacy/"
-													target="_blank"
-													rel="noopener noreferrer"
-												>
-													{ __( 'Privacy Policy.', 'elementor' ) }
-												</Link>
+												{ interpolateLinks(
+													sprintf(
+														// translators: %1$s is the Terms link, %2$s is the Privacy Policy link.
+														__( 'I agree to the %1$s & %2$s', 'elementor' ),
+														'{{terms}}',
+														'{{privacy}}'
+													),
+													{
+														terms: {
+															label: __( 'Terms', 'elementor' ),
+															href: 'https://elementor.com/terms/angie-terms-conditions/',
+														},
+														privacy: {
+															label: __( 'Privacy Policy.', 'elementor' ),
+															href: 'https://elementor.com/about/privacy/',
+														},
+													}
+												) }
 											</Typography>
 										}
 									/>

--- a/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
+++ b/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
@@ -154,7 +154,7 @@ function CreateWidgetModal( { prompt, entryPoint, onClose }: CreateWidgetModalPr
 												{ interpolateLinks(
 													sprintf(
 														// translators: %1$s is the Terms link, %2$s is the Privacy Policy link.
-														__( 'I agree to the %1$s & %2$s', 'elementor' ),
+														__( 'I agree to the %1$s & %2$s.', 'elementor' ),
 														'{{terms}}',
 														'{{privacy}}'
 													),
@@ -164,7 +164,7 @@ function CreateWidgetModal( { prompt, entryPoint, onClose }: CreateWidgetModalPr
 															href: 'https://elementor.com/terms/angie-terms-conditions/',
 														},
 														privacy: {
-															label: __( 'Privacy Policy.', 'elementor' ),
+															label: __( 'Privacy Policy', 'elementor' ),
 															href: 'https://elementor.com/about/privacy/',
 														},
 													}

--- a/packages/packages/core/editor-widget-creation/src/interpolate-links.tsx
+++ b/packages/packages/core/editor-widget-creation/src/interpolate-links.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { Link } from '@elementor/ui';
+
+type LinkConfig = {
+	label: string;
+	href: string;
+};
+
+type LinksMap = Record< string, LinkConfig >;
+
+const LINK_PLACEHOLDER_PATTERN = /\{\{(\w+)}}/g;
+
+export const interpolateLinks = ( text: string, links: LinksMap ) => {
+	return text.split( LINK_PLACEHOLDER_PATTERN ).map( ( part, i ) => {
+		const link = links[ part ];
+
+		if ( ! link ) {
+			return part;
+		}
+
+		return (
+			<Link key={ i } sx={ { px: 0.5 } } href={ link.href } target="_blank" rel="noopener noreferrer">
+				{ link.label }
+			</Link>
+		);
+	} );
+};


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Refactoring translation strings to follow i18n best practices by consolidating fragmented strings into single translatable units with placeholders, improving translator context and reducing translation complexity.

## 2. What Changed (Where)

- `create-widget.tsx`: Replaced hardcoded Link components with `sprintf()` + `interpolateLinks()` utility for dynamic link injection into single translatable string.
- `interpolate-links.tsx`: New utility that parses `{{placeholder}}` patterns and renders Link components, decoupling i18n from JSX structure.
- Removed unused `Link` import from UI package.

## 3. How It Works

String flows through `sprintf()` with placeholder tokens (`{{terms}}`, `{{privacy}}`), then `interpolateLinks()` regex-splits the result and replaces matching keys with Link components, reconstructing JSX tree from flat string.

## 4. Risks

Regex pattern `/\{\{(\w+)}}/g` assumes well-formed placeholders—malformed input silently renders as text. No validation that all placeholders in text exist in the links map. Minor: key-based rendering uses array index; ensure placeholder ordering matches intended output.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
