### PR TITLE
Fix: Missing dynamic tag for send to field [ED-24782]

### DIFF
--- a/modules/atomic-widgets/prop-types/emails-prop-type.php
+++ b/modules/atomic-widgets/prop-types/emails-prop-type.php
@@ -3,6 +3,8 @@
 namespace Elementor\Modules\AtomicWidgets\PropTypes;
 
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Array_Prop_Type;
+use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Prop_Type;
+use Elementor\Modules\DynamicTags\Module as Dynamic_Tags_Module;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -15,9 +17,20 @@ class Emails_Prop_Type extends Email_Prop_Type {
 
 	protected function define_shape(): array {
 		$shape = parent::define_shape();
-		$shape['to'] = String_Array_Prop_Type::make()->required();
-		$shape['cc'] = String_Array_Prop_Type::make();
-		$shape['bcc'] = String_Array_Prop_Type::make();
+		$shape['to'] = Union_Prop_Type::make()
+			->add_prop_type( String_Array_Prop_Type::make()->required() )
+			->add_prop_type(
+				Dynamic_Prop_Type::make()->categories( [ Dynamic_Tags_Module::TEXT_CATEGORY ] )
+			)
+			->required();
+		$shape['cc'] = Union_Prop_Type::make()->add_prop_type( String_Array_Prop_Type::make() )
+			->add_prop_type(
+				Dynamic_Prop_Type::make()->categories( [ Dynamic_Tags_Module::TEXT_CATEGORY ] )
+			);
+		$shape['bcc'] = Union_Prop_Type::make()->add_prop_type( String_Array_Prop_Type::make() )
+			->add_prop_type(
+				Dynamic_Prop_Type::make()->categories( [ Dynamic_Tags_Module::TEXT_CATEGORY ] )
+			);
 
 		return $shape;
 	}
@@ -28,6 +41,10 @@ class Emails_Prop_Type extends Email_Prop_Type {
 		}
 
 		$to = $value['to'] ?? null;
+
+		if ( Dynamic_Prop_Type::is_dynamic_prop_value( $to ) ) {
+			return true; // dynamic prop type validates its own shape
+		}
 
 		return is_array( $to ) && ! empty( $to['value'] );
 	}

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/email-chips-field.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/email-chips-field.test.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react';
+import { createMockPropType, renderWithTheme } from 'test-utils';
+import { isTransformable, type ObjectPropType, type PropValue, type UnionPropType } from '@elementor/editor-props';
+import { screen } from '@testing-library/react';
+
+import { PropKeyProvider, PropProvider } from '../../bound-prop-context';
+import { ControlActionsProvider } from '../../control-actions/control-actions-context';
+import { ControlReplacementsProvider, createControlReplacementsRegistry } from '../../control-replacements';
+import { EmailChipsField } from '../email-form-action-control/email-chips-field';
+
+const wrap = ( val: string ) => ( { $$type: 'string' as const, value: val } );
+
+const wrapStringArray = ( vals: string[] ) => ( {
+	$$type: 'string-array' as const,
+	value: vals.map( ( v ) => wrap( v ) ),
+} );
+
+const wrapDynamic = ( name: string, group = 'post' ) => ( {
+	$$type: 'dynamic' as const,
+	value: {
+		name,
+		group,
+		settings: { label: 'Author Email' },
+	},
+} );
+
+const createStringPropType = () => createMockPropType( { kind: 'plain', key: 'string' } );
+
+const createStringArrayPropType = () =>
+	createMockPropType( {
+		kind: 'array',
+		key: 'string-array',
+		item_prop_type: createStringPropType(),
+	} );
+
+const createRecipientUnionPropType = (): UnionPropType =>
+	createMockPropType( {
+		kind: 'union',
+		prop_types: {
+			'string-array': createStringArrayPropType(),
+			dynamic: createMockPropType( {
+				kind: 'plain',
+				key: 'dynamic',
+				settings: { categories: [ 'text' ] },
+			} ),
+		},
+	} ) as UnionPropType;
+
+const emailsPropType = createMockPropType( {
+	kind: 'object',
+	key: 'emails',
+	shape: {
+		to: createRecipientUnionPropType(),
+		cc: createRecipientUnionPropType(),
+		bcc: createRecipientUnionPropType(),
+	},
+} );
+
+const DynamicRecipientControl = () => (
+	<div role="status" aria-label="Dynamic recipient tag">
+		Author Email
+	</div>
+);
+
+const { registerControlReplacement, getControlReplacements } = createControlReplacementsRegistry();
+
+registerControlReplacement( {
+	component: DynamicRecipientControl,
+	condition: ( { value } ) => isTransformable( value ) && value.$$type === 'dynamic',
+} );
+
+type RenderRecipientFieldArgs = {
+	fieldBind: 'to' | 'cc' | 'bcc';
+	fieldValue: PropValue;
+};
+
+const renderRecipientField = ( { fieldBind, fieldValue }: RenderRecipientFieldArgs ) => {
+	const setValue = jest.fn();
+
+	renderWithTheme(
+		<PropProvider propType={ emailsPropType } value={ { [ fieldBind ]: fieldValue } } setValue={ setValue }>
+			<PropKeyProvider bind={ fieldBind }>
+				<ControlReplacementsProvider replacements={ getControlReplacements() }>
+					<ControlActionsProvider items={ [] }>
+						<EmailChipsField fieldLabel="Recipients" />
+					</ControlActionsProvider>
+				</ControlReplacementsProvider>
+			</PropKeyProvider>
+		</PropProvider>
+	);
+
+	return { setValue };
+};
+
+describe( 'EmailChipsField dynamic tags', () => {
+	it( 'should render chips when the recipient value is a string array', () => {
+		// Arrange & Act
+		renderRecipientField( {
+			fieldBind: 'to',
+			fieldValue: wrapStringArray( [ 'admin@test.com' ] ),
+		} );
+
+		// Assert
+		expect( screen.getByText( 'admin@test.com' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'combobox' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'status', { name: 'Dynamic recipient tag' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should replace chips with the dynamic tag control when the recipient value is dynamic', () => {
+		// Arrange & Act
+		renderRecipientField( {
+			fieldBind: 'to',
+			fieldValue: wrapDynamic( 'author-email' ),
+		} );
+
+		// Assert
+		expect( screen.getByRole( 'status', { name: 'Dynamic recipient tag' } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'admin@test.com' ) ).not.toBeInTheDocument();
+	} );
+
+	it.each( [ 'cc', 'bcc' ] as const )( 'should support dynamic tags for the %s field', ( fieldBind ) => {
+		// Arrange & Act
+		renderRecipientField( {
+			fieldBind,
+			fieldValue: wrapDynamic( 'author-email' ),
+		} );
+
+		// Assert
+		expect( screen.getByRole( 'status', { name: 'Dynamic recipient tag' } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should expose dynamic support on the recipient union prop type', () => {
+		// Arrange
+		const shape = ( emailsPropType as ObjectPropType ).shape;
+
+		// Assert
+		for ( const fieldBind of [ 'to', 'cc', 'bcc' ] as const ) {
+			const fieldPropType = shape[ fieldBind ];
+
+			expect( fieldPropType.kind ).toBe( 'union' );
+
+			if ( fieldPropType.kind !== 'union' ) {
+				throw new Error( `Expected ${ fieldBind } to be a union prop type` );
+			}
+
+			expect( fieldPropType.prop_types.dynamic?.key ).toBe( 'dynamic' );
+			expect( fieldPropType.prop_types[ 'string-array' ]?.key ).toBe( 'string-array' );
+		}
+	} );
+} );

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/email-form-action-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/email-form-action-control.test.tsx
@@ -1,32 +1,60 @@
 import * as React from 'react';
 import { createMockPropType, renderControl } from 'test-utils';
+import { type ObjectPropType, type UnionPropType } from '@elementor/editor-props';
 import { fireEvent, screen } from '@testing-library/react';
 
 import * as boundPropContext from '../../bound-prop-context';
 import { EmailFormActionControl } from '../email-form-action-control';
-
-const propType = createMockPropType( {
-	kind: 'object',
-	shape: {
-		to: createMockPropType( { kind: 'array', item_prop_type: createMockPropType( { kind: 'plain' } ) } ),
-		subject: createMockPropType( { kind: 'plain' } ),
-		message: createMockPropType( { kind: 'plain' } ),
-		from: createMockPropType( { kind: 'plain' } ),
-		'meta-data': createMockPropType( { kind: 'array', item_prop_type: createMockPropType( { kind: 'plain' } ) } ),
-		'send-as': createMockPropType( { kind: 'plain' } ),
-		'from-name': createMockPropType( { kind: 'plain' } ),
-		'reply-to': createMockPropType( { kind: 'plain' } ),
-		cc: createMockPropType( { kind: 'plain' } ),
-		bcc: createMockPropType( { kind: 'plain' } ),
-	},
-} );
-const setValue = jest.fn();
 
 const wrap = ( val: string ) => ( { $$type: 'string' as const, value: val } );
 const wrapStringArray = ( vals: string[] ) => ( {
 	$$type: 'string-array' as const,
 	value: vals.map( ( v ) => wrap( v ) ),
 } );
+
+const createStringPropType = () => createMockPropType( { kind: 'plain', key: 'string' } );
+
+const createStringArrayPropType = () =>
+	createMockPropType( {
+		kind: 'array',
+		key: 'string-array',
+		item_prop_type: createStringPropType(),
+	} );
+
+const createRecipientUnionPropType = (): UnionPropType =>
+	createMockPropType( {
+		kind: 'union',
+		prop_types: {
+			'string-array': createStringArrayPropType(),
+			dynamic: createMockPropType( {
+				kind: 'plain',
+				key: 'dynamic',
+				settings: { categories: [ 'text' ] },
+			} ),
+		},
+	} ) as UnionPropType;
+
+const propType = createMockPropType( {
+	kind: 'object',
+	shape: {
+		to: createRecipientUnionPropType(),
+		subject: createMockPropType( { kind: 'plain', key: 'string' } ),
+		message: createMockPropType( { kind: 'plain', key: 'string' } ),
+		from: createMockPropType( { kind: 'plain', key: 'string' } ),
+		'meta-data': createMockPropType( {
+			kind: 'array',
+			key: 'string-array',
+			item_prop_type: createStringPropType(),
+		} ),
+		'send-as': createMockPropType( { kind: 'plain', key: 'string' } ),
+		'from-name': createMockPropType( { kind: 'plain', key: 'string' } ),
+		'reply-to': createMockPropType( { kind: 'plain', key: 'string' } ),
+		cc: createRecipientUnionPropType(),
+		bcc: createRecipientUnionPropType(),
+	},
+} );
+
+const setValue = jest.fn();
 
 jest.mock( '../../bound-prop-context', () => ( {
 	...jest.requireActual( '../../bound-prop-context' ),
@@ -38,12 +66,12 @@ const mockUseBoundProp = boundPropContext.useBoundProp as jest.MockedFunction< t
 const defaultEmailValue = {
 	to: wrapStringArray( [ 'admin@test.com' ] ),
 	from: wrap( '' ),
-	fromName: wrap( '' ),
+	'from-name': wrap( '' ),
 	cc: null,
 	bcc: null,
 	subject: wrap( '' ),
 	message: wrap( '' ),
-	replyTo: wrap( '' ),
+	'reply-to': wrap( '' ),
 	'meta-data': null,
 	'send-as': wrap( 'html' ),
 };
@@ -55,11 +83,22 @@ const setupMock = ( emailValue = defaultEmailValue ) => {
 				value: emailValue.to?.value ?? [],
 				setValue,
 				disabled: false,
-				propType:
-					( propType as unknown as { shape: Record< string, unknown > } ).shape?.to ??
-					createMockPropType( { kind: 'array' } ),
+				propType: ( propType as ObjectPropType ).shape.to,
 				bind: 'to',
 				path: [ 'to' ],
+				resetValue: jest.fn(),
+				restoreValue: jest.fn(),
+			};
+		}
+
+		if ( propTypeUtil?.key === 'string' ) {
+			return {
+				value: '',
+				setValue,
+				disabled: false,
+				propType: createStringPropType(),
+				bind: 'subject',
+				path: [ 'subject' ],
 				resetValue: jest.fn(),
 				restoreValue: jest.fn(),
 			};
@@ -82,6 +121,25 @@ describe( 'EmailFormActionControl', () => {
 	beforeEach( () => {
 		setValue.mockClear();
 		setupMock();
+	} );
+
+	it( 'should define to, cc, and bcc as union prop types with dynamic support', () => {
+		// Arrange
+		const shape = ( propType as ObjectPropType ).shape;
+
+		// Assert
+		for ( const fieldBind of [ 'to', 'cc', 'bcc' ] as const ) {
+			const fieldPropType = shape[ fieldBind ];
+
+			expect( fieldPropType.kind ).toBe( 'union' );
+
+			if ( fieldPropType.kind !== 'union' ) {
+				throw new Error( `Expected ${ fieldBind } to be a union prop type` );
+			}
+
+			expect( fieldPropType.prop_types.dynamic?.key ).toBe( 'dynamic' );
+			expect( fieldPropType.prop_types[ 'string-array' ]?.key ).toBe( 'string-array' );
+		}
 	} );
 
 	it( 'should render email control with all required fields', () => {

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control/email-chips-field.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control/email-chips-field.tsx
@@ -6,16 +6,15 @@ import { Autocomplete, Grid, TextField } from '@elementor/ui';
 import { useBoundProp } from '../../bound-prop-context';
 import { ChipsList } from '../../components/chips-list';
 import { ControlFormLabel } from '../../components/control-form-label';
+import ControlActions from '../../control-actions/control-actions';
+import { createControl } from '../../create-control';
 import { CHIP_TRIGGER_KEYS, isValidEmail } from './utils';
 
-// type EmailChip = { label: string; value: string };
-
-type EmailChipsFieldProps = {
-	fieldLabel: string;
+type EmailChipsControlProps = {
 	placeholder?: string;
 };
 
-export const EmailChipsField = ( { fieldLabel, placeholder }: EmailChipsFieldProps ) => {
+export const EmailChipsControl = createControl( ( { placeholder }: EmailChipsControlProps ) => {
 	const { value, setValue, disabled } = useBoundProp( stringArrayPropTypeUtil );
 	const [ inputValue, setInputValue ] = useState( '' );
 
@@ -68,37 +67,48 @@ export const EmailChipsField = ( { fieldLabel, placeholder }: EmailChipsFieldPro
 	};
 
 	return (
-		<Grid container direction="column" gap={ 0.5 }>
-			<Grid item>
-				<ControlFormLabel>{ fieldLabel }</ControlFormLabel>
-			</Grid>
-			<Grid item>
-				<Autocomplete
-					fullWidth
-					multiple
-					freeSolo
-					size="tiny"
-					disabled={ disabled }
-					inputValue={ inputValue }
-					onInputChange={ ( _, val, reason ) => {
-						if ( reason !== 'reset' ) {
-							setInputValue( val );
-						}
-					} }
-					value={ selectedValues }
-					onChange={ handleChange }
-					options={ [] }
-					onBlur={ handleBlur }
-					getOptionLabel={ ( option ) => option }
-					isOptionEqualToValue={ ( option, val ) => option === val }
-					renderInput={ ( params ) => (
-						<TextField { ...params } placeholder={ placeholder } onKeyDown={ handleKeyDown } />
-					) }
-					renderTags={ ( tagValues, getTagProps ) => (
-						<ChipsList getLabel={ ( option ) => option } getTagProps={ getTagProps } values={ tagValues } />
-					) }
-				/>
-			</Grid>
-		</Grid>
+		<ControlActions>
+			<Autocomplete
+				fullWidth
+				multiple
+				freeSolo
+				size="tiny"
+				disabled={ disabled }
+				inputValue={ inputValue }
+				onInputChange={ ( _, val, reason ) => {
+					if ( reason !== 'reset' ) {
+						setInputValue( val );
+					}
+				} }
+				value={ selectedValues }
+				onChange={ handleChange }
+				options={ [] }
+				onBlur={ handleBlur }
+				getOptionLabel={ ( option ) => option }
+				isOptionEqualToValue={ ( option, val ) => option === val }
+				renderInput={ ( params ) => (
+					<TextField { ...params } placeholder={ placeholder } onKeyDown={ handleKeyDown } />
+				) }
+				renderTags={ ( tagValues, getTagProps ) => (
+					<ChipsList getLabel={ ( option ) => option } getTagProps={ getTagProps } values={ tagValues } />
+				) }
+			/>
+		</ControlActions>
 	);
+} );
+
+type EmailChipsFieldProps = {
+	fieldLabel: string;
+	placeholder?: string;
 };
+
+export const EmailChipsField = ( { fieldLabel, placeholder }: EmailChipsFieldProps ) => (
+	<Grid container direction="column" gap={ 0.5 }>
+		<Grid item>
+			<ControlFormLabel>{ fieldLabel }</ControlFormLabel>
+		</Grid>
+		<Grid item>
+			<EmailChipsControl placeholder={ placeholder } />
+		</Grid>
+	</Grid>
+);

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control/fields.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control/fields.tsx
@@ -14,7 +14,9 @@ import { EmailField } from './email-field';
 import { shouldShowMentionsInfo } from './utils';
 
 export const SendToField = ( { placeholder }: { placeholder?: string } ) => (
-	<EmailChipsField fieldLabel={ __( 'Send to', 'elementor' ) } placeholder={ placeholder } />
+	<PropKeyProvider bind="to">
+		<EmailChipsField fieldLabel={ __( 'Send to', 'elementor' ) } placeholder={ placeholder } />
+	</PropKeyProvider>
 );
 
 export const SubjectField = () => (

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control/index.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control/index.tsx
@@ -4,7 +4,7 @@ import { CollapsibleContent } from '@elementor/editor-ui';
 import { Box, Divider, Stack } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
-import { PropKeyProvider, PropProvider, useBoundProp } from '../../bound-prop-context';
+import { PropProvider, useBoundProp } from '../../bound-prop-context';
 import { ControlLabel } from '../../components/control-label';
 import { createControl } from '../../create-control';
 import {
@@ -30,9 +30,7 @@ export const EmailFormActionControl = createControl(
 					<ControlLabel>
 						{ label ? label + ' ' + __( 'settings', 'elementor' ) : __( 'Email settings', 'elementor' ) }
 					</ControlLabel>
-					<PropKeyProvider bind="to">
-						<SendToField placeholder={ toPlaceholder } />
-					</PropKeyProvider>
+					<SendToField placeholder={ toPlaceholder } />
 					<SubjectField />
 					<MessageField />
 					<FromEmailField />


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Email recipient fields (to, cc, bcc) were missing dynamic tag support. This PR adds union prop types allowing recipients to be either static string arrays or dynamic tag references, enabling dynamic recipient resolution at runtime.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `emails-prop-type.php` | Wrapped to/cc/bcc in Union_Prop_Type with Dynamic_Prop_Type; updated validation to bypass array checks for dynamic values |
| `email-chips-field.tsx` | Refactored into EmailChipsControl (logic-only) + EmailChipsField (label wrapper); control wrapped with ControlActions for dynamic tag interception |
| `fields.tsx` | Moved PropKeyProvider binding from parent (index.tsx) into SendToField component |
| `index.tsx` | Removed PropKeyProvider wrapper; now SendToField self-contains binding |
| Test files | Added comprehensive tests validating union prop types, dynamic tag rendering, and control replacements for all recipient fields |

## 3. How It Works

EmailChipsField now delegates via ControlActions to check if the current value is a dynamic tag. When `Dynamic_Prop_Type::is_dynamic_prop_value()` returns true, the ControlReplacementsProvider swaps the Autocomplete chips UI for a dynamic tag control component. Static string arrays render chips normally. Union prop type schema on backend validates both branches; frontend controls conditionally render based on value type.

## 4. Risks

**Validation logic change**: Backend now returns early for dynamic values without array validation—ensure no integration points assume `to` is always an array. **Component composition**: Moving PropKeyProvider into SendToField changes binding scope; verify no sibling fields depend on parent-level binding context.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
