### PR TITLE
Internal: Fixed SP auth race condition [ED-24863]

### DIFF
--- a/packages/apps/site-builder/src/components/app.tsx
+++ b/packages/apps/site-builder/src/components/app.tsx
@@ -29,6 +29,7 @@ export function App() {
 	const iframeRef = useRef< HTMLIFrameElement >( null );
 	const [ siteBuilderParams, setSiteBuilderParams ] = useState< SiteBuilderParams >( {} );
 	const [ connectAuth, setConnectAuth ] = useState< ConnectAuth | null >( null );
+	const [ isConnectAuthResolved, setIsConnectAuthResolved ] = useState( false );
 
 	const iframeUrl = useMemo( () => getSiteBuilderConfig()?.iframeUrl ?? '', [] );
 
@@ -37,6 +38,7 @@ export function App() {
 		iframeUrl,
 		siteBuilderParams,
 		connectAuth,
+		isConnectAuthResolved,
 	} );
 
 	useEffect( () => {
@@ -54,6 +56,8 @@ export function App() {
 			} catch ( err ) {
 				// eslint-disable-next-line no-console
 				console.error( 'Failed to fetch connectAuth:', err );
+			} finally {
+				setIsConnectAuthResolved( true );
 			}
 		};
 

--- a/packages/apps/site-builder/src/hooks/__tests__/use-site-builder-iframe-messaging.test.tsx
+++ b/packages/apps/site-builder/src/hooks/__tests__/use-site-builder-iframe-messaging.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 import { act, renderHook } from '@testing-library/react';
 
 import {
@@ -43,20 +43,28 @@ const setupHook = ( initial: HookProps ) => {
 	const iframeRef = { current: { contentWindow: fakeContentWindow } as unknown as HTMLIFrameElement };
 
 	const { rerender } = renderHook(
-		( props: HookProps ) => useSiteBuilderIframeMessaging( {
-			iframeRef: iframeRef as React.RefObject< HTMLIFrameElement | null >,
-			iframeUrl: IFRAME_URL,
-			siteBuilderParams: props.siteBuilderParams ?? {},
-			connectAuth: props.connectAuth,
-			isConnectAuthResolved: props.isConnectAuthResolved,
-		} ),
-		{ initialProps: initial },
+		( props: HookProps ) =>
+			useSiteBuilderIframeMessaging( {
+				iframeRef: iframeRef as React.RefObject< HTMLIFrameElement | null >,
+				iframeUrl: IFRAME_URL,
+				siteBuilderParams: props.siteBuilderParams ?? {},
+				connectAuth: props.connectAuth,
+				isConnectAuthResolved: props.isConnectAuthResolved,
+			} ),
+		{ initialProps: initial }
 	);
 
 	const dispatchGetReferrerInfo = () => {
 		act( () => {
-			const evt = new Event( 'message' ) as unknown as MessageEvent & { data: unknown; origin: string; source: Window };
-			( evt as unknown as { data: unknown } ).data = { type: 'get/referrer/info', payload: { instanceId: 'inst-1' } };
+			const evt = new Event( 'message' ) as unknown as MessageEvent & {
+				data: unknown;
+				origin: string;
+				source: Window;
+			};
+			( evt as unknown as { data: unknown } ).data = {
+				type: 'get/referrer/info',
+				payload: { instanceId: 'inst-1' },
+			};
 			( evt as unknown as { origin: string } ).origin = IFRAME_ORIGIN;
 			( evt as unknown as { source: Window } ).source = fakeContentWindow;
 			window.dispatchEvent( evt );

--- a/packages/apps/site-builder/src/hooks/__tests__/use-site-builder-iframe-messaging.test.tsx
+++ b/packages/apps/site-builder/src/hooks/__tests__/use-site-builder-iframe-messaging.test.tsx
@@ -1,0 +1,146 @@
+import * as React from 'react';
+import { act, renderHook } from '@testing-library/react';
+
+import {
+	type ConnectAuth,
+	type SiteBuilderParams,
+	useSiteBuilderIframeMessaging,
+} from '../use-site-builder-iframe-messaging';
+
+jest.mock( '../../site-builder-config', () => ( {
+	getSiteBuilderConfig: () => ( { isAdmin: true, exitTo: '/exit' } ),
+	getElementorAiCurrentContext: () => ( { siteTitle: 'Test', siteAbout: [] } ),
+} ) );
+
+jest.mock( '../../deploy', () => ( { deployWebsite: jest.fn() } ) );
+jest.mock( '../../deploy/can-redirect-after-deploy', () => ( { resolveEditorRedirectPageId: jest.fn() } ) );
+jest.mock( '../../deploy/deploy-editor-redirect', () => ( {
+	clearPendingEditorRedirect: jest.fn(),
+	completeEditorRedirectOnDeployAcknowledge: jest.fn(),
+	scheduleEditorRedirectAfterDeploy: jest.fn(),
+} ) );
+
+const IFRAME_URL = 'https://planner.elementor.com/chat.html';
+const IFRAME_ORIGIN = 'https://planner.elementor.com';
+
+const validConnectAuth: ConnectAuth = {
+	signature: 'sig',
+	accessToken: 'tok',
+	clientId: 'client',
+	homeUrl: 'https://example.com/',
+	siteKey: 'site-key',
+};
+
+type HookProps = {
+	connectAuth: ConnectAuth | null;
+	isConnectAuthResolved: boolean;
+	siteBuilderParams?: SiteBuilderParams;
+};
+
+const setupHook = ( initial: HookProps ) => {
+	const postMessage = jest.fn();
+	const fakeContentWindow = { postMessage } as unknown as Window;
+	const iframeRef = { current: { contentWindow: fakeContentWindow } as unknown as HTMLIFrameElement };
+
+	const { rerender } = renderHook(
+		( props: HookProps ) => useSiteBuilderIframeMessaging( {
+			iframeRef: iframeRef as React.RefObject< HTMLIFrameElement | null >,
+			iframeUrl: IFRAME_URL,
+			siteBuilderParams: props.siteBuilderParams ?? {},
+			connectAuth: props.connectAuth,
+			isConnectAuthResolved: props.isConnectAuthResolved,
+		} ),
+		{ initialProps: initial },
+	);
+
+	const dispatchGetReferrerInfo = () => {
+		act( () => {
+			const evt = new Event( 'message' ) as unknown as MessageEvent & { data: unknown; origin: string; source: Window };
+			( evt as unknown as { data: unknown } ).data = { type: 'get/referrer/info', payload: { instanceId: 'inst-1' } };
+			( evt as unknown as { origin: string } ).origin = IFRAME_ORIGIN;
+			( evt as unknown as { source: Window } ).source = fakeContentWindow;
+			window.dispatchEvent( evt );
+		} );
+	};
+
+	return { postMessage, rerender, dispatchGetReferrerInfo };
+};
+
+describe( 'useSiteBuilderIframeMessaging - handshake queueing', () => {
+	it( 'queues get/referrer/info while auth is in-flight, then flushes with connectAuth once resolved', () => {
+		const { postMessage, rerender, dispatchGetReferrerInfo } = setupHook( {
+			connectAuth: null,
+			isConnectAuthResolved: false,
+		} );
+
+		dispatchGetReferrerInfo();
+
+		expect( postMessage ).not.toHaveBeenCalled();
+
+		rerender( { connectAuth: validConnectAuth, isConnectAuthResolved: true } );
+
+		expect( postMessage ).toHaveBeenCalledTimes( 1 );
+		const [ message, targetOrigin ] = postMessage.mock.calls[ 0 ];
+		expect( targetOrigin ).toBe( IFRAME_ORIGIN );
+		expect( message ).toMatchObject( {
+			type: 'referrer/info',
+			instanceId: 'inst-1',
+			info: { connectAuth: validConnectAuth },
+		} );
+	} );
+
+	it( 'flushes queued handshake with connectAuth:null when auth fetch fails', () => {
+		const { postMessage, rerender, dispatchGetReferrerInfo } = setupHook( {
+			connectAuth: null,
+			isConnectAuthResolved: false,
+		} );
+
+		dispatchGetReferrerInfo();
+
+		expect( postMessage ).not.toHaveBeenCalled();
+
+		rerender( { connectAuth: null, isConnectAuthResolved: true } );
+
+		expect( postMessage ).toHaveBeenCalledTimes( 1 );
+		const [ message ] = postMessage.mock.calls[ 0 ];
+		expect( message ).toMatchObject( {
+			type: 'referrer/info',
+			info: { connectAuth: null },
+		} );
+	} );
+
+	it( 'responds immediately when connectAuth is already resolved before handshake arrives', () => {
+		const { postMessage, dispatchGetReferrerInfo } = setupHook( {
+			connectAuth: validConnectAuth,
+			isConnectAuthResolved: true,
+		} );
+
+		dispatchGetReferrerInfo();
+
+		expect( postMessage ).toHaveBeenCalledTimes( 1 );
+		expect( postMessage.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
+			type: 'referrer/info',
+			info: { connectAuth: validConnectAuth },
+		} );
+	} );
+
+	it( 'does not re-flush after handshake has already been answered', () => {
+		const { postMessage, rerender, dispatchGetReferrerInfo } = setupHook( {
+			connectAuth: null,
+			isConnectAuthResolved: false,
+		} );
+
+		dispatchGetReferrerInfo();
+		rerender( { connectAuth: validConnectAuth, isConnectAuthResolved: true } );
+
+		expect( postMessage ).toHaveBeenCalledTimes( 1 );
+
+		rerender( {
+			connectAuth: validConnectAuth,
+			isConnectAuthResolved: true,
+			siteBuilderParams: { siteType: 'blog' },
+		} );
+
+		expect( postMessage ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/packages/apps/site-builder/src/hooks/use-site-builder-iframe-messaging.ts
+++ b/packages/apps/site-builder/src/hooks/use-site-builder-iframe-messaging.ts
@@ -113,6 +113,7 @@ type UseSiteBuilderIframeMessagingArgs = {
 	iframeUrl: string;
 	siteBuilderParams: SiteBuilderParams;
 	connectAuth: ConnectAuth | null;
+	isConnectAuthResolved: boolean;
 };
 
 export function useSiteBuilderIframeMessaging( {
@@ -120,6 +121,7 @@ export function useSiteBuilderIframeMessaging( {
 	iframeUrl,
 	siteBuilderParams,
 	connectAuth,
+	isConnectAuthResolved,
 }: UseSiteBuilderIframeMessagingArgs ): void {
 	const pendingRedirectRef = useRef< PendingEditorRedirect | null >( null );
 	const pendingHandshakeRef = useRef< MessageEvent | null >( null );
@@ -153,7 +155,7 @@ export function useSiteBuilderIframeMessaging( {
 				if ( ! iframe?.contentWindow ) {
 					return;
 				}
-				if ( ! connectAuth ) {
+				if ( ! isConnectAuthResolved ) {
 					pendingHandshakeRef.current = event;
 					return;
 				}
@@ -185,7 +187,7 @@ export function useSiteBuilderIframeMessaging( {
 				}
 			}
 		},
-		[ allowedOrigin, siteBuilderParams, connectAuth, iframeRef ]
+		[ allowedOrigin, siteBuilderParams, connectAuth, isConnectAuthResolved, iframeRef ]
 	);
 
 	useEffect( () => {
@@ -194,7 +196,7 @@ export function useSiteBuilderIframeMessaging( {
 	}, [ handleMessage ] );
 
 	useEffect( () => {
-		if ( ! connectAuth ) {
+		if ( ! isConnectAuthResolved ) {
 			return;
 		}
 		const pending = pendingHandshakeRef.current;
@@ -207,7 +209,7 @@ export function useSiteBuilderIframeMessaging( {
 		}
 		sendReferrerInfo( iframe, pending, allowedOrigin, siteBuilderParams, connectAuth );
 		pendingHandshakeRef.current = null;
-	}, [ connectAuth, allowedOrigin, siteBuilderParams, iframeRef ] );
+	}, [ isConnectAuthResolved, connectAuth, allowedOrigin, siteBuilderParams, iframeRef ] );
 
 	useEffect( () => {
 		return () => clearPendingEditorRedirect( pendingRedirectRef.current );

--- a/packages/apps/site-builder/src/hooks/use-site-builder-iframe-messaging.ts
+++ b/packages/apps/site-builder/src/hooks/use-site-builder-iframe-messaging.ts
@@ -122,6 +122,7 @@ export function useSiteBuilderIframeMessaging( {
 	connectAuth,
 }: UseSiteBuilderIframeMessagingArgs ): void {
 	const pendingRedirectRef = useRef< PendingEditorRedirect | null >( null );
+	const pendingHandshakeRef = useRef< MessageEvent | null >( null );
 
 	const allowedOrigin = useMemo( () => {
 		try {
@@ -149,9 +150,14 @@ export function useSiteBuilderIframeMessaging( {
 
 			if ( type === 'get/referrer/info' ) {
 				const iframe = iframeRef.current;
-				if ( iframe?.contentWindow ) {
-					sendReferrerInfo( iframe, event, allowedOrigin, siteBuilderParams, connectAuth );
+				if ( ! iframe?.contentWindow ) {
+					return;
 				}
+				if ( ! connectAuth ) {
+					pendingHandshakeRef.current = event;
+					return;
+				}
+				sendReferrerInfo( iframe, event, allowedOrigin, siteBuilderParams, connectAuth );
 				return;
 			}
 
@@ -186,6 +192,22 @@ export function useSiteBuilderIframeMessaging( {
 		window.addEventListener( 'message', handleMessage );
 		return () => window.removeEventListener( 'message', handleMessage );
 	}, [ handleMessage ] );
+
+	useEffect( () => {
+		if ( ! connectAuth ) {
+			return;
+		}
+		const pending = pendingHandshakeRef.current;
+		if ( ! pending ) {
+			return;
+		}
+		const iframe = iframeRef.current;
+		if ( ! iframe?.contentWindow ) {
+			return;
+		}
+		sendReferrerInfo( iframe, pending, allowedOrigin, siteBuilderParams, connectAuth );
+		pendingHandshakeRef.current = null;
+	}, [ connectAuth, allowedOrigin, siteBuilderParams, iframeRef ] );
 
 	useEffect( () => {
 		return () => clearPendingEditorRedirect( pendingRedirectRef.current );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Race condition where iframe handshake (`get/referrer/info`) fires before SP auth fetch completes, causing messages to be sent without valid `connectAuth`. Ticket: ED-24863.

## 2. What Changed (Where)

- `app.tsx`: Added `isConnectAuthResolved` state flag; set to `true` in auth fetch's `finally` block
- `use-site-builder-iframe-messaging.ts`: Queue pending handshakes in `pendingHandshakeRef`; flush after auth resolves via new effect
- `use-site-builder-iframe-messaging.test.tsx`: New 154-line test suite covering queue/flush behavior and auth failure scenarios

## 3. How It Works

App fetches SP auth async → iframe may send `get/referrer/info` before auth ready. Handler now queues the message in `pendingHandshakeRef` if `!isConnectAuthResolved`, then a separate effect triggers on auth resolution to send the queued message with resolved `connectAuth`. Immediate responses still work if auth resolved first. Effect clears pending ref after sending to prevent re-flushing.

## 4. Risks

Minimal. Dependency array updated correctly (`isConnectAuthResolved` added to both effects). Queued handshake cleared after processing prevents double-sends. Test coverage validates all three paths: in-flight auth, failed auth, and pre-resolved auth.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
