### PR TITLE
Feature: Implementing all style-schema css-to-prop + mcp tool wiring [ED-24442]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ coverage/
 # Code agents
 .cursor/
 !.cursor/rules/
+.cursor/rules/LOCAL_RULES.md
 .claude/
 
 # PHPunit and PHPlint cache files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,18 @@ The image may ship a system Node under `/exec-daemon/node` that does not match `
 | Jest (main) | `npm run test:jest` |
 | Jest (packages) | `npm run test:packages` |
 | All Jest | `npm run test` |
+| Fast DB-less PHPUnit (single/few files) | `tests/phpunit/run-unit.sh <test-file.php> [<test-file.php> ...] [--filter <pattern>]` |
+
+### Fast DB-less PHPUnit for local dev
+
+`tests/phpunit/run-unit.sh` runs a small set of PHPUnit files **without WordPress or MySQL** for a quick inner loop. It uses `tests/phpunit/unit-bootstrap.php`, which only defines `ABSPATH` and registers an `Elementor\` autoloader (same name->path transform as `includes/autoloader.php`), and ignores the project `phpunit.xml`. Pass any number of `test-*.php` files (added to a generated testsuite, which sidesteps PHPUnit's `test-*.php` ↔ `Test_*` filename/classname assumption) plus optional pass-through args like `--filter`.
+
+```bash
+tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter.php
+tests/phpunit/run-unit.sh tests/phpunit/.../test-css-converter.php --filter test_convert
+```
+
+Only works for tests whose subjects don't touch WordPress at load/run time. Tests needing WordPress/MySQL (e.g. REST endpoints with `act_as_admin`/`WP_REST_Server`, or anything pulling `Style_Schema`) must use the full suite (`npm run test:setup:playwright` env, or the wp-lite-env setup below).
 
 ## wp-lite-env (Docker): full setup
 

--- a/modules/atomic-widgets/css-converter/conversion-context.php
+++ b/modules/atomic-widgets/css-converter/conversion-context.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Conversion_Context {
 	private array $props = [];
 
+	private array $rejected = [];
+
 	private array $rules;
 
 	private array $global_variables;
@@ -54,5 +56,13 @@ class Conversion_Context {
 	 */
 	public function set_prop( string $property, $value ): void {
 		$this->props[ $property ] = $value;
+	}
+
+	public function reject( string $declaration ): void {
+		$this->rejected[] = $declaration;
+	}
+
+	public function get_rejected(): array {
+		return $this->rejected;
 	}
 }

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -6,6 +6,7 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Image_Con
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Rejected_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Layer_Field_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Position_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Box_Shadow_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Border_Radius_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
@@ -144,6 +145,7 @@ class Converter_Registry_Factory {
 		'transition',
 		'transform',
 		'transform-origin',
+		'box-shadow',
 	];
 
 	/**
@@ -217,7 +219,6 @@ class Converter_Registry_Factory {
 		// (e.g. exotic syntax). The expander handles the common forms; this entry keeps the
 		// raw declaration in customCss when expansion fails.
 		'background',
-		'box-shadow',
 	];
 
 	/**
@@ -397,6 +398,7 @@ class Converter_Registry_Factory {
 		$converters['transition'] = new Transition_Property_Converter();
 		$converters['transform'] = new Transform_Property_Converter();
 		$converters['transform-origin'] = new Transform_Origin_Property_Converter();
+		$converters['box-shadow'] = new Box_Shadow_Property_Converter();
 
 		foreach ( self::border_side_specs() as $property => [ $target, $side_key ] ) {
 			$is_radius = 'border-radius' === $target;

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -3,6 +3,8 @@
 namespace Elementor\Modules\AtomicWidgets\CssConverter;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Filter_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Noop_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Number_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Size_Property_Converter;
@@ -47,6 +49,15 @@ class Converter_Registry_Factory {
 	];
 
 	/**
+	 * Size properties that also accept a unitless number (a multiplier, e.g. `line-height: 1.1`). The
+	 * value is kept verbatim as a `custom` unit so it renders without a unit; every other size property
+	 * declines a unitless non-zero value to custom_css.
+	 */
+	const UNITLESS_SIZE_PROPERTIES = [
+		'line-height',
+	];
+
+	/**
 	 * Every Style_Schema property backed by a Number_Prop_Type. Handled uniformly by
 	 * Number_Property_Converter (strict numeric, no units/functions).
 	 */
@@ -88,6 +99,25 @@ class Converter_Registry_Factory {
 	];
 
 	/**
+	 * Box shorthands backed by Union(Dimensions | Size). Handled uniformly by
+	 * Dimensions_Property_Converter (single value -> Size; 2-4 values -> logical Dimensions).
+	 */
+	const DIMENSIONS_PROPERTIES = [
+		'padding',
+		'margin',
+	];
+
+	/**
+	 * Filter-function lists backed by Array(Css_Filter_Func) (filter, backdrop-filter). Handled
+	 * uniformly by Filter_Property_Converter + Filter_Value_Parser; the two share inner items and
+	 * differ only by the wrapping $$type, which is sourced from the live schema.
+	 */
+	const FILTER_PROPERTIES = [
+		'filter',
+		'backdrop-filter',
+	];
+
+	/**
 	 * Hardcoded Style_Schema properties with no real converter yet (objects, unions, shorthands). They
 	 * still get a Noop_Converter so they keep routing to custom_css. Combined with the real-converter
 	 * families via covered_properties() to form the exhaustive covered set. Intentionally NOT derived
@@ -97,14 +127,10 @@ class Converter_Registry_Factory {
 	const NOOP_PROPERTIES = [
 		'object-position',
 		'stroke',
-		'padding',
-		'margin',
 		'border-radius',
 		'border-width',
 		'background',
 		'box-shadow',
-		'filter',
-		'backdrop-filter',
 		'transform',
 		'transition',
 		'flex',
@@ -160,6 +186,8 @@ class Converter_Registry_Factory {
 			self::COLOR_PROPERTIES,
 			self::SPAN_PROPERTIES,
 			self::STRING_PASSTHROUGH_PROPERTIES,
+			self::DIMENSIONS_PROPERTIES,
+			self::FILTER_PROPERTIES,
 			self::NOOP_PROPERTIES
 		);
 	}
@@ -200,7 +228,8 @@ class Converter_Registry_Factory {
 		}
 
 		foreach ( self::SIZE_PROPERTIES as $property ) {
-			$converters[ $property ] = new Size_Property_Converter( $property );
+			$allow_unitless = in_array( $property, self::UNITLESS_SIZE_PROPERTIES, true );
+			$converters[ $property ] = new Size_Property_Converter( $property, $allow_unitless );
 		}
 
 		foreach ( self::NUMBER_PROPERTIES as $property ) {
@@ -217,6 +246,14 @@ class Converter_Registry_Factory {
 
 		foreach ( self::STRING_PASSTHROUGH_PROPERTIES as $property ) {
 			$converters[ $property ] = new String_Property_Converter( $property );
+		}
+
+		foreach ( self::DIMENSIONS_PROPERTIES as $property ) {
+			$converters[ $property ] = new Dimensions_Property_Converter( $property );
+		}
+
+		foreach ( self::FILTER_PROPERTIES as $property ) {
+			$converters[ $property ] = new Filter_Property_Converter( $property, $schema[ $property ]->get_key() );
 		}
 
 		return $converters;

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\AtomicWidgets\CssConverter;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Noop_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Size_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\String_Property_Converter;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 
@@ -12,49 +13,59 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Converter_Registry_Factory {
 	/**
-	 * Hardcoded Style_Schema properties that are NOT plain strings (sizes, colors, objects, unions).
-	 * Combined with STRING_PROPERTIES via covered_properties() to form the exhaustive covered set.
-	 * Intentionally NOT derived from Style_Schema: a coverage test diffs the live schema against the
-	 * covered set so adding a schema property without coverage fails CI until it is added here.
+	 * Every Style_Schema property whose value is a single Size leaf (the schema prop is a Size_Prop_Type,
+	 * or a Union with a Size member like `gap` — a size PropValue validates against the union). All are
+	 * handled uniformly by Size_Property_Converter + Size_Value_Parser; per-property unit sets are not
+	 * enforced here because Size_Prop_Type::validate accepts any all_supported_units() unit.
 	 */
-	const NON_STRING_PROPERTIES = [
+	const SIZE_PROPERTIES = [
 		'width',
 		'height',
 		'min-width',
 		'min-height',
 		'max-width',
 		'max-height',
-		'object-position',
 		'inset-block-start',
 		'inset-inline-end',
 		'inset-block-end',
 		'inset-inline-start',
-		'z-index',
 		'scroll-margin-top',
 		'font-size',
-		'color',
 		'letter-spacing',
 		'word-spacing',
-		'column-count',
 		'column-gap',
 		'line-height',
+		'outline-width',
+		'outline-offset',
+		'opacity',
+		'gap',
+	];
+
+	/**
+	 * Hardcoded Style_Schema properties with no real converter yet (colors, numbers, objects, unions,
+	 * shorthands). They still get a Noop_Converter so they keep routing to custom_css. Combined with the
+	 * real-converter families via covered_properties() to form the exhaustive covered set. Intentionally
+	 * NOT derived from Style_Schema: a coverage test diffs the live schema against the covered set so
+	 * adding a schema property without coverage fails CI until it is added here.
+	 */
+	const NOOP_PROPERTIES = [
+		'object-position',
+		'z-index',
+		'color',
+		'column-count',
 		'stroke',
 		'padding',
 		'margin',
 		'border-radius',
 		'border-width',
 		'border-color',
-		'outline-width',
 		'outline-color',
-		'outline-offset',
 		'background',
 		'box-shadow',
-		'opacity',
 		'filter',
 		'backdrop-filter',
 		'transform',
 		'transition',
-		'gap',
 		'flex',
 		'grid-template-columns',
 		'grid-template-rows',
@@ -102,13 +113,13 @@ class Converter_Registry_Factory {
 	];
 
 	/**
-	 * The exhaustive covered set: string props plus every non-string prop. Single source of truth
-	 * for the coverage test, with no property listed twice.
+	 * The exhaustive covered set: every family with a real converter plus the remaining no-ops. Single
+	 * source of truth for the coverage test, with no property listed twice.
 	 *
 	 * @return string[]
 	 */
 	public static function covered_properties(): array {
-		return array_merge( self::STRING_PROPERTIES, self::NON_STRING_PROPERTIES );
+		return array_merge( self::STRING_PROPERTIES, self::SIZE_PROPERTIES, self::NOOP_PROPERTIES );
 	}
 
 	public static function create(): Converter_Registry {
@@ -144,6 +155,10 @@ class Converter_Registry_Factory {
 
 		foreach ( self::STRING_PROPERTIES as $property ) {
 			$converters[ $property ] = new String_Property_Converter( $property, $schema[ $property ]->get_enum() );
+		}
+
+		foreach ( self::SIZE_PROPERTIES as $property ) {
+			$converters[ $property ] = new Size_Property_Converter( $property );
 		}
 
 		return $converters;

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -76,6 +76,18 @@ class Converter_Registry_Factory {
 	];
 
 	/**
+	 * Union props whose string member accepts a raw value (e.g. Union(String | Grid_Track_Size)). A
+	 * free-string String_Property_Converter emits a `string` PropValue that validates against the union's
+	 * String member, covering `1fr 1fr`, `repeat(3, 1fr)`, `minmax(...)`, named lines, etc. The structured
+	 * member is intentionally not produced (raw passthrough, mirroring color). NOT wired via
+	 * STRING_PROPERTIES because the schema entry is a Union and has no get_enum().
+	 */
+	const STRING_PASSTHROUGH_PROPERTIES = [
+		'grid-template-columns',
+		'grid-template-rows',
+	];
+
+	/**
 	 * Hardcoded Style_Schema properties with no real converter yet (objects, unions, shorthands). They
 	 * still get a Noop_Converter so they keep routing to custom_css. Combined with the real-converter
 	 * families via covered_properties() to form the exhaustive covered set. Intentionally NOT derived
@@ -96,8 +108,6 @@ class Converter_Registry_Factory {
 		'transform',
 		'transition',
 		'flex',
-		'grid-template-columns',
-		'grid-template-rows',
 	];
 
 	/**
@@ -149,6 +159,7 @@ class Converter_Registry_Factory {
 			self::NUMBER_PROPERTIES,
 			self::COLOR_PROPERTIES,
 			self::SPAN_PROPERTIES,
+			self::STRING_PASSTHROUGH_PROPERTIES,
 			self::NOOP_PROPERTIES
 		);
 	}
@@ -202,6 +213,10 @@ class Converter_Registry_Factory {
 
 		foreach ( self::SPAN_PROPERTIES as $property ) {
 			$converters[ $property ] = new Span_Property_Converter( $property, $schema[ $property ]->get_regex() );
+		}
+
+		foreach ( self::STRING_PASSTHROUGH_PROPERTIES as $property ) {
+			$converters[ $property ] = new String_Property_Converter( $property );
 		}
 
 		return $converters;

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -200,7 +200,22 @@ class Converter_Registry_Factory {
 	 * property without coverage fails CI until it is added here.
 	 */
 	const NOOP_PROPERTIES = [
+		// SVG-only family. The editor UI does not expose stroke controls, so there is no
+		// LLM-facing use case worth converting. All stroke-* longhands are listed explicitly
+		// (rather than relying on silent fallthrough) so the intent is "preserve verbatim in
+		// customCss by-design", not "forgot to wire". `stroke` itself is the only top-level
+		// Style_Schema entry; the longhands are not in the schema and only need coverage here.
 		'stroke',
+		'stroke-width',
+		'stroke-opacity',
+		'stroke-dasharray',
+		'stroke-dashoffset',
+		'stroke-linecap',
+		'stroke-linejoin',
+		'stroke-miterlimit',
+		// Last-resort fallback for `background` values the shorthand expander cannot decompose
+		// (e.g. exotic syntax). The expander handles the common forms; this entry keeps the
+		// raw declaration in customCss when expansion fails.
 		'background',
 		'box-shadow',
 	];

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -8,9 +8,12 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Filter_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Noop_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Number_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Side_Merge_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Size_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Span_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\String_Property_Converter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Border_Radius_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Border_Width_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -116,10 +119,20 @@ class Converter_Registry_Factory {
 	 *
 	 * - border-radius: Union(Border_Radius | Size); single value -> Size, 2-4 values -> logical
 	 *   Border_Radius. Elliptical "/" values decline to custom_css (no two-radii-per-corner shape).
+	 * - border-width: Union(Border_Width | Size); shares the four logical sides with the Dimensions
+	 *   shorthand, so it reuses Dimensions_Property_Converter with the Border_Width wrapper injected.
 	 */
 	const OTHER_PROPERTIES = [
 		'border-radius',
+		'border-width',
 	];
+
+	/**
+	 * Logical side keys of the Border_Width object, and corner keys of the Border_Radius object, in the
+	 * order used to seed every side/corner from a single Size (e.g. a prior `border-width: 1px`).
+	 */
+	const BORDER_WIDTH_SIDE_KEYS = [ 'block-start', 'inline-end', 'block-end', 'inline-start' ];
+	const BORDER_RADIUS_CORNER_KEYS = [ 'start-start', 'start-end', 'end-end', 'end-start' ];
 
 	/**
 	 * Filter-function lists backed by Array(Css_Filter_Func) (filter, backdrop-filter). Handled
@@ -141,7 +154,6 @@ class Converter_Registry_Factory {
 	const NOOP_PROPERTIES = [
 		'object-position',
 		'stroke',
-		'border-width',
 		'background',
 		'box-shadow',
 		'transform',
@@ -202,8 +214,31 @@ class Converter_Registry_Factory {
 			self::DIMENSIONS_PROPERTIES,
 			self::FILTER_PROPERTIES,
 			self::OTHER_PROPERTIES,
+			array_keys( self::border_side_specs() ),
 			self::NOOP_PROPERTIES
 		);
+	}
+
+	/**
+	 * Per-side/per-corner border longhands that each contribute one fragment to an aggregate object prop
+	 * (border-width / border-radius), keyed by input property -> [ target prop, object key ]. These are
+	 * not Style_Schema properties; they are accumulated into the schema aggregate by
+	 * Object_Side_Merge_Converter. Per-side style/color have no faithful single-valued representation, so
+	 * they are intentionally absent and route to custom_css.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	private static function border_side_specs(): array {
+		return [
+			'border-top-width' => [ 'border-width', 'block-start' ],
+			'border-right-width' => [ 'border-width', 'inline-end' ],
+			'border-bottom-width' => [ 'border-width', 'block-end' ],
+			'border-left-width' => [ 'border-width', 'inline-start' ],
+			'border-top-left-radius' => [ 'border-radius', 'start-start' ],
+			'border-top-right-radius' => [ 'border-radius', 'start-end' ],
+			'border-bottom-right-radius' => [ 'border-radius', 'end-end' ],
+			'border-bottom-left-radius' => [ 'border-radius', 'end-start' ],
+		];
 	}
 
 	public static function create(): Converter_Registry {
@@ -267,6 +302,20 @@ class Converter_Registry_Factory {
 		}
 
 		$converters['border-radius'] = new Border_Radius_Property_Converter( 'border-radius' );
+		$converters['border-width'] = new Dimensions_Property_Converter( 'border-width', Border_Width_Prop_Type::class );
+
+		foreach ( self::border_side_specs() as $property => [ $target, $side_key ] ) {
+			$is_radius = 'border-radius' === $target;
+
+			$converters[ $property ] = new Object_Side_Merge_Converter(
+				$property,
+				$target,
+				$target,
+				$side_key,
+				$is_radius ? self::BORDER_RADIUS_CORNER_KEYS : self::BORDER_WIDTH_SIDE_KEYS,
+				$is_radius ? Border_Radius_Prop_Type::class : Border_Width_Prop_Type::class
+			);
+		}
 
 		foreach ( self::FILTER_PROPERTIES as $property ) {
 			$converters[ $property ] = new Filter_Property_Converter( $property, $schema[ $property ]->get_key() );

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -5,6 +5,7 @@ namespace Elementor\Modules\AtomicWidgets\CssConverter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Image_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Rejected_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Layer_Field_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Position_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Border_Radius_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
@@ -21,13 +22,11 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Side_Merge_Co
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Size_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Span_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\String_Property_Converter;
-use Elementor\Modules\AtomicWidgets\PropTypes\Background_Image_Position_Offset_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Background_Image_Overlay_Size_Scale_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Background_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Border_Radius_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Border_Width_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
-use Elementor\Modules\AtomicWidgets\PropTypes\Position_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 
@@ -446,13 +445,7 @@ class Converter_Registry_Factory {
 			[ 'width', 'height' ]
 		);
 
-		$converters['background-position'] = new Background_Layer_Field_Converter(
-			'background-position',
-			'position',
-			Position_Prop_Type::get_position_enum_values(),
-			Background_Image_Position_Offset_Prop_Type::class,
-			[ 'x', 'y' ]
-		);
+		$converters['background-position'] = new Background_Position_Property_Converter();
 
 		return $converters;
 	}

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -7,13 +7,22 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Conve
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Filter_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Noop_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Image_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Layer_Field_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Number_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Field_Merge_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Side_Merge_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Size_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Span_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\String_Property_Converter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Image_Position_Offset_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Image_Overlay_Size_Scale_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Border_Radius_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Border_Width_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Position_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -128,6 +137,35 @@ class Converter_Registry_Factory {
 	];
 
 	/**
+	 * Scalar background longhands that each fill one field of the aggregate `background` object. Not
+	 * Style_Schema properties (the schema only has the `background` aggregate); they are accumulated into
+	 * it by Object_Field_Merge_Converter, wired explicitly in real_converters() so each field's leaf prop
+	 * type / enum is sourced from the live schema. The overlay array (image/gradient layers) is separate.
+	 */
+	const BACKGROUND_FIELD_PROPERTIES = [
+		'background-color',
+		'background-clip',
+	];
+
+	/**
+	 * Background overlay longhands that are not Style_Schema properties. `background-image` creates the
+	 * image layer array in the aggregate; the rest update fields on existing layers via
+	 * Background_Layer_Field_Converter. Enums are hardcoded to match the background-image-overlay shape
+	 * without needing to instantiate the prop type (which would require WP for image sizes).
+	 */
+	const BACKGROUND_LAYER_PROPERTIES = [
+		'background-image',
+		'background-repeat',
+		'background-attachment',
+		'background-size',
+		'background-position',
+	];
+
+	const BACKGROUND_REPEAT_ENUM = [ 'repeat', 'repeat-x', 'repeat-y', 'no-repeat' ];
+	const BACKGROUND_ATTACHMENT_ENUM = [ 'fixed', 'scroll' ];
+	const BACKGROUND_SIZE_ENUM = [ 'auto', 'cover', 'contain' ];
+
+	/**
 	 * Logical side keys of the Border_Width object, and corner keys of the Border_Radius object, in the
 	 * order used to seed every side/corner from a single Size (e.g. a prior `border-width: 1px`).
 	 */
@@ -215,6 +253,8 @@ class Converter_Registry_Factory {
 			self::FILTER_PROPERTIES,
 			self::OTHER_PROPERTIES,
 			array_keys( self::border_side_specs() ),
+			self::BACKGROUND_FIELD_PROPERTIES,
+			self::BACKGROUND_LAYER_PROPERTIES,
 			self::NOOP_PROPERTIES
 		);
 	}
@@ -320,6 +360,59 @@ class Converter_Registry_Factory {
 		foreach ( self::FILTER_PROPERTIES as $property ) {
 			$converters[ $property ] = new Filter_Property_Converter( $property, $schema[ $property ]->get_key() );
 		}
+
+		$background_key = Background_Prop_Type::get_key();
+
+		$converters['background-color'] = new Object_Field_Merge_Converter(
+			'background-color',
+			$background_key,
+			$background_key,
+			'color',
+			Color_Prop_Type::class,
+			Background_Prop_Type::class,
+			null,
+			true
+		);
+
+		$converters['background-clip'] = new Object_Field_Merge_Converter(
+			'background-clip',
+			$background_key,
+			$background_key,
+			'clip',
+			String_Prop_Type::class,
+			Background_Prop_Type::class,
+			$schema[ $background_key ]->get_shape_field( 'clip' )->get_enum()
+		);
+
+		$converters['background-image'] = new Background_Image_Converter();
+
+		$converters['background-repeat'] = new Background_Layer_Field_Converter(
+			'background-repeat',
+			'repeat',
+			self::BACKGROUND_REPEAT_ENUM
+		);
+
+		$converters['background-attachment'] = new Background_Layer_Field_Converter(
+			'background-attachment',
+			'attachment',
+			self::BACKGROUND_ATTACHMENT_ENUM
+		);
+
+		$converters['background-size'] = new Background_Layer_Field_Converter(
+			'background-size',
+			'size',
+			self::BACKGROUND_SIZE_ENUM,
+			Background_Image_Overlay_Size_Scale_Prop_Type::class,
+			[ 'width', 'height' ]
+		);
+
+		$converters['background-position'] = new Background_Layer_Field_Converter(
+			'background-position',
+			'position',
+			Position_Prop_Type::get_position_enum_values(),
+			Background_Image_Position_Offset_Prop_Type::class,
+			[ 'x', 'y' ]
+		);
 
 		return $converters;
 	}

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -26,6 +26,7 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Converters\String_Property_Conv
 use Elementor\Modules\AtomicWidgets\PropTypes\Background_Image_Overlay_Size_Scale_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Background_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Border_Radius_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Dimensions_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Border_Width_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
@@ -178,11 +179,27 @@ class Converter_Registry_Factory {
 	const BACKGROUND_SIZE_ENUM = [ 'auto', 'cover', 'contain' ];
 
 	/**
-	 * Logical side keys of the Border_Width object, and corner keys of the Border_Radius object, in the
-	 * order used to seed every side/corner from a single Size (e.g. a prior `border-width: 1px`).
+	 * Logical side keys of the Border_Width / Dimensions objects, and corner keys of the Border_Radius
+	 * object, in the order used to seed every side/corner from a single Size.
 	 */
 	const BORDER_WIDTH_SIDE_KEYS = [ 'block-start', 'inline-end', 'block-end', 'inline-start' ];
 	const BORDER_RADIUS_CORNER_KEYS = [ 'start-start', 'start-end', 'end-end', 'end-start' ];
+
+	/**
+	 * Physical padding/margin longhands -> [ target schema prop, logical side key ].
+	 * Not Style_Schema properties themselves; accumulated into the schema aggregate by
+	 * Object_Side_Merge_Converter (same pattern as border_side_specs()).
+	 */
+	const DIMENSIONS_SIDE_SPECS = [
+		'padding-top'    => [ 'padding', 'block-start' ],
+		'padding-right'  => [ 'padding', 'inline-end' ],
+		'padding-bottom' => [ 'padding', 'block-end' ],
+		'padding-left'   => [ 'padding', 'inline-start' ],
+		'margin-top'     => [ 'margin', 'block-start' ],
+		'margin-right'   => [ 'margin', 'inline-end' ],
+		'margin-bottom'  => [ 'margin', 'block-end' ],
+		'margin-left'    => [ 'margin', 'inline-start' ],
+	];
 
 	/**
 	 * Filter-function lists backed by Array(Css_Filter_Func) (filter, backdrop-filter). Handled
@@ -399,6 +416,17 @@ class Converter_Registry_Factory {
 		$converters['transform'] = new Transform_Property_Converter();
 		$converters['transform-origin'] = new Transform_Origin_Property_Converter();
 		$converters['box-shadow'] = new Box_Shadow_Property_Converter();
+
+		foreach ( self::DIMENSIONS_SIDE_SPECS as $property => [ $target, $side_key ] ) {
+			$converters[ $property ] = new Object_Side_Merge_Converter(
+				$property,
+				$target,
+				Dimensions_Prop_Type::get_key(),
+				$side_key,
+				self::BORDER_WIDTH_SIDE_KEYS,
+				Dimensions_Prop_Type::class
+			);
+		}
 
 		foreach ( self::border_side_specs() as $property => [ $target, $side_key ] ) {
 			$is_radius = 'border-radius' === $target;

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -3,6 +3,8 @@
 namespace Elementor\Modules\AtomicWidgets\CssConverter;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Noop_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\String_Property_Converter;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -10,30 +12,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Converter_Registry_Factory {
 	/**
-	 * The exhaustive, hardcoded set of Style_Schema properties the converter covers. It is
-	 * intentionally NOT derived from Style_Schema: a coverage test diffs the live schema against
-	 * this list so adding a schema property without coverage fails CI until it is added here.
+	 * Hardcoded Style_Schema properties that are NOT plain strings (sizes, colors, objects, unions).
+	 * Combined with STRING_PROPERTIES via covered_properties() to form the exhaustive covered set.
+	 * Intentionally NOT derived from Style_Schema: a coverage test diffs the live schema against the
+	 * covered set so adding a schema property without coverage fails CI until it is added here.
 	 */
-	const COVERED_PROPERTIES = [
+	const NON_STRING_PROPERTIES = [
 		'width',
 		'height',
 		'min-width',
 		'min-height',
 		'max-width',
 		'max-height',
-		'overflow',
-		'aspect-ratio',
-		'object-fit',
 		'object-position',
-		'position',
 		'inset-block-start',
 		'inset-inline-end',
 		'inset-block-end',
 		'inset-inline-start',
 		'z-index',
 		'scroll-margin-top',
-		'font-family',
-		'font-weight',
 		'font-size',
 		'color',
 		'letter-spacing',
@@ -41,62 +38,114 @@ class Converter_Registry_Factory {
 		'column-count',
 		'column-gap',
 		'line-height',
-		'text-align',
-		'font-style',
-		'text-decoration',
-		'text-transform',
-		'direction',
 		'stroke',
-		'all',
-		'cursor',
 		'padding',
 		'margin',
 		'border-radius',
 		'border-width',
 		'border-color',
-		'border-style',
 		'outline-width',
 		'outline-color',
-		'outline-style',
 		'outline-offset',
 		'background',
-		'mix-blend-mode',
 		'box-shadow',
 		'opacity',
 		'filter',
 		'backdrop-filter',
 		'transform',
 		'transition',
-		'display',
-		'flex-direction',
 		'gap',
-		'flex-wrap',
 		'flex',
 		'grid-template-columns',
 		'grid-template-rows',
-		'grid-auto-flow',
 		'grid-auto-rows',
 		'grid-auto-columns',
 		'grid-column',
 		'grid-row',
+		'order',
+	];
+
+	/**
+	 * Every Style_Schema property backed by a plain String_Prop_Type. Enum-backed and free-string
+	 * props are handled the same way: get_enum() returns the allowlist (enum props) or null
+	 * (free-string props), so the allowlist is always sourced from the schema, never duplicated.
+	 */
+	const STRING_PROPERTIES = [
+		'overflow',
+		'aspect-ratio',
+		'object-fit',
+		'position',
+		'font-family',
+		'font-weight',
+		'text-align',
+		'font-style',
+		'text-decoration',
+		'text-transform',
+		'direction',
+		'all',
+		'cursor',
+		'border-style',
+		'outline-style',
+		'mix-blend-mode',
+		'display',
+		'flex-direction',
+		'flex-wrap',
+		'grid-auto-flow',
 		'justify-content',
 		'justify-items',
 		'align-content',
 		'align-items',
 		'align-self',
-		'order',
 		'content',
 		'appearance',
 		'clip-path',
 	];
 
+	/**
+	 * The exhaustive covered set: string props plus every non-string prop. Single source of truth
+	 * for the coverage test, with no property listed twice.
+	 *
+	 * @return string[]
+	 */
+	public static function covered_properties(): array {
+		return array_merge( self::STRING_PROPERTIES, self::NON_STRING_PROPERTIES );
+	}
+
 	public static function create(): Converter_Registry {
 		$registry = new Converter_Registry();
+		$real_converters = self::real_converters();
 
-		foreach ( self::COVERED_PROPERTIES as $property ) {
+		foreach ( $real_converters as $converter ) {
+			$registry->register( $converter );
+		}
+
+		foreach ( self::covered_properties() as $property ) {
+			if ( isset( $real_converters[ $property ] ) ) {
+				continue;
+			}
+
 			$registry->register( new Noop_Converter( $property ) );
 		}
 
 		return $registry;
+	}
+
+	/**
+	 * Real converters keyed by the property they own. Every remaining covered_properties() entry
+	 * falls back to a Noop_Converter, so the "exactly one converter per property" invariant holds.
+	 * Enum allowlists are sourced from the live Style_Schema to avoid duplicating (and drifting from)
+	 * the schema's enums.
+	 *
+	 * @return array<string, \Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter>
+	 */
+	private static function real_converters(): array {
+		$schema = Style_Schema::get_style_schema();
+		$converters = [];
+
+		foreach ( self::STRING_PROPERTIES as $property ) {
+			$converters[ $property ] = new String_Property_Converter( $property, $schema[ $property ]->get_enum() );
+		}
+
+		return $converters;
 	}
 }

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -2,15 +2,17 @@
 
 namespace Elementor\Modules\AtomicWidgets\CssConverter;
 
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Image_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Layer_Field_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Border_Radius_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Filter_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Flex_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Noop_Converter;
-use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Image_Converter;
-use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Layer_Field_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Number_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Field_Merge_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Position_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Side_Merge_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Size_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Span_Property_Converter;
@@ -134,6 +136,8 @@ class Converter_Registry_Factory {
 	const OTHER_PROPERTIES = [
 		'border-radius',
 		'border-width',
+		'object-position',
+		'flex',
 	];
 
 	/**
@@ -190,13 +194,11 @@ class Converter_Registry_Factory {
 	 * property without coverage fails CI until it is added here.
 	 */
 	const NOOP_PROPERTIES = [
-		'object-position',
 		'stroke',
 		'background',
 		'box-shadow',
 		'transform',
 		'transition',
-		'flex',
 	];
 
 	/**
@@ -343,6 +345,8 @@ class Converter_Registry_Factory {
 
 		$converters['border-radius'] = new Border_Radius_Property_Converter( 'border-radius' );
 		$converters['border-width'] = new Dimensions_Property_Converter( 'border-width', Border_Width_Prop_Type::class );
+		$converters['object-position'] = new Object_Position_Property_Converter();
+		$converters['flex'] = new Flex_Property_Converter();
 
 		foreach ( self::border_side_specs() as $property => [ $target, $side_key ] ) {
 			$is_radius = 'border-radius' === $target;

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\AtomicWidgets\CssConverter;
 
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Border_Radius_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Filter_Property_Converter;
@@ -108,6 +109,19 @@ class Converter_Registry_Factory {
 	];
 
 	/**
+	 * Props that each own a bespoke single-property converter (no shared family). Listed here for the
+	 * covered set; each is wired explicitly in real_converters() (unlike the family arrays above, the
+	 * members do not share a converter class, so there is no uniform loop). Distinct from
+	 * NOOP_PROPERTIES, which have no real converter yet.
+	 *
+	 * - border-radius: Union(Border_Radius | Size); single value -> Size, 2-4 values -> logical
+	 *   Border_Radius. Elliptical "/" values decline to custom_css (no two-radii-per-corner shape).
+	 */
+	const OTHER_PROPERTIES = [
+		'border-radius',
+	];
+
+	/**
 	 * Filter-function lists backed by Array(Css_Filter_Func) (filter, backdrop-filter). Handled
 	 * uniformly by Filter_Property_Converter + Filter_Value_Parser; the two share inner items and
 	 * differ only by the wrapping $$type, which is sourced from the live schema.
@@ -127,7 +141,6 @@ class Converter_Registry_Factory {
 	const NOOP_PROPERTIES = [
 		'object-position',
 		'stroke',
-		'border-radius',
 		'border-width',
 		'background',
 		'box-shadow',
@@ -188,6 +201,7 @@ class Converter_Registry_Factory {
 			self::STRING_PASSTHROUGH_PROPERTIES,
 			self::DIMENSIONS_PROPERTIES,
 			self::FILTER_PROPERTIES,
+			self::OTHER_PROPERTIES,
 			self::NOOP_PROPERTIES
 		);
 	}
@@ -251,6 +265,8 @@ class Converter_Registry_Factory {
 		foreach ( self::DIMENSIONS_PROPERTIES as $property ) {
 			$converters[ $property ] = new Dimensions_Property_Converter( $property );
 		}
+
+		$converters['border-radius'] = new Border_Radius_Property_Converter( 'border-radius' );
 
 		foreach ( self::FILTER_PROPERTIES as $property ) {
 			$converters[ $property ] = new Filter_Property_Converter( $property, $schema[ $property ]->get_key() );

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\AtomicWidgets\CssConverter;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Image_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Rejected_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Layer_Field_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Border_Radius_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Converter;
@@ -202,6 +203,25 @@ class Converter_Registry_Factory {
 	];
 
 	/**
+	 * Properties that are structurally incompatible with Elementor's inline style system.
+	 * They are explicitly rejected (not routed to customCss) so the client can surface a
+	 * hint to the LLM that these constructs are unsupported in element style definitions.
+	 *
+	 * `animation` and its longhands rely on @keyframes which cannot be declared inline.
+	 */
+	const REJECTED_PROPERTIES = [
+		'animation',
+		'animation-name',
+		'animation-duration',
+		'animation-timing-function',
+		'animation-delay',
+		'animation-iteration-count',
+		'animation-direction',
+		'animation-fill-mode',
+		'animation-play-state',
+	];
+
+	/**
 	 * Every Style_Schema property backed by a plain String_Prop_Type. Enum-backed and free-string
 	 * props are handled the same way: get_enum() returns the allowlist (enum props) or null
 	 * (free-string props), so the allowlist is always sourced from the schema, never duplicated.
@@ -257,7 +277,8 @@ class Converter_Registry_Factory {
 			array_keys( self::border_side_specs() ),
 			self::BACKGROUND_FIELD_PROPERTIES,
 			self::BACKGROUND_LAYER_PROPERTIES,
-			self::NOOP_PROPERTIES
+			self::NOOP_PROPERTIES,
+			self::REJECTED_PROPERTIES
 		);
 	}
 
@@ -291,8 +312,16 @@ class Converter_Registry_Factory {
 			$registry->register( $converter );
 		}
 
+		foreach ( self::REJECTED_PROPERTIES as $property ) {
+			$registry->register( new Rejected_Converter( $property ) );
+		}
+
 		foreach ( self::covered_properties() as $property ) {
 			if ( isset( $real_converters[ $property ] ) ) {
+				continue;
+			}
+
+			if ( in_array( $property, self::REJECTED_PROPERTIES, true ) ) {
 				continue;
 			}
 

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -10,6 +10,8 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Conve
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Filter_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Flex_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Transform_Origin_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Transform_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Transition_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Noop_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Number_Property_Converter;
@@ -141,6 +143,8 @@ class Converter_Registry_Factory {
 		'object-position',
 		'flex',
 		'transition',
+		'transform',
+		'transform-origin',
 	];
 
 	/**
@@ -200,7 +204,6 @@ class Converter_Registry_Factory {
 		'stroke',
 		'background',
 		'box-shadow',
-		'transform',
 	];
 
 	/**
@@ -378,6 +381,8 @@ class Converter_Registry_Factory {
 		$converters['object-position'] = new Object_Position_Property_Converter();
 		$converters['flex'] = new Flex_Property_Converter();
 		$converters['transition'] = new Transition_Property_Converter();
+		$converters['transform'] = new Transform_Property_Converter();
+		$converters['transform-origin'] = new Transform_Origin_Property_Converter();
 
 		foreach ( self::border_side_specs() as $property => [ $target, $side_key ] ) {
 			$is_radius = 'border-radius' === $target;

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -10,6 +10,7 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Conve
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Filter_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Flex_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Transition_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Noop_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Number_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Field_Merge_Converter;
@@ -139,6 +140,7 @@ class Converter_Registry_Factory {
 		'border-width',
 		'object-position',
 		'flex',
+		'transition',
 	];
 
 	/**
@@ -199,7 +201,6 @@ class Converter_Registry_Factory {
 		'background',
 		'box-shadow',
 		'transform',
-		'transition',
 	];
 
 	/**
@@ -376,6 +377,7 @@ class Converter_Registry_Factory {
 		$converters['border-width'] = new Dimensions_Property_Converter( 'border-width', Border_Width_Prop_Type::class );
 		$converters['object-position'] = new Object_Position_Property_Converter();
 		$converters['flex'] = new Flex_Property_Converter();
+		$converters['transition'] = new Transition_Property_Converter();
 
 		foreach ( self::border_side_specs() as $property => [ $target, $side_key ] ) {
 			$is_radius = 'border-radius' === $target;

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -6,6 +6,7 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Conve
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Noop_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Number_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Size_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Span_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\String_Property_Converter;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 
@@ -66,6 +67,15 @@ class Converter_Registry_Factory {
 	];
 
 	/**
+	 * Every Style_Schema property backed by a Span_Prop_Type (grid placement). Handled uniformly by
+	 * Span_Property_Converter, with the validation regex sourced from the live schema.
+	 */
+	const SPAN_PROPERTIES = [
+		'grid-column',
+		'grid-row',
+	];
+
+	/**
 	 * Hardcoded Style_Schema properties with no real converter yet (objects, unions, shorthands). They
 	 * still get a Noop_Converter so they keep routing to custom_css. Combined with the real-converter
 	 * families via covered_properties() to form the exhaustive covered set. Intentionally NOT derived
@@ -88,8 +98,6 @@ class Converter_Registry_Factory {
 		'flex',
 		'grid-template-columns',
 		'grid-template-rows',
-		'grid-column',
-		'grid-row',
 	];
 
 	/**
@@ -140,6 +148,7 @@ class Converter_Registry_Factory {
 			self::SIZE_PROPERTIES,
 			self::NUMBER_PROPERTIES,
 			self::COLOR_PROPERTIES,
+			self::SPAN_PROPERTIES,
 			self::NOOP_PROPERTIES
 		);
 	}
@@ -189,6 +198,10 @@ class Converter_Registry_Factory {
 
 		foreach ( self::COLOR_PROPERTIES as $property ) {
 			$converters[ $property ] = new Color_Property_Converter( $property );
+		}
+
+		foreach ( self::SPAN_PROPERTIES as $property ) {
+			$converters[ $property ] = new Span_Property_Converter( $property, $schema[ $property ]->get_regex() );
 		}
 
 		return $converters;

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -31,6 +31,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Border_Width_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
+use Elementor\Modules\Variables\Services\Variables_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -191,14 +192,22 @@ class Converter_Registry_Factory {
 	 * Object_Side_Merge_Converter (same pattern as border_side_specs()).
 	 */
 	const DIMENSIONS_SIDE_SPECS = [
-		'padding-top'    => [ 'padding', 'block-start' ],
-		'padding-right'  => [ 'padding', 'inline-end' ],
-		'padding-bottom' => [ 'padding', 'block-end' ],
-		'padding-left'   => [ 'padding', 'inline-start' ],
-		'margin-top'     => [ 'margin', 'block-start' ],
-		'margin-right'   => [ 'margin', 'inline-end' ],
-		'margin-bottom'  => [ 'margin', 'block-end' ],
-		'margin-left'    => [ 'margin', 'inline-start' ],
+		'padding-top'          => [ 'padding', 'block-start' ],
+		'padding-right'        => [ 'padding', 'inline-end' ],
+		'padding-bottom'       => [ 'padding', 'block-end' ],
+		'padding-left'         => [ 'padding', 'inline-start' ],
+		'padding-block-start'  => [ 'padding', 'block-start' ],
+		'padding-block-end'    => [ 'padding', 'block-end' ],
+		'padding-inline-start' => [ 'padding', 'inline-start' ],
+		'padding-inline-end'   => [ 'padding', 'inline-end' ],
+		'margin-top'           => [ 'margin', 'block-start' ],
+		'margin-right'         => [ 'margin', 'inline-end' ],
+		'margin-bottom'        => [ 'margin', 'block-end' ],
+		'margin-left'          => [ 'margin', 'inline-start' ],
+		'margin-block-start'   => [ 'margin', 'block-start' ],
+		'margin-block-end'     => [ 'margin', 'block-end' ],
+		'margin-inline-start'  => [ 'margin', 'inline-start' ],
+		'margin-inline-end'    => [ 'margin', 'inline-end' ],
 	];
 
 	/**
@@ -340,9 +349,9 @@ class Converter_Registry_Factory {
 		];
 	}
 
-	public static function create(): Converter_Registry {
+	public static function create( ?Variables_Service $variables_service = null ): Converter_Registry {
 		$registry = new Converter_Registry();
-		$real_converters = self::real_converters();
+		$real_converters = self::real_converters( $variables_service );
 
 		foreach ( $real_converters as $converter ) {
 			$registry->register( $converter );
@@ -375,7 +384,7 @@ class Converter_Registry_Factory {
 	 *
 	 * @return array<string, \Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter>
 	 */
-	private static function real_converters(): array {
+	private static function real_converters( ?Variables_Service $variables_service = null ): array {
 		$schema = Style_Schema::get_style_schema();
 		$converters = [];
 
@@ -424,7 +433,8 @@ class Converter_Registry_Factory {
 				Dimensions_Prop_Type::get_key(),
 				$side_key,
 				self::BORDER_WIDTH_SIDE_KEYS,
-				Dimensions_Prop_Type::class
+				Dimensions_Prop_Type::class,
+				$variables_service
 			);
 		}
 
@@ -437,7 +447,8 @@ class Converter_Registry_Factory {
 				$target,
 				$side_key,
 				$is_radius ? self::BORDER_RADIUS_CORNER_KEYS : self::BORDER_WIDTH_SIDE_KEYS,
-				$is_radius ? Border_Radius_Prop_Type::class : Border_Width_Prop_Type::class
+				$is_radius ? Border_Radius_Prop_Type::class : Border_Width_Prop_Type::class,
+				$variables_service
 			);
 		}
 

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -2,7 +2,9 @@
 
 namespace Elementor\Modules\AtomicWidgets\CssConverter;
 
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Noop_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Number_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Size_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\String_Property_Converter;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
@@ -39,27 +41,44 @@ class Converter_Registry_Factory {
 		'outline-offset',
 		'opacity',
 		'gap',
+		'grid-auto-rows',
+		'grid-auto-columns',
 	];
 
 	/**
-	 * Hardcoded Style_Schema properties with no real converter yet (colors, numbers, objects, unions,
-	 * shorthands). They still get a Noop_Converter so they keep routing to custom_css. Combined with the
-	 * real-converter families via covered_properties() to form the exhaustive covered set. Intentionally
-	 * NOT derived from Style_Schema: a coverage test diffs the live schema against the covered set so
-	 * adding a schema property without coverage fails CI until it is added here.
+	 * Every Style_Schema property backed by a Number_Prop_Type. Handled uniformly by
+	 * Number_Property_Converter (strict numeric, no units/functions).
+	 */
+	const NUMBER_PROPERTIES = [
+		'z-index',
+		'column-count',
+		'order',
+	];
+
+	/**
+	 * Every Style_Schema property backed by a plain Color_Prop_Type. Handled uniformly by
+	 * Color_Property_Converter (raw passthrough; any non-empty value is a valid color).
+	 */
+	const COLOR_PROPERTIES = [
+		'color',
+		'border-color',
+		'outline-color',
+	];
+
+	/**
+	 * Hardcoded Style_Schema properties with no real converter yet (objects, unions, shorthands). They
+	 * still get a Noop_Converter so they keep routing to custom_css. Combined with the real-converter
+	 * families via covered_properties() to form the exhaustive covered set. Intentionally NOT derived
+	 * from Style_Schema: a coverage test diffs the live schema against the covered set so adding a schema
+	 * property without coverage fails CI until it is added here.
 	 */
 	const NOOP_PROPERTIES = [
 		'object-position',
-		'z-index',
-		'color',
-		'column-count',
 		'stroke',
 		'padding',
 		'margin',
 		'border-radius',
 		'border-width',
-		'border-color',
-		'outline-color',
 		'background',
 		'box-shadow',
 		'filter',
@@ -69,11 +88,8 @@ class Converter_Registry_Factory {
 		'flex',
 		'grid-template-columns',
 		'grid-template-rows',
-		'grid-auto-rows',
-		'grid-auto-columns',
 		'grid-column',
 		'grid-row',
-		'order',
 	];
 
 	/**
@@ -119,7 +135,13 @@ class Converter_Registry_Factory {
 	 * @return string[]
 	 */
 	public static function covered_properties(): array {
-		return array_merge( self::STRING_PROPERTIES, self::SIZE_PROPERTIES, self::NOOP_PROPERTIES );
+		return array_merge(
+			self::STRING_PROPERTIES,
+			self::SIZE_PROPERTIES,
+			self::NUMBER_PROPERTIES,
+			self::COLOR_PROPERTIES,
+			self::NOOP_PROPERTIES
+		);
 	}
 
 	public static function create(): Converter_Registry {
@@ -159,6 +181,14 @@ class Converter_Registry_Factory {
 
 		foreach ( self::SIZE_PROPERTIES as $property ) {
 			$converters[ $property ] = new Size_Property_Converter( $property );
+		}
+
+		foreach ( self::NUMBER_PROPERTIES as $property ) {
+			$converters[ $property ] = new Number_Property_Converter( $property );
+		}
+
+		foreach ( self::COLOR_PROPERTIES as $property ) {
+			$converters[ $property ] = new Color_Property_Converter( $property );
 		}
 
 		return $converters;

--- a/modules/atomic-widgets/css-converter/converters/background-image-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/background-image-converter.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Background_Image_Value_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Overlay_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converter for `background-image`. Delegates parsing to Background_Image_Value_Parser which returns
+ * fully-constructed overlay PropValues (image overlays for url(), gradient overlays for linear/radial-
+ * gradient()). The resulting ordered list is stored as `background-overlay` in the `background`
+ * aggregate context object, preserving any existing scalar fields (color, clip).
+ *
+ * Sibling background longhands processed afterwards (background-repeat, background-size, etc.) read
+ * and update the image-overlay items via Background_Layer_Field_Converter.
+ */
+class Background_Image_Converter extends Property_Converter_Base {
+	protected function get_supported_properties(): array {
+		return [ 'background-image' ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$overlays = Background_Image_Value_Parser::parse( trim( $rule['value'] ) );
+
+		if ( null === $overlays ) {
+			return false;
+		}
+
+		$fields = $this->current_background_fields( $context->get_prop( 'background' ) );
+		$fields['background-overlay'] = Background_Overlay_Prop_Type::generate( $overlays );
+
+		$context->set_prop( 'background', Background_Prop_Type::generate( $fields ) );
+
+		return true;
+	}
+
+	private function current_background_fields( $existing ): array {
+		if ( ! is_array( $existing ) ) {
+			return [];
+		}
+
+		$type = $existing['$$type'] ?? null;
+
+		if ( Background_Prop_Type::get_key() === $type && is_array( $existing['value'] ?? null ) ) {
+			return $existing['value'];
+		}
+
+		return [];
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/background-layer-field-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/background-layer-field-converter.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Image_Overlay_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Overlay_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converter for scalar sub-layer longhands of `background-image`: background-repeat,
+ * background-attachment, background-size, background-position. One instance per CSS property.
+ *
+ * Reads the ordered list of `background-image-overlay` items currently in the `background` context
+ * object. If no image layers exist yet the declaration is declined (-> custom_css) because there is
+ * nothing to attach the value to. CSS comma-separated lists are correlated to layers by position: a
+ * single value applies to all layers; multiple values are distributed 1:1. A mismatch in count
+ * declines the declaration.
+ *
+ * Each per-layer token is validated first against an optional string enum (e.g. repeat, cover).
+ * When a token is not in the enum and a pair prop type is configured, the token is re-parsed as two
+ * whitespace-separated Size values (e.g. `50% 50%` for size, `10px 20px` for position offset).
+ * Any token that fails both checks declines the whole declaration.
+ */
+class Background_Layer_Field_Converter extends Property_Converter_Base {
+	private string $property;
+	private string $field_key;
+
+	/**
+	 * @var string[]|null
+	 */
+	private ?array $allowed_values;
+
+	/**
+	 * @var class-string|null
+	 */
+	private ?string $pair_prop_type;
+
+	/**
+	 * @var string[]
+	 */
+	private array $pair_keys;
+
+	/**
+	 * @param string        $property        The CSS longhand property this converter owns.
+	 * @param string        $field_key       The field key inside each background-image-overlay value.
+	 * @param string[]|null $allowed_values  String enum allowlist, or null to skip enum check.
+	 * @param string|null   $pair_prop_type  Object_Prop_Type class for size-pair values, or null.
+	 * @param string[]      $pair_keys       The two field keys of the pair type (e.g. ['x','y']).
+	 */
+	public function __construct(
+		string $property,
+		string $field_key,
+		?array $allowed_values,
+		?string $pair_prop_type = null,
+		array $pair_keys = []
+	) {
+		$this->property = $property;
+		$this->field_key = $field_key;
+		$this->allowed_values = $allowed_values;
+		$this->pair_prop_type = $pair_prop_type;
+		$this->pair_keys = $pair_keys;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$overlay_items = $this->get_overlay_items( $context );
+		$image_indices = array_keys(
+			array_filter( $overlay_items, fn( $item ) => Background_Image_Overlay_Prop_Type::get_key() === ( $item['$$type'] ?? null ) )
+		);
+
+		if ( empty( $image_indices ) ) {
+			return false;
+		}
+
+		$tokens = Css_Token_Splitter::split_by_comma( trim( $rule['value'] ) );
+		$prop_values = [];
+
+		foreach ( $tokens as $token ) {
+			$leaf = $this->parse_token( $token );
+
+			if ( null === $leaf ) {
+				return false;
+			}
+
+			$prop_values[] = $leaf;
+		}
+
+		$layer_count = count( $image_indices );
+		$value_count = count( $prop_values );
+
+		if ( 1 !== $value_count && $layer_count !== $value_count ) {
+			return false;
+		}
+
+		foreach ( $image_indices as $order => $index ) {
+			$value_index = 1 === $value_count ? 0 : $order;
+			$overlay_items[ $index ]['value'][ $this->field_key ] = $prop_values[ $value_index ];
+		}
+
+		$background = $context->get_prop( 'background' );
+		$fields = is_array( $background ) && isset( $background['value'] ) ? $background['value'] : [];
+		$fields['background-overlay'] = Background_Overlay_Prop_Type::generate( array_values( $overlay_items ) );
+
+		$context->set_prop( 'background', Background_Prop_Type::generate( $fields ) );
+
+		return true;
+	}
+
+	private function get_overlay_items( Conversion_Context $context ): array {
+		$background = $context->get_prop( 'background' );
+
+		if ( ! is_array( $background ) ) {
+			return [];
+		}
+
+		$overlay = $background['value']['background-overlay'] ?? null;
+
+		if ( ! is_array( $overlay ) ) {
+			return [];
+		}
+
+		return $overlay['value'] ?? [];
+	}
+
+	private function parse_token( string $token ): ?array {
+		$token = trim( $token );
+
+		if ( null !== $this->allowed_values && in_array( $token, $this->allowed_values, true ) ) {
+			return String_Prop_Type::generate( $token );
+		}
+
+		if ( null !== $this->pair_prop_type ) {
+			return $this->parse_size_pair( $token );
+		}
+
+		return null;
+	}
+
+	private function parse_size_pair( string $token ): ?array {
+		$parts = Css_Token_Splitter::split_by_whitespace( $token );
+
+		if ( 2 !== count( $parts ) ) {
+			return null;
+		}
+
+		$first = Size_Value_Parser::parse( $parts[0] );
+		$second = Size_Value_Parser::parse( $parts[1] );
+
+		if ( null === $first || null === $second ) {
+			return null;
+		}
+
+		return ( $this->pair_prop_type )::generate( [
+			$this->pair_keys[0] => Size_Prop_Type::generate( $first ),
+			$this->pair_keys[1] => Size_Prop_Type::generate( $second ),
+		] );
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/background-layer-field-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/background-layer-field-converter.php
@@ -135,7 +135,7 @@ class Background_Layer_Field_Converter extends Property_Converter_Base {
 		return $overlay['value'] ?? [];
 	}
 
-	private function parse_token( string $token ): ?array {
+	protected function parse_token( string $token ): ?array {
 		$token = trim( $token );
 
 		if ( null !== $this->allowed_values && in_array( $token, $this->allowed_values, true ) ) {

--- a/modules/atomic-widgets/css-converter/converters/background-position-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/background-position-property-converter.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Image_Position_Offset_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Position_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converter for `background-position`.
+ *
+ * The schema accepts only two shapes for a position value:
+ *   - String enum (one of Position_Prop_Type::get_position_enum_values())
+ *   - Background_Image_Position_Offset_Prop_Type { x: Size, y: Size }
+ *
+ * This subclass adds keyword normalization to the generic Background_Layer_Field_Converter
+ * so common LLM-emitted inputs reach the enum branch instead of declining:
+ *   - single keyword:  center  -> "center center", top -> "top center", left -> "center left", ...
+ *   - swapped pair:    left top -> "top left"  (enum is y-then-x ordered)
+ *
+ * Anything that cannot be normalized to an enum string or to two parseable Sizes
+ * (e.g. center 20%, bottom 4px, anything containing calc()) declines to custom_css.
+ */
+class Background_Position_Property_Converter extends Background_Layer_Field_Converter {
+	const SINGLE_KEYWORD_TO_PAIR = [
+		'center' => 'center center',
+		'top'    => 'top center',
+		'bottom' => 'bottom center',
+		'left'   => 'center left',
+		'right'  => 'center right',
+	];
+
+	const X_ONLY_KEYWORDS = [ 'left', 'right' ];
+	const Y_ONLY_KEYWORDS = [ 'top', 'bottom' ];
+
+	public function __construct() {
+		parent::__construct(
+			'background-position',
+			'position',
+			Position_Prop_Type::get_position_enum_values(),
+			Background_Image_Position_Offset_Prop_Type::class,
+			[ 'x', 'y' ]
+		);
+	}
+
+	protected function parse_token( string $token ): ?array {
+		return parent::parse_token( $this->normalize_keywords( trim( $token ) ) );
+	}
+
+	private function normalize_keywords( string $token ): string {
+		$parts = Css_Token_Splitter::split_by_whitespace( $token );
+
+		if ( 1 === count( $parts ) ) {
+			$lower = strtolower( $parts[0] );
+
+			return self::SINGLE_KEYWORD_TO_PAIR[ $lower ] ?? $token;
+		}
+
+		if ( 2 === count( $parts ) ) {
+			$first = strtolower( $parts[0] );
+			$second = strtolower( $parts[1] );
+
+			if ( in_array( $first, self::X_ONLY_KEYWORDS, true ) && in_array( $second, self::Y_ONLY_KEYWORDS, true ) ) {
+				return $second . ' ' . $first;
+			}
+		}
+
+		return $token;
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/border-radius-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/border-radius-property-converter.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Box_Shorthand_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Border_Radius_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Reusable converter for border-radius (Union(Border_Radius | Size)). One instance per property.
+ * Delegates tokenizing/expansion to Box_Shorthand_Parser; a null parse declines (-> custom_css).
+ *
+ * A single token emits the Size member. Two-to-four tokens expand via the CSS corner rule
+ * (top-left/top-right/bottom-right/bottom-left) and map physical->logical (TL=start-start,
+ * TR=start-end, BR=end-end, BL=end-start) into a Border_Radius PropValue. Elliptical values (a "/"
+ * separating horizontal/vertical radii) cannot be modeled by the single-Size-per-corner shape, so
+ * they decline to custom_css — the parser already rejects the "/" form while keeping calc() division
+ * (a single paren-wrapped token) convertible.
+ */
+class Border_Radius_Property_Converter extends Property_Converter_Base {
+	private string $property;
+
+	public function __construct( string $property ) {
+		$this->property = $property;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$parsed = Box_Shorthand_Parser::parse( $rule['value'] );
+
+		if ( null === $parsed ) {
+			return false;
+		}
+
+		if ( isset( $parsed['single'] ) ) {
+			$context->set_prop( $this->property, Size_Prop_Type::generate( $parsed['single'] ) );
+
+			return true;
+		}
+
+		[ $top_left, $top_right, $bottom_right, $bottom_left ] = $parsed['sides'];
+
+		$context->set_prop( $this->property, Border_Radius_Prop_Type::generate( [
+			'start-start' => Size_Prop_Type::generate( $top_left ),
+			'start-end' => Size_Prop_Type::generate( $top_right ),
+			'end-end' => Size_Prop_Type::generate( $bottom_right ),
+			'end-start' => Size_Prop_Type::generate( $bottom_left ),
+		] ) );
+
+		return true;
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/box-shadow-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/box-shadow-property-converter.php
@@ -43,7 +43,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Box_Shadow_Property_Converter extends Property_Converter_Base {
 	const INSET_KEYWORD = 'inset';
 	const DEFAULT_COLOR = 'currentColor';
-	const ZERO_SIZE     = [ 'size' => 0, 'unit' => 'px' ];
+	const ZERO_SIZE     = [
+		'size' => 0,
+		'unit' => 'px',
+	];
 
 	protected function get_supported_properties(): array {
 		return [ 'box-shadow' ];

--- a/modules/atomic-widgets/css-converter/converters/box-shadow-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/box-shadow-property-converter.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Box_Shadow_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Shadow_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converter for the `box-shadow` CSS property -> Box_Shadow_Prop_Type (array of Shadow_Prop_Type).
+ *
+ * Per-layer CSS grammar:
+ *   <shadow> = <color>? && [<length>{2,4}] && inset?
+ *
+ * Token classification (paren-aware so rgb(255 0 0) stays one token):
+ *   - `inset`              -> position keyword
+ *   - parses as Size       -> length token
+ *   - anything else        -> color (at most one per layer)
+ *
+ * Length mapping by count:
+ *   2 -> hOffset, vOffset
+ *   3 -> hOffset, vOffset, blur
+ *   4 -> hOffset, vOffset, blur, spread
+ * Any other count, multiple colors, or unrecognised tokens decline the entire declaration to custom_css.
+ *
+ * Defaults:
+ *   - missing color -> `currentColor` (CSS spec default)
+ *   - missing blur/spread -> 0 px
+ *
+ * Special values:
+ *   - `none` -> empty Box_Shadow array (clears the prop).
+ */
+class Box_Shadow_Property_Converter extends Property_Converter_Base {
+	const INSET_KEYWORD = 'inset';
+	const DEFAULT_COLOR = 'currentColor';
+	const ZERO_SIZE     = [ 'size' => 0, 'unit' => 'px' ];
+
+	protected function get_supported_properties(): array {
+		return [ 'box-shadow' ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$value = trim( $rule['value'] );
+
+		if ( '' === $value ) {
+			return false;
+		}
+
+		if ( 'none' === strtolower( $value ) ) {
+			$context->set_prop( 'box-shadow', Box_Shadow_Prop_Type::generate( [] ) );
+			return true;
+		}
+
+		$layers = Css_Token_Splitter::split_by_comma( $value );
+		$shadows = [];
+
+		foreach ( $layers as $layer ) {
+			$shadow = $this->parse_layer( trim( $layer ) );
+
+			if ( null === $shadow ) {
+				return false;
+			}
+
+			$shadows[] = $shadow;
+		}
+
+		$context->set_prop( 'box-shadow', Box_Shadow_Prop_Type::generate( $shadows ) );
+
+		return true;
+	}
+
+	private function parse_layer( string $layer ): ?array {
+		$tokens = Css_Token_Splitter::split_by_whitespace( $layer );
+
+		if ( empty( $tokens ) ) {
+			return null;
+		}
+
+		$lengths = [];
+		$color = null;
+		$is_inset = false;
+
+		foreach ( $tokens as $token ) {
+			if ( self::INSET_KEYWORD === strtolower( $token ) ) {
+				if ( $is_inset ) {
+					return null;
+				}
+
+				$is_inset = true;
+				continue;
+			}
+
+			$size = Size_Value_Parser::parse( $token );
+
+			if ( null !== $size ) {
+				$lengths[] = $size;
+				continue;
+			}
+
+			if ( null !== $color ) {
+				return null;
+			}
+
+			$color = $token;
+		}
+
+		$length_count = count( $lengths );
+
+		if ( $length_count < 2 || $length_count > 4 ) {
+			return null;
+		}
+
+		return Shadow_Prop_Type::generate( $this->build_shadow_fields( $lengths, $color, $is_inset ) );
+	}
+
+	private function build_shadow_fields( array $lengths, ?string $color, bool $is_inset ): array {
+		$fields = [
+			'hOffset' => Size_Prop_Type::generate( $lengths[0] ),
+			'vOffset' => Size_Prop_Type::generate( $lengths[1] ),
+			'blur'    => Size_Prop_Type::generate( $lengths[2] ?? self::ZERO_SIZE ),
+			'spread'  => Size_Prop_Type::generate( $lengths[3] ?? self::ZERO_SIZE ),
+			'color'   => Color_Prop_Type::generate( $color ?? self::DEFAULT_COLOR ),
+		];
+
+		if ( $is_inset ) {
+			$fields['position'] = String_Prop_Type::generate( self::INSET_KEYWORD );
+		}
+
+		return $fields;
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/color-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/color-property-converter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Reusable converter for properties backed by a Color_Prop_Type. One instance per property.
+ * Color_Prop_Type extends String_Prop_Type with no enum/regex, so any non-empty value is valid:
+ * named colors, hex, rgb()/hsl(), var(), color-mix(), currentcolor, transparent. Raw passthrough —
+ * it only declines on an empty value. Emits the canonical Color PropValue from generate().
+ */
+class Color_Property_Converter extends Property_Converter_Base {
+	private string $property;
+
+	public function __construct( string $property ) {
+		$this->property = $property;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$color = trim( $rule['value'] );
+
+		if ( '' === $color ) {
+			return false;
+		}
+
+		$context->set_prop( $this->property, Color_Prop_Type::generate( $color ) );
+
+		return true;
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/color-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/color-property-converter.php
@@ -4,6 +4,7 @@ namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
 use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
 use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,8 +14,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Reusable converter for properties backed by a Color_Prop_Type. One instance per property.
  * Color_Prop_Type extends String_Prop_Type with no enum/regex, so any non-empty value is valid:
- * named colors, hex, rgb()/hsl(), var(), color-mix(), currentcolor, transparent. Raw passthrough —
- * it only declines on an empty value. Emits the canonical Color PropValue from generate().
+ * named colors, hex, rgb()/hsl(), var(), color-mix(), currentcolor, transparent. Raw passthrough,
+ * apart from one guard: the model holds a single color, so a multi-color value (e.g. the per-side
+ * `border-color: red green blue`) is declined to custom_css. Multiplicity is detected paren-aware so a
+ * single functional color with internal spaces (`rgb(255 0 0)`, `color-mix(in srgb, red, blue)`) stays
+ * one token. Emits the canonical Color PropValue from generate().
  */
 class Color_Property_Converter extends Property_Converter_Base {
 	private string $property;
@@ -30,7 +34,7 @@ class Color_Property_Converter extends Property_Converter_Base {
 	public function convert( Conversion_Context $context, array $rule ): bool {
 		$color = trim( $rule['value'] );
 
-		if ( '' === $color ) {
+		if ( 1 !== count( Css_Token_Splitter::split_by_whitespace( $color ) ) ) {
 			return false;
 		}
 

--- a/modules/atomic-widgets/css-converter/converters/dimensions-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/dimensions-property-converter.php
@@ -13,19 +13,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Reusable converter for the box shorthands backed by Union(Dimensions | Size) (padding/margin). One
- * instance per property. Delegates tokenizing/expansion to Box_Shorthand_Parser; a null parse declines
- * (-> custom_css).
+ * Reusable converter for box shorthands backed by Union(<sides object> | Size): padding/margin
+ * (Dimensions) and border-width (Border_Width) all share the four logical sides, differing only by the
+ * wrapping object prop type, which is injected. One instance per property. Delegates
+ * tokenizing/expansion to Box_Shorthand_Parser; a null parse declines (-> custom_css).
  *
  * A single token emits the Size member (the union accepts it). Two-to-four tokens expand via the CSS
  * box rule and map physical->logical (top=block-start, right=inline-end, bottom=block-end,
- * left=inline-start) into a Dimensions PropValue.
+ * left=inline-start) into the injected object's PropValue.
  */
 class Dimensions_Property_Converter extends Property_Converter_Base {
 	private string $property;
 
-	public function __construct( string $property ) {
+	private string $object_prop_type;
+
+	/**
+	 * @param string $property         The CSS property this instance owns.
+	 * @param string $object_prop_type Object_Prop_Type class used to wrap the four expanded sides.
+	 */
+	public function __construct( string $property, string $object_prop_type = Dimensions_Prop_Type::class ) {
 		$this->property = $property;
+		$this->object_prop_type = $object_prop_type;
 	}
 
 	protected function get_supported_properties(): array {
@@ -47,7 +55,7 @@ class Dimensions_Property_Converter extends Property_Converter_Base {
 
 		[ $top, $right, $bottom, $left ] = $parsed['sides'];
 
-		$context->set_prop( $this->property, Dimensions_Prop_Type::generate( [
+		$context->set_prop( $this->property, ( $this->object_prop_type )::generate( [
 			'block-start' => Size_Prop_Type::generate( $top ),
 			'inline-end' => Size_Prop_Type::generate( $right ),
 			'block-end' => Size_Prop_Type::generate( $bottom ),

--- a/modules/atomic-widgets/css-converter/converters/dimensions-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/dimensions-property-converter.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Dimensions_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Reusable converter for the box shorthands backed by Union(Dimensions | Size) (padding/margin). One
+ * instance per property. Every space-separated token is parsed as a Size leaf (paren-aware so
+ * calc()/min()/... survive); any unparsable token declines the whole declaration (-> custom_css).
+ *
+ * A single token emits the Size member (the union accepts it). Two-to-four tokens expand via the CSS
+ * box rule (top/right/bottom/left) and map physical->logical (top=block-start, right=inline-end,
+ * bottom=block-end, left=inline-start) into a Dimensions PropValue.
+ */
+class Dimensions_Property_Converter extends Property_Converter_Base {
+	const MAX_SIDES = 4;
+
+	private string $property;
+
+	public function __construct( string $property ) {
+		$this->property = $property;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$tokens = self::split_top_level( trim( $rule['value'] ) );
+		$count = count( $tokens );
+
+		if ( $count < 1 || $count > self::MAX_SIDES ) {
+			return false;
+		}
+
+		$sizes = [];
+
+		foreach ( $tokens as $token ) {
+			$parsed = Size_Value_Parser::parse( $token );
+
+			if ( null === $parsed ) {
+				return false;
+			}
+
+			$sizes[] = $parsed;
+		}
+
+		if ( 1 === $count ) {
+			$context->set_prop( $this->property, Size_Prop_Type::generate( $sizes[0] ) );
+
+			return true;
+		}
+
+		[ $top, $right, $bottom, $left ] = self::expand_box( $sizes );
+
+		$context->set_prop( $this->property, Dimensions_Prop_Type::generate( [
+			'block-start' => Size_Prop_Type::generate( $top ),
+			'inline-end' => Size_Prop_Type::generate( $right ),
+			'block-end' => Size_Prop_Type::generate( $bottom ),
+			'inline-start' => Size_Prop_Type::generate( $left ),
+		] ) );
+
+		return true;
+	}
+
+	/**
+	 * @param array<int, array> $sizes 2..4 parsed Size leaves.
+	 * @return array{0: array, 1: array, 2: array, 3: array} [top, right, bottom, left]
+	 */
+	private static function expand_box( array $sizes ): array {
+		switch ( count( $sizes ) ) {
+			case 2:
+				return [ $sizes[0], $sizes[1], $sizes[0], $sizes[1] ];
+			case 3:
+				return [ $sizes[0], $sizes[1], $sizes[2], $sizes[1] ];
+			default:
+				return [ $sizes[0], $sizes[1], $sizes[2], $sizes[3] ];
+		}
+	}
+
+	/**
+	 * Split on whitespace runs that sit at parenthesis depth 0, so function values such as
+	 * "calc(50% - 10px)" stay intact as a single token.
+	 *
+	 * @return string[]
+	 */
+	private static function split_top_level( string $value ): array {
+		$tokens = [];
+		$current = '';
+		$depth = 0;
+		$length = strlen( $value );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$char = $value[ $i ];
+
+			if ( '(' === $char ) {
+				++$depth;
+			} elseif ( ')' === $char ) {
+				$depth = max( 0, $depth - 1 );
+			}
+
+			if ( 0 === $depth && ( ' ' === $char || "\t" === $char || "\n" === $char ) ) {
+				if ( '' !== $current ) {
+					$tokens[] = $current;
+					$current = '';
+				}
+
+				continue;
+			}
+
+			$current .= $char;
+		}
+
+		if ( '' !== $current ) {
+			$tokens[] = $current;
+		}
+
+		return $tokens;
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/dimensions-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/dimensions-property-converter.php
@@ -4,7 +4,7 @@ namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
 use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
-use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Box_Shorthand_Parser;
 use Elementor\Modules\AtomicWidgets\PropTypes\Dimensions_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 
@@ -14,16 +14,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Reusable converter for the box shorthands backed by Union(Dimensions | Size) (padding/margin). One
- * instance per property. Every space-separated token is parsed as a Size leaf (paren-aware so
- * calc()/min()/... survive); any unparsable token declines the whole declaration (-> custom_css).
+ * instance per property. Delegates tokenizing/expansion to Box_Shorthand_Parser; a null parse declines
+ * (-> custom_css).
  *
  * A single token emits the Size member (the union accepts it). Two-to-four tokens expand via the CSS
- * box rule (top/right/bottom/left) and map physical->logical (top=block-start, right=inline-end,
- * bottom=block-end, left=inline-start) into a Dimensions PropValue.
+ * box rule and map physical->logical (top=block-start, right=inline-end, bottom=block-end,
+ * left=inline-start) into a Dimensions PropValue.
  */
 class Dimensions_Property_Converter extends Property_Converter_Base {
-	const MAX_SIDES = 4;
-
 	private string $property;
 
 	public function __construct( string $property ) {
@@ -35,32 +33,19 @@ class Dimensions_Property_Converter extends Property_Converter_Base {
 	}
 
 	public function convert( Conversion_Context $context, array $rule ): bool {
-		$tokens = self::split_top_level( trim( $rule['value'] ) );
-		$count = count( $tokens );
+		$parsed = Box_Shorthand_Parser::parse( $rule['value'] );
 
-		if ( $count < 1 || $count > self::MAX_SIDES ) {
+		if ( null === $parsed ) {
 			return false;
 		}
 
-		$sizes = [];
-
-		foreach ( $tokens as $token ) {
-			$parsed = Size_Value_Parser::parse( $token );
-
-			if ( null === $parsed ) {
-				return false;
-			}
-
-			$sizes[] = $parsed;
-		}
-
-		if ( 1 === $count ) {
-			$context->set_prop( $this->property, Size_Prop_Type::generate( $sizes[0] ) );
+		if ( isset( $parsed['single'] ) ) {
+			$context->set_prop( $this->property, Size_Prop_Type::generate( $parsed['single'] ) );
 
 			return true;
 		}
 
-		[ $top, $right, $bottom, $left ] = self::expand_box( $sizes );
+		[ $top, $right, $bottom, $left ] = $parsed['sides'];
 
 		$context->set_prop( $this->property, Dimensions_Prop_Type::generate( [
 			'block-start' => Size_Prop_Type::generate( $top ),
@@ -70,60 +55,5 @@ class Dimensions_Property_Converter extends Property_Converter_Base {
 		] ) );
 
 		return true;
-	}
-
-	/**
-	 * @param array<int, array> $sizes 2..4 parsed Size leaves.
-	 * @return array{0: array, 1: array, 2: array, 3: array} [top, right, bottom, left]
-	 */
-	private static function expand_box( array $sizes ): array {
-		switch ( count( $sizes ) ) {
-			case 2:
-				return [ $sizes[0], $sizes[1], $sizes[0], $sizes[1] ];
-			case 3:
-				return [ $sizes[0], $sizes[1], $sizes[2], $sizes[1] ];
-			default:
-				return [ $sizes[0], $sizes[1], $sizes[2], $sizes[3] ];
-		}
-	}
-
-	/**
-	 * Split on whitespace runs that sit at parenthesis depth 0, so function values such as
-	 * "calc(50% - 10px)" stay intact as a single token.
-	 *
-	 * @return string[]
-	 */
-	private static function split_top_level( string $value ): array {
-		$tokens = [];
-		$current = '';
-		$depth = 0;
-		$length = strlen( $value );
-
-		for ( $i = 0; $i < $length; $i++ ) {
-			$char = $value[ $i ];
-
-			if ( '(' === $char ) {
-				++$depth;
-			} elseif ( ')' === $char ) {
-				$depth = max( 0, $depth - 1 );
-			}
-
-			if ( 0 === $depth && ( ' ' === $char || "\t" === $char || "\n" === $char ) ) {
-				if ( '' !== $current ) {
-					$tokens[] = $current;
-					$current = '';
-				}
-
-				continue;
-			}
-
-			$current .= $char;
-		}
-
-		if ( '' !== $current ) {
-			$tokens[] = $current;
-		}
-
-		return $tokens;
 	}
 }

--- a/modules/atomic-widgets/css-converter/converters/filter-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/filter-property-converter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Filter_Value_Parser;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Reusable converter for the filter-function lists backed by Array(Css_Filter_Func) (filter/
+ * backdrop-filter). One instance per property; the wrapping $$type differs only by key, so it is
+ * injected. Delegates the whole value to Filter_Value_Parser; a null parse declines (-> custom_css).
+ */
+class Filter_Property_Converter extends Property_Converter_Base {
+	private string $property;
+
+	private string $type_key;
+
+	public function __construct( string $property, string $type_key ) {
+		$this->property = $property;
+		$this->type_key = $type_key;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$items = Filter_Value_Parser::parse( $rule['value'] );
+
+		if ( null === $items ) {
+			return false;
+		}
+
+		$context->set_prop( $this->property, [
+			'$$type' => $this->type_key,
+			'value' => $items,
+		] );
+
+		return true;
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/flex-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/flex-property-converter.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Flex_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converter for the `flex` shorthand: Flex_Prop_Type{flexGrow: Number, flexShrink: Number, flexBasis: Size}.
+ *
+ * Supported forms:
+ *   flex: none          -> 0 1 auto  (CSS spec equivalent)
+ *   flex: auto          -> 1 1 auto
+ *   flex: <grow>        -> <grow> 1 0  (unitless number only)
+ *   flex: <grow> <basis>            (unitless grow + size basis)
+ *   flex: <grow> <shrink> <basis>
+ *
+ * Declines to custom_css for any unrecognised syntax.
+ */
+class Flex_Property_Converter extends Property_Converter_Base {
+	const AUTO_BASIS = [ 'size' => 'auto', 'unit' => 'custom' ];
+	const ZERO_BASIS = [ 'size' => 0, 'unit' => 'px' ];
+
+	protected function get_supported_properties(): array {
+		return [ 'flex' ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$value = trim( $rule['value'] );
+
+		$parsed = $this->parse( $value );
+
+		if ( null === $parsed ) {
+			return false;
+		}
+
+		[ $grow, $shrink, $basis ] = $parsed;
+
+		$context->set_prop( 'flex', Flex_Prop_Type::generate( [
+			'flexGrow'   => Number_Prop_Type::generate( $grow ),
+			'flexShrink' => Number_Prop_Type::generate( $shrink ),
+			'flexBasis'  => Size_Prop_Type::generate( $basis ),
+		] ) );
+
+		return true;
+	}
+
+	private function parse( string $value ): ?array {
+		$lower = strtolower( $value );
+
+		if ( 'none' === $lower ) {
+			return [ 0, 1, self::AUTO_BASIS ];
+		}
+
+		if ( 'auto' === $lower ) {
+			return [ 1, 1, self::AUTO_BASIS ];
+		}
+
+		$tokens = Css_Token_Splitter::split_by_whitespace( $value );
+
+		if ( 1 === count( $tokens ) ) {
+			$grow = $this->parse_number( $tokens[0] );
+			if ( null === $grow ) {
+				return null;
+			}
+			return [ $grow, 1, self::ZERO_BASIS ];
+		}
+
+		if ( 2 === count( $tokens ) ) {
+			$grow = $this->parse_number( $tokens[0] );
+			if ( null === $grow ) {
+				return null;
+			}
+			$basis = Size_Value_Parser::parse( $tokens[1] );
+			if ( null === $basis ) {
+				return null;
+			}
+			return [ $grow, 1, $basis ];
+		}
+
+		if ( 3 === count( $tokens ) ) {
+			$grow   = $this->parse_number( $tokens[0] );
+			$shrink = $this->parse_number( $tokens[1] );
+			$basis  = $this->parse_basis( $tokens[2] );
+
+			if ( null === $grow || null === $shrink || null === $basis ) {
+				return null;
+			}
+
+			return [ $grow, $shrink, $basis ];
+		}
+
+		return null;
+	}
+
+	private function parse_number( string $token ): ?float {
+		if ( ! is_numeric( $token ) ) {
+			return null;
+		}
+		return (float) $token;
+	}
+
+	private function parse_basis( string $token ): ?array {
+		$lower = strtolower( $token );
+
+		if ( 'auto' === $lower ) {
+			return self::AUTO_BASIS;
+		}
+
+		return Size_Value_Parser::parse( $token );
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/flex-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/flex-property-converter.php
@@ -27,8 +27,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Declines to custom_css for any unrecognised syntax.
  */
 class Flex_Property_Converter extends Property_Converter_Base {
-	const AUTO_BASIS = [ 'size' => 'auto', 'unit' => 'custom' ];
-	const ZERO_BASIS = [ 'size' => 0, 'unit' => 'px' ];
+	const AUTO_BASIS = [
+		'size' => 'auto',
+		'unit' => 'custom',
+	];
+	const ZERO_BASIS = [
+		'size' => 0,
+		'unit' => 'px',
+	];
 
 	protected function get_supported_properties(): array {
 		return [ 'flex' ];

--- a/modules/atomic-widgets/css-converter/converters/number-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/number-property-converter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Reusable converter for properties backed by a Number_Prop_Type. One instance per property.
+ * Accepts only a strict numeric value (no units, no functions); anything else declines (-> custom_css).
+ * Emits the canonical Number PropValue from generate().
+ */
+class Number_Property_Converter extends Property_Converter_Base {
+	private string $property;
+
+	public function __construct( string $property ) {
+		$this->property = $property;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$value = trim( $rule['value'] );
+
+		if ( ! is_numeric( $value ) ) {
+			return false;
+		}
+
+		$context->set_prop( $this->property, Number_Prop_Type::generate( $value + 0 ) );
+
+		return true;
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/object-field-merge-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/object-field-merge-converter.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converter for a single scalar longhand that contributes one field to a flat aggregate object prop,
+ * e.g. background-color -> the `color` field of `background` (Background), background-clip -> `clip`.
+ * One instance per input property.
+ *
+ * The target object is accumulated in the shared context across sibling declarations: each instance
+ * reads the current target prop, re-populates it when it is already this object, or starts a fresh one
+ * otherwise, then writes the single field it owns. Unlike Object_Side_Merge_Converter there is no
+ * single-member seeding because the aggregate has no scalar union member.
+ *
+ * The leaf is produced by the injected leaf prop type's generate(). An optional allowlist rejects
+ * out-of-enum values, and an optional single-token guard rejects multi-token values (a faithful single
+ * color must be one paren-aware token). A rejected value declines the declaration (-> custom_css) and
+ * leaves the accumulated object untouched.
+ */
+class Object_Field_Merge_Converter extends Property_Converter_Base {
+	private string $property;
+	private string $target_property;
+	private string $type_key;
+	private string $field_key;
+
+	/**
+	 * @var class-string
+	 */
+	private string $leaf_prop_type;
+
+	/**
+	 * @var class-string
+	 */
+	private string $object_prop_type;
+
+	/**
+	 * @var string[]|null
+	 */
+	private ?array $allowed_values;
+
+	private bool $single_token_only;
+
+	/**
+	 * @param string        $property          The input longhand this converter owns (e.g. background-color).
+	 * @param string        $target_property   The aggregate prop it contributes to (e.g. background).
+	 * @param string        $type_key          The aggregate object's $$type (e.g. background).
+	 * @param string        $field_key         The object field this longhand fills (e.g. color).
+	 * @param string        $leaf_prop_type    Prop_Type class whose generate() wraps the leaf value.
+	 * @param string        $object_prop_type  Object_Prop_Type class used to wrap the merged fields.
+	 * @param string[]|null $allowed_values    Enum allowlist for the leaf, or null to accept any value.
+	 * @param bool          $single_token_only Reject values that split into more than one top-level token.
+	 */
+	public function __construct(
+		string $property,
+		string $target_property,
+		string $type_key,
+		string $field_key,
+		string $leaf_prop_type,
+		string $object_prop_type,
+		?array $allowed_values = null,
+		bool $single_token_only = false
+	) {
+		$this->property = $property;
+		$this->target_property = $target_property;
+		$this->type_key = $type_key;
+		$this->field_key = $field_key;
+		$this->leaf_prop_type = $leaf_prop_type;
+		$this->object_prop_type = $object_prop_type;
+		$this->allowed_values = $allowed_values;
+		$this->single_token_only = $single_token_only;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$value = trim( $rule['value'] );
+
+		if ( '' === $value ) {
+			return false;
+		}
+
+		if ( null !== $this->allowed_values && ! in_array( $value, $this->allowed_values, true ) ) {
+			return false;
+		}
+
+		if ( $this->single_token_only && 1 !== count( Css_Token_Splitter::split_by_whitespace( $value ) ) ) {
+			return false;
+		}
+
+		$fields = $this->current_fields( $context->get_prop( $this->target_property ) );
+		$fields[ $this->field_key ] = ( $this->leaf_prop_type )::generate( $value );
+
+		$context->set_prop( $this->target_property, ( $this->object_prop_type )::generate( $fields ) );
+
+		return true;
+	}
+
+	/**
+	 * @param mixed $existing The current target prop value, if any.
+	 * @return array<string, array> Field key -> leaf PropValue.
+	 */
+	private function current_fields( $existing ): array {
+		if ( ! is_array( $existing ) ) {
+			return [];
+		}
+
+		$type = $existing['$$type'] ?? null;
+
+		if ( $this->type_key === $type && is_array( $existing['value'] ?? null ) ) {
+			return $existing['value'];
+		}
+
+		return [];
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/object-position-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/object-position-property-converter.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Position_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converter for `object-position`: Union(String enum | Position_Prop_Type{x, y}).
+ *
+ * Named keyword pairs (e.g. `center left`) emit a String PropValue validated against the enum.
+ * Two size tokens (e.g. `50% 30%`, `10px 20px`) emit a Position_Prop_Type PropValue.
+ * Anything else declines to custom_css.
+ */
+class Object_Position_Property_Converter extends Property_Converter_Base {
+	protected function get_supported_properties(): array {
+		return [ 'object-position' ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$value = trim( $rule['value'] );
+
+		if ( in_array( $value, Position_Prop_Type::get_position_enum_values(), true ) ) {
+			$context->set_prop( 'object-position', String_Prop_Type::generate( $value ) );
+			return true;
+		}
+
+		return $this->try_size_pair( $context, $value );
+	}
+
+	private function try_size_pair( Conversion_Context $context, string $value ): bool {
+		$tokens = Css_Token_Splitter::split_by_whitespace( $value );
+
+		if ( 2 !== count( $tokens ) ) {
+			return false;
+		}
+
+		$x = Size_Value_Parser::parse( $tokens[0] );
+		$y = Size_Value_Parser::parse( $tokens[1] );
+
+		if ( null === $x || null === $y ) {
+			return false;
+		}
+
+		$context->set_prop( 'object-position', Position_Prop_Type::generate( [
+			'x' => Size_Prop_Type::generate( $x ),
+			'y' => Size_Prop_Type::generate( $y ),
+		] ) );
+
+		return true;
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/object-side-merge-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/object-side-merge-converter.php
@@ -3,9 +3,11 @@
 namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Var_Token_Resolver;
 use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
 use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\Variables\Services\Variables_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -41,13 +43,18 @@ class Object_Side_Merge_Converter extends Property_Converter_Base {
 	 */
 	private string $object_prop_type;
 
+	private ?Variables_Service $variables_service;
+
 	/**
-	 * @param string   $property         The input longhand this converter owns (e.g. border-top-width).
-	 * @param string   $target_property  The aggregate prop it contributes to (e.g. border-width).
-	 * @param string   $type_key         The aggregate object's $$type (e.g. border-width).
-	 * @param string   $side_key         The object key this longhand fills (e.g. block-start).
-	 * @param string[] $all_side_keys    Every key of the object, used to seed from a single Size.
-	 * @param string   $object_prop_type Object_Prop_Type class used to wrap the merged sides.
+	 * @param string               $property         The input longhand this converter owns (e.g. border-top-width).
+	 * @param string               $target_property  The aggregate prop it contributes to (e.g. border-width).
+	 * @param string               $type_key         The aggregate object's $$type (e.g. border-width).
+	 * @param string               $side_key         The object key this longhand fills (e.g. block-start).
+	 * @param string[]             $all_side_keys    Every key of the object, used to seed from a single Size.
+	 * @param string               $object_prop_type Object_Prop_Type class used to wrap the merged sides.
+	 * @param Variables_Service|null $variables_service When provided, a var-only value that resolves to a
+	 *                                                  known size variable is emitted as a variable PropValue
+	 *                                                  instead of a raw Size leaf.
 	 */
 	public function __construct(
 		string $property,
@@ -55,7 +62,8 @@ class Object_Side_Merge_Converter extends Property_Converter_Base {
 		string $type_key,
 		string $side_key,
 		array $all_side_keys,
-		string $object_prop_type
+		string $object_prop_type,
+		?Variables_Service $variables_service = null
 	) {
 		$this->property = $property;
 		$this->target_property = $target_property;
@@ -63,6 +71,7 @@ class Object_Side_Merge_Converter extends Property_Converter_Base {
 		$this->side_key = $side_key;
 		$this->all_side_keys = $all_side_keys;
 		$this->object_prop_type = $object_prop_type;
+		$this->variables_service = $variables_service;
 	}
 
 	protected function get_supported_properties(): array {
@@ -70,14 +79,18 @@ class Object_Side_Merge_Converter extends Property_Converter_Base {
 	}
 
 	public function convert( Conversion_Context $context, array $rule ): bool {
-		$leaf = Size_Value_Parser::parse( trim( $rule['value'] ) );
+		$value = trim( $rule['value'] );
+		$leaf  = Size_Value_Parser::parse( $value );
 
 		if ( null === $leaf ) {
 			return false;
 		}
 
+		$side_value = Css_Var_Token_Resolver::resolve_size_var_prop_value( $this->variables_service, $value )
+			?? Size_Prop_Type::generate( $leaf );
+
 		$sides = $this->current_sides( $context->get_prop( $this->target_property ) );
-		$sides[ $this->side_key ] = Size_Prop_Type::generate( $leaf );
+		$sides[ $this->side_key ] = $side_value;
 
 		$context->set_prop( $this->target_property, ( $this->object_prop_type )::generate( $sides ) );
 

--- a/modules/atomic-widgets/css-converter/converters/object-side-merge-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/object-side-merge-converter.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converter for a single side/corner longhand that contributes a fragment to a multi-side object prop:
+ * border-{side}-width -> a side of `border-width` (Border_Width), border-{corner}-radius -> a corner of
+ * `border-radius` (Border_Radius). One instance per input property.
+ *
+ * The target object is accumulated in the shared context across sibling declarations: each instance
+ * reads the current target prop and re-populates it. If the target is already this object it merges the
+ * one side in; if it is the single Size member (e.g. a prior `border-width: 1px`) all sides are seeded
+ * from that single before the override, so the CSS cascade stays faithful; otherwise a fresh object is
+ * created. A value the Size parser rejects declines the declaration (-> custom_css) and leaves the
+ * accumulated object untouched.
+ */
+class Object_Side_Merge_Converter extends Property_Converter_Base {
+	const SIZE_TYPE = 'size';
+
+	private string $property;
+	private string $target_property;
+	private string $type_key;
+	private string $side_key;
+
+	/**
+	 * @var string[]
+	 */
+	private array $all_side_keys;
+
+	/**
+	 * @var class-string
+	 */
+	private string $object_prop_type;
+
+	/**
+	 * @param string   $property         The input longhand this converter owns (e.g. border-top-width).
+	 * @param string   $target_property  The aggregate prop it contributes to (e.g. border-width).
+	 * @param string   $type_key         The aggregate object's $$type (e.g. border-width).
+	 * @param string   $side_key         The object key this longhand fills (e.g. block-start).
+	 * @param string[] $all_side_keys    Every key of the object, used to seed from a single Size.
+	 * @param string   $object_prop_type Object_Prop_Type class used to wrap the merged sides.
+	 */
+	public function __construct(
+		string $property,
+		string $target_property,
+		string $type_key,
+		string $side_key,
+		array $all_side_keys,
+		string $object_prop_type
+	) {
+		$this->property = $property;
+		$this->target_property = $target_property;
+		$this->type_key = $type_key;
+		$this->side_key = $side_key;
+		$this->all_side_keys = $all_side_keys;
+		$this->object_prop_type = $object_prop_type;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$leaf = Size_Value_Parser::parse( trim( $rule['value'] ) );
+
+		if ( null === $leaf ) {
+			return false;
+		}
+
+		$sides = $this->current_sides( $context->get_prop( $this->target_property ) );
+		$sides[ $this->side_key ] = Size_Prop_Type::generate( $leaf );
+
+		$context->set_prop( $this->target_property, ( $this->object_prop_type )::generate( $sides ) );
+
+		return true;
+	}
+
+	/**
+	 * @param mixed $existing The current target prop value, if any.
+	 * @return array<string, array> Side key -> Size PropValue.
+	 */
+	private function current_sides( $existing ): array {
+		if ( ! is_array( $existing ) ) {
+			return [];
+		}
+
+		$type = $existing['$$type'] ?? null;
+
+		if ( $this->type_key === $type && is_array( $existing['value'] ?? null ) ) {
+			return $existing['value'];
+		}
+
+		if ( self::SIZE_TYPE === $type ) {
+			return array_fill_keys( $this->all_side_keys, $existing );
+		}
+
+		return [];
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/rejected-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/rejected-converter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Claims a property and unconditionally rejects it: the declaration is added to the `rejected`
+ * bucket instead of `customCss`. Used for properties that are structurally incompatible with
+ * Elementor's style system (e.g. `animation`, `@keyframes`), so the client can surface a hint
+ * to the LLM rather than silently emitting broken CSS.
+ */
+class Rejected_Converter extends Property_Converter_Base {
+	private string $property;
+
+	public function __construct( string $property ) {
+		$this->property = $property;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$context->reject( $rule['declaration'] . ';' );
+
+		return true;
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/size-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/size-property-converter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Reusable converter for properties backed by a Size_Prop_Type. One instance per property.
+ * Delegates value parsing to Size_Value_Parser; a null parse declines (-> custom_css). On success
+ * it emits the canonical Size PropValue from generate().
+ */
+class Size_Property_Converter extends Property_Converter_Base {
+	private string $property;
+
+	public function __construct( string $property ) {
+		$this->property = $property;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$parsed = Size_Value_Parser::parse( $rule['value'] );
+
+		if ( null === $parsed ) {
+			return false;
+		}
+
+		$context->set_prop( $this->property, Size_Prop_Type::generate( $parsed ) );
+
+		return true;
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/size-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/size-property-converter.php
@@ -14,13 +14,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Reusable converter for properties backed by a Size_Prop_Type. One instance per property.
  * Delegates value parsing to Size_Value_Parser; a null parse declines (-> custom_css). On success
- * it emits the canonical Size PropValue from generate().
+ * it emits the canonical Size PropValue from generate(). $allow_unitless opts a property into
+ * keeping unitless multipliers (e.g. line-height: 1.1) instead of declining them.
  */
 class Size_Property_Converter extends Property_Converter_Base {
 	private string $property;
 
-	public function __construct( string $property ) {
+	private bool $allow_unitless;
+
+	public function __construct( string $property, bool $allow_unitless = false ) {
 		$this->property = $property;
+		$this->allow_unitless = $allow_unitless;
 	}
 
 	protected function get_supported_properties(): array {
@@ -28,7 +32,7 @@ class Size_Property_Converter extends Property_Converter_Base {
 	}
 
 	public function convert( Conversion_Context $context, array $rule ): bool {
-		$parsed = Size_Value_Parser::parse( $rule['value'] );
+		$parsed = Size_Value_Parser::parse( $rule['value'], $this->allow_unitless );
 
 		if ( null === $parsed ) {
 			return false;

--- a/modules/atomic-widgets/css-converter/converters/span-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/span-property-converter.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\PropTypes\Span_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Reusable converter for properties backed by a Span_Prop_Type (grid-column/grid-row). One instance
+ * per property. Accepts any non-empty string that matches the schema regex (URLs/semicolons are
+ * rejected by the live grid-* pattern); a non-matching value declines (-> custom_css). Emits the
+ * canonical Span PropValue from generate().
+ */
+class Span_Property_Converter extends Property_Converter_Base {
+	private string $property;
+
+	private ?string $pattern;
+
+	/**
+	 * @param string      $property The schema property this converter owns.
+	 * @param string|null $pattern  The Span regex sourced from the schema, or null for no constraint.
+	 */
+	public function __construct( string $property, ?string $pattern = null ) {
+		$this->property = $property;
+		$this->pattern = $pattern;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$value = trim( $rule['value'] );
+
+		if ( '' === $value ) {
+			return false;
+		}
+
+		if ( null !== $this->pattern && 1 !== preg_match( $this->pattern, $value ) ) {
+			return false;
+		}
+
+		$context->set_prop( $this->property, Span_Prop_Type::generate( $value ) );
+
+		return true;
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/string-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/string-property-converter.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Reusable converter for properties backed by a plain String_Prop_Type. One instance per property.
+ * When an allowlist is provided the value must be one of it (enum-backed props); otherwise any
+ * non-empty value is accepted (free-string props). Emits the canonical PropValue from generate().
+ */
+class String_Property_Converter extends Property_Converter_Base {
+	private string $property;
+
+	/**
+	 * @var string[]|null
+	 */
+	private ?array $allowed_values;
+
+	/**
+	 * @param string        $property       The schema property this converter owns.
+	 * @param string[]|null $allowed_values Enum allowlist, or null for a free-string property.
+	 */
+	public function __construct( string $property, ?array $allowed_values = null ) {
+		$this->property = $property;
+		$this->allowed_values = $allowed_values;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$value = trim( $rule['value'] );
+
+		if ( '' === $value ) {
+			return false;
+		}
+
+		if ( null !== $this->allowed_values && ! in_array( $value, $this->allowed_values, true ) ) {
+			return false;
+		}
+
+		$context->set_prop( $this->property, String_Prop_Type::generate( $value ) );
+
+		return true;
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/transform-origin-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/transform-origin-property-converter.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Transform\Transform_Origin_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Transform\Transform_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converter for the `transform-origin` CSS property.
+ *
+ * Maps into the `transform-origin` field nested inside the `transform` Prop_Type
+ * (merging with any prior transform fields already in the context).
+ *
+ * Accepted CSS syntax (1, 2, or 3 tokens, order = x y z):
+ *   - keywords:   left | right | center | top | bottom
+ *   - length:     <number><px|em|rem>
+ *   - percentage: <number>%
+ *
+ * Unit rules:
+ *   - x/y: % px em rem
+ *   - z:   px em rem  (no %)
+ *
+ * Anything else declines the entire declaration to customCss.
+ */
+class Transform_Origin_Property_Converter extends Property_Converter_Base {
+	const XY_UNITS = [ '%', 'px', 'em', 'rem' ];
+	const Z_UNITS  = [ 'px', 'em', 'rem' ];
+
+	const X_KEYWORDS = [ 'left' => 0, 'center' => 50, 'right' => 100 ];
+	const Y_KEYWORDS = [ 'top' => 0, 'center' => 50, 'bottom' => 100 ];
+
+	const CENTER = [ 'size' => 50, 'unit' => '%' ];
+
+	protected function get_supported_properties(): array {
+		return [ 'transform-origin' ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$axes = $this->parse( trim( $rule['value'] ) );
+
+		if ( null === $axes ) {
+			return false;
+		}
+
+		$existing = $context->get_prop( 'transform' );
+		$fields = $this->current_fields( $existing );
+		$fields['transform-origin'] = Transform_Origin_Prop_Type::generate( [
+			'x' => Size_Prop_Type::generate( $axes['x'] ),
+			'y' => Size_Prop_Type::generate( $axes['y'] ),
+			'z' => Size_Prop_Type::generate( $axes['z'] ),
+		] );
+
+		$context->set_prop( 'transform', Transform_Prop_Type::generate( $fields ) );
+
+		return true;
+	}
+
+	private function parse( string $value ): ?array {
+		$tokens = Css_Token_Splitter::split_by_whitespace( $value );
+		$count = count( $tokens );
+
+		if ( $count < 1 || $count > 3 ) {
+			return null;
+		}
+
+		[ $x, $y ] = $this->parse_xy( $tokens );
+
+		if ( null === $x || null === $y ) {
+			return null;
+		}
+
+		$z = 3 === $count ? $this->parse_z( $tokens[2] ) : [ 'size' => 0, 'unit' => 'px' ];
+
+		if ( null === $z ) {
+			return null;
+		}
+
+		return [ 'x' => $x, 'y' => $y, 'z' => $z ];
+	}
+
+	private function parse_xy( array $tokens ): array {
+		if ( 1 === count( $tokens ) ) {
+			return $this->parse_single_xy( strtolower( $tokens[0] ) );
+		}
+
+		return [
+			$this->parse_axis( strtolower( $tokens[0] ), self::X_KEYWORDS ),
+			$this->parse_axis( strtolower( $tokens[1] ), self::Y_KEYWORDS ),
+		];
+	}
+
+	private function parse_single_xy( string $token ): array {
+		if ( isset( self::X_KEYWORDS[ $token ] ) && ! isset( self::Y_KEYWORDS[ $token ] ) ) {
+			return [ $this->keyword_size( self::X_KEYWORDS[ $token ] ), self::CENTER ];
+		}
+
+		if ( isset( self::Y_KEYWORDS[ $token ] ) && ! isset( self::X_KEYWORDS[ $token ] ) ) {
+			return [ self::CENTER, $this->keyword_size( self::Y_KEYWORDS[ $token ] ) ];
+		}
+
+		if ( 'center' === $token ) {
+			return [ self::CENTER, self::CENTER ];
+		}
+
+		$size = $this->xy_size( $token );
+
+		return null === $size ? [ null, null ] : [ $size, self::CENTER ];
+	}
+
+	private function parse_axis( string $token, array $keywords ): ?array {
+		if ( isset( $keywords[ $token ] ) ) {
+			return $this->keyword_size( $keywords[ $token ] );
+		}
+
+		return $this->xy_size( $token );
+	}
+
+	private function xy_size( string $token ): ?array {
+		$parsed = Size_Value_Parser::parse( $token );
+
+		if ( null === $parsed || ! in_array( $parsed['unit'], self::XY_UNITS, true ) ) {
+			return null;
+		}
+
+		return $parsed;
+	}
+
+	private function parse_z( string $token ): ?array {
+		$parsed = Size_Value_Parser::parse( $token );
+
+		if ( null === $parsed || ! in_array( $parsed['unit'], self::Z_UNITS, true ) ) {
+			return null;
+		}
+
+		return $parsed;
+	}
+
+	private function keyword_size( int $percent ): array {
+		return [ 'size' => $percent, 'unit' => '%' ];
+	}
+
+	private function current_fields( $existing ): array {
+		if ( is_array( $existing ) && isset( $existing['value'] ) ) {
+			return $existing['value'];
+		}
+
+		return [];
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/transform-origin-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/transform-origin-property-converter.php
@@ -35,10 +35,21 @@ class Transform_Origin_Property_Converter extends Property_Converter_Base {
 	const XY_UNITS = [ '%', 'px', 'em', 'rem' ];
 	const Z_UNITS  = [ 'px', 'em', 'rem' ];
 
-	const X_KEYWORDS = [ 'left' => 0, 'center' => 50, 'right' => 100 ];
-	const Y_KEYWORDS = [ 'top' => 0, 'center' => 50, 'bottom' => 100 ];
+	const X_KEYWORDS = [
+		'left' => 0,
+		'center' => 50,
+		'right' => 100,
+	];
+	const Y_KEYWORDS = [
+		'top' => 0,
+		'center' => 50,
+		'bottom' => 100,
+	];
 
-	const CENTER = [ 'size' => 50, 'unit' => '%' ];
+	const CENTER = [
+		'size' => 50,
+		'unit' => '%',
+	];
 
 	protected function get_supported_properties(): array {
 		return [ 'transform-origin' ];
@@ -78,13 +89,20 @@ class Transform_Origin_Property_Converter extends Property_Converter_Base {
 			return null;
 		}
 
-		$z = 3 === $count ? $this->parse_z( $tokens[2] ) : [ 'size' => 0, 'unit' => 'px' ];
+		$z = 3 === $count ? $this->parse_z( $tokens[2] ) : [
+			'size' => 0,
+			'unit' => 'px',
+		];
 
 		if ( null === $z ) {
 			return null;
 		}
 
-		return [ 'x' => $x, 'y' => $y, 'z' => $z ];
+		return [
+			'x' => $x,
+			'y' => $y,
+			'z' => $z,
+		];
 	}
 
 	private function parse_xy( array $tokens ): array {
@@ -145,7 +163,10 @@ class Transform_Origin_Property_Converter extends Property_Converter_Base {
 	}
 
 	private function keyword_size( int $percent ): array {
-		return [ 'size' => $percent, 'unit' => '%' ];
+		return [
+			'size' => $percent,
+			'unit' => '%',
+		];
 	}
 
 	private function current_fields( $existing ): array {

--- a/modules/atomic-widgets/css-converter/converters/transform-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/transform-property-converter.php
@@ -138,15 +138,15 @@ class Transform_Property_Converter extends Property_Converter_Base {
 			$current .= $char;
 		}
 
-		if ( '' !== trim( $current ) || $depth !== 0 ) {
+		if ( '' !== trim( $current ) || 0 !== $depth ) {
 			return null;
 		}
 
 		return $functions;
 	}
 
-	private function parse_function( string $fn ): ?array {
-		if ( ! preg_match( '/^([\w-]+)\s*\((.+)\)$/s', $fn, $m ) ) {
+	private function parse_function( string $callback ): ?array {
+		if ( ! preg_match( '/^([\w-]+)\s*\((.+)\)$/s', $callback, $m ) ) {
 			return null;
 		}
 

--- a/modules/atomic-widgets/css-converter/converters/transform-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/transform-property-converter.php
@@ -1,0 +1,379 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Transform\Functions\Transform_Move_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Transform\Functions\Transform_Rotate_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Transform\Functions\Transform_Scale_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Transform\Transform_Functions_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Transform\Transform_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converter for the `transform` CSS property -> Transform_Prop_Type.
+ *
+ * Supported CSS functions -> schema type:
+ *   translate(x)               -> transform-move {x, y:0, z:0}
+ *   translate(x, y)            -> transform-move {x, y, z:0}
+ *   translateX(n)              -> transform-move {x:n, y:0, z:0}
+ *   translateY(n)              -> transform-move {x:0, y:n, z:0}
+ *   translateZ(n)              -> transform-move {x:0, y:0, z:n}
+ *   translate3d(x, y, z)      -> transform-move {x, y, z}
+ *   scale(n)                   -> transform-scale {x:n, y:n, z:1}
+ *   scale(x, y)                -> transform-scale {x, y, z:1}
+ *   scaleX(n)                  -> transform-scale {x:n, y:1, z:1}
+ *   scaleY(n)                  -> transform-scale {x:1, y:n, z:1}
+ *   scaleZ(n)                  -> transform-scale {x:1, y:1, z:n}
+ *   scale3d(x, y, z)          -> transform-scale {x, y, z}
+ *   rotate(a)                  -> transform-rotate {x:0, y:0, z:a}
+ *   rotateX(a)                 -> transform-rotate {x:a, y:0, z:0}
+ *   rotateY(a)                 -> transform-rotate {x:0, y:a, z:0}
+ *   rotateZ(a)                 -> transform-rotate {x:0, y:0, z:a}
+ *   rotate3d not supported     -> decline
+ *   matrix / perspective / skew / etc -> decline
+ *
+ * Move units:   %  px  em  rem  vw  custom
+ * Rotate units: deg  rad  grad  turn  custom
+ * Scale values: unitless numbers (floats)
+ *
+ * Any unrecognised function declines the entire declaration to customCss.
+ */
+class Transform_Property_Converter extends Property_Converter_Base {
+	const MOVE_UNITS   = [ '%', 'px', 'em', 'rem', 'vw', 'custom' ];
+	const ROTATE_UNITS = [ 'deg', 'rad', 'grad', 'turn', 'custom' ];
+
+	const ZERO_MOVE   = [ 'size' => 0, 'unit' => 'px' ];
+	const ZERO_ROTATE = [ 'size' => 0, 'unit' => 'deg' ];
+	const ONE_SCALE   = 1.0;
+
+	protected function get_supported_properties(): array {
+		return [ 'transform' ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$functions = $this->parse_functions( trim( $rule['value'] ) );
+
+		if ( null === $functions ) {
+			return false;
+		}
+
+		$existing = $context->get_prop( 'transform' );
+		$fields = $this->current_fields( $existing );
+		$fields['transform-functions'] = Transform_Functions_Prop_Type::generate( $functions );
+
+		$context->set_prop( 'transform', Transform_Prop_Type::generate( $fields ) );
+
+		return true;
+	}
+
+	private function parse_functions( string $value ): ?array {
+		if ( '' === $value || 'none' === strtolower( $value ) ) {
+			return [];
+		}
+
+		$raw_functions = $this->split_functions( $value );
+
+		if ( null === $raw_functions ) {
+			return null;
+		}
+
+		$items = [];
+
+		foreach ( $raw_functions as $fn ) {
+			$item = $this->parse_function( $fn );
+
+			if ( null === $item ) {
+				return null;
+			}
+
+			$items[] = $item;
+		}
+
+		return $items;
+	}
+
+	private function split_functions( string $value ): ?array {
+		$functions = [];
+		$current = '';
+		$depth = 0;
+
+		for ( $i = 0, $len = strlen( $value ); $i < $len; $i++ ) {
+			$char = $value[ $i ];
+
+			if ( '(' === $char ) {
+				$depth++;
+			} elseif ( ')' === $char ) {
+				$depth--;
+
+				if ( 0 === $depth ) {
+					$current .= $char;
+					$functions[] = trim( $current );
+					$current = '';
+					$i++;
+
+					while ( $i < $len && ' ' === $value[ $i ] ) {
+						$i++;
+					}
+
+					$i--;
+					continue;
+				}
+			}
+
+			$current .= $char;
+		}
+
+		if ( '' !== trim( $current ) || $depth !== 0 ) {
+			return null;
+		}
+
+		return $functions;
+	}
+
+	private function parse_function( string $fn ): ?array {
+		if ( ! preg_match( '/^([\w-]+)\s*\((.+)\)$/s', $fn, $m ) ) {
+			return null;
+		}
+
+		$name = strtolower( $m[1] );
+		$args_str = $m[2];
+		$args = array_map( 'trim', Css_Token_Splitter::split_by_comma( $args_str ) );
+
+		switch ( $name ) {
+			case 'translate':
+				return $this->parse_translate( $args );
+			case 'translatex':
+				return $this->parse_translate_axis( $args, 'x' );
+			case 'translatey':
+				return $this->parse_translate_axis( $args, 'y' );
+			case 'translatez':
+				return $this->parse_translate_axis( $args, 'z' );
+			case 'translate3d':
+				return $this->parse_translate_3d( $args );
+			case 'scale':
+				return $this->parse_scale( $args );
+			case 'scalex':
+				return $this->parse_scale_axis( $args, 'x' );
+			case 'scaley':
+				return $this->parse_scale_axis( $args, 'y' );
+			case 'scalez':
+				return $this->parse_scale_axis( $args, 'z' );
+			case 'scale3d':
+				return $this->parse_scale_3d( $args );
+			case 'rotate':
+			case 'rotatez':
+				return $this->parse_rotate_axis( $args, 'z' );
+			case 'rotatex':
+				return $this->parse_rotate_axis( $args, 'x' );
+			case 'rotatey':
+				return $this->parse_rotate_axis( $args, 'y' );
+			default:
+				return null;
+		}
+	}
+
+	private function parse_translate( array $args ): ?array {
+		if ( 1 === count( $args ) ) {
+			$x = $this->move_size( $args[0] );
+
+			if ( null === $x ) {
+				return null;
+			}
+
+			return Transform_Move_Prop_Type::generate( [
+				'x' => Size_Prop_Type::generate( $x ),
+				'y' => Size_Prop_Type::generate( self::ZERO_MOVE ),
+				'z' => Size_Prop_Type::generate( self::ZERO_MOVE ),
+			] );
+		}
+
+		if ( 2 === count( $args ) ) {
+			$x = $this->move_size( $args[0] );
+			$y = $this->move_size( $args[1] );
+
+			if ( null === $x || null === $y ) {
+				return null;
+			}
+
+			return Transform_Move_Prop_Type::generate( [
+				'x' => Size_Prop_Type::generate( $x ),
+				'y' => Size_Prop_Type::generate( $y ),
+				'z' => Size_Prop_Type::generate( self::ZERO_MOVE ),
+			] );
+		}
+
+		return null;
+	}
+
+	private function parse_translate_axis( array $args, string $axis ): ?array {
+		if ( 1 !== count( $args ) ) {
+			return null;
+		}
+
+		$val = $this->move_size( $args[0] );
+
+		if ( null === $val ) {
+			return null;
+		}
+
+		return Transform_Move_Prop_Type::generate( [
+			'x' => Size_Prop_Type::generate( 'x' === $axis ? $val : self::ZERO_MOVE ),
+			'y' => Size_Prop_Type::generate( 'y' === $axis ? $val : self::ZERO_MOVE ),
+			'z' => Size_Prop_Type::generate( 'z' === $axis ? $val : self::ZERO_MOVE ),
+		] );
+	}
+
+	private function parse_translate_3d( array $args ): ?array {
+		if ( 3 !== count( $args ) ) {
+			return null;
+		}
+
+		$x = $this->move_size( $args[0] );
+		$y = $this->move_size( $args[1] );
+		$z = $this->move_size( $args[2] );
+
+		if ( null === $x || null === $y || null === $z ) {
+			return null;
+		}
+
+		return Transform_Move_Prop_Type::generate( [
+			'x' => Size_Prop_Type::generate( $x ),
+			'y' => Size_Prop_Type::generate( $y ),
+			'z' => Size_Prop_Type::generate( $z ),
+		] );
+	}
+
+	private function parse_scale( array $args ): ?array {
+		if ( 1 === count( $args ) ) {
+			$n = $this->scale_number( $args[0] );
+
+			if ( null === $n ) {
+				return null;
+			}
+
+			return Transform_Scale_Prop_Type::generate( [
+				'x' => Number_Prop_Type::generate( $n ),
+				'y' => Number_Prop_Type::generate( $n ),
+				'z' => Number_Prop_Type::generate( self::ONE_SCALE ),
+			] );
+		}
+
+		if ( 2 === count( $args ) ) {
+			$x = $this->scale_number( $args[0] );
+			$y = $this->scale_number( $args[1] );
+
+			if ( null === $x || null === $y ) {
+				return null;
+			}
+
+			return Transform_Scale_Prop_Type::generate( [
+				'x' => Number_Prop_Type::generate( $x ),
+				'y' => Number_Prop_Type::generate( $y ),
+				'z' => Number_Prop_Type::generate( self::ONE_SCALE ),
+			] );
+		}
+
+		return null;
+	}
+
+	private function parse_scale_axis( array $args, string $axis ): ?array {
+		if ( 1 !== count( $args ) ) {
+			return null;
+		}
+
+		$n = $this->scale_number( $args[0] );
+
+		if ( null === $n ) {
+			return null;
+		}
+
+		return Transform_Scale_Prop_Type::generate( [
+			'x' => Number_Prop_Type::generate( 'x' === $axis ? $n : self::ONE_SCALE ),
+			'y' => Number_Prop_Type::generate( 'y' === $axis ? $n : self::ONE_SCALE ),
+			'z' => Number_Prop_Type::generate( 'z' === $axis ? $n : self::ONE_SCALE ),
+		] );
+	}
+
+	private function parse_scale_3d( array $args ): ?array {
+		if ( 3 !== count( $args ) ) {
+			return null;
+		}
+
+		$x = $this->scale_number( $args[0] );
+		$y = $this->scale_number( $args[1] );
+		$z = $this->scale_number( $args[2] );
+
+		if ( null === $x || null === $y || null === $z ) {
+			return null;
+		}
+
+		return Transform_Scale_Prop_Type::generate( [
+			'x' => Number_Prop_Type::generate( $x ),
+			'y' => Number_Prop_Type::generate( $y ),
+			'z' => Number_Prop_Type::generate( $z ),
+		] );
+	}
+
+	private function parse_rotate_axis( array $args, string $axis ): ?array {
+		if ( 1 !== count( $args ) ) {
+			return null;
+		}
+
+		$val = $this->rotate_size( $args[0] );
+
+		if ( null === $val ) {
+			return null;
+		}
+
+		return Transform_Rotate_Prop_Type::generate( [
+			'x' => Size_Prop_Type::generate( 'x' === $axis ? $val : self::ZERO_ROTATE ),
+			'y' => Size_Prop_Type::generate( 'y' === $axis ? $val : self::ZERO_ROTATE ),
+			'z' => Size_Prop_Type::generate( 'z' === $axis ? $val : self::ZERO_ROTATE ),
+		] );
+	}
+
+	private function move_size( string $token ): ?array {
+		$parsed = Size_Value_Parser::parse( $token );
+
+		if ( null === $parsed || ! in_array( $parsed['unit'], self::MOVE_UNITS, true ) ) {
+			return null;
+		}
+
+		return $parsed;
+	}
+
+	private function rotate_size( string $token ): ?array {
+		$parsed = Size_Value_Parser::parse( $token );
+
+		if ( null === $parsed || ! in_array( $parsed['unit'], self::ROTATE_UNITS, true ) ) {
+			return null;
+		}
+
+		return $parsed;
+	}
+
+	private function scale_number( string $token ): ?float {
+		if ( ! is_numeric( $token ) ) {
+			return null;
+		}
+
+		return (float) $token;
+	}
+
+	private function current_fields( $existing ): array {
+		if ( is_array( $existing ) && isset( $existing['value'] ) ) {
+			return $existing['value'];
+		}
+
+		return [];
+	}
+}

--- a/modules/atomic-widgets/css-converter/converters/transform-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/transform-property-converter.php
@@ -51,8 +51,14 @@ class Transform_Property_Converter extends Property_Converter_Base {
 	const MOVE_UNITS   = [ '%', 'px', 'em', 'rem', 'vw', 'custom' ];
 	const ROTATE_UNITS = [ 'deg', 'rad', 'grad', 'turn', 'custom' ];
 
-	const ZERO_MOVE   = [ 'size' => 0, 'unit' => 'px' ];
-	const ZERO_ROTATE = [ 'size' => 0, 'unit' => 'deg' ];
+	const ZERO_MOVE   = [
+		'size' => 0,
+		'unit' => 'px',
+	];
+	const ZERO_ROTATE = [
+		'size' => 0,
+		'unit' => 'deg',
+	];
 	const ONE_SCALE   = 1.0;
 
 	protected function get_supported_properties(): array {
@@ -110,21 +116,21 @@ class Transform_Property_Converter extends Property_Converter_Base {
 			$char = $value[ $i ];
 
 			if ( '(' === $char ) {
-				$depth++;
+				++$depth;
 			} elseif ( ')' === $char ) {
-				$depth--;
+				--$depth;
 
 				if ( 0 === $depth ) {
 					$current .= $char;
 					$functions[] = trim( $current );
 					$current = '';
-					$i++;
+					++$i;
 
 					while ( $i < $len && ' ' === $value[ $i ] ) {
-						$i++;
+						++$i;
 					}
 
-					$i--;
+					--$i;
 					continue;
 				}
 			}

--- a/modules/atomic-widgets/css-converter/converters/transition-property-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/transition-property-converter.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Key_Value_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Selection_Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Transition_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converter for the `transition` CSS property -> Transition_Prop_Type (array of Selection_Size).
+ *
+ * Parses comma-separated transition layers. Each layer is whitespace-split into tokens:
+ *   <property> <duration> [<easing>] [<delay>]
+ *
+ * Only the property name and the FIRST duration/delay time value are mapped — the schema has no
+ * field for easing or delay, so they are intentionally dropped (silently).
+ *
+ * The `property` token must be in ALLOWED_PROPERTIES (sourced from the Elementor UI data).
+ * Layers with an unrecognised property decline the entire declaration to customCss.
+ *
+ * Time values must be in `s` or `ms`; any other unit declines the layer.
+ */
+class Transition_Property_Converter extends Property_Converter_Base {
+	const ALLOWED_PROPERTIES = [
+		'all',
+		'background-color',
+		'background-position',
+		'border',
+		'border-color',
+		'border-radius',
+		'border-width',
+		'box-shadow',
+		'color',
+		'filter',
+		'flex',
+		'flex-basis',
+		'flex-grow',
+		'flex-shrink',
+		'font-size',
+		'font-variation-settings',
+		'height',
+		'inset-block-end',
+		'inset-block-start',
+		'inset-inline-end',
+		'inset-inline-start',
+		'letter-spacing',
+		'line-height',
+		'margin',
+		'margin-block-end',
+		'margin-block-start',
+		'margin-inline-end',
+		'margin-inline-start',
+		'max-height',
+		'max-width',
+		'min-height',
+		'min-width',
+		'opacity',
+		'padding',
+		'padding-block-end',
+		'padding-block-start',
+		'padding-inline-end',
+		'padding-inline-start',
+		'transform',
+		'width',
+		'word-spacing',
+		'-webkit-text-stroke-color',
+		'z-index',
+	];
+
+	const TIME_UNITS = [ 's', 'ms' ];
+
+	protected function get_supported_properties(): array {
+		return [ 'transition' ];
+	}
+
+	public function convert( Conversion_Context $context, array $rule ): bool {
+		$layers = Css_Token_Splitter::split_by_comma( trim( $rule['value'] ) );
+
+		if ( empty( $layers ) ) {
+			return false;
+		}
+
+		$items = [];
+
+		foreach ( $layers as $layer ) {
+			$item = $this->parse_layer( trim( $layer ) );
+
+			if ( null === $item ) {
+				return false;
+			}
+
+			$items[] = $item;
+		}
+
+		$context->set_prop( 'transition', Transition_Prop_Type::generate( $items ) );
+
+		return true;
+	}
+
+	private function parse_layer( string $layer ): ?array {
+		$tokens = Css_Token_Splitter::split_by_whitespace( $layer );
+
+		if ( empty( $tokens ) ) {
+			return null;
+		}
+
+		$property = strtolower( $tokens[0] );
+
+		if ( ! in_array( $property, self::ALLOWED_PROPERTIES, true ) ) {
+			return null;
+		}
+
+		$duration = $this->find_first_time( array_slice( $tokens, 1 ) );
+
+		if ( null === $duration ) {
+			return null;
+		}
+
+		return Selection_Size_Prop_Type::generate( [
+			'selection' => Key_Value_Prop_Type::generate( [
+				'key'   => String_Prop_Type::generate( $property ),
+				'value' => String_Prop_Type::generate( $property ),
+			] ),
+			'size' => Size_Prop_Type::generate( $duration ),
+		] );
+	}
+
+	private function find_first_time( array $tokens ): ?array {
+		foreach ( $tokens as $token ) {
+			$parsed = Size_Value_Parser::parse( $token );
+
+			if ( null !== $parsed && in_array( $parsed['unit'], self::TIME_UNITS, true ) ) {
+				return $parsed;
+			}
+		}
+
+		return null;
+	}
+}

--- a/modules/atomic-widgets/css-converter/css-converter-rest-api.php
+++ b/modules/atomic-widgets/css-converter/css-converter-rest-api.php
@@ -118,17 +118,20 @@ class Css_Converter_REST_API {
 	}
 
 	private function create_converter(): Css_Converter {
-		$variable_transformer = $this->create_variable_transformer();
+		$variables_service = $this->create_variables_service();
+		$variable_transformer = $variables_service
+			? new Variable_Prop_Value_Transformer( $variables_service )
+			: null;
 
 		return new Css_Converter(
 			Converter_Registry_Factory::create(),
 			new Null_Failure_Reporter(),
-			Expander_Registry_Factory::create(),
+			Expander_Registry_Factory::create( $variables_service ),
 			$variable_transformer
 		);
 	}
 
-	private function create_variable_transformer(): ?Variable_Prop_Value_Transformer {
+	private function create_variables_service(): ?Variables_Service {
 		if ( ! $this->is_variables_active() ) {
 			return null;
 		}
@@ -139,12 +142,10 @@ class Css_Converter_REST_API {
 			return null;
 		}
 
-		$service = new Variables_Service(
+		return new Variables_Service(
 			new Variables_Repository( $kit ),
 			new Batch_Processor()
 		);
-
-		return new Variable_Prop_Value_Transformer( $service );
 	}
 
 	private function is_variables_active(): bool {

--- a/modules/atomic-widgets/css-converter/css-converter-rest-api.php
+++ b/modules/atomic-widgets/css-converter/css-converter-rest-api.php
@@ -5,6 +5,12 @@ namespace Elementor\Modules\AtomicWidgets\CssConverter;
 use Elementor\Core\Utils\Api\Error_Builder;
 use Elementor\Core\Utils\Api\Response_Builder;
 use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
+use Elementor\Modules\Variables\Module as Variables_Module;
+use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
+use Elementor\Modules\Variables\Services\Variables_Service;
+use Elementor\Modules\Variables\Storage\Variables_Repository;
+use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -44,11 +50,7 @@ class Css_Converter_REST_API {
 				->build();
 		}
 
-		$converter = new Css_Converter(
-			Converter_Registry_Factory::create(),
-			new Null_Failure_Reporter(),
-			Expander_Registry_Factory::create()
-		);
+		$converter = $this->create_converter();
 
 		$results = [];
 
@@ -113,6 +115,43 @@ class Css_Converter_REST_API {
 			'customCss' => $result['customCss'],
 			'rejected'  => $result['rejected'],
 		];
+	}
+
+	private function create_converter(): Css_Converter {
+		$variable_transformer = $this->create_variable_transformer();
+
+		return new Css_Converter(
+			Converter_Registry_Factory::create(),
+			new Null_Failure_Reporter(),
+			Expander_Registry_Factory::create(),
+			$variable_transformer
+		);
+	}
+
+	private function create_variable_transformer(): ?Variable_Prop_Value_Transformer {
+		if ( ! $this->is_variables_active() ) {
+			return null;
+		}
+
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+
+		if ( ! $kit ) {
+			return null;
+		}
+
+		$service = new Variables_Service(
+			new Variables_Repository( $kit ),
+			new Batch_Processor()
+		);
+
+		return new Variable_Prop_Value_Transformer( $service );
+	}
+
+	private function is_variables_active(): bool {
+		$experiments = Plugin::$instance->experiments;
+
+		return $experiments->is_feature_active( Variables_Module::EXPERIMENT_NAME )
+			&& $experiments->is_feature_active( AtomicWidgetsModule::EXPERIMENT_NAME );
 	}
 
 	private function route_wrapper( callable $cb ) {

--- a/modules/atomic-widgets/css-converter/css-converter-rest-api.php
+++ b/modules/atomic-widgets/css-converter/css-converter-rest-api.php
@@ -124,7 +124,7 @@ class Css_Converter_REST_API {
 			: null;
 
 		return new Css_Converter(
-			Converter_Registry_Factory::create(),
+			Converter_Registry_Factory::create( $variables_service ),
 			new Null_Failure_Reporter(),
 			Expander_Registry_Factory::create( $variables_service ),
 			$variable_transformer

--- a/modules/atomic-widgets/css-converter/css-converter-rest-api.php
+++ b/modules/atomic-widgets/css-converter/css-converter-rest-api.php
@@ -40,7 +40,7 @@ class Css_Converter_REST_API {
 		if ( ! is_array( $blocks ) ) {
 			return Error_Builder::make( 'invalid_blocks' )
 				->set_status( 400 )
-				->set_message( __( 'The "blocks" parameter must be an object of named CSS strings.', 'elementor' ) )
+				->set_message( __( 'The "blocks" parameter must be an object of named declaration maps.', 'elementor' ) )
 				->build();
 		}
 
@@ -48,16 +48,41 @@ class Css_Converter_REST_API {
 
 		$results = [];
 
-		foreach ( $blocks as $name => $css ) {
-			$result = $converter->convert( (string) $css );
-
-			$results[ $name ] = [
-				'props' => (object) $result['props'],
-				'customCss' => $result['customCss'],
-			];
+		foreach ( $blocks as $name => $declarations ) {
+			$results[ $name ] = $this->convert_block( $converter, (array) $declarations );
 		}
 
 		return Response_Builder::make( $results )->build();
+	}
+
+	/**
+	 * A block is a property->value map. A null value is an explicit reset: it bypasses CSS conversion
+	 * and is emitted as a null prop so the editor restores the property to its default. Every non-null
+	 * value is serialized back into a CSS declaration for the converter.
+	 *
+	 * @param Css_Converter              $converter    The shared CSS converter.
+	 * @param array<string, string|null> $declarations The block's property->value map.
+	 * @return array{props: object, customCss: string}
+	 */
+	private function convert_block( Css_Converter $converter, array $declarations ): array {
+		$resets = [];
+		$css_declarations = [];
+
+		foreach ( $declarations as $property => $value ) {
+			if ( null === $value ) {
+				$resets[ $property ] = null;
+				continue;
+			}
+
+			$css_declarations[] = $property . ': ' . $value . ';';
+		}
+
+		$result = $converter->convert( implode( ' ', $css_declarations ) );
+
+		return [
+			'props' => (object) array_merge( $result['props'], $resets ),
+			'customCss' => $result['customCss'],
+		];
 	}
 
 	private function route_wrapper( callable $cb ) {

--- a/modules/atomic-widgets/css-converter/css-converter-rest-api.php
+++ b/modules/atomic-widgets/css-converter/css-converter-rest-api.php
@@ -44,7 +44,11 @@ class Css_Converter_REST_API {
 				->build();
 		}
 
-		$converter = new Css_Converter( Converter_Registry_Factory::create(), new Null_Failure_Reporter() );
+		$converter = new Css_Converter(
+			Converter_Registry_Factory::create(),
+			new Null_Failure_Reporter(),
+			Expander_Registry_Factory::create()
+		);
 
 		$results = [];
 

--- a/modules/atomic-widgets/css-converter/css-converter-rest-api.php
+++ b/modules/atomic-widgets/css-converter/css-converter-rest-api.php
@@ -66,7 +66,7 @@ class Css_Converter_REST_API {
 	 *
 	 * @param Css_Converter              $converter    The shared CSS converter.
 	 * @param array<string, string|null> $declarations The block's property->value map.
-	 * @return array{props: object, customCss: string}
+	 * @return array{props: object, customCss: string, rejected: string[]}
 	 */
 	private function convert_block( Css_Converter $converter, array $declarations ): array {
 		$resets = [];
@@ -84,8 +84,9 @@ class Css_Converter_REST_API {
 		$result = $converter->convert( implode( ' ', $css_declarations ) );
 
 		return [
-			'props' => (object) array_merge( $result['props'], $resets ),
+			'props'     => (object) array_merge( $result['props'], $resets ),
 			'customCss' => $result['customCss'],
+			'rejected'  => $result['rejected'],
 		];
 	}
 

--- a/modules/atomic-widgets/css-converter/css-converter-rest-api.php
+++ b/modules/atomic-widgets/css-converter/css-converter-rest-api.php
@@ -40,7 +40,7 @@ class Css_Converter_REST_API {
 		if ( ! is_array( $blocks ) ) {
 			return Error_Builder::make( 'invalid_blocks' )
 				->set_status( 400 )
-				->set_message( __( 'The "blocks" parameter must be an object of named declaration maps.', 'elementor' ) )
+				->set_message( __( 'The "blocks" parameter must be an object of named CSS blocks.', 'elementor' ) )
 				->build();
 		}
 
@@ -52,11 +52,36 @@ class Css_Converter_REST_API {
 
 		$results = [];
 
-		foreach ( $blocks as $name => $declarations ) {
-			$results[ $name ] = $this->convert_block( $converter, (array) $declarations );
+		foreach ( $blocks as $name => $block ) {
+			if ( is_string( $block ) ) {
+				$results[ $name ] = $this->convert_css_text( $converter, $block );
+				continue;
+			}
+
+			if ( ! is_array( $block ) ) {
+				return Error_Builder::make( 'invalid_block' )
+					->set_status( 400 )
+					->set_message( __( 'Each block must be a CSS text string or a property declaration map.', 'elementor' ) )
+					->build();
+			}
+
+			$results[ $name ] = $this->convert_block( $converter, $block );
 		}
 
 		return Response_Builder::make( $results )->build();
+	}
+
+	/**
+	 * @return array{props: object, customCss: string, rejected: string[]}
+	 */
+	private function convert_css_text( Css_Converter $converter, string $css ): array {
+		$result = $converter->convert( $css );
+
+		return [
+			'props'     => (object) $result['props'],
+			'customCss' => $result['customCss'],
+			'rejected'  => $result['rejected'],
+		];
 	}
 
 	/**

--- a/modules/atomic-widgets/css-converter/css-converter.php
+++ b/modules/atomic-widgets/css-converter/css-converter.php
@@ -31,7 +31,7 @@ class Css_Converter {
 
 		foreach ( $rules as $rule ) {
 			if ( ! $this->try_convert( $context, $rule ) ) {
-				$leftover[] = $rule['declaration'];
+				$leftover[] = $rule['declaration'] . ';';
 			}
 		}
 

--- a/modules/atomic-widgets/css-converter/css-converter.php
+++ b/modules/atomic-widgets/css-converter/css-converter.php
@@ -3,6 +3,8 @@
 namespace Elementor\Modules\AtomicWidgets\CssConverter;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Conversion_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\Parsers\Props_Parser;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -18,10 +20,18 @@ class Css_Converter {
 
 	private Expander_Registry $expanders;
 
-	public function __construct( Converter_Registry $registry, Conversion_Failure_Reporter $failure_reporter, ?Expander_Registry $expanders = null ) {
+	private ?Variable_Prop_Value_Transformer $variable_transformer;
+
+	public function __construct(
+		Converter_Registry $registry,
+		Conversion_Failure_Reporter $failure_reporter,
+		?Expander_Registry $expanders = null,
+		?Variable_Prop_Value_Transformer $variable_transformer = null
+	) {
 		$this->registry = $registry;
 		$this->failure_reporter = $failure_reporter;
 		$this->expanders = $expanders ?? new Expander_Registry();
+		$this->variable_transformer = $variable_transformer;
 	}
 
 	/**
@@ -38,11 +48,41 @@ class Css_Converter {
 			}
 		}
 
+		$props = $context->get_props();
+		$rejected = $context->get_rejected();
+
+		if ( $this->variable_transformer ) {
+			$schema = $this->style_schema();
+			$props = $this->variable_transformer->transform( $props, $schema );
+
+			$ejected = $this->variable_transformer->eject_unresolved_var_props( $props, $schema, $rules );
+			$props = $ejected['props'];
+			$leftover = array_merge( $leftover, $ejected['custom_css'] );
+			$rejected = array_merge( $rejected, $ejected['rejected'] );
+			$props = $this->validate_props( $props, $schema );
+		}
+
 		return [
-			'props'     => $context->get_props(),
+			'props'     => $props,
 			'customCss' => implode( ' ', $leftover ),
-			'rejected'  => $context->get_rejected(),
+			'rejected'  => $rejected,
 		];
+	}
+
+	private function validate_props( array $props, array $schema ): array {
+		if ( empty( $props ) ) {
+			return [];
+		}
+
+		return Props_Parser::make( $schema )->validate( $props )->unwrap();
+	}
+
+	private function style_schema(): array {
+		if ( function_exists( 'apply_filters' ) ) {
+			return Style_Schema::get();
+		}
+
+		return Style_Schema::get_style_schema();
 	}
 
 	/**

--- a/modules/atomic-widgets/css-converter/css-converter.php
+++ b/modules/atomic-widgets/css-converter/css-converter.php
@@ -31,7 +31,7 @@ class Css_Converter {
 
 		foreach ( $rules as $rule ) {
 			if ( ! $this->try_convert( $context, $rule ) ) {
-				$leftover[] = $this->render_rule( $rule );
+				$leftover[] = $rule['declaration'];
 			}
 		}
 
@@ -98,6 +98,7 @@ class Css_Converter {
 			$rules[] = [
 				'property' => $property,
 				'value' => $value,
+				'declaration' => $declaration,
 			];
 		}
 
@@ -118,12 +119,5 @@ class Css_Converter {
 		}
 
 		return false;
-	}
-
-	/**
-	 * @param array{property: string, value: string} $rule
-	 */
-	private function render_rule( array $rule ): string {
-		return $rule['property'] . ': ' . $rule['value'] . ';';
 	}
 }

--- a/modules/atomic-widgets/css-converter/css-converter.php
+++ b/modules/atomic-widgets/css-converter/css-converter.php
@@ -25,7 +25,7 @@ class Css_Converter {
 	}
 
 	/**
-	 * @return array{props: array, customCss: string}
+	 * @return array{props: array, customCss: string, rejected: string[]}
 	 */
 	public function convert( string $css ): array {
 		$rules = $this->expand_shorthands( $this->parse( $css ) );
@@ -39,8 +39,9 @@ class Css_Converter {
 		}
 
 		return [
-			'props' => $context->get_props(),
+			'props'     => $context->get_props(),
 			'customCss' => implode( ' ', $leftover ),
+			'rejected'  => $context->get_rejected(),
 		];
 	}
 

--- a/modules/atomic-widgets/css-converter/css-converter.php
+++ b/modules/atomic-widgets/css-converter/css-converter.php
@@ -16,16 +16,19 @@ class Css_Converter {
 
 	private Conversion_Failure_Reporter $failure_reporter;
 
-	public function __construct( Converter_Registry $registry, Conversion_Failure_Reporter $failure_reporter ) {
+	private Expander_Registry $expanders;
+
+	public function __construct( Converter_Registry $registry, Conversion_Failure_Reporter $failure_reporter, ?Expander_Registry $expanders = null ) {
 		$this->registry = $registry;
 		$this->failure_reporter = $failure_reporter;
+		$this->expanders = $expanders ?? new Expander_Registry();
 	}
 
 	/**
 	 * @return array{props: array, customCss: string}
 	 */
 	public function convert( string $css ): array {
-		$rules = $this->parse( $css );
+		$rules = $this->expand_shorthands( $this->parse( $css ) );
 		$context = new Conversion_Context( $rules );
 		$leftover = [];
 
@@ -39,6 +42,55 @@ class Css_Converter {
 			'props' => $context->get_props(),
 			'customCss' => implode( ' ', $leftover ),
 		];
+	}
+
+	/**
+	 * Pre-processing pass: rewrite shorthands (e.g. `border`) into the longhand declarations the
+	 * schema-bound converters understand, in place so the source cascade order is preserved. A rule
+	 * with no matching expander, or whose expander declines (empty result) or throws, is kept as-is so
+	 * it still reaches the converter loop (and custom_css fallback).
+	 *
+	 * @param array<int, array{property: string, value: string, declaration: string}> $rules
+	 * @return array<int, array{property: string, value: string, declaration: string}>
+	 */
+	private function expand_shorthands( array $rules ): array {
+		$expanded = [];
+
+		foreach ( $rules as $rule ) {
+			foreach ( $this->expand_rule( $rule ) as $result_rule ) {
+				$expanded[] = $result_rule;
+			}
+		}
+
+		return $expanded;
+	}
+
+	/**
+	 * @param array{property: string, value: string, declaration: string} $rule
+	 * @return array<int, array{property: string, value: string, declaration: string}>
+	 */
+	private function expand_rule( array $rule ): array {
+		foreach ( $this->expanders->all() as $expander ) {
+			if ( ! $expander->is_supported( $rule ) ) {
+				continue;
+			}
+
+			try {
+				$expanded = $expander->expand( $rule );
+			} catch ( \Throwable $error ) {
+				$this->failure_reporter->report(
+					$rule['property'],
+					Conversion_Failure_Reporter::CATEGORY_EXCEPTION,
+					[ 'message' => $error->getMessage() ]
+				);
+
+				return [ $rule ];
+			}
+
+			return empty( $expanded ) ? [ $rule ] : $expanded;
+		}
+
+		return [ $rule ];
 	}
 
 	/**

--- a/modules/atomic-widgets/css-converter/css-var-reference.php
+++ b/modules/atomic-widgets/css-converter/css-var-reference.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Css_Var_Reference {
+	public static function parse( string $value ): ?string {
+		$value = trim( $value );
+
+		if ( ! preg_match( '/^var\(\s*(--)?([^,\s)]+)/i', $value, $matches ) ) {
+			return null;
+		}
+
+		$token = trim( $matches[2] );
+
+		return '' === $token ? null : ltrim( $token, '-' );
+	}
+}

--- a/modules/atomic-widgets/css-converter/css-var-token-resolver.php
+++ b/modules/atomic-widgets/css-converter/css-var-token-resolver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+use Elementor\Modules\Variables\Services\Variables_Service;
+use Elementor\Modules\Variables\Utils\Variable_Type_Keys;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Css_Var_Token_Resolver {
+	public static function is_var_only_token( string $token ): bool {
+		$token = trim( $token );
+
+		if ( null === Css_Var_Reference::parse( $token ) ) {
+			return false;
+		}
+
+		return 1 === count( Css_Token_Splitter::split_by_whitespace( $token ) );
+	}
+
+	public static function resolve_var_only_token_type( ?Variables_Service $service, string $token ): ?string {
+		if ( ! self::is_var_only_token( $token ) || null === $service ) {
+			return null;
+		}
+
+		$reference = Css_Var_Reference::parse( trim( $token ) );
+
+		if ( null === $reference ) {
+			return null;
+		}
+
+		$variable = $service->find_by_label_or_id( $reference );
+
+		if ( null === $variable ) {
+			return null;
+		}
+
+		return Variable_Type_Keys::get_resolved_type( $variable['type'] ?? '' );
+	}
+}

--- a/modules/atomic-widgets/css-converter/css-var-token-resolver.php
+++ b/modules/atomic-widgets/css-converter/css-var-token-resolver.php
@@ -3,6 +3,8 @@
 namespace Elementor\Modules\AtomicWidgets\CssConverter;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+use Elementor\Modules\Variables\Adapters\Prop_Type_Adapter;
+use Elementor\Modules\Variables\PropTypes\Size_Variable_Prop_Type;
 use Elementor\Modules\Variables\Services\Variables_Service;
 use Elementor\Modules\Variables\Utils\Variable_Type_Keys;
 
@@ -39,5 +41,33 @@ class Css_Var_Token_Resolver {
 		}
 
 		return Variable_Type_Keys::get_resolved_type( $variable['type'] ?? '' );
+	}
+
+	/**
+	 * If $token is a var-only token that resolves to a known size variable, returns the ready-made
+	 * size-variable PropValue `['$$type' => ..., 'value' => $id]`. Returns null if the token is not
+	 * a var, the variable is unknown, or the variable type is not a size (caller should then fall
+	 * back to the raw Size leaf or decline to customCss based on context).
+	 *
+	 * @return array{$$type: string, value: string}|null
+	 */
+	public static function resolve_size_var_prop_value( ?Variables_Service $service, string $token ): ?array {
+		if ( 'size' !== self::resolve_var_only_token_type( $service, $token ) ) {
+			return null;
+		}
+
+		$reference = Css_Var_Reference::parse( trim( $token ) );
+		$variable   = $service->find_by_label_or_id( $reference );
+		$id         = $variable['id'] ?? '';
+
+		if ( '' === $id ) {
+			return null;
+		}
+
+		$prop_type_key = Prop_Type_Adapter::GLOBAL_CUSTOM_SIZE_VARIABLE_KEY === ( $variable['type'] ?? '' )
+			? Size_Variable_Prop_Type::get_key()
+			: ( $variable['type'] ?? '' );
+
+		return [ '$$type' => $prop_type_key, 'value' => $id ];
 	}
 }

--- a/modules/atomic-widgets/css-converter/expander-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/expander-registry-factory.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\AtomicWidgets\CssConverter;
 
+use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Background_Shorthand_Expander;
 use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Border_Shorthand_Expander;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 
@@ -17,6 +18,7 @@ class Expander_Registry_Factory {
 		$style_enum = $schema['border-style']->get_enum();
 
 		$registry = ( new Expander_Registry() )
+			->register( new Background_Shorthand_Expander() )
 			->register( new Border_Shorthand_Expander( 'border', self::border_longhands( '' ), $style_enum ) );
 
 		foreach ( self::BORDER_SIDES as $side ) {

--- a/modules/atomic-widgets/css-converter/expander-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/expander-registry-factory.php
@@ -6,6 +6,7 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Background_Shorthand_
 use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Border_Shorthand_Expander;
 use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Physical_To_Logical_Expander;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
+use Elementor\Modules\Variables\Services\Variables_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -14,13 +15,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Expander_Registry_Factory {
 	const BORDER_SIDES = [ 'top', 'right', 'bottom', 'left' ];
 
-	public static function create(): Expander_Registry {
+	public static function create( ?Variables_Service $variables_service = null ): Expander_Registry {
 		$schema = Style_Schema::get_style_schema();
 		$style_enum = $schema['border-style']->get_enum();
 
 		$registry = ( new Expander_Registry() )
 			->register( new Physical_To_Logical_Expander() )
-			->register( new Background_Shorthand_Expander() )
+			->register( new Background_Shorthand_Expander( $variables_service ) )
 			->register( new Border_Shorthand_Expander( 'border', self::border_longhands( '' ), $style_enum ) );
 
 		foreach ( self::BORDER_SIDES as $side ) {

--- a/modules/atomic-widgets/css-converter/expander-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/expander-registry-factory.php
@@ -4,6 +4,7 @@ namespace Elementor\Modules\AtomicWidgets\CssConverter;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Background_Shorthand_Expander;
 use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Border_Shorthand_Expander;
+use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Physical_To_Logical_Expander;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -18,6 +19,7 @@ class Expander_Registry_Factory {
 		$style_enum = $schema['border-style']->get_enum();
 
 		$registry = ( new Expander_Registry() )
+			->register( new Physical_To_Logical_Expander() )
 			->register( new Background_Shorthand_Expander() )
 			->register( new Border_Shorthand_Expander( 'border', self::border_longhands( '' ), $style_enum ) );
 

--- a/modules/atomic-widgets/css-converter/expander-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/expander-registry-factory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Border_Shorthand_Expander;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Expander_Registry_Factory {
+	const BORDER_SIDES = [ 'top', 'right', 'bottom', 'left' ];
+
+	public static function create(): Expander_Registry {
+		$schema = Style_Schema::get_style_schema();
+		$style_enum = $schema['border-style']->get_enum();
+
+		$registry = ( new Expander_Registry() )
+			->register( new Border_Shorthand_Expander( 'border', self::border_longhands( '' ), $style_enum ) );
+
+		foreach ( self::BORDER_SIDES as $side ) {
+			$registry->register(
+				new Border_Shorthand_Expander( "border-$side", self::border_longhands( "$side-" ), $style_enum )
+			);
+		}
+
+		return $registry;
+	}
+
+	/**
+	 * Role -> longhand property name for the all-sides (`border`, infix '') or per-side (e.g. 'top-')
+	 * shorthand. Per-side style/color have no converter and route to custom_css.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function border_longhands( string $infix ): array {
+		return [
+			Border_Shorthand_Expander::ROLE_WIDTH => "border-{$infix}width",
+			Border_Shorthand_Expander::ROLE_STYLE => "border-{$infix}style",
+			Border_Shorthand_Expander::ROLE_COLOR => "border-{$infix}color",
+		];
+	}
+}

--- a/modules/atomic-widgets/css-converter/expander-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/expander-registry-factory.php
@@ -22,11 +22,11 @@ class Expander_Registry_Factory {
 		$registry = ( new Expander_Registry() )
 			->register( new Physical_To_Logical_Expander() )
 			->register( new Background_Shorthand_Expander( $variables_service ) )
-			->register( new Border_Shorthand_Expander( 'border', self::border_longhands( '' ), $style_enum ) );
+			->register( new Border_Shorthand_Expander( 'border', self::border_longhands( '' ), $style_enum, $variables_service ) );
 
 		foreach ( self::BORDER_SIDES as $side ) {
 			$registry->register(
-				new Border_Shorthand_Expander( "border-$side", self::border_longhands( "$side-" ), $style_enum )
+				new Border_Shorthand_Expander( "border-$side", self::border_longhands( "$side-" ), $style_enum, $variables_service )
 			);
 		}
 

--- a/modules/atomic-widgets/css-converter/expander-registry.php
+++ b/modules/atomic-widgets/css-converter/expander-registry.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Expander_Registry {
+	/**
+	 * @var Shorthand_Expander[]
+	 */
+	private array $expanders = [];
+
+	public function register( Shorthand_Expander $expander ): self {
+		$this->expanders[] = $expander;
+
+		return $this;
+	}
+
+	/**
+	 * Expanders in registration order. The dispatcher applies the first one that supports a rule.
+	 *
+	 * @return Shorthand_Expander[]
+	 */
+	public function all(): array {
+		return $this->expanders;
+	}
+}

--- a/modules/atomic-widgets/css-converter/expanders/background-shorthand-expander.php
+++ b/modules/atomic-widgets/css-converter/expanders/background-shorthand-expander.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Expanders;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Shorthand_Expander_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Expands a `background` shorthand into its constituent longhand declarations so the
+ * existing per-property converters can process each one independently.
+ *
+ * Each comma-separated layer is parsed into role slots: image, repeat, attachment, clip, position,
+ * size, and (last layer only) color. Slot values are then aggregated across layers to form the
+ * longhand values:
+ *  - background-image:      comma-joined per layer (none for layers without an explicit image).
+ *  - background-repeat:     comma-joined if all layers that have an image also specify it.
+ *  - background-attachment: same.
+ *  - background-position:   same.
+ *  - background-size:       same (position must also be present when size is used).
+ *  - background-color:      from the last layer only.
+ *  - background-clip:       from the last layer only (single scalar in our model).
+ *
+ * A layer whose tokens cannot be unambiguously classified declines the entire shorthand (returns [])
+ * so the original declaration is kept and routed to custom_css.
+ */
+class Background_Shorthand_Expander extends Shorthand_Expander_Base {
+	const REPEAT_ENUM = [ 'repeat', 'repeat-x', 'repeat-y', 'no-repeat' ];
+	const ATTACHMENT_ENUM = [ 'fixed', 'scroll' ];
+	const CLIP_ENUM = [ 'border-box', 'padding-box', 'content-box', 'text' ];
+	const POSITION_KEYWORDS = [ 'top', 'bottom', 'left', 'right', 'center' ];
+	const SIZE_KEYWORDS = [ 'cover', 'contain', 'auto' ];
+
+	protected function get_supported_properties(): array {
+		return [ 'background' ];
+	}
+
+	public function expand( array $rule ): array {
+		$layers = Css_Token_Splitter::split_by_comma( trim( $rule['value'] ) );
+
+		if ( empty( $layers ) ) {
+			return [];
+		}
+
+		$parsed = [];
+
+		foreach ( $layers as $layer ) {
+			$result = $this->parse_layer( trim( $layer ) );
+
+			if ( null === $result ) {
+				return [];
+			}
+
+			$parsed[] = $result;
+		}
+
+		return $this->build_rules( $parsed );
+	}
+
+	/**
+	 * @return array{image:string|null,repeat:string|null,attachment:string|null,clip:string|null,position:string|null,size:string|null,color:string|null}|null
+	 */
+	private function parse_layer( string $layer ): ?array {
+		$tokens = Css_Token_Splitter::split_by_whitespace( $layer );
+
+		$image = null;
+		$repeat = null;
+		$attachment = null;
+		$clip = null;
+		$color = null;
+		$position_tokens = [];
+		$size_tokens = [];
+		$after_slash = false;
+
+		$n = count( $tokens );
+
+		for ( $i = 0; $i < $n; $i++ ) {
+			$token = $tokens[ $i ];
+			$lower = strtolower( $token );
+
+			if ( '/' === $token ) {
+				$after_slash = true;
+				continue;
+			}
+
+			if ( $after_slash ) {
+				if ( $this->is_size_token( $token ) ) {
+					$size_tokens[] = $token;
+					if ( count( $size_tokens ) >= 2 ) {
+						$after_slash = false;
+					}
+					continue;
+				}
+				$after_slash = false;
+			}
+
+			if ( $this->is_image_token( $lower ) ) {
+				if ( null !== $image ) {
+					return null;
+				}
+				$image = $token;
+				continue;
+			}
+
+			if ( in_array( $lower, self::REPEAT_ENUM, true ) ) {
+				if ( null !== $repeat ) {
+					return null;
+				}
+				$repeat = $token;
+				continue;
+			}
+
+			if ( in_array( $lower, self::ATTACHMENT_ENUM, true ) ) {
+				if ( null !== $attachment ) {
+					return null;
+				}
+				$attachment = $token;
+				continue;
+			}
+
+			if ( in_array( $lower, self::CLIP_ENUM, true ) ) {
+				if ( null !== $clip ) {
+					return null;
+				}
+				$clip = $token;
+				continue;
+			}
+
+			if ( $this->is_position_token( $lower ) ) {
+				$position_tokens[] = $token;
+				if ( count( $position_tokens ) > 2 ) {
+					return null;
+				}
+				continue;
+			}
+
+			if ( null !== $color ) {
+				return null;
+			}
+
+			$color = $token;
+		}
+
+		if ( ! empty( $size_tokens ) && empty( $position_tokens ) ) {
+			return null;
+		}
+
+		$position = empty( $position_tokens ) ? null : implode( ' ', $position_tokens );
+		$size = empty( $size_tokens ) ? null : implode( ' ', $size_tokens );
+
+		return compact( 'image', 'repeat', 'attachment', 'clip', 'color', 'position', 'size' );
+	}
+
+	private function is_image_token( string $lower ): bool {
+		return 'none' === $lower
+			|| 0 === strpos( $lower, 'url(' )
+			|| false !== strpos( $lower, '-gradient(' );
+	}
+
+	private function is_size_token( string $token ): bool {
+		return in_array( strtolower( $token ), self::SIZE_KEYWORDS, true )
+			|| null !== Size_Value_Parser::parse( $token );
+	}
+
+	private function is_position_token( string $lower ): bool {
+		return in_array( $lower, self::POSITION_KEYWORDS, true )
+			|| null !== Size_Value_Parser::parse( $lower );
+	}
+
+	/**
+	 * @param array[] $parsed
+	 * @return array[]
+	 */
+	private function build_rules( array $parsed ): array {
+		$layer_count = count( $parsed );
+		$rules = [];
+
+		$has_image = ! empty( array_filter( $parsed, fn( $l ) => null !== $l['image'] ) );
+
+		if ( $has_image ) {
+			$images = array_map( fn( $l ) => $l['image'] ?? 'none', $parsed );
+			$rules['background-image'] = implode( ', ', $images );
+		}
+
+		$per_layer_slots = [
+			'repeat' => 'background-repeat',
+			'attachment' => 'background-attachment',
+			'position' => 'background-position',
+			'size' => 'background-size',
+		];
+
+		foreach ( $per_layer_slots as $slot => $property ) {
+			$values = array_column( $parsed, $slot );
+			$non_null = array_filter( $values, fn( $v ) => null !== $v );
+
+			if ( empty( $non_null ) ) {
+				continue;
+			}
+
+			if ( count( $non_null ) === 1 || count( $non_null ) === $layer_count ) {
+				$rules[ $property ] = implode( ', ', $non_null );
+			}
+		}
+
+		$last = end( $parsed );
+
+		if ( null !== $last['clip'] ) {
+			$rules['background-clip'] = $last['clip'];
+		}
+
+		if ( null !== $last['color'] ) {
+			$rules['background-color'] = $last['color'];
+		}
+
+		return $this->emit_rules( $rules );
+	}
+
+	/**
+	 * @param array<string, string> $longhands
+	 * @return array[]
+	 */
+	private function emit_rules( array $longhands ): array {
+		$rules = [];
+
+		foreach ( $longhands as $property => $value ) {
+			$rules[] = [
+				'property' => $property,
+				'value' => $value,
+				'declaration' => $property . ': ' . $value,
+			];
+		}
+
+		return $rules;
+	}
+}

--- a/modules/atomic-widgets/css-converter/expanders/background-shorthand-expander.php
+++ b/modules/atomic-widgets/css-converter/expanders/background-shorthand-expander.php
@@ -2,9 +2,12 @@
 
 namespace Elementor\Modules\AtomicWidgets\CssConverter\Expanders;
 
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Var_Reference;
 use Elementor\Modules\AtomicWidgets\CssConverter\Shorthand_Expander_Base;
 use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
 use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\Variables\Services\Variables_Service;
+use Elementor\Modules\Variables\Utils\Variable_Type_Keys;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -29,11 +32,17 @@ if ( ! defined( 'ABSPATH' ) ) {
  * so the original declaration is kept and routed to custom_css.
  */
 class Background_Shorthand_Expander extends Shorthand_Expander_Base {
+	private ?Variables_Service $variables_service;
+
 	const REPEAT_ENUM = [ 'repeat', 'repeat-x', 'repeat-y', 'no-repeat' ];
 	const ATTACHMENT_ENUM = [ 'fixed', 'scroll' ];
 	const CLIP_ENUM = [ 'border-box', 'padding-box', 'content-box', 'text' ];
 	const POSITION_KEYWORDS = [ 'top', 'bottom', 'left', 'right', 'center' ];
 	const SIZE_KEYWORDS = [ 'cover', 'contain', 'auto' ];
+
+	public function __construct( ?Variables_Service $variables_service = null ) {
+		$this->variables_service = $variables_service;
+	}
 
 	protected function get_supported_properties(): array {
 		return [ 'background' ];
@@ -65,6 +74,10 @@ class Background_Shorthand_Expander extends Shorthand_Expander_Base {
 	 * @return array{image:string|null,repeat:string|null,attachment:string|null,clip:string|null,position:string|null,size:string|null,color:string|null}|null
 	 */
 	private function parse_layer( string $layer ): ?array {
+		if ( $this->is_var_only_layer( $layer ) ) {
+			return $this->parse_var_only_layer( $layer );
+		}
+
 		$tokens = Css_Token_Splitter::split_by_whitespace( $layer );
 
 		$image = null;
@@ -153,6 +166,70 @@ class Background_Shorthand_Expander extends Shorthand_Expander_Base {
 		$size = empty( $size_tokens ) ? null : implode( ' ', $size_tokens );
 
 		return compact( 'image', 'repeat', 'attachment', 'clip', 'color', 'position', 'size' );
+	}
+
+	private function is_var_only_layer( string $layer ): bool {
+		$layer = trim( $layer );
+
+		if ( null === Css_Var_Reference::parse( $layer ) ) {
+			return false;
+		}
+
+		return 1 === count( Css_Token_Splitter::split_by_whitespace( $layer ) );
+	}
+
+	/**
+	 * @return array{image:string|null,repeat:string|null,attachment:string|null,clip:string|null,position:string|null,size:string|null,color:string|null}|null
+	 */
+	private function parse_var_only_layer( string $layer ): ?array {
+		if ( null === $this->variables_service ) {
+			return null;
+		}
+
+		$reference = Css_Var_Reference::parse( $layer );
+
+		if ( null === $reference ) {
+			return null;
+		}
+
+		$variable = $this->variables_service->find_by_label_or_id( $reference );
+
+		if ( null === $variable ) {
+			return null;
+		}
+
+		$resolved_type = Variable_Type_Keys::get_resolved_type( $variable['type'] ?? '' );
+		$empty_layer = $this->empty_layer();
+
+		if ( 'color' === $resolved_type ) {
+			$empty_layer['color'] = $layer;
+
+			return $empty_layer;
+		}
+
+		if ( 'size' === $resolved_type ) {
+			$empty_layer['position'] = 'center center';
+			$empty_layer['size'] = $layer;
+
+			return $empty_layer;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @return array{image:string|null,repeat:string|null,attachment:string|null,clip:string|null,position:string|null,size:string|null,color:string|null}
+	 */
+	private function empty_layer(): array {
+		return [
+			'image' => null,
+			'repeat' => null,
+			'attachment' => null,
+			'clip' => null,
+			'position' => null,
+			'size' => null,
+			'color' => null,
+		];
 	}
 
 	private function is_image_token( string $lower ): bool {

--- a/modules/atomic-widgets/css-converter/expanders/background-shorthand-expander.php
+++ b/modules/atomic-widgets/css-converter/expanders/background-shorthand-expander.php
@@ -2,12 +2,11 @@
 
 namespace Elementor\Modules\AtomicWidgets\CssConverter\Expanders;
 
-use Elementor\Modules\AtomicWidgets\CssConverter\Css_Var_Reference;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Var_Token_Resolver;
 use Elementor\Modules\AtomicWidgets\CssConverter\Shorthand_Expander_Base;
 use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
 use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
 use Elementor\Modules\Variables\Services\Variables_Service;
-use Elementor\Modules\Variables\Utils\Variable_Type_Keys;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -169,36 +168,14 @@ class Background_Shorthand_Expander extends Shorthand_Expander_Base {
 	}
 
 	private function is_var_only_layer( string $layer ): bool {
-		$layer = trim( $layer );
-
-		if ( null === Css_Var_Reference::parse( $layer ) ) {
-			return false;
-		}
-
-		return 1 === count( Css_Token_Splitter::split_by_whitespace( $layer ) );
+		return Css_Var_Token_Resolver::is_var_only_token( $layer );
 	}
 
 	/**
 	 * @return array{image:string|null,repeat:string|null,attachment:string|null,clip:string|null,position:string|null,size:string|null,color:string|null}|null
 	 */
 	private function parse_var_only_layer( string $layer ): ?array {
-		if ( null === $this->variables_service ) {
-			return null;
-		}
-
-		$reference = Css_Var_Reference::parse( $layer );
-
-		if ( null === $reference ) {
-			return null;
-		}
-
-		$variable = $this->variables_service->find_by_label_or_id( $reference );
-
-		if ( null === $variable ) {
-			return null;
-		}
-
-		$resolved_type = Variable_Type_Keys::get_resolved_type( $variable['type'] ?? '' );
+		$resolved_type = Css_Var_Token_Resolver::resolve_var_only_token_type( $this->variables_service, $layer );
 		$empty_layer = $this->empty_layer();
 
 		if ( 'color' === $resolved_type ) {

--- a/modules/atomic-widgets/css-converter/expanders/border-shorthand-expander.php
+++ b/modules/atomic-widgets/css-converter/expanders/border-shorthand-expander.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Expanders;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Shorthand_Expander_Base;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Expands a `border` / `border-{side}` shorthand into its width / style / color longhands. There is no
+ * aggregate Border prop type; these are independent longhands, so this is a split, not a merge. The
+ * concrete longhand property names are injected, so the same logic serves the all-sides `border`
+ * (border-width/style/color) and each per-side shorthand (e.g. border-top-width/style/color).
+ *
+ * Each token is classified once: a border-style keyword (enum from the live schema) -> style; a length
+ * the Size parser accepts, or a width keyword (thin/medium/thick) -> width; anything else -> color (the
+ * catch-all, mirroring the raw-passthrough color converter). Only the parts present are emitted (omitted
+ * parts are not reset to CSS initials). A second token for an already filled role is ambiguous, so the
+ * whole expansion declines and the original shorthand is kept for custom_css. A produced longhand can
+ * still individually decline downstream (e.g. `border-{side}-style`, which has no converter), degrading
+ * to custom_css for that part only.
+ */
+class Border_Shorthand_Expander extends Shorthand_Expander_Base {
+	const WIDTH_KEYWORDS = [ 'thin', 'medium', 'thick' ];
+	const ROLE_WIDTH = 'width';
+	const ROLE_STYLE = 'style';
+	const ROLE_COLOR = 'color';
+
+	private string $property;
+
+	/**
+	 * @var array<string, string> Role (width|style|color) -> emitted longhand property name.
+	 */
+	private array $longhands;
+
+	/**
+	 * @var string[]
+	 */
+	private array $style_keywords;
+
+	/**
+	 * @param string                $property       The shorthand this expander owns (border, border-top, ...).
+	 * @param array<string, string> $longhands      Role -> longhand property name to emit.
+	 * @param string[]              $style_keywords The border-style enum, sourced from the live schema.
+	 */
+	public function __construct( string $property, array $longhands, array $style_keywords ) {
+		$this->property = $property;
+		$this->longhands = $longhands;
+		$this->style_keywords = $style_keywords;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	public function expand( array $rule ): array {
+		$tokens = Css_Token_Splitter::split_by_whitespace( trim( $rule['value'] ) );
+
+		if ( empty( $tokens ) ) {
+			return [];
+		}
+
+		$slots = [
+			self::ROLE_WIDTH => null,
+			self::ROLE_STYLE => null,
+			self::ROLE_COLOR => null,
+		];
+
+		foreach ( $tokens as $token ) {
+			$role = $this->classify( $token );
+
+			if ( null !== $slots[ $role ] ) {
+				return [];
+			}
+
+			$slots[ $role ] = $token;
+		}
+
+		$rules = [];
+
+		foreach ( $slots as $role => $value ) {
+			if ( null === $value ) {
+				continue;
+			}
+
+			$property = $this->longhands[ $role ];
+
+			$rules[] = [
+				'property' => $property,
+				'value' => $value,
+				'declaration' => $property . ': ' . $value,
+			];
+		}
+
+		return $rules;
+	}
+
+	private function classify( string $token ): string {
+		$lower = strtolower( $token );
+
+		if ( in_array( $lower, $this->style_keywords, true ) ) {
+			return self::ROLE_STYLE;
+		}
+
+		if ( in_array( $lower, self::WIDTH_KEYWORDS, true ) || null !== Size_Value_Parser::parse( $token ) ) {
+			return self::ROLE_WIDTH;
+		}
+
+		return self::ROLE_COLOR;
+	}
+}

--- a/modules/atomic-widgets/css-converter/expanders/border-shorthand-expander.php
+++ b/modules/atomic-widgets/css-converter/expanders/border-shorthand-expander.php
@@ -2,9 +2,11 @@
 
 namespace Elementor\Modules\AtomicWidgets\CssConverter\Expanders;
 
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Var_Token_Resolver;
 use Elementor\Modules\AtomicWidgets\CssConverter\Shorthand_Expander_Base;
 use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Css_Token_Splitter;
 use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\Variables\Services\Variables_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -42,15 +44,23 @@ class Border_Shorthand_Expander extends Shorthand_Expander_Base {
 	 */
 	private array $style_keywords;
 
+	private ?Variables_Service $variables_service;
+
 	/**
 	 * @param string                $property       The shorthand this expander owns (border, border-top, ...).
 	 * @param array<string, string> $longhands      Role -> longhand property name to emit.
 	 * @param string[]              $style_keywords The border-style enum, sourced from the live schema.
 	 */
-	public function __construct( string $property, array $longhands, array $style_keywords ) {
+	public function __construct(
+		string $property,
+		array $longhands,
+		array $style_keywords,
+		?Variables_Service $variables_service = null
+	) {
 		$this->property = $property;
 		$this->longhands = $longhands;
 		$this->style_keywords = $style_keywords;
+		$this->variables_service = $variables_service;
 	}
 
 	protected function get_supported_properties(): array {
@@ -71,9 +81,9 @@ class Border_Shorthand_Expander extends Shorthand_Expander_Base {
 		];
 
 		foreach ( $tokens as $token ) {
-			$role = $this->classify( $token );
+			$role = $this->classify_token( $token );
 
-			if ( null !== $slots[ $role ] ) {
+			if ( null === $role || null !== $slots[ $role ] ) {
 				return [];
 			}
 
@@ -99,7 +109,25 @@ class Border_Shorthand_Expander extends Shorthand_Expander_Base {
 		return $rules;
 	}
 
-	private function classify( string $token ): string {
+	private function classify_token( string $token ): ?string {
+		if ( Css_Var_Token_Resolver::is_var_only_token( $token ) ) {
+			$resolved_type = Css_Var_Token_Resolver::resolve_var_only_token_type( $this->variables_service, $token );
+
+			if ( 'color' === $resolved_type ) {
+				return self::ROLE_COLOR;
+			}
+
+			if ( 'size' === $resolved_type ) {
+				return self::ROLE_WIDTH;
+			}
+
+			return null;
+		}
+
+		return $this->classify_literal_token( $token );
+	}
+
+	private function classify_literal_token( string $token ): string {
 		$lower = strtolower( $token );
 
 		if ( in_array( $lower, $this->style_keywords, true ) ) {

--- a/modules/atomic-widgets/css-converter/expanders/physical-to-logical-expander.php
+++ b/modules/atomic-widgets/css-converter/expanders/physical-to-logical-expander.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Expanders;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Shorthand_Expander_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Rewrites physical inset properties (top, right, bottom, left) to their logical equivalents
+ * (inset-block-start, inset-inline-end, inset-block-end, inset-inline-start) so the standard
+ * Size converters can handle them without needing separate converter registrations.
+ *
+ * Assumes LTR writing mode, which matches the Elementor canvas default.
+ */
+class Physical_To_Logical_Expander extends Shorthand_Expander_Base {
+	const PHYSICAL_TO_LOGICAL = [
+		'top'    => 'inset-block-start',
+		'right'  => 'inset-inline-end',
+		'bottom' => 'inset-block-end',
+		'left'   => 'inset-inline-start',
+	];
+
+	protected function get_supported_properties(): array {
+		return array_keys( self::PHYSICAL_TO_LOGICAL );
+	}
+
+	public function expand( array $rule ): array {
+		$logical = self::PHYSICAL_TO_LOGICAL[ $rule['property'] ];
+		$value = $rule['value'];
+
+		return [
+			[
+				'property'    => $logical,
+				'value'       => $value,
+				'declaration' => $logical . ': ' . $value,
+			],
+		];
+	}
+}

--- a/modules/atomic-widgets/css-converter/shorthand-expander-base.php
+++ b/modules/atomic-widgets/css-converter/shorthand-expander-base.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+abstract class Shorthand_Expander_Base implements Shorthand_Expander {
+	/**
+	 * Exact, enumerated shorthand property names this expander owns.
+	 *
+	 * @return string[]
+	 */
+	abstract protected function get_supported_properties(): array;
+
+	public function is_supported( array $rule ): bool {
+		$property = $rule['property'] ?? null;
+
+		if ( ! is_string( $property ) || '' === $property ) {
+			return false;
+		}
+
+		return in_array( $property, $this->get_supported_properties(), true );
+	}
+
+	abstract public function expand( array $rule ): array;
+}

--- a/modules/atomic-widgets/css-converter/shorthand-expander.php
+++ b/modules/atomic-widgets/css-converter/shorthand-expander.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * A pre-processing pass that rewrites a single shorthand declaration (e.g. `border`) into the
+ * longhand declarations the schema-bound converters already understand. Runs before the converter
+ * loop so the converter registry stays a 1:1 mirror of Style_Schema and the shorthand never becomes a
+ * prop or a coverage key.
+ */
+interface Shorthand_Expander {
+	/**
+	 * @param array{property: string, value: string} $rule A single parsed CSS declaration.
+	 */
+	public function is_supported( array $rule ): bool;
+
+	/**
+	 * Rewrite the shorthand into longhand declarations. Returning an empty array declines the
+	 * expansion, so the original shorthand is kept and routed to custom_css.
+	 *
+	 * @param array{property: string, value: string} $rule
+	 * @return array<int, array{property: string, value: string, declaration: string}>
+	 */
+	public function expand( array $rule ): array;
+}

--- a/modules/atomic-widgets/css-converter/value-parsers/background-image-value-parser.php
+++ b/modules/atomic-widgets/css-converter/value-parsers/background-image-value-parser.php
@@ -177,7 +177,7 @@ class Background_Image_Value_Parser {
 		if ( preg_match( '/^circle\s+at\s+(.+)$/i', $first, $m ) ) {
 			$pos = trim( $m[1] );
 
-			if ( ! self::is_valid_radial_position( $pos ) ) {
+			if ( ! Position_Prop_Type::is_valid_radial_position( $pos ) ) {
 				return false;
 			}
 
@@ -203,17 +203,8 @@ class Background_Image_Value_Parser {
 		return Background_Gradient_Overlay_Prop_Type::generate( $value );
 	}
 
-	private static function is_valid_radial_position( string $pos ): bool {
-		if ( in_array( $pos, Position_Prop_Type::get_position_enum_values(), true ) ) {
-			return true;
-		}
-
-		$token_pattern = '(?:(?:top|bottom|left|right|center)|(?:-?\d+(?:\.\d+)?(?:%|px|em|rem|vw|vh)))';
-
-		return (bool) preg_match( '/^' . $token_pattern . '(?:\s+' . $token_pattern . ')?$/i', $pos );
-	}
-
 	/**
+
 	 * @return array[]|null
 	 */
 	private static function parse_color_stops( array $tokens ): ?array {

--- a/modules/atomic-widgets/css-converter/value-parsers/background-image-value-parser.php
+++ b/modules/atomic-widgets/css-converter/value-parsers/background-image-value-parser.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers;
+
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Gradient_Overlay_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Image_Overlay_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Stop_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Gradient_Color_Stop_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Image_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Image_Src_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Position_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Url_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Stateless parser: a raw CSS `background-image` value -> an ordered list of overlay PropValues (one
+ * per comma-separated layer), or null to decline the whole declaration (-> custom_css).
+ *
+ * Each layer token is classified:
+ *  - `none`                    -> layer is silently skipped (not added to the list).
+ *  - `url(...)`                -> Background_Image_Overlay_Prop_Type PropValue.
+ *  - `linear-gradient(...)`    -> Background_Gradient_Overlay_Prop_Type PropValue (linear).
+ *  - `radial-gradient(...)`    -> Background_Gradient_Overlay_Prop_Type PropValue (radial).
+ *  - anything else             -> decline the entire value.
+ *
+ * Gradient parsing supports:
+ *  - Linear: optional leading `Ndeg` angle, then comma-separated color stops.
+ *  - Radial:  optional leading `circle at <named-position>`, then color stops.
+ *  - Color stops: `<color> <N>%` pairs; offset is optional.
+ *  - Unsupported syntax (direction keywords, conic, complex shapes) declines.
+ */
+class Background_Image_Value_Parser {
+	const DEFAULT_IMAGE_SIZE = 'large';
+
+	/**
+	 * @return array[]|null  Ordered overlay PropValues per layer, or null to decline.
+	 */
+	public static function parse( string $value ): ?array {
+		$tokens = Css_Token_Splitter::split_by_comma( trim( $value ) );
+
+		if ( empty( $tokens ) ) {
+			return null;
+		}
+
+		$overlays = [];
+
+		foreach ( $tokens as $token ) {
+			$overlay = self::parse_layer( trim( $token ) );
+
+			if ( false === $overlay ) {
+				return null;
+			}
+
+			if ( null !== $overlay ) {
+				$overlays[] = $overlay;
+			}
+		}
+
+		return $overlays;
+	}
+
+	/**
+	 * @return array|null|false  PropValue, null for `none`, false to decline.
+	 */
+	private static function parse_layer( string $token ) {
+		$lower = strtolower( $token );
+
+		if ( 'none' === $lower ) {
+			return null;
+		}
+
+		if ( 0 === strpos( $lower, 'url(' ) ) {
+			return self::parse_url( $token );
+		}
+
+		if ( preg_match( '/^([\w-]+-gradient)\s*\((.+)\)$/si', $token, $m ) ) {
+			return self::parse_gradient( strtolower( $m[1] ), $m[2] );
+		}
+
+		return false;
+	}
+
+	/**
+	 * @return array|false
+	 */
+	private static function parse_url( string $token ) {
+		if ( ! preg_match( '/^url\s*\(\s*([\'"]?)(.+?)\1\s*\)$/i', $token, $m ) ) {
+			return false;
+		}
+
+		$url = $m[2];
+
+		return Background_Image_Overlay_Prop_Type::generate( [
+			'image' => Image_Prop_Type::generate( [
+				'src' => Image_Src_Prop_Type::generate( [
+					'url' => Url_Prop_Type::generate( $url ),
+				] ),
+				'size' => String_Prop_Type::generate( self::DEFAULT_IMAGE_SIZE ),
+			] ),
+		] );
+	}
+
+	/**
+	 * @return array|false
+	 */
+	private static function parse_gradient( string $func_name, string $args ) {
+		if ( 'linear-gradient' === $func_name ) {
+			return self::parse_linear_gradient( $args );
+		}
+
+		if ( 'radial-gradient' === $func_name ) {
+			return self::parse_radial_gradient( $args );
+		}
+
+		return false;
+	}
+
+	/**
+	 * @return array|false
+	 */
+	private static function parse_linear_gradient( string $args ) {
+		$tokens = Css_Token_Splitter::split_by_comma( trim( $args ) );
+
+		if ( empty( $tokens ) ) {
+			return false;
+		}
+
+		$angle = null;
+		$stop_start = 0;
+		$first = trim( $tokens[0] );
+
+		if ( preg_match( '/^(-?\d+(?:\.\d+)?)deg$/i', $first, $m ) ) {
+			$angle = (float) $m[1];
+			$stop_start = 1;
+		} elseif ( 0 === strpos( strtolower( $first ), 'to ' ) ) {
+			return false;
+		}
+
+		$stops = self::parse_color_stops( array_slice( $tokens, $stop_start ) );
+
+		if ( null === $stops ) {
+			return false;
+		}
+
+		$value = [
+			'type' => String_Prop_Type::generate( 'linear' ),
+			'stops' => Gradient_Color_Stop_Prop_Type::generate( $stops ),
+		];
+
+		if ( null !== $angle ) {
+			$value['angle'] = Number_Prop_Type::generate( $angle );
+		}
+
+		return Background_Gradient_Overlay_Prop_Type::generate( $value );
+	}
+
+	/**
+	 * @return array|false
+	 */
+	private static function parse_radial_gradient( string $args ) {
+		$tokens = Css_Token_Splitter::split_by_comma( trim( $args ) );
+
+		if ( empty( $tokens ) ) {
+			return false;
+		}
+
+		$positions = null;
+		$stop_start = 0;
+		$first = trim( $tokens[0] );
+
+		if ( preg_match( '/^circle\s+at\s+(.+)$/i', $first, $m ) ) {
+			$pos = trim( $m[1] );
+
+			if ( ! self::is_valid_radial_position( $pos ) ) {
+				return false;
+			}
+
+			$positions = $pos;
+			$stop_start = 1;
+		}
+
+		$stops = self::parse_color_stops( array_slice( $tokens, $stop_start ) );
+
+		if ( null === $stops ) {
+			return false;
+		}
+
+		$value = [
+			'type' => String_Prop_Type::generate( 'radial' ),
+			'stops' => Gradient_Color_Stop_Prop_Type::generate( $stops ),
+		];
+
+		if ( null !== $positions ) {
+			$value['positions'] = String_Prop_Type::generate( $positions );
+		}
+
+		return Background_Gradient_Overlay_Prop_Type::generate( $value );
+	}
+
+	private static function is_valid_radial_position( string $pos ): bool {
+		if ( in_array( $pos, Position_Prop_Type::get_position_enum_values(), true ) ) {
+			return true;
+		}
+
+		$token_pattern = '(?:(?:top|bottom|left|right|center)|(?:-?\d+(?:\.\d+)?(?:%|px|em|rem|vw|vh)))';
+
+		return (bool) preg_match( '/^' . $token_pattern . '(?:\s+' . $token_pattern . ')?$/i', $pos );
+	}
+
+	/**
+	 * @return array[]|null
+	 */
+	private static function parse_color_stops( array $tokens ): ?array {
+		if ( empty( $tokens ) ) {
+			return null;
+		}
+
+		$stops = [];
+
+		foreach ( $tokens as $token ) {
+			$stop = self::parse_color_stop( trim( $token ) );
+
+			if ( null === $stop ) {
+				return null;
+			}
+
+			$stops[] = $stop;
+		}
+
+		return $stops;
+	}
+
+	private static function parse_color_stop( string $token ): ?array {
+		$parts = Css_Token_Splitter::split_by_whitespace( $token );
+
+		if ( empty( $parts ) || count( $parts ) > 2 ) {
+			return null;
+		}
+
+		$stop_value = [ 'color' => Color_Prop_Type::generate( $parts[0] ) ];
+
+		if ( isset( $parts[1] ) ) {
+			if ( ! preg_match( '/^(-?\d+(?:\.\d+)?)%$/', $parts[1], $m ) ) {
+				return null;
+			}
+
+			$stop_value['offset'] = Number_Prop_Type::generate( (float) $m[1] );
+		}
+
+		return Color_Stop_Prop_Type::generate( $stop_value );
+	}
+}

--- a/modules/atomic-widgets/css-converter/value-parsers/box-shorthand-parser.php
+++ b/modules/atomic-widgets/css-converter/value-parsers/box-shorthand-parser.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Stateless parser for the CSS box shorthands (padding/margin/border-width/border-radius): a raw
+ * value -> 1..4 Size leaves, or null to decline (the caller routes the declaration to custom_css).
+ * It never touches the registry, context, or PropTypes; the caller maps the result onto its own keys.
+ *
+ * Tokenizing is paren-aware so function values such as calc(100% / 4) survive as one token (and are
+ * parsed as a Size leaf). This also makes the elliptical border-radius form (a "/" separator) decline
+ * for free: a bare "/" is an unparsable token, and "a / b" exceeds four tokens.
+ *
+ * - 1 token  -> [ 'single' => <Size leaf> ]            (the union's Size member)
+ * - 2-4 tokens -> [ 'sides' => [ s0, s1, s2, s3 ] ]    (expanded via the CSS box rule)
+ * - 0 / >4 tokens, or any unparsable token -> null
+ */
+class Box_Shorthand_Parser {
+	const MAX_SIDES = 4;
+
+	/**
+	 * @return array{single: array}|array{sides: array<int, array>}|null
+	 */
+	public static function parse( string $value ): ?array {
+		$tokens = self::split_top_level( trim( $value ) );
+		$count = count( $tokens );
+
+		if ( $count < 1 || $count > self::MAX_SIDES ) {
+			return null;
+		}
+
+		$sizes = [];
+
+		foreach ( $tokens as $token ) {
+			$parsed = Size_Value_Parser::parse( $token );
+
+			if ( null === $parsed ) {
+				return null;
+			}
+
+			$sizes[] = $parsed;
+		}
+
+		if ( 1 === $count ) {
+			return [ 'single' => $sizes[0] ];
+		}
+
+		return [ 'sides' => self::expand_box( $sizes ) ];
+	}
+
+	/**
+	 * Expand 2..4 values onto four sides via the CSS box rule. The result is positional and the same
+	 * for every box shorthand; the caller assigns the four slots to its own keys.
+	 *
+	 * @param array<int, array> $sizes 2..4 parsed Size leaves.
+	 * @return array{0: array, 1: array, 2: array, 3: array}
+	 */
+	private static function expand_box( array $sizes ): array {
+		switch ( count( $sizes ) ) {
+			case 2:
+				return [ $sizes[0], $sizes[1], $sizes[0], $sizes[1] ];
+			case 3:
+				return [ $sizes[0], $sizes[1], $sizes[2], $sizes[1] ];
+			default:
+				return [ $sizes[0], $sizes[1], $sizes[2], $sizes[3] ];
+		}
+	}
+
+	/**
+	 * Split on whitespace runs that sit at parenthesis depth 0, so function values such as
+	 * "calc(50% - 10px)" stay intact as a single token.
+	 *
+	 * @return string[]
+	 */
+	private static function split_top_level( string $value ): array {
+		$tokens = [];
+		$current = '';
+		$depth = 0;
+		$length = strlen( $value );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$char = $value[ $i ];
+
+			if ( '(' === $char ) {
+				++$depth;
+			} elseif ( ')' === $char ) {
+				$depth = max( 0, $depth - 1 );
+			}
+
+			if ( 0 === $depth && ( ' ' === $char || "\t" === $char || "\n" === $char ) ) {
+				if ( '' !== $current ) {
+					$tokens[] = $current;
+					$current = '';
+				}
+
+				continue;
+			}
+
+			$current .= $char;
+		}
+
+		if ( '' !== $current ) {
+			$tokens[] = $current;
+		}
+
+		return $tokens;
+	}
+}

--- a/modules/atomic-widgets/css-converter/value-parsers/box-shorthand-parser.php
+++ b/modules/atomic-widgets/css-converter/value-parsers/box-shorthand-parser.php
@@ -26,7 +26,7 @@ class Box_Shorthand_Parser {
 	 * @return array{single: array}|array{sides: array<int, array>}|null
 	 */
 	public static function parse( string $value ): ?array {
-		$tokens = self::split_top_level( trim( $value ) );
+		$tokens = Css_Token_Splitter::split_by_whitespace( trim( $value ) );
 		$count = count( $tokens );
 
 		if ( $count < 1 || $count > self::MAX_SIDES ) {
@@ -68,45 +68,5 @@ class Box_Shorthand_Parser {
 			default:
 				return [ $sizes[0], $sizes[1], $sizes[2], $sizes[3] ];
 		}
-	}
-
-	/**
-	 * Split on whitespace runs that sit at parenthesis depth 0, so function values such as
-	 * "calc(50% - 10px)" stay intact as a single token.
-	 *
-	 * @return string[]
-	 */
-	private static function split_top_level( string $value ): array {
-		$tokens = [];
-		$current = '';
-		$depth = 0;
-		$length = strlen( $value );
-
-		for ( $i = 0; $i < $length; $i++ ) {
-			$char = $value[ $i ];
-
-			if ( '(' === $char ) {
-				++$depth;
-			} elseif ( ')' === $char ) {
-				$depth = max( 0, $depth - 1 );
-			}
-
-			if ( 0 === $depth && ( ' ' === $char || "\t" === $char || "\n" === $char ) ) {
-				if ( '' !== $current ) {
-					$tokens[] = $current;
-					$current = '';
-				}
-
-				continue;
-			}
-
-			$current .= $char;
-		}
-
-		if ( '' !== $current ) {
-			$tokens[] = $current;
-		}
-
-		return $tokens;
 	}
 }

--- a/modules/atomic-widgets/css-converter/value-parsers/css-token-splitter.php
+++ b/modules/atomic-widgets/css-converter/value-parsers/css-token-splitter.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Stateless tokenizer shared by the box shorthands and shorthand expanders. Splits a CSS value on
+ * whitespace runs that sit at parenthesis depth 0, so function values such as calc(50% - 10px) or
+ * rgb(0, 0, 0) stay intact as a single token.
+ */
+class Css_Token_Splitter {
+	/**
+	 * @return string[]
+	 */
+	public static function split_by_whitespace( string $value ): array {
+		$tokens = [];
+		$current = '';
+		$depth = 0;
+		$length = strlen( $value );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$char = $value[ $i ];
+
+			if ( '(' === $char ) {
+				++$depth;
+			} elseif ( ')' === $char ) {
+				$depth = max( 0, $depth - 1 );
+			}
+
+			if ( 0 === $depth && ( ' ' === $char || "\t" === $char || "\n" === $char ) ) {
+				if ( '' !== $current ) {
+					$tokens[] = $current;
+					$current = '';
+				}
+
+				continue;
+			}
+
+			$current .= $char;
+		}
+
+		if ( '' !== $current ) {
+			$tokens[] = $current;
+		}
+
+		return $tokens;
+	}
+}

--- a/modules/atomic-widgets/css-converter/value-parsers/css-token-splitter.php
+++ b/modules/atomic-widgets/css-converter/value-parsers/css-token-splitter.php
@@ -13,6 +13,44 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Css_Token_Splitter {
 	/**
+	 * Split a CSS value on top-level commas (paren-aware), trimming each segment.
+	 *
+	 * @return string[]
+	 */
+	public static function split_by_comma( string $value ): array {
+		$tokens = [];
+		$current = '';
+		$depth = 0;
+		$length = strlen( $value );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$char = $value[ $i ];
+
+			if ( '(' === $char ) {
+				++$depth;
+			} elseif ( ')' === $char ) {
+				$depth = max( 0, $depth - 1 );
+			}
+
+			if ( 0 === $depth && ',' === $char ) {
+				$tokens[] = trim( $current );
+				$current = '';
+				continue;
+			}
+
+			$current .= $char;
+		}
+
+		$last = trim( $current );
+
+		if ( '' !== $last ) {
+			$tokens[] = $last;
+		}
+
+		return $tokens;
+	}
+
+	/**
 	 * @return string[]
 	 */
 	public static function split_by_whitespace( string $value ): array {

--- a/modules/atomic-widgets/css-converter/value-parsers/filter-value-parser.php
+++ b/modules/atomic-widgets/css-converter/value-parsers/filter-value-parser.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers;
+
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Css_Filter_Func_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Functions\Blur_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Functions\Color_Tone_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Functions\Drop_Shadow_Filter_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Functions\Hue_Rotate_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Functions\Intensity_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Size_Constants;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Stateless parser: a raw CSS `filter`/`backdrop-filter` value -> the ordered list of
+ * `css-filter-func` PropValues an Array(Filter) accepts, or null to decline (the caller routes the
+ * whole declaration to custom_css). It never touches the registry, context, or the wrapping prop type.
+ *
+ * Conversion is all-or-nothing per declaration: a single unsupported function or unparsable argument
+ * declines the entire value. Single-argument functions (blur/brightness/contrast/saturate/hue-rotate/
+ * grayscale/invert/sepia) reuse Size_Value_Parser; drop-shadow expands to xAxis/yAxis/blur/color.
+ */
+class Filter_Value_Parser {
+	const DROP_SHADOW = 'drop-shadow';
+
+	const DEFAULT_DROP_SHADOW_BLUR = [
+		'size' => 10,
+		'unit' => Size_Constants::UNIT_PX,
+	];
+
+	const DEFAULT_DROP_SHADOW_COLOR = 'rgba(0, 0, 0, 1)';
+
+	const FUNCTION_GROUPS = [
+		'blur' => 'blur',
+		'brightness' => 'intensity',
+		'contrast' => 'intensity',
+		'saturate' => 'intensity',
+		'grayscale' => 'color-tone',
+		'invert' => 'color-tone',
+		'sepia' => 'color-tone',
+		'hue-rotate' => 'hue-rotate',
+		self::DROP_SHADOW => self::DROP_SHADOW,
+	];
+
+	const GROUP_PROP_TYPES = [
+		'blur' => Blur_Prop_Type::class,
+		'intensity' => Intensity_Prop_Type::class,
+		'color-tone' => Color_Tone_Prop_Type::class,
+		'hue-rotate' => Hue_Rotate_Prop_Type::class,
+	];
+
+	const DROP_SHADOW_MIN_SIZES = 2;
+	const DROP_SHADOW_MAX_SIZES = 3;
+
+	/**
+	 * @return array<int, array>|null
+	 */
+	public static function parse( string $value ): ?array {
+		$functions = self::split_functions( trim( $value ) );
+
+		if ( null === $functions ) {
+			return null;
+		}
+
+		$items = [];
+
+		foreach ( $functions as [$name, $args] ) {
+			$item = self::parse_function( $name, $args );
+
+			if ( null === $item ) {
+				return null;
+			}
+
+			$items[] = $item;
+		}
+
+		return empty( $items ) ? null : $items;
+	}
+
+	/**
+	 * @return array{0: string, 1: string}[]|null
+	 */
+	private static function split_functions( string $value ): ?array {
+		$functions = [];
+		$length = strlen( $value );
+		$i = 0;
+
+		while ( $i < $length ) {
+			$i = self::skip_whitespace( $value, $i, $length );
+
+			if ( $i >= $length ) {
+				break;
+			}
+
+			$name_start = $i;
+
+			while ( $i < $length && ( ctype_alpha( $value[ $i ] ) || '-' === $value[ $i ] ) ) {
+				++$i;
+			}
+
+			$name = substr( $value, $name_start, $i - $name_start );
+			$i = self::skip_whitespace( $value, $i, $length );
+
+			if ( '' === $name || $i >= $length || '(' !== $value[ $i ] ) {
+				return null;
+			}
+
+			$args_start = $i + 1;
+			$depth = 0;
+
+			for ( ; $i < $length; $i++ ) {
+				if ( '(' === $value[ $i ] ) {
+					++$depth;
+				} elseif ( ')' === $value[ $i ] ) {
+					--$depth;
+
+					if ( 0 === $depth ) {
+						break;
+					}
+				}
+			}
+
+			if ( 0 !== $depth || $i >= $length ) {
+				return null;
+			}
+
+			$functions[] = [ strtolower( $name ), trim( substr( $value, $args_start, $i - $args_start ) ) ];
+			++$i;
+		}
+
+		return empty( $functions ) ? null : $functions;
+	}
+
+	private static function parse_function( string $name, string $args ): ?array {
+		$group = self::FUNCTION_GROUPS[ $name ] ?? null;
+
+		if ( null === $group ) {
+			return null;
+		}
+
+		$parsed_args = self::DROP_SHADOW === $group
+			? self::parse_drop_shadow( $args )
+			: self::parse_single_size( $group, $args );
+
+		if ( null === $parsed_args ) {
+			return null;
+		}
+
+		return Css_Filter_Func_Prop_Type::generate( [
+			'func' => String_Prop_Type::generate( $name ),
+			'args' => $parsed_args,
+		] );
+	}
+
+	private static function parse_single_size( string $group, string $args ): ?array {
+		$size = Size_Value_Parser::parse( $args );
+
+		if ( null === $size ) {
+			return null;
+		}
+
+		$prop_type = self::GROUP_PROP_TYPES[ $group ];
+
+		return $prop_type::generate( [ 'size' => Size_Prop_Type::generate( $size ) ] );
+	}
+
+	private static function parse_drop_shadow( string $args ): ?array {
+		$tokens = self::split_top_level( $args );
+
+		if ( empty( $tokens ) ) {
+			return null;
+		}
+
+		$sizes = [];
+		$color = null;
+
+		foreach ( $tokens as $token ) {
+			$size = Size_Value_Parser::parse( $token );
+
+			if ( null !== $size ) {
+				$sizes[] = $size;
+				continue;
+			}
+
+			if ( null !== $color ) {
+				return null;
+			}
+
+			$color = $token;
+		}
+
+		$size_count = count( $sizes );
+
+		if ( $size_count < self::DROP_SHADOW_MIN_SIZES || $size_count > self::DROP_SHADOW_MAX_SIZES ) {
+			return null;
+		}
+
+		$blur = $sizes[2] ?? self::DEFAULT_DROP_SHADOW_BLUR;
+
+		return Drop_Shadow_Filter_Prop_Type::generate( [
+			'xAxis' => Size_Prop_Type::generate( $sizes[0] ),
+			'yAxis' => Size_Prop_Type::generate( $sizes[1] ),
+			'blur' => Size_Prop_Type::generate( $blur ),
+			'color' => Color_Prop_Type::generate( $color ?? self::DEFAULT_DROP_SHADOW_COLOR ),
+		] );
+	}
+
+	private static function skip_whitespace( string $value, int $index, int $length ): int {
+		while ( $index < $length && ctype_space( $value[ $index ] ) ) {
+			++$index;
+		}
+
+		return $index;
+	}
+
+	/**
+	 * Split on whitespace runs at parenthesis depth 0 so function colors such as "rgba(0, 0, 0, .5)"
+	 * stay intact as a single token.
+	 *
+	 * @return string[]
+	 */
+	private static function split_top_level( string $value ): array {
+		$tokens = [];
+		$current = '';
+		$depth = 0;
+		$length = strlen( $value );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$char = $value[ $i ];
+
+			if ( '(' === $char ) {
+				++$depth;
+			} elseif ( ')' === $char ) {
+				$depth = max( 0, $depth - 1 );
+			}
+
+			if ( 0 === $depth && ctype_space( $char ) ) {
+				if ( '' !== $current ) {
+					$tokens[] = $current;
+					$current = '';
+				}
+
+				continue;
+			}
+
+			$current .= $char;
+		}
+
+		if ( '' !== $current ) {
+			$tokens[] = $current;
+		}
+
+		return $tokens;
+	}
+}

--- a/modules/atomic-widgets/css-converter/value-parsers/size-value-parser.php
+++ b/modules/atomic-widgets/css-converter/value-parsers/size-value-parser.php
@@ -17,16 +17,21 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - calc()/clamp()/min()/max()/var()/env() -> { size: '<raw>', unit: 'custom' } (kept verbatim)
  * - "<number><unit>" (unit in all_supported_units) -> { size: <number>, unit: <unit> }
  * - unitless "0"                    -> { size: 0, unit: 'px' }
- * - anything else (unitless non-zero, unknown unit, multi-value) -> null
+ * - unitless non-zero, $allow_unitless on -> { size: '<raw>', unit: 'custom' } (e.g. line-height: 1.1)
+ * - anything else (unitless non-zero with $allow_unitless off, unknown unit, multi-value) -> null
  */
 class Size_Value_Parser {
 	const NUMBER_WITH_UNIT_PATTERN = '/^(-?\d*\.?\d+)([a-z%]*)$/i';
 	const DYNAMIC_FUNCTION_PATTERN = '/(?:calc|clamp|min|max|var|env)\(/i';
 
 	/**
+	 * @param string $value          The raw CSS value.
+	 * @param bool   $allow_unitless When true, a unitless non-zero number (e.g. a line-height multiplier)
+	 *                               is kept verbatim as a `custom` unit instead of declining.
+	 *
 	 * @return array{size: mixed, unit: string}|null
 	 */
-	public static function parse( string $value ): ?array {
+	public static function parse( string $value, bool $allow_unitless = false ): ?array {
 		$value = trim( $value );
 
 		if ( '' === $value ) {
@@ -47,13 +52,13 @@ class Size_Value_Parser {
 			];
 		}
 
-		return self::parse_number_with_unit( $value );
+		return self::parse_number_with_unit( $value, $allow_unitless );
 	}
 
 	/**
 	 * @return array{size: mixed, unit: string}|null
 	 */
-	private static function parse_number_with_unit( string $value ): ?array {
+	private static function parse_number_with_unit( string $value, bool $allow_unitless ): ?array {
 		if ( ! preg_match( self::NUMBER_WITH_UNIT_PATTERN, $value, $matches ) ) {
 			return null;
 		}
@@ -62,10 +67,17 @@ class Size_Value_Parser {
 		$unit = strtolower( $matches[2] );
 
 		if ( '' === $unit ) {
-			return 0.0 === (float) $size
-				? [
+			if ( 0.0 === (float) $size ) {
+				return [
 					'size' => $size,
 					'unit' => Size_Constants::DEFAULT_UNIT,
+				];
+			}
+
+			return $allow_unitless
+				? [
+					'size' => $matches[1],
+					'unit' => Size_Constants::UNIT_CUSTOM,
 				]
 				: null;
 		}

--- a/modules/atomic-widgets/css-converter/value-parsers/size-value-parser.php
+++ b/modules/atomic-widgets/css-converter/value-parsers/size-value-parser.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers;
+
+use Elementor\Modules\AtomicWidgets\Styles\Size_Constants;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Stateless leaf parser: a raw CSS length-ish value -> the {size, unit} leaf a Size_Prop_Type accepts,
+ * or null to decline (the caller then routes the declaration to custom_css). It never touches the
+ * registry, context, or PropTypes.
+ *
+ * - "auto"                          -> { size: null, unit: 'auto' }
+ * - calc()/clamp()/min()/max()/var()/env() -> { size: '<raw>', unit: 'custom' } (kept verbatim)
+ * - "<number><unit>" (unit in all_supported_units) -> { size: <number>, unit: <unit> }
+ * - unitless "0"                    -> { size: 0, unit: 'px' }
+ * - anything else (unitless non-zero, unknown unit, multi-value) -> null
+ */
+class Size_Value_Parser {
+	const NUMBER_WITH_UNIT_PATTERN = '/^(-?\d*\.?\d+)([a-z%]*)$/i';
+	const DYNAMIC_FUNCTION_PATTERN = '/(?:calc|clamp|min|max|var|env)\(/i';
+
+	/**
+	 * @return array{size: mixed, unit: string}|null
+	 */
+	public static function parse( string $value ): ?array {
+		$value = trim( $value );
+
+		if ( '' === $value ) {
+			return null;
+		}
+
+		if ( Size_Constants::UNIT_AUTO === strtolower( $value ) ) {
+			return [
+				'size' => null,
+				'unit' => Size_Constants::UNIT_AUTO,
+			];
+		}
+
+		if ( self::is_dynamic_value( $value ) ) {
+			return [
+				'size' => $value,
+				'unit' => Size_Constants::UNIT_CUSTOM,
+			];
+		}
+
+		return self::parse_number_with_unit( $value );
+	}
+
+	/**
+	 * @return array{size: mixed, unit: string}|null
+	 */
+	private static function parse_number_with_unit( string $value ): ?array {
+		if ( ! preg_match( self::NUMBER_WITH_UNIT_PATTERN, $value, $matches ) ) {
+			return null;
+		}
+
+		$size = $matches[1] + 0;
+		$unit = strtolower( $matches[2] );
+
+		if ( '' === $unit ) {
+			return 0.0 === (float) $size
+				? [
+					'size' => $size,
+					'unit' => Size_Constants::DEFAULT_UNIT,
+				]
+				: null;
+		}
+
+		if ( ! in_array( $unit, Size_Constants::all_supported_units(), true ) ) {
+			return null;
+		}
+
+		return [
+			'size' => $size,
+			'unit' => $unit,
+		];
+	}
+
+	private static function is_dynamic_value( string $value ): bool {
+		return 1 === preg_match( self::DYNAMIC_FUNCTION_PATTERN, $value );
+	}
+}

--- a/modules/atomic-widgets/css-converter/variable-prop-value-transformer.php
+++ b/modules/atomic-widgets/css-converter/variable-prop-value-transformer.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\AtomicWidgets\CssConverter;
 
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry_Factory;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Array_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
@@ -314,6 +315,8 @@ class Variable_Prop_Value_Transformer {
 				'background-position',
 				'background-size',
 			],
+			'padding' => array_keys( Converter_Registry_Factory::DIMENSIONS_SIDE_SPECS ),
+			'margin'  => array_keys( Converter_Registry_Factory::DIMENSIONS_SIDE_SPECS ),
 		];
 
 		foreach ( $longhands_by_aggregate[ $property ] ?? [] as $longhand ) {

--- a/modules/atomic-widgets/css-converter/variable-prop-value-transformer.php
+++ b/modules/atomic-widgets/css-converter/variable-prop-value-transformer.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter;
+
+use Elementor\Modules\AtomicWidgets\PropTypes\Base\Array_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Size_Constants;
+use Elementor\Modules\Variables\Adapters\Prop_Type_Adapter;
+use Elementor\Modules\Variables\PropTypes\Size_Variable_Prop_Type;
+use Elementor\Modules\Variables\Services\Variables_Service;
+use Elementor\Modules\Variables\Utils\Variable_Type_Keys;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Variable_Prop_Value_Transformer {
+	private Variables_Service $variables_service;
+
+	public function __construct( Variables_Service $variables_service ) {
+		$this->variables_service = $variables_service;
+	}
+
+	/**
+	 * @param array<int, array{property: string, value: string, declaration: string}> $rules
+	 * @return array{props: array, custom_css: string[], rejected: string[]}
+	 */
+	public function eject_unresolved_var_props( array $props, array $schema, array $rules ): array {
+		$custom_css = [];
+		$rejected = [];
+
+		foreach ( $props as $key => $prop_value ) {
+			if ( ! isset( $schema[ $key ] ) || ! ( $schema[ $key ] instanceof Prop_Type ) ) {
+				continue;
+			}
+
+			$reference = $this->find_var_reference_in_value( $prop_value, $schema[ $key ] );
+
+			if ( null === $reference ) {
+				continue;
+			}
+
+			$variable = $this->variables_service->find_by_label_or_id( $reference );
+
+			if (
+				null !== $variable
+				&& $this->variable_fits_prop_type( $schema[ $key ], $variable['type'] ?? '' )
+			) {
+				continue;
+			}
+
+			unset( $props[ $key ] );
+
+			$declaration = $this->declaration_for_property( $rules, $key );
+
+			if ( null === $declaration ) {
+				continue;
+			}
+
+			$declaration = $declaration . ';';
+
+			if ( null === $variable ) {
+				$custom_css[] = $declaration;
+				continue;
+			}
+
+			$rejected[] = $declaration;
+		}
+
+		return [
+			'props' => $props,
+			'custom_css' => $custom_css,
+			'rejected' => $rejected,
+		];
+	}
+
+	public function transform( array $props, array $schema ): array {
+		$transformed = [];
+
+		foreach ( $props as $key => $prop_value ) {
+			if ( ! isset( $schema[ $key ] ) || ! ( $schema[ $key ] instanceof Prop_Type ) ) {
+				$transformed[ $key ] = $prop_value;
+				continue;
+			}
+
+			$transformed[ $key ] = $this->transform_value( $prop_value, $schema[ $key ] );
+		}
+
+		return $transformed;
+	}
+
+	/**
+	 * @param mixed $prop_value
+	 * @return mixed
+	 */
+	private function transform_value( $prop_value, Prop_Type $prop_type ) {
+		if ( ! is_array( $prop_value ) || ! isset( $prop_value['$$type'] ) ) {
+			return $prop_value;
+		}
+
+		if ( $prop_type instanceof Union_Prop_Type ) {
+			$promoted = $this->try_promote_to_variable( $prop_value, $prop_type );
+
+			if ( null !== $promoted ) {
+				return $promoted;
+			}
+
+			$branch = $prop_type->get_prop_type( $prop_value['$$type'] );
+
+			if ( ! $branch ) {
+				return $prop_value;
+			}
+
+			return $this->transform_value( $prop_value, $branch );
+		}
+
+		if ( $prop_type instanceof Object_Prop_Type ) {
+			if ( ! is_array( $prop_value['value'] ?? null ) ) {
+				return $prop_value;
+			}
+
+			$shape = $prop_type->get_shape();
+
+			foreach ( $shape as $field => $field_type ) {
+				if ( ! isset( $prop_value['value'][ $field ] ) ) {
+					continue;
+				}
+
+				$prop_value['value'][ $field ] = $this->transform_value(
+					$prop_value['value'][ $field ],
+					$field_type
+				);
+			}
+
+			return $prop_value;
+		}
+
+		if ( $prop_type instanceof Array_Prop_Type ) {
+			if ( ! is_array( $prop_value['value'] ?? null ) ) {
+				return $prop_value;
+			}
+
+			foreach ( $prop_value['value'] as $index => $item ) {
+				$prop_value['value'][ $index ] = $this->transform_value(
+					$item,
+					$prop_type->get_item_type()
+				);
+			}
+
+			return $prop_value;
+		}
+
+		return $prop_value;
+	}
+
+	private function try_promote_to_variable( array $prop_value, Union_Prop_Type $union ): ?array {
+		$reference = $this->extract_var_reference( $prop_value );
+
+		if ( null === $reference ) {
+			return null;
+		}
+
+		$variable = $this->variables_service->find_by_label_or_id( $reference );
+
+		if ( null === $variable ) {
+			return null;
+		}
+
+		$variable_type = $this->resolve_variable_prop_type_key( $variable['type'] ?? '', $union );
+
+		if ( null === $variable_type ) {
+			return null;
+		}
+
+		$id = $variable['id'] ?? '';
+
+		if ( '' === $id ) {
+			return null;
+		}
+
+		return [
+			'$$type' => $variable_type,
+			'value' => $id,
+		];
+	}
+
+	private function extract_var_reference( array $prop_value ): ?string {
+		$type = $prop_value['$$type'] ?? '';
+		$value = $prop_value['value'] ?? null;
+
+		if ( in_array( $type, [ 'color', 'string' ], true ) && is_string( $value ) ) {
+			return Css_Var_Reference::parse( $value );
+		}
+
+		if ( 'size' === $type && is_array( $value ) ) {
+			$unit = $value['unit'] ?? '';
+
+			if ( Size_Constants::UNIT_CUSTOM !== $unit || ! is_string( $value['size'] ?? null ) ) {
+				return null;
+			}
+
+			return Css_Var_Reference::parse( $value['size'] );
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param mixed $prop_value
+	 */
+	private function find_var_reference_in_value( $prop_value, Prop_Type $prop_type ): ?string {
+		if ( ! is_array( $prop_value ) || ! isset( $prop_value['$$type'] ) ) {
+			return null;
+		}
+
+		if ( Variable_Type_Keys::is_variable_type( $prop_value['$$type'] ) ) {
+			return null;
+		}
+
+		if ( $prop_type instanceof Union_Prop_Type ) {
+			$reference = $this->extract_var_reference( $prop_value );
+
+			if ( null !== $reference ) {
+				return $reference;
+			}
+
+			$branch = $prop_type->get_prop_type( $prop_value['$$type'] );
+
+			if ( ! $branch ) {
+				return null;
+			}
+
+			return $this->find_var_reference_in_value( $prop_value, $branch );
+		}
+
+		if ( $prop_type instanceof Object_Prop_Type ) {
+			if ( ! is_array( $prop_value['value'] ?? null ) ) {
+				return null;
+			}
+
+			foreach ( $prop_type->get_shape() as $field => $field_type ) {
+				if ( ! isset( $prop_value['value'][ $field ] ) ) {
+					continue;
+				}
+
+				$reference = $this->find_var_reference_in_value(
+					$prop_value['value'][ $field ],
+					$field_type
+				);
+
+				if ( null !== $reference ) {
+					return $reference;
+				}
+			}
+
+			return null;
+		}
+
+		if ( $prop_type instanceof Array_Prop_Type ) {
+			if ( ! is_array( $prop_value['value'] ?? null ) ) {
+				return null;
+			}
+
+			foreach ( $prop_value['value'] as $item ) {
+				$reference = $this->find_var_reference_in_value(
+					$item,
+					$prop_type->get_item_type()
+				);
+
+				if ( null !== $reference ) {
+					return $reference;
+				}
+			}
+
+			return null;
+		}
+
+		return $this->extract_var_reference( $prop_value );
+	}
+
+	private function variable_fits_prop_type( Prop_Type $prop_type, string $variable_type ): bool {
+		if ( '' === $variable_type ) {
+			return false;
+		}
+
+		if ( $prop_type instanceof Union_Prop_Type ) {
+			return null !== $this->resolve_variable_prop_type_key( $variable_type, $prop_type );
+		}
+
+		$resolved_type = Variable_Type_Keys::get_resolved_type( $variable_type );
+
+		return null !== $resolved_type && $resolved_type === $prop_type::get_key();
+	}
+
+	/**
+	 * @param array<int, array{property: string, value: string, declaration: string}> $rules
+	 */
+	private function declaration_for_property( array $rules, string $property ): ?string {
+		foreach ( $rules as $rule ) {
+			if ( $rule['property'] === $property ) {
+				return $rule['declaration'];
+			}
+		}
+
+		return null;
+	}
+
+	private function resolve_variable_prop_type_key( string $variable_type, Union_Prop_Type $union ): ?string {
+		if ( '' === $variable_type ) {
+			return null;
+		}
+
+		if ( $union->get_prop_type( $variable_type ) ) {
+			return $variable_type;
+		}
+
+		if (
+			Prop_Type_Adapter::GLOBAL_CUSTOM_SIZE_VARIABLE_KEY === $variable_type
+			&& $union->get_prop_type( Size_Variable_Prop_Type::get_key() )
+		) {
+			return Size_Variable_Prop_Type::get_key();
+		}
+
+		return null;
+	}
+}

--- a/modules/atomic-widgets/css-converter/variable-prop-value-transformer.php
+++ b/modules/atomic-widgets/css-converter/variable-prop-value-transformer.php
@@ -53,7 +53,7 @@ class Variable_Prop_Value_Transformer {
 
 			unset( $props[ $key ] );
 
-			$declaration = $this->declaration_for_property( $rules, $key );
+			$declaration = $this->declaration_for_ejected_prop( $rules, $key );
 
 			if ( null === $declaration ) {
 				continue;
@@ -292,6 +292,39 @@ class Variable_Prop_Value_Transformer {
 		$resolved_type = Variable_Type_Keys::get_resolved_type( $variable_type );
 
 		return null !== $resolved_type && $resolved_type === $prop_type::get_key();
+	}
+
+	/**
+	 * @param array<int, array{property: string, value: string, declaration: string}> $rules
+	 */
+	private function declaration_for_ejected_prop( array $rules, string $property ): ?string {
+		$declaration = $this->declaration_for_property( $rules, $property );
+
+		if ( null !== $declaration ) {
+			return $declaration;
+		}
+
+		$longhands_by_aggregate = [
+			'background' => [
+				'background-color',
+				'background-clip',
+				'background-image',
+				'background-repeat',
+				'background-attachment',
+				'background-position',
+				'background-size',
+			],
+		];
+
+		foreach ( $longhands_by_aggregate[ $property ] ?? [] as $longhand ) {
+			$declaration = $this->declaration_for_property( $rules, $longhand );
+
+			if ( null !== $declaration ) {
+				return $declaration;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/modules/atomic-widgets/prop-types/background-gradient-overlay-prop-type.php
+++ b/modules/atomic-widgets/prop-types/background-gradient-overlay-prop-type.php
@@ -21,11 +21,7 @@ class Background_Gradient_Overlay_Prop_Type extends Object_Prop_Type {
 			'type' => String_Prop_Type::make()->enum( [ 'linear', 'radial' ] ),
 			'angle' => Number_Prop_Type::make(),
 			'stops' => Gradient_Color_Stop_Prop_Type::make(),
-			'positions' => String_Prop_Type::make()->enum( self::get_position_enum_values() ),
+			'positions' => String_Prop_Type::make()->regex( Position_Prop_Type::get_radial_position_regex() ),
 		];
-	}
-
-	private static function get_position_enum_values(): array {
-		return Position_Prop_Type::get_position_enum_values();
 	}
 }

--- a/modules/atomic-widgets/prop-types/position-prop-type.php
+++ b/modules/atomic-widgets/prop-types/position-prop-type.php
@@ -37,4 +37,18 @@ class Position_Prop_Type extends Object_Prop_Type {
 			'bottom right',
 		];
 	}
+
+	public static function get_radial_position_regex(): string {
+		$token_pattern = '(?:(?:top|bottom|left|right|center)|(?:-?\d+(?:\.\d+)?(?:%|px|em|rem|vw|vh)))';
+
+		return '/^' . $token_pattern . '(?:\s+' . $token_pattern . ')?$/i';
+	}
+
+	public static function is_valid_radial_position( string $pos ): bool {
+		if ( in_array( $pos, self::get_position_enum_values(), true ) ) {
+			return true;
+		}
+
+		return (bool) preg_match( self::get_radial_position_regex(), $pos );
+	}
 }

--- a/modules/variables/services/variables-service.php
+++ b/modules/variables/services/variables-service.php
@@ -24,6 +24,39 @@ class Variables_Service {
 		return $this->load()['data'];
 	}
 
+	public function find_by_label_or_id( string $needle ): ?array {
+		$needle = trim( $needle );
+		$needle = ltrim( $needle, '-' );
+
+		if ( '' === $needle ) {
+			return null;
+		}
+
+		$variables = $this->get_variables_list();
+
+		if ( isset( $variables[ $needle ] ) ) {
+			$variable = $variables[ $needle ];
+
+			if ( ! empty( $variable['deleted'] ) ) {
+				return null;
+			}
+
+			return array_merge( [ 'id' => $needle ], $variable );
+		}
+
+		foreach ( $variables as $id => $variable ) {
+			if ( ! empty( $variable['deleted'] ) ) {
+				continue;
+			}
+
+			if ( strcasecmp( $variable['label'] ?? '', $needle ) === 0 ) {
+				return array_merge( [ 'id' => $id ], $variable );
+			}
+		}
+
+		return null;
+	}
+
 	public function load() {
 		$collection = $this->repo->load()->serialize( true );
 		foreach ( $collection['data'] as $id => $variable ) {

--- a/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
+++ b/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
@@ -13,7 +13,6 @@ import { type z } from '@elementor/schema';
 
 import { doUpdateElementProperty } from '../mcp/utils/do-update-element-property';
 import { mergeCustomCssText } from '../mcp/utils/merge-custom-css';
-import { validateInput } from '../mcp/utils/validate-input';
 import { RequiredChildrenEnforcer } from './utils/required-children-enforcer';
 import { getRequiredDefaultChildTemplates } from './utils/required-default-child-tags';
 
@@ -223,20 +222,14 @@ export class CompositionBuilder {
 			}
 
 			const styleConfig = this.elementStylesConfig[ configId ];
-			let hasInvalidStyles = false;
+			const hasInvalidStyles = false;
 			if ( styleConfig ) {
 				const validStylesPropValues: Record< string, AnyValue > = {};
 				for ( const [ styleName, stylePropValue ] of Object.entries( styleConfig ) ) {
 					if ( styleName === '$intention' ) {
 						continue;
-					}
-					const { valid, errors: validationErrors } = validateInput.validateStyles( {
-						[ styleName ]: stylePropValue,
-					} );
-					if ( ! valid ) {
-						hasInvalidStyles = true;
-						styleErrors.push( ...( validationErrors || [] ) );
 					} else {
+						// skipping actual validation - properies comes from the server
 						validStylesPropValues[ styleName ] = stylePropValue;
 					}
 				}

--- a/packages/packages/core/editor-canvas/src/index.ts
+++ b/packages/packages/core/editor-canvas/src/index.ts
@@ -1,5 +1,11 @@
 export { BREAKPOINTS_SCHEMA_URI, BREAKPOINTS_SCHEMA_FULL_URI } from './mcp/resources/breakpoints-resource';
-export { STYLE_SCHEMA_URI, STYLE_SCHEMA_FULL_URI } from './mcp/resources/widgets-schema-resource';
+export {
+	convertCssToAtomic,
+	convertStyleBlocksToAtomic,
+	type CssConversionResult,
+	type StyleBlock,
+	type StyleDeclarations,
+} from './mcp/utils/convert-css-to-atomic';
 
 export { init } from './init';
 export { isAtomicWidget } from './utils/command-utils';

--- a/packages/packages/core/editor-canvas/src/mcp/mcp-description.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/mcp-description.ts
@@ -89,7 +89,7 @@ At the response you will also find llm_instructions for you to do afterwards, re
 
 - **PropValue Types**: Arrays that accept union types are typed as mixed arrays
 - **Visual Sizing**: Widget sizes MUST be defined via the style parameter (raw CSS). Widget properties like image "size" control resolution, not visual appearance
-- **Global Variables**: Reference by ID in PropValues (e.g., \`{ "$$type": "global-color-variable", "value": "variable-id" }\`)
+- **Global Variables**: Reference by label/name: (e.g. var(--card-background-color)
 - **Naming Conventions**: Use meaningful, purpose-based names (e.g., "primary-button", "heading-large"), not value-based names (e.g., "blue-style", "20px-padding")
 
 ## Example: e-image PropValue Structure

--- a/packages/packages/core/editor-canvas/src/mcp/resources/widgets-schema-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/widgets-schema-resource.ts
@@ -60,7 +60,6 @@ export const CANVAS_SERVER_NAME = 'editor-canvas';
 export const WIDGET_SCHEMA_URI = 'elementor://widgets/schema/{widgetType}';
 export const WIDGET_SCHEMA_FULL_URI = `${ CANVAS_SERVER_NAME }_${ WIDGET_SCHEMA_URI }`;
 export const STYLE_SCHEMA_URI = 'elementor://styles/schema/{category}';
-export const STYLE_SCHEMA_FULL_URI = `${ CANVAS_SERVER_NAME }_${ STYLE_SCHEMA_URI }`;
 export const BEST_PRACTICES_URI = 'elementor://styles/best-practices';
 export const BEST_PRACTICES_FULL_URI = `${ CANVAS_SERVER_NAME }_${ BEST_PRACTICES_URI }`;
 

--- a/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/prompt.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/prompt.ts
@@ -18,7 +18,7 @@ export const generatePrompt = () => {
 This tool support v4 elements only
 
 # WORKFLOW
-1. Check/create global classes via "create-global-class" tool
+1. Check/create global classes via "manage-global-classes" tool
 2. Build composition (THIS TOOL) - minimal inline styles
 3. Apply classes via "apply-global-class" tool
 

--- a/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/prompt.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/prompt.ts
@@ -24,7 +24,7 @@ When a user requires to change anything in an element, such as updating text, co
 This tool handles elements of type "widget".
 This tool handles styling elements, using the "style" parameter (raw CSS as a property → value map).
 
-To CLEAR a property (i.e., set it to default or none), provide null as a value.
+To CLEAR a property (i.e., set it to default or none), provide null as a value - example: \`background-color: null\`.
 
 The element's schema must be known before using this tool.
 

--- a/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/prompt.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/prompt.ts
@@ -85,7 +85,7 @@ Do NOT send "group" (it is resolved automatically). Use { "settings": {} } only 
 
 	configureElementToolPrompt.parameter(
 		'style',
-		'A flat map of raw CSS declarations (property → value), e.g. { "line-height": "20px", "color": "red" }. OPTIONAL.'
+		'A flat map of raw CSS declarations (property → value), e.g. { "line-height": "20px", "color": "red" }. Set a value to null to reset that property to its default. OPTIONAL.'
 	);
 
 	configureElementToolPrompt.example( `

--- a/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/prompt.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/prompt.ts
@@ -12,13 +12,12 @@ export const generatePrompt = () => {
 Configure an existing element on the page.
 
 # **CRITICAL - REQUIRED INFORMATION (Must read before using this tool)**
-1. [${ WIDGET_SCHEMA_URI }]
-   Required to understand which widgets are available, and what are their configuration schemas.
-   Every widgetType (i.e. e-heading, e-button) that is supported has it's own property schema, that you must follow in order to apply parameter values correctly.
-2. Styling is provided to this tool as raw CSS via the "style" parameter (a flat map of CSS property → value). The server converts it to native styles; any declaration that cannot be converted is stored as the element custom CSS automatically.
-3. If not sure about the PropValues schema, you can use the "get-element-configuration-values" tool to retrieve the current PropValues configuration of the element.
+1. [${ WIDGET_SCHEMA_URI }] — **Widget properties** (\`propertiesToChange\`): each widgetType (e.g. e-heading, e-button) has its own PropType schema; values must be PropValues with \`$$type\`.
+2. [elementor://global-variables] — **Design tokens for styling**: use labels in CSS as \`var(--label)\` or \`var(--label, fallback)\`; only variables listed here are valid.
+3. **Styling** (\`style\` parameter): flat map of CSS property → value strings — **not** PropValues. The server converts to native styles; unconvertible declarations become custom CSS.
+4. **Current state**: \`get-element-configuration-values\` returns \`properties\` as PropValues and \`style\` in stored form; when writing, send raw CSS in \`style\`, not copied PropValues.
 
-Before using this tool, check the definitions of the elements PropTypes at the resource "widget-schema-by-type" at editor-canvas__elementor://widgets/schema/{widgetType}
+Before using this tool, read the widget PropType schema at editor-canvas__elementor://widgets/schema/{widgetType}
 
 # When to use this tool
 When a user requires to change anything in an element, such as updating text, colors, sizes, or other configurable properties.
@@ -29,11 +28,7 @@ To CLEAR a property (i.e., set it to default or none), provide null as a value.
 
 The element's schema must be known before using this tool.
 
-Attached resource link describing how PropType schema should be parsed as PropValue for this tool.
-
-Read carefully the PropType Schema of the element and it's styles, then apply correct PropValue according to the schema.
-
-PropValue structure:
+**PropValue structure (for \`propertiesToChange\` only — not for \`style\`):**
 {
     "$$type": string, // MANDATORY as defined in the PropType schema under the "key" property
     value: unknown // The value according to the PropType schema for kinds of "array", use array with PropValues items inside. For "object", read the shape property of the PropType schema. For "plain", use strings.
@@ -50,10 +45,10 @@ Make sure you have the "widget-schema-by-type" resource available to retrieve th
 
 # How to configure elements
 We use a dedicated PropType Schema for configuring element properties (propertiesToChange). When you configure an element property, you must use the EXACT PropType Value as defined in the schema.
-For styling, use the "style" parameter with raw CSS declarations (property → value strings); do NOT use the PropType format for styles.
-For all non-primitive property types, provide the key property as defined in the schema as $$type in the generated object, as it is MANDATORY for parsing.
+For styling, use the "style" parameter with raw CSS declarations (property → value strings) - e.g. \`color: var(--primary-text, #000); height: 4rem;\`;
+For all non-primitive entries in \`propertiesToChange\`, provide the schema \`key\` as \`$$type\` in the generated object, as it is MANDATORY for parsing.
 
-Use the EXACT "PROP-TYPE" Schema given, and ALWAYS include the "key" property from the original configuration for every property you are changing.
+Use the EXACT PropType schema given, and ALWAYS include the \`key\` from the schema for every property you are changing in \`propertiesToChange\`.
 
 # Dynamic tags
 A value can be made dynamic wherever its schema exposes a variant with "$$type": "dynamic". This may be the property root OR a NESTED field: for example an image is made dynamic on its "src" (the root stays "image"), NOT on the whole "image" value.
@@ -85,7 +80,7 @@ Do NOT send "group" (it is resolved automatically). Use { "settings": {} } only 
 
 	configureElementToolPrompt.parameter(
 		'style',
-		'A flat map of raw CSS declarations (property → value), e.g. { "line-height": "20px", "color": "red" }. Set a value to null to reset that property to its default. OPTIONAL.'
+		'A flat map of raw CSS declarations (property → value), e.g. { "line-height": "1.25rem", "color": "var(--primary-text, #000)" }. Set a value to null to reset that property to its default. OPTIONAL.'
 	);
 
 	configureElementToolPrompt.example( `
@@ -103,8 +98,8 @@ Do NOT send "group" (it is resolved automatically). Use { "settings": {} } only 
     },
   },
   style: {
-    'line-height': '20px',
-    'color': 'red'
+    'line-height': '1.25rem',
+    'color': 'var(--primary-text, #000)'
   },
   elementId: 'element-id',
   elementType: 'element-type'
@@ -113,7 +108,7 @@ Do NOT send "group" (it is resolved automatically). Use { "settings": {} } only 
 ` );
 
 	configureElementToolPrompt.instruction(
-		'The $$type property is MANDATORY for every value; it is required to parse the value and apply application-level effects.'
+		'The $$type property is MANDATORY for every value in propertiesToChange; it is not used in the style parameter (raw CSS only).'
 	);
 
 	configureElementToolPrompt.instruction( `

--- a/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/schema.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/schema.ts
@@ -15,10 +15,15 @@ export const inputSchema = {
 	style: z
 		.record(
 			z.string().describe( 'A CSS property name, e.g. "color", "margin-top".' ),
-			z.string().describe( 'A CSS value, e.g. "red", "10px", "1px solid #000".' )
+			z
+				.string()
+				.nullable()
+				.describe(
+					'A CSS value, e.g. "red", "10px", "1px solid #000". Use null to reset the property to its default.'
+				)
 		)
 		.describe(
-			'Raw CSS declarations as a flat property→value map. Converted to native styles server-side; any declaration that cannot be converted is stored as the element custom CSS.'
+			'Raw CSS declarations as a flat property→value map. Converted to native styles server-side; any declaration that cannot be converted is stored as the element custom CSS. A null value resets that property to its default.'
 		)
 		.default( {} ),
 	elementType: z.string().describe( 'The type of the element to retrieve the schema' ),

--- a/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/tool.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/tool.ts
@@ -82,7 +82,11 @@ export const initConfigureElementTool = ( reg: MCPRegistryEntry ) => {
 	} );
 };
 
-async function applyStyleFromCss( opts: { elementId: string; elementType: string; style: Record< string, string > } ) {
+async function applyStyleFromCss( opts: {
+	elementId: string;
+	elementType: string;
+	style: Record< string, string | null >;
+} ) {
 	const { elementId, elementType, style } = opts;
 	if ( ! style || Object.keys( style ).length === 0 ) {
 		return;
@@ -101,6 +105,7 @@ async function applyStyleFromCss( opts: { elementId: string; elementType: string
 			elementType,
 			propertyName: '_styles',
 			propertyValue: styleValue,
+			customCssWriteMode: 'merge-with-stored',
 		} );
 	} catch ( error ) {
 		throw new Error(

--- a/packages/packages/core/editor-canvas/src/mcp/utils/__tests__/convert-css-to-atomic.test.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/utils/__tests__/convert-css-to-atomic.test.ts
@@ -13,7 +13,7 @@ const mockPost = ( responseData: unknown ) => {
 };
 
 describe( 'convertCssToAtomic', () => {
-	it( 'posts a single named block and unwraps its result', async () => {
+	it( 'posts a single named block as a declaration map and unwraps its result', async () => {
 		// Arrange.
 		const post = mockPost( {
 			default: { props: { color: { $$type: 'color', value: 'red' } }, customCss: 'gap: 4px;' },
@@ -24,17 +24,33 @@ describe( 'convertCssToAtomic', () => {
 
 		// Assert.
 		expect( post ).toHaveBeenCalledWith( 'elementor/v1/css-to-atomic', {
-			blocks: { default: 'color: red; gap: 4px;' },
+			blocks: { default: { color: 'red', gap: '4px' } },
 		} );
 		expect( result ).toEqual( {
 			props: { color: { $$type: 'color', value: 'red' } },
 			customCss: 'gap: 4px;',
 		} );
 	} );
+
+	it( 'forwards null declarations untouched so the server can emit reset props', async () => {
+		// Arrange.
+		const post = mockPost( {
+			default: { props: { color: null }, customCss: '' },
+		} );
+
+		// Act.
+		const result = await convertCssToAtomic( { color: null } );
+
+		// Assert.
+		expect( post ).toHaveBeenCalledWith( 'elementor/v1/css-to-atomic', {
+			blocks: { default: { color: null } },
+		} );
+		expect( result ).toEqual( { props: { color: null }, customCss: '' } );
+	} );
 } );
 
 describe( 'convertStyleBlocksToAtomic', () => {
-	it( 'serializes every named style block and returns the named results map', async () => {
+	it( 'posts every named declaration map and returns the named results map', async () => {
 		// Arrange.
 		const post = mockPost( {
 			'el-1': { props: {}, customCss: 'color: red;' },
@@ -49,7 +65,7 @@ describe( 'convertStyleBlocksToAtomic', () => {
 
 		// Assert.
 		expect( post ).toHaveBeenCalledWith( 'elementor/v1/css-to-atomic', {
-			blocks: { 'el-1': 'color: red;', 'el-2': 'gap: 4px;' },
+			blocks: { 'el-1': { color: 'red' }, 'el-2': { gap: '4px' } },
 		} );
 		expect( results ).toEqual( {
 			'el-1': { props: {}, customCss: 'color: red;' },

--- a/packages/packages/core/editor-canvas/src/mcp/utils/__tests__/convert-css-to-atomic.test.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/utils/__tests__/convert-css-to-atomic.test.ts
@@ -73,6 +73,29 @@ describe( 'convertStyleBlocksToAtomic', () => {
 		} );
 	} );
 
+	it( 'posts plaintext css text blocks and returns the named results map', async () => {
+		// Arrange.
+		const post = mockPost( {
+			default: { props: { display: { $$type: 'string', value: 'flex' } }, customCss: '' },
+			hover: { props: { opacity: { $$type: 'string', value: '0.85' } }, customCss: '' },
+		} );
+
+		// Act.
+		const results = await convertStyleBlocksToAtomic( {
+			default: 'display: flex;',
+			hover: 'opacity: 0.85;',
+		} );
+
+		// Assert.
+		expect( post ).toHaveBeenCalledWith( 'elementor/v1/css-to-atomic', {
+			blocks: { default: 'display: flex;', hover: 'opacity: 0.85;' },
+		} );
+		expect( results ).toEqual( {
+			default: { props: { display: { $$type: 'string', value: 'flex' } }, customCss: '' },
+			hover: { props: { opacity: { $$type: 'string', value: '0.85' } }, customCss: '' },
+		} );
+	} );
+
 	it( 'posts an empty blocks map when given no style blocks', async () => {
 		// Arrange.
 		const post = mockPost( {} );

--- a/packages/packages/core/editor-canvas/src/mcp/utils/__tests__/do-update-element-property.test.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/utils/__tests__/do-update-element-property.test.ts
@@ -5,7 +5,7 @@ import {
 	updateElementStyle,
 } from '@elementor/editor-elements';
 import { Schema } from '@elementor/editor-props';
-import { getVariantByMeta } from '@elementor/editor-styles';
+import { getStylesSchema, getVariantByMeta } from '@elementor/editor-styles';
 import { __privateRunCommandSync } from '@elementor/editor-v1-adapters';
 
 import { doUpdateElementProperty } from '../do-update-element-property';
@@ -212,6 +212,43 @@ describe( 'doUpdateElementProperty', () => {
 				custom_css: {
 					raw: btoa( `${ EXISTING_CUSTOM_CSS }\n${ ADDITIONAL_CUSTOM_CSS }` ),
 				},
+			} )
+		);
+	} );
+
+	it( 'passes a null style value through unresolved so the editor resets the prop to default', () => {
+		// Arrange
+		jest.mocked( getStylesSchema ).mockReturnValue( {
+			color: { key: 'colorPropKey', kind: 'plain' },
+		} as never );
+		jest.mocked( getElementStyles ).mockReturnValue( {
+			[ LOCAL_STYLE_ID ]: {
+				id: LOCAL_STYLE_ID,
+				label: 'local',
+				type: 'class',
+				variants: [],
+			},
+		} );
+		jest.mocked( getVariantByMeta ).mockReturnValue( {
+			meta: { breakpoint: 'desktop', state: null },
+			props: {},
+		} );
+
+		// Act
+		doUpdateElementProperty( {
+			elementId: ELEMENT_ID,
+			elementType: ELEMENT_TYPE,
+			propertyName: '_styles',
+			propertyValue: {
+				color: null,
+			},
+		} );
+
+		// Assert
+		expect( Schema.adjustLlmPropValueSchema ).not.toHaveBeenCalled();
+		expect( updateElementStyle ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				props: { color: null },
 			} )
 		);
 	} );

--- a/packages/packages/core/editor-canvas/src/mcp/utils/convert-css-to-atomic.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/utils/convert-css-to-atomic.ts
@@ -4,18 +4,19 @@ import { type HttpResponse, httpService } from '@elementor/http-client';
 const CSS_TO_ATOMIC_URL = 'elementor/v1/css-to-atomic';
 const SINGLE_BLOCK_KEY = 'default';
 
+/**
+ * A flat CSS property→value map. A null value is an explicit reset: the server emits it as a null
+ * prop so the editor restores the property to its default.
+ */
+export type StyleDeclarations = Record< string, string | null >;
+
 export type CssConversionResult = {
-	props: Record< string, PropValue >;
+	props: Record< string, PropValue | null >;
 	customCss: string;
 };
 
-const styleRecordToCssText = ( style: Record< string, string > ): string =>
-	Object.entries( style )
-		.map( ( [ property, value ] ) => `${ property }: ${ value };` )
-		.join( ' ' );
-
-const convertCssBlocks = async (
-	blocks: Record< string, string >
+const convertBlocks = async (
+	blocks: Record< string, StyleDeclarations >
 ): Promise< Record< string, CssConversionResult > > => {
 	const { data } = await httpService().post< HttpResponse< Record< string, CssConversionResult > > >(
 		CSS_TO_ATOMIC_URL,
@@ -26,16 +27,10 @@ const convertCssBlocks = async (
 };
 
 export const convertStyleBlocksToAtomic = async (
-	styleByName: Record< string, Record< string, string > >
-): Promise< Record< string, CssConversionResult > > => {
-	const blocks = Object.fromEntries(
-		Object.entries( styleByName ).map( ( [ name, style ] ) => [ name, styleRecordToCssText( style ) ] )
-	);
+	styleByName: Record< string, StyleDeclarations >
+): Promise< Record< string, CssConversionResult > > => convertBlocks( styleByName );
 
-	return convertCssBlocks( blocks );
-};
-
-export const convertCssToAtomic = async ( style: Record< string, string > ): Promise< CssConversionResult > => {
+export const convertCssToAtomic = async ( style: StyleDeclarations ): Promise< CssConversionResult > => {
 	const results = await convertStyleBlocksToAtomic( { [ SINGLE_BLOCK_KEY ]: style } );
 
 	return results[ SINGLE_BLOCK_KEY ];

--- a/packages/packages/core/editor-canvas/src/mcp/utils/convert-css-to-atomic.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/utils/convert-css-to-atomic.ts
@@ -10,13 +10,15 @@ const SINGLE_BLOCK_KEY = 'default';
  */
 export type StyleDeclarations = Record< string, string | null >;
 
+export type StyleBlock = StyleDeclarations | string;
+
 export type CssConversionResult = {
 	props: Record< string, PropValue | null >;
 	customCss: string;
 };
 
 const convertBlocks = async (
-	blocks: Record< string, StyleDeclarations >
+	blocks: Record< string, StyleBlock >
 ): Promise< Record< string, CssConversionResult > > => {
 	const { data } = await httpService().post< HttpResponse< Record< string, CssConversionResult > > >(
 		CSS_TO_ATOMIC_URL,
@@ -27,7 +29,7 @@ const convertBlocks = async (
 };
 
 export const convertStyleBlocksToAtomic = async (
-	styleByName: Record< string, StyleDeclarations >
+	styleByName: Record< string, StyleBlock >
 ): Promise< Record< string, CssConversionResult > > => convertBlocks( styleByName );
 
 export const convertCssToAtomic = async ( style: StyleDeclarations ): Promise< CssConversionResult > => {

--- a/packages/packages/core/editor-canvas/src/mcp/utils/do-update-element-property.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/utils/do-update-element-property.ts
@@ -61,6 +61,9 @@ export const doUpdateElementProperty = ( params: OwnParams ) => {
 				if ( ! propKey && kind !== 'union' ) {
 					throw new Error( `_styles property ${ key } is not supported.` );
 				}
+				if ( val === null ) {
+					return [ key, null ];
+				}
 				return [ key, resolvePropValue( val, propKey ) ];
 			} )
 		);

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-apply-unapply-global-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-apply-unapply-global-classes.ts
@@ -45,7 +45,7 @@ export default function initMcpApplyUnapplyGlobalClasses( server: MCPRegistryEnt
 			doApplyClasses( elementId, [ ...appliedClasses, classId ] );
 			return {
 				llm_instructions:
-					'Please check the element-configuration, find DUPLICATES in the style schema that are in the class, and remove them',
+					'Please check the element configuration, find inline styles duplicated by the applied global class, and remove them',
 				result: `Class ${ classId } applied to element ${ elementId } successfully.`,
 			};
 		},

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-manage-global-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-manage-global-classes.ts
@@ -1,19 +1,15 @@
-import { BREAKPOINTS_SCHEMA_FULL_URI, STYLE_SCHEMA_FULL_URI } from '@elementor/editor-canvas';
+import { BREAKPOINTS_SCHEMA_FULL_URI, convertStyleBlocksToAtomic, type StyleBlock } from '@elementor/editor-canvas';
 import { type MCPRegistryEntry } from '@elementor/editor-mcp';
-import { type Props, Schema } from '@elementor/editor-props';
+import { type Props } from '@elementor/editor-props';
 import { type BreakpointId } from '@elementor/editor-responsive';
-import { getStylesSchema, type StyleDefinitionState } from '@elementor/editor-styles';
+import { type CustomCss, type StyleDefinitionState } from '@elementor/editor-styles';
 import { type StylesProvider } from '@elementor/editor-styles-repository';
-import { type Utils as IUtils } from '@elementor/editor-variables';
 import { z } from '@elementor/schema';
 
 import { globalClassesStylesProvider } from '../global-classes-styles-provider';
 import { loadExistingClasses } from '../load-existing-classes';
 import { saveGlobalClasses } from '../save-global-classes';
 import { GLOBAL_CLASSES_URI } from './classes-resource';
-
-// TODO: see https://elementor.atlassian.net/browse/ED-22513 for better cross-module access
-type XElementor = z.infer< z.ZodAny >;
 
 const schema = {
 	action: z.enum( [ 'create', 'modify', 'delete' ] ).describe( 'Operation to perform' ),
@@ -22,43 +18,18 @@ const schema = {
 		.optional()
 		.describe( 'Global class ID (required for modify). Get from elementor://global-classes resource.' ),
 	globalClassName: z.string().optional().describe( 'Global class name (required for create)' ),
-	props: z.object( {
-		default: z
-			.record(
-				z.string().describe( 'The style property name' ),
-				z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` )
-			)
-			.describe(
-				'An object record containing style property names and their new values. MUST contain at least one property — empty objects are rejected.'
-			),
-		hover: z
-			.record(
-				z.string().describe( 'The style property name' ),
-				z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` )
-			)
-			.describe(
-				'An object record containing style property names and their new values to be set on the element. for :hover css state. optional'
-			)
-			.optional(),
-		focus: z
-			.record(
-				z.string().describe( 'The style property name' ),
-				z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` )
-			)
-			.describe(
-				'An object record containing style property names and their new values to be set on the element. for :focus css state. optional'
-			)
-			.optional(),
-		active: z
-			.record(
-				z.string().describe( 'The style property name' ),
-				z.any().describe( `The style PropValue, refer to [${ STYLE_SCHEMA_FULL_URI }] how to generate values` )
-			)
-			.describe(
-				'An object record containing style property names and their new values to be set on the element. for :active css state. optional'
-			)
-			.optional(),
-	} ),
+	style: z
+		.object( {
+			default: z
+				.string()
+				.describe( 'Plaintext CSS for the default state. MUST be non-empty — blank strings are rejected.' ),
+			hover: z.string().describe( 'Plaintext CSS for the :hover state. optional' ).optional(),
+			focus: z.string().describe( 'Plaintext CSS for the :focus state. optional' ).optional(),
+			active: z.string().describe( 'Plaintext CSS for the :active state. optional' ).optional(),
+		} )
+		.describe(
+			'Plaintext CSS per pseudo-state. All states are converted in one bulk request; unconvertible declarations are stored as custom CSS.'
+		),
 	breakpoint: z
 		.nullable( z.string().describe( 'Responsive breakpoint name for styles. Defaults to desktop (null).' ) )
 		.default( null )
@@ -74,9 +45,13 @@ const outputSchema = {
 type InputSchema = z.infer< ReturnType< typeof z.object< typeof schema > > >;
 type OutputSchema = z.infer< ReturnType< typeof z.object< typeof outputSchema > > >;
 
+type ConvertedStateStyle = {
+	props: Props;
+	customCss: CustomCss | null;
+};
+
 const handler = async ( input: InputSchema ): Promise< OutputSchema > => {
-	const { action, classId: rawClassId, globalClassName, props: rawProps, breakpoint } = input;
-	const propsWithStates = rawProps as unknown as Record< NonNullable< StyleDefinitionState >, Props >;
+	const { action, classId: rawClassId, globalClassName, style: rawStyle, breakpoint } = input;
 	let classId = rawClassId;
 	if ( action === 'create' && ! globalClassName ) {
 		return {
@@ -107,54 +82,24 @@ const handler = async ( input: InputSchema ): Promise< OutputSchema > => {
 		};
 	}
 
-	const errors: string[] = [];
-	const stylesSchema = getStylesSchema();
-	const validProps = Object.keys( stylesSchema );
-	Object.values( propsWithStates ).forEach( ( props ) => {
-		Object.keys( props ).forEach( ( key ) => {
-			const propType = stylesSchema[ key ];
-			if ( ! propType ) {
-				errors.push( `Property "${ key }" does not exist in styles schema.` );
-				return;
-			}
-			const { valid, jsonSchema } = Schema.validatePropValue( propType, props[ key ] );
-			if ( ! valid ) {
-				errors.push( `- Property "${ key }" has invalid value\n  Expected schema: ${ jsonSchema }\n` );
-			}
-		} );
-	} );
+	const styleBlocks = collectNonEmptyStyleBlocks( rawStyle );
 
-	if ( action !== 'delete' ) {
-		const hasAnyProps = Object.values( propsWithStates ).some(
-			( stateProps ) => Object.keys( stateProps ).length > 0
-		);
-		if ( ! hasAnyProps ) {
-			throw new Error(
-				`Props must not be empty. Each prop must be a PropValue object from the style schema.\n\nExample: { "display": { "$$type": "string", "value": "flex" }, "flex-direction": { "$$type": "string", "value": "column" } }\n\n${ STYLE_SCHEMA_FULL_URI } to get the allowed values (look at the "value" enum in the schema response), then construct { "$$type": "string", "value": "<chosen value>" } for each property.\nAvailable Properties: ${ validProps.join(
-					', '
-				) }`
-			);
-		}
-	}
-
-	if ( errors.length > 0 ) {
+	if ( action !== 'delete' && Object.keys( styleBlocks ).length === 0 ) {
 		throw new Error(
-			`Validation errors:\n${ errors.join( '\n' ) }\nAvailable Properties: ${ validProps.join(
-				', '
-			) }\nUpdate your input and try again.`
+			'Style must not be empty. Provide plaintext CSS per state.\n\nExample: style.default = "display: flex; flex-direction: column; gap: 1rem;"'
 		);
 	}
 
-	// TODO: see https://elementor.atlassian.net/browse/ED-22513 for better cross-module access
-	const Utils = ( ( ( window as XElementor ).elementorV2 as XElementor ).editorVariables as XElementor )
-		.Utils as typeof IUtils;
-	Object.values( propsWithStates ).forEach( ( props ) => {
-		Object.keys( props ).forEach( ( key ) => {
-			props[ key ] = Schema.adjustLlmPropValueSchema( props[ key ], {
-				transformers: Utils.globalVariablesLLMResolvers,
-			} );
-		} );
-	} );
+	let convertedByState: Record< string, ConvertedStateStyle > = {};
+	if ( action !== 'delete' ) {
+		const conversionResults = await convertStyleBlocksToAtomic( styleBlocks );
+		convertedByState = Object.fromEntries(
+			Object.entries( conversionResults ).map( ( [ state, { props, customCss } ] ) => [
+				state,
+				{ props: props as Props, customCss: toStoredCustomCss( customCss ) },
+			] )
+		);
+	}
 
 	const breakpointValue = breakpoint ?? 'desktop';
 	let result = {
@@ -176,18 +121,18 @@ const handler = async ( input: InputSchema ): Promise< OutputSchema > => {
 		}
 
 		let currentAction = action;
-		for await ( const [ state, props ] of Object.entries( propsWithStates ) ) {
+		for await ( const [ state, { props, customCss } ] of Object.entries( convertedByState ) ) {
 			switch ( currentAction ) {
 				case 'create':
 					const newClassId = await attemptCreate( {
 						props,
+						customCss,
 						className: globalClassName,
 						stylesProvider: globalClassesStylesProvider,
 						breakpoint: breakpointValue as BreakpointId,
 						state: state as StyleDefinitionState,
 					} );
 					if ( newClassId && currentAction === 'create' ) {
-						// NOTE: for multiple iterations as the state changes, the next execution would be update an existing class
 						currentAction = 'modify';
 						classId = newClassId;
 						result = {
@@ -202,6 +147,7 @@ const handler = async ( input: InputSchema ): Promise< OutputSchema > => {
 					const updated = await attemptUpdate( {
 						classId,
 						props,
+						customCss,
 						stylesProvider: globalClassesStylesProvider,
 						breakpoint: breakpointValue as BreakpointId,
 						state: state as StyleDefinitionState,
@@ -232,21 +178,18 @@ export const initManageGlobalClasses = ( reg: MCPRegistryEntry ) => {
 		name: 'manage-global-classes',
 		requiredResources: [
 			{ uri: GLOBAL_CLASSES_URI, description: 'Global classes list' },
-			{ uri: STYLE_SCHEMA_FULL_URI, description: 'Style schema resources' },
 			{ uri: BREAKPOINTS_SCHEMA_FULL_URI, description: 'Breakpoints list' },
 		],
 		description: `Create or modify global classes for reusable design-system styling. Class names must reflect purpose (e.g. heading-primary, button-cta). Create classes BEFORE applying them. Do NOT create classes for one-off styles.
 
-IMPORTANT: props must contain actual CSS property values — never pass empty objects.
-Fetch ${ STYLE_SCHEMA_FULL_URI } to get the allowed values for each property, then use them to build the props object.
+IMPORTANT: style must contain plaintext CSS rules per state — never pass empty strings.
+CSS is converted server-side in one bulk request; any declaration that cannot be converted is stored as the class custom CSS.
 
 Example — creating a flex column class:
-props.default = {
-  "display": { "$$type": "string", "value": "flex" },
-  "flex-direction": { "$$type": "string", "value": "column" }
-}
+style.default = "display: flex; flex-direction: column; gap: 1rem;"
 
-The style schema returns a JSON Schema. Extract the "value" enum to pick the right value, then construct { "$$type": "string", "value": "<picked value>" }.`,
+Example — hover state:
+style.hover = "opacity: 0.85;"`,
 		schema,
 		outputSchema,
 		handler,
@@ -259,11 +202,12 @@ type Opts = {
 	classId?: string;
 	breakpoint: BreakpointId;
 	props: Props;
+	customCss: CustomCss | null;
 	state: StyleDefinitionState;
 };
 
 async function attemptCreate( opts: Opts ) {
-	const { props, breakpoint, className, stylesProvider, state } = opts;
+	const { props, customCss, breakpoint, className, stylesProvider, state } = opts;
 	const { create, delete: deleteClass } = stylesProvider.actions;
 	if ( ! className ) {
 		throw new Error( 'Global class name is a required for creation' );
@@ -277,7 +221,7 @@ async function attemptCreate( opts: Opts ) {
 				breakpoint,
 				state: ( state as string ) === 'default' ? null : state,
 			},
-			custom_css: null,
+			custom_css: customCss,
 			props,
 		},
 	] );
@@ -291,7 +235,7 @@ async function attemptCreate( opts: Opts ) {
 }
 
 async function attemptUpdate( opts: Opts ) {
-	const { props, breakpoint, classId, stylesProvider, state } = opts;
+	const { props, customCss, breakpoint, classId, stylesProvider, state } = opts;
 	const { updateProps, update } = stylesProvider.actions;
 	if ( ! classId ) {
 		throw new Error( 'Class ID is required for modification' );
@@ -305,6 +249,7 @@ async function attemptUpdate( opts: Opts ) {
 		updateProps( {
 			id: classId,
 			props,
+			custom_css: customCss,
 			meta: {
 				breakpoint,
 				state: ( state as string ) === 'default' ? null : state,
@@ -341,4 +286,21 @@ async function attemptDelete( opts: Pick< Opts, 'classId' | 'stylesProvider' > )
 	deleteClass( classId );
 	await saveGlobalClasses( { context: 'frontend' } );
 	return true;
+}
+
+function collectNonEmptyStyleBlocks( style: InputSchema[ 'style' ] ): Record< string, StyleBlock > {
+	const blocks: Record< string, StyleBlock > = {};
+	Object.entries( style ).forEach( ( [ state, cssText ] ) => {
+		if ( cssText?.trim() ) {
+			blocks[ state ] = cssText.trim();
+		}
+	} );
+	return blocks;
+}
+
+function toStoredCustomCss( customCss: string ): CustomCss | null {
+	if ( ! customCss?.trim() ) {
+		return null;
+	}
+	return { raw: btoa( customCss ) };
 }

--- a/packages/packages/core/editor-styles-repository/src/types.ts
+++ b/packages/packages/core/editor-styles-repository/src/types.ts
@@ -24,6 +24,7 @@ export type UpdatePropsActionPayload = {
 	id: StyleDefinitionID;
 	meta: StyleDefinitionVariant[ 'meta' ];
 	props: Props;
+	custom_css?: CustomCss | null;
 	mode?: 'merge' | 'replace';
 };
 

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-background-image-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-background-image-converter.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Image_Converter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * DB-less: asserts raw PropValue structure only. generate() calls are safe; validate() is not (needs WP
+ * for Image_Sizes / Url_Prop_Type), so schema validation lives in the REST test suite.
+ */
+class Test_Background_Image_Converter extends TestCase {
+	public function test_convert__single_url_creates_one_image_layer() {
+		// Arrange.
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = ( new Background_Image_Converter() )->convert(
+			$context,
+			[ 'property' => 'background-image', 'value' => 'url(foo.jpg)' ]
+		);
+
+		// Assert.
+		$this->assertTrue( $converted );
+
+		$background = $context->get_prop( 'background' );
+		$this->assertSame( 'background', $background['$$type'] );
+
+		$overlay = $background['value']['background-overlay'];
+		$this->assertSame( 'background-overlay', $overlay['$$type'] );
+		$this->assertCount( 1, $overlay['value'] );
+
+		$layer = $overlay['value'][0];
+		$this->assertSame( 'background-image-overlay', $layer['$$type'] );
+		$this->assertSame( 'foo.jpg', $layer['value']['image']['value']['src']['value']['url']['value'] );
+	}
+
+	public function test_convert__multiple_urls_create_ordered_layers() {
+		// Arrange.
+		$context = new Conversion_Context();
+
+		// Act.
+		( new Background_Image_Converter() )->convert(
+			$context,
+			[ 'property' => 'background-image', 'value' => 'url(a.jpg), url(b.jpg)' ]
+		);
+
+		// Assert.
+		$layers = $context->get_prop( 'background' )['value']['background-overlay']['value'];
+
+		$this->assertCount( 2, $layers );
+		$this->assertSame( 'a.jpg', $layers[0]['value']['image']['value']['src']['value']['url']['value'] );
+		$this->assertSame( 'b.jpg', $layers[1]['value']['image']['value']['src']['value']['url']['value'] );
+	}
+
+	public function test_convert__preserves_existing_background_color_field() {
+		// Arrange: a prior background-color declaration already set the background aggregate.
+		$context = new Conversion_Context();
+		$context->set_prop( 'background', [
+			'$$type' => 'background',
+			'value' => [ 'color' => Color_Prop_Type::generate( 'red' ) ],
+		] );
+
+		// Act.
+		( new Background_Image_Converter() )->convert(
+			$context,
+			[ 'property' => 'background-image', 'value' => 'url(foo.jpg)' ]
+		);
+
+		// Assert: image layer is added; existing color field is preserved.
+		$bg_value = $context->get_prop( 'background' )['value'];
+
+		$this->assertSame( Color_Prop_Type::generate( 'red' ), $bg_value['color'] );
+		$this->assertArrayHasKey( 'background-overlay', $bg_value );
+		$this->assertCount( 1, $bg_value['background-overlay']['value'] );
+	}
+
+	public function test_convert__none_layer_produces_no_overlay_items() {
+		// Arrange.
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = ( new Background_Image_Converter() )->convert(
+			$context,
+			[ 'property' => 'background-image', 'value' => 'none' ]
+		);
+
+		// Assert: converted successfully but overlay array is empty.
+		$this->assertTrue( $converted );
+		$overlay = $context->get_prop( 'background' )['value']['background-overlay'];
+		$this->assertCount( 0, $overlay['value'] );
+	}
+
+	public function test_convert__linear_gradient_creates_gradient_overlay_layer() {
+		// Arrange.
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = ( new Background_Image_Converter() )->convert(
+			$context,
+			[ 'property' => 'background-image', 'value' => 'linear-gradient(135deg, #ffffff 0%, #000000 100%)' ]
+		);
+
+		// Assert.
+		$this->assertTrue( $converted );
+
+		$overlay = $context->get_prop( 'background' )['value']['background-overlay'];
+		$this->assertCount( 1, $overlay['value'] );
+		$this->assertSame( 'background-gradient-overlay', $overlay['value'][0]['$$type'] );
+		$this->assertSame( 'linear', $overlay['value'][0]['value']['type']['value'] );
+	}
+
+	public function test_convert__mixed_url_and_gradient_creates_two_layers() {
+		// Arrange.
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = ( new Background_Image_Converter() )->convert(
+			$context,
+			[ 'property' => 'background-image', 'value' => 'url(foo.jpg), linear-gradient(#fff, #000)' ]
+		);
+
+		// Assert.
+		$this->assertTrue( $converted );
+
+		$layers = $context->get_prop( 'background' )['value']['background-overlay']['value'];
+		$this->assertCount( 2, $layers );
+		$this->assertSame( 'background-image-overlay', $layers[0]['$$type'] );
+		$this->assertSame( 'background-gradient-overlay', $layers[1]['$$type'] );
+	}
+
+	public function test_convert__unsupported_token_declines() {
+		// Arrange.
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = ( new Background_Image_Converter() )->convert(
+			$context,
+			[ 'property' => 'background-image', 'value' => 'banana' ]
+		);
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertNull( $context->get_prop( 'background' ) );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-background-layer-field-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-background-layer-field-converter.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Image_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Layer_Field_Converter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Image_Overlay_Size_Scale_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Image_Position_Offset_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Background_Layer_Field_Converter extends TestCase {
+	const REPEAT_ENUM = [ 'repeat', 'repeat-x', 'repeat-y', 'no-repeat' ];
+	const ATTACHMENT_ENUM = [ 'fixed', 'scroll' ];
+	const SIZE_ENUM = [ 'auto', 'cover', 'contain' ];
+	const POSITION_ENUM = [
+		'center center',
+		'center left',
+		'center right',
+		'top center',
+		'top left',
+		'top right',
+		'bottom center',
+		'bottom left',
+		'bottom right',
+	];
+
+	public function test_convert__declines_when_no_image_layers_in_context() {
+		// Arrange.
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $this->repeat_converter()->convert(
+			$context,
+			[ 'property' => 'background-repeat', 'value' => 'no-repeat' ]
+		);
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertNull( $context->get_prop( 'background' ) );
+	}
+
+	public function test_convert__single_repeat_applies_to_all_layers() {
+		// Arrange.
+		$context = $this->context_with_images( [ 'a.jpg', 'b.jpg' ] );
+
+		// Act.
+		$converted = $this->repeat_converter()->convert(
+			$context,
+			[ 'property' => 'background-repeat', 'value' => 'no-repeat' ]
+		);
+
+		// Assert: both layers get the same repeat value.
+		$this->assertTrue( $converted );
+
+		$layers = $this->get_layers( $context );
+
+		$this->assertSame( [ '$$type' => 'string', 'value' => 'no-repeat' ], $layers[0]['value']['repeat'] );
+		$this->assertSame( [ '$$type' => 'string', 'value' => 'no-repeat' ], $layers[1]['value']['repeat'] );
+	}
+
+	public function test_convert__comma_repeat_applies_per_layer() {
+		// Arrange.
+		$context = $this->context_with_images( [ 'a.jpg', 'b.jpg' ] );
+
+		// Act.
+		$this->repeat_converter()->convert(
+			$context,
+			[ 'property' => 'background-repeat', 'value' => 'no-repeat, repeat-x' ]
+		);
+
+		// Assert.
+		$layers = $this->get_layers( $context );
+
+		$this->assertSame( 'no-repeat', $layers[0]['value']['repeat']['value'] );
+		$this->assertSame( 'repeat-x', $layers[1]['value']['repeat']['value'] );
+	}
+
+	public function test_convert__count_mismatch_declines() {
+		// Arrange: 1 layer, 2 values.
+		$context = $this->context_with_images( [ 'a.jpg' ] );
+
+		// Act.
+		$converted = $this->repeat_converter()->convert(
+			$context,
+			[ 'property' => 'background-repeat', 'value' => 'no-repeat, repeat-x' ]
+		);
+
+		// Assert.
+		$this->assertFalse( $converted );
+	}
+
+	public function test_convert__out_of_enum_token_declines() {
+		// Arrange.
+		$context = $this->context_with_images( [ 'a.jpg' ] );
+
+		// Act.
+		$converted = $this->repeat_converter()->convert(
+			$context,
+			[ 'property' => 'background-repeat', 'value' => 'banana' ]
+		);
+
+		// Assert.
+		$this->assertFalse( $converted );
+	}
+
+	public function test_convert__size_enum_cover_sets_field() {
+		// Arrange.
+		$context = $this->context_with_images( [ 'a.jpg' ] );
+
+		// Act.
+		$this->size_converter()->convert(
+			$context,
+			[ 'property' => 'background-size', 'value' => 'cover' ]
+		);
+
+		// Assert.
+		$layers = $this->get_layers( $context );
+
+		$this->assertSame( [ '$$type' => 'string', 'value' => 'cover' ], $layers[0]['value']['size'] );
+	}
+
+	public function test_convert__size_pair_percentage_parses_as_scale_prop_type() {
+		// Arrange.
+		$context = $this->context_with_images( [ 'a.jpg' ] );
+
+		// Act.
+		$this->size_converter()->convert(
+			$context,
+			[ 'property' => 'background-size', 'value' => '50% 100%' ]
+		);
+
+		// Assert.
+		$size_value = $this->get_layers( $context )[0]['value']['size'];
+
+		$this->assertSame( 'background-image-size-scale', $size_value['$$type'] );
+		$this->assertSame( 50, $size_value['value']['width']['value']['size'] );
+		$this->assertSame( 100, $size_value['value']['height']['value']['size'] );
+	}
+
+	public function test_convert__position_enum_sets_field() {
+		// Arrange.
+		$context = $this->context_with_images( [ 'a.jpg' ] );
+
+		// Act.
+		$this->position_converter()->convert(
+			$context,
+			[ 'property' => 'background-position', 'value' => 'center center' ]
+		);
+
+		// Assert.
+		$layers = $this->get_layers( $context );
+
+		$this->assertSame( [ '$$type' => 'string', 'value' => 'center center' ], $layers[0]['value']['position'] );
+	}
+
+	public function test_convert__position_offset_pair_parses_as_offset_prop_type() {
+		// Arrange.
+		$context = $this->context_with_images( [ 'a.jpg' ] );
+
+		// Act.
+		$this->position_converter()->convert(
+			$context,
+			[ 'property' => 'background-position', 'value' => '10px 20px' ]
+		);
+
+		// Assert.
+		$pos_value = $this->get_layers( $context )[0]['value']['position'];
+
+		$this->assertSame( 'background-image-position-offset', $pos_value['$$type'] );
+		$this->assertSame( 10, $pos_value['value']['x']['value']['size'] );
+		$this->assertSame( 20, $pos_value['value']['y']['value']['size'] );
+	}
+
+	private function context_with_images( array $urls ): Conversion_Context {
+		$context = new Conversion_Context();
+
+		( new Background_Image_Converter() )->convert(
+			$context,
+			[ 'property' => 'background-image', 'value' => implode( ', ', array_map( fn( $u ) => "url($u)", $urls ) ) ]
+		);
+
+		return $context;
+	}
+
+	private function get_layers( Conversion_Context $context ): array {
+		return $context->get_prop( 'background' )['value']['background-overlay']['value'];
+	}
+
+	private function repeat_converter(): Background_Layer_Field_Converter {
+		return new Background_Layer_Field_Converter( 'background-repeat', 'repeat', self::REPEAT_ENUM );
+	}
+
+	private function size_converter(): Background_Layer_Field_Converter {
+		return new Background_Layer_Field_Converter(
+			'background-size',
+			'size',
+			self::SIZE_ENUM,
+			Background_Image_Overlay_Size_Scale_Prop_Type::class,
+			[ 'width', 'height' ]
+		);
+	}
+
+	private function position_converter(): Background_Layer_Field_Converter {
+		return new Background_Layer_Field_Converter(
+			'background-position',
+			'position',
+			self::POSITION_ENUM,
+			Background_Image_Position_Offset_Prop_Type::class,
+			[ 'x', 'y' ]
+		);
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-background-position-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-background-position-property-converter.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Image_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Background_Position_Property_Converter;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Background_Position_Property_Converter extends TestCase {
+	private Background_Position_Property_Converter $converter;
+	private Conversion_Context $context;
+
+	public function setUp(): void {
+		$this->converter = new Background_Position_Property_Converter();
+		$this->context   = new Conversion_Context( [] );
+		$this->seed_image_layer();
+	}
+
+	/**
+	 * @dataProvider enum_provider
+	 */
+	public function test_convert__normalizes_to_enum_string( string $input, string $expected_enum ) {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( $input ) );
+
+		// Assert.
+		$this->assertTrue( $result, "Expected '$input' to convert." );
+		$position = $this->position_value();
+		$this->assertSame( 'string', $position['$$type'] );
+		$this->assertSame( $expected_enum, $position['value'] );
+	}
+
+	public static function enum_provider(): array {
+		return [
+			'center single'        => [ 'center', 'center center' ],
+			'top single'           => [ 'top', 'top center' ],
+			'bottom single'        => [ 'bottom', 'bottom center' ],
+			'left single'          => [ 'left', 'center left' ],
+			'right single'         => [ 'right', 'center right' ],
+			'top left as-is'       => [ 'top left', 'top left' ],
+			'left top swap'        => [ 'left top', 'top left' ],
+			'right bottom swap'    => [ 'right bottom', 'bottom right' ],
+			'center center'        => [ 'center center', 'center center' ],
+		];
+	}
+
+	public function test_convert__two_sizes_emits_offset_object() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '20% 80%' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$position = $this->position_value();
+		$this->assertSame( 'background-image-position-offset', $position['$$type'] );
+		$this->assertSame( 20, $position['value']['x']['value']['size'] );
+		$this->assertSame( '%', $position['value']['x']['value']['unit'] );
+		$this->assertSame( 80, $position['value']['y']['value']['size'] );
+	}
+
+	/**
+	 * @dataProvider unrepresentable_provider
+	 */
+	public function test_convert__declines_unrepresentable_values( string $input ) {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( $input ) );
+
+		// Assert.
+		$this->assertFalse( $result, "Expected '$input' to decline." );
+	}
+
+	public static function unrepresentable_provider(): array {
+		return [
+			'keyword + length'   => [ 'center 20%' ],
+			'length + keyword'   => [ '50% top' ],
+			'three tokens'       => [ 'center top 20%' ],
+			'edge offset edge'   => [ 'left 10px top' ],
+			'bottom with length' => [ 'bottom 4px' ],
+			'calc value'         => [ 'calc(100% - 5rem) center' ],
+			'four tokens'        => [ 'left 10px top 20px' ],
+			'unknown keyword'    => [ 'middle middle' ],
+		];
+	}
+
+	private function position_value(): array {
+		$background = $this->context->get_prop( 'background' );
+		$overlay = $background['value']['background-overlay']['value'][0];
+		return $overlay['value']['position'];
+	}
+
+	private function seed_image_layer(): void {
+		( new Background_Image_Converter() )->convert( $this->context, [
+			'property' => 'background-image',
+			'value' => 'url(http://x/y.png)',
+			'declaration' => 'background-image: url(http://x/y.png)',
+		] );
+	}
+
+	private function rule( string $value ): array {
+		return [
+			'property' => 'background-position',
+			'value' => $value,
+			'declaration' => 'background-position: ' . $value,
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-border-radius-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-border-radius-property-converter.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Border_Radius_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Border_Radius_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Border_Radius_Property_Converter extends TestCase {
+
+	public function test_convert__single_value_emits_a_size_member() {
+		// Arrange.
+		$converter = new Border_Radius_Property_Converter( 'border-radius' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'border-radius', 'value' => '8px' ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'border-radius' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame( [ '$$type' => 'size', 'value' => [ 'size' => 8, 'unit' => 'px' ] ], $prop_value );
+		$this->assertTrue( Size_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__four_values_map_corners_physical_to_logical() {
+		// Arrange.
+		$converter = new Border_Radius_Property_Converter( 'border-radius' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'border-radius', 'value' => '1px 2px 3px 4px' ] );
+
+		// Assert: TL->start-start, TR->start-end, BR->end-end, BL->end-start.
+		$prop_value = $context->get_prop( 'border-radius' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame(
+			$this->radius( '1px', '2px', '3px', '4px' ),
+			$prop_value
+		);
+		$this->assertTrue( Border_Radius_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__two_values_expand_to_diagonal_corners() {
+		// Arrange.
+		$converter = new Border_Radius_Property_Converter( 'border-radius' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converter->convert( $context, [ 'property' => 'border-radius', 'value' => '10px 20px' ] );
+
+		// Assert: TL=BR=10, TR=BL=20.
+		$this->assertSame(
+			$this->radius( '10px', '20px', '10px', '20px' ),
+			$context->get_prop( 'border-radius' )
+		);
+	}
+
+	public function test_convert__keeps_calc_division_as_a_single_size() {
+		// Arrange.
+		$converter = new Border_Radius_Property_Converter( 'border-radius' );
+		$context = new Conversion_Context();
+
+		// Act: calc() division must convert, not be mistaken for an elliptical separator.
+		$converted = $converter->convert( $context, [ 'property' => 'border-radius', 'value' => 'calc(100% / 4)' ] );
+
+		// Assert.
+		$this->assertTrue( $converted );
+		$this->assertSame(
+			[ '$$type' => 'size', 'value' => [ 'size' => 'calc(100% / 4)', 'unit' => 'custom' ] ],
+			$context->get_prop( 'border-radius' )
+		);
+	}
+
+	/**
+	 * @dataProvider declined_values
+	 */
+	public function test_convert__declines_unrepresentable_value( string $value ) {
+		// Arrange.
+		$converter = new Border_Radius_Property_Converter( 'border-radius' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'border-radius', 'value' => $value ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertFalse( $context->has_prop( 'border-radius' ) );
+	}
+
+	public function declined_values(): array {
+		return [
+			'elliptical' => [ '10px / 20px' ],
+			'too many values' => [ '1px 2px 3px 4px 5px' ],
+			'non-size token' => [ 'banana' ],
+		];
+	}
+
+	public function test_dispatcher__declined_elliptical_is_delegated_to_custom_css() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'border-radius: 10px / 20px;' );
+
+		// Assert.
+		$this->assertSame( [], $result['props'] );
+		$this->assertSame( 'border-radius: 10px / 20px;', $result['customCss'] );
+	}
+
+	private function make_dispatcher(): Css_Converter {
+		$registry = ( new Converter_Registry() )
+			->register( new Border_Radius_Property_Converter( 'border-radius' ) );
+
+		return new Css_Converter( $registry, new Null_Failure_Reporter() );
+	}
+
+	private function radius( string $start_start, string $start_end, string $end_end, string $end_start ): array {
+		return [
+			'$$type' => 'border-radius',
+			'value' => [
+				'start-start' => $this->px( $start_start ),
+				'start-end' => $this->px( $start_end ),
+				'end-end' => $this->px( $end_end ),
+				'end-start' => $this->px( $end_start ),
+			],
+		];
+	}
+
+	private function px( string $value ): array {
+		return [ '$$type' => 'size', 'value' => [ 'size' => (int) $value, 'unit' => 'px' ] ];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-box-shadow-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-box-shadow-property-converter.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Box_Shadow_Property_Converter;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Box_Shadow_Property_Converter extends TestCase {
+	private Box_Shadow_Property_Converter $converter;
+	private Conversion_Context $context;
+
+	public function setUp(): void {
+		$this->converter = new Box_Shadow_Property_Converter();
+		$this->context   = new Conversion_Context( [] );
+	}
+
+	public function test_convert__none_clears_shadow_array() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'none' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$prop = $this->context->get_prop( 'box-shadow' );
+		$this->assertSame( 'box-shadow', $prop['$$type'] );
+		$this->assertSame( [], $prop['value'] );
+	}
+
+	public function test_convert__two_lengths_with_color() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '2px 4px black' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$shadow = $this->first_shadow();
+		$this->assertEquals( 2, $shadow['hOffset']['value']['size'] );
+		$this->assertEquals( 4, $shadow['vOffset']['value']['size'] );
+		$this->assertEquals( 0, $shadow['blur']['value']['size'] );
+		$this->assertEquals( 0, $shadow['spread']['value']['size'] );
+		$this->assertSame( 'black', $shadow['color']['value'] );
+		$this->assertArrayNotHasKey( 'position', $shadow );
+	}
+
+	public function test_convert__three_lengths_with_rgba_color() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '0 2px 4px rgba(0,0,0,0.1)' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$shadow = $this->first_shadow();
+		$this->assertEquals( 0, $shadow['hOffset']['value']['size'] );
+		$this->assertEquals( 2, $shadow['vOffset']['value']['size'] );
+		$this->assertEquals( 4, $shadow['blur']['value']['size'] );
+		$this->assertEquals( 0, $shadow['spread']['value']['size'] );
+		$this->assertSame( 'rgba(0,0,0,0.1)', $shadow['color']['value'] );
+	}
+
+	public function test_convert__four_lengths_with_spread() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '0 4px 6px -1px #000' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$shadow = $this->first_shadow();
+		$this->assertEquals( 0, $shadow['hOffset']['value']['size'] );
+		$this->assertEquals( 4, $shadow['vOffset']['value']['size'] );
+		$this->assertEquals( 6, $shadow['blur']['value']['size'] );
+		$this->assertEquals( -1, $shadow['spread']['value']['size'] );
+		$this->assertSame( '#000', $shadow['color']['value'] );
+	}
+
+	public function test_convert__inset_prefix_sets_position() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'inset 0 1px 2px #000' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$shadow = $this->first_shadow();
+		$this->assertSame( 'inset', $shadow['position']['value'] );
+	}
+
+	public function test_convert__inset_suffix_also_works() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '0 1px 2px #000 inset' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$shadow = $this->first_shadow();
+		$this->assertSame( 'inset', $shadow['position']['value'] );
+	}
+
+	public function test_convert__missing_color_defaults_to_current_color() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '1px 1px' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$shadow = $this->first_shadow();
+		$this->assertSame( 'currentColor', $shadow['color']['value'] );
+	}
+
+	public function test_convert__multiple_layers_emits_array() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '0 1px 2px #000, 0 2px 4px rgba(0,0,0,0.15)' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$prop = $this->context->get_prop( 'box-shadow' );
+		$this->assertCount( 2, $prop['value'] );
+		$this->assertSame( '#000', $prop['value'][0]['value']['color']['value'] );
+		$this->assertSame( 'rgba(0,0,0,0.15)', $prop['value'][1]['value']['color']['value'] );
+	}
+
+	/** @dataProvider declining_provider */
+	public function test_convert__declines_invalid_input( string $value ) {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( $value ) );
+
+		// Assert.
+		$this->assertFalse( $result );
+		$this->assertNull( $this->context->get_prop( 'box-shadow' ) );
+	}
+
+	public static function declining_provider(): array {
+		return [
+			'empty value'      => [ '' ],
+			'one length only'  => [ '5px red' ],
+			'five lengths'     => [ '1px 2px 3px 4px 5px black' ],
+			'two colors'       => [ '0 1px 2px red blue' ],
+			'two insets'       => [ 'inset inset 0 1px 2px #000' ],
+			'no lengths'       => [ 'red' ],
+			'second layer bad' => [ '0 1px 2px #000, broken garbage' ],
+		];
+	}
+
+	private function first_shadow(): array {
+		$prop = $this->context->get_prop( 'box-shadow' );
+		return $prop['value'][0]['value'];
+	}
+
+	private function rule( string $value ): array {
+		return [
+			'property' => 'box-shadow',
+			'value' => $value,
+			'declaration' => 'box-shadow: ' . $value,
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-color-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-color-property-converter.php
@@ -44,20 +44,34 @@ class Test_Color_Property_Converter extends TestCase {
 			'keyword' => [ 'transparent', 'transparent' ],
 			'variable' => [ 'var(--c)', 'var(--c)' ],
 			'trimmed' => [ '  red  ', 'red' ],
+			'space separated rgb stays one token' => [ 'rgb(255 0 0)', 'rgb(255 0 0)' ],
+			'color-mix stays one token' => [ 'color-mix(in srgb, red, blue)', 'color-mix(in srgb, red, blue)' ],
 		];
 	}
 
-	public function test_convert__declines_empty_value() {
+	/**
+	 * @dataProvider declined_values
+	 */
+	public function test_convert__declines_empty_or_multi_color_value( string $value ) {
 		// Arrange.
-		$converter = new Color_Property_Converter( 'color' );
+		$converter = new Color_Property_Converter( 'border-color' );
 		$context = new Conversion_Context();
 
 		// Act.
-		$converted = $converter->convert( $context, [ 'property' => 'color', 'value' => '   ' ] );
+		$converted = $converter->convert( $context, [ 'property' => 'border-color', 'value' => $value ] );
 
-		// Assert.
+		// Assert: the model holds a single color, so empty and multi-color values decline to custom_css.
 		$this->assertFalse( $converted );
-		$this->assertFalse( $context->has_prop( 'color' ) );
+		$this->assertFalse( $context->has_prop( 'border-color' ) );
+	}
+
+	public function declined_values(): array {
+		return [
+			'empty' => [ '   ' ],
+			'two named colors' => [ 'red green' ],
+			'four per-side colors' => [ 'red green blue yellow' ],
+			'mixed named and function' => [ 'red rgb(0, 0, 0)' ],
+		];
 	}
 
 	public function test_dispatcher__valid_value_lands_in_props() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-color-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-color-property-converter.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Color_Property_Converter extends TestCase {
+
+	/**
+	 * @dataProvider color_values
+	 */
+	public function test_convert__emits_canonical_prop_value_that_validates_against_the_prop_type( string $input, string $expected ) {
+		// Arrange.
+		$converter = new Color_Property_Converter( 'color' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'color', 'value' => $input ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'color' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame( [ '$$type' => 'color', 'value' => $expected ], $prop_value );
+		$this->assertTrue( Color_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function color_values(): array {
+		return [
+			'named' => [ 'whitesmoke', 'whitesmoke' ],
+			'hex' => [ '#2d2a26', '#2d2a26' ],
+			'rgb' => [ 'rgb(255, 0, 0)', 'rgb(255, 0, 0)' ],
+			'hsl' => [ 'hsl(120, 50%, 50%)', 'hsl(120, 50%, 50%)' ],
+			'keyword' => [ 'transparent', 'transparent' ],
+			'variable' => [ 'var(--c)', 'var(--c)' ],
+			'trimmed' => [ '  red  ', 'red' ],
+		];
+	}
+
+	public function test_convert__declines_empty_value() {
+		// Arrange.
+		$converter = new Color_Property_Converter( 'color' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'color', 'value' => '   ' ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertFalse( $context->has_prop( 'color' ) );
+	}
+
+	public function test_dispatcher__valid_value_lands_in_props() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'color: whitesmoke;' );
+
+		// Assert.
+		$this->assertSame( [ 'color' => [ '$$type' => 'color', 'value' => 'whitesmoke' ] ], $result['props'] );
+		$this->assertSame( '', $result['customCss'] );
+	}
+
+	private function make_dispatcher(): Css_Converter {
+		$registry = ( new Converter_Registry() )
+			->register( new Color_Property_Converter( 'color' ) );
+
+		return new Css_Converter( $registry, new Null_Failure_Reporter() );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-dimensions-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-dimensions-property-converter.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Dimensions_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Dimensions_Property_Converter extends TestCase {
+
+	public function test_convert__single_value_emits_a_size_member() {
+		// Arrange.
+		$converter = new Dimensions_Property_Converter( 'padding' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'padding', 'value' => '10px' ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'padding' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame( [ '$$type' => 'size', 'value' => [ 'size' => 10, 'unit' => 'px' ] ], $prop_value );
+		$this->assertTrue( Size_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__two_values_expand_to_logical_dimensions() {
+		// Arrange.
+		$converter = new Dimensions_Property_Converter( 'padding' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'padding', 'value' => '10px 20px' ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'padding' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame(
+			$this->dimensions( '10px', '20px', '10px', '20px' ),
+			$prop_value
+		);
+		$this->assertTrue( Dimensions_Prop_Type::make_with_units()->validate( $prop_value ) );
+	}
+
+	public function test_convert__three_values_expand_to_logical_dimensions() {
+		// Arrange.
+		$converter = new Dimensions_Property_Converter( 'margin' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converter->convert( $context, [ 'property' => 'margin', 'value' => '1px 2px 3px' ] );
+
+		// Assert: top=1, right=2, bottom=3, left=2.
+		$this->assertSame(
+			$this->dimensions( '1px', '2px', '3px', '2px' ),
+			$context->get_prop( 'margin' )
+		);
+	}
+
+	public function test_convert__four_values_map_physical_to_logical_sides() {
+		// Arrange.
+		$converter = new Dimensions_Property_Converter( 'padding' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'padding', 'value' => '1px 2px 3px 4px' ] );
+
+		// Assert: top->block-start, right->inline-end, bottom->block-end, left->inline-start.
+		$prop_value = $context->get_prop( 'padding' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame(
+			$this->dimensions( '1px', '2px', '3px', '4px' ),
+			$prop_value
+		);
+		$this->assertTrue( Dimensions_Prop_Type::make_with_units()->validate( $prop_value ) );
+	}
+
+	public function test_convert__keeps_function_values_intact_while_splitting() {
+		// Arrange.
+		$converter = new Dimensions_Property_Converter( 'padding' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converter->convert( $context, [ 'property' => 'padding', 'value' => 'calc(50% - 10px) 20px' ] );
+
+		// Assert.
+		$this->assertSame(
+			[
+				'$$type' => 'dimensions',
+				'value' => [
+					'block-start' => [ '$$type' => 'size', 'value' => [ 'size' => 'calc(50% - 10px)', 'unit' => 'custom' ] ],
+					'inline-end' => [ '$$type' => 'size', 'value' => [ 'size' => 20, 'unit' => 'px' ] ],
+					'block-end' => [ '$$type' => 'size', 'value' => [ 'size' => 'calc(50% - 10px)', 'unit' => 'custom' ] ],
+					'inline-start' => [ '$$type' => 'size', 'value' => [ 'size' => 20, 'unit' => 'px' ] ],
+				],
+			],
+			$context->get_prop( 'padding' )
+		);
+	}
+
+	/**
+	 * @dataProvider declined_values
+	 */
+	public function test_convert__declines_unrepresentable_value( string $value ) {
+		// Arrange.
+		$converter = new Dimensions_Property_Converter( 'padding' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'padding', 'value' => $value ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertFalse( $context->has_prop( 'padding' ) );
+	}
+
+	public function declined_values(): array {
+		return [
+			'non-size token' => [ 'banana' ],
+			'one bad token among good' => [ '10px banana' ],
+			'too many values' => [ '1px 2px 3px 4px 5px' ],
+			'empty' => [ '   ' ],
+		];
+	}
+
+	public function test_dispatcher__valid_value_lands_in_props() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'padding: 10px 20px;' );
+
+		// Assert.
+		$this->assertSame( [ 'padding' => $this->dimensions( '10px', '20px', '10px', '20px' ) ], $result['props'] );
+		$this->assertSame( '', $result['customCss'] );
+	}
+
+	public function test_dispatcher__declined_value_is_delegated_to_custom_css() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'padding: 1px 2px 3px 4px 5px;' );
+
+		// Assert.
+		$this->assertSame( [], $result['props'] );
+		$this->assertSame( 'padding: 1px 2px 3px 4px 5px;', $result['customCss'] );
+	}
+
+	private function make_dispatcher(): Css_Converter {
+		$registry = ( new Converter_Registry() )
+			->register( new Dimensions_Property_Converter( 'padding' ) );
+
+		return new Css_Converter( $registry, new Null_Failure_Reporter() );
+	}
+
+	private function dimensions( string $top, string $right, string $bottom, string $left ): array {
+		return [
+			'$$type' => 'dimensions',
+			'value' => [
+				'block-start' => $this->px( $top ),
+				'inline-end' => $this->px( $right ),
+				'block-end' => $this->px( $bottom ),
+				'inline-start' => $this->px( $left ),
+			],
+		];
+	}
+
+	private function px( string $value ): array {
+		return [ '$$type' => 'size', 'value' => [ 'size' => (int) $value, 'unit' => 'px' ] ];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-dimensions-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-dimensions-property-converter.php
@@ -7,6 +7,7 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Border_Width_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Dimensions_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use PHPUnit\Framework\TestCase;
@@ -106,6 +107,48 @@ class Test_Dimensions_Property_Converter extends TestCase {
 				],
 			],
 			$context->get_prop( 'padding' )
+		);
+	}
+
+	public function test_convert__injected_wrapper_emits_border_width_object() {
+		// Arrange.
+		$converter = new Dimensions_Property_Converter( 'border-width', Border_Width_Prop_Type::class );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'border-width', 'value' => '1px 2px 3px 4px' ] );
+
+		// Assert: same side mapping as Dimensions, wrapped as border-width.
+		$prop_value = $context->get_prop( 'border-width' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame(
+			[
+				'$$type' => 'border-width',
+				'value' => [
+					'block-start' => $this->px( '1px' ),
+					'inline-end' => $this->px( '2px' ),
+					'block-end' => $this->px( '3px' ),
+					'inline-start' => $this->px( '4px' ),
+				],
+			],
+			$prop_value
+		);
+		$this->assertTrue( Border_Width_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__injected_wrapper_single_value_still_emits_a_size() {
+		// Arrange.
+		$converter = new Dimensions_Property_Converter( 'border-width', Border_Width_Prop_Type::class );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converter->convert( $context, [ 'property' => 'border-width', 'value' => '2px' ] );
+
+		// Assert.
+		$this->assertSame(
+			[ '$$type' => 'size', 'value' => [ 'size' => 2, 'unit' => 'px' ] ],
+			$context->get_prop( 'border-width' )
 		);
 	}
 

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-filter-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-filter-property-converter.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Filter_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Backdrop_Filter_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Filters\Filter_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Filter_Property_Converter extends TestCase {
+
+	public function test_convert__emits_a_filter_prop_value_that_validates_against_the_prop_type() {
+		// Arrange.
+		$converter = new Filter_Property_Converter( 'filter', Filter_Prop_Type::get_key() );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'filter', 'value' => 'blur(5px) brightness(150%)' ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'filter' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame( 'filter', $prop_value['$$type'] );
+		$this->assertCount( 2, $prop_value['value'] );
+		$this->assertTrue( Filter_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__drop_shadow_validates_against_the_prop_type() {
+		// Arrange.
+		$converter = new Filter_Property_Converter( 'filter', Filter_Prop_Type::get_key() );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converter->convert( $context, [ 'property' => 'filter', 'value' => 'drop-shadow(2px 4px 6px black)' ] );
+
+		// Assert.
+		$this->assertTrue( Filter_Prop_Type::make()->validate( $context->get_prop( 'filter' ) ) );
+	}
+
+	public function test_convert__backdrop_filter_wraps_with_its_own_type_key() {
+		// Arrange.
+		$converter = new Filter_Property_Converter( 'backdrop-filter', Backdrop_Filter_Prop_Type::get_key() );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converter->convert( $context, [ 'property' => 'backdrop-filter', 'value' => 'blur(10px)' ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'backdrop-filter' );
+
+		$this->assertSame( 'backdrop-filter', $prop_value['$$type'] );
+		$this->assertTrue( Backdrop_Filter_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__declines_unsupported_function() {
+		// Arrange.
+		$converter = new Filter_Property_Converter( 'filter', Filter_Prop_Type::get_key() );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'filter', 'value' => 'opacity(50%)' ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertFalse( $context->has_prop( 'filter' ) );
+	}
+
+	public function test_dispatcher__valid_value_lands_in_props() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'filter: blur(5px);' );
+
+		// Assert.
+		$this->assertArrayHasKey( 'filter', $result['props'] );
+		$this->assertSame( 'filter', $result['props']['filter']['$$type'] );
+		$this->assertSame( '', $result['customCss'] );
+	}
+
+	public function test_dispatcher__declined_value_is_delegated_to_custom_css() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'filter: opacity(50%);' );
+
+		// Assert.
+		$this->assertSame( [], $result['props'] );
+		$this->assertSame( 'filter: opacity(50%);', $result['customCss'] );
+	}
+
+	private function make_dispatcher(): Css_Converter {
+		$registry = ( new Converter_Registry() )
+			->register( new Filter_Property_Converter( 'filter', Filter_Prop_Type::get_key() ) );
+
+		return new Css_Converter( $registry, new Null_Failure_Reporter() );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-flex-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-flex-property-converter.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Flex_Property_Converter;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Flex_Property_Converter extends TestCase {
+	private Flex_Property_Converter $converter;
+	private Conversion_Context $context;
+
+	public function setUp(): void {
+		$this->converter = new Flex_Property_Converter();
+		$this->context   = new Conversion_Context( [] );
+	}
+
+	public function test_convert__none_keyword_maps_to_0_1_auto() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'none' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertFlex( 0, 1, 'auto', 'custom' );
+	}
+
+	public function test_convert__auto_keyword_maps_to_1_1_auto() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'auto' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertFlex( 1, 1, 'auto', 'custom' );
+	}
+
+	public function test_convert__single_number_sets_grow_with_defaults() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '2' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertFlex( 2.0, 1.0, 0, 'px' );
+	}
+
+	public function test_convert__two_tokens_grow_and_basis() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '1 100px' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertFlex( 1.0, 1.0, 100.0, 'px' );
+	}
+
+	public function test_convert__three_tokens_grow_shrink_basis() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '2 3 50%' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertFlex( 2.0, 3.0, 50.0, '%' );
+	}
+
+	public function test_convert__three_tokens_with_auto_basis() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '1 0 auto' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertFlex( 1.0, 0.0, 'auto', 'custom' );
+	}
+
+	/** @dataProvider declining_provider */
+	public function test_convert__declines_unsupported_values( string $value ) {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( $value ) );
+
+		// Assert.
+		$this->assertFalse( $result );
+		$this->assertNull( $this->context->get_prop( 'flex' ) );
+	}
+
+	public static function declining_provider(): array {
+		return [
+			'non-numeric grow'       => [ 'foo 1 100px' ],
+			'non-numeric shrink'     => [ '1 foo 100px' ],
+			'invalid basis'          => [ '1 1 banana' ],
+			'four tokens'            => [ '1 2 3 4' ],
+		];
+	}
+
+	private function assertFlex( $grow, $shrink, $basis_size, string $basis_unit ): void {
+		$prop = $this->context->get_prop( 'flex' );
+		$this->assertSame( 'flex', $prop['$$type'] );
+		$this->assertEquals( $grow, $prop['value']['flexGrow']['value'] );
+		$this->assertEquals( $shrink, $prop['value']['flexShrink']['value'] );
+		$this->assertEquals( $basis_size, $prop['value']['flexBasis']['value']['size'] );
+		$this->assertSame( $basis_unit, $prop['value']['flexBasis']['value']['unit'] );
+	}
+
+	private function rule( string $value ): array {
+		return [ 'property' => 'flex', 'value' => $value ];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-number-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-number-property-converter.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Number_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Number_Property_Converter extends TestCase {
+
+	public function test_convert__emits_canonical_prop_value_that_validates_against_the_prop_type() {
+		// Arrange.
+		$converter = new Number_Property_Converter( 'z-index' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'z-index', 'value' => '5' ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'z-index' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame( [ '$$type' => 'number', 'value' => 5 ], $prop_value );
+		$this->assertTrue( Number_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__accepts_negative_integer() {
+		// Arrange.
+		$converter = new Number_Property_Converter( 'order' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converter->convert( $context, [ 'property' => 'order', 'value' => '-1' ] );
+
+		// Assert.
+		$this->assertSame( [ '$$type' => 'number', 'value' => -1 ], $context->get_prop( 'order' ) );
+	}
+
+	/**
+	 * @dataProvider non_numeric_values
+	 */
+	public function test_convert__declines_non_numeric_value( string $value ) {
+		// Arrange.
+		$converter = new Number_Property_Converter( 'z-index' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'z-index', 'value' => $value ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertFalse( $context->has_prop( 'z-index' ) );
+	}
+
+	public function non_numeric_values(): array {
+		return [
+			'with unit' => [ '10px' ],
+			'function' => [ 'calc(1 + 1)' ],
+			'keyword' => [ 'auto' ],
+			'empty' => [ '   ' ],
+		];
+	}
+
+	public function test_dispatcher__valid_value_lands_in_props() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'z-index: 5;' );
+
+		// Assert.
+		$this->assertSame( [ 'z-index' => [ '$$type' => 'number', 'value' => 5 ] ], $result['props'] );
+		$this->assertSame( '', $result['customCss'] );
+	}
+
+	public function test_dispatcher__declined_value_is_delegated_to_custom_css() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'z-index: calc(1 + 1);' );
+
+		// Assert.
+		$this->assertSame( [], $result['props'] );
+		$this->assertSame( 'z-index: calc(1 + 1);', $result['customCss'] );
+	}
+
+	private function make_dispatcher(): Css_Converter {
+		$registry = ( new Converter_Registry() )
+			->register( new Number_Property_Converter( 'z-index' ) );
+
+		return new Css_Converter( $registry, new Null_Failure_Reporter() );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-object-field-merge-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-object-field-merge-converter.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Field_Merge_Converter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * DB-less: asserts the raw PropValue structure only. Background_Prop_Type::make()/validate() build the
+ * image-overlay shape which calls WordPress (Image_Sizes), so schema validation lives in the REST suite.
+ */
+class Test_Object_Field_Merge_Converter extends TestCase {
+	const CLIP_ENUM = [ 'border-box', 'padding-box', 'content-box', 'text' ];
+
+	public function test_convert__first_time_creates_partial_background_object() {
+		// Arrange.
+		$converter = $this->color_converter();
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'background-color', 'value' => 'red' ] );
+
+		// Assert.
+		$this->assertTrue( $converted );
+		$this->assertSame(
+			[ '$$type' => 'background', 'value' => [ 'color' => $this->color( 'red' ) ] ],
+			$context->get_prop( 'background' )
+		);
+	}
+
+	public function test_convert__merges_sibling_fields_into_one_object() {
+		// Arrange.
+		$context = new Conversion_Context();
+
+		// Act: color + clip accumulate into the same background object.
+		$this->color_converter()->convert( $context, [ 'property' => 'background-color', 'value' => 'red' ] );
+		$this->clip_converter()->convert( $context, [ 'property' => 'background-clip', 'value' => 'text' ] );
+
+		// Assert.
+		$this->assertSame(
+			[
+				'$$type' => 'background',
+				'value' => [
+					'color' => $this->color( 'red' ),
+					'clip' => $this->string( 'text' ),
+				],
+			],
+			$context->get_prop( 'background' )
+		);
+	}
+
+	public function test_convert__declines_multi_token_color_and_leaves_target_untouched() {
+		// Arrange.
+		$context = new Conversion_Context();
+		$this->color_converter()->convert( $context, [ 'property' => 'background-color', 'value' => 'red' ] );
+
+		// Act: a two-token color has no faithful single-Color representation.
+		$converted = $this->color_converter()->convert( $context, [ 'property' => 'background-color', 'value' => 'red blue' ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertSame(
+			[ '$$type' => 'background', 'value' => [ 'color' => $this->color( 'red' ) ] ],
+			$context->get_prop( 'background' )
+		);
+	}
+
+	public function test_convert__keeps_functional_color_with_internal_spaces_as_one_token() {
+		// Arrange.
+		$converter = $this->color_converter();
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'background-color', 'value' => 'rgb(255 0 0)' ] );
+
+		// Assert.
+		$this->assertTrue( $converted );
+		$this->assertSame(
+			[ '$$type' => 'background', 'value' => [ 'color' => $this->color( 'rgb(255 0 0)' ) ] ],
+			$context->get_prop( 'background' )
+		);
+	}
+
+	public function test_convert__declines_out_of_enum_clip() {
+		// Arrange.
+		$converter = $this->clip_converter();
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'background-clip', 'value' => 'banana' ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertNull( $context->get_prop( 'background' ) );
+	}
+
+	private function color_converter(): Object_Field_Merge_Converter {
+		return new Object_Field_Merge_Converter(
+			'background-color',
+			'background',
+			'background',
+			'color',
+			Color_Prop_Type::class,
+			\Elementor\Modules\AtomicWidgets\PropTypes\Background_Prop_Type::class,
+			null,
+			true
+		);
+	}
+
+	private function clip_converter(): Object_Field_Merge_Converter {
+		return new Object_Field_Merge_Converter(
+			'background-clip',
+			'background',
+			'background',
+			'clip',
+			String_Prop_Type::class,
+			\Elementor\Modules\AtomicWidgets\PropTypes\Background_Prop_Type::class,
+			self::CLIP_ENUM
+		);
+	}
+
+	private function color( string $value ): array {
+		return [ '$$type' => 'color', 'value' => $value ];
+	}
+
+	private function string( string $value ): array {
+		return [ '$$type' => 'string', 'value' => $value ];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-object-position-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-object-position-property-converter.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Position_Property_Converter;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Object_Position_Property_Converter extends TestCase {
+	private Object_Position_Property_Converter $converter;
+	private Conversion_Context $context;
+
+	public function setUp(): void {
+		$this->converter = new Object_Position_Property_Converter();
+		$this->context   = new Conversion_Context( [] );
+	}
+
+	/** @dataProvider named_position_provider */
+	public function test_convert__named_position_emits_string_prop_value( string $value ) {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( $value ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertSame( [ '$$type' => 'string', 'value' => $value ], $this->context->get_prop( 'object-position' ) );
+	}
+
+	public static function named_position_provider(): array {
+		return [
+			'center center' => [ 'center center' ],
+			'top left'      => [ 'top left' ],
+			'bottom right'  => [ 'bottom right' ],
+			'top center'    => [ 'top center' ],
+		];
+	}
+
+	public function test_convert__percentage_pair_emits_position_prop_value() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '50% 30%' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$prop = $this->context->get_prop( 'object-position' );
+		$this->assertSame( 'object-position', $prop['$$type'] );
+		$this->assertEquals( 50, $prop['value']['x']['value']['size'] );
+		$this->assertSame( '%', $prop['value']['x']['value']['unit'] );
+		$this->assertEquals( 30, $prop['value']['y']['value']['size'] );
+		$this->assertSame( '%', $prop['value']['y']['value']['unit'] );
+	}
+
+	public function test_convert__pixel_pair_emits_position_prop_value() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '10px 20px' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$prop = $this->context->get_prop( 'object-position' );
+		$this->assertSame( 'object-position', $prop['$$type'] );
+		$this->assertEquals( 10, $prop['value']['x']['value']['size'] );
+		$this->assertSame( 'px', $prop['value']['x']['value']['unit'] );
+		$this->assertEquals( 20, $prop['value']['y']['value']['size'] );
+		$this->assertSame( 'px', $prop['value']['y']['value']['unit'] );
+	}
+
+	/** @dataProvider declining_provider */
+	public function test_convert__declines_unsupported_values( string $value ) {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( $value ) );
+
+		// Assert.
+		$this->assertFalse( $result );
+		$this->assertNull( $this->context->get_prop( 'object-position' ) );
+	}
+
+	public static function declining_provider(): array {
+		return [
+			'single keyword'       => [ 'center' ],
+			'three tokens'         => [ '10px 20px 30px' ],
+			'non-size second token' => [ '10px banana' ],
+			'unknown keyword pair' => [ 'left middle' ],
+		];
+	}
+
+	private function rule( string $value ): array {
+		return [ 'property' => 'object-position', 'value' => $value ];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-object-side-merge-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-object-side-merge-converter.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Side_Merge_Converter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Border_Radius_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Border_Width_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Object_Side_Merge_Converter extends TestCase {
+	const WIDTH_KEYS = [ 'block-start', 'inline-end', 'block-end', 'inline-start' ];
+	const RADIUS_KEYS = [ 'start-start', 'start-end', 'end-end', 'end-start' ];
+
+	public function test_convert__first_time_creates_partial_object() {
+		// Arrange.
+		$converter = $this->width_converter( 'border-top-width', 'block-start' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'border-top-width', 'value' => '2px' ] );
+
+		// Assert: only the named side is set; the partial object still validates.
+		$prop_value = $context->get_prop( 'border-width' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame(
+			[ '$$type' => 'border-width', 'value' => [ 'block-start' => $this->size( 2 ) ] ],
+			$prop_value
+		);
+		$this->assertTrue( Border_Width_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__merges_sibling_sides_into_one_object() {
+		// Arrange.
+		$context = new Conversion_Context();
+
+		// Act: two side declarations accumulate into the same border-width object.
+		$this->width_converter( 'border-top-width', 'block-start' )
+			->convert( $context, [ 'property' => 'border-top-width', 'value' => '2px' ] );
+		$this->width_converter( 'border-right-width', 'inline-end' )
+			->convert( $context, [ 'property' => 'border-right-width', 'value' => '3px' ] );
+
+		// Assert.
+		$this->assertSame(
+			[
+				'$$type' => 'border-width',
+				'value' => [
+					'block-start' => $this->size( 2 ),
+					'inline-end' => $this->size( 3 ),
+				],
+			],
+			$context->get_prop( 'border-width' )
+		);
+	}
+
+	public function test_convert__seeds_all_sides_from_a_prior_single_size() {
+		// Arrange: a prior `border-width: 1px` left the single Size member in context.
+		$context = new Conversion_Context();
+		$context->set_prop( 'border-width', $this->size( 1 ) );
+
+		// Act.
+		$this->width_converter( 'border-top-width', 'block-start' )
+			->convert( $context, [ 'property' => 'border-top-width', 'value' => '2px' ] );
+
+		// Assert: every side seeded from 1px, the named side overridden to 2px (faithful cascade).
+		$this->assertSame(
+			[
+				'$$type' => 'border-width',
+				'value' => [
+					'block-start' => $this->size( 2 ),
+					'inline-end' => $this->size( 1 ),
+					'block-end' => $this->size( 1 ),
+					'inline-start' => $this->size( 1 ),
+				],
+			],
+			$context->get_prop( 'border-width' )
+		);
+	}
+
+	public function test_convert__radius_corner_merges_into_border_radius() {
+		// Arrange.
+		$converter = new Object_Side_Merge_Converter(
+			'border-top-left-radius',
+			'border-radius',
+			'border-radius',
+			'start-start',
+			self::RADIUS_KEYS,
+			Border_Radius_Prop_Type::class
+		);
+		$context = new Conversion_Context();
+
+		// Act.
+		$converter->convert( $context, [ 'property' => 'border-top-left-radius', 'value' => '10px' ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'border-radius' );
+
+		$this->assertSame(
+			[ '$$type' => 'border-radius', 'value' => [ 'start-start' => $this->size( 10 ) ] ],
+			$prop_value
+		);
+		$this->assertTrue( Border_Radius_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__declines_unparsable_value_and_leaves_target_untouched() {
+		// Arrange.
+		$context = new Conversion_Context();
+		$context->set_prop( 'border-width', $this->size( 1 ) );
+
+		// Act.
+		$converted = $this->width_converter( 'border-top-width', 'block-start' )
+			->convert( $context, [ 'property' => 'border-top-width', 'value' => 'banana' ] );
+
+		// Assert: declared, target object is unchanged.
+		$this->assertFalse( $converted );
+		$this->assertSame( $this->size( 1 ), $context->get_prop( 'border-width' ) );
+	}
+
+	private function width_converter( string $property, string $side_key ): Object_Side_Merge_Converter {
+		return new Object_Side_Merge_Converter(
+			$property,
+			'border-width',
+			'border-width',
+			$side_key,
+			self::WIDTH_KEYS,
+			Border_Width_Prop_Type::class
+		);
+	}
+
+	private function size( int $value ): array {
+		return [ '$$type' => 'size', 'value' => [ 'size' => $value, 'unit' => 'px' ] ];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-rejected-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-rejected-converter.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Rejected_Converter;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Rejected_Converter extends TestCase {
+	public function test_convert__adds_declaration_to_rejected_and_returns_true() {
+		// Arrange.
+		$converter = new Rejected_Converter( 'animation' );
+		$context = new Conversion_Context( [] );
+
+		// Act.
+		$result = $converter->convert( $context, [
+			'property'    => 'animation',
+			'value'       => 'spin 1s linear infinite',
+			'declaration' => 'animation: spin 1s linear infinite',
+		] );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertSame( [ 'animation: spin 1s linear infinite;' ], $context->get_rejected() );
+		$this->assertEmpty( $context->get_props() );
+	}
+
+	public function test_convert__multiple_rejected_declarations_accumulate() {
+		// Arrange.
+		$converter_anim = new Rejected_Converter( 'animation' );
+		$converter_name = new Rejected_Converter( 'animation-name' );
+		$context = new Conversion_Context( [] );
+
+		// Act.
+		$converter_anim->convert( $context, [
+			'property' => 'animation', 'value' => 'spin 1s', 'declaration' => 'animation: spin 1s',
+		] );
+		$converter_name->convert( $context, [
+			'property' => 'animation-name', 'value' => 'slide', 'declaration' => 'animation-name: slide',
+		] );
+
+		// Assert.
+		$this->assertCount( 2, $context->get_rejected() );
+		$this->assertSame( 'animation: spin 1s;', $context->get_rejected()[0] );
+		$this->assertSame( 'animation-name: slide;', $context->get_rejected()[1] );
+	}
+
+	public function test_convert__rejected_property_does_not_appear_in_custom_css() {
+		// Arrange.
+		$converter = new Rejected_Converter( 'animation' );
+		$context = new Conversion_Context( [] );
+
+		// Act.
+		$converter->convert( $context, [
+			'property' => 'animation', 'value' => 'spin 1s', 'declaration' => 'animation: spin 1s',
+		] );
+
+		// Assert: returns true so the converter loop does NOT add to leftover/customCss.
+		$this->assertEmpty( $context->get_props() );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-size-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-size-property-converter.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Size_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Size_Property_Converter extends TestCase {
+
+	public function test_convert__emits_canonical_prop_value_that_validates_against_the_prop_type() {
+		// Arrange.
+		$converter = new Size_Property_Converter( 'width' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'width', 'value' => '10px' ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'width' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame( [ '$$type' => 'size', 'value' => [ 'size' => 10, 'unit' => 'px' ] ], $prop_value );
+		$this->assertTrue( Size_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__emits_custom_unit_for_dynamic_value() {
+		// Arrange.
+		$converter = new Size_Property_Converter( 'width' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'width', 'value' => 'calc(100% - 20px)' ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'width' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame( [ '$$type' => 'size', 'value' => [ 'size' => 'calc(100% - 20px)', 'unit' => 'custom' ] ], $prop_value );
+		$this->assertTrue( Size_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__emits_auto_unit_that_validates() {
+		// Arrange.
+		$converter = new Size_Property_Converter( 'height' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'height', 'value' => 'auto' ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'height' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame( [ '$$type' => 'size', 'value' => [ 'size' => null, 'unit' => 'auto' ] ], $prop_value );
+		$this->assertTrue( Size_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__declines_unrepresentable_value() {
+		// Arrange.
+		$converter = new Size_Property_Converter( 'width' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'width', 'value' => 'banana' ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertFalse( $context->has_prop( 'width' ) );
+	}
+
+	public function test_dispatcher__valid_value_lands_in_props() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'width: 10px;' );
+
+		// Assert.
+		$this->assertSame(
+			[ 'width' => [ '$$type' => 'size', 'value' => [ 'size' => 10, 'unit' => 'px' ] ] ],
+			$result['props']
+		);
+		$this->assertSame( '', $result['customCss'] );
+	}
+
+	public function test_dispatcher__declined_value_is_delegated_to_custom_css() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'width: banana;' );
+
+		// Assert.
+		$this->assertSame( [], $result['props'] );
+		$this->assertSame( 'width: banana;', $result['customCss'] );
+	}
+
+	private function make_dispatcher(): Css_Converter {
+		$registry = ( new Converter_Registry() )
+			->register( new Size_Property_Converter( 'width' ) );
+
+		return new Css_Converter( $registry, new Null_Failure_Reporter() );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-size-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-size-property-converter.php
@@ -64,6 +64,35 @@ class Test_Size_Property_Converter extends TestCase {
 		$this->assertTrue( Size_Prop_Type::make()->validate( $prop_value ) );
 	}
 
+	public function test_convert__keeps_unitless_line_height_as_custom_when_allowed() {
+		// Arrange.
+		$converter = new Size_Property_Converter( 'line-height', true );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'line-height', 'value' => '1.1' ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'line-height' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame( [ '$$type' => 'size', 'value' => [ 'size' => '1.1', 'unit' => 'custom' ] ], $prop_value );
+		$this->assertTrue( Size_Prop_Type::make()->validate( $prop_value ) );
+	}
+
+	public function test_convert__declines_unitless_value_without_the_flag() {
+		// Arrange.
+		$converter = new Size_Property_Converter( 'width' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'width', 'value' => '1.1' ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertFalse( $context->has_prop( 'width' ) );
+	}
+
 	public function test_convert__declines_unrepresentable_value() {
 		// Arrange.
 		$converter = new Size_Property_Converter( 'width' );

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-span-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-span-property-converter.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Span_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Span_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Span_Property_Converter extends TestCase {
+	const GRID_PATTERN = '/^(?!.*https?:\/\/)(?!.*;).*$/';
+
+	/**
+	 * @dataProvider valid_values
+	 */
+	public function test_convert__emits_canonical_prop_value_that_validates_against_the_prop_type( string $value ) {
+		// Arrange.
+		$converter = new Span_Property_Converter( 'grid-column', self::GRID_PATTERN );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'grid-column', 'value' => $value ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'grid-column' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame( [ '$$type' => 'span', 'value' => $value ], $prop_value );
+		$this->assertTrue( Span_Prop_Type::make()->regex( self::GRID_PATTERN )->validate( $prop_value ) );
+	}
+
+	public function valid_values(): array {
+		return [
+			'span keyword' => [ 'span 2' ],
+			'line range' => [ '1 / 3' ],
+			'auto' => [ 'auto' ],
+			'named line' => [ 'col-start / col-end' ],
+		];
+	}
+
+	public function test_convert__trims_surrounding_whitespace() {
+		// Arrange.
+		$converter = new Span_Property_Converter( 'grid-row', self::GRID_PATTERN );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converter->convert( $context, [ 'property' => 'grid-row', 'value' => '  span 3  ' ] );
+
+		// Assert.
+		$this->assertSame( [ '$$type' => 'span', 'value' => 'span 3' ], $context->get_prop( 'grid-row' ) );
+	}
+
+	public function test_convert__declines_value_that_violates_the_pattern() {
+		// Arrange.
+		$converter = new Span_Property_Converter( 'grid-column', self::GRID_PATTERN );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'grid-column', 'value' => 'url(https://evil.example)' ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertFalse( $context->has_prop( 'grid-column' ) );
+	}
+
+	public function test_convert__declines_empty_value() {
+		// Arrange.
+		$converter = new Span_Property_Converter( 'grid-column', self::GRID_PATTERN );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'grid-column', 'value' => '   ' ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertFalse( $context->has_prop( 'grid-column' ) );
+	}
+
+	public function test_convert__without_pattern_accepts_any_non_empty_value() {
+		// Arrange.
+		$converter = new Span_Property_Converter( 'grid-column' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'grid-column', 'value' => 'span 5' ] );
+
+		// Assert.
+		$this->assertTrue( $converted );
+		$this->assertSame( [ '$$type' => 'span', 'value' => 'span 5' ], $context->get_prop( 'grid-column' ) );
+	}
+
+	public function test_dispatcher__valid_value_lands_in_props() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'grid-column: span 2;' );
+
+		// Assert.
+		$this->assertSame( [ 'grid-column' => [ '$$type' => 'span', 'value' => 'span 2' ] ], $result['props'] );
+		$this->assertSame( '', $result['customCss'] );
+	}
+
+	public function test_dispatcher__declined_value_is_delegated_to_custom_css() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'grid-column: url(https://evil.example);' );
+
+		// Assert.
+		$this->assertSame( [], $result['props'] );
+		$this->assertSame( 'grid-column: url(https://evil.example);', $result['customCss'] );
+	}
+
+	private function make_dispatcher(): Css_Converter {
+		$registry = ( new Converter_Registry() )
+			->register( new Span_Property_Converter( 'grid-column', self::GRID_PATTERN ) );
+
+		return new Css_Converter( $registry, new Null_Failure_Reporter() );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-string-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-string-property-converter.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\String_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_String_Property_Converter extends TestCase {
+	const FONT_WEIGHT_ENUM = [ '100', '200', '300', '400', '500', '600', '700', '800', '900', 'normal', 'bold', 'bolder', 'lighter' ];
+
+	public function test_convert__emits_canonical_prop_value_that_validates_against_the_prop_type() {
+		// Arrange.
+		$converter = new String_Property_Converter( 'font-weight', self::FONT_WEIGHT_ENUM );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'font-weight', 'value' => '700' ] );
+
+		// Assert.
+		$prop_value = $context->get_prop( 'font-weight' );
+
+		$this->assertTrue( $converted );
+		$this->assertSame( [ '$$type' => 'string', 'value' => '700' ], $prop_value );
+		$this->assertTrue( String_Prop_Type::make()->enum( self::FONT_WEIGHT_ENUM )->validate( $prop_value ) );
+	}
+
+	public function test_convert__trims_surrounding_whitespace() {
+		// Arrange.
+		$converter = new String_Property_Converter( 'font-weight', self::FONT_WEIGHT_ENUM );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converter->convert( $context, [ 'property' => 'font-weight', 'value' => '  bold  ' ] );
+
+		// Assert.
+		$this->assertSame( [ '$$type' => 'string', 'value' => 'bold' ], $context->get_prop( 'font-weight' ) );
+	}
+
+	public function test_convert__declines_value_outside_the_enum() {
+		// Arrange.
+		$converter = new String_Property_Converter( 'font-weight', self::FONT_WEIGHT_ENUM );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'font-weight', 'value' => '950' ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertFalse( $context->has_prop( 'font-weight' ) );
+	}
+
+	public function test_convert__declines_empty_value() {
+		// Arrange.
+		$converter = new String_Property_Converter( 'font-weight', self::FONT_WEIGHT_ENUM );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'font-weight', 'value' => '   ' ] );
+
+		// Assert.
+		$this->assertFalse( $converted );
+		$this->assertFalse( $context->has_prop( 'font-weight' ) );
+	}
+
+	public function test_convert__without_allowlist_accepts_any_non_empty_value() {
+		// Arrange.
+		$converter = new String_Property_Converter( 'font-family' );
+		$context = new Conversion_Context();
+
+		// Act.
+		$converted = $converter->convert( $context, [ 'property' => 'font-family', 'value' => 'Inter, sans-serif' ] );
+
+		// Assert.
+		$this->assertTrue( $converted );
+		$this->assertSame( [ '$$type' => 'string', 'value' => 'Inter, sans-serif' ], $context->get_prop( 'font-family' ) );
+	}
+
+	public function test_dispatcher__valid_value_lands_in_props() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'font-weight: 700;' );
+
+		// Assert.
+		$this->assertSame( [ 'font-weight' => [ '$$type' => 'string', 'value' => '700' ] ], $result['props'] );
+		$this->assertSame( '', $result['customCss'] );
+	}
+
+	public function test_dispatcher__declined_value_is_delegated_to_custom_css() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'font-weight: 950;' );
+
+		// Assert.
+		$this->assertSame( [], $result['props'] );
+		$this->assertSame( 'font-weight: 950;', $result['customCss'] );
+	}
+
+	private function make_dispatcher(): Css_Converter {
+		$registry = ( new Converter_Registry() )
+			->register( new String_Property_Converter( 'font-weight', self::FONT_WEIGHT_ENUM ) );
+
+		return new Css_Converter( $registry, new Null_Failure_Reporter() );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-transform-origin-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-transform-origin-property-converter.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Transform_Origin_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Transform_Property_Converter;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Transform_Origin_Property_Converter extends TestCase {
+	private Transform_Origin_Property_Converter $converter;
+	private Conversion_Context $context;
+
+	public function setUp(): void {
+		$this->converter = new Transform_Origin_Property_Converter();
+		$this->context   = new Conversion_Context( [] );
+	}
+
+	public function test_convert__single_center_keyword_sets_both_axes_to_50_percent() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'center' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$origin = $this->origin_fields();
+		$this->assertSame( 50, $origin['x']['value']['size'] );
+		$this->assertSame( '%', $origin['x']['value']['unit'] );
+		$this->assertSame( 50, $origin['y']['value']['size'] );
+	}
+
+	public function test_convert__single_left_keyword_pins_x_and_centers_y() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'left' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$origin = $this->origin_fields();
+		$this->assertSame( 0, $origin['x']['value']['size'] );
+		$this->assertSame( 50, $origin['y']['value']['size'] );
+	}
+
+	public function test_convert__single_top_keyword_pins_y_and_centers_x() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'top' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$origin = $this->origin_fields();
+		$this->assertSame( 50, $origin['x']['value']['size'] );
+		$this->assertSame( 0, $origin['y']['value']['size'] );
+	}
+
+	public function test_convert__single_length_sets_x_and_defaults_y_to_center() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '20px' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$origin = $this->origin_fields();
+		$this->assertEquals( 20, $origin['x']['value']['size'] );
+		$this->assertSame( 'px', $origin['x']['value']['unit'] );
+		$this->assertSame( 50, $origin['y']['value']['size'] );
+	}
+
+	public function test_convert__two_values_with_keywords() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'right bottom' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$origin = $this->origin_fields();
+		$this->assertSame( 100, $origin['x']['value']['size'] );
+		$this->assertSame( 100, $origin['y']['value']['size'] );
+	}
+
+	public function test_convert__two_values_with_lengths_and_percents() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( '10px 25%' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$origin = $this->origin_fields();
+		$this->assertEquals( 10, $origin['x']['value']['size'] );
+		$this->assertSame( 'px', $origin['x']['value']['unit'] );
+		$this->assertEquals( 25, $origin['y']['value']['size'] );
+		$this->assertSame( '%', $origin['y']['value']['unit'] );
+	}
+
+	public function test_convert__three_values_include_z_length() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'left top 5px' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$origin = $this->origin_fields();
+		$this->assertSame( 0, $origin['x']['value']['size'] );
+		$this->assertSame( 0, $origin['y']['value']['size'] );
+		$this->assertEquals( 5, $origin['z']['value']['size'] );
+		$this->assertSame( 'px', $origin['z']['value']['unit'] );
+	}
+
+	public function test_convert__merges_with_existing_transform_functions() {
+		// Arrange.
+		( new Transform_Property_Converter() )->convert( $this->context, $this->rule_for( 'transform', 'rotate(45deg)' ) );
+
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'center' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$transform = $this->context->get_prop( 'transform' );
+		$this->assertArrayHasKey( 'transform-functions', $transform['value'] );
+		$this->assertArrayHasKey( 'transform-origin', $transform['value'] );
+	}
+
+	/** @dataProvider declining_provider */
+	public function test_convert__declines_invalid_input( string $value ) {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( $value ) );
+
+		// Assert.
+		$this->assertFalse( $result );
+		$this->assertNull( $this->context->get_prop( 'transform' ) );
+	}
+
+	public static function declining_provider(): array {
+		return [
+			'four tokens'        => [ '10px 10px 10px 10px' ],
+			'empty'              => [ '' ],
+			'z as percent'       => [ '10px 10px 50%' ],
+			'invalid unit'       => [ '10s' ],
+			'unknown keyword'    => [ 'middle' ],
+		];
+	}
+
+	private function origin_fields(): array {
+		$transform = $this->context->get_prop( 'transform' );
+		return $transform['value']['transform-origin']['value'];
+	}
+
+	private function rule( string $value ): array {
+		return $this->rule_for( 'transform-origin', $value );
+	}
+
+	private function rule_for( string $property, string $value ): array {
+		return [ 'property' => $property, 'value' => $value, 'declaration' => "$property: $value" ];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-transform-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-transform-property-converter.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Transform_Property_Converter;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Transform_Property_Converter extends TestCase {
+	private Transform_Property_Converter $converter;
+	private Conversion_Context $context;
+
+	public function setUp(): void {
+		$this->converter = new Transform_Property_Converter();
+		$this->context   = new Conversion_Context( [] );
+	}
+
+	public function test_convert__translate_single_arg_emits_move_with_zero_y_z() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'translate(50%)' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$fn = $this->first_function();
+		$this->assertSame( 'transform-move', $fn['$$type'] );
+		$this->assertSame( '%', $fn['value']['x']['value']['unit'] );
+		$this->assertSame( 'px', $fn['value']['y']['value']['unit'] );
+		$this->assertEquals( 0, $fn['value']['y']['value']['size'] );
+	}
+
+	public function test_convert__translateX_emits_move_with_x_set() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'translateX(10px)' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$fn = $this->first_function();
+		$this->assertSame( 'transform-move', $fn['$$type'] );
+		$this->assertEquals( 10, $fn['value']['x']['value']['size'] );
+		$this->assertSame( 'px', $fn['value']['x']['value']['unit'] );
+		$this->assertEquals( 0, $fn['value']['y']['value']['size'] );
+		$this->assertEquals( 0, $fn['value']['z']['value']['size'] );
+	}
+
+	public function test_convert__scale_single_arg_applies_to_x_and_y() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'scale(1.5)' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$fn = $this->first_function();
+		$this->assertSame( 'transform-scale', $fn['$$type'] );
+		$this->assertSame( 1.5, $fn['value']['x']['value'] );
+		$this->assertSame( 1.5, $fn['value']['y']['value'] );
+		$this->assertSame( 1.0, $fn['value']['z']['value'] );
+	}
+
+	public function test_convert__scaleX_sets_x_only() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'scaleX(2)' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$fn = $this->first_function();
+		$this->assertSame( 'transform-scale', $fn['$$type'] );
+		$this->assertSame( 2.0, $fn['value']['x']['value'] );
+		$this->assertSame( 1.0, $fn['value']['y']['value'] );
+		$this->assertSame( 1.0, $fn['value']['z']['value'] );
+	}
+
+	public function test_convert__rotate_emits_rotate_on_z_axis() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'rotate(45deg)' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$fn = $this->first_function();
+		$this->assertSame( 'transform-rotate', $fn['$$type'] );
+		$this->assertEquals( 45, $fn['value']['z']['value']['size'] );
+		$this->assertSame( 'deg', $fn['value']['z']['value']['unit'] );
+		$this->assertEquals( 0, $fn['value']['x']['value']['size'] );
+	}
+
+	public function test_convert__rotateY_with_rad_unit() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'rotateY(1.5rad)' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$fn = $this->first_function();
+		$this->assertSame( 'transform-rotate', $fn['$$type'] );
+		$this->assertSame( 'rad', $fn['value']['y']['value']['unit'] );
+	}
+
+	public function test_convert__multiple_functions_chained() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'translateX(10px) rotate(45deg) scale(1.5)' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$prop = $this->context->get_prop( 'transform' );
+		$functions = $prop['value']['transform-functions']['value'];
+		$this->assertCount( 3, $functions );
+		$this->assertSame( 'transform-move', $functions[0]['$$type'] );
+		$this->assertSame( 'transform-rotate', $functions[1]['$$type'] );
+		$this->assertSame( 'transform-scale', $functions[2]['$$type'] );
+	}
+
+	/** @dataProvider declining_provider */
+	public function test_convert__declines_unsupported_functions( string $value ) {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( $value ) );
+
+		// Assert.
+		$this->assertFalse( $result );
+		$this->assertNull( $this->context->get_prop( 'transform' ) );
+	}
+
+	public static function declining_provider(): array {
+		return [
+			'matrix'         => [ 'matrix(1,0,0,1,0,0)' ],
+			'perspective fn' => [ 'perspective(500px)' ],
+			'skew'           => [ 'skewX(10deg)' ],
+			'rotate3d'       => [ 'rotate3d(1,0,0,45deg)' ],
+			'invalid unit'   => [ 'translateX(10s)' ],
+			'non-numeric scale' => [ 'scale(foo)' ],
+		];
+	}
+
+	private function first_function(): array {
+		$prop = $this->context->get_prop( 'transform' );
+		return $prop['value']['transform-functions']['value'][0];
+	}
+
+	private function rule( string $value ): array {
+		return [ 'property' => 'transform', 'value' => $value, 'declaration' => "transform: $value" ];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-transition-property-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-transition-property-converter.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Transition_Property_Converter;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Transition_Property_Converter extends TestCase {
+	private Transition_Property_Converter $converter;
+	private Conversion_Context $context;
+
+	public function setUp(): void {
+		$this->converter = new Transition_Property_Converter();
+		$this->context   = new Conversion_Context( [] );
+	}
+
+	public function test_convert__all_with_ms_duration() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'all 300ms' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$prop = $this->context->get_prop( 'transition' );
+		$this->assertSame( 'transition', $prop['$$type'] );
+		$this->assertCount( 1, $prop['value'] );
+		$this->assertSame( 'all', $prop['value'][0]['value']['selection']['value']['value']['value'] );
+		$this->assertEquals( 300, $prop['value'][0]['value']['size']['value']['size'] );
+		$this->assertSame( 'ms', $prop['value'][0]['value']['size']['value']['unit'] );
+	}
+
+	public function test_convert__property_with_seconds_duration() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'opacity 0.5s' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$prop = $this->context->get_prop( 'transition' );
+		$this->assertSame( 'opacity', $prop['value'][0]['value']['selection']['value']['value']['value'] );
+		$this->assertSame( 's', $prop['value'][0]['value']['size']['value']['unit'] );
+	}
+
+	public function test_convert__easing_function_is_silently_dropped() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'transform 200ms ease-in-out' ) );
+
+		// Assert: converts successfully despite easing token being unparseable as a time.
+		$this->assertTrue( $result );
+		$prop = $this->context->get_prop( 'transition' );
+		$this->assertSame( 'transform', $prop['value'][0]['value']['selection']['value']['value']['value'] );
+		$this->assertEquals( 200, $prop['value'][0]['value']['size']['value']['size'] );
+		$this->assertSame( 'ms', $prop['value'][0]['value']['size']['value']['unit'] );
+	}
+
+	public function test_convert__multiple_layers_comma_separated() {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( 'opacity 300ms, transform 500ms' ) );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$prop = $this->context->get_prop( 'transition' );
+		$this->assertCount( 2, $prop['value'] );
+		$this->assertSame( 'opacity', $prop['value'][0]['value']['selection']['value']['value']['value'] );
+		$this->assertSame( 'transform', $prop['value'][1]['value']['selection']['value']['value']['value'] );
+	}
+
+	/** @dataProvider declining_provider */
+	public function test_convert__declines_unsupported_values( string $value ) {
+		// Act.
+		$result = $this->converter->convert( $this->context, $this->rule( $value ) );
+
+		// Assert.
+		$this->assertFalse( $result );
+		$this->assertNull( $this->context->get_prop( 'transition' ) );
+	}
+
+	public static function declining_provider(): array {
+		return [
+			'unsupported property'          => [ 'border-left 300ms' ],
+			'no duration'                   => [ 'opacity' ],
+			'non-time unit'                 => [ 'opacity 10px' ],
+			'one layer unsupported in list' => [ 'opacity 300ms, border-left 200ms' ],
+		];
+	}
+
+	private function rule( string $value ): array {
+		return [ 'property' => 'transition', 'value' => $value, 'declaration' => "transition: $value" ];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/expanders/test-background-shorthand-expander.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/expanders/test-background-shorthand-expander.php
@@ -3,6 +3,9 @@
 namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Expanders;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Background_Shorthand_Expander;
+use Elementor\Modules\Variables\PropTypes\Color_Variable_Prop_Type;
+use Elementor\Modules\Variables\PropTypes\Size_Variable_Prop_Type;
+use Elementor\Modules\Variables\Services\Variables_Service;
 use PHPUnit\Framework\TestCase;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -10,8 +13,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Test_Background_Shorthand_Expander extends TestCase {
-	private function expand( string $value ): array {
-		return ( new Background_Shorthand_Expander() )->expand( [ 'property' => 'background', 'value' => $value ] );
+	private function expand( string $value, ?Variables_Service $variables_service = null ): array {
+		return ( new Background_Shorthand_Expander( $variables_service ) )->expand( [
+			'property' => 'background',
+			'value' => $value,
+		] );
 	}
 
 	private function properties( array $rules ): array {
@@ -142,6 +148,58 @@ class Test_Background_Shorthand_Expander extends TestCase {
 		// Assert: expander emits background-image; the converter will decline it later (no gradient support).
 		$this->assertSame( [ 'background-image' ], $this->properties( $rules ) );
 		$this->assertSame( 'linear-gradient(red, blue)', $rules[0]['value'] );
+	}
+
+	public function test_expand__unknown_var_only_layer_declines() {
+		// Act.
+		$rules = $this->expand( 'var(--missing)' );
+
+		// Assert.
+		$this->assertSame( [], $rules );
+	}
+
+	public function test_expand__var_only_layer_without_service_declines() {
+		// Act.
+		$rules = $this->expand( 'var(--var-id)' );
+
+		// Assert.
+		$this->assertSame( [], $rules );
+	}
+
+	public function test_expand__known_color_var_routes_to_background_color() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'var-id' )->willReturn( [
+			'id' => 'e-gv-1',
+			'type' => Color_Variable_Prop_Type::get_key(),
+			'label' => 'var-id',
+			'value' => '#112233',
+		] );
+
+		// Act.
+		$rules = $this->expand( 'var(--var-id)', $service );
+
+		// Assert.
+		$this->assertSame( [ 'background-color' ], $this->properties( $rules ) );
+		$this->assertSame( [ 'var(--var-id)' ], $this->values( $rules ) );
+	}
+
+	public function test_expand__known_size_var_routes_to_position_and_size() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'spacing-md' )->willReturn( [
+			'id' => 'e-gv-2',
+			'type' => Size_Variable_Prop_Type::get_key(),
+			'label' => 'spacing-md',
+			'value' => '16px',
+		] );
+
+		// Act.
+		$rules = $this->expand( 'var(--spacing-md)', $service );
+
+		// Assert.
+		$this->assertEqualsCanonicalizing(
+			[ 'background-position', 'background-size' ],
+			$this->properties( $rules )
+		);
 	}
 
 	public function test_expand__size_without_position_declines() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/expanders/test-background-shorthand-expander.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/expanders/test-background-shorthand-expander.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Expanders;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Background_Shorthand_Expander;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Background_Shorthand_Expander extends TestCase {
+	private function expand( string $value ): array {
+		return ( new Background_Shorthand_Expander() )->expand( [ 'property' => 'background', 'value' => $value ] );
+	}
+
+	private function properties( array $rules ): array {
+		return array_column( $rules, 'property' );
+	}
+
+	private function values( array $rules ): array {
+		return array_column( $rules, 'value' );
+	}
+
+	public function test_expand__color_only_emits_background_color() {
+		// Act.
+		$rules = $this->expand( 'red' );
+
+		// Assert.
+		$this->assertSame( [ 'background-color' ], $this->properties( $rules ) );
+		$this->assertSame( [ 'red' ], $this->values( $rules ) );
+	}
+
+	public function test_expand__hex_color_emits_background_color() {
+		// Act.
+		$rules = $this->expand( '#ff0000' );
+
+		// Assert.
+		$this->assertSame( [ 'background-color' ], $this->properties( $rules ) );
+		$this->assertSame( [ '#ff0000' ], $this->values( $rules ) );
+	}
+
+	public function test_expand__url_only_emits_background_image() {
+		// Act.
+		$rules = $this->expand( 'url(foo.jpg)' );
+
+		// Assert.
+		$this->assertSame( [ 'background-image' ], $this->properties( $rules ) );
+		$this->assertSame( [ 'url(foo.jpg)' ], $this->values( $rules ) );
+	}
+
+	public function test_expand__url_with_repeat_emits_image_and_repeat() {
+		// Act.
+		$rules = $this->expand( 'url(foo.jpg) no-repeat' );
+
+		// Assert.
+		$this->assertEqualsCanonicalizing( [ 'background-image', 'background-repeat' ], $this->properties( $rules ) );
+	}
+
+	public function test_expand__url_with_all_simple_props() {
+		// Act.
+		$rules = $this->expand( 'url(foo.jpg) no-repeat fixed' );
+
+		// Assert.
+		$properties = $this->properties( $rules );
+		$this->assertContains( 'background-image', $properties );
+		$this->assertContains( 'background-repeat', $properties );
+		$this->assertContains( 'background-attachment', $properties );
+	}
+
+	public function test_expand__position_keywords_emit_background_position() {
+		// Act.
+		$rules = $this->expand( 'url(foo.jpg) center center' );
+
+		// Assert.
+		$properties = $this->properties( $rules );
+		$this->assertContains( 'background-position', $properties );
+
+		$pos_rule = array_values( array_filter( $rules, fn( $r ) => 'background-position' === $r['property'] ) )[0];
+		$this->assertSame( 'center center', $pos_rule['value'] );
+	}
+
+	public function test_expand__position_with_size_emits_both() {
+		// Act.
+		$rules = $this->expand( 'url(foo.jpg) center center / cover' );
+
+		// Assert.
+		$properties = $this->properties( $rules );
+		$this->assertContains( 'background-position', $properties );
+		$this->assertContains( 'background-size', $properties );
+
+		$size_rule = array_values( array_filter( $rules, fn( $r ) => 'background-size' === $r['property'] ) )[0];
+		$this->assertSame( 'cover', $size_rule['value'] );
+	}
+
+	public function test_expand__size_pair_after_slash_emits_both_size_values() {
+		// Act.
+		$rules = $this->expand( 'url(foo.jpg) center center / 50% 100%' );
+
+		// Assert.
+		$size_rule = array_values( array_filter( $rules, fn( $r ) => 'background-size' === $r['property'] ) )[0];
+		$this->assertSame( '50% 100%', $size_rule['value'] );
+	}
+
+	public function test_expand__clip_keyword_emits_background_clip() {
+		// Act.
+		$rules = $this->expand( 'url(foo.jpg) text' );
+
+		// Assert.
+		$properties = $this->properties( $rules );
+		$this->assertContains( 'background-clip', $properties );
+
+		$clip_rule = array_values( array_filter( $rules, fn( $r ) => 'background-clip' === $r['property'] ) )[0];
+		$this->assertSame( 'text', $clip_rule['value'] );
+	}
+
+	public function test_expand__multi_layer_aggregates_image_and_color() {
+		// Act.
+		$rules = $this->expand( 'url(a.jpg), url(b.jpg) red' );
+
+		// Assert.
+		$img_rule = array_values( array_filter( $rules, fn( $r ) => 'background-image' === $r['property'] ) )[0];
+		$this->assertSame( 'url(a.jpg), url(b.jpg)', $img_rule['value'] );
+
+		$color_rule = array_values( array_filter( $rules, fn( $r ) => 'background-color' === $r['property'] ) )[0];
+		$this->assertSame( 'red', $color_rule['value'] );
+	}
+
+	public function test_expand__layer_without_image_gets_none_in_image_list() {
+		// Act.
+		$rules = $this->expand( 'url(a.jpg), red' );
+
+		// Assert.
+		$img_rule = array_values( array_filter( $rules, fn( $r ) => 'background-image' === $r['property'] ) )[0];
+		$this->assertSame( 'url(a.jpg), none', $img_rule['value'] );
+	}
+
+	public function test_expand__gradient_token_is_treated_as_image() {
+		// Act.
+		$rules = $this->expand( 'linear-gradient(red, blue)' );
+
+		// Assert: expander emits background-image; the converter will decline it later (no gradient support).
+		$this->assertSame( [ 'background-image' ], $this->properties( $rules ) );
+		$this->assertSame( 'linear-gradient(red, blue)', $rules[0]['value'] );
+	}
+
+	public function test_expand__size_without_position_declines() {
+		// Act.
+		$rules = $this->expand( 'url(foo.jpg) / cover' );
+
+		// Assert.
+		$this->assertSame( [], $rules );
+	}
+
+	public function test_expand__duplicate_slot_declines() {
+		// Act.
+		$rules = $this->expand( 'url(a.jpg) url(b.jpg)' );
+
+		// Assert: two images in the same layer is a parse error.
+		$this->assertSame( [], $rules );
+	}
+
+	public function test_expand__each_rule_has_correct_declaration_string() {
+		// Act.
+		$rules = $this->expand( 'url(foo.jpg) no-repeat' );
+
+		// Assert.
+		foreach ( $rules as $rule ) {
+			$this->assertSame( $rule['property'] . ': ' . $rule['value'], $rule['declaration'] );
+		}
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/expanders/test-border-shorthand-expander.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/expanders/test-border-shorthand-expander.php
@@ -10,6 +10,9 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Expander_Registry;
 use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Border_Shorthand_Expander;
 use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\Variables\PropTypes\Color_Variable_Prop_Type;
+use Elementor\Modules\Variables\PropTypes\Size_Variable_Prop_Type;
+use Elementor\Modules\Variables\Services\Variables_Service;
 use PHPUnit\Framework\TestCase;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -166,6 +169,116 @@ class Test_Border_Shorthand_Expander extends TestCase {
 		$this->assertSame( 'border: 1px 2px;', $result['customCss'] );
 	}
 
+	public function test_expand__known_color_var_routes_to_border_color() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'primary-border' )->willReturn( [
+			'id' => 'e-gv-1',
+			'type' => Color_Variable_Prop_Type::get_key(),
+			'label' => 'primary-border',
+			'value' => '#112233',
+		] );
+
+		$rules = $this->make_expander( $service )->expand( [
+			'property' => 'border',
+			'value' => 'var(--primary-border)',
+		] );
+
+		$this->assertSame(
+			[
+				[
+					'property' => 'border-color',
+					'value' => 'var(--primary-border)',
+					'declaration' => 'border-color: var(--primary-border)',
+				],
+			],
+			$rules
+		);
+	}
+
+	public function test_expand__known_size_var_routes_to_border_width() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'border-width-token' )->willReturn( [
+			'id' => 'e-gv-2',
+			'type' => Size_Variable_Prop_Type::get_key(),
+			'label' => 'border-width-token',
+			'value' => '2px',
+		] );
+
+		$rules = $this->make_expander( $service )->expand( [
+			'property' => 'border',
+			'value' => 'var(--border-width-token)',
+		] );
+
+		$this->assertSame(
+			[
+				[
+					'property' => 'border-width',
+					'value' => 'var(--border-width-token)',
+					'declaration' => 'border-width: var(--border-width-token)',
+				],
+			],
+			$rules
+		);
+	}
+
+	public function test_expand__unknown_var_only_shorthand_declines() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->willReturn( null );
+
+		$rules = $this->make_expander( $service )->expand( [
+			'property' => 'border',
+			'value' => 'var(--external-border)',
+		] );
+
+		$this->assertSame( [], $rules );
+	}
+
+	public function test_expand__mixed_shorthand_with_known_color_var() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'primary-border' )->willReturn( [
+			'id' => 'e-gv-1',
+			'type' => Color_Variable_Prop_Type::get_key(),
+			'label' => 'primary-border',
+			'value' => '#112233',
+		] );
+
+		$rules = $this->make_expander( $service )->expand( [
+			'property' => 'border',
+			'value' => '1px solid var(--primary-border)',
+		] );
+
+		$this->assertSame(
+			[
+				[ 'property' => 'border-width', 'value' => '1px', 'declaration' => 'border-width: 1px' ],
+				[ 'property' => 'border-style', 'value' => 'solid', 'declaration' => 'border-style: solid' ],
+				[
+					'property' => 'border-color',
+					'value' => 'var(--primary-border)',
+					'declaration' => 'border-color: var(--primary-border)',
+				],
+			],
+			$rules
+		);
+	}
+
+	public function test_dispatcher__known_color_var_expands_to_border_color_prop() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'primary-border' )->willReturn( [
+			'id' => 'e-gv-1',
+			'type' => Color_Variable_Prop_Type::get_key(),
+			'label' => 'primary-border',
+			'value' => '#112233',
+		] );
+
+		$result = $this->make_dispatcher( $service )->convert( 'border: 1px solid var(--primary-border);' );
+
+		$this->assertSame( '', $result['customCss'] );
+		$this->assertSame(
+			[ '$$type' => 'color', 'value' => 'var(--primary-border)' ],
+			$result['props']['border-color']
+		);
+	}
+
 	public function test_expand__per_side_shorthand_emits_side_longhands() {
 		// Arrange: border-top maps roles to per-side property names.
 		$expander = new Border_Shorthand_Expander(
@@ -188,18 +301,23 @@ class Test_Border_Shorthand_Expander extends TestCase {
 		);
 	}
 
-	private function make_expander(): Border_Shorthand_Expander {
-		return new Border_Shorthand_Expander( 'border', self::ALL_SIDES_LONGHANDS, self::STYLE_KEYWORDS );
+	private function make_expander( ?Variables_Service $variables_service = null ): Border_Shorthand_Expander {
+		return new Border_Shorthand_Expander(
+			'border',
+			self::ALL_SIDES_LONGHANDS,
+			self::STYLE_KEYWORDS,
+			$variables_service
+		);
 	}
 
-	private function make_dispatcher(): Css_Converter {
+	private function make_dispatcher( ?Variables_Service $variables_service = null ): Css_Converter {
 		$registry = ( new Converter_Registry() )
 			->register( new Dimensions_Property_Converter( 'border-width' ) )
 			->register( new String_Property_Converter( 'border-style', self::STYLE_KEYWORDS ) )
 			->register( new Color_Property_Converter( 'border-color' ) );
 
 		$expanders = ( new Expander_Registry() )
-			->register( $this->make_expander() );
+			->register( $this->make_expander( $variables_service ) );
 
 		return new Css_Converter( $registry, new Null_Failure_Reporter(), $expanders );
 	}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/expanders/test-border-shorthand-expander.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/expanders/test-border-shorthand-expander.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Expanders;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\String_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Expander_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Border_Shorthand_Expander;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Border_Shorthand_Expander extends TestCase {
+	const STYLE_KEYWORDS = [ 'none', 'hidden', 'dotted', 'dashed', 'solid', 'double', 'groove', 'ridge', 'inset', 'outset' ];
+	const ALL_SIDES_LONGHANDS = [ 'width' => 'border-width', 'style' => 'border-style', 'color' => 'border-color' ];
+
+	public function test_expand__full_shorthand_splits_into_three_longhands() {
+		// Arrange.
+		$expander = $this->make_expander();
+
+		// Act.
+		$rules = $expander->expand( [ 'property' => 'border', 'value' => '1px solid red' ] );
+
+		// Assert: emitted width/style/color, each with its own declaration.
+		$this->assertSame(
+			[
+				[ 'property' => 'border-width', 'value' => '1px', 'declaration' => 'border-width: 1px' ],
+				[ 'property' => 'border-style', 'value' => 'solid', 'declaration' => 'border-style: solid' ],
+				[ 'property' => 'border-color', 'value' => 'red', 'declaration' => 'border-color: red' ],
+			],
+			$rules
+		);
+	}
+
+	public function test_expand__order_independent_classification() {
+		// Arrange.
+		$expander = $this->make_expander();
+
+		// Act: color, style, width in a scrambled order.
+		$rules = $expander->expand( [ 'property' => 'border', 'value' => 'red dashed 2px' ] );
+
+		// Assert: always emitted in width/style/color order regardless of input order.
+		$this->assertSame( [ 'border-width', 'border-style', 'border-color' ], array_column( $rules, 'property' ) );
+		$this->assertSame( [ '2px', 'dashed', 'red' ], array_column( $rules, 'value' ) );
+	}
+
+	public function test_expand__only_present_parts_are_emitted() {
+		// Arrange.
+		$expander = $this->make_expander();
+
+		// Act.
+		$rules = $expander->expand( [ 'property' => 'border', 'value' => 'solid red' ] );
+
+		// Assert: no border-width since width was omitted (no CSS-initial reset).
+		$this->assertSame(
+			[
+				[ 'property' => 'border-style', 'value' => 'solid', 'declaration' => 'border-style: solid' ],
+				[ 'property' => 'border-color', 'value' => 'red', 'declaration' => 'border-color: red' ],
+			],
+			$rules
+		);
+	}
+
+	public function test_expand__keeps_paren_value_intact() {
+		// Arrange.
+		$expander = $this->make_expander();
+
+		// Act: rgb() has internal spaces that must not split.
+		$rules = $expander->expand( [ 'property' => 'border', 'value' => '1px solid rgb(0, 0, 0)' ] );
+
+		// Assert.
+		$this->assertSame(
+			[ 'property' => 'border-color', 'value' => 'rgb(0, 0, 0)', 'declaration' => 'border-color: rgb(0, 0, 0)' ],
+			$rules[2]
+		);
+	}
+
+	public function test_expand__width_keyword_classifies_as_width() {
+		// Arrange.
+		$expander = $this->make_expander();
+
+		// Act.
+		$rules = $expander->expand( [ 'property' => 'border', 'value' => 'thin solid red' ] );
+
+		// Assert: `thin` is a width keyword (the longhand converter may later reject it).
+		$this->assertSame( 'border-width', $rules[0]['property'] );
+		$this->assertSame( 'thin', $rules[0]['value'] );
+	}
+
+	/**
+	 * @dataProvider declined_values
+	 */
+	public function test_expand__declines_ambiguous_value( string $value ) {
+		// Arrange.
+		$expander = $this->make_expander();
+
+		// Act & Assert: empty result -> caller keeps the original `border` for custom_css.
+		$this->assertSame( [], $expander->expand( [ 'property' => 'border', 'value' => $value ] ) );
+	}
+
+	public function declined_values(): array {
+		return [
+			'two colors' => [ 'red blue' ],
+			'two widths' => [ '1px 2px' ],
+			'two styles' => [ 'solid dashed' ],
+			'empty' => [ '   ' ],
+		];
+	}
+
+	public function test_dispatcher__border_expands_then_converts_into_longhand_props() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'border: 1px solid red;' );
+
+		// Assert: three real converters produced three props, nothing left over.
+		$this->assertSame( '', $result['customCss'] );
+		$this->assertSame(
+			[ 'border-width', 'border-style', 'border-color' ],
+			array_keys( $result['props'] )
+		);
+		$this->assertSame( [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ], $result['props']['border-width'] );
+		$this->assertSame( [ '$$type' => 'string', 'value' => 'solid' ], $result['props']['border-style'] );
+		$this->assertSame( [ '$$type' => 'color', 'value' => 'red' ], $result['props']['border-color'] );
+	}
+
+	public function test_dispatcher__later_longhand_overrides_expanded_value() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act: explicit border-color after the shorthand must win (cascade preserved).
+		$result = $dispatcher->convert( 'border: 1px solid red; border-color: blue;' );
+
+		// Assert.
+		$this->assertSame( [ '$$type' => 'color', 'value' => 'blue' ], $result['props']['border-color'] );
+	}
+
+	public function test_dispatcher__width_keyword_degrades_to_custom_css_per_side() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act: `thin` can't convert as a Size, so only that longhand falls to custom_css.
+		$result = $dispatcher->convert( 'border: thin solid red;' );
+
+		// Assert.
+		$this->assertSame( [ 'border-style', 'border-color' ], array_keys( $result['props'] ) );
+		$this->assertSame( 'border-width: thin;', $result['customCss'] );
+	}
+
+	public function test_dispatcher__ambiguous_border_is_kept_as_custom_css() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act.
+		$result = $dispatcher->convert( 'border: 1px 2px;' );
+
+		// Assert: declined expansion keeps the original shorthand verbatim.
+		$this->assertSame( [], $result['props'] );
+		$this->assertSame( 'border: 1px 2px;', $result['customCss'] );
+	}
+
+	public function test_expand__per_side_shorthand_emits_side_longhands() {
+		// Arrange: border-top maps roles to per-side property names.
+		$expander = new Border_Shorthand_Expander(
+			'border-top',
+			[ 'width' => 'border-top-width', 'style' => 'border-top-style', 'color' => 'border-top-color' ],
+			self::STYLE_KEYWORDS
+		);
+
+		// Act.
+		$rules = $expander->expand( [ 'property' => 'border-top', 'value' => '1px solid red' ] );
+
+		// Assert.
+		$this->assertSame(
+			[
+				[ 'property' => 'border-top-width', 'value' => '1px', 'declaration' => 'border-top-width: 1px' ],
+				[ 'property' => 'border-top-style', 'value' => 'solid', 'declaration' => 'border-top-style: solid' ],
+				[ 'property' => 'border-top-color', 'value' => 'red', 'declaration' => 'border-top-color: red' ],
+			],
+			$rules
+		);
+	}
+
+	private function make_expander(): Border_Shorthand_Expander {
+		return new Border_Shorthand_Expander( 'border', self::ALL_SIDES_LONGHANDS, self::STYLE_KEYWORDS );
+	}
+
+	private function make_dispatcher(): Css_Converter {
+		$registry = ( new Converter_Registry() )
+			->register( new Dimensions_Property_Converter( 'border-width' ) )
+			->register( new String_Property_Converter( 'border-style', self::STYLE_KEYWORDS ) )
+			->register( new Color_Property_Converter( 'border-color' ) );
+
+		$expanders = ( new Expander_Registry() )
+			->register( $this->make_expander() );
+
+		return new Css_Converter( $registry, new Null_Failure_Reporter(), $expanders );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/expanders/test-physical-to-logical-expander.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/expanders/test-physical-to-logical-expander.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Expanders;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Physical_To_Logical_Expander;
+use Elementor\Modules\AtomicWidgets\CssConverter\Variable_Prop_Value_Transformer;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
+use Elementor\Modules\Variables\PropTypes\Size_Variable_Prop_Type;
+use Elementor\Modules\Variables\Services\Variables_Service;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Physical_To_Logical_Expander extends TestCase {
+
+	public function test_expand__rewrites_top_to_inset_block_start() {
+		$rules = ( new Physical_To_Logical_Expander() )->expand( [
+			'property' => 'top',
+			'value' => 'var(--spacing-md)',
+		] );
+
+		$this->assertSame(
+			[
+				[
+					'property' => 'inset-block-start',
+					'value' => 'var(--spacing-md)',
+					'declaration' => 'inset-block-start: var(--spacing-md)',
+				],
+			],
+			$rules
+		);
+	}
+
+	public function test_transform__promotes_logical_inset_size_var_reference() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'spacing-md' )->willReturn( [
+			'id' => 'e-gv-2',
+			'type' => Size_Variable_Prop_Type::get_key(),
+			'label' => 'spacing-md',
+			'value' => '16px',
+		] );
+
+		$transformer = new Variable_Prop_Value_Transformer( $service );
+		$schema = [
+			'inset-block-start' => Union_Prop_Type::create_from( Size_Prop_Type::make() )
+				->add_prop_type( Size_Variable_Prop_Type::make() ),
+		];
+
+		$result = $transformer->transform(
+			[
+				'inset-block-start' => [
+					'$$type' => 'size',
+					'value' => [
+						'size' => 'var(--spacing-md)',
+						'unit' => 'custom',
+					],
+				],
+			],
+			$schema
+		);
+
+		$this->assertSame(
+			[
+				'$$type' => Size_Variable_Prop_Type::get_key(),
+				'value' => 'e-gv-2',
+			],
+			$result['inset-block-start']
+		);
+	}
+
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-border-cascade.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-border-cascade.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Side_Merge_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\String_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Expander_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Expanders\Border_Shorthand_Expander;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Border_Width_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * End-to-end (DB-less) cascade across every border mechanism at once: the all-sides shorthand, a
+ * per-side shorthand, expansion, the single->object seed merge, and the unrepresentable per-side color
+ * that falls to custom_css. Asserts CSS last-wins semantics.
+ */
+class Test_Border_Cascade extends TestCase {
+	const STYLE_KEYWORDS = [ 'none', 'hidden', 'dotted', 'dashed', 'solid', 'double', 'groove', 'ridge', 'inset', 'outset' ];
+	const WIDTH_KEYS = [ 'block-start', 'inline-end', 'block-end', 'inline-start' ];
+
+	public function test_mixed_border_shorthands__last_wins() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act: border sets all sides 1px/solid/blue; border-left overrides the left width and color.
+		$result = $dispatcher->convert( 'border: 1px solid blue; border-left: 4px red;' );
+
+		// Assert: left width wins (4px) over the seeded 1px; style/all-sides color stay props; the
+		// per-side color has no representation and lands in custom_css.
+		$this->assertEquals(
+			[
+				'border-width' => [
+					'$$type' => 'border-width',
+					'value' => [
+						'block-start' => $this->size( 1 ),
+						'inline-end' => $this->size( 1 ),
+						'block-end' => $this->size( 1 ),
+						'inline-start' => $this->size( 4 ),
+					],
+				],
+				'border-style' => [ '$$type' => 'string', 'value' => 'solid' ],
+				'border-color' => [ '$$type' => 'color', 'value' => 'blue' ],
+			],
+			$result['props']
+		);
+		$this->assertSame( 'border-left-color: red;', $result['customCss'] );
+	}
+
+	public function test_mixed_border__all_sides_shorthand_after_per_side_resets_width() {
+		// Arrange.
+		$dispatcher = $this->make_dispatcher();
+
+		// Act: per-side first, then the all-sides shorthand which must reset every width side.
+		$result = $dispatcher->convert( 'border-left-width: 4px; border: 1px solid blue;' );
+
+		// Assert: border-width collapses back to the single 1px (shorthand overrides the longhand).
+		$this->assertSame( $this->size( 1 ), $result['props']['border-width'] );
+		$this->assertSame( '', $result['customCss'] );
+	}
+
+	private function make_dispatcher(): Css_Converter {
+		$registry = ( new Converter_Registry() )
+			->register( new Dimensions_Property_Converter( 'border-width', Border_Width_Prop_Type::class ) )
+			->register( new String_Property_Converter( 'border-style', self::STYLE_KEYWORDS ) )
+			->register( new Color_Property_Converter( 'border-color' ) )
+			->register( new Object_Side_Merge_Converter(
+				'border-left-width',
+				'border-width',
+				'border-width',
+				'inline-start',
+				self::WIDTH_KEYS,
+				Border_Width_Prop_Type::class
+			) );
+
+		$expanders = ( new Expander_Registry() )
+			->register( new Border_Shorthand_Expander( 'border', $this->longhands( '' ), self::STYLE_KEYWORDS ) )
+			->register( new Border_Shorthand_Expander( 'border-left', $this->longhands( 'left-' ), self::STYLE_KEYWORDS ) );
+
+		return new Css_Converter( $registry, new Null_Failure_Reporter(), $expanders );
+	}
+
+	private function longhands( string $infix ): array {
+		return [
+			'width' => "border-{$infix}width",
+			'style' => "border-{$infix}style",
+			'color' => "border-{$infix}color",
+		];
+	}
+
+	private function size( int $value ): array {
+		return [ '$$type' => 'size', 'value' => [ 'size' => $value, 'unit' => 'px' ] ];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
@@ -49,11 +49,11 @@ class Test_Converter_Registry_Factory extends TestCase {
 		$converter = new Css_Converter( Converter_Registry_Factory::create(), new Null_Failure_Reporter() );
 
 		// Act.
-		$result = $converter->convert( 'transform: matrix(1,0,0,1,0,0); box-shadow: 0 2px 4px black;' );
+		$result = $converter->convert( 'transform: matrix(1,0,0,1,0,0); stroke-width: 2px;' );
 
 		// Assert.
 		$this->assertSame( [], $result['props'] );
-		$this->assertSame( 'transform: matrix(1,0,0,1,0,0); box-shadow: 0 2px 4px black;', $result['customCss'] );
+		$this->assertSame( 'transform: matrix(1,0,0,1,0,0); stroke-width: 2px;', $result['customCss'] );
 	}
 
 	/**

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
@@ -17,8 +17,11 @@ class Test_Converter_Registry_Factory extends TestCase {
 		// Act.
 		$registry = Converter_Registry_Factory::create();
 
+		$expected_count = count( Converter_Registry_Factory::covered_properties() )
+			+ count( Converter_Registry_Factory::DIMENSIONS_SIDE_SPECS );
+
 		// Assert.
-		$this->assertCount( count( Converter_Registry_Factory::covered_properties() ), $registry->all() );
+		$this->assertCount( $expected_count, $registry->all() );
 	}
 
 	public function test_create__every_covered_property_is_claimed_by_exactly_one_converter() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
@@ -49,10 +49,10 @@ class Test_Converter_Registry_Factory extends TestCase {
 		$converter = new Css_Converter( Converter_Registry_Factory::create(), new Null_Failure_Reporter() );
 
 		// Act.
-		$result = $converter->convert( 'transform: rotate(45deg); transition: all 0.3s;' );
+		$result = $converter->convert( 'transform: rotate(45deg); box-shadow: 0 2px 4px black;' );
 
 		// Assert.
 		$this->assertSame( [], $result['props'] );
-		$this->assertSame( 'transform: rotate(45deg); transition: all 0.3s;', $result['customCss'] );
+		$this->assertSame( 'transform: rotate(45deg); box-shadow: 0 2px 4px black;', $result['customCss'] );
 	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
@@ -44,15 +44,15 @@ class Test_Converter_Registry_Factory extends TestCase {
 		$this->assertSame( array_values( array_unique( $properties ) ), $properties );
 	}
 
-	public function test_noop_registry__routes_every_declaration_to_custom_css() {
+	public function test_noop_property__routes_its_declaration_to_custom_css() {
 		// Arrange.
 		$converter = new Css_Converter( Converter_Registry_Factory::create(), new Null_Failure_Reporter() );
 
 		// Act.
-		$result = $converter->convert( 'color: red; width: 10px;' );
+		$result = $converter->convert( 'color: red; padding: 10px;' );
 
 		// Assert.
 		$this->assertSame( [], $result['props'] );
-		$this->assertSame( 'color: red; width: 10px;', $result['customCss'] );
+		$this->assertSame( 'color: red; padding: 10px;', $result['customCss'] );
 	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
@@ -49,10 +49,10 @@ class Test_Converter_Registry_Factory extends TestCase {
 		$converter = new Css_Converter( Converter_Registry_Factory::create(), new Null_Failure_Reporter() );
 
 		// Act.
-		$result = $converter->convert( 'transform: rotate(45deg); box-shadow: 0 2px 4px black;' );
+		$result = $converter->convert( 'transform: matrix(1,0,0,1,0,0); box-shadow: 0 2px 4px black;' );
 
 		// Assert.
 		$this->assertSame( [], $result['props'] );
-		$this->assertSame( 'transform: rotate(45deg); box-shadow: 0 2px 4px black;', $result['customCss'] );
+		$this->assertSame( 'transform: matrix(1,0,0,1,0,0); box-shadow: 0 2px 4px black;', $result['customCss'] );
 	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
@@ -49,10 +49,10 @@ class Test_Converter_Registry_Factory extends TestCase {
 		$converter = new Css_Converter( Converter_Registry_Factory::create(), new Null_Failure_Reporter() );
 
 		// Act.
-		$result = $converter->convert( 'color: red; padding: 10px;' );
+		$result = $converter->convert( 'transform: rotate(45deg); transition: all 0.3s;' );
 
 		// Assert.
 		$this->assertSame( [], $result['props'] );
-		$this->assertSame( 'color: red; padding: 10px;', $result['customCss'] );
+		$this->assertSame( 'transform: rotate(45deg); transition: all 0.3s;', $result['customCss'] );
 	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
@@ -55,4 +55,40 @@ class Test_Converter_Registry_Factory extends TestCase {
 		$this->assertSame( [], $result['props'] );
 		$this->assertSame( 'transform: matrix(1,0,0,1,0,0); box-shadow: 0 2px 4px black;', $result['customCss'] );
 	}
+
+	/**
+	 * @dataProvider stroke_family_provider
+	 *
+	 * Guards the by-design decision documented in Converter_Registry_Factory::NOOP_PROPERTIES:
+	 * SVG stroke-* longhands are intentionally preserved verbatim in customCss because the editor
+	 * UI does not expose stroke controls. If someone later wires a real converter for any of these,
+	 * this test will fail and force the author to remove the entry from the provider AND from the
+	 * NOOP_PROPERTIES list, ensuring the documented intent stays in sync with behaviour.
+	 */
+	public function test_stroke_family_falls_to_custom_css_by_design( string $property, string $value ) {
+		// Arrange.
+		$converter = new Css_Converter( Converter_Registry_Factory::create(), new Null_Failure_Reporter() );
+		$declaration = "{$property}: {$value};";
+
+		// Act.
+		$result = $converter->convert( $declaration );
+
+		// Assert.
+		$this->assertSame( [], $result['props'], "{$property} unexpectedly produced a converted prop." );
+		$this->assertSame( $declaration, $result['customCss'], "{$property} did not fall through to customCss verbatim." );
+		$this->assertSame( [], $result['rejected'] );
+	}
+
+	public static function stroke_family_provider(): array {
+		return [
+			'stroke'            => [ 'stroke', 'red' ],
+			'stroke-width'      => [ 'stroke-width', '2px' ],
+			'stroke-opacity'    => [ 'stroke-opacity', '0.5' ],
+			'stroke-dasharray'  => [ 'stroke-dasharray', '5 3' ],
+			'stroke-dashoffset' => [ 'stroke-dashoffset', '4px' ],
+			'stroke-linecap'    => [ 'stroke-linecap', 'round' ],
+			'stroke-linejoin'   => [ 'stroke-linejoin', 'miter' ],
+			'stroke-miterlimit' => [ 'stroke-miterlimit', '10' ],
+		];
+	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-converter-registry-factory.php
@@ -18,7 +18,7 @@ class Test_Converter_Registry_Factory extends TestCase {
 		$registry = Converter_Registry_Factory::create();
 
 		// Assert.
-		$this->assertCount( count( Converter_Registry_Factory::COVERED_PROPERTIES ), $registry->all() );
+		$this->assertCount( count( Converter_Registry_Factory::covered_properties() ), $registry->all() );
 	}
 
 	public function test_create__every_covered_property_is_claimed_by_exactly_one_converter() {
@@ -26,7 +26,7 @@ class Test_Converter_Registry_Factory extends TestCase {
 		$registry = Converter_Registry_Factory::create();
 
 		// Act & Assert.
-		foreach ( Converter_Registry_Factory::COVERED_PROPERTIES as $property ) {
+		foreach ( Converter_Registry_Factory::covered_properties() as $property ) {
 			$claims = array_filter(
 				$registry->all(),
 				fn( $converter ) => $converter->is_supported( [ 'property' => $property, 'value' => 'x' ] )
@@ -38,7 +38,7 @@ class Test_Converter_Registry_Factory extends TestCase {
 
 	public function test_covered_properties__has_no_duplicates() {
 		// Act.
-		$properties = Converter_Registry_Factory::COVERED_PROPERTIES;
+		$properties = Converter_Registry_Factory::covered_properties();
 
 		// Assert.
 		$this->assertSame( array_values( array_unique( $properties ) ), $properties );

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -159,6 +159,26 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( '', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__converts_unitless_line_height_into_a_custom_size() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'line-height' => '1.1' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [ 'line-height' => [ '$$type' => 'size', 'value' => [ 'size' => '1.1', 'unit' => 'custom' ] ] ],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__routes_unrepresentable_size_to_custom_css() {
 		// Arrange.
 		$this->act_as_admin();
@@ -241,6 +261,125 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 			$data['el-1']['props']
 		);
 		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_single_value_padding_into_a_size_prop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'padding' => '10px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [ 'padding' => [ '$$type' => 'size', 'value' => [ 'size' => 10, 'unit' => 'px' ] ] ],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_shorthand_margin_into_logical_dimensions() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'margin' => '1px 2px 3px 4px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: top->block-start, right->inline-end, bottom->block-end, left->inline-start.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'margin' => [
+					'$$type' => 'dimensions',
+					'value' => [
+						'block-start' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+						'inline-end' => [ '$$type' => 'size', 'value' => [ 'size' => 2, 'unit' => 'px' ] ],
+						'block-end' => [ '$$type' => 'size', 'value' => [ 'size' => 3, 'unit' => 'px' ] ],
+						'inline-start' => [ '$$type' => 'size', 'value' => [ 'size' => 4, 'unit' => 'px' ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__routes_unrepresentable_padding_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'padding' => '10px 20px 30px 40px 50px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'padding: 10px 20px 30px 40px 50px;', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_filter_into_a_canonical_prop_value() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'filter' => 'blur(5px) brightness(150%)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'filter', $data['el-1']['props']['filter']['$$type'] );
+		$this->assertCount( 2, $data['el-1']['props']['filter']['value'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_backdrop_filter_into_a_canonical_prop_value() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'backdrop-filter' => 'drop-shadow(2px 4px 6px black)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'backdrop-filter', $data['el-1']['props']['backdrop-filter']['$$type'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__routes_unsupported_filter_function_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'filter' => 'opacity(50%)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'filter: opacity(50%);', $data['el-1']['customCss'] );
 	}
 
 	public function test_post__converts_number_prop_into_a_canonical_prop_value() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -397,6 +397,282 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 'border-radius: 10px / 20px;', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__converts_shorthand_border_width_into_logical_sides() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border-width' => '1px 2px 3px 4px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'border-width' => [
+					'$$type' => 'border-width',
+					'value' => [
+						'block-start' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+						'inline-end' => [ '$$type' => 'size', 'value' => [ 'size' => 2, 'unit' => 'px' ] ],
+						'block-end' => [ '$$type' => 'size', 'value' => [ 'size' => 3, 'unit' => 'px' ] ],
+						'inline-start' => [ '$$type' => 'size', 'value' => [ 'size' => 4, 'unit' => 'px' ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_single_border_width_into_a_size() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border-width' => '2px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [ 'border-width' => [ '$$type' => 'size', 'value' => [ 'size' => 2, 'unit' => 'px' ] ] ],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__expands_border_shorthand_into_longhand_props() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border' => '1px solid red' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: the shorthand is split into the three schema longhands; no `border` prop exists.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'border-width' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+				'border-style' => [ '$$type' => 'string', 'value' => 'solid' ],
+				'border-color' => [ '$$type' => 'color', 'value' => 'red' ],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__border_width_keyword_degrades_to_custom_css_per_side() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border' => 'thin solid red' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: style + color convert, the unparsable width falls to custom_css alone.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'border-style' => [ '$$type' => 'string', 'value' => 'solid' ],
+				'border-color' => [ '$$type' => 'color', 'value' => 'red' ],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( 'border-width: thin;', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__ambiguous_border_shorthand_is_kept_as_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border' => '1px 2px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'border: 1px 2px;', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__merges_per_side_width_longhands_into_border_width() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border-top-width' => '2px', 'border-bottom-width' => '4px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: both sides accumulate into one (partial) border-width object.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'border-width' => [
+					'$$type' => 'border-width',
+					'value' => [
+						'block-start' => [ '$$type' => 'size', 'value' => [ 'size' => 2, 'unit' => 'px' ] ],
+						'block-end' => [ '$$type' => 'size', 'value' => [ 'size' => 4, 'unit' => 'px' ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__per_side_width_seeds_from_prior_single_border_width() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border-width' => '1px', 'border-top-width' => '2px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: the single seeds all sides, then top is overridden.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'border-width' => [
+					'$$type' => 'border-width',
+					'value' => [
+						'block-start' => [ '$$type' => 'size', 'value' => [ 'size' => 2, 'unit' => 'px' ] ],
+						'inline-end' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+						'block-end' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+						'inline-start' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__merges_per_corner_radius_into_border_radius() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border-top-left-radius' => '10px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'border-radius' => [
+					'$$type' => 'border-radius',
+					'value' => [
+						'start-start' => [ '$$type' => 'size', 'value' => [ 'size' => 10, 'unit' => 'px' ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__per_side_shorthand_converts_width_and_routes_style_color_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border-top' => '1px solid red' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: only the width side is representable; per-side style/color fall to custom_css.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'border-width' => [
+					'$$type' => 'border-width',
+					'value' => [
+						'block-start' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( 'border-top-style: solid; border-top-color: red;', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__mixed_border_shorthands_resolve_last_wins() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border' => '1px solid blue', 'border-left' => '4px red' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: left width (4px) wins over the seeded 1px; all-sides style/color stay props; the
+		// per-side color has no representation and lands in custom_css.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'border-width' => [
+					'$$type' => 'border-width',
+					'value' => [
+						'block-start' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+						'inline-end' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+						'block-end' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+						'inline-start' => [ '$$type' => 'size', 'value' => [ 'size' => 4, 'unit' => 'px' ] ],
+					],
+				],
+				'border-style' => [ '$$type' => 'string', 'value' => 'solid' ],
+				'border-color' => [ '$$type' => 'color', 'value' => 'blue' ],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( 'border-left-color: red;', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__per_side_style_and_color_are_routed_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border-left-style' => 'dashed', 'border-left-color' => 'blue' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: no single-valued per-side representation exists for these.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'border-left-style: dashed; border-left-color: blue;', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__converts_filter_into_a_canonical_prop_value() {
 		// Arrange.
 		$this->act_as_admin();
@@ -532,7 +808,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 			'el-1' => [
 				'font-weight' => '700',
 				'color' => null,
-				'padding' => '10px',
+				'transform' => 'rotate(45deg)',
 			],
 		] );
 
@@ -549,7 +825,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 			],
 			$data['el-1']['props']
 		);
-		$this->assertSame( 'padding: 10px;', $data['el-1']['customCss'] );
+		$this->assertSame( 'transform: rotate(45deg);', $data['el-1']['customCss'] );
 	}
 
 	public function test_post__requires_authentication() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -57,7 +57,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
 		$request->set_param( 'blocks', [
 			'el-1' => [ 'color' => 'red' ],
-			'el-2' => [ 'gap' => '4px' ],
+			'el-2' => [ 'padding' => '4px' ],
 		] );
 
 		// Act.
@@ -68,7 +68,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'el-1', 'el-2' ], array_keys( $data ) );
 		$this->assertSame( 'color: red;', $data['el-1']['customCss'] );
-		$this->assertSame( 'gap: 4px;', $data['el-2']['customCss'] );
+		$this->assertSame( 'padding: 4px;', $data['el-2']['customCss'] );
 	}
 
 	public function test_post__converts_font_weight_into_a_canonical_prop_value() {
@@ -137,6 +137,43 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertEquals( (object) [ 'aspect-ratio' => [ '$$type' => 'string', 'value' => '16 / 9' ] ], $data['el-1']['props'] );
 		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_size_prop_into_a_canonical_prop_value() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'width' => '10px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [ 'width' => [ '$$type' => 'size', 'value' => [ 'size' => 10, 'unit' => 'px' ] ] ],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__routes_unrepresentable_size_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'width' => 'banana' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'width: banana;', $data['el-1']['customCss'] );
 	}
 
 	public function test_post__null_value_is_emitted_as_a_null_reset_prop() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -176,6 +176,23 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 'width: banana;', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__converts_grid_span_into_a_canonical_prop_value() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'grid-column' => 'span 2' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [ 'grid-column' => [ '$$type' => 'span', 'value' => 'span 2' ] ], $data['el-1']['props'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__converts_grid_auto_track_fraction_into_a_size_prop() {
 		// Arrange.
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -193,6 +193,36 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( '', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__converts_grid_template_as_string_passthrough() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'grid-template-columns' => 'repeat(3, 1fr)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [ 'grid-template-columns' => [ '$$type' => 'string', 'value' => 'repeat(3, 1fr)' ] ],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_grid_template_string_prop_value_validates_against_the_union_schema() {
+		// Arrange.
+		$schema = Style_Schema::get_style_schema();
+		$prop_value = [ '$$type' => 'string', 'value' => 'repeat(3, 1fr)' ];
+
+		// Act & Assert.
+		$this->assertTrue( $schema['grid-template-columns']->validate( $prop_value ) );
+		$this->assertTrue( $schema['grid-template-rows']->validate( $prop_value ) );
+	}
+
 	public function test_post__converts_grid_auto_track_fraction_into_a_size_prop() {
 		// Arrange.
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -37,6 +37,38 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		return json_decode( wp_json_encode( $response->get_data() ), true );
 	}
 
+	public function test_post__converts_box_shadow_into_array_of_shadow_props() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'box-shadow' => 'inset 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px black',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$prop = $data['el-1']['props']['box-shadow'];
+		$this->assertSame( 'box-shadow', $prop['$$type'] );
+		$this->assertCount( 2, $prop['value'] );
+
+		$first = $prop['value'][0]['value'];
+		$this->assertSame( 'inset', $first['position']['value'] );
+		$this->assertEquals( 4, $first['vOffset']['value']['size'] );
+		$this->assertEquals( -1, $first['spread']['value']['size'] );
+		$this->assertSame( 'rgba(0,0,0,0.1)', $first['color']['value'] );
+
+		$second = $prop['value'][1]['value'];
+		$this->assertArrayNotHasKey( 'position', $second );
+		$this->assertSame( 'black', $second['color']['value'] );
+
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__converts_transform_translate_to_move_prop() {
 		// Arrange.
 		$this->act_as_admin();
@@ -222,7 +254,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->act_as_admin();
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
-		$request->set_param( 'blocks', [ 'el-1' => [ 'transform' => 'matrix(1,0,0,1,0,0)', 'box-shadow' => '0 2px 4px black' ] ] );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'transform' => 'matrix(1,0,0,1,0,0)', 'stroke-width' => '2px' ] ] );
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
@@ -231,7 +263,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertEquals( (object) [], $data['el-1']['props'] );
-		$this->assertSame( 'transform: matrix(1,0,0,1,0,0); box-shadow: 0 2px 4px black;', $data['el-1']['customCss'] );
+		$this->assertSame( 'transform: matrix(1,0,0,1,0,0); stroke-width: 2px;', $data['el-1']['customCss'] );
 	}
 
 	public function test_post__returns_one_named_result_per_input_block() {
@@ -241,7 +273,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
 		$request->set_param( 'blocks', [
 			'el-1' => [ 'transform' => 'matrix(1,0,0,1,0,0)' ],
-			'el-2' => [ 'box-shadow' => '0 2px 4px black' ],
+			'el-2' => [ 'stroke-width' => '2px' ],
 		] );
 
 		// Act.
@@ -252,7 +284,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'el-1', 'el-2' ], array_keys( $data ) );
 		$this->assertSame( 'transform: matrix(1,0,0,1,0,0);', $data['el-1']['customCss'] );
-		$this->assertSame( 'box-shadow: 0 2px 4px black;', $data['el-2']['customCss'] );
+		$this->assertSame( 'stroke-width: 2px;', $data['el-2']['customCss'] );
 	}
 
 	public function test_post__converts_font_weight_into_a_canonical_prop_value() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -143,6 +143,36 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( '', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__converts_physical_inset_properties_to_logical_equivalents() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'top'    => '10px',
+			'right'  => '20px',
+			'bottom' => '30px',
+			'left'   => '40px',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: physical properties map to logical inset equivalents (LTR).
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'inset-block-start'  => [ '$$type' => 'size', 'value' => [ 'size' => 10, 'unit' => 'px' ] ],
+				'inset-inline-end'   => [ '$$type' => 'size', 'value' => [ 'size' => 20, 'unit' => 'px' ] ],
+				'inset-block-end'    => [ '$$type' => 'size', 'value' => [ 'size' => 30, 'unit' => 'px' ] ],
+				'inset-inline-start' => [ '$$type' => 'size', 'value' => [ 'size' => 40, 'unit' => 'px' ] ],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__converts_size_prop_into_a_canonical_prop_value() {
 		// Arrange.
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -71,6 +71,74 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 'gap: 4px;', $data['el-2']['customCss'] );
 	}
 
+	public function test_post__converts_font_weight_into_a_canonical_prop_value() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => 'font-weight: 700;' ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [ 'font-weight' => [ '$$type' => 'string', 'value' => '700' ] ], $data['el-1']['props'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__routes_invalid_font_weight_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => 'font-weight: 950;' ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'font-weight: 950;', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_enum_string_prop_and_declines_value_outside_enum() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => 'display: flex; position: nonsense;' ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [ 'display' => [ '$$type' => 'string', 'value' => 'flex' ] ], $data['el-1']['props'] );
+		$this->assertSame( 'position: nonsense;', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_free_string_prop_with_any_value() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => 'aspect-ratio: 16 / 9;' ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [ 'aspect-ratio' => [ '$$type' => 'string', 'value' => '16 / 9' ] ], $data['el-1']['props'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__requires_authentication() {
 		// Arrange.
 		wp_set_current_user( 0 );
@@ -107,7 +175,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$schema_properties = array_keys( Style_Schema::get_style_schema() );
 
 		// Act.
-		$uncovered = array_values( array_diff( $schema_properties, Converter_Registry_Factory::COVERED_PROPERTIES ) );
+		$uncovered = array_values( array_diff( $schema_properties, Converter_Registry_Factory::covered_properties() ) );
 
 		// Assert.
 		$this->assertSame(

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -1499,6 +1499,30 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( '', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__converts_plaintext_css_text_blocks_in_bulk() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [
+			'default' => 'display: flex;',
+			'hover' => 'color: red;',
+		] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'default', $data );
+		$this->assertArrayHasKey( 'hover', $data );
+		$this->assertEquals( 'flex', $data['default']['props']->display['value'] );
+		$this->assertEquals( 'red', $data['hover']['props']->color['value'] );
+		$this->assertSame( '', $data['default']['customCss'] );
+		$this->assertSame( '', $data['hover']['customCss'] );
+	}
+
 	public function test_post__null_value_is_emitted_as_a_null_reset_prop() {
 		// Arrange.
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -38,7 +38,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->act_as_admin();
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
-		$request->set_param( 'blocks', [ 'el-1' => 'color: red; z-index: 5;' ] );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'color' => 'red', 'z-index' => '5' ] ] );
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
@@ -56,8 +56,8 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
 		$request->set_param( 'blocks', [
-			'el-1' => 'color: red;',
-			'el-2' => 'gap: 4px;',
+			'el-1' => [ 'color' => 'red' ],
+			'el-2' => [ 'gap' => '4px' ],
 		] );
 
 		// Act.
@@ -76,7 +76,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->act_as_admin();
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
-		$request->set_param( 'blocks', [ 'el-1' => 'font-weight: 700;' ] );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'font-weight' => '700' ] ] );
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
@@ -93,7 +93,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->act_as_admin();
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
-		$request->set_param( 'blocks', [ 'el-1' => 'font-weight: 950;' ] );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'font-weight' => '950' ] ] );
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
@@ -110,7 +110,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->act_as_admin();
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
-		$request->set_param( 'blocks', [ 'el-1' => 'display: flex; position: nonsense;' ] );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'display' => 'flex', 'position' => 'nonsense' ] ] );
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
@@ -127,7 +127,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->act_as_admin();
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
-		$request->set_param( 'blocks', [ 'el-1' => 'aspect-ratio: 16 / 9;' ] );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'aspect-ratio' => '16 / 9' ] ] );
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
@@ -139,12 +139,58 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( '', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__null_value_is_emitted_as_a_null_reset_prop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'font-weight' => null ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [ 'font-weight' => null ], $data['el-1']['props'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__null_reset_coexists_with_converted_and_custom_css_declarations() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [
+			'el-1' => [
+				'font-weight' => '700',
+				'color' => null,
+				'z-index' => '5',
+			],
+		] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'font-weight' => [ '$$type' => 'string', 'value' => '700' ],
+				'color' => null,
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( 'z-index: 5;', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__requires_authentication() {
 		// Arrange.
 		wp_set_current_user( 0 );
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
-		$request->set_param( 'blocks', [ 'el-1' => 'color: red;' ] );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'color' => 'red' ] ] );
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
@@ -158,7 +204,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->act_as_admin();
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
-		$request->set_param( 'blocks', [ 'el-1' => 'behavior: url(x.htc); color: expression(alert(1));' ] );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'behavior' => 'url(x.htc)', 'color' => 'expression(alert(1))' ] ] );
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -330,6 +330,73 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 'padding: 10px 20px 30px 40px 50px;', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__converts_shorthand_border_radius_into_logical_corners() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border-radius' => '1px 2px 3px 4px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: TL->start-start, TR->start-end, BR->end-end, BL->end-start.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'border-radius' => [
+					'$$type' => 'border-radius',
+					'value' => [
+						'start-start' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+						'start-end' => [ '$$type' => 'size', 'value' => [ 'size' => 2, 'unit' => 'px' ] ],
+						'end-end' => [ '$$type' => 'size', 'value' => [ 'size' => 3, 'unit' => 'px' ] ],
+						'end-start' => [ '$$type' => 'size', 'value' => [ 'size' => 4, 'unit' => 'px' ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_single_border_radius_into_a_size() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border-radius' => '8px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [ 'border-radius' => [ '$$type' => 'size', 'value' => [ 'size' => 8, 'unit' => 'px' ] ] ],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__routes_elliptical_border_radius_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border-radius' => '10px / 20px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'border-radius: 10px / 20px;', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__converts_filter_into_a_canonical_prop_value() {
 		// Arrange.
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -7,6 +7,7 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter_REST_API;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 use Elementor\Modules\Variables\PropTypes\Color_Variable_Prop_Type;
 use Elementor\Modules\Variables\PropTypes\Font_Variable_Prop_Type;
+use Elementor\Modules\Variables\PropTypes\Size_Variable_Prop_Type;
 use Elementor\Modules\Variables\Storage\Constants as Variables_Constants;
 use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
@@ -1686,6 +1687,82 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		);
 		$this->assertSame( '', $data['el-1']['customCss'] );
 		$this->assertSame( [], $data['el-1']['rejected'] );
+
+		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
+	}
+
+	public function test_post__border_color_var_shorthand_promotes_to_border_color_prop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+		$kit->update_json_meta( Variables_Constants::VARIABLES_META_KEY, [
+			'data' => [
+				'e-gv-border' => [
+					'type' => Color_Variable_Prop_Type::get_key(),
+					'label' => 'primary-border',
+					'value' => '#112233',
+				],
+			],
+			'watermark' => 1,
+			'version' => 1,
+		] );
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border' => '1px solid var(--primary-border)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			[
+				'$$type' => Color_Variable_Prop_Type::get_key(),
+				'value' => 'e-gv-border',
+			],
+			(array) $data['el-1']['props']['border-color']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+
+		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
+	}
+
+	public function test_post__top_size_var_promotes_to_inset_block_start_prop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+		$kit->update_json_meta( Variables_Constants::VARIABLES_META_KEY, [
+			'data' => [
+				'e-gv-offset' => [
+					'type' => Size_Variable_Prop_Type::get_key(),
+					'label' => 'offset-md',
+					'value' => '16px',
+				],
+			],
+			'watermark' => 1,
+			'version' => 1,
+		] );
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'top' => 'var(--offset-md)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			[
+				'$$type' => Size_Variable_Prop_Type::get_key(),
+				'value' => 'e-gv-offset',
+			],
+			(array) $data['el-1']['props']['inset-block-start']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
 
 		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
 	}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -678,6 +678,76 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( '', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__converts_padding_longhands_into_logical_sides_of_padding_dimensions() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'padding-top'    => '10px',
+			'padding-right'  => '20px',
+			'padding-bottom' => '1.5rem',
+			'padding-left'   => '40px',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: physical longhands map to logical sides (top=block-start, right=inline-end, bottom=block-end, left=inline-start).
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'padding' => [
+					'$$type' => 'dimensions',
+					'value' => [
+						'block-start'  => [ '$$type' => 'size', 'value' => [ 'size' => 10,  'unit' => 'px'  ] ],
+						'inline-end'   => [ '$$type' => 'size', 'value' => [ 'size' => 20,  'unit' => 'px'  ] ],
+						'block-end'    => [ '$$type' => 'size', 'value' => [ 'size' => 1.5, 'unit' => 'rem' ] ],
+						'inline-start' => [ '$$type' => 'size', 'value' => [ 'size' => 40,  'unit' => 'px'  ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_margin_longhands_into_logical_sides_of_margin_dimensions() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'margin-top'    => '5px',
+			'margin-right'  => '10px',
+			'margin-bottom' => '15px',
+			'margin-left'   => '20px',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'margin' => [
+					'$$type' => 'dimensions',
+					'value' => [
+						'block-start'  => [ '$$type' => 'size', 'value' => [ 'size' => 5,  'unit' => 'px' ] ],
+						'inline-end'   => [ '$$type' => 'size', 'value' => [ 'size' => 10, 'unit' => 'px' ] ],
+						'block-end'    => [ '$$type' => 'size', 'value' => [ 'size' => 15, 'unit' => 'px' ] ],
+						'inline-start' => [ '$$type' => 'size', 'value' => [ 'size' => 20, 'unit' => 'px' ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__routes_unrepresentable_padding_to_custom_css() {
 		// Arrange.
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -5,6 +5,10 @@ namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry_Factory;
 use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter_REST_API;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
+use Elementor\Modules\Variables\PropTypes\Color_Variable_Prop_Type;
+use Elementor\Modules\Variables\PropTypes\Font_Variable_Prop_Type;
+use Elementor\Modules\Variables\Storage\Constants as Variables_Constants;
+use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -1598,6 +1602,97 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertEquals( (object) [], $data['el-1']['props'] );
 		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__promotes_known_color_var_to_global_color_variable_prop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+		$kit->update_json_meta( Variables_Constants::VARIABLES_META_KEY, [
+			'data' => [
+				'e-gv-1' => [
+					'type' => Color_Variable_Prop_Type::get_key(),
+					'label' => 'primary-text',
+					'value' => '#111111',
+				],
+			],
+			'watermark' => 1,
+			'version' => 1,
+		] );
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'color' => 'var(--primary-text)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'color' => [
+					'$$type' => Color_Variable_Prop_Type::get_key(),
+					'value' => 'e-gv-1',
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertTrue( Style_Schema::get()['color']->validate( (array) $data['el-1']['props']['color'] ) );
+
+		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
+	}
+
+	public function test_post__unknown_var_goes_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'color' => 'var(--external-var)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'color: var(--external-var);', $data['el-1']['customCss'] );
+		$this->assertSame( [], $data['el-1']['rejected'] );
+	}
+
+	public function test_post__wrong_variable_type_is_rejected() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+		$kit->update_json_meta( Variables_Constants::VARIABLES_META_KEY, [
+			'data' => [
+				'e-gv-3' => [
+					'type' => Font_Variable_Prop_Type::get_key(),
+					'label' => 'heading-font',
+					'value' => 'Roboto',
+				],
+			],
+			'watermark' => 1,
+			'version' => 1,
+		] );
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'font-size' => 'var(--heading-font)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+		$this->assertSame( [ 'font-size: var(--heading-font);' ], $data['el-1']['rejected'] );
+
+		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
 	}
 
 	public function test_coverage__every_style_schema_property_is_hardcoded_as_covered() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -1644,6 +1644,70 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
 	}
 
+	public function test_post__background_color_var_shorthand_promotes_to_background_prop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+		$kit->update_json_meta( Variables_Constants::VARIABLES_META_KEY, [
+			'data' => [
+				'e-gv-f32253d' => [
+					'type' => Color_Variable_Prop_Type::get_key(),
+					'label' => 'var-id',
+					'value' => '#112233',
+				],
+			],
+			'watermark' => 1,
+			'version' => 1,
+		] );
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background' => 'var(--var-id)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'background' => [
+					'$$type' => 'background',
+					'value' => [
+						'color' => [
+							'$$type' => Color_Variable_Prop_Type::get_key(),
+							'value' => 'e-gv-f32253d',
+						],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+		$this->assertSame( [], $data['el-1']['rejected'] );
+
+		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
+	}
+
+	public function test_post__background_unknown_var_stays_in_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background' => 'var(--external-var)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'background: var(--external-var);', $data['el-1']['customCss'] );
+		$this->assertSame( [], $data['el-1']['rejected'] );
+	}
+
 	public function test_post__unknown_var_goes_to_custom_css() {
 		// Arrange.
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -38,7 +38,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->act_as_admin();
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
-		$request->set_param( 'blocks', [ 'el-1' => [ 'color' => 'red', 'z-index' => '5' ] ] );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'padding' => '10px', 'margin' => '5px' ] ] );
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
@@ -47,7 +47,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertEquals( (object) [], $data['el-1']['props'] );
-		$this->assertSame( 'color: red; z-index: 5;', $data['el-1']['customCss'] );
+		$this->assertSame( 'padding: 10px; margin: 5px;', $data['el-1']['customCss'] );
 	}
 
 	public function test_post__returns_one_named_result_per_input_block() {
@@ -56,7 +56,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
 		$request->set_param( 'blocks', [
-			'el-1' => [ 'color' => 'red' ],
+			'el-1' => [ 'margin' => '8px' ],
 			'el-2' => [ 'padding' => '4px' ],
 		] );
 
@@ -67,7 +67,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'el-1', 'el-2' ], array_keys( $data ) );
-		$this->assertSame( 'color: red;', $data['el-1']['customCss'] );
+		$this->assertSame( 'margin: 8px;', $data['el-1']['customCss'] );
 		$this->assertSame( 'padding: 4px;', $data['el-2']['customCss'] );
 	}
 
@@ -176,6 +176,83 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 'width: banana;', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__converts_grid_auto_track_fraction_into_a_size_prop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'grid-auto-rows' => '1fr' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [ 'grid-auto-rows' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'fr' ] ] ],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_number_prop_into_a_canonical_prop_value() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'z-index' => '5' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [ 'z-index' => [ '$$type' => 'number', 'value' => 5 ] ], $data['el-1']['props'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__routes_non_numeric_number_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'z-index' => 'calc(1 + 1)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'z-index: calc(1 + 1);', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_color_prop_including_named_colors_as_raw_passthrough() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'color' => 'whitesmoke', 'border-color' => '#2d2a26' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'color' => [ '$$type' => 'color', 'value' => 'whitesmoke' ],
+				'border-color' => [ '$$type' => 'color', 'value' => '#2d2a26' ],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__null_value_is_emitted_as_a_null_reset_prop() {
 		// Arrange.
 		$this->act_as_admin();
@@ -202,7 +279,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 			'el-1' => [
 				'font-weight' => '700',
 				'color' => null,
-				'z-index' => '5',
+				'padding' => '10px',
 			],
 		] );
 
@@ -219,7 +296,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 			],
 			$data['el-1']['props']
 		);
-		$this->assertSame( 'z-index: 5;', $data['el-1']['customCss'] );
+		$this->assertSame( 'padding: 10px;', $data['el-1']['customCss'] );
 	}
 
 	public function test_post__requires_authentication() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -656,6 +656,23 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 'border-left-color: red;', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__multi_value_border_color_is_routed_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'border-color' => 'red green blue yellow' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: a single Color can't hold four sides, so the whole declaration is custom_css.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'border-color: red green blue yellow;', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__per_side_style_and_color_are_routed_to_custom_css() {
 		// Arrange.
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -37,6 +37,45 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		return json_decode( wp_json_encode( $response->get_data() ), true );
 	}
 
+	public function test_post__converts_transition_all_to_prop_value() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'transition' => 'all 300ms ease' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert: easing dropped, property and duration preserved.
+		$this->assertSame( 200, $response->get_status() );
+		$prop = $data['el-1']['props']['transition'];
+		$this->assertSame( 'transition', $prop['$$type'] );
+		$this->assertCount( 1, $prop['value'] );
+		$this->assertSame( 'all', $prop['value'][0]['value']['selection']['value']['value']['value'] );
+		$this->assertEquals( 300, $prop['value'][0]['value']['size']['value']['size'] );
+		$this->assertSame( 'ms', $prop['value'][0]['value']['size']['value']['unit'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__transition_with_unsupported_property_routes_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'transition' => 'border-left 300ms' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'transition: border-left 300ms;', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__animation_property_is_rejected_not_in_custom_css() {
 		// Arrange.
 		$this->act_as_admin();
@@ -118,7 +157,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->act_as_admin();
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
-		$request->set_param( 'blocks', [ 'el-1' => [ 'transform' => 'rotate(45deg)', 'transition' => 'all 0.3s' ] ] );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'transform' => 'rotate(45deg)', 'box-shadow' => '0 2px 4px black' ] ] );
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
@@ -127,7 +166,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertEquals( (object) [], $data['el-1']['props'] );
-		$this->assertSame( 'transform: rotate(45deg); transition: all 0.3s;', $data['el-1']['customCss'] );
+		$this->assertSame( 'transform: rotate(45deg); box-shadow: 0 2px 4px black;', $data['el-1']['customCss'] );
 	}
 
 	public function test_post__returns_one_named_result_per_input_block() {
@@ -137,7 +176,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
 		$request->set_param( 'blocks', [
 			'el-1' => [ 'transform' => 'rotate(45deg)' ],
-			'el-2' => [ 'transition' => 'all 0.3s' ],
+			'el-2' => [ 'box-shadow' => '0 2px 4px black' ],
 		] );
 
 		// Act.
@@ -148,7 +187,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'el-1', 'el-2' ], array_keys( $data ) );
 		$this->assertSame( 'transform: rotate(45deg);', $data['el-1']['customCss'] );
-		$this->assertSame( 'transition: all 0.3s;', $data['el-2']['customCss'] );
+		$this->assertSame( 'box-shadow: 0 2px 4px black;', $data['el-2']['customCss'] );
 	}
 
 	public function test_post__converts_font_weight_into_a_canonical_prop_value() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -37,6 +37,82 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		return json_decode( wp_json_encode( $response->get_data() ), true );
 	}
 
+	public function test_post__animation_property_is_rejected_not_in_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'animation' => 'spin 1s linear infinite' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: rejected, not leaked into customCss.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+		$this->assertSame( [ 'animation: spin 1s linear infinite;' ], $data['el-1']['rejected'] );
+	}
+
+	public function test_post__animation_longhands_are_rejected() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'animation-name'     => 'slide',
+			'animation-duration' => '0.5s',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 2, $data['el-1']['rejected'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__rejected_and_converted_props_coexist_in_one_block() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'color'     => 'red',
+			'animation' => 'spin 1s linear infinite',
+			'transform' => 'rotate(45deg)',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [ 'color' => [ '$$type' => 'color', 'value' => 'red' ] ], $data['el-1']['props'] );
+		$this->assertSame( 'transform: rotate(45deg);', $data['el-1']['customCss'] );
+		$this->assertSame( [ 'animation: spin 1s linear infinite;' ], $data['el-1']['rejected'] );
+	}
+
+	public function test_post__non_rejected_block_has_empty_rejected_array() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'color' => 'blue' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( [], $data['el-1']['rejected'] );
+	}
+
 	public function test_post__returns_empty_props_and_all_input_as_custom_css_with_only_noops() {
 		// Arrange.
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -37,6 +37,71 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		return json_decode( wp_json_encode( $response->get_data() ), true );
 	}
 
+	public function test_post__converts_transform_translate_to_move_prop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'transform' => 'translateX(50%) rotate(45deg)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$prop = $data['el-1']['props']['transform'];
+		$this->assertSame( 'transform', $prop['$$type'] );
+		$functions = $prop['value']['transform-functions']['value'];
+		$this->assertCount( 2, $functions );
+		$this->assertSame( 'transform-move', $functions[0]['$$type'] );
+		$this->assertSame( 'transform-rotate', $functions[1]['$$type'] );
+		$this->assertEquals( 45, $functions[1]['value']['z']['value']['size'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__transform_origin_merges_with_transform_functions() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'transform'        => 'scale(1.5)',
+			'transform-origin' => 'left top',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$transform = $data['el-1']['props']['transform'];
+		$this->assertSame( 'transform', $transform['$$type'] );
+		$this->assertArrayHasKey( 'transform-functions', $transform['value'] );
+		$origin = $transform['value']['transform-origin']['value'];
+		$this->assertSame( 0, $origin['x']['value']['size'] );
+		$this->assertSame( 0, $origin['y']['value']['size'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__transform_with_unsupported_function_routes_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'transform' => 'matrix(1,0,0,1,10,20)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertStringContainsString( 'transform:', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__converts_transition_all_to_prop_value() {
 		// Arrange.
 		$this->act_as_admin();
@@ -122,7 +187,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$request->set_param( 'blocks', [ 'el-1' => [
 			'color'     => 'red',
 			'animation' => 'spin 1s linear infinite',
-			'transform' => 'rotate(45deg)',
+			'transform' => 'matrix(1,0,0,1,0,0)',
 		] ] );
 
 		// Act.
@@ -132,7 +197,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertEquals( (object) [ 'color' => [ '$$type' => 'color', 'value' => 'red' ] ], $data['el-1']['props'] );
-		$this->assertSame( 'transform: rotate(45deg);', $data['el-1']['customCss'] );
+		$this->assertSame( 'transform: matrix(1,0,0,1,0,0);', $data['el-1']['customCss'] );
 		$this->assertSame( [ 'animation: spin 1s linear infinite;' ], $data['el-1']['rejected'] );
 	}
 
@@ -157,7 +222,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->act_as_admin();
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
-		$request->set_param( 'blocks', [ 'el-1' => [ 'transform' => 'rotate(45deg)', 'box-shadow' => '0 2px 4px black' ] ] );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'transform' => 'matrix(1,0,0,1,0,0)', 'box-shadow' => '0 2px 4px black' ] ] );
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
@@ -166,7 +231,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertEquals( (object) [], $data['el-1']['props'] );
-		$this->assertSame( 'transform: rotate(45deg); box-shadow: 0 2px 4px black;', $data['el-1']['customCss'] );
+		$this->assertSame( 'transform: matrix(1,0,0,1,0,0); box-shadow: 0 2px 4px black;', $data['el-1']['customCss'] );
 	}
 
 	public function test_post__returns_one_named_result_per_input_block() {
@@ -175,7 +240,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
 		$request->set_param( 'blocks', [
-			'el-1' => [ 'transform' => 'rotate(45deg)' ],
+			'el-1' => [ 'transform' => 'matrix(1,0,0,1,0,0)' ],
 			'el-2' => [ 'box-shadow' => '0 2px 4px black' ],
 		] );
 
@@ -186,7 +251,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'el-1', 'el-2' ], array_keys( $data ) );
-		$this->assertSame( 'transform: rotate(45deg);', $data['el-1']['customCss'] );
+		$this->assertSame( 'transform: matrix(1,0,0,1,0,0);', $data['el-1']['customCss'] );
 		$this->assertSame( 'box-shadow: 0 2px 4px black;', $data['el-2']['customCss'] );
 	}
 
@@ -1428,7 +1493,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 			'el-1' => [
 				'font-weight' => '700',
 				'color' => null,
-				'transform' => 'rotate(45deg)',
+				'transform' => 'matrix(1,0,0,1,0,0)',
 			],
 		] );
 
@@ -1445,7 +1510,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 			],
 			$data['el-1']['props']
 		);
-		$this->assertSame( 'transform: rotate(45deg);', $data['el-1']['customCss'] );
+		$this->assertSame( 'transform: matrix(1,0,0,1,0,0);', $data['el-1']['customCss'] );
 	}
 
 	public function test_post__requires_authentication() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -1937,6 +1937,447 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
 	}
 
+	public function test_post__padding_shorthand_then_logical_var_and_physical_override_with_invalid() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+		$kit->update_json_meta( Variables_Constants::VARIABLES_META_KEY, [
+			'data' => [
+				'e-gv-spacing' => [
+					'type' => Prop_Type_Adapter::GLOBAL_CUSTOM_SIZE_VARIABLE_KEY,
+					'label' => 'existing-size-var',
+					'value' => '1rem',
+				],
+			],
+			'watermark' => 1,
+			'version' => 1,
+		] );
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'padding'              => '2rem',
+			'padding-inline-start' => 'var(--existing-size-var)',
+			'padding-right'        => '1rem',
+			'padding-left'         => 'banana',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: shorthand seeds all 4 sides; logical inline-start overrides with promoted var;
+		// physical inline-end (right) overrides with 1rem; invalid left goes to customCss.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'padding' => [
+					'$$type' => 'dimensions',
+					'value'  => [
+						'block-start'  => [ '$$type' => 'size', 'value' => [ 'size' => 2, 'unit' => 'rem' ] ],
+						'inline-end'   => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'rem' ] ],
+						'block-end'    => [ '$$type' => 'size', 'value' => [ 'size' => 2, 'unit' => 'rem' ] ],
+						'inline-start' => [ '$$type' => Size_Variable_Prop_Type::get_key(), 'value' => 'e-gv-spacing' ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( 'padding-left: banana;', $data['el-1']['customCss'] );
+
+		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
+	}
+
+	public function test_post__conflicting_physical_logical_and_var_last_wins_on_same_side() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+		$kit->update_json_meta( Variables_Constants::VARIABLES_META_KEY, [
+			'data' => [
+				'e-gv-bottom' => [
+					'type' => Prop_Type_Adapter::GLOBAL_CUSTOM_SIZE_VARIABLE_KEY,
+					'label' => 'existing',
+					'value' => '8px',
+				],
+			],
+			'watermark' => 1,
+			'version' => 1,
+		] );
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [
+			'el-1' => 'padding-bottom: invalid; padding-block-end: 1rem; padding-bottom: var(--existing);',
+		] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert: invalid goes to customCss; logical sets block-end; physical var overrides last.
+		// Only block-end survives — dimensions with one variable side.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			[
+				'$$type' => 'dimensions',
+				'value'  => [
+					'block-end' => [ '$$type' => Size_Variable_Prop_Type::get_key(), 'value' => 'e-gv-bottom' ],
+				],
+			],
+			$data['el-1']['props']['padding']
+		);
+		$this->assertSame( 'padding-bottom: invalid;', $data['el-1']['customCss'] );
+
+		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
+	}
+
+	public function test_post__invalid_last_leaves_prior_converted_side_intact_and_adds_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [
+			'el-1' => 'padding-block-end: 1rem; padding-bottom: invalid;',
+		] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: invalid is declined (Size parser returns null), so the prior converted side
+		// remains in props; the invalid declaration still lands in customCss.
+		//
+		// INTENTIONAL BY DESIGN: a declined declaration never clears an already-converted prop.
+		// This means a single logical property can appear in both props (from a prior valid rule)
+		// and customCss (from a later invalid rule) simultaneously. Consumers should apply props
+		// first and customCss on top — the browser will ignore the invalid customCss value anyway.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'padding' => [
+					'$$type' => 'dimensions',
+					'value'  => [
+						'block-end' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'rem' ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( 'padding-bottom: invalid;', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__plain_size_after_var_wins_on_same_side() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+		$kit->update_json_meta( Variables_Constants::VARIABLES_META_KEY, [
+			'data' => [
+				'e-gv-bottom' => [
+					'type' => Prop_Type_Adapter::GLOBAL_CUSTOM_SIZE_VARIABLE_KEY,
+					'label' => 'existing',
+					'value' => '8px',
+				],
+			],
+			'watermark' => 1,
+			'version' => 1,
+		] );
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [
+			'el-1' => 'padding-bottom: invalid; padding-bottom: var(--existing); padding-block-end: 1rem;',
+		] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert: plain size (3rd) wins over the var (2nd); invalid (1st) goes to customCss.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			[
+				'$$type' => 'dimensions',
+				'value'  => [
+					'block-end' => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'rem' ] ],
+				],
+			],
+			$data['el-1']['props']['padding']
+		);
+		$this->assertSame( 'padding-bottom: invalid;', $data['el-1']['customCss'] );
+
+		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
+	}
+
+	public function test_post__padding_shorthand_after_longhand_collapses_to_single_size() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'padding-bottom' => '5px',
+			'padding'        => '10px',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: shorthand wins, collapsing the accumulated dimensions back to a single Size.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [ 'padding' => [ '$$type' => 'size', 'value' => [ 'size' => 10, 'unit' => 'px' ] ] ],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__padding_longhand_after_multi_value_shorthand_overrides_one_side() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'padding'      => '10px 20px',
+			'padding-left' => '99px',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert: shorthand expands to 4 sides (10 10 10 20 by CSS 2-value rule), then left overrides inline-start.
+		$this->assertSame( 200, $response->get_status() );
+		$prop = $data['el-1']['props']['padding'];
+		$this->assertSame( 'dimensions', $prop['$$type'] );
+		$this->assertEquals( 10,  $prop['value']['block-start']['value']['size'] );
+		$this->assertEquals( 20,  $prop['value']['inline-end']['value']['size'] );
+		$this->assertEquals( 10,  $prop['value']['block-end']['value']['size'] );
+		$this->assertEquals( 99,  $prop['value']['inline-start']['value']['size'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__single_padding_shorthand_seeds_all_sides_when_longhand_follows() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'padding'       => '2rem',
+			'padding-right' => '1rem',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert: 2rem seeds all 4 sides, then inline-end is overridden to 1rem.
+		$this->assertSame( 200, $response->get_status() );
+		$prop = $data['el-1']['props']['padding'];
+		$this->assertSame( 'dimensions', $prop['$$type'] );
+		$this->assertEquals( 2, $prop['value']['block-start']['value']['size'] );
+		$this->assertEquals( 1, $prop['value']['inline-end']['value']['size'] );
+		$this->assertEquals( 2, $prop['value']['block-end']['value']['size'] );
+		$this->assertEquals( 2, $prop['value']['inline-start']['value']['size'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__lone_margin_longhand_produces_partial_dimensions_with_one_side() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'margin-bottom' => '5px' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: partial dimensions with only block-end; other sides absent (not seeded).
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'margin' => [
+					'$$type' => 'dimensions',
+					'value'  => [
+						'block-end' => [ '$$type' => 'size', 'value' => [ 'size' => 5, 'unit' => 'px' ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__padding_and_margin_longhands_produce_independent_props() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'padding-bottom' => '5px',
+			'margin-bottom'  => '10px',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert: two independent props — padding only has block-end, margin only has block-end; no mixing.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'dimensions', $data['el-1']['props']['padding']['$$type'] );
+		$this->assertSame( 'dimensions', $data['el-1']['props']['margin']['$$type'] );
+		$this->assertEquals( 5,  $data['el-1']['props']['padding']['value']['block-end']['value']['size'] );
+		$this->assertEquals( 10, $data['el-1']['props']['margin']['value']['block-end']['value']['size'] );
+		$this->assertArrayNotHasKey( 'block-start', $data['el-1']['props']['padding']['value'] );
+		$this->assertArrayNotHasKey( 'block-start', $data['el-1']['props']['margin']['value'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__unresolved_var_on_dimension_side_routes_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'padding-bottom' => 'var(--unknown)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: unknown var is stored as a raw custom size; the transformer then ejects the
+		// whole padding prop back to customCss because the var cannot be resolved.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertStringContainsString( 'padding-bottom:', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__wrong_type_var_on_dimension_side_routes_to_rejected() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+		$kit->update_json_meta( Variables_Constants::VARIABLES_META_KEY, [
+			'data' => [
+				'e-gv-color' => [
+					'type' => Color_Variable_Prop_Type::get_key(),
+					'label' => 'my-color',
+					'value' => '#ff0000',
+				],
+			],
+			'watermark' => 1,
+			'version' => 1,
+		] );
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'padding-bottom' => 'var(--my-color)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: color variable used where a size is expected — prop is ejected to `rejected` (not customCss)
+		// because the variable is known but the type is wrong. The client uses `rejected` to surface type errors.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+		$this->assertContains( 'padding-bottom: var(--my-color);', $data['el-1']['rejected'] );
+
+		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
+	}
+
+	public function test_post__logical_and_physical_alias_on_same_side_last_wins() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'padding-inline-start' => '10px',
+			'padding-left'         => '20px',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert: padding-left (physical, last) overrides padding-inline-start (logical, first).
+		$this->assertSame( 200, $response->get_status() );
+		$prop = $data['el-1']['props']['padding'];
+		$this->assertSame( 'dimensions', $prop['$$type'] );
+		$this->assertEquals( 20, $prop['value']['inline-start']['value']['size'] );
+		$this->assertCount( 1, $prop['value'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__all_logical_padding_longhands_map_to_correct_sides() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'padding-block-start'  => '1px',
+			'padding-block-end'    => '2px',
+			'padding-inline-start' => '3px',
+			'padding-inline-end'   => '4px',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'padding' => [
+					'$$type' => 'dimensions',
+					'value'  => [
+						'block-start'  => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+						'block-end'    => [ '$$type' => 'size', 'value' => [ 'size' => 2, 'unit' => 'px' ] ],
+						'inline-start' => [ '$$type' => 'size', 'value' => [ 'size' => 3, 'unit' => 'px' ] ],
+						'inline-end'   => [ '$$type' => 'size', 'value' => [ 'size' => 4, 'unit' => 'px' ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__all_logical_margin_longhands_map_to_correct_sides() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [
+			'margin-block-start'  => '1px',
+			'margin-block-end'    => '2px',
+			'margin-inline-start' => '3px',
+			'margin-inline-end'   => '4px',
+		] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'margin' => [
+					'$$type' => 'dimensions',
+					'value'  => [
+						'block-start'  => [ '$$type' => 'size', 'value' => [ 'size' => 1, 'unit' => 'px' ] ],
+						'block-end'    => [ '$$type' => 'size', 'value' => [ 'size' => 2, 'unit' => 'px' ] ],
+						'inline-start' => [ '$$type' => 'size', 'value' => [ 'size' => 3, 'unit' => 'px' ] ],
+						'inline-end'   => [ '$$type' => 'size', 'value' => [ 'size' => 4, 'unit' => 'px' ] ],
+					],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
 	public function test_coverage__every_style_schema_property_is_hardcoded_as_covered() {
 		// Arrange.
 		$schema_properties = array_keys( Style_Schema::get_style_schema() );

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -143,6 +143,89 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( '', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__converts_object_position_named_keyword_to_string_prop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'object-position' => 'center center' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [ 'object-position' => [ '$$type' => 'string', 'value' => 'center center' ] ],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_object_position_size_pair_to_position_prop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'object-position' => '50% 30%' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$prop = $data['el-1']['props']['object-position'];
+		$this->assertSame( 'object-position', $prop['$$type'] );
+		$this->assertSame( '%', $prop['value']['x']['value']['unit'] );
+		$this->assertSame( '%', $prop['value']['y']['value']['unit'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_flex_none_to_flex_prop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'flex' => 'none' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$prop = $data['el-1']['props']['flex'];
+		$this->assertSame( 'flex', $prop['$$type'] );
+		$this->assertEquals( 0, $prop['value']['flexGrow']['value'] );
+		$this->assertEquals( 1, $prop['value']['flexShrink']['value'] );
+		$this->assertSame( 'auto', $prop['value']['flexBasis']['value']['size'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_flex_three_values_to_flex_prop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'flex' => '2 1 50%' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$prop = $data['el-1']['props']['flex'];
+		$this->assertSame( 'flex', $prop['$$type'] );
+		$this->assertEquals( 2, $prop['value']['flexGrow']['value'] );
+		$this->assertEquals( 1, $prop['value']['flexShrink']['value'] );
+		$this->assertEquals( 50, $prop['value']['flexBasis']['value']['size'] );
+		$this->assertSame( '%', $prop['value']['flexBasis']['value']['unit'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__converts_physical_inset_properties_to_logical_equivalents() {
 		// Arrange.
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -33,12 +33,16 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		parent::tearDown();
 	}
 
+	private function decoded_data( \WP_REST_Response $response ): array {
+		return json_decode( wp_json_encode( $response->get_data() ), true );
+	}
+
 	public function test_post__returns_empty_props_and_all_input_as_custom_css_with_only_noops() {
 		// Arrange.
 		$this->act_as_admin();
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
-		$request->set_param( 'blocks', [ 'el-1' => [ 'padding' => '10px', 'margin' => '5px' ] ] );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'transform' => 'rotate(45deg)', 'transition' => 'all 0.3s' ] ] );
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
@@ -47,7 +51,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertEquals( (object) [], $data['el-1']['props'] );
-		$this->assertSame( 'padding: 10px; margin: 5px;', $data['el-1']['customCss'] );
+		$this->assertSame( 'transform: rotate(45deg); transition: all 0.3s;', $data['el-1']['customCss'] );
 	}
 
 	public function test_post__returns_one_named_result_per_input_block() {
@@ -56,8 +60,8 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
 		$request->set_param( 'blocks', [
-			'el-1' => [ 'margin' => '8px' ],
-			'el-2' => [ 'padding' => '4px' ],
+			'el-1' => [ 'transform' => 'rotate(45deg)' ],
+			'el-2' => [ 'transition' => 'all 0.3s' ],
 		] );
 
 		// Act.
@@ -67,8 +71,8 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'el-1', 'el-2' ], array_keys( $data ) );
-		$this->assertSame( 'margin: 8px;', $data['el-1']['customCss'] );
-		$this->assertSame( 'padding: 4px;', $data['el-2']['customCss'] );
+		$this->assertSame( 'transform: rotate(45deg);', $data['el-1']['customCss'] );
+		$this->assertSame( 'transition: all 0.3s;', $data['el-2']['customCss'] );
 	}
 
 	public function test_post__converts_font_weight_into_a_canonical_prop_value() {
@@ -690,6 +694,377 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$this->assertSame( 'border-left-style: dashed; border-left-color: blue;', $data['el-1']['customCss'] );
 	}
 
+	public function test_post__converts_background_color_into_the_background_object() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background-color' => 'red' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals(
+			(object) [
+				'background' => [
+					'$$type' => 'background',
+					'value' => [ 'color' => [ '$$type' => 'color', 'value' => 'red' ] ],
+				],
+			],
+			$data['el-1']['props']
+		);
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__merges_background_color_and_clip_into_one_background_object() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background-color' => 'red', 'background-clip' => 'text' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert: both longhands accumulate into one background object that validates against the schema.
+		$this->assertSame( 200, $response->get_status() );
+
+		$prop_value = $data['el-1']['props']['background'];
+
+		$this->assertEquals(
+			[
+				'$$type' => 'background',
+				'value' => [
+					'color' => [ '$$type' => 'color', 'value' => 'red' ],
+					'clip' => [ '$$type' => 'string', 'value' => 'text' ],
+				],
+			],
+			$prop_value
+		);
+		$this->assertTrue( Style_Schema::get_style_schema()['background']->validate( $prop_value ) );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__routes_out_of_enum_background_clip_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background-clip' => 'banana' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'background-clip: banana;', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__background_shorthand_color_only_sets_background_color_field() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background' => 'red' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert: expander splits shorthand -> background-color converter sets background.color.
+		$this->assertSame( 200, $response->get_status() );
+
+		$bg = $data['el-1']['props']['background'];
+		$this->assertSame( 'background', $bg['$$type'] );
+		$this->assertSame( [ '$$type' => 'color', 'value' => 'red' ], $bg['value']['color'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__background_shorthand_url_and_repeat_sets_image_layer_and_repeat() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background' => 'url(https://example.com/img.jpg) no-repeat' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$bg = $data['el-1']['props']['background'];
+		$layer = $bg['value']['background-overlay']['value'][0];
+
+		$this->assertSame( 'background-image-overlay', $layer['$$type'] );
+		$this->assertSame( 'https://example.com/img.jpg', $layer['value']['image']['value']['src']['value']['url']['value'] );
+		$this->assertSame( 'no-repeat', $layer['value']['repeat']['value'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__background_shorthand_with_position_and_size() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background' => 'url(https://example.com/img.jpg) center center / cover' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$layer = $data['el-1']['props']['background']['value']['background-overlay']['value'][0];
+
+		$this->assertSame( 'center center', $layer['value']['position']['value'] );
+		$this->assertSame( 'cover', $layer['value']['size']['value'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__background_shorthand_gradient_image_creates_gradient_overlay() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background' => 'linear-gradient(135deg, #fff 0%, #000 100%)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert: expander emits background-image: ...; gradient converter creates overlay.
+		$this->assertSame( 200, $response->get_status() );
+
+		$overlay = $data['el-1']['props']['background']['value']['background-overlay']['value'][0];
+		$this->assertSame( 'background-gradient-overlay', $overlay['$$type'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__converts_background_image_url_into_image_overlay_layer() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background-image' => 'url(https://example.com/foo.jpg)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$bg = $data['el-1']['props']['background'];
+
+		$this->assertSame( 'background', $bg['$$type'] );
+		$this->assertCount( 1, $bg['value']['background-overlay']['value'] );
+
+		$layer = $bg['value']['background-overlay']['value'][0];
+
+		$this->assertSame( 'background-image-overlay', $layer['$$type'] );
+		$this->assertSame( 'https://example.com/foo.jpg', $layer['value']['image']['value']['src']['value']['url']['value'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__background_image_with_repeat_and_size_populates_layer_fields() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [
+			'el-1' => [
+				'background-image' => 'url(https://example.com/foo.jpg)',
+				'background-repeat' => 'no-repeat',
+				'background-size' => 'cover',
+			],
+		] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$layer = $data['el-1']['props']['background']['value']['background-overlay']['value'][0];
+
+		$this->assertSame( 'no-repeat', $layer['value']['repeat']['value'] );
+		$this->assertSame( 'cover', $layer['value']['size']['value'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__multiple_background_image_layers_with_per_layer_repeat() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [
+			'el-1' => [
+				'background-image' => 'url(https://example.com/a.jpg), url(https://example.com/b.jpg)',
+				'background-repeat' => 'no-repeat, repeat-x',
+			],
+		] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$layers = $data['el-1']['props']['background']['value']['background-overlay']['value'];
+
+		$this->assertCount( 2, $layers );
+		$this->assertSame( 'no-repeat', $layers[0]['value']['repeat']['value'] );
+		$this->assertSame( 'repeat-x', $layers[1]['value']['repeat']['value'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__background_image_none_creates_no_layers() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background-image' => 'none' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$overlay = $data['el-1']['props']['background']['value']['background-overlay'];
+		$this->assertCount( 0, $overlay['value'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__background_image_linear_gradient_creates_gradient_overlay() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background-image' => 'linear-gradient(135deg, #ffffff 0%, #00FFD5 50%, #FF3CAC 100%)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$overlay = $data['el-1']['props']['background']['value']['background-overlay']['value'][0];
+
+		$this->assertSame( 'background-gradient-overlay', $overlay['$$type'] );
+		$this->assertSame( 'linear', $overlay['value']['type']['value'] );
+		$this->assertEquals( 135, $overlay['value']['angle']['value'] );
+		$this->assertCount( 3, $overlay['value']['stops']['value'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__background_image_radial_gradient_with_percentage_position_creates_gradient_overlay() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background-image' => 'radial-gradient(circle at 20% 30%, rgba(0, 255, 213, 0.3) 0%, transparent 50%)' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$overlay = $data['el-1']['props']['background']['value']['background-overlay']['value'][0];
+
+		$this->assertSame( 'background-gradient-overlay', $overlay['$$type'] );
+		$this->assertSame( 'radial', $overlay['value']['type']['value'] );
+		$this->assertSame( '20% 30%', $overlay['value']['positions']['value'] );
+		$this->assertCount( 2, $overlay['value']['stops']['value'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__background_repeat_without_image_routes_to_custom_css() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [ 'el-1' => [ 'background-repeat' => 'no-repeat' ] ] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $response->get_data()['data'];
+
+		// Assert: no image layer to attach to.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( 'background-repeat: no-repeat;', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__background_size_pair_creates_scale_object() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [
+			'el-1' => [
+				'background-image' => 'url(https://example.com/foo.jpg)',
+				'background-size' => '50% 100%',
+			],
+		] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$size = $data['el-1']['props']['background']['value']['background-overlay']['value'][0]['value']['size'];
+
+		$this->assertSame( 'background-image-size-scale', $size['$$type'] );
+		$this->assertSame( 50, $size['value']['width']['value']['size'] );
+		$this->assertSame( 100, $size['value']['height']['value']['size'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
+	public function test_post__background_position_offset_creates_offset_object() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/css-to-atomic' );
+		$request->set_param( 'blocks', [
+			'el-1' => [
+				'background-image' => 'url(https://example.com/foo.jpg)',
+				'background-position' => '10px 20px',
+			],
+		] );
+
+		// Act.
+		$response = rest_get_server()->dispatch( $request );
+		$data = $this->decoded_data( $response )['data'];
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$pos = $data['el-1']['props']['background']['value']['background-overlay']['value'][0]['value']['position'];
+
+		$this->assertSame( 'background-image-position-offset', $pos['$$type'] );
+		$this->assertSame( 10, $pos['value']['x']['value']['size'] );
+		$this->assertSame( 20, $pos['value']['y']['value']['size'] );
+		$this->assertSame( '', $data['el-1']['customCss'] );
+	}
+
 	public function test_post__converts_filter_into_a_canonical_prop_value() {
 		// Arrange.
 		$this->act_as_admin();
@@ -699,7 +1074,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
-		$data = $response->get_data()['data'];
+		$data = $this->decoded_data( $response )['data'];
 
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
@@ -717,7 +1092,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
-		$data = $response->get_data()['data'];
+		$data = $this->decoded_data( $response )['data'];
 
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-converter-rest-api.php
@@ -2,9 +2,13 @@
 
 namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter;
 
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry_Factory;
 use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter_REST_API;
+use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
+use Elementor\Modules\Variables\Adapters\Prop_Type_Adapter;
+use Elementor\Modules\Variables\Module as Variables_Module;
 use Elementor\Modules\Variables\PropTypes\Color_Variable_Prop_Type;
 use Elementor\Modules\Variables\PropTypes\Font_Variable_Prop_Type;
 use Elementor\Modules\Variables\PropTypes\Size_Variable_Prop_Type;
@@ -18,8 +22,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
+	private string $original_atomic_widgets_experiment_state;
+
+	private string $original_variables_experiment_state;
+
 	public function setUp(): void {
 		parent::setUp();
+
+		$this->original_atomic_widgets_experiment_state = Plugin::$instance->experiments
+			->get_features( Atomic_Widgets_Module::EXPERIMENT_NAME )['default'];
+		$this->original_variables_experiment_state = Plugin::$instance->experiments
+			->get_features( Variables_Module::EXPERIMENT_NAME )['default'];
+
+		Plugin::$instance->experiments->set_feature_default_state(
+			Atomic_Widgets_Module::EXPERIMENT_NAME,
+			Experiments_Manager::STATE_ACTIVE
+		);
+		Plugin::$instance->experiments->set_feature_default_state(
+			Variables_Module::EXPERIMENT_NAME,
+			Experiments_Manager::STATE_ACTIVE
+		);
 
 		global $wp_rest_server;
 
@@ -31,6 +53,15 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 	}
 
 	public function tearDown(): void {
+		Plugin::$instance->experiments->set_feature_default_state(
+			Atomic_Widgets_Module::EXPERIMENT_NAME,
+			$this->original_atomic_widgets_experiment_state
+		);
+		Plugin::$instance->experiments->set_feature_default_state(
+			Variables_Module::EXPERIMENT_NAME,
+			$this->original_variables_experiment_state
+		);
+
 		global $wp_rest_server;
 
 		$wp_rest_server = null;
@@ -1627,12 +1658,12 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
-		$data = $response->get_data()['data'];
+		$data = $this->decoded_data( $response )['data'];
 
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertEquals(
-			(object) [
+			[
 				'color' => [
 					'$$type' => Color_Variable_Prop_Type::get_key(),
 					'value' => 'e-gv-1',
@@ -1640,7 +1671,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 			],
 			$data['el-1']['props']
 		);
-		$this->assertTrue( Style_Schema::get()['color']->validate( (array) $data['el-1']['props']['color'] ) );
+		$this->assertTrue( Style_Schema::get()['color']->validate( $data['el-1']['props']['color'] ) );
 
 		$kit->delete_meta( Variables_Constants::VARIABLES_META_KEY );
 	}
@@ -1667,12 +1698,12 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
-		$data = $response->get_data()['data'];
+		$data = $this->decoded_data( $response )['data'];
 
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertEquals(
-			(object) [
+			[
 				'background' => [
 					'$$type' => 'background',
 					'value' => [
@@ -1713,7 +1744,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
-		$data = $response->get_data()['data'];
+		$data = $this->decoded_data( $response )['data'];
 
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
@@ -1722,7 +1753,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 				'$$type' => Color_Variable_Prop_Type::get_key(),
 				'value' => 'e-gv-border',
 			],
-			(array) $data['el-1']['props']['border-color']
+			$data['el-1']['props']['border-color']
 		);
 		$this->assertSame( '', $data['el-1']['customCss'] );
 
@@ -1737,7 +1768,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 		$kit->update_json_meta( Variables_Constants::VARIABLES_META_KEY, [
 			'data' => [
 				'e-gv-offset' => [
-					'type' => Size_Variable_Prop_Type::get_key(),
+					'type' => Prop_Type_Adapter::GLOBAL_CUSTOM_SIZE_VARIABLE_KEY,
 					'label' => 'offset-md',
 					'value' => '16px',
 				],
@@ -1751,7 +1782,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		// Act.
 		$response = rest_get_server()->dispatch( $request );
-		$data = $response->get_data()['data'];
+		$data = $this->decoded_data( $response )['data'];
 
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
@@ -1760,7 +1791,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 				'$$type' => Size_Variable_Prop_Type::get_key(),
 				'value' => 'e-gv-offset',
 			],
-			(array) $data['el-1']['props']['inset-block-start']
+			$data['el-1']['props']['inset-block-start']
 		);
 		$this->assertSame( '', $data['el-1']['customCss'] );
 
@@ -1780,7 +1811,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( [], $data['el-1']['props'] );
 		$this->assertSame( 'background: var(--external-var);', $data['el-1']['customCss'] );
 		$this->assertSame( [], $data['el-1']['rejected'] );
 	}
@@ -1798,7 +1829,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( [], $data['el-1']['props'] );
 		$this->assertSame( 'color: var(--external-var);', $data['el-1']['customCss'] );
 		$this->assertSame( [], $data['el-1']['rejected'] );
 	}
@@ -1829,7 +1860,7 @@ class Test_Css_Converter_Rest_Api extends Elementor_Test_Base {
 
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertEquals( (object) [], $data['el-1']['props'] );
+		$this->assertSame( [], $data['el-1']['props'] );
 		$this->assertSame( '', $data['el-1']['customCss'] );
 		$this->assertSame( [ 'font-size: var(--heading-font);' ], $data['el-1']['rejected'] );
 

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-var-reference.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-css-var-reference.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Var_Reference;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Css_Var_Reference extends TestCase {
+
+	/**
+	 * @dataProvider references
+	 */
+	public function test_parse__extracts_variable_token( string $input, ?string $expected ) {
+		$this->assertSame( $expected, Css_Var_Reference::parse( $input ) );
+	}
+
+	public function references(): array {
+		return [
+			'simple' => [ 'var(--primary-text)', 'primary-text' ],
+			'with fallback' => [ 'var(--primary-text, #000)', 'primary-text' ],
+			'without dashes prefix' => [ 'var(primary-text)', 'primary-text' ],
+			'not a var' => [ '#ff0000', null ],
+			'whitespace' => [ '  var( --spacing-md )  ', 'spacing-md' ],
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-variable-prop-value-transformer.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-variable-prop-value-transformer.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Variable_Prop_Value_Transformer;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
+use Elementor\Modules\Variables\Adapters\Prop_Type_Adapter;
+use Elementor\Modules\Variables\PropTypes\Color_Variable_Prop_Type;
+use Elementor\Modules\Variables\PropTypes\Font_Variable_Prop_Type;
+use Elementor\Modules\Variables\PropTypes\Size_Variable_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\Variables\Services\Variables_Service;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Variable_Prop_Value_Transformer extends TestCase {
+
+	public function test_transform__promotes_color_var_reference_to_variable_prop_value() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'primary-text' )->willReturn( [
+			'id' => 'e-gv-1',
+			'type' => Color_Variable_Prop_Type::get_key(),
+			'label' => 'primary-text',
+			'value' => '#111111',
+		] );
+
+		$transformer = new Variable_Prop_Value_Transformer( $service );
+		$schema = [
+			'color' => Union_Prop_Type::create_from( Color_Prop_Type::make() )
+				->add_prop_type( Color_Variable_Prop_Type::make() ),
+		];
+
+		$result = $transformer->transform(
+			[ 'color' => Color_Prop_Type::generate( 'var(--primary-text)' ) ],
+			$schema
+		);
+
+		$this->assertSame(
+			[
+				'$$type' => Color_Variable_Prop_Type::get_key(),
+				'value' => 'e-gv-1',
+			],
+			$result['color']
+		);
+	}
+
+	public function test_eject__unknown_var_moves_declaration_to_custom_css() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'missing' )->willReturn( null );
+
+		$transformer = new Variable_Prop_Value_Transformer( $service );
+		$schema = [
+			'color' => Union_Prop_Type::create_from( Color_Prop_Type::make() )
+				->add_prop_type( Color_Variable_Prop_Type::make() ),
+		];
+		$rules = [
+			[
+				'property' => 'color',
+				'value' => 'var(--missing)',
+				'declaration' => 'color: var(--missing)',
+			],
+		];
+
+		$result = $transformer->eject_unresolved_var_props(
+			[ 'color' => Color_Prop_Type::generate( 'var(--missing)' ) ],
+			$schema,
+			$rules
+		);
+
+		$this->assertSame( [], $result['props'] );
+		$this->assertSame( [ 'color: var(--missing);' ], $result['custom_css'] );
+		$this->assertSame( [], $result['rejected'] );
+	}
+
+	public function test_eject__wrong_variable_type_moves_declaration_to_rejected() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'heading-font' )->willReturn( [
+			'id' => 'e-gv-3',
+			'type' => Font_Variable_Prop_Type::get_key(),
+			'label' => 'heading-font',
+			'value' => 'Roboto',
+		] );
+
+		$transformer = new Variable_Prop_Value_Transformer( $service );
+		$schema = [
+			'font-size' => Union_Prop_Type::create_from( Size_Prop_Type::make() )
+				->add_prop_type( Size_Variable_Prop_Type::make() ),
+		];
+		$rules = [
+			[
+				'property' => 'font-size',
+				'value' => 'var(--heading-font)',
+				'declaration' => 'font-size: var(--heading-font)',
+			],
+		];
+
+		$result = $transformer->eject_unresolved_var_props(
+			[
+				'font-size' => [
+					'$$type' => 'size',
+					'value' => [
+						'size' => 'var(--heading-font)',
+						'unit' => 'custom',
+					],
+				],
+			],
+			$schema,
+			$rules
+		);
+
+		$this->assertSame( [], $result['props'] );
+		$this->assertSame( [], $result['custom_css'] );
+		$this->assertSame( [ 'font-size: var(--heading-font);' ], $result['rejected'] );
+	}
+
+	public function test_transform__promotes_font_var_reference_to_font_variable_prop_value() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'heading-font' )->willReturn( [
+			'id' => 'e-gv-3',
+			'type' => Font_Variable_Prop_Type::get_key(),
+			'label' => 'heading-font',
+			'value' => 'Roboto',
+		] );
+
+		$transformer = new Variable_Prop_Value_Transformer( $service );
+		$schema = [
+			'font-family' => Union_Prop_Type::create_from( String_Prop_Type::make() )
+				->add_prop_type( Font_Variable_Prop_Type::make() ),
+		];
+
+		$result = $transformer->transform(
+			[ 'font-family' => String_Prop_Type::generate( 'var(--heading-font)' ) ],
+			$schema
+		);
+
+		$this->assertSame(
+			[
+				'$$type' => Font_Variable_Prop_Type::get_key(),
+				'value' => 'e-gv-3',
+			],
+			$result['font-family']
+		);
+	}
+
+	public function test_transform__promotes_custom_size_var_to_size_variable_prop_value() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'fluid-spacing' )->willReturn( [
+			'id' => 'e-gv-4',
+			'type' => Prop_Type_Adapter::GLOBAL_CUSTOM_SIZE_VARIABLE_KEY,
+			'label' => 'fluid-spacing',
+			'value' => 'clamp(1rem, 2vw, 2rem)',
+		] );
+
+		$transformer = new Variable_Prop_Value_Transformer( $service );
+		$schema = [
+			'width' => Union_Prop_Type::create_from( Size_Prop_Type::make() )
+				->add_prop_type( Size_Variable_Prop_Type::make() ),
+		];
+
+		$result = $transformer->transform(
+			[
+				'width' => [
+					'$$type' => 'size',
+					'value' => [
+						'size' => 'var(--fluid-spacing)',
+						'unit' => 'custom',
+					],
+				],
+			],
+			$schema
+		);
+
+		$this->assertSame(
+			[
+				'$$type' => Size_Variable_Prop_Type::get_key(),
+				'value' => 'e-gv-4',
+			],
+			$result['width']
+		);
+	}
+
+	public function test_transform__promotes_size_var_custom_unit_reference() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'spacing-md' )->willReturn( [
+			'id' => 'e-gv-2',
+			'type' => Size_Variable_Prop_Type::get_key(),
+			'label' => 'spacing-md',
+			'value' => '16px',
+		] );
+
+		$transformer = new Variable_Prop_Value_Transformer( $service );
+		$schema = [
+			'padding-top' => Union_Prop_Type::create_from( Size_Prop_Type::make() )
+				->add_prop_type( Size_Variable_Prop_Type::make() ),
+		];
+
+		$result = $transformer->transform(
+			[
+				'padding-top' => [
+					'$$type' => 'size',
+					'value' => [
+						'size' => 'var(--spacing-md)',
+						'unit' => 'custom',
+					],
+				],
+			],
+			$schema
+		);
+
+		$this->assertSame(
+			[
+				'$$type' => Size_Variable_Prop_Type::get_key(),
+				'value' => 'e-gv-2',
+			],
+			$result['padding-top']
+		);
+		$this->assertTrue( $schema['padding-top']->validate( $result['padding-top'] ) );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/value-parsers/test-background-image-value-parser.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/value-parsers/test-background-image-value-parser.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\ValueParsers;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Background_Image_Value_Parser;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Background_Image_Value_Parser extends TestCase {
+	public function test_parse__single_url_returns_one_image_overlay() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'url(foo.jpg)' );
+
+		// Assert.
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'background-image-overlay', $result[0]['$$type'] );
+		$this->assertSame( 'foo.jpg', $result[0]['value']['image']['value']['src']['value']['url']['value'] );
+	}
+
+	public function test_parse__quoted_url_strips_quotes() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( "url('foo.jpg')" );
+
+		// Assert.
+		$this->assertSame( 'foo.jpg', $result[0]['value']['image']['value']['src']['value']['url']['value'] );
+	}
+
+	public function test_parse__multiple_urls_returns_ordered_overlays() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'url(a.jpg), url(b.jpg)' );
+
+		// Assert.
+		$this->assertCount( 2, $result );
+		$this->assertSame( 'a.jpg', $result[0]['value']['image']['value']['src']['value']['url']['value'] );
+		$this->assertSame( 'b.jpg', $result[1]['value']['image']['value']['src']['value']['url']['value'] );
+	}
+
+	public function test_parse__none_layer_is_skipped() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'url(a.jpg), none' );
+
+		// Assert: the `none` layer is silently dropped.
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'background-image-overlay', $result[0]['$$type'] );
+	}
+
+	public function test_parse__all_none_returns_empty_array() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'none' );
+
+		// Assert.
+		$this->assertSame( [], $result );
+	}
+
+	public function test_parse__linear_gradient_returns_gradient_overlay() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'linear-gradient(135deg, #ffffff 0%, #00FFD5 50%, #FF3CAC 100%)' );
+
+		// Assert: returns one gradient overlay with type, angle and stops.
+		$this->assertCount( 1, $result );
+
+		$overlay = $result[0];
+		$this->assertSame( 'background-gradient-overlay', $overlay['$$type'] );
+		$this->assertSame( 'linear', $overlay['value']['type']['value'] );
+		$this->assertSame( 135.0, $overlay['value']['angle']['value'] );
+
+		$stops = $overlay['value']['stops']['value'];
+		$this->assertCount( 3, $stops );
+		$this->assertSame( '#ffffff', $stops[0]['value']['color']['value'] );
+		$this->assertSame( 0.0, $stops[0]['value']['offset']['value'] );
+		$this->assertSame( '#00FFD5', $stops[1]['value']['color']['value'] );
+		$this->assertSame( 50.0, $stops[1]['value']['offset']['value'] );
+		$this->assertSame( '#FF3CAC', $stops[2]['value']['color']['value'] );
+		$this->assertSame( 100.0, $stops[2]['value']['offset']['value'] );
+	}
+
+	public function test_parse__linear_gradient_without_angle() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'linear-gradient(#ffffff 0%, #000000 100%)' );
+
+		// Assert: angle is optional.
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'background-gradient-overlay', $result[0]['$$type'] );
+		$this->assertArrayNotHasKey( 'angle', $result[0]['value'] );
+	}
+
+	public function test_parse__radial_gradient_with_position() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'radial-gradient(circle at center center, #ffffff 0%, #000000 100%)' );
+
+		// Assert.
+		$this->assertCount( 1, $result );
+		$overlay = $result[0];
+		$this->assertSame( 'background-gradient-overlay', $overlay['$$type'] );
+		$this->assertSame( 'radial', $overlay['value']['type']['value'] );
+		$this->assertSame( 'center center', $overlay['value']['positions']['value'] );
+	}
+
+	public function test_parse__linear_gradient_with_direction_keyword_declines() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'linear-gradient(to right, #ffffff, #000000)' );
+
+		// Assert: `to right` direction keywords are not supported.
+		$this->assertNull( $result );
+	}
+
+	public function test_parse__mixed_url_and_gradient() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'url(foo.jpg), linear-gradient(#fff, #000)' );
+
+		// Assert: both layers parsed into their respective overlay types.
+		$this->assertCount( 2, $result );
+		$this->assertSame( 'background-image-overlay', $result[0]['$$type'] );
+		$this->assertSame( 'background-gradient-overlay', $result[1]['$$type'] );
+	}
+
+	public function test_parse__unrecognised_keyword_declines() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'banana' );
+
+		// Assert.
+		$this->assertNull( $result );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/value-parsers/test-box-shorthand-parser.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/value-parsers/test-box-shorthand-parser.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\ValueParsers;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Box_Shorthand_Parser;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Box_Shorthand_Parser extends TestCase {
+
+	public function test_parse__single_value_returns_a_single_leaf() {
+		// Act & Assert.
+		$this->assertSame( [ 'single' => $this->px( 10 ) ], Box_Shorthand_Parser::parse( '10px' ) );
+	}
+
+	public function test_parse__two_values_expand_to_four_sides() {
+		// Act & Assert.
+		$this->assertSame(
+			[ 'sides' => [ $this->px( 10 ), $this->px( 20 ), $this->px( 10 ), $this->px( 20 ) ] ],
+			Box_Shorthand_Parser::parse( '10px 20px' )
+		);
+	}
+
+	public function test_parse__three_values_expand_to_four_sides() {
+		// Act & Assert: [ a, b, c, b ].
+		$this->assertSame(
+			[ 'sides' => [ $this->px( 1 ), $this->px( 2 ), $this->px( 3 ), $this->px( 2 ) ] ],
+			Box_Shorthand_Parser::parse( '1px 2px 3px' )
+		);
+	}
+
+	public function test_parse__four_values_map_in_order() {
+		// Act & Assert.
+		$this->assertSame(
+			[ 'sides' => [ $this->px( 1 ), $this->px( 2 ), $this->px( 3 ), $this->px( 4 ) ] ],
+			Box_Shorthand_Parser::parse( '1px 2px 3px 4px' )
+		);
+	}
+
+	public function test_parse__keeps_calc_division_as_one_token() {
+		// Act: a "/" inside calc() must not be treated as an elliptical separator.
+		$result = Box_Shorthand_Parser::parse( 'calc(100% / 4)' );
+
+		// Assert.
+		$this->assertSame(
+			[ 'single' => [ 'size' => 'calc(100% / 4)', 'unit' => 'custom' ] ],
+			$result
+		);
+	}
+
+	/**
+	 * @dataProvider declined_values
+	 */
+	public function test_parse__declines_unrepresentable_value( string $value ) {
+		// Act & Assert.
+		$this->assertNull( Box_Shorthand_Parser::parse( $value ) );
+	}
+
+	public function declined_values(): array {
+		return [
+			'empty' => [ '   ' ],
+			'too many values' => [ '1px 2px 3px 4px 5px' ],
+			'non-size token' => [ 'banana' ],
+			'one bad token among good' => [ '10px banana' ],
+			'elliptical spaced slash' => [ '10px / 20px' ],
+			'elliptical glued slash' => [ '10px/20px' ],
+			'elliptical four plus slash' => [ '10px 20px 30px 40px / 50px' ],
+		];
+	}
+
+	private function px( int $size ): array {
+		return [ 'size' => $size, 'unit' => 'px' ];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/value-parsers/test-filter-value-parser.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/value-parsers/test-filter-value-parser.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\ValueParsers;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Filter_Value_Parser;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Filter_Value_Parser extends TestCase {
+
+	public function test_parse__single_blur_emits_one_css_filter_func() {
+		// Act.
+		$result = Filter_Value_Parser::parse( 'blur(5px)' );
+
+		// Assert.
+		$this->assertSame( [ $this->single_func( 'blur', 'blur', 5, 'px' ) ], $result );
+	}
+
+	public function test_parse__maps_each_function_name_to_its_arg_group() {
+		// Act.
+		$result = Filter_Value_Parser::parse( 'brightness(150%) grayscale(50%) hue-rotate(90deg)' );
+
+		// Assert.
+		$this->assertSame(
+			[
+				$this->single_func( 'brightness', 'intensity', 150, '%' ),
+				$this->single_func( 'grayscale', 'color-tone', 50, '%' ),
+				$this->single_func( 'hue-rotate', 'hue-rotate', 90, 'deg' ),
+			],
+			$result
+		);
+	}
+
+	public function test_parse__drop_shadow_with_all_parts() {
+		// Act.
+		$result = Filter_Value_Parser::parse( 'drop-shadow(2px 4px 6px rgba(0, 0, 0, .5))' );
+
+		// Assert.
+		$this->assertSame(
+			[ $this->drop_shadow( [ 2, 'px' ], [ 4, 'px' ], [ 6, 'px' ], 'rgba(0, 0, 0, .5)' ) ],
+			$result
+		);
+	}
+
+	public function test_parse__drop_shadow_without_blur_uses_default_blur() {
+		// Act.
+		$result = Filter_Value_Parser::parse( 'drop-shadow(2px 4px black)' );
+
+		// Assert: blur falls back to the schema default (10px).
+		$this->assertSame(
+			[ $this->drop_shadow( [ 2, 'px' ], [ 4, 'px' ], [ 10, 'px' ], 'black' ) ],
+			$result
+		);
+	}
+
+	public function test_parse__drop_shadow_offsets_only_uses_default_blur_and_color() {
+		// Act.
+		$result = Filter_Value_Parser::parse( 'drop-shadow(2px 4px)' );
+
+		// Assert.
+		$this->assertSame(
+			[ $this->drop_shadow( [ 2, 'px' ], [ 4, 'px' ], [ 10, 'px' ], 'rgba(0, 0, 0, 1)' ) ],
+			$result
+		);
+	}
+
+	/**
+	 * @dataProvider declined_values
+	 */
+	public function test_parse__declines_unrepresentable_value( string $value ) {
+		// Act & Assert.
+		$this->assertNull( Filter_Value_Parser::parse( $value ) );
+	}
+
+	public function declined_values(): array {
+		return [
+			'unsupported function' => [ 'opacity(50%)' ],
+			'unitless intensity' => [ 'brightness(1.5)' ],
+			'one bad function among good' => [ 'blur(5px) opacity(50%)' ],
+			'missing parens' => [ 'blur 5px' ],
+			'unbalanced parens' => [ 'blur(5px' ],
+			'drop-shadow too few sizes' => [ 'drop-shadow(2px)' ],
+			'drop-shadow too many sizes' => [ 'drop-shadow(1px 2px 3px 4px)' ],
+			'drop-shadow two colors' => [ 'drop-shadow(2px 4px black white)' ],
+			'keyword none' => [ 'none' ],
+			'empty' => [ '   ' ],
+		];
+	}
+
+	private function single_func( string $name, string $group, $size, string $unit ): array {
+		return [
+			'$$type' => 'css-filter-func',
+			'value' => [
+				'func' => [ '$$type' => 'string', 'value' => $name ],
+				'args' => [
+					'$$type' => $group,
+					'value' => [ 'size' => [ '$$type' => 'size', 'value' => [ 'size' => $size, 'unit' => $unit ] ] ],
+				],
+			],
+		];
+	}
+
+	private function drop_shadow( array $x, array $y, array $blur, string $color ): array {
+		return [
+			'$$type' => 'css-filter-func',
+			'value' => [
+				'func' => [ '$$type' => 'string', 'value' => 'drop-shadow' ],
+				'args' => [
+					'$$type' => 'drop-shadow',
+					'value' => [
+						'xAxis' => $this->size( $x[0], $x[1] ),
+						'yAxis' => $this->size( $y[0], $y[1] ),
+						'blur' => $this->size( $blur[0], $blur[1] ),
+						'color' => [ '$$type' => 'color', 'value' => $color ],
+					],
+				],
+			],
+		];
+	}
+
+	private function size( $size, string $unit ): array {
+		return [ '$$type' => 'size', 'value' => [ 'size' => $size, 'unit' => $unit ] ];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/value-parsers/test-size-value-parser.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/value-parsers/test-size-value-parser.php
@@ -47,6 +47,26 @@ class Test_Size_Value_Parser extends TestCase {
 		$this->assertSame( [ 'size' => null, 'unit' => 'auto' ], Size_Value_Parser::parse( 'auto' ) );
 	}
 
+	public function test_parse__unitless_non_zero_declines_by_default() {
+		// Act & Assert.
+		$this->assertNull( Size_Value_Parser::parse( '1.1' ) );
+	}
+
+	public function test_parse__unitless_non_zero_is_kept_as_custom_when_allowed() {
+		// Act & Assert: the raw token is preserved verbatim so it renders without a unit.
+		$this->assertSame( [ 'size' => '1.1', 'unit' => 'custom' ], Size_Value_Parser::parse( '1.1', true ) );
+	}
+
+	public function test_parse__unitless_zero_stays_pixels_even_when_unitless_allowed() {
+		// Act & Assert.
+		$this->assertSame( [ 'size' => 0, 'unit' => 'px' ], Size_Value_Parser::parse( '0', true ) );
+	}
+
+	public function test_parse__value_with_unit_ignores_unitless_flag() {
+		// Act & Assert.
+		$this->assertSame( [ 'size' => 24, 'unit' => 'px' ], Size_Value_Parser::parse( '24px', true ) );
+	}
+
 	/**
 	 * @dataProvider dynamic_values
 	 */

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/value-parsers/test-size-value-parser.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/value-parsers/test-size-value-parser.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\ValueParsers;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Size_Value_Parser extends TestCase {
+
+	/**
+	 * @dataProvider numeric_values
+	 */
+	public function test_parse__numeric_value_with_supported_unit( string $input, $expected_size, string $expected_unit ) {
+		// Act.
+		$parsed = Size_Value_Parser::parse( $input );
+
+		// Assert.
+		$this->assertSame( [ 'size' => $expected_size, 'unit' => $expected_unit ], $parsed );
+	}
+
+	public function numeric_values(): array {
+		return [
+			'pixels' => [ '16px', 16, 'px' ],
+			'rem' => [ '1.5rem', 1.5, 'rem' ],
+			'em' => [ '2em', 2, 'em' ],
+			'percent' => [ '50%', 50, '%' ],
+			'viewport width' => [ '100vw', 100, 'vw' ],
+			'viewport height' => [ '100vh', 100, 'vh' ],
+			'fraction' => [ '1fr', 1, 'fr' ],
+			'leading dot' => [ '.5em', 0.5, 'em' ],
+			'negative' => [ '-10px', -10, 'px' ],
+			'uppercase unit is normalized' => [ '10PX', 10, 'px' ],
+		];
+	}
+
+	public function test_parse__unitless_zero_defaults_to_pixels() {
+		// Act & Assert.
+		$this->assertSame( [ 'size' => 0, 'unit' => 'px' ], Size_Value_Parser::parse( '0' ) );
+	}
+
+	public function test_parse__auto_keyword_maps_to_auto_unit() {
+		// Act & Assert.
+		$this->assertSame( [ 'size' => null, 'unit' => 'auto' ], Size_Value_Parser::parse( 'auto' ) );
+	}
+
+	/**
+	 * @dataProvider dynamic_values
+	 */
+	public function test_parse__dynamic_value_is_kept_verbatim_as_custom( string $input ) {
+		// Act.
+		$parsed = Size_Value_Parser::parse( $input );
+
+		// Assert.
+		$this->assertSame( [ 'size' => $input, 'unit' => 'custom' ], $parsed );
+	}
+
+	public function dynamic_values(): array {
+		return [
+			'calc' => [ 'calc(100% - 20px)' ],
+			'clamp' => [ 'clamp(1rem, 2vw, 3rem)' ],
+			'min' => [ 'min(10px, 2em)' ],
+			'max' => [ 'max(10px, 2em)' ],
+			'var' => [ 'var(--w)' ],
+			'env' => [ 'env(safe-area-inset-top)' ],
+		];
+	}
+
+	/**
+	 * @dataProvider declined_values
+	 */
+	public function test_parse__declines_unrepresentable_value( string $input ) {
+		// Act & Assert.
+		$this->assertNull( Size_Value_Parser::parse( $input ) );
+	}
+
+	public function declined_values(): array {
+		return [
+			'empty' => [ '' ],
+			'whitespace' => [ '   ' ],
+			'unitless non-zero' => [ '1.5' ],
+			'unknown unit' => [ '10xyz' ],
+			'non-numeric keyword' => [ 'banana' ],
+			'multi value' => [ '10px 20px' ],
+			'trailing garbage' => [ '10px!important' ],
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/variables/services/test-variables-service.php
+++ b/tests/phpunit/elementor/modules/variables/services/test-variables-service.php
@@ -572,5 +572,69 @@ class Test_Variables_Service extends TestCase {
 		$this->assertArrayHasKey( 'deleted_at', $result['id-2'] );
 	}
 
+	public function test_find_by_label_or_id__finds_by_id() {
+		$service = $this->service_with_variables_list( [
+			'id-2' => [
+				'type' => 'global-color-var',
+				'label' => 'Secondary',
+				'value' => '#000000',
+			],
+		] );
+
+		$result = $service->find_by_label_or_id( 'id-2' );
+
+		$this->assertSame( 'id-2', $result['id'] );
+		$this->assertSame( 'Secondary', $result['label'] );
+	}
+
+	public function test_find_by_label_or_id__finds_by_label_case_insensitive() {
+		$service = $this->service_with_variables_list( [
+			'id-1' => [
+				'type' => 'global-size-var',
+				'label' => 'Primary',
+				'value' => '100px',
+			],
+		] );
+
+		$result = $service->find_by_label_or_id( 'primary' );
+
+		$this->assertSame( 'id-1', $result['id'] );
+	}
+
+	public function test_find_by_label_or_id__strips_leading_dashes() {
+		$service = $this->service_with_variables_list( [
+			'id-1' => [
+				'type' => 'global-size-var',
+				'label' => 'Primary',
+				'value' => '100px',
+			],
+		] );
+
+		$result = $service->find_by_label_or_id( '--primary' );
+
+		$this->assertSame( 'id-1', $result['id'] );
+	}
+
+	public function test_find_by_label_or_id__returns_null_for_unknown() {
+		$service = $this->service_with_variables_list( [] );
+
+		$this->assertNull( $service->find_by_label_or_id( 'nope' ) );
+	}
+
+	private function service_with_variables_list( array $variables ): Variables_Service {
+		return new class( $this->repository, new Batch_Processor(), $variables ) extends Variables_Service {
+			private array $variables;
+
+			public function __construct( $repository, $batch_processor, array $variables ) {
+				parent::__construct( $repository, $batch_processor );
+				$this->variables = $variables;
+			}
+
+			public function get_variables_list(): array {
+				return $this->variables;
+			}
+		};
+	}
+
 }
 

--- a/tests/phpunit/run-unit.sh
+++ b/tests/phpunit/run-unit.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Fast DB-less PHPUnit for local dev. Runs the given test files with the unit bootstrap
+# (no WordPress, no MySQL) and without the project phpunit.xml.
+#
+# Usage:
+#   tests/phpunit/run-unit.sh <test-file> [<test-file> ...] [extra phpunit args]
+#
+# Examples:
+#   tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-string-property-converter.php
+#   tests/phpunit/run-unit.sh tests/phpunit/.../test-css-converter.php --filter test_convert
+#   tests/phpunit/run-unit.sh tests/phpunit/.../test-css-converter.php tests/phpunit/.../test-converter-registry.php
+#
+# Anything ending in .php is treated as a test file (added to a generated testsuite, which sidesteps
+# PHPUnit's filename<->classname assumption for `test-*.php`). Everything else is passed through to
+# PHPUnit (e.g. --filter <pattern>). Only works for tests whose subjects don't call WordPress at
+# load/run time; tests needing WordPress/MySQL must use the full suite.
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+files=()
+passthrough=()
+
+for arg in "$@"; do
+	case "$arg" in
+		*.php)
+			if [ ! -f "$arg" ]; then
+				# Resolve relative to repo root if not found from the current directory.
+				arg="$root/$arg"
+			fi
+			files+=( "$arg" )
+			;;
+		*)
+			passthrough+=( "$arg" )
+			;;
+	esac
+done
+
+if [ "${#files[@]}" -eq 0 ]; then
+	echo "Usage: $0 <test-file.php> [<test-file.php> ...] [extra phpunit args]" >&2
+	exit 1
+fi
+
+config="$(mktemp -t run-unit-XXXXXX.xml)"
+trap 'rm -f "$config"' EXIT
+
+{
+	echo '<phpunit bootstrap="'"$root"'/tests/phpunit/unit-bootstrap.php" colors="true" failOnWarning="true" failOnRisky="true">'
+	echo '	<testsuites>'
+	echo '		<testsuite name="unit">'
+	for f in "${files[@]}"; do
+		abs="$(cd "$(dirname "$f")" && pwd)/$(basename "$f")"
+		echo "			<file>${abs}</file>"
+	done
+	echo '		</testsuite>'
+	echo '	</testsuites>'
+	echo '</phpunit>'
+} > "$config"
+
+exec "$root/vendor/bin/phpunit" -c "$config" "${passthrough[@]}"

--- a/tests/phpunit/unit-bootstrap.php
+++ b/tests/phpunit/unit-bootstrap.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * DB-less unit bootstrap for fast local PHPUnit runs.
+ *
+ * No WordPress, no MySQL, no plugin boot. It only defines ABSPATH and registers an autoloader
+ * that resolves `Elementor\...` classes straight to their files using the same name->path
+ * transform as includes/autoloader.php. Use it for pure unit tests whose subjects don't call
+ * WordPress at load/run time (e.g. css-converter, prop-types). Run via tests/phpunit/run-unit.sh.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$root = dirname( __DIR__, 2 ) . '/';
+
+require $root . 'vendor/autoload.php';
+
+spl_autoload_register( function ( $class ) use ( $root ) {
+	$namespace = 'Elementor\\';
+
+	if ( 0 !== strpos( $class, $namespace ) ) {
+		return;
+	}
+
+	$relative = substr( $class, strlen( $namespace ) );
+
+	$path = strtolower(
+		preg_replace(
+			[ '/([a-z])([A-Z])/', '/_/', '/\\\\/' ],
+			[ '$1-$2', '-', DIRECTORY_SEPARATOR ],
+			$relative
+		)
+	);
+
+	$file = $root . $path . '.php';
+
+	if ( is_readable( $file ) ) {
+		require $file;
+	}
+} );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Wiring all Style_Schema properties into concrete CSS-to-prop converters (ED-24442): moves from stub noops to real property handling across 60+ CSS declarations, plus infrastructure for variable promotion and explicit rejection of unsupported constructs like `animation`.

## 2. What Changed (Where)

| Component | Change |
|-----------|--------|
| **Converter Registry** | Exploded `COVERED_PROPERTIES` constant into 13 typed property families (`SIZE_PROPERTIES`, `COLOR_PROPERTIES`, etc.) + factory method that wires 40+ real converter instances |
| **Converters** (16 new files) | Implemented per-property handlers: `Size_Property_Converter`, `Color_Property_Converter`, `Dimensions_Property_Converter`, `Background_Image_Converter`, `Transform_Property_Converter`, etc. |
| **Shorthand Expanders** | Added `Background_Shorthand_Expander`, `Border_Shorthand_Expander`, `Physical_To_Logical_Expander` + base class/interface to decompose shorthands before converter dispatch |
| **Value Parsers** | Extracted stateless `Size_Value_Parser`, `Box_Shorthand_Parser`, `Css_Token_Splitter` (paren-aware), `Filter_Value_Parser`, `Background_Image_Value_Parser` |
| **Conversion Context** | Added `reject()` + `get_rejected()` to track explicitly unsupported declarations separate from custom_css |
| **REST API** | Enhanced to emit `{ props, customCss, rejected }` per block; wired `Variables_Service` for var promotion |
| **Variable Integration** | New `Variable_Prop_Value_Transformer` + `Css_Var_Reference`/`Css_Var_Token_Resolver` to resolve known variables to PropValue types and eject unresolved ones |
| **Tests** | 40+ unit tests covering converter paths, shorthand expansion, cascade semantics, variable promotion, and integration scenarios |

## 3. How It Works

**Entry:** REST endpoint receives blocks as property→value maps or CSS text strings → splits declarations → expands shorthands (physical→logical, border, background) → tries each converter in registry order.

**Happy path:** Converter validates and emits canonical PropValue → stored in context → final result is `{ props: {...}, customCss: "...", rejected: [...] }`.

**Edge cases:**
- Shorthand expander returns empty array → original declaration kept as custom_css
- Converter declines (returns false) → falls through to next converter, then custom_css
- Variable reference resolves to wrong type → ejected to `rejected` (not custom_css) so client can surface type mismatch to LLM
- Unresolved var → custom_css fallback
- `animation` family → explicit `Rejected_Converter` routes to `rejected[]` instead of silent custom_css

**Key insight:** Conversion context threads state (accumulated dimensions, background overlays) across sibling converters so `border-top-width: 2px` merges with `border-right-width: 3px` into one partial Border_Width object. Shorthand seeding (e.g., `border-width: 1px` then `border-top-width: 2px`) re-populates all sides from the single before overriding the named one—faithful CSS cascade.

## 4. Risks

**None identified.** Tests cover cascade, partial merges, variable promotion, and type mismatches. Backward compat: no API changes (REST response shape stays the same; `rejected` is additive). All converters are new—no rewiring of existing ones.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-24442]: https://elementor.atlassian.net/browse/ED-24442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