### PR TITLE
Feature: Send Document-Isolation-Policy header [ED-24218]

### DIFF
--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -592,7 +592,7 @@ class Editor {
 	 * preview iframe handler. No-op when {@see self::should_use_document_isolation_policy()}
 	 * returns false.
 	 *
-	 * @since X.X.X
+	 * @since 4.1.0
 	 */
 	public static function send_document_isolation_policy_header() {
 		if ( ! self::should_use_document_isolation_policy() || headers_sent() ) {

--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -595,12 +595,11 @@ class Editor {
 	 * @since X.X.X
 	 */
 	public static function send_document_isolation_policy_header() {
-		if ( ! self::should_use_document_isolation_policy() ) {
+		if ( ! self::should_use_document_isolation_policy() || headers_sent() ) {
 			return;
 		}
 
-		// @ suppresses "headers already sent" warnings in environments that have flushed output.
-		@header( 'Document-Isolation-Policy: isolate-and-credentialless' );
+		header( 'Document-Isolation-Policy: isolate-and-credentialless' );
 	}
 
 	/**

--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -578,7 +578,7 @@ class Editor {
 		 * Filters whether Elementor sends the Document-Isolation-Policy header
 		 * on the editor screen and preview iframe.
 		 *
-		 * @since X.X.X
+		 * @since 4.1.0
 		 *
 		 * @param bool $enabled Whether DIP is enabled. Defaults to true on a secure context.
 		 */

--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -560,7 +560,7 @@ class Editor {
 	 * localhost) so the helper short-circuits on insecure origins to avoid
 	 * sending a header that the browser will ignore.
 	 *
-	 * @since X.X.X
+	 * @since 4.1.0
 	 *
 	 * @return bool
 	 */

--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -117,6 +117,8 @@ class Editor {
 		// Send MIME Type header like WP admin-header.
 		@header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option( 'blog_charset' ) );
 
+		self::send_document_isolation_policy_header();
+
 		add_filter( 'show_admin_bar', '__return_false' );
 
 		// Remove all WordPress actions
@@ -540,6 +542,65 @@ class Editor {
 		add_filter( 'wp_link_query', [ $this, 'filter_wp_link_query' ] );
 
 		add_filter( 'replace_editor', [ $this, 'filter_replace_editor' ], 10, 2 );
+	}
+
+	/**
+	 * Whether the Document-Isolation-Policy header should be sent on the
+	 * Elementor editor screen and the editor preview iframe.
+	 *
+	 * DIP places the document in its own agent cluster, which is the prerequisite
+	 * for cross-origin isolation features such as SharedArrayBuffer (required by
+	 * WordPress core's client-side media processing introduced in WP 7.1).
+	 *
+	 * Both the editor parent document and the preview iframe must send the same
+	 * DIP header so they join the same agent cluster and synchronous DOM access
+	 * between them (e.g. `iframe.contentWindow.elementorFrontend`) keeps working.
+	 *
+	 * The header is only honored by browsers on a secure context (HTTPS or
+	 * localhost) so the helper short-circuits on insecure origins to avoid
+	 * sending a header that the browser will ignore.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return bool
+	 */
+	public static function should_use_document_isolation_policy() {
+		if ( ! is_ssl() ) {
+			$raw_host = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+			$host = strtolower( (string) strtok( $raw_host, ':' ) );
+
+			if ( 'localhost' !== $host && ! str_ends_with( $host, '.localhost' ) ) {
+				return false;
+			}
+		}
+
+		/**
+		 * Filters whether Elementor sends the Document-Isolation-Policy header
+		 * on the editor screen and preview iframe.
+		 *
+		 * @since X.X.X
+		 *
+		 * @param bool $enabled Whether DIP is enabled. Defaults to true on a secure context.
+		 */
+		return (bool) apply_filters( 'elementor/editor/use_document_isolation_policy', true );
+	}
+
+	/**
+	 * Send the Document-Isolation-Policy header for the current response.
+	 *
+	 * Safe to call from both the Elementor editor screen handler and the
+	 * preview iframe handler. No-op when {@see self::should_use_document_isolation_policy()}
+	 * returns false.
+	 *
+	 * @since X.X.X
+	 */
+	public static function send_document_isolation_policy_header() {
+		if ( ! self::should_use_document_isolation_policy() ) {
+			return;
+		}
+
+		// @ suppresses "headers already sent" warnings in environments that have flushed output.
+		@header( 'Document-Isolation-Policy: isolate-and-credentialless' );
 	}
 
 	/**

--- a/includes/preview.php
+++ b/includes/preview.php
@@ -2,6 +2,7 @@
 namespace Elementor;
 
 use Elementor\Core\Base\App;
+use Elementor\Core\Editor\Editor;
 use Elementor\Core\Settings\Manager as SettingsManager;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -92,6 +93,11 @@ class Preview extends App {
 
 		$this->post_id = get_the_ID();
 		$this->is_preview = true;
+
+		// Send Document-Isolation-Policy on the preview iframe so it shares
+		// an agent cluster with the editor parent and synchronous DOM access
+		// (e.g. iframe.contentWindow.elementorFrontend) keeps working.
+		Editor::send_document_isolation_policy_header();
 
 		// Don't redirect to permalink.
 		remove_action( 'template_redirect', 'redirect_canonical' );

--- a/tests/phpunit/elementor/test-editor.php
+++ b/tests/phpunit/elementor/test-editor.php
@@ -1,9 +1,17 @@
 <?php
 namespace Elementor\Testing;
 
+use Elementor\Core\Editor\Editor;
 use ElementorEditorTesting\Elementor_Test_Base;
 
 class Elementor_Test_Editor extends Elementor_Test_Base {
+
+	/**
+	 * Original $_SERVER values, restored in tearDown.
+	 *
+	 * @var array
+	 */
+	private $original_server = [];
 
 	public function setUp(): void {
 		parent::setUp();
@@ -11,6 +19,23 @@ class Elementor_Test_Editor extends Elementor_Test_Base {
 		wp_set_current_user( $this->factory()->get_administrator_user()->ID );
 
 		$GLOBALS['post'] = $this->factory()->create_and_get_default_post()->IDs;
+
+		$this->original_server = [
+			'HTTPS' => $_SERVER['HTTPS'] ?? null,
+			'HTTP_HOST' => $_SERVER['HTTP_HOST'] ?? null,
+		];
+	}
+
+	public function tearDown(): void {
+		foreach ( $this->original_server as $key => $value ) {
+			if ( null === $value ) {
+				unset( $_SERVER[ $key ] );
+			} else {
+				$_SERVER[ $key ] = $value;
+			}
+		}
+
+		parent::tearDown();
 	}
 
 	public function test_getInstance() {
@@ -73,4 +98,64 @@ class Elementor_Test_Editor extends Elementor_Test_Base {
 
 		$this->assertNotEmpty( $buffer );
 	}*/
+
+	public function test_should_use_document_isolation_policy__https() {
+		$_SERVER['HTTPS'] = 'on';
+		$_SERVER['HTTP_HOST'] = 'example.com';
+
+		$this->assertTrue( Editor::should_use_document_isolation_policy() );
+	}
+
+	public function test_should_use_document_isolation_policy__localhost() {
+		unset( $_SERVER['HTTPS'] );
+		$_SERVER['HTTP_HOST'] = 'localhost';
+
+		$this->assertTrue( Editor::should_use_document_isolation_policy() );
+	}
+
+	public function test_should_use_document_isolation_policy__localhost_subdomain() {
+		unset( $_SERVER['HTTPS'] );
+		$_SERVER['HTTP_HOST'] = 'site.localhost';
+
+		$this->assertTrue( Editor::should_use_document_isolation_policy() );
+	}
+
+	public function test_should_use_document_isolation_policy__localhost_with_port() {
+		unset( $_SERVER['HTTPS'] );
+		$_SERVER['HTTP_HOST'] = 'localhost:8888';
+
+		$this->assertTrue( Editor::should_use_document_isolation_policy() );
+	}
+
+	public function test_should_use_document_isolation_policy__insecure() {
+		unset( $_SERVER['HTTPS'] );
+		$_SERVER['HTTP_HOST'] = 'example.com';
+
+		$this->assertFalse( Editor::should_use_document_isolation_policy() );
+	}
+
+	public function test_should_use_document_isolation_policy__filter_can_disable() {
+		$_SERVER['HTTPS'] = 'on';
+		$_SERVER['HTTP_HOST'] = 'example.com';
+
+		add_filter( 'elementor/editor/use_document_isolation_policy', '__return_false' );
+
+		$this->assertFalse( Editor::should_use_document_isolation_policy() );
+
+		remove_filter( 'elementor/editor/use_document_isolation_policy', '__return_false' );
+	}
+
+	public function test_should_use_document_isolation_policy__filter_cannot_force_on_insecure() {
+		unset( $_SERVER['HTTPS'] );
+		$_SERVER['HTTP_HOST'] = 'example.com';
+
+		add_filter( 'elementor/editor/use_document_isolation_policy', '__return_true' );
+
+		$this->assertFalse(
+			Editor::should_use_document_isolation_policy(),
+			'Filter should not bypass the secure-context requirement.'
+		);
+
+		remove_filter( 'elementor/editor/use_document_isolation_policy', '__return_true' );
+	}
 }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Feature

## Summary

This PR can be summarized in the following changelog entry:

* Send `Document-Isolation-Policy: isolate-and-credentialless` on the Elementor editor screen and preview iframe so Elementor sites can take advantage of WordPress 7.1's client-side media processing (and any future capability gated on cross-origin isolation).

Closes https://github.com/elementor/elementor/issues/35975.

## Description

WordPress 7.1 introduces `Document-Isolation-Policy: isolate-and-credentialless` (DIP) on the block editor to enable cross-origin isolation, which is the prerequisite for `SharedArrayBuffer` and therefore for core's new client-side media processing feature (HEIC/AVIF in-browser, sub-size generation, Ultra HDR, etc.).

When DIP is applied to a parent document but not to its same-origin preview iframe, the browser places them in separate agent clusters and blocks synchronous DOM access between them. Elementor's editor relies on `iframe.contentWindow.elementorFrontend.*` to drive the preview, so applying DIP only on the editor surfaces as:

```
Uncaught SecurityError: Failed to read a named property 'elementorFrontend' from 'Window':
Blocked a frame with origin "..." from accessing a cross-origin frame.
```

(Originally reported by the Elementor team in [WordPress/wordpress-develop#11170](https://github.com/WordPress/wordpress-develop/pull/11170) against WordPress 7.0-beta3.)

### What this PR does

1. Adds two static helpers on `Elementor\Core\Editor\Editor`:
   - `should_use_document_isolation_policy()` — secure-context gate (HTTPS or localhost) plus an `elementor/editor/use_document_isolation_policy` filter for opt-out (defaults to `true`).
   - `send_document_isolation_policy_header()` — emits `Document-Isolation-Policy: isolate-and-credentialless` when the gate allows it.
2. Calls the helper from `Editor::init()` (the editor screen) right after the `Content-Type` header.
3. Calls the helper from `Preview::init()` (the preview iframe) before any output.

Because both the editor parent and the preview iframe send the same DIP header, they join the same agent cluster - synchronous DOM access between them is preserved, and the editor continues to work unchanged.

### What this PR does *not* change

- The existing `filter_replace_editor()` workaround from #34900 is left in place. It signals to WordPress that Elementor is replacing the block editor and serves purposes beyond the DIP gate. WordPress core's DIP code is keyed on the `action=edit` query parameter (see [WordPress/wordpress-develop#11170](https://github.com/WordPress/wordpress-develop/pull/11170)), so for `action=elementor` core does not send DIP at all - Elementor needs to send it itself, which is what this PR does.
- No changes to the editor UI, preview lifecycle, or any other behavior.

### Why default to enabled

- The header is only honored by browsers on a secure context, so insecure origins are unaffected.
- Non-Chromium browsers and Chrome < 137 ignore the header.
- Sites that hit an edge case can opt out via `add_filter( 'elementor/editor/use_document_isolation_policy', '__return_false' );`.

Filing this issue first: [#35975](https://github.com/elementor/elementor/issues/35975).

## Test instructions

### Automated

```bash
composer test -- --filter Elementor_Test_Editor
```

New tests cover:

- DIP enabled on HTTPS
- DIP enabled on `localhost`, `*.localhost`, and `localhost:port`
- DIP disabled on insecure non-localhost origins
- `elementor/editor/use_document_isolation_policy` filter can disable
- Filter cannot force DIP on an insecure context (secure-context check wins)

### Manual

1. Install WordPress 7.1 nightly (via the WordPress Beta Tester plugin set to "Bleeding edge").
2. Install Elementor with this branch applied. Serve the site over HTTPS or `localhost`.
3. Open an Elementor edit page in Chrome 137+ and verify:
    - DevTools > Network: the editor response has `Document-Isolation-Policy: isolate-and-credentialless`.
    - DevTools > Network: the preview iframe response also has `Document-Isolation-Policy: isolate-and-credentialless`.
    - DevTools > Console: `window.crossOriginIsolated === true`.
    - The Elementor editor loads, previews render, and editing/dragging/dropping all work as before.
    - No `SecurityError: Failed to read a named property 'elementorFrontend' from 'Window'` errors.
4. In the WordPress media library inside the Elementor editor, upload an image and confirm client-side media processing kicks in (look for the wasm-vips worker in DevTools > Sources, and the `wp_client_side_media_processing_enabled` filter response in the REST schema).
5. Opt-out path: add `add_filter( 'elementor/editor/use_document_isolation_policy', '__return_false' );` to a mu-plugin. Reload the editor and confirm the DIP header is no longer sent.
6. Insecure context: load the editor over plain HTTP (non-localhost) and confirm no DIP header is sent (the secure-context gate short-circuits).

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended

## References

- Tracking issue: https://github.com/elementor/elementor/issues/35975
- WordPress core DIP PR: https://github.com/WordPress/wordpress-develop/pull/11098
- WordPress core page-builder workaround: https://github.com/WordPress/wordpress-develop/pull/11170
- Existing Elementor `replace_editor` workaround: https://github.com/elementor/elementor/pull/34900
- Gutenberg client-side media tracking: https://github.com/WordPress/gutenberg/issues/76756
- Chrome DIP explainer: https://developer.chrome.com/blog/document-isolation-policy
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Elementor editor and preview iframe need Document-Isolation-Policy (DIP) header to enable cross-origin isolation for SharedArrayBuffer and synchronous DOM access. DIP enforcement is only meaningful on secure contexts (HTTPS/localhost), so the implementation guards against sending headers browsers ignore.

## 2. What Changed (Where)

- **core/editor/editor.php**: Added `should_use_document_isolation_policy()` (validates secure context, applies filter) and `send_document_isolation_policy_header()` (sends DIP header); calls header function in editor initialization.
- **includes/preview.php**: Imported Editor class, calls `send_document_isolation_policy_header()` during preview setup.
- **tests/phpunit/elementor/test-editor.php**: Added comprehensive test suite covering HTTPS, localhost variants, port handling, insecure contexts, filter disable/override logic.

## 3. How It Works

Editor calls `send_document_isolation_policy_header()` during init (line 120); preview calls same method during setup (line 100). Both check `should_use_document_isolation_policy()` which validates secure context (SSL or localhost), sanitizes $_SERVER['HTTP_HOST'], respects filter override, then conditionally sends `Document-Isolation-Policy: isolate-and-credentialless` header. No-op if headers already sent.

## 4. Risks

Filter at line 585 can disable DIP on secure contexts (acceptable), but intentionally cannot force-enable on insecure contexts (tested, correct). Header safety check via `headers_sent()` prevents issues from duplicate calls. Minor: `strtok()` modifies state but safe here since return value captured immediately.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
