### PR TITLE
Fix: Improve atomic style validation error context [ED-20879]

### DIFF
--- a/modules/atomic-widgets/elements/base/has-atomic-base.php
+++ b/modules/atomic-widgets/elements/base/has-atomic-base.php
@@ -111,7 +111,11 @@ trait Has_Atomic_Base {
 		string $validation_errors
 	): string {
 		$widget_id = $data['id'] ?? 'unknown';
-		$element_name = $this->get_title() ?: $this->get_name();
+		$element_name = $this->get_title();
+
+		if ( '' === $element_name ) {
+			$element_name = $this->get_name();
+		}
 		$structure_label = $this->get_editor_structure_label( $data );
 		$style_label = isset( $style['label'] ) && is_string( $style['label'] ) ? $style['label'] : null;
 

--- a/modules/atomic-widgets/elements/base/has-atomic-base.php
+++ b/modules/atomic-widgets/elements/base/has-atomic-base.php
@@ -110,29 +110,28 @@ trait Has_Atomic_Base {
 		array $style,
 		string $validation_errors
 	): string {
-		$widget_id = $data['id'] ?? 'unknown';
-		$element_name = $this->get_title();
-
-		if ( '' === $element_name ) {
-			$element_name = $this->get_name();
-		}
 		$structure_label = $this->get_editor_structure_label( $data );
 		$style_label = isset( $style['label'] ) && is_string( $style['label'] ) ? $style['label'] : null;
 
 		$message_parts = [
 			"Styles validation failed for style `$style_id`",
-			"Element: `$element_name`",
 		];
 
 		if ( $structure_label ) {
 			$message_parts[] = "Structure label: `$structure_label`";
+		} else {
+			$element_name = $this->get_title();
+
+			if ( '' === $element_name ) {
+				$element_name = $this->get_name();
+			}
+
+			$message_parts[] = "Element: `$element_name`";
 		}
 
 		if ( $style_label ) {
 			$message_parts[] = "Style label: `$style_label`";
 		}
-
-		$message_parts[] = "Widget ID: `$widget_id`";
 
 		return implode( '. ', $message_parts ) . '. ' . $validation_errors;
 	}

--- a/modules/atomic-widgets/elements/base/has-atomic-base.php
+++ b/modules/atomic-widgets/elements/base/has-atomic-base.php
@@ -93,14 +93,54 @@ trait Has_Atomic_Base {
 			$result = $style_parser->parse( $style );
 
 			if ( ! $result->is_valid() ) {
-				$widget_id = $data['id'] ?? 'unknown';
-				throw new \Exception( esc_html( "Styles validation failed for style `$style_id`. Widget ID: `$widget_id`. " . $result->errors()->to_string() ) );
+				throw new \Exception(
+					esc_html( $this->format_styles_validation_error_message( $style_id, $data, $style, $result->errors()->to_string() ) )
+				);
 			}
 
 			$styles[ $style_id ] = $result->unwrap();
 		}
 
 		return $styles;
+	}
+
+	private function format_styles_validation_error_message(
+		string $style_id,
+		array $data,
+		array $style,
+		string $validation_errors
+	): string {
+		$widget_id = $data['id'] ?? 'unknown';
+		$element_name = $this->get_title() ?: $this->get_name();
+		$structure_label = $this->get_editor_structure_label( $data );
+		$style_label = isset( $style['label'] ) && is_string( $style['label'] ) ? $style['label'] : null;
+
+		$message_parts = [
+			"Styles validation failed for style `$style_id`",
+			"Element: `$element_name`",
+		];
+
+		if ( $structure_label ) {
+			$message_parts[] = "Structure label: `$structure_label`";
+		}
+
+		if ( $style_label ) {
+			$message_parts[] = "Style label: `$style_label`";
+		}
+
+		$message_parts[] = "Widget ID: `$widget_id`";
+
+		return implode( '. ', $message_parts ) . '. ' . $validation_errors;
+	}
+
+	private function get_editor_structure_label( array $data ): ?string {
+		$title = $data['editor_settings']['title'] ?? $this->editor_settings['title'] ?? null;
+
+		if ( ! is_string( $title ) || '' === $title ) {
+			return null;
+		}
+
+		return $title;
 	}
 
 	private function parse_atomic_settings( array $settings ): array {

--- a/modules/atomic-widgets/elements/base/has-atomic-base.php
+++ b/modules/atomic-widgets/elements/base/has-atomic-base.php
@@ -110,11 +110,12 @@ trait Has_Atomic_Base {
 		array $style,
 		string $validation_errors
 	): string {
+		$widget_id = $data['id'] ?? 'unknown';
 		$structure_label = $this->get_editor_structure_label( $data );
 		$style_label = isset( $style['label'] ) && is_string( $style['label'] ) ? $style['label'] : null;
 
 		$message_parts = [
-			"Styles validation failed for style `$style_id`",
+			"Styles validation failed for style `$style_id` (widget `$widget_id`)",
 		];
 
 		if ( $structure_label ) {

--- a/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-widget-base.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-widget-base.php
@@ -660,7 +660,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `my-class`. Widget ID: `1`. meta.state: missing_or_invalid_value' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `my-class`. meta.state: missing_or_invalid_value' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -695,7 +695,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `my-class`. Widget ID: `1`. meta.breakpoint: missing_or_invalid_value' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `my-class`. meta.breakpoint: missing_or_invalid_value' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -732,7 +732,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `1234`. Element: `test-widget`. Widget ID: `1`. id: missing_or_invalid, label: missing_or_invalid' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `1234`. Element: `test-widget`. id: missing_or_invalid, label: missing_or_invalid' );
 
 		// Act.
 		$data = $widget->get_data_for_save();
@@ -773,7 +773,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `my-class`. Widget ID: `1`. type: missing_or_invalid' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `my-class`. type: missing_or_invalid' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -810,7 +810,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Widget ID: `1`. label: missing_or_invalid' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. label: missing_or_invalid' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -853,7 +853,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `Test`. Widget ID: `1`. variants[1].padding: invalid_value' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `Test`. variants[1].padding: invalid_value' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -892,7 +892,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Structure label: `Hero Section`. Style label: `hero-style`. Widget ID: `1`. variants[0].gap: invalid_value' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Structure label: `Hero Section`. Style label: `hero-style`. variants[0].gap: invalid_value' );
 
 		// Act.
 		$widget->get_data_for_save();

--- a/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-widget-base.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-widget-base.php
@@ -660,7 +660,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Widget ID: `1`. meta.state: missing_or_invalid_value' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `my-class`. Widget ID: `1`. meta.state: missing_or_invalid_value' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -695,7 +695,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Widget ID: `1`. meta.breakpoint: missing_or_invalid_value' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `my-class`. Widget ID: `1`. meta.breakpoint: missing_or_invalid_value' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -732,7 +732,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `1234`. Widget ID: `1`. id: missing_or_invalid, label: missing_or_invalid' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `1234`. Element: `test-widget`. Widget ID: `1`. id: missing_or_invalid, label: missing_or_invalid' );
 
 		// Act.
 		$data = $widget->get_data_for_save();
