### PR TITLE
Internal: Cherry-pick PR 36369 to 4.01: Bump packages [ED-24759]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "elementor/wp-one-package": "1.0.65"
+        "elementor/wp-one-package": "1.0.66"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "237fb693f8f0df09d2c4a804c7312f92",
+    "content-hash": "d9867a7d4c2af17d8f202bb70ee314ce",
     "packages": [
         {
             "name": "elementor/wp-notifications-package",
@@ -39,10 +39,10 @@
         },
         {
             "name": "elementor/wp-one-package",
-            "version": "1.0.65",
+            "version": "1.0.66",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.65"
+                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.66"
             },
             "require": {
                 "elementor/wp-notifications-package": "^1.2"
@@ -69,7 +69,7 @@
                     "vendor/bin/phpcbf ."
                 ]
             },
-            "time": "2026-06-16T07:28:42+00:00"
+            "time": "2026-06-24T10:34:47+00:00"
         }
     ],
     "packages-dev": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "packages/apps/*"
       ],
       "dependencies": {
-        "@elementor/elementor-one-assets": "0.4.37",
+        "@elementor/elementor-one-assets": "0.4.38",
         "@elementor/icons": "~1.75.1",
         "@elementor/ui": "1.39.1",
         "@reach/router": "1.3.4",
@@ -4513,9 +4513,9 @@
       "link": true
     },
     "node_modules/@elementor/elementor-one-assets": {
-      "version": "0.4.37",
-      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.37.tgz",
-      "integrity": "sha512-iY7FGmpvkZFxh8wrtZYqtq3imd3YYtX82KLp45CUDiYITYiy8fm37BiyAPdWDSPkLXMdxWTVbRhF9v52XHP0yA==",
+      "version": "0.4.38",
+      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.38.tgz",
+      "integrity": "sha512-NaowqfUl7hJRJBsxDigfZm5ySWgMChE3Bk2sG+76tyZpEvGbfeaIByvw8nEPJrRtq6zgGo8WpeCQS4LuYh2miw==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/icons": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "write": "^2.0.0"
   },
   "dependencies": {
-    "@elementor/elementor-one-assets": "0.4.37",
+    "@elementor/elementor-one-assets": "0.4.38",
     "@elementor/icons": "~1.75.1",
     "@elementor/ui": "1.39.1",
     "@reach/router": "1.3.4",


### PR DESCRIPTION
Cherry-pick of #36369 to the 4.01 release branch.

## Changes
- Bump `elementor/wp-one-package` from `1.0.65` to `1.0.66`
- Bump `@elementor/elementor-one-assets` from `0.4.37` to `0.4.38`

## Original PR
#36369

## Jira
[ED-24759](https://elementor.atlassian.net/browse/ED-24759)

Made with [Cursor](https://cursor.com)

[ED-24759]: https://elementor.atlassian.net/browse/ED-24759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick of PR 36369 to branch 4.01: bumps internal dependencies to align versions across codebase (ED-24759).

## 2. What Changed (Where)

- `composer.json`: `elementor/wp-one-package` bumped from 1.0.65 → 1.0.66
- `package.json`: `@elementor/elementor-one-assets` bumped from 0.4.37 → 0.4.38

## 3. How It Works

Straightforward dependency version increments. Both packages maintain semver patch-level changes with no breaking API surface expected.

## 4. Risks

None — patch-level bumps with low blast radius. Verify dependent systems tested against 1.0.66 and 0.4.38 in 4.01 integration.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
