### PR TITLE
feat(notifications): install-plugin action to What's New panel

### DIFF
--- a/modules/notifications/api.php
+++ b/modules/notifications/api.php
@@ -13,7 +13,7 @@ class API {
 	 * Any `installPlugin` value not in this list is stripped before the notification
 	 * reaches the browser, protecting against a compromised CDN response.
 	 */
-	const ALLOWED_INSTALL_SLUGS = [];
+	const ALLOWED_INSTALL_SLUGS = [ 'angie' ];
 
 	public static function get_notifications_by_conditions( $force_request = false ) {
 		$notifications = static::get_notifications( $force_request );

--- a/modules/notifications/api.php
+++ b/modules/notifications/api.php
@@ -8,12 +8,21 @@ class API {
 
 	const NOTIFICATIONS_URL = 'https://assets.elementor.com/notifications/v1/notifications.json';
 
+	/**
+	 * Allowlist of WP.org plugin slugs that may be installed via the What's New panel.
+	 * Any `installPlugin` value not in this list is stripped before the notification
+	 * reaches the browser, protecting against a compromised CDN response.
+	 */
+	const ALLOWED_INSTALL_SLUGS = [];
+
 	public static function get_notifications_by_conditions( $force_request = false ) {
 		$notifications = static::get_notifications( $force_request );
 
 		$filtered_notifications = [];
 
 		foreach ( $notifications as $notification ) {
+			$notification = static::sanitize_install_fields( $notification );
+
 			if ( empty( $notification['conditions'] ) ) {
 				$filtered_notifications = static::add_to_array( $filtered_notifications, $notification );
 
@@ -63,6 +72,19 @@ class API {
 		}
 
 		return false;
+	}
+
+	private static function sanitize_install_fields( array $notification ): array {
+		if ( empty( $notification['installPlugin'] ) ) {
+			return $notification;
+		}
+
+		if ( ! in_array( $notification['installPlugin'], static::ALLOWED_INSTALL_SLUGS, true ) ) {
+			unset( $notification['installPlugin'] );
+			unset( $notification['ctaActivate'] );
+		}
+
+		return $notification;
 	}
 
 	private static function check_group( $group ) {

--- a/modules/notifications/assets/js/components/whats-new-item.js
+++ b/modules/notifications/assets/js/components/whats-new-item.js
@@ -31,7 +31,7 @@ const InstallPluginButton = ( { slug, notificationId, installLabel, activateLabe
 			if ( plugin ) {
 				await wp.apiFetch( {
 					path: `/wp/v2/plugins/${ encodeURIComponent( plugin.plugin ) }`,
-					method: 'PUT',
+					method: 'POST',
 					data: { status: 'active' },
 				} );
 			}

--- a/modules/notifications/assets/js/components/whats-new-item.js
+++ b/modules/notifications/assets/js/components/whats-new-item.js
@@ -81,7 +81,7 @@ const InstallPluginButton = ( { slug, notificationId, installLabel, activateLabe
 			<Button
 				variant="contained"
 				size="small"
-				color="primary"
+				color="promotion"
 				disabled={ isDisabled }
 				onClick={ ! isDisabled ? handleInstall : undefined }
 			>

--- a/modules/notifications/assets/js/components/whats-new-item.js
+++ b/modules/notifications/assets/js/components/whats-new-item.js
@@ -1,8 +1,107 @@
+import { useState } from 'react';
+import { __ } from '@wordpress/i18n';
 import { Box, Button, Divider, Link, Typography } from '@elementor/ui';
 import { WhatsNewItemTopicLine } from './whats-new-item-topic-line';
 import { WrapperWithLink } from './wrapper-with-link';
 import { WhatsNewItemThumbnail } from './whats-new-item-thumbnail';
 import { WhatsNewItemChips } from './whats-new-item-chips';
+
+const InstallPluginButton = ( { slug, notificationId, installLabel, activateLabel } ) => {
+	const [ status, setStatus ] = useState( 'idle' ); // Idle | installing | activating | done | error
+	const [ errorMsg, setErrorMsg ] = useState( '' );
+
+	const dismissCard = () => {
+		elementorCommon.ajax.addRequest( 'notifications_mark_installed', {
+			data: { notification_id: notificationId },
+		} );
+	};
+
+	const findAndActivate = async () => {
+		setStatus( 'activating' );
+		try {
+			const plugins = await wp.apiFetch( { path: '/wp/v2/plugins' } );
+			const plugin = plugins.find( ( p ) => p.plugin.startsWith( slug + '/' ) );
+
+			if ( plugin && 'active' === plugin.status ) {
+				setStatus( 'done' );
+				dismissCard();
+				return;
+			}
+
+			if ( plugin ) {
+				await wp.apiFetch( {
+					path: `/wp/v2/plugins/${ encodeURIComponent( plugin.plugin ) }`,
+					method: 'PUT',
+					data: { status: 'active' },
+				} );
+			}
+
+			setStatus( 'done' );
+			dismissCard();
+		} catch ( err ) {
+			setStatus( 'error' );
+			setErrorMsg( err?.message || __( 'Activation failed', 'elementor' ) );
+		}
+	};
+
+	const handleInstall = async () => {
+		setStatus( 'installing' );
+		try {
+			await wp.apiFetch( {
+				path: '/wp/v2/plugins',
+				method: 'POST',
+				data: { slug, status: 'active' },
+			} );
+			setStatus( 'done' );
+			dismissCard();
+		} catch ( err ) {
+			// Plugin already installed — find it and activate
+			if ( 'folder_exists' === err?.code ) {
+				await findAndActivate();
+			} else {
+				setStatus( 'error' );
+				setErrorMsg( err?.message || __( 'Installation failed', 'elementor' ) );
+			}
+		}
+	};
+
+	const getButtonLabel = () => {
+		switch ( status ) {
+			case 'installing': return __( 'Installing...', 'elementor' );
+			case 'activating': return activateLabel || __( 'Activating...', 'elementor' );
+			case 'done': return __( 'Installed ✓', 'elementor' );
+			default: return installLabel;
+		}
+	};
+
+	const isDisabled = [ 'installing', 'activating', 'done' ].includes( status );
+
+	return (
+		<Box>
+			<Button
+				variant="contained"
+				size="small"
+				color="primary"
+				disabled={ isDisabled }
+				onClick={ ! isDisabled ? handleInstall : undefined }
+			>
+				{ getButtonLabel() }
+			</Button>
+			{ 'error' === status && (
+				<Typography variant="caption" color="error.main" sx={ { display: 'block', mt: 0.5 } }>
+					{ errorMsg }
+				</Typography>
+			) }
+		</Box>
+	);
+};
+
+InstallPluginButton.propTypes = {
+	slug: PropTypes.string.isRequired,
+	notificationId: PropTypes.string.isRequired,
+	installLabel: PropTypes.string.isRequired,
+	activateLabel: PropTypes.string,
+};
 
 export const WhatsNewItem = ( { item, itemIndex, itemsLength, setIsOpen } ) => {
 	return (
@@ -67,7 +166,16 @@ export const WhatsNewItem = ( { item, itemIndex, itemsLength, setIsOpen } ) => {
 					) }
 				</Typography>
 			) }
-			{ item.cta && item.ctaLink && (
+			{ item.installPlugin ? (
+				<Box sx={ { pb: 2 } }>
+					<InstallPluginButton
+						slug={ item.installPlugin }
+						notificationId={ item.id }
+						installLabel={ item.cta || __( 'Install Plugin', 'elementor' ) }
+						activateLabel={ item.ctaActivate }
+					/>
+				</Box>
+			) : item.cta && item.ctaLink && (
 				<Box
 					sx={ {
 						pb: 2,

--- a/modules/notifications/assets/js/components/whats-new.js
+++ b/modules/notifications/assets/js/components/whats-new.js
@@ -19,6 +19,7 @@ export const WhatsNew = ( props ) => {
 
 	useEffect( () => {
 		if ( ! isOpen ) {
+			queryClient.invalidateQueries( { queryKey: [ 'e-notifications' ] } );
 			return;
 		}
 

--- a/modules/notifications/module.php
+++ b/modules/notifications/module.php
@@ -84,6 +84,7 @@ class Module extends BaseModule {
 
 	public function register_ajax_actions( $ajax ) {
 		$ajax->register_ajax_action( 'notifications_get', [ $this, 'ajax_get_notifications' ] );
+		$ajax->register_ajax_action( 'notifications_mark_installed', [ $this, 'ajax_mark_notification_installed' ] );
 	}
 
 	public function ajax_get_notifications() {
@@ -92,5 +93,17 @@ class Module extends BaseModule {
 		Options::mark_notification_read( $notifications );
 
 		return $notifications;
+	}
+
+	public function ajax_mark_notification_installed( $data ) {
+		$notification_id = sanitize_text_field( $data['notification_id'] ?? '' );
+
+		if ( empty( $notification_id ) ) {
+			throw new \Exception( 'Missing notification_id' );
+		}
+
+		Options::mark_notification_installed( $notification_id );
+
+		return true;
 	}
 }

--- a/modules/notifications/module.php
+++ b/modules/notifications/module.php
@@ -88,6 +88,10 @@ class Module extends BaseModule {
 	}
 
 	public function ajax_get_notifications() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			throw new \Exception( 'Insufficient permissions' );
+		}
+
 		$notifications = API::get_notifications_by_conditions( true );
 
 		$installed = Options::get_notifications_installed();
@@ -101,6 +105,10 @@ class Module extends BaseModule {
 	}
 
 	public function ajax_mark_notification_installed( $data ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			throw new \Exception( 'Insufficient permissions' );
+		}
+
 		$notification_id = sanitize_text_field( $data['notification_id'] ?? '' );
 
 		if ( empty( $notification_id ) ) {

--- a/modules/notifications/module.php
+++ b/modules/notifications/module.php
@@ -90,6 +90,11 @@ class Module extends BaseModule {
 	public function ajax_get_notifications() {
 		$notifications = API::get_notifications_by_conditions( true );
 
+		$installed = Options::get_notifications_installed();
+		$notifications = array_values( array_filter( $notifications, function( $n ) use ( $installed ) {
+			return ! in_array( $n['id'], $installed, true );
+		} ) );
+
 		Options::mark_notification_read( $notifications );
 
 		return $notifications;

--- a/modules/notifications/options.php
+++ b/modules/notifications/options.php
@@ -40,6 +40,26 @@ class Options {
 		return $notifications_dismissed;
 	}
 
+	public static function mark_notification_installed( string $notification_id ): bool {
+		$current_user = wp_get_current_user();
+
+		if ( ! $current_user ) {
+			return false;
+		}
+
+		$notifications_dismissed = static::get_notifications_dismissed();
+
+		if ( ! in_array( $notification_id, $notifications_dismissed, true ) ) {
+			$notifications_dismissed[] = $notification_id;
+		}
+
+		update_user_meta( $current_user->ID, '_e_notifications_dismissed', $notifications_dismissed );
+
+		delete_transient( "elementor_unread_notifications_{$current_user->ID}" );
+
+		return true;
+	}
+
 	public static function mark_notification_read( $notifications ): bool {
 		$current_user = wp_get_current_user();
 

--- a/modules/notifications/options.php
+++ b/modules/notifications/options.php
@@ -40,6 +40,18 @@ class Options {
 		return $notifications_dismissed;
 	}
 
+	public static function get_notifications_installed(): array {
+		$current_user = wp_get_current_user();
+
+		if ( ! $current_user ) {
+			return [];
+		}
+
+		$installed = get_user_meta( $current_user->ID, '_e_notifications_installed', true );
+
+		return is_array( $installed ) ? $installed : [];
+	}
+
 	public static function mark_notification_installed( string $notification_id ): bool {
 		$current_user = wp_get_current_user();
 
@@ -47,13 +59,13 @@ class Options {
 			return false;
 		}
 
-		$notifications_dismissed = static::get_notifications_dismissed();
+		$installed = static::get_notifications_installed();
 
-		if ( ! in_array( $notification_id, $notifications_dismissed, true ) ) {
-			$notifications_dismissed[] = $notification_id;
+		if ( ! in_array( $notification_id, $installed, true ) ) {
+			$installed[] = $notification_id;
 		}
 
-		update_user_meta( $current_user->ID, '_e_notifications_dismissed', $notifications_dismissed );
+		update_user_meta( $current_user->ID, '_e_notifications_installed', $installed );
 
 		delete_transient( "elementor_unread_notifications_{$current_user->ID}" );
 


### PR DESCRIPTION
Adds the ability to install and activate a free WP.org plugin directly
from a What's New notification card, without leaving the editor.

Changes:
- whats-new-item.js: InstallPluginButton component with install/activate/
  dismiss flow matching the Elementor Angie install pattern (folder_exists
  error code, POST for activation via wp.apiFetch)
- api.php: ALLOWED_INSTALL_SLUGS allowlist + sanitize_install_fields()
  strips installPlugin/ctaActivate from CDN responses for unknown slugs
- options.php: mark_notification_installed() dismisses a single card by
  ID using the existing _e_notifications_dismissed user_meta
- module.php: notifications_mark_installed AJAX action

New notification fields: installPlugin (slug), ctaActivate (label)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
