### PR TITLE
Internal: Add section id registry [ED-24331]

### DIFF
--- a/modules/atomic-widgets/controls/section.php
+++ b/modules/atomic-widgets/controls/section.php
@@ -63,9 +63,10 @@ class Section implements JsonSerializable {
 		return [
 			'type' => 'section',
 			'value' => [
-				'label' => $this->label,
+				'id'          => $this->id,
+				'label'       => $this->label,
 				'description' => $this->description,
-				'items' => $this->items,
+				'items'       => $this->items,
 			],
 		];
 	}

--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.php
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.php
@@ -72,6 +72,7 @@ class Atomic_Button extends Atomic_Widget_Base {
 		return [
 			Section::make()
 				->set_label( __( 'Content', 'elementor' ) )
+				->set_id( 'content' )
 				->set_items( [
 					Inline_Editing_Control::bind_to( 'text' )
 						->set_placeholder( __( 'Type your button text here', 'elementor' ) )

--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.php
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.php
@@ -176,6 +176,7 @@ class Atomic_Form extends Atomic_Element_Base {
 		return [
 			Section::make()
 				->set_label( __( 'Content', 'elementor' ) )
+				->set_id( 'content' )
 				->set_items( $content_controls ),
 			...$email_controls,
 			Section::make()

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.php
@@ -71,6 +71,7 @@ class Atomic_Heading extends Atomic_Widget_Base {
 	protected function define_atomic_controls(): array {
 		$content_section = Section::make()
 			->set_label( __( 'Content', 'elementor' ) )
+			->set_id( 'content' )
 			->set_items( [
 				Inline_Editing_Control::bind_to( 'title' )
 					->set_placeholder( __( 'Type your title here', 'elementor' ) )

--- a/modules/atomic-widgets/elements/atomic-image/atomic-image.php
+++ b/modules/atomic-widgets/elements/atomic-image/atomic-image.php
@@ -65,6 +65,7 @@ class Atomic_Image extends Atomic_Widget_Base {
 		return [
 			Section::make()
 				->set_label( esc_html__( 'Content', 'elementor' ) )
+				->set_id( 'content' )
 				->set_items( [
 					Image_Control::bind_to( 'image' )
 						->set_label( __( 'Image', 'elementor' ) ),

--- a/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.php
+++ b/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.php
@@ -72,6 +72,7 @@ class Atomic_Paragraph extends Atomic_Widget_Base {
 		return [
 			Section::make()
 				->set_label( __( 'Content', 'elementor' ) )
+				->set_id( 'content' )
 				->set_items( [
 					Inline_Editing_Control::bind_to( 'paragraph' )
 						->set_placeholder( __( 'Type your paragraph here', 'elementor' ) )

--- a/modules/atomic-widgets/elements/atomic-self-hosted-video/atomic-self-hosted-video.php
+++ b/modules/atomic-widgets/elements/atomic-self-hosted-video/atomic-self-hosted-video.php
@@ -132,6 +132,7 @@ class Atomic_Self_Hosted_Video extends Atomic_Widget_Base {
 		return [
 			Section::make()
 				->set_label( __( 'Content', 'elementor' ) )
+				->set_id( 'content' )
 				->set_items([
 					Video_Control::bind_to( 'source' )
 						->set_label( esc_html__( 'Video', 'elementor' ) ),

--- a/modules/atomic-widgets/elements/atomic-svg/atomic-svg.php
+++ b/modules/atomic-widgets/elements/atomic-svg/atomic-svg.php
@@ -60,6 +60,7 @@ class Atomic_Svg extends Atomic_Widget_Base {
 		return [
 			Section::make()
 				->set_label( esc_html__( 'Content', 'elementor' ) )
+				->set_id( 'content' )
 				->set_items( [
 					Svg_Control::bind_to( 'svg' )
 						->set_label( __( 'SVG', 'elementor' ) ),

--- a/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.php
+++ b/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.php
@@ -74,6 +74,7 @@ class Atomic_Youtube extends Atomic_Widget_Base {
 		return [
 			Section::make()
 				->set_label( __( 'Content', 'elementor' ) )
+				->set_id( 'content' )
 				->set_items( [
 					Text_Control::bind_to( 'source' )
 						->set_placeholder( esc_html__( 'Type or paste your URL', 'elementor' ) )

--- a/packages/packages/core/editor-editing-panel/src/components/__tests__/settings-tab.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/__tests__/settings-tab.test.tsx
@@ -122,7 +122,7 @@ describe( '<SettingsTab />', () => {
 
 		jest.mocked( useDefaultPanelSettings ).mockReturnValue( {
 			defaultSectionsExpanded: {
-				settings: [ 'Section 1', 'Section 2' ],
+				settings: [ 'section' ],
 			},
 			defaultTab: 'settings',
 		} );
@@ -361,6 +361,13 @@ describe( '<SettingsTab />', () => {
 			},
 		} );
 
+		jest.mocked( useDefaultPanelSettings ).mockReturnValue( {
+			defaultSectionsExpanded: {
+				settings: [ 'section' ],
+			},
+			defaultTab: 'settings',
+		} );
+
 		// Act.
 		renderWithTheme( <SettingsTab /> );
 
@@ -388,7 +395,7 @@ describe( '<SettingsTab />', () => {
 		} );
 		jest.mocked( useDefaultPanelSettings ).mockReturnValue( {
 			defaultSectionsExpanded: {
-				settings: [ 'Element Control Section' ],
+				settings: [ 'section' ],
 			},
 			defaultTab: 'settings',
 		} );
@@ -403,12 +410,14 @@ describe( '<SettingsTab />', () => {
 } );
 
 export const mockSection = ( {
+	id = 'section',
 	label = 'Section',
 	description = 'Section description',
 	items = [],
 }: Partial< ControlsSection[ 'value' ] > ): ControlsSection => ( {
 	type: 'section',
 	value: {
+		id,
 		label,
 		description,
 		items,

--- a/packages/packages/core/editor-editing-panel/src/components/settings-tab.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/settings-tab.tsx
@@ -15,8 +15,8 @@ export const SettingsTab = () => {
 	const settingsDefault = useDefaultPanelSettings();
 	const currentSettings = settings as Props;
 
-	const isDefaultExpanded = ( sectionId: string ) =>
-		settingsDefault.defaultSectionsExpanded.settings?.includes( sectionId );
+	const isDefaultExpanded = ( sectionId: string | null | undefined ) =>
+		!! sectionId && settingsDefault.defaultSectionsExpanded.settings?.includes( sectionId );
 
 	return (
 		<SessionStorageProvider prefix={ element.id }>
@@ -44,7 +44,7 @@ export const SettingsTab = () => {
 							<Section
 								title={ value.label }
 								key={ type + '.' + index }
-								defaultExpanded={ isDefaultExpanded( value.label ) }
+								defaultExpanded={ isDefaultExpanded( value.id ) }
 							>
 								{ sectionItems }
 							</Section>

--- a/packages/packages/core/editor-editing-panel/src/hooks/use-default-panel-settings.ts
+++ b/packages/packages/core/editor-editing-panel/src/hooks/use-default-panel-settings.ts
@@ -9,7 +9,7 @@ export type { Defaults as ElementPanelDefaults };
 
 const fallbackEditorSettings: Defaults = {
 	defaultSectionsExpanded: {
-		settings: [ 'Content', 'Settings' ],
+		settings: [ 'content', 'settings' ],
 		style: [],
 	},
 	defaultTab: 'settings',

--- a/packages/packages/libs/editor-elements/src/types.ts
+++ b/packages/packages/libs/editor-elements/src/types.ts
@@ -26,6 +26,7 @@ export type ElementType = {
 export type ControlsSection = {
 	type: 'section';
 	value: {
+		id?: string | null;
 		description?: string;
 		label: string;
 		items: ControlItem[];

--- a/tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/test-dynamic-tags-module.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/test-dynamic-tags-module.php
@@ -111,12 +111,13 @@ class Test_Dynamic_Tags_Module extends Elementor_Test_Base {
 				],
 				'group' => 'post',
 				'atomic_controls' => [
-					[
-						'type' => 'section',
-						'value' => [
-							'label' => 'Settings',
-							'description' => null,
-							'items' => [
+				[
+					'type' => 'section',
+					'value' => [
+						'id' => null,
+						'label' => 'Settings',
+						'description' => null,
+						'items' => [
 								[
 									'type' => 'control',
 									'value' => [


### PR DESCRIPTION
## Summary

Re-applies the section ID registry (reverted in #36069) and adds the missing `content` section id on `e-form`. Panel default expansion now matches sections by stable id instead of label.

## What changed

- Restore section id serialization in `Section` control and `id` field on Core atomic widgets
- Switch `SettingsTab` default expansion to match `value.id` (fallback: `content`, `settings`)
- Add `->set_id( 'content' )` on the `e-form` Content section so form panel controls expand correctly

## Why the revert happened

The original merge (#36060) broke Pro atomic-form Playwright tests because Pro field widgets lacked Content section ids. This PR includes the Core `e-form` fix; Pro field widget ids are in elementor/elementor-pro#7019.

## Test plan

- [ ] Select an atomic heading — Content and Settings sections expand by default
- [ ] Select `e-form` — Content section (Form name, Actions after submit) is expanded
- [ ] Pro custom-core Playwright atomic-form suite passes after elementor/elementor-pro#7019 merges