### PR TITLE
Fix: Cherry-pick PR 36266 to 4.02: On kit creation, create new posts for global classes [ED-24663]

### DIFF
--- a/core/kits/manager.php
+++ b/core/kits/manager.php
@@ -152,6 +152,11 @@ class Manager {
 			update_option( self::OPTION_ACTIVE, $id );
 		}
 
+		do_action( 'elementor/kit/after_new_kit_created', [
+			'new_kit_id' => $id,
+			'previous_kit_id' => $current_kit->get_post()->ID,
+		] );
+
 		return $id;
 	}
 

--- a/modules/global-classes/global-class-post.php
+++ b/modules/global-classes/global-class-post.php
@@ -197,6 +197,18 @@ class Global_Class_Post {
 		return is_array( $data ) ? $data : [];
 	}
 
+	private function get_preview_data(): array {
+		$data = get_post_meta( $this->post->ID, self::META_KEY_DATA_PREVIEW, true );
+
+		return is_array( $data ) ? $data : [];
+	}
+
+	private function get_version(): string {
+		$version = get_post_meta( $this->post->ID, self::META_KEY_VERSION, true );
+
+		return is_string( $version ) ? $version : '';
+	}
+
 	public function update_data(
 		array $data,
 		string $version = ELEMENTOR_VERSION
@@ -260,5 +272,46 @@ class Global_Class_Post {
 		$result = wp_delete_post( $this->post->ID, true );
 
 		return false !== $result;
+	}
+
+	public static function clone_to_other_kit( string $style_id, Kit $source_kit, Kit $target_kit ): ?Global_Class_Post {
+		$source_post = self::find_by_class_id( $style_id, false, $source_kit );
+
+		if ( ! $source_post ) {
+			return null;
+		}
+
+		$new_post_id = wp_insert_post( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_title' => $source_post->get_label(),
+			'post_status' => 'publish',
+		] );
+
+		if ( is_wp_error( $new_post_id ) || ! $new_post_id ) {
+			return null;
+		}
+
+		update_post_meta( $new_post_id, self::META_KEY_ID, $style_id );
+		update_post_meta( $new_post_id, self::META_KEY_VERSION, $source_post->get_version() );
+
+		$frontend_data = $source_post->get_frontend_data();
+		$preview_data = $source_post->get_preview_data();
+		$last_edited_timestamp = get_post_meta( $source_post->get_post_id(), self::META_KEY_EDITED, true );
+
+		if ( ! empty( $frontend_data ) ) {
+			update_post_meta( $new_post_id, self::META_KEY_DATA, $frontend_data );
+		}
+
+		if ( ! empty( $preview_data ) ) {
+			update_post_meta( $new_post_id, self::META_KEY_DATA_PREVIEW, $preview_data );
+		}
+
+		if ( $last_edited_timestamp ) {
+			update_post_meta( $new_post_id, self::META_KEY_EDITED, $last_edited_timestamp );
+		}
+
+		Global_Classes_Post_IDs::make( $target_kit )->set( $style_id, (int) $new_post_id );
+
+		return self::from_post_id( $new_post_id );
 	}
 }

--- a/modules/global-classes/module.php
+++ b/modules/global-classes/module.php
@@ -81,6 +81,8 @@ class Module extends BaseModule {
 				'elementor/kit/meta_to_preserve_on_kit_import',
 				[ $this, 'add_meta_to_preserve_on_kit_import' ]
 			);
+
+			add_action( 'elementor/kit/after_new_kit_created', [ $this, 'create_global_classes_posts_for_new_kit' ], 10, 1 );
 		}
 	}
 
@@ -89,9 +91,38 @@ class Module extends BaseModule {
 			Global_Classes_Order::META_KEY,
 			Global_Classes_Labels::META_KEY_FRONTEND,
 			Global_Classes_Labels::META_KEY_PREVIEW,
+			Global_Classes_Relations::META_KEY_FRONTEND,
+			Global_Classes_Relations::META_KEY_PREVIEW,
+			Global_Classes_Relations::META_KEY_USAGE_INDEXED_FRONTEND,
+			Global_Classes_Relations::META_KEY_USAGE_INDEXED_PREVIEW,
+			Global_Classes_Relations::META_KEY_CLASS_RELATED_POSTS_FRONTEND,
+			Global_Classes_Relations::META_KEY_CLASS_RELATED_POSTS_PREVIEW,
 			Global_Classes_Sync_Map::META_KEY,
-			Global_Classes_Post_IDs::META_KEY,
 		] );
