### PR TITLE
Internal: Fix types for BC [ED-24520]

### DIFF
--- a/packages/packages/core/editor-components/src/utils/tracking.ts
+++ b/packages/packages/core/editor-components/src/utils/tracking.ts
@@ -10,19 +10,6 @@ export type ExecutedBy = 'user' | 'mcp_tool' | 'system';
 /** @deprecated since 4.2.1 - use `ExecutedBy` instead */
 export type Source = ExecutedBy;
 
-// TODO: Remove `source` parameter in version 4.4.0 - it's replaced by `executedBy`, but pro's older versions will still send `source`
-// so we keep both for backward compatibility
-type ExecutedByParam =
-	| {
-			executedBy: ExecutedBy;
-			source?: never;
-	  }
-	| {
-			/** @deprecated since 4.2.1 - use `executedBy` instead */
-			source: ExecutedBy;
-			executedBy?: never;
-	  };
-
 type ComponentEventData = Record< string, unknown > & {
 	action:
 		| 'createClicked'
@@ -35,7 +22,12 @@ type ComponentEventData = Record< string, unknown > & {
 		| 'propertiesPanelOpened'
 		| 'propertiesGroupCreated'
 		| 'detached';
-} & ExecutedByParam;
+	executedBy?: ExecutedBy;
+	// TODO: Remove `source` parameter in version 4.4.0 - it's replaced by `executedBy`, but pro's older versions will still send `source`
+	// so we keep both for backward compatibility
+	/** @deprecated since 4.2.1 - use `executedBy` instead */
+	source?: Source;
+};
 
 const FEATURE_NAME = 'Components';
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Relaxing type constraints to support backward compatibility: older Pro versions send `source` while new code uses `executedBy`. The union type was too strict—both parameters can now be optional and coexist.

## 2. What Changed (Where)

`packages/core/editor-components/src/utils/tracking.ts`: Removed discriminated union `ExecutedByParam` type; inlined `executedBy?` and `source?` as optional properties directly into `ComponentEventData`.

## 3. How It Works

Handler accepts either parameter (or both) at runtime; logic checks `source === 'system' || executedBy === 'system'` to filter events. No validation—graceful degradation lets old clients continue working during deprecation window.

## 4. Risks

None. Expanding optionality is backward compatible. Deprecation comments preserve migration path for version 4.4.0 cleanup.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
