### PR TITLE
Internal: Removing redux/RTK dupes from bundle and runtime [ED-24246]

### DIFF
--- a/.grunt-config/webpack.js
+++ b/.grunt-config/webpack.js
@@ -85,6 +85,7 @@ const entry = {
 	'admin-feedback': path.resolve( __dirname, '../assets/dev/js/admin/admin-feedback.js' ),
 	'announcements-app': path.resolve( __dirname, '../modules/announcements/assets/js/index.js' ),
 	'common': path.resolve( __dirname, '../core/common/assets/js/common.js' ),
+	'vendors-redux': path.resolve( __dirname, '../core/common/assets/js/vendors-redux.js' ),
 	'dev-tools': path.resolve( __dirname, '../modules/dev-tools/assets/js/index.js' ),
 	'elementor-admin-bar': path.resolve( __dirname, '../modules/admin-bar/assets/js/frontend/module.js' ),
 	'gutenberg': path.resolve( __dirname, '../assets/dev/js/admin/gutenberg.js' ),
@@ -185,11 +186,21 @@ const externals = [
 		'@woocommerce/admin-layout': 'wc.adminLayout',
 	},
 	// Handle tree-shaking imports for ui and icons packages (@elementor/ui/xxx) to be pointed to the external object (elementorV2.ui.xxx).
-	function ( { request }, callback ) {
+	function ( { request, context, contextInfo }, callback ) {
 		const matches = request.match( /^@elementor\/(ui|icons)\/(.+)$/ );
 
 		if ( matches?.length ) {
 			return callback( null, `elementorV2.${ matches[ 1 ] }['${ matches[ 2 ] }']` );
+		}
+
+		if ( '@reduxjs/toolkit' === request ) {
+			const issuer = contextInfo?.issuer || context;
+
+			if ( issuer.includes( 'vendors-redux.js' ) ) {
+				return callback();
+			}
+
+			return callback( null, 'elementorVendors.reduxToolkit' );
 		}
 
 		callback();

--- a/.grunt-config/webpack.packages.js
+++ b/.grunt-config/webpack.packages.js
@@ -55,6 +55,8 @@ const common = {
 				{ request: REGEXES.wordpressPackages, handle: 'wp-$1' },
 				{ request: 'react', handle: 'react' },
 				{ request: 'react-dom', handle: 'react-dom' },
+				{ request: '@reduxjs/toolkit', handle: 'elementor-vendors-redux' },
+				{ request: 'react-redux', handle: 'elementor-vendors-redux' },
 			]
 		} ),
 		new ExternalizeWordPressAssetsWebpackPlugin( {
@@ -65,6 +67,8 @@ const common = {
 				{ request: REGEXES.wordpressPackages, global: [ 'wp', '$1' ] },
 				{ request: 'react', global: 'React' },
 				{ request: 'react-dom', global: 'ReactDOM' },
+				{ request: '@reduxjs/toolkit', global: [ 'elementorVendors', 'reduxToolkit' ] },
+				{ request: 'react-redux', global: [ 'elementorVendors', 'reactRedux' ] },
 			]
 		} ),
 		new EntryInitializationWebpackPlugin( {

--- a/core/common/app.php
+++ b/core/common/app.php
@@ -101,9 +101,22 @@ class App extends BaseApp {
 	 */
 	public function register_scripts() {
 		wp_register_script(
+			'elementor-vendors-redux',
+			$this->get_js_assets_url( 'vendors-redux' ),
+			[
+				'react',
+				'react-dom',
+			],
+			ELEMENTOR_VERSION,
+			true
+		);
+
+		wp_register_script(
 			'elementor-common-modules',
 			$this->get_js_assets_url( 'common-modules' ),
-			[],
+			[
+				'elementor-vendors-redux',
+			],
 			ELEMENTOR_VERSION,
 			true
 		);

--- a/core/common/assets/js/vendors-redux.js
+++ b/core/common/assets/js/vendors-redux.js
@@ -1,0 +1,6 @@
+import * as reduxToolkit from '@reduxjs/toolkit';
+import * as reactRedux from 'react-redux';
+
+window.elementorVendors = window.elementorVendors || {};
+window.elementorVendors.reduxToolkit = reduxToolkit;
+window.elementorVendors.reactRedux = reactRedux;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,6 +26,7 @@ module.exports = function( config ) {
 			'tests/qunit/vendor/wp-includes/backbone.min.js',
 			'tests/qunit/vendor/wp-includes/react.min.js',
 			'tests/qunit/vendor/wp-includes/react-dom.min.js',
+			'assets/js/vendors-redux.min.js',
 			'tests/qunit/vendor/wp-includes/i18n.min.js',
 			'assets/lib/backbone/backbone.marionette.min.js',
 			'assets/lib/backbone/backbone.radio.min.js',

--- a/modules/web-cli/module.php
+++ b/modules/web-cli/module.php
@@ -25,6 +25,7 @@ class Module extends App {
 			'elementor-web-cli',
 			$this->get_js_assets_url( 'web-cli' ),
 			[
+				'elementor-vendors-redux',
 				'jquery',
 			],
 			ELEMENTOR_VERSION,

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@elementor/icons": "~1.75.1",
         "@elementor/ui": "1.39.1",
         "@reach/router": "1.3.4",
-        "@reduxjs/toolkit": "^1.8.3",
+        "@reduxjs/toolkit": "^1.9.7",
         "@woocommerce/admin-layout": "^1.1.0",
         "@wordpress/components": "^27.4.0",
         "@wordpress/core-data": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "@elementor/icons": "~1.75.1",
     "@elementor/ui": "1.39.1",
     "@reach/router": "1.3.4",
-    "@reduxjs/toolkit": "^1.8.3",
+    "@reduxjs/toolkit": "^1.9.7",
     "@woocommerce/admin-layout": "^1.1.0",
     "@wordpress/components": "^27.4.0",
     "@wordpress/core-data": "^7.5.0",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Redux/RTK was bundled multiple times across the codebase, inflating bundle size. Consolidating into a single `vendors-redux` entry point with proper externals handling eliminates duplication while maintaining compatibility.

## 2. What Changed (Where)

- New `vendors-redux.js` entry point exposes Redux/RTK to window for shared consumption across modules
- Webpack externals and package configuration route `@reduxjs/toolkit` and `react-redux` imports to bundled vendor or external reference
- Script registrations updated: `elementor-common-modules` and `elementor-web-cli` now depend on `elementor-vendors-redux`
- RTK version bumped 1.8.3 → 1.9.7; test karma config updated to load built vendors bundle

## 3. How It Works

New imports of `@reduxjs/toolkit` resolve differently based on context: the `vendors-redux.js` bundle imports them natively and exposes to `window.elementorVendors`, while other modules reference the external global object via webpack's externals handler (which checks issuer path). This eliminates duplicate bundling while maintaining the vendor entry as the single source of truth.

## 4. Risks

Potential issue if modules import Redux before `vendors-redux` script loads—dependency ordering must be enforced at script registration level. Version bump (1.9.7) should be validated for breaking changes in consuming code.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
