### PR TITLE
Fix: Add option to reset grid auto flow in CSS settings [ED-24770]

### DIFF
--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/__tests__/grid-auto-flow-field.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/__tests__/grid-auto-flow-field.test.tsx
@@ -79,7 +79,7 @@ describe( '<GridAutoFlowField />', () => {
 		renderGridAutoFlowField();
 
 		// Assert.
-		expect( screen.getByLabelText( 'Dense' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Dense' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'should reset grid-auto-flow when the selected direction is clicked again', () => {
@@ -109,5 +109,45 @@ describe( '<GridAutoFlowField />', () => {
 			{ 'grid-auto-flow': null },
 			{ history: { propDisplayName: 'Auto flow' } }
 		);
+	} );
+
+	it( 'should set row dense when dense is toggled on without a direction', () => {
+		// Arrange.
+		const setValues = jest.fn();
+
+		jest.mocked( useDirection ).mockReturnValue( { isUiRtl: false, isSiteRtl: false } );
+		jest.mocked( useStylesFields ).mockReturnValue( {
+			values: { 'grid-auto-flow': null },
+			setValues,
+			canEdit: true,
+		} );
+
+		// Act.
+		renderGridAutoFlowField();
+		fireEvent.click( screen.getByRole( 'button', { name: 'Dense' } ) );
+
+		// Assert.
+		expect( setValues ).toHaveBeenCalledWith(
+			{ 'grid-auto-flow': { $$type: 'string', value: 'row dense' } },
+			{ history: { propDisplayName: 'Auto flow' } }
+		);
+	} );
+
+	it( 'should disable direction and dense controls when editing is not allowed', () => {
+		// Arrange.
+		jest.mocked( useDirection ).mockReturnValue( { isUiRtl: false, isSiteRtl: false } );
+		jest.mocked( useStylesFields ).mockReturnValue( {
+			values: { 'grid-auto-flow': { $$type: 'string', value: 'row' } },
+			setValues: jest.fn(),
+			canEdit: false,
+		} );
+
+		// Act.
+		renderGridAutoFlowField();
+
+		// Assert.
+		expect( screen.getByLabelText( 'Row' ) ).toHaveClass( 'Mui-disabled' );
+		expect( screen.getByLabelText( 'Column' ) ).toHaveClass( 'Mui-disabled' );
+		expect( screen.getByRole( 'button', { name: 'Dense' } ) ).toBeDisabled();
 	} );
 } );

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/__tests__/grid-auto-flow-field.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/__tests__/grid-auto-flow-field.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { createMockPropType, renderField } from 'test-utils';
-import { screen } from '@testing-library/react';
+import { useBoundProp } from '@elementor/editor-controls';
+import { fireEvent, screen } from '@testing-library/react';
 
 import { useDirection } from '../../../../hooks/use-direction';
 import { useStylesFields } from '../../../../hooks/use-styles-fields';
@@ -22,6 +23,7 @@ jest.mock( '@elementor/editor-controls', () => {
 		useControlActions: () => ( {
 			items: [],
 		} ),
+		useBoundProp: jest.fn(),
 	};
 } );
 
