### PR TITLE
Revert "Internal: Change supported node engines to >=20.19.0"

### DIFF
--- a/packages/package.json
+++ b/packages/package.json
@@ -3,7 +3,7 @@
   "author": "Elementor Team",
   "license": "GPL-3.0-or-later",
   "engines": {
-    "node": ">=20.19.0",
+    "node": ">=24.15.0",
     "npm": ">=10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts elementor/elementor#36200
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Reverting Node.js engine requirement from >=20.19.0 back to >=24.15.0. The ticket ED-24530 indicates a previous update was rolled back due to compatibility or stability concerns.

## 2. What Changed (Where)

- `packages/package.json`: Node engine requirement bumped from >=20.19.0 to >=24.15.0

## 3. How It Works

This is a manifest-only change affecting dependency resolution. npm will enforce the higher version floor at install time; existing lockfiles may require regeneration if lower Node versions were previously pinned.

## 4. Risks

Developers on Node <24.15.0 will face installation failures. Verify CI/CD pipelines and developer onboarding docs are updated to reflect the newer minimum version requirement.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
