### PR TITLE
Internal: Editor floating panels - Add Redux state management and persistence [ED-24738]

### DIFF
--- a/packages/jest.config.js
+++ b/packages/jest.config.js
@@ -3,7 +3,18 @@ module.exports = {
 	rootDir: __dirname,
 	testEnvironment: 'jsdom',
 	transform: {
-		'^.+\\.(t|j)sx?$': '@swc/jest',
+		'^.+\\.(t|j)sx?$': [
+			'@swc/jest',
+			{
+				jsc: {
+					transform: {
+						react: {
+							runtime: 'automatic',
+						},
+					},
+				},
+			},
+		],
 	},
 	moduleNameMapper: {
 		'^@elementor/(?!ui|icons|design-tokens)(.*)$': [

--- a/packages/packages/core/editor-floating-panels/package.json
+++ b/packages/packages/core/editor-floating-panels/package.json
@@ -38,6 +38,10 @@
     "build": "tsup --config=../../tsup.build.ts",
     "dev": "tsup --config=../../tsup.dev.ts"
   },
+  "dependencies": {
+    "@elementor/locations": "4.3.0",
+    "@elementor/store": "4.3.0"
+  },
   "peerDependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/packages/packages/core/editor-floating-panels/src/__tests__/persistence.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/persistence.test.ts
@@ -1,0 +1,100 @@
+import { decodePersistedState, encodePersistedState } from '../persistence';
+
+const validPanelState = {
+	isOpen: true,
+	zIndex: 3,
+	size: { inlineSize: 320, blockSize: 480 },
+	corner: 'block-start-inline-start' as const,
+	position: {
+		insetBlockStart: 80,
+		insetBlockEnd: 0,
+		insetInlineStart: 24,
+		insetInlineEnd: 0,
+	},
+};
+
+describe( 'persistence', () => {
+	it( 'round-trips a panel state through encode/decode', () => {
+		// Arrange.
+		const input = {
+			'audit-panel': validPanelState,
+		};
+
+		// Act.
+		const decoded = decodePersistedState( encodePersistedState( input ) );
+
+		// Assert.
+		expect( decoded ).toEqual( input );
+	} );
+
+	it( 'returns an empty record for non-JSON input', () => {
+		expect( decodePersistedState( 'not json' ) ).toEqual( {} );
+	} );
+
+	it( 'returns an empty record for null/undefined input', () => {
+		expect( decodePersistedState( null ) ).toEqual( {} );
+		expect( decodePersistedState( undefined ) ).toEqual( {} );
+	} );
+
+	it( 'drops malformed panel entries', () => {
+		// Arrange.
+		const raw = JSON.stringify( {
+			'audit-panel': 'not an object',
+			'valid-panel': {
+				isOpen: false,
+				zIndex: 1,
+				size: { inlineSize: 300, blockSize: 400 },
+				corner: 'block-start-inline-start',
+				position: {
+					insetBlockStart: 10,
+					insetBlockEnd: 0,
+					insetInlineStart: 10,
+					insetInlineEnd: 0,
+				},
+			},
+		} );
+
+		// Act.
+		const decoded = decodePersistedState( raw );
+
+		// Assert.
+		expect( decoded[ 'audit-panel' ] ).toBeUndefined();
+		expect( decoded[ 'valid-panel' ] ).toBeDefined();
+	} );
+
+	it( 'drops panel entries with shallow position or size objects', () => {
+		// Arrange.
+		const raw = JSON.stringify( {
+			'shallow-panel': {
+				isOpen: true,
+				zIndex: 1,
+				size: {},
+				position: {},
+			},
+		} );
+
+		// Act.
+		const decoded = decodePersistedState( raw );
+
+		// Assert.
+		expect( decoded[ 'shallow-panel' ] ).toBeUndefined();
+	} );
+
+	it( 'drops legacy two-inset-only payloads without corner', () => {
+		// Arrange.
+		const raw = JSON.stringify( {
+			'legacy-panel': {
+				isOpen: true,
+				zIndex: 1,
+				position: { insetInlineStart: 24, insetBlockStart: 80 },
+				size: { inlineSize: 320, blockSize: 480 },
+			},
+		} );
+
+		// Act.
+		const decoded = decodePersistedState( raw );
+
+		// Assert.
+		expect( decoded ).toEqual( {} );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/__tests__/slice.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/slice.test.ts
@@ -1,0 +1,246 @@
+import { __createStore, __deleteStore, __dispatch, __getState, __registerSlice } from '@elementor/store';
+
+import {
+	selectCorner,
+	selectIsDraggable,
+	selectIsOpen,
+	selectIsResizable,
+	selectMinSize,
+	selectPanelState,
+	selectPosition,
+	selectSize,
+	selectTopZIndex,
+} from '../store/selectors';
+import { slice } from '../store/slice';
+import { type FloatingPanelDefaults } from '../types';
+
+const defaults: FloatingPanelDefaults = {
+	width: 320,
+	height: 480,
+	minWidth: 240,
+	minHeight: 320,
+};
+
+const defaultPosition = {
+	insetBlockStart: 80,
+	insetBlockEnd: 0,
+	insetInlineStart: 24,
+	insetInlineEnd: 0,
+};
+
+describe( 'floating-panels slice', () => {
+	beforeEach( () => {
+		__registerSlice( slice );
+		__createStore();
+	} );
+
+	afterEach( () => {
+		__deleteStore();
+	} );
+
+	it( 'registers a panel with its defaults', () => {
+		// Act.
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+
+		// Assert.
+		const state = selectPanelState( __getState(), 'a' );
+		expect( state ).toMatchObject( {
+			isOpen: false,
+			corner: 'block-start-inline-start',
+			position: defaultPosition,
+		} );
+		expect( state?.size ).toEqual( { inlineSize: 320, blockSize: 480 } );
+		expect( selectMinSize( __getState(), 'a' ) ).toEqual( { inlineSize: 240, blockSize: 320 } );
+	} );
+
+	it( 'opens and closes a panel', () => {
+		// Arrange.
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+
+		// Act.
+		__dispatch( slice.actions.open( 'a' ) );
+
+		// Assert.
+		expect( selectIsOpen( __getState(), 'a' ) ).toBe( true );
+
+		// Act.
+		__dispatch( slice.actions.close( 'a' ) );
+
+		// Assert.
+		expect( selectIsOpen( __getState(), 'a' ) ).toBe( false );
+	} );
+
+	it( 'updates position', () => {
+		// Arrange.
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+
+		// Act.
+		__dispatch(
+			slice.actions.setPosition( {
+				id: 'a',
+				position: {
+					insetBlockStart: 80,
+					insetBlockEnd: 0,
+					insetInlineStart: 200,
+					insetInlineEnd: 0,
+				},
+			} )
+		);
+
+		// Assert.
+		expect( selectPosition( __getState(), 'a' ) ).toEqual( {
+			insetBlockStart: 80,
+			insetBlockEnd: 0,
+			insetInlineStart: 200,
+			insetInlineEnd: 0,
+		} );
+	} );
+
+	it( 'register with persisted state restores that state and derives min size from defaults', () => {
+		// Arrange.
+		const persisted = {
+			isOpen: true,
+			zIndex: 7,
+			size: { inlineSize: 400, blockSize: 500 },
+			corner: 'block-start-inline-start' as const,
+			position: {
+				insetBlockStart: 200,
+				insetBlockEnd: 0,
+				insetInlineStart: 500,
+				insetInlineEnd: 0,
+			},
+		};
+
+		// Act.
+		__dispatch( slice.actions.register( { id: 'a', defaults, persisted } ) );
+
+		// Assert.
+		expect( selectPanelState( __getState(), 'a' ) ).toEqual( persisted );
+		expect( selectMinSize( __getState(), 'a' ) ).toEqual( { inlineSize: 240, blockSize: 320 } );
+		expect( selectTopZIndex( __getState() ) ).toBeGreaterThanOrEqual( 7 );
+	} );
+
+	it( 'discards persisted state when persisted corner differs from defaults corner', () => {
+		// Arrange.
+		const persisted = {
+			isOpen: true,
+			zIndex: 5,
+			size: { inlineSize: 400, blockSize: 500 },
+			corner: 'block-start-inline-start' as const,
+			position: {
+				insetBlockStart: 200,
+				insetBlockEnd: 0,
+				insetInlineStart: 500,
+				insetInlineEnd: 0,
+			},
+		};
+
+		// Act.
+		__dispatch(
+			slice.actions.register( {
+				id: 'a',
+				defaults: { ...defaults, corner: 'block-start-inline-end' },
+				persisted,
+			} )
+		);
+
+		// Assert.
+		const state = selectPanelState( __getState(), 'a' );
+		expect( state?.corner ).toBe( 'block-start-inline-end' );
+		expect( state?.isOpen ).toBe( false );
+		expect( state?.position ).toEqual( {
+			insetBlockStart: 80,
+			insetBlockEnd: 0,
+			insetInlineStart: 0,
+			insetInlineEnd: 24,
+		} );
+	} );
+
+	it( 'registers block-end-inline-end corner with custom initialPosition', () => {
+		// Act.
+		__dispatch(
+			slice.actions.register( {
+				id: 'a',
+				defaults: {
+					...defaults,
+					corner: 'block-end-inline-end',
+					initialPosition: { insetInlineEnd: 100, insetBlockEnd: 50 },
+				},
+			} )
+		);
+
+		// Assert.
+		expect( selectCorner( __getState(), 'a' ) ).toBe( 'block-end-inline-end' );
+		expect( selectPosition( __getState(), 'a' ) ).toEqual( {
+			insetBlockStart: 0,
+			insetBlockEnd: 50,
+			insetInlineStart: 0,
+			insetInlineEnd: 100,
+		} );
+	} );
+
+	it( 'updates size', () => {
+		// Arrange.
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+
+		// Act.
+		__dispatch( slice.actions.setSize( { id: 'a', size: { inlineSize: 600, blockSize: 700 } } ) );
+
+		// Assert.
+		expect( selectSize( __getState(), 'a' ) ).toEqual( { inlineSize: 600, blockSize: 700 } );
+	} );
+
+	it( 'stores isDraggable as false by default', () => {
+		// Act.
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+
+		// Assert.
+		expect( selectIsDraggable( __getState(), 'a' ) ).toBe( false );
+	} );
+
+	it( 'stores isDraggable as true when provided', () => {
+		// Act.
+		__dispatch( slice.actions.register( { id: 'a', defaults, isDraggable: true } ) );
+
+		// Assert.
+		expect( selectIsDraggable( __getState(), 'a' ) ).toBe( true );
+	} );
+
+	it( 'stores isResizable as false by default', () => {
+		// Act.
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+
+		// Assert.
+		expect( selectIsResizable( __getState(), 'a' ) ).toBe( false );
+	} );
+
+	it( 'stores isResizable as true when provided', () => {
+		// Act.
+		__dispatch( slice.actions.register( { id: 'a', defaults, isResizable: true } ) );
+
+		// Assert.
+		expect( selectIsResizable( __getState(), 'a' ) ).toBe( true );
+	} );
+
+	it( 'bringToFront raises zIndex above all others', () => {
+		// Arrange.
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+		__dispatch( slice.actions.register( { id: 'b', defaults } ) );
+
+		// Act.
+		__dispatch( slice.actions.bringToFront( 'a' ) );
+		__dispatch( slice.actions.bringToFront( 'b' ) );
+
+		// Assert.
+		expect( selectTopZIndex( __getState() ) ).toBeGreaterThanOrEqual( 2 );
+
+		const a = selectPanelState( __getState(), 'a' );
+		const b = selectPanelState( __getState(), 'b' );
+
+		if ( ! a || ! b ) {
+			throw new Error( 'Expected both panels to be registered' );
+		}
+
+		expect( b.zIndex ).toBeGreaterThan( a.zIndex );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/__tests__/sync.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/sync.test.ts
@@ -108,6 +108,51 @@ describe( 'sync', () => {
 		// Assert.
 		expect( writeSpy ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'merges store updates with preloaded panels not yet registered', () => {
+		// Arrange.
+		const panelB: FloatingPanelState = {
+			...persisted,
+			isOpen: false,
+			zIndex: 2,
+		};
+		const storage = createMemoryStorage( encodePersistedState( { a: persisted, b: panelB } ) );
+		sync( storage );
+
+		// Act.
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+		__dispatch( slice.actions.open( 'a' ) );
+		jest.advanceTimersByTime( 300 );
+
+		// Assert.
+		const written = JSON.parse( storage.snapshot() as string );
+		expect( written.a.isOpen ).toBe( true );
+		expect( written.b ).toEqual( panelB );
+	} );
+
+	it( 'calling sync() twice cancels pending debounce from the first session', () => {
+		// Arrange.
+		const storage = createMemoryStorage();
+		const writeSpy = jest.spyOn( storage, 'write' );
+
+		// Act.
+		sync( storage );
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+		sync( storage );
+		jest.advanceTimersByTime( 300 );
+
+		// Assert — stale timer from the first session must not write.
+		expect( writeSpy ).not.toHaveBeenCalled();
+
+		// Act — change after re-sync schedules persistence for the active session.
+		__dispatch( slice.actions.open( 'a' ) );
+		jest.advanceTimersByTime( 300 );
+
+		// Assert — only the final state is written once.
+		expect( writeSpy ).toHaveBeenCalledTimes( 1 );
+		const written = JSON.parse( storage.snapshot() as string );
+		expect( written.a.isOpen ).toBe( true );
+	} );
 } );
 
 describe( 'sync before the store is ready', () => {

--- a/packages/packages/core/editor-floating-panels/src/__tests__/sync.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/sync.test.ts
@@ -1,0 +1,167 @@
+import { __createStore, __deleteStore, __dispatch, __registerSlice } from '@elementor/store';
+
+import { encodePersistedState } from '../persistence';
+import { slice } from '../store/slice';
+import { getPersistedState, localStorageAdapter, type PanelStateStorage, sync } from '../sync';
+import { type FloatingPanelDefaults, type FloatingPanelState } from '../types';
+
+const persisted: FloatingPanelState = {
+	isOpen: true,
+	zIndex: 1,
+	size: { inlineSize: 320, blockSize: 480 },
+	corner: 'block-start-inline-start',
+	position: {
+		insetBlockStart: 80,
+		insetBlockEnd: 0,
+		insetInlineStart: 24,
+		insetInlineEnd: 0,
+	},
+};
+
+const defaults: FloatingPanelDefaults = {
+	width: 320,
+	height: 480,
+	minWidth: 240,
+	minHeight: 320,
+};
+
+function createMemoryStorage( initial: string | null = null ): PanelStateStorage & { snapshot: () => string | null } {
+	let value: string | null = initial;
+
+	return {
+		read: () => value,
+		write: ( v ) => {
+			value = v;
+		},
+		snapshot: () => value,
+	};
+}
+
+describe( 'sync', () => {
+	beforeEach( () => {
+		__registerSlice( slice );
+		__createStore();
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		__deleteStore();
+	} );
+
+	it( 'reads persisted state on sync() and exposes it via getPersistedState', () => {
+		// Arrange.
+		const storage = createMemoryStorage( encodePersistedState( { 'audit-panel': persisted } ) );
+
+		// Act.
+		sync( storage );
+
+		// Assert.
+		expect( getPersistedState( 'audit-panel' ) ).toEqual( persisted );
+	} );
+
+	it( 'returns undefined for unknown panel IDs', () => {
+		// Arrange.
+		const storage = createMemoryStorage();
+
+		// Act.
+		sync( storage );
+
+		// Assert.
+		expect( getPersistedState( 'never-persisted' ) ).toBeUndefined();
+	} );
+
+	it( 'writes the store state to storage after a debounced delay', () => {
+		// Arrange.
+		const storage = createMemoryStorage();
+		sync( storage );
+
+		// Act.
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+		__dispatch( slice.actions.open( 'a' ) );
+
+		// Assert — nothing written yet (still inside debounce window).
+		expect( storage.snapshot() ).toBe( null );
+
+		// Act — fast-forward past the debounce.
+		jest.advanceTimersByTime( 300 );
+
+		// Assert.
+		const written = storage.snapshot();
+		expect( written ).not.toBe( null );
+		const parsed = JSON.parse( written as string );
+		expect( parsed.a.isOpen ).toBe( true );
+	} );
+
+	it( 'calling sync() twice keeps a single persistence subscription', () => {
+		// Arrange.
+		const storage = createMemoryStorage();
+		const writeSpy = jest.spyOn( storage, 'write' );
+
+		// Act.
+		sync( storage );
+		sync( storage );
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+		__dispatch( slice.actions.open( 'a' ) );
+		jest.advanceTimersByTime( 300 );
+
+		// Assert.
+		expect( writeSpy ).toHaveBeenCalledTimes( 1 );
+	} );
+} );
+
+describe( 'sync before the store is ready', () => {
+	beforeEach( () => {
+		__registerSlice( slice );
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		__deleteStore();
+	} );
+
+	it( 'subscribes to persistence after the store becomes ready', () => {
+		// Arrange.
+		const storage = createMemoryStorage();
+		sync( storage );
+
+		// Act.
+		__createStore();
+		jest.advanceTimersByTime( 20 );
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+		jest.advanceTimersByTime( 300 );
+
+		// Assert.
+		expect( storage.snapshot() ).not.toBe( null );
+	} );
+} );
+
+describe( 'localStorageAdapter', () => {
+	it( 'returns null when localStorage read throws', () => {
+		// Arrange.
+		const getItem = jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+			throw new Error( 'blocked' );
+		} );
+
+		// Act.
+		const value = localStorageAdapter.read();
+
+		// Assert.
+		expect( value ).toBeNull();
+
+		getItem.mockRestore();
+	} );
+
+	it( 'swallows localStorage write errors', () => {
+		// Arrange.
+		const setItem = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new Error( 'quota exceeded' );
+		} );
+
+		// Act / Assert.
+		expect( () => localStorageAdapter.write( '{}' ) ).not.toThrow();
+
+		setItem.mockRestore();
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/location.ts
+++ b/packages/packages/core/editor-floating-panels/src/location.ts
@@ -1,0 +1,3 @@
+import { createLocation } from '@elementor/locations';
+
+export const { inject: injectIntoFloatingPanels, useInjections: useFloatingPanelsInjections } = createLocation();

--- a/packages/packages/core/editor-floating-panels/src/persistence.ts
+++ b/packages/packages/core/editor-floating-panels/src/persistence.ts
@@ -1,0 +1,76 @@
+import { type FloatingPanelState, type PanelCorner } from './types';
+
+export const PERSISTENCE_STORAGE_KEY = 'elementor_floating_panels_state';
+
+const VALID_PANEL_CORNERS = new Set< PanelCorner >( [
+	'block-start-inline-start',
+	'block-start-inline-end',
+	'block-end-inline-start',
+	'block-end-inline-end',
+] );
+
+type PersistedState = Record< string, FloatingPanelState >;
+
+export function encodePersistedState( state: PersistedState ): string {
+	return JSON.stringify( state );
+}
+
+export function decodePersistedState( raw: string | null | undefined ): PersistedState {
+	if ( ! raw ) {
+		return {};
+	}
+
+	let parsed: unknown;
+
+	try {
+		parsed = JSON.parse( raw );
+	} catch {
+		return {};
+	}
+
+	if ( typeof parsed !== 'object' || parsed === null ) {
+		return {};
+	}
+
+	const result: PersistedState = {};
+
+	for ( const [ id, value ] of Object.entries( parsed as Record< string, unknown > ) ) {
+		if ( isPanelState( value ) ) {
+			result[ id ] = value;
+		}
+	}
+
+	return result;
+}
+
+function isPanelState( value: unknown ): value is FloatingPanelState {
+	if ( typeof value !== 'object' || value === null ) {
+		return false;
+	}
+
+	const v = value as Record< string, unknown >;
+
+	if ( typeof v.size !== 'object' || v.size === null ) {
+		return false;
+	}
+
+	if ( typeof v.position !== 'object' || v.position === null ) {
+		return false;
+	}
+
+	const size = v.size as Record< string, unknown >;
+	const position = v.position as Record< string, unknown >;
+
+	return (
+		typeof v.isOpen === 'boolean' &&
+		typeof v.zIndex === 'number' &&
+		typeof v.corner === 'string' &&
+		VALID_PANEL_CORNERS.has( v.corner as PanelCorner ) &&
+		typeof size.inlineSize === 'number' &&
+		typeof size.blockSize === 'number' &&
+		typeof position.insetInlineStart === 'number' &&
+		typeof position.insetInlineEnd === 'number' &&
+		typeof position.insetBlockStart === 'number' &&
+		typeof position.insetBlockEnd === 'number'
+	);
+}

--- a/packages/packages/core/editor-floating-panels/src/store/index.ts
+++ b/packages/packages/core/editor-floating-panels/src/store/index.ts
@@ -1,0 +1,2 @@
+export { slice } from './slice';
+export * from './selectors';

--- a/packages/packages/core/editor-floating-panels/src/store/selectors.ts
+++ b/packages/packages/core/editor-floating-panels/src/store/selectors.ts
@@ -1,0 +1,61 @@
+import { __createSelector } from '@elementor/store';
+
+import { FLOATING_PANEL_Z_INDEX_BASE } from '../constants';
+import { type FloatingPanelsSliceState } from './slice';
+
+export type GlobalState = { floatingPanels: FloatingPanelsSliceState };
+
+export function selectPanelState( state: GlobalState, id: string ) {
+	return state.floatingPanels.byId[ id ];
+}
+
+export function resolvePanelZIndex( state: GlobalState, id: string ): number {
+	return FLOATING_PANEL_Z_INDEX_BASE + ( state.floatingPanels.byId[ id ]?.zIndex ?? 0 );
+}
+
+export function resolveOverlayZIndex( state: GlobalState, id: string ): number {
+	return resolvePanelZIndex( state, id ) + 1;
+}
+
+export function selectIsOpen( state: GlobalState, id: string ): boolean {
+	return state.floatingPanels.byId[ id ]?.isOpen ?? false;
+}
+
+export function selectCorner( state: GlobalState, id: string ) {
+	return state.floatingPanels.byId[ id ]?.corner;
+}
+
+export function selectPosition( state: GlobalState, id: string ) {
+	return state.floatingPanels.byId[ id ]?.position;
+}
+
+export function selectSize( state: GlobalState, id: string ) {
+	return state.floatingPanels.byId[ id ]?.size;
+}
+
+export function selectMinSize( state: GlobalState, id: string ) {
+	return state.floatingPanels.minSizeById[ id ];
+}
+
+export function selectIsDraggable( state: GlobalState, id: string ): boolean {
+	return state.floatingPanels.isDraggableById[ id ] ?? false;
+}
+
+export function selectIsResizable( state: GlobalState, id: string ): boolean {
+	return state.floatingPanels.isResizableById[ id ] ?? false;
+}
+
+export function selectPanelTitle( state: GlobalState, id: string ): string | undefined {
+	return state.floatingPanels.titlesById[ id ];
+}
+
+export function selectTopZIndex( state: GlobalState ): number {
+	return state.floatingPanels.topZIndex;
+}
+
+export const selectOpenPanelIds = __createSelector( [ ( state: GlobalState ) => state.floatingPanels.byId ], ( byId ) =>
+	Object.entries( byId )
+		.filter( ( [ , panel ] ) => panel.isOpen )
+		.sort( ( [ , a ], [ , b ] ) => a.zIndex - b.zIndex )
+		.map( ( [ id ] ) => id )
+);

--- a/packages/packages/core/editor-floating-panels/src/store/slice.ts
+++ b/packages/packages/core/editor-floating-panels/src/store/slice.ts
@@ -1,0 +1,113 @@
+import { __createSlice, type PayloadAction } from '@elementor/store';
+
+import { type FloatingPanelDefaults, type FloatingPanelState, type LogicalPosition, type LogicalSize } from '../types';
+import { buildInitialPosition, type PanelCorner } from '../utils/corner-position';
+
+type SliceState = {
+	byId: Record< string, FloatingPanelState >;
+	minSizeById: Record< string, LogicalSize >;
+	titlesById: Record< string, string >;
+	isDraggableById: Record< string, boolean >;
+	isResizableById: Record< string, boolean >;
+	topZIndex: number;
+};
+
+const DEFAULT_CORNER: PanelCorner = 'block-start-inline-start';
+
+const initialState: SliceState = {
+	byId: {},
+	minSizeById: {},
+	titlesById: {},
+	isDraggableById: {},
+	isResizableById: {},
+	topZIndex: 0,
+};
+
+export const slice = __createSlice( {
+	name: 'floatingPanels',
+	initialState,
+	reducers: {
+		register(
+			state,
+			action: PayloadAction< {
+				id: string;
+				defaults: FloatingPanelDefaults;
+				title?: string;
+				isDraggable?: boolean;
+				isResizable?: boolean;
+				persisted?: FloatingPanelState;
+			} >
+		) {
+			const { id, defaults, title, isDraggable, isResizable, persisted } = action.payload;
+
+			state.minSizeById[ id ] = { inlineSize: defaults.minWidth, blockSize: defaults.minHeight };
+			state.isDraggableById[ id ] = isDraggable ?? false;
+			state.isResizableById[ id ] = isResizable ?? false;
+
+			if ( title !== undefined ) {
+				state.titlesById[ id ] = title;
+			}
+
+			if ( state.byId[ id ] ) {
+				return;
+			}
+
+			const corner = defaults.corner ?? DEFAULT_CORNER;
+			const canReusePersisted = persisted && persisted.corner === corner;
+
+			state.byId[ id ] = canReusePersisted
+				? persisted
+				: {
+						isOpen: false,
+						corner,
+						position: buildInitialPosition( corner, defaults.initialPosition ),
+						size: { inlineSize: defaults.width, blockSize: defaults.height },
+						zIndex: 0,
+				  };
+
+			if ( persisted && persisted.zIndex > state.topZIndex ) {
+				state.topZIndex = persisted.zIndex;
+			}
+		},
+		open( state, action: PayloadAction< string > ) {
+			const panel = state.byId[ action.payload ];
+
+			if ( panel ) {
+				panel.isOpen = true;
+			}
+		},
+		close( state, action: PayloadAction< string > ) {
+			const panel = state.byId[ action.payload ];
+
+			if ( panel ) {
+				panel.isOpen = false;
+			}
+		},
+		setPosition( state, action: PayloadAction< { id: string; position: LogicalPosition } > ) {
+			const panel = state.byId[ action.payload.id ];
+
+			if ( panel ) {
+				panel.position = action.payload.position;
+			}
+		},
+		setSize( state, action: PayloadAction< { id: string; size: LogicalSize } > ) {
+			const panel = state.byId[ action.payload.id ];
+
+			if ( panel ) {
+				panel.size = action.payload.size;
+			}
+		},
+		bringToFront( state, action: PayloadAction< string > ) {
+			const panel = state.byId[ action.payload ];
+
+			if ( ! panel ) {
+				return;
+			}
+
+			state.topZIndex += 1;
+			panel.zIndex = state.topZIndex;
+		},
+	},
+} );
+
+export type FloatingPanelsSliceState = SliceState;

--- a/packages/packages/core/editor-floating-panels/src/sync.ts
+++ b/packages/packages/core/editor-floating-panels/src/sync.ts
@@ -1,0 +1,93 @@
+import { __getStore, __subscribeWithSelector } from '@elementor/store';
+
+import { decodePersistedState, encodePersistedState, PERSISTENCE_STORAGE_KEY } from './persistence';
+import { type GlobalState } from './store/selectors';
+import { type FloatingPanelState } from './types';
+
+const PERSIST_DEBOUNCE_MS = 250;
+
+export interface PanelStateStorage {
+	read: () => string | null;
+	write: ( value: string ) => void;
+}
+
+export const localStorageAdapter: PanelStateStorage = {
+	read: () => {
+		try {
+			return globalThis.localStorage?.getItem( PERSISTENCE_STORAGE_KEY ) ?? null;
+		} catch {
+			return null;
+		}
+	},
+	write: ( value ) => {
+		try {
+			globalThis.localStorage?.setItem( PERSISTENCE_STORAGE_KEY, value );
+		} catch {
+			// Best-effort: storage may be full, blocked, or unavailable.
+		}
+	},
+};
+
+let cachedPersistedState: Record< string, FloatingPanelState > = {};
+let isSyncInitialized = false;
+let persistenceUnsubscribe: ( () => void ) | null = null;
+let persistenceSession = 0;
+
+export function isFloatingPanelsSyncInitialized(): boolean {
+	return isSyncInitialized;
+}
+
+export function sync( storage: PanelStateStorage = localStorageAdapter ): void {
+	isSyncInitialized = true;
+	cachedPersistedState = decodePersistedState( storage.read() );
+
+	schedulePersistence( storage );
+}
+
+export function getPersistedState( id: string ): FloatingPanelState | undefined {
+	return cachedPersistedState[ id ];
+}
+
+const STORE_READY_POLL_MS = 16;
+
+function schedulePersistence( storage: PanelStateStorage ): void {
+	persistenceUnsubscribe?.();
+	persistenceUnsubscribe = null;
+
+	const session = ++persistenceSession;
+	let timer: ReturnType< typeof setTimeout > | null = null;
+
+	const subscribe = () => {
+		if ( session !== persistenceSession ) {
+			return;
+		}
+
+		persistenceUnsubscribe = __subscribeWithSelector(
+			( state: GlobalState ) => state.floatingPanels.byId,
+			( byId ) => {
+				if ( timer ) {
+					clearTimeout( timer );
+				}
+
+				timer = setTimeout( () => {
+					storage.write( encodePersistedState( byId ) );
+				}, PERSIST_DEBOUNCE_MS );
+			}
+		);
+	};
+
+	const waitForStore = () => {
+		if ( session !== persistenceSession ) {
+			return;
+		}
+
+		if ( __getStore() ) {
+			subscribe();
+			return;
+		}
+
+		setTimeout( waitForStore, STORE_READY_POLL_MS );
+	};
+
+	waitForStore();
+}

--- a/packages/packages/core/editor-floating-panels/src/sync.ts
+++ b/packages/packages/core/editor-floating-panels/src/sync.ts
@@ -30,6 +30,7 @@ export const localStorageAdapter: PanelStateStorage = {
 
 let cachedPersistedState: Record< string, FloatingPanelState > = {};
 let isSyncInitialized = false;
+let persistenceTimer: ReturnType< typeof setTimeout > | null = null;
 let persistenceUnsubscribe: ( () => void ) | null = null;
 let persistenceSession = 0;
 
@@ -50,12 +51,19 @@ export function getPersistedState( id: string ): FloatingPanelState | undefined 
 
 const STORE_READY_POLL_MS = 16;
 
+function clearPersistenceTimer(): void {
+	if ( persistenceTimer ) {
+		clearTimeout( persistenceTimer );
+		persistenceTimer = null;
+	}
+}
+
 function schedulePersistence( storage: PanelStateStorage ): void {
+	clearPersistenceTimer();
 	persistenceUnsubscribe?.();
 	persistenceUnsubscribe = null;
 
 	const session = ++persistenceSession;
-	let timer: ReturnType< typeof setTimeout > | null = null;
 
 	const subscribe = () => {
 		if ( session !== persistenceSession ) {
@@ -65,12 +73,15 @@ function schedulePersistence( storage: PanelStateStorage ): void {
 		persistenceUnsubscribe = __subscribeWithSelector(
 			( state: GlobalState ) => state.floatingPanels.byId,
 			( byId ) => {
-				if ( timer ) {
-					clearTimeout( timer );
-				}
+				clearPersistenceTimer();
 
-				timer = setTimeout( () => {
-					storage.write( encodePersistedState( byId ) );
+				persistenceTimer = setTimeout( () => {
+					if ( session !== persistenceSession ) {
+						return;
+					}
+
+					cachedPersistedState = { ...cachedPersistedState, ...byId };
+					storage.write( encodePersistedState( cachedPersistedState ) );
 				}, PERSIST_DEBOUNCE_MS );
 			}
 		);

--- a/packages/packages/core/editor-floating-panels/src/utils/__tests__/corner-position.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/__tests__/corner-position.test.ts
@@ -3,13 +3,16 @@ import {
 	buildInitialPosition,
 	fromStartAnchoredPosition,
 	getActiveInsetKeys,
+	getDragBounds,
 	type PanelCorner,
 	positionToCssInsets,
 	toStartAnchoredPosition,
 } from '../corner-position';
+import { APP_BAR_HEIGHT_PX } from '../viewport-bounds';
 
 const VIEWPORT = { width: 1200, height: 900 };
 const SIZE: LogicalSize = { inlineSize: 320, blockSize: 480 };
+const SIDE_PANEL_INLINE_SIZE_PX = 280;
 
 describe( 'corner-position', () => {
 	it.each< [ PanelCorner, [ keyof LogicalPosition, keyof LogicalPosition ] ] >( [
@@ -59,5 +62,33 @@ describe( 'corner-position', () => {
 		const restored = fromStartAnchoredPosition( 'block-end-inline-end', startAnchored, SIZE, VIEWPORT );
 
 		expect( restored ).toEqual( position );
+	} );
+
+	it( 'getDragBounds returns normal bounds within the viewport', () => {
+		expect( getDragBounds( SIZE, VIEWPORT, SIDE_PANEL_INLINE_SIZE_PX, APP_BAR_HEIGHT_PX ) ).toEqual( {
+			minInlineStart: SIDE_PANEL_INLINE_SIZE_PX,
+			maxInlineStart: VIEWPORT.width - SIZE.inlineSize,
+			minInlineEnd: 0,
+			maxInlineEnd: VIEWPORT.width - SIDE_PANEL_INLINE_SIZE_PX - SIZE.inlineSize,
+			minBlockStart: APP_BAR_HEIGHT_PX,
+			maxBlockStart: VIEWPORT.height - SIZE.blockSize,
+			minBlockEnd: 0,
+			maxBlockEnd: VIEWPORT.height - APP_BAR_HEIGHT_PX - SIZE.blockSize,
+		} );
+	} );
+
+	it( 'getDragBounds allows inverted bounds when the panel exceeds the viewport', () => {
+		const oversizedSize: LogicalSize = { inlineSize: 1000, blockSize: 900 };
+
+		expect( getDragBounds( oversizedSize, VIEWPORT, SIDE_PANEL_INLINE_SIZE_PX, APP_BAR_HEIGHT_PX ) ).toEqual( {
+			minInlineStart: SIDE_PANEL_INLINE_SIZE_PX,
+			maxInlineStart: VIEWPORT.width - oversizedSize.inlineSize,
+			minInlineEnd: 0,
+			maxInlineEnd: VIEWPORT.width - SIDE_PANEL_INLINE_SIZE_PX - oversizedSize.inlineSize,
+			minBlockStart: APP_BAR_HEIGHT_PX,
+			maxBlockStart: VIEWPORT.height - oversizedSize.blockSize,
+			minBlockEnd: 0,
+			maxBlockEnd: VIEWPORT.height - APP_BAR_HEIGHT_PX - oversizedSize.blockSize,
+		} );
 	} );
 } );

--- a/packages/packages/core/editor-floating-panels/src/utils/__tests__/direction.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/__tests__/direction.test.ts
@@ -1,0 +1,23 @@
+import { isRtl } from '../direction';
+
+describe( 'direction', () => {
+	afterEach( () => {
+		document.documentElement.removeAttribute( 'dir' );
+	} );
+
+	it( 'returns true when document dir is rtl', () => {
+		// Arrange.
+		document.documentElement.dir = 'rtl';
+
+		// Act & Assert.
+		expect( isRtl() ).toBe( true );
+	} );
+
+	it( 'returns false when document dir is ltr', () => {
+		// Arrange.
+		document.documentElement.dir = 'ltr';
+
+		// Act & Assert.
+		expect( isRtl() ).toBe( false );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/utils/resize-math.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/resize-math.ts
@@ -1,15 +1,12 @@
 import { type LogicalPosition, type LogicalSize } from '../types';
 import { clamp } from './clamp';
+import { type PanelCorner } from './corner-position';
 
 export type ResizeEdge = 'inline-start' | 'inline-end' | 'block-start' | 'block-end';
 
-export type ResizeCorner =
-	| 'block-start-inline-start'
-	| 'block-start-inline-end'
-	| 'block-end-inline-start'
-	| 'block-end-inline-end';
+export type ResizeCorner = PanelCorner;
 
-export type ResizeDirection = ResizeEdge | ResizeCorner;
+export type ResizeDirection = ResizeEdge | PanelCorner;
 
 export type ResizeBounds = {
 	minInlineSize: number;


### PR DESCRIPTION
## Summary

Adds Redux slice, selectors, localStorage persistence, and sync for floating panel state.

Split from #36308 (2/5). Stacked on #36358.

## Scope

- Redux slice: register, open/close, position, size, z-index
- Persistence: encode/decode with validation
- Sync: debounced localStorage adapter
- Location injection point

## Review focus

State shape design, localStorage validation, debounced persistence, idempotency.

Ref: ED-24738

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding Redux-based state management and localStorage persistence for floating panel UI state (position, size, z-index, open/closed). Enables state survival across sessions and coordinated multi-panel interactions. Ticket: ED-24738.

## 2. What Changed (Where)

- **State layer**: New Redux slice with register/open/close/setPosition/setSize/bringToFront reducers; selectors for panel queries
- **Persistence**: Encode/decode with validation; debounced localStorage sync; handles malformed/legacy data gracefully
- **Location**: Injection point via @elementor/locations for decoupled panel registration
- **Utilities**: Extracted PanelCorner type; new getDragBounds bounds calculation; RTL direction detection
- **Tests**: 246 slice tests, 100 persistence tests, 212 sync tests; corner-position and direction helpers
- **Config**: Updated Jest to use SWC with React automatic runtime; added @elementor/store and @elementor/locations dependencies

## 3. How It Works

Panel registration → Redux slice stores state keyed by ID (byId, minSizeById, titlesById, flags, topZIndex). On sync(), loads persisted state from storage and subscribes to store changes. On panel mutation, debounce-delays (250ms) encoding to localStorage. Deserializer validates schema (all 6 insets, corner validity, numeric size/z-index) and drops malformed entries. On re-register, reuses persisted state if corner matches defaults; discards if divergent (forces re-layout). z-Index increments via bringToFront; resolves to base offset for CSS application.

## 4. Risks

Session isolation: calling sync() twice could leak timers/subscriptions—mitigated by session counter canceling stale operations. Storage quota failures silently swallowed (best-effort)—acceptable for non-critical panel state. Persisted corner mismatch triggers data loss—intentional (prevents broken layouts) but undocumented. No migration path for old two-inset payloads (dropped silently).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
