### PR TITLE
Fix: Ensure await for angieSDK readiness [ED-24517]

### DIFF
--- a/packages/packages/libs/editor-mcp/src/__tests__/init.test.ts
+++ b/packages/packages/libs/editor-mcp/src/__tests__/init.test.ts
@@ -60,8 +60,7 @@ describe( 'startMCPServer', () => {
 		setModelContext( navigator, navigatorModelContext );
 
 		// Act.
-		startMCPServer();
-		await Promise.resolve();
+		await startMCPServer();
 
 		// Assert.
 		expect( registerMcpAdapter ).toHaveBeenCalledTimes( 1 );
@@ -77,8 +76,7 @@ describe( 'startMCPServer', () => {
 		setModelContext( navigator, navigatorModelContext );
 
 		// Act.
-		startMCPServer();
-		await Promise.resolve();
+		await startMCPServer();
 
 		// Assert.
 		expect( registerMcpAdapter ).toHaveBeenCalledTimes( 1 );

--- a/packages/packages/libs/editor-mcp/src/__tests__/init.test.ts
+++ b/packages/packages/libs/editor-mcp/src/__tests__/init.test.ts
@@ -3,7 +3,7 @@ import { startMCPServer } from '../init';
 import { activateAdapters, registerMcpAdapter, signalMcpReady } from '../mcp-registry';
 
 jest.mock( '../mcp-registry', () => ( {
-	activateAdapters: jest.fn(),
+	activateAdapters: jest.fn( () => Promise.resolve() ),
 	registerMcpAdapter: jest.fn(),
 	signalMcpReady: jest.fn(),
 } ) );
@@ -51,7 +51,7 @@ describe( 'startMCPServer', () => {
 		deleteModelContext( navigator );
 	} );
 
-	it( 'prefers the document model context when it is available', () => {
+	it( 'prefers the document model context when it is available', async () => {
 		// Arrange.
 		const documentModelContext = createModelContext();
 		const navigatorModelContext = createModelContext();
@@ -61,6 +61,7 @@ describe( 'startMCPServer', () => {
 
 		// Act.
 		startMCPServer();
+		await Promise.resolve();
 
 		// Assert.
 		expect( registerMcpAdapter ).toHaveBeenCalledTimes( 1 );
@@ -69,7 +70,7 @@ describe( 'startMCPServer', () => {
 		expect( signalMcpReady ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'falls back to the navigator model context for older browser support', () => {
+	it( 'falls back to the navigator model context for older browser support', async () => {
 		// Arrange.
 		const navigatorModelContext = createModelContext();
 
@@ -77,6 +78,7 @@ describe( 'startMCPServer', () => {
 
 		// Act.
 		startMCPServer();
+		await Promise.resolve();
 
 		// Assert.
 		expect( registerMcpAdapter ).toHaveBeenCalledTimes( 1 );

--- a/packages/packages/libs/editor-mcp/src/init.ts
+++ b/packages/packages/libs/editor-mcp/src/init.ts
@@ -28,8 +28,9 @@ export function startMCPServer() {
 		registerMcpAdapter( new AngieMcpAdapter( getSDK() ) );
 	}
 
-	activateAdapters();
-	signalMcpReady();
+	activateAdapters().then( () => {
+		signalMcpReady();
+	} );
 }
 
 if ( typeof document !== 'undefined' ) {

--- a/packages/packages/libs/editor-mcp/src/init.ts
+++ b/packages/packages/libs/editor-mcp/src/init.ts
@@ -28,9 +28,7 @@ export function startMCPServer() {
 		registerMcpAdapter( new AngieMcpAdapter( getSDK() ) );
 	}
 
-	activateAdapters().then( () => {
-		signalMcpReady();
-	} );
+	return activateAdapters().then( () => signalMcpReady() );
 }
 
 if ( typeof document !== 'undefined' ) {

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -50,8 +50,7 @@ export const registerMcpAdapter = ( adapter: IMcpRegistrationAdapter ): void => 
 
 export const signalMcpReady = (): void => resolveReady();
 
-export const activateAdapters = (): Promise< void > =>
-	callAdapters( ( adapter ) => Promise.resolve( adapter.activate() ) );
+export const activateAdapters = (): Promise< void > => callAdapters( ( adapter ) => adapter.activate() );
 
 async function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => void | Promise< void > ) {
 	for ( const adapter of registrationAdapters ) {

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -50,12 +50,12 @@ export const registerMcpAdapter = ( adapter: IMcpRegistrationAdapter ): void => 
 
 export const signalMcpReady = (): void => resolveReady();
 
-export const activateAdapters = (): void => callAdapters( ( adapter ) => adapter.activate() );
+export const activateAdapters = () => callAdapters( async ( adapter ) => adapter.activate() );
 
-function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => void ): void {
-	for ( const adapter of registrationAdapters ) {
+async function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => Promise< void > ) {
+	for await ( const adapter of registrationAdapters ) {
 		try {
-			fn( adapter );
+			await fn( adapter );
 		} catch {
 			// adapter failed — exit quietly, continue to next
 		}

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -50,12 +50,13 @@ export const registerMcpAdapter = ( adapter: IMcpRegistrationAdapter ): void => 
 
 export const signalMcpReady = (): void => resolveReady();
 
-export const activateAdapters = () => callAdapters( async ( adapter ) => adapter.activate() );
+export const activateAdapters = (): Promise< void > =>
+	callAdapters( ( adapter ) => Promise.resolve( adapter.activate() ) );
 
-async function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => Promise< void > ) {
-	for await ( const adapter of registrationAdapters ) {
+async function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => void | Promise< void > ) {
+	for ( const adapter of registrationAdapters ) {
 		try {
-			await fn( adapter );
+			await Promise.resolve( fn( adapter ) );
 		} catch {
 			// adapter failed — exit quietly, continue to next
 		}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Async adapter activation wasn't awaited, causing race conditions where `signalMcpReady()` fired before adapters fully initialized. ED-24517.

## 2. What Changed (Where)

- `init.ts`: `startMCPServer()` now returns a promise that chains adapter activation completion
- `mcp-registry.ts`: `activateAdapters()` converted to async, `callAdapters()` now awaits adapter promises with proper error handling
- `init.test.ts`: Tests updated to await `startMCPServer()` and mock `activateAdapters` as promise-returning

## 3. How It Works

`startMCPServer()` calls `activateAdapters().then(() => signalMcpReady())`, ensuring sequential execution. `callAdapters()` iterates adapters, awaiting each `adapter.activate()` wrapped in `Promise.resolve()` to handle both sync and async implementations safely.

## 4. Risks

Low risk—mock already returns resolved promise, tests await properly. Only concern: callers of `startMCPServer()` must now handle the returned promise or race conditions resurface. Documentation should clarify this requirement.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
