### PR TITLE
Internal: Update browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,9 +1,11 @@
 last 3 versions
-Chrome >= 111
-Firefox >= 111
-Edge >= 111
-Safari >= 16.4
-iOS >= 16.4
-Android >= 111
-ChromeAndroid >= 111
 not dead
+
+# Minimum versions (updated 2026-06-01)
+Chrome >= 146
+Firefox >= 148
+Edge >= 146
+Safari >= 26.2
+iOS >= 26.2
+Android >= 148
+ChromeAndroid >= 148

--- a/package-lock.json
+++ b/package-lock.json
@@ -21547,9 +21547,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001754",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
-      "integrity": "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "funding": [
         {
           "type": "opencollective",
@@ -33524,17 +33524,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/luxon": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -42753,24 +42742,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/tsup/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tunnel": {


### PR DESCRIPTION
Automated monthly browserslist update.

**Changes:**
- Updated `caniuse-lite` database in `package-lock.json`
- Auto-resolved minimum browser version floors in `.browserslistrc`

**Created by:** GitHub Actions (`browserslist-update` workflow)
**Branch:** `chore/update-browserslist-2026-06-01`
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Browserslist configuration rotates minimum browser versions forward by ~1 year (June 2026), dropping support for older versions and aligning with modern browser release cycles.

## 2. What Changed (Where)

`.browserslistrc` — Updated all minimum version constraints: Chrome/Edge/Android from 111→146, Firefox/ChromeAndroid from 111→148, Safari/iOS from 16.4→26.2.

## 3. How It Works

No changes to mechanism — this is purely a data update. The browserslist package continues evaluating these constraints for transpilation targets and polyfill decisions.

## 4. Risks

None material. Dropped browser versions are now 1+ years old; any downstream tooling already targets these minimums should handle gracefully. Verify CI passes with new constraints.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
