### PR TITLE
Fix: Deduplicate wp.media attachment fetches by ID [ED-24407]

### DIFF
--- a/packages/packages/libs/wp-media/src/get-media-attachment.ts
+++ b/packages/packages/libs/wp-media/src/get-media-attachment.ts
@@ -1,22 +1,59 @@
 import media from './media';
 import normalize from './normalize';
+import { type Attachment } from './types/attachment';
 
-export async function getMediaAttachment( { id }: { id: number | null } ) {
+const resolvedAttachments = new Map< number, Attachment >();
+const inFlightAttachments = new Map< number, Promise< Attachment | null > >();
+
+export function clearMediaAttachmentCache(): void {
+	resolvedAttachments.clear();
+	inFlightAttachments.clear();
+}
+
+export async function getMediaAttachment( { id }: { id: number | null } ): Promise< Attachment | null > {
 	if ( ! id ) {
 		return null;
 	}
 
+	const cached = resolvedAttachments.get( id );
+
+	if ( cached ) {
+		return cached;
+	}
+
+	const inFlight = inFlightAttachments.get( id );
+
+	if ( inFlight ) {
+		return inFlight;
+	}
+
+	const request = loadMediaAttachment( id ).finally( () => {
+		inFlightAttachments.delete( id );
+	} );
+
+	inFlightAttachments.set( id, request );
+
+	return request;
+}
+
+async function loadMediaAttachment( id: number ): Promise< Attachment | null > {
 	const model = media().attachment( id );
 	const wpAttachment = model.toJSON();
 
 	const isFetched = 'url' in wpAttachment;
 
 	if ( isFetched ) {
-		return normalize( wpAttachment );
+		const normalized = normalize( wpAttachment );
+		resolvedAttachments.set( id, normalized );
+
+		return normalized;
 	}
 
 	try {
-		return normalize( await model.fetch() );
+		const normalized = normalize( await model.fetch() );
+		resolvedAttachments.set( id, normalized );
+
+		return normalized;
 	} catch {
 		return null;
 	}

--- a/packages/packages/libs/wp-media/src/hooks/__tests__/get-media-attachment.test.ts
+++ b/packages/packages/libs/wp-media/src/hooks/__tests__/get-media-attachment.test.ts
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react';
 
-import { getMediaAttachment } from '../../get-media-attachment';
+import { clearMediaAttachmentCache, getMediaAttachment } from '../../get-media-attachment';
 import media from '../../media';
 import { type Attachment } from '../../types/attachment';
 import { type WpAttachmentJSON } from '../../types/wp-media';
@@ -13,6 +13,11 @@ jest.mock( '../../media', () => ( {
 } ) );
 
 describe( 'getMediaAttachment', () => {
+	beforeEach( () => {
+		clearMediaAttachmentCache();
+		jest.clearAllMocks();
+	} );
+
 	it( 'should return null when there is no attachment id', async () => {
 		// Act.
 		const result = await getMediaAttachment( { id: null } );
@@ -140,6 +145,71 @@ describe( 'getMediaAttachment', () => {
 		await waitFor( () => {
 			expect( result ).toEqual( expected );
 		} );
+	} );
+
+	it( 'should call fetch only once for parallel requests with the same id', async () => {
+		const fetch = jest.fn().mockResolvedValue( {
+			id: 123,
+			url: 'url',
+			alt: 'alt',
+			height: 0,
+			width: 0,
+			filename: 'filename',
+			title: 'title',
+			mime: 'mime',
+			sizes: {},
+			type: 'type',
+			subtype: 'subtype',
+			uploadedTo: 2,
+			filesizeInBytes: 3,
+			filesizeHumanReadable: 'filesizeHumanReadable',
+			author: '4',
+			authorName: 'authorName',
+		} );
+
+		jest.mocked( media().attachment ).mockImplementation( ( id ) => ( {
+			toJSON: () => ( { id } ),
+			fetch,
+		} ) );
+
+		const [ first, second ] = await Promise.all( [
+			getMediaAttachment( { id: 123 } ),
+			getMediaAttachment( { id: 123 } ),
+		] );
+
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+		expect( first ).toEqual( second );
+	} );
+
+	it( 'should return cached attachment without calling fetch again', async () => {
+		const fetch = jest.fn().mockResolvedValue( {
+			id: 123,
+			url: 'url',
+			alt: 'alt',
+			height: 0,
+			width: 0,
+			filename: 'filename',
+			title: 'title',
+			mime: 'mime',
+			sizes: {},
+			type: 'type',
+			subtype: 'subtype',
+			uploadedTo: 2,
+			filesizeInBytes: 3,
+			filesizeHumanReadable: 'filesizeHumanReadable',
+			author: '4',
+			authorName: 'authorName',
+		} );
+
+		jest.mocked( media().attachment ).mockImplementation( ( id ) => ( {
+			toJSON: () => ( { id } ),
+			fetch,
+		} ) );
+
+		await getMediaAttachment( { id: 123 } );
+		await getMediaAttachment( { id: 123 } );
+
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( "should return null when the attachment can't be fetched", async () => {

--- a/packages/packages/libs/wp-media/src/index.ts
+++ b/packages/packages/libs/wp-media/src/index.ts
@@ -4,4 +4,4 @@ export type { OpenOptions, MediaType } from './hooks/use-wp-media-frame';
 export { default as useWpMediaAttachment } from './hooks/use-wp-media-attachment';
 export { default as useWpMediaFrame } from './hooks/use-wp-media-frame';
 
-export { getMediaAttachment } from './get-media-attachment';
+export { clearMediaAttachmentCache, getMediaAttachment } from './get-media-attachment';

--- a/tests/playwright/sanity/modules/v4-tests/media-attachment-dedup.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/media-attachment-dedup.test.ts
@@ -1,0 +1,103 @@
+import { resolve } from 'path';
+import { expect } from '@playwright/test';
+import { parallelTest as test } from '../../../parallelTest';
+import WpAdminPage from '../../../pages/wp-admin-page';
+import { type Image } from '../../../types/types';
+
+const SAMPLE_IMAGE: Image = {
+	title: 'dedup-test-image',
+	extension: 'png',
+	filePath: resolve( __dirname, '../home/assets/upgrade-free.png' ),
+};
+
+const isGetAttachmentRequest = ( url: string, postData: string | null ): boolean => {
+	if ( url.includes( 'get-attachment' ) ) {
+		return true;
+	}
+
+	if ( ! url.includes( 'admin-ajax.php' ) ) {
+		return false;
+	}
+
+	const payload = postData ?? '';
+
+	return payload.includes( 'action=get-attachment' );
+};
+
+const countGetAttachmentRequests = ( requests: { url: string; postData: string | null }[] ): number =>
+	requests.filter( ( { url, postData } ) => isGetAttachmentRequest( url, postData ) ).length;
+
+test.describe( 'Media attachment fetch deduplication @v4-media-dedup', () => {
+	test( 'Editor reload does not duplicate get-attachment for the same media ID', async ( {
+		page,
+		apiRequests,
+		request,
+	}, testInfo ) => {
+		test.setTimeout( 180000 );
+		const mediaId = await apiRequests.createMedia( request, SAMPLE_IMAGE );
+
+		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+		const editor = await wpAdmin.openNewPage();
+
+		const imageSettings = {
+			image: {
+				$$type: 'image',
+				value: {
+					src: {
+						$$type: 'image-src',
+						value: {
+							id: { $$type: 'image-attachment-id', value: mediaId },
+							url: null,
+						},
+					},
+					size: { $$type: 'string', value: 'full' },
+				},
+			},
+		};
+
+		const containerId = await editor.addElement( { elType: 'container' }, 'document' );
+
+		const imageWidgetIds: string[] = [];
+
+		for ( let index = 0; index < 3; index++ ) {
+			const widgetId = await editor.addWidget( { widgetType: 'e-image', container: containerId } );
+			await editor.applyElementSettings( widgetId, imageSettings );
+			imageWidgetIds.push( widgetId );
+		}
+
+		await editor.waitForPreviewFrame();
+
+		for ( const widgetId of imageWidgetIds ) {
+			await expect( editor.getPreviewFrame().locator( `[data-id="${ widgetId }"] img` ) ).toBeVisible( {
+				timeout: 30000,
+			} );
+		}
+
+		await page.evaluate( async () => {
+			await $e.run( 'document/save/update' );
+		} );
+
+		const editorUrl = page.url();
+		const getAttachmentRequests: { url: string; postData: string | null }[] = [];
+
+		page.on( 'request', ( req ) => {
+			getAttachmentRequests.push( {
+				url: req.url(),
+				postData: 'POST' === req.method() ? req.postData() : null,
+			} );
+		} );
+
+		await page.reload( { waitUntil: 'load', timeout: 120000 } );
+
+		await editor.waitForPreviewFrame();
+
+		await page.waitForTimeout( 15000 );
+
+		const getAttachmentCount = countGetAttachmentRequests( getAttachmentRequests );
+
+		expect(
+			getAttachmentCount,
+			`Expected at most one get-attachment request for shared media ID ${ mediaId } after reload, got ${ getAttachmentCount }. Editor URL: ${ editorUrl }`,
+		).toBeLessThanOrEqual( 1 );
+	} );
+} );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes duplicate `admin-ajax.php?action=get-attachment` requests reported in [ED-24407](https://elementor.atlassian.net/browse/ED-24407) / [BFJSM-2240](https://elementor.atlassian.net/browse/BFJSM-2240).

V4 style resolution and panel controls both call `getMediaAttachment()` from `@elementor/wp-media`. Each call previously invoked `wp.media.attachment( id ).fetch()` independently, so the same attachment ID could trigger multiple parallel or repeated AJAX requests on editor load.

## Changes

- **In-flight deduplication:** parallel `getMediaAttachment({ id })` calls for the same ID share one `fetch()` promise.
- **Settled cache:** successful attachments are stored in a module-level map so later calls return without hitting `wp.media` again.
- **`clearMediaAttachmentCache()`:** exported for tests (and future document-switch invalidation if needed).
- **Playwright regression:** `media-attachment-dedup.test.ts` — three `e-image` widgets sharing one media ID, editor reload, asserts ≤1 `get-attachment` request.

## Validation

| Check | Result |
|--------|--------|
| `npm run test:packages -- --testPathPattern=packages/libs/wp-media` | 16 passed |
| `npm run test:packages` (styles/settings resolver) | 21 passed |
| `npm run build:packages` | Success |
| `npm run build:packages` + `npx grunt scripts` | Success |
| WP Playground (`npm run wp-playground` @ http://127.0.0.1:9400) | Running |
| `DEV_SERVER=http://127.0.0.1:9400 npm run test:playwright -- tests/playwright/sanity/modules/v4-tests/media-attachment-dedup.test.ts` | **Passed** |

## Notes

- Failed fetches are not cached, so retries still work.
- Distinct attachment IDs still perform one fetch each (expected).
- Batching via `elementor_get_images_details` remains a possible follow-up for image-heavy pages.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e529b0d-9837-432b-91da-0aa13f122c55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e529b0d-9837-432b-91da-0aa13f122c55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ED-24407]: https://elementor.atlassian.net/browse/ED-24407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BFJSM-2240]: https://elementor.atlassian.net/browse/BFJSM-2240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