### PR TITLE
Fix: Tools page break when Cloud Kits API unavailable [ED-24714]

### DIFF
--- a/core/common/modules/connect/apps/base-app.php
+++ b/core/common/modules/connect/apps/base-app.php
@@ -466,9 +466,8 @@ abstract class Base_App {
 			$args
 		);
 
-		if ( is_wp_error( $response ) && empty( $options['with_error_data'] ) ) {
-			// PHPCS - the variable $response does not contain a user input value.
-			wp_die( $response, [ 'back_link' => true ] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		if ( is_wp_error( $response ) ) {
+			return $response;
 		}
 
 		$body = wp_remote_retrieve_body( $response );

--- a/core/common/modules/connect/apps/base-app.php
+++ b/core/common/modules/connect/apps/base-app.php
@@ -466,8 +466,9 @@ abstract class Base_App {
 			$args
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return $response;
+		if ( is_wp_error( $response ) && empty( $options['with_error_data'] ) ) {
+			// PHPCS - the variable $response does not contain a user input value.
+			wp_die( $response, [ 'back_link' => true ] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
 		$body = wp_remote_retrieve_body( $response );

--- a/modules/cloud-kit-library/connect/cloud-kits.php
+++ b/modules/cloud-kit-library/connect/cloud-kits.php
@@ -45,6 +45,7 @@ class Cloud_Kits extends Library {
 
 		return $this->http_request( 'GET', 'quota/kits', [], [
 			'return_type' => static::HTTP_RETURN_TYPE_ARRAY,
+			'with_error_data' => true,
 		] );
 	}
 

--- a/tests/phpunit/elementor/core/common/modules/connect/apps/test-common-app.php
+++ b/tests/phpunit/elementor/core/common/modules/connect/apps/test-common-app.php
@@ -115,6 +115,25 @@ class Test_Common_App extends Elementor_Test_Base {
 		$this->assertEquals( 401, $result->get_error_code() );
 	}
 
+	public function test_http_request__returns_wp_error_on_connection_failure_with_error_data() {
+		// Arrange
+		$this->http_stub
+			->expects( $this->once() )
+			->method( 'request' )
+			->willReturn( new \WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out after 10000 milliseconds with 0 bytes received' ) );
+
+		// Act
+		$result = $this->app_stub->proxy_http_request( 'GET', 'quota/kits', [], [
+			'with_error_data' => true,
+			'return_type' => Base_App::HTTP_RETURN_TYPE_ARRAY,
+		] );
+
+		// Assert
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 500, $result->get_error_code() );
+		$this->assertEquals( 'No Response', $result->get_error_message() );
+	}
+
 	public function test_http_request__return_error_when_not_response_code() {
 		// Arrange
 		$this->http_stub

--- a/tests/phpunit/elementor/core/common/modules/connect/apps/test-common-app.php
+++ b/tests/phpunit/elementor/core/common/modules/connect/apps/test-common-app.php
@@ -115,6 +115,42 @@ class Test_Common_App extends Elementor_Test_Base {
 		$this->assertEquals( 401, $result->get_error_code() );
 	}
 
+	public function test_http_request__returns_wp_error_on_connection_failure() {
+		// Arrange
+		$connection_error = new \WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out after 10000 milliseconds with 0 bytes received' );
+
+		$this->http_stub
+			->expects( $this->once() )
+			->method( 'request' )
+			->willReturn( $connection_error );
+
+		// Act
+		$result = $this->app_stub->proxy_http_request( 'GET', 'quota' );
+
+		// Assert
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( $connection_error, $result );
+	}
+
+	public function test_http_request__returns_wp_error_on_connection_failure_with_error_data() {
+		// Arrange
+		$connection_error = new \WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out after 10000 milliseconds with 0 bytes received' );
+
+		$this->http_stub
+			->expects( $this->once() )
+			->method( 'request' )
+			->willReturn( $connection_error );
+
+		// Act
+		$result = $this->app_stub->proxy_http_request( 'GET', 'quota', [], [
+			'with_error_data' => true,
+		] );
+
+		// Assert
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( $connection_error, $result );
+	}
+
 	public function test_http_request__return_error_when_not_response_code() {
 		// Arrange
 		$this->http_stub

--- a/tests/phpunit/elementor/core/common/modules/connect/apps/test-common-app.php
+++ b/tests/phpunit/elementor/core/common/modules/connect/apps/test-common-app.php
@@ -115,42 +115,6 @@ class Test_Common_App extends Elementor_Test_Base {
 		$this->assertEquals( 401, $result->get_error_code() );
 	}
 
-	public function test_http_request__returns_wp_error_on_connection_failure() {
-		// Arrange
-		$connection_error = new \WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out after 10000 milliseconds with 0 bytes received' );
-
-		$this->http_stub
-			->expects( $this->once() )
-			->method( 'request' )
-			->willReturn( $connection_error );
-
-		// Act
-		$result = $this->app_stub->proxy_http_request( 'GET', 'quota' );
-
-		// Assert
-		$this->assertInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( $connection_error, $result );
-	}
-
-	public function test_http_request__returns_wp_error_on_connection_failure_with_error_data() {
-		// Arrange
-		$connection_error = new \WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out after 10000 milliseconds with 0 bytes received' );
-
-		$this->http_stub
-			->expects( $this->once() )
-			->method( 'request' )
-			->willReturn( $connection_error );
-
-		// Act
-		$result = $this->app_stub->proxy_http_request( 'GET', 'quota', [], [
-			'with_error_data' => true,
-		] );
-
-		// Assert
-		$this->assertInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( $connection_error, $result );
-	}
-
 	public function test_http_request__return_error_when_not_response_code() {
 		// Arrange
 		$this->http_stub


### PR DESCRIPTION
## Summary

When the cloud kits quota endpoint is unreachable, `Cloud_Kits::get_quota()` triggers `Base_App::http_request()`, which called `wp_die()` on transport errors — breaking admin page rendering mid-response (e.g. Elementor → Tools).

This adds `with_error_data => true` to the `get_quota()` HTTP request so transport failures return a `WP_Error` that existing callers (such as `check_eligibility()`) already handle gracefully.

## Changes

- `modules/cloud-kit-library/connect/cloud-kits.php` — pass `with_error_data => true` in `get_quota()` `http_request()` options

## Notes

Keeps the existing `http_request()` contract unchanged; surgical fix scoped to the Tools page quota check path as suggested in review.
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Tools page crashes when Cloud Kits API is unavailable due to unhandled HTTP errors. Adding error data tracking prevents fatal wp_die() calls and gracefully handles timeout/connection failures (ED-24714).

## 2. What Changed (Where)

- **cloud-kits.php**: Added `'with_error_data' => true` flag to http_request() call for quota/kits endpoint.
- **test-common-app.php**: New test validates WP_Error handling with error_data flag on connection failures.

## 3. How It Works

The `with_error_data` flag signals the HTTP layer to wrap API failures (timeouts, connection errors) as structured WP_Error objects with code 500/"No Response" rather than triggering fatal errors. Calling code then handles gracefully instead of page breaking.

## 4. Risks

None — backward compatible flag addition. Existing error handling paths unaffected; new flag only activates structured error wrapping for this specific quota endpoint.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
