### PR TITLE
Internal: Duplicated Library (modelcontext) moved to common [ED-24243]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44523,8 +44523,7 @@
       "dependencies": {
         "@elementor/editor-mcp": "4.2.0",
         "@elementor/elementor-mcp-common": "4.2.0",
-        "@elementor/schema": "4.2.0",
-        "@modelcontextprotocol/sdk": "1.27.1"
+        "@elementor/schema": "4.2.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -46009,6 +46008,9 @@
       "name": "@elementor/elementor-mcp-common",
       "version": "4.2.0",
       "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.27.1"
+      },
       "devDependencies": {
         "tsup": "^8.3.5"
       }

--- a/packages/apps/elementor-capabilities-mcp/package.json
+++ b/packages/apps/elementor-capabilities-mcp/package.json
@@ -28,8 +28,7 @@
   "dependencies": {
     "@elementor/editor-mcp": "4.2.0",
     "@elementor/elementor-mcp-common": "4.2.0",
-    "@elementor/schema": "4.2.0",
-    "@modelcontextprotocol/sdk": "1.27.1"
+    "@elementor/schema": "4.2.0"
   },
   "files": [
     "README.md",

--- a/packages/apps/elementor-capabilities-mcp/src/elementor-capabilities-mcp-server.ts
+++ b/packages/apps/elementor-capabilities-mcp/src/elementor-capabilities-mcp-server.ts
@@ -1,7 +1,6 @@
 import { AngieMessageEvenetType as MessageEventType, getAngieIframe } from '@elementor/editor-mcp';
-import { callWpApi } from '@elementor/elementor-mcp-common';
+import { callWpApi, McpServer } from '@elementor/elementor-mcp-common';
 import { z } from '@elementor/schema';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { addCapabilitiesDescriptionResource, CAPABILITIES_DESCRIPTION_URI } from './mcp-description-resource';
 import { addPagesListResource, PAGES_LIST_RESOURCE_URI } from './pages-list-resource';

--- a/packages/apps/elementor-capabilities-mcp/src/mcp-description-resource.ts
+++ b/packages/apps/elementor-capabilities-mcp/src/mcp-description-resource.ts
@@ -1,4 +1,4 @@
-import { type McpServer } from '@elementor/editor-mcp';
+import { type McpServer } from '@elementor/elementor-mcp-common';
 
 import { PAGES_LIST_RESOURCE_URI } from './pages-list-resource';
 

--- a/packages/apps/elementor-capabilities-mcp/src/pages-list-resource.ts
+++ b/packages/apps/elementor-capabilities-mcp/src/pages-list-resource.ts
@@ -1,5 +1,4 @@
-import { type McpServer } from '@elementor/editor-mcp';
-import { callWpApi } from '@elementor/elementor-mcp-common';
+import { type McpServer, callWpApi } from '@elementor/elementor-mcp-common';
 
 type WPPage = {
 	id: number;

--- a/packages/apps/elementor-capabilities-mcp/src/pages-list-resource.ts
+++ b/packages/apps/elementor-capabilities-mcp/src/pages-list-resource.ts
@@ -1,4 +1,4 @@
-import { type McpServer, callWpApi } from '@elementor/elementor-mcp-common';
+import { callWpApi, type McpServer } from '@elementor/elementor-mcp-common';
 
 type WPPage = {
 	id: number;

--- a/packages/packages/libs/elementor-mcp-common/package.json
+++ b/packages/packages/libs/elementor-mcp-common/package.json
@@ -41,5 +41,7 @@
   "devDependencies": {
     "tsup": "^8.3.5"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.27.1"
+  }
 }

--- a/packages/packages/libs/elementor-mcp-common/src/index.ts
+++ b/packages/packages/libs/elementor-mcp-common/src/index.ts
@@ -1,4 +1,12 @@
 export {
+	McpServer,
+	ResourceTemplate,
+	type RegisteredResource,
+	type ToolCallback,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
+export { SamplingMessageSchema } from '@modelcontextprotocol/sdk/types.js';
+
+export {
 	isGutenbergEditor,
 	isElementorEditor,
 	isElementorAIActive,


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Consolidates duplicated MCP (Model Context Protocol) types and utilities into the common library, eliminating redundant dependencies and improving maintainability across packages.

## 2. What Changed (Where)

- **elementor-mcp-common**: Exports MCP SDK types (`McpServer`, `ResourceTemplate`, etc.) previously scattered across consumers
- **elementor-capabilities-mcp**: Imports unified MCP exports from common; removes direct `@modelcontextprotocol/sdk` dependency
- **mcp-description-resource.ts & pages-list-resource.ts**: Updated import sources to use common library

## 3. How It Works

Previously, `McpServer` was imported from `@modelcontextprotocol/sdk` directly in consumers. Now it's re-exported through `elementor-mcp-common/index.ts`, creating a single source of truth. Consumers import from common instead, reducing version management friction and centralizing SDK surface area.

## 4. Risks

Minimal—pure refactor with no behavioral changes. Single concern: ensure all consumers update imports simultaneously to avoid transient breakage during rollout.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
