### PR TITLE
Fix: Elements Manager top bar location [ED-24871]

### DIFF
--- a/modules/element-manager/assets/js/app-editor-one/components/SearchFilters.js
+++ b/modules/element-manager/assets/js/app-editor-one/components/SearchFilters.js
@@ -66,7 +66,10 @@ export const SearchFilters = ( {
 			gap={ 1.5 }
 			sx={ ( theme ) => ( {
 				position: 'sticky',
-				top: theme.spacing( 10 ),
+				top: 0,
+				'@media screen and (max-width: 782px)': {
+					top: 'calc(var(--e-admin-bar-height, 0px) + var(--e-top-bar-header-height, 0px))',
+				},
 				backgroundColor: 'var(--e-one-palette-background-default)',
 				zIndex: 10,
 				paddingBlock: 2,


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The sticky search filters bar had hardcoded spacing that didn't account for WordPress admin bar/top bar on smaller screens, causing layout overlap. This fixes positioning to be responsive and respect the actual top bar height.

## 2. What Changed (Where)

SearchFilters.js: Replaced fixed `top: theme.spacing(10)` with responsive positioning—`top: 0` on desktop, `top: calc(var(--e-admin-bar-height, 0px) + var(--e-top-bar-header-height, 0px))` on mobile.

## 3. How It Works

Mobile viewports (≤782px) now calculate sticky offset dynamically using CSS custom properties for admin and top bar heights. Desktop stays anchored at viewport top. Fallback to 0px if variables undefined.

## 4. Risks

Depends on CSS variables being defined correctly in parent context. If `--e-admin-bar-height` or `--e-top-bar-header-height` aren't set, mobile sticky positioning reverts to `top: 0`, potentially overlapping content—acceptable given fallback safety.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
