### PR TITLE
Internal: Sync package-lock.json missing yaml@2.9.0 [ED-24894]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42757,6 +42757,24 @@
         "node": ">= 12"
       }
     },
+    "node_modules/tsup/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",


### PR DESCRIPTION
## Summary
- Fixes `npm ci` failure on npm 10.x caused by missing `yaml@2.9.0` entry in `package-lock.json` (required by `tsup`)
- Adds only the missing `node_modules/tsup/node_modules/yaml` lockfile entry — no other dependency changes

## Context
The lockfile was out of sync after recent dependency updates. The issue reproduces on `main` and `4.02` when running `npm ci` with npm 10.x.

After merge to `main`, this should be cherry-picked to `4.02`. During cherry-pick, conflict markers in `package-lock.json` may need to be resolved manually (similar to ED-24869).

## Test plan
- [ ] `npm ci` succeeds on npm 10.x
- [ ] No changes to `package.json` — lockfile-only fix
- [ ] CI install step passes


Made with [Cursor](https://cursor.com)