### PR TITLE
Fix: Atomic Form Angie support > inputs are not wrapped with an atomic form container [ED-24881]

### DIFF
--- a/packages/packages/core/editor-canvas/src/__tests__/parse-xml.ts
+++ b/packages/packages/core/editor-canvas/src/__tests__/parse-xml.ts
@@ -1,0 +1,2 @@
+export const parseXml = ( xml: string ): Document =>
+	new DOMParser().parseFromString( `<root>${ xml }</root>`, 'application/xml' );

--- a/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
+++ b/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
@@ -15,6 +15,7 @@ import { doUpdateElementProperty } from '../mcp/utils/do-update-element-property
 import { mergeCustomCssText } from '../mcp/utils/merge-custom-css';
 import { RequiredChildrenEnforcer } from './utils/required-children-enforcer';
 import { getRequiredDefaultChildTemplates } from './utils/required-default-child-tags';
+import { collectFormAncestorErrors, collectSubmitButtonErrors, collectEmptyMessageErrors } from '../form-structure/utils';
 
 type AnyValue = z.infer< z.ZodTypeAny >;
 type AnyConfig = Record< string, Record< string, AnyValue > >;
@@ -292,6 +293,25 @@ export class CompositionBuilder {
 		}
 		if ( childTypeErrors.length ) {
 			throw new Error( `Invalid element structure:\n${ childTypeErrors.join( '\n' ) }` );
+		}
+
+		const formAncestorErrors = collectFormAncestorErrors(this.xml);
+
+		if (formAncestorErrors.length) {
+		  throw new Error(`Invalid form structure:\n${formAncestorErrors.join('\n')}`);
+		}
+
+
+		const submitErrors = collectSubmitButtonErrors(this.xml);
+
+		if (submitErrors.length) {
+			throw new Error(`Invalid form structure:\n${submitErrors.join('\n')}`);
+		}
+
+		const emptyMessageErrors = collectEmptyMessageErrors(this.xml);
+
+		if (emptyMessageErrors.length) {
+			throw new Error(`Invalid form structure:\n${emptyMessageErrors.join('\n')}`);
 		}
 
 		const children = Array.from( this.xml.children );

--- a/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
+++ b/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
@@ -11,11 +11,15 @@ import {
 } from '@elementor/editor-elements';
 import { type z } from '@elementor/schema';
 
+import {
+	collectEmptyMessageErrors,
+	collectFormAncestorErrors,
+	collectSubmitButtonErrors,
+} from '../form-structure/utils';
 import { doUpdateElementProperty } from '../mcp/utils/do-update-element-property';
 import { mergeCustomCssText } from '../mcp/utils/merge-custom-css';
 import { RequiredChildrenEnforcer } from './utils/required-children-enforcer';
 import { getRequiredDefaultChildTemplates } from './utils/required-default-child-tags';
-import { collectFormAncestorErrors, collectSubmitButtonErrors, collectEmptyMessageErrors } from '../form-structure/utils';
 
 type AnyValue = z.infer< z.ZodTypeAny >;
 type AnyConfig = Record< string, Record< string, AnyValue > >;

--- a/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
+++ b/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
@@ -295,23 +295,15 @@ export class CompositionBuilder {
 			throw new Error( `Invalid element structure:\n${ childTypeErrors.join( '\n' ) }` );
 		}
 
-		const formAncestorErrors = collectFormAncestorErrors(this.xml);
+		
+		const formErrors = [
+			...collectFormAncestorErrors( this.xml ),
+			...collectSubmitButtonErrors( this.xml ),
+			...collectEmptyMessageErrors( this.xml ),
+		];
 
