### PR TITLE
Internal: Add auto-reviewed label to cherry-pick workflow PRs [ED-24885]

### DIFF
--- a/.github/workflows/cherry-pick-pr.yml
+++ b/.github/workflows/cherry-pick-pr.yml
@@ -88,11 +88,18 @@ jobs:
           FILTERED_LABELS_CSV: ${{ steps.get_labels.outputs.filtered_labels_csv }}
           EVENT_ACTION: ${{ github.event.action }}
           SOURCE_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          GH_REPO: ${{ github.repository }}
         run: |
           PR_TITLE=$(echo "$PR_TITLE" | sed 's/[;&|<>`$()]//g')
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          gh label create "auto-reviewed" \
+            --repo "$GH_REPO" \
+            --description "PR has been automatically reviewed by CI" \
+            --color "0e8a16" \
+            --force 2>/dev/null || true
 
           IFS=',' read -ra BRANCHES <<< "$FILTERED_LABELS_CSV"
           for lbl in "${BRANCHES[@]}"; do
@@ -148,6 +155,7 @@ jobs:
                   gh pr create \
                     --base "$TARGET" \
                     --head "$CONFLICT_BRANCH" \
+                    --label "auto-reviewed" \
                     --title "${TYPE} Cherry-pick PR ${PR_NUMBER} to ${TARGET} with conflicts: ${PR_TITLE_BODY}" \
                     --body "⚠️ **Manual Resolution Required**
 
@@ -217,6 +225,7 @@ jobs:
               PR_URL=$(gh pr create \
                 --base "$TARGET" \
                 --head "$BRANCH" \
+                --label "auto-reviewed" \
                 --title "${TYPE} Cherry-pick PR ${PR_NUMBER} to ${TARGET}: ${PR_TITLE_BODY}" \
                 --body "Automatic cherry-pick of [#${PR_NUMBER}](${ORIG_URL}) to \`${TARGET}\` branch.
 

--- a/.github/workflows/cherry-pick-pr.yml
+++ b/.github/workflows/cherry-pick-pr.yml
@@ -88,18 +88,11 @@ jobs:
           FILTERED_LABELS_CSV: ${{ steps.get_labels.outputs.filtered_labels_csv }}
           EVENT_ACTION: ${{ github.event.action }}
           SOURCE_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          GH_REPO: ${{ github.repository }}
         run: |
           PR_TITLE=$(echo "$PR_TITLE" | sed 's/[;&|<>`$()]//g')
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          gh label create "auto-reviewed" \
-            --repo "$GH_REPO" \
-            --description "PR has been automatically reviewed by CI" \
-            --color "0e8a16" \
-            --force 2>/dev/null || true
 
           IFS=',' read -ra BRANCHES <<< "$FILTERED_LABELS_CSV"
           for lbl in "${BRANCHES[@]}"; do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR Type
- [x] CI related changes

## Summary

This PR can be summarized in the following changelog entry:

* Cherry-pick workflow now tags created PRs with `auto-reviewed` so enhanced PR review is skipped.

## Description

Cherry-pick PRs are mechanical backports of already-reviewed code and do not need the enhanced PR review workflow. This change ensures the cherry-pick workflow applies the `auto-reviewed` label when creating PRs (including conflict draft PRs), matching the skip logic already present in `pr-enhance-review.yml`.

## Test instructions

1. Merge a PR with a `cp_*` label to trigger the cherry-pick workflow.
2. Verify the created cherry-pick PR has the `auto-reviewed` label.
3. Confirm the enhanced PR review workflow does not run for that PR.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes ED-24885
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bb40dc1-dc9e-4fc2-99e0-3e7f7dce324f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bb40dc1-dc9e-4fc2-99e0-3e7f7dce324f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

