### PR TITLE
Internal: Add insert_subtree method to Document_Mutator [ED-24826]

### DIFF
--- a/core/utils/document/document-mutator.php
+++ b/core/utils/document/document-mutator.php
@@ -136,6 +136,43 @@ class Document_Mutator {
 		return $result;
 	}
 
+	/**
+	 * Insert a subtree into the document tree, recursively generating IDs for all elements.
+	 *
+	 * @param array    $tree      The current document tree.
+	 * @param string   $parent_id Parent element ID or 'document' for root.
+	 * @param int|null $index     Insertion index (null = append).
+	 * @param array    $subtree   The subtree to insert (single element with nested children).
+	 *
+	 * @return array|\WP_Error The updated tree or error.
+	 */
+	public function insert_subtree( array $tree, string $parent_id, ?int $index, array $subtree ) {
+		$subtree_with_ids = $this->generate_ids_recursive( $subtree );
+
+		return $this->insert_at( $tree, $parent_id, $index, $subtree_with_ids );
+	}
+
+	/**
+	 * Recursively generate IDs for an element and all its children.
+	 * Always generates new IDs to avoid duplicates when inserting subtrees.
+	 *
+	 * @param array $element The element to process.
+	 *
+	 * @return array The element with new IDs assigned.
+	 */
+	private function generate_ids_recursive( array $element ): array {
+		$element['id'] = $this->generate_id();
+
+		if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
+			$element['elements'] = array_map(
+				fn( array $child ) => $this->generate_ids_recursive( $child ),
+				$element['elements']
+			);
+		}
+
+		return $element;
+	}
+
 	private function splice_into( array $children, ?int $index, array $element ): array {
 		$count = count( $children );
 

--- a/tests/phpunit/core/utils/document/test-document-mutator.php
+++ b/tests/phpunit/core/utils/document/test-document-mutator.php
@@ -308,6 +308,122 @@ class Document_Mutator_Test extends TestCase {
 		$this->assertSame( $original, $tree );
 	}
 
+	// insert_subtree
+
+	public function test_insert_subtree_generates_ids_for_all_elements() {
+		// Arrange
+		$subtree = [
+			'elType' => 'container',
+			'settings' => [],
+			'elements' => [
+				[ 'elType' => 'widget', 'widgetType' => 'text-editor', 'settings' => [], 'elements' => [] ],
+				[ 'elType' => 'widget', 'widgetType' => 'text-editor', 'settings' => [], 'elements' => [] ],
+			],
+		];
+		$tree = [ $this->make_container( 'c1' ) ];
+
+		// Act
+		$result = $this->mutator->insert_subtree( $tree, 'document', null, $subtree );
+
+		// Assert
+		$this->assertIsArray( $result );
+		$this->assertCount( 2, $result );
+
+		$inserted = $result[1];
+		$this->assertNotEmpty( $inserted['id'] );
+		$this->assertNotEmpty( $inserted['elements'][0]['id'] );
+		$this->assertNotEmpty( $inserted['elements'][1]['id'] );
+
+		$this->assertNotEquals( $inserted['id'], $inserted['elements'][0]['id'] );
+		$this->assertNotEquals( $inserted['elements'][0]['id'], $inserted['elements'][1]['id'] );
+	}
+
+	public function test_insert_subtree_always_regenerates_ids() {
+		// Arrange
+		$subtree = [
+			'id' => 'my-custom-id',
+			'elType' => 'container',
+			'settings' => [],
+			'elements' => [
+				[ 'id' => 'child-1', 'elType' => 'widget', 'widgetType' => 'text-editor', 'settings' => [], 'elements' => [] ],
+				[ 'elType' => 'widget', 'widgetType' => 'text-editor', 'settings' => [], 'elements' => [] ],
+			],
+		];
+		$tree = [];
+
+		// Act
+		$result = $this->mutator->insert_subtree( $tree, 'document', null, $subtree );
+
+		// Assert - all IDs should be regenerated, never preserved
+		$inserted = $result[0];
+		$this->assertNotSame( 'my-custom-id', $inserted['id'] );
+		$this->assertNotEmpty( $inserted['id'] );
+		$this->assertNotSame( 'child-1', $inserted['elements'][0]['id'] );
+		$this->assertNotEmpty( $inserted['elements'][0]['id'] );
+		$this->assertNotEmpty( $inserted['elements'][1]['id'] );
+	}
+
+	public function test_insert_subtree_into_parent_container() {
+		// Arrange
+		$subtree = [
+			'elType' => 'widget',
+			'widgetType' => 'text-editor',
+			'settings' => [],
+			'elements' => [],
+		];
+		$tree = [ $this->make_container( 'c1' ) ];
+
+		// Act
+		$result = $this->mutator->insert_subtree( $tree, 'c1', null, $subtree );
+
+		// Assert
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result[0]['elements'] );
+		$this->assertNotEmpty( $result[0]['elements'][0]['id'] );
+	}
+
+	public function test_insert_subtree_handles_deeply_nested_elements() {
+		// Arrange
+		$subtree = [
+			'elType' => 'container',
+			'settings' => [],
+			'elements' => [
+				[
+					'elType' => 'container',
+					'settings' => [],
+					'elements' => [
+						[
+							'elType' => 'container',
+							'settings' => [],
+							'elements' => [
+								[ 'elType' => 'widget', 'widgetType' => 'text-editor', 'settings' => [], 'elements' => [] ],
+							],
+						],
+					],
+				],
+			],
+		];
+		$tree = [];
+
+		// Act
+		$result = $this->mutator->insert_subtree( $tree, 'document', null, $subtree );
+
+		// Assert
+		$inserted = $result[0];
+		$this->assertNotEmpty( $inserted['id'] );
+		$this->assertNotEmpty( $inserted['elements'][0]['id'] );
+		$this->assertNotEmpty( $inserted['elements'][0]['elements'][0]['id'] );
+		$this->assertNotEmpty( $inserted['elements'][0]['elements'][0]['elements'][0]['id'] );
+
+		$all_ids = [
+			$inserted['id'],
+			$inserted['elements'][0]['id'],
+			$inserted['elements'][0]['elements'][0]['id'],
+			$inserted['elements'][0]['elements'][0]['elements'][0]['id'],
+		];
+		$this->assertCount( 4, array_unique( $all_ids ) );
+	}
+
 	// Helpers
 
 	private function assertWPError( $value, string $code ): void {


### PR DESCRIPTION
## Summary

Add `insert_subtree()` method to `Document_Mutator` for inserting element subtrees into the document tree at a specified parent and optional index position.

The method generates new unique IDs for all elements in the inserted subtree to avoid ID collisions.

## Changes

- Add `insert_subtree(array $tree, string $parent_id, ?int $index, array $subtree): array` method
- Add private `generate_ids_recursive(array $element): array` helper method
- Add corresponding unit tests

## Test plan

- [x] Unit tests added for insert_subtree method
- [ ] Verify existing Document_Mutator functionality is not affected

Ref: ED-24826

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds `insert_subtree` method to `Document_Mutator` to safely insert document fragments while automatically generating unique IDs for all nested elements, preventing ID collisions when pasting/duplicating content (ED-24826).

## 2. What Changed (Where)

- `document-mutator.php`: Two new methods—`insert_subtree()` delegates to existing `insert_at()` after ID generation; `generate_ids_recursive()` recursively assigns new IDs to element tree.
- `test-document-mutator.php`: Four test cases covering basic insertion, ID regeneration on existing IDs, parent container targeting, and deep nesting scenarios.

## 3. How It Works

Entry point is `insert_subtree($tree, $parent_id, $index, $subtree)`, which calls `generate_ids_recursive()` to walk the subtree depth-first, assigning fresh IDs via `generate_id()` to root and all children, then delegates positioning to existing `insert_at()`. Always regenerates IDs (never preserves input IDs) to guarantee uniqueness.

## 4. Risks

None identified. Reuses battle-tested `insert_at()` for placement logic; recursive ID generation is straightforward and well-tested across nested structures; no breaking changes to existing API.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
