### PR TITLE
Internal: Fix flaky Editor Responsive Control Conditions test [ED-24569]

### DIFF
--- a/tests/playwright/pages/wp-admin-page.ts
+++ b/tests/playwright/pages/wp-admin-page.ts
@@ -436,8 +436,9 @@ export default class WpAdminPage extends BasePage {
 			window.sessionStorage.setItem( 'ai_promotion_introduction_editor_session_key', editorSessionId );
 		} );
 
-		if ( await this.page.getByTestId( 'e-angie-guide-card' ).isVisible() ) {
-			await this.page.getByRole( 'button', { name: 'Try for free' } ).click();
+		const angieGuideCard = this.page.getByTestId( 'e-angie-guide-card' );
+		if ( await angieGuideCard.isVisible() ) {
+			await angieGuideCard.getByRole( 'button', { name: 'Close' } ).click();
 		}
 	}
 

--- a/tests/playwright/pages/wp-admin-page.ts
+++ b/tests/playwright/pages/wp-admin-page.ts
@@ -1,10 +1,10 @@
 import { type APIRequestContext, type Page, Response, type TestInfo } from '@playwright/test';
+import ApiRequests from '../assets/api-requests';
+import { wpCli } from '../assets/wp-cli';
+import { timeouts } from '../config/timeouts';
+import { ElementorType, WindowType } from '../types/types';
 import BasePage from './base-page';
 import EditorPage from './editor-page';
-import { ElementorType, WindowType } from '../types/types';
-import { wpCli } from '../assets/wp-cli';
-import ApiRequests from '../assets/api-requests';
-import { timeouts } from '../config/timeouts';
 let elementor: ElementorType;
 
 export default class WpAdminPage extends BasePage {
@@ -435,6 +435,10 @@ export default class WpAdminPage extends BasePage {
 			const editorSessionId = window.EDITOR_SESSION_ID;
 			window.sessionStorage.setItem( 'ai_promotion_introduction_editor_session_key', editorSessionId );
 		} );
+
+		if ( await this.page.getByTestId( 'e-angie-guide-card' ).isVisible() ) {
+			await this.page.getByRole( 'button', { name: 'Try for free' } ).click();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Test flakiness in responsive control conditions caused by stray UI elements. The Angie guide card wasn't being dismissed before test execution, leading to intermittent failures.

## 2. What Changed (Where)

`tests/playwright/pages/wp-admin-page.ts`: Reorganized imports alphabetically and added guide card dismissal logic to `loginAndGetToken()` method.

## 3. How It Works

After setting the AI promotion session key, the method now checks if the Angie guide card is visible and closes it via the "Close" button before proceeding. This ensures a clean test state.

## 4. Risks

None. Dismissal is gated by visibility check; safe for all environments where card may or may not appear.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
