### PR TITLE
Internal: Fix post-to-slack workflow

### DIFF
--- a/.github/workflows/post-to-slack/action.yml
+++ b/.github/workflows/post-to-slack/action.yml
@@ -15,10 +15,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+      - name: Prepare Slack payload
+        shell: bash
+        env:
+          PAYLOAD: ${{ inputs.PAYLOAD }}
+          SLACK_CHANNEL: ${{ inputs.SLACK_TAG_CHANNELS }}
+        run: |
+          echo "$PAYLOAD" | jq --arg channel "$SLACK_CHANNEL" '. + {channel: $channel}' > "${{ runner.temp }}/slack-payload.json"
       - name: Post to a Slack channel
         uses: slackapi/slack-github-action@v3
         with:
-          channel-id: ${{ inputs.SLACK_TAG_CHANNELS }}
-          payload: ${{ inputs.PAYLOAD }}
-        env:
-          SLACK_BOT_TOKEN: ${{ inputs.SLACK_BOT_TOKEN }}
+          method: chat.postMessage
+          token: ${{ inputs.SLACK_BOT_TOKEN }}
+          payload-file-path: ${{ runner.temp }}/slack-payload.json


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The Slack GitHub Action was using deprecated API parameters. This refactors it to use `chat.postMessage` with proper token authentication and payload file approach, aligning with current Slack API best practices.

## 2. What Changed (Where)

- `.github/workflows/post-to-slack/action.yml`: Refactored Slack posting logic to use `payload-file-path` instead of inline `payload`, added preprocessing step to inject channel into JSON payload, moved token to explicit `token` parameter.

## 3. How It Works

New workflow: (1) Prepare step merges channel into payload JSON using `jq`, writes to temp file; (2) Post step uses `chat.postMessage` method with token and file-path reference. Decouples payload construction from API call, enabling dynamic channel injection.

## 4. Risks

Potential `jq` parsing failures if payload input is malformed—consider adding validation or error handling in the prepare step. Token exposure in env vars is standard but ensure `SLACK_BOT_TOKEN` input is marked as secret in calling workflows.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
