### PR TITLE
Fix: Limit banner override [ED-24474]

### DIFF
--- a/modules/promotions/conversion-banner.php
+++ b/modules/promotions/conversion-banner.php
@@ -23,6 +23,7 @@ class Conversion_Banner {
 	const BIRTHDAY_PROMOTION_URL = 'https://go.elementor.com/go-pro-wp-admin-upgrad-notice/';
 
 	const HELLO_THEME_CONFIG_FILTER = 'hello-plus-theme/rest/admin-config';
+	const THEME_SLUGS = [ 'hello-elementor', 'hello-biz', 'hello-commerce' ];
 	const GO_PRO_TITLE_PREFIX = 'Go Pro';
 
 	public function __construct() {
@@ -55,11 +56,10 @@ class Conversion_Banner {
 	}
 
 	public function suppress_hello_theme_banner( $config ) {
-		if ( ! ( is_array( $config ) && isset( $config['welcome'] ) ) ) {
-			return $config;
-		}
-
-		if ( Utils::has_pro() ) {
+		if ( $this->is_request_from_theme_admin_page()
+			|| ! ( is_array( $config ) && isset( $config['welcome'] ) )
+			|| Utils::has_pro()
+		) {
 			return $config;
 		}
 
@@ -70,6 +70,18 @@ class Conversion_Banner {
 		}
 
 		return $config;
+	}
+
+	private function is_request_from_theme_admin_page(): bool {
+		$referer = wp_get_referer();
+
+		if ( ! $referer ) {
+			return false;
+		}
+
+		parse_str( (string) wp_parse_url( $referer, PHP_URL_QUERY ), $query_args );
+
+		return in_array( $query_args['page'] ?? '', self::THEME_SLUGS );
 	}
 
 	public function ajax_dismiss_banner(): void {

--- a/modules/promotions/conversion-banner.php
+++ b/modules/promotions/conversion-banner.php
@@ -62,7 +62,9 @@ class Conversion_Banner {
 			return $config;
 		}
 
-		$config['welcome'] = [];
+		if ( isset( $config['welcome']['title'] ) && substr( $config['welcome']['title'], 0, 6 ) === 'Go Pro' ) {
+			$config['welcome'] = [];
+		}
 
 		return $config;
 	}

--- a/modules/promotions/conversion-banner.php
+++ b/modules/promotions/conversion-banner.php
@@ -23,6 +23,7 @@ class Conversion_Banner {
 	const BIRTHDAY_PROMOTION_URL = 'https://go.elementor.com/go-pro-wp-admin-upgrad-notice/';
 
 	const HELLO_THEME_CONFIG_FILTER = 'hello-plus-theme/rest/admin-config';
+	const GO_PRO_TITLE_PREFIX = 'Go Pro';
 
 	public function __construct() {
 		add_action( 'wp_ajax_' . self::AJAX_ACTION, [ $this, 'ajax_dismiss_banner' ] );
@@ -62,7 +63,9 @@ class Conversion_Banner {
 			return $config;
 		}
 
-		if ( isset( $config['welcome']['title'] ) && substr( $config['welcome']['title'], 0, 6 ) === 'Go Pro' ) {
+		$title = $config['welcome']['title'] ?? '';
+
+		if ( is_string( $title ) && substr( $title, 0, strlen( self::GO_PRO_TITLE_PREFIX ) ) === self::GO_PRO_TITLE_PREFIX ) {
 			$config['welcome'] = [];
 		}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Fixes banner override behavior in Hello Theme integration (ED-24474). Currently suppresses all "Go Pro" banners; needs to limit suppression to only when accessing theme admin pages and exclude overrides when user already has Pro.

## 2. What Changed (Where)
`conversion-banner.php`: Added theme slug constants and Go Pro title prefix check; refactored `suppress_hello_theme_banner()` logic to validate referer, check Pro status, and detect title prefix; extracted `is_request_from_theme_admin_page()` helper.

## 3. How It Works
Before suppressing the Hello Theme welcome banner: (1) validates request originated from theme admin page via referer check against whitelist (`hello-elementor`, `hello-biz`, `hello-commerce`), (2) returns config unchanged if user has Pro or config invalid, (3) checks if welcome title starts with "Go Pro" prefix and only then clears the welcome section.

## 4. Risks
Referer validation is spoofable but acceptable for non-security UX control. Edge case: malformed URLs in `wp_parse_url()` handled gracefully. Title prefix check is string-safe but locale-dependent—might miss translated variants of "Go Pro".

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
