### PR TITLE
Internal: Track classes/variables events via design system [ED-24348]

### DIFF
--- a/core/common/modules/events-manager/assets/js/events-config.js
+++ b/core/common/modules/events-manager/assets/js/events-config.js
@@ -245,6 +245,8 @@ const eventsConfig = {
 			confirmed: 'design_system_import_confirmed',
 			imported: 'design_system_imported',
 			importFailed: 'design_system_import_failed',
+			export: 'design_system_export',
+			opened: 'design_system_opened',
 		},
 		components: {
 			createClicked: 'component_create_clicked',

--- a/packages/packages/core/editor-design-system/src/components/__tests__/design-system-panel-content.test.tsx
+++ b/packages/packages/core/editor-design-system/src/components/__tests__/design-system-panel-content.test.tsx
@@ -42,12 +42,18 @@ jest.mock( '../../initial-tab', () => ( {
 	persistDesignSystemTab: jest.fn(),
 } ) );
 
+const mockTrackGlobalClasses = jest.fn();
+
 jest.mock( '@elementor/editor-global-classes', () => ( {
 	ClassManagerPanelEmbedded: jest.fn(),
+	trackGlobalClasses: ( ...args: unknown[] ) => mockTrackGlobalClasses( ...args ),
 } ) );
+
+const mockTrackVariablesManagerEvent = jest.fn();
 
 jest.mock( '@elementor/editor-variables', () => ( {
 	VariablesManagerPanelEmbedded: jest.fn(),
+	trackVariablesManagerEvent: ( ...args: unknown[] ) => mockTrackVariablesManagerEvent( ...args ),
 } ) );
 
 const mockVariablesManagerPanelEmbedded = require( '@elementor/editor-variables' )
@@ -229,6 +235,30 @@ describe( 'DesignSystemPanelContent', () => {
 			fireEvent.click( screen.getByRole( 'tab', { name: 'Classes' } ) );
 
 			expect( jest.mocked( notifyDesignSystemTabChange ) ).toHaveBeenCalledWith( 'classes' );
+		} );
+
+		it( 'should track classManagerOpened with system-panel when Classes tab is clicked', () => {
+			render( <DesignSystemPanelContent onRequestClose={ onRequestClose } /> );
+
+			fireEvent.click( screen.getByRole( 'tab', { name: 'Classes' } ) );
+
+			expect( mockTrackGlobalClasses ).toHaveBeenCalledWith( {
+				event: 'classManagerOpened',
+				source: 'system-panel',
+			} );
+		} );
+
+		it( 'should track open_variables_manager with system-panel when Variables tab is clicked', () => {
+			jest.mocked( getInitialDesignSystemTab ).mockReturnValue( 'classes' );
+
+			render( <DesignSystemPanelContent onRequestClose={ onRequestClose } /> );
+
+			fireEvent.click( screen.getByRole( 'tab', { name: 'Variables' } ) );
+
+			expect( mockTrackVariablesManagerEvent ).toHaveBeenCalledWith( {
+				action: 'openManager',
+				source: 'system-panel',
+			} );
 		} );
 	} );
 

--- a/packages/packages/core/editor-design-system/src/components/design-system-header-menu.tsx
+++ b/packages/packages/core/editor-design-system/src/components/design-system-header-menu.tsx
@@ -59,7 +59,7 @@ export const DesignSystemHeaderMenu = () => {
 	const handleExport = () => {
 		popupState.close();
 		trackDesignSystem( { event: 'export' } );
-		runExport();
+		void runExport();
 	};
 
 	const triggerLabel = __( 'Design system actions', 'elementor' );

--- a/packages/packages/core/editor-design-system/src/components/design-system-header-menu.tsx
+++ b/packages/packages/core/editor-design-system/src/components/design-system-header-menu.tsx
@@ -58,7 +58,8 @@ export const DesignSystemHeaderMenu = () => {
 
 	const handleExport = () => {
 		popupState.close();
-		void runExport();
+		trackDesignSystem( { event: 'export' } );
+		runExport();
 	};
 
 	const triggerLabel = __( 'Design system actions', 'elementor' );

--- a/packages/packages/core/editor-design-system/src/components/design-system-panel-content.tsx
+++ b/packages/packages/core/editor-design-system/src/components/design-system-panel-content.tsx
@@ -31,12 +31,14 @@ export type DesignSystemPanelContentProps = {
 const EVENT_SET_TAB = 'elementor/design-system/set-tab';
 
 const trackDesignSystemTabOpened = ( tab: DesignSystemTab ) => {
-	if ( tab === 'classes' ) {
-		trackGlobalClasses( { event: 'classManagerOpened', source: 'system-panel' } );
-		return;
+	switch ( tab ) {
+		case 'classes':
+			trackGlobalClasses( { event: 'classManagerOpened', source: 'system-panel' } );
+			break;
+		case 'variables':
+			trackVariablesManagerEvent( { action: 'openManager', source: 'system-panel' } );
+			break;
 	}
-
-	trackVariablesManagerEvent( { action: 'openManager', source: 'system-panel' } );
 };
 
 export function DesignSystemPanelContent( { onRequestClose }: DesignSystemPanelContentProps ) {

--- a/packages/packages/core/editor-design-system/src/components/design-system-panel-content.tsx
+++ b/packages/packages/core/editor-design-system/src/components/design-system-panel-content.tsx
@@ -81,6 +81,7 @@ export function DesignSystemPanelContent( { onRequestClose }: DesignSystemPanelC
 			setCurrentTab( tab );
 			persistDesignSystemTab( tab );
 			notifyDesignSystemTabChange( tab );
+			trackDesignSystemTabOpened( tab );
 		};
 
 		window.addEventListener( EVENT_SET_TAB, handler as EventListener );

--- a/packages/packages/core/editor-design-system/src/components/design-system-panel-content.tsx
+++ b/packages/packages/core/editor-design-system/src/components/design-system-panel-content.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { type SyntheticEvent, useCallback, useEffect, useRef, useState } from 'react';
-import { ClassManagerPanelEmbedded } from '@elementor/editor-global-classes';
+import { ClassManagerPanelEmbedded, trackGlobalClasses } from '@elementor/editor-global-classes';
 import { Panel, PanelBody, PanelHeader, PanelHeaderTitle } from '@elementor/editor-panels';
 import { ThemeProvider } from '@elementor/editor-ui';
-import { VariablesManagerPanelEmbedded } from '@elementor/editor-variables';
+import { trackVariablesManagerEvent, VariablesManagerPanelEmbedded } from '@elementor/editor-variables';
 import { ColorFilterIcon, ColorSwatchIcon } from '@elementor/icons';
 import { Box, CloseButton, Divider, Stack, Tab, Tabs, useTabs } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
@@ -29,6 +29,15 @@ export type DesignSystemPanelContentProps = {
 };
 
 const EVENT_SET_TAB = 'elementor/design-system/set-tab';
+
+const trackDesignSystemTabOpened = ( tab: DesignSystemTab ) => {
+	if ( tab === 'classes' ) {
+		trackGlobalClasses( { event: 'classManagerOpened', source: 'system-panel' } );
+		return;
+	}
+
+	trackVariablesManagerEvent( { action: 'openManager', source: 'system-panel' } );
+};
 
 export function DesignSystemPanelContent( { onRequestClose }: DesignSystemPanelContentProps ) {
 	const [ currentTab, setCurrentTab ] = useState( () => getInitialDesignSystemTab() );
@@ -132,6 +141,7 @@ export function DesignSystemPanelContent( { onRequestClose }: DesignSystemPanelC
 									setCurrentTab( newValue );
 									persistDesignSystemTab( newValue );
 									notifyDesignSystemTabChange( newValue );
+									trackDesignSystemTabOpened( newValue );
 								} }
 							>
 								<Tab

--- a/packages/packages/core/editor-design-system/src/import/tracking.ts
+++ b/packages/packages/core/editor-design-system/src/import/tracking.ts
@@ -10,6 +10,8 @@ type EventMap = {
 	confirmed: { conflict_choice: ConflictStrategy };
 	imported: object;
 	importFailed: object;
+	export: object;
+	opened: object;
 };
 
 export type DesignSystemTrackingEvent = {

--- a/packages/packages/core/editor-design-system/src/use-open-design-system-toolbar.ts
+++ b/packages/packages/core/editor-design-system/src/use-open-design-system-toolbar.ts
@@ -6,12 +6,17 @@ import { __ } from '@wordpress/i18n';
 const EVENT_TOGGLE = 'elementor/toggle-design-system';
 
 import { usePanelStatus } from './design-system-panel';
+import { trackDesignSystem } from './import/tracking';
 import { getActiveDesignSystemTab } from './initial-tab';
 
 export function useOpenDesignSystemToolbar(): ToggleActionProps {
 	const { isOpen } = usePanelStatus();
 
 	const onClick = useCallback( () => {
+		if ( ! isOpen ) {
+			trackDesignSystem( { event: 'opened' } );
+		}
+
 		const tab = getActiveDesignSystemTab() ?? 'variables';
 
 		window.dispatchEvent(
@@ -19,7 +24,7 @@ export function useOpenDesignSystemToolbar(): ToggleActionProps {
 				detail: { tab },
 			} )
 		);
-	}, [] );
+	}, [ isOpen ] );
 
 	return {
 		title: __( 'Design System', 'elementor' ),

--- a/packages/packages/core/editor-design-system/src/use-open-design-system-toolbar.ts
+++ b/packages/packages/core/editor-design-system/src/use-open-design-system-toolbar.ts
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import { type ToggleActionProps } from '@elementor/editor-app-bar';
 import { DropletHalfFilledIcon } from '@elementor/icons';
 import { __ } from '@wordpress/i18n';
@@ -12,24 +11,22 @@ import { getActiveDesignSystemTab } from './initial-tab';
 export function useOpenDesignSystemToolbar(): ToggleActionProps {
 	const { isOpen } = usePanelStatus();
 
-	const onClick = useCallback( () => {
-		if ( ! isOpen ) {
-			trackDesignSystem( { event: 'opened' } );
-		}
-
-		const tab = getActiveDesignSystemTab() ?? 'variables';
-
-		window.dispatchEvent(
-			new CustomEvent( EVENT_TOGGLE, {
-				detail: { tab },
-			} )
-		);
-	}, [ isOpen ] );
-
 	return {
 		title: __( 'Design System', 'elementor' ),
 		icon: DropletHalfFilledIcon,
-		onClick,
+		onClick: () => {
+			if ( ! isOpen ) {
+				trackDesignSystem( { event: 'opened' } );
+			}
+
+			const tab = getActiveDesignSystemTab() ?? 'variables';
+
+			window.dispatchEvent(
+				new CustomEvent( EVENT_TOGGLE, {
+					detail: { tab },
+				} )
+			);
+		},
 		selected: isOpen,
 	};
 }

--- a/packages/packages/core/editor-global-classes/src/index.ts
+++ b/packages/packages/core/editor-global-classes/src/index.ts
@@ -10,3 +10,4 @@ export { loadExistingClasses } from './load-existing-classes';
 export { addDocumentClasses } from './load-document-classes';
 export type { GlobalClassIndexEntry } from './api';
 export { createLabelsForClasses } from './utils/create-labels-for-classes';
+export { trackGlobalClasses } from './utils/tracking';

--- a/packages/packages/core/editor-global-classes/src/utils/tracking.ts
+++ b/packages/packages/core/editor-global-classes/src/utils/tracking.ts
@@ -38,7 +38,7 @@ type EventMap = {
 		classType: 'global' | 'local';
 	};
 	classManagerOpened: {
-		source: 'style-panel';
+		source: 'style-panel' | 'system-panel';
 	};
 	classManagerSearched: Record< string, never >;
 	classManagerFiltersOpened: Record< string, never >;

--- a/packages/packages/core/editor-variables/src/components/variables-selection.tsx
+++ b/packages/packages/core/editor-variables/src/components/variables-selection.tsx
@@ -95,6 +95,7 @@ export const VariablesSelection = ( { closePopover, onAdd, onEdit, onSettings, d
 			onSettings();
 			trackVariablesManagerEvent( {
 				action: 'openManager',
+				source: 'vars-popover',
 				varType: variableType,
 				controlPath: path.join( '.' ),
 			} );

--- a/packages/packages/core/editor-variables/src/index.ts
+++ b/packages/packages/core/editor-variables/src/index.ts
@@ -15,6 +15,7 @@ export {
 	type VariableManagerMenuAction,
 } from './variables-registry/variable-type-registry';
 export { hasVariable } from './hooks/use-prop-variables';
+export { trackVariablesManagerEvent } from './utils/tracking';
 
 import { globalVariablesLLMResolvers } from './utils/llm-propvalue-label-resolver';
 

--- a/packages/packages/core/editor-variables/src/utils/tracking.ts
+++ b/packages/packages/core/editor-variables/src/utils/tracking.ts
@@ -45,7 +45,7 @@ export const trackVariablesManagerEvent = ( { action, source, varType, controlPa
 		action_type: name,
 	};
 
-	if ( action === 'openManager' && source ) {
+	if ( source ) {
 		eventData.source = source;
 	}
 

--- a/packages/packages/core/editor-variables/src/utils/tracking.ts
+++ b/packages/packages/core/editor-variables/src/utils/tracking.ts
@@ -32,12 +32,7 @@ type VariablesManagerEventData = {
 	controlPath?: string;
 };
 
-export const trackVariablesManagerEvent = ( {
-	action,
-	source,
-	varType,
-	controlPath,
-}: VariablesManagerEventData ) => {
+export const trackVariablesManagerEvent = ( { action, source, varType, controlPath }: VariablesManagerEventData ) => {
 	const { dispatchEvent, config } = getMixpanel();
 	if ( ! config?.names?.variables?.[ action ] ) {
 		return;

--- a/packages/packages/core/editor-variables/src/utils/tracking.ts
+++ b/packages/packages/core/editor-variables/src/utils/tracking.ts
@@ -23,13 +23,21 @@ export const trackVariableEvent = ( { varType, controlPath, action }: VariableEv
 	} );
 };
 
+export type VariablesManagerOpenSource = 'vars-popover' | 'system-panel';
+
 type VariablesManagerEventData = {
 	action: 'openManager' | 'add' | 'saveChanges' | 'delete' | 'duplicate';
+	source?: VariablesManagerOpenSource;
 	varType?: string;
 	controlPath?: string;
 };
 
-export const trackVariablesManagerEvent = ( { action, varType, controlPath }: VariablesManagerEventData ) => {
+export const trackVariablesManagerEvent = ( {
+	action,
+	source,
+	varType,
+	controlPath,
+}: VariablesManagerEventData ) => {
 	const { dispatchEvent, config } = getMixpanel();
 	if ( ! config?.names?.variables?.[ action ] ) {
 		return;
@@ -41,6 +49,10 @@ export const trackVariablesManagerEvent = ( { action, varType, controlPath }: Va
 		trigger: config?.triggers?.click || '',
 		action_type: name,
 	};
+
+	if ( action === 'openManager' && source ) {
+		eventData.source = source;
+	}
 
 	if ( varType ) {
 		eventData.var_type = varType;


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

PR tracks design system interactions (tab opens, exports) via Mixpanel for analytics. Supports both classes and variables managers with source attribution to distinguish panel-triggered vs. popover-triggered events.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `design-system-panel-content.tsx` | Added `trackDesignSystemTabOpened()` function; tracks tab switches with source='system-panel' |
| `design-system-header-menu.tsx` | Track export event |
| `use-open-design-system-toolbar.ts` | Track opened event; removed unused `useCallback` |
| `editor-global-classes/utils/tracking.ts` | Extended `classManagerOpened` event schema with source field |
| `editor-variables/utils/tracking.ts` | Added `VariablesManagerOpenSource` type; extended `trackVariablesManagerEvent()` with optional source param |
| Test file | Added mocks and test cases for tracking calls |
| `events-config.js` | Registered two new event names (design_system_export, design_system_opened) |

## 3. How It Works

Tab switches dispatch `trackDesignSystemTabOpened()` which routes to appropriate tracker: `trackGlobalClasses()` for classes tab, `trackVariablesManagerEvent()` for variables tab. Both receive `source: 'system-panel'` to differentiate from other entry points (e.g., 'vars-popover'). Toolbar onClick now tracks panel opens before dispatching toggle event.

## 4. Risks

None identified. Schema extensions are backward-compatible (source is optional). Tests cover tab tracking paths. Event names registered in config prevents Mixpanel silencing.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
