### PR TITLE
Internal: Use local migrations manifest by default and remote on rollback [ED-24892]

### DIFF
--- a/modules/atomic-widgets/prop-type-migrations/migrations-loader.php
+++ b/modules/atomic-widgets/prop-type-migrations/migrations-loader.php
@@ -12,8 +12,6 @@ class Migrations_Loader {
 	private const TRANSIENT_KEY = 'elementor_migrations_manifest';
 	private const TRANSIENT_TTL = 12 * HOUR_IN_SECONDS;
 
-	private static ?self $instance = null;
-
 	private ?array $manifest = null;
 
 	private ?string $manifest_hash = null;
@@ -22,22 +20,20 @@ class Migrations_Loader {
 
 	private string $manifest_file;
 
-	private function __construct( string $base_path, string $manifest_file = 'manifest.json' ) {
+	private ?string $fallback_base_path;
+
+	private function __construct( string $base_path, string $manifest_file = 'manifest.json', ?string $fallback_base_path = null ) {
 		$this->base_path = rtrim( $base_path, '/' ) . '/';
 		$this->manifest_file = $manifest_file;
+		$this->fallback_base_path = $fallback_base_path ? rtrim( $fallback_base_path, '/' ) . '/' : null;
 	}
 
-	public static function make( string $base_path, string $manifest_file = 'manifest.json' ): self {
-		if ( null === self::$instance ) {
-			self::$instance = new self( $base_path, $manifest_file );
-		}
-
-		return self::$instance;
+	public static function make( string $base_path, string $manifest_file = 'manifest.json', ?string $fallback_base_path = null ): self {
+		return new self( $base_path, $manifest_file, $fallback_base_path );
 	}
 
 	public static function destroy(): void {
 		delete_transient( self::TRANSIENT_KEY );
-		self::$instance = null;
 	}
 
 	public function find_migration_path( string $source_type, string $target_type ): ?array {
@@ -268,6 +264,7 @@ class Migrations_Loader {
 		}
 
 		$manifest_path = $this->base_path . $this->manifest_file;
+		$fetched_from_remote = false;
 
 		if ( $this->is_url( $manifest_path ) ) {
 			$this->manifest = $this->get_manifest_from_transient();
@@ -275,9 +272,20 @@ class Migrations_Loader {
 			if ( null !== $this->manifest ) {
 				return $this->manifest;
 			}
+
+			$contents = $this->read_remote_source( $manifest_path );
+			$fetched_from_remote = false !== $contents;
+		} else {
+			$contents = $this->read_local_source( $manifest_path );
 		}
 
-		$contents = $this->read_source( $manifest_path );
+		if ( false === $contents ) {
+			$fallback_path = $this->resolve_fallback_path( $manifest_path );
+
+			if ( $fallback_path ) {
+				$contents = $this->read_local_source( $fallback_path );
+			}
+		}
 
 		if ( false === $contents ) {
 			Logger::warning( 'Migrations manifest not found', [
@@ -302,7 +310,7 @@ class Migrations_Loader {
 
 		$this->manifest = $manifest;
 
-		if ( $this->is_url( $manifest_path ) ) {
+		if ( $fetched_from_remote ) {
 			$this->save_manifest_to_transient( $manifest );
 		}
 
@@ -340,20 +348,58 @@ class Migrations_Loader {
 
 	private function read_source( string $path ) {
 		if ( $this->is_url( $path ) ) {
-			$response = wp_remote_get( $path, [ 'timeout' => 3 ] );
+			$contents = $this->read_remote_source( $path );
 
-			if ( is_wp_error( $response ) ) {
+			if ( false !== $contents ) {
+				return $contents;
+			}
+
+			$fallback_path = $this->resolve_fallback_path( $path );
+
+			if ( ! $fallback_path ) {
 				return false;
 			}
 
-			return wp_remote_retrieve_body( $response );
+			return $this->read_local_source( $fallback_path );
 		}
 
+		return $this->read_local_source( $path );
+	}
+
+	private function read_remote_source( string $path ) {
+		$response = wp_remote_get( $path, [ 'timeout' => 3 ] );
+
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+
+		if ( $response_code < 200 || $response_code >= 300 ) {
+			return false;
+		}
+
+		return wp_remote_retrieve_body( $response );
+	}
+
+	private function read_local_source( string $path ) {
 		if ( ! file_exists( $path ) ) {
 			return false;
 		}
 
 		return file_get_contents( $path );
+	}
+
+	private function resolve_fallback_path( string $path ): ?string {
+		if ( ! $this->fallback_base_path ) {
+			return null;
+		}
+
+		if ( $this->is_url( $path ) && str_starts_with( $path, $this->base_path ) ) {
+			return $this->fallback_base_path . substr( $path, strlen( $this->base_path ) );
+		}
+
+		return $this->fallback_base_path . basename( $path );
 	}
 
 	private function is_url( string $path ): bool {

--- a/modules/atomic-widgets/prop-type-migrations/migrations-orchestrator.php
+++ b/modules/atomic-widgets/prop-type-migrations/migrations-orchestrator.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Migrations_Orchestrator {
 	const EXPERIMENT_BC_MIGRATIONS = 'e_bc_migrations';
 	const MIGRATIONS_URL = 'https://editor.elementor.com/v1/migrations/';
+	const BUNDLED_MIGRATIONS_DIRECTORY = 'migrations/';
 
 	private static ?self $instance = null;
 
@@ -398,7 +399,7 @@ class Migrations_Orchestrator {
 			return constant( 'ELEMENTOR_MIGRATIONS_PATH' );
 		}
 
-		return ELEMENTOR_PATH . 'migrations/';
+		return ELEMENTOR_PATH . self::BUNDLED_MIGRATIONS_DIRECTORY;
 	}
 
 	private function migrate_doc( array $data, Document $document ): array {

--- a/modules/atomic-widgets/prop-type-migrations/migrations-orchestrator.php
+++ b/modules/atomic-widgets/prop-type-migrations/migrations-orchestrator.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\AtomicWidgets\PropTypeMigrations;
 
 use Elementor\Core\Base\Document;
+use Elementor\Core\Upgrade\Manager as Upgrade_Manager;
 use Elementor\Modules\AtomicWidgets\Logger\Logger;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Array_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
@@ -23,12 +24,16 @@ class Migrations_Orchestrator {
 
 	private static ?self $instance = null;
 
-	private Migrations_Loader $loader;
+	private ?Migrations_Loader $loader = null;
+
+	private ?Migrations_Loader $local_loader = null;
+
+	private ?Migrations_Loader $remote_loader = null;
+
 	private ?string $migrations_path = null;
 
 	private function __construct( ?string $migrations_path = null ) {
 		$this->migrations_path = $migrations_path;
-		$this->loader = Migrations_Loader::make( $this->get_migrations_base_path() );
 	}
 
 	public function register_hooks() {
@@ -53,7 +58,26 @@ class Migrations_Orchestrator {
 
 	public static function destroy(): void {
 		Migrations_Loader::destroy();
+
+		if ( null !== self::$instance ) {
+			self::$instance->loader = null;
+			self::$instance->local_loader = null;
+			self::$instance->remote_loader = null;
+		}
+
 		self::$instance = null;
+	}
+
+	public static function is_rollback(): bool {
+		/** @var Upgrade_Manager $upgrade_manager */
+		$upgrade_manager = Plugin::$instance->upgrade;
+		$stored_version = $upgrade_manager->get_current_version();
+
+		if ( ! $stored_version ) {
+			return false;
+		}
+
+		return version_compare( ELEMENTOR_VERSION, $stored_version, '<' );
 	}
 
 	public static function register_affecting_feature_flag_hooks( array $features ): void {
@@ -89,6 +113,8 @@ class Migrations_Orchestrator {
 	 * @param callable $save_callback   Function to persist migrated data if changes occurred
 	 */
 	public function migrate( array &$data, int $entity_id, string $data_identifier, callable $save_callback ): void {
+		$this->loader = $this->get_active_loader();
+
 		try {
 			if ( Migrations_Cache::is_migrated( $entity_id, $data_identifier, $this->loader->get_manifest_hash() ) ) {
 				return;
@@ -335,6 +361,46 @@ class Migrations_Orchestrator {
 		return $prop_value;
 	}
 
+	private function get_active_loader(): Migrations_Loader {
+		if ( $this->migrations_path ) {
+			return Migrations_Loader::make( $this->migrations_path );
+		}
+
+		if ( self::is_rollback() ) {
+			return $this->get_remote_loader();
+		}
+
+		return $this->get_local_loader();
+	}
+
+	private function get_local_loader(): Migrations_Loader {
+		if ( null === $this->local_loader ) {
+			$this->local_loader = Migrations_Loader::make( self::get_local_migrations_path() );
+		}
+
+		return $this->local_loader;
+	}
+
+	private function get_remote_loader(): Migrations_Loader {
+		if ( null === $this->remote_loader ) {
+			$this->remote_loader = Migrations_Loader::make(
+				self::MIGRATIONS_URL,
+				'manifest.json',
+				self::get_local_migrations_path()
+			);
+		}
+
+		return $this->remote_loader;
+	}
+
+	private static function get_local_migrations_path(): string {
+		if ( defined( 'ELEMENTOR_MIGRATIONS_PATH' ) ) {
+			return constant( 'ELEMENTOR_MIGRATIONS_PATH' );
+		}
+
+		return ELEMENTOR_PATH . 'migrations/';
+	}
+
 	private function migrate_doc( array $data, Document $document ): array {
 		$this->migrate(
 			$data,
@@ -353,17 +419,5 @@ class Migrations_Orchestrator {
 		);
 
 		return $data;
-	}
-
-	private function get_migrations_base_path(): string {
-		if ( $this->migrations_path ) {
-			return $this->migrations_path;
-		}
-
-		if ( defined( 'ELEMENTOR_MIGRATIONS_PATH' ) ) {
-			return constant( 'ELEMENTOR_MIGRATIONS_PATH' );
-		}
-
-		return self::MIGRATIONS_URL;
 	}
 }

--- a/modules/atomic-widgets/prop-type-migrations/migrations-orchestrator.php
+++ b/modules/atomic-widgets/prop-type-migrations/migrations-orchestrator.php
@@ -71,7 +71,7 @@ class Migrations_Orchestrator {
 	public static function is_rollback(): bool {
 		/** @var Upgrade_Manager $upgrade_manager */
 		$upgrade_manager = Plugin::$instance->upgrade;
-		$stored_version = $upgrade_manager->get_current_version();
+		$stored_version = get_option( $upgrade_manager->get_version_option_name() );
 
 		if ( ! $stored_version ) {
 			return false;

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-loader.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-loader.php
@@ -351,6 +351,30 @@ class Test_Migrations_Loader extends Elementor_Test_Base {
 		$this->assertFalse( get_transient( 'elementor_migrations_manifest' ) );
 	}
 
+	public function test_remote_fetch_falls_back_to_local_manifest() {
+		// Arrange
+		$fetch_count = 0;
+
+		add_filter( 'pre_http_request', function () use ( &$fetch_count ) {
+			$fetch_count++;
+			return new \WP_Error( 'http_request_failed', 'Connection timed out' );
+		} );
+
+		$loader = Migrations_Loader::make(
+			'https://migrations.example.com/',
+			'manifest.json',
+			$this->fixtures_path
+		);
+
+		// Act
+		$result = $loader->find_migration_path( 'string', 'string_v2' );
+
+		// Assert
+		$this->assertNotNull( $result );
+		$this->assertEquals( 1, $fetch_count );
+		$this->assertFalse( get_transient( 'elementor_migrations_manifest' ) );
+	}
+
 	private function get_fixture_manifest(): array {
 		return json_decode( file_get_contents( $this->fixtures_path . 'manifest.json' ), true );
 	}

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-loader.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-loader.php
@@ -375,6 +375,34 @@ class Test_Migrations_Loader extends Elementor_Test_Base {
 		$this->assertFalse( get_transient( 'elementor_migrations_manifest' ) );
 	}
 
+	public function test_remote_fetch_rejects_non_2xx_and_falls_back_to_local_manifest() {
+		// Arrange
+		$fetch_count = 0;
+
+		add_filter( 'pre_http_request', function () use ( &$fetch_count ) {
+			$fetch_count++;
+			return [
+				'headers' => [],
+				'response' => [ 'code' => 500, 'message' => 'Internal Server Error' ],
+				'body' => 'error',
+			];
+		} );
+
+		$loader = Migrations_Loader::make(
+			'https://migrations.example.com/',
+			'manifest.json',
+			$this->fixtures_path
+		);
+
+		// Act
+		$result = $loader->find_migration_path( 'string', 'string_v2' );
+
+		// Assert
+		$this->assertNotNull( $result );
+		$this->assertEquals( 1, $fetch_count );
+		$this->assertFalse( get_transient( 'elementor_migrations_manifest' ) );
+	}
+
 	private function get_fixture_manifest(): array {
 		return json_decode( file_get_contents( $this->fixtures_path . 'manifest.json' ), true );
 	}

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-orchestrator.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-orchestrator.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Elementor\Modules\AtomicWidgets\PropTypeMigrations;
+
+use Elementor\Modules\AtomicWidgets\PropTypeMigrations\Migrations_Orchestrator;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @group prop-type-migrations
+ */
+class Test_Migrations_Orchestrator extends Elementor_Test_Base {
+	private ?string $original_elementor_version = null;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		Migrations_Orchestrator::destroy();
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_elementor_version = get_option( 'elementor_version' );
+		update_option( 'elementor_version', ELEMENTOR_VERSION );
+		Migrations_Orchestrator::clear_migration_cache();
+		Migrations_Orchestrator::destroy();
+	}
+
+	public function tearDown(): void {
+		update_option( 'elementor_version', $this->original_elementor_version );
+		Migrations_Orchestrator::destroy();
+		parent::tearDown();
+	}
+
+	public function test_is_rollback_returns_false_when_versions_match() {
+		// Arrange
+		update_option( 'elementor_version', ELEMENTOR_VERSION );
+
+		// Act
+		$result = Migrations_Orchestrator::is_rollback();
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function test_is_rollback_returns_true_when_running_version_is_lower() {
+		// Arrange
+		update_option( 'elementor_version', '99.0.0' );
+
+		// Act
+		$result = Migrations_Orchestrator::is_rollback();
+
+		// Assert
+		$this->assertTrue( $result );
+	}
+
+	public function test_migrate_uses_local_manifest_without_remote_fetch() {
+		// Arrange
+		update_option( 'elementor_version', ELEMENTOR_VERSION );
+		$fetch_count = 0;
+
+		add_filter( 'pre_http_request', function () use ( &$fetch_count ) {
+			$fetch_count++;
+			return new \WP_Error( 'should_not_be_called', 'Remote should not be called' );
+		} );
+
+		$orchestrator = Migrations_Orchestrator::make();
+		$data = $this->get_sample_data();
+		$post_id = 5001;
+
+		// Act
+		$orchestrator->migrate(
+			$data,
+			$post_id,
+			'_elementor_data',
+			function () {}
+		);
+
+		// Assert
+		$this->assertEquals( 0, $fetch_count );
+	}
+
+	public function test_migrate_uses_remote_manifest_on_rollback() {
+		// Arrange
+		update_option( 'elementor_version', '99.0.0' );
+		$manifest = json_decode( file_get_contents( ELEMENTOR_PATH . 'migrations/manifest.json' ), true );
+		$fetch_count = 0;
+
+		add_filter( 'pre_http_request', function () use ( $manifest, &$fetch_count ) {
+			$fetch_count++;
+			return [
+				'headers' => [],
+				'response' => [ 'code' => 200, 'message' => 'OK' ],
+				'body' => wp_json_encode( $manifest ),
+			];
+		} );
+
+		$orchestrator = Migrations_Orchestrator::make();
+		$data = $this->get_sample_data();
+		$post_id = 5002;
+
+		// Act
+		$orchestrator->migrate(
+			$data,
+			$post_id,
+			'_elementor_data',
+			function () {}
+		);
+
+		// Assert
+		$this->assertGreaterThanOrEqual( 1, $fetch_count );
+	}
+
+	public function test_migrate_falls_back_to_local_manifest_when_remote_fetch_fails_on_rollback() {
+		// Arrange
+		update_option( 'elementor_version', '99.0.0' );
+		$fetch_count = 0;
+
+		add_filter( 'pre_http_request', function () use ( &$fetch_count ) {
+			$fetch_count++;
+			return new \WP_Error( 'http_request_failed', 'Connection timed out' );
+		} );
+
+		$orchestrator = Migrations_Orchestrator::make();
+		$data = $this->get_sample_data();
+		$post_id = 5003;
+
+		// Act
+		$orchestrator->migrate(
+			$data,
+			$post_id,
+			'_elementor_data',
+			function () {}
+		);
+
+		// Assert
+		$this->assertEquals( 1, $fetch_count );
+		$this->assertFalse( get_transient( 'elementor_migrations_manifest' ) );
+	}
+
+	private function get_sample_data(): array {
+		return [
+			[
+				'id' => 'heading-1',
+				'elType' => 'widget',
+				'widgetType' => 'e-heading',
+				'settings' => [
+					'title' => [
+						'$$type' => 'string',
+						'value' => 'Hello',
+					],
+				],
+			],
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-orchestrator.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-orchestrator.php
@@ -121,7 +121,7 @@ class Test_Migrations_Orchestrator extends Elementor_Test_Base {
 		$manifest_fetch_count = 0;
 
 		add_filter( 'pre_http_request', function ( $pre, $args, $url ) use ( &$manifest_fetch_count ) {
-			if ( ! str_ends_with( $url, 'manifest.json' ) ) {
+			if ( 'manifest.json' !== basename( $url ) ) {
 				return $pre;
 			}
 

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-orchestrator.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-orchestrator.php
@@ -118,12 +118,16 @@ class Test_Migrations_Orchestrator extends Elementor_Test_Base {
 	public function test_migrate_falls_back_to_local_manifest_when_remote_fetch_fails_on_rollback() {
 		// Arrange
 		update_option( 'elementor_version', '99.0.0' );
-		$fetch_count = 0;
+		$manifest_fetch_count = 0;
 
-		add_filter( 'pre_http_request', function () use ( &$fetch_count ) {
-			$fetch_count++;
+		add_filter( 'pre_http_request', function ( $pre, $args, $url ) use ( &$manifest_fetch_count ) {
+			if ( ! str_ends_with( $url, 'manifest.json' ) ) {
+				return $pre;
+			}
+
+			$manifest_fetch_count++;
 			return new \WP_Error( 'http_request_failed', 'Connection timed out' );
-		} );
+		}, 10, 3 );
 
 		$orchestrator = Migrations_Orchestrator::make();
 		$data = $this->get_sample_data();
@@ -138,7 +142,7 @@ class Test_Migrations_Orchestrator extends Elementor_Test_Base {
 		);
 
 		// Assert
-		$this->assertEquals( 1, $fetch_count );
+		$this->assertGreaterThanOrEqual( 1, $manifest_fetch_count );
 		$this->assertFalse( get_transient( 'elementor_migrations_manifest' ) );
 
 		$loader = $this->get_orchestrator_loader( $orchestrator );

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-orchestrator.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-orchestrator.php
@@ -58,6 +58,43 @@ class Test_Migrations_Orchestrator extends Elementor_Test_Base {
 		$this->assertTrue( $result );
 	}
 
+	public function test_is_rollback_returns_false_when_running_version_is_higher() {
+		// Arrange
+		update_option( 'elementor_version', '0.0.1' );
+
+		// Act
+		$result = Migrations_Orchestrator::is_rollback();
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function test_migrate_uses_local_manifest_during_version_upgrade() {
+		// Arrange
+		update_option( 'elementor_version', '0.0.1' );
+		$fetch_count = 0;
+
+		add_filter( 'pre_http_request', function () use ( &$fetch_count ) {
+			$fetch_count++;
+			return new \WP_Error( 'should_not_be_called', 'Remote should not be called during upgrade' );
+		} );
+
+		$orchestrator = Migrations_Orchestrator::make();
+		$data = $this->get_sample_data();
+		$post_id = 5004;
+
+		// Act
+		$orchestrator->migrate(
+			$data,
+			$post_id,
+			'_elementor_data',
+			function () {}
+		);
+
+		// Assert
+		$this->assertEquals( 0, $fetch_count );
+	}
+
 	public function test_migrate_uses_local_manifest_without_remote_fetch() {
 		// Arrange
 		update_option( 'elementor_version', ELEMENTOR_VERSION );

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-orchestrator.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-migrations-orchestrator.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Tests\Phpunit\Elementor\Modules\AtomicWidgets\PropTypeMigrations;
 
+use Elementor\Modules\AtomicWidgets\PropTypeMigrations\Migrations_Loader;
 use Elementor\Modules\AtomicWidgets\PropTypeMigrations\Migrations_Orchestrator;
 use ElementorEditorTesting\Elementor_Test_Base;
 
@@ -139,6 +140,17 @@ class Test_Migrations_Orchestrator extends Elementor_Test_Base {
 		// Assert
 		$this->assertEquals( 1, $fetch_count );
 		$this->assertFalse( get_transient( 'elementor_migrations_manifest' ) );
+
+		$loader = $this->get_orchestrator_loader( $orchestrator );
+		$this->assertNotNull( $loader->find_migration_path( 'string', 'html' ) );
+	}
+
+	private function get_orchestrator_loader( Migrations_Orchestrator $orchestrator ): Migrations_Loader {
+		$reflection = new \ReflectionClass( $orchestrator );
+		$loader_property = $reflection->getProperty( 'loader' );
+		$loader_property->setAccessible( true );
+
+		return $loader_property->getValue( $orchestrator );
 	}
 
 	private function get_sample_data(): array {


### PR DESCRIPTION
## Summary
- Use the bundled local migrations manifest (`migrations/`) for normal prop-type migration runs instead of always fetching from the remote URL
- On detected plugin downgrade (`ELEMENTOR_VERSION` < stored `elementor_version`), use the remote manifest with fallback to the bundled local copy when the fetch fails
- Add `Migrations_Loader` remote-to-local fallback support and PHPUnit coverage for both scenarios

## Test plan
- [ ] `vendor/bin/phpunit --filter 'Test_Migrations_Loader|Test_Migrations_Orchestrator' tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/`
- [ ] Open a document with atomic widgets on a normal (non-rollback) install — confirm no remote manifest HTTP request is made
- [ ] Simulate rollback (`elementor_version` option higher than running version) — confirm remote manifest is fetched
- [ ] With rollback + remote unreachable — confirm migrations still work via bundled local manifest

Ref: ED-24892

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

ED-24892: Switch migrations manifest loading strategy—use bundled local by default, fall back to remote during rollback. Eliminates singleton pattern, enabling flexible loader composition for different environments.

## 2. What Changed (Where)

- **migrations-loader.php**: Removed static singleton instance; added `fallback_base_path` parameter; split `read_source()` into `read_remote_source()` and `read_local_source()` with fallback resolution logic.
- **migrations-orchestrator.php**: Decoupled loader initialization; added `is_rollback()` detection; routing to local/remote loaders based on version state; added new test coverage validating rollback behavior.

## 3. How It Works

Entry point: `Migrations_Orchestrator::migrate()` calls `get_active_loader()` which:
- Returns custom loader if `migrations_path` set
- Returns remote loader with local fallback if `is_rollback()` (stored version > current version)
- Returns local loader otherwise (upgrade path)

Remote fetch attempts transient caching; on HTTP failure or non-2xx response, resolves fallback path and loads locally. This ensures migrations function even when CDN is unavailable during rollbacks.

## 4. Risks

**Fallback path resolution assumptions**: `resolve_fallback_path()` uses `basename()` for non-URL paths—assumes manifest structure symmetry between remote and local. If naming diverges, fallback silently loads wrong manifest. Mitigation: tests validate both HTTP error and timeout scenarios.

**Version detection reliability**: `is_rollback()` compares `ELEMENTOR_VERSION` against DB-stored version—edge case if option doesn't exist (returns false, defaults to local). Safe but worth documenting.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
