### PR TITLE
Fix: Avoid whitespace argument split for checklist wp-cli eval [ED-24921]

### DIFF
--- a/tests/playwright/sanity/modules/checklist/helper.ts
+++ b/tests/playwright/sanity/modules/checklist/helper.ts
@@ -140,8 +140,10 @@ export class ChecklistHelper {
 	}
 
 	async enableChecklistVisibilityPreference() {
+		// Wp-lite-env's docker-compose "run" splits the command on whitespace instead of invoking a shell,
+		// so the PHP passed to `wp eval` must be a single whitespace-free token (no surrounding quotes either).
 		await wpCli(
-			'wp eval \'update_user_meta( 1, "elementor_preferences", array_merge( (array) get_user_meta( 1, "elementor_preferences", true ), array( "show_launchpad_checklist" => "yes" ) ) );\'',
+			'wp eval update_user_meta(1,"elementor_preferences",array_merge((array)get_user_meta(1,"elementor_preferences",true),array("show_launchpad_checklist"=>"yes")));',
 		);
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Root cause

CI job [Playwright test - 5](https://github.com/elementor/elementor/actions/runs/29479662185/job/87561306176?pr=36537) fails `checklist.test.ts › Checklist automatically opens on the 2nd visit to the editor` with:

```
Error: Too many positional arguments: 1, "elementor_preferences", array_merge( (array) get_user_meta( 1, "elementor_preferences", true ), array( "show_launchpad_checklist" => "yes" ) ) );'
```

`ChecklistHelper.enableChecklistVisibilityPreference()` calls `wpCli()`, which forwards the command string to `@elementor/wp-lite-env`'s `cli()`, which calls `docker-compose`'s `run(container, command, options)`. That function does:

```js
const args = Array.isArray(command) ? command : command.split(/\s+/);
```

There is no shell in between (`child_process.spawn` without `shell: true`), so wrapping the PHP snippet in single quotes has no effect — the quotes become literal characters and every space inside the `array_merge( ... )` expression becomes its own positional argument to `wp eval`, which only accepts one.

Reproduced locally against the same wp-lite-env stack used in CI:
- With the previous (quoted) command: fails with the exact same "Too many positional arguments" error.
- With this fix: passes.

### Fix

Write the PHP snippet as a single whitespace-free token with no surrounding shell quotes, matching the already-working `wp eval` call in `welcome-screen.test.ts`:

```
wp eval update_user_meta(1,"elementor_preferences",array_merge((array)get_user_meta(1,"elementor_preferences",true),array("show_launchpad_checklist"=>"yes")));
```

This is a 1-line code change targeting the `fix/ED-24921-stabilize-checklist-auto-open-test` branch (#36537), which had several prior attempts at fixing this same CI failure via different shell-quoting strategies — none addressed the real root cause (no shell is involved).

### Testing
- Set up wp-lite-env locally (ports 8888/8889) and reproduced the exact CI error with the pre-fix command.
- Applied the fix and confirmed `Checklist automatically opens on the 2nd visit to the editor` passes.
- Ran the full `checklist.test.ts` suite twice; all tests pass (one unrelated flake in `Checklist visible only to admin`, an MUI dialog click-timing issue unrelated to this change).
- `npx eslint tests/playwright/sanity/modules/checklist/helper.ts` passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c104c51f-3c4b-479b-bc56-1c9baedd700e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c104c51f-3c4b-479b-bc56-1c9baedd700e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

