### PR TITLE
Tweak: Update Requires at least to WordPress 6.8 [ED-23932]

### DIFF
--- a/elementor.php
+++ b/elementor.php
@@ -29,6 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'ELEMENTOR_VERSION', '4.2.0' );
+define( 'ELEMENTOR_MINIMUM_WP_VERSION', '6.8' );
 
 define( 'ELEMENTOR__FILE__', __FILE__ );
 define( 'ELEMENTOR_PLUGIN_BASE', plugin_basename( ELEMENTOR__FILE__ ) );
@@ -66,7 +67,7 @@ if ( file_exists( $deprecation_func_file ) ) {
 
 if ( ! version_compare( PHP_VERSION, '7.4', '>=' ) ) {
 	add_action( 'admin_notices', 'elementor_fail_php_version' );
-} elseif ( ! version_compare( get_bloginfo( 'version' ), '6.8', '>=' ) ) {
+} elseif ( ! version_compare( get_bloginfo( 'version' ), ELEMENTOR_MINIMUM_WP_VERSION, '>=' ) ) {
 	add_action( 'admin_notices', 'elementor_fail_wp_version' );
 } else {
 	require ELEMENTOR_PATH . 'includes/plugin.php';
@@ -112,7 +113,7 @@ function elementor_fail_wp_version() {
 		sprintf(
 			/* translators: %s: WordPress version. */
 			esc_html__( 'Update to version %s and get back to creating!', 'elementor' ),
-			'6.5'
+			ELEMENTOR_MINIMUM_WP_VERSION
 		),
 		esc_html__( 'Show me how', 'elementor' )
 	);

--- a/elementor.php
+++ b/elementor.php
@@ -66,7 +66,7 @@ if ( file_exists( $deprecation_func_file ) ) {
 
 if ( ! version_compare( PHP_VERSION, '7.4', '>=' ) ) {
 	add_action( 'admin_notices', 'elementor_fail_php_version' );
-} elseif ( ! version_compare( get_bloginfo( 'version' ), '6.5', '>=' ) ) {
+} elseif ( ! version_compare( get_bloginfo( 'version' ), '6.8', '>=' ) ) {
 	add_action( 'admin_notices', 'elementor_fail_wp_version' );
 } else {
 	require ELEMENTOR_PATH . 'includes/plugin.php';

--- a/elementor.php
+++ b/elementor.php
@@ -7,7 +7,7 @@
  * Author: Elementor.com
  * Author URI: https://elementor.com/?utm_source=wp-plugins&utm_campaign=author-uri&utm_medium=wp-dash
  * Requires PHP: 7.4
- * Requires at least: 6.6
+ * Requires at least: 6.8
  * Text Domain: elementor
  *
  * @package Elementor

--- a/readme.txt
+++ b/readme.txt
@@ -263,7 +263,7 @@ Join a global community that helps each other achieve their goals.
 
 = Minimum Requirements =
 
-* WordPress 6.5 or greater
+* WordPress 6.8 or greater
 * PHP version 7.4 or greater
 * MySQL version 5.0 or greater
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Bumping minimum WordPress version requirement from 6.5 to 6.8 to align with plugin development standards and ensure compatibility with required core features.

## 2. What Changed (Where)

- **elementor.php**: Updated plugin header `Requires at least` from 6.6 to 6.8, added `ELEMENTOR_MINIMUM_WP_VERSION` constant, updated version check logic and error message to use constant.

## 3. How It Works

Plugin now defines minimum WP version as a constant (line 32), then checks it during initialization (line 70) before loading the main plugin file. If WordPress version is below 6.8, the `elementor_fail_wp_version()` admin notice displays the minimum required version dynamically from the constant (line 116).

## 4. Risks

None identified. Change is straightforward constant extraction and version check update. Existing installations below 6.8 will see the updated requirement notice on admin dashboard; already mitigated by version checks before plugin load.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
