### PR TITLE
Internal: Editor floating panels - Add UI components and panel rendering [ED-24738]

### DIFF
--- a/packages/jest.config.js
+++ b/packages/jest.config.js
@@ -3,7 +3,18 @@ module.exports = {
 	rootDir: __dirname,
 	testEnvironment: 'jsdom',
 	transform: {
-		'^.+\\.(t|j)sx?$': '@swc/jest',
+		'^.+\\.(t|j)sx?$': [
+			'@swc/jest',
+			{
+				jsc: {
+					transform: {
+						react: {
+							runtime: 'automatic',
+						},
+					},
+				},
+			},
+		],
 	},
 	moduleNameMapper: {
 		'^@elementor/(?!ui|icons|design-tokens)(.*)$': [

--- a/packages/packages/core/editor-floating-panels/package.json
+++ b/packages/packages/core/editor-floating-panels/package.json
@@ -39,8 +39,13 @@
     "dev": "tsup --config=../../tsup.dev.ts"
   },
   "dependencies": {
+    "@elementor/editor-ui": "4.3.0",
+    "@elementor/editor-v1-adapters": "4.3.0",
+    "@elementor/icons": "~1.75.1",
     "@elementor/locations": "4.3.0",
-    "@elementor/store": "4.3.0"
+    "@elementor/store": "4.3.0",
+    "@elementor/ui": "1.37.5",
+    "@wordpress/i18n": "^5.13.0"
   },
   "peerDependencies": {
     "react": "^18.3.1",

--- a/packages/packages/core/editor-floating-panels/src/__tests__/floating-panel-header.test.tsx
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/floating-panel-header.test.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react';
+import { type ComponentType } from 'react';
+import { renderWithTheme } from 'test-utils';
+import {
+	__createStore,
+	__deleteStore,
+	__dispatch,
+	__getStore,
+	__registerSlice,
+	__StoreProvider as StoreProvider,
+} from '@elementor/store';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import FloatingPanelHeader from '../components/external/floating-panel-header';
+import { slice } from '../store/slice';
+import { mockEditMode } from './mock-edit-mode';
+
+const PANEL_ID = 'test-panel';
+
+const MockActionIcon: ComponentType = () => <svg aria-hidden="true" />;
+
+function renderHeader( props: Partial< React.ComponentProps< typeof FloatingPanelHeader > > = {} ) {
+	const store = __getStore();
+
+	if ( ! store ) {
+		throw new Error( 'Store not initialized' );
+	}
+
+	return renderWithTheme(
+		<StoreProvider store={ store }>
+			<FloatingPanelHeader panelId={ PANEL_ID } title="Test Panel" { ...props } />
+		</StoreProvider>
+	);
+}
+
+describe( 'FloatingPanelHeader', () => {
+	beforeEach( () => {
+		mockEditMode( 'edit' );
+		__registerSlice( slice );
+		__createStore();
+		__dispatch(
+			slice.actions.register( {
+				id: PANEL_ID,
+				isDraggable: true,
+				defaults: {
+					width: 320,
+					height: 480,
+					minWidth: 240,
+					minHeight: 320,
+				},
+			} )
+		);
+	} );
+
+	afterEach( () => {
+		__deleteStore();
+	} );
+
+	it( 'renders header actions with accessible labels', () => {
+		renderHeader( {
+			actions: [
+				{
+					id: 'test-action',
+					icon: MockActionIcon,
+					label: 'Test action',
+				},
+			],
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Test action' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows a tooltip for an action label on hover', async () => {
+		renderHeader( {
+			actions: [
+				{
+					id: 'test-action',
+					icon: MockActionIcon,
+					label: 'Coming soon',
+				},
+			],
+		} );
+
+		fireEvent.mouseOver( screen.getByRole( 'button', { name: 'Coming soon' } ) );
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'tooltip' ) ).toHaveTextContent( 'Coming soon' );
+		} );
+	} );
+
+	it( 'does not invoke onClick when a disabled action is clicked', () => {
+		const onClick = jest.fn();
+
+		renderHeader( {
+			actions: [
+				{
+					id: 'disabled-action',
+					icon: MockActionIcon,
+					label: 'Coming soon',
+					disabled: true,
+					onClick,
+				},
+			],
+		} );
+
+		const actionButton = screen.getByRole( 'button', { name: 'Coming soon' } );
+
+		expect( actionButton ).toBeDisabled();
+
+		fireEvent.click( actionButton );
+
+		expect( onClick ).not.toHaveBeenCalled();
+	} );
+
+	it( 'invokes onClick when an enabled action is clicked', () => {
+		const onClick = jest.fn();
+
+		renderHeader( {
+			actions: [
+				{
+					id: 'enabled-action',
+					icon: MockActionIcon,
+					label: 'Run action',
+					onClick,
+				},
+			],
+		} );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Run action' } ) );
+
+		expect( onClick ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'renders drag handle when isDraggable is true', () => {
+		renderHeader();
+
+		expect( screen.getByRole( 'toolbar', { name: /drag to reposition/i } ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render drag handle when isDraggable is false', () => {
+		__deleteStore();
+		__registerSlice( slice );
+		__createStore();
+		__dispatch(
+			slice.actions.register( {
+				id: PANEL_ID,
+				isDraggable: false,
+				defaults: {
+					width: 320,
+					height: 480,
+					minWidth: 240,
+					minHeight: 320,
+				},
+			} )
+		);
+
+		renderHeader();
+
+		expect( screen.queryByRole( 'toolbar', { name: /drag to reposition/i } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/__tests__/floating-panel-header.test.tsx
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/floating-panel-header.test.tsx
@@ -134,7 +134,7 @@ describe( 'FloatingPanelHeader', () => {
 	it( 'renders drag handle when isDraggable is true', () => {
 		renderHeader();
 
-		expect( screen.getByRole( 'toolbar', { name: /drag to reposition/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /drag to reposition/i } ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not render drag handle when isDraggable is false', () => {
@@ -156,6 +156,6 @@ describe( 'FloatingPanelHeader', () => {
 
 		renderHeader();
 
-		expect( screen.queryByRole( 'toolbar', { name: /drag to reposition/i } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /drag to reposition/i } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/packages/core/editor-floating-panels/src/__tests__/host.test.tsx
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/host.test.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import { renderWithTheme } from 'test-utils';
+import {
+	__createStore,
+	__deleteStore,
+	__dispatch,
+	__getStore,
+	__registerSlice,
+	__StoreProvider as StoreProvider,
+} from '@elementor/store';
+import { screen } from '@testing-library/react';
+
+import FloatingPanelsHost from '../components/internal/host';
+import { injectIntoFloatingPanels } from '../location';
+import { slice } from '../store/slice';
+import { mockEditMode } from './mock-edit-mode';
+
+describe( 'FloatingPanelsHost', () => {
+	beforeEach( () => {
+		mockEditMode( 'edit' );
+		__registerSlice( slice );
+		__createStore();
+	} );
+
+	afterEach( () => {
+		__deleteStore();
+	} );
+
+	it( 'keeps an open panel visible in edit mode', () => {
+		// Arrange.
+		mockEditMode( 'edit' );
+		const PanelA = () => <div>Panel A body</div>;
+
+		injectIntoFloatingPanels( { id: 'a', component: PanelA } );
+
+		__dispatch(
+			slice.actions.register( {
+				id: 'a',
+				defaults: {
+					width: 200,
+					height: 300,
+					minWidth: 100,
+					minHeight: 100,
+					corner: 'block-start-inline-start',
+				},
+			} )
+		);
+		__dispatch( slice.actions.open( 'a' ) );
+
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store not initialized' );
+		}
+
+		renderWithTheme(
+			<StoreProvider store={ store }>
+				<FloatingPanelsHost />
+			</StoreProvider>
+		);
+
+		// Assert.
+		expect( screen.getByText( 'Panel A body' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'complementary' ) ).not.toHaveAttribute( 'aria-hidden', 'true' );
+	} );
+
+	it( 'hides an open panel in preview mode', () => {
+		// Arrange.
+		mockEditMode( 'preview' );
+		const PanelA = () => <div>Panel A body</div>;
+
+		injectIntoFloatingPanels( { id: 'a', component: PanelA } );
+
+		__dispatch(
+			slice.actions.register( {
+				id: 'a',
+				defaults: {
+					width: 200,
+					height: 300,
+					minWidth: 100,
+					minHeight: 100,
+					corner: 'block-start-inline-start',
+				},
+			} )
+		);
+		__dispatch( slice.actions.open( 'a' ) );
+
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store not initialized' );
+		}
+
+		renderWithTheme(
+			<StoreProvider store={ store }>
+				<FloatingPanelsHost />
+			</StoreProvider>
+		);
+
+		// Assert.
+		const panel = screen.getByRole( 'complementary', { hidden: true } );
+
+		expect( panel ).toHaveTextContent( 'Panel A body' );
+		expect( panel ).toHaveAttribute( 'aria-hidden', 'true' );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/__tests__/panel-window.test.tsx
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/panel-window.test.tsx
@@ -31,7 +31,7 @@ const DEFAULT_POSITION: LogicalPosition = {
 	insetInlineEnd: 0,
 };
 
-function renderPanelWindow( isResizable: boolean ) {
+function renderPanelWindow( isResizable: boolean, visible = true ) {
 	__dispatch(
 		slice.actions.register( {
 			id: PANEL_ID,
@@ -54,7 +54,7 @@ function renderPanelWindow( isResizable: boolean ) {
 				size={ { inlineSize: 320, blockSize: 480 } }
 				corner={ DEFAULT_CORNER }
 				position={ DEFAULT_POSITION }
-				visible
+				visible={ visible }
 				onFocus={ () => undefined }
 			>
 				<div>Panel body</div>
@@ -85,6 +85,22 @@ describe( 'PanelWindow', () => {
 
 		expect( document.querySelectorAll( '[data-resize-edge]' ).length ).toBe( 0 );
 		expect( document.querySelectorAll( '[data-resize-corner]' ).length ).toBe( 0 );
+	} );
+
+	it( 'applies pointer-events auto when visible', () => {
+		renderPanelWindow( false, true );
+
+		const panel = document.querySelector( '[data-floating-panel="test-panel"]' );
+		expect( panel ).toHaveStyle( { pointerEvents: 'auto' } );
+		expect( panel ).not.toHaveAttribute( 'inert' );
+	} );
+
+	it( 'applies pointer-events none and inert when not visible', () => {
+		renderPanelWindow( false, false );
+
+		const panel = document.querySelector( '[data-floating-panel="test-panel"]' );
+		expect( panel ).toHaveStyle( { pointerEvents: 'none' } );
+		expect( panel ).toHaveAttribute( 'inert' );
 	} );
 
 	it( 'applies insetInlineEnd and insetBlockEnd for block-end-inline-end', () => {

--- a/packages/packages/core/editor-floating-panels/src/__tests__/panel-window.test.tsx
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/panel-window.test.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import { renderWithTheme } from 'test-utils';
+import {
+	__createStore,
+	__deleteStore,
+	__dispatch,
+	__getStore,
+	__registerSlice,
+	__StoreProvider as StoreProvider,
+} from '@elementor/store';
+
+import PanelWindow from '../components/internal/panel-window';
+import { slice } from '../store/slice';
+import { type LogicalPosition } from '../types';
+
+const PANEL_ID = 'test-panel';
+
+const defaults = {
+	width: 320,
+	height: 480,
+	minWidth: 240,
+	minHeight: 320,
+};
+
+const DEFAULT_CORNER = 'block-start-inline-start' as const;
+
+const DEFAULT_POSITION: LogicalPosition = {
+	insetBlockStart: 80,
+	insetBlockEnd: 0,
+	insetInlineStart: 24,
+	insetInlineEnd: 0,
+};
+
+function renderPanelWindow( isResizable: boolean ) {
+	__dispatch(
+		slice.actions.register( {
+			id: PANEL_ID,
+			defaults,
+			isResizable,
+		} )
+	);
+
+	const store = __getStore();
+
+	if ( ! store ) {
+		throw new Error( 'Store not initialized' );
+	}
+
+	return renderWithTheme(
+		<StoreProvider store={ store }>
+			<PanelWindow
+				panelId={ PANEL_ID }
+				zIndex={ 1000 }
+				size={ { inlineSize: 320, blockSize: 480 } }
+				corner={ DEFAULT_CORNER }
+				position={ DEFAULT_POSITION }
+				visible
+				onFocus={ () => undefined }
+			>
+				<div>Panel body</div>
+			</PanelWindow>
+		</StoreProvider>
+	);
+}
+
+describe( 'PanelWindow', () => {
+	beforeEach( () => {
+		__registerSlice( slice );
+		__createStore();
+	} );
+
+	afterEach( () => {
+		__deleteStore();
+	} );
+
+	it( 'renders resize handles when isResizable is true', () => {
+		renderPanelWindow( true );
+
+		expect( document.querySelectorAll( '[data-resize-edge]' ).length ).toBe( 4 );
+		expect( document.querySelectorAll( '[data-resize-corner]' ).length ).toBe( 4 );
+	} );
+
+	it( 'does not render resize handles when isResizable is false', () => {
+		renderPanelWindow( false );
+
+		expect( document.querySelectorAll( '[data-resize-edge]' ).length ).toBe( 0 );
+		expect( document.querySelectorAll( '[data-resize-corner]' ).length ).toBe( 0 );
+	} );
+
+	it( 'applies insetInlineEnd and insetBlockEnd for block-end-inline-end', () => {
+		__dispatch(
+			slice.actions.register( {
+				id: PANEL_ID,
+				defaults: { ...defaults, corner: 'block-end-inline-end' },
+				isResizable: false,
+			} )
+		);
+
+		const store = __getStore();
+
+		if ( ! store ) {
+			throw new Error( 'Store not initialized' );
+		}
+
+		renderWithTheme(
+			<StoreProvider store={ store }>
+				<PanelWindow
+					panelId={ PANEL_ID }
+					zIndex={ 1000 }
+					size={ { inlineSize: 320, blockSize: 480 } }
+					corner="block-end-inline-end"
+					position={ {
+						insetBlockStart: 0,
+						insetBlockEnd: 80,
+						insetInlineStart: 0,
+						insetInlineEnd: 24,
+					} }
+					visible
+					onFocus={ () => undefined }
+				>
+					<div>Panel body</div>
+				</PanelWindow>
+			</StoreProvider>
+		);
+
+		const panel = document.querySelector( '[data-floating-panel="test-panel"]' );
+		expect( panel ).toHaveStyle( { insetInlineEnd: '24px', insetBlockEnd: '80px' } );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/__tests__/sync.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/sync.test.ts
@@ -108,6 +108,51 @@ describe( 'sync', () => {
 		// Assert.
 		expect( writeSpy ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'merges store updates with preloaded panels not yet registered', () => {
+		// Arrange.
+		const panelB: FloatingPanelState = {
+			...persisted,
+			isOpen: false,
+			zIndex: 2,
+		};
+		const storage = createMemoryStorage( encodePersistedState( { a: persisted, b: panelB } ) );
+		sync( storage );
+
+		// Act.
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+		__dispatch( slice.actions.open( 'a' ) );
+		jest.advanceTimersByTime( 300 );
+
+		// Assert.
+		const written = JSON.parse( storage.snapshot() as string );
+		expect( written.a.isOpen ).toBe( true );
+		expect( written.b ).toEqual( panelB );
+	} );
+
+	it( 'calling sync() twice cancels pending debounce from the first session', () => {
+		// Arrange.
+		const storage = createMemoryStorage();
+		const writeSpy = jest.spyOn( storage, 'write' );
+
+		// Act.
+		sync( storage );
+		__dispatch( slice.actions.register( { id: 'a', defaults } ) );
+		sync( storage );
+		jest.advanceTimersByTime( 300 );
+
+		// Assert — stale timer from the first session must not write.
+		expect( writeSpy ).not.toHaveBeenCalled();
+
+		// Act — change after re-sync schedules persistence for the active session.
+		__dispatch( slice.actions.open( 'a' ) );
+		jest.advanceTimersByTime( 300 );
+
+		// Assert — only the final state is written once.
+		expect( writeSpy ).toHaveBeenCalledTimes( 1 );
+		const written = JSON.parse( storage.snapshot() as string );
+		expect( written.a.isOpen ).toBe( true );
+	} );
 } );
 
 describe( 'sync before the store is ready', () => {

--- a/packages/packages/core/editor-floating-panels/src/components/external/__tests__/floating-panel-footer.test.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/__tests__/floating-panel-footer.test.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { renderWithTheme } from 'test-utils';
+import { screen } from '@testing-library/react';
+
+import FloatingPanelFooter from '../floating-panel-footer';
+
+describe( 'FloatingPanelFooter', () => {
+	it( 'renders footer children', () => {
+		// Act.
+		renderWithTheme( <FloatingPanelFooter>Footer actions</FloatingPanelFooter> );
+
+		// Assert.
+		expect( screen.getByText( 'Footer actions' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/components/external/__tests__/floating-panel.test.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/__tests__/floating-panel.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import FloatingPanel from '../floating-panel';
+
+describe( 'FloatingPanel', () => {
+	it( 'renders its children', () => {
+		// Act.
+		render(
+			<FloatingPanel>
+				<div>Panel content</div>
+			</FloatingPanel>
+		);
+
+		// Assert.
+		expect( screen.getByText( 'Panel content' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-body.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-body.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { Box, type BoxProps } from '@elementor/ui';
+
+export default function FloatingPanelBody( props: BoxProps ) {
+	return (
+		<Box
+			{ ...props }
+			sx={ {
+				flex: 1,
+				overflowY: 'auto',
+				...( props.sx ?? {} ),
+			} }
+		/>
+	);
+}

--- a/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-body.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-body.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Box, type BoxProps } from '@elementor/ui';
 
 export default function FloatingPanelBody( props: BoxProps ) {

--- a/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-footer.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-footer.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { Box, type BoxProps } from '@elementor/ui';
+
+export default function FloatingPanelFooter( { children, sx, ...props }: BoxProps ) {
+	return (
+		<Box
+			{ ...props }
+			sx={ {
+				px: 2,
+				py: 1.5,
+				borderTop: 1,
+				borderColor: 'var(--e-a-border-color)',
+				display: 'flex',
+				alignItems: 'center',
+				gap: 1,
+				...( sx ?? {} ),
+			} }
+		>
+			{ children }
+		</Box>
+	);
+}

--- a/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-footer.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-footer.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Box, type BoxProps } from '@elementor/ui';
 
 export default function FloatingPanelFooter( { children, sx, ...props }: BoxProps ) {

--- a/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-header.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-header.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { XIcon } from '@elementor/icons';
+import { __useSelector as useSelector } from '@elementor/store';
+import { Box, IconButton, Stack, Tooltip, Typography } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import { useFloatingPanelActions } from '../../hooks/use-floating-panel-actions';
+import { useFloatingPanelZIndex } from '../../hooks/use-floating-panel-z-index';
+import { type GlobalState, selectIsDraggable } from '../../store/selectors';
+import { type FloatingPanelHeaderAction } from '../../types';
+import DragHandle from '../internal/drag-handle';
+
+type Props = {
+	panelId: string;
+	title: string;
+	icon?: React.ComponentType;
+	actions?: FloatingPanelHeaderAction[];
+};
+
+function HeaderAction( {
+	icon: Icon,
+	label,
+	onClick,
+	panelZIndex,
+	disabled = false,
+}: FloatingPanelHeaderAction & { panelZIndex: number } ) {
+	return (
+		<Tooltip
+			title={ label }
+			placement="top"
+			PopperProps={ {
+				sx: { zIndex: panelZIndex },
+			} }
+		>
+			<Box component="span" aria-label={ undefined }>
+				<IconButton
+					size="small"
+					color="inherit"
+					aria-label={ label }
+					disabled={ disabled }
+					onClick={ disabled ? undefined : onClick }
+					sx={ { borderRadius: 0, p: 1 } }
+				>
+					<Icon />
+				</IconButton>
+			</Box>
+		</Tooltip>
+	);
+}
+
+export default function FloatingPanelHeader( { panelId, title, icon: Icon, actions }: Props ) {
+	const { close } = useFloatingPanelActions( panelId );
+	const isDraggable = useSelector( ( state: GlobalState ) => selectIsDraggable( state, panelId ) );
+	const hasActions = Boolean( actions?.length );
+	const panelZIndex = useFloatingPanelZIndex( panelId );
+
+	const titleContent = (
+		<Box sx={ { display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1, height: '100%' } }>
+			{ Icon ? <Icon /> : null }
+			<Typography component="h2" sx={ { textAlign: 'center', fontSize: '13px', fontWeight: 400 } }>
+				{ title }
+			</Typography>
+		</Box>
+	);
+
+	return (
+		<Box
+			sx={ {
+				display: 'flex',
+				alignItems: 'stretch',
+				borderBottom: 1,
+				borderColor: 'var(--e-a-border-color)',
+				overflow: 'visible',
+			} }
+		>
+			{ hasActions ? (
+				<Stack direction="row" alignItems="center" sx={ { flexShrink: 0, overflow: 'visible' } }>
+					{ actions?.map( ( action ) => (
+						<HeaderAction key={ action.id } panelZIndex={ panelZIndex } { ...action } />
+					) ) }
+				</Stack>
+			) : null }
+			{ isDraggable ? (
+				<DragHandle panelId={ panelId }>{ titleContent }</DragHandle>
+			) : (
+				<Box sx={ { flex: 1 } }>{ titleContent }</Box>
+			) }
+			<IconButton
+				size="small"
+				color="inherit"
+				aria-label={ __( 'Close panel', 'elementor' ) }
+				onClick={ close }
+				sx={ { borderRadius: 0, p: 1 } }
+			>
+				<XIcon fontSize="small" />
+			</IconButton>
+		</Box>
+	);
+}

--- a/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-header.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-header.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { type ComponentType } from 'react';
 import { XIcon } from '@elementor/icons';
 import { __useSelector as useSelector } from '@elementor/store';
 import { Box, IconButton, Stack, Tooltip, Typography } from '@elementor/ui';
@@ -13,7 +13,7 @@ import DragHandle from '../internal/drag-handle';
 type Props = {
 	panelId: string;
 	title: string;
-	icon?: React.ComponentType;
+	icon?: ComponentType;
 	actions?: FloatingPanelHeaderAction[];
 };
 

--- a/packages/packages/core/editor-floating-panels/src/components/external/floating-panel.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/floating-panel.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import { type ReactNode } from 'react';
 
 type Props = {
-	children: React.ReactNode;
+	children: ReactNode;
 };
 
 export default function FloatingPanel( { children }: Props ) {

--- a/packages/packages/core/editor-floating-panels/src/components/external/floating-panel.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/floating-panel.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+type Props = {
+	children: React.ReactNode;
+};
+
+export default function FloatingPanel( { children }: Props ) {
+	return <>{ children }</>;
+}

--- a/packages/packages/core/editor-floating-panels/src/components/external/index.ts
+++ b/packages/packages/core/editor-floating-panels/src/components/external/index.ts
@@ -1,0 +1,4 @@
+export { default as FloatingPanel } from './floating-panel';
+export { default as FloatingPanelBody } from './floating-panel-body';
+export { default as FloatingPanelFooter } from './floating-panel-footer';
+export { default as FloatingPanelHeader } from './floating-panel-header';

--- a/packages/packages/core/editor-floating-panels/src/components/internal/corner-resize-handle.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/internal/corner-resize-handle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { type PointerEventHandler } from 'react';
 import { Box } from '@elementor/ui';
 
 import { isRtl } from '../../utils/direction';
@@ -31,10 +31,10 @@ const RTL_CURSORS: Record< ResizeCorner, string > = {
 
 type Props = {
 	corner: ResizeCorner;
-	onPointerDown: React.PointerEventHandler< HTMLElement >;
-	onPointerMove: React.PointerEventHandler< HTMLElement >;
-	onPointerUp: React.PointerEventHandler< HTMLElement >;
-	onPointerCancel: React.PointerEventHandler< HTMLElement >;
+	onPointerDown: PointerEventHandler< HTMLElement >;
+	onPointerMove: PointerEventHandler< HTMLElement >;
+	onPointerUp: PointerEventHandler< HTMLElement >;
+	onPointerCancel: PointerEventHandler< HTMLElement >;
 };
 
 export default function CornerResizeHandle( {

--- a/packages/packages/core/editor-floating-panels/src/components/internal/corner-resize-handle.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/internal/corner-resize-handle.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { Box } from '@elementor/ui';
+
+import { isRtl } from '../../utils/direction';
+import { type ResizeCorner } from '../../utils/resize-math';
+
+const HANDLE_SIZE_PX = 8;
+
+type CornerPosition = { insetBlockStart?: 0; insetBlockEnd?: 0; insetInlineStart?: 0; insetInlineEnd?: 0 };
+
+const CORNER_POSITION: Record< ResizeCorner, CornerPosition > = {
+	'block-start-inline-start': { insetBlockStart: 0, insetInlineStart: 0 },
+	'block-start-inline-end': { insetBlockStart: 0, insetInlineEnd: 0 },
+	'block-end-inline-start': { insetBlockEnd: 0, insetInlineStart: 0 },
+	'block-end-inline-end': { insetBlockEnd: 0, insetInlineEnd: 0 },
+};
+
+const LTR_CURSORS: Record< ResizeCorner, string > = {
+	'block-start-inline-start': 'nwse-resize',
+	'block-start-inline-end': 'nesw-resize',
+	'block-end-inline-start': 'nesw-resize',
+	'block-end-inline-end': 'nwse-resize',
+};
+
+const RTL_CURSORS: Record< ResizeCorner, string > = {
+	'block-start-inline-start': 'nesw-resize',
+	'block-start-inline-end': 'nwse-resize',
+	'block-end-inline-start': 'nwse-resize',
+	'block-end-inline-end': 'nesw-resize',
+};
+
+type Props = {
+	corner: ResizeCorner;
+	onPointerDown: React.PointerEventHandler< HTMLElement >;
+	onPointerMove: React.PointerEventHandler< HTMLElement >;
+	onPointerUp: React.PointerEventHandler< HTMLElement >;
+	onPointerCancel: React.PointerEventHandler< HTMLElement >;
+};
+
+export default function CornerResizeHandle( {
+	corner,
+	onPointerDown,
+	onPointerMove,
+	onPointerUp,
+	onPointerCancel,
+}: Props ) {
+	const cursor = isRtl() ? RTL_CURSORS[ corner ] : LTR_CURSORS[ corner ];
+
+	return (
+		<Box
+			data-resize-corner={ corner }
+			aria-hidden="true"
+			onPointerDown={ onPointerDown }
+			onPointerMove={ onPointerMove }
+			onPointerUp={ onPointerUp }
+			onPointerCancel={ onPointerCancel }
+			sx={ {
+				position: 'absolute',
+				touchAction: 'none',
+				zIndex: 2,
+				inlineSize: `${ HANDLE_SIZE_PX }px`,
+				blockSize: `${ HANDLE_SIZE_PX }px`,
+				cursor,
+				...CORNER_POSITION[ corner ],
+			} }
+		/>
+	);
+}

--- a/packages/packages/core/editor-floating-panels/src/components/internal/drag-handle.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/internal/drag-handle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { type ReactNode } from 'react';
 import { Box } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
@@ -6,7 +6,7 @@ import { useFloatingPanelDrag } from '../../hooks/use-floating-panel-drag';
 
 type Props = {
 	panelId: string;
-	children: React.ReactNode;
+	children: ReactNode;
 };
 
 export default function DragHandle( { panelId, children }: Props ) {
@@ -14,7 +14,7 @@ export default function DragHandle( { panelId, children }: Props ) {
 
 	return (
 		<Box
-			role="toolbar"
+			role="button"
 			aria-label={ __( 'Drag to reposition', 'elementor' ) }
 			onPointerDown={ onPointerDown }
 			onPointerMove={ onPointerMove }

--- a/packages/packages/core/editor-floating-panels/src/components/internal/drag-handle.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/internal/drag-handle.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Box } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import { useFloatingPanelDrag } from '../../hooks/use-floating-panel-drag';
+
+type Props = {
+	panelId: string;
+	children: React.ReactNode;
+};
+
+export default function DragHandle( { panelId, children }: Props ) {
+	const { onPointerDown, onPointerMove, onPointerUp, onPointerCancel } = useFloatingPanelDrag( panelId );
+
+	return (
+		<Box
+			role="toolbar"
+			aria-label={ __( 'Drag to reposition', 'elementor' ) }
+			onPointerDown={ onPointerDown }
+			onPointerMove={ onPointerMove }
+			onPointerUp={ onPointerUp }
+			onPointerCancel={ onPointerCancel }
+			sx={ { cursor: 'move', touchAction: 'none', flex: 1 } }
+		>
+			{ children }
+		</Box>
+	);
+}

--- a/packages/packages/core/editor-floating-panels/src/components/internal/host.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/internal/host.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { type ReactNode, useMemo } from 'react';
+import { useEditMode } from '@elementor/editor-v1-adapters';
+import { __useDispatch as useDispatch, __useSelector as useSelector } from '@elementor/store';
+
+import { useFloatingPanelsInjections } from '../../location';
+import {
+	type GlobalState,
+	resolvePanelZIndex,
+	selectOpenPanelIds,
+	selectPanelState,
+	selectPanelTitle,
+} from '../../store/selectors';
+import { slice } from '../../store/slice';
+import PanelWindow from './panel-window';
+
+export default function FloatingPanelsHost() {
+	const openIds = useSelector( selectOpenPanelIds );
+	const injections = useFloatingPanelsInjections();
+	const dispatch = useDispatch();
+	const isPreviewMode = useEditMode() === 'preview';
+
+	const declarationById = useMemo( () => {
+		return Object.fromEntries( injections.map( ( inj ) => [ inj.id, inj ] ) );
+	}, [ injections ] );
+
+	return (
+		<>
+			{ openIds.map( ( id ) => {
+				const declaration = declarationById[ id ];
+
+				if ( ! declaration ) {
+					return null;
+				}
+
+				const Component = declaration.component;
+
+				return (
+					<HostedPanel
+						key={ id }
+						id={ id }
+						visible={ ! isPreviewMode }
+						onFocus={ () => dispatch( slice.actions.bringToFront( id ) ) }
+					>
+						<Component />
+					</HostedPanel>
+				);
+			} ) }
+		</>
+	);
+}
+
+function HostedPanel( {
+	id,
+	children,
+	onFocus,
+	visible,
+}: {
+	id: string;
+	children: ReactNode;
+	onFocus: () => void;
+	visible: boolean;
+} ) {
+	const panel = useSelector( ( state: GlobalState ) => selectPanelState( state, id ) );
+	const title = useSelector( ( state: GlobalState ) => selectPanelTitle( state, id ) );
+	const zIndex = useSelector( ( state: GlobalState ) => resolvePanelZIndex( state, id ) );
+
+	if ( ! panel ) {
+		return null;
+	}
+
+	return (
+		<PanelWindow
+			panelId={ id }
+			corner={ panel.corner }
+			position={ panel.position }
+			size={ panel.size }
+			zIndex={ zIndex }
+			visible={ visible }
+			onFocus={ onFocus }
+			title={ title }
+		>
+			{ children }
+		</PanelWindow>
+	);
+}

--- a/packages/packages/core/editor-floating-panels/src/components/internal/host.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/internal/host.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { type ReactNode, useMemo } from 'react';
 import { useEditMode } from '@elementor/editor-v1-adapters';
 import { __useDispatch as useDispatch, __useSelector as useSelector } from '@elementor/store';

--- a/packages/packages/core/editor-floating-panels/src/components/internal/panel-window.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/internal/panel-window.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { ThemeProvider } from '@elementor/editor-ui';
+import { __useSelector as useSelector } from '@elementor/store';
+import { Box, Fade, Paper } from '@elementor/ui';
+
+import { usePanelResizeInteraction } from '../../hooks/use-floating-panel-resize';
+import { type GlobalState, selectIsResizable } from '../../store/selectors';
+import { type LogicalPosition, type LogicalSize } from '../../types';
+import { type PanelCorner, positionToCssInsets } from '../../utils/corner-position';
+import { type ResizeCorner, type ResizeEdge } from '../../utils/resize-math';
+import CornerResizeHandle from './corner-resize-handle';
+import ResizeHandle from './resize-handle';
+
+const FADE_ENTER_MS = 225;
+const FADE_EXIT_MS = 195;
+
+const RESIZE_EDGES: ResizeEdge[] = [ 'inline-start', 'inline-end', 'block-start', 'block-end' ];
+
+const RESIZE_CORNERS: ResizeCorner[] = [
+	'block-start-inline-start',
+	'block-start-inline-end',
+	'block-end-inline-start',
+	'block-end-inline-end',
+];
+
+type Props = {
+	panelId: string;
+	corner: PanelCorner;
+	position: LogicalPosition;
+	size: LogicalSize;
+	title?: string;
+	zIndex: number;
+	visible: boolean;
+	onFocus: () => void;
+	children: React.ReactNode;
+};
+
+function PanelResizeHandles( { panelId }: { panelId: string } ) {
+	const { getResizeHandleProps } = usePanelResizeInteraction( panelId );
+
+	return (
+		<>
+			{ RESIZE_EDGES.map( ( edge ) => (
+				<ResizeHandle key={ edge } edge={ edge } { ...getResizeHandleProps( edge ) } />
+			) ) }
+			{ RESIZE_CORNERS.map( ( corner ) => (
+				<CornerResizeHandle key={ corner } corner={ corner } { ...getResizeHandleProps( corner ) } />
+			) ) }
+		</>
+	);
+}
+
+export default function PanelWindow( {
+	panelId,
+	corner,
+	position,
+	size,
+	title,
+	zIndex,
+	visible,
+	onFocus,
+	children,
+}: Props ) {
+	const isResizable = useSelector( ( state: GlobalState ) => selectIsResizable( state, panelId ) );
+
+	return (
+		<Fade in={ visible } timeout={ { enter: FADE_ENTER_MS, exit: FADE_EXIT_MS } }>
+			<Paper
+				component="aside"
+				data-floating-panel={ panelId }
+				elevation={ 0 }
+				aria-label={ title || panelId }
+				aria-hidden={ ! visible }
+				onMouseDown={ onFocus }
+				sx={ {
+					position: 'fixed',
+					...positionToCssInsets( corner, position ),
+					inlineSize: `${ size.inlineSize }px`,
+					blockSize: `${ size.blockSize }px`,
+					zIndex,
+					display: 'flex',
+					flexDirection: 'column',
+					bgcolor: 'var(--e-a-bg-default)',
+					color: 'var(--e-a-color-txt)',
+					border: 'var(--e-a-border)',
+					boxShadow: `0 2px 20px 0 rgba(0, 0, 0, 0.1)`,
+				} }
+			>
+				<ThemeProvider>
+					<Box sx={ { display: 'flex', flexDirection: 'column', height: '100%' } }>{ children }</Box>
+				</ThemeProvider>
+				{ isResizable && <PanelResizeHandles panelId={ panelId } /> }
+			</Paper>
+		</Fade>
+	);
+}

--- a/packages/packages/core/editor-floating-panels/src/components/internal/panel-window.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/internal/panel-window.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { type ReactNode } from 'react';
 import { ThemeProvider } from '@elementor/editor-ui';
 import { __useSelector as useSelector } from '@elementor/store';
 import { Box, Fade, Paper } from '@elementor/ui';
@@ -32,7 +32,7 @@ type Props = {
 	zIndex: number;
 	visible: boolean;
 	onFocus: () => void;
-	children: React.ReactNode;
+	children: ReactNode;
 };
 
 function PanelResizeHandles( { panelId }: { panelId: string } ) {
@@ -71,7 +71,9 @@ export default function PanelWindow( {
 				elevation={ 0 }
 				aria-label={ title || panelId }
 				aria-hidden={ ! visible }
+				inert={ ! visible ? '' : undefined }
 				onMouseDown={ onFocus }
+				onFocusCapture={ onFocus }
 				sx={ {
 					position: 'fixed',
 					...positionToCssInsets( corner, position ),
@@ -80,6 +82,7 @@ export default function PanelWindow( {
 					zIndex,
 					display: 'flex',
 					flexDirection: 'column',
+					pointerEvents: visible ? 'auto' : 'none',
 					bgcolor: 'var(--e-a-bg-default)',
 					color: 'var(--e-a-color-txt)',
 					border: 'var(--e-a-border)',

--- a/packages/packages/core/editor-floating-panels/src/components/internal/resize-handle.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/internal/resize-handle.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { Box } from '@elementor/ui';
+
+import { type ResizeEdge } from '../../utils/resize-math';
+
+const HANDLE_THICKNESS_PX = 8;
+
+const EDGE_SX: Record< ResizeEdge, object > = {
+	'inline-start': {
+		insetBlockStart: 0,
+		insetBlockEnd: 0,
+		insetInlineStart: 0,
+		inlineSize: `${ HANDLE_THICKNESS_PX }px`,
+		cursor: 'ew-resize',
+	},
+	'inline-end': {
+		insetBlockStart: 0,
+		insetBlockEnd: 0,
+		insetInlineEnd: 0,
+		inlineSize: `${ HANDLE_THICKNESS_PX }px`,
+		cursor: 'ew-resize',
+	},
+	'block-start': {
+		insetInlineStart: 0,
+		insetInlineEnd: 0,
+		insetBlockStart: 0,
+		blockSize: `${ HANDLE_THICKNESS_PX }px`,
+		cursor: 'ns-resize',
+	},
+	'block-end': {
+		insetInlineStart: 0,
+		insetInlineEnd: 0,
+		insetBlockEnd: 0,
+		blockSize: `${ HANDLE_THICKNESS_PX }px`,
+		cursor: 'ns-resize',
+	},
+};
+
+type Props = {
+	edge: ResizeEdge;
+	onPointerDown: React.PointerEventHandler< HTMLElement >;
+	onPointerMove: React.PointerEventHandler< HTMLElement >;
+	onPointerUp: React.PointerEventHandler< HTMLElement >;
+	onPointerCancel: React.PointerEventHandler< HTMLElement >;
+};
+
+export default function ResizeHandle( { edge, onPointerDown, onPointerMove, onPointerUp, onPointerCancel }: Props ) {
+	return (
+		<Box
+			data-resize-edge={ edge }
+			aria-hidden="true"
+			onPointerDown={ onPointerDown }
+			onPointerMove={ onPointerMove }
+			onPointerUp={ onPointerUp }
+			onPointerCancel={ onPointerCancel }
+			sx={ { position: 'absolute', touchAction: 'none', zIndex: 1, ...EDGE_SX[ edge ] } }
+		/>
+	);
+}

--- a/packages/packages/core/editor-floating-panels/src/components/internal/resize-handle.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/internal/resize-handle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { type PointerEventHandler } from 'react';
 import { Box } from '@elementor/ui';
 
 import { type ResizeEdge } from '../../utils/resize-math';
@@ -38,10 +38,10 @@ const EDGE_SX: Record< ResizeEdge, object > = {
 
 type Props = {
 	edge: ResizeEdge;
-	onPointerDown: React.PointerEventHandler< HTMLElement >;
-	onPointerMove: React.PointerEventHandler< HTMLElement >;
-	onPointerUp: React.PointerEventHandler< HTMLElement >;
-	onPointerCancel: React.PointerEventHandler< HTMLElement >;
+	onPointerDown: PointerEventHandler< HTMLElement >;
+	onPointerMove: PointerEventHandler< HTMLElement >;
+	onPointerUp: PointerEventHandler< HTMLElement >;
+	onPointerCancel: PointerEventHandler< HTMLElement >;
 };
 
 export default function ResizeHandle( { edge, onPointerDown, onPointerMove, onPointerUp, onPointerCancel }: Props ) {

--- a/packages/packages/core/editor-floating-panels/src/hooks/__tests__/use-floating-panel-actions.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/__tests__/use-floating-panel-actions.test.ts
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import {
+	__createStore,
+	__deleteStore,
+	__dispatch,
+	__getState,
+	__getStore,
+	__registerSlice,
+	__StoreProvider as StoreProvider,
+} from '@elementor/store';
+import { act, renderHook } from '@testing-library/react';
+
+import { selectIsOpen, selectPanelState } from '../../store/selectors';
+import { slice } from '../../store/slice';
+import { type FloatingPanelDefaults } from '../../types';
+import { useFloatingPanelActions } from '../use-floating-panel-actions';
+
+const PANEL_ID = 'actions-panel';
+
+const defaults: FloatingPanelDefaults = {
+	width: 320,
+	height: 480,
+	minWidth: 240,
+	minHeight: 320,
+};
+
+function renderActionsHook() {
+	const store = __getStore();
+
+	if ( ! store ) {
+		throw new Error( 'Store is not initialized' );
+	}
+
+	const wrapper = ( { children }: { children: React.ReactNode } ) =>
+		React.createElement( StoreProvider, { store }, children );
+
+	return renderHook( () => useFloatingPanelActions( PANEL_ID ), { wrapper } );
+}
+
+describe( 'useFloatingPanelActions', () => {
+	beforeEach( () => {
+		__registerSlice( slice );
+		__createStore();
+		__dispatch( slice.actions.register( { id: PANEL_ID, defaults } ) );
+	} );
+
+	afterEach( () => {
+		__deleteStore();
+	} );
+
+	it( 'open dispatches open + bringToFront', () => {
+		// Arrange.
+		const { result } = renderActionsHook();
+
+		// Act.
+		act( () => result.current.open() );
+
+		// Assert.
+		expect( selectIsOpen( __getState(), PANEL_ID ) ).toBe( true );
+		expect( selectPanelState( __getState(), PANEL_ID )?.zIndex ).toBe( 1 );
+	} );
+
+	it( 'toggle opens when closed and closes when open', () => {
+		// Arrange.
+		const { result } = renderActionsHook();
+
+		// Assert — initial closed.
+		expect( selectIsOpen( __getState(), PANEL_ID ) ).toBe( false );
+
+		// Act — open via toggle.
+		act( () => result.current.toggle() );
+
+		// Assert.
+		expect( selectIsOpen( __getState(), PANEL_ID ) ).toBe( true );
+		expect( selectPanelState( __getState(), PANEL_ID )?.zIndex ).toBe( 1 );
+
+		// Act — close via toggle.
+		act( () => result.current.toggle() );
+
+		// Assert.
+		expect( selectIsOpen( __getState(), PANEL_ID ) ).toBe( false );
+	} );
+
+	it( 'focus dispatches bringToFront', () => {
+		// Arrange.
+		const { result } = renderActionsHook();
+
+		// Act.
+		act( () => result.current.focus() );
+
+		// Assert.
+		expect( selectPanelState( __getState(), PANEL_ID )?.zIndex ).toBe( 1 );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-drag.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-drag.ts
@@ -1,25 +1,19 @@
 import { type PointerEvent as ReactPointerEvent, useCallback, useRef } from 'react';
 
-import { type LogicalPosition, type LogicalSize } from '../types';
-import { getDragBounds, type PanelCorner } from '../utils/corner-position';
+import { type LogicalPosition } from '../types';
+import { activePositionChanged, getDragBounds, type PanelCorner } from '../utils/corner-position';
 import { isRtl } from '../utils/direction';
 import { applyDragDelta, type DragBounds, physicalToLogicalDelta } from '../utils/drag-math';
 import { APP_BAR_HEIGHT_PX, getSidePanelInlineSize } from '../utils/viewport-bounds';
 import { useFloatingPanelActions } from './use-floating-panel-actions';
 import { useFloatingPanelStatus } from './use-floating-panel-status';
 
-const EMPTY_POSITION: LogicalPosition = {
-	insetBlockStart: 0,
-	insetBlockEnd: 0,
-	insetInlineStart: 0,
-	insetInlineEnd: 0,
-};
-
 type DragSession = {
 	pointerId: number;
 	startClientX: number;
 	startClientY: number;
 	startPosition: LogicalPosition;
+	lastDispatchedPosition: LogicalPosition;
 	bounds: DragBounds;
 	corner: PanelCorner;
 	isRtl: boolean;
@@ -32,22 +26,25 @@ export function useFloatingPanelDrag( id: string ) {
 
 	const onPointerDown = useCallback(
 		( event: ReactPointerEvent< HTMLElement > ) => {
-			event.currentTarget.setPointerCapture( event.pointerId );
+			if ( ! corner || ! position || ! size ) {
+				return;
+			}
 
-			const panelSize: LogicalSize = size ?? { inlineSize: 0, blockSize: 0 };
+			event.currentTarget.setPointerCapture( event.pointerId );
 
 			sessionRef.current = {
 				pointerId: event.pointerId,
 				startClientX: event.clientX,
 				startClientY: event.clientY,
-				startPosition: position ?? EMPTY_POSITION,
+				startPosition: position,
+				lastDispatchedPosition: position,
 				bounds: getDragBounds(
-					panelSize,
+					size,
 					{ width: window.innerWidth, height: window.innerHeight },
 					getSidePanelInlineSize(),
 					APP_BAR_HEIGHT_PX
 				),
-				corner: corner ?? 'block-start-inline-start',
+				corner,
 				isRtl: isRtl(),
 			};
 		},
@@ -64,8 +61,12 @@ export function useFloatingPanelDrag( id: string ) {
 
 			const physical = { dx: event.clientX - session.startClientX, dy: event.clientY - session.startClientY };
 			const logical = physicalToLogicalDelta( physical, session.isRtl );
+			const nextPosition = applyDragDelta( session.corner, session.startPosition, logical, session.bounds );
 
-			setPosition( applyDragDelta( session.corner, session.startPosition, logical, session.bounds ) );
+			if ( activePositionChanged( session.corner, session.lastDispatchedPosition, nextPosition ) ) {
+				setPosition( nextPosition );
+				session.lastDispatchedPosition = nextPosition;
+			}
 		},
 		[ setPosition ]
 	);

--- a/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-resize.ts
+++ b/packages/packages/core/editor-floating-panels/src/hooks/use-floating-panel-resize.ts
@@ -23,6 +23,8 @@ type ResizeSession = {
 	startClientY: number;
 	startPosition: LogicalPosition;
 	startSize: LogicalSize;
+	lastPosition: LogicalPosition;
+	lastSize: LogicalSize;
 	bounds: ResizeBounds;
 	corner: PanelCorner;
 	isRtl: boolean;
@@ -75,6 +77,8 @@ export function usePanelResizeInteraction( id: string ) {
 				startClientY: event.clientY,
 				startPosition: position,
 				startSize: size,
+				lastPosition: position,
+				lastSize: size,
 				bounds: getResizeBounds( corner, position, size, minSize ),
 				corner,
 				isRtl: isRtl(),
@@ -119,16 +123,18 @@ export function usePanelResizeInteraction( id: string ) {
 				viewport
 			);
 
-			if ( activePositionChanged( session.corner, session.startPosition, nextPosition ) ) {
+			if ( activePositionChanged( session.corner, session.lastPosition, nextPosition ) ) {
 				setPosition( nextPosition );
+				session.lastPosition = nextPosition;
 			}
 
 			const sizeChanged =
-				next.size.inlineSize !== session.startSize.inlineSize ||
-				next.size.blockSize !== session.startSize.blockSize;
+				next.size.inlineSize !== session.lastSize.inlineSize ||
+				next.size.blockSize !== session.lastSize.blockSize;
 
 			if ( sizeChanged ) {
 				setSize( next.size );
+				session.lastSize = next.size;
 			}
 		},
 		[ setPosition, setSize ]

--- a/packages/packages/core/editor-floating-panels/src/sync.ts
+++ b/packages/packages/core/editor-floating-panels/src/sync.ts
@@ -30,6 +30,7 @@ export const localStorageAdapter: PanelStateStorage = {
 
 let cachedPersistedState: Record< string, FloatingPanelState > = {};
 let isSyncInitialized = false;
+let persistenceTimer: ReturnType< typeof setTimeout > | null = null;
 let persistenceUnsubscribe: ( () => void ) | null = null;
 let persistenceSession = 0;
 
@@ -50,12 +51,19 @@ export function getPersistedState( id: string ): FloatingPanelState | undefined 
 
 const STORE_READY_POLL_MS = 16;
 
+function clearPersistenceTimer(): void {
+	if ( persistenceTimer ) {
+		clearTimeout( persistenceTimer );
+		persistenceTimer = null;
+	}
+}
+
 function schedulePersistence( storage: PanelStateStorage ): void {
+	clearPersistenceTimer();
 	persistenceUnsubscribe?.();
 	persistenceUnsubscribe = null;
 
 	const session = ++persistenceSession;
-	let timer: ReturnType< typeof setTimeout > | null = null;
 
 	const subscribe = () => {
 		if ( session !== persistenceSession ) {
@@ -65,12 +73,15 @@ function schedulePersistence( storage: PanelStateStorage ): void {
 		persistenceUnsubscribe = __subscribeWithSelector(
 			( state: GlobalState ) => state.floatingPanels.byId,
 			( byId ) => {
-				if ( timer ) {
-					clearTimeout( timer );
-				}
+				clearPersistenceTimer();
 
-				timer = setTimeout( () => {
-					storage.write( encodePersistedState( byId ) );
+				persistenceTimer = setTimeout( () => {
+					if ( session !== persistenceSession ) {
+						return;
+					}
+
+					cachedPersistedState = { ...cachedPersistedState, ...byId };
+					storage.write( encodePersistedState( cachedPersistedState ) );
 				}, PERSIST_DEBOUNCE_MS );
 			}
 		);

--- a/packages/packages/core/editor-floating-panels/src/utils/__tests__/corner-position.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/__tests__/corner-position.test.ts
@@ -3,13 +3,16 @@ import {
 	buildInitialPosition,
 	fromStartAnchoredPosition,
 	getActiveInsetKeys,
+	getDragBounds,
 	type PanelCorner,
 	positionToCssInsets,
 	toStartAnchoredPosition,
 } from '../corner-position';
+import { APP_BAR_HEIGHT_PX } from '../viewport-bounds';
 
 const VIEWPORT = { width: 1200, height: 900 };
 const SIZE: LogicalSize = { inlineSize: 320, blockSize: 480 };
+const SIDE_PANEL_INLINE_SIZE_PX = 280;
 
 describe( 'corner-position', () => {
 	it.each< [ PanelCorner, [ keyof LogicalPosition, keyof LogicalPosition ] ] >( [
@@ -59,5 +62,33 @@ describe( 'corner-position', () => {
 		const restored = fromStartAnchoredPosition( 'block-end-inline-end', startAnchored, SIZE, VIEWPORT );
 
 		expect( restored ).toEqual( position );
+	} );
+
+	it( 'getDragBounds returns normal bounds within the viewport', () => {
+		expect( getDragBounds( SIZE, VIEWPORT, SIDE_PANEL_INLINE_SIZE_PX, APP_BAR_HEIGHT_PX ) ).toEqual( {
+			minInlineStart: SIDE_PANEL_INLINE_SIZE_PX,
+			maxInlineStart: VIEWPORT.width - SIZE.inlineSize,
+			minInlineEnd: 0,
+			maxInlineEnd: VIEWPORT.width - SIDE_PANEL_INLINE_SIZE_PX - SIZE.inlineSize,
+			minBlockStart: APP_BAR_HEIGHT_PX,
+			maxBlockStart: VIEWPORT.height - SIZE.blockSize,
+			minBlockEnd: 0,
+			maxBlockEnd: VIEWPORT.height - APP_BAR_HEIGHT_PX - SIZE.blockSize,
+		} );
+	} );
+
+	it( 'getDragBounds allows inverted bounds when the panel exceeds the viewport', () => {
+		const oversizedSize: LogicalSize = { inlineSize: 1000, blockSize: 900 };
+
+		expect( getDragBounds( oversizedSize, VIEWPORT, SIDE_PANEL_INLINE_SIZE_PX, APP_BAR_HEIGHT_PX ) ).toEqual( {
+			minInlineStart: SIDE_PANEL_INLINE_SIZE_PX,
+			maxInlineStart: VIEWPORT.width - oversizedSize.inlineSize,
+			minInlineEnd: 0,
+			maxInlineEnd: VIEWPORT.width - SIDE_PANEL_INLINE_SIZE_PX - oversizedSize.inlineSize,
+			minBlockStart: APP_BAR_HEIGHT_PX,
+			maxBlockStart: VIEWPORT.height - oversizedSize.blockSize,
+			minBlockEnd: 0,
+			maxBlockEnd: VIEWPORT.height - APP_BAR_HEIGHT_PX - oversizedSize.blockSize,
+		} );
 	} );
 } );

--- a/packages/packages/core/editor-floating-panels/src/utils/__tests__/direction.test.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/__tests__/direction.test.ts
@@ -1,0 +1,23 @@
+import { isRtl } from '../direction';
+
+describe( 'direction', () => {
+	afterEach( () => {
+		document.documentElement.removeAttribute( 'dir' );
+	} );
+
+	it( 'returns true when document dir is rtl', () => {
+		// Arrange.
+		document.documentElement.dir = 'rtl';
+
+		// Act & Assert.
+		expect( isRtl() ).toBe( true );
+	} );
+
+	it( 'returns false when document dir is ltr', () => {
+		// Arrange.
+		document.documentElement.dir = 'ltr';
+
+		// Act & Assert.
+		expect( isRtl() ).toBe( false );
+	} );
+} );

--- a/packages/packages/core/editor-floating-panels/src/utils/resize-math.ts
+++ b/packages/packages/core/editor-floating-panels/src/utils/resize-math.ts
@@ -1,15 +1,12 @@
 import { type LogicalPosition, type LogicalSize } from '../types';
 import { clamp } from './clamp';
+import { type PanelCorner } from './corner-position';
 
 export type ResizeEdge = 'inline-start' | 'inline-end' | 'block-start' | 'block-end';
 
-export type ResizeCorner =
-	| 'block-start-inline-start'
-	| 'block-start-inline-end'
-	| 'block-end-inline-start'
-	| 'block-end-inline-end';
+export type ResizeCorner = PanelCorner;
 
-export type ResizeDirection = ResizeEdge | ResizeCorner;
+export type ResizeDirection = ResizeEdge | PanelCorner;
 
 export type ResizeBounds = {
 	minInlineSize: number;


### PR DESCRIPTION
## Summary

Adds React UI components for floating panel rendering, drag/resize handles, and public API primitives.

Split from #36308 (4/5). Stacked on #36360.

## Scope

- Internal: Host, PanelWindow, drag/resize handles
- External: Header, Body, Footer, FloatingPanel wrapper
- Component tests

## Review focus

Component structure, accessibility, preview-mode hiding, z-index layering, CSS positioning.

Ref: ED-24738

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

ED-24738: Implement floating panel UI component library with header, body, footer components and panel window rendering with drag/resize interactions. Completes the external API surface for consumer panels.

## 2. What Changed (Where)

| Category | Changes |
|----------|---------|
| **UI Components** | FloatingPanel, FloatingPanelHeader (with actions/drag handle), FloatingPanelBody, FloatingPanelFooter wrappers |
| **Internal Rendering** | PanelWindow (Fade + Paper container), DragHandle, ResizeHandle (edges/corners) with pointer event handlers |
| **Drag/Resize Logic** | Track last dispatched position/size to debounce updates; refactored getDragBounds into corner-position util |
| **State Persistence** | Global persistenceTimer tracks debounce across sessions; merges preloaded unregistered panels with store updates |
| **Tests** | 161 lines covering header actions/drag, host visibility modes, panel window resize handles, sync merging, utils |
| **Config** | Added @swc/jest with React automatic JSX transform; added UI/store/i18n dependencies to package.json |

## 3. How It Works

Consumer wraps content in `<FloatingPanel><FloatingPanelHeader/><FloatingPanelBody/><FloatingPanelFooter/></FloatingPanel>`. Host renders injected panels as PanelWindow (fixed positioned Paper with Fade animation). Drag/resize compute deltas from pointer events, debounce position/size updates via lastDispatchedPosition/lastSize to avoid thrashing the store, then persist debounced state. RTL handled in resize cursor logic; preview mode hides panels via aria-hidden + inert.

## 4. Risks

**State debouncing race condition**: Multiple sync() calls create sessions; stale timers from previous calls could write old state. Mitigated by session counter and clearPersistenceTimer(). **Type cleanup**: ResizeCorner type moved to reference PanelCorner alias—verify no downstream breakage. **Transform config change**: @swc/jest automatic JSX runtime assumes all React imports removed—safe if codebase consistent, but risky if any implicit React usage exists.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
