### PR TITLE
Fix: Use "back up" instead of "backup" in rollback warning [ED-24713]

### DIFF
--- a/includes/settings/tools.php
+++ b/includes/settings/tools.php
@@ -386,7 +386,7 @@ class Tools extends Settings_Page {
 										esc_html__( 'Reinstall', 'elementor' ),
 										wp_nonce_url( admin_url( 'admin-post.php?action=elementor_rollback&version=VERSION' ), 'elementor_rollback' )
 									),
-									'desc' => $this->get_warning_span( esc_html__( 'Warning: Please backup your database before making the rollback.', 'elementor' ) ),
+									'desc' => $this->get_warning_span( esc_html__( 'Warning: Please back up your database before making the rollback.', 'elementor' ) ),
 								],
 							],
 						],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Correct rollback warning copy on Tools → Version Control to use "back up" as a verb

## Description

Updates the rollback warning on **Elementor → Tools → Version Control → Rollback to Previous Version** so the verb form reads "back up" instead of "backup".

Fixes ED-24713

## Test instructions

1. Go to **WP Admin → Elementor → Tools**
2. Open the **Version Control** tab
3. Under **Rollback to Previous Version**, confirm the warning reads: `Warning: Please back up your database before making the rollback.`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://elementor.slack.com/archives/C08LJA2S4KX/p1782138418241799?thread_ts=1782138418.241799&cid=C08LJA2S4KX)

<div><a href="https://cursor.com/agents/bc-a4d40b7e-b399-5da1-9a0b-8cd246ccbe0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4d40b7e-b399-5da1-9a0b-8cd246ccbe0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

