### PR TITLE
Fix: latest-release workflow case fall-through and always-truthy Slack condition

### DIFF
--- a/.github/workflows/bump-channel-version/action.yml
+++ b/.github/workflows/bump-channel-version/action.yml
@@ -22,17 +22,17 @@ runs:
     - shell: bash
       run: |
         case ${{ inputs.CHANNEL }} in
+          "latest" )
+            NEW_CHANNEL_VERSION=-$(date +%s)
+            ELEMENTOR_CHANNEL_PACKAGE_VERSION=${{ inputs.CLEAN_PACKAGE_VERSION }}-${{ inputs.CHANNEL }}${NEW_CHANNEL_VERSION}
+            ;;
+          "ga" )
+            ELEMENTOR_CHANNEL_PACKAGE_VERSION=${{ inputs.CLEAN_PACKAGE_VERSION }}
+            ;;
           * )
             CURRENT_CHANNEL_VERSION=${{ env.CURRENT_CHANNEL_VERSION }}
             NEW_CHANNEL_VERSION=$((CURRENT_CHANNEL_VERSION+1))
             ELEMENTOR_CHANNEL_PACKAGE_VERSION=${{ inputs.CLEAN_PACKAGE_VERSION }}-${{ inputs.CHANNEL }}${NEW_CHANNEL_VERSION}
-            ;;&
-          "latest" )
-            NEW_CHANNEL_VERSION=-$(date +%s)
-            ELEMENTOR_CHANNEL_PACKAGE_VERSION=${{ inputs.CLEAN_PACKAGE_VERSION }}-${{ inputs.CHANNEL }}${NEW_CHANNEL_VERSION}
-           ;;
-          "ga" )
-            ELEMENTOR_CHANNEL_PACKAGE_VERSION=${{ inputs.CLEAN_PACKAGE_VERSION }}
             ;;
         esac
 

--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -81,7 +81,7 @@ jobs:
           prerelease: ${{ env.PRERELEASE }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Post To Slack Created Latest auto Release
-        if: ${{ github.event.inputs.pre_release }} == false
+        if: ${{ env.PRERELEASE == 'false' }}
         uses: ./.github/workflows/post-to-slack
         with:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}


### PR DESCRIPTION
## Summary

- **`bump-channel-version/action.yml`**: Reorders `case` branches so `"latest"` and `"ga"` are matched explicitly **before** the wildcard `*`. Previously the wildcard used `;;&` (fall-through) and always executed arithmetic on `CURRENT_CHANNEL_VERSION` — which is never set in this workflow — before reaching the `"latest"` branch. On the runner this caused a bash arithmetic error and **exit code 1**, failing the job.

- **`latest-release.yml` line 84**: Fixes the `if:` condition on the **Post To Slack** step. The comparison `== false` was outside the `${{ }}` block, making the entire expression always evaluate to truthy. Changed to `${{ env.PRERELEASE == 'false' }}` using the workflow-level env var already correctly defined at the top of the file.

## Root cause

Failing CI run: https://github.com/elementor/elementor/actions/runs/28651366988/job/84969942512

GitHub issue: https://github.com/elementor/elementor/issues/36436

## Test plan

- [ ] Trigger the `latest-release` workflow via a merged PR to `main` and confirm **Bump Channel Version** completes successfully
- [ ] Confirm the **Post To Slack** step only fires when `PRERELEASE` is `false`

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Case statement was falling through due to missing `;;` after "latest" handler and incorrect condition syntax checking pre-release flag. Default case was unreachable, and Slack notifications fired on all releases regardless of pre-release status.

## 2. What Changed (Where)

- `.github/workflows/bump-channel-version/action.yml`: Reordered case statement, added missing break statement after "latest" case, implemented proper default handler for custom channels.
- `.github/workflows/latest-release.yml`: Fixed Slack notification condition from string comparison to proper boolean check against environment variable.

## 3. How It Works

The bash case statement now correctly terminates each branch with `;;`. The default case (`*`) handles custom channel versions via increment logic, only executing if neither "latest" nor "ga" match. Slack step now conditionally runs only when `PRERELEASE` env var equals `'false'` rather than comparing input string directly.

## 4. Risks

Minimal—fixes obvious bugs. Verify "ga" channel still behaves identically (no version increment). Confirm Slack notifications only fire for GA releases in practice.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
