### PR TITLE
Fix: Reduce selection outline offset for atomic form input [ED-22742]

### DIFF
--- a/packages/packages/core/editor-canvas/src/components/elements-overlays.tsx
+++ b/packages/packages/core/editor-canvas/src/components/elements-overlays.tsx
@@ -45,18 +45,19 @@ export function ElementsOverlays() {
 		return null;
 	}
 
-	return elements.map( ( { id, domElement, isGlobal } ) => {
+	return elements.map( ( { id, domElement, isGlobal, widgetType } ) => {
 		const isSelected = selected.element?.id === id;
 
 		return overlayRegistry.map(
 			( { shouldRender, component: Overlay }, index ) =>
-				shouldRender( { id, element: domElement, isSelected } ) && (
+				shouldRender( { id, element: domElement, isSelected, widgetType } ) && (
 					<Overlay
 						key={ `${ id }-${ index }` }
 						id={ id }
 						element={ domElement }
 						isSelected={ isSelected }
 						isGlobal={ isGlobal }
+						widgetType={ widgetType }
 					/>
 				)
 		);
@@ -67,6 +68,7 @@ type ElementData = {
 	id: string;
 	domElement: HTMLElement;
 	isGlobal: boolean;
+	widgetType?: string;
 };
 
 function useElementsDom() {
@@ -79,6 +81,7 @@ function useElementsDom() {
 					id: element.id,
 					domElement: element.view?.getDomElement?.()?.get?.( 0 ),
 					isGlobal: element.model.get( 'isGlobal' ) ?? false,
+					widgetType: element.model.get( 'widgetType' ),
 				} ) )
 				.filter( ( item ): item is ElementData => !! item.domElement );
 		}

--- a/packages/packages/core/editor-canvas/src/components/elements-overlays.tsx
+++ b/packages/packages/core/editor-canvas/src/components/elements-overlays.tsx
@@ -68,13 +68,13 @@ type ElementData = {
 	id: string;
 	domElement: HTMLElement;
 	isGlobal: boolean;
-	widgetType?: string;
+	widgetType: string | undefined;
 };
 
-function useElementsDom() {
+function useElementsDom(): ElementData[] {
 	return useListenTo(
 		[ windowEvent( 'elementor/editor/element-rendered' ), windowEvent( 'elementor/editor/element-destroyed' ) ],
-		() => {
+		(): ElementData[] => {
 			return getElements()
 				.filter( ( el ) => isV4Element( el.view?.el?.dataset ) )
 				.map( ( element ) => ( {

--- a/packages/packages/core/editor-canvas/src/components/outline-overlay.tsx
+++ b/packages/packages/core/editor-canvas/src/components/outline-overlay.tsx
@@ -6,6 +6,7 @@ import { useBindReactPropsToElement } from '../hooks/use-bind-react-props-to-ele
 import { useFloatingOnElement } from '../hooks/use-floating-on-element';
 import { useHasOverlapping } from '../hooks/use-has-overlapping';
 import type { ElementOverlayProps } from '../types/element-overlay';
+import { shouldUseSmallerOutlineOffset } from '../utils/outline-offset-utils';
 
 export const CANVAS_WRAPPER_ID = 'elementor-preview-responsive-wrapper';
 
@@ -25,13 +26,19 @@ const OverlayBox = styled( Box, {
 	} )
 );
 
-export const OutlineOverlay = ( { element, isSelected, id, isGlobal = false }: Props ): React.ReactElement | false => {
+export const OutlineOverlay = ( {
+	element,
+	isSelected,
+	id,
+	isGlobal = false,
+	widgetType,
+}: Props ): React.ReactElement | false => {
 	const { context, floating, isVisible } = useFloatingOnElement( { element, isSelected } );
 	const { getFloatingProps, getReferenceProps } = useInteractions( [ useHover( context ) ] );
 	const hasOverlapping = useHasOverlapping();
 
 	useBindReactPropsToElement( element, getReferenceProps );
-	const isSmallerOffset = element.offsetHeight <= 1;
+	const isSmallerOffset = shouldUseSmallerOutlineOffset( element, widgetType );
 
 	return (
 		isVisible &&

--- a/packages/packages/core/editor-canvas/src/types/element-overlay.ts
+++ b/packages/packages/core/editor-canvas/src/types/element-overlay.ts
@@ -5,12 +5,14 @@ export type ElementOverlayProps = {
 	id: string;
 	isSelected: boolean;
 	isGlobal?: boolean;
+	widgetType?: string;
 };
 
 export type OverlayFilterArgs = {
 	id: string;
 	element: HTMLElement;
 	isSelected: boolean;
+	widgetType?: string;
 };
 
 export type ElementOverlayConfig = {

--- a/packages/packages/core/editor-canvas/src/utils/__tests__/outline-offset-utils.test.ts
+++ b/packages/packages/core/editor-canvas/src/utils/__tests__/outline-offset-utils.test.ts
@@ -1,7 +1,4 @@
-import {
-	shouldUseSmallerOutlineOffset,
-	THIN_ELEMENT_MAX_HEIGHT_PX,
-} from '../outline-offset-utils';
+import { shouldUseSmallerOutlineOffset, THIN_ELEMENT_MAX_HEIGHT_PX } from '../outline-offset-utils';
 
 describe( 'shouldUseSmallerOutlineOffset', () => {
 	it( 'returns true for thin elements like dividers', () => {

--- a/packages/packages/core/editor-canvas/src/utils/__tests__/outline-offset-utils.test.ts
+++ b/packages/packages/core/editor-canvas/src/utils/__tests__/outline-offset-utils.test.ts
@@ -1,0 +1,42 @@
+import {
+	shouldUseSmallerOutlineOffset,
+	THIN_ELEMENT_MAX_HEIGHT_PX,
+} from '../outline-offset-utils';
+
+describe( 'shouldUseSmallerOutlineOffset', () => {
+	it( 'returns true for thin elements like dividers', () => {
+		// Arrange.
+		const element = document.createElement( 'hr' );
+		Object.defineProperty( element, 'offsetHeight', { value: THIN_ELEMENT_MAX_HEIGHT_PX } );
+
+		// Act.
+		const result = shouldUseSmallerOutlineOffset( element );
+
+		// Assert.
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns true for atomic form input widgets', () => {
+		// Arrange.
+		const element = document.createElement( 'input' );
+		Object.defineProperty( element, 'offsetHeight', { value: 36 } );
+
+		// Act.
+		const result = shouldUseSmallerOutlineOffset( element, 'e-form-input' );
+
+		// Assert.
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns false for other atomic widgets', () => {
+		// Arrange.
+		const element = document.createElement( 'div' );
+		Object.defineProperty( element, 'offsetHeight', { value: 100 } );
+
+		// Act.
+		const result = shouldUseSmallerOutlineOffset( element, 'e-heading' );
+
+		// Assert.
+		expect( result ).toBe( false );
+	} );
+} );

--- a/packages/packages/core/editor-canvas/src/utils/outline-offset-utils.ts
+++ b/packages/packages/core/editor-canvas/src/utils/outline-offset-utils.ts
@@ -1,0 +1,11 @@
+export const THIN_ELEMENT_MAX_HEIGHT_PX = 1;
+
+export const SMALLER_OUTLINE_OFFSET_WIDGET_TYPES = new Set( [ 'e-form-input' ] );
+
+export function shouldUseSmallerOutlineOffset( element: HTMLElement, widgetType?: string ): boolean {
+	if ( element.offsetHeight <= THIN_ELEMENT_MAX_HEIGHT_PX ) {
+		return true;
+	}
+
+	return widgetType !== undefined && SMALLER_OUTLINE_OFFSET_WIDGET_TYPES.has( widgetType );
+}


### PR DESCRIPTION
## Summary
- Apply a smaller editor selection outline offset for atomic form input fields (`e-form-input`), matching the existing divider approach
- Pass `widgetType` from the element model into the canvas outline overlay so bordered inputs are detected reliably in the editor
- Extract shared `shouldUseSmallerOutlineOffset` logic and add unit tests

## Test plan
- [x] `npx jest packages/core/editor-canvas/src/utils/__tests__/outline-offset-utils.test.ts`
- [x] `npx jest packages/core/editor-canvas/src/components/__tests__/elements-overlays.test.tsx`
- [x] Manual: select an atomic form input in the editor and confirm the pink selection outline no longer overlaps the input border

## Jira
[ED-22742](https://elementor.atlassian.net/browse/ED-22742)

Made with [Cursor](https://cursor.com)

[ED-22742]: https://elementor.atlassian.net/browse/ED-22742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Selection outline offset for atomic form inputs (e.g., `e-form-input`) was inconsistent. The fix extracts outline offset logic into a reusable utility that accounts for both thin elements and specific widget types.

## 2. What Changed (Where)

- **outline-offset-utils.ts** (new): Extracted logic for determining smaller outline offset into `shouldUseSmallerOutlineOffset()` with configurable widget types.
- **outline-overlay.tsx**: Replaced inline `element.offsetHeight <= 1` check with call to new utility, accepts `widgetType` prop.
- **elements-overlays.tsx**: Thread `widgetType` through component hierarchy; updated `ElementData` type and `useElementsDom()` return signature.
- **element-overlay.ts** (types): Added `widgetType` to `ElementOverlayProps` and `OverlayFilterArgs`.
- **outline-offset-utils.test.ts** (new): Tests for thin elements, form inputs, and non-matching widget types.

## 3. How It Works

Flow: `elements-overlays` extracts `widgetType` from element model → passes to `OutlineOverlay` → calls `shouldUseSmallerOutlineOffset(element, widgetType)` → returns true if element height ≤ 1px OR widgetType in `SMALLER_OUTLINE_OFFSET_WIDGET_TYPES` set → applies `-1px` outline offset instead of `-2px`.

## 4. Risks

Minor: `widgetType` is optional throughout the chain—gracefully handles undefined. Set-based widget type matching (`e-form-input`) scales cleanly but requires audit if new atomic types need smaller offset. Test coverage present but DOM height mocking is brittle if offsetHeight behavior changes.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
