### PR TITLE
Internal: Update browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,9 +1,11 @@
 last 3 versions
-Chrome >= 111
-Firefox >= 111
-Edge >= 111
-Safari >= 16.4
-iOS >= 16.4
-Android >= 111
-ChromeAndroid >= 111
 not dead
+
+# Minimum versions (updated 2026-07-01)
+Chrome >= 147
+Firefox >= 150
+Edge >= 147
+Safari >= 26.2
+iOS >= 26.2
+Android >= 149
+ChromeAndroid >= 149

--- a/package-lock.json
+++ b/package-lock.json
@@ -21560,9 +21560,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001754",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
-      "integrity": "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "funding": [
         {
           "type": "opencollective",
@@ -42755,24 +42755,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/tsup/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tunnel": {


### PR DESCRIPTION
Automated monthly browserslist update.

**Changes:**
- Updated `caniuse-lite` database in `package-lock.json`
- Auto-resolved minimum browser version floors in `.browserslistrc`

**Created by:** GitHub Actions (`browserslist-update` workflow)
**Branch:** `chore/update-browserslist-2026-07-01`
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Routine browserslist maintenance updating minimum browser versions to current releases as of July 2026. Reflects deprecation of older browser versions (e.g., Chrome 111 → 147).

## 2. What Changed (Where)

`.browserslistrc`: Bumped all minimum browser versions ~36 major versions forward across Chrome, Firefox, Edge, Safari, iOS, Android, and ChromeAndroid.

## 3. How It Works

N/A — configuration file update only; no logic changes.

## 4. Risks

Build tools/transpilers may now drop polyfills/transforms for older browsers; verify target environment compatibility before merge. Consider staggered rollout if supporting legacy deployments.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
