### PR TITLE
Feature: Add disabled class state to atomic style states [ED-24827]

### DIFF
--- a/modules/atomic-widgets/styles/style-states.php
+++ b/modules/atomic-widgets/styles/style-states.php
@@ -10,6 +10,7 @@ class Style_States {
 	const CHECKED = 'checked';
 
 	const SELECTED = 'e--selected';
+	const DISABLED = 'e--disabled';
 
 	private static function get_pseudo_states(): array {
 		return [
@@ -24,6 +25,7 @@ class Style_States {
 	private static function get_class_states(): array {
 		return [
 			self::SELECTED,
+			self::DISABLED,
 		];
 	}
 
@@ -92,6 +94,10 @@ class Style_States {
 			'selected' => [
 				'name' => 'selected',
 				'value' => self::SELECTED,
+			],
+			'disabled' => [
+				'name' => 'disabled',
+				'value' => self::DISABLED,
 			],
 		];
 	}

--- a/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/css-classes/css-class-menu.tsx
@@ -134,6 +134,9 @@ const CLASS_STATES_MAP: Record< string, { label: string } > = {
 	selected: {
 		label: __( 'selected', 'elementor' ),
 	},
+	disabled: {
+		label: __( 'disabled', 'elementor' ),
+	},
 };
 
 export function useElementStates() {

--- a/packages/packages/libs/editor-styles/src/types.ts
+++ b/packages/packages/libs/editor-styles/src/types.ts
@@ -1,10 +1,15 @@
 import { type Props } from '@elementor/editor-props';
 import { type BreakpointId } from '@elementor/editor-responsive';
 
-export type ClassState = {
-	name: 'selected';
-	value: 'e--selected';
-};
+export type ClassState =
+	| {
+			name: 'selected';
+			value: 'e--selected';
+	  }
+	| {
+			name: 'disabled';
+			value: 'e--disabled';
+	  };
 
 export type StyleDefinitionAdditionalPseudoState = 'focus-visible';
 

--- a/packages/packages/libs/editor-styles/src/utils/state-utils.ts
+++ b/packages/packages/libs/editor-styles/src/utils/state-utils.ts
@@ -8,7 +8,7 @@ import {
 
 const PSEUDO_STATES: StyleDefinitionPseudoState[] = [ 'hover', 'focus', 'active', 'focus-visible' ];
 
-const CLASS_STATES: StyleDefinitionClassState[] = [ 'e--selected' ];
+const CLASS_STATES: StyleDefinitionClassState[] = [ 'e--selected', 'e--disabled' ];
 
 function getAdditionalStates( state: StyleDefinitionState ): StyleDefinitionAdditionalPseudoState[] {
 	if ( state === 'hover' ) {

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/test-style-states.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/test-style-states.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Elementor\Modules\AtomicWidgets\Styles;
+
+use Elementor\Modules\AtomicWidgets\Styles\Style_States;
+use PHPUnit\Framework\TestCase;
+
+class Test_Style_States extends TestCase {
+
+	public function test_disabled_is_a_valid_class_state() {
+		// Arrange + Act.
+		$class_states_map = Style_States::get_class_states_map();
+
+		// Assert.
+		$this->assertArrayHasKey( 'disabled', $class_states_map );
+		$this->assertSame( 'disabled', $class_states_map['disabled']['name'] );
+		$this->assertSame( Style_States::DISABLED, $class_states_map['disabled']['value'] );
+		$this->assertTrue( Style_States::is_valid_state( Style_States::DISABLED ) );
+		$this->assertTrue( Style_States::is_class_state( Style_States::DISABLED ) );
+	}
+
+	public function test_get_selector_with_state__disabled() {
+		// Arrange + Act.
+		$selector = Style_States::get_selector_with_state( '.pagination-prev', Style_States::DISABLED );
+
+		// Assert.
+		$this->assertSame( '.pagination-prev.e--disabled', $selector );
+	}
+}

--- a/tests/phpunit/elementor/modules/variables/atomic-widgets-styles/test-style-renderer.php
+++ b/tests/phpunit/elementor/modules/variables/atomic-widgets-styles/test-style-renderer.php
@@ -176,6 +176,10 @@ class Test_Style_Renderer extends TestCase {
 					'props' => [ 'color' => '#222' ],
 						'meta' => [ 'state' => Style_States::SELECTED ],
 					],
+					[
+					'props' => [ 'color' => '#333' ],
+						'meta' => [ 'state' => Style_States::DISABLED ],
+					],
 				],
 			],
 		];
@@ -188,6 +192,7 @@ class Test_Style_Renderer extends TestCase {
 		// Assert.
 		$this->assertStringContainsString( '.state-test:hover,.state-test:focus-visible{color:#111;}', $css );
 		$this->assertStringContainsString( '.state-test.e--selected{color:#222;}', $css );
+		$this->assertStringContainsString( '.state-test.e--disabled{color:#333;}', $css );
 	}
 
 }


### PR DESCRIPTION
## PR Type
- [x] Feature

## Summary

This PR can be summarized in the following changelog entry:

* Added `e--disabled` as a class-based atomic style state so elements can expose a stylable disabled state in the editor.

## Description

Collection Loop pagination prev/next controls render as anchor tags (for URL navigation and a11y), so there is no native `:disabled` pseudo-class. This adds a reusable class state (`disabled` / `e--disabled`) to the existing atomic style-states infrastructure (same pattern as tabs `selected`).

Changes:
- Register `DISABLED` in `Style_States` and `get_class_states_map()`
- Mirror the state in `@elementor/editor-styles` types and `state-utils`
- Add editor label in the CSS class states menu

Pro will opt pagination elements into this state in a companion PR.

## Test instructions

1. Open an element that opts into the `disabled` style state (e.g. Collection Loop pagination after Pro PR merges).
2. In the Style tab, open the class states menu and confirm **disabled** appears under element states.
3. Style the disabled state and verify CSS is emitted with `.e--disabled`.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended

Fixes ED-24827

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding `disabled` as a class state for atomic widgets alongside the existing `selected` state. Enables styling of disabled widget states without pseudo-selectors (ED-24827).

## 2. What Changed (Where)

- **style-states.php**: Added `DISABLED` constant and registered in class states map
- **TypeScript types**: Extended `ClassState` union to include disabled variant
- **state-utils.ts**: Added `'e--disabled'` to CLASS_STATES array
- **CSS class menu & tests**: UI mapping and comprehensive test coverage for disabled state

## 3. How It Works

Disabled state uses class-based styling (`.e--disabled`) mirroring the `selected` state pattern. Registered in `get_class_states_map()` and `get_class_states()`, enabling consistent state validation and selector generation across PHP and TypeScript layers.

## 4. Risks

None identified. Change is additive, follows established patterns for class states, and includes test coverage validating selector generation and state validation.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
