### PR TITLE
Internal: Update text for CTA [ED-24298]

### DIFF
--- a/core/admin/admin.php
+++ b/core/admin/admin.php
@@ -374,7 +374,7 @@ class Admin extends App {
 
 		$go_pro_text = esc_html__( 'Get Elementor Pro', 'elementor' );
 		if ( Utils::is_sale_time() ) {
-			$go_pro_text = esc_html__( 'Discounted Upgrades Now!', 'elementor' );
+			$go_pro_text = esc_html__( 'Upgrade Sale Now', 'elementor' );
 		}
 
 		$links['go_pro'] = sprintf( '<a href="%1$s" target="_blank" class="elementor-plugins-gopro">%2$s</a>', 'https://go.elementor.com/go-pro-wp-plugins/', $go_pro_text );

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -929,8 +929,8 @@ class Utils {
 	}
 
 	public static function is_sale_time(): bool {
-		$sale_start_time = gmmktime( 12, 0, 0, 6, 15, 2026 );
-		$sale_end_time = gmmktime( 3, 59, 0, 6, 18, 2026 );
+		$sale_start_time = gmmktime( 10, 0, 0, 6, 15, 2026 );
+		$sale_end_time = gmmktime( 3, 59, 0, 6, 17, 2026 );
 
 		$now_time = gmdate( 'U' );
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -929,8 +929,8 @@ class Utils {
 	}
 
 	public static function is_sale_time(): bool {
-		$sale_start_time = gmmktime( 12, 0, 0, 11, 25, 2025 );
-		$sale_end_time = gmmktime( 3, 59, 0, 12, 3, 2025 );
+		$sale_start_time = gmmktime( 12, 0, 0, 6, 15, 2026 );
+		$sale_end_time = gmmktime( 3, 59, 0, 6, 18, 2026 );
 
 		$now_time = gmdate( 'U' );
 

--- a/modules/promotions/module.php
+++ b/modules/promotions/module.php
@@ -22,6 +22,7 @@ use Elementor\Widgets_Manager;
 use Elementor\Utils;
 use Elementor\Includes\EditorAssetsAPI;
 use Elementor\Plugin;
+use Elementor\Modules\EditorOne\Classes\Menu_Config;
 use Elementor\Modules\EditorOne\Classes\Menu_Data_Provider;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -52,6 +53,10 @@ class Module extends Base_Module {
 		add_action( 'elementor/editor-one/menu/register', function ( Menu_Data_Provider $menu_data_provider ) {
 			$this->register_editor_one_menu_items( $menu_data_provider );
 		} );
+
+		if ( Utils::is_sale_time() ) {
+			add_filter( 'add_menu_classes', [ $this, 'override_one_menu_upgrade_label_during_sale' ] );
+		}
 
 		add_action( 'elementor/widgets/register', function( Widgets_Manager $manager ) {
 			foreach ( Api::get_promotion_widgets() as $widget_data ) {
@@ -108,6 +113,26 @@ class Module extends Base_Module {
 			wp_redirect( Go_Pro_Promotion_Item::get_url() ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 			die;
 		}
+	}
+
+	public function override_one_menu_upgrade_label_during_sale( $menu ) {
+		global $submenu;
+
+		$parent_slug = Menu_Config::ELEMENTOR_HOME_MENU_SLUG;
+		$upgrade_slug = 'elementor-one-upgrade';
+
+		if ( empty( $submenu[ $parent_slug ] ) ) {
+			return $menu;
+		}
+
+		foreach ( $submenu[ $parent_slug ] as &$item ) {
+			if ( isset( $item[2] ) && $upgrade_slug === $item[2] ) {
+				$item[0] = esc_html__( 'Upgrade & Save', 'elementor' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				break;
+			}
+		}
+
+		return $menu;
 	}
 
 	private function register_editor_one_menu_items( Menu_Data_Provider $menu_data_provider ) {

--- a/modules/promotions/pointers/birthday.php
+++ b/modules/promotions/pointers/birthday.php
@@ -80,8 +80,8 @@ class Birthday {
 	}
 
 	private static function is_campaign_time() {
-		$start = new \DateTime( '2026-06-15 12:00:00', new \DateTimeZone( 'UTC' ) );
-		$end = new \DateTime( '2026-06-18 03:59:00', new \DateTimeZone( 'UTC' ) );
+		$start = new \DateTime( '2026-06-15 10:00:00', new \DateTimeZone( 'UTC' ) );
+		$end = new \DateTime( '2026-06-17 03:59:00', new \DateTimeZone( 'UTC' ) );
 		$now = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
 
 		return $now >= $start && $now <= $end;

--- a/modules/promotions/pointers/birthday.php
+++ b/modules/promotions/pointers/birthday.php
@@ -11,9 +11,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Birthday {
 	const PROMOTION_URL = 'https://go.elementor.com/go-pro-wordpress-notice-birthday/';
-	const ELEMENTOR_POINTER_ID = 'toplevel_page_elementor';
-	const SEEN_TODAY_KEY = '_elementor-2025-birthday';
-	const DISMISS_ACTION_KEY = 'birthday_pointer_2025';
+	const ELEMENTOR_POINTER_ID = 'toplevel_page_elementor-home';
+	const SEEN_TODAY_KEY = '_elementor-2026-birthday';
+	const DISMISS_ACTION_KEY = 'birthday_pointer_2026';
 
 	public function __construct() {
 		add_action( 'admin_print_footer_scripts-index.php', [ $this, 'enqueue_notice' ] );
@@ -27,8 +27,8 @@ class Birthday {
 		$this->set_seen_today();
 		$this->enqueue_dependencies();
 
-		$pointer_content = '<h3>' . esc_html__( 'Elementor’s 9th Birthday sale!', 'elementor' ) . '</h3>';
-		$pointer_content .= '<p>' . esc_html__( 'Celebrate Elementor’s birthday with us—exclusive deals are available now.', 'elementor' );
+		$pointer_content = '<h3>' . esc_html__( 'Elementor’s 10th Birthday sale!', 'elementor' ) . '</h3>';
+		$pointer_content .= '<p>' . esc_html__( 'Get more capabilities for less with exclusive discounts. Limited time only.', 'elementor' );
 		$pointer_content .= sprintf(
 			'<p><a class="button button-primary" href="%s" target="_blank">%s</a></p>',
 			self::PROMOTION_URL,
@@ -80,8 +80,8 @@ class Birthday {
 	}
 
 	private static function is_campaign_time() {
-		$start = new \DateTime( '2025-06-10 12:00:00', new \DateTimeZone( 'UTC' ) );
-		$end = new \DateTime( '2025-06-17 03:59:00', new \DateTimeZone( 'UTC' ) );
+		$start = new \DateTime( '2026-06-15 12:00:00', new \DateTimeZone( 'UTC' ) );
+		$end = new \DateTime( '2026-06-18 03:59:00', new \DateTimeZone( 'UTC' ) );
 		$now = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
 
 		return $now >= $start && $now <= $end;


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Birthday sale campaign timing updated from June 2025 to June 2026 with refreshed promotional messaging across admin UI and editor menus.

## 2. What Changed (Where)

- **core/admin/admin.php**: CTA text changed from "Discounted Upgrades Now!" to "Upgrade Sale Now" during sale window
- **includes/utils.php**: `is_sale_time()` dates shifted to June 15-17, 2026 (10:00-03:59 UTC)
- **modules/promotions/module.php**: Added `Menu_Config` import and conditional filter to override editor menu upgrade label to "Upgrade & Save" during sale
- **modules/promotions/pointers/birthday.php**: Updated constants (pointer ID, cache keys), campaign dates to 2026, and pointer copy ("10th Birthday" vs "9th")

## 3. How It Works

During the sale window, two parallel mechanisms trigger: (1) `Utils::is_sale_time()` gates conditional logic, (2) promotional modules conditionally register filters that override UI labels. The birthday pointer independently checks campaign time via DateTime comparison. No data flow changes—purely conditional text/timing updates.

## 4. Risks

Hardcoded future dates (June 2026) will require another PR update. No validation that `Menu_Config::ELEMENTOR_HOME_MENU_SLUG` exists before accessing `$submenu` global—safe only if Editor One guarantees the parent menu slug, but missing defensive null check on `$submenu[$parent_slug]` is already handled.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
