### PR TITLE
Feat(notifications): [ED-XXXXX] What's New — featured item hero + also-new accordion

### DIFF
--- a/modules/notifications/assets/js/components/bar-button-notification.js
+++ b/modules/notifications/assets/js/components/bar-button-notification.js
@@ -1,48 +1,78 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { WhatsNew } from './whats-new';
-import { Badge } from '@elementor/ui';
+import { Box } from '@elementor/ui';
+
+const floatUpKeyframes = `
+@keyframes e-notification-badge-float {
+	0%   { transform: translateY( 6px ); opacity: 0; }
+	60%  { transform: translateY( -3px ); opacity: 1; }
+	100% { transform: translateY( 0 ); opacity: 1; }
+}
+`;
+
+const badgeSx = {
+	position: 'absolute',
+	top: -8,
+	insetInlineEnd: -8,
+	backgroundColor: 'primary.main',
+	color: 'primary.contrastText',
+	borderRadius: '10px',
+	minWidth: '18px',
+	height: '18px',
+	fontSize: '0.65rem',
+	fontWeight: 700,
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	lineHeight: 1,
+	padding: '0 4px',
+	animation: 'e-notification-badge-float 0.45s ease-out 0.3s both',
+};
 
 export const BarButtonNotification = ( props ) => {
-	const { defaultIsRead } = props;
-
 	const [ isOpen, setIsOpen ] = useState( false );
-	const [ isRead, setIsRead ] = useState( defaultIsRead );
+	const [ unreadCount, setUnreadCount ] = useState( window.elementorNotifications?.unread_count ?? 0 );
+
+	useEffect( () => {
+		const handler = () => setUnreadCount( ( prev ) => Math.max( 0, prev - 1 ) );
+		window.addEventListener( 'e-notification-item-seen', handler );
+		return () => window.removeEventListener( 'e-notification-item-seen', handler );
+	}, [] );
+
+	const handleOpen = ( event ) => {
+		event.preventDefault();
+		setIsOpen( true );
+	};
 
 	// TODO: This is a temporary solution until we have a proper admin bar component.
 	return (
 		<>
+			{ unreadCount > 0 && <style>{ floatUpKeyframes }</style> }
 			<button
 				className="e-admin-top-bar__bar-button"
 				style={ {
 					backgroundColor: 'transparent',
 					border: 'none',
 				} }
-				onClick={ ( event ) => {
-					event.preventDefault();
-
-					setIsOpen( true );
-				} }
+				onClick={ handleOpen }
 			>
-				<Badge
-					color="primary"
-					variant="dot"
-					invisible={ isRead }
-					sx={ {
-						mx: 0.5,
-					} }
-				>
+				<Box sx={ { mx: 0.5, position: 'relative', display: 'inline-flex' } }>
 					<i className="e-admin-top-bar__bar-button-icon eicon-speakerphone"></i>
-				</Badge>
+					{ unreadCount > 0 && (
+						<Box component="span" sx={ badgeSx }>
+							{ unreadCount }
+						</Box>
+					) }
+				</Box>
 				<span className="e-admin-top-bar__bar-button-title">
 					{ props.children }
 				</span>
 			</button>
-			<WhatsNew isOpen={ isOpen } setIsOpen={ setIsOpen } setIsRead={ setIsRead } />
+			<WhatsNew isOpen={ isOpen } setIsOpen={ setIsOpen } setIsRead={ () => {} } />
 		</>
 	);
 };
 
 BarButtonNotification.propTypes = {
-	defaultIsRead: PropTypes.bool,
 	children: PropTypes.any.isRequired,
 };

--- a/modules/notifications/assets/js/components/editor-app-bar-link.js
+++ b/modules/notifications/assets/js/components/editor-app-bar-link.js
@@ -1,20 +1,55 @@
 import * as EditorAppBar from '@elementor/editor-app-bar';
 import { editorOnButtonClicked } from './editor-on-button-clicked';
-import { Badge } from '@elementor/ui';
+import { Box } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import SpeakerphoneIcon from '@elementor/icons/SpeakerphoneIcon';
 
