### PR TITLE
Fix: Always inject editor-site-navigation env key [ED-24346]

### DIFF
--- a/modules/site-navigation/module.php
+++ b/modules/site-navigation/module.php
@@ -33,15 +33,17 @@ class Module extends Module_Base {
 
 		add_filter( 'elementor/editor/v2/packages', fn( $packages ) => $this->add_packages( $packages ) );
 
+		add_filter( 'elementor/editor/v2/scripts/env', function( $env ) {
+			$env['@elementor/editor-site-navigation'] = [
+				'is_pages_panel_active' => Plugin::$instance->experiments->is_feature_active(
+					self::PAGES_PANEL_EXPERIMENT_NAME
+				),
+			];
+
+			return $env;
+		} );
+
 		if ( Plugin::$instance->experiments->is_feature_active( self::PAGES_PANEL_EXPERIMENT_NAME ) ) {
-			add_filter( 'elementor/editor/v2/scripts/env', function( $env ) {
-				$env['@elementor/editor-site-navigation'] = [
-					'is_pages_panel_active' => true,
-				];
-
-				return $env;
-			} );
-
 			$this->register_rest_fields();
 		}
 	}

--- a/tests/phpunit/elementor/modules/site-navigation/test-module.php
+++ b/tests/phpunit/elementor/modules/site-navigation/test-module.php
@@ -41,7 +41,7 @@ class Elementor_Test_Module extends Elementor_Test_Base {
 
 		// Assert.
 		$env = apply_filters( 'elementor/editor/v2/scripts/env', [] );
-		$this->assertArrayNotHasKey( '@elementor/editor-site-navigation', $env );
+		$this->assertFalse( $env['@elementor/editor-site-navigation']['is_pages_panel_active'] );
 	}
 
 	public function test_construct_experiment_active() {


### PR DESCRIPTION
## Summary
- The `editor-site-navigation` JS package is always loaded, but the `@elementor/editor-site-navigation` env key was only injected into `window.elementorEditorV2Env` when the `pages_panel` experiment was active
- When the experiment is off (the default), `parseEnv()` found no key and fired `console.warn('@elementor/editor-site-navigation - Settings object not found')` on every editor load
- Fix: always inject the env key with `is_pages_panel_active` reflecting the actual experiment state, keeping REST field registration gated behind the experiment as before

## Test plan
- [ ] Load the editor with the `pages_panel` experiment **inactive** (default) — confirm the console warning is gone
- [ ] Load the editor with the `pages_panel` experiment **active** — confirm the pages panel still works correctly
- [ ] Verify no regression in editor load for both cases

## Jira
[ED-24346](https://elementor.atlassian.net/browse/ED-24346)

Made with [Cursor](https://cursor.com)

[ED-24346]: https://elementor.atlassian.net/browse/ED-24346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The editor-site-navigation env key was only injected when the pages panel experiment was active, causing it to be missing in the editor otherwise. Now it's always injected with the experiment state, fixing ED-24346.

## 2. What Changed (Where)

- **module.php**: Moved env filter registration outside the experiment conditional; now always injects `@elementor/editor-site-navigation` with dynamic `is_pages_panel_active` state.
- **test-module.php**: Updated assertion to verify env key exists and reflects inactive experiment state instead of checking key absence.

## 3. How It Works

The module now unconditionally registers the `elementor/editor/v2/scripts/env` filter during initialization, injecting the site-navigation config with the current experiment status. REST fields registration remains gated behind the experiment check.

## 4. Risks

Minimal—the env injection is side-effect free and the experiment status is already computed at module init time. Dependent code consuming `is_pages_panel_active` from env must now handle both true/false cases explicitly.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
