### PR TITLE
Internal: Cherry pick => Add mention support for newly added form field types [ED-24059]

### DIFF
--- a/modules/atomic-widgets/assets/js/frontend/form-handlers.js
+++ b/modules/atomic-widgets/assets/js/frontend/form-handlers.js
@@ -138,12 +138,18 @@ function getAtomicFormFields( form ) {
 	return fields;
 }
 
+function getGroupedFieldId( name, inputs, checkedInputs ) {
+	const primaryInput = checkedInputs[ 0 ] ?? inputs[ 0 ];
+
+	return primaryInput?.dataset.interactionId ?? name;
+}
+
 function getGroupedFields( name, inputs, type, form ) {
 	const checkedInputs = inputs.filter( ( input ) => input.checked );
 	const value = getAtomicFormFieldValue( checkedInputs, type );
 	const options = getAtomicFieldOptions( inputs, type, form );
 	return {
-		id: name,
+		id: getGroupedFieldId( name, inputs, checkedInputs ),
 		type,
 		label: name,
 		value,

--- a/packages/packages/libs/editor-controls/src/hooks/__tests__/use-form-field-suggestions.test.ts
+++ b/packages/packages/libs/editor-controls/src/hooks/__tests__/use-form-field-suggestions.test.ts
@@ -1,0 +1,231 @@
+import {
+	createMockChild,
+	createMockContainer,
+	createMockPropType,
+	dispatchCommandAfter,
+	dispatchV1ReadyEvent,
+} from 'test-utils';
+import { getContainer, getSelectedElements, getWidgetsCache } from '@elementor/editor-elements';
+import { act, renderHook } from '@testing-library/react';
+
+import { useFormFieldSuggestions } from '../use-form-field-suggestions';
+
+jest.mock( '@elementor/editor-elements', () => ( {
+	getContainer: jest.fn(),
+	getSelectedElements: jest.fn(),
+	getWidgetsCache: jest.fn(),
+} ) );
+
+const mockGetContainer = jest.mocked( getContainer );
+const mockGetSelectedElements = jest.mocked( getSelectedElements );
+const mockGetWidgetsCache = jest.mocked( getWidgetsCache );
+
+function createFormFieldChild( id: string, widgetType: string, settings: Record< string, unknown > = {} ) {
+	const child = createMockChild( { id, elType: 'widget', widgetType } );
+
+	Object.entries( settings ).forEach( ( [ key, value ] ) => {
+		const settingValue = typeof value === 'string' ? { $$type: 'string', value } : value;
+
+		child.settings.set( key, settingValue as never );
+	} );
+
+	return child;
+}
+
+describe( 'useFormFieldSuggestions', () => {
+	beforeEach( () => {
+		mockGetContainer.mockClear();
+		mockGetSelectedElements.mockClear();
+		mockGetWidgetsCache.mockReturnValue( null );
+	} );
+
+	it( 'should return empty array when nothing is selected', () => {
+		mockGetSelectedElements.mockReturnValue( [] );
+
+		const { result } = renderHook( () => useFormFieldSuggestions() );
+
+		expect( result.current ).toEqual( [] );
+	} );
+
+	it( 'should include select, date picker, and time picker fields by css id', () => {
+		const form = createMockContainer(
+			'form-1',
+			[
+				createFormFieldChild( 'select-1', 'e-form-select', { _cssid: 'country' } ),
+				createFormFieldChild( 'date-1', 'e-form-date-picker', { _cssid: 'appointment-date' } ),
+				createFormFieldChild( 'time-1', 'e-form-time-picker', { _cssid: 'appointment-time' } ),
+			],
+			'e-form'
+		);
+
+		mockGetSelectedElements.mockReturnValue( [ { id: 'form-1', type: 'e-form' } ] );
+		mockGetContainer.mockReturnValue( form );
+
+		const { result } = renderHook( () => useFormFieldSuggestions() );
+
+		expect( result.current ).toEqual(
+			expect.arrayContaining( [
+				{ label: 'country', value: 'country' },
+				{ label: 'appointment-date', value: 'appointment-date' },
+				{ label: 'appointment-time', value: 'appointment-time' },
+			] )
+		);
+	} );
+
+	it( 'should use schema default css id when settings are empty', () => {
+		const selectField = createFormFieldChild( 'select-1', 'e-form-select' );
+		const form = createMockContainer( 'form-1', [ selectField ], 'e-form' );
+
+		mockGetWidgetsCache.mockReturnValue( {
+			'e-form-select': {
+				title: 'Select',
+				controls: {},
+				atomic_props_schema: {
+					_cssid: createMockPropType( {
+						kind: 'plain',
+						key: 'string',
+						default: { $$type: 'string', value: 'e-form-select-13' },
+					} ),
+				},
+			},
+		} );
+
+		mockGetSelectedElements.mockReturnValue( [ { id: 'form-1', type: 'e-form' } ] );
+		mockGetContainer.mockReturnValue( form );
+
+		const { result } = renderHook( () => useFormFieldSuggestions() );
+
+		expect( result.current ).toEqual( [ { label: 'e-form-select-13', value: 'e-form-select-13' } ] );
+	} );
+
+	it( 'should deduplicate suggestions when multiple fields share the same css id', () => {
+		const form = createMockContainer(
+			'form-1',
+			[
+				createFormFieldChild( 'select-1', 'e-form-select', { _cssid: 'e-form-select-13' } ),
+				createFormFieldChild( 'select-2', 'e-form-select', { _cssid: 'e-form-select-13' } ),
+			],
+			'e-form'
+		);
+
+		mockGetSelectedElements.mockReturnValue( [ { id: 'form-1', type: 'e-form' } ] );
+		mockGetContainer.mockReturnValue( form );
+
+		const { result } = renderHook( () => useFormFieldSuggestions() );
+
+		expect( result.current ).toEqual( [ { label: 'e-form-select-13', value: 'e-form-select-13' } ] );
+	} );
+
+	it( 'should list each field by its css id including radio buttons', () => {
+		const form = createMockContainer(
+			'form-1',
+			[
+				createFormFieldChild( 'radio-1', 'e-form-radio-button', {
+					name: 'meal',
+					_cssid: 'e-form-radio-button-13',
+				} ),
+				createFormFieldChild( 'radio-2', 'e-form-radio-button', {
+					name: 'meal',
+					_cssid: 'e-form-radio-button-14',
+				} ),
+			],
+			'e-form'
+		);
+
+		mockGetSelectedElements.mockReturnValue( [ { id: 'form-1', type: 'e-form' } ] );
+		mockGetContainer.mockReturnValue( form );
+
+		const { result } = renderHook( () => useFormFieldSuggestions() );
+
+		expect( result.current ).toEqual( [
+			{ label: 'e-form-radio-button-13', value: 'e-form-radio-button-13' },
+			{ label: 'e-form-radio-button-14', value: 'e-form-radio-button-14' },
+		] );
+	} );
+
+	it( 'should resolve the parent form when a nested field is selected', () => {
+		const selectField = createFormFieldChild( 'select-1', 'e-form-select', { _cssid: 'country' } );
+		const form = createMockContainer( 'form-1', [ selectField ], 'e-form' );
+
+		selectField.parent = form;
+
+		mockGetSelectedElements.mockReturnValue( [ { id: 'select-1', type: 'e-form-select' } ] );
+		mockGetContainer.mockImplementation( ( id ) => {
+			if ( id === 'select-1' ) {
+				return selectField;
+			}
+
+			return null;
+		} );
+
+		const { result } = renderHook( () => useFormFieldSuggestions() );
+
+		expect( result.current ).toEqual( [ { label: 'country', value: 'country' } ] );
+	} );
+
+	it( 'should filter email fields when inputType is email', () => {
+		const form = createMockContainer(
+			'form-1',
+			[
+				createFormFieldChild( 'input-1', 'e-form-input', { _cssid: 'email', type: 'email' } ),
+				createFormFieldChild( 'input-2', 'e-form-input', { _cssid: 'name', type: 'text' } ),
+			],
+			'e-form'
+		);
+
+		mockGetSelectedElements.mockReturnValue( [ { id: 'form-1', type: 'e-form' } ] );
+		mockGetContainer.mockReturnValue( form );
+
+		const { result } = renderHook( () => useFormFieldSuggestions( { inputType: 'email' } ) );
+
+		expect( result.current ).toEqual( [ { label: 'email', value: 'email' } ] );
+	} );
+
+	it( 'should update when document/elements/set-settings command ends', () => {
+		const form = createMockContainer( 'form-1', [], 'e-form' );
+
+		mockGetSelectedElements.mockReturnValue( [ { id: 'form-1', type: 'e-form' } ] );
+		mockGetContainer.mockReturnValue( form );
+
+		const { result } = renderHook( () => useFormFieldSuggestions() );
+
+		expect( result.current ).toEqual( [] );
+
+		const updatedForm = createMockContainer(
+			'form-1',
+			[ createFormFieldChild( 'select-1', 'e-form-select', { _cssid: 'country' } ) ],
+			'e-form'
+		);
+
+		mockGetContainer.mockReturnValue( updatedForm );
+
+		act( () => {
+			dispatchCommandAfter( 'document/elements/set-settings' );
+		} );
+
+		expect( result.current ).toEqual( [ { label: 'country', value: 'country' } ] );
+	} );
+
+	it( 'should update when V1 ready event is dispatched', () => {
+		const form = createMockContainer( 'form-1', [], 'e-form' );
+
+		mockGetSelectedElements.mockReturnValue( [ { id: 'form-1', type: 'e-form' } ] );
+		mockGetContainer.mockReturnValue( form );
+
+		const { result } = renderHook( () => useFormFieldSuggestions() );
+
+		const updatedForm = createMockContainer(
+			'form-1',
+			[ createFormFieldChild( 'date-1', 'e-form-date-picker', { _cssid: 'appointment-date' } ) ],
+			'e-form'
+		);
+
+		mockGetContainer.mockReturnValue( updatedForm );
+
+		act( () => {
+			dispatchV1ReadyEvent();
+		} );
+
+		expect( result.current ).toEqual( [ { label: 'appointment-date', value: 'appointment-date' } ] );
+	} );
+} );

--- a/packages/packages/libs/editor-controls/src/hooks/use-form-field-suggestions.ts
+++ b/packages/packages/libs/editor-controls/src/hooks/use-form-field-suggestions.ts
@@ -1,5 +1,5 @@
-import { getContainer, getSelectedElements } from '@elementor/editor-elements';
-import { isTransformable } from '@elementor/editor-props';
+import { getContainer, getSelectedElements, getWidgetsCache, type V1Element } from '@elementor/editor-elements';
+import { type PropsSchema, stringPropTypeUtil } from '@elementor/editor-props';
 import { __privateUseListenTo as useListenTo, commandEndEvent, v1ReadyEvent } from '@elementor/editor-v1-adapters';
 
 export type Suggestion = {
@@ -15,11 +15,52 @@ const FORM_FIELD_WIDGET_TYPES = [
 	'e-form-select',
 	'e-form-date-picker',
 	'e-form-time-picker',
-];
+] as const;
+
+const FORM_ELEMENT_TYPE = 'e-form';
+const CSS_ID_PROP_KEY = '_cssid';
+
+function isFormFieldWidgetType( widgetType: string ): boolean {
+	return ( FORM_FIELD_WIDGET_TYPES as readonly string[] ).includes( widgetType );
+}
 
 type Options = {
 	inputType?: string;
 };
+
+function extractStringPropValue( value: unknown ): string | null {
+	return stringPropTypeUtil.extract( value );
+}
+
+function getSettingWithDefault( child: V1Element, widgetType: string, key: string ): unknown {
+	const fromGet = child.settings.get( key );
+
+	if ( fromGet !== null && fromGet !== undefined ) {
+		return fromGet;
+	}
+
+	const schema = getWidgetsCache()?.[ widgetType ]?.atomic_props_schema as PropsSchema | undefined;
+
+	return schema?.[ key ]?.default ?? null;
+}
+
+function getFieldCssId( child: V1Element, widgetType: string ): string | null {
+	return extractStringPropValue( getSettingWithDefault( child, widgetType, CSS_ID_PROP_KEY ) );
+}
+
+function getFormContainer( elementId: string ): V1Element | null {
+	let container = getContainer( elementId );
+
+	while ( container ) {
+		if ( container.model.get( 'elType' ) === FORM_ELEMENT_TYPE ) {
+			return container;
+		}
+
+		container = container.parent ?? null;
+	}
+
+	return null;
+}
 
 export function useFormFieldSuggestions( options?: Options ): Suggestion[] {
 	return useListenTo(
@@ -31,42 +72,44 @@ export function useFormFieldSuggestions( options?: Options ): Suggestion[] {
 		],
 		() => {
 			const selectedElements = getSelectedElements();
-			const formElement = selectedElements[ 0 ];
+			const selectedElement = selectedElements[ 0 ];
 
-			if ( ! formElement ) {
+			if ( ! selectedElement ) {
 				return [];
 			}
 
-			const container = getContainer( formElement.id );
+			const formContainer = getFormContainer( selectedElement.id );
 
-			if ( ! container?.children ) {
+			if ( ! formContainer?.children ) {
 				return [];
 			}
 
 			const suggestions: Suggestion[] = [];
+			const seenCssIds = new Set< string >();
 
-			container.children.forEachRecursive?.( ( child ) => {
+			formContainer.children.forEachRecursive?.( ( child ) => {
 				const widgetType = child.model.get( 'widgetType' ) as string | undefined;
 
-				if ( ! widgetType || ! FORM_FIELD_WIDGET_TYPES.includes( widgetType ) ) {
+				if ( ! widgetType || ! isFormFieldWidgetType( widgetType ) ) {
 					return;
 				}
 
 				if ( options?.inputType ) {
-					const typeProp = child.settings.get( 'type' );
-					const typeValue = isTransformable( typeProp ) ? typeProp.value : typeProp;
+					const typeValue = extractStringPropValue( getSettingWithDefault( child, widgetType, 'type' ) );
 
 					if ( typeValue !== options.inputType ) {
 						return;
 					}
 				}
 
-				const cssIdProp = child.settings.get( '_cssid' );
-				const fieldId = isTransformable( cssIdProp ) ? cssIdProp.value : cssIdProp;
+				const cssId = getFieldCssId( child, widgetType );
 
-				if ( fieldId && typeof fieldId === 'string' ) {
-					suggestions.push( { label: fieldId, value: fieldId } );
+				if ( ! cssId || seenCssIds.has( cssId ) ) {
+					return;
 				}
+
+				seenCssIds.add( cssId );
+				suggestions.push( { label: cssId, value: cssId } );
 			} );
 
 			return suggestions;


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements: **Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no
spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

PR extends form field mention support to newly added field types (date picker, time picker, select) by refactoring property extraction logic and deduplicating CSS IDs. Ticket: ED-24059.

## 2. What Changed (Where)

- `use-form-field-suggestions.ts`: Refactored to extract string props via schema defaults, dedup suggestions by CSS ID, walk form tree properly from selected element
- `form-handlers.js`: Added `getGroupedFieldId()` to use interaction ID from data attributes instead of field name
- Added comprehensive test suite covering schema defaults, deduplication, nested selection, filtering

## 3. How It Works

Hook now traverses up from selected element to find parent form, then recursively collects all form field children. For each field, extracts CSS ID using `stringPropTypeUtil.extract()` with schema default fallback. Deduplicates via Set before returning suggestions. Frontend handler uses `data-interactionId` attribute for grouped fields (radio/checkbox) to preserve Elementor's internal field tracking.

## 4. Risks

Minor: schema lookup can return undefined if widget not in cache—mitigated by null coalescing to field name. String prop extraction assumes `$type` structure—validate compatibility with existing prop serialization format.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

---------

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
