### PR TITLE
Internal: Plugin tester - reduce timing [ED-24825]

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -92,8 +92,10 @@ jobs:
         include:
           - shardIndex: "elements-regression-core"
           - shardIndex: "elements-regression-atomic"
-          - shardIndex: "plugin_tester_section"
-          - shardIndex: "plugin_tester_container"
+          - shardIndex: "plugin_tester_section_1"
+          - shardIndex: "plugin_tester_section_2"
+          - shardIndex: "plugin_tester_container_1"
+          - shardIndex: "plugin_tester_container_2"
           - shardIndex: "import_export_customization"
     steps:
       - name: Checkout source code
@@ -201,8 +203,8 @@ jobs:
         if: ${{
           matrix.shardIndex != 'elements-regression-core' &&
           matrix.shardIndex != 'elements-regression-atomic' &&
-          matrix.shardIndex != 'plugin_tester_container' &&
-          matrix.shardIndex != 'plugin_tester_section' &&
+          !startsWith(matrix.shardIndex, 'plugin_tester_container_') &&
+          !startsWith(matrix.shardIndex, 'plugin_tester_section_') &&
           matrix.shardIndex != 'import_export_customization'
           }}
         run: |
@@ -212,21 +214,25 @@ jobs:
           fi
           npm run test:playwright -- --grep-invert="@plugin_tester_container|@plugin_tester_section|@import_export_customization" --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} $PROJECT_ARG
       - name: Run Playwright Plugin Container tests
-        if: ${{ matrix.shardIndex == 'plugin_tester_container' }}
+        if: ${{ startsWith(matrix.shardIndex, 'plugin_tester_container_') }}
         run: |
           PROJECT_ARG=""
           if [ "$BROWSER" != "all" ] && [ "$BROWSER" != "chromium" ]; then
             PROJECT_ARG="--project=$BROWSER"
           fi
-          npm run test:playwright -- --grep="@plugin_tester_container" $PROJECT_ARG
+          SHARD_NUM="${{ matrix.shardIndex }}"
+          SHARD_NUM="${SHARD_NUM##*_}"
+          npm run test:playwright -- --grep="@plugin_tester_container" --shard=${SHARD_NUM}/2 $PROJECT_ARG
       - name: Run Playwright Plugin Section tests
-        if: ${{ matrix.shardIndex == 'plugin_tester_section' }}
+        if: ${{ startsWith(matrix.shardIndex, 'plugin_tester_section_') }}
         run: |
           PROJECT_ARG=""
           if [ "$BROWSER" != "all" ] && [ "$BROWSER" != "chromium" ]; then
             PROJECT_ARG="--project=$BROWSER"
           fi
-          npm run test:playwright -- --grep="@plugin_tester_section" $PROJECT_ARG
+          SHARD_NUM="${{ matrix.shardIndex }}"
+          SHARD_NUM="${SHARD_NUM##*_}"
+          npm run test:playwright -- --grep="@plugin_tester_section" --shard=${SHARD_NUM}/2 $PROJECT_ARG
       - name: Run import export customization tests
         if: ${{ matrix.shardIndex == 'import_export_customization' }}
         run: |

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -60,8 +60,10 @@ jobs:
         shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
         shardTotal: [17]
         include:
-          - shardIndex: "plugin_tester_section"
-          - shardIndex: "plugin_tester_container"
+          - shardIndex: "plugin_tester_section_1"
+          - shardIndex: "plugin_tester_section_2"
+          - shardIndex: "plugin_tester_container_1"
+          - shardIndex: "plugin_tester_container_2"
           - shardIndex: "elements-regression-core"
           - shardIndex: "elements-regression-atomic"
     steps:
@@ -101,8 +103,8 @@ jobs:
 
       - name: Update snapshots
         if: ${{
-          matrix.shardIndex != 'plugin_tester_container' &&
-          matrix.shardIndex != 'plugin_tester_section' &&
+          !startsWith(matrix.shardIndex, 'plugin_tester_container_') &&
+          !startsWith(matrix.shardIndex, 'plugin_tester_section_') &&
           matrix.shardIndex != 'elements-regression-core' &&
           matrix.shardIndex != 'elements-regression-atomic'
           }}
@@ -116,24 +118,30 @@ jobs:
             --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Update plugin tester container snapshots
