### PR TITLE
Fix: Moving the parent of an atomic form shows invalid message [ED-23858]

### DIFF
--- a/packages/packages/core/editor-canvas/src/form-structure/enforce-form-ancestor-commands.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/enforce-form-ancestor-commands.ts
@@ -5,9 +5,11 @@ import { __ } from '@wordpress/i18n';
 import {
 	clipboardRootsAreAtomicForms,
 	type CreateArgs,
+	FORM_ELEMENT_TYPE,
 	FORM_FIELD_ELEMENT_TYPES,
 	getArgsElementType,
 	hasClipboardElementTypes,
+	hasElementType,
 	hasElementTypes,
 	isWithinForm,
 	type MoveArgs,
@@ -58,11 +60,14 @@ function blockFormFieldCreate( args: CreateArgs ): boolean {
 function blockFormFieldMove( args: MoveArgs ): boolean {
 	const { containers = [ args.container ], target } = args;
 
-	const hasFormFieldElement = containers.some( ( container ) =>
-		container ? hasElementTypes( container, FORM_FIELD_ELEMENT_TYPES ) : false
+	// Form fields must not be outside a form, but can be moved while inside a form or the container IS a form [ED-23858]
+	const hasLooseFormFields = containers.some( ( container ) =>
+		container
+			? ! hasElementType( container, FORM_ELEMENT_TYPE ) && hasElementTypes( container, FORM_FIELD_ELEMENT_TYPES )
+			: false
 	);
 
-	if ( hasFormFieldElement && ! isWithinForm( target ) && ! movedContainersIncludeAtomicFormRoot( containers ) ) {
+	if ( hasLooseFormFields && ! isWithinForm( target ) && ! movedContainersIncludeAtomicFormRoot( containers ) ) {
 		handleBlockedFormField();
 
 		return true;


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Moving an atomic form parent was incorrectly blocked. Logic was checking if containers held form fields, but not distinguishing between loose fields (invalid to move outside forms) and fields within form containers (valid moves). ED-23858 fixes this.

## 2. What Changed (Where)

`enforce-form-ancestor-commands.ts`: Updated `blockFormFieldMove()` to check if containers are form fields *not* within a form, then validates target context.

## 3. How It Works

Changed validation from checking `hasElementTypes(container, FORM_FIELD_ELEMENT_TYPES)` to `!hasElementType(container, FORM_ELEMENT_TYPE) && hasElementTypes(container, FORM_FIELD_ELEMENT_TYPES)`. Now only blocks moves when loose field elements target non-form destinations, allowing atomic form parents with field children to move freely.

## 4. Risks

Low. Conditional logic is more specific—reduces false positives without relaxing safety constraints on genuinely orphaned form fields.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
