### PR TITLE
Fix: Cherry-pick PR 36196 to 4.01: Ensure await for angieSDK readiness [ED-24517]

### DIFF
--- a/packages/packages/libs/editor-mcp/src/__tests__/init.test.ts
+++ b/packages/packages/libs/editor-mcp/src/__tests__/init.test.ts
@@ -60,8 +60,7 @@ describe( 'startMCPServer', () => {
 		setModelContext( navigator, navigatorModelContext );
 
 		// Act.
-		startMCPServer();
-		await Promise.resolve();
+		await startMCPServer();
 
 		// Assert.
 		expect( registerMcpAdapter ).toHaveBeenCalledTimes( 1 );
@@ -77,8 +76,7 @@ describe( 'startMCPServer', () => {
 		setModelContext( navigator, navigatorModelContext );
 
 		// Act.
-		startMCPServer();
-		await Promise.resolve();
+		await startMCPServer();
 
 		// Assert.
 		expect( registerMcpAdapter ).toHaveBeenCalledTimes( 1 );

--- a/packages/packages/libs/editor-mcp/src/__tests__/init.test.ts
+++ b/packages/packages/libs/editor-mcp/src/__tests__/init.test.ts
@@ -1,0 +1,89 @@
+import { type ModelContext, WebMCPAdapter } from '../adapters/web-mcp-adapter';
+import { startMCPServer } from '../init';
+import { activateAdapters, registerMcpAdapter, signalMcpReady } from '../mcp-registry';
+
+jest.mock( '../mcp-registry', () => ( {
+	activateAdapters: jest.fn( () => Promise.resolve() ),
+	registerMcpAdapter: jest.fn(),
+	signalMcpReady: jest.fn(),
+} ) );
+
+jest.mock( '../utils/get-sdk', () => ( {
+	getSDK: jest.fn(),
+} ) );
+
+jest.mock( '../utils/is-angie-available', () => ( {
+	isAngieAvailable: jest.fn( () => false ),
+} ) );
+
+const createModelContext = (): ModelContext => ( {
+	registerTool: jest.fn(),
+	unregisterTool: jest.fn(),
+} );
+
+const setModelContext = ( target: object, modelContext: ModelContext ): void => {
+	Object.defineProperty( target, 'modelContext', {
+		configurable: true,
+		value: modelContext,
+	} );
+};
+
+const deleteModelContext = ( target: object ): void => {
+	Reflect.deleteProperty( target, 'modelContext' );
+};
+
+const getRegisteredWebMCPAdapterContext = (): ModelContext => {
+	const mockRegisterMcpAdapter = jest.mocked( registerMcpAdapter );
+	const adapter = mockRegisterMcpAdapter.mock.calls[ 0 ][ 0 ];
+
+	expect( adapter ).toBeInstanceOf( WebMCPAdapter );
+
+	return ( adapter as unknown as { ctx: ModelContext } ).ctx;
+};
+
+describe( 'startMCPServer', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	afterEach( () => {
+		deleteModelContext( document );
+		deleteModelContext( navigator );
+	} );
+
+	it( 'prefers the document model context when it is available', async () => {
+		// Arrange.
+		const documentModelContext = createModelContext();
+		const navigatorModelContext = createModelContext();
+
+		setModelContext( document, documentModelContext );
+		setModelContext( navigator, navigatorModelContext );
+
+		// Act.
+		startMCPServer();
+		await Promise.resolve();
+
+		// Assert.
+		expect( registerMcpAdapter ).toHaveBeenCalledTimes( 1 );
+		expect( getRegisteredWebMCPAdapterContext() ).toBe( documentModelContext );
+		expect( activateAdapters ).toHaveBeenCalledTimes( 1 );
+		expect( signalMcpReady ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'falls back to the navigator model context for older browser support', async () => {
+		// Arrange.
+		const navigatorModelContext = createModelContext();
+
+		setModelContext( navigator, navigatorModelContext );
+
+		// Act.
+		startMCPServer();
+		await Promise.resolve();
+
+		// Assert.
+		expect( registerMcpAdapter ).toHaveBeenCalledTimes( 1 );
+		expect( getRegisteredWebMCPAdapterContext() ).toBe( navigatorModelContext );
+		expect( activateAdapters ).toHaveBeenCalledTimes( 1 );
+		expect( signalMcpReady ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/packages/packages/libs/editor-mcp/src/init.ts
+++ b/packages/packages/libs/editor-mcp/src/init.ts
@@ -15,8 +15,9 @@ export function startMCPServer() {
 		registerMcpAdapter( new AngieMcpAdapter( getSDK() ) );
 	}
 
-	activateAdapters();
-	signalMcpReady();
+	activateAdapters().then( () => {
+		signalMcpReady();
+	} );
 }
 
 if ( typeof document !== 'undefined' ) {

--- a/packages/packages/libs/editor-mcp/src/init.ts
+++ b/packages/packages/libs/editor-mcp/src/init.ts
@@ -15,9 +15,7 @@ export function startMCPServer() {
 		registerMcpAdapter( new AngieMcpAdapter( getSDK() ) );
 	}
 
-	activateAdapters().then( () => {
-		signalMcpReady();
-	} );
+	return activateAdapters().then( () => signalMcpReady() );
 }
 
 if ( typeof document !== 'undefined' ) {

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -50,8 +50,7 @@ export const registerMcpAdapter = ( adapter: IMcpRegistrationAdapter ): void => 
 
 export const signalMcpReady = (): void => resolveReady();
 
-export const activateAdapters = (): Promise< void > =>
-	callAdapters( ( adapter ) => Promise.resolve( adapter.activate() ) );
+export const activateAdapters = (): Promise< void > => callAdapters( ( adapter ) => adapter.activate() );
 
 async function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => void | Promise< void > ) {
 	for ( const adapter of registrationAdapters ) {

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -50,12 +50,12 @@ export const registerMcpAdapter = ( adapter: IMcpRegistrationAdapter ): void => 
 
 export const signalMcpReady = (): void => resolveReady();
 
-export const activateAdapters = (): void => callAdapters( ( adapter ) => adapter.activate() );
+export const activateAdapters = () => callAdapters( async ( adapter ) => adapter.activate() );
 
-function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => void ): void {
-	for ( const adapter of registrationAdapters ) {
+async function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => Promise< void > ) {
+	for await ( const adapter of registrationAdapters ) {
 		try {
-			fn( adapter );
+			await fn( adapter );
 		} catch {
 			// adapter failed — exit quietly, continue to next
 		}

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -50,12 +50,13 @@ export const registerMcpAdapter = ( adapter: IMcpRegistrationAdapter ): void => 
 
 export const signalMcpReady = (): void => resolveReady();
 
-export const activateAdapters = () => callAdapters( async ( adapter ) => adapter.activate() );
+export const activateAdapters = (): Promise< void > =>
+	callAdapters( ( adapter ) => Promise.resolve( adapter.activate() ) );
 
-async function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => Promise< void > ) {
-	for await ( const adapter of registrationAdapters ) {
+async function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => void | Promise< void > ) {
+	for ( const adapter of registrationAdapters ) {
 		try {
-			await fn( adapter );
+			await Promise.resolve( fn( adapter ) );
 		} catch {
 			// adapter failed — exit quietly, continue to next
 		}


### PR DESCRIPTION
Cherry-pick of #36196 onto `4.01`.

## Commits
- `a45bee0` Fix: Ensure await for angieSDK readiness [ED-24517]
- `ffcea56` fixing type
- `d224d25` removing extra promise, correct signature

## Conflicts resolved
- `packages/packages/libs/editor-mcp/src/__tests__/init.test.ts` — kept modified version from PR (file was deleted in 4.01)

Made with [Cursor](https://cursor.com)

[ED-24517]: https://elementor.atlassian.net/browse/ED-24517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

MCP adapter activation was fire-and-forget, risking race conditions where `signalMcpReady()` fired before adapters actually finished initializing. This ensures async completion before signaling readiness (ED-24517).

## 2. What Changed (Where)

- **init.ts**: `startMCPServer()` now returns a promise chain awaiting `activateAdapters()` then `signalMcpReady()`
- **mcp-registry.ts**: `activateAdapters()` converted to async, `callAdapters()` now awaits adapter promises, handles sync/async uniformly
- **init.test.ts**: Added test coverage for initialization sequencing and context resolution

## 3. How It Works

`startMCPServer()` registers adapters, chains promise: `activateAdapters()` iterates registered adapters calling `adapter.activate()` with `await Promise.resolve()` to handle both sync and async implementations, then `signalMcpReady()` fires only after all complete.

## 4. Risks

Callers must now await `startMCPServer()` or handle promise rejection; existing fire-and-forget calls silently break. Mitigation: DOMContentLoaded and else branches both execute async context correctly, tests validate sequencing.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
