### PR TITLE
fix: guard Hints::is_plugin_active() against missing plugin.php on front-end requests

### DIFF
--- a/core/utils/hints.php
+++ b/core/utils/hints.php
@@ -362,6 +362,10 @@ class Hints {
 	 * @return bool
 	 */
 	public static function is_plugin_active( $plugin ): bool {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		$plugin = self::ensure_plugin_folder( $plugin );
 		return is_plugin_active( $plugin );
 	}


### PR DESCRIPTION
Hey team,

`Hints::is_plugin_active()` fatals on the front end. It calls WordPress core `is_plugin_active()` directly, but that function lives in `wp-admin/includes/plugin.php`, which isn't loaded on front-end requests. When `Hints::is_plugin_active()` runs on a front-end `init` (for example via the Angie promotion path), the core function is undefined and PHP throws `Uncaught Error: Call to undefined function is_plugin_active()`, white-screening the site.

The sibling method directly above it, `is_plugin_installed()`, already handles exactly this case — it requires `wp-admin/includes/plugin.php` when `get_plugins()` is missing. This change mirrors that guard in `is_plugin_active()`: require the admin file when the core function isn't loaded, then proceed as before. It's the same pattern the class already trusts, so it stays consistent with the surrounding code instead of introducing a new one.

This PR can be summarized in the following changelog entry:
* Fix: `Hints::is_plugin_active()` fatal error on the front-end when `wp-admin/includes/plugin.php` is not loaded

PR Type: Bugfix

Test instructions:
1. On a front-end request (not wp-admin), before `wp-admin/includes/plugin.php` has been loaded, call `\Elementor\Core\Utils\Hints::is_plugin_active( 'a-plugin/a-plugin.php' )` — e.g. hook it to an early front-end `init`.
2. On current `main`, the request fatals with `Call to undefined function is_plugin_active()`.
3. With this change, the admin file is loaded on demand and the call returns a boolean with no fatal.

On the QA checklist I've left "I have added unittests" unchecked, and want to be upfront about why. This is a load-context bug — the function is simply absent on the front end. The DB-less unit bootstrap doesn't load WordPress at all, and the full integration harness loads the admin includes, so `is_plugin_active()` always exists there; neither harness reproduces "admin file absent on the front end" without contrived function-hiding that isn't a pattern used elsewhere in this suite. The change mirrors an already-shipped guard on the sibling method, and the reproduction above is the meaningful verification.

One heads-up: as an external contributor I can't attach an ED- Jira ticket, so the Jira Ticket check will need a maintainer to associate one.

Fixes #36184

(full disclosure: AI helped me identify the issue and verify my work)

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Front-end requests lack access to `wp-admin/includes/plugin.php`, causing `is_plugin_active()` calls to fail. This guards against fatal errors when the Hints class checks plugin status outside admin context.

## 2. What Changed (Where)

`core/utils/hints.php` — Added conditional require of `plugin.php` before calling `is_plugin_active()` in the `is_plugin_active()` method (lines 365-367).

## 3. How It Works

Before invoking `is_plugin_active()`, the code checks if the function exists; if missing, it loads the admin include file. Subsequent call proceeds normally with dependencies satisfied.

## 4. Risks

Minimal. The `require_once` guard is idempotent and only executes when needed. Loading admin files on front-end is not ideal but necessary here and scoped to this single use case.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