-		if (formAncestorErrors.length) {
-		  throw new Error(`Invalid form structure:\n${formAncestorErrors.join('\n')}`);
-		}
-
-
-		const submitErrors = collectSubmitButtonErrors(this.xml);
-
-		if (submitErrors.length) {
-			throw new Error(`Invalid form structure:\n${submitErrors.join('\n')}`);
-		}
-
-		const emptyMessageErrors = collectEmptyMessageErrors(this.xml);
-
-		if (emptyMessageErrors.length) {
-			throw new Error(`Invalid form structure:\n${emptyMessageErrors.join('\n')}`);
+		if ( formErrors.length ) {
+			throw new Error( `Invalid form structure:\n${ formErrors.join( n ) }` );
 		}
 
 		const children = Array.from( this.xml.children );

--- a/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
+++ b/packages/packages/core/editor-canvas/src/composition-builder/composition-builder.ts
@@ -295,16 +295,11 @@ export class CompositionBuilder {
 			throw new Error( `Invalid element structure:\n${ childTypeErrors.join( '\n' ) }` );
 		}
 
-		
 		const formErrors = [
 			...collectFormAncestorErrors( this.xml ),
 			...collectSubmitButtonErrors( this.xml ),
 			...collectEmptyMessageErrors( this.xml ),
 		];
-
-		if ( formErrors.length ) {
-			throw new Error( `Invalid form structure:\n${ formErrors.join( n ) }` );
-		}
 
 		const children = Array.from( this.xml.children );
 		for ( const childNode of children ) {
@@ -344,6 +339,7 @@ export class CompositionBuilder {
 		return {
 			configErrors,
 			styleErrors,
+			formErrors,
 			rootContainers: [ ...this.rootContainers ],
 		};
 	}

--- a/packages/packages/core/editor-canvas/src/form-structure/__tests__/form-structure-utils.test.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/__tests__/form-structure-utils.test.ts
@@ -1,5 +1,6 @@
 import type { V1Element } from '@elementor/editor-elements';
 
+import { parseXml } from '../../__tests__/parse-xml';
 import {
 	clipboardRootsAreAtomicForms,
 	collectFormAncestorErrors,
@@ -24,10 +25,6 @@ function mockElement( widgetType?: string, elType?: string ): V1Element {
 			},
 		},
 	} as V1Element;
-}
-
-function parseXml( xml: string ): Document {
-    return new DOMParser().parseFromString( `<root>${ xml }</root>`, 'text/xml' );
 }
 
 describe( 'form-structure utils', () => {

--- a/packages/packages/core/editor-canvas/src/form-structure/__tests__/form-structure-utils.test.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/__tests__/form-structure-utils.test.ts
@@ -3,9 +3,9 @@ import type { V1Element } from '@elementor/editor-elements';
 import { parseXml } from '../../__tests__/parse-xml';
 import {
 	clipboardRootsAreAtomicForms,
+	collectEmptyMessageErrors,
 	collectFormAncestorErrors,
 	collectSubmitButtonErrors,
-	collectEmptyMessageErrors,
 	FORM_ELEMENT_TYPE,
 	getClipboardElementType,
 	movedContainersIncludeAtomicFormRoot,
@@ -152,7 +152,7 @@ describe( 'form-structure utils', () => {
 			` );
 			expect( collectSubmitButtonErrors( xml ) ).toHaveLength( 0 );
 		} );
-	
+
 		it( 'returns no errors when submit button is nested inside a container within e-form', () => {
 			const xml = parseXml( `
 				<e-form>
@@ -163,7 +163,7 @@ describe( 'form-structure utils', () => {
 			` );
 			expect( collectSubmitButtonErrors( xml ) ).toHaveLength( 0 );
 		} );
-	
+
 		it( 'returns an error when e-form has no submit button', () => {
 			const xml = parseXml( `
 				<e-form>
@@ -174,7 +174,7 @@ describe( 'form-structure utils', () => {
 			expect( errors ).toHaveLength( 1 );
 			expect( errors[ 0 ] ).toContain( 'e-form-submit-button' );
 		} );
-	
+
 		it( 'returns an error when e-form has more than one submit button', () => {
 			const xml = parseXml( `
 				<e-form>
@@ -186,7 +186,7 @@ describe( 'form-structure utils', () => {
 			expect( errors ).toHaveLength( 1 );
 			expect( errors[ 0 ] ).toContain( '2' );
 		} );
-	
+
 		it( 'returns one error per e-form that is missing a submit button', () => {
 			const xml = parseXml( `
 				<e-form>
@@ -198,7 +198,7 @@ describe( 'form-structure utils', () => {
 			` );
 			expect( collectSubmitButtonErrors( xml ) ).toHaveLength( 2 );
 		} );
-	
+
 		it( 'returns no errors when there are no e-form elements', () => {
 			const xml = parseXml( `
 				<e-flexbox>
@@ -220,7 +220,7 @@ describe( 'form-structure utils', () => {
 			` );
 			expect( collectEmptyMessageErrors( xml ) ).toHaveLength( 0 );
 		} );
-	
+
 		it( 'returns no errors when error message has children', () => {
 			const xml = parseXml( `
 				<e-form>
@@ -231,7 +231,7 @@ describe( 'form-structure utils', () => {
 			` );
 			expect( collectEmptyMessageErrors( xml ) ).toHaveLength( 0 );
 		} );
-	
+
 		it( 'returns an error when success message is empty', () => {
 			const xml = parseXml( `
 				<e-form>
@@ -242,7 +242,7 @@ describe( 'form-structure utils', () => {
 			expect( errors ).toHaveLength( 1 );
 			expect( errors[ 0 ] ).toContain( 'e-form-success-message' );
 		} );
-	
+
 		it( 'returns an error when error message is empty', () => {
 			const xml = parseXml( `
 				<e-form>
@@ -253,7 +253,7 @@ describe( 'form-structure utils', () => {
 			expect( errors ).toHaveLength( 1 );
 			expect( errors[ 0 ] ).toContain( 'e-form-error-message' );
 		} );
-	
+
 		it( 'returns two errors when both success and error messages are empty', () => {
 			const xml = parseXml( `
 				<e-form>
@@ -263,7 +263,7 @@ describe( 'form-structure utils', () => {
 			` );
 			expect( collectEmptyMessageErrors( xml ) ).toHaveLength( 2 );
 		} );
-	
+
 		it( 'returns no errors when there are no message elements', () => {
 			const xml = parseXml( `
 				<e-form>
@@ -273,7 +273,7 @@ describe( 'form-structure utils', () => {
 			` );
 			expect( collectEmptyMessageErrors( xml ) ).toHaveLength( 0 );
 		} );
-	
+
 		it( 'returns no errors when message element is outside e-form but has children', () => {
 			const xml = parseXml( `
 				<e-flexbox>

--- a/packages/packages/core/editor-canvas/src/form-structure/__tests__/form-structure-utils.test.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/__tests__/form-structure-utils.test.ts
@@ -2,6 +2,9 @@ import type { V1Element } from '@elementor/editor-elements';
 
 import {
 	clipboardRootsAreAtomicForms,
+	collectFormAncestorErrors,
+	collectSubmitButtonErrors,
+	collectEmptyMessageErrors,
 	FORM_ELEMENT_TYPE,
 	getClipboardElementType,
 	movedContainersIncludeAtomicFormRoot,
@@ -21,6 +24,10 @@ function mockElement( widgetType?: string, elType?: string ): V1Element {
 			},
 		},
 	} as V1Element;
+}
+
+function parseXml( xml: string ): Document {
+    return new DOMParser().parseFromString( `<root>${ xml }</root>`, 'text/xml' );
 }
 
 describe( 'form-structure utils', () => {
@@ -65,6 +72,220 @@ describe( 'form-structure utils', () => {
 
 		it( 'returns false for empty roots', () => {
 			expect( clipboardRootsAreAtomicForms( [] ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'collectFormAncestorErrors', () => {
+		it( 'returns no errors when form field is a direct child of e-form', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-form-input />
+				</e-form>
+			` );
+			expect( collectFormAncestorErrors( xml ) ).toHaveLength( 0 );
+		} );
+		it( 'returns no errors when form field is a deep descendant of e-form (valid)', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-flexbox>
+						<e-form-input />
+					</e-flexbox>
+				</e-form>
+			` );
+			expect( collectFormAncestorErrors( xml ) ).toHaveLength( 0 );
+		} );
+		it( 'returns no errors when e-form wraps multiple containers with fields (valid)', () => {
+			const xml = parseXml( `
+				<e-flexbox>
+					<e-form>
+						<e-form-input />
+					</e-form>
+				</e-flexbox>
+			` );
+			expect( collectFormAncestorErrors( xml ) ).toHaveLength( 0 );
+		} );
+		it( 'returns an error when form field has no e-form ancestor (invalid)', () => {
+			const xml = parseXml( `
+				<e-flexbox>
+					<e-flexbox>
+						<e-form-input />
+					</e-flexbox>
+				</e-flexbox>
+			` );
+			const errors = collectFormAncestorErrors( xml );
+			expect( errors ).toHaveLength( 1 );
+			expect( errors[ 0 ] ).toContain( 'e-form-input' );
+			expect( errors[ 0 ] ).toContain( 'e-form' );
+		} );
+		it( 'returns an error for each orphaned form field', () => {
+			const xml = parseXml( `
+				<e-flexbox>
+					<e-form-input />
+					<e-form-label />
+				</e-flexbox>
+			` );
+			expect( collectFormAncestorErrors( xml ) ).toHaveLength( 2 );
+		} );
+		it( 'includes configuration-id in the error message when present', () => {
+			const xml = parseXml( `
+				<e-flexbox>
+					<e-form-input configuration-id="my-input" />
+				</e-flexbox>
+			` );
+			const errors = collectFormAncestorErrors( xml );
+			expect( errors[ 0 ] ).toContain( 'configuration-id="my-input"' );
+		} );
+		it( 'returns no errors when there are no form fields at all', () => {
+			const xml = parseXml( `
+				<e-flexbox>
+					<e-heading />
+				</e-flexbox>
+			` );
+			expect( collectFormAncestorErrors( xml ) ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'collectSubmitButtonErrors', () => {
+		it( 'returns no errors when e-form has exactly one submit button', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-form-input />
+					<e-form-submit-button />
+				</e-form>
+			` );
+			expect( collectSubmitButtonErrors( xml ) ).toHaveLength( 0 );
+		} );
+	
+		it( 'returns no errors when submit button is nested inside a container within e-form', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-flexbox>
+						<e-form-submit-button />
+					</e-flexbox>
+				</e-form>
+			` );
+			expect( collectSubmitButtonErrors( xml ) ).toHaveLength( 0 );
+		} );
+	
+		it( 'returns an error when e-form has no submit button', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-form-input />
+				</e-form>
+			` );
+			const errors = collectSubmitButtonErrors( xml );
+			expect( errors ).toHaveLength( 1 );
+			expect( errors[ 0 ] ).toContain( 'e-form-submit-button' );
+		} );
+	
+		it( 'returns an error when e-form has more than one submit button', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-form-submit-button />
+					<e-form-submit-button />
+				</e-form>
+			` );
+			const errors = collectSubmitButtonErrors( xml );
+			expect( errors ).toHaveLength( 1 );
+			expect( errors[ 0 ] ).toContain( '2' );
+		} );
+	
+		it( 'returns one error per e-form that is missing a submit button', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-form-input />
+				</e-form>
+				<e-form>
+					<e-form-input />
+				</e-form>
+			` );
+			expect( collectSubmitButtonErrors( xml ) ).toHaveLength( 2 );
+		} );
+	
+		it( 'returns no errors when there are no e-form elements', () => {
+			const xml = parseXml( `
+				<e-flexbox>
+					<e-heading />
+				</e-flexbox>
+			` );
+			expect( collectSubmitButtonErrors( xml ) ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'collectEmptyMessageErrors', () => {
+		it( 'returns no errors when success message has children', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-form-success-message>
+						<e-atomic-paragraph />
+					</e-form-success-message>
+				</e-form>
+			` );
+			expect( collectEmptyMessageErrors( xml ) ).toHaveLength( 0 );
+		} );
+	
+		it( 'returns no errors when error message has children', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-form-error-message>
+						<e-atomic-paragraph />
+					</e-form-error-message>
+				</e-form>
+			` );
+			expect( collectEmptyMessageErrors( xml ) ).toHaveLength( 0 );
+		} );
+	
+		it( 'returns an error when success message is empty', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-form-success-message />
+				</e-form>
+			` );
+			const errors = collectEmptyMessageErrors( xml );
+			expect( errors ).toHaveLength( 1 );
+			expect( errors[ 0 ] ).toContain( 'e-form-success-message' );
+		} );
+	
+		it( 'returns an error when error message is empty', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-form-error-message />
+				</e-form>
+			` );
+			const errors = collectEmptyMessageErrors( xml );
+			expect( errors ).toHaveLength( 1 );
+			expect( errors[ 0 ] ).toContain( 'e-form-error-message' );
+		} );
+	
+		it( 'returns two errors when both success and error messages are empty', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-form-success-message />
+					<e-form-error-message />
+				</e-form>
+			` );
+			expect( collectEmptyMessageErrors( xml ) ).toHaveLength( 2 );
+		} );
+	
+		it( 'returns no errors when there are no message elements', () => {
+			const xml = parseXml( `
+				<e-form>
+					<e-form-input />
+					<e-form-submit-button />
+				</e-form>
+			` );
+			expect( collectEmptyMessageErrors( xml ) ).toHaveLength( 0 );
+		} );
+	
+		it( 'returns no errors when message element is outside e-form but has children', () => {
+			const xml = parseXml( `
+				<e-flexbox>
+					<e-form-success-message>
+						<e-atomic-paragraph />
+					</e-form-success-message>
+				</e-flexbox>
+			` );
+			expect( collectEmptyMessageErrors( xml ) ).toHaveLength( 0 );
 		} );
 	} );
 } );

--- a/packages/packages/core/editor-canvas/src/form-structure/utils.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/utils.ts
@@ -119,7 +119,7 @@ export function clipboardRootsAreAtomicForms( elements: ClipboardElement[] ): bo
 export function hasFormAncestor(node: Element): boolean {
 	let parent = node.parentElement;
 	while (parent) {
-	  if (parent.tagName === FORM_ELEMENT_TYPE) return true;
+	  if (parent.tagName.toLowerCase() === FORM_ELEMENT_TYPE) return true;
 	  parent = parent.parentElement;
 	}
 	return false;

--- a/packages/packages/core/editor-canvas/src/form-structure/utils.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/utils.ts
@@ -117,12 +117,7 @@ export function clipboardRootsAreAtomicForms( elements: ClipboardElement[] ): bo
 }
 
 export function hasFormAncestor(node: Element): boolean {
-	let parent = node.parentElement;
-	while (parent) {
-	  if (parent.tagName.toLowerCase() === FORM_ELEMENT_TYPE) return true;
-	  parent = parent.parentElement;
-	}
-	return false;
+    return node.closest(FORM_ELEMENT_TYPE) !== null;
 }
 
 export function collectFormAncestorErrors(xml: Document): string[] {

--- a/packages/packages/core/editor-canvas/src/form-structure/utils.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/utils.ts
@@ -116,43 +116,48 @@ export function clipboardRootsAreAtomicForms( elements: ClipboardElement[] ): bo
 	return elements.every( ( el ) => getClipboardElementType( el ) === FORM_ELEMENT_TYPE );
 }
 
-export function hasFormAncestor(node: Element): boolean {
-    return node.closest(FORM_ELEMENT_TYPE) !== null;
+export function hasFormAncestor( node: Element ): boolean {
+	return node.closest( FORM_ELEMENT_TYPE ) !== null;
 }
 
-export function collectFormAncestorErrors(xml: Document): string[] {
+export function collectFormAncestorErrors( xml: Document ): string[] {
 	const errors: string[] = [];
-	for (const node of xml.querySelectorAll('*')) {
-		if (!FORM_FIELD_ELEMENT_TYPES.has(node.tagName.toLowerCase())) continue;
-		if (hasFormAncestor(node)) continue;
-		const id = node.getAttribute('configuration-id');
+	for ( const node of xml.querySelectorAll( '*' ) ) {
+		if ( ! FORM_FIELD_ELEMENT_TYPES.has( node.tagName.toLowerCase() ) ) {
+			continue;
+		}
+		if ( hasFormAncestor( node ) ) {
+			continue;
+		}
+		const id = node.getAttribute( 'configuration-id' );
 		errors.push(
-			`<${node.tagName}${id ? ` configuration-id="${id}"` : ''}> must be nested inside <e-form> (any ancestor depth is allowed).`
+			`<${ node.tagName }${
+				id ? ` configuration-id="${ id }"` : ''
+			}> must be nested inside <e-form> (any ancestor depth is allowed).`
 		);
 	}
 	return errors;
 }
 
-export function collectSubmitButtonErrors(xml: Document): string[] {
+export function collectSubmitButtonErrors( xml: Document ): string[] {
 	const errors: string[] = [];
-	for (const form of xml.querySelectorAll('e-form')) {
-		const submitButtons = form.querySelectorAll('e-form-submit-button');
-		if (submitButtons.length === 0) {
-			errors.push(`<e-form> has no <e-form-submit-button>.`);
-		} else if (submitButtons.length > 1) {
-			errors.push(`<e-form> has ${submitButtons.length} submit buttons — only 1 is allowed.`);
+	for ( const form of xml.querySelectorAll( 'e-form' ) ) {
+		const submitButtons = form.querySelectorAll( 'e-form-submit-button' );
+		if ( submitButtons.length === 0 ) {
+			errors.push( `<e-form> has no <e-form-submit-button>.` );
+		} else if ( submitButtons.length > 1 ) {
+			errors.push( `<e-form> has ${ submitButtons.length } submit buttons — only 1 is allowed.` );
 		}
 	}
 	return errors;
 }
 
-export function collectEmptyMessageErrors(xml: Document): string[] {
+export function collectEmptyMessageErrors( xml: Document ): string[] {
 	const errors: string[] = [];
-	for (const node of xml.querySelectorAll('e-form-success-message, e-form-error-message')) {
-		if (node.children.length === 0) {
-			errors.push(`<${node.tagName}> must have at least one child element (e.g. <e-atomic-paragraph>).`);
+	for ( const node of xml.querySelectorAll( 'e-form-success-message, e-form-error-message' ) ) {
+		if ( node.children.length === 0 ) {
+			errors.push( `<${ node.tagName }> must have at least one child element (e.g. <e-atomic-paragraph>).` );
 		}
 	}
 	return errors;
-  }
-  
+}

--- a/packages/packages/core/editor-canvas/src/form-structure/utils.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/utils.ts
@@ -123,40 +123,40 @@ export function hasFormAncestor(node: Element): boolean {
 	  parent = parent.parentElement;
 	}
 	return false;
-  }
+}
 
-  export function collectFormAncestorErrors(xml: Document): string[] {
+export function collectFormAncestorErrors(xml: Document): string[] {
 	const errors: string[] = [];
 	for (const node of xml.querySelectorAll('*')) {
-	  if (!FORM_FIELD_ELEMENT_TYPES.has(node.tagName.toLowerCase())) continue;
-	  if (hasFormAncestor(node)) continue;
-	  const id = node.getAttribute('configuration-id');
-	  errors.push(
-		`<${node.tagName}${id ? ` configuration-id="${id}"` : ''}> must be nested inside <e-form> (any ancestor depth is allowed).`
-	  );
+		if (!FORM_FIELD_ELEMENT_TYPES.has(node.tagName.toLowerCase())) continue;
+		if (hasFormAncestor(node)) continue;
+		const id = node.getAttribute('configuration-id');
+		errors.push(
+			`<${node.tagName}${id ? ` configuration-id="${id}"` : ''}> must be nested inside <e-form> (any ancestor depth is allowed).`
+		);
 	}
 	return errors;
-  }
+}
 
-  export function collectSubmitButtonErrors(xml: Document): string[] {
+export function collectSubmitButtonErrors(xml: Document): string[] {
 	const errors: string[] = [];
 	for (const form of xml.querySelectorAll('e-form')) {
-	  const submitButtons = form.querySelectorAll('e-form-submit-button');
-	  if (submitButtons.length === 0) {
-		errors.push(`<e-form> has no <e-form-submit-button>.`);
-	  } else if (submitButtons.length > 1) {
-		errors.push(`<e-form> has ${submitButtons.length} submit buttons — only 1 is allowed.`);
-	  }
+		const submitButtons = form.querySelectorAll('e-form-submit-button');
+		if (submitButtons.length === 0) {
+			errors.push(`<e-form> has no <e-form-submit-button>.`);
+		} else if (submitButtons.length > 1) {
+			errors.push(`<e-form> has ${submitButtons.length} submit buttons — only 1 is allowed.`);
+		}
 	}
 	return errors;
-  }
+}
 
 export function collectEmptyMessageErrors(xml: Document): string[] {
 	const errors: string[] = [];
 	for (const node of xml.querySelectorAll('e-form-success-message, e-form-error-message')) {
-	  if (node.children.length === 0) {
-		errors.push(`<${node.tagName}> must have at least one child element (e.g. <e-atomic-paragraph>).`);
-	  }
+		if (node.children.length === 0) {
+			errors.push(`<${node.tagName}> must have at least one child element (e.g. <e-atomic-paragraph>).`);
+		}
 	}
 	return errors;
   }

--- a/packages/packages/core/editor-canvas/src/form-structure/utils.ts
+++ b/packages/packages/core/editor-canvas/src/form-structure/utils.ts
@@ -115,3 +115,49 @@ export function clipboardRootsAreAtomicForms( elements: ClipboardElement[] ): bo
 
 	return elements.every( ( el ) => getClipboardElementType( el ) === FORM_ELEMENT_TYPE );
 }
+
+export function hasFormAncestor(node: Element): boolean {
+	let parent = node.parentElement;
+	while (parent) {
+	  if (parent.tagName === FORM_ELEMENT_TYPE) return true;
+	  parent = parent.parentElement;
+	}
+	return false;
+  }
+
+  export function collectFormAncestorErrors(xml: Document): string[] {
+	const errors: string[] = [];
+	for (const node of xml.querySelectorAll('*')) {
+	  if (!FORM_FIELD_ELEMENT_TYPES.has(node.tagName.toLowerCase())) continue;
+	  if (hasFormAncestor(node)) continue;
+	  const id = node.getAttribute('configuration-id');
+	  errors.push(
+		`<${node.tagName}${id ? ` configuration-id="${id}"` : ''}> must be nested inside <e-form> (any ancestor depth is allowed).`
+	  );
+	}
+	return errors;
+  }
+
+  export function collectSubmitButtonErrors(xml: Document): string[] {
+	const errors: string[] = [];
+	for (const form of xml.querySelectorAll('e-form')) {
+	  const submitButtons = form.querySelectorAll('e-form-submit-button');
+	  if (submitButtons.length === 0) {
+		errors.push(`<e-form> has no <e-form-submit-button>.`);
+	  } else if (submitButtons.length > 1) {
+		errors.push(`<e-form> has ${submitButtons.length} submit buttons — only 1 is allowed.`);
+	  }
+	}
+	return errors;
+  }
+
+export function collectEmptyMessageErrors(xml: Document): string[] {
+	const errors: string[] = [];
+	for (const node of xml.querySelectorAll('e-form-success-message, e-form-error-message')) {
+	  if (node.children.length === 0) {
+		errors.push(`<${node.tagName}> must have at least one child element (e.g. <e-atomic-paragraph>).`);
+	  }
+	}
+	return errors;
+  }
+  

--- a/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/tool.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/tool.ts
@@ -84,7 +84,7 @@ export const initBuildCompositionsTool = ( reg: MCPRegistryEntry ) => {
 				compositionBuilder.setStylesConfig( stylesConfig );
 				compositionBuilder.setCustomCSS( customCSS );
 
-				const { configErrors, rootContainers: generatedRootContainers } =
+				const { configErrors, formErrors, rootContainers: generatedRootContainers } =
 					await compositionBuilder.build( targetContainer );
 
 				rootContainers.push( ...generatedRootContainers );
@@ -104,6 +104,10 @@ export const initBuildCompositionsTool = ( reg: MCPRegistryEntry ) => {
 
 				if ( configErrors.length ) {
 					errors.push( ...configErrors.map( ( msg ) => new Error( msg ) ) );
+				}
+
+				if ( formErrors.length ) {
+					errors.push( ...formErrors.map( ( msg ) => new Error( msg ) ) );
 				}
 			} catch ( error ) {
 				errors.push( error as Error );

--- a/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/tool.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/build-composition/tool.ts
@@ -84,8 +84,11 @@ export const initBuildCompositionsTool = ( reg: MCPRegistryEntry ) => {
 				compositionBuilder.setStylesConfig( stylesConfig );
 				compositionBuilder.setCustomCSS( customCSS );
 
-				const { configErrors, formErrors, rootContainers: generatedRootContainers } =
-					await compositionBuilder.build( targetContainer );
+				const {
+					configErrors,
+					formErrors,
+					rootContainers: generatedRootContainers,
+				} = await compositionBuilder.build( targetContainer );
 
 				rootContainers.push( ...generatedRootContainers );
 				generatedXML = new XMLSerializer().serializeToString( compositionBuilder.getXML() );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Form fields weren't being validated as wrapped within atomic form containers during composition building, allowing invalid structure. Adding structural validation catches orphaned fields, missing/duplicate submit buttons, and empty message elements at build time.

## 2. What Changed (Where)

- **form-structure/utils.ts**: Added three validation functions (`collectFormAncestorErrors`, `collectSubmitButtonErrors`, `collectEmptyMessageErrors`) to detect form structure violations
- **composition-builder.ts**: Integrated form validation into build pipeline, collects errors alongside existing config/style checks
- **build-composition/tool.ts**: Surfaces form errors to error handler; refactored destructuring to include new `formErrors` field
- **Test files**: Added utility helper and comprehensive test suite covering all validation scenarios

## 3. How It Works

Build process now executes three validation passes on the XML document:
1. **Form ancestor validation**: Traverses all form field elements, ensures each has `e-form` ancestor (any depth)
2. **Submit button validation**: Per-form checks that exactly one submit button exists
3. **Message validation**: Ensures success/error message elements contain children

All errors collected and returned alongside existing `configErrors`, then mapped to Error objects and reported through standard error handling pipeline.

## 4. Risks

None identified. Validation is purely additive—only detects structural problems, doesn't modify behavior for valid structures. Comprehensive test coverage (18 test cases across three functions) de-risks edge cases.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
