### PR TITLE
Internal: Add to_json_schema() method to prop types [ED-24826]

### DIFF
--- a/modules/atomic-widgets/prop-types/base/array-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/array-prop-type.php
@@ -125,7 +125,7 @@ abstract class Array_Prop_Type implements Transformable_Prop_Type {
 		return $this->dependencies;
 	}
 
-	public function to_json_schema( bool $suppress_dynamic = false ): array {
+	public function to_json_schema(): array {
 		$schema = $this->with_json_schema_meta( [] );
 
 		$schema['type'] = 'object';
@@ -133,7 +133,7 @@ abstract class Array_Prop_Type implements Transformable_Prop_Type {
 		$value_schema = [ 'type' => 'array' ];
 
 		if ( $this->get_item_type() ) {
-			$value_schema['items'] = $this->get_item_type()->to_json_schema( $suppress_dynamic );
+			$value_schema['items'] = $this->get_item_type()->to_json_schema();
 		}
 
 		$schema['properties'] = [

--- a/modules/atomic-widgets/prop-types/base/array-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/array-prop-type.php
@@ -22,6 +22,7 @@ abstract class Array_Prop_Type implements Transformable_Prop_Type {
 	use Concerns\Has_Settings;
 	use Concerns\Has_Transformable_Validation;
 	use Concerns\Has_Initial_Value;
+	use Concerns\Has_Json_Schema_Meta;
 
 	protected Prop_Type $item_type;
 
@@ -122,5 +123,27 @@ abstract class Array_Prop_Type implements Transformable_Prop_Type {
 
 	public function get_dependencies(): ?array {
 		return $this->dependencies;
+	}
+
+	public function to_json_schema( bool $suppress_dynamic = false ): array {
+		$schema = $this->with_json_schema_meta( [] );
+
+		$schema['type'] = 'object';
+
+		$value_schema = [ 'type' => 'array' ];
+
+		if ( $this->get_item_type() ) {
+			$value_schema['items'] = $this->get_item_type()->to_json_schema( $suppress_dynamic );
+		}
+
+		$schema['properties'] = [
+			'$$type' => [
+				'type' => 'string',
+				'const' => static::get_key(),
+			],
+			'value' => $value_schema,
+		];
+
+		return $schema;
 	}
 }

--- a/modules/atomic-widgets/prop-types/base/object-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/object-prop-type.php
@@ -170,7 +170,7 @@ abstract class Object_Prop_Type implements Transformable_Prop_Type {
 		return $this;
 	}
 
-	public function to_json_schema( bool $suppress_dynamic = false ): array {
+	public function to_json_schema(): array {
 		$schema = $this->with_json_schema_meta( [] );
 
 		$schema['type'] = 'object';
@@ -179,7 +179,7 @@ abstract class Object_Prop_Type implements Transformable_Prop_Type {
 		$value_required = [];
 
 		foreach ( $this->get_shape() as $key => $prop_type ) {
-			$value_properties[ $key ] = $prop_type->to_json_schema( $suppress_dynamic );
+			$value_properties[ $key ] = $prop_type->to_json_schema();
 
 			if ( $prop_type->get_setting( 'required', false ) ) {
 				$value_required[] = $key;

--- a/modules/atomic-widgets/prop-types/base/object-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/object-prop-type.php
@@ -23,6 +23,7 @@ abstract class Object_Prop_Type implements Transformable_Prop_Type {
 	use Concerns\Has_Settings;
 	use Concerns\Has_Transformable_Validation;
 	use Concerns\Has_Initial_Value;
+	use Concerns\Has_Json_Schema_Meta;
 
 	/**
 	 * @var array<Prop_Type>
@@ -167,5 +168,43 @@ abstract class Object_Prop_Type implements Transformable_Prop_Type {
 		}
 
 		return $this;
+	}
+
+	public function to_json_schema( bool $suppress_dynamic = false ): array {
+		$schema = $this->with_json_schema_meta( [] );
+
+		$schema['type'] = 'object';
+
+		$value_properties = [];
+		$value_required = [];
+
+		foreach ( $this->get_shape() as $key => $prop_type ) {
+			$value_properties[ $key ] = $prop_type->to_json_schema( $suppress_dynamic );
+
+			if ( $prop_type->get_setting( 'required', false ) ) {
+				$value_required[] = $key;
+			}
+		}
+
+		$value_schema = [
+			'type' => 'object',
+			'properties' => $value_properties,
+			'additionalProperties' => false,
+		];
+
+		if ( ! empty( $value_required ) ) {
+			$value_schema['required'] = $value_required;
+		}
+
+		$schema['properties'] = [
+			'$$type' => [
+				'type' => 'string',
+				'const' => static::get_key(),
+			],
+			'value' => $value_schema,
+		];
+		$schema['required'] = [ '$$type', 'value' ];
+
+		return $schema;
 	}
 }

--- a/modules/atomic-widgets/prop-types/base/plain-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/plain-prop-type.php
@@ -97,14 +97,16 @@ abstract class Plain_Prop_Type implements Transformable_Prop_Type {
 	}
 
 	public function to_json_schema(): array {
-		return $this->envelope_json_schema( [ 'type' => 'object' ] );
+		return $this->wrap_json_schema( [ 'type' => 'object' ] );
 	}
 
 	/**
-	 * Builds the `{$$type, value}` envelope shared by the primitive prop types (string/number/boolean).
+	 * Wraps the given value schema in the `{$$type, value}` shape shared by the primitive
+	 * prop types (string/number/boolean). Additional JSON schema meta may be provided by
+	 * subclasses (e.g. `title`, custom `description` overrides).
 	 */
-	protected function envelope_json_schema( array $value_schema ): array {
-		$schema = $this->with_json_schema_meta( [] );
+	protected function wrap_json_schema( array $value_schema, array $json_schema_meta = [] ): array {
+		$schema = $this->with_json_schema_meta( $json_schema_meta );
 
 		$schema['type'] = 'object';
 		$schema['properties'] = [

--- a/modules/atomic-widgets/prop-types/base/plain-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/plain-prop-type.php
@@ -96,20 +96,8 @@ abstract class Plain_Prop_Type implements Transformable_Prop_Type {
 		return $this->dependencies;
 	}
 
-	/**
-	 * Fallback JSON Schema for plain prop types that don't override this method (e.g. `classes`,
-	 * `dynamic`, `overridable`). Mirrors the frontend's `propTypeToJsonSchema` default case, which
-	 * only special-cases `string`/`number`/`boolean`/`unknown`.
-	 */
-	public function to_json_schema( bool $suppress_dynamic = false ): array {
-		$schema = $this->with_json_schema_meta( [] );
-
-		$schema['type'] = 'object';
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$schema['$$type'] = $this->get_type();
-		$schema['value'] = [ 'type' => $this->get_type() ];
-
-		return $schema;
+	public function to_json_schema(): array {
+		return $this->envelope_json_schema( [ 'type' => 'object' ] );
 	}
 
 	/**

--- a/modules/atomic-widgets/prop-types/base/plain-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/plain-prop-type.php
@@ -21,6 +21,7 @@ abstract class Plain_Prop_Type implements Transformable_Prop_Type {
 	use Concerns\Has_Settings;
 	use Concerns\Has_Transformable_Validation;
 	use Concerns\Has_Initial_Value;
+	use Concerns\Has_Json_Schema_Meta;
 
 	/**
 	 * @return array<Plain_Prop_Type>
@@ -93,5 +94,40 @@ abstract class Plain_Prop_Type implements Transformable_Prop_Type {
 
 	public function get_dependencies(): ?array {
 		return $this->dependencies;
+	}
+
+	/**
+	 * Fallback JSON Schema for plain prop types that don't override this method (e.g. `classes`,
+	 * `dynamic`, `overridable`). Mirrors the frontend's `propTypeToJsonSchema` default case, which
+	 * only special-cases `string`/`number`/`boolean`/`unknown`.
+	 */
+	public function to_json_schema( bool $suppress_dynamic = false ): array {
+		$schema = $this->with_json_schema_meta( [] );
+
+		$schema['type'] = 'object';
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$schema['$$type'] = $this->get_type();
+		$schema['value'] = [ 'type' => $this->get_type() ];
+
+		return $schema;
+	}
+
+	/**
+	 * Builds the `{$$type, value}` envelope shared by the primitive prop types (string/number/boolean).
+	 */
+	protected function envelope_json_schema( array $value_schema ): array {
+		$schema = $this->with_json_schema_meta( [] );
+
+		$schema['type'] = 'object';
+		$schema['properties'] = [
+			'$$type' => [
+				'type' => 'string',
+				'const' => static::get_key(),
+			],
+			'value' => $value_schema,
+		];
+		$schema['required'] = [ '$$type', 'value' ];
+
+		return $schema;
 	}
 }

--- a/modules/atomic-widgets/prop-types/base/unknown-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/unknown-prop-type.php
@@ -48,7 +48,11 @@ class Unknown_Prop_Type implements Prop_Type {
 		return null;
 	}
 
-	public function to_json_schema( bool $suppress_dynamic = false ): array {
+	public function to_json_schema(): array {
+		return [];
+	}
+
+	public function get_aliases(): array {
 		return [];
 	}
 

--- a/modules/atomic-widgets/prop-types/base/unknown-prop-type.php
+++ b/modules/atomic-widgets/prop-types/base/unknown-prop-type.php
@@ -48,6 +48,10 @@ class Unknown_Prop_Type implements Prop_Type {
 		return null;
 	}
 
+	public function to_json_schema( bool $suppress_dynamic = false ): array {
+		return [];
+	}
+
 	public function jsonSerialize(): array {
 		return [
 			'kind' => 'unknown',

--- a/modules/atomic-widgets/prop-types/classes-prop-type.php
+++ b/modules/atomic-widgets/prop-types/classes-prop-type.php
@@ -45,7 +45,7 @@ class Classes_Prop_Type extends Plain_Prop_Type {
 	}
 
 	public function to_json_schema(): array {
-		return $this->envelope_json_schema( [
+		return $this->wrap_json_schema( [
 			'type' => 'array',
 			'items' => [ 'type' => 'string' ],
 		] );

--- a/modules/atomic-widgets/prop-types/classes-prop-type.php
+++ b/modules/atomic-widgets/prop-types/classes-prop-type.php
@@ -43,4 +43,11 @@ class Classes_Prop_Type extends Plain_Prop_Type {
 			return ! empty( $class_name );
 		});
 	}
+
+	public function to_json_schema(): array {
+		return $this->envelope_json_schema( [
+			'type' => 'array',
+			'items' => [ 'type' => 'string' ],
+		] );
+	}
 }

--- a/modules/atomic-widgets/prop-types/concerns/has-json-schema-meta.php
+++ b/modules/atomic-widgets/prop-types/concerns/has-json-schema-meta.php
@@ -7,6 +7,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 trait Has_Json_Schema_Meta {
+	/**
+	 * Enriches the given JSON schema fragment with prop-type meta (e.g. `description`).
+	 * Callers typically pass an empty array to start a fresh meta bag, but may pass
+	 * pre-existing schema keys that should be preserved alongside the meta.
+	 */
 	protected function with_json_schema_meta( array $schema ): array {
 		$description = $this->get_meta_item( 'description' );
 

--- a/modules/atomic-widgets/prop-types/concerns/has-json-schema-meta.php
+++ b/modules/atomic-widgets/prop-types/concerns/has-json-schema-meta.php
@@ -14,12 +14,6 @@ trait Has_Json_Schema_Meta {
 			$schema['description'] = $description;
 		}
 
-		$initial_value = $this->get_initial_value();
-
-		if ( null !== $initial_value ) {
-			$schema['examples'] = [ $initial_value ];
-		}
-
 		return $schema;
 	}
 }

--- a/modules/atomic-widgets/prop-types/concerns/has-json-schema-meta.php
+++ b/modules/atomic-widgets/prop-types/concerns/has-json-schema-meta.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\PropTypes\Concerns;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+trait Has_Json_Schema_Meta {
+	protected function with_json_schema_meta( array $schema ): array {
+		$description = $this->get_meta_item( 'description' );
+
+		if ( $description ) {
+			$schema['description'] = $description;
+		}
+
+		$initial_value = $this->get_initial_value();
+
+		if ( null !== $initial_value ) {
+			$schema['examples'] = [ $initial_value ];
+		}
+
+		return $schema;
+	}
+}

--- a/modules/atomic-widgets/prop-types/concerns/has-meta.php
+++ b/modules/atomic-widgets/prop-types/concerns/has-meta.php
@@ -53,4 +53,10 @@ trait Has_Meta {
 	public function get_meta_item( $key, $default_value = null ) {
 		return array_key_exists( $key, $this->meta ) ? $this->meta[ $key ] : $default_value;
 	}
+
+	public function get_aliases(): array {
+		$aliases = $this->meta['aliases'] ?? [];
+
+		return is_array( $aliases ) ? $aliases : [];
+	}
 }

--- a/modules/atomic-widgets/prop-types/contracts/prop-type.php
+++ b/modules/atomic-widgets/prop-types/contracts/prop-type.php
@@ -34,10 +34,7 @@ interface Prop_Type extends \JsonSerializable {
 	 * Returns a JSON Schema representation of this prop type's enveloped ({$$type, value}) input
 	 * format, mirroring the frontend's propTypeToJsonSchema converter.
 	 *
-	 * @param bool $suppress_dynamic When true, an ancestor union already offered the "dynamic" option
-	 *                               for this branch, so nested unions should not offer it again.
-	 *
 	 * @return array JSON Schema array.
 	 */
-	public function to_json_schema( bool $suppress_dynamic = false ): array;
+	public function to_json_schema(): array;
 }

--- a/modules/atomic-widgets/prop-types/contracts/prop-type.php
+++ b/modules/atomic-widgets/prop-types/contracts/prop-type.php
@@ -21,4 +21,23 @@ interface Prop_Type extends \JsonSerializable {
 	public function set_dependencies( ?array $dependencies ): self;
 	public function get_dependencies(): ?array;
 	public function get_initial_value();
+
+	/**
+	 * Returns the list of alias names for this prop type.
+	 * Aliases allow the LLM to use alternative names for the same prop.
+	 *
+	 * @return string[]
+	 */
+	public function get_aliases(): array;
+
+	/**
+	 * Returns a JSON Schema representation of this prop type's enveloped ({$$type, value}) input
+	 * format, mirroring the frontend's propTypeToJsonSchema converter.
+	 *
+	 * @param bool $suppress_dynamic When true, an ancestor union already offered the "dynamic" option
+	 *                               for this branch, so nested unions should not offer it again.
+	 *
+	 * @return array JSON Schema array.
+	 */
+	public function to_json_schema( bool $suppress_dynamic = false ): array;
 }

--- a/modules/atomic-widgets/prop-types/primitives/boolean-prop-type.php
+++ b/modules/atomic-widgets/prop-types/primitives/boolean-prop-type.php
@@ -26,6 +26,6 @@ class Boolean_Prop_Type extends Plain_Prop_Type {
 	}
 
 	public function to_json_schema(): array {
-		return $this->envelope_json_schema( [ 'type' => 'boolean' ] );
+		return $this->wrap_json_schema( [ 'type' => 'boolean' ] );
 	}
 }

--- a/modules/atomic-widgets/prop-types/primitives/boolean-prop-type.php
+++ b/modules/atomic-widgets/prop-types/primitives/boolean-prop-type.php
@@ -24,4 +24,8 @@ class Boolean_Prop_Type extends Plain_Prop_Type {
 	protected function sanitize_value( $value ) {
 		return (bool) $value;
 	}
+
+	public function to_json_schema( bool $suppress_dynamic = false ): array {
+		return $this->envelope_json_schema( [ 'type' => 'boolean' ] );
+	}
 }

--- a/modules/atomic-widgets/prop-types/primitives/boolean-prop-type.php
+++ b/modules/atomic-widgets/prop-types/primitives/boolean-prop-type.php
@@ -25,7 +25,7 @@ class Boolean_Prop_Type extends Plain_Prop_Type {
 		return (bool) $value;
 	}
 
-	public function to_json_schema( bool $suppress_dynamic = false ): array {
+	public function to_json_schema(): array {
 		return $this->envelope_json_schema( [ 'type' => 'boolean' ] );
 	}
 }

--- a/modules/atomic-widgets/prop-types/primitives/number-prop-type.php
+++ b/modules/atomic-widgets/prop-types/primitives/number-prop-type.php
@@ -32,4 +32,8 @@ class Number_Prop_Type extends Plain_Prop_Type {
 	protected function sanitize_value( $value ) {
 		return $this->is_float ? (float) $value : (int) $value;
 	}
+
+	public function to_json_schema( bool $suppress_dynamic = false ): array {
+		return $this->envelope_json_schema( [ 'type' => 'number' ] );
+	}
 }

--- a/modules/atomic-widgets/prop-types/primitives/number-prop-type.php
+++ b/modules/atomic-widgets/prop-types/primitives/number-prop-type.php
@@ -33,7 +33,7 @@ class Number_Prop_Type extends Plain_Prop_Type {
 		return $this->is_float ? (float) $value : (int) $value;
 	}
 
-	public function to_json_schema( bool $suppress_dynamic = false ): array {
+	public function to_json_schema(): array {
 		return $this->envelope_json_schema( [ 'type' => 'number' ] );
 	}
 }

--- a/modules/atomic-widgets/prop-types/primitives/number-prop-type.php
+++ b/modules/atomic-widgets/prop-types/primitives/number-prop-type.php
@@ -34,6 +34,6 @@ class Number_Prop_Type extends Plain_Prop_Type {
 	}
 
 	public function to_json_schema(): array {
-		return $this->envelope_json_schema( [ 'type' => 'number' ] );
+		return $this->wrap_json_schema( [ 'type' => 'number' ] );
 	}
 }

--- a/modules/atomic-widgets/prop-types/primitives/string-prop-type.php
+++ b/modules/atomic-widgets/prop-types/primitives/string-prop-type.php
@@ -75,4 +75,15 @@ class String_Prop_Type extends Plain_Prop_Type {
 			return $leading . sanitize_text_field( $value ) . $trailing;
 		}, $value );
 	}
+
+	public function to_json_schema( bool $suppress_dynamic = false ): array {
+		$value_schema = [ 'type' => 'string' ];
+
+		$enum = $this->get_enum();
+		if ( $enum ) {
+			$value_schema['enum'] = $enum;
+		}
+
+		return $this->envelope_json_schema( $value_schema );
+	}
 }

--- a/modules/atomic-widgets/prop-types/primitives/string-prop-type.php
+++ b/modules/atomic-widgets/prop-types/primitives/string-prop-type.php
@@ -84,6 +84,6 @@ class String_Prop_Type extends Plain_Prop_Type {
 			$value_schema['enum'] = $enum;
 		}
 
-		return $this->envelope_json_schema( $value_schema );
+		return $this->wrap_json_schema( $value_schema );
 	}
 }

--- a/modules/atomic-widgets/prop-types/primitives/string-prop-type.php
+++ b/modules/atomic-widgets/prop-types/primitives/string-prop-type.php
@@ -76,7 +76,7 @@ class String_Prop_Type extends Plain_Prop_Type {
 		}, $value );
 	}
 
-	public function to_json_schema( bool $suppress_dynamic = false ): array {
+	public function to_json_schema(): array {
 		$value_schema = [ 'type' => 'string' ];
 
 		$enum = $this->get_enum();

--- a/modules/atomic-widgets/prop-types/union-prop-type.php
+++ b/modules/atomic-widgets/prop-types/union-prop-type.php
@@ -26,41 +26,6 @@ class Union_Prop_Type implements Prop_Type {
 
 	private ?array $dependencies = null;
 
-	/**
-	 * Variant keys (e.g. `overridable`) that should never be advertised in the JSON schema.
-	 * Populated by the owning modules via `register_omitted_variant_key()` when they boot, so this
-	 * class doesn't need to know about specific prop types (e.g. `Overridable_Prop_Type`) by name.
-	 *
-	 * @var array<string, true>
-	 */
-	private static array $omitted_variant_keys = [];
-
-	/**
-	 * Variant keys (e.g. `dynamic`) that are advertised at most once per branch, via a custom schema
-	 * builder, and suppressed for descendants of the node that offered them. Populated the same way
-	 * as `$omitted_variant_keys`.
-	 *
-	 * @var array<string, callable>
-	 */
-	private static array $exclusive_variant_builders = [];
-
-	public static function register_omitted_variant_key( string $key ): void {
-		self::$omitted_variant_keys[ $key ] = true;
-	}
-
-	public static function register_exclusive_variant( string $key, callable $schema_builder ): void {
-		self::$exclusive_variant_builders[ $key ] = $schema_builder;
-	}
-
-	/**
-	 * Resets the state populated by `register_omitted_variant_key()`/`register_exclusive_variant()`.
-	 * Intended for tests that register their own variants and need a clean slate between cases.
-	 */
-	public static function reset_registered_variants(): void {
-		self::$omitted_variant_keys = [];
-		self::$exclusive_variant_builders = [];
-	}
-
 	/** @var Array<string, Transformable_Prop_Type> */
 	protected array $prop_types = [];
 
@@ -209,55 +174,14 @@ class Union_Prop_Type implements Prop_Type {
 		return $this;
 	}
 
-	/**
-	 * An "exclusive" variant (e.g. `dynamic`) replaces the value of the exact node it is attached to,
-	 * which may be a nested field (e.g. an image's `src`) rather than the property root. It is
-	 * advertised once per branch, at the outermost prop type that supports it, and suppressed for
-	 * descendants of that node to avoid offering the same option twice on a single branch.
-	 *
-	 * Which variant keys are omitted or exclusive is not known to this class: it is populated by the
-	 * owning modules via `register_omitted_variant_key()`/`register_exclusive_variant()` when they
-	 * boot, keeping this class decoupled from specific prop types (e.g. `dynamic`, `overridable`).
-	 */
-	public function to_json_schema( bool $suppress_dynamic = false ): array {
-		$prop_types = $this->get_prop_types();
-		$offers_exclusive_variant = ! $suppress_dynamic && $this->has_exclusive_variant( $prop_types );
-		$suppress_nested_exclusive_variant = $suppress_dynamic || $offers_exclusive_variant;
-
-		$schemas = [];
-
-		foreach ( $prop_types as $key => $prop_type ) {
-			if ( isset( self::$omitted_variant_keys[ $key ] ) ) {
-				continue;
-			}
-
-			if ( isset( self::$exclusive_variant_builders[ $key ] ) ) {
-				if ( $offers_exclusive_variant ) {
-					$schemas[] = call_user_func( self::$exclusive_variant_builders[ $key ], $prop_type );
-				}
-
-				continue;
-			}
-
-			$schemas[] = $prop_type->to_json_schema( $suppress_nested_exclusive_variant );
-		}
-
+	public function to_json_schema(): array {
 		$schema = $this->with_json_schema_meta( [] );
 
-		if ( ! empty( $schemas ) ) {
-			$schema['anyOf'] = $schemas;
-		}
+		$schema['anyOf'] = array_map(
+			fn( $prop_type ) => $prop_type->to_json_schema(),
+			array_values( $this->get_prop_types() )
+		);
 
 		return $schema;
-	}
-
-	private function has_exclusive_variant( array $prop_types ): bool {
-		foreach ( array_keys( $prop_types ) as $key ) {
-			if ( isset( self::$exclusive_variant_builders[ $key ] ) ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 }

--- a/modules/atomic-widgets/prop-types/union-prop-type.php
+++ b/modules/atomic-widgets/prop-types/union-prop-type.php
@@ -18,12 +18,48 @@ class Union_Prop_Type implements Prop_Type {
 	use Concerns\Has_Meta;
 	use Concerns\Has_Settings;
 	use Concerns\Has_Required_Setting;
+	use Concerns\Has_Json_Schema_Meta;
 
 	protected $default = null;
 
 	protected $initial_value = null;
 
 	private ?array $dependencies = null;
+
+	/**
+	 * Variant keys (e.g. `overridable`) that should never be advertised in the JSON schema.
+	 * Populated by the owning modules via `register_omitted_variant_key()` when they boot, so this
+	 * class doesn't need to know about specific prop types (e.g. `Overridable_Prop_Type`) by name.
+	 *
+	 * @var array<string, true>
+	 */
+	private static array $omitted_variant_keys = [];
+
+	/**
+	 * Variant keys (e.g. `dynamic`) that are advertised at most once per branch, via a custom schema
+	 * builder, and suppressed for descendants of the node that offered them. Populated the same way
+	 * as `$omitted_variant_keys`.
+	 *
+	 * @var array<string, callable>
+	 */
+	private static array $exclusive_variant_builders = [];
+
+	public static function register_omitted_variant_key( string $key ): void {
+		self::$omitted_variant_keys[ $key ] = true;
+	}
+
+	public static function register_exclusive_variant( string $key, callable $schema_builder ): void {
+		self::$exclusive_variant_builders[ $key ] = $schema_builder;
+	}
+
+	/**
+	 * Resets the state populated by `register_omitted_variant_key()`/`register_exclusive_variant()`.
+	 * Intended for tests that register their own variants and need a clean slate between cases.
+	 */
+	public static function reset_registered_variants(): void {
+		self::$omitted_variant_keys = [];
+		self::$exclusive_variant_builders = [];
+	}
 
 	/** @var Array<string, Transformable_Prop_Type> */
 	protected array $prop_types = [];
@@ -171,5 +207,57 @@ class Union_Prop_Type implements Prop_Type {
 		}
 
 		return $this;
+	}
+
+	/**
+	 * An "exclusive" variant (e.g. `dynamic`) replaces the value of the exact node it is attached to,
+	 * which may be a nested field (e.g. an image's `src`) rather than the property root. It is
+	 * advertised once per branch, at the outermost prop type that supports it, and suppressed for
+	 * descendants of that node to avoid offering the same option twice on a single branch.
+	 *
+	 * Which variant keys are omitted or exclusive is not known to this class: it is populated by the
+	 * owning modules via `register_omitted_variant_key()`/`register_exclusive_variant()` when they
+	 * boot, keeping this class decoupled from specific prop types (e.g. `dynamic`, `overridable`).
+	 */
+	public function to_json_schema( bool $suppress_dynamic = false ): array {
+		$prop_types = $this->get_prop_types();
+		$offers_exclusive_variant = ! $suppress_dynamic && $this->has_exclusive_variant( $prop_types );
+		$suppress_nested_exclusive_variant = $suppress_dynamic || $offers_exclusive_variant;
+
+		$schemas = [];
+
+		foreach ( $prop_types as $key => $prop_type ) {
+			if ( isset( self::$omitted_variant_keys[ $key ] ) ) {
+				continue;
+			}
+
+			if ( isset( self::$exclusive_variant_builders[ $key ] ) ) {
+				if ( $offers_exclusive_variant ) {
+					$schemas[] = call_user_func( self::$exclusive_variant_builders[ $key ], $prop_type );
+				}
+
+				continue;
+			}
+
+			$schemas[] = $prop_type->to_json_schema( $suppress_nested_exclusive_variant );
+		}
+
+		$schema = $this->with_json_schema_meta( [] );
+
+		if ( ! empty( $schemas ) ) {
+			$schema['anyOf'] = $schemas;
+		}
+
+		return $schema;
+	}
+
+	private function has_exclusive_variant( array $prop_types ): bool {
+		foreach ( array_keys( $prop_types ) as $key ) {
+			if ( isset( self::$exclusive_variant_builders[ $key ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/modules/components/prop-types/overridable-prop-type.php
+++ b/modules/components/prop-types/overridable-prop-type.php
@@ -77,7 +77,7 @@ class Overridable_Prop_Type extends Plain_Prop_Type {
 	public function to_json_schema(): array {
 		$origin_prop_type = $this->get_origin_prop_type();
 
-		return $this->envelope_json_schema( [
+		return $this->wrap_json_schema( [
 			'type' => 'object',
 			'properties' => [
 				'override_key' => [ 'type' => 'string' ],

--- a/modules/components/prop-types/overridable-prop-type.php
+++ b/modules/components/prop-types/overridable-prop-type.php
@@ -73,4 +73,20 @@ class Overridable_Prop_Type extends Plain_Prop_Type {
 	public function get_origin_prop_type() {
 		return $this->settings['origin_prop_type'] ?? null;
 	}
+
+	public function to_json_schema(): array {
+		$origin_prop_type = $this->get_origin_prop_type();
+
+		return $this->envelope_json_schema( [
+			'type' => 'object',
+			'properties' => [
+				'override_key' => [ 'type' => 'string' ],
+				'origin_value' => $origin_prop_type
+					? $origin_prop_type->to_json_schema()
+					: [],
+			],
+			'required' => [ 'override_key', 'origin_value' ],
+			'additionalProperties' => false,
+		] );
+	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-prop-type-json-schema.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-prop-type-json-schema.php
@@ -5,11 +5,13 @@ namespace Elementor\Tests\Phpunit\Modules\AtomicWidgets\PropTypes;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Array_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Unknown_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Boolean_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
 use PHPUnit\Framework\TestCase;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -137,6 +139,42 @@ class Test_Prop_Type_Json_Schema extends TestCase {
 		$this->assertSame( [ 'type' => 'string', 'const' => 'test-array' ], $result['properties']['$$type'] );
 		$this->assertSame( 'array', $result['properties']['value']['type'] );
 		$this->assertArrayHasKey( 'items', $result['properties']['value'] );
+	}
+
+	public function test_to_json_schema__classes_prop_type() {
+		// Arrange
+		$prop_type = Classes_Prop_Type::make();
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertSame( 'object', $result['type'] );
+		$this->assertSame( [ 'type' => 'string', 'const' => 'classes' ], $result['properties']['$$type'] );
+		$this->assertSame(
+			[ 'type' => 'array', 'items' => [ 'type' => 'string' ] ],
+			$result['properties']['value']
+		);
+	}
+
+	public function test_to_json_schema__overridable_prop_type_wraps_origin_schema() {
+		// Arrange
+		$prop_type = Overridable_Prop_Type::make()->set_origin_prop_type( String_Prop_Type::make() );
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertSame( [ 'type' => 'string', 'const' => 'overridable' ], $result['properties']['$$type'] );
+
+		$value = $result['properties']['value'];
+		$this->assertSame( 'object', $value['type'] );
+		$this->assertSame( [ 'override_key', 'origin_value' ], $value['required'] );
+		$this->assertSame( [ 'type' => 'string' ], $value['properties']['override_key'] );
+		$this->assertSame(
+			[ 'type' => 'string', 'const' => 'string' ],
+			$value['properties']['origin_value']['properties']['$$type']
+		);
 	}
 
 	public function test_to_json_schema__plain_prop_type_without_override_uses_envelope() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-prop-type-json-schema.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-prop-type-json-schema.php
@@ -2,7 +2,6 @@
 
 namespace Elementor\Tests\Phpunit\Modules\AtomicWidgets\PropTypes;
 
-use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Array_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Unknown_Prop_Type;
@@ -11,7 +10,6 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Boolean_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
-use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
 use PHPUnit\Framework\TestCase;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,23 +20,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @group Elementor\Modules\AtomicWidgets\PropTypes
  */
 class Test_Prop_Type_Json_Schema extends TestCase {
-
-	public function setUp(): void {
-		parent::setUp();
-
-		Union_Prop_Type::reset_registered_variants();
-		Dynamic_Prop_Type::set_tag_names_resolver( null );
-
-		Dynamic_Prop_Type::register_union_json_schema_variant();
-		Union_Prop_Type::register_omitted_variant_key( Overridable_Prop_Type::get_key() );
-	}
-
-	public function tearDown(): void {
-		Union_Prop_Type::reset_registered_variants();
-		Dynamic_Prop_Type::set_tag_names_resolver( null );
-
-		parent::tearDown();
-	}
 
 	public function test_to_json_schema__string_prop_type() {
 		// Arrange
@@ -92,21 +73,6 @@ class Test_Prop_Type_Json_Schema extends TestCase {
 		$this->assertSame( [ 'start', 'center', 'end' ], $result['properties']['value']['enum'] );
 	}
 
-	public function test_to_json_schema__prop_type_with_initial_value_adds_examples() {
-		// Arrange
-		$prop_type = String_Prop_Type::make()->initial_value( 'Hello World' );
-
-		// Act
-		$result = $prop_type->to_json_schema();
-
-		// Assert
-		$this->assertArrayHasKey( 'examples', $result );
-		$this->assertSame( [ [
-			'$$type' => 'string',
-			'value' => 'Hello World',
-		] ], $result['examples'] );
-	}
-
 	public function test_to_json_schema__unknown_prop_type_returns_empty_object() {
 		// Arrange
 		$prop_type = Unknown_Prop_Type::make();
@@ -132,89 +98,6 @@ class Test_Prop_Type_Json_Schema extends TestCase {
 		$this->assertSame( 'A union of string and number', $result['description'] );
 		$this->assertArrayHasKey( 'anyOf', $result );
 		$this->assertCount( 2, $result['anyOf'] );
-	}
-
-	public function test_to_json_schema__union_with_dynamic_offers_dynamic_variant() {
-		// Arrange
-		$dynamic_prop = Dynamic_Prop_Type::make();
-
-		$prop_type = Union_Prop_Type::make()
-			->add_prop_type( String_Prop_Type::make() )
-			->add_prop_type( $dynamic_prop );
-
-		// Act
-		$result = $prop_type->to_json_schema();
-
-		// Assert
-		$dynamic_variant = $this->find_variant_by_type( $result['anyOf'] ?? [], 'dynamic' );
-		$this->assertNotNull( $dynamic_variant, 'Dynamic variant should be present' );
-		$this->assertSame( [ 'name' ], $dynamic_variant['properties']['value']['required'] );
-		$this->assertArrayNotHasKey( 'group', $dynamic_variant['properties']['value']['properties'] );
-	}
-
-	public function test_to_json_schema__union_with_dynamic_constrains_tag_names_via_resolver() {
-		// Arrange
-		Dynamic_Prop_Type::set_tag_names_resolver( fn( $categories ) => [ 'post-title', 'site-title' ] );
-
-		$dynamic_prop = Dynamic_Prop_Type::make()->categories( [ 'text' ] );
-
-		$prop_type = Union_Prop_Type::make()
-			->add_prop_type( String_Prop_Type::make() )
-			->add_prop_type( $dynamic_prop );
-
-		// Act
-		$result = $prop_type->to_json_schema();
-
-		// Assert
-		$dynamic_variant = $this->find_variant_by_type( $result['anyOf'] ?? [], 'dynamic' );
-		$this->assertSame(
-			[ 'post-title', 'site-title' ],
-			$dynamic_variant['properties']['value']['properties']['name']['enum']
-		);
-	}
-
-	public function test_to_json_schema__union_with_overridable_skips_overridable_variant() {
-		// Arrange
-		$overridable_prop = Overridable_Prop_Type::make();
-
-		$prop_type = Union_Prop_Type::make()
-			->add_prop_type( String_Prop_Type::make() )
-			->add_prop_type( $overridable_prop );
-
-		// Act
-		$result = $prop_type->to_json_schema();
-
-		// Assert
-		$overridable_variant = $this->find_variant_by_type( $result['anyOf'] ?? [], 'overridable' );
-		$this->assertNull( $overridable_variant, 'Overridable variant should be skipped' );
-		$this->assertCount( 1, $result['anyOf'] );
-	}
-
-	public function test_to_json_schema__nested_union_suppresses_dynamic_at_inner_level() {
-		// Arrange
-		$dynamic_prop = Dynamic_Prop_Type::make();
-
-		$inner_union = Union_Prop_Type::make()
-			->add_prop_type( String_Prop_Type::make() )
-			->add_prop_type( $dynamic_prop );
-
-		$outer_union = Union_Prop_Type::make()
-			->add_prop_type( $this->create_object_with_content_field( $inner_union ) )
-			->add_prop_type( $dynamic_prop );
-
-		// Act
-		$result = $outer_union->to_json_schema();
-
-		// Assert — outer level should have dynamic
-		$outer_dynamic = $this->find_variant_by_type( $result['anyOf'] ?? [], 'dynamic' );
-		$this->assertNotNull( $outer_dynamic, 'Outer dynamic variant should be present' );
-
-		// Assert — inner level should NOT have dynamic (suppressed because outer already offers it)
-		$object_variant = $this->find_variant_by_type( $result['anyOf'] ?? [], 'test-object' );
-		$this->assertNotNull( $object_variant );
-		$content_field = $object_variant['properties']['value']['properties']['content'] ?? [];
-		$inner_dynamic = $this->find_variant_by_type( $content_field['anyOf'] ?? [], 'dynamic' );
-		$this->assertNull( $inner_dynamic, 'Inner dynamic variant should be suppressed' );
 	}
 
 	public function test_to_json_schema__object_prop_type() {
@@ -256,7 +139,7 @@ class Test_Prop_Type_Json_Schema extends TestCase {
 		$this->assertArrayHasKey( 'items', $result['properties']['value'] );
 	}
 
-	public function test_to_json_schema__plain_prop_type_without_override_uses_default_fallback() {
+	public function test_to_json_schema__plain_prop_type_without_override_uses_envelope() {
 		// Arrange
 		$prop_type = $this->create_plain_prop_type_without_override();
 
@@ -265,19 +148,9 @@ class Test_Prop_Type_Json_Schema extends TestCase {
 
 		// Assert
 		$this->assertSame( 'object', $result['type'] );
-		$this->assertSame( 'plain', $result['$$type'] );
-		$this->assertSame( [ 'type' => 'plain' ], $result['value'] );
-	}
-
-	private function find_variant_by_type( array $variants, string $type ): ?array {
-		foreach ( $variants as $variant ) {
-			if ( isset( $variant['properties']['$$type']['const'] ) &&
-				$variant['properties']['$$type']['const'] === $type ) {
-				return $variant;
-			}
-		}
-
-		return null;
+		$this->assertSame( [ '$$type', 'value' ], $result['required'] );
+		$this->assertSame( [ 'type' => 'string', 'const' => 'plain-test' ], $result['properties']['$$type'] );
+		$this->assertSame( [ 'type' => 'object' ], $result['properties']['value'] );
 	}
 
 	private function create_plain_prop_type_without_override(): Prop_Type {
@@ -320,27 +193,6 @@ class Test_Prop_Type_Json_Schema extends TestCase {
 				return [
 					'required_field' => String_Prop_Type::make()->required(),
 					'optional_field' => String_Prop_Type::make(),
-				];
-			}
-		};
-	}
-
-	private function create_object_with_content_field( Prop_Type $content_type ): Object_Prop_Type {
-		return new class( $content_type ) extends Object_Prop_Type {
-			private Prop_Type $content_type;
-
-			public function __construct( Prop_Type $content_type ) {
-				$this->content_type = $content_type;
-				parent::__construct();
-			}
-
-			public static function get_key(): string {
-				return 'test-object';
-			}
-
-			protected function define_shape(): array {
-				return [
-					'content' => $this->content_type,
 				];
 			}
 		};

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-prop-type-json-schema.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-prop-type-json-schema.php
@@ -1,0 +1,360 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\AtomicWidgets\PropTypes;
+
+use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Base\Array_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Base\Unknown_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Boolean_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @group Elementor\Modules\AtomicWidgets\PropTypes
+ */
+class Test_Prop_Type_Json_Schema extends TestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		Union_Prop_Type::reset_registered_variants();
+		Dynamic_Prop_Type::set_tag_names_resolver( null );
+
+		Dynamic_Prop_Type::register_union_json_schema_variant();
+		Union_Prop_Type::register_omitted_variant_key( Overridable_Prop_Type::get_key() );
+	}
+
+	public function tearDown(): void {
+		Union_Prop_Type::reset_registered_variants();
+		Dynamic_Prop_Type::set_tag_names_resolver( null );
+
+		parent::tearDown();
+	}
+
+	public function test_to_json_schema__string_prop_type() {
+		// Arrange
+		$prop_type = String_Prop_Type::make()->meta( 'description', 'A string property' );
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertSame( 'A string property', $result['description'] );
+		$this->assertSame( 'object', $result['type'] );
+		$this->assertSame( [ '$$type', 'value' ], $result['required'] );
+		$this->assertSame( [ 'type' => 'string', 'const' => 'string' ], $result['properties']['$$type'] );
+		$this->assertSame( [ 'type' => 'string' ], $result['properties']['value'] );
+	}
+
+	public function test_to_json_schema__number_prop_type() {
+		// Arrange
+		$prop_type = Number_Prop_Type::make()->meta( 'description', 'A number property' );
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertSame( 'A number property', $result['description'] );
+		$this->assertSame( [ 'type' => 'string', 'const' => 'number' ], $result['properties']['$$type'] );
+		$this->assertSame( [ 'type' => 'number' ], $result['properties']['value'] );
+	}
+
+	public function test_to_json_schema__boolean_prop_type() {
+		// Arrange
+		$prop_type = Boolean_Prop_Type::make()->meta( 'description', 'A boolean property' );
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertSame( 'A boolean property', $result['description'] );
+		$this->assertSame( [ 'type' => 'string', 'const' => 'boolean' ], $result['properties']['$$type'] );
+		$this->assertSame( [ 'type' => 'boolean' ], $result['properties']['value'] );
+	}
+
+	public function test_to_json_schema__string_prop_type_with_enum() {
+		// Arrange
+		$prop_type = String_Prop_Type::make()->enum( [ 'start', 'center', 'end' ] );
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertSame( [ 'start', 'center', 'end' ], $result['properties']['value']['enum'] );
+	}
+
+	public function test_to_json_schema__prop_type_with_initial_value_adds_examples() {
+		// Arrange
+		$prop_type = String_Prop_Type::make()->initial_value( 'Hello World' );
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertArrayHasKey( 'examples', $result );
+		$this->assertSame( [ [
+			'$$type' => 'string',
+			'value' => 'Hello World',
+		] ], $result['examples'] );
+	}
+
+	public function test_to_json_schema__unknown_prop_type_returns_empty_object() {
+		// Arrange
+		$prop_type = Unknown_Prop_Type::make();
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertSame( [], $result );
+	}
+
+	public function test_to_json_schema__union_prop_type() {
+		// Arrange
+		$prop_type = Union_Prop_Type::make()
+			->add_prop_type( String_Prop_Type::make() )
+			->add_prop_type( Number_Prop_Type::make() )
+			->meta( 'description', 'A union of string and number' );
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertSame( 'A union of string and number', $result['description'] );
+		$this->assertArrayHasKey( 'anyOf', $result );
+		$this->assertCount( 2, $result['anyOf'] );
+	}
+
+	public function test_to_json_schema__union_with_dynamic_offers_dynamic_variant() {
+		// Arrange
+		$dynamic_prop = Dynamic_Prop_Type::make();
+
+		$prop_type = Union_Prop_Type::make()
+			->add_prop_type( String_Prop_Type::make() )
+			->add_prop_type( $dynamic_prop );
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$dynamic_variant = $this->find_variant_by_type( $result['anyOf'] ?? [], 'dynamic' );
+		$this->assertNotNull( $dynamic_variant, 'Dynamic variant should be present' );
+		$this->assertSame( [ 'name' ], $dynamic_variant['properties']['value']['required'] );
+		$this->assertArrayNotHasKey( 'group', $dynamic_variant['properties']['value']['properties'] );
+	}
+
+	public function test_to_json_schema__union_with_dynamic_constrains_tag_names_via_resolver() {
+		// Arrange
+		Dynamic_Prop_Type::set_tag_names_resolver( fn( $categories ) => [ 'post-title', 'site-title' ] );
+
+		$dynamic_prop = Dynamic_Prop_Type::make()->categories( [ 'text' ] );
+
+		$prop_type = Union_Prop_Type::make()
+			->add_prop_type( String_Prop_Type::make() )
+			->add_prop_type( $dynamic_prop );
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$dynamic_variant = $this->find_variant_by_type( $result['anyOf'] ?? [], 'dynamic' );
+		$this->assertSame(
+			[ 'post-title', 'site-title' ],
+			$dynamic_variant['properties']['value']['properties']['name']['enum']
+		);
+	}
+
+	public function test_to_json_schema__union_with_overridable_skips_overridable_variant() {
+		// Arrange
+		$overridable_prop = Overridable_Prop_Type::make();
+
+		$prop_type = Union_Prop_Type::make()
+			->add_prop_type( String_Prop_Type::make() )
+			->add_prop_type( $overridable_prop );
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$overridable_variant = $this->find_variant_by_type( $result['anyOf'] ?? [], 'overridable' );
+		$this->assertNull( $overridable_variant, 'Overridable variant should be skipped' );
+		$this->assertCount( 1, $result['anyOf'] );
+	}
+
+	public function test_to_json_schema__nested_union_suppresses_dynamic_at_inner_level() {
+		// Arrange
+		$dynamic_prop = Dynamic_Prop_Type::make();
+
+		$inner_union = Union_Prop_Type::make()
+			->add_prop_type( String_Prop_Type::make() )
+			->add_prop_type( $dynamic_prop );
+
+		$outer_union = Union_Prop_Type::make()
+			->add_prop_type( $this->create_object_with_content_field( $inner_union ) )
+			->add_prop_type( $dynamic_prop );
+
+		// Act
+		$result = $outer_union->to_json_schema();
+
+		// Assert — outer level should have dynamic
+		$outer_dynamic = $this->find_variant_by_type( $result['anyOf'] ?? [], 'dynamic' );
+		$this->assertNotNull( $outer_dynamic, 'Outer dynamic variant should be present' );
+
+		// Assert — inner level should NOT have dynamic (suppressed because outer already offers it)
+		$object_variant = $this->find_variant_by_type( $result['anyOf'] ?? [], 'test-object' );
+		$this->assertNotNull( $object_variant );
+		$content_field = $object_variant['properties']['value']['properties']['content'] ?? [];
+		$inner_dynamic = $this->find_variant_by_type( $content_field['anyOf'] ?? [], 'dynamic' );
+		$this->assertNull( $inner_dynamic, 'Inner dynamic variant should be suppressed' );
+	}
+
+	public function test_to_json_schema__object_prop_type() {
+		// Arrange
+		$prop_type = $this->create_simple_object_prop_type();
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertSame( 'object', $result['type'] );
+		$this->assertSame( [ 'type' => 'string', 'const' => 'test-object' ], $result['properties']['$$type'] );
+		$this->assertSame( 'object', $result['properties']['value']['type'] );
+		$this->assertArrayHasKey( 'name', $result['properties']['value']['properties'] );
+	}
+
+	public function test_to_json_schema__object_prop_type_with_required_field() {
+		// Arrange
+		$prop_type = $this->create_object_with_required_field();
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertContains( 'required_field', $result['properties']['value']['required'] );
+	}
+
+	public function test_to_json_schema__array_prop_type() {
+		// Arrange
+		$prop_type = $this->create_simple_array_prop_type();
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertSame( 'object', $result['type'] );
+		$this->assertSame( [ 'type' => 'string', 'const' => 'test-array' ], $result['properties']['$$type'] );
+		$this->assertSame( 'array', $result['properties']['value']['type'] );
+		$this->assertArrayHasKey( 'items', $result['properties']['value'] );
+	}
+
+	public function test_to_json_schema__plain_prop_type_without_override_uses_default_fallback() {
+		// Arrange
+		$prop_type = $this->create_plain_prop_type_without_override();
+
+		// Act
+		$result = $prop_type->to_json_schema();
+
+		// Assert
+		$this->assertSame( 'object', $result['type'] );
+		$this->assertSame( 'plain', $result['$$type'] );
+		$this->assertSame( [ 'type' => 'plain' ], $result['value'] );
+	}
+
+	private function find_variant_by_type( array $variants, string $type ): ?array {
+		foreach ( $variants as $variant ) {
+			if ( isset( $variant['properties']['$$type']['const'] ) &&
+				$variant['properties']['$$type']['const'] === $type ) {
+				return $variant;
+			}
+		}
+
+		return null;
+	}
+
+	private function create_plain_prop_type_without_override(): Prop_Type {
+		return new class extends \Elementor\Modules\AtomicWidgets\PropTypes\Base\Plain_Prop_Type {
+			public static function get_key(): string {
+				return 'plain-test';
+			}
+
+			protected function validate_value( $value ): bool {
+				return true;
+			}
+
+			protected function sanitize_value( $value ) {
+				return $value;
+			}
+		};
+	}
+
+	private function create_simple_object_prop_type(): Object_Prop_Type {
+		return new class extends Object_Prop_Type {
+			public static function get_key(): string {
+				return 'test-object';
+			}
+
+			protected function define_shape(): array {
+				return [
+					'name' => String_Prop_Type::make(),
+				];
+			}
+		};
+	}
+
+	private function create_object_with_required_field(): Object_Prop_Type {
+		return new class extends Object_Prop_Type {
+			public static function get_key(): string {
+				return 'test-object-required';
+			}
+
+			protected function define_shape(): array {
+				return [
+					'required_field' => String_Prop_Type::make()->required(),
+					'optional_field' => String_Prop_Type::make(),
+				];
+			}
+		};
+	}
+
+	private function create_object_with_content_field( Prop_Type $content_type ): Object_Prop_Type {
+		return new class( $content_type ) extends Object_Prop_Type {
+			private Prop_Type $content_type;
+
+			public function __construct( Prop_Type $content_type ) {
+				$this->content_type = $content_type;
+				parent::__construct();
+			}
+
+			public static function get_key(): string {
+				return 'test-object';
+			}
+
+			protected function define_shape(): array {
+				return [
+					'content' => $this->content_type,
+				];
+			}
+		};
+	}
+
+	private function create_simple_array_prop_type(): Array_Prop_Type {
+		return new class extends Array_Prop_Type {
+			public static function get_key(): string {
+				return 'test-array';
+			}
+
+			protected function define_item_type(): Prop_Type {
+				return String_Prop_Type::make();
+			}
+		};
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/utils/mock-prop-type.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/utils/mock-prop-type.php
@@ -66,7 +66,11 @@ class Mock_Prop_Type implements Prop_Type {
 		return $this->dependencies;
 	}
 
-	public function to_json_schema( bool $suppress_dynamic = false ): array {
+	public function to_json_schema(): array {
+		return [];
+	}
+
+	public function get_aliases(): array {
 		return [];
 	}
 

--- a/tests/phpunit/elementor/modules/atomic-widgets/utils/mock-prop-type.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/utils/mock-prop-type.php
@@ -66,6 +66,10 @@ class Mock_Prop_Type implements Prop_Type {
 		return $this->dependencies;
 	}
 
+	public function to_json_schema( bool $suppress_dynamic = false ): array {
+		return [];
+	}
+
 	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return [


### PR DESCRIPTION
## Summary

Add JSON Schema generation capability to all prop types via the new `Has_Json_Schema_Meta` concern. This allows prop types to be serialized as JSON Schema for MCP/LLM consumption.

## Changes

- Add `Has_Json_Schema_Meta` trait with `to_json_schema()` method
- Add `to_json_schema()` to `Prop_Type` contract
- Implement `to_json_schema()` in all prop type classes:
  - `Array_Prop_Type`, `Object_Prop_Type`, `Plain_Prop_Type`, `Unknown_Prop_Type`
  - `Boolean_Prop_Type`, `Number_Prop_Type`, `String_Prop_Type`
  - `Union_Prop_Type`
- Update `Mock_Prop_Type` for testing
- Add comprehensive tests for JSON schema generation

## Test plan

- [x] Unit tests added for to_json_schema() on all prop types
- [ ] Verify existing prop type functionality is not affected

Ref: ED-24826

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds JSON Schema serialization to prop types to enable LLM integration. Enables programmatic schema generation for atomic widgets' type system without frontend code duplication.

## 2. What Changed (Where)

| Component | Change |
|-----------|--------|
| Base prop types (Plain, Array, Object, Union) | Added `to_json_schema()` implementing enveloped `{$type, value}` structure |
| Primitives (String, Number, Boolean) | Implemented schema generation with enum support for String |
| Special types | Unknown returns `[]`; Classes returns array schema; Overridable wraps origin schema |
| Concerns | New `Has_Json_Schema_Meta` trait extracts description from meta |
| Contract & mocks | Added `to_json_schema()` and `get_aliases()` to Prop_Type interface; updated implementations |
| Tests | 250 lines covering all prop type schemas with fixture helpers |

## 3. How It Works

Each prop type wraps its value schema in a discriminated union: `{$type: <key>, value: <schema>}`. Base Plain_Prop_Type provides `wrap_json_schema()` helper for primitives. Container types (Array, Object, Union) recursively call `to_json_schema()` on children. `Has_Json_Schema_Meta` enriches schemas with stored description metadata. Unknown_Prop_Type short-circuits to empty object for graceful degradation.

## 4. Risks

None identified. Interface addition is backward-compatible (all implementations added). Schema structure mirrors frontend converter (reduces sync issues). Comprehensive test coverage validates all paths. Edge case: null item_type in Array_Prop_Type handled safely with conditional.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
