### PR TITLE
Internal: Twig check demo [ED-24230]

### DIFF
--- a/.github/workflows/lint-php-changes-only.yml
+++ b/.github/workflows/lint-php-changes-only.yml
@@ -54,3 +54,5 @@ jobs:
         run: |
           #composer lint $(echo "${PHP_CHANGED_FILES}" | tr '\n' ' ')
           vendor/bin/phpcs --extensions=php --standard=./ruleset.xml --warning-severity=0 $(echo "${PHP_CHANGED_FILES}" | tr '\n' ' ')
+      - name: Twig safety check
+        run: composer run check-twig-safety

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,6 +82,10 @@ jobs:
       - name: Run Lint
         run: |
           vendor/bin/phpcs -p -s -n . --standard=./ruleset.xml --extensions=php
+      - name: Twig safety check
+        run: composer run check-twig-safety
+      - name: Composer audit
+        run: composer audit --locked --abandoned=report
       - name: Setup PHP 7.4 # not included in ubuntu 22.04
         uses: shivammathur/setup-php@v2
         with:

--- a/bin/check-twig-safety.sh
+++ b/bin/check-twig-safety.sh
@@ -3,6 +3,10 @@
 # Guards the assumptions behind composer.json's config.policy.advisories.ignore-id
 # list for Twig.
 #
+# Matches are confirmed against comment-stripped file contents (see
+# strip-comments.php) so docblocks/comments that merely mention one of these
+# APIs by name (e.g. to explain why the code is safe) don't false-positive.
+#
 # If a change trips one of these checks, either remove the usage or, if it's
 # genuinely needed, re-evaluate composer.json's ignore-id list (and the CVEs
 # behind it) before relaxing this script.
@@ -39,14 +43,13 @@ has_extension() {
 	return 1
 }
 