-const IconWithBadge = ( { invisible } ) => {
+const floatUpKeyframes = `
+@keyframes e-notification-badge-float {
+	0%   { transform: translateY( 6px ); opacity: 0; }
+	60%  { transform: translateY( -3px ); opacity: 1; }
+	100% { transform: translateY( 0 ); opacity: 1; }
+}
+`;
+
+const badgeSx = {
+	position: 'absolute',
+	top: -8,
+	insetInlineEnd: -8,
+	backgroundColor: 'primary.main',
+	color: 'primary.contrastText',
+	borderRadius: '10px',
+	minWidth: '18px',
+	height: '18px',
+	fontSize: '0.65rem',
+	fontWeight: 700,
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	lineHeight: 1,
+	padding: '0 4px',
+	animation: 'e-notification-badge-float 0.45s ease-out 0.3s both',
+};
+
+const IconWithBadge = ( { count } ) => {
 	return (
-		<Badge color="primary" variant="dot" invisible={ invisible }>
-			<SpeakerphoneIcon />
-		</Badge>
+		<>
+			{ count > 0 && <style>{ floatUpKeyframes }</style> }
+			<Box sx={ { position: 'relative', display: 'inline-flex' } }>
+				<SpeakerphoneIcon />
+				{ count > 0 && (
+					<Box component="span" sx={ badgeSx }>
+						{ count }
+					</Box>
+				) }
+			</Box>
+		</>
 	);
 };
 
 IconWithBadge.propTypes = {
-	invisible: PropTypes.bool,
+	count: PropTypes.number,
 };
 
 export const editorAppBarLink = () => {
@@ -24,11 +59,17 @@ export const editorAppBarLink = () => {
 		id: 'app-bar-menu-item-whats-new',
 		priority: 10,
 		useProps: () => {
-			const [ isRead, setIsRead ] = useState( ! elementorNotifications.is_unread );
+			const [ unreadCount, setUnreadCount ] = useState( elementorNotifications.unread_count ?? 0 );
+
+			useEffect( () => {
+				const handler = () => setUnreadCount( ( prev ) => Math.max( 0, prev - 1 ) );
+				window.addEventListener( 'e-notification-item-seen', handler );
+				return () => window.removeEventListener( 'e-notification-item-seen', handler );
+			}, [] );
 
 			return {
 				title: __( "What's New", 'elementor' ),
-				icon: () => <IconWithBadge invisible={ isRead } />,
+				icon: () => <IconWithBadge count={ unreadCount } />,
 				onClick: () => {
 					elementorCommon.eventsManager.dispatchEvent(
 						elementorCommon.eventsManager.config.names.topBar.whatsNew,
@@ -39,9 +80,6 @@ export const editorAppBarLink = () => {
 							element: elementorCommon.eventsManager.config.elements.buttonIcon,
 						},
 					);
-
-					setIsRead( true );
-					elementorNotifications.is_unread = false;
 
 					editorOnButtonClicked( 'right' );
 				},

--- a/modules/notifications/assets/js/components/editor-v1.js
+++ b/modules/notifications/assets/js/components/editor-v1.js
@@ -2,7 +2,7 @@ import { editorOnButtonClicked } from './editor-on-button-clicked';
 
 export const editorV1 = () => {
 	elementor.on( 'panel:init', () => {
-		if ( elementorNotifications.is_unread ) {
+		if ( elementorNotifications.unread_count > 0 ) {
 			document.body.classList.add( 'e-has-notification' );
 		}
 

--- a/modules/notifications/assets/js/components/whats-new-drawer-content.js
+++ b/modules/notifications/assets/js/components/whats-new-drawer-content.js
@@ -1,13 +1,35 @@
+/* eslint-disable react/prop-types */
+import { useEffect } from 'react';
 import { useQuery } from '@elementor/query';
 import { getNotifications } from '../api';
-import { Box, LinearProgress } from '@elementor/ui';
+import { Box, Divider, LinearProgress, Typography } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
 import { WhatsNewItem } from './whats-new-item';
+import { WhatsNewItemCollapsed } from './whats-new-item-collapsed';
 
-export const WhatsNewDrawerContent = ( { setIsOpen } ) => {
+export const WhatsNewDrawerContent = ( { setIsOpen, seenItemIds, onSeen, initialHasUnread } ) => {
 	const { isPending, error, data: items } = useQuery( {
 		queryKey: [ 'e-notifications' ],
 		queryFn: getNotifications,
 	} );
+
+	// Auto-mark fully-visible items as seen so they don't inflate the badge.
+	// - Featured items: always visible in the hero section.
+	// - Regular items (no featured exist): all fully visible as expanded cards.
+	// The seenItemIds check prevents re-dispatching on subsequent drawer opens.
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	useEffect( () => {
+		if ( ! items ) {
+			return;
+		}
+		const hasFeatured = items.some( ( item ) => item.featured );
+		const fullyVisibleItems = hasFeatured
+			? items.filter( ( item ) => item.featured )
+			: items;
+		fullyVisibleItems
+			.filter( ( item ) => ! seenItemIds.has( item.id ) )
+			.forEach( ( item ) => onSeen( item.id ) );
+	}, [ items ] );
 
 	if ( isPending ) {
 		return (
@@ -27,21 +49,53 @@ export const WhatsNewDrawerContent = ( { setIsOpen } ) => {
 		);
 	}
 
+	const featuredItems = items.filter( ( item ) => item.featured );
+	const alsoNewItems = featuredItems.length > 0 ? items.filter( ( item ) => ! item.featured ) : [];
+	const regularItems = featuredItems.length > 0 ? [] : items;
+
 	return (
-		items.map( ( item, itemIndex ) => {
-			return (
+		<>
+			{ featuredItems.map( ( item, index ) => (
+				<WhatsNewItem
+					key={ index }
+					item={ item }
+					itemIndex={ index }
+					itemsLength={ featuredItems.length }
+					setIsOpen={ setIsOpen }
+					featured={ true }
+				/>
+			) ) }
+			{ alsoNewItems.length > 0 && (
+				<>
+					<Divider sx={ { my: 1.5 } }>
+						<Typography
+							variant="caption"
+							color="text.secondary"
+							sx={ { px: 1, textTransform: 'uppercase', letterSpacing: '0.08em' } }
+						>
+							{ __( 'Also new', 'elementor' ) }
+						</Typography>
+					</Divider>
+					{ alsoNewItems.map( ( item, index ) => (
+						<WhatsNewItemCollapsed
+							key={ index }
+							item={ item }
+							itemIndex={ index }
+							isNew={ initialHasUnread && ! seenItemIds.has( item.id ) }
+							onSeen={ () => onSeen( item.id ) }
+						/>
+					) ) }
+				</>
+			) }
+			{ regularItems.map( ( item, itemIndex ) => (
 				<WhatsNewItem
 					key={ itemIndex }
 					item={ item }
 					itemIndex={ itemIndex }
-					itemsLength={ items.length }
+					itemsLength={ regularItems.length }
 					setIsOpen={ setIsOpen }
 				/>
-			);
-		} )
+			) ) }
+		</>
 	);
-};
-
-WhatsNewDrawerContent.propTypes = {
-	setIsOpen: PropTypes.func.isRequired,
 };

--- a/modules/notifications/assets/js/components/whats-new-item-collapsed.js
+++ b/modules/notifications/assets/js/components/whats-new-item-collapsed.js
@@ -1,0 +1,119 @@
+/* eslint-disable react/prop-types */
+import { useState } from 'react';
+import { Box, Button, Collapse, Divider, Link, Typography } from '@elementor/ui';
+import { ChevronDownIcon } from '@elementor/icons';
+import { WhatsNewItemMedia } from './whats-new-item-media';
+import { WhatsNewItemChips } from './whats-new-item-chips';
+
+export const WhatsNewItemCollapsed = ( { item, itemIndex, isNew, onSeen } ) => {
+	const [ expanded, setExpanded ] = useState( false );
+
+	const handleToggle = () => {
+		if ( ! expanded && onSeen ) {
+			onSeen();
+		}
+		setExpanded( ! expanded );
+	};
+
+	// When a topic line appears above the title, the header row is taller.
+	// top: 50% would land between the two lines, so we pin to the topic line center instead.
+	// py: 1.5 = 12px padding-top, caption line-height ≈ 20px → center at 12 + 10 - 3 (half-dot) = 19px.
+	const dotSx = item.topic
+		? { top: '19px' }
+		: { top: '50%', transform: 'translateY(-50%)' };
+
+	return (
+		<Box>
+			<Box
+				onClick={ handleToggle }
+				sx={ {
+					position: 'relative',
+					display: 'flex',
+					alignItems: 'center',
+					gap: 1,
+					cursor: 'pointer',
+					py: 1.5,
+					paddingInlineStart: 1,
+				} }
+			>
+				<Box
+					component="span"
+					sx={ {
+						position: 'absolute',
+						insetInlineStart: '-6px',
+						...dotSx,
+						width: 6,
+						height: 6,
+						borderRadius: '50%',
+						backgroundColor: 'primary.main',
+						opacity: isNew ? 1 : 0,
+						transition: 'opacity 0.2s ease',
+						pointerEvents: 'none',
+					} }
+				/>
+				<Box sx={ { flex: 1, minWidth: 0 } }>
+					{ item.topic && (
+						<Typography variant="caption" color="text.tertiary" display="block">
+							{ item.topic }
+						</Typography>
+					) }
+					<Typography variant="subtitle2" noWrap>{ item.title }</Typography>
+				</Box>
+				<ChevronDownIcon
+					sx={ {
+						flexShrink: 0,
+						color: 'secondary.main',
+						fontSize: 'small',
+						transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+						transition: 'transform 0.2s',
+					} }
+				/>
+			</Box>
+			<Collapse in={ expanded }>
+				<Box sx={ { pb: 2, paddingInlineStart: 1 } }>
+					<WhatsNewItemMedia item={ item } />
+					<WhatsNewItemChips
+						chipPlan={ item.chipPlan }
+						chipTags={ item.chipTags }
+						itemIndex={ itemIndex }
+					/>
+					{ item.description && (
+						<Typography
+							variant="body2"
+							color="text.secondary"
+							sx={ { pb: 2 } }
+						>
+							{ item.description }
+							{ item.readMoreText && (
+								<>
+									{ ' ' }
+									<Link
+										href={ item.link }
+										color="info.main"
+										target="_blank"
+									>
+										{ item.readMoreText }
+									</Link>
+								</>
+							) }
+						</Typography>
+					) }
+					{ item.cta && item.ctaLink && (
+						<Box sx={ { pb: 2 } }>
+							<Button
+								href={ item.ctaLink }
+								target={ item.ctaLink.startsWith( '#' ) ? '_self' : '_blank' }
+								variant="contained"
+								size="small"
+								color="promotion"
+							>
+								{ item.cta }
+							</Button>
+						</Box>
+					) }
+				</Box>
+			</Collapse>
+			<Divider />
+		</Box>
+	);
+};

--- a/modules/notifications/assets/js/components/whats-new-item.js
+++ b/modules/notifications/assets/js/components/whats-new-item.js
@@ -1,10 +1,12 @@
-import { Box, Button, Divider, Link, Typography } from '@elementor/ui';
+import { Box, Button, Chip, Divider, Link, Typography } from '@elementor/ui';
 import { WhatsNewItemTopicLine } from './whats-new-item-topic-line';
 import { WrapperWithLink } from './wrapper-with-link';
 import { WhatsNewItemMedia } from './whats-new-item-media';
 import { WhatsNewItemChips } from './whats-new-item-chips';
 
-export const WhatsNewItem = ( { item, itemIndex, itemsLength, setIsOpen } ) => {
+export const WhatsNewItem = ( { item, itemIndex, itemsLength, setIsOpen, featured = false } ) => {
+	const hasMedia = item.imageSrc || item.gifSrc || item.youtubeEmbedId;
+
 	return (
 		<Box
 			key={ itemIndex }
@@ -12,6 +14,7 @@ export const WhatsNewItem = ( { item, itemIndex, itemsLength, setIsOpen } ) => {
 			flexDirection="column"
 			sx={ {
 				pt: 2,
+				...( featured && { px: 1 } ),
 			} }
 		>
 			{ ( item.topic || item.date ) && (
@@ -25,15 +28,26 @@ export const WhatsNewItem = ( { item, itemIndex, itemsLength, setIsOpen } ) => {
 					variant="subtitle1"
 					sx={ {
 						pb: 2,
+						...( featured && { fontSize: '1.2rem' } ),
 					} }
 				>
 					{ item.title }
 				</Typography>
 			</WrapperWithLink>
-			<WhatsNewItemMedia item={ item } />
+			<Box sx={ { position: 'relative' } }>
+				<WhatsNewItemMedia item={ item } />
+				{ featured && item.chipPlan && hasMedia && (
+					<Chip
+						label={ item.chipPlan }
+						color="promotion"
+						size="small"
+						sx={ { position: 'absolute', top: 8, left: 8 } }
+					/>
+				) }
+			</Box>
 
 			<WhatsNewItemChips
-				chipPlan={ item.chipPlan }
+				chipPlan={ featured && hasMedia ? null : item.chipPlan }
 				chipTags={ item.chipTags }
 				itemIndex={ itemIndex }
 			/>
@@ -95,4 +109,5 @@ WhatsNewItem.propTypes = {
 	itemIndex: PropTypes.number.isRequired,
 	itemsLength: PropTypes.number.isRequired,
 	setIsOpen: PropTypes.func.isRequired,
+	featured: PropTypes.bool,
 };

--- a/modules/notifications/assets/js/components/whats-new.js
+++ b/modules/notifications/assets/js/components/whats-new.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, DirectionProvider, Drawer, ThemeProvider } from '@elementor/ui';
 import { QueryClient, QueryClientProvider } from '@elementor/query';
 import { WhatsNewTopBar } from './whats-new-top-bar';
@@ -14,8 +14,12 @@ const queryClient = new QueryClient( {
 	},
 } );
 
+// Captured once at page load — reflects PHP's persisted unread state.
+const initialHasUnread = ( window.elementorNotifications?.unread_count ?? 0 ) > 0;
+
 export const WhatsNew = ( props ) => {
 	const { isOpen, setIsOpen, setIsRead, anchorPosition = 'right' } = props;
+	const [ seenItemIds, setSeenItemIds ] = useState( () => new Set() );
 
 	useEffect( () => {
 		if ( ! isOpen ) {
@@ -24,6 +28,11 @@ export const WhatsNew = ( props ) => {
 
 		setIsRead( true );
 	}, [ isOpen, setIsRead ] );
+
+	const handleSeen = ( itemId ) => {
+		setSeenItemIds( ( prev ) => new Set( [ ...prev, itemId ] ) );
+		window.dispatchEvent( new CustomEvent( 'e-notification-item-seen' ) );
+	};
 
 	return (
 		<>
@@ -54,7 +63,12 @@ export const WhatsNew = ( props ) => {
 										padding: '16px',
 									} }
 								>
-									<WhatsNewDrawerContent setIsOpen={ setIsOpen } />
+									<WhatsNewDrawerContent
+										setIsOpen={ setIsOpen }
+										seenItemIds={ seenItemIds }
+										onSeen={ handleSeen }
+										initialHasUnread={ initialHasUnread }
+									/>
 								</Box>
 							</Box>
 						</Drawer>

--- a/modules/notifications/module.php
+++ b/modules/notifications/module.php
@@ -78,7 +78,7 @@ class Module extends BaseModule {
 
 	private function get_app_js_config(): array {
 		return [
-			'is_unread' => Options::has_unread_notifications(),
+			'unread_count' => Options::get_unread_count(),
 		];
 	}
 

--- a/modules/notifications/options.php
+++ b/modules/notifications/options.php
@@ -40,6 +40,27 @@ class Options {
 		return $notifications_dismissed;
 	}
 
+	public static function get_unread_count(): int {
+		$current_user = wp_get_current_user();
+
+		if ( ! $current_user ) {
+			return 0;
+		}
+
+		$unread_notifications = get_transient( "elementor_unread_notifications_{$current_user->ID}" );
+
+		if ( false === $unread_notifications ) {
+			$notifications = API::get_notifications_by_conditions();
+			$notifications_ids = wp_list_pluck( $notifications, 'id' );
+
+			$unread_notifications = array_diff( $notifications_ids, static::get_notifications_dismissed() );
+
+			set_transient( "elementor_unread_notifications_{$current_user->ID}", $unread_notifications, HOUR_IN_SECONDS );
+		}
+
+		return count( $unread_notifications );
+	}
+
 	public static function mark_notification_read( $notifications ): bool {
 		$current_user = wp_get_current_user();
 


### PR DESCRIPTION
## Summary

- Adds a **featured item hero** layout at the top of the What's New drawer — large image, title, optional plan chip overlay, and CTA button
- Adds an **"Also new" collapsed accordion** section for all non-featured items, each with expand/collapse (chevron icon) and a per-item unread dot
- Badge (admin bar + editor app bar) now decrements per item via a `e-notification-item-seen` window event — no 9+ cap, corner-overlap position
- `seenItemIds` state lifted to `WhatsNew` so it survives drawer close/reopen within a session
- `initialHasUnread` flag (captured once at page load from PHP) suppresses dots after a page refresh when there are no unread items
- Fully-visible items (featured hero + all items when no featured exist) are auto-marked as seen on drawer open so the badge clears correctly

## Test plan

- [ ] Reset notifications via `?reset_notifications=1`, reload — badge shows unread count
- [ ] Open What's New drawer — featured item renders as hero with image; remaining items in "Also new" collapsed list with blue dots
- [ ] Expand a collapsed item — its dot disappears, badge decrements by 1
- [ ] Close and reopen drawer — expanded items remain without dots; unexpanded still have dots
- [ ] Expand all items — badge reaches 0 and disappears
- [ ] Refresh page — no dots, no badge (PHP says 0 unread)
- [ ] Test with no featured items — all items render as original full-card layout, badge clears on drawer open
- [ ] Test RTL — dots and chevrons align correctly using CSS logical properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)