### PR TITLE
Fix: Cherry-pick PR 36329 to 4.02: Fire atomic widgets render actions for editor preview context [ED-24763]

### DIFF
--- a/modules/atomic-widgets/ajax/render-element-action.php
+++ b/modules/atomic-widgets/ajax/render-element-action.php
@@ -37,9 +37,12 @@ class Render_Element_Action {
 
 		Plugin::$instance->documents->switch_to_document( $document );
 
+		do_action( 'elementor/atomic_widgets/before_render', $document );
+
 		try {
 			$render_html = $this->render_element( $element_data );
 		} finally {
+			do_action( 'elementor/atomic_widgets/after_render', $document );
 			$editor->set_edit_mode( $is_edit_mode );
 			Plugin::$instance->db->restore_current_query();
 		}

--- a/tests/phpunit/elementor/modules/atomic-widgets/ajax/test-render-element-action.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/ajax/test-render-element-action.php
@@ -99,4 +99,78 @@ class Test_Render_Element_Action extends Elementor_Test_Base {
 			],
 		] );
 	}
+
+	public function test_handle__fires_atomic_widgets_render_actions_with_document(): void {
+		// Arrange.
+		$this->act_as_admin();
+		$document = $this->factory()->documents->create_and_get();
+		$post_id = $document->get_id();
+
+		$before_calls = [];
+		$after_calls = [];
+
+		$before_listener = function ( $doc ) use ( &$before_calls ) {
+			$before_calls[] = $doc;
+		};
+		$after_listener = function ( $doc ) use ( &$after_calls ) {
+			$after_calls[] = $doc;
+		};
+
+		add_action( 'elementor/atomic_widgets/before_render', $before_listener );
+		add_action( 'elementor/atomic_widgets/after_render', $after_listener );
+
+		try {
+			// Act.
+			( new Render_Element_Action() )->handle( [
+				'editor_post_id' => $post_id,
+				'data' => [
+					'id' => 'e1234567',
+					'elType' => 'widget',
+					'settings' => [],
+					'widgetType' => Atomic_Heading::get_element_type(),
+				],
+			] );
+		} finally {
+			remove_action( 'elementor/atomic_widgets/before_render', $before_listener );
+			remove_action( 'elementor/atomic_widgets/after_render', $after_listener );
+		}
+
+		// Assert.
+		$this->assertCount( 1, $before_calls );
+		$this->assertCount( 1, $after_calls );
+		$this->assertSame( $post_id, $before_calls[0]->get_main_id() );
+		$this->assertSame( $post_id, $after_calls[0]->get_main_id() );
+	}
+
+	public function test_handle__fires_after_render_even_on_failure(): void {
+		// Arrange.
+		$this->act_as_admin();
+		$post_id = $this->factory()->documents->create_and_get()->get_id();
+
+		$after_calls = 0;
+		$after_listener = function () use ( &$after_calls ) {
+			$after_calls++;
+		};
+
+		add_action( 'elementor/atomic_widgets/after_render', $after_listener );
+
+		// Act & Assert.
+		try {
+			( new Render_Element_Action() )->handle( [
+				'editor_post_id' => $post_id,
+				'data' => [
+					'elType' => 'widget',
+					'widgetType' => 'non-existent-widget-type',
+				],
+			] );
+
+			$this->fail( 'Expected exception was not thrown.' );
+		} catch ( \Exception $e ) {
+			// Expected.
+		} finally {
+			remove_action( 'elementor/atomic_widgets/after_render', $after_listener );
+		}
+
+		$this->assertSame( 1, $after_calls );
+	}
 }


### PR DESCRIPTION
Automatic cherry-pick of [#36329](https://github.com/elementor/elementor/pull/36329) to `4.02` branch.

**Source:** elementor/elementor
**Original Author:** @IshayMaya

## Summary

- Adds `elementor/atomic_widgets/before_render` and `after_render` actions around `render_atomic_element` in `Render_Element_Action::handle`, fired after `switch_to_document` and restored in `finally`.
- Enables archive/single preview context for v4 server renders (collection loop static items, archive-aware dynamic tags).

## Test plan

- [ ] `tests/phpunit/elementor/modules/atomic-widgets/ajax/test-render-element-action.php` — new tests assert both actions fire with the document instance, including on render failure.
- [ ] Smoke: regular page with atomic widgets still renders via `render_atomic_element` (non-Theme documents unaffected).

Fixes ED-24763

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Fire action hooks during atomic widget rendering in editor preview context to allow subscribers to hook into render lifecycle (ED-24763). Cherry-pick of PR 36329 to 4.02 branch.

## 2. What Changed (Where)

- `render-element-action.php`: Added `before_render` and `after_render` action hooks around element rendering, with `after_render` guaranteed via finally block
- `test-render-element-action.php`: Added two tests verifying hooks fire with correct document and that `after_render` fires even on failure

## 3. How It Works

When `Render_Element_Action::handle()` executes: (1) switches to target document, (2) fires `before_render` hook, (3) attempts render in try block, (4) fires `after_render` in finally block (guaranteeing execution regardless of exception), (5) restores state. Tests verify hook invocation and exception resilience.

## 4. Risks

Minimal. Action hooks are fire-and-forget with no expected side effects on render output. Finally block ensures cleanup always occurs. Tests confirm behavior under success and failure paths.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
