### PR TITLE
Internal: Update internal css print order [ED-24276]

### DIFF
--- a/core/experiments/manager.php
+++ b/core/experiments/manager.php
@@ -379,6 +379,15 @@ class Manager extends Base_Object {
 				'minimum_installation_version' => '3.30.0',
 			],
 		] );
+
+		$this->add_feature( [
+			'name' => 'order_internal_css_printing',
+			'title' => esc_html__( 'Order internal CSS printing', 'elementor' ),
+			'description' => esc_html__( 'Prints internal CSS in the same order as external CSS files for consistent cascade.', 'elementor' ),
+			'hidden' => true,
+			'default' => self::STATE_INACTIVE,
+			'release_status' => self::RELEASE_STATUS_DEV,
+		] );
 	}
 
 	/**

--- a/core/files/css/base.php
+++ b/core/files/css/base.php
@@ -232,13 +232,7 @@ abstract class Base extends Base_File {
 		}
 
 		if ( self::CSS_STATUS_INLINE === $meta['status'] ) {
-			$dep = $this->get_inline_dependency();
-			// If the dependency has already been printed ( like a template in footer )
-			if ( wp_styles()->query( $dep, 'done' ) ) {
-				printf( '<style id="%1$s">%2$s</style>', $this->get_file_handle_id(), $meta['css'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			} else {
-				wp_add_inline_style( $dep, $meta['css'] );
-			}
+			$this->enqueue_inline_css( $meta );
 		} elseif ( self::CSS_STATUS_FILE === $meta['status'] ) { // Re-check if it's not empty after CSS update.
 			wp_enqueue_style( $this->get_file_handle_id(), $this->get_url(), $this->get_enqueue_dependencies(), null );
 		}
@@ -652,6 +646,32 @@ abstract class Base extends Base_File {
 	 */
 	protected function get_inline_dependency() {
 		return '';
+	}
+
+	private function enqueue_inline_css( array $meta ) {
+		$inline_stylesheet_handle = $this->get_inline_dependency();
+		$css_file_handle = $this->get_file_handle_id();
+		$is_inline_stylesheet_handle_printed = wp_styles()->query( $inline_stylesheet_handle, 'done' );
+
+		if ( $is_inline_stylesheet_handle_printed ) {
+			printf( '<style id="%1$s">%2$s</style>', $css_file_handle, $meta['css'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			return;
+		}
+
+		if ( Plugin::$instance->experiments->is_feature_active( 'order_internal_css_printing' ) ) {
+			$stylesheet_dependency_handles = $this->get_enqueue_dependencies();
+
+			if ( empty( $stylesheet_dependency_handles ) && $inline_stylesheet_handle ) {
+				$stylesheet_dependency_handles = [ $inline_stylesheet_handle ];
+			}
+
+			wp_register_style( $css_file_handle, false, $stylesheet_dependency_handles, null );
+			wp_enqueue_style( $css_file_handle );
+			wp_add_inline_style( $css_file_handle, $meta['css'] );
+			return;
+		}
+
+		wp_add_inline_style( $inline_stylesheet_handle, $meta['css'] );
 	}
 
 	/**

--- a/tests/playwright/sanity/modules/nested-tabs/nested-tabs-4.test.ts
+++ b/tests/playwright/sanity/modules/nested-tabs/nested-tabs-4.test.ts
@@ -348,37 +348,39 @@ test.describe( 'Nested Tabs tests @nested-tabs', () => {
 		} );
 
 		await test.step( 'Verify hover styling - internal CSS @nested-tabs-internal-css', async () => {
-			await wpCli( 'wp option update elementor_css_print_method internal' );
-			await wpCli( 'wp elementor experiments activate order_internal_css_printing' );
-			await wpCli( 'wp elementor flush_css' );
+			try {
+				await wpCli( 'wp option update elementor_css_print_method internal' );
+				await wpCli( 'wp elementor experiments activate order_internal_css_printing' );
+				await wpCli( 'wp elementor flush_css' );
 
-			await page.reload();
-			await page.waitForSelector( '.elementor-widget-n-tabs' );
-			await page.setViewportSize( viewportSize.desktop );
+				await page.reload();
+				await page.waitForSelector( '.elementor-widget-n-tabs' );
+				await page.setViewportSize( viewportSize.desktop );
 
-			await test.step( 'Verify hover styling - desktop', async () => {
-				await secondTab.hover();
-				await page.waitForTimeout( 500 );
+				await test.step( 'Verify hover styling - desktop', async () => {
+					await secondTab.hover();
+					await page.waitForTimeout( 500 );
 
-				expect.soft( await widget.screenshot( {
-					type: 'png',
-				} ) ).toMatchSnapshot( 'tabs-with-hover-desktop.png' );
-			} );
+					expect.soft( await widget.screenshot( {
+						type: 'png',
+					} ) ).toMatchSnapshot( 'tabs-with-hover-desktop.png' );
+				} );
 
-			await test.step( 'Verify hover styling - mobile', async () => {
-				await page.setViewportSize( viewportSize.mobile );
+				await test.step( 'Verify hover styling - mobile', async () => {
+					await page.setViewportSize( viewportSize.mobile );
 
-				await secondTab.hover();
-				await page.waitForTimeout( 500 );
+					await secondTab.hover();
+					await page.waitForTimeout( 500 );
 
-				expect.soft( await widget.screenshot( {
-					type: 'png',
-				} ) ).toMatchSnapshot( 'tabs-with-hover-mobile.png' );
-			} );
-
-			await wpCli( 'wp elementor experiments deactivate order_internal_css_printing' );
-			await wpCli( 'wp option update elementor_css_print_method external' );
-			await wpCli( 'wp elementor flush_css' );
+					expect.soft( await widget.screenshot( {
+						type: 'png',
+					} ) ).toMatchSnapshot( 'tabs-with-hover-mobile.png' );
+				} );
+			} finally {
+				await wpCli( 'wp elementor experiments deactivate order_internal_css_printing' );
+				await wpCli( 'wp option update elementor_css_print_method external' );
+				await wpCli( 'wp elementor flush_css' );
+			}
 		} );
 	} );
 

--- a/tests/playwright/sanity/modules/nested-tabs/nested-tabs-4.test.ts
+++ b/tests/playwright/sanity/modules/nested-tabs/nested-tabs-4.test.ts
@@ -3,6 +3,7 @@ import { parallelTest as test } from '../../../parallelTest';
 import WpAdminPage from '../../../pages/wp-admin-page';
 import { viewportSize } from '../../../enums/viewport-sizes';
 import { clickTabByPosition, setBackgroundVideoUrl, isTabTitleVisible } from './helper';
+import { wpCli } from '../../../assets/wp-cli';
 import _path from 'path';
 
 test.describe( 'Nested Tabs tests @nested-tabs', () => {
@@ -344,6 +345,40 @@ test.describe( 'Nested Tabs tests @nested-tabs', () => {
 			expect.soft( await widget.screenshot( {
 				type: 'png',
 			} ) ).toMatchSnapshot( 'tabs-with-hover-mobile.png' );
+		} );
+
+		await test.step( 'Verify hover styling - internal CSS @nested-tabs-internal-css', async () => {
+			await wpCli( 'wp option update elementor_css_print_method internal' );
+			await wpCli( 'wp elementor experiments activate order_internal_css_printing' );
+			await wpCli( 'wp elementor flush_css' );
+
+			await page.reload();
+			await page.waitForSelector( '.elementor-widget-n-tabs' );
+			await page.setViewportSize( viewportSize.desktop );
+
+			await test.step( 'Verify hover styling - desktop', async () => {
+				await secondTab.hover();
+				await page.waitForTimeout( 500 );
+
+				expect.soft( await widget.screenshot( {
+					type: 'png',
+				} ) ).toMatchSnapshot( 'tabs-with-hover-desktop.png' );
+			} );
+
+			await test.step( 'Verify hover styling - mobile', async () => {
+				await page.setViewportSize( viewportSize.mobile );
+
+				await secondTab.hover();
+				await page.waitForTimeout( 500 );
+
+				expect.soft( await widget.screenshot( {
+					type: 'png',
+				} ) ).toMatchSnapshot( 'tabs-with-hover-mobile.png' );
+			} );
+
+			await wpCli( 'wp elementor experiments deactivate order_internal_css_printing' );
+			await wpCli( 'wp option update elementor_css_print_method external' );
+			await wpCli( 'wp elementor flush_css' );
 		} );
 	} );
 

--- a/tests/playwright/sanity/modules/nested-tabs/nested-tabs-5.test.ts
+++ b/tests/playwright/sanity/modules/nested-tabs/nested-tabs-5.test.ts
@@ -139,26 +139,28 @@ test.describe( 'Nested Tabs tests @nested-tabs', () => {
 		await expect.soft( nonActiveTab ).toHaveCSS( 'background-color', hoverTabBackgroundColor );
 
 		await test.step( 'Assert - internal CSS @nested-tabs-internal-css', async () => {
-			await wpCli( 'wp option update elementor_css_print_method internal' );
-			await wpCli( 'wp elementor experiments activate order_internal_css_printing' );
-			await wpCli( 'wp elementor flush_css' );
+			try {
+				await wpCli( 'wp option update elementor_css_print_method internal' );
+				await wpCli( 'wp elementor experiments activate order_internal_css_printing' );
+				await wpCli( 'wp elementor flush_css' );
 
-			await page.reload();
-			await page.waitForSelector( '.elementor-widget-n-tabs' );
+				await page.reload();
+				await page.waitForSelector( '.elementor-widget-n-tabs' );
 
-			await expect.soft( activeTab ).not.toHaveCSS( 'background-color', hoverTabBackgroundColor );
-			await expect.soft( activeTab ).toHaveCSS( 'background-color', activeTabBackgroundColor );
-			await expect.soft( nonActiveTab ).not.toHaveCSS( 'background-color', hoverTabBackgroundColor );
+				await expect.soft( activeTab ).not.toHaveCSS( 'background-color', hoverTabBackgroundColor );
+				await expect.soft( activeTab ).toHaveCSS( 'background-color', activeTabBackgroundColor );
+				await expect.soft( nonActiveTab ).not.toHaveCSS( 'background-color', hoverTabBackgroundColor );
 
-			await activeTab.hover();
-			await expect.soft( activeTab ).not.toHaveCSS( 'background-color', hoverTabBackgroundColor );
-			await expect.soft( activeTab ).toHaveCSS( 'background-color', activeTabBackgroundColor );
-			await nonActiveTab.hover();
-			await expect.soft( nonActiveTab ).toHaveCSS( 'background-color', hoverTabBackgroundColor );
-
-			await wpCli( 'wp elementor experiments deactivate order_internal_css_printing' );
-			await wpCli( 'wp option update elementor_css_print_method external' );
-			await wpCli( 'wp elementor flush_css' );
+				await activeTab.hover();
+				await expect.soft( activeTab ).not.toHaveCSS( 'background-color', hoverTabBackgroundColor );
+				await expect.soft( activeTab ).toHaveCSS( 'background-color', activeTabBackgroundColor );
+				await nonActiveTab.hover();
+				await expect.soft( nonActiveTab ).toHaveCSS( 'background-color', hoverTabBackgroundColor );
+			} finally {
+				await wpCli( 'wp elementor experiments deactivate order_internal_css_printing' );
+				await wpCli( 'wp option update elementor_css_print_method external' );
+				await wpCli( 'wp elementor flush_css' );
+			}
 		} );
 	} );
 

--- a/tests/playwright/sanity/modules/nested-tabs/nested-tabs-5.test.ts
+++ b/tests/playwright/sanity/modules/nested-tabs/nested-tabs-5.test.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test';
 import { parallelTest as test } from '../../../parallelTest';
 import WpAdminPage from '../../../pages/wp-admin-page';
 import { setTabItemColor, setTabBorderColor, templatePath } from './helper';
+import { wpCli } from '../../../assets/wp-cli';
 
 test.describe( 'Nested Tabs tests @nested-tabs', () => {
 	test( 'Verify the correct working of the title alignment', async ( { page, apiRequests }, testInfo ) => {
@@ -136,6 +137,29 @@ test.describe( 'Nested Tabs tests @nested-tabs', () => {
 		// Check that non-active tab receives the hover background color.
 		await nonActiveTab.hover();
 		await expect.soft( nonActiveTab ).toHaveCSS( 'background-color', hoverTabBackgroundColor );
+
+		await test.step( 'Assert - internal CSS @nested-tabs-internal-css', async () => {
+			await wpCli( 'wp option update elementor_css_print_method internal' );
+			await wpCli( 'wp elementor experiments activate order_internal_css_printing' );
+			await wpCli( 'wp elementor flush_css' );
+
+			await page.reload();
+			await page.waitForSelector( '.elementor-widget-n-tabs' );
+
+			await expect.soft( activeTab ).not.toHaveCSS( 'background-color', hoverTabBackgroundColor );
+			await expect.soft( activeTab ).toHaveCSS( 'background-color', activeTabBackgroundColor );
+			await expect.soft( nonActiveTab ).not.toHaveCSS( 'background-color', hoverTabBackgroundColor );
+
+			await activeTab.hover();
+			await expect.soft( activeTab ).not.toHaveCSS( 'background-color', hoverTabBackgroundColor );
+			await expect.soft( activeTab ).toHaveCSS( 'background-color', activeTabBackgroundColor );
+			await nonActiveTab.hover();
+			await expect.soft( nonActiveTab ).toHaveCSS( 'background-color', hoverTabBackgroundColor );
+
+			await wpCli( 'wp elementor experiments deactivate order_internal_css_printing' );
+			await wpCli( 'wp option update elementor_css_print_method external' );
+			await wpCli( 'wp elementor flush_css' );
+		} );
 	} );
 
 	test( 'Check if the hover style changes the normal tab styling', async ( { page, apiRequests }, testInfo ) => {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Internal CSS printing doesn't maintain cascade order consistency with external CSS files, causing style conflicts. This experiment introduces ordered internal CSS printing to match external stylesheet behavior.

## 2. What Changed (Where)

- **core/experiments/manager.php**: Added `order_internal_css_printing` feature flag (dev status, hidden).
- **core/files/css/base.php**: Refactored inline CSS enqueue logic into `enqueue_inline_css()` method; registers handle with dependencies when feature active, otherwise preserves fallback behavior.
- **Test files**: Added wpCli imports and test coverage for internal CSS printing with experiment activated/deactivated.

## 3. How It Works

When `order_internal_css_printing` is active: inline CSS registers as a stylesheet with explicit dependencies (external CSS handles), ensuring WordPress processes it after dependencies. Falls back to `wp_add_inline_style()` when inactive. Test suite validates hover styles render correctly under both modes.

## 4. Risks

Minimal—feature is hidden and dev-only. Potential issue: if `get_enqueue_dependencies()` returns dependencies that haven't loaded yet, the cascade ordering could still break, but that's pre-existing. No BC breaks since feature defaults inactive.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
