### PR TITLE
Internal: Add list-resources and read-resource tools [ED-24951]

### DIFF
--- a/modules/mcp/abilities/list-resources-ability.php
+++ b/modules/mcp/abilities/list-resources-ability.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities;
+
+use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class List_Resources_Ability extends Abstract_Ability {
+
+	protected function get_ability_id(): string {
+		return 'elementor/list-resources';
+	}
+
+	protected function get_definition(): Ability_Definition {
+		return new Ability_Definition(
+			__( 'List Elementor Resources', 'elementor' ),
+			Prompt_Loader::load( 'list-resources' ),
+			'elementor',
+			[
+				'type' => 'object',
+				'properties' => [
+					'resources' => [
+						'type' => 'array',
+						'items' => [
+							'type' => 'object',
+							'properties' => [
+								'uri' => [ 'type' => 'string' ],
+								'name' => [ 'type' => 'string' ],
+								'description' => [ 'type' => 'string' ],
+								'mimeType' => [ 'type' => 'string' ],
+							],
+						],
+					],
+				],
+			],
+			[
+				'annotations' => [
+					'readonly' => true,
+					'idempotent' => true,
+					'destructive' => false,
+				],
+			],
+			fn() => current_user_can( 'edit_posts' )
+		);
+	}
+
+	public function execute( $input = [] ) {
+		return [
+			'resources' => $this->get_resource_catalog(),
+		];
+	}
+
+	private function get_resource_catalog(): array {
+		return [
+			[
+				'uri' => Style_Best_Practices_Ability::URI,
+				'name' => 'Style Best Practices',
+				'description' => 'Design quality guidelines for creating distinctive, intentional aesthetics. Covers typography, color strategy, spacing, motion, and visual hierarchy.',
+				'mimeType' => 'text/markdown',
+			],
+			[
+				'uri' => Manage_Variable_Guide_Ability::URI,
+				'name' => 'Manage Global Variable Guide',
+				'description' => 'Detailed guide for using the manage-global-variable tool. Covers available types, naming rules, value rules, and operation examples.',
+				'mimeType' => 'text/plain',
+			],
+		];
+	}
+}

