### PR TITLE
Fix: Cherry-pick PR 35994 to 4.01: Fix classes import for 4.0.1 beta versions exported data [ED-24240]

### DIFF
--- a/modules/global-classes/import-export-customization/runners/import.php
+++ b/modules/global-classes/import-export-customization/runners/import.php
@@ -50,10 +50,10 @@ class Import extends Import_Runner_Base {
 		return Import_Utils::import_classes( $global_classes_dir, [ 'conflict_resolution' => $conflict_resolution ] );
 	}
 
-	private function is_legacy_import_format( array $data ): bool {
+	protected function is_legacy_import_format( array $data ): bool {
 		$manifest = $data['manifest'];
 		$elementor_version = $manifest['elementor_version'];
 
-		return version_compare( $elementor_version, '4.1.0', '<' );
+		return version_compare( $elementor_version, '4.1.0-beta1', '<' );
 	}
 }

--- a/tests/phpunit/elementor/modules/global-classes/import-export-customization/test-import-runner.php
+++ b/tests/phpunit/elementor/modules/global-classes/import-export-customization/test-import-runner.php
@@ -311,6 +311,40 @@ class Test_Import_Runner extends Elementor_Test_Base {
 		$this->assertContains( 'Test2', $labels );
 	}
 
+	/**
+	 * @dataProvider legacy_format_version_provider
+	 */
+	public function test_is_legacy_import_format( string $elementor_version, bool $expected_legacy ) {
+		// Arrange.
+		$runner = new class() extends Import_Runner {
+			public function public_is_legacy_import_format( array $data ): bool {
+				return $this->is_legacy_import_format( $data );
+			}
+		};
+
+		// Act.
+		$actual = $runner->public_is_legacy_import_format( [
+			'manifest' => [ 'elementor_version' => $elementor_version ],
+		] );
+
+		// Assert.
+		$this->assertSame( $expected_legacy, $actual );
+	}
+
+	public function legacy_format_version_provider(): array {
+		return [
+			'4.0.0-beta1 is legacy' => [ '4.0.0-beta1', true ],
+			'4.0.0 is legacy' => [ '4.0.0', true ],
+			'4.0.9 is legacy' => [ '4.0.9', true ],
+			'4.1.0-beta1 is not legacy (first version with new export format)' => [ '4.1.0-beta1', false ],
+			'4.1.0-beta2 is not legacy' => [ '4.1.0-beta2', false ],
+			'4.1.0-beta3 is not legacy' => [ '4.1.0-beta3', false ],
+			'4.1.0 is not legacy' => [ '4.1.0', false ],
+			'4.1.1 is not legacy' => [ '4.1.1', false ],
+			'4.2.0-beta1 is not legacy' => [ '4.2.0-beta1', false ],
+		];
+	}
+
 	public function test_import__directory_format__design_system_override_all_replaces_existing() {
 		// Arrange - existing classes that should be removed.
 		$repository = Global_Classes_Repository::make();


### PR DESCRIPTION
cherry-pick of https://github.com/elementor/elementor/pull/35994 to 4.01 branch.
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Fixes import handling for 4.0.1 beta exports by correcting version comparison logic. 4.0.x betas exported with old format; 4.1.0-beta1+ uses new format. ED-24240.

## 2. What Changed (Where)

- `import.php`: Changed `is_legacy_import_format()` from `private` to `protected`; updated version threshold from `'4.1.0'` to `'4.1.0-beta1'`
- `test-import-runner.php`: Added comprehensive test with 8 version scenarios covering beta/release boundaries

## 3. How It Works

Version comparison now correctly identifies 4.0.x and 4.0.x-betaY exports as legacy (returns `true`), while 4.1.0-beta1 and later use new format. Protected visibility enables test override via anonymous class wrapper.

## 4. Risks

Minimal—mechanical change fixes overly strict threshold. Test coverage validates both legacy and current formats across beta/release boundaries.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
