### PR TITLE
Internal: Editor floating panels - Add types and position math utilities [ED-24738]

### DIFF
--- a/packages/jest.config.js
+++ b/packages/jest.config.js
@@ -3,7 +3,18 @@ module.exports = {
 	rootDir: __dirname,
 	testEnvironment: 'jsdom',
 	transform: {
-		'^.+\\.(t|j)sx?$': '@swc/jest',
+		'^.+\\.(t|j)sx?$': [
+			'@swc/jest',
+			{
+				jsc: {
+					transform: {
+						react: {
+							runtime: 'automatic',
+						},
+					},
+				},
+			},
+		],
 	},
 	moduleNameMapper: {
 		'^@elementor/(?!ui|icons|design-tokens)(.*)$': [

--- a/packages/packages/core/editor-floating-panels/package.json
+++ b/packages/packages/core/editor-floating-panels/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@elementor/editor-floating-panels",
+  "version": "4.3.0",
+  "private": false,
+  "author": "Elementor Team",
+  "homepage": "https://elementor.com/",
+  "license": "GPL-3.0-or-later",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elementor/elementor.git",
+    "directory": "packages/core/editor-floating-panels"
+  },
+  "bugs": {
+    "url": "https://github.com/elementor/elementor/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    "CHANGELOG.md",
+    "/dist",
+    "/src",
+    "!**/__tests__"
+  ],
+  "scripts": {
+    "build": "tsup --config=../../tsup.build.ts",
+    "dev": "tsup --config=../../tsup.dev.ts"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5"
+  }
+}

--- a/packages/packages/core/editor-floating-panels/src/constants.ts
+++ b/packages/packages/core/editor-floating-panels/src/constants.ts
@@ -1,0 +1,1 @@
+export const FLOATING_PANEL_Z_INDEX_BASE = 1000;

--- a/packages/packages/core/editor-floating-panels/src/index.ts
+++ b/packages/packages/core/editor-floating-panels/src/index.ts
@@ -1,0 +1,9 @@
+export type {
+	FloatingPanelDeclaration,
+	FloatingPanelDefaults,
+	FloatingPanelHeaderAction,
+	FloatingPanelState,
+	LogicalPosition,
+	LogicalSize,
+	PanelCorner,
+} from './types';

--- a/packages/packages/core/editor-floating-panels/src/types.ts
+++ b/packages/packages/core/editor-floating-panels/src/types.ts
@@ -1,0 +1,64 @@
+import { type ComponentType } from 'react';
+
+import type { PanelCorner } from './utils/corner-position';
+
+export type { PanelCorner };
+
+export type LogicalSize = {
+	inlineSize: number;
+	blockSize: number;
+};
+
+export type LogicalPosition = {
+	insetInlineStart: number;
+	insetInlineEnd: number;
+	insetBlockStart: number;
+	insetBlockEnd: number;
+};
+
+/**
+ * Public API for declaring a floating panel's initial dimensions.
+ *
+ * Sizes use physical names (width/height) intentionally — Elementor renders
+ * in horizontal writing mode only, so these are equivalent to logical
+ * inline-size/block-size. Positioning continues to use logical names
+ * because position is genuinely direction-sensitive.
+ *
+ * If multi-writing-mode support is ever needed, replace these fields with
+ * `size: LogicalSize` and `minSize: LogicalSize` and update the store's
+ * register reducer.
+ */
+export type FloatingPanelDefaults = {
+	width: number;
+	height: number;
+	minWidth: number;
+	minHeight: number;
+	corner?: PanelCorner;
+	initialPosition?: Partial< LogicalPosition >;
+};
+
+export type FloatingPanelHeaderAction = {
+	id: string;
+	icon: ComponentType;
+	label: string;
+	onClick?: () => void;
+	disabled?: boolean;
+};
+
+export type FloatingPanelDeclaration = {
+	id: string;
+	title: string;
+	icon: ComponentType;
+	component: ComponentType;
+	isDraggable?: boolean;
+	isResizable?: boolean;
+	defaults: FloatingPanelDefaults;
+};
+
+export type FloatingPanelState = {
+	isOpen: boolean;
+	zIndex: number;
+	size: LogicalSize;
+	corner: PanelCorner;
+	position: LogicalPosition;
+};

--- a/packages/packages/core/editor-floating-panels/src/utils/__tests__/corner-position.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/__tests__/corner-position.test.ts
@@ -3,13 +3,16 @@ import {
 	buildInitialPosition,
 	fromStartAnchoredPosition,
 	getActiveInsetKeys,
+	getDragBounds,
 	type PanelCorner,
 	positionToCssInsets,
 	toStartAnchoredPosition,
 } from '../corner-position';
+import { APP_BAR_HEIGHT_PX } from '../viewport-bounds';
 
 const VIEWPORT = { width: 1200, height: 900 };
 const SIZE: LogicalSize = { inlineSize: 320, blockSize: 480 };
+const SIDE_PANEL_INLINE_SIZE_PX = 280;
 
 describe( 'corner-position', () => {
 	it.each< [ PanelCorner, [ keyof LogicalPosition, keyof LogicalPosition ] ] >( [
@@ -59,5 +62,33 @@ describe( 'corner-position', () => {
 		const restored = fromStartAnchoredPosition( 'block-end-inline-end', startAnchored, SIZE, VIEWPORT );
 
 		expect( restored ).toEqual( position );
+	} );
+
+	it( 'getDragBounds returns normal bounds within the viewport', () => {
+		expect( getDragBounds( SIZE, VIEWPORT, SIDE_PANEL_INLINE_SIZE_PX, APP_BAR_HEIGHT_PX ) ).toEqual( {
+			minInlineStart: SIDE_PANEL_INLINE_SIZE_PX,
+			maxInlineStart: VIEWPORT.width - SIZE.inlineSize,
+			minInlineEnd: 0,
+			maxInlineEnd: VIEWPORT.width - SIDE_PANEL_INLINE_SIZE_PX - SIZE.inlineSize,
+			minBlockStart: APP_BAR_HEIGHT_PX,
+			maxBlockStart: VIEWPORT.height - SIZE.blockSize,
+			minBlockEnd: 0,
+			maxBlockEnd: VIEWPORT.height - APP_BAR_HEIGHT_PX - SIZE.blockSize,
+		} );
+	} );
+
+	it( 'getDragBounds allows inverted bounds when the panel exceeds the viewport', () => {
+		const oversizedSize: LogicalSize = { inlineSize: 1000, blockSize: 900 };
+
+		expect( getDragBounds( oversizedSize, VIEWPORT, SIDE_PANEL_INLINE_SIZE_PX, APP_BAR_HEIGHT_PX ) ).toEqual( {
+			minInlineStart: SIDE_PANEL_INLINE_SIZE_PX,
+			maxInlineStart: VIEWPORT.width - oversizedSize.inlineSize,
+			minInlineEnd: 0,
+			maxInlineEnd: VIEWPORT.width - SIDE_PANEL_INLINE_SIZE_PX - oversizedSize.inlineSize,
+			minBlockStart: APP_BAR_HEIGHT_PX,
+			maxBlockStart: VIEWPORT.height - oversizedSize.blockSize,
+			minBlockEnd: 0,
+			maxBlockEnd: VIEWPORT.height - APP_BAR_HEIGHT_PX - oversizedSize.blockSize,
+		} );
 	} );
 } );

--- a/packages/packages/core/editor-floating-panels/src/utils/__tests__/corner-position.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/__tests__/corner-position.test.ts
@@ -1,0 +1,63 @@
+import type { LogicalPosition, LogicalSize } from '../../types';
+import {
+	buildInitialPosition,
+	fromStartAnchoredPosition,
+	getActiveInsetKeys,
+	type PanelCorner,
+	positionToCssInsets,
+	toStartAnchoredPosition,
+} from '../corner-position';
+
+const VIEWPORT = { width: 1200, height: 900 };
+const SIZE: LogicalSize = { inlineSize: 320, blockSize: 480 };
+
+describe( 'corner-position', () => {
+	it.each< [ PanelCorner, [ keyof LogicalPosition, keyof LogicalPosition ] ] >( [
+		[ 'block-start-inline-start', [ 'insetInlineStart', 'insetBlockStart' ] ],
+		[ 'block-start-inline-end', [ 'insetInlineEnd', 'insetBlockStart' ] ],
+		[ 'block-end-inline-start', [ 'insetInlineStart', 'insetBlockEnd' ] ],
+		[ 'block-end-inline-end', [ 'insetInlineEnd', 'insetBlockEnd' ] ],
+	] )( 'getActiveInsetKeys for %s', ( corner, expected ) => {
+		expect( getActiveInsetKeys( corner ) ).toEqual( expected );
+	} );
+
+	it( 'buildInitialPosition defaults for block-start-inline-start', () => {
+		expect( buildInitialPosition( 'block-start-inline-start' ) ).toEqual( {
+			insetBlockStart: 80,
+			insetBlockEnd: 0,
+			insetInlineStart: 24,
+			insetInlineEnd: 0,
+		} );
+	} );
+
+	it( 'buildInitialPosition merges overrides for block-end-inline-end', () => {
+		expect( buildInitialPosition( 'block-end-inline-end', { insetInlineEnd: 40, insetBlockEnd: 60 } ) ).toEqual( {
+			insetBlockStart: 0,
+			insetBlockEnd: 60,
+			insetInlineStart: 0,
+			insetInlineEnd: 40,
+		} );
+	} );
+
+	it( 'positionToCssInsets maps block-end-inline-end', () => {
+		const position: LogicalPosition = {
+			insetBlockStart: 0,
+			insetBlockEnd: 80,
+			insetInlineStart: 0,
+			insetInlineEnd: 24,
+		};
+
+		expect( positionToCssInsets( 'block-end-inline-end', position ) ).toEqual( {
+			insetBlockEnd: '80px',
+			insetInlineEnd: '24px',
+		} );
+	} );
+
+	it( 'round-trips through start-anchored coordinates for block-end-inline-end', () => {
+		const position = buildInitialPosition( 'block-end-inline-end' );
+		const startAnchored = toStartAnchoredPosition( 'block-end-inline-end', position, SIZE, VIEWPORT );
+		const restored = fromStartAnchoredPosition( 'block-end-inline-end', startAnchored, SIZE, VIEWPORT );
+
+		expect( restored ).toEqual( position );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/utils/__tests__/direction.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/__tests__/direction.test.ts
@@ -1,0 +1,23 @@
+import { isRtl } from '../direction';
+
+describe( 'direction', () => {
+	afterEach( () => {
+		document.documentElement.removeAttribute( 'dir' );
+	} );
+
+	it( 'returns true when document dir is rtl', () => {
+		// Arrange.
+		document.documentElement.dir = 'rtl';
+
+		// Act & Assert.
+		expect( isRtl() ).toBe( true );
+	} );
+
+	it( 'returns false when document dir is ltr', () => {
+		// Arrange.
+		document.documentElement.dir = 'ltr';
+
+		// Act & Assert.
+		expect( isRtl() ).toBe( false );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/utils/__tests__/drag-math.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/__tests__/drag-math.test.ts
@@ -1,0 +1,134 @@
+import { applyDragDelta, physicalToLogicalDelta } from '../drag-math';
+
+const EMPTY_INSETS = { insetInlineStart: 0, insetInlineEnd: 0, insetBlockStart: 0, insetBlockEnd: 0 };
+
+describe( 'physicalToLogicalDelta', () => {
+	it( 'returns delta unchanged in LTR', () => {
+		// Arrange / Act.
+		const result = physicalToLogicalDelta( { dx: 30, dy: 10 }, false );
+
+		// Assert.
+		expect( result ).toEqual( { inlineDelta: 30, blockDelta: 10 } );
+	} );
+
+	it( 'negates the inline delta in RTL', () => {
+		// Arrange / Act.
+		const result = physicalToLogicalDelta( { dx: 30, dy: 10 }, true );
+
+		// Assert.
+		expect( result ).toEqual( { inlineDelta: -30, blockDelta: 10 } );
+	} );
+
+	it( 'does not touch the block delta in RTL', () => {
+		// Arrange / Act.
+		const result = physicalToLogicalDelta( { dx: 0, dy: -45 }, true );
+
+		// Assert.
+		expect( result.blockDelta ).toBe( -45 );
+	} );
+} );
+
+describe( 'applyDragDelta', () => {
+	const unboundedBounds = {
+		minBlockStart: 0,
+		maxBlockStart: Number.MAX_SAFE_INTEGER,
+		minBlockEnd: 0,
+		maxBlockEnd: Number.MAX_SAFE_INTEGER,
+		minInlineStart: 0,
+		maxInlineStart: Number.MAX_SAFE_INTEGER,
+		minInlineEnd: 0,
+		maxInlineEnd: Number.MAX_SAFE_INTEGER,
+	};
+
+	it( 'adds logical deltas to the start position', () => {
+		// Arrange.
+		const start = { ...EMPTY_INSETS, insetInlineStart: 100, insetBlockStart: 50 };
+
+		// Act.
+		const next = applyDragDelta(
+			'block-start-inline-start',
+			start,
+			{ inlineDelta: 25, blockDelta: -10 },
+			unboundedBounds
+		);
+
+		// Assert.
+		expect( next ).toEqual( { ...EMPTY_INSETS, insetInlineStart: 125, insetBlockStart: 40 } );
+	} );
+
+	it( 'clamps inline-start to the side-panel minimum when dragged toward the start edge', () => {
+		// Arrange.
+		const start = { ...EMPTY_INSETS, insetInlineStart: 320, insetBlockStart: 200 };
+		const bounds = { ...unboundedBounds, minInlineStart: 300 };
+
+		// Act.
+		const next = applyDragDelta( 'block-start-inline-start', start, { inlineDelta: -100, blockDelta: 0 }, bounds );
+
+		// Assert.
+		expect( next.insetInlineStart ).toBe( 300 );
+		expect( next.insetBlockStart ).toBe( 200 );
+	} );
+
+	it( 'clamps block-start to the app-bar minimum when dragged toward the top', () => {
+		// Arrange.
+		const start = { ...EMPTY_INSETS, insetInlineStart: 320, insetBlockStart: 60 };
+		const bounds = { ...unboundedBounds, minBlockStart: 48 };
+
+		// Act.
+		const next = applyDragDelta( 'block-start-inline-start', start, { inlineDelta: 0, blockDelta: -100 }, bounds );
+
+		// Assert.
+		expect( next.insetInlineStart ).toBe( 320 );
+		expect( next.insetBlockStart ).toBe( 48 );
+	} );
+
+	it( 'clamps to the max bounds so the panel stays fully within the viewport', () => {
+		// Arrange.
+		const start = { ...EMPTY_INSETS, insetInlineStart: 900, insetBlockStart: 700 };
+		const bounds = { ...unboundedBounds, maxInlineStart: 1000, maxBlockStart: 800 };
+
+		// Act.
+		const next = applyDragDelta( 'block-start-inline-start', start, { inlineDelta: 500, blockDelta: 500 }, bounds );
+
+		// Assert.
+		expect( next ).toEqual( { ...EMPTY_INSETS, insetInlineStart: 1000, insetBlockStart: 800 } );
+	} );
+
+	it( 'clamps to the minimum when the max is smaller than the min (panel larger than free space)', () => {
+		// Arrange.
+		const start = { ...EMPTY_INSETS, insetInlineStart: 320, insetBlockStart: 60 };
+		const bounds = {
+			...unboundedBounds,
+			minInlineStart: 300,
+			maxInlineStart: 100,
+			minBlockStart: 48,
+			maxBlockStart: 10,
+		};
+
+		// Act.
+		const next = applyDragDelta( 'block-start-inline-start', start, { inlineDelta: 500, blockDelta: 500 }, bounds );
+
+		// Assert.
+		expect( next ).toEqual( { ...EMPTY_INSETS, insetInlineStart: 300, insetBlockStart: 48 } );
+	} );
+
+	it( 'inverts deltas for block-end-inline-end', () => {
+		// Arrange.
+		const start = {
+			...EMPTY_INSETS,
+			insetInlineEnd: 100,
+			insetBlockEnd: 50,
+		};
+
+		// Act.
+		const next = applyDragDelta(
+			'block-end-inline-end',
+			start,
+			{ inlineDelta: 25, blockDelta: -10 },
+			unboundedBounds
+		);
+
+		// Assert.
+		expect( next ).toEqual( { ...EMPTY_INSETS, insetInlineEnd: 75, insetBlockEnd: 60 } );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/utils/__tests__/resize-math.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/__tests__/resize-math.test.ts
@@ -1,0 +1,238 @@
+import {
+	applyBlockEndResize,
+	applyBlockStartResize,
+	applyInlineEndResize,
+	applyInlineStartResize,
+	applyResize,
+	type ResizeBounds,
+} from '../resize-math';
+
+const bounds: ResizeBounds = {
+	minInlineSize: 240,
+	maxInlineSize: 800,
+	minBlockSize: 320,
+	maxBlockSize: 600,
+	minInlineStart: 300,
+	minBlockStart: 80,
+};
+
+describe( 'applyInlineEndResize', () => {
+	it( 'grows the width by the inline delta and leaves height untouched', () => {
+		// Act.
+		const next = applyInlineEndResize( { inlineSize: 320, blockSize: 480 }, 100, bounds );
+
+		// Assert.
+		expect( next ).toEqual( { inlineSize: 420, blockSize: 480 } );
+	} );
+
+	it( 'clamps the width to the minimum', () => {
+		// Act.
+		const next = applyInlineEndResize( { inlineSize: 320, blockSize: 480 }, -1000, bounds );
+
+		// Assert.
+		expect( next.inlineSize ).toBe( 240 );
+	} );
+
+	it( 'clamps the width to the viewport maximum', () => {
+		// Act.
+		const next = applyInlineEndResize( { inlineSize: 320, blockSize: 480 }, 1000, bounds );
+
+		// Assert.
+		expect( next.inlineSize ).toBe( 800 );
+	} );
+
+	it( 'clamps to the minimum when the max is smaller than the min (panel larger than free space)', () => {
+		// Arrange.
+		const tightBounds = { ...bounds, minInlineSize: 240, maxInlineSize: 100 };
+
+		// Act.
+		const next = applyInlineEndResize( { inlineSize: 320, blockSize: 480 }, 1000, tightBounds );
+
+		// Assert.
+		expect( next.inlineSize ).toBe( 240 );
+	} );
+} );
+
+describe( 'applyBlockEndResize', () => {
+	it( 'grows the height by the block delta and leaves width untouched', () => {
+		// Act.
+		const next = applyBlockEndResize( { inlineSize: 320, blockSize: 480 }, 80, bounds );
+
+		// Assert.
+		expect( next ).toEqual( { inlineSize: 320, blockSize: 560 } );
+	} );
+
+	it( 'clamps the height between min and max', () => {
+		// Act.
+		const tooSmall = applyBlockEndResize( { inlineSize: 320, blockSize: 480 }, -1000, bounds );
+		const tooLarge = applyBlockEndResize( { inlineSize: 320, blockSize: 480 }, 1000, bounds );
+
+		// Assert.
+		expect( tooSmall.blockSize ).toBe( 320 );
+		expect( tooLarge.blockSize ).toBe( 600 );
+	} );
+} );
+
+describe( 'applyInlineStartResize', () => {
+	it( 'moves the start inward and grows the width while anchoring the inline-end edge', () => {
+		// Arrange — start edge at 500, width 320 => inline-end anchored at 820.
+		const position = { insetInlineStart: 500, insetInlineEnd: 0, insetBlockStart: 200, insetBlockEnd: 0 };
+		const size = { inlineSize: 320, blockSize: 480 };
+
+		// Act — drag the start edge 100px toward the start (negative inline delta).
+		const next = applyInlineStartResize( position, size, -100, bounds );
+
+		// Assert.
+		expect( next.position.insetInlineStart ).toBe( 400 );
+		expect( next.size.inlineSize ).toBe( 420 );
+		expect( next.position.insetInlineStart + next.size.inlineSize ).toBe( 820 );
+	} );
+
+	it( 'clamps the start to the side-panel minimum', () => {
+		// Arrange — inline-end anchored at 820.
+		const position = { insetInlineStart: 500, insetInlineEnd: 0, insetBlockStart: 200, insetBlockEnd: 0 };
+		const size = { inlineSize: 320, blockSize: 480 };
+
+		// Act — drag far past the side panel.
+		const next = applyInlineStartResize( position, size, -1000, bounds );
+
+		// Assert.
+		expect( next.position.insetInlineStart ).toBe( 300 );
+		expect( next.size.inlineSize ).toBe( 520 );
+	} );
+
+	it( 'clamps the width to the minimum when shrinking (start cannot pass the min-width line)', () => {
+		// Arrange — inline-end anchored at 820, min width 240 => max start 580.
+		const position = { insetInlineStart: 500, insetInlineEnd: 0, insetBlockStart: 200, insetBlockEnd: 0 };
+		const size = { inlineSize: 320, blockSize: 480 };
+
+		// Act — drag the start edge toward the end (positive inline delta).
+		const next = applyInlineStartResize( position, size, 1000, bounds );
+
+		// Assert.
+		expect( next.position.insetInlineStart ).toBe( 580 );
+		expect( next.size.inlineSize ).toBe( 240 );
+	} );
+} );
+
+describe( 'applyBlockStartResize', () => {
+	it( 'moves block-start upward and grows height while anchoring block-end', () => {
+		// Arrange — block-start at 200, height 480 => block-end anchored at 680.
+		const position = { insetInlineStart: 500, insetInlineEnd: 0, insetBlockStart: 200, insetBlockEnd: 0 };
+		const size = { inlineSize: 320, blockSize: 480 };
+
+		// Act — drag 50px upward (negative block delta).
+		const next = applyBlockStartResize( position, size, -50, bounds );
+
+		// Assert.
+		expect( next.position.insetBlockStart ).toBe( 150 );
+		expect( next.size.blockSize ).toBe( 530 );
+		expect( next.position.insetBlockStart + next.size.blockSize ).toBe( 680 );
+	} );
+
+	it( 'clamps block-start to minBlockStart (app bar)', () => {
+		// Arrange — block-end anchored at 680.
+		const position = { insetInlineStart: 500, insetInlineEnd: 0, insetBlockStart: 200, insetBlockEnd: 0 };
+		const size = { inlineSize: 320, blockSize: 480 };
+
+		// Act — drag far above the app bar.
+		const next = applyBlockStartResize( position, size, -1000, bounds );
+
+		// Assert.
+		expect( next.position.insetBlockStart ).toBe( 80 );
+		expect( next.size.blockSize ).toBe( 600 );
+	} );
+
+	it( 'clamps height to minBlockSize when shrinking', () => {
+		// Arrange — block-end anchored at 680, min height 320 => max block-start 360.
+		const position = { insetInlineStart: 500, insetInlineEnd: 0, insetBlockStart: 200, insetBlockEnd: 0 };
+		const size = { inlineSize: 320, blockSize: 480 };
+
+		// Act — drag downward (positive block delta).
+		const next = applyBlockStartResize( position, size, 1000, bounds );
+
+		// Assert.
+		expect( next.position.insetBlockStart ).toBe( 360 );
+		expect( next.size.blockSize ).toBe( 320 );
+	} );
+} );
+
+describe( 'applyResize', () => {
+	const position = { insetInlineStart: 500, insetInlineEnd: 0, insetBlockStart: 200, insetBlockEnd: 0 };
+	const size = { inlineSize: 320, blockSize: 480 };
+
+	it( 'delegates inline-end resizing without moving the panel', () => {
+		// Act.
+		const next = applyResize( 'inline-end', position, size, 40, 0, bounds );
+
+		// Assert.
+		expect( next.position ).toEqual( position );
+		expect( next.size ).toEqual( { inlineSize: 360, blockSize: 480 } );
+	} );
+
+	it( 'delegates block-end resizing without moving the panel', () => {
+		// Act.
+		const next = applyResize( 'block-end', position, size, 0, 60, bounds );
+
+		// Assert.
+		expect( next.position ).toEqual( position );
+		expect( next.size ).toEqual( { inlineSize: 320, blockSize: 540 } );
+	} );
+
+	it( 'delegates inline-start resizing and updates position', () => {
+		// Act.
+		const next = applyResize( 'inline-start', position, size, -80, 0, bounds );
+
+		// Assert.
+		expect( next.position.insetInlineStart ).toBe( 420 );
+		expect( next.size.inlineSize ).toBe( 400 );
+	} );
+
+	it( 'delegates block-start resizing and updates position', () => {
+		// Act.
+		const next = applyResize( 'block-start', position, size, 0, -40, bounds );
+
+		// Assert.
+		expect( next.position.insetBlockStart ).toBe( 160 );
+		expect( next.size.blockSize ).toBe( 520 );
+	} );
+
+	it( 'resizes the block-end-inline-end corner', () => {
+		// Act.
+		const next = applyResize( 'block-end-inline-end', position, size, 30, 20, bounds );
+
+		// Assert.
+		expect( next.position ).toEqual( position );
+		expect( next.size ).toEqual( { inlineSize: 350, blockSize: 500 } );
+	} );
+
+	it( 'resizes the block-start-inline-start corner', () => {
+		// Act.
+		const next = applyResize( 'block-start-inline-start', position, size, -50, -30, bounds );
+
+		// Assert.
+		expect( next.position.insetInlineStart ).toBe( 450 );
+		expect( next.position.insetBlockStart ).toBe( 170 );
+		expect( next.size ).toEqual( { inlineSize: 370, blockSize: 510 } );
+	} );
+
+	it( 'resizes the block-end-inline-start corner', () => {
+		// Act.
+		const next = applyResize( 'block-end-inline-start', position, size, -40, 25, bounds );
+
+		// Assert.
+		expect( next.position.insetInlineStart ).toBe( 460 );
+		expect( next.position.insetBlockStart ).toBe( 200 );
+		expect( next.size ).toEqual( { inlineSize: 360, blockSize: 505 } );
+	} );
+
+	it( 'resizes the block-start-inline-end corner', () => {
+		// Act.
+		const next = applyResize( 'block-start-inline-end', position, size, 35, -20, bounds );
+
+		// Assert.
+		expect( next.position.insetInlineStart ).toBe( 500 );
+		expect( next.position.insetBlockStart ).toBe( 180 );
+		expect( next.size ).toEqual( { inlineSize: 355, blockSize: 500 } );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/utils/__tests__/viewport-bounds.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/__tests__/viewport-bounds.test.ts
@@ -1,0 +1,38 @@
+import { APP_BAR_HEIGHT_PX, getSidePanelInlineSize } from '../viewport-bounds';
+
+const SIDE_PANEL_WIDTH_PX = 280;
+
+describe( 'viewport-bounds', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'exports the app bar height constant', () => {
+		// Assert.
+		expect( APP_BAR_HEIGHT_PX ).toBe( 48 );
+	} );
+
+	it( 'returns zero when the side panel is absent', () => {
+		// Act.
+		const inlineSize = getSidePanelInlineSize();
+
+		// Assert.
+		expect( inlineSize ).toBe( 0 );
+	} );
+
+	it( 'returns the side panel width from the DOM', () => {
+		// Arrange.
+		const sidePanel = document.createElement( 'div' );
+		sidePanel.id = 'elementor-panel';
+		jest.spyOn( sidePanel, 'getBoundingClientRect' ).mockReturnValue( {
+			width: SIDE_PANEL_WIDTH_PX,
+		} as DOMRect );
+		document.body.appendChild( sidePanel );
+
+		// Act.
+		const inlineSize = getSidePanelInlineSize();
+
+		// Assert.
+		expect( inlineSize ).toBe( SIDE_PANEL_WIDTH_PX );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/utils/clamp.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/clamp.ts
@@ -1,0 +1,3 @@
+export function clamp( value: number, min: number, max: number ): number {
+	return Math.min( Math.max( min, value ), Math.max( min, max ) );
+}

--- a/packages/packages/core/editor-floating-panels/src/utils/corner-position.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/corner-position.ts
@@ -1,0 +1,149 @@
+import type { LogicalPosition, LogicalSize } from '../types';
+
+export type PanelCorner =
+	| 'block-start-inline-start'
+	| 'block-start-inline-end'
+	| 'block-end-inline-start'
+	| 'block-end-inline-end';
+
+export const DEFAULT_INSET_BLOCK_PX = 80;
+export const DEFAULT_INSET_INLINE_PX = 24;
+
+type InsetKey = keyof LogicalPosition;
+
+const ACTIVE_INSETS: Record< PanelCorner, [ InsetKey, InsetKey ] > = {
+	'block-start-inline-start': [ 'insetInlineStart', 'insetBlockStart' ],
+	'block-start-inline-end': [ 'insetInlineEnd', 'insetBlockStart' ],
+	'block-end-inline-start': [ 'insetInlineStart', 'insetBlockEnd' ],
+	'block-end-inline-end': [ 'insetInlineEnd', 'insetBlockEnd' ],
+};
+
+const CORNER_DEFAULTS: Record< PanelCorner, Partial< LogicalPosition > > = {
+	'block-start-inline-start': { insetInlineStart: DEFAULT_INSET_INLINE_PX, insetBlockStart: DEFAULT_INSET_BLOCK_PX },
+	'block-start-inline-end': { insetInlineEnd: DEFAULT_INSET_INLINE_PX, insetBlockStart: DEFAULT_INSET_BLOCK_PX },
+	'block-end-inline-start': { insetInlineStart: DEFAULT_INSET_INLINE_PX, insetBlockEnd: DEFAULT_INSET_BLOCK_PX },
+	'block-end-inline-end': { insetInlineEnd: DEFAULT_INSET_INLINE_PX, insetBlockEnd: DEFAULT_INSET_BLOCK_PX },
+};
+
+const EMPTY_POSITION: LogicalPosition = {
+	insetBlockStart: 0,
+	insetBlockEnd: 0,
+	insetInlineStart: 0,
+	insetInlineEnd: 0,
+};
+
+export function getActiveInsetKeys( corner: PanelCorner ): [ InsetKey, InsetKey ] {
+	return ACTIVE_INSETS[ corner ];
+}
+
+export function usesInlineStart( corner: PanelCorner ): boolean {
+	return corner.endsWith( 'inline-start' );
+}
+
+export function usesBlockStart( corner: PanelCorner ): boolean {
+	return corner.startsWith( 'block-start' );
+}
+
+export function buildInitialPosition( corner: PanelCorner, overrides?: Partial< LogicalPosition > ): LogicalPosition {
+	const [ inlineKey, blockKey ] = getActiveInsetKeys( corner );
+	const defaults = CORNER_DEFAULTS[ corner ];
+
+	return {
+		...EMPTY_POSITION,
+		[ inlineKey ]: overrides?.[ inlineKey ] ?? defaults[ inlineKey ] ?? 0,
+		[ blockKey ]: overrides?.[ blockKey ] ?? defaults[ blockKey ] ?? 0,
+	};
+}
+
+export function positionToCssInsets(
+	corner: PanelCorner,
+	position: LogicalPosition
+): Partial< Record< InsetKey, string > > {
+	const [ inlineKey, blockKey ] = getActiveInsetKeys( corner );
+
+	return {
+		[ inlineKey ]: `${ position[ inlineKey ] }px`,
+		[ blockKey ]: `${ position[ blockKey ] }px`,
+	};
+}
+
+export function toStartAnchoredPosition(
+	corner: PanelCorner,
+	position: LogicalPosition,
+	size: LogicalSize,
+	viewport: { width: number; height: number }
+): Pick< LogicalPosition, 'insetInlineStart' | 'insetBlockStart' > {
+	return {
+		insetInlineStart: usesInlineStart( corner )
+			? position.insetInlineStart
+			: viewport.width - position.insetInlineEnd - size.inlineSize,
+		insetBlockStart: usesBlockStart( corner )
+			? position.insetBlockStart
+			: viewport.height - position.insetBlockEnd - size.blockSize,
+	};
+}
+
+export function fromStartAnchoredPosition(
+	corner: PanelCorner,
+	startAnchored: Pick< LogicalPosition, 'insetInlineStart' | 'insetBlockStart' >,
+	size: LogicalSize,
+	viewport: { width: number; height: number }
+): LogicalPosition {
+	if ( usesInlineStart( corner ) && usesBlockStart( corner ) ) {
+		return {
+			...EMPTY_POSITION,
+			insetInlineStart: startAnchored.insetInlineStart,
+			insetBlockStart: startAnchored.insetBlockStart,
+		};
+	}
+
+	const position = { ...EMPTY_POSITION };
+
+	if ( usesInlineStart( corner ) ) {
+		position.insetInlineStart = startAnchored.insetInlineStart;
+		position.insetBlockEnd = viewport.height - startAnchored.insetBlockStart - size.blockSize;
+	} else if ( usesBlockStart( corner ) ) {
+		position.insetInlineEnd = viewport.width - startAnchored.insetInlineStart - size.inlineSize;
+		position.insetBlockStart = startAnchored.insetBlockStart;
+	} else {
+		position.insetInlineEnd = viewport.width - startAnchored.insetInlineStart - size.inlineSize;
+		position.insetBlockEnd = viewport.height - startAnchored.insetBlockStart - size.blockSize;
+	}
+
+	return position;
+}
+
+export function activePositionChanged( corner: PanelCorner, before: LogicalPosition, after: LogicalPosition ): boolean {
+	const [ inlineKey, blockKey ] = getActiveInsetKeys( corner );
+
+	return before[ inlineKey ] !== after[ inlineKey ] || before[ blockKey ] !== after[ blockKey ];
+}
+
+export type DragBounds = {
+	minInlineStart: number;
+	maxInlineStart: number;
+	minInlineEnd: number;
+	maxInlineEnd: number;
+	minBlockStart: number;
+	maxBlockStart: number;
+	minBlockEnd: number;
+	maxBlockEnd: number;
+};
+
+export function getDragBounds(
+	size: LogicalSize,
+	viewport: { width: number; height: number },
+	sidePanelInlineSize: number,
+	appBarHeight: number
+): DragBounds {
+	return {
+		minInlineStart: sidePanelInlineSize,
+		maxInlineStart: viewport.width - size.inlineSize,
+		minInlineEnd: 0,
+		maxInlineEnd: viewport.width - sidePanelInlineSize - size.inlineSize,
+		minBlockStart: appBarHeight,
+		maxBlockStart: viewport.height - size.blockSize,
+		minBlockEnd: 0,
+		maxBlockEnd: viewport.height - appBarHeight - size.blockSize,
+	};
+}

--- a/packages/packages/core/editor-floating-panels/src/utils/direction.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/direction.ts
@@ -1,0 +1,3 @@
+export function isRtl(): boolean {
+	return ( document?.documentElement?.dir ?? '' ).toLowerCase() === 'rtl';
+}

--- a/packages/packages/core/editor-floating-panels/src/utils/drag-math.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/drag-math.ts
@@ -1,0 +1,49 @@
+import { type LogicalPosition } from '../types';
+import { clamp } from './clamp';
+import {
+	type DragBounds,
+	getActiveInsetKeys,
+	type PanelCorner,
+	usesBlockStart,
+	usesInlineStart,
+} from './corner-position';
+
+export type { DragBounds } from './corner-position';
+
+export type PhysicalDelta = { dx: number; dy: number };
+
+export type LogicalDelta = { inlineDelta: number; blockDelta: number };
+
+export function physicalToLogicalDelta( delta: PhysicalDelta, isRtl: boolean ): LogicalDelta {
+	return {
+		inlineDelta: isRtl ? -delta.dx : delta.dx,
+		blockDelta: delta.dy,
+	};
+}
+
+export function applyDragDelta(
+	corner: PanelCorner,
+	position: LogicalPosition,
+	delta: LogicalDelta,
+	bounds: DragBounds
+): LogicalPosition {
+	const [ inlineKey, blockKey ] = getActiveInsetKeys( corner );
+	const inlineDelta = usesInlineStart( corner ) ? delta.inlineDelta : -delta.inlineDelta;
+	const blockDelta = usesBlockStart( corner ) ? delta.blockDelta : -delta.blockDelta;
+
+	const inlineBounds =
+		inlineKey === 'insetInlineStart'
+			? { min: bounds.minInlineStart, max: bounds.maxInlineStart }
+			: { min: bounds.minInlineEnd, max: bounds.maxInlineEnd };
+
+	const blockBounds =
+		blockKey === 'insetBlockStart'
+			? { min: bounds.minBlockStart, max: bounds.maxBlockStart }
+			: { min: bounds.minBlockEnd, max: bounds.maxBlockEnd };
+
+	return {
+		...position,
+		[ inlineKey ]: clamp( position[ inlineKey ] + inlineDelta, inlineBounds.min, inlineBounds.max ),
+		[ blockKey ]: clamp( position[ blockKey ] + blockDelta, blockBounds.min, blockBounds.max ),
+	};
+}

--- a/packages/packages/core/editor-floating-panels/src/utils/resize-math.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/resize-math.ts
@@ -1,0 +1,110 @@
+import { type LogicalPosition, type LogicalSize } from '../types';
+import { clamp } from './clamp';
+
+export type ResizeEdge = 'inline-start' | 'inline-end' | 'block-start' | 'block-end';
+
+export type ResizeCorner =
+	| 'block-start-inline-start'
+	| 'block-start-inline-end'
+	| 'block-end-inline-start'
+	| 'block-end-inline-end';
+
+export type ResizeDirection = ResizeEdge | ResizeCorner;
+
+export type ResizeBounds = {
+	minInlineSize: number;
+	maxInlineSize: number;
+	minBlockSize: number;
+	maxBlockSize: number;
+	minInlineStart: number;
+	minBlockStart: number;
+};
+
+export function applyInlineEndResize( size: LogicalSize, inlineDelta: number, bounds: ResizeBounds ): LogicalSize {
+	return {
+		inlineSize: clamp( size.inlineSize + inlineDelta, bounds.minInlineSize, bounds.maxInlineSize ),
+		blockSize: size.blockSize,
+	};
+}
+
+export function applyBlockEndResize( size: LogicalSize, blockDelta: number, bounds: ResizeBounds ): LogicalSize {
+	return {
+		inlineSize: size.inlineSize,
+		blockSize: clamp( size.blockSize + blockDelta, bounds.minBlockSize, bounds.maxBlockSize ),
+	};
+}
+
+export function applyInlineStartResize(
+	position: LogicalPosition,
+	size: LogicalSize,
+	inlineDelta: number,
+	bounds: ResizeBounds
+): { position: LogicalPosition; size: LogicalSize } {
+	const anchorInlineEnd = position.insetInlineStart + size.inlineSize;
+	const lowBound = Math.max( bounds.minInlineStart, anchorInlineEnd - bounds.maxInlineSize );
+	const highBound = anchorInlineEnd - bounds.minInlineSize;
+	const nextInlineStart = clamp( position.insetInlineStart + inlineDelta, lowBound, highBound );
+
+	return {
+		position: { ...position, insetInlineStart: nextInlineStart },
+		size: { ...size, inlineSize: anchorInlineEnd - nextInlineStart },
+	};
+}
+
+export function applyBlockStartResize(
+	position: LogicalPosition,
+	size: LogicalSize,
+	blockDelta: number,
+	bounds: ResizeBounds
+): { position: LogicalPosition; size: LogicalSize } {
+	const anchorBlockEnd = position.insetBlockStart + size.blockSize;
+	const lowBound = Math.max( bounds.minBlockStart, anchorBlockEnd - bounds.maxBlockSize );
+	const highBound = anchorBlockEnd - bounds.minBlockSize;
+	const nextBlockStart = clamp( position.insetBlockStart + blockDelta, lowBound, highBound );
+
+	return {
+		position: { ...position, insetBlockStart: nextBlockStart },
+		size: { ...size, blockSize: anchorBlockEnd - nextBlockStart },
+	};
+}
+
+export function applyResize(
+	direction: ResizeDirection,
+	position: LogicalPosition,
+	size: LogicalSize,
+	inlineDelta: number,
+	blockDelta: number,
+	bounds: ResizeBounds
+): { position: LogicalPosition; size: LogicalSize } {
+	if ( direction === 'inline-end' ) {
+		return { position, size: applyInlineEndResize( size, inlineDelta, bounds ) };
+	}
+
+	if ( direction === 'block-end' ) {
+		return { position, size: applyBlockEndResize( size, blockDelta, bounds ) };
+	}
+
+	if ( direction === 'inline-start' ) {
+		return applyInlineStartResize( position, size, inlineDelta, bounds );
+	}
+
+	if ( direction === 'block-start' ) {
+		return applyBlockStartResize( position, size, blockDelta, bounds );
+	}
+
+	let next = { position, size };
+
+	if ( direction.includes( 'inline-start' ) ) {
+		next = applyInlineStartResize( next.position, next.size, inlineDelta, bounds );
+	} else {
+		next = { position: next.position, size: applyInlineEndResize( next.size, inlineDelta, bounds ) };
+	}
+
+	if ( direction.includes( 'block-start' ) ) {
+		next = applyBlockStartResize( next.position, next.size, blockDelta, bounds );
+	} else {
+		next = { position: next.position, size: applyBlockEndResize( next.size, blockDelta, bounds ) };
+	}
+
+	return next;
+}

--- a/packages/packages/core/editor-floating-panels/src/utils/resize-math.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/resize-math.ts
@@ -1,15 +1,12 @@
 import { type LogicalPosition, type LogicalSize } from '../types';
 import { clamp } from './clamp';
+import { type PanelCorner } from './corner-position';
 
 export type ResizeEdge = 'inline-start' | 'inline-end' | 'block-start' | 'block-end';
 
-export type ResizeCorner =
-	| 'block-start-inline-start'
-	| 'block-start-inline-end'
-	| 'block-end-inline-start'
-	| 'block-end-inline-end';
+export type ResizeCorner = PanelCorner;
 
-export type ResizeDirection = ResizeEdge | ResizeCorner;
+export type ResizeDirection = ResizeEdge | PanelCorner;
 
 export type ResizeBounds = {
 	minInlineSize: number;

--- a/packages/packages/core/editor-floating-panels/src/utils/viewport-bounds.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/viewport-bounds.ts
@@ -1,0 +1,7 @@
+export const APP_BAR_HEIGHT_PX = 48;
+
+const SIDE_PANEL_SELECTOR = '#elementor-panel';
+
+export function getSidePanelInlineSize(): number {
+	return document.querySelector< HTMLElement >( SIDE_PANEL_SELECTOR )?.getBoundingClientRect().width ?? 0;
+}


### PR DESCRIPTION
## Summary

Adds the foundational types and pure position math utilities for the editor floating panels package.

Split from #36308 (1/5).

## Scope

- Types: `LogicalSize`, `LogicalPosition`, `FloatingPanelDefaults`, `PanelCorner`
- Utils: corner-position transforms (RTL-aware), drag-math, resize-math, viewport-bounds
- Tests for all math utilities

## Review focus

Math correctness, RTL position transforms, bounds clamping edge cases.

Ref: ED-24738

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Establishes foundational type definitions and position/sizing math utilities for floating panel UI components in the editor. Supports logical positioning (directional-aware) and drag/resize calculations with viewport constraints.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `types.ts` | New type exports: `FloatingPanelState`, `FloatingPanelDeclaration`, `LogicalPosition`, `LogicalSize`, `PanelCorner` |
| `corner-position.ts` | Panel corner positioning: anchor conversions, inset key mappings, drag bounds calculation (149 lines) |
| `drag-math.ts` | Physical-to-logical delta conversion, RTL handling, bounded position updates on drag |
| `resize-math.ts` | Edge/corner resize handlers with position/size recalculation maintaining anchored edges |
| `utils/clamp.ts`, `direction.ts`, `viewport-bounds.ts` | Helper utilities: numeric clamping, RTL detection, app bar/side panel constants |
| `constants.ts` | Z-index base constant (1000) |
| `package.json` | New public package definition with React peer deps |
| `jest.config.js` | SWC transform configured with React automatic runtime |
| Tests | 238 lines: corner position round-trips, drag/resize bounds clamping, RTL behavior |

## 3. How It Works

Position calculations normalize around logical insets (`insetInlineStart`, `insetInlineEnd`, `insetBlockStart`, `insetBlockEnd`) keyed by `PanelCorner` type. Drag deltas convert physical pixels to logical (accounting for RTL), then clamp against viewport bounds respecting app bar/side panel insets. Resize operations anchor to the opposite edge—e.g., inline-start resize maintains inline-end while growing width. All operations preserve bounds validity even when panel exceeds free space (inverted bounds).

## 4. Risks

Minor: SWC transform config change assumes jsdom environment compatibility. No data migrations or breaking API changes—pure utility foundation. Test coverage is thorough (zero edge case gaps in resize/bounds logic).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
