### PR TITLE
Internal: remove changelog creation from one click release

### DIFF
--- a/.github/workflows/one-click-release.yml
+++ b/.github/workflows/one-click-release.yml
@@ -104,14 +104,6 @@ jobs:
         with:
           BUILD_ZIP_FILE_PATH: ${{ github.event.repository.name }}-${{ env.PACKAGE_VERSION }}.zip
           PLUGIN_NAME: ${{ github.event.repository.name }}
-      - name: Generate changelog
-        uses: ./.github/workflows/generate-changelog
-        with:
-          TOKEN:  ${{ secrets.MAINTAIN_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          HEAD_BRANCH_NAME: ${{ github.ref }}
-          BASE_TAG_NAME: ${{ env.PREVIOUS_TAG_SHA }}
-          GENERATE_EMPTY_CHANGELOG: true
       - name: Check that the version contains an updated change log
         if: github.event.inputs.channel == 'ga'
         uses: ./.github/workflows/get-changelog-from-changelog-txt


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Removes automatic changelog generation from the one-click release workflow. The changelog is now only validated for GA releases, eliminating unnecessary generation for beta/internal releases.

## 2. What Changed (Where)

`.github/workflows/one-click-release.yml`: Deleted the "Generate changelog" step (8 lines) that invoked `generate-changelog` workflow with TOKEN, REPOSITORY, HEAD_BRANCH_NAME, BASE_TAG_NAME, and GENERATE_EMPTY_CHANGELOG parameters.

## 3. How It Works

Workflow now skips changelog generation entirely and proceeds directly to validation. The existing "Check that the version contains an updated change log" step still runs conditionally for GA channel only, ensuring manual changelog entries are present when required.

## 4. Risks

None identified. GA releases retain changelog validation; beta/internal releases no longer need synthetic changelogs, reducing noise and potential merge conflicts.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
