### PR TITLE
CI: Fix changelog generation Removal from one-click-release workflow [ED-24907]

### DIFF
--- a/.github/scripts/verify-version-changelog.js
+++ b/.github/scripts/verify-version-changelog.js
@@ -12,7 +12,7 @@ const getVersionHeaderPattern = (version) =>
 
 const getVersionSectionPattern = (version) =>
 	new RegExp(
-		`^= ${escapeVersionForRegex(version)} - \\d{4}-\\d{2}-\\d{2} =\\s*\\n+([\\s\\S]*?)(?=^= \\d+\\.\\d+\\.\\d+ - |\\Z)`,
+		`^= ${escapeVersionForRegex(version)} - \\d{4}-\\d{2}-\\d{2} =\\s*\\n+([\\s\\S]*?)(?=^= \\d+\\.\\d+\\.\\d+ - \\d{4}-\\d{2}-\\d{2} =|(?![\\s\\S]))`,
 		'm'
 	);
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The changelog regex pattern was incorrectly matching version sections. The fix adjusts the lookahead assertion to properly handle changelog boundaries, ensuring version section extraction stops at the next version entry or end-of-string rather than prematurely at partial version patterns.

## 2. What Changed (Where)

`.github/scripts/verify-version-changelog.js` — Updated `getVersionSectionPattern()` regex lookahead from `(?=^= \\d+\\.\\d+\\.\\d+ - |\\Z)` to `(?=^= \\d+\\.\\d+\\.\\d+ - \\d{4}-\\d{2}-\\d{2} =|(?![\\s\\S]))` to match full version headers with dates.

## 3. How It Works

The lookahead now requires the complete version header format (version + date stamp) before terminating a section match, preventing false stops on incomplete patterns. The fallback `(?![\\s\\S])` (negative lookahead for any character) serves as explicit end-of-string sentinel.

## 4. Risks

Minimal — regex-only change with narrower matching scope. Verify against actual changelog format variations; if entries deviate from `= X.Y.Z - YYYY-MM-DD =` pattern, extraction may fail silently.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