--- a/modules/mcp/abilities/read-resource-ability.php
+++ b/modules/mcp/abilities/read-resource-ability.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities;
+
+use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Read_Resource_Ability extends Abstract_Ability {
+
+	protected function get_ability_id(): string {
+		return 'elementor/read-resource';
+	}
+
+	protected function get_definition(): Ability_Definition {
+		return new Ability_Definition(
+			__( 'Read Elementor Resource', 'elementor' ),
+			Prompt_Loader::load( 'read-resource' ),
+			'elementor',
+			[
+				'type' => 'object',
+				'properties' => [
+					'uri' => [ 'type' => 'string' ],
+					'mimeType' => [ 'type' => 'string' ],
+					'content' => [ 'type' => 'string' ],
+				],
+			],
+			[
+				'annotations' => [
+					'readonly' => true,
+					'idempotent' => true,
+					'destructive' => false,
+				],
+			],
+			fn() => current_user_can( 'edit_posts' ),
+			[
+				'type' => 'object',
+				'required' => [ 'uri' ],
+				'properties' => [
+					'uri' => [
+						'type' => 'string',
+						'description' => 'The resource URI to read. Use list-resources to discover available URIs.',
+					],
+				],
+			]
+		);
+	}
+
+	public function execute( $input = [] ) {
+		$input = is_array( $input ) ? $input : [];
+		$uri = $input['uri'] ?? '';
+
+		if ( '' === $uri ) {
+			return new \WP_Error(
+				'missing_uri',
+				__( 'Resource URI is required. Use list-resources to discover available URIs.', 'elementor' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$executors = $this->get_resource_executors();
+
+		if ( ! isset( $executors[ $uri ] ) ) {
+			return new \WP_Error(
+				'resource_not_found',
+				sprintf(
+					/* translators: %s: resource URI */
+					__( 'Resource not found: %s. Use list-resources to discover available URIs.', 'elementor' ),
+					$uri
+				),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$executor = $executors[ $uri ];
+		$content = $executor['execute']();
+
+		if ( is_wp_error( $content ) ) {
+			return $content;
+		}
+
+		return [
+			'uri' => $uri,
+			'mimeType' => $executor['mimeType'],
+			'content' => is_string( $content ) ? $content : wp_json_encode( $content ),
+		];
+	}
+
+	private function get_resource_executors(): array {
+		return [
+			Style_Best_Practices_Ability::URI => [
+				'execute' => fn() => ( new Style_Best_Practices_Ability() )->execute(),
+				'mimeType' => 'text/markdown',
+			],
+			Manage_Variable_Guide_Ability::URI => [
+				'execute' => fn() => ( new Manage_Variable_Guide_Ability() )->execute(),
+				'mimeType' => 'text/plain',
+			],
+		];
+	}
+}

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -68,6 +68,8 @@ class Module extends BaseModule {
 		( new Abilities\List_Widget_Schemas_Ability() )->register();
 		( new Abilities\List_Dynamic_Tags_Ability() )->register();
 		( new Abilities\Build_Composition_Ability() )->register();
+		( new Abilities\List_Resources_Ability() )->register();
+		( new Abilities\Read_Resource_Ability() )->register();
 	}
 
 	public function register_server( $adapter ) {
@@ -96,6 +98,8 @@ class Module extends BaseModule {
 				'elementor/list-widget-schemas',
 				'elementor/list-dynamic-tags',
 				'elementor/build-composition',
+				'elementor/list-resources',
+				'elementor/read-resource',
 			],
 			[
 				'elementor/style-best-practices',

--- a/modules/mcp/rest-api/mcp-proxy-rest-api.php
+++ b/modules/mcp/rest-api/mcp-proxy-rest-api.php
@@ -7,9 +7,11 @@ use Elementor\Core\Utils\Api\Response_Builder;
 use Elementor\Modules\Mcp\Abilities\Build_Composition_Ability;
 use Elementor\Modules\Mcp\Abilities\Get_Widget_Schema_Ability;
 use Elementor\Modules\Mcp\Abilities\List_Dynamic_Tags_Ability;
+use Elementor\Modules\Mcp\Abilities\List_Resources_Ability;
 use Elementor\Modules\Mcp\Abilities\List_Widget_Schemas_Ability;
 use Elementor\Modules\Mcp\Abilities\List_Widgets_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Variable_Ability;
+use Elementor\Modules\Mcp\Abilities\Read_Resource_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Variable_Guide_Ability;
 use Elementor\Modules\Mcp\Abilities\Style_Best_Practices_Ability;
 
@@ -32,6 +34,8 @@ class Mcp_Proxy_REST_API {
 			'list-widget-schemas' => fn( array $input ) => ( new List_Widget_Schemas_Ability() )->execute( $input ),
 			'list-dynamic-tags' => fn( array $input ) => ( new List_Dynamic_Tags_Ability() )->execute( $input ),
 			'build-composition' => fn( array $input ) => ( new Build_Composition_Ability() )->execute( $input ),
+			'list-resources' => fn( array $input ) => ( new List_Resources_Ability() )->execute( $input ),
+			'read-resource' => fn( array $input ) => ( new Read_Resource_Ability() )->execute( $input ),
 		];
 
 		$this->resources = [

--- a/modules/mcp/static-resources/abilities/list-resources.md
+++ b/modules/mcp/static-resources/abilities/list-resources.md
@@ -1,0 +1,5 @@
+Returns all available Elementor MCP resource URIs with descriptions. Use this to discover what resources can be fetched with read-resource.
+
+Resources provide read-only context data such as design guidelines, tool usage guides, and configuration information. Unlike tools, resources don't perform actions — they provide information to help you make better decisions.
+
+After discovering resources with this tool, use read-resource with the URI to fetch the actual content.

--- a/modules/mcp/static-resources/abilities/read-resource.md
+++ b/modules/mcp/static-resources/abilities/read-resource.md
@@ -1,0 +1,10 @@
+Fetches the content of an Elementor MCP resource by URI. Use list-resources first to discover available URIs.
+
+Input:
+- uri (required): The resource URI to read, as returned by list-resources.
+
+Returns the resource content along with its MIME type. Text resources (markdown, plain text) return content as a string. JSON resources are serialized to a JSON string.
+
+Common resources:
+- elementor://style/best-practices — Design quality guidelines for distinctive aesthetics
+- elementor://variables/tools/manage-global-variable-guide — Guide for the manage-global-variable tool


### PR DESCRIPTION
## Summary

This PR adds two new MCP tools that enable LLMs (Claude, Cursor) to dynamically discover and fetch MCP resources:

- `elementor/list-resources` - Returns all available resource URIs with descriptions
- `elementor/read-resource` - Fetches resource content by URI

## Background

Claude Desktop and Cursor don't auto-fetch MCP resources via the standard `resources/read` method ([documented issues](https://layered.dev/mcp-resources-the-overlooked-primitive/)). Rather than dual-exposing every resource as a `get-*` tool (which would cause surface bloat), these two tools provide a generic interface to access all resources dynamically.

From the [MCP Architecture Rethink decision](https://elementor.atlassian.net/wiki/spaces/RDDEP/pages/2748841995):
> Claude and Cursor don't auto-fetch resources; rather than dual-exposing every resource as a `get-*` tool (surface bloat, N tools for N resources), one `read-resource` tool lets the model reach any resource dynamically.

## Changes

### New Files
- `modules/mcp/abilities/list-resources-ability.php` - Lists all available resources
- `modules/mcp/abilities/read-resource-ability.php` - Fetches resource content by URI
- `modules/mcp/static-resources/abilities/list-resources.md` - Tool prompt
- `modules/mcp/static-resources/abilities/read-resource.md` - Tool prompt

### Modified Files
- `modules/mcp/module.php` - Register both abilities
- `modules/mcp/rest-api/mcp-proxy-rest-api.php` - Add tools to proxy

## Usage

```json
// Discover available resources
{ "tool": "list-resources", "input": {} }

// Fetch a specific resource
{ "tool": "read-resource", "input": { "uri": "elementor://style/best-practices" } }
```

## Related
- MCP Architecture Rethink - ED-24919


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Adds resource discovery and retrieval to MCP, enabling LLMs to query available documentation (style guides, tool manuals) without direct ability execution. Separates read-only reference data from actionable tools.

## 2. What Changed (Where)
- Two new abilities: `List_Resources_Ability` (enumerates available resources) and `Read_Resource_Ability` (fetches resource content by URI)
- Registered in module and REST API proxy with markdown/text prompt definitions
- Populated with two resources: Style Best Practices and Manage Global Variable Guide

## 3. How It Works
`list-resources` returns catalog of {uri, name, description, mimeType}. `read-resource` accepts uri input, validates against executor registry, invokes corresponding ability's execute(), returns {uri, mimeType, content}. Both require `edit_posts` capability and are idempotent/readonly/non-destructive. Error handling on missing uri or unknown resource URI.

## 4. Risks
Resource executors hardcoded in registry — adding new resources requires code changes. No validation that listed resources match executor registry; inconsistency breaks discovery contract. Consider making registry discoverable or using reflection to sync.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
