### PR TITLE
Revert "Internal: Cherry-pick PR 36294 to 4.02: Bump packages [ED-24611]"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "elementor/wp-one-package": "1.0.65"
+        "elementor/wp-one-package": "1.0.64"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "237fb693f8f0df09d2c4a804c7312f92",
+    "content-hash": "93b7b927ef351f3c860d6112aa6f6576",
     "packages": [
         {
             "name": "elementor/wp-notifications-package",
@@ -39,10 +39,10 @@
         },
         {
             "name": "elementor/wp-one-package",
-            "version": "1.0.65",
+            "version": "1.0.64",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.65"
+                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.64"
             },
             "require": {
                 "elementor/wp-notifications-package": "^1.2"
@@ -69,7 +69,7 @@
                     "vendor/bin/phpcbf ."
                 ]
             },
-            "time": "2026-06-16T07:28:42+00:00"
+            "time": "2026-06-11T08:34:37+00:00"
         }
     ],
     "packages-dev": [
@@ -144,7 +144,6 @@
                     "type": "tidelift"
                 }
             ],
-            "abandoned": true,
             "time": "2022-01-17T14:14:24+00:00"
         },
         {
@@ -3182,16 +3181,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.38.1",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
-                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
                 "shasum": ""
             },
             "require": {
@@ -3240,7 +3239,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -3260,20 +3259,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T05:58:03+00:00"
+            "time": "2026-04-26T13:13:48+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.38.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
-                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
                 "shasum": ""
             },
             "require": {
@@ -3325,7 +3324,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -3345,20 +3344,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T13:48:31+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.2",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
-                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
                 "shasum": ""
             },
             "require": {
@@ -3410,7 +3409,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -3430,7 +3429,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-27T06:59:30+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -3518,16 +3517,16 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.38.1",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
+                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
-                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
                 "shasum": ""
             },
             "require": {
@@ -3574,7 +3573,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -3594,7 +3593,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:45:58+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/property-access",
@@ -4042,16 +4041,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.53",
+            "version": "v5.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "ae0bbb46f77ff56591d0a0259c7f458f4b3e1f77"
+                "reference": "a454d47278cc16a5db371fe73ae66a78a633371e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ae0bbb46f77ff56591d0a0259c7f458f4b3e1f77",
-                "reference": "ae0bbb46f77ff56591d0a0259c7f458f4b3e1f77",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a454d47278cc16a5db371fe73ae66a78a633371e",
+                "reference": "a454d47278cc16a5db371fe73ae66a78a633371e",
                 "shasum": ""
             },
             "require": {
@@ -4097,7 +4096,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.53"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.45"
             },
             "funding": [
                 {
@@ -4109,15 +4108,11 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T17:13:41+00:00"
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "thecodingmachine/safe",
@@ -4575,16 +4570,16 @@
         },
         {
             "name": "wordpress/php-mcp-schema",
-            "version": "v0.1.2",
+            "version": "v0.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress/php-mcp-schema",
-                "reference": "95df8a50a3bd54f6b7c4869c6e2185db380d4d63"
+                "url": "https://github.com/WordPress/php-mcp-schema.git",
+                "reference": "e2118ec421ead51a3e17a3d8160f4537727e91b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/95df8a50a3bd54f6b7c4869c6e2185db380d4d63",
-                "reference": "95df8a50a3bd54f6b7c4869c6e2185db380d4d63",
+                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/e2118ec421ead51a3e17a3d8160f4537727e91b9",
+                "reference": "e2118ec421ead51a3e17a3d8160f4537727e91b9",
                 "shasum": ""
             },
             "require": {
@@ -4618,7 +4613,11 @@
                 "php",
                 "schema"
             ],
-            "time": "2026-06-05T08:26:32+00:00"
+            "support": {
+                "issues": "https://github.com/WordPress/php-mcp-schema/issues",
+                "source": "https://github.com/WordPress/php-mcp-schema/tree/v0.1.1"
+            },
+            "time": "2026-04-10T19:35:16+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -4752,15 +4751,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "packages/apps/*"
       ],
       "dependencies": {
-        "@elementor/elementor-one-assets": "0.4.37",
+        "@elementor/elementor-one-assets": "0.4.35",
         "@elementor/icons": "~1.75.1",
         "@elementor/ui": "1.39.1",
         "@reach/router": "1.3.4",
@@ -4522,9 +4522,9 @@
       "link": true
     },
     "node_modules/@elementor/elementor-one-assets": {
-      "version": "0.4.37",
-      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.37.tgz",
-      "integrity": "sha512-iY7FGmpvkZFxh8wrtZYqtq3imd3YYtX82KLp45CUDiYITYiy8fm37BiyAPdWDSPkLXMdxWTVbRhF9v52XHP0yA==",
+      "version": "0.4.35",
+      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.35.tgz",
+      "integrity": "sha512-z5EZIPedcicUFVqQs8NNAyBDrh/sCn0czsqYr/plrNpdrVKQdnuMeVJvp7ZlbfbcErYZvEZLREWwnNivF2/PyA==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/icons": "^1.60.0",
@@ -44634,10 +44634,10 @@
     },
     "packages/apps/birthday-easter-egg-modal": {
       "name": "@elementor/birthday-easter-egg-modal",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-modal-shell": "4.3.0",
+        "@elementor/editor-modal-shell": "4.2.0",
         "@elementor/ui": "1.37.5",
         "@wordpress/i18n": "^5.13.0"
       },
@@ -44651,12 +44651,12 @@
     },
     "packages/apps/elementor-capabilities-mcp": {
       "name": "@elementor/elementor-capabilities-mcp",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-mcp": "4.3.0",
-        "@elementor/elementor-mcp-common": "4.3.0",
-        "@elementor/schema": "4.3.0"
+        "@elementor/editor-mcp": "4.2.0",
+        "@elementor/elementor-mcp-common": "4.2.0",
+        "@elementor/schema": "4.2.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -44664,15 +44664,15 @@
     },
     "packages/apps/onboarding": {
       "name": "@elementor/onboarding",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/events": "4.3.0",
+        "@elementor/events": "4.2.0",
         "@elementor/icons": "~1.75.1",
-        "@elementor/query": "4.3.0",
-        "@elementor/store": "4.3.0",
+        "@elementor/query": "4.2.0",
+        "@elementor/store": "4.2.0",
         "@elementor/ui": "1.37.5",
-        "@elementor/utils": "4.3.0"
+        "@elementor/utils": "4.2.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -44694,10 +44694,10 @@
     },
     "packages/apps/site-builder": {
       "name": "@elementor/site-builder",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/schema": "4.3.0",
+        "@elementor/schema": "4.2.0",
         "@wordpress/api-fetch": "^6.42.0"
       },
       "devDependencies": {
@@ -44710,14 +44710,14 @@
     },
     "packages/apps/unlock-v4-promo": {
       "name": "@elementor/unlock-v4-promo",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-current-user": "4.3.0",
-        "@elementor/editor-elements-panel-notice": "4.3.0",
-        "@elementor/editor-notifications": "4.3.0",
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/http-client": "4.3.0",
+        "@elementor/editor-current-user": "4.2.0",
+        "@elementor/editor-elements-panel-notice": "4.2.0",
+        "@elementor/editor-notifications": "4.2.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/http-client": "4.2.0",
         "@elementor/ui": "1.37.5",
         "@wordpress/i18n": "^5.13.0"
       },
@@ -44731,10 +44731,10 @@
     },
     "packages/apps/v4-activation-modal": {
       "name": "@elementor/v4-activation-modal",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-modal-shell": "4.3.0",
+        "@elementor/editor-modal-shell": "4.2.0",
         "@elementor/icons": "~1.75.1",
         "@elementor/ui": "1.37.5",
         "@wordpress/i18n": "^5.13.0",
@@ -44888,7 +44888,7 @@
     },
     "packages/packages/core/alpinejs": {
       "name": "@elementor/alpinejs",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@alpinejs/csp": "3.15.0"
@@ -44900,15 +44900,15 @@
     },
     "packages/packages/core/editor": {
       "name": "@elementor/editor",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-current-user": "4.3.0",
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/locations": "4.3.0",
-        "@elementor/query": "4.3.0",
-        "@elementor/store": "4.3.0",
+        "@elementor/editor-current-user": "4.2.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/locations": "4.2.0",
+        "@elementor/query": "4.2.0",
+        "@elementor/store": "4.2.0",
         "@elementor/ui": "1.37.5"
       },
       "devDependencies": {
@@ -44921,21 +44921,21 @@
     },
     "packages/packages/core/editor-app-bar": {
       "name": "@elementor/editor-app-bar",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-current-user": "4.3.0",
-        "@elementor/editor-documents": "4.3.0",
-        "@elementor/editor-mcp": "4.3.0",
-        "@elementor/editor-responsive": "4.3.0",
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/events": "4.3.0",
-        "@elementor/http-client": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-current-user": "4.2.0",
+        "@elementor/editor-documents": "4.2.0",
+        "@elementor/editor-mcp": "4.2.0",
+        "@elementor/editor-responsive": "4.2.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/events": "4.2.0",
+        "@elementor/http-client": "4.2.0",
         "@elementor/icons": "~1.75.1",
-        "@elementor/locations": "4.3.0",
-        "@elementor/menus": "4.3.0",
+        "@elementor/locations": "4.2.0",
+        "@elementor/menus": "4.2.0",
         "@elementor/ui": "1.37.5",
         "@wordpress/i18n": "^5.13.0"
       },
@@ -44949,28 +44949,28 @@
     },
     "packages/packages/core/editor-canvas": {
       "name": "@elementor/editor-canvas",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-controls": "4.3.0",
-        "@elementor/editor-documents": "4.3.0",
-        "@elementor/editor-elements": "4.3.0",
-        "@elementor/editor-interactions": "4.3.0",
-        "@elementor/editor-mcp": "4.3.0",
-        "@elementor/editor-notifications": "4.3.0",
-        "@elementor/editor-props": "4.3.0",
-        "@elementor/editor-responsive": "4.3.0",
-        "@elementor/editor-styles": "4.3.0",
-        "@elementor/editor-styles-repository": "4.3.0",
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/http-client": "4.3.0",
-        "@elementor/schema": "4.3.0",
-        "@elementor/twing": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-controls": "4.2.0",
+        "@elementor/editor-documents": "4.2.0",
+        "@elementor/editor-elements": "4.2.0",
+        "@elementor/editor-interactions": "4.2.0",
+        "@elementor/editor-mcp": "4.2.0",
+        "@elementor/editor-notifications": "4.2.0",
+        "@elementor/editor-props": "4.2.0",
+        "@elementor/editor-responsive": "4.2.0",
+        "@elementor/editor-styles": "4.2.0",
+        "@elementor/editor-styles-repository": "4.2.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/http-client": "4.2.0",
+        "@elementor/schema": "4.2.0",
+        "@elementor/twing": "4.2.0",
         "@elementor/ui": "1.37.5",
-        "@elementor/utils": "4.3.0",
-        "@elementor/wp-media": "4.3.0",
+        "@elementor/utils": "4.2.0",
+        "@elementor/wp-media": "4.2.0",
         "@floating-ui/react": "^0.27.5",
         "@wordpress/i18n": "^5.13.0",
         "dompurify": "^3.2.6"
@@ -44985,33 +44985,33 @@
     },
     "packages/packages/core/editor-components": {
       "name": "@elementor/editor-components",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-canvas": "4.3.0",
-        "@elementor/editor-controls": "4.3.0",
-        "@elementor/editor-current-user": "4.3.0",
-        "@elementor/editor-documents": "4.3.0",
-        "@elementor/editor-editing-panel": "4.3.0",
-        "@elementor/editor-elements": "4.3.0",
-        "@elementor/editor-elements-panel": "4.3.0",
-        "@elementor/editor-embedded-documents-manager": "4.3.0",
-        "@elementor/editor-mcp": "4.3.0",
-        "@elementor/editor-notifications": "4.3.0",
-        "@elementor/editor-panels": "4.3.0",
-        "@elementor/editor-props": "4.3.0",
-        "@elementor/editor-templates": "4.3.0",
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/events": "4.3.0",
-        "@elementor/http-client": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-canvas": "4.2.0",
+        "@elementor/editor-controls": "4.2.0",
+        "@elementor/editor-current-user": "4.2.0",
+        "@elementor/editor-documents": "4.2.0",
+        "@elementor/editor-editing-panel": "4.2.0",
+        "@elementor/editor-elements": "4.2.0",
+        "@elementor/editor-elements-panel": "4.2.0",
+        "@elementor/editor-embedded-documents-manager": "4.2.0",
+        "@elementor/editor-mcp": "4.2.0",
+        "@elementor/editor-notifications": "4.2.0",
+        "@elementor/editor-panels": "4.2.0",
+        "@elementor/editor-props": "4.2.0",
+        "@elementor/editor-templates": "4.2.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/events": "4.2.0",
+        "@elementor/http-client": "4.2.0",
         "@elementor/icons": "~1.75.1",
-        "@elementor/query": "4.3.0",
-        "@elementor/schema": "4.3.0",
-        "@elementor/store": "4.3.0",
+        "@elementor/query": "4.2.0",
+        "@elementor/schema": "4.2.0",
+        "@elementor/store": "4.2.0",
         "@elementor/ui": "1.37.5",
-        "@elementor/utils": "4.3.0",
+        "@elementor/utils": "4.2.0",
         "@wordpress/i18n": "^5.13.0"
       },
       "devDependencies": {
@@ -45024,24 +45024,24 @@
     },
     "packages/packages/core/editor-design-system": {
       "name": "@elementor/editor-design-system",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-app-bar": "4.3.0",
-        "@elementor/editor-canvas": "4.3.0",
-        "@elementor/editor-current-user": "4.3.0",
-        "@elementor/editor-documents": "4.3.0",
-        "@elementor/editor-global-classes": "4.3.0",
-        "@elementor/editor-notifications": "4.3.0",
-        "@elementor/editor-panels": "4.3.0",
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/editor-variables": "4.3.0",
-        "@elementor/events": "4.3.0",
-        "@elementor/http-client": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-app-bar": "4.2.0",
+        "@elementor/editor-canvas": "4.2.0",
+        "@elementor/editor-current-user": "4.2.0",
+        "@elementor/editor-documents": "4.2.0",
+        "@elementor/editor-global-classes": "4.2.0",
+        "@elementor/editor-notifications": "4.2.0",
+        "@elementor/editor-panels": "4.2.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/editor-variables": "4.2.0",
+        "@elementor/events": "4.2.0",
+        "@elementor/http-client": "4.2.0",
         "@elementor/icons": "~1.75.1",
-        "@elementor/query": "4.3.0",
+        "@elementor/query": "4.2.0",
         "@elementor/ui": "1.37.5",
         "@wordpress/i18n": "^5.13.0"
       },
@@ -45055,14 +45055,14 @@
     },
     "packages/packages/core/editor-documents": {
       "name": "@elementor/editor-documents",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-elements": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/store": "4.3.0",
-        "@elementor/utils": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-elements": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/store": "4.2.0",
+        "@elementor/utils": "4.2.0",
         "@wordpress/i18n": "^5.13.0"
       },
       "devDependencies": {
@@ -45074,34 +45074,34 @@
     },
     "packages/packages/core/editor-editing-panel": {
       "name": "@elementor/editor-editing-panel",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-canvas": "4.3.0",
-        "@elementor/editor-controls": "4.3.0",
-        "@elementor/editor-documents": "4.3.0",
-        "@elementor/editor-elements": "4.3.0",
-        "@elementor/editor-interactions": "4.3.0",
-        "@elementor/editor-notifications": "4.3.0",
-        "@elementor/editor-panels": "4.3.0",
-        "@elementor/editor-props": "4.3.0",
-        "@elementor/editor-responsive": "4.3.0",
-        "@elementor/editor-styles": "4.3.0",
-        "@elementor/editor-styles-repository": "4.3.0",
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/editor-variables": "4.3.0",
-        "@elementor/http-client": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-canvas": "4.2.0",
+        "@elementor/editor-controls": "4.2.0",
+        "@elementor/editor-documents": "4.2.0",
+        "@elementor/editor-elements": "4.2.0",
+        "@elementor/editor-interactions": "4.2.0",
+        "@elementor/editor-notifications": "4.2.0",
+        "@elementor/editor-panels": "4.2.0",
+        "@elementor/editor-props": "4.2.0",
+        "@elementor/editor-responsive": "4.2.0",
+        "@elementor/editor-styles": "4.2.0",
+        "@elementor/editor-styles-repository": "4.2.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/editor-variables": "4.2.0",
+        "@elementor/http-client": "4.2.0",
         "@elementor/icons": "~1.75.1",
-        "@elementor/locations": "4.3.0",
-        "@elementor/menus": "4.3.0",
-        "@elementor/query": "4.3.0",
-        "@elementor/schema": "4.3.0",
-        "@elementor/session": "4.3.0",
+        "@elementor/locations": "4.2.0",
+        "@elementor/menus": "4.2.0",
+        "@elementor/query": "4.2.0",
+        "@elementor/schema": "4.2.0",
+        "@elementor/session": "4.2.0",
         "@elementor/ui": "1.37.5",
-        "@elementor/utils": "4.3.0",
-        "@elementor/wp-media": "4.3.0",
+        "@elementor/utils": "4.2.0",
+        "@elementor/wp-media": "4.2.0",
         "@wordpress/i18n": "^5.13.0"
       },
       "devDependencies": {
@@ -45114,13 +45114,13 @@
     },
     "packages/packages/core/editor-elements-panel": {
       "name": "@elementor/editor-elements-panel",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
         "@elementor/ui": "1.37.5",
-        "@elementor/utils": "4.3.0"
+        "@elementor/utils": "4.2.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45132,11 +45132,11 @@
     },
     "packages/packages/core/editor-elements-panel-notice": {
       "name": "@elementor/editor-elements-panel-notice",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
         "@elementor/ui": "1.37.5"
       },
       "devDependencies": {
@@ -45149,14 +45149,14 @@
     },
     "packages/packages/core/editor-embedded-documents-manager": {
       "name": "@elementor/editor-embedded-documents-manager",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-documents": "4.3.0",
-        "@elementor/editor-elements": "4.3.0",
-        "@elementor/editor-styles": "4.3.0",
-        "@elementor/editor-styles-repository": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0"
+        "@elementor/editor-documents": "4.2.0",
+        "@elementor/editor-elements": "4.2.0",
+        "@elementor/editor-styles": "4.2.0",
+        "@elementor/editor-styles-repository": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45164,31 +45164,31 @@
     },
     "packages/packages/core/editor-global-classes": {
       "name": "@elementor/editor-global-classes",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-canvas": "4.3.0",
-        "@elementor/editor-current-user": "4.3.0",
-        "@elementor/editor-documents": "4.3.0",
-        "@elementor/editor-editing-panel": "4.3.0",
-        "@elementor/editor-embedded-documents-manager": "4.3.0",
-        "@elementor/editor-mcp": "4.3.0",
-        "@elementor/editor-panels": "4.3.0",
-        "@elementor/editor-props": "4.3.0",
-        "@elementor/editor-styles": "4.3.0",
-        "@elementor/editor-styles-repository": "4.3.0",
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/editor-variables": "4.3.0",
-        "@elementor/events": "4.3.0",
-        "@elementor/http-client": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-canvas": "4.2.0",
+        "@elementor/editor-current-user": "4.2.0",
+        "@elementor/editor-documents": "4.2.0",
+        "@elementor/editor-editing-panel": "4.2.0",
+        "@elementor/editor-embedded-documents-manager": "4.2.0",
+        "@elementor/editor-mcp": "4.2.0",
+        "@elementor/editor-panels": "4.2.0",
+        "@elementor/editor-props": "4.2.0",
+        "@elementor/editor-styles": "4.2.0",
+        "@elementor/editor-styles-repository": "4.2.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/editor-variables": "4.2.0",
+        "@elementor/events": "4.2.0",
+        "@elementor/http-client": "4.2.0",
         "@elementor/icons": "~1.75.1",
-        "@elementor/query": "4.3.0",
-        "@elementor/schema": "4.3.0",
-        "@elementor/store": "4.3.0",
+        "@elementor/query": "4.2.0",
+        "@elementor/schema": "4.2.0",
+        "@elementor/store": "4.2.0",
         "@elementor/ui": "1.37.5",
-        "@elementor/utils": "4.3.0",
+        "@elementor/utils": "4.2.0",
         "@tanstack/react-virtual": "^3.13.24",
         "@wordpress/i18n": "^5.13.0"
       },
@@ -45202,22 +45202,22 @@
     },
     "packages/packages/core/editor-interactions": {
       "name": "@elementor/editor-interactions",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-controls": "4.3.0",
-        "@elementor/editor-elements": "4.3.0",
-        "@elementor/editor-mcp": "4.3.0",
-        "@elementor/editor-props": "4.3.0",
-        "@elementor/editor-responsive": "4.3.0",
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/events": "4.3.0",
+        "@elementor/editor-controls": "4.2.0",
+        "@elementor/editor-elements": "4.2.0",
+        "@elementor/editor-mcp": "4.2.0",
+        "@elementor/editor-props": "4.2.0",
+        "@elementor/editor-responsive": "4.2.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/events": "4.2.0",
         "@elementor/icons": "~1.75.1",
-        "@elementor/schema": "4.3.0",
-        "@elementor/session": "4.3.0",
+        "@elementor/schema": "4.2.0",
+        "@elementor/session": "4.2.0",
         "@elementor/ui": "1.37.5",
-        "@elementor/utils": "4.3.0",
+        "@elementor/utils": "4.2.0",
         "@wordpress/i18n": "^5.13.0"
       },
       "devDependencies": {
@@ -45230,12 +45230,12 @@
     },
     "packages/packages/core/editor-notifications": {
       "name": "@elementor/editor-notifications",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
+        "@elementor/editor": "4.2.0",
         "@elementor/icons": "~1.75.1",
-        "@elementor/store": "4.3.0",
+        "@elementor/store": "4.2.0",
         "@elementor/ui": "1.37.5",
         "notistack": "^3.0.2"
       },
@@ -45249,13 +45249,13 @@
     },
     "packages/packages/core/editor-panels": {
       "name": "@elementor/editor-panels",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/locations": "4.3.0",
-        "@elementor/store": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/locations": "4.2.0",
+        "@elementor/store": "4.2.0",
         "@elementor/ui": "1.37.5"
       },
       "devDependencies": {
@@ -45268,17 +45268,17 @@
     },
     "packages/packages/core/editor-site-navigation": {
       "name": "@elementor/editor-site-navigation",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-app-bar": "4.3.0",
-        "@elementor/editor-documents": "4.3.0",
-        "@elementor/editor-panels": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/env": "4.3.0",
-        "@elementor/events": "4.3.0",
+        "@elementor/editor-app-bar": "4.2.0",
+        "@elementor/editor-documents": "4.2.0",
+        "@elementor/editor-panels": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/env": "4.2.0",
+        "@elementor/events": "4.2.0",
         "@elementor/icons": "~1.75.1",
-        "@elementor/query": "4.3.0",
+        "@elementor/query": "4.2.0",
         "@elementor/ui": "1.37.5",
         "@wordpress/api-fetch": "^6.42.0",
         "@wordpress/i18n": "^5.13.0"
@@ -45293,11 +45293,11 @@
     },
     "packages/packages/core/editor-starter": {
       "name": "@elementor/editor-starter",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
         "@elementor/icons": "~1.75.1",
         "@elementor/ui": "1.37.5",
         "@wordpress/api-fetch": "^7.12.0",
@@ -45382,16 +45382,16 @@
     },
     "packages/packages/core/editor-styles-repository": {
       "name": "@elementor/editor-styles-repository",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-current-user": "4.3.0",
-        "@elementor/editor-elements": "4.3.0",
-        "@elementor/editor-props": "4.3.0",
-        "@elementor/editor-styles": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/schema": "4.3.0",
-        "@elementor/utils": "4.3.0",
+        "@elementor/editor-current-user": "4.2.0",
+        "@elementor/editor-elements": "4.2.0",
+        "@elementor/editor-props": "4.2.0",
+        "@elementor/editor-styles": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/schema": "4.2.0",
+        "@elementor/utils": "4.2.0",
         "@wordpress/i18n": "^5.13.0"
       },
       "devDependencies": {
@@ -45403,15 +45403,15 @@
     },
     "packages/packages/core/editor-templates": {
       "name": "@elementor/editor-templates",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-documents": "4.3.0",
-        "@elementor/editor-styles-repository": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/store": "4.3.0",
-        "@elementor/utils": "4.3.0"
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-documents": "4.2.0",
+        "@elementor/editor-styles-repository": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/store": "4.2.0",
+        "@elementor/utils": "4.2.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45422,25 +45422,25 @@
     },
     "packages/packages/core/editor-variables": {
       "name": "@elementor/editor-variables",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-canvas": "4.3.0",
-        "@elementor/editor-controls": "4.3.0",
-        "@elementor/editor-current-user": "4.3.0",
-        "@elementor/editor-mcp": "4.3.0",
-        "@elementor/editor-panels": "4.3.0",
-        "@elementor/editor-props": "4.3.0",
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/events": "4.3.0",
-        "@elementor/http-client": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-canvas": "4.2.0",
+        "@elementor/editor-controls": "4.2.0",
+        "@elementor/editor-current-user": "4.2.0",
+        "@elementor/editor-mcp": "4.2.0",
+        "@elementor/editor-panels": "4.2.0",
+        "@elementor/editor-props": "4.2.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/events": "4.2.0",
+        "@elementor/http-client": "4.2.0",
         "@elementor/icons": "~1.75.1",
-        "@elementor/menus": "4.3.0",
-        "@elementor/schema": "4.3.0",
+        "@elementor/menus": "4.2.0",
+        "@elementor/schema": "4.2.0",
         "@elementor/ui": "1.37.5",
-        "@elementor/utils": "4.3.0",
+        "@elementor/utils": "4.2.0",
         "@wordpress/i18n": "^5.13.0"
       },
       "devDependencies": {
@@ -45453,13 +45453,13 @@
     },
     "packages/packages/core/editor-widget-creation": {
       "name": "@elementor/editor-widget-creation",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor": "4.3.0",
-        "@elementor/editor-mcp": "4.3.0",
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/events": "4.3.0",
+        "@elementor/editor": "4.2.0",
+        "@elementor/editor-mcp": "4.2.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/events": "4.2.0",
         "@elementor/icons": "~1.75.1",
         "@elementor/ui": "1.37.5",
         "@wordpress/i18n": "^5.13.0"
@@ -45474,12 +45474,12 @@
     },
     "packages/packages/core/elementor-kit-mcp": {
       "name": "@elementor/elementor-kit-mcp",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-mcp": "4.3.0",
-        "@elementor/elementor-mcp-common": "4.3.0",
-        "@elementor/schema": "4.3.0"
+        "@elementor/editor-mcp": "4.2.0",
+        "@elementor/elementor-mcp-common": "4.2.0",
+        "@elementor/schema": "4.2.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45487,12 +45487,12 @@
     },
     "packages/packages/core/elementor-v3-mcp": {
       "name": "@elementor/elementor-v3-mcp",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-mcp": "4.3.0",
-        "@elementor/elementor-mcp-common": "4.3.0",
-        "@elementor/schema": "4.3.0",
+        "@elementor/editor-mcp": "4.2.0",
+        "@elementor/elementor-mcp-common": "4.2.0",
+        "@elementor/schema": "4.2.0",
         "@modelcontextprotocol/sdk": "1.27.1"
       },
       "devDependencies": {
@@ -45501,7 +45501,7 @@
     },
     "packages/packages/core/frontend-handlers": {
       "name": "@elementor/frontend-handlers",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45509,26 +45509,26 @@
     },
     "packages/packages/libs/editor-controls": {
       "name": "@elementor/editor-controls",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-current-user": "4.3.0",
-        "@elementor/editor-elements": "4.3.0",
-        "@elementor/editor-props": "4.3.0",
-        "@elementor/editor-responsive": "4.3.0",
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/env": "4.3.0",
-        "@elementor/events": "4.3.0",
-        "@elementor/http-client": "4.3.0",
+        "@elementor/editor-current-user": "4.2.0",
+        "@elementor/editor-elements": "4.2.0",
+        "@elementor/editor-props": "4.2.0",
+        "@elementor/editor-responsive": "4.2.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/env": "4.2.0",
+        "@elementor/events": "4.2.0",
+        "@elementor/http-client": "4.2.0",
         "@elementor/icons": "~1.75.1",
-        "@elementor/locations": "4.3.0",
-        "@elementor/query": "4.3.0",
-        "@elementor/schema": "4.3.0",
-        "@elementor/session": "4.3.0",
+        "@elementor/locations": "4.2.0",
+        "@elementor/query": "4.2.0",
+        "@elementor/schema": "4.2.0",
+        "@elementor/session": "4.2.0",
         "@elementor/ui": "1.37.5",
-        "@elementor/utils": "4.3.0",
-        "@elementor/wp-media": "4.3.0",
+        "@elementor/utils": "4.2.0",
+        "@elementor/wp-media": "4.2.0",
         "@monaco-editor/react": "^4.7.0",
         "@tiptap/extension-bold": "^3.11.1",
         "@tiptap/extension-document": "^3.11.1",
@@ -45560,12 +45560,12 @@
     },
     "packages/packages/libs/editor-current-user": {
       "name": "@elementor/editor-current-user",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/http-client": "4.3.0",
-        "@elementor/query": "4.3.0"
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/http-client": "4.2.0",
+        "@elementor/query": "4.2.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45576,15 +45576,15 @@
     },
     "packages/packages/libs/editor-elements": {
       "name": "@elementor/editor-elements",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-mcp": "4.3.0",
-        "@elementor/editor-props": "4.3.0",
-        "@elementor/editor-styles": "4.3.0",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/schema": "4.3.0",
-        "@elementor/utils": "4.3.0",
+        "@elementor/editor-mcp": "4.2.0",
+        "@elementor/editor-props": "4.2.0",
+        "@elementor/editor-styles": "4.2.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/schema": "4.2.0",
+        "@elementor/utils": "4.2.0",
         "@wordpress/i18n": "^3.1.0"
       },
       "devDependencies": {
@@ -45623,13 +45623,13 @@
     },
     "packages/packages/libs/editor-mcp": {
       "name": "@elementor/editor-mcp",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor-external/angie-sdk": "npm:@elementor/angie-sdk@^1.4.5",
-        "@elementor/editor-v1-adapters": "4.3.0",
-        "@elementor/schema": "4.3.0",
-        "@elementor/store": "4.3.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/schema": "4.2.0",
+        "@elementor/store": "4.2.0",
         "@modelcontextprotocol/sdk": "1.27.1",
         "@wordpress/api-fetch": "^6.42.0",
         "zod-to-json-schema": "3.24.6"
@@ -45640,7 +45640,7 @@
     },
     "packages/packages/libs/editor-modal-shell": {
       "name": "@elementor/editor-modal-shell",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/icons": "~1.75.1",
@@ -45657,10 +45657,10 @@
     },
     "packages/packages/libs/editor-props": {
       "name": "@elementor/editor-props",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/schema": "4.3.0",
+        "@elementor/schema": "4.2.0",
         "jsonschema": "1.5.0"
       },
       "devDependencies": {
@@ -45669,10 +45669,10 @@
     },
     "packages/packages/libs/editor-responsive": {
       "name": "@elementor/editor-responsive",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-v1-adapters": "4.3.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
         "@wordpress/i18n": "^5.13.0"
       },
       "devDependencies": {
@@ -45684,11 +45684,11 @@
     },
     "packages/packages/libs/editor-styles": {
       "name": "@elementor/editor-styles",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-props": "4.3.0",
-        "@elementor/editor-responsive": "4.3.0"
+        "@elementor/editor-props": "4.2.0",
+        "@elementor/editor-responsive": "4.2.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45696,10 +45696,10 @@
     },
     "packages/packages/libs/editor-ui": {
       "name": "@elementor/editor-ui",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-v1-adapters": "4.3.0",
+        "@elementor/editor-v1-adapters": "4.2.0",
         "@elementor/icons": "~1.75.1",
         "@elementor/ui": "1.37.5",
         "@tanstack/react-virtual": "^3.13.3",
@@ -45715,10 +45715,10 @@
     },
     "packages/packages/libs/editor-v1-adapters": {
       "name": "@elementor/editor-v1-adapters",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/utils": "4.3.0"
+        "@elementor/utils": "4.2.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45729,7 +45729,7 @@
     },
     "packages/packages/libs/elementor-mcp-common": {
       "name": "@elementor/elementor-mcp-common",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1"
@@ -45740,7 +45740,7 @@
     },
     "packages/packages/libs/env": {
       "name": "@elementor/env",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45748,7 +45748,7 @@
     },
     "packages/packages/libs/events": {
       "name": "@elementor/events",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45759,10 +45759,10 @@
     },
     "packages/packages/libs/http-client": {
       "name": "@elementor/http-client",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/env": "4.3.0",
+        "@elementor/env": "4.2.0",
         "axios": "^1.9.0"
       },
       "devDependencies": {
@@ -45771,7 +45771,7 @@
     },
     "packages/packages/libs/locations": {
       "name": "@elementor/locations",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45782,13 +45782,13 @@
     },
     "packages/packages/libs/menus": {
       "name": "@elementor/menus",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/editor-ui": "4.3.0",
-        "@elementor/locations": "4.3.0",
+        "@elementor/editor-ui": "4.2.0",
+        "@elementor/locations": "4.2.0",
         "@elementor/ui": "1.37.5",
-        "@elementor/utils": "4.3.0"
+        "@elementor/utils": "4.2.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45799,7 +45799,7 @@
     },
     "packages/packages/libs/query": {
       "name": "@elementor/query",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tanstack/react-query": "^5.62.3"
@@ -45813,7 +45813,7 @@
     },
     "packages/packages/libs/schema": {
       "name": "@elementor/schema",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "zod": "^3.25.76"
@@ -45824,7 +45824,7 @@
     },
     "packages/packages/libs/session": {
       "name": "@elementor/session",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45835,7 +45835,7 @@
     },
     "packages/packages/libs/store": {
       "name": "@elementor/store",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
@@ -45850,7 +45850,7 @@
     },
     "packages/packages/libs/twing": {
       "name": "@elementor/twing",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "twing": "7.0.0"
@@ -45861,7 +45861,7 @@
     },
     "packages/packages/libs/utils": {
       "name": "@elementor/utils",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45872,11 +45872,11 @@
     },
     "packages/packages/libs/wp-media": {
       "name": "@elementor/wp-media",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elementor/query": "4.3.0",
-        "@elementor/utils": "4.3.0"
+        "@elementor/query": "4.2.0",
+        "@elementor/utils": "4.2.0"
       },
       "devDependencies": {
         "tsup": "^8.3.5"
@@ -45887,7 +45887,7 @@
     },
     "packages/packages/tools/commitlint-plugin-editor": {
       "name": "@elementor/commitlint-plugin-editor",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@commitlint/types": "^19.8.1"
@@ -45898,7 +45898,7 @@
     },
     "packages/packages/tools/entry-initialization-webpack-plugin": {
       "name": "@elementor/entry-initialization-webpack-plugin",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "memfs": "^4.17.0",
@@ -45910,7 +45910,7 @@
     },
     "packages/packages/tools/eslint-plugin-editor": {
       "name": "@elementor/eslint-plugin-editor",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@typescript-eslint/utils": "^8.6.0"
@@ -45927,7 +45927,7 @@
     },
     "packages/packages/tools/externalize-wordpress-assets-webpack-plugin": {
       "name": "@elementor/externalize-wordpress-assets-webpack-plugin",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "memfs": "^4.17.0",
@@ -45939,7 +45939,7 @@
     },
     "packages/packages/tools/extract-i18n-wordpress-expressions-webpack-plugin": {
       "name": "@elementor/extract-i18n-wordpress-expressions-webpack-plugin",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "glob": "^11.0.0"
@@ -45955,7 +45955,7 @@
     },
     "packages/packages/tools/generate-wordpress-asset-file-webpack-plugin": {
       "name": "@elementor/generate-wordpress-asset-file-webpack-plugin",
-      "version": "4.3.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "memfs": "^4.17.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "write": "^2.0.0"
   },
   "dependencies": {
-    "@elementor/elementor-one-assets": "0.4.37",
+    "@elementor/elementor-one-assets": "0.4.35",
     "@elementor/icons": "~1.75.1",
     "@elementor/ui": "1.39.1",
     "@reach/router": "1.3.4",


### PR DESCRIPTION
Reverts elementor/elementor#36296
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Reverting package bumps from PR #36294 that were cherry-picked to the 4.02 branch (ED-24611). Rolling back to earlier dependency versions.

## 2. What Changed (Where)

- `composer.json`: Downgraded `elementor/wp-one-package` from 1.0.65 → 1.0.64
- `package.json`: Downgraded `@elementor/elementor-one-assets` from 0.4.37 → 0.4.35

## 3. How It Works

Reverting dependency versions to previous stable releases by updating version constraints in both PHP and Node dependency manifests.

## 4. Risks

None — this is a rollback to known-good versions. Verify downstream projects pinning these dependencies explicitly don't break.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
