### PR TITLE
Internal: Optimize dynamic tags fetching [ED-24339]

### DIFF
--- a/assets/dev/js/editor/components/dynamic-tags/manager.js
+++ b/assets/dev/js/editor/components/dynamic-tags/manager.js
@@ -8,26 +8,35 @@ module.exports = elementorModules.Module.extend( {
 
 	cache: {},
 
+	batchCache: {},
+
 	cacheRequests: {},
+
+	batchCacheRequests: {},
 
 	cacheCallbacks: [],
 
-	addCacheRequest( tag ) {
-		const postId = this.getTagRenderPostId( tag );
-		const cacheKey = this.createCacheKey( tag );
+	batchCacheCallbacks: [],
 
-		if ( ! this.cacheRequests[ postId ] ) {
-			this.cacheRequests[ postId ] = {};
-		}
+	flushCallbacks: [],
 
-		this.cacheRequests[ postId ][ cacheKey ] = true;
+	isBatchPostContext( postId ) {
+		return Number( postId ) !== Number( elementor.config.document.id );
+	},
+
+	getCacheStore( postId ) {
+		return this.isBatchPostContext( postId ) ? this.batchCache : this.cache;
 	},
 
 	getTagRenderPostId( tag ) {
 		return tag.editorRenderPostId ?? elementor.config.document.id;
 	},
 
-	createCacheKey( tag ) {
+	createLegacyCacheKey( tag ) {
+		return btoa( tag.getOption( 'name' ) ) + '-' + btoa( encodeURIComponent( JSON.stringify( tag.model ) ) );
+	},
+
+	createBatchCacheKey( tag ) {
 		return this.buildCacheKeyFor(
 			tag.getOption( 'name' ),
 			tag.model,
@@ -35,22 +44,81 @@ module.exports = elementorModules.Module.extend( {
 		);
 	},
 
+	getCacheKeyForTag( tag ) {
+		const postId = this.getTagRenderPostId( tag );
+
+		if ( this.isBatchPostContext( postId ) ) {
+			return this.createBatchCacheKey( tag );
+		}
+
+		return this.createLegacyCacheKey( tag );
+	},
+
+	createCacheKey( tag ) {
+		return this.getCacheKeyForTag( tag );
+	},
+
 	buildCacheKeyFor( tagName, tagSettings, postId ) {
 		return btoa( tagName ) + '-' + btoa( encodeURIComponent( JSON.stringify( tagSettings ) ) ) + '-' + postId;
 	},
 
-	loadTagDataFromCache( tag ) {
-		var cacheKey = this.createCacheKey( tag );
+	addCacheRequest( tag ) {
+		const postId = this.getTagRenderPostId( tag );
+		const cacheKey = this.getCacheKeyForTag( tag );
 
-		if ( undefined !== this.cache[ cacheKey ] ) {
-			return this.cache[ cacheKey ];
+		if ( this.isBatchPostContext( postId ) ) {
+			if ( ! this.batchCacheRequests[ postId ] ) {
+				this.batchCacheRequests[ postId ] = {};
+			}
+
+			this.batchCacheRequests[ postId ][ cacheKey ] = true;
+
+			return;
 		}
 
-		const postId = this.getTagRenderPostId( tag );
+		this.cacheRequests[ cacheKey ] = true;
+	},
 
-		if ( ! this.cacheRequests[ postId ] || ! this.cacheRequests[ postId ][ cacheKey ] ) {
+	loadTagDataFromCache( tag ) {
+		const postId = this.getTagRenderPostId( tag );
+		const cacheKey = this.getCacheKeyForTag( tag );
+		const cacheStore = this.getCacheStore( postId );
+
+		if ( undefined !== cacheStore[ cacheKey ] ) {
+			return cacheStore[ cacheKey ];
+		}
+
+		if ( this.isBatchPostContext( postId ) ) {
+			if ( ! this.batchCacheRequests[ postId ] || ! this.batchCacheRequests[ postId ][ cacheKey ] ) {
+				this.addCacheRequest( tag );
+			}
+
+			return;
+		}
+
+		if ( ! this.cacheRequests[ cacheKey ] ) {
 			this.addCacheRequest( tag );
 		}
+	},
+
+	hasPendingLegacyCacheRequests() {
+		return Object.keys( this.cacheRequests ).some(
+			( cacheKey ) => undefined === this.cache[ cacheKey ],
+		);
+	},
+
+	hasPendingBatchCacheRequests() {
+		return Object.keys( this.batchCacheRequests ).some( ( postId ) => {
+			return Object.keys( this.batchCacheRequests[ postId ] ).some(
+				( cacheKey ) => undefined === this.batchCache[ cacheKey ],
+			);
+		} );
+	},
+
+	runCacheCallbacks( callbacks ) {
+		callbacks.forEach( ( entry ) => {
+			entry.callback();
+		} );
 	},
 
 	loadCacheRequests() {
@@ -61,17 +129,59 @@ module.exports = elementorModules.Module.extend( {
 
 		this.cacheCallbacks = [];
 
-		var groups = Object.keys( cacheRequests )
+		var tags = Object.keys( cacheRequests ).filter( ( cacheKey ) => undefined === this.cache[ cacheKey ] );
+
+		if ( 0 === tags.length ) {
+			this.runCacheCallbacks( cacheCallbacks );
+
+			return;
+		}
+
+		var ajaxOptions = {
+			data: {
+				post_id: elementor.config.document.id,
+				tags,
+			},
+			success: ( data ) => {
+				this.cache = {
+					...this.cache,
+					...data,
+				};
+
+				this.runCacheCallbacks( cacheCallbacks );
+			},
+		};
+
+		var disableCache = cacheCallbacks.some( ( entry ) => {
+			return entry.disableCache;
+		} );
+
+		if ( disableCache ) {
+			ajaxOptions.unique_id = `render_tags-${ elementorCommon.helpers.getUniqueId() }`;
+		}
+
+		elementorCommon.ajax.addRequest( 'render_tags', ajaxOptions );
+	},
+
+	loadBatchCacheRequests() {
+		var batchCacheRequests = this.batchCacheRequests,
+			batchCacheCallbacks = this.batchCacheCallbacks;
+
+		this.batchCacheRequests = {};
+
+		this.batchCacheCallbacks = [];
+
+		var groups = Object.keys( batchCacheRequests )
 			.map( ( postId ) => ( {
 				post_id: Number( postId ),
-				tags: Object.keys( cacheRequests[ postId ] ).filter( ( cacheKey ) => undefined === this.cache[ cacheKey ] ),
+				tags: Object.keys( batchCacheRequests[ postId ] ).filter(
+					( cacheKey ) => undefined === this.batchCache[ cacheKey ],
+				),
 			} ) )
 			.filter( ( group ) => group.tags.length > 0 );
 
 		if ( 0 === groups.length ) {
-			cacheCallbacks.forEach( ( entry ) => {
-				entry.callback();
-			} );
+			this.runCacheCallbacks( batchCacheCallbacks );
 
 			return;
 		}
@@ -81,18 +191,16 @@ module.exports = elementorModules.Module.extend( {
 				groups,
 			},
 			success: ( data ) => {
-				this.cache = {
-					...this.cache,
+				this.batchCache = {
+					...this.batchCache,
 					...data,
 				};
 
-				cacheCallbacks.forEach( ( entry ) => {
-					entry.callback();
-				} );
+				this.runCacheCallbacks( batchCacheCallbacks );
 			},
 		};
 
-		var disableCache = cacheCallbacks.some( ( entry ) => {
+		var disableCache = batchCacheCallbacks.some( ( entry ) => {
 			return entry.disableCache;
 		} );
 
@@ -103,37 +211,82 @@ module.exports = elementorModules.Module.extend( {
 		elementorCommon.ajax.addRequest( 'render_tags_batch', ajaxOptions );
 	},
 
+	flushCacheRequests() {
+		const flushCallbacks = this.flushCallbacks;
+		const disableCache = flushCallbacks.some( ( entry ) => entry.disableCache );
+
+		this.flushCallbacks = [];
+
+		let pendingPaths = 0;
+
+		const completeFlush = () => {
+			pendingPaths--;
+
+			if ( pendingPaths > 0 ) {
+				return;
+			}
+
+			this.runCacheCallbacks( flushCallbacks );
+		};
+
+		if ( this.hasPendingLegacyCacheRequests() ) {
+			pendingPaths++;
+
+			this.cacheCallbacks.push( {
+				callback: completeFlush,
+				disableCache,
+			} );
+
+			this.loadCacheRequestsImmediate();
+		}
+
+		if ( this.hasPendingBatchCacheRequests() ) {
+			pendingPaths++;
+
+			this.batchCacheCallbacks.push( {
+				callback: completeFlush,
+				disableCache,
+			} );
+
+			this.loadBatchCacheRequestsImmediate();
+		}
+
+		if ( 0 === pendingPaths ) {
+			this.runCacheCallbacks( flushCallbacks );
+		}
+	},
+
 	prefetchTags( tagsByPostId ) {
 		var self = this;
 
 		Object.keys( tagsByPostId ).forEach( ( postId ) => {
-			if ( ! self.cacheRequests[ postId ] ) {
-				self.cacheRequests[ postId ] = {};
+			if ( ! self.batchCacheRequests[ postId ] ) {
+				self.batchCacheRequests[ postId ] = {};
 			}
 
 			tagsByPostId[ postId ].forEach( ( cacheKey ) => {
-				if ( undefined === self.cache[ cacheKey ] ) {
-					self.cacheRequests[ postId ][ cacheKey ] = true;
+				if ( undefined === self.batchCache[ cacheKey ] ) {
+					self.batchCacheRequests[ postId ][ cacheKey ] = true;
 				}
 			} );
 		} );
 
 		return new Promise( ( resolve ) => {
-			self.cacheCallbacks.push( {
+			self.batchCacheCallbacks.push( {
 				callback: resolve,
 			} );
 
-			self.loadCacheRequestsImmediate();
+			self.loadBatchCacheRequestsImmediate();
 		} );
 	},
 
 	refreshCacheFromServer( callback, options ) {
-		this.cacheCallbacks.push( {
+		this.flushCallbacks.push( {
 			callback,
 			disableCache: options?.disableCache,
 		} );
 
-		this.loadCacheRequests();
+		this.flushCacheRequests();
 	},
 
 	getConfig( key ) {
@@ -223,10 +376,19 @@ module.exports = elementorModules.Module.extend( {
 
 	cleanCache() {
 		this.cache = {};
+		this.batchCache = {};
+		this.cacheRequests = {};
+		this.batchCacheRequests = {};
 	},
 
 	onInit() {
 		this.loadCacheRequestsImmediate = this.loadCacheRequests.bind( this );
 		this.loadCacheRequests = _.debounce( this.loadCacheRequestsImmediate, 300 );
+
+		this.loadBatchCacheRequestsImmediate = this.loadBatchCacheRequests.bind( this );
+		this.loadBatchCacheRequests = _.debounce( this.loadBatchCacheRequestsImmediate, 300 );
+
+		this.flushCacheRequestsImmediate = this.flushCacheRequests.bind( this );
+		this.flushCacheRequests = _.debounce( this.flushCacheRequestsImmediate, 300 );
 	},
 } );

--- a/assets/dev/js/editor/components/dynamic-tags/manager.js
+++ b/assets/dev/js/editor/components/dynamic-tags/manager.js
@@ -13,11 +13,30 @@ module.exports = elementorModules.Module.extend( {
 	cacheCallbacks: [],
 
 	addCacheRequest( tag ) {
-		this.cacheRequests[ this.createCacheKey( tag ) ] = true;
+		const postId = this.getTagRenderPostId( tag );
+		const cacheKey = this.createCacheKey( tag );
+
+		if ( ! this.cacheRequests[ postId ] ) {
+			this.cacheRequests[ postId ] = {};
+		}
+
+		this.cacheRequests[ postId ][ cacheKey ] = true;
+	},
+
+	getTagRenderPostId( tag ) {
+		return tag.editorRenderPostId ?? elementor.config.document.id;
 	},
 
 	createCacheKey( tag ) {
-		return btoa( tag.getOption( 'name' ) ) + '-' + btoa( encodeURIComponent( JSON.stringify( tag.model ) ) );
+		return this.buildCacheKeyFor(
+			tag.getOption( 'name' ),
+			tag.model,
+			this.getTagRenderPostId( tag ),
+		);
+	},
+
+	buildCacheKeyFor( tagName, tagSettings, postId ) {
+		return btoa( tagName ) + '-' + btoa( encodeURIComponent( JSON.stringify( tagSettings ) ) ) + '-' + postId;
 	},
 
 	loadTagDataFromCache( tag ) {
@@ -27,7 +46,9 @@ module.exports = elementorModules.Module.extend( {
 			return this.cache[ cacheKey ];
 		}
 
-		if ( ! this.cacheRequests[ cacheKey ] ) {
+		const postId = this.getTagRenderPostId( tag );
+
+		if ( ! this.cacheRequests[ postId ] || ! this.cacheRequests[ postId ][ cacheKey ] ) {
 			this.addCacheRequest( tag );
 		}
 	},
@@ -40,10 +61,24 @@ module.exports = elementorModules.Module.extend( {
 
 		this.cacheCallbacks = [];
 
+		var groups = Object.keys( cacheRequests )
+			.map( ( postId ) => ( {
+				post_id: Number( postId ),
+				tags: Object.keys( cacheRequests[ postId ] ).filter( ( cacheKey ) => undefined === this.cache[ cacheKey ] ),
+			} ) )
+			.filter( ( group ) => group.tags.length > 0 );
+
+		if ( 0 === groups.length ) {
+			cacheCallbacks.forEach( ( entry ) => {
+				entry.callback();
+			} );
+
+			return;
+		}
+
 		var ajaxOptions = {
 			data: {
-				post_id: elementor.config.document.id,
-				tags: Object.keys( cacheRequests ),
+				groups,
 			},
 			success: ( data ) => {
 				this.cache = {
@@ -51,21 +86,45 @@ module.exports = elementorModules.Module.extend( {
 					...data,
 				};
 
-				cacheCallbacks.forEach( function( entry ) {
+				cacheCallbacks.forEach( ( entry ) => {
 					entry.callback();
 				} );
 			},
 		};
 
-		var disableCache = cacheCallbacks.some( function( entry ) {
+		var disableCache = cacheCallbacks.some( ( entry ) => {
 			return entry.disableCache;
 		} );
 
 		if ( disableCache ) {
-			ajaxOptions.unique_id = `render_tags-${ elementorCommon.helpers.getUniqueId() }`;
+			ajaxOptions.unique_id = `render_tags_batch-${ elementorCommon.helpers.getUniqueId() }`;
 		}
 
-		elementorCommon.ajax.addRequest( 'render_tags', ajaxOptions );
+		elementorCommon.ajax.addRequest( 'render_tags_batch', ajaxOptions );
+	},
+
+	prefetchTags( tagsByPostId ) {
+		var self = this;
+
+		Object.keys( tagsByPostId ).forEach( ( postId ) => {
+			if ( ! self.cacheRequests[ postId ] ) {
+				self.cacheRequests[ postId ] = {};
+			}
+
+			tagsByPostId[ postId ].forEach( ( cacheKey ) => {
+				if ( undefined === self.cache[ cacheKey ] ) {
+					self.cacheRequests[ postId ][ cacheKey ] = true;
+				}
+			} );
+		} );
+
+		return new Promise( ( resolve ) => {
+			self.cacheCallbacks.push( {
+				callback: resolve,
+			} );
+
+			self.loadCacheRequestsImmediate();
+		} );
 	},
 
 	refreshCacheFromServer( callback, options ) {
@@ -167,6 +226,7 @@ module.exports = elementorModules.Module.extend( {
 	},
 
 	onInit() {
-		this.loadCacheRequests = _.debounce( this.loadCacheRequests, 300 );
+		this.loadCacheRequestsImmediate = this.loadCacheRequests.bind( this );
+		this.loadCacheRequests = _.debounce( this.loadCacheRequestsImmediate, 300 );
 	},
 } );

--- a/assets/dev/js/editor/components/dynamic-tags/manager.js
+++ b/assets/dev/js/editor/components/dynamic-tags/manager.js
@@ -8,31 +8,25 @@ module.exports = elementorModules.Module.extend( {
 
 	cache: {},
 
-	batchCache: {},
-
 	cacheRequests: {},
-
-	batchCacheRequests: {},
 
 	cacheCallbacks: [],
 
+	batchCache: {},
+
+	batchCacheRequests: {},
+
 	batchCacheCallbacks: [],
-
-	flushCallbacks: [],
-
-	isBatchPostContext( postId ) {
-		return Number( postId ) !== Number( elementor.config.document.id );
-	},
-
-	getCacheStore( postId ) {
-		return this.isBatchPostContext( postId ) ? this.batchCache : this.cache;
-	},
 
 	getTagRenderPostId( tag ) {
 		return tag.editorRenderPostId ?? elementor.config.document.id;
 	},
 
-	createLegacyCacheKey( tag ) {
+	isBatchPostContext( postId ) {
+		return Number( postId ) !== Number( elementor.config.document.id );
+	},
+
+	createCacheKey( tag ) {
 		return btoa( tag.getOption( 'name' ) ) + '-' + btoa( encodeURIComponent( JSON.stringify( tag.model ) ) );
 	},
 
@@ -44,56 +38,48 @@ module.exports = elementorModules.Module.extend( {
 		);
 	},
 
-	getCacheKeyForTag( tag ) {
-		const postId = this.getTagRenderPostId( tag );
-
-		if ( this.isBatchPostContext( postId ) ) {
-			return this.createBatchCacheKey( tag );
-		}
-
-		return this.createLegacyCacheKey( tag );
-	},
-
-	createCacheKey( tag ) {
-		return this.getCacheKeyForTag( tag );
-	},
-
 	buildCacheKeyFor( tagName, tagSettings, postId ) {
 		return btoa( tagName ) + '-' + btoa( encodeURIComponent( JSON.stringify( tagSettings ) ) ) + '-' + postId;
 	},
 
 	addCacheRequest( tag ) {
 		const postId = this.getTagRenderPostId( tag );
-		const cacheKey = this.getCacheKeyForTag( tag );
 
 		if ( this.isBatchPostContext( postId ) ) {
+			const batchCacheKey = this.createBatchCacheKey( tag );
+
 			if ( ! this.batchCacheRequests[ postId ] ) {
 				this.batchCacheRequests[ postId ] = {};
 			}
 
-			this.batchCacheRequests[ postId ][ cacheKey ] = true;
-
+			this.batchCacheRequests[ postId ][ batchCacheKey ] = true;
 			return;
 		}
 
-		this.cacheRequests[ cacheKey ] = true;
+		this.cacheRequests[ this.createCacheKey( tag ) ] = true;
 	},
 
 	loadTagDataFromCache( tag ) {
 		const postId = this.getTagRenderPostId( tag );
-		const cacheKey = this.getCacheKeyForTag( tag );
-		const cacheStore = this.getCacheStore( postId );
-
-		if ( undefined !== cacheStore[ cacheKey ] ) {
-			return cacheStore[ cacheKey ];
-		}
 
 		if ( this.isBatchPostContext( postId ) ) {
-			if ( ! this.batchCacheRequests[ postId ] || ! this.batchCacheRequests[ postId ][ cacheKey ] ) {
+			const batchCacheKey = this.createBatchCacheKey( tag );
+
+			if ( undefined !== this.batchCache[ batchCacheKey ] ) {
+				return this.batchCache[ batchCacheKey ];
+			}
+
+			if ( ! this.batchCacheRequests[ postId ] || ! this.batchCacheRequests[ postId ][ batchCacheKey ] ) {
 				this.addCacheRequest( tag );
 			}
 
 			return;
+		}
+
+		const cacheKey = this.createCacheKey( tag );
+
+		if ( undefined !== this.cache[ cacheKey ] ) {
+			return this.cache[ cacheKey ];
 		}
 
 		if ( ! this.cacheRequests[ cacheKey ] ) {
@@ -101,38 +87,17 @@ module.exports = elementorModules.Module.extend( {
 		}
 	},
 
-	hasPendingLegacyCacheRequests() {
-		return Object.keys( this.cacheRequests ).some(
-			( cacheKey ) => undefined === this.cache[ cacheKey ],
-		);
-	},
-
-	hasPendingBatchCacheRequests() {
-		return Object.keys( this.batchCacheRequests ).some( ( postId ) => {
-			return Object.keys( this.batchCacheRequests[ postId ] ).some(
-				( cacheKey ) => undefined === this.batchCache[ cacheKey ],
-			);
-		} );
-	},
-
-	runCacheCallbacks( callbacks ) {
-		callbacks.forEach( ( entry ) => {
-			entry.callback();
-		} );
-	},
-
 	loadCacheRequests() {
 		var cacheRequests = this.cacheRequests,
 			cacheCallbacks = this.cacheCallbacks;
 
 		this.cacheRequests = {};
-
 		this.cacheCallbacks = [];
 
-		var tags = Object.keys( cacheRequests ).filter( ( cacheKey ) => undefined === this.cache[ cacheKey ] );
-
-		if ( 0 === tags.length ) {
-			this.runCacheCallbacks( cacheCallbacks );
+		if ( 0 === Object.keys( cacheRequests ).length ) {
+			cacheCallbacks.forEach( ( entry ) => {
+				entry.callback();
+			} );
 
 			return;
 		}
@@ -140,7 +105,7 @@ module.exports = elementorModules.Module.extend( {
 		var ajaxOptions = {
 			data: {
 				post_id: elementor.config.document.id,
-				tags,
+				tags: Object.keys( cacheRequests ),
 			},
 			success: ( data ) => {
 				this.cache = {
@@ -148,7 +113,9 @@ module.exports = elementorModules.Module.extend( {
 					...data,
 				};
 
-				this.runCacheCallbacks( cacheCallbacks );
+				cacheCallbacks.forEach( ( entry ) => {
+					entry.callback();
+				} );
 			},
 		};
 
@@ -168,20 +135,19 @@ module.exports = elementorModules.Module.extend( {
 			batchCacheCallbacks = this.batchCacheCallbacks;
 
 		this.batchCacheRequests = {};
-
 		this.batchCacheCallbacks = [];
 
 		var groups = Object.keys( batchCacheRequests )
 			.map( ( postId ) => ( {
 				post_id: Number( postId ),
-				tags: Object.keys( batchCacheRequests[ postId ] ).filter(
-					( cacheKey ) => undefined === this.batchCache[ cacheKey ],
-				),
+				tags: Object.keys( batchCacheRequests[ postId ] ).filter( ( cacheKey ) => undefined === this.batchCache[ cacheKey ] ),
 			} ) )
 			.filter( ( group ) => group.tags.length > 0 );
 
 		if ( 0 === groups.length ) {
-			this.runCacheCallbacks( batchCacheCallbacks );
+			batchCacheCallbacks.forEach( ( entry ) => {
+				entry.callback();
+			} );
 
 			return;
 		}
@@ -196,7 +162,9 @@ module.exports = elementorModules.Module.extend( {
 					...data,
 				};
 
-				this.runCacheCallbacks( batchCacheCallbacks );
+				batchCacheCallbacks.forEach( ( entry ) => {
+					entry.callback();
+				} );
 			},
 		};
 
@@ -209,51 +177,6 @@ module.exports = elementorModules.Module.extend( {
 		}
 
 		elementorCommon.ajax.addRequest( 'render_tags_batch', ajaxOptions );
-	},
-
-	flushCacheRequests() {
-		const flushCallbacks = this.flushCallbacks;
-		const disableCache = flushCallbacks.some( ( entry ) => entry.disableCache );
-
-		this.flushCallbacks = [];
-
-		let pendingPaths = 0;
-
-		const completeFlush = () => {
-			pendingPaths--;
-
-			if ( pendingPaths > 0 ) {
-				return;
-			}
-
-			this.runCacheCallbacks( flushCallbacks );
-		};
-
-		if ( this.hasPendingLegacyCacheRequests() ) {
-			pendingPaths++;
-
-			this.cacheCallbacks.push( {
-				callback: completeFlush,
-				disableCache,
-			} );
-
-			this.loadCacheRequestsImmediate();
-		}
-
-		if ( this.hasPendingBatchCacheRequests() ) {
-			pendingPaths++;
-
-			this.batchCacheCallbacks.push( {
-				callback: completeFlush,
-				disableCache,
-			} );
-
-			this.loadBatchCacheRequestsImmediate();
-		}
-
-		if ( 0 === pendingPaths ) {
-			this.runCacheCallbacks( flushCallbacks );
-		}
 	},
 
 	prefetchTags( tagsByPostId ) {
@@ -281,12 +204,19 @@ module.exports = elementorModules.Module.extend( {
 	},
 
 	refreshCacheFromServer( callback, options ) {
-		this.flushCallbacks.push( {
+		const entry = {
 			callback,
 			disableCache: options?.disableCache,
-		} );
+		};
 
-		this.flushCacheRequests();
+		if ( Object.keys( this.batchCacheRequests ).length > 0 ) {
+			this.batchCacheCallbacks.push( entry );
+			this.loadBatchCacheRequests();
+			return;
+		}
+
+		this.cacheCallbacks.push( entry );
+		this.loadCacheRequests();
 	},
 
 	getConfig( key ) {
@@ -377,8 +307,6 @@ module.exports = elementorModules.Module.extend( {
 	cleanCache() {
 		this.cache = {};
 		this.batchCache = {};
-		this.cacheRequests = {};
-		this.batchCacheRequests = {};
 	},
 
 	onInit() {
@@ -387,8 +315,5 @@ module.exports = elementorModules.Module.extend( {
 
 		this.loadBatchCacheRequestsImmediate = this.loadBatchCacheRequests.bind( this );
 		this.loadBatchCacheRequests = _.debounce( this.loadBatchCacheRequestsImmediate, 300 );
-
-		this.flushCacheRequestsImmediate = this.flushCacheRequests.bind( this );
-		this.flushCacheRequests = _.debounce( this.flushCacheRequestsImmediate, 300 );
 	},
 } );

--- a/core/dynamic-tags/manager.php
+++ b/core/dynamic-tags/manager.php
@@ -459,19 +459,7 @@ class Manager {
 		 */
 		do_action( 'elementor/dynamic_tags/before_render' );
 
-		$tags_data = [];
-
-		foreach ( $data['tags'] as $tag_key ) {
-			$tag_key_parts = explode( '-', $tag_key );
-
-			$tag_name = base64_decode( $tag_key_parts[0] );
-
-			$tag_settings = json_decode( urldecode( base64_decode( $tag_key_parts[1] ) ), true );
-
-			$tag = $this->create_tag( null, $tag_name, $tag_settings );
-
-			$tags_data[ $tag_key ] = $tag->get_content();
-		}
+		$tags_data = $this->resolve_tag_keys( $data['tags'] );
 
 		/**
 		 * After dynamic tags rendered.
@@ -481,6 +469,86 @@ class Manager {
 		 * @since 2.0.0
 		 */
 		do_action( 'elementor/dynamic_tags/after_render' );
+
+		return $tags_data;
+	}
+
+	/**
+	 * @since 3.35.0
+	 * @access public
+	 *
+	 * @param array $data
+	 * @return array
+	 */
+	public function ajax_render_tags_batch( $data ) {
+		if ( empty( $data['groups'] ) || ! is_array( $data['groups'] ) ) {
+			return [];
+		}
+
+		$tags_data = [];
+
+		foreach ( $data['groups'] as $group ) {
+			if ( empty( $group['post_id'] ) || empty( $group['tags'] ) || ! is_array( $group['tags'] ) ) {
+				continue;
+			}
+
+			$post_id = (int) $group['post_id'];
+
+			if ( ! User::is_current_user_can_edit( $post_id ) ) {
+				continue;
+			}
+
+			Plugin::$instance->db->switch_to_post( $post_id );
+
+			/**
+			 * Before dynamic tags rendered.
+			 *
+			 * Fires before Elementor renders the dynamic tags.
+			 *
+			 * @since 2.0.0
+			 */
+			do_action( 'elementor/dynamic_tags/before_render' );
+
+			$tags_data = array_merge( $tags_data, $this->resolve_tag_keys( $group['tags'] ) );
+
+			/**
+			 * After dynamic tags rendered.
+			 *
+			 * Fires after Elementor renders the dynamic tags.
+			 *
+			 * @since 2.0.0
+			 */
+			do_action( 'elementor/dynamic_tags/after_render' );
+		}
+
+		return $tags_data;
+	}
+
+	/**
+	 * @since 3.35.0
+	 * @access private
+	 *
+	 * @param array $tag_keys
+	 * @return array
+	 */
+	private function resolve_tag_keys( array $tag_keys ) {
+		$tags_data = [];
+
+		foreach ( $tag_keys as $tag_key ) {
+			$tag_key_parts = explode( '-', $tag_key );
+
+			$tag_name = base64_decode( $tag_key_parts[0] );
+
+			$tag_settings = json_decode( urldecode( base64_decode( $tag_key_parts[1] ) ), true );
+
+			$tag = $this->create_tag( null, $tag_name, $tag_settings );
+
+			if ( ! $tag ) {
+				continue;
+			}
+
+			$tags_data[ $tag_key ] = $tag->get_content();
+		}
 
 		return $tags_data;
 	}
@@ -524,6 +592,7 @@ class Manager {
 	 */
 	public function register_ajax_actions( Ajax $ajax ) {
 		$ajax->register_ajax_action( 'render_tags', [ $this, 'ajax_render_tags' ] );
+		$ajax->register_ajax_action( 'render_tags_batch', [ $this, 'ajax_render_tags_batch' ] );
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "@babel/preset-typescript": "^7.26.0",
         "@babel/runtime-corejs3": "^7.26.0",
         "@elementor/wp-lite-env": "^0.0.20",
+        "@emotion/babel-plugin": "^11.13.5",
         "@jest/globals": "~29.7.0",
         "@lodder/grunt-postcss": "^3.1.1",
         "@playwright/test": "~1.54.1",

--- a/packages/packages/core/editor-canvas/src/legacy/create-nested-templated-element-type.ts
+++ b/packages/packages/core/editor-canvas/src/legacy/create-nested-templated-element-type.ts
@@ -181,7 +181,8 @@ export function createNestedTemplatedElementView( {
 					} );
 				} )
 				.then( async ( settings ) => {
-					const settingsHash = JSON.stringify( settings );
+					const resolvedSettings = this.afterSettingsResolve( settings );
+					const settingsHash = JSON.stringify( resolvedSettings );
 					const settingsChanged = settingsHash !== this._lastResolvedSettingsHash;
 
 					if ( ! settingsChanged && this.isRendered ) {
@@ -196,7 +197,7 @@ export function createNestedTemplatedElementView( {
 						id: model.get( 'id' ),
 						interaction_id: this.getInteractionId(),
 						type,
-						settings,
+						settings: resolvedSettings,
 						base_styles: baseStylesDictionary,
 						editor_attributes: buildEditorAttributes( model ),
 						editor_classes: buildEditorClasses( model ),
@@ -217,6 +218,10 @@ export function createNestedTemplatedElementView( {
 			this.bindUIElements();
 
 			this.triggerMethod( 'render:template' );
+		},
+
+		afterSettingsResolve( settings: { [ key: string ]: unknown } ) {
+			return settings;
 		},
 
 		getRenderContext() {

--- a/packages/packages/core/editor-editing-panel/src/dynamics/dynamic-transformer.ts
+++ b/packages/packages/core/editor-editing-panel/src/dynamics/dynamic-transformer.ts
@@ -9,12 +9,14 @@ type Dynamic = {
 	settings?: Props;
 };
 
-export const dynamicTransformer = createTransformer< Dynamic >( ( value, { propType } ) => {
+export const dynamicTransformer = createTransformer< Dynamic >( ( value, { propType, renderContext } ) => {
 	if ( ! value?.name || ! isDynamicTagSupported( value.name ) ) {
 		return propType?.default ?? null;
 	}
 
-	return getDynamicValue( value.name, simpleTransform( value?.settings ?? {} ) );
+	const renderPostId = ( renderContext as { currentPostId?: number } | undefined )?.currentPostId;
+
+	return getDynamicValue( value.name, simpleTransform( value?.settings ?? {} ), renderPostId );
 } );
 
 // Temporary naive transformation until we'll have a `backendTransformer` that
@@ -29,7 +31,7 @@ function simpleTransform( props: Props ) {
 	return Object.fromEntries( transformed );
 }
 
-function getDynamicValue( name: string, settings: Record< string, unknown > ) {
+function getDynamicValue( name: string, settings: Record< string, unknown >, renderPostId?: number ) {
 	const { dynamicTags } = window.elementor ?? {};
 
 	if ( ! dynamicTags ) {
@@ -41,6 +43,10 @@ function getDynamicValue( name: string, settings: Record< string, unknown > ) {
 
 		if ( ! tag ) {
 			return null;
+		}
+
+		if ( renderPostId ) {
+			tag.editorRenderPostId = renderPostId;
 		}
 
 		return dynamicTags.loadTagDataFromCache( tag ) ?? null;

--- a/tests/jest/unit/assets/dev/js/editor/components/dynamic-tags/manager.test.js
+++ b/tests/jest/unit/assets/dev/js/editor/components/dynamic-tags/manager.test.js
@@ -74,6 +74,8 @@ describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
 		jest.clearAllMocks();
 	} );
 
+	const DOCUMENT_POST_ID = 100;
+
 	function createTagStub( postId ) {
 		return {
 			getOption: ( key ) => ( 'name' === key ? 'test-tag' : null ),
@@ -82,19 +84,20 @@ describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
 		};
 	}
 
-	it( 'addCacheRequest queues document post tags in flat cacheRequests', () => {
+	it( 'addCacheRequest routes document-post tag to legacy flat cacheRequests', () => {
 		// Arrange.
-		const documentTag = createTagStub( 100 );
+		const tag = createTagStub( DOCUMENT_POST_ID );
+		const legacyKey = manager.createCacheKey( tag );
 
 		// Act.
-		manager.addCacheRequest( documentTag );
+		manager.addCacheRequest( tag );
 
 		// Assert.
-		expect( Object.keys( manager.cacheRequests ).length ).toBe( 1 );
-		expect( manager.batchCacheRequests[ 100 ] ).toBeUndefined();
+		expect( manager.cacheRequests[ legacyKey ] ).toBe( true );
+		expect( manager.batchCacheRequests ).toEqual( {} );
 	} );
 
-	it( 'addCacheRequest buckets alternate post tags in batchCacheRequests', () => {
+	it( 'addCacheRequest routes alternate-post tags into batchCacheRequests bucketed by post id', () => {
 		// Arrange.
 		const tagOne = createTagStub( 1 );
 		const tagTwo = createTagStub( 2 );
@@ -111,16 +114,15 @@ describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
 		expect( Object.keys( manager.batchCacheRequests[ 2 ] ).length ).toBe( 1 );
 	} );
 
-	it( 'loadCacheRequests sends render_tags for document post and writes to cache only', () => {
+	it( 'loadCacheRequests sends a render_tags request for the document post and writes to cache', () => {
 		// Arrange.
-		const documentTag = createTagStub( 100 );
-		const callback = jest.fn();
+		const tag = createTagStub( DOCUMENT_POST_ID );
+		const legacyKey = manager.createCacheKey( tag );
 
-		manager.addCacheRequest( documentTag );
-		manager.cacheCallbacks.push( { callback } );
+		manager.addCacheRequest( tag );
 
 		ajaxAddRequest.mockImplementation( ( action, options ) => {
-			options.success( { [ manager.createLegacyCacheKey( documentTag ) ]: 'legacy-resolved' } );
+			options.success( { [ legacyKey ]: 'legacy-value' } );
 		} );
 
 		// Act.
@@ -131,30 +133,29 @@ describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
 			'render_tags',
 			expect.objectContaining( {
 				data: {
-					post_id: 100,
-					tags: expect.any( Array ),
+					post_id: DOCUMENT_POST_ID,
+					tags: [ legacyKey ],
 				},
 			} ),
 		);
-		expect( manager.cache[ manager.createLegacyCacheKey( documentTag ) ] ).toBe( 'legacy-resolved' );
+		expect( manager.cache[ legacyKey ] ).toBe( 'legacy-value' );
 		expect( manager.batchCache ).toEqual( {} );
-		expect( callback ).toHaveBeenCalled();
 	} );
 
-	it( 'loadBatchCacheRequests sends render_tags_batch and writes to batchCache only', () => {
+	it( 'loadBatchCacheRequests sends a single render_tags_batch request with grouped tags and writes to batchCache', () => {
 		// Arrange.
 		const tagOne = createTagStub( 1 );
 		const tagTwo = createTagStub( 2 );
-		const callback = jest.fn();
+		const batchKeyOne = manager.createBatchCacheKey( tagOne );
+		const batchKeyTwo = manager.createBatchCacheKey( tagTwo );
 
 		manager.addCacheRequest( tagOne );
 		manager.addCacheRequest( tagTwo );
-		manager.batchCacheCallbacks.push( { callback } );
 
 		ajaxAddRequest.mockImplementation( ( action, options ) => {
 			options.success( {
-				[ manager.createBatchCacheKey( tagOne ) ]: 'batch-one',
-				[ manager.createBatchCacheKey( tagTwo ) ]: 'batch-two',
+				[ batchKeyOne ]: 'value-one',
+				[ batchKeyTwo ]: 'value-two',
 			} );
 		} );
 
@@ -173,27 +174,39 @@ describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
 				},
 			} ),
 		);
-		expect( manager.batchCache[ manager.createBatchCacheKey( tagOne ) ] ).toBe( 'batch-one' );
+		expect( manager.batchCache[ batchKeyOne ] ).toBe( 'value-one' );
+		expect( manager.batchCache[ batchKeyTwo ] ).toBe( 'value-two' );
 		expect( manager.cache ).toEqual( {} );
-		expect( callback ).toHaveBeenCalled();
 	} );
 
-	it( 'loadTagDataFromCache reads alternate post values from batchCache', () => {
+	it( 'loadTagDataFromCache reads batchCache for alternate post context', () => {
 		// Arrange.
-		const alternatePostTag = createTagStub( 42 );
-		const batchCacheKey = manager.createBatchCacheKey( alternatePostTag );
-
-		manager.batchCache[ batchCacheKey ] = 'from-batch-cache';
+		const tag = createTagStub( 7 );
+		const batchKey = manager.createBatchCacheKey( tag );
+		manager.batchCache[ batchKey ] = 'batch-value';
+		manager.cache[ batchKey ] = 'legacy-value';
 
 		// Act.
-		const value = manager.loadTagDataFromCache( alternatePostTag );
+		const result = manager.loadTagDataFromCache( tag );
 
 		// Assert.
-		expect( value ).toBe( 'from-batch-cache' );
-		expect( manager.cache[ batchCacheKey ] ).toBeUndefined();
+		expect( result ).toBe( 'batch-value' );
 	} );
 
-	it( 'prefetchTags resolves after batch request succeeds into batchCache', async () => {
+	it( 'loadTagDataFromCache reads legacy cache for document post context', () => {
+		// Arrange.
+		const tag = createTagStub( DOCUMENT_POST_ID );
+		const legacyKey = manager.createCacheKey( tag );
+		manager.cache[ legacyKey ] = 'legacy-value';
+
+		// Act.
+		const result = manager.loadTagDataFromCache( tag );
+
+		// Assert.
+		expect( result ).toBe( 'legacy-value' );
+	} );
+
+	it( 'prefetchTags resolves after batch request succeeds and writes to batchCache only', async () => {
 		// Arrange.
 		const cacheKey = manager.buildCacheKeyFor( 'test-tag', {}, 42 );
 
@@ -211,12 +224,10 @@ describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
 		expect( ajaxAddRequest ).toHaveBeenCalledWith( 'render_tags_batch', expect.any( Object ) );
 	} );
 
-	it( 'cleanCache clears cache and batchCache', () => {
+	it( 'cleanCache empties both legacy cache and batchCache', () => {
 		// Arrange.
-		manager.cache = { legacy: 'value' };
-		manager.batchCache = { batch: 'value' };
-		manager.cacheRequests = { pending: true };
-		manager.batchCacheRequests = { 1: { pending: true } };
+		manager.cache[ 'legacy-key' ] = 'legacy-value';
+		manager.batchCache[ 'batch-key' ] = 'batch-value';
 
 		// Act.
 		manager.cleanCache();
@@ -224,7 +235,5 @@ describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
 		// Assert.
 		expect( manager.cache ).toEqual( {} );
 		expect( manager.batchCache ).toEqual( {} );
-		expect( manager.cacheRequests ).toEqual( {} );
-		expect( manager.batchCacheRequests ).toEqual( {} );
 	} );
 } );

--- a/tests/jest/unit/assets/dev/js/editor/components/dynamic-tags/manager.test.js
+++ b/tests/jest/unit/assets/dev/js/editor/components/dynamic-tags/manager.test.js
@@ -82,7 +82,19 @@ describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
 		};
 	}
 
-	it( 'addCacheRequest buckets cache keys by post id', () => {
+	it( 'addCacheRequest queues document post tags in flat cacheRequests', () => {
+		// Arrange.
+		const documentTag = createTagStub( 100 );
+
+		// Act.
+		manager.addCacheRequest( documentTag );
+
+		// Assert.
+		expect( Object.keys( manager.cacheRequests ).length ).toBe( 1 );
+		expect( manager.batchCacheRequests[ 100 ] ).toBeUndefined();
+	} );
+
+	it( 'addCacheRequest buckets alternate post tags in batchCacheRequests', () => {
 		// Arrange.
 		const tagOne = createTagStub( 1 );
 		const tagTwo = createTagStub( 2 );
@@ -92,13 +104,44 @@ describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
 		manager.addCacheRequest( tagTwo );
 
 		// Assert.
-		expect( manager.cacheRequests[ 1 ] ).toBeDefined();
-		expect( manager.cacheRequests[ 2 ] ).toBeDefined();
-		expect( Object.keys( manager.cacheRequests[ 1 ] ).length ).toBe( 1 );
-		expect( Object.keys( manager.cacheRequests[ 2 ] ).length ).toBe( 1 );
+		expect( manager.cacheRequests ).toEqual( {} );
+		expect( manager.batchCacheRequests[ 1 ] ).toBeDefined();
+		expect( manager.batchCacheRequests[ 2 ] ).toBeDefined();
+		expect( Object.keys( manager.batchCacheRequests[ 1 ] ).length ).toBe( 1 );
+		expect( Object.keys( manager.batchCacheRequests[ 2 ] ).length ).toBe( 1 );
 	} );
 
-	it( 'loadCacheRequests sends a single render_tags_batch request with grouped tags', () => {
+	it( 'loadCacheRequests sends render_tags for document post and writes to cache only', () => {
+		// Arrange.
+		const documentTag = createTagStub( 100 );
+		const callback = jest.fn();
+
+		manager.addCacheRequest( documentTag );
+		manager.cacheCallbacks.push( { callback } );
+
+		ajaxAddRequest.mockImplementation( ( action, options ) => {
+			options.success( { [ manager.createLegacyCacheKey( documentTag ) ]: 'legacy-resolved' } );
+		} );
+
+		// Act.
+		manager.loadCacheRequestsImmediate();
+
+		// Assert.
+		expect( ajaxAddRequest ).toHaveBeenCalledWith(
+			'render_tags',
+			expect.objectContaining( {
+				data: {
+					post_id: 100,
+					tags: expect.any( Array ),
+				},
+			} ),
+		);
+		expect( manager.cache[ manager.createLegacyCacheKey( documentTag ) ] ).toBe( 'legacy-resolved' );
+		expect( manager.batchCache ).toEqual( {} );
+		expect( callback ).toHaveBeenCalled();
+	} );
+
+	it( 'loadBatchCacheRequests sends render_tags_batch and writes to batchCache only', () => {
 		// Arrange.
 		const tagOne = createTagStub( 1 );
 		const tagTwo = createTagStub( 2 );
@@ -106,10 +149,17 @@ describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
 
 		manager.addCacheRequest( tagOne );
 		manager.addCacheRequest( tagTwo );
-		manager.cacheCallbacks.push( { callback } );
+		manager.batchCacheCallbacks.push( { callback } );
+
+		ajaxAddRequest.mockImplementation( ( action, options ) => {
+			options.success( {
+				[ manager.createBatchCacheKey( tagOne ) ]: 'batch-one',
+				[ manager.createBatchCacheKey( tagTwo ) ]: 'batch-two',
+			} );
+		} );
 
 		// Act.
-		manager.loadCacheRequestsImmediate();
+		manager.loadBatchCacheRequestsImmediate();
 
 		// Assert.
 		expect( ajaxAddRequest ).toHaveBeenCalledWith(
@@ -123,10 +173,27 @@ describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
 				},
 			} ),
 		);
-		expect( callback ).not.toHaveBeenCalled();
+		expect( manager.batchCache[ manager.createBatchCacheKey( tagOne ) ] ).toBe( 'batch-one' );
+		expect( manager.cache ).toEqual( {} );
+		expect( callback ).toHaveBeenCalled();
 	} );
 
-	it( 'prefetchTags resolves after batch request succeeds', async () => {
+	it( 'loadTagDataFromCache reads alternate post values from batchCache', () => {
+		// Arrange.
+		const alternatePostTag = createTagStub( 42 );
+		const batchCacheKey = manager.createBatchCacheKey( alternatePostTag );
+
+		manager.batchCache[ batchCacheKey ] = 'from-batch-cache';
+
+		// Act.
+		const value = manager.loadTagDataFromCache( alternatePostTag );
+
+		// Assert.
+		expect( value ).toBe( 'from-batch-cache' );
+		expect( manager.cache[ batchCacheKey ] ).toBeUndefined();
+	} );
+
+	it( 'prefetchTags resolves after batch request succeeds into batchCache', async () => {
 		// Arrange.
 		const cacheKey = manager.buildCacheKeyFor( 'test-tag', {}, 42 );
 
@@ -139,7 +206,25 @@ describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
 
 		// Assert.
 		await expect( prefetchPromise ).resolves.toBeUndefined();
-		expect( manager.cache[ cacheKey ] ).toBe( 'resolved' );
+		expect( manager.batchCache[ cacheKey ] ).toBe( 'resolved' );
+		expect( manager.cache[ cacheKey ] ).toBeUndefined();
 		expect( ajaxAddRequest ).toHaveBeenCalledWith( 'render_tags_batch', expect.any( Object ) );
+	} );
+
+	it( 'cleanCache clears cache and batchCache', () => {
+		// Arrange.
+		manager.cache = { legacy: 'value' };
+		manager.batchCache = { batch: 'value' };
+		manager.cacheRequests = { pending: true };
+		manager.batchCacheRequests = { 1: { pending: true } };
+
+		// Act.
+		manager.cleanCache();
+
+		// Assert.
+		expect( manager.cache ).toEqual( {} );
+		expect( manager.batchCache ).toEqual( {} );
+		expect( manager.cacheRequests ).toEqual( {} );
+		expect( manager.batchCacheRequests ).toEqual( {} );
 	} );
 } );

--- a/tests/jest/unit/assets/dev/js/editor/components/dynamic-tags/manager.test.js
+++ b/tests/jest/unit/assets/dev/js/editor/components/dynamic-tags/manager.test.js
@@ -1,0 +1,145 @@
+jest.mock( 'elementor-dynamic-tags/tag', () => class Tag {} );
+
+describe( 'assets/dev/js/editor/components/dynamic-tags/manager.js', () => {
+	let DynamicTagsManager;
+	let manager;
+	let ajaxAddRequest;
+
+	beforeEach( async () => {
+		global._ = {
+			debounce: ( fn ) => fn,
+		};
+
+		global.elementorModules = {
+			Module: {
+				extend: ( proto ) => {
+					class Manager {
+						constructor() {
+							Object.assign( this, proto );
+							if ( this.onInit ) {
+								this.onInit();
+							}
+						}
+					}
+
+					return Manager;
+				},
+			},
+			editor: {
+				elements: {
+					models: {
+						BaseSettings: class {
+							constructor( settings ) {
+								this.settings = settings;
+							}
+						},
+					},
+				},
+			},
+		};
+
+		global.elementor = {
+			config: {
+				document: {
+					id: 100,
+				},
+				dynamicTags: {
+					tags: {
+						'test-tag': {
+							controls: {},
+						},
+					},
+				},
+			},
+		};
+
+		ajaxAddRequest = jest.fn();
+		global.elementorCommon = {
+			ajax: {
+				addRequest: ajaxAddRequest,
+			},
+			helpers: {
+				getUniqueId: () => 'unique-id',
+			},
+		};
+
+		jest.isolateModules( () => {
+			DynamicTagsManager = require( 'elementor/assets/dev/js/editor/components/dynamic-tags/manager.js' );
+		} );
+
+		manager = new DynamicTagsManager();
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	function createTagStub( postId ) {
+		return {
+			getOption: ( key ) => ( 'name' === key ? 'test-tag' : null ),
+			model: {},
+			editorRenderPostId: postId,
+		};
+	}
+
+	it( 'addCacheRequest buckets cache keys by post id', () => {
+		// Arrange.
+		const tagOne = createTagStub( 1 );
+		const tagTwo = createTagStub( 2 );
+
+		// Act.
+		manager.addCacheRequest( tagOne );
+		manager.addCacheRequest( tagTwo );
+
+		// Assert.
+		expect( manager.cacheRequests[ 1 ] ).toBeDefined();
+		expect( manager.cacheRequests[ 2 ] ).toBeDefined();
+		expect( Object.keys( manager.cacheRequests[ 1 ] ).length ).toBe( 1 );
+		expect( Object.keys( manager.cacheRequests[ 2 ] ).length ).toBe( 1 );
+	} );
+
+	it( 'loadCacheRequests sends a single render_tags_batch request with grouped tags', () => {
+		// Arrange.
+		const tagOne = createTagStub( 1 );
+		const tagTwo = createTagStub( 2 );
+		const callback = jest.fn();
+
+		manager.addCacheRequest( tagOne );
+		manager.addCacheRequest( tagTwo );
+		manager.cacheCallbacks.push( { callback } );
+
+		// Act.
+		manager.loadCacheRequestsImmediate();
+
+		// Assert.
+		expect( ajaxAddRequest ).toHaveBeenCalledWith(
+			'render_tags_batch',
+			expect.objectContaining( {
+				data: {
+					groups: expect.arrayContaining( [
+						expect.objectContaining( { post_id: 1 } ),
+						expect.objectContaining( { post_id: 2 } ),
+					] ),
+				},
+			} ),
+		);
+		expect( callback ).not.toHaveBeenCalled();
+	} );
+
+	it( 'prefetchTags resolves after batch request succeeds', async () => {
+		// Arrange.
+		const cacheKey = manager.buildCacheKeyFor( 'test-tag', {}, 42 );
+
+		ajaxAddRequest.mockImplementation( ( action, options ) => {
+			options.success( { [ cacheKey ]: 'resolved' } );
+		} );
+
+		// Act.
+		const prefetchPromise = manager.prefetchTags( { 42: [ cacheKey ] } );
+
+		// Assert.
+		await expect( prefetchPromise ).resolves.toBeUndefined();
+		expect( manager.cache[ cacheKey ] ).toBe( 'resolved' );
+		expect( ajaxAddRequest ).toHaveBeenCalledWith( 'render_tags_batch', expect.any( Object ) );
+	} );
+} );

--- a/tests/phpunit/elementor/core/dynamic-tags/test-render-tags-batch.php
+++ b/tests/phpunit/elementor/core/dynamic-tags/test-render-tags-batch.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Elementor\Core\DynamicTags;
+
+use Elementor\Core\DynamicTags\Manager as Dynamic_Tags_Manager;
+use Elementor\Core\DynamicTags\Tag;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Render_Tags_Batch extends Elementor_Test_Base {
+
+	private Dynamic_Tags_Manager $manager;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->manager = Plugin::$instance->dynamic_tags;
+
+		add_action(
+			'elementor/dynamic_tags/register',
+			function ( Dynamic_Tags_Manager $dynamic_tags_manager ) {
+				$dynamic_tags_manager->register( $this->create_batch_test_tag() );
+			}
+		);
+
+		do_action( 'elementor/dynamic_tags/register', $this->manager );
+	}
+
+	public function test_ajax_render_tags_batch__returns_empty_array_when_groups_missing() {
+		// Act.
+		$result = $this->manager->ajax_render_tags_batch( [] );
+
+		// Assert.
+		$this->assertSame( [], $result );
+	}
+
+	public function test_ajax_render_tags_batch__resolves_tags_for_multiple_post_ids() {
+		// Arrange.
+		$post_one = $this->factory()->post->create_and_get();
+		$post_two = $this->factory()->post->create_and_get();
+
+		$settings = [ 'text' => 'hello' ];
+		$cache_key_one = $this->build_cache_key( 'batch-test-tag', $settings, $post_one->ID );
+		$cache_key_two = $this->build_cache_key( 'batch-test-tag', $settings, $post_two->ID );
+
+		// Act.
+		$result = $this->manager->ajax_render_tags_batch( [
+			'groups' => [
+				[
+					'post_id' => $post_one->ID,
+					'tags' => [ $cache_key_one ],
+				],
+				[
+					'post_id' => $post_two->ID,
+					'tags' => [ $cache_key_two ],
+				],
+			],
+		] );
+
+		// Assert.
+		$this->assertArrayHasKey( $cache_key_one, $result );
+		$this->assertArrayHasKey( $cache_key_two, $result );
+		$this->assertSame( 'batch-content', $result[ $cache_key_one ] );
+		$this->assertSame( 'batch-content', $result[ $cache_key_two ] );
+	}
+
+	public function test_ajax_render_tags_batch__skips_groups_without_edit_permission() {
+		// Arrange.
+		$author_id = $this->factory()->user->create( [ 'role' => 'author' ] );
+		$own_post = $this->factory()->post->create_and_get( [ 'post_author' => $author_id ] );
+		$other_post = $this->factory()->post->create_and_get();
+
+		$settings = [ 'text' => 'hello' ];
+		$allowed_key = $this->build_cache_key( 'batch-test-tag', $settings, $own_post->ID );
+		$denied_key = $this->build_cache_key( 'batch-test-tag', $settings, $other_post->ID );
+
+		wp_set_current_user( $author_id );
+
+		// Act.
+		$result = $this->manager->ajax_render_tags_batch( [
+			'groups' => [
+				[
+					'post_id' => $own_post->ID,
+					'tags' => [ $allowed_key ],
+				],
+				[
+					'post_id' => $other_post->ID,
+					'tags' => [ $denied_key ],
+				],
+			],
+		] );
+
+		// Assert.
+		$this->assertArrayHasKey( $allowed_key, $result );
+		$this->assertArrayNotHasKey( $denied_key, $result );
+	}
+
+	public function test_ajax_render_tags_batch__fires_before_and_after_render_per_group() {
+		// Arrange.
+		$post_one = $this->factory()->post->create_and_get();
+		$post_two = $this->factory()->post->create_and_get();
+		$settings = [ 'text' => 'hello' ];
+
+		$before_count = 0;
+		$after_count = 0;
+
+		add_action(
+			'elementor/dynamic_tags/before_render',
+			function () use ( &$before_count ) {
+				$before_count++;
+			}
+		);
+
+		add_action(
+			'elementor/dynamic_tags/after_render',
+			function () use ( &$after_count ) {
+				$after_count++;
+			}
+		);
+
+		// Act.
+		$this->manager->ajax_render_tags_batch( [
+			'groups' => [
+				[
+					'post_id' => $post_one->ID,
+					'tags' => [ $this->build_cache_key( 'batch-test-tag', $settings, $post_one->ID ) ],
+				],
+				[
+					'post_id' => $post_two->ID,
+					'tags' => [ $this->build_cache_key( 'batch-test-tag', $settings, $post_two->ID ) ],
+				],
+			],
+		] );
+
+		// Assert.
+		$this->assertSame( 2, $before_count );
+		$this->assertSame( 2, $after_count );
+	}
+
+	private function build_cache_key( string $tag_name, array $settings, int $post_id ): string {
+		return base64_encode( $tag_name ) . '-' . base64_encode( rawurlencode( wp_json_encode( $settings ) ) ) . '-' . $post_id;
+	}
+
+	private function create_batch_test_tag(): Tag {
+		return new class() extends Tag {
+			public function get_name() {
+				return 'batch-test-tag';
+			}
+
+			public function get_title() {
+				return 'Batch Test Tag';
+			}
+
+			public function get_group() {
+				return 'post';
+			}
+
+			public function get_categories() {
+				return [ 'text' ];
+			}
+
+			protected function register_controls() {
+				$this->add_control(
+					'text',
+					[
+						'type' => 'text',
+						'label' => 'Text',
+						'default' => '',
+					]
+				);
+			}
+
+			protected function register_advanced_section() {}
+
+			public function get_content() {
+				return 'batch-content';
+			}
+		};
+	}
+}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Dynamic tag rendering was inefficient when tags from multiple post contexts needed prefetching (e.g., related posts, ACF repeaters). Current implementation only batches tags from the active document; this adds server-side and client-side batch processing to handle tags from arbitrary post IDs in a single round trip.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `core/dynamic-tags/manager.php` | Refactored `ajax_render_tags()` → extract `resolve_tag_keys()` private method; add `ajax_render_tags_batch()` to handle multi-post groups; register new AJAX action |
| `assets/dev/js/editor/components/dynamic-tags/manager.js` | Split cache into document (`cache`/`cacheRequests`) and batch (`batchCache`/`batchCacheRequests`) flows; add `prefetchTags()`, `addCacheRequest()`, `loadBatchCacheRequests()`; debounce both loaders independently |
| `packages/core/editor-canvas/src/legacy/create-nested-templated-element-type.ts` | Extract `resolvedSettings` before hash comparison; pass resolved settings to renderer context instead of raw |
| `packages/core/editor-editing-panel/src/dynamics/dynamic-transformer.ts` | Add `renderPostId` parameter to `getDynamicValue()`; set `tag.editorRenderPostId` for cross-post context rendering |
| Tests | Add PHP batch tests (`test-render-tags-batch.php`); add JS manager tests (`manager.test.js`) |

## 3. How It Works

**Legacy flow** (unchanged for document tags): Tag → `addCacheRequest()` → `loadCacheRequests()` → `render_tags` AJAX → cache → resolve.

**Batch flow** (new, for cross-post tags): `prefetchTags({postId: [keys]})` → `addCacheRequest()` routes to `batchCacheRequests[postId]` → `loadBatchCacheRequests()` → `render_tags_batch` AJAX with grouped posts → `Manager::ajax_render_tags_batch()` switches post context per group → merges results into `batchCache` → `loadTagDataFromCache()` checks batch cache first by post ID.

Settings flow: Renderer now calls `afterSettingsResolve()` hook before hashing to allow modifications; passes resolved settings to template (enables post-specific filtering).

## 4. Risks

**Post context switching**: `switch_to_post()` loop in `ajax_render_tags_batch()` must restore properly on error/exception — no explicit restoration visible, relies on loop end or exception handlers elsewhere. **Mitigation**: Add try-finally or verify restoration guarantees in integration tests.

**Cache key collision**: Both flows use `base64(name) + '-' + base64(settings)`, batch adds `postId` suffix. Possible old cache keys leak into batch if client doesn't clear properly. **Mitigation**: `cleanCache()` now clears both buckets; debounce isolation prevents interleaving.

**Performance regression if batch requests fail silently**: `prefetchTags()` resolves even if AJAX fails (no error handling in success callback). **Mitigation**: Test server-side validation; consider reject path or error logging.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
