### PR TITLE
CI: Suppress non-applicable Twig advisories in composer audit [ED-24231]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,19 @@
             "php": "7.4"
         }
     },
+    "audit": {
+        "ignore": {
+            "PKSA-sjvz-tbbr-vwth": "CVE-2026-46628 (spaceless filter implicitly marks output as safe) - we only render our twig templates and don't allow users to upload their own templates. Our templates do not use the spaceless filter.",
+            "PKSA-h8hf-ytnd-5t9q": "CVE-2026-46633 (PHP code injection via {% use %} template name) - template names passed to Twig are hardcoded. No user can inject twig source.",
+            "PKSA-wwb1-81rc-pd65": "CVE-2026-47730 (XSS in profiler HtmlDumper via unescaped template/profile names) - we don't use Twig's profiler/HtmlDumper.",
+            "PKSA-kvv6-36cr-fkzb": "CVE-2026-46627 (sandbox does not protect against resource exhaustion) - we don't enable sandbox.",
+            "PKSA-n14z-jjjg-g8vd": "CVE-2026-46635 (sandbox property allowlist bypass via the column filter) - we don't enable sandbox.",
+            "PKSA-3mcc-k66d-pydb": "CVE-2026-46638 ({% sandbox %}{% include %} skips checkSecurity on cached templates) - we don't enable sandbox.",
+            "PKSA-gw7n-z4yx-7xjt": "CVE-2026-24425 (possible sandbox bypass when using a source policy) - we don't configure a SourcePolicy and don't enable sandbox.",
+            "PKSA-dpx1-78wg-1kqs": "CVE-2026-47732 (sandbox __toString() policy bypasses via unguarded coercion) - we don't enable sandbox.",
+            "PKSA-21g2-dzjv-sky5": "CVE-2026-46634 (template_from_string() escapes SourcePolicy-driven sandbox) - we don't call template_from_string() and don't configure a SourcePolicy or sandbox."
+        }
+    },
     "authors": [
         {
             "name": "Elementor team"

--- a/composer.json
+++ b/composer.json
@@ -63,19 +63,19 @@
         },
         "platform": {
             "php": "7.4"
-        }
-    },
-    "audit": {
-        "ignore": {
-            "PKSA-sjvz-tbbr-vwth": "CVE-2026-46628 (spaceless filter implicitly marks output as safe) - we only render our twig templates and don't allow users to upload their own templates. Our templates do not use the spaceless filter.",
-            "PKSA-h8hf-ytnd-5t9q": "CVE-2026-46633 (PHP code injection via {% use %} template name) - template names passed to Twig are hardcoded. No user can inject twig source.",
-            "PKSA-wwb1-81rc-pd65": "CVE-2026-47730 (XSS in profiler HtmlDumper via unescaped template/profile names) - we don't use Twig's profiler/HtmlDumper.",
-            "PKSA-kvv6-36cr-fkzb": "CVE-2026-46627 (sandbox does not protect against resource exhaustion) - we don't enable sandbox.",
-            "PKSA-n14z-jjjg-g8vd": "CVE-2026-46635 (sandbox property allowlist bypass via the column filter) - we don't enable sandbox.",
-            "PKSA-3mcc-k66d-pydb": "CVE-2026-46638 ({% sandbox %}{% include %} skips checkSecurity on cached templates) - we don't enable sandbox.",
-            "PKSA-gw7n-z4yx-7xjt": "CVE-2026-24425 (possible sandbox bypass when using a source policy) - we don't configure a SourcePolicy and don't enable sandbox.",
-            "PKSA-dpx1-78wg-1kqs": "CVE-2026-47732 (sandbox __toString() policy bypasses via unguarded coercion) - we don't enable sandbox.",
-            "PKSA-21g2-dzjv-sky5": "CVE-2026-46634 (template_from_string() escapes SourcePolicy-driven sandbox) - we don't call template_from_string() and don't configure a SourcePolicy or sandbox."
+        },
+        "audit": {
+            "ignore": {
+                "PKSA-sjvz-tbbr-vwth": "CVE-2026-46628 (spaceless filter implicitly marks output as safe) - we only render our twig templates and don't allow users to upload their own templates. Our templates do not use the spaceless filter.",
+                "PKSA-h8hf-ytnd-5t9q": "CVE-2026-46633 (PHP code injection via {% use %} template name) - template names passed to Twig are hardcoded. No user can inject twig source.",
+                "PKSA-wwb1-81rc-pd65": "CVE-2026-47730 (XSS in profiler HtmlDumper via unescaped template/profile names) - we don't use Twig's profiler/HtmlDumper.",
+                "PKSA-kvv6-36cr-fkzb": "CVE-2026-46627 (sandbox does not protect against resource exhaustion) - we don't enable sandbox.",
+                "PKSA-n14z-jjjg-g8vd": "CVE-2026-46635 (sandbox property allowlist bypass via the column filter) - we don't enable sandbox.",
+                "PKSA-3mcc-k66d-pydb": "CVE-2026-46638 ({% sandbox %}{% include %} skips checkSecurity on cached templates) - we don't enable sandbox.",
+                "PKSA-gw7n-z4yx-7xjt": "CVE-2026-24425 (possible sandbox bypass when using a source policy) - we don't configure a SourcePolicy and don't enable sandbox.",
+                "PKSA-dpx1-78wg-1kqs": "CVE-2026-47732 (sandbox __toString() policy bypasses via unguarded coercion) - we don't enable sandbox.",
+                "PKSA-21g2-dzjv-sky5": "CVE-2026-46634 (template_from_string() escapes SourcePolicy-driven sandbox) - we don't call template_from_string() and don't configure a SourcePolicy or sandbox."
+            }
         }
     },
     "authors": [


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Composer audit is flagging Twig CVEs that don't apply to this codebase since Twig features aren't used in a way that triggers the vulnerabilities. Suppressing these false positives prevents CI/CD noise and unblocks dependency updates.

## 2. What Changed (Where)

composer.json: Added `audit.ignore` configuration with 9 Twig CVE exceptions, each documented with rationale (sandbox disabled, hardcoded templates, no profiler usage, etc.).

## 3. How It Works

Composer audit respects the `config.audit.ignore` map to skip flagged vulnerabilities; keyed by advisory ID (PKSA-*), values provide suppression justification for maintainability.

## 4. Risks

Documentation accuracy: rationales must remain valid if Twig usage patterns change. Consider adding periodic review comments or linting to catch stale suppressions.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
