### PR TITLE
Internal: Ensure loop items are rerendered after creation [ED-24480]

### DIFF
--- a/packages/packages/core/editor-canvas/src/composition-builder/__tests__/composition-builder.test.ts
+++ b/packages/packages/core/editor-canvas/src/composition-builder/__tests__/composition-builder.test.ts
@@ -75,6 +75,23 @@ const createMockPartialContainer = ( id: string ): V1Element =>
 		children: [],
 	} ) as unknown as V1Element;
 
+const createMockPartialContainerWithView = ( id: string ) => {
+	const render = jest.fn();
+	const currentRenderPromise = Promise.resolve();
+	const container = {
+		id,
+		model: { get: jest.fn(), set: jest.fn(), toJSON: jest.fn() },
+		settings: { get: jest.fn(), set: jest.fn(), toJSON: jest.fn() },
+		children: [],
+		view: {
+			render,
+			_currentRenderPromise: currentRenderPromise,
+		},
+	} as unknown as V1Element;
+
+	return { container, render, currentRenderPromise };
+};
+
 describe( 'CompositionBuilder.build createElement failure cleanup', () => {
 	it( 'calls deleteElement when createElement fails and getContainer returns a container', async () => {
 		// Arrange
@@ -303,5 +320,53 @@ describe( 'CompositionBuilder.build required children', () => {
 		expect( childElements.filter( ( child ) => child.elType === 'e-form-success-message' ).length ).toBe( 1 );
 		expect( childElements.filter( ( child ) => child.elType === 'e-form-error-message' ).length ).toBe( 1 );
 		expect( childElements.some( ( child ) => child.widgetType === 'e-form-input' ) ).toBe( true );
+	} );
+} );
+
+describe( 'CompositionBuilder.build final root container render', () => {
+	it( 'calls view.render on root containers after applyProperties completes', async () => {
+		// Arrange
+		const { container: createdElement, render } = createMockPartialContainerWithView( GENERATED_ELEMENT_ID );
+		const doUpdateElementProperty = jest.fn();
+		const createElement = jest.fn().mockReturnValue( createdElement );
+		const getContainer = jest
+			.fn()
+			.mockImplementation( ( id: string ) => ( id === GENERATED_ELEMENT_ID ? createdElement : undefined ) );
+		const builder = CompositionBuilder.fromXMLString( xmlStringWithConfiguration, {
+			createElement,
+			deleteElement: jest.fn(),
+			getContainer,
+			generateElementId: jest.fn().mockReturnValue( GENERATED_ELEMENT_ID ),
+			getWidgetsCache: jest.fn().mockReturnValue( createMinimalWidgetsCache() ),
+			doUpdateElementProperty,
+		} );
+		builder.setElementConfig( createElementConfigPayload() );
+
+		// Act
+		await builder.build( createMockRootContainer() );
+
+		// Assert
+		expect( doUpdateElementProperty ).toHaveBeenCalledTimes( 1 );
+		expect( render ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'calls view.render on root containers even when no element config is applied', async () => {
+		// Arrange
+		const { container: createdElement, render } = createMockPartialContainerWithView( GENERATED_ELEMENT_ID );
+		const createElement = jest.fn().mockReturnValue( createdElement );
+		const builder = CompositionBuilder.fromXMLString( `<${ ROOT_CHILD_TAG } />`, {
+			createElement,
+			deleteElement: jest.fn(),
+			getContainer: jest.fn(),
+			generateElementId: jest.fn().mockReturnValue( GENERATED_ELEMENT_ID ),
+			getWidgetsCache: jest.fn().mockReturnValue( createMinimalWidgetsCache() ),
+			doUpdateElementProperty: jest.fn(),
+		} );
+
+		// Act
+		await builder.build( createMockRootContainer() );
+
+		// Assert
+		expect( render ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/packages/packages/core/editor-canvas/src/composition-builder/__tests__/composition-builder.test.ts
+++ b/packages/packages/core/editor-canvas/src/composition-builder/__tests__/composition-builder.test.ts
@@ -75,23 +75,6 @@ const createMockPartialContainer = ( id: string ): V1Element =>
 		children: [],
 	} ) as unknown as V1Element;
 
-const createMockPartialContainerWithView = ( id: string ) => {
-	const render = jest.fn();
-	const currentRenderPromise = Promise.resolve();
-	const container = {
-		id,
-		model: { get: jest.fn(), set: jest.fn(), toJSON: jest.fn() },
-		settings: { get: jest.fn(), set: jest.fn(), toJSON: jest.fn() },
-		children: [],
-		view: {
-			render,
-			_currentRenderPromise: currentRenderPromise,
-		},
-	} as unknown as V1Element;
-
-	return { container, render, currentRenderPromise };
-};
-
 describe( 'CompositionBuilder.build createElement failure cleanup', () => {
 	it( 'calls deleteElement when createElement fails and getContainer returns a container', async () => {
 		// Arrange
@@ -323,10 +306,20 @@ describe( 'CompositionBuilder.build required children', () => {
 	} );
 } );
 
-describe( 'CompositionBuilder.build final root container render', () => {
-	it( 'calls view.render on root containers after applyProperties completes', async () => {
+describe( 'CompositionBuilder.build final composition built event', () => {
+	let dispatchEventSpy: jest.SpyInstance;
+
+	beforeEach( () => {
+		dispatchEventSpy = jest.spyOn( window, 'dispatchEvent' );
+	} );
+
+	afterEach( () => {
+		dispatchEventSpy.mockRestore();
+	} );
+
+	it( 'dispatches elementor/composition/built event with root container IDs after applyProperties completes', async () => {
 		// Arrange
-		const { container: createdElement, render } = createMockPartialContainerWithView( GENERATED_ELEMENT_ID );
+		const createdElement = createMockPartialContainer( GENERATED_ELEMENT_ID );
 		const doUpdateElementProperty = jest.fn();
 		const createElement = jest.fn().mockReturnValue( createdElement );
 		const getContainer = jest
@@ -347,26 +340,13 @@ describe( 'CompositionBuilder.build final root container render', () => {
 
 		// Assert
 		expect( doUpdateElementProperty ).toHaveBeenCalledTimes( 1 );
-		expect( render ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	it( 'calls view.render on root containers even when no element config is applied', async () => {
-		// Arrange
-		const { container: createdElement, render } = createMockPartialContainerWithView( GENERATED_ELEMENT_ID );
-		const createElement = jest.fn().mockReturnValue( createdElement );
-		const builder = CompositionBuilder.fromXMLString( `<${ ROOT_CHILD_TAG } />`, {
-			createElement,
-			deleteElement: jest.fn(),
-			getContainer: jest.fn(),
-			generateElementId: jest.fn().mockReturnValue( GENERATED_ELEMENT_ID ),
-			getWidgetsCache: jest.fn().mockReturnValue( createMinimalWidgetsCache() ),
-			doUpdateElementProperty: jest.fn(),
-		} );
-
-		// Act
-		await builder.build( createMockRootContainer() );
-
-		// Assert
-		expect( render ).toHaveBeenCalledTimes( 1 );
+		expect( dispatchEventSpy ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				type: 'elementor/composition/built',
+				detail: {
+					rootContainers: [ GENERATED_ELEMENT_ID ],
+				},
+			} )
+		);
 	} );
 } );

--- a/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
+++ b/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
@@ -320,6 +320,15 @@ export class CompositionBuilder {
 
 		const { configErrors, styleErrors } = await this.applyProperties();
 
+		// Ensure all containers are rendered after applying properties
+		for ( const container of this.rootContainers ) {
+			const view = container.view as Record< string, unknown > | undefined;
+			if ( typeof view?.render === 'function' ) {
+				( view.render as () => void )();
+			}
+			await this.awaitViewRender( container );
+		}
+
 		return {
 			configErrors,
 			styleErrors,

--- a/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
+++ b/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
@@ -320,13 +320,13 @@ export class CompositionBuilder {
 
 		const { configErrors, styleErrors } = await this.applyProperties();
 
-		// Ensure all containers are rendered after applying properties
-		for ( const container of this.rootContainers ) {
-			const view = container.view as Record< string, unknown > | undefined;
-			if ( typeof view?.render === 'function' ) {
-				( view.render as () => void )();
-			}
-			await this.awaitViewRender( container );
+		if ( typeof window !== 'undefined' ) {
+			const targetWindow = window.top || window;
+			targetWindow.dispatchEvent(
+				new CustomEvent( 'elementor/composition/built', {
+					detail: { rootContainers: this.rootContainers.map( ( c ) => c.id ) },
+				} )
+			);
 		}
 
 		return {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Loop items weren't rerendering after creation because consumers had no signal when composition build completed. This event enables downstream systems (e.g., loop handlers) to trigger necessary rerenders post-build.

## 2. What Changed (Where)

- **composition-builder.ts**: Dispatches `elementor/composition/built` CustomEvent with root container IDs after properties applied
- **composition-builder.test.ts**: Added test suite verifying event dispatch with correct payload and timing

## 3. How It Works

After `applyProperties()` completes, the builder dispatches a CustomEvent to `window.top` (or `window` as fallback) containing mapped root container IDs. Listeners can then perform post-build operations like rerendering loop items. Window check prevents SSR breaks.

## 4. Risks

None identified. Event is fire-and-forget, non-blocking, and isolated to browser context. Existing consumers unaffected since this is new functionality.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
