### PR TITLE
Internal: Cherry-pick PR 36369 to 3.35: Bump packages [ED-24759]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "elementor/wp-one-package": "1.0.57"
+        "elementor/wp-one-package": "1.0.66"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c322ff6bb86b5e3c1ab0035466940216",
+    "content-hash": "58c7d75099b5734f8eb067b734f8ffa9",
     "packages": [
         {
             "name": "elementor/wp-notifications-package",
@@ -39,10 +39,10 @@
         },
         {
             "name": "elementor/wp-one-package",
-            "version": "1.0.57",
+            "version": "1.0.66",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.57"
+                "url": "https://composer.elementor.com/download/elementor/wp-one-package/1.0.66"
             },
             "require": {
                 "elementor/wp-notifications-package": "^1.2"
@@ -69,7 +69,7 @@
                     "vendor/bin/phpcbf ."
                 ]
             },
-            "time": "2026-03-17T14:35:00+00:00"
+            "time": "2026-06-24T10:34:47+00:00"
         }
     ],
     "packages-dev": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "elementor",
       "version": "3.35.0",
       "dependencies": {
-        "@elementor/elementor-one-assets": "0.4.28",
+        "@elementor/elementor-one-assets": "0.4.38",
         "@elementor/icons": "1.63.0",
         "@elementor/ui": "1.36.17",
         "@reach/router": "1.3.4",
@@ -3550,9 +3550,9 @@
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@elementor/elementor-one-assets": {
-      "version": "0.4.28",
-      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.28.tgz",
-      "integrity": "sha512-MTqVbUQOLIWEBI6DRCOGYbh738h01llUbtsWQvrAsICTaF/tdiddMDhDURLD/8ILI1k/yC/RklafQX7UTK7/Sg==",
+      "version": "0.4.38",
+      "resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.38.tgz",
+      "integrity": "sha512-NaowqfUl7hJRJBsxDigfZm5ySWgMChE3Bk2sG+76tyZpEvGbfeaIByvw8nEPJrRtq6zgGo8WpeCQS4LuYh2miw==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elementor/icons": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "write": "^2.0.0"
   },
   "dependencies": {
-    "@elementor/elementor-one-assets": "0.4.28",
+    "@elementor/elementor-one-assets": "0.4.38",
     "@elementor/icons": "1.63.0",
     "@elementor/ui": "1.36.17",
     "@reach/router": "1.3.4",


### PR DESCRIPTION
Cherry-pick of #36369 to the 3.35 release branch.

## Changes
- Bump `elementor/wp-one-package` from `1.0.57` to `1.0.66`
- Bump `@elementor/elementor-one-assets` from `0.4.28` to `0.4.38`

## Original PR
#36369

## Jira
[ED-24759](https://elementor.atlassian.net/browse/ED-24759)

Made with [Cursor](https://cursor.com)

[ED-24759]: https://elementor.atlassian.net/browse/ED-24759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick of upstream PR 36369 to 3.35 branch bumping Elementor package dependencies. Routine maintenance to align versions across branches (ED-24759).

## 2. What Changed (Where)

- **composer.json**: `elementor/wp-one-package` 1.0.57 → 1.0.66
- **package.json**: `@elementor/elementor-one-assets` 0.4.28 → 0.4.38

## 3. How It Works

Dependency version updates only; no code logic changes. Composer and npm will resolve and install specified versions on next install cycle.

## 4. Risks

Verify upstream PR 36369 doesn't contain breaking changes in minor/patch bumps. Run existing test suite to confirm compatibility.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
