### PR TITLE
docs: add AGENTS.md with cloud-specific development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,14 +3,13 @@
 ## Cursor Cloud specific instructions
 
 ### System Requirements (pre-installed in update script)
-- Node.js 24.15.0 (via nvm, path prepended in `~/.bashrc`)
-- npm 11.x (comes with Node 24)
-- PHP 8.3 with extensions: mbstring, xml, zip, curl, dom, bcmath
+- Node.js version from `.nvmrc` (via nvm, path prepended in `~/.bashrc`)
+- PHP >= 7.4 with extensions: mbstring, xml, zip, curl, dom, bcmath
 - Composer 2.x
 - Docker (with fuse-overlayfs + iptables-legacy for nested containers)
 
 ### PATH Note
-The VM has a system Node at `/exec-daemon/node` (v22). The nvm-managed v24.15.0 is prepended to PATH via `~/.bashrc`. If commands fail with engine mismatch, verify `which node` points to `~/.nvm/versions/node/v24.15.0/bin/node`.
+The VM has a system Node at `/exec-daemon/node` that may be a different version. The nvm-managed Node (version from `.nvmrc`) is prepended to PATH via `~/.bashrc`. If commands fail with engine mismatch, verify `which node` points to the nvm-managed binary.
 
 ### Key Commands (see CONTRIBUTING.md and package.json for full list)
 | Action | Command |
@@ -43,5 +42,5 @@ WordPress will be available at http://localhost:8888 (admin/password).
 - PHPCS reports only warnings (0 errors) on the current codebase - this is expected.
 - The `composer install` post-install script runs `php-scoper` to prefix Twig. This requires the `humbug/php-scoper` dev dependency.
 - For production-like builds (`./build` dir), use `composer install --no-scripts --no-dev` first, then `npx grunt copy`. Dev dependencies must be restored afterward with `composer install`.
-- The `engines` field requires Node >=24.15.0. Do not downgrade.
+- The `engines` field in `package.json` enforces the minimum Node version. Always use the version from `.nvmrc`.
 - Husky pre-commit hook runs `lint-staged` with `NODE_OPTIONS=--max-old-space-size=8192`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Elementor Development Guide
+
+## Cursor Cloud specific instructions
+
+### System Requirements (pre-installed in update script)
+- Node.js 24.15.0 (via nvm, path prepended in `~/.bashrc`)
+- npm 11.x (comes with Node 24)
+- PHP 8.3 with extensions: mbstring, xml, zip, curl, dom, bcmath
+- Composer 2.x
+- Docker (with fuse-overlayfs + iptables-legacy for nested containers)
+
+### PATH Note
+The VM has a system Node at `/exec-daemon/node` (v22). The nvm-managed v24.15.0 is prepended to PATH via `~/.bashrc`. If commands fail with engine mismatch, verify `which node` points to `~/.nvm/versions/node/v24.15.0/bin/node`.
+
+### Key Commands (see CONTRIBUTING.md and package.json for full list)
+| Action | Command |
+|--------|---------|
+| Install all deps | `npm ci --ignore-scripts && composer install` |
+| Build packages | `npm run build:packages` |
+| Build styles | `npx grunt styles` |
+| Build scripts | `npx grunt scripts` |
+| Full dev watch | `npm run watch` |
+| Lint JS/TS (root) | `npx eslint .` |
+| Lint JS/TS (packages) | `cd packages && npx eslint . --report-unused-disable-directives-severity error` |
+| Lint PHP | `vendor/bin/phpcs --extensions=php --standard=./ruleset.xml .` |
+| Jest tests (main) | `npm run test:jest` |
+| Jest tests (packages) | `npm run test:packages` |
+| All Jest tests | `npm run test` |
+
+### Starting the WordPress Dev Environment
+The WordPress test environment uses `@elementor/wp-lite-env` (Docker-based). Before starting:
+1. Docker daemon must be running: `sudo dockerd &>/tmp/dockerd.log &` then `sudo chmod 666 /var/run/docker.sock`
+2. Build the plugin into `./build/`: `composer install --no-scripts --no-dev && composer dump-autoload && npx grunt copy`
+3. Download hello-elementor theme if not present: `curl -L -o hello-elementor.zip https://downloads.wordpress.org/theme/hello-elementor.zip && unzip -o hello-elementor.zip && rm hello-elementor.zip`
+4. Set up templates: `npm run setup-templates`
+5. Start: `npx wp-lite-env start --config=./tests/playwright/.playwright-wp-lite-env.json --port=8888`
+6. Run setup: `npm run test:setup:playwright`
+
+WordPress will be available at http://localhost:8888 (admin/password).
+
+### Gotchas
+- The `npm run lint` command runs ESLint on root AND packages workspace (`npm run lint -w elementor-packages`). Both must pass.
+- PHPCS reports only warnings (0 errors) on the current codebase - this is expected.
+- The `composer install` post-install script runs `php-scoper` to prefix Twig. This requires the `humbug/php-scoper` dev dependency.
+- For production-like builds (`./build` dir), use `composer install --no-scripts --no-dev` first, then `npx grunt copy`. Dev dependencies must be restored afterward with `composer install`.
+- The `engines` field requires Node >=24.15.0. Do not downgrade.
+- Husky pre-commit hook runs `lint-staged` with `NODE_OPTIONS=--max-old-space-size=8192`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR adds an `AGENTS.md` file with Cursor Cloud-specific development instructions for automated agents.

## Description

Adds `AGENTS.md` with:
- System requirements and PATH configuration notes
- Key development commands reference table
- WordPress dev environment startup instructions
- Important gotchas discovered during environment setup

This file serves as durable context for future cloud agents setting up and developing in this codebase.

## Test instructions

N/A - documentation only change.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

### Environment Verification

[elementor-hello-world-demo.mp4](https://cursor.com/agents/bc-2e1bda1d-e194-48ab-9aef-90df0ab541e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Felementor-hello-world-demo.mp4)

Elementor editor successfully loaded and working in the development environment.

[Elementor editor fully loaded](https://cursor.com/agents/bc-2e1bda1d-e194-48ab-9aef-90df0ab541e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Felementor_editor_working.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e1bda1d-e194-48ab-9aef-90df0ab541e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e1bda1d-e194-48ab-9aef-90df0ab541e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

