### PR TITLE
Internal: Add superpowers paths to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ data/languages
 tests/data
 
 graphify-out/
+.superpowers/
+docs/superpowers/
 
 # build outputs
 build/


### PR DESCRIPTION
## Summary

Adds `.superpowers/` and `docs/superpowers/` to `.gitignore`.

Split from #36308 — unrelated housekeeping change.

Ref: ED-24738

Made with [Cursor](https://cursor.com)