-check() {
-	local advisories="$1"
-	local description="$2"
-	local pattern="$3"
-	shift 3
+# Candidate files: a cheap raw grep (no comment-stripping) over the relevant
+# extensions, just to narrow down which files are worth the (more expensive)
+# comment-aware check below.
+candidate_files() {
+	local pattern="$1"
+	shift
 	local extensions=("$@")
-
-	local matches=""
 
 	if [ "${#FILES[@]}" -eq 0 ]; then
 		local includes=()
@@ -54,26 +57,40 @@ check() {
 		for ext in "${extensions[@]}"; do
 			includes+=(--include="*.${ext}")
 		done
-		matches=$(grep -rnEI "${EXCLUDES[@]}" "${includes[@]}" -e "${pattern}" . 2>/dev/null || true)
+		grep -rlEI "${EXCLUDES[@]}" "${includes[@]}" -e "${pattern}" . 2>/dev/null | sed 's#^\./##' || true
 	else
-		local targets=()
 		local f
 		for f in "${FILES[@]}"; do
 			if [ -f "${f}" ] && has_extension "${f}" "${extensions[@]}"; then
-				targets+=("${f}")
+				printf '%s\n' "${f}"
 			fi
 		done
-		if [ "${#targets[@]}" -gt 0 ]; then
-			matches=$(grep -nEI -e "${pattern}" "${targets[@]}" 2>/dev/null || true)
-		fi
 	fi
+}
 
-	if [ -n "${matches}" ]; then
-		echo "::error::Forbidden Twig usage detected (${advisories} - ${description})"
-		echo "${matches}"
-		echo
-		failures=$((failures + 1))
-	fi
+check() {
+	local advisories="$1"
+	local description="$2"
+	local pattern="$3"
+	shift 3
+	local extensions=("$@")
+
+	local file
+	while IFS= read -r file; do
+		[ -n "${file}" ] || continue
+
+		local match
+		match=$(php bin/strip-comments.php "${file}" | grep -nE -e "${pattern}" || true)
+
+		if [ -n "${match}" ]; then
+			echo "::error::Forbidden Twig usage detected (${advisories} - ${description})"
+			while IFS= read -r line; do
+				echo "${file}:${line}"
+			done <<< "${match}"
+			echo
+			failures=$((failures + 1))
+		fi
+	done < <(candidate_files "${pattern}" "${extensions[@]}")
 }
 
 check "PKSA-8zx5-v2nz-58pb, PKSA-kvv6-36cr-fkzb, PKSA-n14z-jjjg-g8vd, PKSA-3mcc-k66d-pydb, PKSA-dpx1-78wg-1kqs, PKSA-g9zw-qxh8-pq8w, PKSA-yd6k-t2gh-1m43, PKSA-1tmc-rt7x-12w6, PKSA-xx6c-6d96-db2w" \

--- a/bin/check-twig-safety.sh
+++ b/bin/check-twig-safety.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Guards the assumptions behind composer.json's config.policy.advisories.ignore-id
+# list for Twig.
+#
+# If a change trips one of these checks, either remove the usage or, if it's
+# genuinely needed, re-evaluate composer.json's ignore-id list (and the CVEs
+# behind it) before relaxing this script.
+#
+# Usage:
+#   bin/check-twig-safety.sh              # scan the whole repo (used in CI)
+#   bin/check-twig-safety.sh file1 file2  # scan only these files (used by lint-staged)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+FILES=("$@")
+
+EXCLUDES=(
+	--exclude-dir=vendor
+	--exclude-dir=vendor_prefixed
+	--exclude-dir=node_modules
+	--exclude-dir=.git
+	--exclude-dir=build
+)
+
+failures=0
+
+has_extension() {
+	local file="$1"
+	shift
+
+	local ext
+	for ext in "$@"; do
+		[[ "${file}" == *".${ext}" ]] && return 0
+	done
+
+	return 1
+}
+
+check() {
+	local advisories="$1"
+	local description="$2"
+	local pattern="$3"
+	shift 3
+	local extensions=("$@")
+
+	local matches=""
+
+	if [ "${#FILES[@]}" -eq 0 ]; then
+		local includes=()
+		local ext
+		for ext in "${extensions[@]}"; do
+			includes+=(--include="*.${ext}")
+		done
+		matches=$(grep -rnEI "${EXCLUDES[@]}" "${includes[@]}" -e "${pattern}" . 2>/dev/null || true)
+	else
+		local targets=()
+		local f
+		for f in "${FILES[@]}"; do
+			if [ -f "${f}" ] && has_extension "${f}" "${extensions[@]}"; then
+				targets+=("${f}")
+			fi
+		done
+		if [ "${#targets[@]}" -gt 0 ]; then
+			matches=$(grep -nEI -e "${pattern}" "${targets[@]}" 2>/dev/null || true)
+		fi
+	fi
+
+	if [ -n "${matches}" ]; then
+		echo "::error::Forbidden Twig usage detected (${advisories} - ${description})"
+		echo "${matches}"
+		echo
+		failures=$((failures + 1))
+	fi
+}
+
+check "PKSA-8zx5-v2nz-58pb, PKSA-kvv6-36cr-fkzb, PKSA-n14z-jjjg-g8vd, PKSA-3mcc-k66d-pydb, PKSA-dpx1-78wg-1kqs, PKSA-g9zw-qxh8-pq8w, PKSA-yd6k-t2gh-1m43, PKSA-1tmc-rt7x-12w6, PKSA-xx6c-6d96-db2w" \
+	"Twig sandbox must stay disabled" \
+	'enableSandbox|SandboxExtension|\{%[[:space:]]*sandbox' \
+	php twig
+
+check "PKSA-gw7n-z4yx-7xjt, PKSA-21g2-dzjv-sky5, PKSA-fbvq-z33h-r2np" \
+	"Twig SourcePolicy must stay unconfigured" \
+	'SourcePolicyInterface|setSourcePolicy|new[[:space:]]+SourcePolicy' \
+	php
+
+check "PKSA-sjvz-tbbr-vwth" \
+	"Twig 'spaceless' filter/tag must not be used in templates" \
+	'\{%[[:space:]]*spaceless|\bspaceless\(' \
+	twig php
+
+check "PKSA-h8hf-ytnd-5t9q" \
+	"Twig {% use %} must only reference hardcoded, quoted template names" \
+	'\{%[[:space:]]*use[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*%\}' \
+	twig
+
+check "PKSA-wwb1-81rc-pd65" \
+	"Twig profiler/HtmlDumper must not be used" \
+	'HtmlDumper|ProfilerExtension|Twig\\\\Profiler' \
+	php
+
+check "PKSA-21g2-dzjv-sky5" \
+	"template_from_string() must not be called" \
+	'template_from_string' \
+	php twig
+
+if [ "${failures}" -gt 0 ]; then
+	echo "One or more Twig usages violate the assumptions used to ignore advisories in composer.json (config.policy.advisories.ignore-id)."
+	echo "Either remove the usage, or re-evaluate the ignored advisories before relaxing bin/check-twig-safety.sh."
+	exit 1
+fi
+
+echo "Twig safety check passed."

--- a/bin/strip-comments.php
+++ b/bin/strip-comments.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Prints a file's contents with comments blanked out, preserving line
+ * numbers, so bin/check-twig-safety.sh doesn't false-positive on docblocks
+ * or // comments that merely mention a forbidden Twig API by name.
+ *
+ * PHP files: uses the tokenizer to blank T_COMMENT / T_DOC_COMMENT tokens
+ * only (string literals and real code are left untouched).
+ * Everything else (e.g. .twig): blanks {# ... #} comments via regex.
+ *
+ * Usage: php strip-comments.php <file>
+ */
+
+if ( $argc < 2 ) {
+	fwrite( STDERR, "Usage: php strip-comments.php <file>\n" );
+	exit( 1 );
+}
+
+$path = $argv[1];
+$contents = file_get_contents( $path );
+
+if ( false === $contents ) {
+	fwrite( STDERR, "Unable to read {$path}\n" );
+	exit( 1 );
+}
+
+function blank( string $text ): string {
+	return str_repeat( "\n", substr_count( $text, "\n" ) );
+}
+
+if ( preg_match( '/\.php$/', $path ) ) {
+	$output = '';
+
+	foreach ( token_get_all( $contents ) as $token ) {
+		if ( is_array( $token ) ) {
+			[ $id, $text ] = $token;
+			$output .= in_array( $id, [ T_COMMENT, T_DOC_COMMENT ], true ) ? blank( $text ) : $text;
+		} else {
+			$output .= $token;
+		}
+	}
+
+	echo $output;
+	exit( 0 );
+}
+
+echo preg_replace_callback( '/\{#.*?#\}/s', fn( $m ) => blank( $m[0] ), $contents );

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     "scripts": {
         "lint": "vendor/bin/phpcs --extensions=php --standard=./ruleset.xml",
         "format": "vendor/bin/phpcbf --extensions=php --standard=./ruleset.xml",
+        "check-twig-safety": "bash bin/check-twig-safety.sh",
         "test": "phpunit",
         "test:install": "bash ./bin/install-wp-tests-local.sh",
         "phpunit:local": "bash ./bin/phpunit-local.sh",

--- a/demo-twig-violation.php
+++ b/demo-twig-violation.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * DEMO: DO NOT MERGE.
+ *
+ * Purpose: prove that bin/check-twig-safety.sh in CI catches a real Twig
+ * usage that would violate an assumption behind the ignored advisories in
+ * composer.json. This file is not autoloaded and is never executed - it
+ * only exists so the lint job fails on this branch.
+ *
+ * Expected CI outcome:
+ *   Lint / PHP-Lint  ->  step "Twig safety check"  ->  FAIL (exit 1)
+ *   with an "::error::Forbidden Twig usage detected ..." message pointing here.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$env->enableSandbox();

--- a/package.json
+++ b/package.json
@@ -225,6 +225,9 @@
     ],
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix"
+    ],
+    "*.{php,twig}": [
+      "bash bin/check-twig-safety.sh"
     ]
   }
 }

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -14,6 +14,7 @@
 	<exclude-pattern>vendor_prefixed/</exclude-pattern>
 	<exclude-pattern>tmp/</exclude-pattern>
 	<exclude-pattern>build/</exclude-pattern>
+	<exclude-pattern>bin/strip-comments.php</exclude-pattern>
 	<exclude-pattern>node_modules/</exclude-pattern>
 	<exclude-pattern>includes/libraries/</exclude-pattern>
 	<exclude-pattern>assets/js/packages/</exclude-pattern>


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Demonstrates that `bin/check-twig-safety.sh` catches real Twig API violations that would violate ignored CVE assumptions. Demo file (`demo-twig-violation.php`) intentionally triggers the CI check to prove the safety mechanism works before merging the tooling.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `bin/strip-comments.php` | New utility strips PHP/Twig comments while preserving line numbers for accurate linting |
| `bin/check-twig-safety.sh` | New bash script patterns-matches forbidden Twig APIs (sandbox, SourcePolicy, etc.) against 9 CVE groups |
| `demo-twig-violation.php` | Demo file with `$env->enableSandbox()` to trigger CI failure (not autoloaded) |
| `composer.json` | Added `check-twig-safety` script command |
| `.github/workflows/lint.yml`, `lint-php-changes-only.yml` | Integrated Twig safety check + composer audit into CI pipeline |
| `package.json` | Added lint-staged hook for `.php,.twig` files |
| `ruleset.xml` | Excluded `strip-comments.php` from phpcs analysis |

## 3. How It Works

Safety check runs regex patterns against comment-stripped file contents: cheap raw grep narrows candidates, then PHP tokenizer removes comments (PHP) or `{#...#}` (Twig) to avoid false positives in docstrings, then final regex confirms violations. Nine discrete checks map to Packagist Security advisories (PKSA IDs) covering sandbox disable, SourcePolicy, spaceless, `{% use %}`, profiler, and `template_from_string()`.

## 4. Risks

Demo file will fail CI on merge—must be deleted before landing. No runtime impact (file not autoloaded/executed). Edge case: complex string literals mimicking forbidden patterns could trigger false positives, but comment-stripping mitigates most cases.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
