### PR TITLE
feat(notifications): support video and GIF media in What's New panel

### DIFF
--- a/modules/notifications/assets/js/components/whats-new-item.js
+++ b/modules/notifications/assets/js/components/whats-new-item.js
@@ -30,9 +30,20 @@ export const WhatsNewItem = ( { item, itemIndex, itemsLength, setIsOpen } ) => {
 					{ item.title }
 				</Typography>
 			</WrapperWithLink>
-			{ item.imageSrc && (
+			{ item.youtubeEmbedId ? (
+				<Box sx={ { pb: 2 } }>
+					<Box
+						component="iframe"
+						src={ `https://www.youtube.com/embed/${ item.youtubeEmbedId }${ item.youtubeAutoplay ? '?autoplay=1&mute=1' : '' }` }
+						title={ item.title }
+						allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+						allowFullScreen={ true }
+						sx={ { aspectRatio: '16/9', width: '100%', display: 'block', border: 'none' } }
+					/>
+				</Box>
+			) : ( item.gifSrc || item.imageSrc ) && (
 				<WhatsNewItemThumbnail
-					imageSrc={ item.imageSrc }
+					imageSrc={ item.gifSrc || item.imageSrc }
 					link={ item.link }
 					title={ item.title }
 				/>


### PR DESCRIPTION
## Summary
- Adds support for YouTube video embed in What's New notification items via `youtubeEmbedId` field
- Adds `youtubeAutoplay` boolean field to control autoplay (muted, per browser policy)
- Adds `gifSrc` field for GIF media, rendered via the existing thumbnail component
- All fields are optional — existing `imageSrc` behavior is fully unchanged

## How it works
- `youtubeEmbedId` → renders a 16:9 YouTube iframe (full panel width)
- `youtubeAutoplay: true` → appends `?autoplay=1&mute=1` to the embed URL
- `gifSrc` → renders as `<img>` (GIFs auto-play natively)
- Priority: YouTube > GIF > static image

## Assets side
Fields can be added to any notification entry in `editor-assets` without a schema change (schema does not enforce `additionalProperties: false`).

## Test plan
- [ ] Notification with `youtubeEmbedId` renders YouTube iframe at correct aspect ratio
- [ ] Notification with `youtubeAutoplay: true` autoplays muted
- [ ] Notification with `gifSrc` renders animated GIF
- [ ] Notification with only `imageSrc` (existing behavior) renders unchanged
- [ ] Notification with no media fields renders unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Extends What's New panel to display rich media—YouTube embeds take priority, falling back to GIF/image thumbnails when unavailable.

## 2. What Changed (Where)
`whats-new-item.js`: Conditional rendering chain added; YouTube iframe component (lines 33–43) precedes fallback thumbnail with GIF support (line 44–50).

## 3. How It Works
Render logic: `youtubeEmbedId` → iframe with optional autoplay; else if `gifSrc` or `imageSrc` exist → `WhatsNewItemThumbnail`. Iframe uses 16:9 aspect ratio, allowFullScreen, and sandbox attributes.

## 4. Risks
Missing validation for malformed `youtubeEmbedId` could produce broken iframe URLs. GIF CORS/loading behavior undefined if `gifSrc` domain differs from parent. Consider sanitizing embed ID.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
