### PR TITLE
Fix design system typography breakpoint order

### DIFF
--- a/modules/design-system-sync/classes/stylesheet-manager.php
+++ b/modules/design-system-sync/classes/stylesheet-manager.php
@@ -68,10 +68,24 @@ class Stylesheet_Manager extends Base_File {
 		$typography_entries = Classes_Provider::get_synced_typography_css_entries();
 
 		foreach ( $typography_entries as $device => $entries ) {
-			$css = ':root { ' . implode( ' ', $entries ) . ' }';
-			$device_key = ( Breakpoints_Manager::BREAKPOINT_KEY_DESKTOP === $device ) ? '' : $device;
+			$css = implode( ' ', $entries );
 
-			$stylesheet->add_raw_css( $css, $device_key );
+			if ( Breakpoints_Manager::BREAKPOINT_KEY_DESKTOP === $device ) {
+				$stylesheet->add_rules( ':root', $css );
+				continue;
+			}
+
+			if ( ! isset( $breakpoints[ $device ] ) ) {
+				continue;
+			}
+
+			$stylesheet->add_rules(
+				':root',
+				$css,
+				[
+					$breakpoints[ $device ]->get_direction() => $device,
+				]
+			);
 		}
 
 		return (string) $stylesheet;


### PR DESCRIPTION
## PR Checklist

* [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type

What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix synced design system typography CSS media query ordering when additional breakpoints are enabled.

## Description

This PR fixes the generated CSS order for synced design system typography variables.

Synced typography CSS was previously added via `add_raw_css()`, which outputs responsive blocks in insertion order. When an additional max-width breakpoint such as Laptop/Portable (`1366px`) is enabled and its typography variants are inserted after tablet/mobile variants, the generated `design-system-sync.css` can print the larger breakpoint after the smaller ones.

This can cause the `max-width: 1366px` typography variables to override tablet or mobile typography variables.

This change uses `add_rules()` for synced typography variables instead, allowing Elementor’s existing stylesheet media query ordering logic to handle responsive breakpoint order correctly.

## Test instructions

This PR can be tested by following these steps:

* Enable an additional max-width breakpoint such as Laptop/Portable.
* Create or sync typography classes through the design system sync module.
* Define typography values for desktop, tablet, mobile, and the additional breakpoint.
* Regenerate `design-system-sync.css`.
* Confirm that max-width media queries are output from larger to smaller breakpoints, for example:

  * `max-width: 1366px`
  * `max-width: 1024px`
  * `max-width: 767px`
* Confirm that mobile typography variables are no longer overridden by the additional larger breakpoint.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] Docs have been added / updated (for bug fixes / features)

Fixes #36383

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Typography CSS entries were being applied with incorrect breakpoint ordering—desktop rules were mixing with media query logic instead of being prioritized at root level. This refactor separates desktop (root-level) from responsive (media-query) typography rules.

## 2. What Changed (Where)

Stylesheet_Manager: Replaced string concatenation + raw CSS output with structured `add_rules()` calls that properly distinguish desktop vs. breakpoint-specific typography entries.

## 3. How It Works

Loop iterates typography by device. Desktop rules added directly to `:root` without media query wrapper. Non-desktop devices validated against breakpoints map, then wrapped in appropriate media query via `get_direction()`. Skips invalid breakpoints gracefully.

## 4. Risks

Assumes `Breakpoints_Manager::BREAKPOINT_KEY_DESKTOP` constant exists and matches incoming device keys. If breakpoints map is incomplete or device naming misaligns, responsive typography silently skips (current logic mitigates via continue guard).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
