### PR TITLE
Fix: Cherry-pick 36291 to 4.02 - What's New media support [ED-24716]

### DIFF
--- a/modules/notifications/assets/js/components/whats-new-item-media.js
+++ b/modules/notifications/assets/js/components/whats-new-item-media.js
@@ -1,0 +1,38 @@
+/* eslint-disable react/prop-types */
+import { Box } from '@elementor/ui';
+import { WhatsNewItemThumbnail } from './whats-new-item-thumbnail';
+
+export const WhatsNewItemMedia = ( { item } ) => {
+	if ( item.youtubeEmbedId ) {
+		const videoId = item.youtubeEmbedId.split( '?' )[ 0 ];
+		const src = `https://www.youtube.com/embed/${ videoId }${ item.youtubeAutoplay ? '?autoplay=1&mute=1' : '' }`;
+		const allow = `encrypted-media; picture-in-picture${ item.youtubeAutoplay ? '; autoplay' : '' }`;
+
+		return (
+			<Box sx={ { pb: 2 } }>
+				<Box
+					component="iframe"
+					src={ src }
+					title={ item.title }
+					allow={ allow }
+					allowFullScreen={ true }
+					sx={ { aspectRatio: '16/9', width: '100%', display: 'block', border: 'none' } }
+				/>
+			</Box>
+		);
+	}
+
+	const mediaSrc = item.gifSrc || item.imageSrc;
+
+	if ( ! mediaSrc ) {
+		return null;
+	}
+
+	return (
+		<WhatsNewItemThumbnail
+			imageSrc={ mediaSrc }
+			link={ item.link }
+			title={ item.title }
+		/>
+	);
+};

--- a/modules/notifications/assets/js/components/whats-new-item.js
+++ b/modules/notifications/assets/js/components/whats-new-item.js
@@ -1,7 +1,7 @@
 import { Box, Button, Divider, Link, Typography } from '@elementor/ui';
 import { WhatsNewItemTopicLine } from './whats-new-item-topic-line';
 import { WrapperWithLink } from './wrapper-with-link';
-import { WhatsNewItemThumbnail } from './whats-new-item-thumbnail';
+import { WhatsNewItemMedia } from './whats-new-item-media';
 import { WhatsNewItemChips } from './whats-new-item-chips';
 
 export const WhatsNewItem = ( { item, itemIndex, itemsLength, setIsOpen } ) => {
@@ -30,13 +30,7 @@ export const WhatsNewItem = ( { item, itemIndex, itemsLength, setIsOpen } ) => {
 					{ item.title }
 				</Typography>
 			</WrapperWithLink>
-			{ item.imageSrc && (
-				<WhatsNewItemThumbnail
-					imageSrc={ item.imageSrc }
-					link={ item.link }
-					title={ item.title }
-				/>
-			) }
+			<WhatsNewItemMedia item={ item } />
 
 			<WhatsNewItemChips
 				chipPlan={ item.chipPlan }


### PR DESCRIPTION
Cherry-pick of #36291 to the `4.02` release branch.

Adds YouTube embed and GIF support to What's New notifications (`youtubeEmbedId`, `youtubeAutoplay`, `gifSrc` fields + new `WhatsNewItemMedia` component).

Original PR: #36291
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick to 4.02 branch adding YouTube embed and GIF support to What's New notifications, replacing thumbnail-only display. Enables richer media previews for feature announcements.

## 2. What Changed (Where)

- **whats-new-item-media.js** (new): Abstracted media rendering logic handling YouTube embeds with autoplay/mute controls, GIF, and image fallbacks
- **whats-new-item.js**: Replaced inline thumbnail conditional with `WhatsNewItemMedia` component; removed direct `WhatsNewItemThumbnail` import

## 3. How It Works

Component checks `youtubeEmbedId` first, constructs iframe with sanitized videoId and conditional autoplay params; falls back to GIF or image via `WhatsNewItemThumbnail`. Returns null if no media present.

## 4. Risks

YouTube embed allows fullscreen—validate `item.youtubeEmbedId` format server-side to prevent XSS. Missing `item.link` handling for media click-through (GIF/image reliance on thumbnail component).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
