### PR TITLE
Fix: Add missing unit to size zod schema [ED-24800]

### DIFF
--- a/packages/packages/libs/editor-controls/src/components/size-control/size-input.tsx
+++ b/packages/packages/libs/editor-controls/src/components/size-control/size-input.tsx
@@ -4,19 +4,19 @@ import { Box, InputAdornment, type PopupState } from '@elementor/ui';
 
 import ControlActions from '../../control-actions/control-actions';
 import { useTypingBuffer } from '../../hooks/use-typing-buffer';
-import { type ExtendedOption, isUnitExtendedOption, type Unit } from '../../utils/size-control';
+import { isUnitExtendedOption, type SizeUnit } from '../../utils/size-control';
 import { SelectionEndAdornment, TextFieldInnerSelection } from '../size-control/text-field-inner-selection';
 
 type SizeInputProps = {
-	unit: Unit | ExtendedOption;
+	unit: SizeUnit;
 	size: number | string;
 	placeholder?: string;
 	startIcon?: React.ReactNode;
-	units: ( Unit | ExtendedOption )[];
+	units: SizeUnit[];
 	onBlur?: ( event: React.FocusEvent< HTMLInputElement > ) => void;
 	onFocus?: ( event: React.FocusEvent< HTMLInputElement > ) => void;
 	onClick?: ( event: React.MouseEvent< HTMLInputElement > ) => void;
-	handleUnitChange: ( unit: Unit | ExtendedOption ) => void;
+	handleUnitChange: ( unit: SizeUnit ) => void;
 	handleSizeChange: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
 	popupState: PopupState;
 	disabled?: boolean;

--- a/packages/packages/libs/editor-controls/src/controls/size-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/size-control.tsx
@@ -19,10 +19,12 @@ import {
 	isUnitExtendedOption,
 	type LengthUnit,
 	lengthUnits,
+	type SizeUnit,
 	type TimeUnit,
 	timeUnits,
 	type Unit,
 } from '../utils/size-control';
+import { getPropTypeSettings } from './size-control/utils/settings/get-prop-type-settings';
 
 type SizeValue = SizePropValue[ 'value' ];
 
@@ -65,7 +67,7 @@ export type SizeControlProps = LengthSizeControlProps | AngleSizeControlProps | 
 type State = {
 	numeric: number;
 	custom: string;
-	unit: Unit | ExtendedOption;
+	unit: SizeUnit;
 };
 
 const defaultSelectedUnit: Record< SizeControlProps[ 'variant' ], Unit > = {
@@ -133,7 +135,7 @@ export const SizeControl = createControl(
 		const { size: controlSize = DEFAULT_SIZE, unit: controlUnit = actualDefaultUnit } =
 			extractValueFromState( state, true ) || {};
 
-		const handleUnitChange = ( newUnit: Unit | ExtendedOption ) => {
+		const handleUnitChange = ( newUnit: SizeUnit ) => {
 			if ( newUnit === 'custom' ) {
 				popupState.open( anchorRef?.current );
 			}
@@ -217,17 +219,17 @@ function resolveUnits(
 	variant: SizeVariant,
 	externalUnits?: Unit[],
 	actualExtendedOptions?: ExtendedOption[]
-) {
+): SizeUnit[] {
 	const fallback = [ ...defaultUnits[ variant ] ];
 
 	if ( ! enablePropTypeUnits ) {
 		return [ ...( externalUnits ?? fallback ), ...( actualExtendedOptions || [] ) ];
 	}
 
-	return ( propType.settings?.available_units as Unit[] ) ?? fallback;
+	return getPropTypeSettings( propType )?.available_units ?? fallback;
 }
 
-function formatSize< TSize extends string | number >( size: TSize, unit: Unit | ExtendedOption ): TSize {
+function formatSize< TSize extends string | number >( size: TSize, unit: SizeUnit ): TSize {
 	if ( isUnitExtendedOption( unit ) ) {
 		return unit === 'auto' ? ( '' as TSize ) : ( String( size ?? '' ) as TSize );
 	}
@@ -237,7 +239,7 @@ function formatSize< TSize extends string | number >( size: TSize, unit: Unit | 
 
 function createStateFromSizeProp(
 	sizeValue: SizeValue | null,
-	defaultUnit: Unit | ExtendedOption,
+	defaultUnit: SizeUnit,
 	defaultSize: string | number = '',
 	customState: string = ''
 ): State {

--- a/packages/packages/libs/editor-controls/src/controls/size-control/types.ts
+++ b/packages/packages/libs/editor-controls/src/controls/size-control/types.ts
@@ -1,17 +1,10 @@
 import type { CreateOptions } from '@elementor/editor-props';
 
 import { type SetValueMeta } from '../../bound-prop-context';
+import { type ExtendedOption } from '../../utils/size-control';
 
-type LengthUnit = 'px' | '%' | 'em' | 'rem' | 'vw' | 'vh' | 'ch';
-type AngleUnit = 'deg' | 'rad' | 'grad' | 'turn';
-type TimeUnit = 's' | 'ms';
-
-type Unit = LengthUnit | AngleUnit | TimeUnit;
-
-export type ExtendedSizeOption = 'auto' | 'custom';
-
-export type SizeUnit = Unit | ExtendedSizeOption;
-
+export type ExtendedSizeOption = ExtendedOption;
+export type { SizeUnit } from '../../utils/size-control';
 export type SizeVariant = 'length' | 'angle' | 'time';
 
 export type SetSizeValue< T > = ( value: T, options?: CreateOptions, meta?: SetValueMeta ) => void;

--- a/packages/packages/libs/editor-controls/src/utils/size-control.ts
+++ b/packages/packages/libs/editor-controls/src/utils/size-control.ts
@@ -1,10 +1,9 @@
 import type { SizePropValue } from '@elementor/editor-props';
 
-type SizeValueUnit = SizePropValue[ 'value' ][ 'unit' ];
+export type SizeUnit = SizePropValue[ 'value' ][ 'unit' ];
 
-export type ExtendedOption = Extract< SizeValueUnit, 'auto' | 'custom' >;
-export type Unit = Exclude< SizeValueUnit, ExtendedOption >;
-export type SizeUnit = SizeValueUnit;
+export type ExtendedOption = Extract< SizeUnit, 'auto' | 'custom' >;
+export type Unit = Exclude< SizeUnit, ExtendedOption >;
 
 export const lengthUnits = [ 'px', '%', 'em', 'rem', 'vw', 'vh', 'ch' ] as const satisfies readonly Unit[];
 export const angleUnits = [ 'deg', 'rad', 'grad', 'turn' ] as const satisfies readonly Unit[];

--- a/packages/packages/libs/editor-controls/src/utils/size-control.ts
+++ b/packages/packages/libs/editor-controls/src/utils/size-control.ts
@@ -1,18 +1,24 @@
-export const lengthUnits = [ 'px', '%', 'em', 'rem', 'vw', 'vh', 'ch' ] as const;
-export const angleUnits = [ 'deg', 'rad', 'grad', 'turn' ] as const;
-export const timeUnits = [ 's', 'ms' ] as const;
-const defaultExtendedOptions = [ 'auto', 'custom' ] as const;
+import type { SizePropValue } from '@elementor/editor-props';
 
-export const DEFAULT_UNIT = 'px';
+type SizeValueUnit = SizePropValue[ 'value' ][ 'unit' ];
+
+export type ExtendedOption = Extract< SizeValueUnit, 'auto' | 'custom' >;
+export type Unit = Exclude< SizeValueUnit, ExtendedOption >;
+export type SizeUnit = SizeValueUnit;
+
+export const lengthUnits = [ 'px', '%', 'em', 'rem', 'vw', 'vh', 'ch' ] as const satisfies readonly Unit[];
+export const angleUnits = [ 'deg', 'rad', 'grad', 'turn' ] as const satisfies readonly Unit[];
+export const timeUnits = [ 's', 'ms' ] as const satisfies readonly Unit[];
+
+export const DEFAULT_UNIT = 'px' satisfies Unit;
 export const DEFAULT_SIZE = NaN;
 
-export type LengthUnit = ( typeof lengthUnits )[ number ];
+export type LengthUnit = Extract< Unit, ( typeof lengthUnits )[ number ] | 'fr' >;
 export type AngleUnit = ( typeof angleUnits )[ number ];
 export type TimeUnit = ( typeof timeUnits )[ number ];
-export type ExtendedOption = ( typeof defaultExtendedOptions )[ number ];
 
-export type Unit = LengthUnit | AngleUnit | TimeUnit;
+const extendedOptions = [ 'auto', 'custom' ] as const satisfies readonly ExtendedOption[];
 
-export function isUnitExtendedOption( unit: Unit | ExtendedOption ): unit is ExtendedOption {
-	return defaultExtendedOptions.includes( unit as ExtendedOption );
+export function isUnitExtendedOption( unit: SizeUnit ): unit is ExtendedOption {
+	return extendedOptions.includes( unit as ExtendedOption );
 }

--- a/packages/packages/libs/editor-props/src/prop-types/__tests__/size.test.ts
+++ b/packages/packages/libs/editor-props/src/prop-types/__tests__/size.test.ts
@@ -1,10 +1,29 @@
-import { sizePropTypeUtil } from '../size';
+import { sizePropTypeUtil, type SizePropValue } from '../size';
+
+const sizeUnitCases: SizePropValue[ 'value' ][] = [
+	{ unit: 'px', size: 10 },
+	{ unit: 'em', size: 1.5 },
+	{ unit: 'rem', size: 2 },
+	{ unit: '%', size: 50 },
+	{ unit: 'vw', size: 100 },
+	{ unit: 'vh', size: 50 },
+	{ unit: 'ch', size: 40 },
+	{ unit: 'fr', size: 1 },
+	{ unit: 'deg', size: 90 },
+	{ unit: 'rad', size: 1 },
+	{ unit: 'grad', size: 100 },
+	{ unit: 'turn', size: 0.5 },
+	{ unit: 's', size: 1 },
+	{ unit: 'ms', size: 300 },
+	{ unit: 'auto', size: '' },
+	{ unit: 'custom', size: 'calc(100% - 10px)' },
+];
 
 describe( 'sizePropTypeUtil', () => {
-	it( 'should accept fr unit values used by grid auto track styles', () => {
-		const value = sizePropTypeUtil.create( { size: 1, unit: 'fr' } );
+	it.each( sizeUnitCases )( 'should accept $unit unit values', ( sizeValue ) => {
+		const value = sizePropTypeUtil.create( sizeValue );
 
 		expect( sizePropTypeUtil.isValid( value ) ).toBe( true );
-		expect( sizePropTypeUtil.extract( value ) ).toEqual( { size: 1, unit: 'fr' } );
+		expect( sizePropTypeUtil.extract( value ) ).toEqual( sizeValue );
 	} );
 } );

--- a/packages/packages/libs/editor-props/src/prop-types/__tests__/size.test.ts
+++ b/packages/packages/libs/editor-props/src/prop-types/__tests__/size.test.ts
@@ -1,0 +1,10 @@
+import { sizePropTypeUtil } from '../size';
+
+describe( 'sizePropTypeUtil', () => {
+	it( 'should accept fr unit values used by grid auto track styles', () => {
+		const value = sizePropTypeUtil.create( { size: 1, unit: 'fr' } );
+
+		expect( sizePropTypeUtil.isValid( value ) ).toBe( true );
+		expect( sizePropTypeUtil.extract( value ) ).toEqual( { size: 1, unit: 'fr' } );
+	} );
+} );

--- a/packages/packages/libs/editor-props/src/prop-types/size.ts
+++ b/packages/packages/libs/editor-props/src/prop-types/size.ts
@@ -9,7 +9,7 @@ export const sizePropTypeUtil = createPropUtils(
 	'size',
 	z
 		.strictObject( {
-			unit: z.enum( [ 'px', 'em', 'rem', '%', 'vw', 'vh', 'ch' ] ),
+			unit: z.enum( [ 'px', 'em', 'rem', '%', 'vw', 'vh', 'ch', 'fr' ] ),
 			size: sizeNumberOrEmpty,
 		} )
 		.or(


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The size zod schema was missing the 'fr' unit in length units, causing validation failures for fractional grid units. This PR consolidates scattered type definitions and fixes the schema.

## 2. What Changed (Where)

- **size-control.ts**: Refactored unit types to derive from `SizePropValue` API contract instead of local definitions; added `DEFAULT_UNIT` export.
- **size-control/types.ts**: Removed local type definitions; now re-exports from centralized utils.
- **size.ts (prop-types)**: Added missing 'fr' unit to length schema enum.
- **size-input.tsx, size-control.tsx**: Updated type signatures to use `SizeUnit` instead of union of `Unit | ExtendedOption`.
- **size.test.ts**: New test covering all unit variants including 'fr', 'auto', 'custom'.

## 3. How It Works

Single source of truth: `SizePropValue['value']['unit']` from editor-props defines all valid units. Types now extract from this contract using `Extract`/`Exclude` utilities. Schema validation and runtime types stay synchronized. Test suite validates all unit cases.

## 4. Risks

Minimal—types are now stricter and validated. Only risk is if external code was relying on the old loose `Unit | ExtendedOption` union typing, but that's unlikely given this is internal control lib. Backward compatible at runtime.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
