### PR TITLE
Fix: Cherry-pick PR 36196 to 4.02: Ensure await for angieSDK readiness [ED-24517]

### DIFF
--- a/packages/packages/libs/editor-mcp/src/__tests__/init.test.ts
+++ b/packages/packages/libs/editor-mcp/src/__tests__/init.test.ts
@@ -77,7 +77,7 @@ describe( 'startMCPServer', () => {
 		deleteModelContext( navigator );
 	} );
 
-	it( 'prefers the document model context when it is available', () => {
+	it( 'prefers the document model context when it is available', async () => {
 		// Arrange.
 		const documentModelContext = createModelContext();
 		const navigatorModelContext = createModelContext();
@@ -87,6 +87,7 @@ describe( 'startMCPServer', () => {
 
 		// Act.
 		startMCPServer();
+		await Promise.resolve();
 
 		// Assert.
 		expect( mockRegisterMcpAdapter ).toHaveBeenCalledTimes( 1 );
@@ -94,7 +95,7 @@ describe( 'startMCPServer', () => {
 		expect( mockSignalMcpReady ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'falls back to the navigator model context for older browser support', () => {
+	it( 'falls back to the navigator model context for older browser support', async () => {
 		// Arrange.
 		const navigatorModelContext = createModelContext();
 
@@ -102,6 +103,7 @@ describe( 'startMCPServer', () => {
 
 		// Act.
 		startMCPServer();
+		await Promise.resolve();
 
 		// Assert.
 		expect( mockRegisterMcpAdapter ).toHaveBeenCalledTimes( 1 );

--- a/packages/packages/libs/editor-mcp/src/__tests__/init.test.ts
+++ b/packages/packages/libs/editor-mcp/src/__tests__/init.test.ts
@@ -86,8 +86,7 @@ describe( 'startMCPServer', () => {
 		setModelContext( navigator, navigatorModelContext );
 
 		// Act.
-		startMCPServer();
-		await Promise.resolve();
+		await startMCPServer();
 
 		// Assert.
 		expect( mockRegisterMcpAdapter ).toHaveBeenCalledTimes( 1 );
@@ -102,8 +101,7 @@ describe( 'startMCPServer', () => {
 		setModelContext( navigator, navigatorModelContext );
 
 		// Act.
-		startMCPServer();
-		await Promise.resolve();
+		await startMCPServer();
 
 		// Assert.
 		expect( mockRegisterMcpAdapter ).toHaveBeenCalledTimes( 1 );

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -76,7 +76,7 @@ export const createAndRegisterAdapters = () => {
 function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => unknown ) {
 	for ( const adapter of registrationAdapters ) {
 		try {
-			await fn( adapter );
+			await Promise.resolve( fn( adapter ) );
 		} catch {
 			// adapter failed — exit quietly, continue to next
 		}

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -73,8 +73,8 @@ export const createAndRegisterAdapters = () => {
 };
 
 // utility function to run a callback on all MCP interfaces
-function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => unknown ) {
-	for ( const adapter of registrationAdapters ) {
+async function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => unknown ) {
+	for await ( const adapter of registrationAdapters ) {
 		try {
 			await Promise.resolve( fn( adapter ) );
 		} catch {

--- a/packages/packages/libs/editor-mcp/src/mcp-registry.ts
+++ b/packages/packages/libs/editor-mcp/src/mcp-registry.ts
@@ -76,7 +76,7 @@ export const createAndRegisterAdapters = () => {
 function callAdapters( fn: ( adapter: IMcpRegistrationAdapter ) => unknown ) {
 	for ( const adapter of registrationAdapters ) {
 		try {
-			fn( adapter );
+			await fn( adapter );
 		} catch {
 			// adapter failed — exit quietly, continue to next
 		}


### PR DESCRIPTION
Cherry-pick of #36196 onto `4.02`.

## Commits
- `a45bee0` Fix: Ensure await for angieSDK readiness [ED-24517]
- `ffcea56` fixing type
- `d224d25` removing extra promise, correct signature

## Conflicts resolved
- `packages/packages/libs/editor-mcp/src/init.ts` — content conflicts (all 3 commits)
- `packages/packages/libs/editor-mcp/src/mcp-registry.ts` — content conflicts (all 3 commits)
- `packages/packages/libs/editor-mcp/src/__tests__/init.test.ts` — content conflicts (commits 2 & 3)

Made with [Cursor](https://cursor.com)

[ED-24517]: https://elementor.atlassian.net/browse/ED-24517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick of PR 36196 to 4.02 branch. Ensures angieSDK readiness is properly awaited before callbacks execute, preventing race conditions where adapters run before initialization completes (ED-24517).

## 2. What Changed (Where)

- `mcp-registry.ts`: `callAdapters()` converted to async function with `for await` loop and `await Promise.resolve()` wrapping callback execution.
- `init.test.ts`: Test cases updated to async and now `await startMCPServer()` to match async behavior.

## 3. How It Works

`callAdapters()` now sequentially awaits each adapter callback, ensuring completion before proceeding. Tests validate that `startMCPServer()` properly awaits initialization before assertions run, catching timing issues that synchronous execution would miss.

## 4. Risks

Minimal—straightforward async conversion of callback loop. Only risk is if callers of `callAdapters()` aren't awaiting the result, but that's a caller-side issue outside this diff scope.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
