### PR TITLE
Fix: Change require to require_once for WP_Importer [ED-24785]

### DIFF
--- a/core/utils/import-export/wp-import.php
+++ b/core/utils/import-export/wp-import.php
@@ -27,7 +27,7 @@ if ( ! class_exists( 'WP_Importer' ) ) {
 	$class_wp_importer = ABSPATH . 'wp-admin/includes/class-wp-importer.php';
 
 	if ( file_exists( $class_wp_importer ) ) {
-		require $class_wp_importer;
+		require_once $class_wp_importer;
 	}
 }
 


### PR DESCRIPTION
I am running into PHP errors from including the file twice. As a good practice 'require' should almost never used.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Prevents duplicate class inclusions by switching from `require` to `require_once` for WP_Importer, avoiding redeclaration errors if the file is loaded multiple times in the import flow.

## 2. What Changed (Where)

- `core/utils/import-export/wp-import.php`: Line 30 changed `require` to `require_once` for class-wp-importer.php inclusion.

## 3. How It Works

The conditional check `file_exists()` validates the path before inclusion, but `require_once` adds safety against re-inclusion even if the conditional block executes repeatedly during the import lifecycle.

## 4. Risks

None — `require_once` is idempotent and aligns with existing pattern on line 35 where `require_once` is already used for import.php. This is purely a safety hardening with no behavioral change under normal operation.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
