### PR TITLE
Internal: Export `ControlLabel` [ED-24051]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/index.ts
+++ b/packages/packages/core/editor-editing-panel/src/index.ts
@@ -1,5 +1,6 @@
 export { type ValidationEvent, type ValidationResult } from './components/creatable-autocomplete';
 export { injectIntoCssClassConvert } from './components/css-classes/css-class-convert-local';
+export { ControlLabel } from './components/control-label';
 export { injectIntoClassSelectorActions } from './components/css-classes/css-class-selector';
 export { CustomCssIndicator } from './components/custom-css-indicator';
 export { injectIntoPanelHeaderTop } from './components/editing-panel';


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Exposing `ControlLabel` component from the public API (ED-24051) to enable external consumers to import and use it directly.

## 2. What Changed (Where)
- `packages/core/editor-editing-panel/src/index.ts`: Added `ControlLabel` export alongside existing component exports.

## 3. How It Works
Named export added to barrel file; consumers can now `import { ControlLabel }` from the package.

## 4. Risks
None — additive export, no breaking changes or behavioral modifications.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
