### PR TITLE
Fix: Strip display-conditions promo prop from widget schema [ED-24951]

### DIFF
--- a/modules/mcp/abilities/utils/widget-context-helper.php
+++ b/modules/mcp/abilities/utils/widget-context-helper.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Widget_Context_Helper {
 
-	const NON_CONFIGURABLE_PROP_KEYS = [ '_cssid', 'classes', 'attributes' ];
+	const NON_CONFIGURABLE_PROP_KEYS = [ '_cssid', 'classes', 'attributes', 'display-conditions' ];
 
 	const LINK_PROP_KEY = 'link';
 


### PR DESCRIPTION
## Summary
- Add `display-conditions` to `Widget_Context_Helper::NON_CONFIGURABLE_PROP_KEYS` so it is excluded from the widget schema returned by the `get-widget-schema` MCP tool.
- The Promotions module injects this prop as a Pro upsell placeholder; it has no meaning for LLM content authoring and only inflates schema context.

## Test plan
- [ ] Call `get-widget-schema` for an atomic widget (e.g. `e-heading`) and confirm `display-conditions` is not present in `properties`.
- [ ] Confirm other props (e.g. `title`, `tag`, `link`) are still returned as expected.

Ref: https://elementor.atlassian.net/browse/ED-24951

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
ED-24951: The widget schema exposed the `display-conditions` property to LLMs via MCP abilities, but this is a promo-only field that shouldn't be configurable. Stripping it aligns schema with actual widget configurability.

## 2. What Changed (Where)
`widget-context-helper.php`: Added `'display-conditions'` to the `NON_CONFIGURABLE_PROP_KEYS` constant, joining existing excluded props (`_cssid`, `classes`, `attributes`).

## 3. How It Works
The constant filters widget properties before JSON schema generation for LLM consumption. Properties in this list are stripped from the schema output, preventing them from appearing in LLM prompts or ability definitions.

## 4. Risks
None — purely additive to exclusion list. No downstream changes needed; schema filtering already consumes this constant.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
