### PR TITLE
Fix: Collect Submissions behaviour according to tier. [ED-24734]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.php
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.php
@@ -158,16 +158,25 @@ class Atomic_Form extends Atomic_Element_Base {
 		$form_action_chips = $email_control_settings['form-action-chips'];
 		$email_controls = $email_control_settings['email-controls'];
 
+		if ( class_exists( '\ElementorPro\License\API' ) ) {
+			$tier = \ElementorPro\License\API::get_plan_type();
+
+			if ( false === strpos( $tier, 'essential' ) ) {
+				$form_action_chips = array_merge( $form_action_chips, [
+					[
+						'label' => __( 'Collect submissions', 'elementor' ),
+						'value' => self::ACTION_COLLECT_SUBMISSIONS,
+					],
+				] );
+			}
+		}
+
 		$content_controls = [
 			Text_Control::bind_to( 'form-name' )
 				->set_label( __( 'Form name', 'elementor' ) ),
 			$state_control,
 			Chips_Control::bind_to( 'actions-after-submit' )
 				->set_options( array_merge( $form_action_chips, [
-					[
-						'label' => __( 'Collect submissions', 'elementor' ),
-						'value' => self::ACTION_COLLECT_SUBMISSIONS,
-					],
 					[
 						'label' => __( 'Webhook', 'elementor' ),
 						'value' => self::ACTION_WEBHOOK,

--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.php
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.php
@@ -159,9 +159,9 @@ class Atomic_Form extends Atomic_Element_Base {
 		$email_controls = $email_control_settings['email-controls'];
 
 		if ( class_exists( '\ElementorPro\License\API' ) ) {
-			$tier = \ElementorPro\License\API::get_plan_type();
+			$has_form_submissions_feature = \ElementorPro\License\API::is_licence_has_feature( 'form-submissions' );
 
-			if ( false === strpos( $tier, 'essential' ) ) {
+			if ( $has_form_submissions_feature ) {
 				$form_action_chips = array_merge( $form_action_chips, [
 					[
 						'label' => __( 'Collect submissions', 'elementor' ),

--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-form.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-form.php
@@ -12,7 +12,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+require_once __DIR__ . '/../../components/mocks/mock-pro-license-api.php';
+
 class Test_Atomic_Form extends Elementor_Test_Base {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		\Mock_Pro_License_API::reset();
+	}
 
 	public function test_action_webhook_constant_matches_expected_slug() {
 		$this->assertSame( 'webhook', Atomic_Form::ACTION_WEBHOOK );
@@ -42,6 +50,36 @@ class Test_Atomic_Form extends Elementor_Test_Base {
 
 		$values = array_column( $chips->get_props()['options'] ?? [], 'value' );
 		$this->assertContains( Atomic_Form::ACTION_WEBHOOK, $values );
+	}
+
+	/**
+	 * @dataProvider collect_submissions_chip_by_plan_type_provider
+	 */
+	public function test_actions_after_submit_collect_submissions_chip_by_plan_type( string $plan_type, bool $should_include_chip ) {
+		// Arrange
+		\Mock_Pro_License_API::set_license_state( true );
+		\Mock_Pro_License_API::set_plan_type( $plan_type );
+
+		// Act
+		$form = $this->make_atomic_form_instance();
+		$chips = $this->find_control_by_bind( $form->get_atomic_controls(), 'actions-after-submit' );
+		$values = array_column( $chips->get_props()['options'] ?? [], 'value' );
+
+		// Assert
+		if ( $should_include_chip ) {
+			$this->assertContains( Atomic_Form::ACTION_COLLECT_SUBMISSIONS, $values );
+		} else {
+			$this->assertNotContains( Atomic_Form::ACTION_COLLECT_SUBMISSIONS, $values );
+		}
+	}
+
+	public function collect_submissions_chip_by_plan_type_provider(): array {
+		return [
+			'essential plan' => [ 'essential', false ],
+			'advanced plan' => [ 'advanced', true ],
+			'expert plan' => [ 'expert', true ],
+			'agency plan' => [ 'agency', true ],
+		];
 	}
 
 	public function test_webhook_url_text_control_is_registered() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-form.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-form.php
@@ -53,12 +53,12 @@ class Test_Atomic_Form extends Elementor_Test_Base {
 	}
 
 	/**
-	 * @dataProvider collect_submissions_chip_by_plan_type_provider
+	 * @dataProvider collect_submissions_chip_by_license_feature_provider
 	 */
-	public function test_actions_after_submit_collect_submissions_chip_by_plan_type( string $plan_type, bool $should_include_chip ) {
+	public function test_actions_after_submit_collect_submissions_chip_by_license_feature( array $features, bool $should_include_chip ) {
 		// Arrange
 		\Mock_Pro_License_API::set_license_state( true );
-		\Mock_Pro_License_API::set_plan_type( $plan_type );
+		\Mock_Pro_License_API::set_features( $features );
 
 		// Act
 		$form = $this->make_atomic_form_instance();
@@ -73,12 +73,11 @@ class Test_Atomic_Form extends Elementor_Test_Base {
 		}
 	}
 
-	public function collect_submissions_chip_by_plan_type_provider(): array {
+	public function collect_submissions_chip_by_license_feature_provider(): array {
 		return [
-			'essential plan' => [ 'essential', false ],
-			'advanced plan' => [ 'advanced', true ],
-			'expert plan' => [ 'expert', true ],
-			'agency plan' => [ 'agency', true ],
+			'with form-submissions feature' => [ [ 'form-submissions' ], true ],
+			'without form-submissions feature' => [ [ 'template_access_level_1' ], false ],
+			'no features' => [ [], false ],
 		];
 	}
 

--- a/tests/phpunit/elementor/modules/components/mocks/mock-pro-license-api.php
+++ b/tests/phpunit/elementor/modules/components/mocks/mock-pro-license-api.php
@@ -5,10 +5,21 @@ if ( ! class_exists( '\ElementorPro\License\API' ) ) {
 	class Mock_Pro_License_API {
 		private static bool $active = true;
 		private static bool $expired = false;
+		private static string $plan_type = 'essential';
+
+		public static function reset(): void {
+			self::$active = true;
+			self::$expired = false;
+			self::$plan_type = 'essential';
+		}
 
 		public static function set_license_state( bool $active, bool $expired = false ): void {
 			self::$active = $active;
 			self::$expired = $expired;
+		}
+
+		public static function set_plan_type( string $plan_type ): void {
+			self::$plan_type = $plan_type;
 		}
 
 		public static function is_license_active(): bool {
@@ -17,6 +28,14 @@ if ( ! class_exists( '\ElementorPro\License\API' ) ) {
 
 		public static function is_license_expired(): bool {
 			return self::$expired;
+		}
+
+		public static function get_plan_type(): string {
+			if ( ! self::is_license_active() ) {
+				return 'free';
+			}
+
+			return self::$plan_type;
 		}
 	}
 

--- a/tests/phpunit/elementor/modules/components/mocks/mock-pro-license-api.php
+++ b/tests/phpunit/elementor/modules/components/mocks/mock-pro-license-api.php
@@ -5,12 +5,12 @@ if ( ! class_exists( '\ElementorPro\License\API' ) ) {
 	class Mock_Pro_License_API {
 		private static bool $active = true;
 		private static bool $expired = false;
-		private static string $plan_type = 'essential';
+		private static array $features = [];
 
 		public static function reset(): void {
 			self::$active = true;
 			self::$expired = false;
-			self::$plan_type = 'essential';
+			self::$features = [];
 		}
 
 		public static function set_license_state( bool $active, bool $expired = false ): void {
@@ -18,8 +18,8 @@ if ( ! class_exists( '\ElementorPro\License\API' ) ) {
 			self::$expired = $expired;
 		}
 
-		public static function set_plan_type( string $plan_type ): void {
-			self::$plan_type = $plan_type;
+		public static function set_features( array $features ): void {
+			self::$features = $features;
 		}
 
 		public static function is_license_active(): bool {
@@ -30,12 +30,10 @@ if ( ! class_exists( '\ElementorPro\License\API' ) ) {
 			return self::$expired;
 		}
 
-		public static function get_plan_type(): string {
-			if ( ! self::is_license_active() ) {
-				return 'free';
-			}
+		public static function is_licence_has_feature( $feature_name, $license_check_validator = null ): bool {
+			unset( $license_check_validator );
 
-			return self::$plan_type;
+			return in_array( $feature_name, self::$features, true );
 		}
 	}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Moving "Collect submissions" action behind license tier check. Previously always available; now conditional on Elementor Pro's form-submissions feature. ED-24734.

## 2. What Changed (Where)

- **atomic-form.php**: Added license feature check before injecting "Collect submissions" chip into form actions.
- **test-atomic-form.php**: Added parameterized test with mock license API to validate feature-gated behavior.
- **mock-pro-license-api.php**: Extended mock with `set_features()` and `is_licence_has_feature()` to support test scenarios.

## 3. How It Works

On form initialization, checks if `\ElementorPro\License\API` exists and validates `form-submissions` feature flag. Only appends the "Collect submissions" option if the feature is licensed. Falls back gracefully if API missing.

## 4. Risks

Minimal. Backward compatible—actions array just conditionally longer. Test coverage added for all three feature states (present, absent, empty).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
