### PR TITLE
Internal: Bump packages on 4.02 [ED-24611]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "elementor/wp-one-package": "1.0.64"
+        "elementor/wp-one-package": "1.0.65"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93b7b927ef351f3c860d6112aa6f6576",
+    "content-hash": "237fb693f8f0df09d2c4a804c7312f92",
     "packages": [
         {
             "name": "elementor/wp-notifications-package",
@@ -39,10 +39,10 @@
         },
         {
             "name": "elementor/wp-one-package",
-            "version": "1.0.64",
+            "version": "1.0.65",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.64"
+                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.65"
             },
             "require": {
                 "elementor/wp-notifications-package": "^1.2"
@@ -69,7 +69,7 @@
                     "vendor/bin/phpcbf ."
                 ]
             },
-            "time": "2026-06-11T08:34:37+00:00"
+            "time": "2026-06-16T07:28:42+00:00"
         }
     ],
     "packages-dev": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "packages/apps/*"
       ],
       "dependencies": {
-        "@elementor/elementor-one-assets": "0.4.35",
+        "@elementor/elementor-one-assets": "0.4.37",
         "@elementor/icons": "~1.75.1",
         "@elementor/ui": "1.39.1",
         "@reach/router": "1.3.4",
@@ -4522,9 +4522,9 @@
       "link": true
     },
     "node_modules/@elementor/elementor-one-assets": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.35.tgz",
-      "integrity": "sha512-z5EZIPedcicUFVqQs8NNAyBDrh/sCn0czsqYr/plrNpdrVKQdnuMeVJvp7ZlbfbcErYZvEZLREWwnNivF2/PyA==",
+      "version": "0.4.37",
+      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.37.tgz",
+      "integrity": "sha512-iY7FGmpvkZFxh8wrtZYqtq3imd3YYtX82KLp45CUDiYITYiy8fm37BiyAPdWDSPkLXMdxWTVbRhF9v52XHP0yA==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/icons": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "write": "^2.0.0"
   },
   "dependencies": {
-    "@elementor/elementor-one-assets": "0.4.35",
+    "@elementor/elementor-one-assets": "0.4.37",
     "@elementor/icons": "~1.75.1",
     "@elementor/ui": "1.39.1",
     "@reach/router": "1.3.4",


### PR DESCRIPTION
## Summary

Replaces the reverted cherry-pick ([#36296](https://github.com/elementor/elementor/pull/36296)) with a clean manual bump from the `4.02` branch.

The cherry-pick incorrectly bumped workspace packages to `4.3.0` in `package-lock.json` (e.g. `@elementor/editor-modal-shell` `4.2.0` → `4.3.0`). This PR only updates the intended packages:

- `@elementor/elementor-one-assets`: `0.4.35` → `0.4.37`
- `elementor/wp-one-package`: `1.0.64` → `1.0.65`

Lockfiles were regenerated via `npm install` and `composer update elementor/wp-one-package`, keeping all workspace packages at `4.2.0`.

**Note:** Merge [#36298](https://github.com/elementor/elementor/pull/36298) (revert) before this PR, or this PR can serve as the fix on its own.

## Test plan

- [ ] CI passes (Build plugin, JS-Lint, QUnit)
- [ ] `package-lock.json` has no conflict markers
- [ ] Workspace packages remain at `4.2.0` (no `4.3.0` bumps)
- [ ] `@elementor/elementor-one-assets` resolves to `0.4.37`
- [ ] `elementor/wp-one-package` resolves to `1.0.65`


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Routine dependency updates for 4.02 release cycle (ED-24611). Incremental bumps on two core packages.

## 2. What Changed (Where)

- `composer.json`: `elementor/wp-one-package` 1.0.64 → 1.0.65
- `package.json`: `@elementor/elementor-one-assets` 0.4.35 → 0.4.37

## 3. How It Works

Composer and npm will resolve updated package versions on next install. No code changes—purely dependency manifest updates.

## 4. Risks

None apparent. Patch-level increments are low-risk; verify integration testing covers both packages in concert.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
