### PR TITLE
Fix: Background & lightbox video Jetpack VideoPress links don't display on the frontend [ED-13224]

### DIFF
--- a/assets/dev/js/frontend/utils/lightbox/lightbox.js
+++ b/assets/dev/js/frontend/utils/lightbox/lightbox.js
@@ -249,7 +249,7 @@ module.exports = elementorModules.ViewModule.extend( {
 
 		let $videoElement;
 
-		if ( 'hosted' === options.videoType ) {
+		if ( [ 'hosted', 'videopress', 'dailymotion' ].includes( options.videoType ) ) {
 			const videoParams = $.extend( { src: options.url, autoplay: '' }, options.videoParams );
 
 			const paramKeys = Object.keys( videoParams );

--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -195,12 +195,6 @@ class Container extends Element_Base {
 	protected function render_video_background() {
 		$settings = $this->get_settings_for_display();
 
-		// Embed::get_video_properties() recognizes four providers, but the background-video
-		// frontend handler only mounts YouTube/Vimeo players on .elementor-background-video-embed.
-		// Dailymotion and VideoPress must render .elementor-background-video-hosted so activate()
-		// can set the video src instead of querying a missing hosted element.
-		$video_embed_providers = [ 'youtube', 'vimeo' ];
-
 		if ( 'video' !== $settings['background_background'] ) {
 			return;
 		}

--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -199,7 +199,7 @@ class Container extends Element_Base {
 		// frontend handler only mounts YouTube/Vimeo players on .elementor-background-video-embed.
 		// Dailymotion and VideoPress must render .elementor-background-video-hosted so activate()
 		// can set the video src instead of querying a missing hosted element.
-		$background_video_embed_providers = [ 'youtube', 'vimeo' ];
+		$video_embed_providers = [ 'youtube', 'vimeo' ];
 
 		if ( 'video' !== $settings['background_background'] ) {
 			return;
@@ -211,7 +211,7 @@ class Container extends Element_Base {
 
 		$video_properties = Embed::get_video_properties( $settings['background_video_link'] );
 
-		$is_embed_video = null !== $video_properties && in_array( $video_properties['provider'], $background_video_embed_providers, true );
+		$is_embed_video = null !== $video_properties && in_array( $video_properties['provider'], $video_embed_providers, true );
 
 		$this->add_render_attribute(
 			'background-video-container',

--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -195,6 +195,12 @@ class Container extends Element_Base {
 	protected function render_video_background() {
 		$settings = $this->get_settings_for_display();
 
+		// Embed::get_video_properties() recognizes four providers, but the background-video
+		// frontend handler only mounts YouTube/Vimeo players on .elementor-background-video-embed.
+		// Dailymotion and VideoPress must render .elementor-background-video-hosted so activate()
+		// can set the video src instead of querying a missing hosted element.
+		$background_video_embed_providers = [ 'youtube', 'vimeo' ];
+
 		if ( 'video' !== $settings['background_background'] ) {
 			return;
 		}
@@ -204,6 +210,8 @@ class Container extends Element_Base {
 		}
 
 		$video_properties = Embed::get_video_properties( $settings['background_video_link'] );
+
+		$is_embed_video = null !== $video_properties && in_array( $video_properties['provider'], $background_video_embed_providers, true );
 
 		$this->add_render_attribute(
 			'background-video-container',
@@ -217,7 +225,7 @@ class Container extends Element_Base {
 		}
 
 		?><div <?php $this->print_render_attribute_string( 'background-video-container' ); ?>>
-			<?php if ( $video_properties ) : ?>
+			<?php if ( $is_embed_video ) : ?>
 				<div class="elementor-background-video-embed" role="presentation"></div>
 				<?php
 			else :

--- a/includes/elements/container.php
+++ b/includes/elements/container.php
@@ -209,9 +209,7 @@ class Container extends Element_Base {
 			return;
 		}
 
-		$video_properties = Embed::get_video_properties( $settings['background_video_link'] );
-
-		$is_embed_video = null !== $video_properties && in_array( $video_properties['provider'], $video_embed_providers, true );
+		$is_embed_video = Embed::is_embed_video( $settings['background_video_link'] );
 
 		$this->add_render_attribute(
 			'background-video-container',

--- a/includes/elements/section.php
+++ b/includes/elements/section.php
@@ -1479,7 +1479,7 @@ class Element_Section extends Element_Base {
 		?> <?php $this->print_render_attribute_string( '_wrapper' ); ?>>
 			<?php
 			if ( 'video' === $settings['background_background'] ) :
-				if ( $settings['background_video_link'] ) :					
+				if ( $settings['background_video_link'] ) :
 					$is_embed_video = Embed::is_embed_video( $settings['background_video_link'] );
 
 					$this->add_render_attribute(

--- a/includes/elements/section.php
+++ b/includes/elements/section.php
@@ -1472,6 +1472,7 @@ class Element_Section extends Element_Base {
 	 */
 	public function before_render() {
 		$settings = $this->get_settings_for_display();
+		$video_embed_providers = [ 'youtube', 'vimeo' ];
 		?>
 		<<?php
 			// PHPCS - the method get_html_tag is safe.
@@ -1481,6 +1482,8 @@ class Element_Section extends Element_Base {
 			if ( 'video' === $settings['background_background'] ) :
 				if ( $settings['background_video_link'] ) :
 					$video_properties = Embed::get_video_properties( $settings['background_video_link'] );
+
+					$is_embed_video = null !== $video_properties && in_array( $video_properties['provider'], $video_embed_providers, true );
 
 					$this->add_render_attribute(
 						'background-video-container',
@@ -1494,7 +1497,7 @@ class Element_Section extends Element_Base {
 					}
 					?>
 					<div <?php $this->print_render_attribute_string( 'background-video-container' ); ?>>
-						<?php if ( $video_properties ) : ?>
+						<?php if ( $is_embed_video ) : ?>
 							<div class="elementor-background-video-embed" role="presentation"></div>
 							<?php
 						else :

--- a/includes/elements/section.php
+++ b/includes/elements/section.php
@@ -1472,7 +1472,6 @@ class Element_Section extends Element_Base {
 	 */
 	public function before_render() {
 		$settings = $this->get_settings_for_display();
-		$video_embed_providers = [ 'youtube', 'vimeo' ];
 		?>
 		<<?php
 			// PHPCS - the method get_html_tag is safe.
@@ -1480,10 +1479,8 @@ class Element_Section extends Element_Base {
 		?> <?php $this->print_render_attribute_string( '_wrapper' ); ?>>
 			<?php
 			if ( 'video' === $settings['background_background'] ) :
-				if ( $settings['background_video_link'] ) :
-					$video_properties = Embed::get_video_properties( $settings['background_video_link'] );
-
-					$is_embed_video = null !== $video_properties && in_array( $video_properties['provider'], $video_embed_providers, true );
+				if ( $settings['background_video_link'] ) :					
+					$is_embed_video = Embed::is_embed_video( $settings['background_video_link'] );
 
 					$this->add_render_attribute(
 						'background-video-container',

--- a/includes/embed.php
+++ b/includes/embed.php
@@ -25,7 +25,6 @@ class Embed {
 	 * get_video_properties() — the frontend background-video handler only mounts
 	 * YouTube/Vimeo players, so other providers must fall through to hosted rendering.
 	 *
-	 * @since 3.x.x
 	 * @access private
 	 * @static
 	 *
@@ -112,7 +111,7 @@ class Embed {
 	 * background-video handler renders as an embedded iframe player.
 	 *
 	 * @param string $video_url Video URL.
-	 * 
+	 *
 	 * @return bool
 	 **/
 	public static function is_embed_video( $video_url ) {
@@ -120,7 +119,7 @@ class Embed {
 
 		return null !== $video_properties && in_array( $video_properties['provider'], self::$video_embed_providers, true );
 	}
-	
+
 	/**
 	 * Get embed URL.
 	 *

--- a/includes/embed.php
+++ b/includes/embed.php
@@ -17,6 +17,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Embed {
 
 	/**
+	 * Embeddable background video providers.
+	 *
+	 * Holds the list of providers whose background video is rendered as an embedded
+	 * iframe player (.elementor-background-video-embed) rather than a hosted <video>
+	 * element. This is intentionally a SUBSET of the providers recognized by
+	 * get_video_properties() — the frontend background-video handler only mounts
+	 * YouTube/Vimeo players, so other providers must fall through to hosted rendering.
+	 *
+	 * @since 3.x.x
+	 * @access private
+	 * @static
+	 *
+	 * @var array Embeddable background video provider slugs.
+	 */
+	private static $video_embed_providers = [ 'youtube', 'vimeo' ];
+
+
+	/**
 	 * Provider match masks.
 	 *
 	 * Holds a list of supported providers with their URL structure in a regex format.
@@ -87,6 +105,22 @@ class Embed {
 		return null;
 	}
 
+	/**
+	 * Is embeddable background video.
+	 *
+	 * Whether a given video URL belongs to a provider that the frontend
+	 * background-video handler renders as an embedded iframe player.
+	 *
+	 * @param string $video_url Video URL.
+	 * 
+	 * @return bool
+	 **/
+	public static function is_embed_video( $video_url ) {
+		$video_properties = self::get_video_properties( $video_url );
+
+		return null !== $video_properties && in_array( $video_properties['provider'], self::$video_embed_providers, true );
+	}
+	
 	/**
 	 * Get embed URL.
 	 *


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Jetpack VideoPress links (and other embeddable providers) weren't rendering in background videos or lightbox because the code was checking `$video_properties` (truthy check) instead of verifying the provider supports embedded rendering. This broke WordPress.com hosted videos in containers/sections and lightbox modals.

## 2. What Changed (Where)

- **includes/embed.php**: Added `is_embed_video()` method to explicitly check if provider is in the embeddable whitelist (YouTube, Vimeo only).
- **includes/elements/container.php & section.php**: Replaced `get_video_properties()` call with `is_embed_video()` for conditional render logic.
- **assets/dev/js/frontend/utils/lightbox/lightbox.js**: Extended lightbox video type check to include `'videopress'` and `'dailymotion'` alongside `'hosted'`.

## 3. How It Works

The fix introduces a two-tier provider system: `get_video_properties()` extracts metadata from any recognized provider, while `is_embed_video()` filters to only providers the frontend can render as iframes. Background video render paths now check `is_embed_video()` to decide between iframe (YouTube/Vimeo) or `<video>` tag (hosted/VideoPress). Lightbox extends its video type check to handle VideoPress URLs that weren't previously triggering video playback.

## 4. Risks

Low. The whitelist approach (`['youtube', 'vimeo']`) is conservative — only affects providers explicitly supported by frontend background-video handler. Lightbox change is additive (new video types supported, no removal of existing paths).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
