### PR TITLE
Internal: Update popup logic text [ED-24301]

### DIFF
--- a/modules/promotions/data/birthday-promotion-actions.php
+++ b/modules/promotions/data/birthday-promotion-actions.php
@@ -20,7 +20,7 @@ class Birthday_Promotion_Actions {
 	}
 
 	private function ajax_set_cta_visited( array $data ): array {
-		if ( ! current_user_can( 'edit_posts' ) ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( 'Insufficient permissions', 403 );
 		}
 

--- a/modules/promotions/widgets/birthday-easter-egg-promotion.php
+++ b/modules/promotions/widgets/birthday-easter-egg-promotion.php
@@ -148,6 +148,7 @@ class Birthday_Easter_Egg_Promotion {
 
 	private function should_show_promotion(): bool {
 		return (
+			$this->does_have_permissions() &&
 			$this->has_valid_assets() &&
 			self::is_v4_active() &&
 			! $this->birthday_promotion_actions->has_visited_cta() &&
@@ -171,6 +172,10 @@ class Birthday_Easter_Egg_Promotion {
 		$now = time();
 
 		return $now >= $start && $now <= $end;
+	}
+
+	private function does_have_permissions(): bool {
+		return current_user_can( 'manage_options' );
 	}
 
 	private function set_lottie_data_transient( array $value ): bool {

--- a/tests/phpunit/elementor/modules/promotions/test-birthday-easter-egg-promotion.php
+++ b/tests/phpunit/elementor/modules/promotions/test-birthday-easter-egg-promotion.php
@@ -64,6 +64,21 @@ class Test_Birthday_Easter_Egg_Promotion extends Elementor_Test_Base {
 		update_user_meta( $this->current_user_id, Birthday_Promotion_Actions::CTA_VISITED_KEY, 1 );
 	}
 
+	/**
+	 * `wp_send_json_error` calls bare `die` outside an ajax context, killing the
+	 * test runner before output can be captured. Forcing the ajax path + swapping
+	 * the ajax `wp_die` handler for a throwing one turns the rejection into a
+	 * catchable exception. WP_UnitTestCase restores filters between tests.
+	 */
+	private function capture_wp_send_json_die(): void {
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', function () {
+			return function ( $message ) {
+				throw new \WPDieException( is_string( $message ) ? $message : '' );
+			};
+		} );
+	}
+
 	private function data_with_window( int $start_offset_seconds, int $end_offset_seconds ): array {
 		return $this->data_with_raw_window(
 			gmdate( 'Y-m-d\TH:i:s\Z', time() + $start_offset_seconds ),
@@ -209,9 +224,11 @@ class Test_Birthday_Easter_Egg_Promotion extends Elementor_Test_Base {
 	public function test_ajax_set_cta_visited__rejects_user_without_manage_options() {
 		$editor_user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
 		wp_set_current_user( $editor_user_id );
+		$this->capture_wp_send_json_die();
 
 		$actions = new Testable_Birthday_Promotion_Actions();
 
+		$this->expectOutputRegex( '/"success":false.*"Insufficient permissions"/' );
 		$this->expectException( \WPDieException::class );
 
 		try {
@@ -226,9 +243,11 @@ class Test_Birthday_Easter_Egg_Promotion extends Elementor_Test_Base {
 
 	public function test_ajax_set_cta_visited__rejects_logged_out_user() {
 		wp_set_current_user( 0 );
+		$this->capture_wp_send_json_die();
 
 		$actions = new Testable_Birthday_Promotion_Actions();
 
+		$this->expectOutputRegex( '/"success":false.*"Insufficient permissions"/' );
 		$this->expectException( \WPDieException::class );
 
 		$actions->call_private(

--- a/tests/phpunit/elementor/modules/promotions/test-birthday-easter-egg-promotion.php
+++ b/tests/phpunit/elementor/modules/promotions/test-birthday-easter-egg-promotion.php
@@ -40,7 +40,7 @@ class Test_Birthday_Easter_Egg_Promotion extends Elementor_Test_Base {
 		$this->original_v4_default_state = Plugin::$instance->experiments
 			->get_features( AtomicWidgetsModule::EXPERIMENT_NAME )['default'];
 
-		$this->current_user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		$this->current_user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $this->current_user_id );
 	}
 
@@ -259,6 +259,33 @@ class Test_Birthday_Easter_Egg_Promotion extends Elementor_Test_Base {
 		$this->assertFalse( $promotion->call_private( 'should_show_promotion' ) );
 	}
 
+	public function test_should_show_promotion__returns_false_when_user_lacks_manage_options() {
+		$this->set_v4_active( true );
+
+		$editor_user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_user_id );
+
+		$promotion = new Testable_Birthday_Easter_Egg_Promotion(
+			$this->data_with_window( -3600, 3600 ),
+			self::VALID_LOTTIE
+		);
+
+		$this->assertFalse( $promotion->call_private( 'should_show_promotion' ) );
+	}
+
+	public function test_should_show_promotion__returns_false_when_user_logged_out() {
+		$this->set_v4_active( true );
+
+		wp_set_current_user( 0 );
+
+		$promotion = new Testable_Birthday_Easter_Egg_Promotion(
+			$this->data_with_window( -3600, 3600 ),
+			self::VALID_LOTTIE
+		);
+
+		$this->assertFalse( $promotion->call_private( 'should_show_promotion' ) );
+	}
+
 	public function test_should_show_promotion__returns_false_when_v4_inactive() {
 		$this->set_v4_active( false );
 
@@ -355,8 +382,10 @@ class Test_Birthday_Easter_Egg_Promotion extends Elementor_Test_Base {
 	public function test_should_show_promotion__short_circuits_on_first_failing_gate() {
 		// Belt-and-braces: every gate fails simultaneously. Just asserts false; if any
 		// gate were to throw on a missing precondition we'd surface it here.
+		$editor_user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_user_id );
+		update_user_meta( $editor_user_id, Birthday_Promotion_Actions::CTA_VISITED_KEY, 1 );
 		$this->set_v4_active( false );
-		$this->mark_cta_visited();
 
 		$promotion = new Testable_Birthday_Easter_Egg_Promotion( [], null );
 

--- a/tests/phpunit/elementor/modules/promotions/test-birthday-easter-egg-promotion.php
+++ b/tests/phpunit/elementor/modules/promotions/test-birthday-easter-egg-promotion.php
@@ -161,9 +161,6 @@ class Test_Birthday_Easter_Egg_Promotion extends Elementor_Test_Base {
 	}
 
 	public function test_ajax_set_cta_visited__persists_true_as_one() {
-		$user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
-		wp_set_current_user( $user_id );
-
 		$actions = new Testable_Birthday_Promotion_Actions();
 		$response = $actions->call_private(
 			'ajax_set_cta_visited',
@@ -171,13 +168,10 @@ class Test_Birthday_Easter_Egg_Promotion extends Elementor_Test_Base {
 		);
 
 		$this->assertSame( [ Birthday_Promotion_Actions::VISITED_PARAM => true ], $response );
-		$this->assertSame( '1', get_user_meta( $user_id, Birthday_Promotion_Actions::CTA_VISITED_KEY, true ) );
+		$this->assertSame( '1', get_user_meta( $this->current_user_id, Birthday_Promotion_Actions::CTA_VISITED_KEY, true ) );
 	}
 
 	public function test_ajax_set_cta_visited__persists_false_as_zero() {
-		$user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
-		wp_set_current_user( $user_id );
-
 		$actions = new Testable_Birthday_Promotion_Actions();
 		$response = $actions->call_private(
 			'ajax_set_cta_visited',
@@ -185,24 +179,18 @@ class Test_Birthday_Easter_Egg_Promotion extends Elementor_Test_Base {
 		);
 
 		$this->assertSame( [ Birthday_Promotion_Actions::VISITED_PARAM => false ], $response );
-		$this->assertSame( '0', get_user_meta( $user_id, Birthday_Promotion_Actions::CTA_VISITED_KEY, true ) );
+		$this->assertSame( '0', get_user_meta( $this->current_user_id, Birthday_Promotion_Actions::CTA_VISITED_KEY, true ) );
 	}
 
 	public function test_ajax_set_cta_visited__defaults_to_true_when_param_missing() {
-		$user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
-		wp_set_current_user( $user_id );
-
 		$actions = new Testable_Birthday_Promotion_Actions();
 		$response = $actions->call_private( 'ajax_set_cta_visited', [ [] ] );
 
 		$this->assertSame( [ Birthday_Promotion_Actions::VISITED_PARAM => true ], $response );
-		$this->assertSame( '1', get_user_meta( $user_id, Birthday_Promotion_Actions::CTA_VISITED_KEY, true ) );
+		$this->assertSame( '1', get_user_meta( $this->current_user_id, Birthday_Promotion_Actions::CTA_VISITED_KEY, true ) );
 	}
 
 	public function test_ajax_set_cta_visited__coerces_string_booleans() {
-		$user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
-		wp_set_current_user( $user_id );
-
 		$actions = new Testable_Birthday_Promotion_Actions();
 
 		$response = $actions->call_private(
@@ -216,6 +204,37 @@ class Test_Birthday_Easter_Egg_Promotion extends Elementor_Test_Base {
 			[ [ Birthday_Promotion_Actions::VISITED_PARAM => '0' ] ]
 		);
 		$this->assertFalse( $response[ Birthday_Promotion_Actions::VISITED_PARAM ] );
+	}
+
+	public function test_ajax_set_cta_visited__rejects_user_without_manage_options() {
+		$editor_user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_user_id );
+
+		$actions = new Testable_Birthday_Promotion_Actions();
+
+		$this->expectException( \WPDieException::class );
+
+		try {
+			$actions->call_private(
+				'ajax_set_cta_visited',
+				[ [ Birthday_Promotion_Actions::VISITED_PARAM => true ] ]
+			);
+		} finally {
+			$this->assertSame( '', get_user_meta( $editor_user_id, Birthday_Promotion_Actions::CTA_VISITED_KEY, true ) );
+		}
+	}
+
+	public function test_ajax_set_cta_visited__rejects_logged_out_user() {
+		wp_set_current_user( 0 );
+
+		$actions = new Testable_Birthday_Promotion_Actions();
+
+		$this->expectException( \WPDieException::class );
+
+		$actions->call_private(
+			'ajax_set_cta_visited',
+			[ [ Birthday_Promotion_Actions::VISITED_PARAM => true ] ]
+		);
 	}
 
 	public function test_should_show_promotion__returns_true_when_all_conditions_met() {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Tightens permission model for birthday promotion feature from 'edit_posts' to 'manage_options', enforcing admin-only access. Aligns with security best practices for administrative UI elements (ED-24301).

## 2. What Changed (Where)

- **birthday-promotion-actions.php**: Permission check changed from `edit_posts` → `manage_options` in ajax handler
- **birthday-easter-egg-promotion.php**: Added `does_have_permissions()` method, integrated into `should_show_promotion()` condition
- **test-birthday-easter-egg-promotion.php**: Test setup uses admin role; added permission rejection tests; removed per-test user setup boilerplate

## 3. How It Works

Permission validation now enforced at two layers: (1) ajax handler rejects non-admins immediately with 403, (2) promotion widget gates visibility behind `does_have_permissions()` check. Tests centralize admin user creation in setUp(), add negative cases for editors and logged-out users via helper `capture_wp_send_json_die()` to handle die() in non-ajax context.

## 4. Risks

None identified. Change is additive (tighter restrictions), backward-compatible test refactoring, and new permission gates have explicit coverage for rejection paths.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
