### PR TITLE
Internal: Add Atomic Form WebMCP render regression tests [ED-24909]

### DIFF
--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/atomic-form/test-render.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/atomic-form/test-render.php
@@ -1,0 +1,100 @@
+<?php
+
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Form\Atomic_Form;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Form\Webmcp_Utils;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Atomic_Form_Render extends Elementor_Test_Base {
+
+	private const FORM_ELEMENT_ID = 'abc123de';
+
+	public function test_render_frontend_includes_webmcp_attributes(): void {
+		// Arrange.
+		$form = $this->make_atomic_form_instance( [
+			'form-name' => [
+				'$$type' => 'string',
+				'value' => 'Contact Form',
+			],
+		] );
+
+		// Act.
+		$rendered_output = $this->render_form( $form, false );
+
+		// Assert.
+		$expected_tool_name = Webmcp_Utils::build_tool_name( 'Contact Form', self::FORM_ELEMENT_ID );
+		$expected_tool_description = Webmcp_Utils::build_tool_description( 'Contact Form' );
+
+		$this->assertStringContainsString( 'toolname="' . $expected_tool_name . '"', $rendered_output );
+		$this->assertStringContainsString( 'tooldescription="' . $expected_tool_description . '"', $rendered_output );
+	}
+
+	public function test_render_frontend_includes_webmcp_autosubmit_when_enabled(): void {
+		// Arrange.
+		$form = $this->make_atomic_form_instance( [
+			'form-name' => [
+				'$$type' => 'string',
+				'value' => 'Contact Form',
+			],
+			'webmcp-autosubmit' => [
+				'$$type' => 'boolean',
+				'value' => true,
+			],
+		] );
+
+		// Act.
+		$rendered_output = $this->render_form( $form, false );
+
+		// Assert.
+		$this->assertStringContainsString( 'toolautosubmit', $rendered_output );
+	}
+
+	public function test_render_editor_excludes_webmcp_attributes(): void {
+		// Arrange.
+		$form = $this->make_atomic_form_instance( [
+			'form-name' => [
+				'$$type' => 'string',
+				'value' => 'Contact Form',
+			],
+			'webmcp-autosubmit' => [
+				'$$type' => 'boolean',
+				'value' => true,
+			],
+		] );
+
+		// Act.
+		$rendered_output = $this->render_form( $form, true );
+
+		// Assert.
+		$this->assertStringNotContainsString( 'toolname=', $rendered_output );
+		$this->assertStringNotContainsString( 'tooldescription=', $rendered_output );
+		$this->assertStringNotContainsString( 'toolautosubmit', $rendered_output );
+	}
+
+	private function make_atomic_form_instance( array $settings = [] ): Atomic_Form {
+		return new Atomic_Form( [
+			'id' => self::FORM_ELEMENT_ID,
+			'elType' => Atomic_Form::get_element_type(),
+			'widgetType' => Atomic_Form::get_element_type(),
+			'settings' => $settings,
+		], null );
+	}
+
+	private function render_form( Atomic_Form $form, bool $is_edit_mode ): string {
+		$original_edit_mode = Plugin::$instance->editor->is_edit_mode();
+		Plugin::$instance->editor->set_edit_mode( $is_edit_mode );
+
+		try {
+			ob_start();
+			$form->print_element();
+
+			return (string) ob_get_clean();
+		} finally {
+			Plugin::$instance->editor->set_edit_mode( $original_edit_mode );
+		}
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds PHPUnit render tests for the Atomic Form WebMCP attribute suppression fix (ED-24909).

These tests ensure:
- Frontend rendering includes `toolname`, `tooldescription`, and `toolautosubmit` when enabled
- Editor rendering excludes all WebMCP attributes to prevent the editor tab crash

## Test plan

- [x] PHPCS passes on the new test file
- [ ] `vendor/bin/phpunit tests/phpunit/elementor/modules/atomic-widgets/elements/atomic-form/test-render.php`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55d1c271-efb8-4484-837c-27465ac9484c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55d1c271-efb8-4484-837c-27465ac9484c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

