### PR TITLE
Internal: Editor floating panels - Add drag, resize, and panel interaction hooks [ED-24738]

### DIFF
--- a/packages/jest.config.js
+++ b/packages/jest.config.js
@@ -3,7 +3,18 @@ module.exports = {
 	rootDir: __dirname,
 	testEnvironment: 'jsdom',
 	transform: {
-		'^.+\\.(t|j)sx?$': '@swc/jest',
+		'^.+\\.(t|j)sx?$': [
+			'@swc/jest',
+			{
+				jsc: {
+					transform: {
+						react: {
+							runtime: 'automatic',
+						},
+					},
+				},
+			},
+		],
 	},
 	moduleNameMapper: {
 		'^@elementor/(?!ui|icons|design-tokens)(.*)$': [

--- a/packages/packages/core/editor-floating-panels/src/__tests__/sync.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/sync.test.ts
@@ -108,6 +108,51 @@ describe( 'sync', () => {
 		// Assert.
 		expect( writeSpy ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'merges store updates with preloaded panels not yet registered', () => {
+		// Arrange.
+		const panelB: FloatingPanelState = {
+			...persisted,
+			isOpen: false,
+			zIndex: 2,
+		};
+		const storage = createMemoryStorage( encodePersistedState( { a: persisted, b: panelB } ) );
+		sync( storage );
+
+		// Act.
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+		__dispatch( slice.actions.open( 'a' ) );
+		jest.advanceTimersByTime( 300 );
+
+		// Assert.
+		const written = JSON.parse( storage.snapshot() as string );
+		expect( written.a.isOpen ).toBe( true );
+		expect( written.b ).toEqual( panelB );
+	} );
+
+	it( 'calling sync() twice cancels pending debounce from the first session', () => {
+		// Arrange.
+		const storage = createMemoryStorage();
+		const writeSpy = jest.spyOn( storage, 'write' );
+
+		// Act.
+		sync( storage );
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+		sync( storage );
+		jest.advanceTimersByTime( 300 );
+
+		// Assert — stale timer from the first session must not write.
+		expect( writeSpy ).not.toHaveBeenCalled();
+
+		// Act — change after re-sync schedules persistence for the active session.
+		__dispatch( slice.actions.open( 'a' ) );
+		jest.advanceTimersByTime( 300 );
+
+		// Assert — only the final state is written once.
+		expect( writeSpy ).toHaveBeenCalledTimes( 1 );
+		const written = JSON.parse( storage.snapshot() as string );
+		expect( written.a.isOpen ).toBe( true );
+	} );
 } );
 
 describe( 'sync before the store is ready', () => {

--- a/packages/packages/core/editor-floating-panels/src/hooks/__tests__/use-floating-panel-actions.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/__tests__/use-floating-panel-actions.test.ts
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import {
+	__createStore,
+	__deleteStore,
+	__dispatch,
+	__getState,
+	__getStore,
+	__registerSlice,
+	__StoreProvider as StoreProvider,
+} from '@elementor/store';
+import { act, renderHook } from '@testing-library/react';
+
+import { selectIsOpen, selectPanelState } from '../../store/selectors';
+import { slice } from '../../store/slice';
+import { type FloatingPanelDefaults } from '../../types';
+import { useFloatingPanelActions } from '../use-floating-panel-actions';
+
+const PANEL_ID = 'actions-panel';
+
+const defaults: FloatingPanelDefaults = {
+	width: 320,
+	height: 480,
+	minWidth: 240,
+	minHeight: 320,
+};
+
+function renderActionsHook() {
+	const store = __getStore();
+
+	if ( ! store ) {
+		throw new Error( 'Store is not initialized' );
+	}
+
+	const wrapper = ( { children }: { children: React.ReactNode } ) =>
+		React.createElement( StoreProvider, { store }, children );
+
+	return renderHook( () => useFloatingPanelActions( PANEL_ID ), { wrapper } );
+}
+
+describe( 'useFloatingPanelActions', () => {
+	beforeEach( () => {
+		__registerSlice( slice );
+		__createStore();
+		__dispatch( slice.actions.register( { id: PANEL_ID, defaults } ) );
+	} );
+
+	afterEach( () => {
+		__deleteStore();
+	} );
+
+	it( 'open dispatches open + bringToFront', () => {
+		// Arrange.
+		const { result } = renderActionsHook();
+
+		// Act.
+		act( () => result.current.open() );
+
+		// Assert.
+		expect( selectIsOpen( __getState(), PANEL_ID ) ).toBe( true );
+		expect( selectPanelState( __getState(), PANEL_ID )?.zIndex ).toBe( 1 );
+	} );
+
+	it( 'toggle opens when closed and closes when open', () => {
+		// Arrange.
+		const { result } = renderActionsHook();
+
+		// Assert — initial closed.
+		expect( selectIsOpen( __getState(), PANEL_ID ) ).toBe( false );
+
+		// Act — open via toggle.
+		act( () => result.current.toggle() );
+
+		// Assert.
+		expect( selectIsOpen( __getState(), PANEL_ID ) ).toBe( true );
+		expect( selectPanelState( __getState(), PANEL_ID )?.zIndex ).toBe( 1 );
+
+		// Act — close via toggle.
+		act( () => result.current.toggle() );
+
+		// Assert.
+		expect( selectIsOpen( __getState(), PANEL_ID ) ).toBe( false );
+	} );
+
+	it( 'focus dispatches bringToFront', () => {
+		// Arrange.
+		const { result } = renderActionsHook();
+
+		// Act.
+		act( () => result.current.focus() );
+
+		// Assert.
+		expect( selectPanelState( __getState(), PANEL_ID )?.zIndex ).toBe( 1 );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/hooks/__tests__/use-floating-panel-drag.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/__tests__/use-floating-panel-drag.test.ts
@@ -1,0 +1,222 @@
+import type { PointerEvent } from 'react';
+import { renderHookWithStore } from 'test-utils';
+import { __createStore, __deleteStore, __dispatch, __getState, __getStore, __registerSlice } from '@elementor/store';
+import { act } from '@testing-library/react';
+
+import { selectPosition } from '../../store/selectors';
+import { slice } from '../../store/slice';
+import { type FloatingPanelDefaults } from '../../types';
+import { APP_BAR_HEIGHT_PX } from '../../utils/viewport-bounds';
+import { useFloatingPanelDrag } from '../use-floating-panel-drag';
+
+const PANEL_ID = 'drag-panel';
+const SIDE_PANEL_WIDTH_PX = 280;
+const VIEWPORT_WIDTH_PX = 1200;
+const VIEWPORT_HEIGHT_PX = 800;
+const POINTER_ID = 1;
+
+const defaults: FloatingPanelDefaults = {
+	width: 320,
+	height: 480,
+	minWidth: 240,
+	minHeight: 320,
+	corner: 'block-start-inline-start',
+};
+
+const startPosition = {
+	insetInlineStart: 400,
+	insetInlineEnd: 0,
+	insetBlockStart: 120,
+	insetBlockEnd: 0,
+};
+
+let sidePanelElement: HTMLElement;
+
+function createPointerTarget() {
+	const target = document.createElement( 'div' );
+	target.setPointerCapture = jest.fn();
+
+	return target;
+}
+
+function createPointerEvent(
+	target: HTMLElement,
+	overrides: Partial< { pointerId: number; clientX: number; clientY: number } > = {}
+) {
+	return {
+		pointerId: POINTER_ID,
+		clientX: 0,
+		clientY: 0,
+		currentTarget: target,
+		...overrides,
+	} as unknown as PointerEvent< HTMLElement >;
+}
+
+function setupViewport() {
+	Object.defineProperty( window, 'innerWidth', { configurable: true, value: VIEWPORT_WIDTH_PX } );
+	Object.defineProperty( window, 'innerHeight', { configurable: true, value: VIEWPORT_HEIGHT_PX } );
+
+	const sidePanel = document.createElement( 'div' );
+	sidePanel.id = 'elementor-panel';
+	jest.spyOn( sidePanel, 'getBoundingClientRect' ).mockReturnValue( { width: SIDE_PANEL_WIDTH_PX } as DOMRect );
+	document.body.appendChild( sidePanel );
+	sidePanelElement = sidePanel;
+}
+
+describe( 'useFloatingPanelDrag', () => {
+	beforeEach( () => {
+		setupViewport();
+		__registerSlice( slice );
+		__createStore();
+		__dispatch( slice.actions.register( { id: PANEL_ID, defaults } ) );
+		__dispatch( slice.actions.open( PANEL_ID ) );
+		__dispatch( slice.actions.setPosition( { id: PANEL_ID, position: startPosition } ) );
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		__deleteStore();
+	} );
+
+	it( 'updates panel position while dragging', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		const target = createPointerTarget();
+		const { result } = renderHookWithStore( () => useFloatingPanelDrag( PANEL_ID ), store );
+
+		// Act.
+		act( () => {
+			result.current.onPointerDown( createPointerEvent( target, { clientX: 100, clientY: 200 } ) );
+			result.current.onPointerMove( createPointerEvent( target, { clientX: 150, clientY: 230 } ) );
+		} );
+
+		// Assert.
+		expect( selectPosition( __getState(), PANEL_ID ) ).toEqual( {
+			insetInlineStart: 450,
+			insetInlineEnd: 0,
+			insetBlockStart: 150,
+			insetBlockEnd: 0,
+		} );
+		expect( target.setPointerCapture ).toHaveBeenCalledWith( POINTER_ID );
+	} );
+
+	it( 'clamps drag position to viewport bounds', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		const target = createPointerTarget();
+		const { result } = renderHookWithStore( () => useFloatingPanelDrag( PANEL_ID ), store );
+
+		// Act.
+		act( () => {
+			result.current.onPointerDown( createPointerEvent( target, { clientX: 0, clientY: 0 } ) );
+			result.current.onPointerMove( createPointerEvent( target, { clientX: -10_000, clientY: -10_000 } ) );
+		} );
+
+		// Assert.
+		expect( selectPosition( __getState(), PANEL_ID ) ).toEqual( {
+			insetInlineStart: SIDE_PANEL_WIDTH_PX,
+			insetInlineEnd: 0,
+			insetBlockStart: APP_BAR_HEIGHT_PX,
+			insetBlockEnd: 0,
+		} );
+	} );
+
+	it( 'ignores pointer move events from a different pointer id', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		const target = createPointerTarget();
+		const { result } = renderHookWithStore( () => useFloatingPanelDrag( PANEL_ID ), store );
+
+		// Act.
+		act( () => {
+			result.current.onPointerDown( createPointerEvent( target, { clientX: 0, clientY: 0 } ) );
+			result.current.onPointerMove( createPointerEvent( target, { pointerId: 2, clientX: 500, clientY: 500 } ) );
+		} );
+
+		// Assert.
+		expect( selectPosition( __getState(), PANEL_ID ) ).toEqual( startPosition );
+	} );
+
+	it( 'snapshots viewport bounds at pointer down', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		const getBoundingClientRect = jest.spyOn( sidePanelElement, 'getBoundingClientRect' );
+		const target = createPointerTarget();
+		const { result } = renderHookWithStore( () => useFloatingPanelDrag( PANEL_ID ), store );
+
+		// Act.
+		act( () => {
+			result.current.onPointerDown( createPointerEvent( target, { clientX: 0, clientY: 0 } ) );
+			getBoundingClientRect.mockClear();
+			result.current.onPointerMove( createPointerEvent( target, { clientX: 50, clientY: 50 } ) );
+			result.current.onPointerMove( createPointerEvent( target, { clientX: 100, clientY: 100 } ) );
+		} );
+
+		// Assert.
+		expect( getBoundingClientRect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'clears the drag session on pointer up', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		const target = createPointerTarget();
+		const { result } = renderHookWithStore( () => useFloatingPanelDrag( PANEL_ID ), store );
+
+		// Act.
+		act( () => {
+			result.current.onPointerDown( createPointerEvent( target, { clientX: 0, clientY: 0 } ) );
+			result.current.onPointerUp( createPointerEvent( target ) );
+			result.current.onPointerMove( createPointerEvent( target, { clientX: 500, clientY: 500 } ) );
+		} );
+
+		// Assert.
+		expect( selectPosition( __getState(), PANEL_ID ) ).toEqual( startPosition );
+	} );
+
+	it( 'clears the drag session on pointer cancel', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		const target = createPointerTarget();
+		const { result } = renderHookWithStore( () => useFloatingPanelDrag( PANEL_ID ), store );
+
+		// Act.
+		act( () => {
+			result.current.onPointerDown( createPointerEvent( target, { clientX: 0, clientY: 0 } ) );
+			result.current.onPointerCancel( createPointerEvent( target ) );
+			result.current.onPointerMove( createPointerEvent( target, { clientX: 500, clientY: 500 } ) );
+		} );
+
+		// Assert.
+		expect( selectPosition( __getState(), PANEL_ID ) ).toEqual( startPosition );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/hooks/__tests__/use-floating-panel-resize.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/__tests__/use-floating-panel-resize.test.ts
@@ -1,0 +1,226 @@
+import type { PointerEvent } from 'react';
+import { renderHookWithStore } from 'test-utils';
+import { __createStore, __deleteStore, __dispatch, __getState, __getStore, __registerSlice } from '@elementor/store';
+import { act } from '@testing-library/react';
+
+import { selectPosition, selectSize } from '../../store/selectors';
+import { slice } from '../../store/slice';
+import { type FloatingPanelDefaults } from '../../types';
+import { usePanelResizeInteraction } from '../use-floating-panel-resize';
+
+const PANEL_ID = 'resize-panel';
+const SIDE_PANEL_WIDTH_PX = 280;
+const VIEWPORT_WIDTH_PX = 1200;
+const VIEWPORT_HEIGHT_PX = 800;
+const POINTER_ID = 1;
+
+const defaults: FloatingPanelDefaults = {
+	width: 320,
+	height: 480,
+	minWidth: 240,
+	minHeight: 320,
+	corner: 'block-start-inline-start',
+};
+
+const startPosition = {
+	insetInlineStart: 400,
+	insetInlineEnd: 0,
+	insetBlockStart: 120,
+	insetBlockEnd: 0,
+};
+const startSize = { inlineSize: 320, blockSize: 480 };
+
+let sidePanelElement: HTMLElement;
+
+function createPointerTarget() {
+	const target = document.createElement( 'div' );
+	target.setPointerCapture = jest.fn();
+
+	return target;
+}
+
+function createPointerEvent(
+	target: HTMLElement,
+	overrides: Partial< { pointerId: number; clientX: number; clientY: number } > = {}
+) {
+	return {
+		pointerId: POINTER_ID,
+		clientX: 0,
+		clientY: 0,
+		currentTarget: target,
+		...overrides,
+	} as unknown as PointerEvent< HTMLElement >;
+}
+
+function setupViewport() {
+	Object.defineProperty( window, 'innerWidth', { configurable: true, value: VIEWPORT_WIDTH_PX } );
+	Object.defineProperty( window, 'innerHeight', { configurable: true, value: VIEWPORT_HEIGHT_PX } );
+
+	const sidePanel = document.createElement( 'div' );
+	sidePanel.id = 'elementor-panel';
+	jest.spyOn( sidePanel, 'getBoundingClientRect' ).mockReturnValue( { width: SIDE_PANEL_WIDTH_PX } as DOMRect );
+	document.body.appendChild( sidePanel );
+	sidePanelElement = sidePanel;
+}
+
+describe( 'usePanelResizeInteraction', () => {
+	beforeEach( () => {
+		setupViewport();
+		__registerSlice( slice );
+		__createStore();
+		__dispatch( slice.actions.register( { id: PANEL_ID, defaults } ) );
+		__dispatch( slice.actions.open( PANEL_ID ) );
+		__dispatch( slice.actions.setPosition( { id: PANEL_ID, position: startPosition } ) );
+		__dispatch( slice.actions.setSize( { id: PANEL_ID, size: startSize } ) );
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		__deleteStore();
+	} );
+
+	it( 'updates panel size while resizing an inline-end edge', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		const target = createPointerTarget();
+		const { result } = renderHookWithStore( () => usePanelResizeInteraction( PANEL_ID ), store );
+		const handleProps = result.current.getResizeHandleProps( 'inline-end' );
+
+		// Act.
+		act( () => {
+			handleProps.onPointerDown( createPointerEvent( target, { clientX: 0, clientY: 0 } ) );
+			handleProps.onPointerMove( createPointerEvent( target, { clientX: 50, clientY: 0 } ) );
+		} );
+
+		// Assert.
+		expect( selectSize( __getState(), PANEL_ID ) ).toEqual( { inlineSize: 370, blockSize: 480 } );
+		expect( selectPosition( __getState(), PANEL_ID ) ).toEqual( startPosition );
+		expect( target.setPointerCapture ).toHaveBeenCalledWith( POINTER_ID );
+	} );
+
+	it( 'updates position and size while resizing an inline-start edge', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		const target = createPointerTarget();
+		const { result } = renderHookWithStore( () => usePanelResizeInteraction( PANEL_ID ), store );
+		const handleProps = result.current.getResizeHandleProps( 'inline-start' );
+
+		// Act.
+		act( () => {
+			handleProps.onPointerDown( createPointerEvent( target, { clientX: 0, clientY: 0 } ) );
+			handleProps.onPointerMove( createPointerEvent( target, { clientX: -40, clientY: 0 } ) );
+		} );
+
+		// Assert.
+		expect( selectPosition( __getState(), PANEL_ID ) ).toEqual( {
+			insetInlineStart: 360,
+			insetInlineEnd: 0,
+			insetBlockStart: 120,
+			insetBlockEnd: 0,
+		} );
+		expect( selectSize( __getState(), PANEL_ID ) ).toEqual( { inlineSize: 360, blockSize: 480 } );
+	} );
+
+	it( 'updates panel size while resizing a block-end edge', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		const target = createPointerTarget();
+		const { result } = renderHookWithStore( () => usePanelResizeInteraction( PANEL_ID ), store );
+		const handleProps = result.current.getResizeHandleProps( 'block-end' );
+
+		// Act.
+		act( () => {
+			handleProps.onPointerDown( createPointerEvent( target, { clientX: 0, clientY: 0 } ) );
+			handleProps.onPointerMove( createPointerEvent( target, { clientX: 0, clientY: 40 } ) );
+		} );
+
+		// Assert.
+		expect( selectSize( __getState(), PANEL_ID ) ).toEqual( { inlineSize: 320, blockSize: 520 } );
+	} );
+
+	it( 'ignores pointer down when the panel has no geometry', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		const target = createPointerTarget();
+		const { result } = renderHookWithStore( () => usePanelResizeInteraction( 'missing-panel' ), store );
+		const handleProps = result.current.getResizeHandleProps( 'inline-end' );
+
+		// Act.
+		act( () => {
+			handleProps.onPointerDown( createPointerEvent( target, { clientX: 0, clientY: 0 } ) );
+			handleProps.onPointerMove( createPointerEvent( target, { clientX: 100, clientY: 0 } ) );
+		} );
+
+		// Assert.
+		expect( target.setPointerCapture ).not.toHaveBeenCalled();
+		expect( selectSize( __getState(), PANEL_ID ) ).toEqual( startSize );
+	} );
+
+	it( 'snapshots viewport bounds at pointer down', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		const getBoundingClientRect = jest.spyOn( sidePanelElement, 'getBoundingClientRect' );
+		const target = createPointerTarget();
+		const { result } = renderHookWithStore( () => usePanelResizeInteraction( PANEL_ID ), store );
+		const handleProps = result.current.getResizeHandleProps( 'inline-end' );
+
+		// Act.
+		act( () => {
+			handleProps.onPointerDown( createPointerEvent( target, { clientX: 0, clientY: 0 } ) );
+			getBoundingClientRect.mockClear();
+			handleProps.onPointerMove( createPointerEvent( target, { clientX: 50, clientY: 0 } ) );
+			handleProps.onPointerMove( createPointerEvent( target, { clientX: 100, clientY: 0 } ) );
+		} );
+
+		// Assert.
+		expect( getBoundingClientRect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'clears the resize session on pointer up', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		const target = createPointerTarget();
+		const { result } = renderHookWithStore( () => usePanelResizeInteraction( PANEL_ID ), store );
+		const handleProps = result.current.getResizeHandleProps( 'inline-end' );
+
+		// Act.
+		act( () => {
+			handleProps.onPointerDown( createPointerEvent( target, { clientX: 0, clientY: 0 } ) );
+			handleProps.onPointerUp( createPointerEvent( target ) );
+			handleProps.onPointerMove( createPointerEvent( target, { clientX: 200, clientY: 0 } ) );
+		} );
+
+		// Assert.
+		expect( selectSize( __getState(), PANEL_ID ) ).toEqual( startSize );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/hooks/__tests__/use-floating-panel-z-index.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/__tests__/use-floating-panel-z-index.test.ts
@@ -1,0 +1,48 @@
+import { renderHookWithStore } from 'test-utils';
+import { __createStore, __deleteStore, __dispatch, __getStore, __registerSlice } from '@elementor/store';
+
+import { FLOATING_PANEL_Z_INDEX_BASE } from '../../constants';
+import { slice } from '../../store/slice';
+import { type FloatingPanelDefaults } from '../../types';
+import { useFloatingPanelZIndex } from '../use-floating-panel-z-index';
+
+const PANEL_ID = 'panel';
+
+const defaults: FloatingPanelDefaults = {
+	width: 320,
+	height: 480,
+	minWidth: 240,
+	minHeight: 320,
+	corner: 'block-start-inline-start',
+};
+
+describe( 'useFloatingPanelZIndex', () => {
+	beforeEach( () => {
+		__registerSlice( slice );
+		__createStore();
+		__dispatch( slice.actions.register( { id: PANEL_ID, defaults } ) );
+		__dispatch( slice.actions.open( PANEL_ID ) );
+		__dispatch( slice.actions.bringToFront( PANEL_ID ) );
+	} );
+
+	afterEach( () => {
+		__deleteStore();
+	} );
+
+	it( 'returns one above the panel z-index', () => {
+		// Arrange.
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store is not initialized' );
+		}
+
+		// Act.
+		const { result } = renderHookWithStore( () => useFloatingPanelZIndex( PANEL_ID ), store );
+
+		// Assert.
+		const BRING_TO_FRONT_Z = 1;
+		const OVERLAY_OFFSET = 1;
+		expect( result.current ).toBe( FLOATING_PANEL_Z_INDEX_BASE + BRING_TO_FRONT_Z + OVERLAY_OFFSET );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-actions.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-actions.ts
@@ -1,0 +1,26 @@
+import { __useDispatch as useDispatch, __useSelector as useSelector } from '@elementor/store';
+
+import { type GlobalState, selectIsOpen } from '../store/selectors';
+import { slice } from '../store/slice';
+import { type LogicalPosition, type LogicalSize } from '../types';
+
+export function useFloatingPanelActions( id: string ) {
+	const dispatch = useDispatch();
+	const isOpen = useSelector( ( state: GlobalState ) => selectIsOpen( state, id ) );
+
+	const open = () => {
+		dispatch( slice.actions.open( id ) );
+		dispatch( slice.actions.bringToFront( id ) );
+	};
+
+	const close = () => dispatch( slice.actions.close( id ) );
+
+	return {
+		open,
+		close,
+		toggle: () => ( isOpen ? close() : open() ),
+		setPosition: ( position: LogicalPosition ) => dispatch( slice.actions.setPosition( { id, position } ) ),
+		setSize: ( size: LogicalSize ) => dispatch( slice.actions.setSize( { id, size } ) ),
+		focus: () => dispatch( slice.actions.bringToFront( id ) ),
+	};
+}

--- a/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-drag.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-drag.ts
@@ -1,25 +1,19 @@
 import { type PointerEvent as ReactPointerEvent, useCallback, useRef } from 'react';
 
-import { type LogicalPosition, type LogicalSize } from '../types';
-import { getDragBounds, type PanelCorner } from '../utils/corner-position';
+import { type LogicalPosition } from '../types';
+import { activePositionChanged, getDragBounds, type PanelCorner } from '../utils/corner-position';
 import { isRtl } from '../utils/direction';
 import { applyDragDelta, type DragBounds, physicalToLogicalDelta } from '../utils/drag-math';
 import { APP_BAR_HEIGHT_PX, getSidePanelInlineSize } from '../utils/viewport-bounds';
 import { useFloatingPanelActions } from './use-floating-panel-actions';
 import { useFloatingPanelStatus } from './use-floating-panel-status';
 
-const EMPTY_POSITION: LogicalPosition = {
-	insetBlockStart: 0,
-	insetBlockEnd: 0,
-	insetInlineStart: 0,
-	insetInlineEnd: 0,
-};
-
 type DragSession = {
 	pointerId: number;
 	startClientX: number;
 	startClientY: number;
 	startPosition: LogicalPosition;
+	lastDispatchedPosition: LogicalPosition;
 	bounds: DragBounds;
 	corner: PanelCorner;
 	isRtl: boolean;
@@ -32,22 +26,25 @@ export function useFloatingPanelDrag( id: string ) {
 
 	const onPointerDown = useCallback(
 		( event: ReactPointerEvent< HTMLElement > ) => {
-			event.currentTarget.setPointerCapture( event.pointerId );
+			if ( ! corner || ! position || ! size ) {
+				return;
+			}
 
-			const panelSize: LogicalSize = size ?? { inlineSize: 0, blockSize: 0 };
+			event.currentTarget.setPointerCapture( event.pointerId );
 
 			sessionRef.current = {
 				pointerId: event.pointerId,
 				startClientX: event.clientX,
 				startClientY: event.clientY,
-				startPosition: position ?? EMPTY_POSITION,
+				startPosition: position,
+				lastDispatchedPosition: position,
 				bounds: getDragBounds(
-					panelSize,
+					size,
 					{ width: window.innerWidth, height: window.innerHeight },
 					getSidePanelInlineSize(),
 					APP_BAR_HEIGHT_PX
 				),
-				corner: corner ?? 'block-start-inline-start',
+				corner,
 				isRtl: isRtl(),
 			};
 		},
@@ -64,8 +61,12 @@ export function useFloatingPanelDrag( id: string ) {
 
 			const physical = { dx: event.clientX - session.startClientX, dy: event.clientY - session.startClientY };
 			const logical = physicalToLogicalDelta( physical, session.isRtl );
+			const nextPosition = applyDragDelta( session.corner, session.startPosition, logical, session.bounds );
 
-			setPosition( applyDragDelta( session.corner, session.startPosition, logical, session.bounds ) );
+			if ( activePositionChanged( session.corner, session.lastDispatchedPosition, nextPosition ) ) {
+				setPosition( nextPosition );
+				session.lastDispatchedPosition = nextPosition;
+			}
 		},
 		[ setPosition ]
 	);

--- a/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-drag.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-drag.ts
@@ -1,0 +1,84 @@
+import { type PointerEvent as ReactPointerEvent, useCallback, useRef } from 'react';
+
+import { type LogicalPosition, type LogicalSize } from '../types';
+import { getDragBounds, type PanelCorner } from '../utils/corner-position';
+import { isRtl } from '../utils/direction';
+import { applyDragDelta, type DragBounds, physicalToLogicalDelta } from '../utils/drag-math';
+import { APP_BAR_HEIGHT_PX, getSidePanelInlineSize } from '../utils/viewport-bounds';
+import { useFloatingPanelActions } from './use-floating-panel-actions';
+import { useFloatingPanelStatus } from './use-floating-panel-status';
+
+const EMPTY_POSITION: LogicalPosition = {
+	insetBlockStart: 0,
+	insetBlockEnd: 0,
+	insetInlineStart: 0,
+	insetInlineEnd: 0,
+};
+
+type DragSession = {
+	pointerId: number;
+	startClientX: number;
+	startClientY: number;
+	startPosition: LogicalPosition;
+	bounds: DragBounds;
+	corner: PanelCorner;
+	isRtl: boolean;
+};
+
+export function useFloatingPanelDrag( id: string ) {
+	const sessionRef = useRef< DragSession | null >( null );
+	const { corner, position, size } = useFloatingPanelStatus( id );
+	const { setPosition } = useFloatingPanelActions( id );
+
+	const onPointerDown = useCallback(
+		( event: ReactPointerEvent< HTMLElement > ) => {
+			event.currentTarget.setPointerCapture( event.pointerId );
+
+			const panelSize: LogicalSize = size ?? { inlineSize: 0, blockSize: 0 };
+
+			sessionRef.current = {
+				pointerId: event.pointerId,
+				startClientX: event.clientX,
+				startClientY: event.clientY,
+				startPosition: position ?? EMPTY_POSITION,
+				bounds: getDragBounds(
+					panelSize,
+					{ width: window.innerWidth, height: window.innerHeight },
+					getSidePanelInlineSize(),
+					APP_BAR_HEIGHT_PX
+				),
+				corner: corner ?? 'block-start-inline-start',
+				isRtl: isRtl(),
+			};
+		},
+		[ corner, position, size ]
+	);
+
+	const onPointerMove = useCallback(
+		( event: ReactPointerEvent< HTMLElement > ) => {
+			const session = sessionRef.current;
+
+			if ( ! session || session.pointerId !== event.pointerId ) {
+				return;
+			}
+
+			const physical = { dx: event.clientX - session.startClientX, dy: event.clientY - session.startClientY };
+			const logical = physicalToLogicalDelta( physical, session.isRtl );
+
+			setPosition( applyDragDelta( session.corner, session.startPosition, logical, session.bounds ) );
+		},
+		[ setPosition ]
+	);
+
+	const clearSession = useCallback( ( event: ReactPointerEvent< HTMLElement > ) => {
+		const session = sessionRef.current;
+
+		if ( ! session || session.pointerId !== event.pointerId ) {
+			return;
+		}
+
+		sessionRef.current = null;
+	}, [] );
+
+	return { onPointerDown, onPointerMove, onPointerUp: clearSession, onPointerCancel: clearSession };
+}

--- a/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-resize.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-resize.ts
@@ -1,0 +1,160 @@
+import { type PointerEvent as ReactPointerEvent, useCallback, useRef } from 'react';
+import { __useSelector as useSelector } from '@elementor/store';
+
+import { type GlobalState, selectMinSize } from '../store/selectors';
+import { type LogicalPosition, type LogicalSize } from '../types';
+import {
+	activePositionChanged,
+	fromStartAnchoredPosition,
+	type PanelCorner,
+	toStartAnchoredPosition,
+} from '../utils/corner-position';
+import { isRtl } from '../utils/direction';
+import { physicalToLogicalDelta } from '../utils/drag-math';
+import { applyResize, type ResizeBounds, type ResizeDirection } from '../utils/resize-math';
+import { APP_BAR_HEIGHT_PX, getSidePanelInlineSize } from '../utils/viewport-bounds';
+import { useFloatingPanelActions } from './use-floating-panel-actions';
+import { useFloatingPanelStatus } from './use-floating-panel-status';
+
+type ResizeSession = {
+	pointerId: number;
+	direction: ResizeDirection;
+	startClientX: number;
+	startClientY: number;
+	startPosition: LogicalPosition;
+	startSize: LogicalSize;
+	bounds: ResizeBounds;
+	corner: PanelCorner;
+	isRtl: boolean;
+};
+
+function getResizeBounds(
+	corner: PanelCorner,
+	position: LogicalPosition,
+	currentSize: LogicalSize,
+	minSize: LogicalSize
+): ResizeBounds {
+	const viewport = { width: window.innerWidth, height: window.innerHeight };
+	const startAnchored = toStartAnchoredPosition( corner, position, currentSize, viewport );
+
+	return {
+		minBlockSize: minSize.blockSize,
+		maxBlockSize: window.innerHeight - startAnchored.insetBlockStart,
+		minInlineSize: minSize.inlineSize,
+		maxInlineSize: window.innerWidth - startAnchored.insetInlineStart,
+		minInlineStart: getSidePanelInlineSize(),
+		minBlockStart: APP_BAR_HEIGHT_PX,
+	};
+}
+
+type ResizeHandlePointerHandlers = {
+	onPointerDown: ( event: ReactPointerEvent< HTMLElement > ) => void;
+	onPointerMove: ( event: ReactPointerEvent< HTMLElement > ) => void;
+	onPointerUp: ( event: ReactPointerEvent< HTMLElement > ) => void;
+	onPointerCancel: ( event: ReactPointerEvent< HTMLElement > ) => void;
+};
+
+export function usePanelResizeInteraction( id: string ) {
+	const sessionRef = useRef< ResizeSession | null >( null );
+	const { corner, position, size } = useFloatingPanelStatus( id );
+	const minSize = useSelector( ( state: GlobalState ) => selectMinSize( state, id ) );
+	const { setPosition, setSize } = useFloatingPanelActions( id );
+
+	const onPointerDown = useCallback(
+		( direction: ResizeDirection, event: ReactPointerEvent< HTMLElement > ) => {
+			if ( ! corner || ! position || ! size || ! minSize ) {
+				return;
+			}
+
+			event.currentTarget.setPointerCapture( event.pointerId );
+
+			sessionRef.current = {
+				pointerId: event.pointerId,
+				direction,
+				startClientX: event.clientX,
+				startClientY: event.clientY,
+				startPosition: position,
+				startSize: size,
+				bounds: getResizeBounds( corner, position, size, minSize ),
+				corner,
+				isRtl: isRtl(),
+			};
+		},
+		[ corner, position, size, minSize ]
+	);
+
+	const onPointerMove = useCallback(
+		( event: ReactPointerEvent< HTMLElement > ) => {
+			const session = sessionRef.current;
+
+			if ( ! session || session.pointerId !== event.pointerId ) {
+				return;
+			}
+
+			const physical = { dx: event.clientX - session.startClientX, dy: event.clientY - session.startClientY };
+			const logical = physicalToLogicalDelta( physical, session.isRtl );
+			const viewport = { width: window.innerWidth, height: window.innerHeight };
+			const startAnchoredPosition = toStartAnchoredPosition(
+				session.corner,
+				session.startPosition,
+				session.startSize,
+				viewport
+			);
+			const resizeInput = { ...session.startPosition, ...startAnchoredPosition };
+			const next = applyResize(
+				session.direction,
+				resizeInput,
+				session.startSize,
+				logical.inlineDelta,
+				logical.blockDelta,
+				session.bounds
+			);
+			const nextPosition = fromStartAnchoredPosition(
+				session.corner,
+				{
+					insetBlockStart: next.position.insetBlockStart,
+					insetInlineStart: next.position.insetInlineStart,
+				},
+				next.size,
+				viewport
+			);
+
+			if ( activePositionChanged( session.corner, session.startPosition, nextPosition ) ) {
+				setPosition( nextPosition );
+			}
+
+			const sizeChanged =
+				next.size.inlineSize !== session.startSize.inlineSize ||
+				next.size.blockSize !== session.startSize.blockSize;
+
+			if ( sizeChanged ) {
+				setSize( next.size );
+			}
+		},
+		[ setPosition, setSize ]
+	);
+
+	const clearSession = useCallback( ( event: ReactPointerEvent< HTMLElement > ) => {
+		const session = sessionRef.current;
+
+		if ( ! session || session.pointerId !== event.pointerId ) {
+			return;
+		}
+
+		sessionRef.current = null;
+	}, [] );
+
+	const getResizeHandleProps = useCallback(
+		( direction: ResizeDirection ): ResizeHandlePointerHandlers => {
+			return {
+				onPointerDown: ( event ) => onPointerDown( direction, event ),
+				onPointerMove,
+				onPointerUp: clearSession,
+				onPointerCancel: clearSession,
+			};
+		},
+		[ onPointerDown, onPointerMove, clearSession ]
+	);
+
+	return { getResizeHandleProps };
+}

--- a/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-resize.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-resize.ts
@@ -23,6 +23,8 @@ type ResizeSession = {
 	startClientY: number;
 	startPosition: LogicalPosition;
 	startSize: LogicalSize;
+	lastPosition: LogicalPosition;
+	lastSize: LogicalSize;
 	bounds: ResizeBounds;
 	corner: PanelCorner;
 	isRtl: boolean;
@@ -75,6 +77,8 @@ export function usePanelResizeInteraction( id: string ) {
 				startClientY: event.clientY,
 				startPosition: position,
 				startSize: size,
+				lastPosition: position,
+				lastSize: size,
 				bounds: getResizeBounds( corner, position, size, minSize ),
 				corner,
 				isRtl: isRtl(),
@@ -119,16 +123,18 @@ export function usePanelResizeInteraction( id: string ) {
 				viewport
 			);
 
-			if ( activePositionChanged( session.corner, session.startPosition, nextPosition ) ) {
+			if ( activePositionChanged( session.corner, session.lastPosition, nextPosition ) ) {
 				setPosition( nextPosition );
+				session.lastPosition = nextPosition;
 			}
 
 			const sizeChanged =
-				next.size.inlineSize !== session.startSize.inlineSize ||
-				next.size.blockSize !== session.startSize.blockSize;
+				next.size.inlineSize !== session.lastSize.inlineSize ||
+				next.size.blockSize !== session.lastSize.blockSize;
 
 			if ( sizeChanged ) {
 				setSize( next.size );
+				session.lastSize = next.size;
 			}
 		},
 		[ setPosition, setSize ]

--- a/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-status.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-status.ts
@@ -1,0 +1,17 @@
+import { __createSelector, __useSelector as useSelector } from '@elementor/store';
+
+import { type GlobalState, selectCorner, selectIsOpen, selectPosition, selectSize } from '../store/selectors';
+
+const selectStatus = __createSelector(
+	[
+		( state: GlobalState, id: string ) => selectIsOpen( state, id ),
+		( state: GlobalState, id: string ) => selectCorner( state, id ),
+		( state: GlobalState, id: string ) => selectPosition( state, id ),
+		( state: GlobalState, id: string ) => selectSize( state, id ),
+	],
+	( isOpen, corner, position, size ) => ( { isOpen, corner, position, size } )
+);
+
+export function useFloatingPanelStatus( id: string ) {
+	return useSelector( ( state: GlobalState ) => selectStatus( state, id ) );
+}

--- a/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-z-index.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-z-index.ts
@@ -1,0 +1,7 @@
+import { __useSelector as useSelector } from '@elementor/store';
+
+import { type GlobalState, resolveOverlayZIndex } from '../store/selectors';
+
+export function useFloatingPanelZIndex( panelId: string ): number {
+	return useSelector( ( state: GlobalState ) => resolveOverlayZIndex( state, panelId ) );
+}

--- a/packages/packages/core/editor-floating-panels/src/sync.ts
+++ b/packages/packages/core/editor-floating-panels/src/sync.ts
@@ -30,6 +30,7 @@ export const localStorageAdapter: PanelStateStorage = {
 
 let cachedPersistedState: Record< string, FloatingPanelState > = {};
 let isSyncInitialized = false;
+let persistenceTimer: ReturnType< typeof setTimeout > | null = null;
 let persistenceUnsubscribe: ( () => void ) | null = null;
 let persistenceSession = 0;
 
@@ -50,12 +51,19 @@ export function getPersistedState( id: string ): FloatingPanelState | undefined 
 
 const STORE_READY_POLL_MS = 16;
 
+function clearPersistenceTimer(): void {
+	if ( persistenceTimer ) {
+		clearTimeout( persistenceTimer );
+		persistenceTimer = null;
+	}
+}
+
 function schedulePersistence( storage: PanelStateStorage ): void {
+	clearPersistenceTimer();
 	persistenceUnsubscribe?.();
 	persistenceUnsubscribe = null;
 
 	const session = ++persistenceSession;
-	let timer: ReturnType< typeof setTimeout > | null = null;
 
 	const subscribe = () => {
 		if ( session !== persistenceSession ) {
@@ -65,12 +73,15 @@ function schedulePersistence( storage: PanelStateStorage ): void {
 		persistenceUnsubscribe = __subscribeWithSelector(
 			( state: GlobalState ) => state.floatingPanels.byId,
 			( byId ) => {
-				if ( timer ) {
-					clearTimeout( timer );
-				}
+				clearPersistenceTimer();
 
-				timer = setTimeout( () => {
-					storage.write( encodePersistedState( byId ) );
+				persistenceTimer = setTimeout( () => {
+					if ( session !== persistenceSession ) {
+						return;
+					}
+
+					cachedPersistedState = { ...cachedPersistedState, ...byId };
+					storage.write( encodePersistedState( cachedPersistedState ) );
 				}, PERSIST_DEBOUNCE_MS );
 			}
 		);

--- a/packages/packages/core/editor-floating-panels/src/utils/__tests__/corner-position.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/__tests__/corner-position.test.ts
@@ -3,13 +3,16 @@ import {
 	buildInitialPosition,
 	fromStartAnchoredPosition,
 	getActiveInsetKeys,
+	getDragBounds,
 	type PanelCorner,
 	positionToCssInsets,
 	toStartAnchoredPosition,
 } from '../corner-position';
+import { APP_BAR_HEIGHT_PX } from '../viewport-bounds';
 
 const VIEWPORT = { width: 1200, height: 900 };
 const SIZE: LogicalSize = { inlineSize: 320, blockSize: 480 };
+const SIDE_PANEL_INLINE_SIZE_PX = 280;
 
 describe( 'corner-position', () => {
 	it.each< [ PanelCorner, [ keyof LogicalPosition, keyof LogicalPosition ] ] >( [
@@ -59,5 +62,33 @@ describe( 'corner-position', () => {
 		const restored = fromStartAnchoredPosition( 'block-end-inline-end', startAnchored, SIZE, VIEWPORT );
 
 		expect( restored ).toEqual( position );
+	} );
+
+	it( 'getDragBounds returns normal bounds within the viewport', () => {
+		expect( getDragBounds( SIZE, VIEWPORT, SIDE_PANEL_INLINE_SIZE_PX, APP_BAR_HEIGHT_PX ) ).toEqual( {
+			minInlineStart: SIDE_PANEL_INLINE_SIZE_PX,
+			maxInlineStart: VIEWPORT.width - SIZE.inlineSize,
+			minInlineEnd: 0,
+			maxInlineEnd: VIEWPORT.width - SIDE_PANEL_INLINE_SIZE_PX - SIZE.inlineSize,
+			minBlockStart: APP_BAR_HEIGHT_PX,
+			maxBlockStart: VIEWPORT.height - SIZE.blockSize,
+			minBlockEnd: 0,
+			maxBlockEnd: VIEWPORT.height - APP_BAR_HEIGHT_PX - SIZE.blockSize,
+		} );
+	} );
+
+	it( 'getDragBounds allows inverted bounds when the panel exceeds the viewport', () => {
+		const oversizedSize: LogicalSize = { inlineSize: 1000, blockSize: 900 };
+
+		expect( getDragBounds( oversizedSize, VIEWPORT, SIDE_PANEL_INLINE_SIZE_PX, APP_BAR_HEIGHT_PX ) ).toEqual( {
+			minInlineStart: SIDE_PANEL_INLINE_SIZE_PX,
+			maxInlineStart: VIEWPORT.width - oversizedSize.inlineSize,
+			minInlineEnd: 0,
+			maxInlineEnd: VIEWPORT.width - SIDE_PANEL_INLINE_SIZE_PX - oversizedSize.inlineSize,
+			minBlockStart: APP_BAR_HEIGHT_PX,
+			maxBlockStart: VIEWPORT.height - oversizedSize.blockSize,
+			minBlockEnd: 0,
+			maxBlockEnd: VIEWPORT.height - APP_BAR_HEIGHT_PX - oversizedSize.blockSize,
+		} );
 	} );
 } );

--- a/packages/packages/core/editor-floating-panels/src/utils/__tests__/direction.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/__tests__/direction.test.ts
@@ -1,0 +1,23 @@
+import { isRtl } from '../direction';
+
+describe( 'direction', () => {
+	afterEach( () => {
+		document.documentElement.removeAttribute( 'dir' );
+	} );
+
+	it( 'returns true when document dir is rtl', () => {
+		// Arrange.
+		document.documentElement.dir = 'rtl';
+
+		// Act & Assert.
+		expect( isRtl() ).toBe( true );
+	} );
+
+	it( 'returns false when document dir is ltr', () => {
+		// Arrange.
+		document.documentElement.dir = 'ltr';
+
+		// Act & Assert.
+		expect( isRtl() ).toBe( false );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/utils/resize-math.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/resize-math.ts
@@ -1,15 +1,12 @@
 import { type LogicalPosition, type LogicalSize } from '../types';
 import { clamp } from './clamp';
+import { type PanelCorner } from './corner-position';
 
 export type ResizeEdge = 'inline-start' | 'inline-end' | 'block-start' | 'block-end';
 
-export type ResizeCorner =
-	| 'block-start-inline-start'
-	| 'block-start-inline-end'
-	| 'block-end-inline-start'
-	| 'block-end-inline-end';
+export type ResizeCorner = PanelCorner;
 
-export type ResizeDirection = ResizeEdge | ResizeCorner;
+export type ResizeDirection = ResizeEdge | PanelCorner;
 
 export type ResizeBounds = {
 	minInlineSize: number;


### PR DESCRIPTION
## Summary

Adds React hooks for floating panel drag, resize, actions, status, and z-index.

Split from #36308 (3/5). Stacked on #36359.

## Scope

- `useFloatingPanelDrag` — pointer capture, bounds clamping, RTL deltas
- `usePanelResizeInteraction` — corner-anchored resize with min/max bounds
- `useFloatingPanelActions`, `useFloatingPanelStatus`, `useFloatingPanelZIndex`

## Review focus

Pointer event lifecycle, pointercancel cleanup, bounds enforcement, RTL delta transforms.

Ref: ED-24738

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding interaction hooks for floating panels to support drag, resize, and z-index management—foundational layer for UI panel interactions in the editor (ED-24738).

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `use-floating-panel-*.ts` (4 new files) | Action dispatcher, drag/resize handlers, status selectors, z-index resolver |
| `sync.ts` | Refactored persistence debounce: local `timer` → module-level `persistenceTimer` with explicit cleanup |
| `resize-math.ts` | Simplified `ResizeCorner` type by aliasing `PanelCorner` instead of duplicating string union |
| `jest.config.js` | Upgraded SWC transform with explicit JSX config (automatic runtime) |
| Test files (5 new) | Comprehensive coverage for hooks, drag/resize, z-index, direction detection |

## 3. How It Works

Drag/resize hooks manage pointer sessions storing initial state (`clientX/Y`, `position`, `size`, bounds, RTL flag). On pointer move, delta is computed, clamped to bounds, and dispatched only if position/size changed (avoiding redundant updates). Sessions are cleared on pointer up/cancel. Persistence debounce now properly cancels stale timers across re-sync calls by checking session IDs, preventing writes from superseded sync cycles.

## 4. Risks

Pointer session state lives in `useRef` and isn't cleared if component unmounts mid-drag—potential memory leak if panel is torn down during interaction. Mitigation: Pointer up/cancel handlers should be bound to document-level listeners, not component unmount. Session ID pattern for persistence is sound but add guard if new sync cycles fire rapidly.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-24738]: https://elementor.atlassian.net/browse/ED-24738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