### PR TITLE
Internal: Improve Editor activity handling [ED-24583]

### DIFF
--- a/core/common/modules/events-manager/assets/js/events-config.js
+++ b/core/common/modules/events-manager/assets/js/events-config.js
@@ -13,6 +13,7 @@ const eventsConfig = {
 		searchInput: 'search_input',
 		searchResult: 'search_result',
 		buttons: 'buttons',
+		popup: 'popup',
 		searchWidget: 'search_widget',
 		wpDashAdminMenuItem: 'wpdash_admin_menu_item',
 		wpDashEditorMenu: 'wpdash_editor_menu',
@@ -32,6 +33,10 @@ const eventsConfig = {
 		noResults: 'no_results',
 		selected: 'selected',
 		promotionViewed: 'promotion_viewed',
+		popupShown: 'popup_shown',
+		popupViewed: 'popup_viewed',
+		exitToLandingPage: 'exit_to_landing_page',
+		cancel: 'cancel',
 		upgradeNow: 'upgrade_now',
 		elementorSideMenuOpened: 'elementor_side_menu_opened',
 		editorSubMenuOpened: 'wpdash_editor_sub_menu_opened',
@@ -318,6 +323,8 @@ const eventsConfig = {
 		promotions: {
 			viewPromotion: 'view_promotion',
 			upgradePromotionClick: 'upgrade_promotion_click',
+			popupOpened: 'locked_widget_popup_opened',
+			popupCtaClick: 'locked_widget_popup_cta_click',
 		},
 	},
 };

--- a/modules/promotions/assets/js/editor/tracking.js
+++ b/modules/promotions/assets/js/editor/tracking.js
@@ -30,7 +30,11 @@ export function trackLockedWidgetPopupShown( widgetName ) {
 	} );
 }
 
