### PR TITLE
Internal: Add query content search support [ED-24286]

### DIFF
--- a/modules/atomic-widgets/query/post-query-builder.php
+++ b/modules/atomic-widgets/query/post-query-builder.php
@@ -14,13 +14,14 @@ class Post_Query_Builder extends Query_Builder_Base {
 		$config = $this->config;
 
 		$params = Post_Query::build_query_params( [
-			Post_Query::KEYS_CONVERSION_MAP_KEY => $config[ Query_Base::KEYS_CONVERSION_MAP_KEY ] ?? null,
-			Post_Query::INCLUDED_TYPE_KEY => $config[ Query_Base::INCLUDED_TYPE_KEY ] ?? null,
-			Post_Query::EXCLUDED_TYPE_KEY => $config[ Query_Base::EXCLUDED_TYPE_KEY ] ?? null,
-			Post_Query::META_QUERY_KEY => $config[ Query_Base::META_QUERY_KEY ] ?? null,
-			Post_Query::TAX_QUERY_KEY => $config[ Query_Base::TAX_QUERY_KEY ] ?? null,
-			Post_Query::IS_PUBLIC_KEY => $config[ Query_Base::IS_PUBLIC_KEY ] ?? null,
-			Post_Query::ITEMS_COUNT_KEY => $config[ Query_Base::ITEMS_COUNT_KEY ] ?? null,
+			Post_Query::KEYS_CONVERSION_MAP_KEY  => $config[ Query_Base::KEYS_CONVERSION_MAP_KEY ] ?? null,
+			Post_Query::INCLUDED_TYPE_KEY        => $config[ Query_Base::INCLUDED_TYPE_KEY ] ?? null,
+			Post_Query::EXCLUDED_TYPE_KEY        => $config[ Query_Base::EXCLUDED_TYPE_KEY ] ?? null,
+			Post_Query::META_QUERY_KEY           => $config[ Query_Base::META_QUERY_KEY ] ?? null,
+			Post_Query::TAX_QUERY_KEY            => $config[ Query_Base::TAX_QUERY_KEY ] ?? null,
+			Post_Query::IS_PUBLIC_KEY            => $config[ Query_Base::IS_PUBLIC_KEY ] ?? null,
+			Post_Query::ITEMS_COUNT_KEY          => $config[ Query_Base::ITEMS_COUNT_KEY ] ?? null,
+			Post_Query::SEARCH_IN_CONTENT_KEY    => $config[ Post_Query::SEARCH_IN_CONTENT_KEY ] ?? null,
 		] );
 
 		$endpoint = $config['endpoint'] ?? Post_Query::ENDPOINT;

--- a/modules/wp-rest/classes/post-query.php
+++ b/modules/wp-rest/classes/post-query.php
@@ -13,6 +13,7 @@ class Post_Query extends Base {
 	const ENDPOINT = 'post';
 	const SEARCH_FILTER_ACCEPTED_ARGS = 2;
 	const DEFAULT_FORBIDDEN_POST_TYPES = [ 'e-floating-buttons', 'e-landing-page', 'elementor_library', 'attachment', 'revision', 'nav_menu_item', 'custom_css', 'customize_changeset' ];
+	const SEARCH_IN_CONTENT_KEY = 'search_in_content';
 
 	/**
 	 * @param string    $search_term The original search query.
@@ -25,8 +26,13 @@ class Post_Query extends Base {
 
 		if ( $is_custom_search && ! empty( $term ) ) {
 			$escaped = esc_sql( $term );
+			$search_in_content = $wp_query->get( self::SEARCH_IN_CONTENT_KEY ) ?? false;
 			$search_term .= ' AND (';
 			$search_term .= "post_title LIKE '%{$escaped}%'";
+			if ( $search_in_content ) {
+				$search_term .= " OR post_content LIKE '%{$escaped}%'";
+				$search_term .= " OR post_excerpt LIKE '%{$escaped}%'";
+			}
 			if ( ctype_digit( $term ) ) {
 				$search_term .= ' OR ID = ' . intval( $term );
 			} else {
@@ -63,14 +69,15 @@ class Post_Query extends Base {
 		$post_types = $this->get_post_types_from_params( $params );
 
 		$query_args = [
-			'post_type' => array_keys( $post_types ),
-			'numberposts' => $post_count,
-			'suppress_filters' => false,
-			'custom_search' => true,
-			'search_term' => $term,
-			'post_status' => $is_public_only ? 'publish' : 'any',
-			'orderby' => 'ID',
-			'order' => 'ASC',
+			'post_type'                    => array_keys( $post_types ),
+			'numberposts'                  => $post_count,
+			'suppress_filters'             => false,
+			'custom_search'                => true,
+			'search_term'                  => $term,
+			self::SEARCH_IN_CONTENT_KEY    => $params[ self::SEARCH_IN_CONTENT_KEY ] ?? false,
+			'post_status'                  => $is_public_only ? 'publish' : 'any',
+			'orderby'                      => 'ID',
+			'order'                        => 'ASC',
 		];
 
 		if ( ! empty( $params[ self::META_QUERY_KEY ] ) && is_array( $params[ self::META_QUERY_KEY ] ) ) {
@@ -192,6 +199,12 @@ class Post_Query extends Base {
 				'default' => null,
 				'sanitize_callback' => fn ( ...$args ) => self::sanitize_string_array( ...$args ),
 			],
+			self::SEARCH_IN_CONTENT_KEY => [
+				'description' => 'Whether to search within post content and excerpt in addition to title',
+				'type' => 'boolean',
+				'required' => false,
+				'default' => false,
+			],
 		];
 	}
 
@@ -204,6 +217,7 @@ class Post_Query extends Base {
 			self::TAX_QUERY_KEY,
 			self::IS_PUBLIC_KEY,
 			self::ITEMS_COUNT_KEY,
+			self::SEARCH_IN_CONTENT_KEY,
 		];
 	}
 

--- a/tests/phpunit/elementor/modules/wp-rest/providers/post-query.php
+++ b/tests/phpunit/elementor/modules/wp-rest/providers/post-query.php
@@ -313,6 +313,34 @@ trait Post_Query {
 					],
 				],
 			],
+			'content_search_on_finds_match_in_post_content_when_title_does_not_match' => [
+				'params' => $this->build_params( [
+					Post_Query_Class::INCLUDED_TYPE_KEY => [ 'movie' ],
+					Post_Query_Class::KEYS_CONVERSION_MAP_KEY => [
+						'ID' => 'id',
+						'post_title' => 'label',
+					],
+					Post_Query_Class::SEARCH_IN_CONTENT_KEY => true,
+					Post_Query_Class::SEARCH_TERM_KEY => 'thriller',
+				] ),
+				'expected' => [
+					[
+						'id' => $this->posts[9]->ID,
+						'label' => $this->posts[9]->post_title,
+					],
+				],
+			],
+			'content_search_off_by_default_does_not_match_content_only_term' => [
+				'params' => $this->build_params( [
+					Post_Query_Class::INCLUDED_TYPE_KEY => [ 'movie' ],
+					Post_Query_Class::KEYS_CONVERSION_MAP_KEY => [
+						'ID' => 'id',
+						'post_title' => 'label',
+					],
+					Post_Query_Class::SEARCH_TERM_KEY => 'thriller',
+				] ),
+				'expected' => [],
+			],
 		];
 	}
 

--- a/tests/phpunit/elementor/modules/wp-rest/test-post-query.php
+++ b/tests/phpunit/elementor/modules/wp-rest/test-post-query.php
@@ -58,6 +58,10 @@ class Test_Post_Query extends Elementor_Test_Base {
 			$request->set_param( Post_Query::ITEMS_COUNT_KEY, $params[ Post_Query::ITEMS_COUNT_KEY ] );
 		}
 
+		if ( isset( $params[ Post_Query::SEARCH_IN_CONTENT_KEY ] ) ) {
+			$request->set_param( Post_Query::SEARCH_IN_CONTENT_KEY, $params[ Post_Query::SEARCH_IN_CONTENT_KEY ] );
+		}
+
 		$request->set_header( Post_Query::NONCE_KEY, wp_create_nonce( 'wp_rest' ) );
 
 		// Act


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds query-time content search capability to Post_Query, allowing searches beyond post titles to include content and excerpts via optional `search_in_content` parameter (ED-24286).

## 2. What Changed (Where)

- `post-query-builder.php`: Reformatted query params array with proper alignment; passes through new `SEARCH_IN_CONTENT_KEY`
- `post-query.php`: New `SEARCH_IN_CONTENT_KEY` constant; conditional SQL injection of `post_content` and `post_excerpt` LIKE clauses; added to API param spec and allowed keys list
- Test files: Two new test cases validating content search behavior on/off

## 3. How It Works

When `search_in_content=true`, `customize_post_query()` conditionally appends `OR post_content LIKE` and `OR post_excerpt LIKE` clauses to the existing title search. Parameter flows from REST endpoint → query builder → `build_query_args()` → WP_Query filter hook. Default is `false` (backwards compatible).

## 4. Risks

SQL injection via `esc_sql()` is already applied to `$term` before interpolation—mitigation sufficient. Consider if `post_excerpt` should have higher weight than content in future ranking; no performance concerns for typical excerpt sizes.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
