### PR TITLE
Internal: Cherry-pick PR 36285 to 4.02: Update ai feature monitoring [ED-24520]

### DIFF
--- a/core/common/modules/events-manager/assets/js/events-config.js
+++ b/core/common/modules/events-manager/assets/js/events-config.js
@@ -244,6 +244,7 @@ const eventsConfig = {
 			add: 'add_new_variable',
 			connect: 'connect_variable',
 			save: 'save_new_variable',
+			update: 'update_variable',
 			openManager: 'open_variables_manager',
 			saveChanges: 'save_variables_changes',
 			delete: 'delete_variable',

--- a/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.js
+++ b/modules/atomic-widgets/assets/js/editor/create-atomic-element-base-view.js
@@ -329,23 +329,6 @@ export default function createAtomicElementBaseView( type ) {
 
 						this.onDrop( event, { at: targetIndex } );
 
-						if ( elementorCommon?.eventsManager?.dispatchEvent ) {
-							const selectedElement = elementor.channels.panelElements.request( 'element:selected' );
-
-							if ( selectedElement ) {
-								const elType = selectedElement.model?.get( 'elType' ) ?? '';
-								const widgetType = selectedElement.model?.get( 'widgetType' ) ?? '';
-								const elementName = 'widget' === elType ? widgetType : elType;
-
-								elementorCommon.eventsManager.dispatchEvent( 'add_element', {
-									location: 'editor_panel',
-									element_name: elementName,
-									element_type: elType,
-									widget_type: widgetType,
-								} );
-							}
-						}
-
 						return;
 					}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44965,6 +44965,7 @@
         "@elementor/editor-styles-repository": "4.2.0",
         "@elementor/editor-ui": "4.2.0",
         "@elementor/editor-v1-adapters": "4.2.0",
+        "@elementor/events": "4.2.0",
         "@elementor/http-client": "4.2.0",
         "@elementor/schema": "4.2.0",
         "@elementor/twing": "4.2.0",

--- a/packages/packages/core/editor-canvas/package.json
+++ b/packages/packages/core/editor-canvas/package.json
@@ -51,6 +51,7 @@
     "@elementor/editor-styles-repository": "4.2.0",
     "@elementor/editor-ui": "4.2.0",
     "@elementor/editor-v1-adapters": "4.2.0",
+    "@elementor/events": "4.2.0",
     "@elementor/http-client": "4.2.0",
     "@elementor/schema": "4.2.0",
     "@elementor/twing": "4.2.0",
@@ -58,7 +59,8 @@
     "@elementor/utils": "4.2.0",
     "@elementor/wp-media": "4.2.0",
     "@floating-ui/react": "^0.27.5",
-    "@wordpress/i18n": "^5.13.0"
+    "@wordpress/i18n": "^5.13.0",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "tsup": "^8.3.5"

--- a/packages/packages/core/editor-canvas/src/index.ts
+++ b/packages/packages/core/editor-canvas/src/index.ts
@@ -44,3 +44,4 @@ export { UnknownStyleTypeError, UnknownStyleStateError } from './renderers/error
 export { useCanvasDocument } from './hooks/use-canvas-document';
 export { useEscapeOnCanvas } from './hooks/use-escape-on-canvas';
 export { doAfterRender } from './utils/after-render';
+export { ELEMENT_ADDED_EVENT, type ElementAddedEvent } from './mcp/tools/build-composition/tool';

--- a/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/tool.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/tool.ts
@@ -5,10 +5,13 @@ import {
 	getContainer,
 	getWidgetsCache,
 	type V1Element,
+	type V1ElementData,
 } from '@elementor/editor-elements';
 import { type MCPRegistryEntry } from '@elementor/editor-mcp';
+import { dispatchMcpStylesAppliedEvent } from '@elementor/editor-mcp';
 
 import { CompositionBuilder } from '../../../composition-builder/composition-builder';
+import { trackCanvasEvent } from '../../../utils/tracking';
 import { AVAILABLE_WIDGETS_URI_V4 } from '../../resources/available-widgets-resource';
 import { DYNAMIC_TAGS_URI } from '../../resources/dynamic-tags-resource';
 import { BEST_PRACTICES_URI, WIDGET_SCHEMA_URI } from '../../resources/widgets-schema-resource';
@@ -18,6 +21,13 @@ import { getCompositionTargetContainer } from '../../utils/get-composition-targe
 import { BUILD_COMPOSITIONS_GUIDE_URI, generatePrompt } from './prompt';
 import { inputSchema as schema, outputSchema } from './schema';
 import { adaptLeafRootParams } from './xml-leaf-wrapper';
+
+export type ElementAddedEvent = {
+	element: V1ElementData;
+	executedBy: 'mcp_tool' | 'user';
+};
+
+export const ELEMENT_ADDED_EVENT = 'elementor/canvas/element-added';
 
 export const initBuildCompositionsTool = ( reg: MCPRegistryEntry ) => {
 	const { addTool, resource } = reg;
@@ -79,6 +89,18 @@ export const initBuildCompositionsTool = ( reg: MCPRegistryEntry ) => {
 
 				rootContainers.push( ...generatedRootContainers );
 				generatedXML = new XMLSerializer().serializeToString( compositionBuilder.getXML() );
+
+				rootContainers.forEach( ( container ) => {
+					const elementData = container.model?.toJSON();
+
+					if ( elementData ) {
+						onElementAdded( elementData as V1ElementData );
+					}
+				} );
+
+				Object.values( stylesConfig ).forEach( ( styleValue ) => {
+					dispatchMcpStylesAppliedEvent( { styleValue } );
+				} );
 
 				if ( configErrors.length ) {
 					errors.push( ...configErrors.map( ( msg ) => new Error( msg ) ) );
@@ -184,5 +206,32 @@ function assertCompositionXmlUsesV4WidgetsOnly( xmlStructure: string ) {
 		if ( ! isWidgetAvailableForLLM( widgetData ) || ! widgetData.atomic_props_schema ) {
 			throw new Error( `This tool does not support element type: ${ type }` );
 		}
+	}
+}
+
+function onElementAdded( element: V1ElementData ) {
+	const elType = element.elType ?? '';
+	const widgetType = element.widgetType ?? '';
+	const elementName = elType === 'widget' ? widgetType : elType;
+
+	trackCanvasEvent( {
+		eventName: 'add_element',
+		executed_by: 'mcp_tool',
+		element_name: elementName,
+		element_type: elType,
+		widget_type: widgetType,
+	} );
+
+	const event: ElementAddedEvent = {
+		element,
+		executedBy: 'mcp_tool',
+	};
+
+	window.dispatchEvent( new CustomEvent( ELEMENT_ADDED_EVENT, { detail: event } ) );
+
+	if ( element.elements?.length ) {
+		element.elements?.forEach( ( childElement ) => {
+			onElementAdded( childElement );
+		} );
 	}
 }

--- a/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/tool.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/configure-element/tool.ts
@@ -1,5 +1,6 @@
 import { getContainer, getWidgetsCache } from '@elementor/editor-elements';
 import { type MCPRegistryEntry } from '@elementor/editor-mcp';
+import { dispatchMcpStylesAppliedEvent } from '@elementor/editor-mcp';
 import { type PropValue, Schema } from '@elementor/editor-props';
 
 import { DYNAMIC_TAGS_URI } from '../../resources/dynamic-tags-resource';
@@ -115,6 +116,8 @@ async function applyStyleFromCss( opts: {
 			propertyValue: styleValue,
 			customCssWriteMode: 'merge-with-stored',
 		} );
+
+		dispatchMcpStylesAppliedEvent( { styleValue } );
 	} catch ( error ) {
 		throw new Error(
 			createUpdateErrorMessage( {

--- a/packages/packages/core/editor-canvas/src/utils/tracking.ts
+++ b/packages/packages/core/editor-canvas/src/utils/tracking.ts
@@ -1,0 +1,14 @@
+import { trackEvent } from '@elementor/events';
+
+type ElementEventData = {
+	eventName: 'add_element';
+	element_name: string;
+	element_type: string;
+	widget_type: string;
+	location?: string;
+	executed_by: 'user' | 'mcp_tool' | 'system';
+};
+
+export const trackCanvasEvent = ( data: ElementEventData ) => {
+	trackEvent( data );
+};

--- a/packages/packages/core/editor-components/src/create-component-type.ts
+++ b/packages/packages/core/editor-components/src/create-component-type.ts
@@ -341,7 +341,7 @@ function createComponentView( options: ComponentTypeOptions ): typeof TemplatedE
 
 			trackComponentEvent( {
 				action: 'edited',
-				source: 'user',
+				executedBy: 'user',
 				component_uid: editorSettings?.component_uid,
 				component_name: editorSettings?.title,
 				location,

--- a/packages/packages/core/editor-components/src/index.ts
+++ b/packages/packages/core/editor-components/src/index.ts
@@ -54,6 +54,8 @@ export {
 	createComponentsAction,
 	registerComponentsReducer,
 	selectOverridableProps,
+	selectCreatedThisSession,
+	selectComponentByUid,
 	selectPath,
 	slice,
 	useCurrentComponent,
@@ -89,5 +91,5 @@ export { isComponentInstance } from './utils/is-component-instance';
 export { resolveOverridePropValue } from './utils/resolve-override-prop-value';
 export { switchToComponent } from './utils/switch-to-component';
 export { onElementDrop, trackComponentEvent } from './utils/tracking';
-export type { Source } from './utils/tracking';
+export type { ExecutedBy } from './utils/tracking';
 export { getComponentDocumentData } from './utils/component-document-data';

--- a/packages/packages/core/editor-components/src/utils/detach-component-instance/detach-component-instance.ts
+++ b/packages/packages/core/editor-components/src/utils/detach-component-instance/detach-component-instance.ts
@@ -111,7 +111,7 @@ export async function detachComponentInstance( {
 				const componentUid = selectComponent( getState(), componentId )?.uid;
 				trackComponentEvent( {
 					action: 'detached',
-					source: 'user',
+					executedBy: 'user',
 					component_uid: componentUid,
 					instance_id: instanceId,
 					location: trackingInfo.location,

--- a/packages/packages/core/editor-components/src/utils/tracking.ts
+++ b/packages/packages/core/editor-components/src/utils/tracking.ts
@@ -5,7 +5,7 @@ import { __getState as getState } from '@elementor/store';
 import { selectCreatedThisSession } from '../store/store';
 import { type ExtendedWindow } from '../types';
 
-export type Source = 'user' | 'mcp_tool' | 'system';
+export type ExecutedBy = 'user' | 'mcp_tool' | 'system';
 
 type ComponentEventData = Record< string, unknown > & {
 	action:
@@ -19,13 +19,16 @@ type ComponentEventData = Record< string, unknown > & {
 		| 'propertiesPanelOpened'
 		| 'propertiesGroupCreated'
 		| 'detached';
-	source: Source;
+	// TODO: Remove `source` parameter in version 4.4.0 - it's replaced by `executedBy`, but pro's older versions will still send `source`
+	// so we keep both for backward compatibility
+	source?: ExecutedBy;
+	executedBy: ExecutedBy;
 };
 
 const FEATURE_NAME = 'Components';
 
-export const trackComponentEvent = ( { action, source, ...data }: ComponentEventData ) => {
-	if ( source === 'system' ) {
+export const trackComponentEvent = ( { action, source, executedBy, ...data }: ComponentEventData ) => {
+	if ( source === 'system' || executedBy === 'system' ) {
 		return;
 	}
 
@@ -35,9 +38,10 @@ export const trackComponentEvent = ( { action, source, ...data }: ComponentEvent
 	}
 
 	const name = config.names.components[ action ];
-	dispatchEvent?.( name, { ...data, source, 'Feature name': FEATURE_NAME } );
+	dispatchEvent?.( name, { ...data, executed_by: executedBy ?? source, 'Feature name': FEATURE_NAME } );
 };
 
+// TODO: Remove this function in version 4.4.0 - moved to pro
 export const onElementDrop = ( _args: unknown, element: V1Element ) => {
 	if ( ! ( element?.model?.get( 'widgetType' ) === 'e-component' ) ) {
 		return;
@@ -56,7 +60,7 @@ export const onElementDrop = ( _args: unknown, element: V1Element ) => {
 
 	trackComponentEvent( {
 		action: 'instanceAdded',
-		source: 'user',
+		executedBy: 'user',
 		instance_id: instanceId,
 		component_uid: componentUID,
 		component_name: componentName,

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-apply-unapply-global-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-apply-unapply-global-classes.ts
@@ -2,6 +2,7 @@ import { doApplyClasses, doGetAppliedClasses, doUnapplyClass } from '@elementor/
 import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 import { z } from '@elementor/schema';
 
+import { globalClassesStylesProvider } from '../global-classes-styles-provider';
 import { APPLY_GLOBAL_CLASS_GUIDE_URI, generateApplyGlobalClassGuidePrompt } from './apply-global-class-guide-prompt';
 import { GLOBAL_CLASSES_URI } from './classes-resource';
 
@@ -43,6 +44,13 @@ export default function initMcpApplyUnapplyGlobalClasses( server: MCPRegistryEnt
 			const { classId, elementId } = params;
 			const appliedClasses = doGetAppliedClasses( elementId );
 			doApplyClasses( elementId, [ ...appliedClasses, classId ] );
+
+			globalClassesStylesProvider.actions.tracking?.( {
+				event: 'classApplied',
+				executedBy: 'mcp_tool',
+				classId,
+			} );
+
 			return {
 				llm_instructions:
 					'Please check the element configuration, find inline styles duplicated by the applied global class, and remove them',

--- a/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-manage-global-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/mcp-integration/mcp-manage-global-classes.ts
@@ -1,4 +1,5 @@
 import { BREAKPOINTS_SCHEMA_FULL_URI, convertStyleBlocksToAtomic, type StyleBlock } from '@elementor/editor-canvas';
+import { dispatchMcpStylesAppliedEvent } from '@elementor/editor-mcp';
 import { type MCPRegistryEntry } from '@elementor/editor-mcp';
 import { type Props } from '@elementor/editor-props';
 import { type BreakpointId } from '@elementor/editor-responsive';
@@ -139,6 +140,12 @@ const handler = async ( input: InputSchema ): Promise< OutputSchema > => {
 							status: 'ok',
 							message: `created global class with ID ${ newClassId }`,
 						};
+						globalClassesStylesProvider.actions.tracking?.( {
+							event: 'classCreated',
+							executedBy: 'mcp_tool',
+							classId: newClassId,
+						} );
+						dispatchMcpStylesAppliedEvent( { styleValue: props } );
 					} else {
 						throw new Error( 'error creating class' );
 					}
@@ -154,6 +161,7 @@ const handler = async ( input: InputSchema ): Promise< OutputSchema > => {
 					} );
 					if ( updated ) {
 						result = { status: 'ok', classId };
+						dispatchMcpStylesAppliedEvent( { styleValue: props } );
 					} else {
 						throw new Error( 'error modifying class' );
 					}

--- a/packages/packages/core/editor-global-classes/src/utils/tracking.ts
+++ b/packages/packages/core/editor-global-classes/src/utils/tracking.ts
@@ -12,6 +12,7 @@ type EventMap = {
 		source?: 'created' | 'converted' | 'duplicated';
 		classId: StyleDefinitionID;
 		classTitle?: string;
+		executedBy?: 'mcp_tool' | 'user';
 	};
 	classDeleted: {
 		classId: StyleDefinitionID;
@@ -27,6 +28,7 @@ type EventMap = {
 		classId: StyleDefinitionID;
 		classTitle: string;
 		totalInstancesAfterApply: number;
+		executedBy?: 'mcp_tool' | 'user';
 	};
 	classRemoved: {
 		classId: StyleDefinitionID;

--- a/packages/packages/core/editor-variables/src/components/__tests__/validations.test.tsx
+++ b/packages/packages/core/editor-variables/src/components/__tests__/validations.test.tsx
@@ -102,11 +102,14 @@ it( 'should successfully change name with valid input', async () => {
 
 	// Assert.
 	await waitFor( () => {
-		expect( mockCreateVariable ).toHaveBeenCalledWith( {
-			value: '#ff0000',
-			label: 'valid-name',
-			type: 'global-color-variable',
-		} );
+		expect( mockCreateVariable ).toHaveBeenCalledWith(
+			{
+				value: '#ff0000',
+				label: 'valid-name',
+				type: 'global-color-variable',
+			},
+			{ eventData: { controlPath: 'settings.color' } }
+		);
 	} );
 } );
 

--- a/packages/packages/core/editor-variables/src/components/__tests__/variable-edit.test.tsx
+++ b/packages/packages/core/editor-variables/src/components/__tests__/variable-edit.test.tsx
@@ -222,11 +222,15 @@ describe( 'ColorVariableEdit', () => {
 
 		// Assert - type should be the new type because it has changed
 		await waitFor( () => {
-			expect( usePropVariablesModule.updateVariable ).toHaveBeenCalledWith( 'e-gv-123', {
-				value: 'Arial',
-				label: 'new-label',
-				type: colorVariablePropTypeUtil.key,
-			} );
+			expect( usePropVariablesModule.updateVariable ).toHaveBeenCalledWith(
+				'e-gv-123',
+				{
+					value: 'Arial',
+					label: 'new-label',
+					type: colorVariablePropTypeUtil.key,
+				},
+				{ eventData: { controlPath: 'font' } }
+			);
 		} );
 	} );
 } );

--- a/packages/packages/core/editor-variables/src/components/mcp-variable-connect-listener.tsx
+++ b/packages/packages/core/editor-variables/src/components/mcp-variable-connect-listener.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { MCP_STYLES_APPLIED_EVENT, type McpStylesAppliedPayload } from '@elementor/editor-mcp';
+
+import { extractVariablesFromStyleValue } from '../utils/extract-variables-from-style-value';
+import { trackVariableEvent } from '../utils/tracking';
+
+export function McpVariableConnectListener() {
+	useEffect( () => {
+		const handleMcpStylesApplied = ( event: CustomEvent< McpStylesAppliedPayload > ) => {
+			const { styleValue } = event.detail;
+			const variables = extractVariablesFromStyleValue( styleValue );
+
+			variables.forEach( ( { type, controlPath } ) => {
+				trackVariableEvent( {
+					varType: type,
+					controlPath,
+					action: 'connect',
+					executedBy: 'mcp_tool',
+				} );
+			} );
+		};
+
+		window.addEventListener( MCP_STYLES_APPLIED_EVENT, handleMcpStylesApplied as EventListener );
+
+		return () => {
+			window.removeEventListener( MCP_STYLES_APPLIED_EVENT, handleMcpStylesApplied as EventListener );
+		};
+	}, [] );
+
+	return null;
+}

--- a/packages/packages/core/editor-variables/src/components/variable-creation.tsx
+++ b/packages/packages/core/editor-variables/src/components/variable-creation.tsx
@@ -10,7 +10,6 @@ import { useVariableType } from '../context/variable-type-context';
 import { useInitialValue } from '../hooks/use-initial-value';
 import { createVariable } from '../hooks/use-prop-variables';
 import { useVariableBoundProp } from '../hooks/use-variable-bound-prop';
-import { trackVariableEvent } from '../utils/tracking';
 import { ERROR_MESSAGES, labelHint, mapServerError } from '../utils/validations';
 import { LabelField, useLabelError } from './fields/label-field';
 import { FormField } from './ui/form-field';
@@ -23,7 +22,7 @@ type Props = {
 };
 
 export const VariableCreation = ( { onGoBack, onClose }: Props ) => {
-	const { icon: VariableIcon, valueField: ValueField, variableType, propTypeUtil } = useVariableType();
+	const { icon: VariableIcon, valueField: ValueField, propTypeUtil } = useVariableType();
 
 	const { setVariableValue: setVariable, path } = useVariableBoundProp();
 	const { propType } = useBoundProp();
@@ -51,11 +50,14 @@ export const VariableCreation = ( { onGoBack, onClose }: Props ) => {
 	};
 
 	const handleCreateAndTrack = () => {
-		createVariable( {
-			value,
-			label,
-			type: propTypeKey,
-		} )
+		createVariable(
+			{
+				value,
+				label,
+				type: propTypeKey,
+			},
+			{ eventData: { controlPath: path.join( '.' ) } }
+		)
 			.then( ( key ) => {
 				setVariable( key );
 				closePopover();
@@ -73,12 +75,6 @@ export const VariableCreation = ( { onGoBack, onClose }: Props ) => {
 
 				setErrorMessage( ERROR_MESSAGES.UNEXPECTED_ERROR );
 			} );
-
-		trackVariableEvent( {
-			varType: variableType,
-			controlPath: path.join( '.' ),
-			action: 'save',
-		} );
 	};
 
 	const hasEmptyFields = () => {

--- a/packages/packages/core/editor-variables/src/components/variable-edit.tsx
+++ b/packages/packages/core/editor-variables/src/components/variable-edit.tsx
@@ -31,7 +31,7 @@ type Props = {
 export const VariableEdit = ( { onClose, onGoBack, onSubmit, editId }: Props ) => {
 	const { icon: VariableIcon, valueField: ValueField, variableType, propTypeUtil } = useVariableType();
 
-	const { setVariableValue: notifyBoundPropChange, variableId } = useVariableBoundProp();
+	const { setVariableValue: notifyBoundPropChange, variableId, path } = useVariableBoundProp();
 	const { propType } = useBoundProp();
 	const [ isMessageSuppressed, suppressMessage ] = useSuppressedMessage( EDIT_CONFIRMATION_DIALOG_ID );
 	const [ deleteConfirmation, setDeleteConfirmation ] = useState( false );
@@ -80,7 +80,7 @@ export const VariableEdit = ( { onClose, onGoBack, onSubmit, editId }: Props ) =
 		const typeChanged = propTypeKey !== variable.type;
 		const updatePayload = typeChanged ? { value, label, type: propTypeKey } : { value, label };
 
-		updateVariable( editId, updatePayload )
+		updateVariable( editId, updatePayload, { eventData: { controlPath: path.join( '.' ) } } )
 			.then( () => {
 				maybeTriggerBoundPropChange();
 				onSubmit?.();

--- a/packages/packages/core/editor-variables/src/hooks/use-prop-variables.ts
+++ b/packages/packages/core/editor-variables/src/hooks/use-prop-variables.ts
@@ -3,7 +3,7 @@ import { useBoundProp } from '@elementor/editor-controls';
 import { type PropKey } from '@elementor/editor-props';
 
 import { useVariableType } from '../context/variable-type-context';
-import { service } from '../service';
+import { type CreateVariableOptions, service, type UpdateVariableOptions } from '../service';
 import { type NormalizedVariable, type Variable } from '../types';
 import { filterBySearch } from '../utils/filter-by-search';
 import { toNormalizedVariable, variablesToList } from '../utils/variables-to-list';
@@ -100,15 +100,16 @@ const normalizeVariables = ( propKey: string ): NormalizedVariable[] => {
 
 const extractId = ( { id }: { id: string } ): string => id;
 
-export const createVariable = ( newVariable: Variable ): Promise< string > => {
-	return service.create( newVariable ).then( extractId );
+export const createVariable = ( newVariable: Variable, options: CreateVariableOptions ): Promise< string > => {
+	return service.create( newVariable, options ).then( extractId );
 };
 
 export const updateVariable = (
 	updateId: string,
-	{ value, label, type }: { value: string; label: string; type?: string }
+	{ value, label, type }: { value: string; label: string; type?: string },
+	options?: UpdateVariableOptions
 ): Promise< string > => {
-	return service.update( updateId, { value, label, type } ).then( extractId );
+	return service.update( updateId, { value, label, type }, options ).then( extractId );
 };
 
 export const deleteVariable = ( deleteId: string ): Promise< string > => {

--- a/packages/packages/core/editor-variables/src/init.ts
+++ b/packages/packages/core/editor-variables/src/init.ts
@@ -5,6 +5,7 @@ import { isTransformable, type PropValue } from '@elementor/editor-props';
 import { controlActionsMenu } from '@elementor/menus';
 
 import { GlobalStylesImportListener } from './components/global-styles-import-listener';
+import { McpVariableConnectListener } from './components/mcp-variable-connect-listener';
 import { VariableControl } from './controls/variable-control';
 import { usePropVariableAction } from './hooks/use-prop-variable-action';
 import { initMcp } from './mcp';
@@ -62,6 +63,11 @@ export function init() {
 	injectIntoLogic( {
 		id: 'variables-import-listener',
 		component: GlobalStylesImportListener,
+	} );
+
+	injectIntoLogic( {
+		id: 'mcp-variable-connect-listener',
+		component: McpVariableConnectListener,
 	} );
 }
 

--- a/packages/packages/core/editor-variables/src/mcp/__tests__/manage-variable-tool.test.ts
+++ b/packages/packages/core/editor-variables/src/mcp/__tests__/manage-variable-tool.test.ts
@@ -101,11 +101,14 @@ describe( 'manage-variable-tool validation', () => {
 				value: '#000',
 			} );
 
-			expect( service.create ).toHaveBeenCalledWith( {
-				type: 'global-color-variable',
-				label: 'headline-primary',
-				value: '#000',
-			} );
+			expect( service.create ).toHaveBeenCalledWith(
+				{
+					type: 'global-color-variable',
+					label: 'headline-primary',
+					value: '#000',
+				},
+				{ eventData: { executedBy: 'mcp_tool' } }
+			);
 		} );
 
 		it( 'should allow label with underscores', async () => {
@@ -116,11 +119,14 @@ describe( 'manage-variable-tool validation', () => {
 				value: '#000',
 			} );
 
-			expect( service.create ).toHaveBeenCalledWith( {
-				type: 'global-color-variable',
-				label: 'headline_primary',
-				value: '#000',
-			} );
+			expect( service.create ).toHaveBeenCalledWith(
+				{
+					type: 'global-color-variable',
+					label: 'headline_primary',
+					value: '#000',
+				},
+				{ eventData: { executedBy: 'mcp_tool' } }
+			);
 		} );
 
 		it( 'should reject empty label', async () => {
@@ -142,11 +148,14 @@ describe( 'manage-variable-tool validation', () => {
 				value: '16px',
 			} );
 
-			expect( service.create ).toHaveBeenCalledWith( {
-				type: 'global-size-variable',
-				label: 'spacing-md',
-				value: '16px',
-			} );
+			expect( service.create ).toHaveBeenCalledWith(
+				{
+					type: 'global-size-variable',
+					label: 'spacing-md',
+					value: '16px',
+				},
+				{ eventData: { executedBy: 'mcp_tool' } }
+			);
 		} );
 
 		it( 'should block size variable creation when Pro is not active at call time', async () => {
@@ -222,11 +231,14 @@ describe( 'manage-variable-tool validation', () => {
 				value: 'Roboto',
 			} );
 
-			expect( service.create ).toHaveBeenCalledWith( {
-				type: 'global-font-variable',
-				label: 'heading-font',
-				value: 'Roboto',
-			} );
+			expect( service.create ).toHaveBeenCalledWith(
+				{
+					type: 'global-font-variable',
+					label: 'heading-font',
+					value: 'Roboto',
+				},
+				{ eventData: { executedBy: 'mcp_tool' } }
+			);
 		} );
 
 		it( 'should reject unsupported font family on create', async () => {
@@ -252,11 +264,14 @@ describe( 'manage-variable-tool validation', () => {
 				value: '24px',
 			} );
 
-			expect( service.create ).toHaveBeenCalledWith( {
-				type: 'global-size-variable',
-				label: 'spacing-md',
-				value: '24px',
-			} );
+			expect( service.create ).toHaveBeenCalledWith(
+				{
+					type: 'global-size-variable',
+					label: 'spacing-md',
+					value: '24px',
+				},
+				{ eventData: { executedBy: 'mcp_tool' } }
+			);
 		} );
 
 		it( 'should reject non-unit value for a size variable', async () => {
@@ -302,7 +317,11 @@ describe( 'manage-variable-tool validation', () => {
 
 			await toolHandler( { action: 'update', id: '123', label: 'heading-font', value: 'Inter' } );
 
-			expect( service.update ).toHaveBeenCalledWith( '123', { label: 'heading-font', value: 'Inter' } );
+			expect( service.update ).toHaveBeenCalledWith(
+				'123',
+				{ label: 'heading-font', value: 'Inter' },
+				{ eventData: { executedBy: 'mcp_tool' } }
+			);
 		} );
 
 		it( 'should reject unsupported font family on update', async () => {
@@ -338,10 +357,14 @@ describe( 'manage-variable-tool validation', () => {
 		it( 'should allow valid label', async () => {
 			await toolHandler( { action: 'update', id: '123', label: 'headline-primary', value: '#000' } );
 
-			expect( service.update ).toHaveBeenCalledWith( '123', {
-				label: 'headline-primary',
-				value: '#000',
-			} );
+			expect( service.update ).toHaveBeenCalledWith(
+				'123',
+				{
+					label: 'headline-primary',
+					value: '#000',
+				},
+				{ eventData: { executedBy: 'mcp_tool' } }
+			);
 		} );
 	} );
 } );

--- a/packages/packages/core/editor-variables/src/mcp/manage-variable-tool.ts
+++ b/packages/packages/core/editor-variables/src/mcp/manage-variable-tool.ts
@@ -128,7 +128,7 @@ function getServiceActions( svc: typeof service ) {
 			if ( valueError ) {
 				throw new Error( valueError );
 			}
-			return svc.create( { type, label, value } );
+			return svc.create( { type, label, value }, { eventData: { executedBy: 'mcp_tool' } } );
 		},
 		update( { id, label, value }: Opts< { id: string; label: string; value: string } > ) {
 			if ( ! id || ! label || ! value ) {
@@ -145,7 +145,7 @@ function getServiceActions( svc: typeof service ) {
 					throw new Error( valueError );
 				}
 			}
-			return svc.update( id, { label, value } );
+			return svc.update( id, { label, value }, { eventData: { executedBy: 'mcp_tool' } } );
 		},
 		delete( { id }: Opts< { id: string } > ) {
 			if ( ! id ) {

--- a/packages/packages/core/editor-variables/src/service.ts
+++ b/packages/packages/core/editor-variables/src/service.ts
@@ -5,6 +5,20 @@ import { buildOperationsArray, type OperationResult } from './batch-operations';
 import { OP_RW, Storage, type TVariable, type TVariablesList } from './storage';
 import { styleVariablesRepository } from './style-variables-repository';
 import { type Variable } from './types';
+import { trackVariableEvent, type VariableEventData } from './utils/tracking';
+
+type EventData = {
+	controlPath?: VariableEventData[ 'controlPath' ];
+	executedBy?: VariableEventData[ 'executedBy' ];
+};
+
+export type CreateVariableOptions = {
+	eventData?: EventData;
+};
+
+export type UpdateVariableOptions = {
+	eventData?: EventData;
+};
 
 const storage = new Storage();
 
@@ -56,7 +70,7 @@ export const service = {
 			} );
 	},
 
-	create: ( { type, label, value }: Variable ) => {
+	create: ( { type, label, value }: Variable, options: CreateVariableOptions = {} ) => {
 		return apiClient
 			.create( type, label, value )
 			.then( ( response ) => {
@@ -82,6 +96,12 @@ export const service = {
 					[ variableId ]: createdVariable,
 				} );
 
+				trackVariableEvent( {
+					varType: type,
+					action: 'save',
+					...options.eventData,
+				} );
+
 				return {
 					id: variableId,
 					variable: createdVariable,
@@ -89,7 +109,11 @@ export const service = {
 			} );
 	},
 
-	update: ( id: string, { label, value, type }: Omit< Variable, 'type' > & { type?: Variable[ 'type' ] } ) => {
+	update: (
+		id: string,
+		{ label, value, type }: Omit< Variable, 'type' > & { type?: Variable[ 'type' ] },
+		options: UpdateVariableOptions = {}
+	) => {
 		return apiClient
 			.update( id, label, value, type )
 			.then( ( response ) => {
@@ -113,6 +137,12 @@ export const service = {
 
 				styleVariablesRepository.update( {
 					[ variableId ]: updatedVariable,
+				} );
+
+				trackVariableEvent( {
+					varType: updatedVariable.type,
+					action: 'update',
+					...options.eventData,
 				} );
 
 				return {

--- a/packages/packages/core/editor-variables/src/utils/__tests__/extract-variables-from-style-value.test.ts
+++ b/packages/packages/core/editor-variables/src/utils/__tests__/extract-variables-from-style-value.test.ts
@@ -1,0 +1,327 @@
+import { getPropSchemaFromCache, isTransformable } from '@elementor/editor-props';
+
+import { extractVariablesFromStyleValue } from '../extract-variables-from-style-value';
+
+jest.mock( '@elementor/editor-props', () => ( {
+	getPropSchemaFromCache: jest.fn(),
+	isTransformable: jest.fn(),
+} ) );
+
+const mockGetPropSchemaFromCache = jest.mocked( getPropSchemaFromCache );
+const mockIsTransformable = jest.mocked( isTransformable );
+
+function createMockPropUtil( key: string ) {
+	return {
+		key,
+		isValid: ( prop: unknown ) => {
+			const typedProp = prop as { $$type?: string; value?: unknown };
+			return typedProp?.$$type === key && typeof typedProp?.value === 'string';
+		},
+		extract: ( prop: unknown ) => {
+			const typedProp = prop as { value?: unknown };
+			return typedProp?.value ?? null;
+		},
+	};
+}
+
+describe( 'extractVariablesFromStyleValue', () => {
+	beforeEach( () => {
+		mockGetPropSchemaFromCache.mockImplementation( ( key: string ) => {
+			const variableTypes = [
+				'global-color-variable',
+				'global-font-variable',
+				'global-size-variable',
+				'global-custom-size-variable',
+			];
+			if ( variableTypes.includes( key ) ) {
+				return createMockPropUtil( key ) as ReturnType< typeof getPropSchemaFromCache >;
+			}
+			return undefined;
+		} );
+
+		mockIsTransformable.mockImplementation( ( value: unknown ) => {
+			if ( ! value || typeof value !== 'object' ) {
+				return false;
+			}
+			const obj = value as Record< string, unknown >;
+			return '$$type' in obj && typeof obj.$$type === 'string' && 'value' in obj;
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return empty array for empty object', () => {
+		// Arrange
+		const styleValue = {};
+
+		// Act
+		const result = extractVariablesFromStyleValue( styleValue );
+
+		// Assert
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'should extract top-level color variable', () => {
+		// Arrange
+		const styleValue = {
+			color: {
+				$$type: 'global-color-variable',
+				value: 'e-gv-fff34d2',
+			},
+		};
+
+		// Act
+		const result = extractVariablesFromStyleValue( styleValue );
+
+		// Assert
+		expect( result ).toEqual( [
+			{
+				type: 'global-color-variable',
+				variableId: 'e-gv-fff34d2',
+				controlPath: 'color',
+			},
+		] );
+	} );
+
+	it( 'should extract nested variable from background', () => {
+		// Arrange
+		const styleValue = {
+			background: {
+				$$type: 'background',
+				value: {
+					color: {
+						$$type: 'global-color-variable',
+						value: 'e-gv-f826663',
+					},
+				},
+			},
+		};
+
+		// Act
+		const result = extractVariablesFromStyleValue( styleValue );
+
+		// Assert
+		expect( result ).toEqual( [
+			{
+				type: 'global-color-variable',
+				variableId: 'e-gv-f826663',
+				controlPath: 'background.color',
+			},
+		] );
+	} );
+
+	it( 'should extract multiple variables at different levels', () => {
+		// Arrange
+		const styleValue = {
+			color: {
+				$$type: 'global-color-variable',
+				value: 'e-gv-fff34d2',
+			},
+			background: {
+				$$type: 'background',
+				value: {
+					color: {
+						$$type: 'global-color-variable',
+						value: 'e-gv-f826663',
+					},
+				},
+			},
+		};
+
+		// Act
+		const result = extractVariablesFromStyleValue( styleValue );
+
+		// Assert
+		expect( result ).toEqual( [
+			{
+				type: 'global-color-variable',
+				variableId: 'e-gv-fff34d2',
+				controlPath: 'color',
+			},
+			{
+				type: 'global-color-variable',
+				variableId: 'e-gv-f826663',
+				controlPath: 'background.color',
+			},
+		] );
+	} );
+
+	it( 'should extract size variables', () => {
+		// Arrange
+		const styleValue = {
+			padding: {
+				$$type: 'global-size-variable',
+				value: 'e-gv-size123',
+			},
+		};
+
+		// Act
+		const result = extractVariablesFromStyleValue( styleValue );
+
+		// Assert
+		expect( result ).toEqual( [
+			{
+				type: 'global-size-variable',
+				variableId: 'e-gv-size123',
+				controlPath: 'padding',
+			},
+		] );
+	} );
+
+	it( 'should extract font variables', () => {
+		// Arrange
+		const styleValue = {
+			fontFamily: {
+				$$type: 'global-font-variable',
+				value: 'e-gv-font456',
+			},
+		};
+
+		// Act
+		const result = extractVariablesFromStyleValue( styleValue );
+
+		// Assert
+		expect( result ).toEqual( [
+			{
+				type: 'global-font-variable',
+				variableId: 'e-gv-font456',
+				controlPath: 'fontFamily',
+			},
+		] );
+	} );
+
+	it( 'should ignore non-variable transformable values', () => {
+		// Arrange
+		const styleValue = {
+			background: {
+				$$type: 'background',
+				value: {
+					type: 'gradient',
+				},
+			},
+			color: '#FF0000',
+		};
+
+		// Act
+		const result = extractVariablesFromStyleValue( styleValue );
+
+		// Assert
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'should handle mixed variable and non-variable properties', () => {
+		// Arrange
+		const styleValue = {
+			color: {
+				$$type: 'global-color-variable',
+				value: 'e-gv-color1',
+			},
+			fontSize: '16px',
+			padding: {
+				$$type: 'size',
+				value: '20px',
+			},
+		};
+
+		// Act
+		const result = extractVariablesFromStyleValue( styleValue );
+
+		// Assert
+		expect( result ).toEqual( [
+			{
+				type: 'global-color-variable',
+				variableId: 'e-gv-color1',
+				controlPath: 'color',
+			},
+		] );
+	} );
+
+	it( 'should handle deeply nested structures', () => {
+		// Arrange
+		const styleValue = {
+			typography: {
+				$$type: 'typography',
+				value: {
+					font: {
+						$$type: 'font',
+						value: {
+							family: {
+								$$type: 'global-font-variable',
+								value: 'e-gv-font789',
+							},
+						},
+					},
+				},
+			},
+		};
+
+		// Act
+		const result = extractVariablesFromStyleValue( styleValue );
+
+		// Assert
+		expect( result ).toEqual( [
+			{
+				type: 'global-font-variable',
+				variableId: 'e-gv-font789',
+				controlPath: 'typography.font.family',
+			},
+		] );
+	} );
+
+	it( 'should extract custom-size variables', () => {
+		// Arrange
+		const styleValue = {
+			margin: {
+				$$type: 'global-custom-size-variable',
+				value: 'e-gv-custom123',
+			},
+		};
+
+		// Act
+		const result = extractVariablesFromStyleValue( styleValue );
+
+		// Assert
+		expect( result ).toEqual( [
+			{
+				type: 'global-custom-size-variable',
+				variableId: 'e-gv-custom123',
+				controlPath: 'margin',
+			},
+		] );
+	} );
+
+	it( 'should not extract variables when prop util is not registered', () => {
+		// Arrange
+		mockGetPropSchemaFromCache.mockReturnValue( undefined );
+		const styleValue = {
+			color: {
+				$$type: 'global-color-variable',
+				value: 'e-gv-color1',
+			},
+		};
+
+		// Act
+		const result = extractVariablesFromStyleValue( styleValue );
+
+		// Assert
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'should not extract unknown variable types', () => {
+		// Arrange
+		const styleValue = {
+			custom: {
+				$$type: 'unknown-variable',
+				value: 'some-value',
+			},
+		};
+
+		// Act
+		const result = extractVariablesFromStyleValue( styleValue );
+
+		// Assert
+		expect( result ).toEqual( [] );
+	} );
+} );

--- a/packages/packages/core/editor-variables/src/utils/extract-variables-from-style-value.ts
+++ b/packages/packages/core/editor-variables/src/utils/extract-variables-from-style-value.ts
@@ -1,0 +1,55 @@
+import { getPropSchemaFromCache, isTransformable } from '@elementor/editor-props';
+
+type VariableInfo = {
+	type: string;
+	variableId: string;
+	controlPath: string;
+};
+
+const VARIABLE_TYPE_KEYS = [
+	'global-color-variable',
+	'global-font-variable',
+	'global-size-variable',
+	'global-custom-size-variable',
+] as const;
+
+function tryExtractVariable( value: unknown ): { type: string; variableId: string } | null {
+	for ( const key of VARIABLE_TYPE_KEYS ) {
+		const propUtil = getPropSchemaFromCache( key );
+		if ( propUtil?.isValid( value ) ) {
+			return {
+				type: key,
+				variableId: propUtil.extract( value ) as string,
+			};
+		}
+	}
+	return null;
+}
+
+function traverse( value: unknown, path: string[], result: VariableInfo[] ): void {
+	const extracted = tryExtractVariable( value );
+	if ( extracted ) {
+		result.push( {
+			...extracted,
+			controlPath: path.join( '.' ),
+		} );
+		return;
+	}
+
+	if ( isTransformable( value ) ) {
+		traverse( value.value, path, result );
+		return;
+	}
+
+	if ( value && typeof value === 'object' ) {
+		for ( const [ key, val ] of Object.entries( value ) ) {
+			traverse( val, [ ...path, key ], result );
+		}
+	}
+}
+
+export function extractVariablesFromStyleValue( styleValue: Record< string, unknown > ): VariableInfo[] {
+	const result: VariableInfo[] = [];
+	traverse( styleValue, [], result );
+	return result;
+}

--- a/packages/packages/core/editor-variables/src/utils/tracking.ts
+++ b/packages/packages/core/editor-variables/src/utils/tracking.ts
@@ -1,26 +1,44 @@
 import { getMixpanel } from '@elementor/events';
 
-type VariableEventData = {
+export type VariableEventData = {
 	varType: string;
-	controlPath: string;
-	action: 'open' | 'add' | 'connect' | 'save';
+	controlPath?: string;
+	action: 'open' | 'add' | 'connect' | 'save' | 'update';
+	executedBy?: 'mcp_tool' | 'user';
 };
 
-export const trackVariableEvent = ( { varType, controlPath, action }: VariableEventData ) => {
+export const trackVariableEvent = ( { varType, controlPath, action, executedBy }: VariableEventData ) => {
 	const { dispatchEvent, config } = getMixpanel();
 	if ( ! config?.names?.variables?.[ action ] ) {
 		return;
 	}
 
 	const name = config.names.variables[ action ];
-	dispatchEvent?.( name, {
+
+	let eventData: Record< string, string > = {
+		var_type: varType,
+		action_type: name,
+	};
+
+	if ( executedBy ) {
+		eventData.executed_by = executedBy;
+	}
+
+	const defaultLocationInfo = {
 		location: config?.locations?.variables || '',
 		secondaryLocation: config?.secondaryLocations?.variablesPopover || '',
 		trigger: config?.triggers?.click || '',
-		var_type: varType,
-		control_path: controlPath,
-		action_type: name,
-	} );
+	};
+
+	if ( ! executedBy || executedBy !== 'mcp_tool' ) {
+		eventData = { ...defaultLocationInfo, ...eventData };
+	}
+
+	if ( controlPath ) {
+		eventData.control_path = controlPath;
+	}
+
+	dispatchEvent?.( name, eventData );
 };
 
 export type VariablesManagerOpenSource = 'vars-popover' | 'system-panel';

--- a/packages/packages/libs/editor-mcp/src/events/mcp-styles-applied-event.ts
+++ b/packages/packages/libs/editor-mcp/src/events/mcp-styles-applied-event.ts
@@ -1,0 +1,9 @@
+export const MCP_STYLES_APPLIED_EVENT = 'elementor/mcp/styles-applied';
+
+export type McpStylesAppliedPayload = {
+	styleValue: Record< string, unknown >;
+};
+
+export function dispatchMcpStylesAppliedEvent( payload: McpStylesAppliedPayload ): void {
+	window.dispatchEvent( new CustomEvent( MCP_STYLES_APPLIED_EVENT, { detail: payload } ) );
+}

--- a/packages/packages/libs/editor-mcp/src/index.ts
+++ b/packages/packages/libs/editor-mcp/src/index.ts
@@ -22,3 +22,8 @@ export { installAngiePlugin, type InstallAngieResult } from './utils/install-ang
 export { saveAngieConsent } from './utils/save-angie-consent';
 export const getAngieSdk = () => getSDK();
 export * from './init';
+export {
+	dispatchMcpStylesAppliedEvent,
+	MCP_STYLES_APPLIED_EVENT,
+	type McpStylesAppliedPayload,
+} from './events/mcp-styles-applied-event';


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick to 4.02 adds monitoring for AI feature usage (MCP tool) by tracking element additions, style applications, variable creation/updates, and global class operations. Intent is unified event telemetry across user vs. system-executed actions via new `executedBy` parameter replacing `source`.

## 2. What Changed (Where)

| Module | Change |
|--------|--------|
| editor-canvas | Track element additions; export `ELEMENT_ADDED_EVENT` and `ElementAddedEvent` type |
| editor-mcp | New `dispatchMcpStylesAppliedEvent` for style application tracking |
| editor-components | Rename `source` → `executedBy`; export `ExecutedBy` type; support backward compat |
| editor-variables | New listener for MCP styles; refactor tracking to accept `eventData` options in service layer |
| editor-global-classes | Wire tracking calls on class create/apply/modify with `executedBy: 'mcp_tool'` |
| events-config.js | Add `update_variable` event name mapping |

## 3. How It Works

**Entry:** MCP tools (build-composition, configure-element, manage-variable, apply-global-class) invoke service methods with `{ eventData: { executedBy: 'mcp_tool' } }`. Services track via `trackCanvasEvent`/`trackVariableEvent`/`trackComponentEvent`, dispatching custom events (e.g., `ELEMENT_ADDED_EVENT`, `MCP_STYLES_APPLIED_EVENT`). New `McpVariableConnectListener` subscribes to style-applied events, extracts variable references, and emits connect tracking. Test updates validate option threading through call chain.

## 4. Risks

**Backward compat:** Components layer accepts both `source` (old) and `executedBy` (new), preferring latter. Flag for removal in 4.4.0. **Event dispatch:** New window custom events may conflict with existing listeners; minimal risk given unique event names. **Test coverage:** Large test updates adequate but some mocks (e.g., `createVariable`) now expect nested `eventData` object—verify integration endpoints match.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