-export function trackLockedWidgetPopupClick( widgetName, action ) {
+function toLowerSnake( value ) {
+	return String( value || '' ).replace( /\s+/g, '_' ).toLowerCase();
+}
+
+function dispatchPopupClick( widgetName, { targetName, interactionResult, locationL1 } ) {
 	const eventsManager = getEventsManager();
 
 	if ( ! eventsManager?.dispatchEvent || ! widgetName ) {
@@ -38,20 +42,43 @@ export function trackLockedWidgetPopupClick( widgetName, action ) {
 	}
 
 	const { config } = eventsManager;
-	const isUpgrade = 'upgrade_now' === action;
 
 	eventsManager.dispatchEvent( config.names.promotions.popupCtaClick, {
 		app_type: config.appTypes.editor,
 		window_name: config.appTypes.editor,
-		interaction_type: 'click',
+		interaction_type: toLowerSnake( config.triggers.click ),
 		target_type: config.targetTypes.button,
-		target_name: action,
-		interaction_result: isUpgrade
-			? config.interactionResults.exitToLandingPage
-			: config.interactionResults.cancel,
+		target_name: targetName,
+		interaction_result: interactionResult,
 		target_location: `locked_widget_promotion_${ widgetName }_popup`,
-		location_l1: isUpgrade
-			? `locked_widget_promotion_${ widgetName }`
-			: 'cancel_button',
+		location_l1: locationL1,
+	} );
+}
+
+export function trackLockedWidgetPopupCtaClick( widgetName ) {
+	const eventsManager = getEventsManager();
+	if ( ! eventsManager?.config ) {
+		return;
+	}
+	const { config } = eventsManager;
+
+	dispatchPopupClick( widgetName, {
+		targetName: config.interactionResults.upgradeNow,
+		interactionResult: config.interactionResults.exitToLandingPage,
+		locationL1: `locked_widget_promotion_${ widgetName }`,
+	} );
+}
+
+export function trackLockedWidgetPopupCancel( widgetName ) {
+	const eventsManager = getEventsManager();
+	if ( ! eventsManager?.config ) {
+		return;
+	}
+	const { config } = eventsManager;
+
+	dispatchPopupClick( widgetName, {
+		targetName: config.interactionResults.cancel,
+		interactionResult: config.interactionResults.cancel,
+		locationL1: 'cancel_button',
 	} );
 }

--- a/modules/promotions/assets/js/editor/tracking.js
+++ b/modules/promotions/assets/js/editor/tracking.js
@@ -1,0 +1,57 @@
+export function normalizeWidgetName( widgetType ) {
+	return String( widgetType || '' )
+		.toLowerCase()
+		.replace( /[^a-z0-9]+/g, '_' )
+		.replace( /^_+|_+$/g, '' );
+}
+
+function getEventsManager() {
+	return typeof elementorCommon !== 'undefined' ? elementorCommon.eventsManager : null;
+}
+
+export function trackLockedWidgetPopupShown( widgetName ) {
+	const eventsManager = getEventsManager();
+
+	if ( ! eventsManager?.dispatchEvent || ! widgetName ) {
+		return;
+	}
+
+	const { config } = eventsManager;
+
+	eventsManager.dispatchEvent( config.names.promotions.popupOpened, {
+		app_type: config.appTypes.editor,
+		window_name: config.appTypes.editor,
+		interaction_type: config.interactionResults.popupShown,
+		target_type: config.targetTypes.popup,
+		target_name: `locked_widget_promotion_${ widgetName }_popup`,
+		interaction_result: config.interactionResults.popupViewed,
+		target_location: config.appTypes.editor,
+		location_l1: 'widget_panel',
+	} );
+}
+
+export function trackLockedWidgetPopupClick( widgetName, action ) {
+	const eventsManager = getEventsManager();
+
+	if ( ! eventsManager?.dispatchEvent || ! widgetName ) {
+		return;
+	}
+
+	const { config } = eventsManager;
+	const isUpgrade = 'upgrade_now' === action;
+
+	eventsManager.dispatchEvent( config.names.promotions.popupCtaClick, {
+		app_type: config.appTypes.editor,
+		window_name: config.appTypes.editor,
+		interaction_type: 'click',
+		target_type: config.targetTypes.button,
+		target_name: action,
+		interaction_result: isUpgrade
+			? config.interactionResults.exitToLandingPage
+			: config.interactionResults.cancel,
+		target_location: `locked_widget_promotion_${ widgetName }_popup`,
+		location_l1: isUpgrade
+			? `locked_widget_promotion_${ widgetName }`
+			: 'cancel_button',
+	} );
+}

--- a/modules/promotions/assets/js/react/app-manager.js
+++ b/modules/promotions/assets/js/react/app-manager.js
@@ -5,7 +5,8 @@ import { __ } from '@wordpress/i18n';
 import { createRoot } from 'react-dom/client';
 import {
 	normalizeWidgetName,
-	trackLockedWidgetPopupClick,
+	trackLockedWidgetPopupCancel,
+	trackLockedWidgetPopupCtaClick,
 	trackLockedWidgetPopupShown,
 } from '../editor/tracking';
 
@@ -95,12 +96,16 @@ export class AppManager {
 
 		this.attachEditorEventListeners();
 
+		this.currentWidgetName = widgetName || null;
+
 		if ( widgetName ) {
 			trackLockedWidgetPopupShown( widgetName );
 		}
 
-		const onCtaClick = widgetName && ( () => trackLockedWidgetPopupClick( widgetName, 'upgrade_now' ) );
-		const onCancelClick = widgetName && ( () => trackLockedWidgetPopupClick( widgetName, 'cancel' ) );
+		const onCtaClick = widgetName && ( () => {
+			trackLockedWidgetPopupCtaClick( widgetName );
+			this.currentWidgetName = null;
+		} );
 
 		this.promotionInfoTip = createRoot( this.promotionWrapper );
 		this.promotionInfoTip.render(
@@ -108,10 +113,7 @@ export class AppManager {
 				colorScheme={ elementor?.getPreferences?.( 'ui_theme' ) || 'auto' }
 				isRTL={ elementorCommon.config.isRTL }
 				anchorTarget={ targetEl }
-				doClose={ () => {
-					onCancelClick?.();
-					this.unmount();
-				} }
+				doClose={ () => this.unmount() }
 				onCtaClick={ onCtaClick }
 				{ ...appProps }
 			/>,
@@ -163,6 +165,9 @@ export class AppManager {
 
 	unmount() {
 		if ( this.promotionInfoTip ) {
+			if ( this.currentWidgetName ) {
+				trackLockedWidgetPopupCancel( this.currentWidgetName );
+			}
 			this.detachEditorEventListeners();
 			this.promotionInfoTip.unmount();
 			this.unbindIframeEvents();
@@ -172,6 +177,7 @@ export class AppManager {
 
 		this.promotionInfoTip = null;
 		this.promotionWrapper = null;
+		this.currentWidgetName = null;
 	}
 
 	attachEditorEventListeners() {

--- a/modules/promotions/assets/js/react/app-manager.js
+++ b/modules/promotions/assets/js/react/app-manager.js
@@ -3,6 +3,11 @@ import { resolvePromotionAnimation } from './atomic-promotion-media';
 import { bindPreviewIframeEvents } from 'elementor-editor-utils/preview-iframe-listeners';
 import { __ } from '@wordpress/i18n';
 import { createRoot } from 'react-dom/client';
+import {
+	normalizeWidgetName,
+	trackLockedWidgetPopupClick,
+	trackLockedWidgetPopupShown,
+} from '../editor/tracking';
 
 export class AppManager {
 	constructor() {
@@ -81,7 +86,7 @@ export class AppManager {
 		);
 	}
 
-	mountCard( targetEl, wrapperClassName, appProps ) {
+	mountCard( targetEl, wrapperClassName, appProps, widgetName = '' ) {
 		this.unmount();
 
 		this.promotionWrapper = document.createElement( 'span' );
@@ -89,13 +94,25 @@ export class AppManager {
 		document.body.appendChild( this.promotionWrapper );
 
 		this.attachEditorEventListeners();
+
+		if ( widgetName ) {
+			trackLockedWidgetPopupShown( widgetName );
+		}
+
+		const onCtaClick = widgetName && ( () => trackLockedWidgetPopupClick( widgetName, 'upgrade_now' ) );
+		const onCancelClick = widgetName && ( () => trackLockedWidgetPopupClick( widgetName, 'cancel' ) );
+
 		this.promotionInfoTip = createRoot( this.promotionWrapper );
 		this.promotionInfoTip.render(
 			<App
 				colorScheme={ elementor?.getPreferences?.( 'ui_theme' ) || 'auto' }
 				isRTL={ elementorCommon.config.isRTL }
 				anchorTarget={ targetEl }
-				doClose={ () => this.unmount() }
+				doClose={ () => {
+					onCancelClick?.();
+					this.unmount();
+				} }
+				onCtaClick={ onCtaClick }
 				{ ...appProps }
 			/>,
 		);
@@ -124,6 +141,7 @@ export class AppManager {
 					event.detail.target,
 					`e-${ type }-promotion-wrapper`,
 					this.resolveAtomicWidgetPromotionCardProps( { cardType, content } ),
+					normalizeWidgetName( type ),
 				);
 			} );
 		} );
@@ -131,10 +149,15 @@ export class AppManager {
 
 	attachWidgetPromotionListeners() {
 		document.addEventListener( 'widget-promotion:open', ( event ) => {
-			this.mountCard( event.detail.target, 'e-widget-promotion-wrapper', {
-				cardType: 'widgetPromotion',
-				promotionData: this.resolveWidgetPromotionData( event.detail ),
-			} );
+			this.mountCard(
+				event.detail.target,
+				'e-widget-promotion-wrapper',
+				{
+					cardType: 'widgetPromotion',
+					promotionData: this.resolveWidgetPromotionData( event.detail ),
+				},
+				normalizeWidgetName( event.detail.widgetType ),
+			);
 		} );
 	}
 

--- a/modules/promotions/assets/js/react/app.js
+++ b/modules/promotions/assets/js/react/app.js
@@ -20,11 +20,11 @@ function getPlacement( anchorTarget, isRTL ) {
 
 function getCardContent( props ) {
 	if ( 'atomic' === props.cardType ) {
-		return <AtomicPromotionCard doClose={ props.doClose } promotionData={ props.promotionData } />;
+		return <AtomicPromotionCard doClose={ props.doClose } onCtaClick={ props.onCtaClick } promotionData={ props.promotionData } />;
 	}
 
 	if ( 'widgetPromotion' === props.cardType ) {
-		return <WidgetPromotionCard doClose={ props.doClose } promotionData={ props.promotionData } />;
+		return <WidgetPromotionCard doClose={ props.doClose } onCtaClick={ props.onCtaClick } promotionData={ props.promotionData } />;
 	}
 
 	return <PromotionCard doClose={ props.onClose } promotionsData={ props.promotionsData } />;
@@ -61,6 +61,7 @@ App.propTypes = {
 	ctaUrl: PropTypes.string,
 	doClose: PropTypes.func,
 	onClose: PropTypes.func,
+	onCtaClick: PropTypes.func,
 };
 
 export default App;

--- a/modules/promotions/assets/js/react/components/atomic-promotion-card.js
+++ b/modules/promotions/assets/js/react/components/atomic-promotion-card.js
@@ -13,7 +13,7 @@ import { AtomicPromotionMedia } from '../atomic-promotion-media';
 
 const CARD_WIDTH = 296;
 
-const AtomicPromotionCard = ( { doClose, promotionData } ) => {
+const AtomicPromotionCard = ( { doClose, onCtaClick, promotionData } ) => {
 	const { title, content, ctaText, ctaUrl, image, animationData } = promotionData ?? {};
 
 	return (
@@ -42,6 +42,7 @@ const AtomicPromotionCard = ( { doClose, promotionData } ) => {
 						href={ ctaUrl }
 						target="_blank"
 						rel="noopener noreferrer"
+						onClick={ onCtaClick }
 					>{ ctaText }</Button>
 				</Stack>
 			</Box>
@@ -51,6 +52,7 @@ const AtomicPromotionCard = ( { doClose, promotionData } ) => {
 
 AtomicPromotionCard.propTypes = {
 	doClose: PropTypes.func,
+	onCtaClick: PropTypes.func,
 	promotionData: PropTypes.object,
 };
 

--- a/modules/promotions/assets/js/react/components/widget-promotion-card.js
+++ b/modules/promotions/assets/js/react/components/widget-promotion-card.js
@@ -16,7 +16,7 @@ const CARD_WIDTH = 296;
 const IMAGE_HEIGHT = 176;
 const DEFAULT_CTA_TEXT = __( 'Upgrade Now', 'elementor' );
 
-const WidgetPromotionCard = ( { doClose, promotionData } ) => {
+const WidgetPromotionCard = ( { doClose, onCtaClick, promotionData } ) => {
 	const { title, content, image, ctaUrl, ctaText, hideProTag } = promotionData;
 
 	return (
@@ -51,6 +51,7 @@ const WidgetPromotionCard = ( { doClose, promotionData } ) => {
 						rel="noopener noreferrer"
 						startIcon={ hideProTag ? null : <CrownFilledIcon /> }
 						sx={ { ml: 'auto' } }
+						onClick={ onCtaClick }
 					>
 						{ ctaText || DEFAULT_CTA_TEXT }
 					</Button>
@@ -62,6 +63,7 @@ const WidgetPromotionCard = ( { doClose, promotionData } ) => {
 
 WidgetPromotionCard.propTypes = {
 	doClose: PropTypes.func,
+	onCtaClick: PropTypes.func,
 	promotionData: PropTypes.object,
 };
 

--- a/tests/jest/unit/modules/promotions/assets/js/editor/tracking.test.js
+++ b/tests/jest/unit/modules/promotions/assets/js/editor/tracking.test.js
@@ -1,0 +1,104 @@
+import {
+	normalizeWidgetName,
+	trackLockedWidgetPopupClick,
+	trackLockedWidgetPopupShown,
+} from 'elementor/modules/promotions/assets/js/editor/tracking';
+import eventsConfig from 'elementor/core/common/modules/events-manager/assets/js/events-config';
+
+describe( 'locked widget popover tracking', () => {
+	let dispatchEvent;
+
+	beforeEach( () => {
+		dispatchEvent = jest.fn();
+		window.elementorCommon = {
+			config: { editor_events: { can_send_events: true } },
+			eventsManager: {
+				config: eventsConfig,
+				dispatchEvent,
+			},
+		};
+	} );
+
+	afterEach( () => {
+		delete window.elementorCommon;
+		jest.clearAllMocks();
+	} );
+
+	describe( 'normalizeWidgetName', () => {
+		test.each( [
+			[ 'posts', 'posts' ],
+			[ 'loop-grid', 'loop_grid' ],
+			[ 'Loop Grid', 'loop_grid' ],
+			[ '  form  ', 'form' ],
+			[ '', '' ],
+			[ null, '' ],
+			[ undefined, '' ],
+		] )( 'normalizes %p to %p', ( input, expected ) => {
+			expect( normalizeWidgetName( input ) ).toBe( expected );
+		} );
+	} );
+
+	describe( 'trackLockedWidgetPopupShown', () => {
+		test( 'dispatches popup_shown event with expected shape', () => {
+			trackLockedWidgetPopupShown( 'loop_grid' );
+
+			expect( dispatchEvent ).toHaveBeenCalledWith( 'locked_widget_popup_opened', {
+				app_type: 'editor',
+				window_name: 'editor',
+				interaction_type: 'popup_shown',
+				target_type: 'popup',
+				target_name: 'locked_widget_promotion_loop_grid_popup',
+				interaction_result: 'popup_viewed',
+				target_location: 'editor',
+				location_l1: 'widget_panel',
+			} );
+		} );
+
+		test( 'no-ops without a widget name', () => {
+			trackLockedWidgetPopupShown( '' );
+			expect( dispatchEvent ).not.toHaveBeenCalled();
+		} );
+
+		test( 'no-ops when eventsManager is unavailable', () => {
+			delete window.elementorCommon;
+			expect( () => trackLockedWidgetPopupShown( 'loop_grid' ) ).not.toThrow();
+		} );
+	} );
+
+	describe( 'trackLockedWidgetPopupClick', () => {
+		test( 'dispatches upgrade_now click', () => {
+			trackLockedWidgetPopupClick( 'loop_grid', 'upgrade_now' );
+
+			expect( dispatchEvent ).toHaveBeenCalledWith( 'locked_widget_popup_cta_click', {
+				app_type: 'editor',
+				window_name: 'editor',
+				interaction_type: 'click',
+				target_type: 'button',
+				target_name: 'upgrade_now',
+				interaction_result: 'exit_to_landing_page',
+				target_location: 'locked_widget_promotion_loop_grid_popup',
+				location_l1: 'locked_widget_promotion_loop_grid',
+			} );
+		} );
+
+		test( 'dispatches cancel click', () => {
+			trackLockedWidgetPopupClick( 'posts', 'cancel' );
+
+			expect( dispatchEvent ).toHaveBeenCalledWith( 'locked_widget_popup_cta_click', {
+				app_type: 'editor',
+				window_name: 'editor',
+				interaction_type: 'click',
+				target_type: 'button',
+				target_name: 'cancel',
+				interaction_result: 'cancel',
+				target_location: 'locked_widget_promotion_posts_popup',
+				location_l1: 'cancel_button',
+			} );
+		} );
+
+		test( 'no-ops without a widget name', () => {
+			trackLockedWidgetPopupClick( '', 'upgrade_now' );
+			expect( dispatchEvent ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/tests/jest/unit/modules/promotions/assets/js/editor/tracking.test.js
+++ b/tests/jest/unit/modules/promotions/assets/js/editor/tracking.test.js
@@ -1,6 +1,7 @@
 import {
 	normalizeWidgetName,
-	trackLockedWidgetPopupClick,
+	trackLockedWidgetPopupCancel,
+	trackLockedWidgetPopupCtaClick,
 	trackLockedWidgetPopupShown,
 } from 'elementor/modules/promotions/assets/js/editor/tracking';
 import eventsConfig from 'elementor/core/common/modules/events-manager/assets/js/events-config';
@@ -65,9 +66,9 @@ describe( 'locked widget popover tracking', () => {
 		} );
 	} );
 
-	describe( 'trackLockedWidgetPopupClick', () => {
+	describe( 'trackLockedWidgetPopupCtaClick', () => {
 		test( 'dispatches upgrade_now click', () => {
-			trackLockedWidgetPopupClick( 'loop_grid', 'upgrade_now' );
+			trackLockedWidgetPopupCtaClick( 'loop_grid' );
 
 			expect( dispatchEvent ).toHaveBeenCalledWith( 'locked_widget_popup_cta_click', {
 				app_type: 'editor',
@@ -81,8 +82,15 @@ describe( 'locked widget popover tracking', () => {
 			} );
 		} );
 
+		test( 'no-ops without a widget name', () => {
+			trackLockedWidgetPopupCtaClick( '' );
+			expect( dispatchEvent ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'trackLockedWidgetPopupCancel', () => {
 		test( 'dispatches cancel click', () => {
-			trackLockedWidgetPopupClick( 'posts', 'cancel' );
+			trackLockedWidgetPopupCancel( 'posts' );
 
 			expect( dispatchEvent ).toHaveBeenCalledWith( 'locked_widget_popup_cta_click', {
 				app_type: 'editor',
@@ -97,7 +105,7 @@ describe( 'locked widget popover tracking', () => {
 		} );
 
 		test( 'no-ops without a widget name', () => {
-			trackLockedWidgetPopupClick( '', 'upgrade_now' );
+			trackLockedWidgetPopupCancel( '' );
 			expect( dispatchEvent ).not.toHaveBeenCalled();
 		} );
 	} );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Add analytics tracking for locked widget promotion popups (ED-24583). Captures user interactions—popup view, CTA click, cancel—to measure promotion effectiveness and locked feature engagement patterns.

## 2. What Changed (Where)

- `events-config.js`: Added `popup` target type and four new event names (`popupShown`, `popupViewed`, `exitToLandingPage`, `cancel`); registered `popupOpened` and `popupCtaClick` under promotions
- `modules/promotions/assets/js/editor/tracking.js` (new): Three exported tracking functions for popup lifecycle events; normalizes widget names to snake_case
- `app-manager.js`: Integrated tracking calls into `mountCard()` and `unmount()` lifecycle; passes `onCtaClick` handler to card components
- `app.js`, `atomic-promotion-card.js`, `widget-promotion-card.js`: Added `onCtaClick` prop threading to CTA buttons
- `tracking.test.js` (new): Unit tests covering all three tracking functions with edge cases

## 3. How It Works

Widget promotion opens → `mountCard()` captures widget name, fires `trackLockedWidgetPopupShown()` → user clicks CTA → `onCtaClick` fires `trackLockedWidgetPopupCtaClick()` → user closes without action → `unmount()` fires `trackLockedWidgetPopupCancel()`. Widget names normalized via regex (lowercase, dashes→underscores, trim edges) for consistent event naming.

## 4. Risks

Minimal. Tracking functions gracefully no-op if `elementorCommon` unavailable (defensive null checks). Test coverage included. Only risk: callback chain could fail silently if `currentWidgetName` tracking gets out of sync, but initialization and cleanup logic appears sound.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