@@ -32,6 +34,19 @@ const renderGridAutoFlowField = () => {
 };
 
 describe( '<GridAutoFlowField />', () => {
+	beforeEach( () => {
+		jest.mocked( useBoundProp ).mockReturnValue( {
+			bind: 'grid-auto-flow',
+			value: null,
+			propType: createMockPropType( { kind: 'plain', key: 'string' } ),
+			path: [ 'grid-auto-flow' ],
+			restoreValue: jest.fn(),
+			resetValue: jest.fn(),
+			placeholder: null,
+			setValue: jest.fn(),
+		} );
+	} );
+
 	it( 'should render Row and Column direction buttons', () => {
 		// Arrange.
 		jest.mocked( useDirection ).mockReturnValue( { isUiRtl: false, isSiteRtl: false } );
@@ -65,5 +80,34 @@ describe( '<GridAutoFlowField />', () => {
 
 		// Assert.
 		expect( screen.getByLabelText( 'Dense' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should reset grid-auto-flow when the selected direction is clicked again', () => {
+		// Arrange.
+		const setValues = jest.fn();
+
+		jest.mocked( useDirection ).mockReturnValue( { isUiRtl: false, isSiteRtl: false } );
+		jest.mocked( useStylesFields ).mockReturnValue( {
+			values: { 'grid-auto-flow': { $$type: 'string', value: 'row' } },
+			setValues,
+			canEdit: true,
+		} );
+
+		// Act.
+		renderGridAutoFlowField();
+
+		const rowButton = screen.getByLabelText( 'Row' );
+
+		// Assert.
+		expect( rowButton ).toHaveClass( 'Mui-selected' );
+
+		// Act.
+		fireEvent.click( rowButton );
+
+		// Assert.
+		expect( setValues ).toHaveBeenCalledWith(
+			{ 'grid-auto-flow': null },
+			{ history: { propDisplayName: 'Auto flow' } }
+		);
 	} );
 } );

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/grid-auto-flow-field.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/grid-auto-flow-field.tsx
@@ -89,6 +89,7 @@ const GridAutoFlowFieldContent = () => {
 							onChange={ handleDenseToggle }
 							size="tiny"
 							aria-label={ DENSE_LABEL }
+							disabled={ ! canEdit }
 						>
 							<LayoutDashboardIcon fontSize="tiny" />
 						</ToggleButton>

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/grid-auto-flow-field.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/grid-auto-flow-field.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ControlToggleButtonGroup, type ToggleButtonGroupItem } from '@elementor/editor-controls';
+import { ControlToggleButtonGroup, type ToggleButtonGroupItem, useBoundProp } from '@elementor/editor-controls';
 import { type StringPropValue } from '@elementor/editor-props';
 import { ArrowDownSmallIcon, ArrowRightIcon, LayoutDashboardIcon } from '@elementor/icons';
 import { Grid, ToggleButton, Tooltip, withDirection } from '@elementor/ui';
@@ -32,9 +32,11 @@ const directionOptions: ToggleButtonGroupItem< AutoFlowDirection >[] = [
 	},
 ];
 
-const parseAutoFlow = ( value: string | null ): { direction: AutoFlowDirection; dense: boolean } => {
+const parseAutoFlow = (
+	value: string | null
+): { direction: AutoFlowDirection | null; dense: boolean } => {
 	if ( ! value ) {
-		return { direction: 'row', dense: false };
+		return { direction: null, dense: false };
 	}
 	const dense = value.includes( 'dense' );
 	const direction = value.replace( /\s*dense\s*/, '' ).trim() as AutoFlowDirection;
@@ -46,21 +48,27 @@ const composeAutoFlow = ( direction: AutoFlowDirection, dense: boolean ): string
 };
 
 const GridAutoFlowFieldContent = () => {
-	const { value, setValue } = useStylesField< StringPropValue | null >( 'grid-auto-flow', {
+	const { value, setValue, canEdit } = useStylesField< StringPropValue | null >( 'grid-auto-flow', {
 		history: { propDisplayName: AUTO_FLOW_LABEL },
 	} );
+	const { placeholder } = useBoundProp();
 
 	const { direction, dense } = parseAutoFlow( value?.value ?? null );
+	const directionPlaceholder = parseAutoFlow(
+		( placeholder as StringPropValue | null )?.value ?? null
+	).direction;
 
 	const handleDirectionChange = ( newDirection: AutoFlowDirection | null ) => {
 		if ( ! newDirection ) {
+			setValue( null );
 			return;
 		}
 		setValue( { $$type: 'string', value: composeAutoFlow( newDirection, dense ) } );
 	};
 
 	const handleDenseToggle = () => {
-		setValue( { $$type: 'string', value: composeAutoFlow( direction, ! dense ) } );
+		const nextDirection = direction ?? 'row';
+		setValue( { $$type: 'string', value: composeAutoFlow( nextDirection, ! dense ) } );
 	};
 
 	return (
@@ -70,9 +78,11 @@ const GridAutoFlowFieldContent = () => {
 					<ControlToggleButtonGroup
 						items={ directionOptions }
 						value={ direction }
+						placeholder={ directionPlaceholder }
 						onChange={ handleDirectionChange }
 						exclusive={ true }
 						fullWidth={ true }
+						disabled={ ! canEdit }
 					/>
 				</Grid>
 				<Grid item>

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/grid-auto-flow-field.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections/layout-section/grid-auto-flow-field.tsx
@@ -32,9 +32,7 @@ const directionOptions: ToggleButtonGroupItem< AutoFlowDirection >[] = [
 	},
 ];
 
-const parseAutoFlow = (
-	value: string | null
-): { direction: AutoFlowDirection | null; dense: boolean } => {
+const parseAutoFlow = ( value: string | null ): { direction: AutoFlowDirection | null; dense: boolean } => {
 	if ( ! value ) {
 		return { direction: null, dense: false };
 	}
@@ -54,9 +52,7 @@ const GridAutoFlowFieldContent = () => {
 	const { placeholder } = useBoundProp();
 
 	const { direction, dense } = parseAutoFlow( value?.value ?? null );
-	const directionPlaceholder = parseAutoFlow(
-		( placeholder as StringPropValue | null )?.value ?? null
-	).direction;
+	const directionPlaceholder = parseAutoFlow( ( placeholder as StringPropValue | null )?.value ?? null ).direction;
 
 	const handleDirectionChange = ( newDirection: AutoFlowDirection | null ) => {
 		if ( ! newDirection ) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes ED-24770 — once a grid auto flow direction (Row/Column) was selected in CSS layout settings, there was no way to clear it. That left `grid-auto-flow` in the generated CSS even when the user wanted the default (no explicit style).

## Changes

- Allow clicking the active Row/Column toggle again to reset `grid-auto-flow` to `null` (same pattern as Order and other toggle controls).
- When unset, the direction buttons no longer show a false "Row" selection; inherited values display as placeholders instead.
- Dense toggle still works when no direction is set (defaults to `row dense` when enabling dense from an empty state).
- Dense toggle now respects `canEdit` (read-only state), matching the direction button group.

## Visual documentation

**Row selected (explicit value):**

[Grid auto flow with Row selected](https://cursor.com/agents/bc-1da6a4bf-8147-5dfa-b94b-9857d3ffd822/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fgrid-auto-flow-row-selected.png)

**After clicking Row again to reset (no selection):**

[Grid auto flow after reset](https://cursor.com/agents/bc-1da6a4bf-8147-5dfa-b94b-9857d3ffd822/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fgrid-auto-flow-reset.png)

## Test instructions

1. Open the editor with a container using grid display (atomic/CSS layout panel).
2. In Layout → Auto flow, select **Row** or **Column** and confirm `grid-auto-flow` appears in CSS.
3. Click the same selected direction again — the control should deselect and `grid-auto-flow` should be removed from CSS.
4. Verify inherited auto flow values still show as placeholders when unset locally.
5. Verify Dense toggle is disabled when the field is read-only.

## Quality assurance

- [x] Added unit test for reset-on-reclick behavior
- [x] Added unit test for dense toggle defaulting to `row dense` when unset
- [x] Added unit test for disabled controls when `canEdit` is false
- [x] Existing grid auto flow field tests pass

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://elementor.slack.com/archives/C0AAX7NQY1J/p1782314963957129?thread_ts=1782314963.957129&cid=C0AAX7NQY1J)

<div><a href="https://cursor.com/agents/bc-1da6a4bf-8147-5dfa-b94b-9857d3ffd822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1da6a4bf-8147-5dfa-b94b-9857d3ffd822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Grid auto-flow CSS field needs nullable state support and permission-based control. Users should be able to reset to default by re-clicking selected direction.

## 2. What Changed (Where)

- **grid-auto-flow-field.tsx**: Added `useBoundProp` import; modified `parseAutoFlow` return type to allow `null` direction; refactored `handleDirectionChange` to call `setValue(null)` on deselection; added `canEdit` check and placeholder support; implemented fallback to 'row' in `handleDenseToggle`.
- **grid-auto-flow-field.test.tsx**: Added `useBoundProp` mock and `beforeEach` setup; added 3 new test cases covering reset-on-reclick, dense-without-direction, and disabled-state scenarios.

## 3. How It Works

User clicks active direction button → `handleDirectionChange` receives `null` → sets value to `null` (reset). Dense toggle now defaults to 'row' if no direction exists. Both controls respect `canEdit` flag from styles field hook. Placeholder flows through from bound prop for preview state.

## 4. Risks

Null handling in `parseAutoFlow` changes return type signature — callers must handle nullable `direction`. Ensure all call sites expect `AutoFlowDirection | null`. Dense toggle defaulting to 'row' is implicit; document or add explicit constant.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
