### PR TITLE
Fix: Defer elementor-kit-mcp schema fetch to avoid 404 on boot [ED-24344]

### DIFF
--- a/packages/packages/core/elementor-kit-mcp/src/__tests__/elementor-kit-mcp-server.test.ts
+++ b/packages/packages/core/elementor-kit-mcp/src/__tests__/elementor-kit-mcp-server.test.ts
@@ -1,0 +1,73 @@
+const mockCallWpApi = jest.fn();
+const mockWaitForReady = jest.fn();
+const mockRegisterLocalServer = jest.fn();
+const mockRegisterResource = jest.fn();
+const mockRegisterTool = jest.fn();
+
+jest.mock( '@elementor/elementor-mcp-common', () => ( {
+	callWpApi: ( ...args: unknown[] ) => mockCallWpApi( ...args ),
+	requireConfirmationMessage: jest.fn(),
+	waitForElementorEditor: jest.fn().mockResolvedValue( undefined ),
+} ) );
+
+jest.mock( '@elementor/editor-mcp', () => {
+	class MockResourceTemplate {
+		uriTemplate: string;
+		callbacks: { list?: () => Promise< unknown > };
+		constructor( uriTemplate: string, callbacks: { list?: () => Promise< unknown > } ) {
+			this.uriTemplate = uriTemplate;
+			this.callbacks = callbacks;
+		}
+	}
+	class MockMcpServer {
+		registerResource = ( ...args: unknown[] ) => mockRegisterResource( ...args );
+		registerTool = ( ...args: unknown[] ) => mockRegisterTool( ...args );
+	}
+	return {
+		getAngieSdk: () => ( {
+			waitForReady: mockWaitForReady,
+			registerLocalServer: mockRegisterLocalServer,
+		} ),
+		McpServer: MockMcpServer,
+		ResourceTemplate: MockResourceTemplate,
+	};
+} );
+
+const SCHEMA_ENDPOINT = '/angie/v1/elementor-kit/schema';
+
+describe( 'createElementorKitServer', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockWaitForReady.mockResolvedValue( undefined );
+		mockCallWpApi.mockResolvedValue( { data: {} } );
+	} );
+
+	it( 'does not fetch the kit schema during server construction (avoids 404 when Angie is inactive)', async () => {
+		const { createElementorKitServer } = await import( '../elementor-kit-mcp-server' );
+
+		await createElementorKitServer();
+
+		const schemaCalls = mockCallWpApi.mock.calls.filter( ( call ) => call[ 0 ] === SCHEMA_ENDPOINT );
+		expect( schemaCalls ).toHaveLength( 0 );
+	} );
+
+	it( 'fetches the kit schema lazily, only when the schema resources are listed', async () => {
+		const { createElementorKitServer } = await import( '../elementor-kit-mcp-server' );
+
+		await createElementorKitServer();
+
+		const schemaResourceCall = mockRegisterResource.mock.calls.find(
+			( call ) => call[ 0 ] === 'elementor-kit-schema'
+		);
+		expect( schemaResourceCall ).toBeDefined();
+
+		// Still not fetched right after construction.
+		expect( mockCallWpApi ).not.toHaveBeenCalledWith( SCHEMA_ENDPOINT, 'GET' );
+
+		const template = schemaResourceCall?.[ 1 ] as { callbacks: { list: () => Promise< unknown > } };
+		await template.callbacks.list();
+
+		// The schema is fetched only once a client lists the resources.
+		expect( mockCallWpApi ).toHaveBeenCalledWith( SCHEMA_ENDPOINT, 'GET' );
+	} );
+} );

--- a/packages/packages/core/elementor-kit-mcp/src/elementor-kit-mcp-server.ts
+++ b/packages/packages/core/elementor-kit-mcp/src/elementor-kit-mcp-server.ts
@@ -213,12 +213,11 @@ export async function createElementorKitServer(): Promise< McpServer > {
 		}
 	);
 
-	const availableTabs = await getAvailableTabs();
-
 	server.registerResource(
 		RESOURCE_NAME_KIT_SCHEMA,
 		new ResourceTemplate( RESOURCE_URI_KIT_SCHEMA_TEMPLATE, {
 			list: async () => {
+				const availableTabs = await getAvailableTabs();
 				return {
 					resources: availableTabs.map( ( tab ) => {
 						return {


### PR DESCRIPTION
## Summary
- `elementor-kit-mcp` fetched `GET /angie/v1/elementor-kit/schema` **eagerly during MCP server construction** (before waiting for the Angie SDK). Those `angie/v1/elementor-kit/*` routes are registered by the Angie plugin, not core — so when Angie is inactive the call returned `404 rest_no_route` on **every editor boot**, causing slow load / white screen.
- Moved the schema fetch out of construction and into the schema resource template's lazy `list` callback, mirroring the sibling `elementor-v3-mcp` server (which does no eager network calls). The schema is now fetched only once Angie connects and lists resources — the exact case where the routes exist.
- With Angie inactive, `sdk.waitForReady()` never resolves, so the server is never registered and the schema route is never called → no 404, no boot-time network cost.
- Added a unit test (`__tests__/elementor-kit-mcp-server.test.ts`) asserting the schema endpoint is **not** hit during construction, and **is** fetched lazily when resources are listed.

## Test plan
- [ ] `cd packages && npx jest core/elementor-kit-mcp` passes.
- [ ] **Angie inactive:** open the editor without the Angie plugin; confirm (DevTools Network) no `rest_route=/angie/v1/elementor-kit/schema` request fires on boot and no `rest_no_route` 404 appears; editor loads without the slow-load/white-screen delay.
- [ ] **Angie active:** open the editor with Angie active; exercise the kit MCP flow (list kit schema tabs / update kit settings) and confirm it still works (schema fetched lazily).

## Jira
[ED-24344](https://elementor.atlassian.net/browse/ED-24344)


[ED-24344]: https://elementor.atlassian.net/browse/ED-24344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Schema fetch on server boot was causing 404 errors when Angie API wasn't ready yet. Deferring it to lazy-load on first resource list request avoids this.

## 2. What Changed (Where)

- **elementor-kit-mcp-server.ts**: Moved `getAvailableTabs()` call inside `list()` callback; was executing synchronously at boot.
- **elementor-kit-mcp-server.test.ts**: Added test suite verifying schema isn't fetched during construction, only on resource listing.

## 3. How It Works

Schema fetch now happens inside the `list` async callback (line 220) instead of at module initialization. When a client requests available resources, `getAvailableTabs()` executes and populates the resource map—eliminating the premature 404.

## 4. Risks

None identified. Lazy loading is safer (defers external dependency call) and test coverage validates both boot-time non-execution and lazy-load execution paths.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
