### PR TITLE
Internal: Add emotion babel plugin for readable MUI class names [ED-20882]

### DIFF
--- a/.grunt-config/webpack.packages.js
+++ b/.grunt-config/webpack.packages.js
@@ -126,6 +126,26 @@ const devConfig = {
 		// Faster rebuilds and stacks that line up with TypeScript; output is larger than the previous minimized dev bundles.
 		minimize: false,
 	},
+	module: {
+		...devCommon.module,
+		rules: devCommon.module.rules.map( ( rule ) => {
+			if ( rule.use?.loader !== 'babel-loader' ) {
+				return rule;
+			}
+			return {
+				...rule,
+				use: {
+					...rule.use,
+					options: {
+						...rule.use.options,
+						plugins: [
+							[ '@emotion/babel-plugin', { autoLabel: 'dev-only', labelFormat: '[local]' } ],
+						],
+					},
+				},
+			};
+		} ),
+	},
 	output: {
 		...( devCommon.output || {} ),
 		filename: '[name]/[name].js',

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime-corejs3": "^7.26.0",
     "@elementor/wp-lite-env": "^0.0.20",
+    "@emotion/babel-plugin": "^11.13.5",
     "@jest/globals": "~29.7.0",
     "@lodder/grunt-postcss": "^3.1.1",
     "@playwright/test": "~1.54.1",

--- a/tests/jest/babel.config.js
+++ b/tests/jest/babel.config.js
@@ -10,5 +10,6 @@ module.exports = {
 		} ],
 		[ '@babel/plugin-transform-runtime' ],
 		[ '@babel/plugin-transform-modules-commonjs' ],
+		[ '@emotion/babel-plugin', { autoLabel: 'always', labelFormat: '[local]' } ],
 	],
 };


### PR DESCRIPTION
## Summary
- Add `@emotion/babel-plugin` as an explicit devDependency (was previously only a transitive dep, v11.13.5)
- Override the `babel-loader` in `devConfig` only, injecting the Emotion plugin with `autoLabel: 'dev-only'` so MUI/Emotion CSS class names like `css-1ba3z7x` become `css-ButtonBase-1ba3z7x` in dev builds
- Add the plugin to the Jest babel config with `autoLabel: 'always'` for consistent readable class names in test output
- Production builds are completely unaffected — `prodConfig` uses a separate `createCommonConfig` call and has no reference to the plugin

## Test plan
- [ ] After rebuilding dev bundles, inspect a MUI component in browser DevTools — class names should include a label segment (e.g. `css-ButtonBase-abc123`)
- [ ] Run `npm run test:jest` — existing tests should pass without snapshot updates (no `.snap` files currently capture `css-` patterns)
- [ ] Confirm production build class names are still opaque hashes (run `grunt webpack:production` and inspect output)

## Jira
[ED-20882](https://elementor.atlassian.net/browse/ED-20882)

Made with [Cursor](https://cursor.com)

[ED-20882]: https://elementor.atlassian.net/browse/ED-20882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds Emotion babel plugin to generate readable class names in dev builds (ED-20882), replacing opaque hashes with human-friendly labels for debugging MUI components.

## 2. What Changed (Where)

- `package.json`: Added `@emotion/babel-plugin@^11.13.5` dependency
- `webpack.packages.js`: Configured plugin for dev builds with `autoLabel: 'dev-only'` and `[local]` format
- `babel.config.js` (tests): Configured plugin for test runs with `autoLabel: 'always'`

## 3. How It Works

Webpack dev config intercepts babel-loader rules, wraps existing options with Emotion plugin that transforms dynamic style-in-JS into readable class names. Test babel config independently enables the plugin. Dev-only mode prevents bloated production builds.

## 4. Risks

Plugin version pinned at minor; Emotion version mismatch with existing dependencies could cause conflicts. Verify MUI and Emotion versions align—no version checks visible in diff.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
