### PR TITLE
Internal: Remove QUnit from production webpack build and add standalone build+test flow [ED-24360]

### DIFF
--- a/.github/workflows/js-qunit.yml
+++ b/.github/workflows/js-qunit.yml
@@ -31,7 +31,5 @@ jobs:
           cache: npm
       - name: Install Dependencies
         run: npm run install:ci
-      - name: "Build Scripts"
-        run: npm run build:ci
       - name: "Run Qunit"
-        run: npx grunt karma:unit
+        run: npx grunt test

--- a/.github/workflows/js-qunit.yml
+++ b/.github/workflows/js-qunit.yml
@@ -31,5 +31,7 @@ jobs:
           cache: npm
       - name: Install Dependencies
         run: npm run install:ci
+      - name: Build Tools
+        run: npm run build:tools
       - name: "Run Qunit"
         run: npx grunt test

--- a/.grunt-config/webpack.js
+++ b/.grunt-config/webpack.js
@@ -75,6 +75,17 @@ const frontendRulesPresets = [ [
 
 const frontendModuleRules = getModuleRules( frontendRulesPresets );
 
+const qunitEntries = {
+	'vendors-redux': path.resolve( __dirname, '../core/common/assets/js/vendors-redux.js' ),
+	'dev-tools': path.resolve( __dirname, '../modules/dev-tools/assets/js/index.js' ),
+	'common-modules': path.resolve( __dirname, '../core/common/assets/js/modules' ),
+	'web-cli': path.resolve( __dirname, '../modules/web-cli/assets/js/index.js' ),
+	'common': path.resolve( __dirname, '../core/common/assets/js/common.js' ),
+	'editor-modules': path.resolve( __dirname, '../assets/dev/js/editor/modules.js' ),
+	'editor-document': path.resolve( __dirname, '../assets/dev/js/editor/editor-document.js' ),
+	'qunit-tests': path.resolve( __dirname, '../tests/qunit/main.js' ),
+};
+
 const entry = {
 	'editor': [
 		path.resolve( __dirname, '../assets/dev/js/editor/utils/jquery-serialize-object.js' ),
@@ -98,7 +109,6 @@ const entry = {
 	'editor-modules': path.resolve( __dirname, '../assets/dev/js/editor/modules.js' ),
 	'admin-modules': path.resolve( __dirname, '../assets/dev/js/admin/modules.js' ),
 	'editor-document': path.resolve( __dirname, '../assets/dev/js/editor/editor-document.js' ),
-	'qunit-tests': path.resolve( __dirname, '../tests/qunit/main.js' ),
 	'admin-top-bar': path.resolve( __dirname, '../modules/admin-top-bar/assets/js/admin.js' ),
 	'checklist': path.resolve( __dirname, '../modules/checklist/assets/js/editor.js' ),
 	'nested-elements': path.resolve( __dirname, '../modules/nested-elements/assets/js/editor/index.js' ),
@@ -394,11 +404,27 @@ const productionWatchConfig = webpackProductionConfig.map( ( config ) => {
 	return { ...config, watch: true };
 } );
 
+const webpackQunitConfig = {
+	...devSharedConfig,
+	watch: false,
+	output: {
+		...devSharedConfig.output,
+		uniqueName: baseOutputUniqueName,
+	},
+	module: moduleRules,
+	plugins: [
+		...plugins,
+	],
+	name: 'qunit',
+	entry: qunitEntries,
+};
+
 const gruntWebpackConfig = {
 	development: webpackConfig,
 	developmentNoWatch: developmentNoWatchConfig,
 	production: webpackProductionConfig,
 	productionWatch: productionWatchConfig,
+	qunit: webpackQunitConfig,
 };
 
 module.exports = gruntWebpackConfig;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,6 +124,7 @@ module.exports = function( grunt ) {
 	} );
 
 	grunt.registerTask( 'test', [
+		'webpack:qunit',
 		'karma:unit',
 	] );
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,22 +26,22 @@ module.exports = function( config ) {
 			'tests/qunit/vendor/wp-includes/backbone.min.js',
 			'tests/qunit/vendor/wp-includes/react.min.js',
 			'tests/qunit/vendor/wp-includes/react-dom.min.js',
-			'assets/js/vendors-redux.min.js',
+			'assets/js/vendors-redux.js',
 			'tests/qunit/vendor/wp-includes/i18n.min.js',
 			'assets/lib/backbone/backbone.marionette.min.js',
 			'assets/lib/backbone/backbone.radio.min.js',
 
 			// Dev tools.
 			'tests/qunit/setup/dev-tools.js',
-			'assets/js/dev-tools.min.js',
+			'assets/js/dev-tools.js',
 
 			// Elementor Common.
 			'tests/qunit/setup/elementor-common.js',
 			'tests/qunit/setup/web-cli.js',
 			'assets/lib/dialog/dialog.js',
-			'assets/js/common-modules.min.js',
-			'assets/js/web-cli.min.js',
-			'assets/js/common.min.js',
+			'assets/js/common-modules.js',
+			'assets/js/web-cli.js',
+			'assets/js/common.js',
 
 			// Editor Fixtures.
 			'tests/qunit/index.html',
@@ -64,11 +64,11 @@ module.exports = function( config ) {
 			'assets/lib/jquery-hover-intent/jquery-hover-intent.min.js',
 
 			// Editor.
-			'assets/js/editor-modules.min.js',
-			'assets/js/editor-document.min.js',
+			'assets/js/editor-modules.js',
+			'assets/js/editor-document.js',
 
 			// Tests.
-			'assets/js/qunit-tests.min.js',
+			'assets/js/qunit-tests.js',
 		],
 		preprocessors: {
 			'tests/qunit/index.html': [ 'html2js' ],


### PR DESCRIPTION
## Summary
- Extracted `qunit-tests` from the shared webpack `entry` object into a standalone `qunitEntries` const so it is no longer compiled during dev or production builds
- Added a dedicated `webpackQunitConfig` (dev mode, no watch) exported as `gruntWebpackConfig.qunit`
- Updated the `test` grunt task to run `webpack:qunit` before `karma:unit`, making `grunt test` fully self-contained without requiring a prior full build

## Test plan
- [ ] Run `grunt scripts` (production) and confirm no `qunit-tests.min.js` is generated in `assets/js/`
- [ ] Run `grunt test` from a clean state (no pre-built assets) and confirm the QUnit bundle is compiled and karma runs successfully
- [ ] Run `grunt build` and confirm the build output in `build/` does not contain any `qunit-tests*` files

## Jira
[ED-24360](https://elementor.atlassian.net/browse/ED-24360)

Made with [Cursor](https://cursor.com)

[ED-24360]: https://elementor.atlassian.net/browse/ED-24360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

QUnit tests were bundled into production webpack builds unnecessarily, inflating bundle size. This PR isolates QUnit into a separate webpack config and dedicated test flow, keeping production builds lean while enabling standalone test execution.

## 2. What Changed (Where)

- `.grunt-config/webpack.js`: Extracted QUnit entries into separate `qunitEntries` object; removed `qunit-tests` from main entry; added `webpackQunitConfig` for standalone QUnit builds
- `Gruntfile.js`: Added `webpack:qunit` task before `karma:unit` in test pipeline
- `karma.conf.js`: Switched from minified assets (`.min.js`) to unminified built outputs from webpack QUnit config
- `.github/workflows/js-qunit.yml`: Replaced `build:ci` with `build:tools`; changed test runner from `karma:unit` to `grunt test`

## 3. How It Works

QUnit dependencies now flow through dedicated webpack build → karma pulls built unminified assets → test runner executes via grunt task orchestration. Decouples QUnit from production bundle while maintaining coverage instrumentation via karma's preprocessor chain.

## 4. Risks

Karma preprocessor still references built assets (e.g., `assets/js/common-modules.js` for coverage) — if webpack QUnit build fails silently, tests run against stale artifacts. Mitigate with explicit build-then-test ordering and CI failure on missing assets.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
