### PR TITLE
Fix: Cherry-pick 36333 to 4.02: Fix phpunit `Test_Post_Query` flaky test [ED-24789]

### DIFF
--- a/tests/phpunit/elementor/modules/wp-rest/providers/post-query.php
+++ b/tests/phpunit/elementor/modules/wp-rest/providers/post-query.php
@@ -32,6 +32,7 @@ trait Post_Query {
 	protected function init() {
 		$this->register_post_types();
 		$this->create_posts();
+		$this->set_deterministic_modified_times();
 		$this->create_and_set_post_term();
 	}
 
@@ -80,6 +81,23 @@ trait Post_Query {
 			'post_status' => $status,
 			'post_type' => $post_type,
 		], $extra_args ) );
+	}
+
+	private function set_deterministic_modified_times() {
+		global $wpdb;
+
+		foreach ( $this->posts as $index => $post ) {
+			$time = gmdate( 'Y-m-d H:i:s', strtotime( "-{$index} minutes" ) );
+			$wpdb->update(
+				$wpdb->posts,
+				[
+					'post_modified' => $time,
+					'post_modified_gmt' => $time,
+				],
+				[ 'ID' => $post->ID ]
+			);
+			clean_post_cache( $post->ID );
+		}
 	}
 
 	private function create_and_set_post_term() {


### PR DESCRIPTION
Cherry-pick of https://github.com/elementor/elementor/pull/36333 to the 4.02 release branch.
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Test flakiness in `Test_Post_Query` caused by non-deterministic post modified timestamps. The fixture now ensures predictable ordering by setting staggered modification times during setup.

## 2. What Changed (Where)

- `tests/phpunit/elementor/modules/wp-rest/providers/post-query.php`: Added `set_deterministic_modified_times()` method called during `init()`, assigns decreasing modified timestamps to posts via direct DB update.

## 3. How It Works

During test fixture initialization, each created post gets a modified timestamp offset by its index (post 0 = now, post 1 = now-1min, etc.). Direct `wpdb->update()` bypasses WordPress hooks, then `clean_post_cache()` ensures consistency. Guarantees reproducible query ordering.

## 4. Risks

None — isolated to test infrastructure with deterministic side effects. No production code touched.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
