### PR TITLE
Fix: Improve events handling [ED-24694]

### DIFF
--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -95,7 +95,11 @@ export default class extends elementorModules.Module {
 			};
 
 			mixpanelInstance.track( name, eventData, options );
-		} catch {
+		} catch ( error ) {
+			if ( elementorCommon.config.editor_events?.debug ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Events Manager dispatch failed:', error );
+			}
 		}
 	}
 

--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -75,25 +75,28 @@ export default class extends elementorModules.Module {
 			return;
 		}
 
-		if ( ! this.trackingEnabled ) {
-			this.enableTracking();
+		try {
+			if ( ! this.trackingEnabled ) {
+				this.enableTracking();
+			}
+
+			const eventData = {
+				user_id: elementorCommon.config.editor_events?.user_id || null,
+				user_roles: elementorCommon.config.library_connect?.user_roles || [],
+				subscription_id: elementorCommon.config.editor_events?.subscription_id || null,
+				user_tier: elementorCommon.config.library_connect?.current_access_tier || null,
+				url: elementorCommon.config.editor_events?.site_url,
+				wp_version: elementorCommon.config.editor_events?.wp_version,
+				client_id: elementorCommon.config.editor_events?.site_key,
+				app_version: elementorCommon.config.editor_events?.elementor_version,
+				site_language: elementorCommon.config.editor_events?.site_language,
+				experiments: this.availableExperiments,
+				...data,
+			};
+
+			mixpanelInstance.track( name, eventData, options );
+		} catch {
 		}
-
-		const eventData = {
-			user_id: elementorCommon.config.editor_events?.user_id || null,
-			user_roles: elementorCommon.config.library_connect?.user_roles || [],
-			subscription_id: elementorCommon.config.editor_events?.subscription_id || null,
-			user_tier: elementorCommon.config.library_connect?.current_access_tier || null,
-			url: elementorCommon.config.editor_events?.site_url,
-			wp_version: elementorCommon.config.editor_events?.wp_version,
-			client_id: elementorCommon.config.editor_events?.site_key,
-			app_version: elementorCommon.config.editor_events?.elementor_version,
-			site_language: elementorCommon.config.editor_events?.site_language,
-			experiments: this.availableExperiments,
-			...data,
-		};
-
-		mixpanelInstance.track( name, eventData, options );
 	}
 
 	async featureFlagIsActive( flagName ) {

--- a/tests/jest/unit/core/common/modules/events-manager/assets/js/module.test.js
+++ b/tests/jest/unit/core/common/modules/events-manager/assets/js/module.test.js
@@ -1,0 +1,85 @@
+const mockTrack = jest.fn();
+const mockMixpanelInstance = {
+	isInitialized: true,
+	get_distinct_id: () => 'test-id',
+	register: jest.fn(),
+	identify: jest.fn(),
+	people: { set_once: jest.fn() },
+	track: mockTrack,
+};
+
+jest.mock( 'mixpanel-browser', () => ( {
+	__esModule: true,
+	default: {
+		init: jest.fn( ( token, config ) => {
+			if ( config.loaded ) {
+				config.loaded( mockMixpanelInstance );
+			}
+
+			return mockMixpanelInstance;
+		} ),
+	},
+	Mixpanel: {},
+} ) );
+
+describe( 'Events Manager module', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		mockTrack.mockReset();
+
+		window.elementorCommon = {
+			config: {
+				editor_events: {
+					can_send_events: true,
+					user_id: 'user-1',
+					site_url: 'https://example.com',
+					wp_version: '6.0',
+					site_key: 'key',
+					elementor_version: '3.0',
+					site_language: 'en',
+				},
+				library_connect: {
+					user_roles: [ 'administrator' ],
+					current_access_tier: 'free',
+					plan_type: 'free',
+				},
+				experimentalFeatures: {},
+			},
+		};
+	} );
+
+	afterEach( () => {
+		delete window.elementorCommon;
+	} );
+
+	test( 'dispatchEvent does not throw when event dispatch fails', () => {
+		mockTrack.mockImplementation( () => {
+			throw new Error( 'event dispatch failure' );
+		} );
+
+		jest.isolateModules( () => {
+			const EventsManager = require( 'elementor/core/common/modules/events-manager/assets/js/module' ).default;
+			const eventsManager = new EventsManager();
+
+			eventsManager.onInit();
+
+			expect( () => eventsManager.dispatchEvent( 'test_event', { foo: 'bar' } ) ).not.toThrow();
+		} );
+	} );
+
+	test( 'dispatchEvent calls mixpanel track when tracking is enabled', () => {
+		jest.isolateModules( () => {
+			const EventsManager = require( 'elementor/core/common/modules/events-manager/assets/js/module' ).default;
+			const eventsManager = new EventsManager();
+
+			eventsManager.onInit();
+			eventsManager.dispatchEvent( 'test_event', { foo: 'bar' } );
+
+			expect( mockTrack ).toHaveBeenCalledWith(
+				'test_event',
+				expect.objectContaining( { foo: 'bar' } ),
+				{},
+			);
+		} );
+	} );
+} );

