### PR TITLE
Fix: Trim build-composition MCP context to prevent OOM [ED-24228]

### DIFF
--- a/modules/mcp/abilities/build-composition-ability.php
+++ b/modules/mcp/abilities/build-composition-ability.php
@@ -19,7 +19,6 @@ use Elementor\Modules\Mcp\Abilities\Build_Composition\Subtree_Builder;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Widget_Type_Resolver;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser;
 use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
-use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 use Elementor\Modules\Variables\Module as Variables_Module;
 use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
 use Elementor\Modules\Variables\Services\Variables_Service;
@@ -158,10 +157,7 @@ class Build_Composition_Ability extends Abstract_Ability {
 	}
 
 	private function get_ability_description(): string {
-		$prompt = Prompt_Loader::load( 'build-composition' );
-		$linkable_widgets = implode( ', ', Widget_Context_Helper::get_linkable_widget_types() );
-
-		return str_replace( '{{LINKABLE_WIDGETS}}', $linkable_widgets, $prompt );
+		return Prompt_Loader::load( 'build-composition' );
 	}
 
 	private function get_output_schema(): array {

--- a/modules/mcp/abilities/build-composition/element-config-applier.php
+++ b/modules/mcp/abilities/build-composition/element-config-applier.php
@@ -102,13 +102,11 @@ class Element_Config_Applier {
 			$canonical = Prop_Canonicalizer::resolve_canonical_key( $schema, $name, $alias_map );
 
 			if ( null === $canonical ) {
-				// Skip unknown keys instead of failing so one stray prop can't discard a valid composition.
 				$warnings[] = sprintf(
-					'[%s] Property "%s" is not supported on element type "%s" and was skipped. Available properties are: %s',
+					'[%s] Property "%s" is not supported on element type "%s" and was skipped.',
 					$config_id,
 					$name,
-					$element_type,
-					implode( ', ', Prop_Canonicalizer::available_prop_names( $schema ) )
+					$element_type
 				);
 				continue;
 			}

--- a/modules/mcp/abilities/utils/widget-context-helper.php
+++ b/modules/mcp/abilities/utils/widget-context-helper.php
@@ -18,8 +18,6 @@ class Widget_Context_Helper {
 
 	const NON_CONFIGURABLE_PROP_KEYS = [ '_cssid', 'classes', 'attributes', 'display-conditions' ];
 
-	const LINK_PROP_KEY = 'link';
-
 	const EXCLUDED_WIDGET_TITLE = 'Component';
 
 	const VERSION_V3 = 'v3';
@@ -58,26 +56,6 @@ class Widget_Context_Helper {
 		$instance = Atomic_Elements_Utils::get_element_instance( $widget_type );
 
 		return $instance ? $instance->get_config() : null;
-	}
-
-	/**
-	 * LLM-eligible widget types whose atomic props schema exposes a `link` prop.
-	 * Derived from the registered widget schemas so the list can never drift.
-	 *
-	 * @return string[]
-	 */
-	public static function get_linkable_widget_types(): array {
-		$linkable = [];
-
-		foreach ( self::get_llm_eligible_widgets() as $widget_type => $config ) {
-			if ( isset( $config['atomic_props_schema'][ self::LINK_PROP_KEY ] ) ) {
-				$linkable[] = $widget_type;
-			}
-		}
-
-		sort( $linkable );
-
-		return $linkable;
 	}
 
 	public static function is_widget_eligible_for_llm( array $config ): bool {

--- a/modules/mcp/static-resources/abilities/build-composition.md
+++ b/modules/mcp/static-resources/abilities/build-composition.md
@@ -33,7 +33,7 @@ Some elements have internal tree structures (nesting). When using these elements
 - style is raw CSS (property → value strings); the server converts it to native styles
 - classes is configuration-id → array of existing global class **labels** from [elementor://global-classes]
 - **CSS shorthand properties may fall back to custom_css which is stripped by Pro 3.35+; prefer longhand properties (e.g., `padding-top`, `padding-right` instead of `padding`)**
-- LINKS: a `link` prop is supported ONLY on these widgets: {{LINKABLE_WIDGETS}}. On any other widget a `link` is skipped and reported in `warnings` (the composition still builds) — to link a non-linkable element, wrap it in a linkable container. Link PropValue shape: `{ "$$type": "link", "value": { "destination": { "$$type": "url", "value": "https://example.com" }, "isTargetBlank": { "$$type": "boolean", "value": true }, "tag": { "$$type": "string", "value": "a" } } }`
+- LINKS: a `link` prop is valid only when the target widget's schema (via `elementor/get-widget-schema`) includes a `link` property. On widgets without it, `link` is skipped and reported in `warnings` (the composition still builds) — wrap the element in a linkable container instead. Link PropValue shape: `{ "$$type": "link", "value": { "destination": { "$$type": "url", "value": "https://example.com" }, "isTargetBlank": { "$$type": "boolean", "value": true }, "tag": { "$$type": "string", "value": "a" } } }`
 - Retry on errors up to 10x
 - Check `llm_guidance.default_settings` in widget schemas — omit only keys listed there from element_config unless the user explicitly asks to change them
 

--- a/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
@@ -11,7 +11,6 @@ use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
 use Elementor\Modules\GlobalClasses\Global_Classes_Labels;
 use Elementor\Modules\GlobalClasses\Global_Classes_Order;
 use Elementor\Modules\Mcp\Abilities\Build_Composition_Ability;
-use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 use Elementor\Modules\Variables\PropTypes\Color_Variable_Prop_Type;
 use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
 use Elementor\Modules\Variables\Services\Variables_Service;
@@ -314,19 +313,6 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 				[ '$$type', 'PropValue envelope' ],
 			],
 		];
-	}
-
-	public function test_linkable_widget_types__derived_from_schemas() {
-		// Arrange
-		$this->act_as_admin();
-
-		// Act
-		$linkable = Widget_Context_Helper::get_linkable_widget_types();
-
-		// Assert
-		$this->assertContains( 'e-button', $linkable );
-		$this->assertContains( 'e-heading', $linkable );
-		$this->assertNotContains( 'e-divider', $linkable );
 	}
 
 	public function test_execute__skips_unsupported_prop_and_warns() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Reduced build-composition MCP ability context size by removing eager widget/prop enumeration that caused OOM.

## Description

The build-composition ability description previously called `Widget_Context_Helper::get_linkable_widget_types()` on every registration, iterating all LLM-eligible widgets and inlining the full list into the prompt. Unsupported-prop warnings also appended every available prop name from the schema.

This change:
- Returns the static `build-composition` prompt without `{{LINKABLE_WIDGETS}}` substitution
- Updates prompt guidance to direct agents to `elementor/get-widget-schema` for link support
- Shortens unsupported-prop warnings (no available-properties list)
- Removes `get_linkable_widget_types()` and its test

Fixes ED-24951

## Test instructions

- [ ] Register or inspect the build-composition MCP ability and confirm the description loads without a large inline widget list
- [ ] Build a composition with an unsupported prop on a widget and confirm warnings still report the skip without listing all available props
- [ ] Build a composition with a `link` prop on a linkable widget (e.g. `e-button`) and confirm it still applies
- [ ] Run `tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php` in a full WP test env

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8592-342f-7fb6-9eec-df00e160a2a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8592-342f-7fb6-9eec-df00e160a2a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

