### PR TITLE
chore: bump wp-one-package to 1.0.64

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "elementor/wp-one-package": "1.0.63"
+        "elementor/wp-one-package": "1.0.64"
     },
     "repositories": [
         {


### PR DESCRIPTION
## Summary
- Bumps `elementor/wp-one-package` from 1.0.63 to 1.0.64
- Depends on https://github.com/elementor/wp-one-package/pull/158 (removes the "Seeing two Elementor tabs?" popup)

## Test plan
- [ ] Merge and release wp-one-package 1.0.64 first
- [ ] Run `composer update elementor/wp-one-package`
- [ ] Verify the editor update notification popup no longer appears on dashboard pages
- [ ] Confirm other One dashboard popups/notices still work


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Bumping wp-one-package dependency from 1.0.63 to 1.0.64 to pick up upstream fixes or features.

## 2. What Changed (Where)
composer.json: elementor/wp-one-package version updated 1.0.63 → 1.0.64.

## 4. Risks
None — patch-level dependency bump with no code changes; verify 1.0.64 release notes for breaking changes if unfamiliar with the package.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