+	}
+
+	/**
+	 * Duplicates global classes posts from the previous kit to the new kit, after a new kit is created.
+	 * So each kit has its own, separate, global classes posts, and editing one kit's classes will not affect the other kits.
+	 *
+	 * @param array $params The parameters passed to the action - 'new_kit_id' and 'previous_kit_id'.
+	 * @return void
+	 */
+	public function create_global_classes_posts_for_new_kit( array $params ): void {
+		[ 'new_kit_id' => $new_kit_id, 'previous_kit_id' => $previous_kit_id ] = $params;
+
+		$previous_kit = Plugin::$instance->kits_manager->get_kit( $previous_kit_id );
+		$new_kit = Plugin::$instance->kits_manager->get_kit( $new_kit_id );
+
+		if ( ! $previous_kit || ! $new_kit ) {
+			return;
+		}
+
+		$all_classes = Global_Classes_Repository::make( $previous_kit )->get_order();
+
+		foreach ( $all_classes as $class_id ) {
+			Global_Class_Post::clone_to_other_kit( $class_id, $previous_kit, $new_kit );
+		}
 	}
 
 	private function register_features() {

--- a/tests/phpunit/elementor/modules/global-classes/test-global-class-post.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-global-class-post.php
@@ -1,9 +1,12 @@
 <?php
 namespace Elementor\Tests\Phpunit\Modules\GlobalClasses;
 
+use Elementor\Core\Kits\Documents\Kit;
 use Elementor\Modules\GlobalClasses\Global_Class_Post;
 use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use Elementor\Modules\GlobalClasses\Global_Classes_Post_IDs;
 use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
+use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -24,6 +27,7 @@ class Global_Class_Post_With_Mocked_Time extends Global_Class_Post {
 
 class Test_Global_Class_Post extends Elementor_Test_Base {
 	private array $created_post_ids = [];
+	private array $created_kit_ids = [];
 
 	public function setUp(): void {
 		parent::setUp();
@@ -36,9 +40,28 @@ class Test_Global_Class_Post extends Elementor_Test_Base {
 			wp_delete_post( $post_id, true );
 		}
 
+		$this->force_delete_kits( $this->created_kit_ids );
+
 		$this->created_post_ids = [];
+		$this->created_kit_ids = [];
 
 		parent::tearDown();
+	}
+
+	private function force_delete_kits( array $kit_ids ): void {
+		if ( empty( $kit_ids ) ) {
+			return;
+		}
+
+		$skip_confirmation = new \ReflectionProperty( Plugin::$instance->kits_manager, 'should_skip_trash_kit_confirmation' );
+		$skip_confirmation->setAccessible( true );
+		$skip_confirmation->setValue( Plugin::$instance->kits_manager, true );
+
+		foreach ( $kit_ids as $kit_id ) {
+			wp_delete_post( $kit_id, true );
+		}
+
+		$skip_confirmation->setValue( Plugin::$instance->kits_manager, false );
 	}
 
 	public function test_create__should_not_mark_post_as_edited() {
@@ -250,5 +273,183 @@ class Test_Global_Class_Post extends Elementor_Test_Base {
 		// Assert
 		$this->assertTrue( $result );
 		$this->assertNull( Global_Class_Post::from_post_id( $post_id ) );
+	}
+
+	public function test_clone_to_other_kit__creates_new_post_with_same_data() {
+		// Arrange
+		$source_kit = Plugin::$instance->kits_manager->get_active_kit();
+		$target_kit_id = Plugin::$instance->kits_manager->create( [ 'post_title' => 'Target Kit' ] );
+		$target_kit = Plugin::$instance->kits_manager->get_kit( $target_kit_id );
+		$this->created_kit_ids[] = $target_kit_id;
+
+		$class_id = 'g-clone-1';
+		$label = 'button-primary';
+		$data = [
+			'type' => 'class',
+			'variants' => [
+				[
+					'meta' => [ 'breakpoint' => 'desktop', 'state' => null ],
+					'props' => [ 'color' => [ '$$type' => 'color', 'value' => 'red' ] ],
+				],
+			],
+		];
+		$source_post = Global_Class_Post::create( $class_id, $label, $data, $source_kit );
+		$this->created_post_ids[] = $source_post->get_post_id();
+
+		// Act
+		$cloned_post = Global_Class_Post::clone_to_other_kit( $class_id, $source_kit, $target_kit );
+		$this->created_post_ids[] = $cloned_post->get_post_id();
+
+		// Assert
+		$this->assertNotNull( $cloned_post );
+		$this->assertNotSame( $source_post->get_post_id(), $cloned_post->get_post_id() );
+		$this->assertSame( $class_id, $cloned_post->get_class_id() );
+		$this->assertSame( $label, $cloned_post->get_label() );
+		$this->assertSame( $data, $cloned_post->get_data() );
+	}
+
+	public function test_clone_to_other_kit__registers_post_with_target_kit() {
+		// Arrange
+		$source_kit = Plugin::$instance->kits_manager->get_active_kit();
+		$target_kit_id = Plugin::$instance->kits_manager->create( [ 'post_title' => 'Target Kit' ] );
+		$target_kit = Plugin::$instance->kits_manager->get_kit( $target_kit_id );
+		$this->created_kit_ids[] = $target_kit_id;
+
+		$class_id = 'g-clone-register-1';
+		$source_post = Global_Class_Post::create( $class_id, 'my-class', [ 'type' => 'class', 'variants' => [] ], $source_kit );
+		$this->created_post_ids[] = $source_post->get_post_id();
+
+		// Act
+		$cloned_post = Global_Class_Post::clone_to_other_kit( $class_id, $source_kit, $target_kit );
+		$this->created_post_ids[] = $cloned_post->get_post_id();
+
+		// Assert
+		$resolved_post_id = Global_Classes_Post_IDs::make( $target_kit )->get_post_id( $class_id );
+		$this->assertSame( $cloned_post->get_post_id(), $resolved_post_id );
+	}
+
+	public function test_clone_to_other_kit__copies_preview_data_when_exists() {
+		// Arrange
+		$source_kit = Plugin::$instance->kits_manager->get_active_kit();
+		$target_kit_id = Plugin::$instance->kits_manager->create( [ 'post_title' => 'Target Kit' ] );
+		$target_kit = Plugin::$instance->kits_manager->get_kit( $target_kit_id );
+		$this->created_kit_ids[] = $target_kit_id;
+
+		$class_id = 'g-clone-preview-1';
+		$frontend_data = [
+			'type' => 'class',
+			'variants' => [
+				[
+					'meta' => [ 'breakpoint' => 'desktop', 'state' => null ],
+					'props' => [ 'color' => [ '$$type' => 'color', 'value' => 'blue' ] ],
+				],
+			],
+		];
+		$preview_data = [
+			'type' => 'class',
+			'variants' => [
+				[
+					'meta' => [ 'breakpoint' => 'desktop', 'state' => null ],
+					'props' => [ 'color' => [ '$$type' => 'color', 'value' => 'green' ] ],
+				],
+			],
+		];
+
+		$source_post = Global_Class_Post::create( $class_id, 'preview-class', $frontend_data, $source_kit );
+		$this->created_post_ids[] = $source_post->get_post_id();
+		$source_post->set_preview( true );
+		$source_post->update_data( $preview_data );
+
+		// Act
+		$cloned_post = Global_Class_Post::clone_to_other_kit( $class_id, $source_kit, $target_kit );
+		$this->created_post_ids[] = $cloned_post->get_post_id();
+
+		// Assert
+		$cloned_frontend = Global_Class_Post::from_post_id( $cloned_post->get_post_id(), false );
+		$cloned_preview = Global_Class_Post::from_post_id( $cloned_post->get_post_id(), true );
+
+		$this->assertSame( $frontend_data, $cloned_frontend->get_data() );
+		$this->assertSame( $preview_data, $cloned_preview->get_data() );
+	}
+
+	public function test_clone_to_other_kit__preserves_edited_timestamp() {
+		// Arrange
+		$source_kit = Plugin::$instance->kits_manager->get_active_kit();
+		$target_kit_id = Plugin::$instance->kits_manager->create( [ 'post_title' => 'Target Kit' ] );
+		$target_kit = Plugin::$instance->kits_manager->get_kit( $target_kit_id );
+		$this->created_kit_ids[] = $target_kit_id;
+
+		$class_id = 'g-clone-timestamp-1';
+		$source_post = Global_Class_Post::create( $class_id, 'timestamp-class', [ 'type' => 'class', 'variants' => [] ], $source_kit );
+		$this->created_post_ids[] = $source_post->get_post_id();
+
+		$fixed_timestamp = time() + 1000;
+		update_post_meta( $source_post->get_post_id(), Global_Class_Post::META_KEY_EDITED, $fixed_timestamp );
+
+		// Act
+		$cloned_post = Global_Class_Post::clone_to_other_kit( $class_id, $source_kit, $target_kit );
+		$this->created_post_ids[] = $cloned_post->get_post_id();
+
+		// Assert
+		$cloned_timestamp = get_post_meta( $cloned_post->get_post_id(), Global_Class_Post::META_KEY_EDITED, true );
+		$this->assertSame( $fixed_timestamp, (int) $cloned_timestamp );
+	}
+
+	public function test_clone_to_other_kit__returns_null_when_source_class_not_found() {
+		// Arrange
+		$source_kit = Plugin::$instance->kits_manager->get_active_kit();
+		$target_kit_id = Plugin::$instance->kits_manager->create( [ 'post_title' => 'Target Kit' ] );
+		$target_kit = Plugin::$instance->kits_manager->get_kit( $target_kit_id );
+		$this->created_kit_ids[] = $target_kit_id;
+
+		// Act
+		$cloned_post = Global_Class_Post::clone_to_other_kit( 'non-existent-class', $source_kit, $target_kit );
+
+		// Assert
+		$this->assertNull( $cloned_post );
+	}
+
+	public function test_clone_to_other_kit__creates_independent_post() {
+		// Arrange
+		$source_kit = Plugin::$instance->kits_manager->get_active_kit();
+		$target_kit_id = Plugin::$instance->kits_manager->create( [ 'post_title' => 'Target Kit' ] );
+		$target_kit = Plugin::$instance->kits_manager->get_kit( $target_kit_id );
+		$this->created_kit_ids[] = $target_kit_id;
+
+		$class_id = 'g-clone-independent-1';
+		$original_data = [
+			'type' => 'class',
+			'variants' => [
+				[
+					'meta' => [ 'breakpoint' => 'desktop', 'state' => null ],
+					'props' => [ 'color' => [ '$$type' => 'color', 'value' => 'red' ] ],
+				],
+			],
+		];
+		$source_post = Global_Class_Post::create( $class_id, 'independent-class', $original_data, $source_kit );
+		$this->created_post_ids[] = $source_post->get_post_id();
+
+		$cloned_post = Global_Class_Post::clone_to_other_kit( $class_id, $source_kit, $target_kit );
+		$this->created_post_ids[] = $cloned_post->get_post_id();
+
+		// Act
+		$modified_data = [
+			'type' => 'class',
+			'variants' => [
+				[
+					'meta' => [ 'breakpoint' => 'desktop', 'state' => null ],
+					'props' => [ 'color' => [ '$$type' => 'color', 'value' => 'blue' ] ],
+				],
+			],
+		];
+		$cloned_post->set_preview( false );
+		$cloned_post->update_data( $modified_data );
+
+		// Assert
+		$reloaded_source = Global_Class_Post::from_post_id( $source_post->get_post_id() );
+		$reloaded_cloned = Global_Class_Post::from_post_id( $cloned_post->get_post_id() );
+
+		$this->assertSame( $original_data, $reloaded_source->get_data() );
+		$this->assertSame( $modified_data, $reloaded_cloned->get_data() );
 	}
 }


### PR DESCRIPTION
cherry-pick of https://github.com/elementor/elementor/pull/36266 to 4.02 branch.