@@ -773,7 +773,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Widget ID: `1`. type: missing_or_invalid' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `my-class`. Widget ID: `1`. type: missing_or_invalid' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -810,7 +810,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Widget ID: `1`. label: missing_or_invalid' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Widget ID: `1`. label: missing_or_invalid' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -853,7 +853,46 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Widget ID: `1`. variants[1].padding: invalid_value' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `Test`. Widget ID: `1`. variants[1].padding: invalid_value' );
+
+		// Act.
+		$widget->get_data_for_save();
+	}
+
+	public function test_get_data_for_save__throws_on_styles_validation_error_with_element_context() {
+		// Arrange.
+		$widget = $this->make_mock_widget( [
+			'editor_settings' => [
+				'title' => 'Hero Section',
+			],
+			'props_schema' => [],
+			'settings' => [],
+			'styles' => [
+				's-1234' => [
+					'id' => 's-1234',
+					'label' => 'hero-style',
+					'type' => 'class',
+					'variants' => [
+						[
+							'props' => [
+								'gap' => [
+									'$$type' => 'size',
+									'value' => 'invalid-gap',
+								],
+							],
+							'meta' => [
+								'breakpoint' => 'desktop',
+								'state' => null,
+							],
+						],
+					],
+				],
+			],
+		] );
+
+		// Expect.
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Structure label: `Hero Section`. Style label: `hero-style`. Widget ID: `1`. variants[0].gap: invalid_value' );
 
 		// Act.
 		$widget->get_data_for_save();

--- a/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-widget-base.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-widget-base.php
@@ -660,7 +660,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `my-class`. meta.state: missing_or_invalid_value' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234` (widget `1`). Element: `test-widget`. Style label: `my-class`. meta.state: missing_or_invalid_value' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -695,7 +695,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `my-class`. meta.breakpoint: missing_or_invalid_value' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234` (widget `1`). Element: `test-widget`. Style label: `my-class`. meta.breakpoint: missing_or_invalid_value' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -732,7 +732,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `1234`. Element: `test-widget`. id: missing_or_invalid, label: missing_or_invalid' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `1234` (widget `1`). Element: `test-widget`. id: missing_or_invalid, label: missing_or_invalid' );
 
 		// Act.
 		$data = $widget->get_data_for_save();
