### PR TITLE
Internal: Remove "For Elementor" link [ED-24510]

### DIFF
--- a/modules/apps/module.php
+++ b/modules/apps/module.php
@@ -32,11 +32,6 @@ class Module extends BaseModule {
 
 			return $categories;
 		} );
-
-		// Add the Elementor Apps link to the plugin install action links.
-		add_filter( 'install_plugins_tabs', [ $this, 'add_elementor_plugin_install_action_link' ] );
-		add_action( 'install_plugins_pre_elementor', [ $this, 'maybe_open_elementor_tab' ] );
-		add_action( 'admin_print_styles-plugin-install.php', [ $this, 'add_plugins_page_styles' ] );
 	}
 
 	public function enqueue_assets() {
@@ -56,44 +51,4 @@ class Module extends BaseModule {
 		return $admin_body_classes;
 	}
 
-	public function add_elementor_plugin_install_action_link( $tabs ) {
-		$tabs['elementor'] = esc_html__( 'For Elementor', 'elementor' );
-
-		return $tabs;
-	}
-
-	public function maybe_open_elementor_tab() {
-		if ( ! isset( $_GET['tab'] ) || 'elementor' !== $_GET['tab'] ) {
-			return;
-		}
-
-		$elementor_url = add_query_arg( [
-			'page' => static::PAGE_ID,
-			'tab' => 'elementor',
-			'ref' => 'plugins',
-		], admin_url( 'admin.php' ) );
-
-		wp_safe_redirect( $elementor_url );
-		exit;
-	}
-
-	public function add_plugins_page_styles() {
-		?>
-		<style>
-			.plugin-install-elementor > a::after {
-				content: "";
-				display: inline-block;
-				background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8.33321 3H12.9999V7.66667H11.9999V4.70711L8.02009 8.68689L7.31299 7.97978L11.2928 4H8.33321V3Z' fill='%23646970'/%3E%3Cpath d='M6.33333 4.1665H4.33333C3.8731 4.1665 3.5 4.5396 3.5 4.99984V11.6665C3.5 12.1267 3.8731 12.4998 4.33333 12.4998H11C11.4602 12.4998 11.8333 12.1267 11.8333 11.6665V9.6665' stroke='%23646970'/%3E%3C/svg%3E%0A");
-				width: 16px;
-				height: 16px;
-				background-repeat: no-repeat;
-				vertical-align: text-top;
-				margin-left: 2px;
-			}
-			.plugin-install-elementor:hover > a::after {
-				background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8.33321 3H12.9999V7.66667H11.9999V4.70711L8.02009 8.68689L7.31299 7.97978L11.2928 4H8.33321V3Z' fill='%23135E96'/%3E%3Cpath d='M6.33333 4.1665H4.33333C3.8731 4.1665 3.5 4.5396 3.5 4.99984V11.6665C3.5 12.1267 3.8731 12.4998 4.33333 12.4998H11C11.4602 12.4998 11.8333 12.1267 11.8333 11.6665V9.6665' stroke='%23135E96'/%3E%3C/svg%3E%0A");
-			}
-		</style>
-		<?php
-	}
 }

--- a/modules/apps/module.php
+++ b/modules/apps/module.php
@@ -1,9 +1,7 @@
 <?php
 namespace Elementor\Modules\Apps;
 
-use Elementor\Core\Admin\Menu\Admin_Menu_Manager;
 use Elementor\Core\Base\Module as BaseModule;
-use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -50,5 +48,4 @@ class Module extends BaseModule {
 
 		return $admin_body_classes;
 	}
-
 }


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Remove tabs fro plugin install screen

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Removing the "For Elementor" plugin install tab and associated redirect logic per ED-24510. Simplifies the plugin installation flow by eliminating unnecessary navigation layer.

## 2. What Changed (Where)

- `modules/apps/module.php`: Removed unused imports (`Admin_Menu_Manager`, `Plugin`), three action/filter hooks for the Elementor tab, and three methods (`add_elementor_plugin_install_action_link`, `maybe_open_elementor_tab`, `add_plugins_page_styles`) totaling 41 lines.

## 3. How It Works

The module's `register` hook previously injected a custom "For Elementor" tab into WordPress plugin install pages, intercepting clicks to redirect to the Elementor Apps admin page. That entire flow is now removed; the module focuses solely on enqueueing assets and managing app categories.

## 4. Risks

None identified—this is a feature removal with no downstream dependencies in the diff. If external code hooks into the removed methods or filters, it will silently fail, but that's expected for intentional feature removal.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
