### PR TITLE
Fix: Cherry-pick PR 36303 to 4.02: Loop manual selection shows empty options [ED-24594]

### DIFF
--- a/modules/wp-rest/classes/post-query.php
+++ b/modules/wp-rest/classes/post-query.php
@@ -57,15 +57,6 @@ class Post_Query extends Base {
 		$params = $request->get_params();
 		$term = trim( $params[ self::SEARCH_TERM_KEY ] ?? '' );
 
-		if ( empty( $term ) ) {
-			return new \WP_REST_Response( [
-				'success' => true,
-				'data' => [
-					'value' => [],
-				],
-			], 200 );
-		}
-
 		$keys_format_map = $this->filter_keys_conversion_map(
 			$params[ self::KEYS_CONVERSION_MAP_KEY ] ?? self::ALLOWED_KEYS_CONVERSION_MAP,
 			self::ALLOWED_KEYS_CONVERSION_MAP
@@ -81,12 +72,15 @@ class Post_Query extends Base {
 			'numberposts'                  => $post_count,
 			'suppress_filters'             => false,
 			'custom_search'                => true,
-			'search_term'                  => $term,
-			self::SEARCH_IN_CONTENT_KEY    => $params[ self::SEARCH_IN_CONTENT_KEY ] ?? false,
 			'post_status'                  => $is_public_only ? 'publish' : 'any',
-			'orderby'                      => 'ID',
-			'order'                        => 'ASC',
+			'orderby'                      => 'modified',
+			'order'                        => 'DESC',
 		];
+
+		if ( ! empty( $term ) ) {
+			$query_args['search_term'] = $term;
+			$query_args[ self::SEARCH_IN_CONTENT_KEY ] = $params[ self::SEARCH_IN_CONTENT_KEY ] ?? false;
+		}
 
 		if ( ! empty( $params[ self::META_QUERY_KEY ] ) && is_array( $params[ self::META_QUERY_KEY ] ) ) {
 			$query_args['meta_query'] = $params[ self::META_QUERY_KEY ];

--- a/packages/packages/libs/editor-controls/src/hooks/__tests__/use-query-autocomplete.test.ts
+++ b/packages/packages/libs/editor-controls/src/hooks/__tests__/use-query-autocomplete.test.ts
@@ -77,4 +77,31 @@ describe( 'useQueryAutocomplete', () => {
 			{ timeout: 1000 }
 		);
 	} );
+
+	it( 'fetches initial options on mount when minInputLength is 0', async () => {
+		// Act.
+		const { result } = renderHook( () => useQueryAutocomplete( { url: '/api', minInputLength: 0 } ) );
+
+		// Assert.
+		await waitFor(
+			() => {
+				expect( result.current.options ).toEqual( [
+					{ id: 1, label: 'Apple' },
+					{ id: 2, label: 'Banana' },
+					{ id: 3, label: 'Cherry' },
+				] );
+			},
+			{ timeout: 1000 }
+		);
+	} );
+
+	it( 'does not fetch on mount when minInputLength is greater than 0', async () => {
+		// Act.
+		renderHook( () => useQueryAutocomplete( { url: '/api', minInputLength: 2 } ) );
+
+		await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
+
+		// Assert.
+		expect( httpService ).not.toHaveBeenCalled();
+	} );
 } );

--- a/packages/packages/libs/editor-controls/src/hooks/use-query-autocomplete.ts
+++ b/packages/packages/libs/editor-controls/src/hooks/use-query-autocomplete.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { numberPropTypeUtil, type QueryPropValue, stringPropTypeUtil } from '@elementor/editor-props';
 import { type HttpResponse, httpService } from '@elementor/http-client';
 import { debounce } from '@elementor/utils';
@@ -7,7 +7,7 @@ import { type CategorizedOption, type FlatOption, isCategorizedOptionPool } from
 
 type Response = HttpResponse< { value: FlatOption[] | CategorizedOption[] } >;
 
-type FetchOptionsParams = Record< string, unknown > & { term: string };
+type FetchOptionsParams = Record< string, unknown > & { term?: string };
 
 type UseQueryAutocompleteOptions = {
 	url: string;
@@ -47,14 +47,22 @@ export function useQueryAutocomplete( {
 		[ url, excludeIdSet ]
 	);
 
-	const updateOptions = ( term: string | null ) => {
-		setOptions( [] );
+	useEffect( () => {
+		if ( minInputLength === 0 && url ) {
+			fetchOptions( url, { ...params, term: '' } ).then( ( newOptions ) => {
+				setOptions( formatOptions( filterExcludedOptions( newOptions, excludeIdSet ) ) );
+			} );
+		}
+	}, [ url, minInputLength, excludeIdSet, params ] );
 
-		if ( ! term || ! url || term.length < minInputLength ) {
+	const updateOptions = ( term: string | null ) => {
+		const termStr = term ?? '';
+
+		if ( ! url || termStr.length < minInputLength ) {
 			return;
 		}
 
-		debounceFetch( { ...params, term } );
+		debounceFetch( { ...params, term: termStr } );
 	};
 
 	return { options, updateOptions };


### PR DESCRIPTION
Cherry-pick of https://github.com/elementor/elementor/pull/36303 to 4.02 branch.