### PR TITLE
Fix: Website template filter did not change from 'featured'. [ED-23131]

### DIFF
--- a/app/modules/kit-library/assets/js/pages/index/index.js
+++ b/app/modules/kit-library/assets/js/pages/index/index.js
@@ -107,12 +107,16 @@ function useRouterQueryParams( queryParams, setQueryParams, exclude = [] ) {
 	}, [] );
 }
 
-export default function Index( props ) {
+export default function Index( {
+	path,
+	initialQueryParams = {},
+	renderNoResultsComponent = ( { defaultComponent } ) => defaultComponent,
+} ) {
 	usePageTitle( {
 		title: __( 'Website Templates', 'elementor' ),
 	} );
 
-	const menuItems = useMenuItems( props.path );
+	const menuItems = useMenuItems( path );
 	const tracking = useTracking();
 
 	const {
@@ -126,9 +130,9 @@ export default function Index( props ) {
 		clearQueryParams,
 		forceRefetch,
 		isFilterActive,
-	} = useKits( props.initialQueryParams );
+	} = useKits( initialQueryParams );
 
-	useRouterQueryParams( queryParams, setQueryParams, [ 'ready', ...Object.keys( props.initialQueryParams ) ] );
+	useRouterQueryParams( queryParams, setQueryParams, [ 'ready', ...Object.keys( initialQueryParams ) ] );
 
 	useEffect( () => {
 		if ( ! queryParams.search ) {
@@ -178,7 +182,7 @@ export default function Index( props ) {
 						selected={ queryParams.taxonomies }
 						onSelect={ selectTaxonomy }
 						taxonomies={ taxonomiesData }
-						category={ props.path }
+						category={ path }
 					/> }
 					menuItems={ menuItems }
 				/>
@@ -220,6 +224,7 @@ export default function Index( props ) {
 							onChange={ ( order ) => setQueryParams( ( prev ) => ( { ...prev, order } ) ) }
 							onChangeSortValue={ ( value ) => {
 								const label = options.find( ( option ) => option.value === value ).label;
+								setQueryParams( ( prev ) => ( { ...prev, order: { ...prev.order, by: value } } ) );
 								tracking.trackKitlibSorterSelected( label );
 							} }
 						/>
@@ -239,22 +244,22 @@ export default function Index( props ) {
 								} }
 							/>
 						}
-						{ isSuccess && 0 < data.length && queryParams.ready && <KitList data={ data } queryParams={ queryParams } source={ props.path } /> }
+						{ isSuccess && 0 < data.length && queryParams.ready && <KitList data={ data } queryParams={ queryParams } source={ path } /> }
 						{
-							isSuccess && 0 === data.length && queryParams.ready && props.renderNoResultsComponent( {
+							isSuccess && 0 === data.length && queryParams.ready && renderNoResultsComponent( {
 								defaultComponent: <ErrorScreen
 									title={ __( 'No results matched your search.', 'elementor' ) }
 									description={ __( 'Try different keywords or ', 'elementor' ) }
 									button={ {
 										text: __( 'Continue browsing.', 'elementor' ),
 										action: clearQueryParams,
-										category: props.path,
+										category: path,
 									} }
 								/>,
 								isFilterActive,
 							} )
 						}
-						<EnvatoPromotion category={ props.path } />
+						<EnvatoPromotion category={ path } />
 					</>
 				</Content>
 			</div>
@@ -266,9 +271,4 @@ Index.propTypes = {
 	path: PropTypes.string,
 	initialQueryParams: PropTypes.object,
 	renderNoResultsComponent: PropTypes.func,
-};
-
-Index.defaultProps = {
-	initialQueryParams: {},
-	renderNoResultsComponent: ( { defaultComponent } ) => defaultComponent,
 };

--- a/tests/playwright/sanity/modules/kit-library/kit-library-sort.test.ts
+++ b/tests/playwright/sanity/modules/kit-library/kit-library-sort.test.ts
@@ -1,0 +1,45 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { parallelTest as test } from '../../../parallelTest';
+
+const KIT_LIBRARY_URL = '/wp-admin/admin.php?page=elementor-app#/kit-library';
+const SORT_SELECT = '.eps-sort-select__select';
+const KIT_ITEM = '.e-kit-library__kit-item';
+const KIT_ITEM_TITLE = `${ KIT_ITEM } .eps-card__headline`;
+const FEATURED_VALUE = 'featuredIndex';
+const NEW_VALUE = 'createdAt';
+
+async function gotoKitLibrary( page: Page ): Promise<void> {
+	await page.goto( KIT_LIBRARY_URL );
+	await page.waitForLoadState( 'networkidle' );
+	await page.locator( KIT_ITEM ).first().waitFor();
+}
+
+async function collectKitTitles( page: Page ): Promise<string[]> {
+	const items: Locator = page.locator( KIT_ITEM_TITLE );
+	await expect.poll( () => items.count() ).toBeGreaterThan( 1 );
+	return items.allInnerTexts();
+}
+
+test.describe( 'Kit Library - Website Templates page', () => {
+	test( 'changing sort from Featured to New produces a different list', async ( { page } ) => {
+		// Arrange
+		await gotoKitLibrary( page );
+		const sortSelect = page.locator( SORT_SELECT );
+		await expect( sortSelect ).toHaveValue( FEATURED_VALUE );
+		const featuredTitles = await collectKitTitles( page );
+		expect( featuredTitles.length ).toBeGreaterThan( 1 );
+
+		// Act
+		await sortSelect.selectOption( NEW_VALUE );
+		await expect( sortSelect ).toHaveValue( NEW_VALUE );
+		await expect.poll( async () => {
+			const titles = await page.locator( KIT_ITEM_TITLE ).allInnerTexts();
+			return JSON.stringify( titles );
+		} ).not.toBe( JSON.stringify( featuredTitles ) );
+		const newTitles = await collectKitTitles( page );
+
+		// Assert
+		expect( newTitles.length ).toBeGreaterThan( 1 );
+		expect( newTitles ).not.toEqual( featuredTitles );
+	} );
+} );


### PR DESCRIPTION
This fixes the filter/sort control so that it works. However, notice that values for trending and popular are all 0 for the templates, for some reason, so choosing those values will change nothing. Moving between featured and new works as expected.