-        if: ${{ matrix.shardIndex == 'plugin_tester_container' }}
+        if: ${{ startsWith(matrix.shardIndex, 'plugin_tester_container_') }}
         continue-on-error: true
         env:
           BROWSERS: ${{ steps.setup.outputs.browsers }}
         run: |
+          SHARD_NUM="${{ matrix.shardIndex }}"
+          SHARD_NUM="${SHARD_NUM##*_}"
           npm run test:playwright -- \
             --update-snapshots \
-            --grep="@plugin_tester_container"
+            --grep="@plugin_tester_container" \
+            --shard=${SHARD_NUM}/2
 
       - name: Update plugin tester section snapshots
-        if: ${{ matrix.shardIndex == 'plugin_tester_section' }}
+        if: ${{ startsWith(matrix.shardIndex, 'plugin_tester_section_') }}
         continue-on-error: true
         env:
           BROWSERS: ${{ steps.setup.outputs.browsers }}
         run: |
+          SHARD_NUM="${{ matrix.shardIndex }}"
+          SHARD_NUM="${SHARD_NUM##*_}"
           npm run test:playwright -- \
             --update-snapshots \
-            --grep="@plugin_tester_section"
+            --grep="@plugin_tester_section" \
+            --shard=${SHARD_NUM}/2
 
       - name: Update elements regression core snapshots
         if: ${{ matrix.shardIndex == 'elements-regression-core' }}

--- a/tests/playwright/sanity/plugin-tester-generator.ts
+++ b/tests/playwright/sanity/plugin-tester-generator.ts
@@ -80,8 +80,9 @@ export const generatePluginTests = ( testType: string ) => {
 					admin.remove();
 				}, adminBar );
 				await editor.removeClasses( 'elementor-motion-effects-element' );
-				await page.locator( '[data-widget_type="progress.default"]' ).first().scrollIntoViewIfNeeded();
-				await page.waitForTimeout( 500 );
+				const progressWidget = page.locator( '[data-widget_type="progress.default"]' ).first();
+				await progressWidget.scrollIntoViewIfNeeded();
+				await expect( progressWidget ).toBeVisible();
 				await expect.soft( page ).toHaveScreenshot( 'frontPage.png', { fullPage: true } );
 
 				if ( plugin.hasInstallationPage ) {


### PR DESCRIPTION
## Summary

- Split each plugin tester CI job (container and section) into two parallel shards using Playwright's `--shard=1/2` and `--shard=2/2`, cutting per-job test execution time from ~8 minutes to ~4 minutes
- Replace a fixed 500ms `waitForTimeout` before front-page screenshots with a visibility assertion on the progress widget

## Jira

https://elementor.atlassian.net/browse/ED-24825

## Test plan

- [ ] Verify CI plugin tester container shards (`plugin_tester_container_1`, `plugin_tester_container_2`) complete in ~4–5 minutes each
- [ ] Verify CI plugin tester section shards (`plugin_tester_section_1`, `plugin_tester_section_2`) complete in ~4–5 minutes each
- [ ] Confirm all plugin tester tests still pass across both shards


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Plugin tester tests were running serially (2 single shards), causing slow CI feedback. This splits them into 4 parallel shards (2 container + 2 section) and removes a hardcoded 500ms timeout that was masking race conditions.

## 2. What Changed (Where)

- `plugin-tester-generator.ts`: Replaced `scrollIntoViewIfNeeded()` + `waitForTimeout(500)` with explicit visibility check—tests timing deterministically now.
- `.github/workflows/playwright.yml`: Refactored single `plugin_tester_container`/`plugin_tester_section` shards into 4 indexed shards with dynamic shard-num extraction.
- `.github/workflows/update-snapshots.yml`: Mirrored workflow changes to snapshot update pipeline for consistency.

## 3. How It Works

Workflow now distributes plugin tests across 4 parallel jobs: each shard extracts its numeric suffix (`plugin_tester_container_1` → `1`) and runs with `--shard=${SHARD_NUM}/2`, filtering via regex. Test itself waits for progress widget visibility instead of blind sleep, eliminating flakiness.

## 4. Risks

Parallelization assumes tests are isolated—shared state or ordering dependencies will cause flakes. Dynamic shard-num extraction via bash parameter expansion could silently fail if naming convention changes. Verify plugin tester tests pass independently on each shard before merge.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