--- a/tests/jest/unit/core/common/modules/events-manager/assets/js/module.test.js
+++ b/tests/jest/unit/core/common/modules/events-manager/assets/js/module.test.js
@@ -73,7 +73,11 @@ describe( 'Events Manager module', () => {
 			const EventsManager = require( 'elementor/core/common/modules/events-manager/assets/js/module' ).default;
 			const eventsManager = new EventsManager();
 
+			eventsManager.onInit();
 			eventsManager.trackingEnabled = false;
+			jest.spyOn( eventsManager, 'enableTracking' ).mockImplementation( () => {
+				throw new Error( 'enableTracking failure' );
+			} );
 
 			expect( () => eventsManager.dispatchEvent( 'test_event', { foo: 'bar' } ) ).not.toThrow();
 			expect( mockTrack ).not.toHaveBeenCalled();

--- a/tests/jest/unit/core/common/modules/events-manager/assets/js/module.test.js
+++ b/tests/jest/unit/core/common/modules/events-manager/assets/js/module.test.js
@@ -64,6 +64,33 @@ describe( 'Events Manager module', () => {
 			eventsManager.onInit();
 
 			expect( () => eventsManager.dispatchEvent( 'test_event', { foo: 'bar' } ) ).not.toThrow();
+			expect( mockTrack ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	test( 'dispatchEvent does not throw when enableTracking fails', () => {
+		jest.isolateModules( () => {
+			const EventsManager = require( 'elementor/core/common/modules/events-manager/assets/js/module' ).default;
+			const eventsManager = new EventsManager();
+
+			eventsManager.trackingEnabled = false;
+
+			expect( () => eventsManager.dispatchEvent( 'test_event', { foo: 'bar' } ) ).not.toThrow();
+			expect( mockTrack ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	test( 'dispatchEvent returns early when events cannot be sent', () => {
+		window.elementorCommon.config.editor_events.can_send_events = false;
+
+		jest.isolateModules( () => {
+			const EventsManager = require( 'elementor/core/common/modules/events-manager/assets/js/module' ).default;
+			const eventsManager = new EventsManager();
+
+			eventsManager.onInit();
+			eventsManager.dispatchEvent( 'test_event', { foo: 'bar' } );
+
+			expect( mockTrack ).not.toHaveBeenCalled();
 		} );
 	} );
 
@@ -73,12 +100,23 @@ describe( 'Events Manager module', () => {
 			const eventsManager = new EventsManager();
 
 			eventsManager.onInit();
-			eventsManager.dispatchEvent( 'test_event', { foo: 'bar' } );
+			eventsManager.dispatchEvent( 'test_event', { foo: 'bar' }, { send_immediately: true } );
 
 			expect( mockTrack ).toHaveBeenCalledWith(
 				'test_event',
-				expect.objectContaining( { foo: 'bar' } ),
-				{},
+				expect.objectContaining( {
+					foo: 'bar',
+					user_id: 'user-1',
+					user_roles: [ 'administrator' ],
+					user_tier: 'free',
+					url: 'https://example.com',
+					wp_version: '6.0',
+					client_id: 'key',
+					app_version: '3.0',
+					site_language: 'en',
+					experiments: [],
+				} ),
+				{ send_immediately: true },
 			);
 		} );
 	} );


### PR DESCRIPTION
## Jira
[ED-24694](https://elementor.atlassian.net/browse/ED-24694)


[ED-24694]: https://elementor.atlassian.net/browse/ED-24694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Wrap event dispatch in try-catch to gracefully handle failures in Mixpanel tracking or tracking initialization, preventing runtime errors from crashing the editor.

## 2. What Changed (Where)

- `events-manager/module.js`: Wrapped `dispatchEvent` logic in try-catch, ensuring errors don't propagate; debug logging added for troubleshooting.
- `events-manager/module.test.js`: New 127-line test suite covering failure scenarios, initialization errors, and normal dispatch flow.

## 3. How It Works

`dispatchEvent` now: (1) checks if tracking enabled, enabling if needed within try block, (2) constructs eventData payload merging user config with custom data, (3) calls `mixpanelInstance.track()`, (4) silently catches exceptions unless debug mode enabled. Tests verify no throws on Mixpanel failures, `enableTracking` failures, or disabled events.

## 4. Risks

Error suppression (when debug off) masks real issues—consider logging to monitoring service for production visibility. Test coverage assumes `elementorCommon.config` structure stability; schema changes break assumptions silently.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
