### PR TITLE
Internal: Cherry-pick PR 36369 to 4.00: Bump packages [ED-24759]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "elementor/wp-one-package": "1.0.62"
+        "elementor/wp-one-package": "1.0.66"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca9c50e9b8bbb42851c91855da171fd2",
+    "content-hash": "58c7d75099b5734f8eb067b734f8ffa9",
     "packages": [
         {
             "name": "elementor/wp-notifications-package",
@@ -39,10 +39,10 @@
         },
         {
             "name": "elementor/wp-one-package",
-            "version": "1.0.62",
+            "version": "1.0.66",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.62"
+                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.66"
             },
             "require": {
                 "elementor/wp-notifications-package": "^1.2"
@@ -69,7 +69,7 @@
                     "vendor/bin/phpcbf ."
                 ]
             },
-            "time": "2026-05-11T10:53:25+00:00"
+            "time": "2026-06-24T10:34:47+00:00"
         }
     ],
     "packages-dev": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "packages/apps/*"
       ],
       "dependencies": {
-        "@elementor/elementor-one-assets": "0.4.35",
+        "@elementor/elementor-one-assets": "0.4.38",
         "@elementor/icons": "~1.75.1",
         "@elementor/ui": "1.36.17",
         "@reach/router": "1.3.4",
@@ -4495,9 +4495,9 @@
       "link": true
     },
     "node_modules/@elementor/elementor-one-assets": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.35.tgz",
-      "integrity": "sha512-z5EZIPedcicUFVqQs8NNAyBDrh/sCn0czsqYr/plrNpdrVKQdnuMeVJvp7ZlbfbcErYZvEZLREWwnNivF2/PyA==",
+      "version": "0.4.38",
+      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.38.tgz",
+      "integrity": "sha512-NaowqfUl7hJRJBsxDigfZm5ySWgMChE3Bk2sG+76tyZpEvGbfeaIByvw8nEPJrRtq6zgGo8WpeCQS4LuYh2miw==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/icons": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "write": "^2.0.0"
   },
   "dependencies": {
-    "@elementor/elementor-one-assets": "0.4.35",
+    "@elementor/elementor-one-assets": "0.4.38",
     "@elementor/icons": "~1.75.1",
     "@elementor/ui": "1.36.17",
     "@reach/router": "1.3.4",


### PR DESCRIPTION
Cherry-pick of #36369 to the 4.00 release branch.

## Changes
- Bump `elementor/wp-one-package` from `1.0.62` to `1.0.66`
- Bump `@elementor/elementor-one-assets` from `0.4.35` to `0.4.38`

## Original PR
#36369

## Jira
[ED-24759](https://elementor.atlassian.net/browse/ED-24759)

Made with [Cursor](https://cursor.com)

[ED-24759]: https://elementor.atlassian.net/browse/ED-24759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick of package dependency updates from main branch to 4.00 release line. Updates Elementor's internal packages to latest stable versions.

## 2. What Changed (Where)

- `composer.json`: Bumped `elementor/wp-one-package` from 1.0.62 → 1.0.66
- `package.json`: Bumped `@elementor/elementor-one-assets` from 0.4.35 → 0.4.38

## 3. How It Works

Straightforward dependency version increments via package manager manifests. No code logic changes—purely version pins that will be resolved during next `composer install` and `npm install` runs.

## 4. Risks

Minimal. Patch-level version bumps are low-risk; verify these versions are already validated upstream before merge.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
