### PR TITLE
Fix: Editor paste crashes when component instances lack valid models [ED-24870]

### DIFF
--- a/modules/atomic-widgets/assets/js/editor/utils/get-element-children.js
+++ b/modules/atomic-widgets/assets/js/editor/utils/get-element-children.js
@@ -1,5 +1,9 @@
 export function getElementChildren( model ) {
-	const childModels = model?.get( 'elements' )?.models ?? [];
+	if ( ! model ) {
+		return [];
+	}
+
+	const childModels = model.get( 'elements' )?.models ?? [];
 	const children = childModels.flatMap( getElementChildren );
 
 	return [ model, ...children ];

--- a/modules/atomic-widgets/assets/js/editor/utils/regenerate-local-style-ids.js
+++ b/modules/atomic-widgets/assets/js/editor/utils/regenerate-local-style-ids.js
@@ -2,10 +2,14 @@ import { getElementChildren } from './get-element-children';
 import { getRandomStyleId } from './get-random-style-id';
 
 export function regenerateLocalStyleIds( container ) {
+	if ( ! container?.model ) {
+		return;
+	}
+
 	const allElements = getElementChildren( container.model );
 
 	const styledElements = allElements.filter( ( model ) => {
-		return Object.keys( model.get( 'styles' ) ?? {} ).length > 0;
+		return model && Object.keys( model.get( 'styles' ) ?? {} ).length > 0;
 	} );
 
 	updateElementsStyleIdsInsideOut( styledElements );

--- a/packages/packages/core/editor-components/src/store/__tests__/load-components-assets.test.ts
+++ b/packages/packages/core/editor-components/src/store/__tests__/load-components-assets.test.ts
@@ -1,4 +1,4 @@
-import { createMockDocument } from 'test-utils';
+import { createMockDocument, createMockElementData } from 'test-utils';
 import { type Document } from '@elementor/editor-documents';
 import { embeddedDocumentsManager } from '@elementor/editor-embedded-documents-manager';
 
@@ -40,6 +40,13 @@ const OVERRIDABLE_PROPS_FIRST_DOCUMENT = createMockDocument( { id: OVERRIDABLE_P
 const OVERRIDABLE_PROPS_SECOND_ID = 40;
 const OVERRIDABLE_PROPS_SECOND_DOCUMENT = createMockDocument( { id: OVERRIDABLE_PROPS_SECOND_ID } );
 
+const MOCK_ELEMENTS = [
+	createMockElementData( {
+		widgetType: 'e-component',
+		elType: 'widget',
+	} ),
+];
+
 describe( 'loadComponentsAssets', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -67,7 +74,7 @@ describe( 'loadComponentsAssets', () => {
 		mockGetComponentDocuments.mockResolvedValue( documents );
 
 		// Act
-		await loadComponentsAssets( [] );
+		await loadComponentsAssets( MOCK_ELEMENTS );
 
 		// Assert
 		expect( mockSetDocument ).toHaveBeenCalledTimes( expectedSetDocumentCalls.length );
@@ -76,12 +83,22 @@ describe( 'loadComponentsAssets', () => {
 		} );
 	} );
 
+	it( 'should return early when elements array is empty', async () => {
+		// Act
+		await loadComponentsAssets( [] );
+
+		// Assert
+		expect( mockGetComponentDocuments ).not.toHaveBeenCalled();
+		expect( mockSetDocument ).not.toHaveBeenCalled();
+		expect( mockLoadComponentsOverridableProps ).not.toHaveBeenCalled();
+	} );
+
 	it( 'should not call setDocument when documents map is empty', async () => {
 		// Arrange
 		mockGetComponentDocuments.mockResolvedValue( createDocumentsMap( [] ) );
 
 		// Act
-		await loadComponentsAssets( [] );
+		await loadComponentsAssets( MOCK_ELEMENTS );
 
 		// Assert
 		expect( mockSetDocument ).not.toHaveBeenCalled();
@@ -96,7 +113,7 @@ describe( 'loadComponentsAssets', () => {
 		mockGetComponentDocuments.mockResolvedValue( documents );
 
 		// Act
-		await loadComponentsAssets( [] );
+		await loadComponentsAssets( MOCK_ELEMENTS );
 
 		// Assert
 		expect( mockLoadComponentsOverridableProps ).toHaveBeenCalledWith( [

--- a/packages/packages/core/editor-components/src/store/actions/load-components-assets.ts
+++ b/packages/packages/core/editor-components/src/store/actions/load-components-assets.ts
@@ -6,6 +6,10 @@ import { type ComponentDocumentsMap, getComponentDocuments } from '../../utils/g
 import { loadComponentsOverridableProps } from './load-components-overridable-props';
 
 export async function loadComponentsAssets( elements: V1ElementData[] ) {
+	if ( ! elements.length ) {
+		return;
+	}
+
 	const documents = await getComponentDocuments( { elements, isRecursive: false } );
 
 	updateDocumentState( documents );

--- a/packages/packages/core/editor-components/src/sync/__tests__/load-component-data-after-instance-added.test.ts
+++ b/packages/packages/core/editor-components/src/sync/__tests__/load-component-data-after-instance-added.test.ts
@@ -48,6 +48,28 @@ describe( 'initLoadComponentDataAfterInstanceAdded', () => {
 		}
 	);
 
+	it( 'should skip containers without a model', () => {
+		// Arrange
+		initLoadComponentDataAfterInstanceAdded();
+
+		const callback = getRegisteredCallback( 'document/elements/paste' );
+
+		const mockElement = createMockElement( {
+			model: {
+				id: 'element-1',
+				widgetType: 'e-component',
+				elType: 'widget',
+			},
+		} );
+
+		// Act
+		callback( {}, [ mockElement, {} as ReturnType< typeof createMockElement > ] );
+
+		// Assert
+		expect( mockLoadComponentsAssets ).toHaveBeenCalledTimes( 1 );
+		expect( mockLoadComponentsAssets ).toHaveBeenCalledWith( [ mockElement.model.toJSON() ] );
+	} );
+
 	it( 'should handle array of elements', () => {
 		// Arrange
 		initLoadComponentDataAfterInstanceAdded();

--- a/packages/packages/core/editor-components/src/sync/load-component-data-after-instance-added.ts
+++ b/packages/packages/core/editor-components/src/sync/load-component-data-after-instance-added.ts
@@ -14,7 +14,14 @@ export function initLoadComponentDataAfterInstanceAdded() {
 }
 
 function load( result: V1Element | V1Element[] ) {
-	const containers = Array.isArray( result ) ? result : [ result ];
+	if ( ! result ) {
+		return;
+	}
 
-	loadComponentsAssets( containers.map( ( container ) => container.model.toJSON() as V1ElementData ) );
+	const containers = Array.isArray( result ) ? result : [ result ];
+	const elements = containers
+		.map( ( container ) => container.model?.toJSON() as V1ElementData | undefined )
+		.filter( ( element ): element is V1ElementData => !! element );
+
+	loadComponentsAssets( elements );
 }

--- a/packages/packages/core/editor-components/src/utils/__tests__/get-component-documents.test.ts
+++ b/packages/packages/core/editor-components/src/utils/__tests__/get-component-documents.test.ts
@@ -24,6 +24,35 @@ describe( 'getComponentDocuments', () => {
 		expect( result.size ).toBe( 0 );
 	} );
 
+	it( 'should ignore undefined elements', async () => {
+		// Arrange
+		const componentId = 123;
+		const mockDocument = createMockDocumentData( { id: componentId } );
+		mockGetComponentDocumentData.mockResolvedValueOnce( mockDocument );
+
+		const elements = [
+			undefined,
+			createMockElementData( {
+				widgetType: 'e-component',
+				settings: {
+					component_instance: {
+						$$type: 'component-instance',
+						value: {
+							component_id: { $$type: 'number', value: componentId },
+						},
+					},
+				},
+			} ),
+		] as V1ElementData[];
+
+		// Act
+		const result = await getComponentDocuments( { elements } );
+
+		// Assert
+		expect( result.size ).toBe( 1 );
+		expect( result.has( componentId ) ).toBe( true );
+	} );
+
 	it( 'should return empty map for non-component elements', async () => {
 		// Arrange
 		const elements = [

--- a/packages/packages/core/editor-components/src/utils/get-component-documents.ts
+++ b/packages/packages/core/editor-components/src/utils/get-component-documents.ts
@@ -30,7 +30,7 @@ async function getComponentIds(
 	isRecursive: boolean
 ): Promise< number[] > {
 	const results = await Promise.all(
-		elements.map( async ( { widgetType, elType, elements: childElements, settings } ) => {
+		elements.filter( Boolean ).map( async ( { widgetType, elType, elements: childElements, settings } ) => {
 			const ids: number[] = [];
 
 			if ( isComponentInstance( { widgetType, elType } ) ) {


### PR DESCRIPTION
## Summary
- Filter invalid paste/import containers before loading component assets
- Ignore falsy entries in `getComponentDocuments` traversal
- Guard atomic widget local style ID regeneration when container models are missing

## Test plan
- [x] `npx jest packages/core/editor-components/src/sync/__tests__/load-component-data-after-instance-added.test.ts packages/core/editor-components/src/utils/__tests__/get-component-documents.test.ts`
- [ ] Paste a component instance in the editor and confirm no JS console errors
- [ ] Paste/import elements that include component instances with nested children


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Editor crashes during paste when component instances lack valid models (null/undefined). PR hardens the paste flow by adding null checks at multiple layers to gracefully skip invalid data rather than throw.

## 2. What Changed (Where)

- **load-components-assets.ts**: Added early return for empty elements array; also guards downstream in get-component-documents.ts with `.filter(Boolean)` 
- **load-component-data-after-instance-added.ts**: Filters containers to only include those with valid models before JSON serialization
- **get-element-children.js & regenerate-local-style-ids.js**: Added null checks for model parameter to return safe defaults
- **Tests**: Added coverage for empty/undefined element scenarios across three test suites

## 3. How It Works

Paste flow now validates at each stage: `load()` filters result containers by model existence → maps to JSON → passes validated elements to `loadComponentsAssets()` → downstream utilities defensively handle null inputs. Falsy elements are silently filtered rather than propagating through the chain.

## 4. Risks

None material. Changes are purely defensive with no logic inversions. Early returns and filters maintain existing behavior for valid data while preventing crashes on malformed input. Test coverage added for new guards.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
