### PR TITLE
Internal: add Icons_Manager::get_library_style_handle() [ED-8462]

### DIFF
--- a/includes/managers/icons.php
+++ b/includes/managers/icons.php
@@ -431,6 +431,16 @@ class Icons_Manager {
 		return $element;
 	}
 
+	public static function get_library_style_handle( string $library ): string {
+		$tabs = self::get_icon_manager_tabs();
+
+		if ( ! isset( $tabs[ $library ]['name'] ) ) {
+			return '';
+		}
+
+		return 'elementor-icons-' . $tabs[ $library ]['name'];
+	}
+
 	public static function is_migration_allowed() {
 		static $migration_allowed = false;
 		if ( false === $migration_allowed ) {


### PR DESCRIPTION
## Summary

Adds `Icons_Manager::get_library_style_handle()` so Pro (and other consumers) can resolve the registered stylesheet handle for an icon library without hardcoding the `elementor-icons-{name}` convention.

Required by elementor/elementor-pro#6947.

## Test plan

- [ ] Call with `fa-solid`, `fa-regular`, `fa-brands` returns matching registered handles
- [ ] Unknown library returns empty string

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Adds utility method to retrieve icon library stylesheet handles, enabling consistent style reference across icon management. Ticket: ED-8462.

## 2. What Changed (Where)
`includes/managers/icons.php`: New static method `get_library_style_handle()` inserted before `is_migration_allowed()`.

## 3. How It Works
Method accepts library string parameter, retrieves icon manager tabs, validates library exists in tabs array, returns prefixed handle (`elementor-icons-{library_name}`) or empty string if invalid.

## 4. Risks
None—pure getter with defensive null-check, no side effects or breaking changes.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
