### PR TITLE
Internal: Faster dev build, better sourcmap handling [ED-24277]

### DIFF
--- a/.grunt-config/webpack.packages.js
+++ b/.grunt-config/webpack.packages.js
@@ -4,9 +4,9 @@ const { GenerateWordPressAssetFileWebpackPlugin } = require( path.resolve( __dir
 const { ExtractI18nWordpressExpressionsWebpackPlugin } = require( path.resolve( __dirname, '../packages/packages/tools/extract-i18n-wordpress-expressions-webpack-plugin' ) );
 const { ExternalizeWordPressAssetsWebpackPlugin } = require( path.resolve( __dirname, '../packages/packages/tools/externalize-wordpress-assets-webpack-plugin' ) );
 const { EntryInitializationWebpackPlugin } = require( path.resolve( __dirname, '../packages/packages/tools/entry-initialization-webpack-plugin' ) );
-const TerserPlugin = require('terser-webpack-plugin');
+const TerserPlugin = require( 'terser-webpack-plugin' );
 
-const packages = getLocalRepoPackagesEntries();
+const packagesDistPattern = /[\\/]packages[\\/](?:packages[\\/](?:core|libs)|apps)[\\/][^\\/]+[\\/]dist[\\/]/;
 
 const REGEXES = {
 	// @elementor/ui/SvgIcon — used inside @elementor/icons.
@@ -21,141 +21,182 @@ const REGEXES = {
 	wordpressPackages: /^@wordpress\/(.+)$/,
 };
 
-const common = {
-	name: 'packages',
-	entry: Object.fromEntries(
-		packages.map( ( { name, path } ) => [ name, path ] )
-	),
-	module: {
-		rules: [
-			{
-				test: /\.[jt]sx?$/,
-				exclude: /node_modules/,
-				use: {
-					loader: 'babel-loader',
-					options: {
-						presets: [
-							'@babel/preset-typescript',
-							'@babel/preset-react',
-						],
+const filesystemCache = {
+	type: 'filesystem',
+	cacheDirectory: path.resolve( __dirname, '../node_modules/.cache/webpack-packages' ),
+	buildDependencies: {
+		config: [ __filename ],
+	},
+};
+
+function createCommonConfig( entrySource ) {
+	const packages = getLocalRepoPackagesEntries( entrySource );
+
+	return {
+		name: 'packages',
+		entry: Object.fromEntries(
+			packages.map( ( { name, path: entryPath } ) => [ name, entryPath ] )
+		),
+		module: {
+			rules: [
+				{
+					enforce: 'pre',
+					test: /\.m?js$/,
+					include: packagesDistPattern,
+					use: [ 'source-map-loader' ],
+				},
+				{
+					test: /\.[jt]sx?$/,
+					exclude: [
+						/node_modules/,
+						packagesDistPattern,
+					],
+					use: {
+						loader: 'babel-loader',
+						options: {
+							sourceMaps: true,
+							presets: [
+								'@babel/preset-typescript',
+								'@babel/preset-react',
+							],
+						},
 					},
 				},
-			},
+			],
+		},
+		resolve: {
+			extensions: [ '.tsx', '.ts', '.js', '.jsx', '.mjs' ],
+		},
+		ignoreWarnings: [
+			/Failed to parse source map/,
 		],
-	},
-	resolve: {
-		extensions: [ '.tsx', '.ts', '.js', '.jsx' ],
-	},
-	plugins: [
-		new GenerateWordPressAssetFileWebpackPlugin( {
-			handle: ( entryName ) => `elementor-v2-${entryName}`,
-			map: [
-				{ request: REGEXES.elementorPathImports, handle: 'elementor-v2-$1' },
-				{ request: REGEXES.elementorPackages, handle: 'elementor-v2-$1' },
-				{ request: REGEXES.wordpressPackages, handle: 'wp-$1' },
-				{ request: 'react', handle: 'react' },
-				{ request: 'react-dom', handle: 'react-dom' },
-				{ request: '@reduxjs/toolkit', handle: 'elementor-vendors-redux' },
-				{ request: 'react-redux', handle: 'elementor-vendors-redux' },
-			]
-		} ),
-		new ExternalizeWordPressAssetsWebpackPlugin( {
-			global: ( entryName ) => [ 'elementorV2', entryName ],
-			map: [
-				{ request: REGEXES.elementorPathImports, global: [ 'elementorV2', '$1', '$2' ] },
-				{ request: REGEXES.elementorPackages, global: [ 'elementorV2', '$1' ] },
-				{ request: REGEXES.wordpressPackages, global: [ 'wp', '$1' ] },
-				{ request: 'react', global: 'React' },
-				{ request: 'react-dom', global: 'ReactDOM' },
-				{ request: '@reduxjs/toolkit', global: [ 'elementorVendors', 'reduxToolkit' ] },
-				{ request: 'react-redux', global: [ 'elementorVendors', 'reactRedux' ] },
-			]
-		} ),
-		new EntryInitializationWebpackPlugin( {
-			initializer: ( { entryName } ) => {
-				return `window.elementorV2.${ entryName }?.init?.();`;
-			},
-		} ),
-	],
-	output: {
-		path: path.resolve( __dirname, '../assets/js/packages/' ),
-	},
-	performance: {
-		hints: false,
-	},
+		cache: filesystemCache,
+		plugins: [
+			new GenerateWordPressAssetFileWebpackPlugin( {
+				handle: ( entryName ) => `elementor-v2-${entryName}`,
+				map: [
+					{ request: REGEXES.elementorPathImports, handle: 'elementor-v2-$1' },
+					{ request: REGEXES.elementorPackages, handle: 'elementor-v2-$1' },
+					{ request: REGEXES.wordpressPackages, handle: 'wp-$1' },
+					{ request: 'react', handle: 'react' },
+					{ request: 'react-dom', handle: 'react-dom' },
+					{ request: '@reduxjs/toolkit', handle: 'elementor-vendors-redux' },
+					{ request: 'react-redux', handle: 'elementor-vendors-redux' },
+				]
+			} ),
+			new ExternalizeWordPressAssetsWebpackPlugin( {
+				global: ( entryName ) => [ 'elementorV2', entryName ],
+				map: [
+					{ request: REGEXES.elementorPathImports, global: [ 'elementorV2', '$1', '$2' ] },
+					{ request: REGEXES.elementorPackages, global: [ 'elementorV2', '$1' ] },
+					{ request: REGEXES.wordpressPackages, global: [ 'wp', '$1' ] },
+					{ request: 'react', global: 'React' },
+					{ request: 'react-dom', global: 'ReactDOM' },
+					{ request: '@reduxjs/toolkit', global: [ 'elementorVendors', 'reduxToolkit' ] },
+					{ request: 'react-redux', global: [ 'elementorVendors', 'reactRedux' ] },
+				]
+			} ),
+			new EntryInitializationWebpackPlugin( {
+				initializer: ( { entryName } ) => {
+					return `window.elementorV2.${ entryName }?.init?.();`;
+				},
+			} ),
+		],
+		output: {
+			path: path.resolve( __dirname, '../assets/js/packages/' ),
+		},
+		performance: {
+			hints: false,
+		},
+	};
 }
 
+const devCommon = createCommonConfig( 'src' );
+const prodCommon = createCommonConfig( 'dist' );
+
 const devConfig = {
-	...common,
+	...devCommon,
 	mode: 'development',
 	devtool: 'source-map',
 	watch: true, // All the webpack config in the plugin that are dev, should have this property.
 	optimization: {
-		...( common.optimization || {} ),
-		// Intentionally minimizing the dev assets to reduce the bundle size.
+		minimize: false,
+	},
+	output: {
+		...( devCommon.output || {} ),
+		filename: '[name]/[name].js',
+	},
+};
+
+const prodConfig = {
+	...prodCommon,
+	mode: 'production',
+	optimization: {
 		minimize: true,
 		minimizer: [
-			new TerserPlugin({
+			new TerserPlugin( {
 				terserOptions: {
 					keep_classnames: true,
 					keep_fnames: true,
-				}
-			})
-		]
-	},
-	output: {
-		...( common.output || {} ),
-		filename: '[name]/[name].js',
-	},
-}
-
-const prodConfig = {
-	...common,
-	mode: 'production',
-	devtool: false, // TODO: Need to check what to do with source maps.
-	optimization: {
-		...( common.optimization || {} ),
-		minimize: true,
+				},
+			} ),
+		],
 	},
 	plugins: [
-		...( common.plugins || [] ),
+		...( prodCommon.plugins || [] ),
 		new ExtractI18nWordpressExpressionsWebpackPlugin( {
 			pattern: ( entryPath ) => path.resolve( entryPath, '../../src/**/*.{ts,tsx,js,jsx}' ),
 		} ),
 	],
 	output: {
-		...( common.output || {} ),
+		...( prodCommon.output || {} ),
 		filename: '[name]/[name].min.js',
-	}
-}
+	},
+};
 
 module.exports = {
 	dev: devConfig,
 	prod: prodConfig,
 };
 
-function getLocalRepoPackagesEntries() {
+function getLocalRepoPackagesEntries( entrySource ) {
 	const repoPath = path.resolve( __dirname, '../packages' );
-	const relevantDirs = [ 'packages/core', 'packages/libs', 'apps' ]
+	const relevantDirs = [ 'packages/core', 'packages/libs', 'apps' ];
 
 	const packages = relevantDirs.flatMap( ( dir ) =>
 		fs.readdirSync( path.resolve( repoPath, dir ) )
 			.map( ( name ) => ( {
 				name,
-				path: path.resolve( repoPath, dir, `${name}/src/index.ts` ),
+				path: getPackageEntryPath( path.resolve( repoPath, dir, name ), entrySource ),
 			} ) )
-			.filter( ( { path } ) => fs.existsSync( path ) )
+			.filter( ( { path: entryPath } ) => fs.existsSync( entryPath ) )
 	);
 
 	packages.push( {
 		name: 'ui',
-		path: './node_modules/@elementor/ui/index.js'
+		path: './node_modules/@elementor/ui/index.js',
 	} );
 
 	packages.push( {
 		name: 'icons',
-		path: './node_modules/@elementor/icons/index.js'
+		path: './node_modules/@elementor/icons/index.js',
 	} );
 
 	return packages;
+}
+
+function getPackageEntryPath( packageDir, entrySource ) {
+	const srcTs = path.join( packageDir, 'src/index.ts' );
+
+	if ( 'src' === entrySource ) {
+		return srcTs;
+	}
+
+	const distJs = path.join( packageDir, 'dist/index.js' );
+
+	if ( fs.existsSync( distJs ) ) {
+		return distJs;
+	}
+
+	return srcTs;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,6 +155,7 @@
         "react-query": "^3.39.1",
         "sass": "^1.83.0",
         "semver": "^7.7.2",
+        "source-map-loader": "^5.0.0",
         "styled-components": "^6.1.13",
         "terser-webpack-plugin": "^5.3.11",
         "ts-node": "^10.9.2",
@@ -40499,6 +40500,27 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-5.0.0.tgz",
+      "integrity": "sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.72.1"
       }
     },
     "node_modules/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "react-query": "^3.39.1",
     "sass": "^1.83.0",
     "semver": "^7.7.2",
+    "source-map-loader": "^5.0.0",
     "styled-components": "^6.1.13",
     "terser-webpack-plugin": "^5.3.11",
     "ts-node": "^10.9.2",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Refactoring webpack packages config to support dual entry points (src for dev, dist for prod) and enable proper source map handling via source-map-loader. This addresses build optimization and debugging needs.

## 2. What Changed (Where)

- `.grunt-config/webpack.packages.js`: Extracted common config into `createCommonConfig()` factory accepting `entrySource` parameter; added `getPackageEntryPath()` to resolve src/dist entries; introduced filesystem caching; dev now disables minification (was minimizing).
- `package.json`: Added `source-map-loader` dev dependency for processing source maps in distributed packages.

## 3. How It Works

`createCommonConfig(entrySource)` generates shared webpack config by invoking `getLocalRepoPackagesEntries(entrySource)`. For dev builds, `entrySource='src'` returns TypeScript source paths; for prod, `entrySource='dist'` returns compiled JS with fallback to src if dist missing. Dev config spreads common config and disables minification; prod adds TerserPlugin and i18n extraction plugin. Source maps flow through new source-map-loader rule for packages matching `packagesDistPattern`.

## 4. Risks

**Dev behavior flip**: Dev now skips minification (previously minimized). If dev bundle size is critical, this could regress metrics. Mitigation: baseline current sizes against new output, monitor in CI.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
