### PR TITLE
Fix: Uncaught exception on the Plugins screen when a plugin update has a four-segment version

### DIFF
--- a/modules/compatibility-tag/base-module.php
+++ b/modules/compatibility-tag/base-module.php
@@ -64,6 +64,10 @@ abstract class Base_Module extends BaseModule {
 	 * @param array $args
 	 */
 	protected function on_plugin_update_message( array $args ) {
+		if ( empty( $args['new_version'] ) || ! Version::is_valid_version( $args['new_version'] ) ) {
+			return;
+		}
+
 		$new_version = Version::create_from_string( $args['new_version'] );
 
 		if ( $new_version->compare( '=', $args['Version'], Version::PART_MAJOR_2 ) ) {

--- a/tests/phpunit/elementor/modules/compatibility-tag/test-module.php
+++ b/tests/phpunit/elementor/modules/compatibility-tag/test-module.php
@@ -75,4 +75,29 @@ class Test_Module extends Elementor_Test_Base {
 		$this->assertDoesNotMatchRegularExpression( '/elementor core/', $result );
 		$this->assertDoesNotMatchRegularExpression( '/elementor beta/', $result );
 	}
+
+	public function test_on_plugin_update_message__with_four_segment_new_version() {
+		$this->mock_wp_api( [
+			'get_plugins' => new Collection( [
+				'old' => [
+					'Name' => 'old version plugin',
+					Module::PLUGIN_VERSION_TESTED_HEADER => '2.9.0',
+				],
+			] ),
+		] );
+
+		new Module();
+
+		// Act - a four-segment version is not parsable and must not cause an uncaught exception.
+		ob_start();
+		do_action( 'in_plugin_update_message-' . ELEMENTOR_PLUGIN_BASE, [
+			'new_version' => '3.1.5.1',
+			'Version' => '3.0.0',
+		] );
+
+		$result = ob_get_clean();
+
+		// Assert
+		$this->assertEmpty( $result );
+	}
 }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Uncaught exception (WSOD) on the Plugins screen when a pending plugin update reports a four-segment version number

## Description

### The bug

`Base_Module::on_plugin_update_message()` (modules/compatibility-tag/base-module.php) runs on the `in_plugin_update_message-{plugin}` hook and parses the incoming update version with validation enabled and no error handling:

```php
$new_version = Version::create_from_string( $args['new_version'] );
```

`Version::is_valid_version()` only accepts up to three numeric segments (`/^(\d+\.)?(\d+\.)?(\*|\d+)(-.+)?$/`), so when the pending update's `new_version` has four segments — e.g. `4.0.4.2`, a versioning scheme WordPress itself permits and some plugins in the Elementor ecosystem actually use — `create_from_string()` throws an uncaught `Exception` ("4.0.4.2 is an invalid version") and the whole **wp-admin Plugins screen fatals** (recovery-mode WSOD) until the update is installed or hidden.

Note that `Version::compare()` already handles invalid input defensively (it coerces to `0.0.0`), and `Compatibility_Tag::is_compatible()` guards header values with `is_valid_version()` before parsing. This call site is the one place in the compatibility-tag flow where an unvalidated, externally-supplied string reaches the throwing path.

This also affects Elementor Pro (and derived plugins): their compatibility-tag module extends this same `Base_Module`, so the guard here fixes the Plugins-screen fatal for the whole ecosystem. We hit this in production when a pending update for a Pro-compatible plugin advertised `new_version = 4.0.4.1`/`4.0.4.2` — wp-admin's Plugins page was unusable until we manually reconciled the version.

### Steps to reproduce (on current `main`)

Add this temporary snippet (mu-plugin) to simulate a pending update with a four-segment version, then open **wp-admin → Plugins**:

```php
add_filter( 'site_transient_update_plugins', function ( $transient ) {
	if ( $transient && isset( $transient->response ) ) {
		$transient->response['elementor/elementor.php'] = (object) [
			'slug'        => 'elementor',
			'plugin'      => 'elementor/elementor.php',
			'new_version' => '99.0.0.1',
			'package'     => '',
		];
	}
	return $transient;
} );
```

Before this PR: fatal error — `Uncaught Exception: 99.0.0.1 is an invalid version` in `core/utils/version.php`, thrown from `base-module.php` line 67.
After this PR: the Plugins screen renders normally; the compatibility message is simply skipped for a version string the parser cannot represent.

### The fix

Bail out of `on_plugin_update_message()` early when `new_version` is missing or fails `Version::is_valid_version()` — consistent with the defensive handling already used in `Version::compare()` and `Compatibility_Tag::is_compatible()`. A regression test is included (`test_on_plugin_update_message__with_four_segment_new_version`).

An alternative (or follow-up) would be to loosen `is_valid_version()` to accept additional numeric segments — `create_from_string()` already ignores anything past the third segment — so that four-segment updates still get a compatibility message. I kept this PR minimal to avoid changing validation semantics used elsewhere, but happy to extend it if you'd prefer that direction.

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Plugin updates with four-segment versions (e.g., 3.1.5.1) crash the compatibility tag module because `Version::create_from_string()` can't parse them. Adding validation prevents the uncaught exception on the Plugins screen.

## 2. What Changed (Where)

- `base-module.php`: Guard clause validates `new_version` exists and is parsable before processing.
- `test-module.php`: New test confirms four-segment versions don't throw exceptions.

## 3. How It Works

Early return on invalid/missing `new_version` prevents downstream parsing failure. Valid versions proceed to comparison logic unchanged.

## 4. Risks

None — fail-safe guards an existing code path without altering behavior for valid versions.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
