### PR TITLE
Fix: Load class before typography sync toggle [ED-24833]

### DIFF
--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
@@ -45,13 +45,7 @@ jest.mock( '@tanstack/react-virtual', () => ( {
 jest.mock( '@elementor/editor-documents' );
 jest.mock( '../class-manager-introduction' );
 jest.mock( '../start-sync-to-v3-modal', () => ( {
-	StartSyncToV3Modal: ( {
-		onConfirm,
-		externalOpen,
-	}: {
-		onConfirm?: () => void;
-		externalOpen?: boolean;
-	} ) =>
+	StartSyncToV3Modal: ( { onConfirm, externalOpen }: { onConfirm?: () => void; externalOpen?: boolean } ) =>
 		externalOpen ? (
 			<button type="button" onClick={ onConfirm }>
 				Confirm sync

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
@@ -15,6 +15,7 @@ import { ThemeProvider } from '@elementor/ui';
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 
 import { apiClient } from '../../../api';
+import { loadExistingClasses } from '../../../load-existing-classes';
 import { slice } from '../../../store';
 import { ClassManagerPanelEmbedded } from '../class-manager-panel';
 
@@ -43,9 +44,25 @@ jest.mock( '@tanstack/react-virtual', () => ( {
 
 jest.mock( '@elementor/editor-documents' );
 jest.mock( '../class-manager-introduction' );
-jest.mock( '../start-sync-to-v3-modal' );
+jest.mock( '../start-sync-to-v3-modal', () => ( {
+	StartSyncToV3Modal: ( {
+		onConfirm,
+		externalOpen,
+	}: {
+		onConfirm?: () => void;
+		externalOpen?: boolean;
+	} ) =>
+		externalOpen ? (
+			<button type="button" onClick={ onConfirm }>
+				Confirm sync
+			</button>
+		) : null,
+} ) );
 
 jest.mock( '../../../api' );
+jest.mock( '../../../load-existing-classes', () => ( {
+	loadExistingClasses: jest.fn().mockResolvedValue( undefined ),
+} ) );
 
 jest.mock( '@elementor/editor-current-user', () => ( {
 	useSuppressedMessage: jest.fn().mockReturnValue( [ false, jest.fn() ] ),
@@ -75,6 +92,7 @@ describe( 'ClassManagerPanel', () => {
 	} );
 
 	beforeEach( () => {
+		jest.clearAllMocks();
 		__registerSlice( slice );
 
 		store = __createStore();
@@ -571,6 +589,75 @@ describe( 'ClassManagerPanel', () => {
 				classId: 'class-2',
 				action: 'unsync',
 			} );
+		} );
+
+		expect( loadExistingClasses ).toHaveBeenCalledWith( [ 'class-2' ] );
+	} );
+
+	it( 'should load existing class before enabling sync when class is not in store', async () => {
+		// Arrange
+		const unloadedClass = createMockStyleDefinition( { id: 'class-3', label: 'Class 3' } );
+
+		jest.mocked( loadExistingClasses ).mockImplementation( async () => {
+			act( () => {
+				__dispatch(
+					slice.actions.mergeExistingClasses( {
+						preview: { [ unloadedClass.id ]: unloadedClass },
+						frontend: { [ unloadedClass.id ]: unloadedClass },
+					} )
+				);
+			} );
+		} );
+
+		act( () => {
+			__dispatch(
+				slice.actions.load( {
+					frontend: { items: {}, order: [ unloadedClass.id ] },
+					preview: { items: {}, order: [ unloadedClass.id ] },
+					classLabels: { [ unloadedClass.id ]: unloadedClass.label },
+				} )
+			);
+		} );
+
+		// Act
+		renderWithStore(
+			<ThemeProvider>
+				<QueryClientProvider client={ queryClient }>
+					<ClassManagerPanelEmbedded onRequestClose={ jest.fn() } onExposeCloseAttempt={ jest.fn() } />
+				</QueryClientProvider>
+			</ThemeProvider>,
+			store
+		);
+
+		const [ classItem ] = screen.getAllByRole( 'listitem' );
+
+		fireEvent.click( within( classItem ).getByRole( 'button', { name: 'More actions' } ) );
+
+		const startSyncButton = screen.getByRole( 'menuitem', { name: /Sync to Global Fonts/i } );
+
+		fireEvent.click( startSyncButton );
+
+		// Assert
+		await waitFor( () => {
+			expect( screen.getByRole( 'button', { name: 'Confirm sync' } ) ).toBeInTheDocument();
+		} );
+
+		// Act
+		fireEvent.click( screen.getByRole( 'button', { name: 'Confirm sync' } ) );
+
+		// Assert
+		await waitFor( () => {
+			expect( loadExistingClasses ).toHaveBeenCalledWith( [ unloadedClass.id ] );
+		} );
+
+		const updatedClass = store.getState().globalClasses.data.items[ unloadedClass.id ];
+
+		expect( updatedClass ).toMatchObject( {
+			id: unloadedClass.id,
+			label: unloadedClass.label,
+			type: 'class',
+			sync_to_v3: true,
+			variants: unloadedClass.variants,
 		} );
 	} );
 } );

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/class-manager-panel.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/class-manager-panel.tsx
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { useClassesOrder } from '../../hooks/use-classes-order';
 import { useDirtyState } from '../../hooks/use-dirty-state';
 import { useFilters } from '../../hooks/use-filters';
+import { loadExistingClasses } from '../../load-existing-classes';
 import { saveGlobalClasses } from '../../save-global-classes';
 import { slice } from '../../store';
 import { trackGlobalClasses } from '../../utils/tracking';
@@ -106,7 +107,9 @@ function ClassManagerPanelContent( {
 		};
 	}, [] );
 
-	const handleStopSync = useCallback( ( classId: string ) => {
+	const handleStopSync = useCallback( async ( classId: string ) => {
+		await loadExistingClasses( [ classId ] );
+
 		dispatch(
 			slice.actions.update( {
 				style: {
@@ -119,7 +122,9 @@ function ClassManagerPanelContent( {
 		setStopSyncConfirmation( null );
 	}, [] );
 
-	const handleStartSync = useCallback( ( classId: string ) => {
+	const handleStartSync = useCallback( async ( classId: string ) => {
+		await loadExistingClasses( [ classId ] );
+
 		dispatch(
 			slice.actions.update( {
 				style: {


### PR DESCRIPTION
## Summary
- Fix Class Manager sync toggle failing with "Something went wrong" when toggling Sync to Global Fonts on a class that was not yet loaded into the editor store
- Load full class data via `loadExistingClasses` before applying `sync_to_v3` updates in both start-sync and stop-sync handlers, matching the existing rename flow
- Add regression tests covering unloaded-class sync and verifying `loadExistingClasses` is invoked during unsync

## Test plan
- [x] Run `npx jest packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx`
- [ ] Open Class Manager on a page that does not use the typography class
- [ ] Toggle "Sync to Global Fonts" and confirm the panel does not show "Something went wrong"
- [ ] Save changes and verify sync persists in Site Settings > Global Fonts
- [ ] Toggle "Stop syncing to Global Fonts" on the same unloaded class and confirm no error

## Jira
[ED-24833](https://elementor.atlassian.net/browse/ED-24833)

Made with [Cursor](https://cursor.com)

[ED-24833]: https://elementor.atlassian.net/browse/ED-24833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Classes not yet loaded in store failed to sync to v3 because sync toggle handlers dispatched actions on undefined class data. Fixes ED-24833.

## 2. What Changed (Where)

- `class-manager-panel.tsx`: Import `loadExistingClasses` and call it before dispatching sync toggle actions in `handleStopSync` and `handleStartSync`
- `class-manager-panel.test.tsx`: Mock `loadExistingClasses` and `StartSyncToV3Modal`, add `jest.clearAllMocks()`, add test case for syncing unloaded classes

## 3. How It Works

Both sync handlers now await `loadExistingClasses([classId])` before updating store state, ensuring class data exists. Test verifies unloaded class gets populated from API before sync state updates.

## 4. Risks

None. Change is additive—awaiting class load before state update just closes a race condition gap where dispatch could operate on missing data.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
