### PR TITLE
Fix: Editor top bar responsiveness and external plugin registration [ED-24890]

### DIFF
--- a/packages/packages/core/editor-app-bar/README.md
+++ b/packages/packages/core/editor-app-bar/README.md
@@ -55,7 +55,7 @@ import { EyeIcon } from '@elementor/icons';
 import { __ } from '@wordpress/i18n';
 
 integrationsMenu.registerToggleAction( {
-	name: 'my-custom-toggle',
+	id: 'my-custom-toggle',
 	useProps: () => {
 		const [ isSelected, setIsSelected ] = useState( false );
 
@@ -78,7 +78,7 @@ import { LinkIcon } from '@elementor/icons';
 import { __ } from '@wordpress/i18n';
 
 integrationsMenu.registerLink( {
-	name: 'my-custom-link',
+	id: 'my-custom-link',
 	props: {
 		title: __( 'My Custom Link', 'elementor' ),
 		icon: LinkIcon,
@@ -100,4 +100,63 @@ integrationsMenu.registerLink( {
 
 ### Custom Locations
 
-TBD
+In addition to the menus above, a few locations accept full custom React components via `injectInto*` functions:
+
+- `injectIntoPageIndication` - Injects a component next to the document title, in the center of the app bar.
+- `injectIntoResponsive` - Injects a component next to the responsive/breakpoints switcher, in the center of the app bar.
+- `injectIntoPrimaryAction` - Injects a component next to the primary action (e.g. "Publish"/"Save"), on the right side of the app bar.
+
+```tsx
+import { injectIntoPageIndication } from '@elementor/editor-app-bar';
+
+injectIntoPageIndication( {
+	id: 'my-custom-indication',
+	component: () => <div>Custom content</div>,
+	options: {
+		priority: 10, // Optional, lower value means higher priority. Default is 10.
+	},
+} );
+```
+
+> [!NOTE]
+> Both the menus (`registerAction`/`registerLink`/`registerToggleAction`) and the custom locations (`injectInto*`) are reactive:
+> registering an item at any time (including after the editor has already loaded) will make it appear immediately, so
+> plugins that load their scripts after the editor (e.g. Pro plugins, or third-party plugins) don't need to register
+> before the app bar has rendered.
+
+### Registering from outside this repository
+
+Third-party plugins (e.g. Elementor Pro, or any WordPress plugin) can register items into the app bar without being
+part of this monorepo's build, by depending on the `elementor-v2-editor-app-bar` script handle and using the
+`elementorV2.editorAppBar` global (which is the same object exported from `@elementor/editor-app-bar`):
+
+```php
+add_action( 'elementor/editor/v2/scripts/enqueue', function () {
+	wp_enqueue_script(
+		'my-plugin-editor-app-bar',
+		plugins_url( 'assets/editor-app-bar.js', __FILE__ ),
+		[ 'elementor-v2-editor-app-bar', 'elementor-v2-ui', 'elementor-v2-icons' ],
+		'1.0.0',
+		true
+	);
+} );
+```
+
+```js
+// my-plugin-editor-app-bar.js
+if ( window.elementorV2?.editorAppBar ) {
+	const { utilitiesMenu } = window.elementorV2.editorAppBar;
+
+	utilitiesMenu.registerLink( {
+		id: 'my-plugin-link',
+		props: {
+			title: 'My Plugin',
+			icon: MyIcon,
+			href: 'https://example.com',
+		},
+	} );
+}
+```
+
+Make sure to always use `id` (not `name`) when registering menu items, and to guard the call with a check for
+`window.elementorV2.editorAppBar`, since script load order across plugins is not guaranteed.

--- a/packages/packages/core/editor-app-bar/src/__tests__/app-bar.test.tsx
+++ b/packages/packages/core/editor-app-bar/src/__tests__/app-bar.test.tsx
@@ -4,6 +4,7 @@ import { __useActiveDocument as useActiveDocument } from '@elementor/editor-docu
 import { act, screen } from '@testing-library/react';
 
 import AppBar from '../components/app-bar';
+import { MIN_APP_BAR_WIDTH } from '../constants';
 import { toolsMenu, utilitiesMenu } from '../locations';
 
 jest.mock( '@elementor/editor-documents', () => ( {
@@ -81,5 +82,21 @@ describe( '@elementor/editor-app-bar - AppBar', () => {
 
 		// Assert - narrowing the app bar moves items from the tools/utilities menus into "More" popovers.
 		expect( screen.getAllByLabelText( 'More' ) ).toHaveLength( 2 );
+	} );
+
+	it( 'should not shrink the app bar content below MIN_APP_BAR_WIDTH, so it scrolls horizontally instead', () => {
+		// Arrange.
+		renderWithTheme( <AppBar /> );
+
+		// Act.
+		act( () => {
+			MockResizeObserver.instances.forEach( ( observer ) => observer.trigger( 400 ) );
+		} );
+
+		// Assert - the grid content keeps its min-width floor regardless of how narrow the app bar itself is.
+		// eslint-disable-next-line testing-library/no-node-access -- no accessible role/label exists for this structural layout container.
+		const grid = document.querySelector( '.MuiToolbar-root > div' ) as HTMLElement;
+
+		expect( getComputedStyle( grid ).minWidth ).toBe( `${ MIN_APP_BAR_WIDTH }px` );
 	} );
 } );

--- a/packages/packages/core/editor-app-bar/src/__tests__/app-bar.test.tsx
+++ b/packages/packages/core/editor-app-bar/src/__tests__/app-bar.test.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { createMockDocument, renderWithTheme } from 'test-utils';
+import { __useActiveDocument as useActiveDocument } from '@elementor/editor-documents';
+import { act, screen } from '@testing-library/react';
+
+import AppBar from '../components/app-bar';
+import { toolsMenu, utilitiesMenu } from '../locations';
+
+jest.mock( '@elementor/editor-documents', () => ( {
+	__useActiveDocument: jest.fn(),
+} ) );
+
+jest.mock( '@elementor/editor-current-user', () => ( {
+	useCurrentUserCapabilities: () => ( { isAdmin: true, canUser: jest.fn(), capabilities: [] } ),
+} ) );
+
+type ResizeCallback = ( entries: Array< { contentRect: { width: number } } > ) => void;
+
+class MockResizeObserver {
+	static instances: MockResizeObserver[] = [];
+	callback: ResizeCallback;
+
+	constructor( callback: ResizeCallback ) {
+		this.callback = callback;
+		MockResizeObserver.instances.push( this );
+	}
+
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+
+	trigger( width: number ) {
+		this.callback( [ { contentRect: { width } } ] );
+	}
+}
+
+function registerMenuActions( menu: typeof toolsMenu | typeof utilitiesMenu, count: number ) {
+	for ( let i = 0; i < count; i++ ) {
+		menu.registerAction( {
+			id: `test-${ menu === toolsMenu ? 'tools' : 'utilities' }-${ i }`,
+			props: {
+				title: `Test ${ i }`,
+				icon: () => <span>icon</span>,
+			},
+		} );
+	}
+}
+
+describe( '@elementor/editor-app-bar - AppBar', () => {
+	const originalResizeObserver = globalThis.ResizeObserver;
+
+	beforeEach( () => {
+		jest.mocked( useActiveDocument ).mockReturnValue(
+			createMockDocument( {
+				permissions: { allowAddingWidgets: true, showCopyAndShare: false },
+			} )
+		);
+
+		MockResizeObserver.instances = [];
+		globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+	} );
+
+	afterEach( () => {
+		globalThis.ResizeObserver = originalResizeObserver;
+	} );
+
+	it( 'should collapse the tools and utilities menus into their "More" popovers as the app bar narrows', () => {
+		// Arrange.
+		registerMenuActions( toolsMenu, 5 );
+		registerMenuActions( utilitiesMenu, 4 );
+
+		renderWithTheme( <AppBar /> );
+
+		// At full width, all the registered items are shown inline (no "More" popover needed).
+		expect( screen.queryByLabelText( 'More' ) ).not.toBeInTheDocument();
+
+		// Act.
+		act( () => {
+			MockResizeObserver.instances.forEach( ( observer ) => observer.trigger( 400 ) );
+		} );
+
+		// Assert - narrowing the app bar moves items from the tools/utilities menus into "More" popovers.
+		expect( screen.getAllByLabelText( 'More' ) ).toHaveLength( 2 );
+	} );
+} );

--- a/packages/packages/core/editor-app-bar/src/components/app-bar.tsx
+++ b/packages/packages/core/editor-app-bar/src/components/app-bar.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
+import { useRef } from 'react';
 import { __useActiveDocument as useActiveDocument } from '@elementor/editor-documents';
 import { AppBar as BaseAppBar, Box, Divider, Grid, ThemeProvider, Toolbar } from '@elementor/ui';
 
+import { AppBarSizeProvider } from '../contexts/app-bar-size-context';
+import { useContainerWidth } from '../hooks/use-container-width';
+import { getMaxToolbarActions } from '../utils/get-max-toolbar-actions';
 import MainMenuLocation from './locations/main-menu-location';
 import PageIndicationLocation from './locations/page-indication-location';
 import PrimaryActionLocation from './locations/primary-action-location';
@@ -12,28 +16,46 @@ import ToolbarMenu from './ui/toolbar-menu';
 
 export default function AppBar() {
 	const document = useActiveDocument();
+	const containerRef = useRef< HTMLDivElement >( null );
+	const containerWidth = useContainerWidth( containerRef );
+	const maxToolbarActions = getMaxToolbarActions( containerWidth );
+
 	return (
 		<ThemeProvider colorScheme="dark">
 			<BaseAppBar position="sticky">
 				<Toolbar disableGutters variant="dense">
-					<Box display="grid" gridTemplateColumns="repeat(3, 1fr)" flexGrow={ 1 }>
-						<Grid container flexWrap="nowrap">
-							<MainMenuLocation />
-							{ document?.permissions?.allowAddingWidgets && <ToolsMenuLocation /> }
-						</Grid>
-						<Grid container justifyContent="center">
-							<ToolbarMenu spacing={ 1.5 }>
-								<Divider orientation="vertical" />
-								<PageIndicationLocation />
-								<Divider orientation="vertical" />
-								<ResponsiveLocation />
-								<Divider orientation="vertical" />
-							</ToolbarMenu>
-						</Grid>
-						<Grid container justifyContent="flex-end" flexWrap="nowrap">
-							<UtilitiesMenuLocation />
-							<PrimaryActionLocation />
-						</Grid>
+					{ /* The center column keeps its natural ("auto") width, so the left and right
+					columns (`minmax(0, 1fr)`) shrink first as the app bar narrows. */ }
+					<Box
+						ref={ containerRef }
+						display="grid"
+						gridTemplateColumns="minmax(0, 1fr) auto minmax(0, 1fr)"
+						flexGrow={ 1 }
+					>
+						<AppBarSizeProvider value={ maxToolbarActions }>
+							<Grid container flexWrap="nowrap" sx={ { minWidth: 0, overflow: 'hidden' } }>
+								<MainMenuLocation />
+								{ document?.permissions?.allowAddingWidgets && <ToolsMenuLocation /> }
+							</Grid>
+							<Grid container justifyContent="center">
+								<ToolbarMenu spacing={ 1.5 }>
+									<Divider orientation="vertical" />
+									<PageIndicationLocation />
+									<Divider orientation="vertical" />
+									<ResponsiveLocation />
+									<Divider orientation="vertical" />
+								</ToolbarMenu>
+							</Grid>
+							<Grid
+								container
+								justifyContent="flex-end"
+								flexWrap="nowrap"
+								sx={ { minWidth: 0, overflow: 'hidden' } }
+							>
+								<UtilitiesMenuLocation />
+								<PrimaryActionLocation />
+							</Grid>
+						</AppBarSizeProvider>
 					</Box>
 				</Toolbar>
 			</BaseAppBar>

--- a/packages/packages/core/editor-app-bar/src/components/app-bar.tsx
+++ b/packages/packages/core/editor-app-bar/src/components/app-bar.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import { __useActiveDocument as useActiveDocument } from '@elementor/editor-documents';
 import { AppBar as BaseAppBar, Box, Divider, Grid, ThemeProvider, Toolbar } from '@elementor/ui';
 
+import { MIN_APP_BAR_WIDTH } from '../constants';
 import { AppBarSizeProvider } from '../contexts/app-bar-size-context';
 import { useContainerWidth } from '../hooks/use-container-width';
 import { getMaxToolbarActions } from '../utils/get-max-toolbar-actions';
@@ -23,7 +24,9 @@ export default function AppBar() {
 	return (
 		<ThemeProvider colorScheme="dark">
 			<BaseAppBar position="sticky">
-				<Toolbar disableGutters variant="dense">
+				{ /* Below MIN_APP_BAR_WIDTH the content can no longer shrink without clipping, so the
+				toolbar scrolls horizontally instead of squeezing the left/right sections further. */ }
+				<Toolbar disableGutters variant="dense" sx={ { overflowX: 'auto' } }>
 					{ /* The center column keeps its natural ("auto") width, so the left and right
 					columns (`minmax(0, 1fr)`) shrink first as the app bar narrows. */ }
 					<Box
@@ -31,6 +34,7 @@ export default function AppBar() {
 						display="grid"
 						gridTemplateColumns="minmax(0, 1fr) auto minmax(0, 1fr)"
 						flexGrow={ 1 }
+						minWidth={ `${ MIN_APP_BAR_WIDTH }px` }
 					>
 						<AppBarSizeProvider value={ maxToolbarActions }>
 							<Grid container flexWrap="nowrap" sx={ { minWidth: 0, overflow: 'hidden' } }>

--- a/packages/packages/core/editor-app-bar/src/components/app-bar.tsx
+++ b/packages/packages/core/editor-app-bar/src/components/app-bar.tsx
@@ -24,11 +24,7 @@ export default function AppBar() {
 	return (
 		<ThemeProvider colorScheme="dark">
 			<BaseAppBar position="sticky">
-				{ /* Below MIN_APP_BAR_WIDTH the content can no longer shrink without clipping, so the
-				toolbar scrolls horizontally instead of squeezing the left/right sections further. */ }
 				<Toolbar disableGutters variant="dense" sx={ { overflowX: 'auto' } }>
-					{ /* The center column keeps its natural ("auto") width, so the left and right
-					columns (`minmax(0, 1fr)`) shrink first as the app bar narrows. */ }
 					<Box
 						ref={ containerRef }
 						display="grid"

--- a/packages/packages/core/editor-app-bar/src/components/locations/__tests__/menus.test.tsx
+++ b/packages/packages/core/editor-app-bar/src/components/locations/__tests__/menus.test.tsx
@@ -7,6 +7,7 @@ jest.mock( '@elementor/editor-current-user', () => ( {
 	useCurrentUserCapabilities: () => ( { isAdmin: true, canUser: jest.fn(), capabilities: [] } ),
 } ) );
 
+import { AppBarSizeProvider } from '../../../contexts/app-bar-size-context';
 import { integrationsMenu, mainMenu, toolsMenu, utilitiesMenu } from '../../../locations';
 import MainMenuLocation from '../main-menu-location';
 import ToolsMenuLocation from '../tools-menu-location';
@@ -121,6 +122,41 @@ describe( 'Menus components', () => {
 
 			// Assert.
 			expect( screen.getAllByRole( 'menuitem' ) ).toHaveLength( extraAfterMax );
+		} );
+
+		it( 'should show fewer inline items and move the rest to the popover when the app bar is narrow', () => {
+			// Arrange.
+			const narrowMaxItems = 1;
+
+			for ( let i = 0; i < maxItems; i++ ) {
+				menu.registerAction( {
+					id: `test-${ i }`,
+					props: {
+						title: `Test ${ i }`,
+						icon: () => <span>a</span>,
+					},
+				} );
+			}
+
+			// Act.
+			renderWithTheme(
+				<AppBarSizeProvider value={ { tools: narrowMaxItems, utilities: narrowMaxItems } }>
+					<Component />
+				</AppBarSizeProvider>
+			);
+
+			// Assert.
+			const toolbarButtons = screen.getAllByRole( 'button' );
+			const popoverButton = toolbarButtons[ narrowMaxItems ];
+
+			expect( toolbarButtons ).toHaveLength( narrowMaxItems + 1 ); // Including the popover button.
+			expect( popoverButton ).toHaveAttribute( 'aria-label', 'More' );
+
+			// Act.
+			fireEvent.click( popoverButton );
+
+			// Assert.
+			expect( screen.getAllByRole( 'menuitem' ) ).toHaveLength( maxItems - narrowMaxItems );
 		} );
 	} );
 } );

--- a/packages/packages/core/editor-app-bar/src/components/locations/tools-menu-location.tsx
+++ b/packages/packages/core/editor-app-bar/src/components/locations/tools-menu-location.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { useMaxToolbarActions } from '../../contexts/app-bar-size-context';
 import { AngieGuideLocation } from '../../extensions/angie/components/angie-guide-location';
 import { toolsMenu } from '../../locations';
 import ToolbarMenu from '../ui/toolbar-menu';
@@ -7,15 +8,14 @@ import ToolbarMenuMore from '../ui/toolbar-menu-more';
 import IntegrationsMenuLocation from './integrations-menu-location';
 import SendFeedbackPopupLocation from './send-feedback-popup-location';
 
-const MAX_TOOLBAR_ACTIONS = 5;
-
 const { useMenuItems } = toolsMenu;
 
 export default function ToolsMenuLocation() {
 	const menuItems = useMenuItems();
+	const { tools: maxToolbarActions } = useMaxToolbarActions();
 
-	const toolbarMenuItems = menuItems.default.slice( 0, MAX_TOOLBAR_ACTIONS );
-	const popoverMenuItems = menuItems.default.slice( MAX_TOOLBAR_ACTIONS );
+	const toolbarMenuItems = menuItems.default.slice( 0, maxToolbarActions );
+	const popoverMenuItems = menuItems.default.slice( maxToolbarActions );
 
 	return (
 		<ToolbarMenu>

--- a/packages/packages/core/editor-app-bar/src/components/locations/utilities-menu-location.tsx
+++ b/packages/packages/core/editor-app-bar/src/components/locations/utilities-menu-location.tsx
@@ -1,23 +1,23 @@
 import * as React from 'react';
 import { Fragment } from 'react';
 
+import { useMaxToolbarActions } from '../../contexts/app-bar-size-context';
 import { utilitiesMenu } from '../../locations';
 import ToolbarMenu from '../ui/toolbar-menu';
 import ToolbarMenuMore from '../ui/toolbar-menu-more';
-
-const MAX_TOOLBAR_ACTIONS = 4;
 
 const { useMenuItems } = utilitiesMenu;
 
 export default function UtilitiesMenuLocation() {
 	const menuItems = useMenuItems();
+	const { utilities: maxToolbarActions } = useMaxToolbarActions();
 
-	// If there are more than 5 items, show the first 4 inline and the rest in the popover.
+	// If there are more items than the allowed max, show the max inline and the rest in the popover.
 	// Otherwise, display all items inline.
-	const shouldUsePopover = menuItems.default.length > MAX_TOOLBAR_ACTIONS + 1;
+	const shouldUsePopover = menuItems.default.length > maxToolbarActions + 1;
 
-	const toolbarMenuItems = shouldUsePopover ? menuItems.default.slice( 0, MAX_TOOLBAR_ACTIONS ) : menuItems.default;
-	const popoverMenuItems = shouldUsePopover ? menuItems.default.slice( MAX_TOOLBAR_ACTIONS ) : [];
+	const toolbarMenuItems = shouldUsePopover ? menuItems.default.slice( 0, maxToolbarActions ) : menuItems.default;
+	const popoverMenuItems = shouldUsePopover ? menuItems.default.slice( maxToolbarActions ) : [];
 
 	return (
 		<ToolbarMenu>

--- a/packages/packages/core/editor-app-bar/src/constants.ts
+++ b/packages/packages/core/editor-app-bar/src/constants.ts
@@ -2,3 +2,13 @@
 // center section (document title, breakpoints switcher) can't shrink further without becoming
 // unusable.
 export const MIN_APP_BAR_WIDTH = 800;
+
+export type MaxToolbarActions = {
+	tools: number;
+	utilities: number;
+};
+
+export const DEFAULT_MAX_TOOLBAR_ACTIONS: MaxToolbarActions = {
+	tools: 5,
+	utilities: 4,
+};

--- a/packages/packages/core/editor-app-bar/src/constants.ts
+++ b/packages/packages/core/editor-app-bar/src/constants.ts
@@ -1,0 +1,4 @@
+// Below this width the app bar stops shrinking and scrolls horizontally instead, since the
+// center section (document title, breakpoints switcher) can't shrink further without becoming
+// unusable.
+export const MIN_APP_BAR_WIDTH = 800;

--- a/packages/packages/core/editor-app-bar/src/contexts/app-bar-size-context.tsx
+++ b/packages/packages/core/editor-app-bar/src/contexts/app-bar-size-context.tsx
@@ -1,15 +1,7 @@
 import * as React from 'react';
 import { createContext, type PropsWithChildren, useContext } from 'react';
 
-export type MaxToolbarActions = {
-	tools: number;
-	utilities: number;
-};
-
-export const DEFAULT_MAX_TOOLBAR_ACTIONS: MaxToolbarActions = {
-	tools: 5,
-	utilities: 4,
-};
+import { DEFAULT_MAX_TOOLBAR_ACTIONS, type MaxToolbarActions } from '../constants';
 
 const AppBarSizeContext = createContext< MaxToolbarActions >( DEFAULT_MAX_TOOLBAR_ACTIONS );
 

--- a/packages/packages/core/editor-app-bar/src/contexts/app-bar-size-context.tsx
+++ b/packages/packages/core/editor-app-bar/src/contexts/app-bar-size-context.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { createContext, type PropsWithChildren, useContext } from 'react';
+
+export type MaxToolbarActions = {
+	tools: number;
+	utilities: number;
+};
+
+export const DEFAULT_MAX_TOOLBAR_ACTIONS: MaxToolbarActions = {
+	tools: 5,
+	utilities: 4,
+};
+
+const AppBarSizeContext = createContext< MaxToolbarActions >( DEFAULT_MAX_TOOLBAR_ACTIONS );
+
+export function AppBarSizeProvider( { value, children }: PropsWithChildren< { value: MaxToolbarActions } > ) {
+	return <AppBarSizeContext.Provider value={ value }>{ children }</AppBarSizeContext.Provider>;
+}
+
+export function useMaxToolbarActions() {
+	return useContext( AppBarSizeContext );
+}

--- a/packages/packages/core/editor-app-bar/src/hooks/__tests__/use-container-width.test.ts
+++ b/packages/packages/core/editor-app-bar/src/hooks/__tests__/use-container-width.test.ts
@@ -1,0 +1,64 @@
+import { createRef } from 'react';
+import { act, renderHook } from '@testing-library/react';
+
+import { useContainerWidth } from '../use-container-width';
+
+type ResizeCallback = ( entries: Array< { contentRect: { width: number } } > ) => void;
+
+class MockResizeObserver {
+	static instances: MockResizeObserver[] = [];
+	callback: ResizeCallback;
+
+	constructor( callback: ResizeCallback ) {
+		this.callback = callback;
+		MockResizeObserver.instances.push( this );
+	}
+
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+
+	trigger( width: number ) {
+		this.callback( [ { contentRect: { width } } ] );
+	}
+}
+
+describe( 'useContainerWidth', () => {
+	const originalResizeObserver = globalThis.ResizeObserver;
+
+	beforeEach( () => {
+		MockResizeObserver.instances = [];
+		globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+	} );
+
+	afterEach( () => {
+		globalThis.ResizeObserver = originalResizeObserver;
+	} );
+
+	it( 'should return 0 before the element has been measured', () => {
+		// Arrange.
+		const ref = createRef< HTMLElement >();
+
+		// Act.
+		const { result } = renderHook( () => useContainerWidth( ref ) );
+
+		// Assert.
+		expect( result.current ).toBe( 0 );
+	} );
+
+	it( 'should update the width when the observed element is resized', () => {
+		// Arrange.
+		const element = document.createElement( 'div' );
+		const ref = { current: element };
+
+		// Act.
+		const { result } = renderHook( () => useContainerWidth( ref ) );
+
+		act( () => {
+			MockResizeObserver.instances[ 0 ].trigger( 640 );
+		} );
+
+		// Assert.
+		expect( result.current ).toBe( 640 );
+	} );
+} );

--- a/packages/packages/core/editor-app-bar/src/hooks/__tests__/use-container-width.test.ts
+++ b/packages/packages/core/editor-app-bar/src/hooks/__tests__/use-container-width.test.ts
@@ -46,6 +46,19 @@ describe( 'useContainerWidth', () => {
 		expect( result.current ).toBe( 0 );
 	} );
 
+	it( 'should read the initial width synchronously, before the ResizeObserver fires', () => {
+		// Arrange.
+		const element = document.createElement( 'div' );
+		jest.spyOn( element, 'getBoundingClientRect' ).mockReturnValue( { width: 320 } as DOMRect );
+		const ref = { current: element };
+
+		// Act.
+		const { result } = renderHook( () => useContainerWidth( ref ) );
+
+		// Assert - the width is available immediately, without waiting for the observer callback.
+		expect( result.current ).toBe( 320 );
+	} );
+
 	it( 'should update the width when the observed element is resized', () => {
 		// Arrange.
 		const element = document.createElement( 'div' );

--- a/packages/packages/core/editor-app-bar/src/hooks/use-container-width.ts
+++ b/packages/packages/core/editor-app-bar/src/hooks/use-container-width.ts
@@ -18,6 +18,8 @@ export function useContainerWidth( ref: RefObject< HTMLElement | null > ) {
 			}
 		} );
 
+		setWidth( element.getBoundingClientRect().width );
+
 		observer.observe( element );
 
 		return () => observer.disconnect();

--- a/packages/packages/core/editor-app-bar/src/hooks/use-container-width.ts
+++ b/packages/packages/core/editor-app-bar/src/hooks/use-container-width.ts
@@ -1,0 +1,27 @@
+import { type RefObject, useEffect, useState } from 'react';
+
+export function useContainerWidth( ref: RefObject< HTMLElement | null > ) {
+	const [ width, setWidth ] = useState( 0 );
+
+	useEffect( () => {
+		const element = ref.current;
+
+		if ( ! element || typeof ResizeObserver === 'undefined' ) {
+			return;
+		}
+
+		const observer = new ResizeObserver( ( entries ) => {
+			const entry = entries[ 0 ];
+
+			if ( entry ) {
+				setWidth( entry.contentRect.width );
+			}
+		} );
+
+		observer.observe( element );
+
+		return () => observer.disconnect();
+	}, [ ref ] );
+
+	return width;
+}

--- a/packages/packages/core/editor-app-bar/src/utils/__tests__/get-max-toolbar-actions.test.ts
+++ b/packages/packages/core/editor-app-bar/src/utils/__tests__/get-max-toolbar-actions.test.ts
@@ -1,0 +1,31 @@
+import { DEFAULT_MAX_TOOLBAR_ACTIONS } from '../../contexts/app-bar-size-context';
+import { getMaxToolbarActions } from '../get-max-toolbar-actions';
+
+describe( 'getMaxToolbarActions', () => {
+	it( 'should return the default (widest) values when the width has not been measured yet', () => {
+		expect( getMaxToolbarActions( 0 ) ).toEqual( DEFAULT_MAX_TOOLBAR_ACTIONS );
+	} );
+
+	it( 'should return the default values on wide containers', () => {
+		expect( getMaxToolbarActions( 1400 ) ).toEqual( DEFAULT_MAX_TOOLBAR_ACTIONS );
+	} );
+
+	it( 'should return fewer inline actions on medium containers', () => {
+		expect( getMaxToolbarActions( 1000 ) ).toEqual( { tools: 3, utilities: 2 } );
+	} );
+
+	it( 'should return the minimum inline actions on narrow containers', () => {
+		expect( getMaxToolbarActions( 400 ) ).toEqual( { tools: 1, utilities: 1 } );
+	} );
+
+	it( 'should shrink further as the container gets narrower', () => {
+		const wide = getMaxToolbarActions( 1400 );
+		const medium = getMaxToolbarActions( 1000 );
+		const narrow = getMaxToolbarActions( 400 );
+
+		expect( medium.tools ).toBeLessThan( wide.tools );
+		expect( medium.utilities ).toBeLessThan( wide.utilities );
+		expect( narrow.tools ).toBeLessThanOrEqual( medium.tools );
+		expect( narrow.utilities ).toBeLessThanOrEqual( medium.utilities );
+	} );
+} );

--- a/packages/packages/core/editor-app-bar/src/utils/__tests__/get-max-toolbar-actions.test.ts
+++ b/packages/packages/core/editor-app-bar/src/utils/__tests__/get-max-toolbar-actions.test.ts
@@ -1,3 +1,4 @@
+import { MIN_APP_BAR_WIDTH } from '../../constants';
 import { DEFAULT_MAX_TOOLBAR_ACTIONS } from '../../contexts/app-bar-size-context';
 import { getMaxToolbarActions } from '../get-max-toolbar-actions';
 
@@ -14,18 +15,22 @@ describe( 'getMaxToolbarActions', () => {
 		expect( getMaxToolbarActions( 1000 ) ).toEqual( { tools: 3, utilities: 2 } );
 	} );
 
-	it( 'should return the minimum inline actions on narrow containers', () => {
-		expect( getMaxToolbarActions( 400 ) ).toEqual( { tools: 1, utilities: 1 } );
+	it( "should return the minimum inline actions at the app bar's min-width floor", () => {
+		expect( getMaxToolbarActions( MIN_APP_BAR_WIDTH ) ).toEqual( { tools: 1, utilities: 0 } );
+	} );
+
+	it( "should fully collapse the utilities menu below the min-width floor, since its primary action button has a fixed minimum width and can't shrink further", () => {
+		expect( getMaxToolbarActions( MIN_APP_BAR_WIDTH - 1 ) ).toEqual( { tools: 0, utilities: 0 } );
 	} );
 
 	it( 'should shrink further as the container gets narrower', () => {
 		const wide = getMaxToolbarActions( 1400 );
 		const medium = getMaxToolbarActions( 1000 );
-		const narrow = getMaxToolbarActions( 400 );
+		const atFloor = getMaxToolbarActions( MIN_APP_BAR_WIDTH );
 
 		expect( medium.tools ).toBeLessThan( wide.tools );
 		expect( medium.utilities ).toBeLessThan( wide.utilities );
-		expect( narrow.tools ).toBeLessThanOrEqual( medium.tools );
-		expect( narrow.utilities ).toBeLessThanOrEqual( medium.utilities );
+		expect( atFloor.tools ).toBeLessThanOrEqual( medium.tools );
+		expect( atFloor.utilities ).toBeLessThanOrEqual( medium.utilities );
 	} );
 } );

--- a/packages/packages/core/editor-app-bar/src/utils/__tests__/get-max-toolbar-actions.test.ts
+++ b/packages/packages/core/editor-app-bar/src/utils/__tests__/get-max-toolbar-actions.test.ts
@@ -1,5 +1,4 @@
-import { MIN_APP_BAR_WIDTH } from '../../constants';
-import { DEFAULT_MAX_TOOLBAR_ACTIONS } from '../../contexts/app-bar-size-context';
+import { DEFAULT_MAX_TOOLBAR_ACTIONS, MIN_APP_BAR_WIDTH } from '../../constants';
 import { getMaxToolbarActions } from '../get-max-toolbar-actions';
 
 describe( 'getMaxToolbarActions', () => {

--- a/packages/packages/core/editor-app-bar/src/utils/get-max-toolbar-actions.ts
+++ b/packages/packages/core/editor-app-bar/src/utils/get-max-toolbar-actions.ts
@@ -1,0 +1,21 @@
+import { DEFAULT_MAX_TOOLBAR_ACTIONS, type MaxToolbarActions } from '../contexts/app-bar-size-context';
+
+// Breakpoints are checked from the widest to the narrowest, so items in the left ("tools") and
+// right ("utilities") sections of the app bar collapse into their "More" popover as the app bar
+// narrows, freeing up space for the center section (document title, breakpoints switcher).
+const BREAKPOINTS: Array< { minWidth: number } & MaxToolbarActions > = [
+	{ minWidth: 1200, ...DEFAULT_MAX_TOOLBAR_ACTIONS },
+	{ minWidth: 950, tools: 3, utilities: 2 },
+	{ minWidth: 0, tools: 1, utilities: 1 },
+];
+
+export function getMaxToolbarActions( containerWidth: number ): MaxToolbarActions {
+	// Avoid collapsing the toolbar before its width has been measured.
+	if ( ! containerWidth ) {
+		return DEFAULT_MAX_TOOLBAR_ACTIONS;
+	}
+
+	const breakpoint = BREAKPOINTS.find( ( { minWidth } ) => containerWidth >= minWidth ) ?? BREAKPOINTS.at( -1 );
+
+	return { tools: breakpoint?.tools ?? 0, utilities: breakpoint?.utilities ?? 0 };
+}

--- a/packages/packages/core/editor-app-bar/src/utils/get-max-toolbar-actions.ts
+++ b/packages/packages/core/editor-app-bar/src/utils/get-max-toolbar-actions.ts
@@ -1,5 +1,4 @@
-import { MIN_APP_BAR_WIDTH } from '../constants';
-import { DEFAULT_MAX_TOOLBAR_ACTIONS, type MaxToolbarActions } from '../contexts/app-bar-size-context';
+import { DEFAULT_MAX_TOOLBAR_ACTIONS, type MaxToolbarActions, MIN_APP_BAR_WIDTH } from '../constants';
 
 // Breakpoints are checked from the widest to the narrowest, so items in the left ("tools") and
 // right ("utilities") sections of the app bar collapse into their "More" popover as the app bar

--- a/packages/packages/core/editor-app-bar/src/utils/get-max-toolbar-actions.ts
+++ b/packages/packages/core/editor-app-bar/src/utils/get-max-toolbar-actions.ts
@@ -1,12 +1,17 @@
+import { MIN_APP_BAR_WIDTH } from '../constants';
 import { DEFAULT_MAX_TOOLBAR_ACTIONS, type MaxToolbarActions } from '../contexts/app-bar-size-context';
 
 // Breakpoints are checked from the widest to the narrowest, so items in the left ("tools") and
 // right ("utilities") sections of the app bar collapse into their "More" popover as the app bar
 // narrows, freeing up space for the center section (document title, breakpoints switcher).
+//
+// The utilities section also holds the primary action (e.g. "Publish"), which has a fixed
+// minimum width and can't shrink, so it gets fewer inline items than tools at the same width.
 const BREAKPOINTS: Array< { minWidth: number } & MaxToolbarActions > = [
 	{ minWidth: 1200, ...DEFAULT_MAX_TOOLBAR_ACTIONS },
 	{ minWidth: 950, tools: 3, utilities: 2 },
-	{ minWidth: 0, tools: 1, utilities: 1 },
+	{ minWidth: MIN_APP_BAR_WIDTH, tools: 1, utilities: 0 },
+	{ minWidth: 0, tools: 0, utilities: 0 },
 ];
 
 export function getMaxToolbarActions( containerWidth: number ): MaxToolbarActions {

--- a/packages/packages/libs/locations/src/__tests__/create-location.test.tsx
+++ b/packages/packages/libs/locations/src/__tests__/create-location.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { lazy } from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 
 import { createLocation } from '../create-location';
 
@@ -221,6 +221,36 @@ describe( 'createLocation', () => {
 		expect( screen.getByText( 'Test 1' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Test 3' ) ).toBeInTheDocument();
 		expect( mockConsoleError ).toHaveBeenCalled();
+	} );
+
+	it( 'should render a component injected after the Slot has already mounted (e.g. by a plugin loaded later)', () => {
+		// Arrange.
+		const { inject, Slot } = createLocation();
+
+		inject( {
+			id: 'test-1',
+			component: () => <div data-testid="element">First div</div>,
+		} );
+
+		// Act.
+		render( <Slot /> );
+
+		// eslint-disable-next-line testing-library/no-test-id-queries
+		expect( screen.getAllByTestId( 'element' ) ).toHaveLength( 1 );
+
+		act( () => {
+			inject( {
+				id: 'test-2',
+				component: () => <div data-testid="element">Second div</div>,
+			} );
+		} );
+
+		// Assert.
+		// eslint-disable-next-line testing-library/no-test-id-queries
+		const elements = screen.getAllByTestId( 'element' );
+
+		expect( elements ).toHaveLength( 2 );
+		expect( elements[ 1 ].innerHTML ).toBe( 'Second div' );
 	} );
 
 	it( 'should pass the props from Slot to the injected component', () => {

--- a/packages/packages/libs/locations/src/__tests__/create-replaceable-location.test.tsx
+++ b/packages/packages/libs/locations/src/__tests__/create-replaceable-location.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 
 import { createReplaceableLocation } from '../create-replaceable-location';
 
@@ -129,6 +129,36 @@ describe( 'createReplaceableLocation', () => {
 		// Assert.
 		expect( screen.queryByText( 'The number is: -1' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'Children' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should replace the component when it is injected after the Slot has already mounted', () => {
+		// Arrange.
+		const { inject, Slot } = createReplaceableLocation< { text: string; number: number } >();
+
+		render(
+			<Slot text="The number is" number={ 1 }>
+				<div>Children</div>
+			</Slot>
+		);
+
+		expect( screen.getByText( 'Children' ) ).toBeInTheDocument();
+
+		// Act.
+		act( () => {
+			inject( {
+				id: 'test-1',
+				component: ( { text, number } ) => (
+					<div>
+						{ text }: { number }
+					</div>
+				),
+				condition: ( { number } ) => number > 0,
+			} );
+		} );
+
+		// Assert.
+		expect( screen.getByText( 'The number is: 1' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should replace the component if the condition is empty', () => {

--- a/packages/packages/libs/locations/src/create-location.tsx
+++ b/packages/packages/libs/locations/src/create-location.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import {
 	createGetInjections,
+	createSubscription,
 	createUseInjections,
 	DEFAULT_PRIORITY,
 	flushInjectionsFns,
@@ -13,14 +14,20 @@ type InjectionsMap< TProps extends object = AnyProps > = Map< Id, Injection< TPr
 
 export function createLocation< TProps extends object = AnyProps >(): Location< TProps > {
 	const injections: InjectionsMap< TProps > = new Map();
+	const { subscribe, notify } = createSubscription();
 
 	const getInjections = createGetInjections( injections );
-	const useInjections = createUseInjections( getInjections );
+	const useInjections = createUseInjections( getInjections, subscribe );
 	const Slot = createSlot( useInjections );
-	const inject = createInject( injections );
+	const inject = createInject( injections, notify );
 
 	// Push the clear function to the flushInjectionsFns array, so we can flush all injections at once.
-	flushInjectionsFns.push( () => injections.clear() );
+	// `notify()` is called too, so any mounted `Slot` (and its cached snapshot) reflects the flush,
+	// which matters for test isolation between test cases.
+	flushInjectionsFns.push( () => {
+		injections.clear();
+		notify();
+	} );
 
 	return {
 		inject,
@@ -44,7 +51,7 @@ function createSlot< TProps extends object = AnyProps >( useInjections: Location
 	};
 }
 
-function createInject< TProps extends object = AnyProps >( injections: InjectionsMap< TProps > ) {
+function createInject< TProps extends object = AnyProps >( injections: InjectionsMap< TProps >, notify: () => void ) {
 	return ( { component, id, options = {} }: InjectArgs< TProps > ) => {
 		if ( injections.has( id ) && ! options?.overwrite ) {
 			// eslint-disable-next-line no-console
@@ -60,5 +67,7 @@ function createInject< TProps extends object = AnyProps >( injections: Injection
 			component: wrapInjectedComponent( component ),
 			priority: options.priority ?? DEFAULT_PRIORITY,
 		} );
+
+		notify();
 	};
 }

--- a/packages/packages/libs/locations/src/create-replaceable-location.tsx
+++ b/packages/packages/libs/locations/src/create-replaceable-location.tsx
@@ -3,6 +3,7 @@ import { type PropsWithChildren } from 'react';
 
 import {
 	createGetInjections,
+	createSubscription,
 	createUseInjections,
 	DEFAULT_PRIORITY,
 	flushInjectionsFns,
@@ -20,14 +21,20 @@ type ReplaceableInjectionsMap< TProps extends object = AnyProps > = Map< Id, Rep
 
 export function createReplaceableLocation< TProps extends object = AnyProps >(): ReplaceableLocation< TProps > {
 	const injections: ReplaceableInjectionsMap< TProps > = new Map();
+	const { subscribe, notify } = createSubscription();
 
 	const getInjections = createGetInjections( injections );
-	const useInjections = createUseInjections( getInjections );
+	const useInjections = createUseInjections( getInjections, subscribe );
 	const Slot = createReplaceable( useInjections );
-	const inject = createRegister( injections );
+	const inject = createRegister( injections, notify );
 
 	// Push the clear function to the flushInjectionsFns array, so we can flush all injections at once.
-	flushInjectionsFns.push( () => injections.clear() );
+	// `notify()` is called too, so any mounted `Slot` (and its cached snapshot) reflects the flush,
+	// which matters for test isolation between test cases.
+	flushInjectionsFns.push( () => {
+		injections.clear();
+		notify();
+	} );
 
 	return {
 		getInjections,
@@ -53,7 +60,10 @@ function createReplaceable< TProps extends PropsWithChildren< object > = AnyProp
 	};
 }
 
-function createRegister< TProps extends object = AnyProps >( injections: ReplaceableInjectionsMap< TProps > ) {
+function createRegister< TProps extends object = AnyProps >(
+	injections: ReplaceableInjectionsMap< TProps >,
+	notify: () => void
+) {
 	return ( { component, id, condition = () => true, options = {} }: ReplaceableInjectArgs< TProps > ) => {
 		injections.set( id, {
 			id,
@@ -61,5 +71,7 @@ function createRegister< TProps extends object = AnyProps >( injections: Replace
 			condition,
 			priority: options.priority ?? DEFAULT_PRIORITY,
 		} );
+
+		notify();
 	};
 }

--- a/packages/packages/libs/locations/src/injections.tsx
+++ b/packages/packages/libs/locations/src/injections.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useMemo } from 'react';
+import { useSyncExternalStore } from 'react';
 
 import InjectedComponentWrapper from './components/injected-component-wrapper';
 import { type AnyProps, type Id, type InjectedComponent, type Injection, type Location } from './types';
@@ -15,14 +15,47 @@ export function flushAllInjections() {
 	flushInjectionsFns.forEach( ( flush ) => flush() );
 }
 
+export type Subscribe = ( listener: () => void ) => () => void;
+
+export function createSubscription() {
+	const listeners = new Set< () => void >();
+
+	return {
+		subscribe: ( listener: () => void ) => {
+			listeners.add( listener );
+
+			return () => listeners.delete( listener );
+		},
+		notify: () => listeners.forEach( ( listener ) => listener() ),
+	};
+}
+
 export function createGetInjections< TProps extends object = AnyProps >( injections: InjectionsMap< TProps > ) {
 	return () => [ ...injections.values() ].sort( ( a, b ) => a.priority - b.priority );
 }
 
+// Injections registered after the `Slot` has already mounted (e.g. by an external plugin's
+// script that loads after the editor has rendered) must still be reflected in the UI, so the
+// snapshot is invalidated and re-read whenever `notify()` is called.
 export function createUseInjections< TProps extends object = AnyProps >(
-	getInjections: Location< TProps >[ 'getInjections' ]
+	getInjections: Location< TProps >[ 'getInjections' ],
+	subscribe: Subscribe
 ) {
-	return () => useMemo( () => getInjections(), [] );
+	let snapshot: ReturnType< Location< TProps >[ 'getInjections' ] > | null = null;
+
+	subscribe( () => {
+		snapshot = null;
+	} );
+
+	const getSnapshot = () => {
+		if ( ! snapshot ) {
+			snapshot = getInjections();
+		}
+
+		return snapshot;
+	};
+
+	return () => useSyncExternalStore( subscribe, getSnapshot );
 }
 
 export function wrapInjectedComponent< TProps extends object = AnyProps >( Component: InjectedComponent< TProps > ) {

--- a/packages/tests/setup.ts
+++ b/packages/tests/setup.ts
@@ -8,6 +8,7 @@ import {
 import { __resetEnv } from '@elementor/env';
 import { __flushAllInjections } from '@elementor/locations';
 import { __deleteStore } from '@elementor/store';
+import { cleanup } from '@testing-library/react';
 import { TextEncoder, TextDecoder } from 'util';
 
 jest.mock( '@elementor/http-client' );
@@ -88,6 +89,10 @@ beforeEach( () => {
 afterEach( () => {
 	jest.clearAllMocks();
 	jest.useRealTimers();
+
+	// Unmount rendered components before flushing injections/listeners, so that reactive
+	// locations don't trigger React state updates on already-torn-down test instances.
+	cleanup();
 
 	__flushAllInjections();
 	flushListeners();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Fixed the editor top bar (`@elementor/editor-app-bar`) not shrinking its left/right sections on narrow screens (and clipping controls when it did), and fixed registrations made after the top bar has mounted (e.g. from a plugin loaded later, such as Elementor Pro or a third-party plugin) being silently ignored.

## Description

Three related fixes to the editor top bar:

1. **Not responsive**: the app bar used a fixed `repeat(3, 1fr)` grid with `flexWrap="nowrap"` on the left/right sections, so they never shrank as the viewport narrowed. Fixed by switching to a `minmax(0, 1fr) auto minmax(0, 1fr)` grid (center keeps its size, sides shrink first) and tracking the app bar's width with a `ResizeObserver` to reduce the number of inline tools/utilities menu items as it narrows (`AppBarSizeProvider` + `useContainerWidth` + `getMaxToolbarActions`), moving the rest into the existing "More" popovers.

2. **Clipped controls at the narrowest widths**: the left/right grid columns split available space evenly, but the right column also holds the primary action button (e.g. "Publish"), which has a fixed minimum width and can't shrink. At the narrowest widths this could squeeze the entire utilities menu (icons + its "More" trigger) out of view via `overflow: hidden`. Fixed by adding a `MIN_APP_BAR_WIDTH` (800px) floor - below it the app bar stops shrinking and scrolls horizontally instead - and fully collapsing the utilities menu's inline items at/below that floor, since the primary action alone leaves no room for anything else. Verified against a live build that no control is clipped/hidden at any width down to 800px, and the bar scrolls horizontally below that.

3. **External registration not working**: `injectIntoPageIndication`/`injectIntoPrimaryAction`/`injectIntoResponsive` (and any `createLocation`/`createReplaceableLocation`-based `Slot`) took a one-time snapshot of registered injections on first render (`useMemo` with empty deps). Registrations made after the `Slot` had already rendered - e.g. by a plugin script that loads after the editor, which is exactly how third-party/Pro plugin scripts are enqueued - were silently ignored. `useInjections` now uses `useSyncExternalStore`, matching the reactive pattern already used by the menu APIs (`registerAction`/`registerLink`/`registerToggleAction`). Also fixed the `README.md` examples that used `name` instead of the required `id` (which silently no-ops registration), documented the previously "TBD" custom locations, and documented the external-plugin registration pattern.

Jira: [ED-24890](https://elementor.atlassian.net/browse/ED-24890)

## Test instructions

This PR can be tested by following these steps:

* `npx jest --config packages/jest.config.js packages/packages/libs/locations packages/packages/libs/menus packages/packages/core/editor-app-bar` - all pass, including new tests covering all three fixes.
* `npx jest --config packages/jest.config.js packages/packages` - full packages suite still passes (476 suites, 3485 tests, 0 failures).
* `npx eslint .` and `npx tsc` in `packages/` - clean.
* `npm run build:packages` - all 58 packages build successfully.
* Verified live against a real built plugin running in `wp-lite-env` (Docker): resized the editor from 1600px down to 500px via Playwright and confirmed the "More" popovers appear/disappear correctly, no control is clipped or hidden at any width >= the 800px floor, the bar scrolls horizontally below 800px, and a `utilitiesMenu.registerLink(...)` call made from the browser console after the editor had already mounted appeared immediately without a reload.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce05025a-9285-4e9a-b440-7d6a4fa619af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce05025a-9285-4e9a-b440-7d6a4fa619af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ED-24890]: https://elementor.atlassian.net/browse/ED-24890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

App bar wasn't responsive to viewport changes and external plugins registering post-mount weren't reflected in UI. ED-24890 fixes both by introducing dynamic width-based toolbar collapsing and reactive injection subscriptions.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `app-bar.tsx` | Added ResizeObserver-based container width tracking; refactored layout to three-column grid with `AppBarSizeProvider` |
| `tools-menu-location.tsx`, `utilities-menu-location.tsx` | Replaced hardcoded `MAX_TOOLBAR_ACTIONS` constants with context-based dynamic values |
| `constants.ts` (new) | Defined `MIN_APP_BAR_WIDTH` (800px floor) and breakpoint config |
| `app-bar-size-context.tsx` (new) | Context provider for max toolbar actions; consumed by menu locations |
| `use-container-width.ts` (new) | Hook wrapping ResizeObserver for width tracking |
| `get-max-toolbar-actions.ts` (new) | Breakpoint logic mapping container width to menu item limits |
| `injections.tsx` | Replaced `useMemo` with `useSyncExternalStore`; added `createSubscription()` for reactive invalidation |
| `create-location.tsx`, `create-replaceable-location.tsx` | Integrated subscription callbacks so late-injected components trigger re-renders |
| Tests + docs | Added comprehensive test coverage and external plugin registration guide |

## 3. How It Works

AppBar measures container width via ResizeObserver → `getMaxToolbarActions()` maps width to breakpoint thresholds (1200px → 5 tools/4 utilities; 950px → 3/2; 800px → 1/0) → `AppBarSizeProvider` distributes values to menu locations, which dynamically slice arrays → items beyond limits move to "More" popovers. For injections: `createSubscription()` returns `notify()` callback passed to `inject()`/`inject()` creators; calling `notify()` invalidates the snapshot cache in `useSyncExternalStore`, forcing re-reads of `getInjections()` even if mount is unchanged.

## 4. Risks

Minor: `useSyncExternalStore` requires React 18.1+; ResizeObserver polyfill check exists but untested in legacy browsers. Breakpoint thresholds are somewhat arbitrary (950px, 1200px) — may need UX tuning post-launch. Test isolation fix (cleanup before flush) is sound but adds ~2ms per test.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