@@ -773,7 +773,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `my-class`. type: missing_or_invalid' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234` (widget `1`). Element: `test-widget`. Style label: `my-class`. type: missing_or_invalid' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -810,7 +810,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. label: missing_or_invalid' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234` (widget `1`). Element: `test-widget`. label: missing_or_invalid' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -853,7 +853,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Element: `test-widget`. Style label: `Test`. variants[1].padding: invalid_value' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234` (widget `1`). Element: `test-widget`. Style label: `Test`. variants[1].padding: invalid_value' );
 
 		// Act.
 		$widget->get_data_for_save();
@@ -892,7 +892,7 @@ class Test_Atomic_Widget_Base extends Elementor_Test_Base {
 
 		// Expect.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234`. Structure label: `Hero Section`. Style label: `hero-style`. variants[0].gap: invalid_value' );
+		$this->expectExceptionMessage( 'Styles validation failed for style `s-1234` (widget `1`). Structure label: `Hero Section`. Style label: `hero-style`. variants[0].gap: invalid_value' );
 
 		// Act.
 		$widget->get_data_for_save();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Improved atomic widget style validation error messages to include navigator structure label and style label alongside existing IDs.

## Description

When atomic style validation fails during save, the error previously only showed the style ID and widget ID (for example: `Styles validation failed for style e-9dac0d3-e3ada51. Widget ID: 9dac0d3. variants[0].gap: invalid_value`).

This change enriches the message with:
- **Structure label** — the custom navigator title from `editor_settings.title`, when set
- **Style label** — the style class label, when present
- **Element** — the element type title (falls back to internal name) only when no structure label is set

Example output:
`Styles validation failed for style s-1234. Structure label: Hero Section. Style label: hero-style. variants[0].gap: invalid_value`

## Test instructions

1. Create or edit an atomic element with a custom navigator title.
2. Introduce an invalid style value (for example, an invalid `gap` size).
3. Save the document and confirm the validation error includes structure label and style label.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes ED-20879
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://elementor.slack.com/archives/C0AAX7NQY1J/p1781089637053729?thread_ts=1781089637.053729&cid=C0AAX7NQY1J)

<div><a href="https://cursor.com/agents/bc-ce6c8109-4dc6-5fc9-8079-77e4b612e2f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce6c8109-4dc6-5fc9-8079-77e4b612e2f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Style validation errors lacked context, making debugging difficult. PR enriches error messages with widget ID, element name, structure label, and style label to pinpoint failures faster.

## 2. What Changed (Where)

- `has-atomic-base.php`: Extracted error formatting logic into `format_styles_validation_error_message()` and `get_editor_structure_label()` helpers; now throws with rich context instead of minimal message.
- `test-atomic-widget-base.php`: Updated 6 existing test assertions and added 1 new test case validating structure label inclusion in error context.

## 3. How It Works

When style validation fails, the code now collects: widget ID, structure label (from editor settings), element name (fallback to title/name), style label. These assemble into a dot-separated message prepended to validation errors, giving full debugging context without changing the exception type or throwing mechanism.

## 4. Risks

None identified. Changes are additive (new private methods) and purely informational (better error messages). Existing exception type preserved, no behavioral changes to success path.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
