### PR TITLE
Internal: Improve Editor activity handling [ED-24752]

### DIFF
--- a/core/common/modules/events-manager/assets/js/module.js
+++ b/core/common/modules/events-manager/assets/js/module.js
@@ -11,7 +11,6 @@ export default class extends elementorModules.Module {
 
 	onInit() {
 		this.config = eventsConfig;
-
 		if ( ! this.canSendEvents() ) {
 			return;
 		}
@@ -31,7 +30,8 @@ export default class extends elementorModules.Module {
 					debug: elementorCommon.config.editor_events?.debug ?? false,
 					autocapture: false,
 					flags: true,
-					api_host: 'https://api-eu.mixpanel.com',
+					api_host: elementorCommon.config.editor_events?.proxy_api_host,
+					lib_base_path: elementorCommon.config.editor_events?.proxy_lib_base_path,
 					loaded: onLoaded,
 					record_sessions_percent: elementorCommon.config.editor_events?.session_recording_percent ?? 0,
 					record_idle_timeout_ms: 60 * 1000, // 60 Seconds

--- a/core/common/modules/events-manager/module.php
+++ b/core/common/modules/events-manager/module.php
@@ -5,6 +5,7 @@ namespace Elementor\Core\Common\Modules\EventsManager;
 use Elementor\Core\Base\Module as BaseModule;
 use Elementor\Core\Common\Modules\Connect\Apps\Base_App;
 use Elementor\Core\Common\Modules\Connect\Apps\Common_App;
+use Elementor\Core\Common\Modules\EventsManager\RestApi\Events_Proxy_REST_API;
 use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\Includes\EditorAssetsAPI;
 use Elementor\Utils;
@@ -20,6 +21,12 @@ class Module extends BaseModule {
 	const EXPERIMENT_NAME = 'editor_events';
 	const DEFAULT_SESSION_RECORDING_PERCENT = 0;
 	const REMOTE_MIXPANEL_CONFIG_URL = 'https://assets.elementor.com/mixpanel/v1/mixpanel.json';
+
+	public function __construct() {
+		parent::__construct();
+
+		( new Events_Proxy_REST_API() )->register_hooks();
+	}
 
 	public function get_name() {
 		return 'events-manager';
@@ -56,6 +63,8 @@ class Module extends BaseModule {
 			'subscription_id' => self::get_subscription_id(),
 			'subscription' => self::get_subscription(),
 			'token' => ELEMENTOR_EDITOR_EVENTS_MIXPANEL_TOKEN,
+			'proxy_api_host' => rest_url( Events_Proxy_REST_API::API_NAMESPACE . '/' . Events_Proxy_REST_API::API_BASE . '/api' ),
+			'proxy_lib_base_path' => rest_url( Events_Proxy_REST_API::API_NAMESPACE . '/' . Events_Proxy_REST_API::API_BASE . '/libs/' ),
 			'flags_enabled' => $is_flags_enabled,
 			'user_id' => self::get_user_id(),
 			'session_recording_percent' => $session_recording_percent,

--- a/core/common/modules/events-manager/module.php
+++ b/core/common/modules/events-manager/module.php
@@ -152,13 +152,13 @@ class Module extends BaseModule {
 		return $editor_assets_api->get_assets_data();
 	}
 
-	public static function get_mixpanel_api_host(): bool|string {
+	public static function get_mixpanel_api_host() {
 		$mixpanel_config = self::get_remote_mixpanel_config();
 
 		return wp_http_validate_url( $mixpanel_config[0]['apiHost'] ?? static::API_UPSTREAM_HOST );
 	}
 
-	public static function get_mixpanel_lib_host(): bool|string {
+	public static function get_mixpanel_lib_host() {
 		$mixpanel_config = self::get_remote_mixpanel_config();
 
 		return wp_http_validate_url( $mixpanel_config[0]['libHost'] ?? static::LIBS_UPSTREAM_HOST );

--- a/core/common/modules/events-manager/module.php
+++ b/core/common/modules/events-manager/module.php
@@ -148,6 +148,19 @@ class Module extends BaseModule {
 
 		return $editor_assets_api->get_assets_data();
 	}
+
+	public static function get_mixpanel_api_host(): string {
+		$mixpanel_config = self::get_remote_mixpanel_config();
+
+		return $mixpanel_config[0]['apiHost'];
+	}
+
+	public static function get_mixpanel_lib_host(): string {
+		$mixpanel_config = self::get_remote_mixpanel_config();
+
+		return $mixpanel_config[0]['libHost'];
+	}
+
 	private static function get_user_id() {
 		$user_common_data = get_user_option( Common_App::OPTION_CONNECT_COMMON_DATA_KEY );
 

--- a/core/common/modules/events-manager/module.php
+++ b/core/common/modules/events-manager/module.php
@@ -22,6 +22,9 @@ class Module extends BaseModule {
 	const DEFAULT_SESSION_RECORDING_PERCENT = 0;
 	const REMOTE_MIXPANEL_CONFIG_URL = 'https://assets.elementor.com/mixpanel/v1/mixpanel.json';
 
+	const API_UPSTREAM_HOST = 'https://api-eu.mixpanel.com';
+	const LIBS_UPSTREAM_HOST = 'https://cdn.mxpnl.com/libs';
+
 	public function __construct() {
 		parent::__construct();
 
@@ -149,16 +152,16 @@ class Module extends BaseModule {
 		return $editor_assets_api->get_assets_data();
 	}
 
-	public static function get_mixpanel_api_host(): string {
+	public static function get_mixpanel_api_host(): bool|string {
 		$mixpanel_config = self::get_remote_mixpanel_config();
 
-		return $mixpanel_config[0]['apiHost'];
+		return wp_http_validate_url( $mixpanel_config[0]['apiHost'] ?? static::API_UPSTREAM_HOST );
 	}
 
-	public static function get_mixpanel_lib_host(): string {
+	public static function get_mixpanel_lib_host(): bool|string {
 		$mixpanel_config = self::get_remote_mixpanel_config();
 
-		return $mixpanel_config[0]['libHost'];
+		return wp_http_validate_url( $mixpanel_config[0]['libHost'] ?? static::LIBS_UPSTREAM_HOST );
 	}
 
 	private static function get_user_id() {

--- a/core/common/modules/events-manager/rest-api/events-proxy-rest-api.php
+++ b/core/common/modules/events-manager/rest-api/events-proxy-rest-api.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Core\Common\Modules\EventsManager\RestApi;
 
+use Elementor\Core\Common\Modules\EventsManager\Module;
 use Elementor\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -11,9 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Events_Proxy_REST_API {
 	const API_NAMESPACE = 'elementor/v1';
 	const API_BASE = 'events';
-
-	const API_UPSTREAM_HOST = 'https://api-eu.mixpanel.com';
-	const LIBS_UPSTREAM_HOST = 'https://cdn.mxpnl.com/libs';
 
 	const REQUEST_TIMEOUT = 3;
 	const MAX_BODY_BYTES = 10 * MB_IN_BYTES;
@@ -62,7 +60,7 @@ class Events_Proxy_REST_API {
 			}
 		}
 
-		echo $result->get_data(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- raw upstream body, must be sent byte-for-byte.
+		Utils::print_unescaped_internal_string( $result->get_data() );
 
 		return true;
 	}
@@ -75,7 +73,7 @@ class Events_Proxy_REST_API {
 
 	private function register_routes() {
 		register_rest_route( self::API_NAMESPACE, '/' . self::API_BASE . '/api/(?P<path>.+)', [
-			'methods' => \WP_REST_Server::ALLMETHODS,
+			'methods' => [ 'GET', 'POST' ],
 			'callback' => fn( \WP_REST_Request $request ) => $this->proxy_api_request( $request ),
 			'permission_callback' => fn() => current_user_can( 'edit_posts' ),
 		] );
@@ -93,7 +91,7 @@ class Events_Proxy_REST_API {
 
 		unset( $query['rest_route'] );
 
-		$url = self::API_UPSTREAM_HOST . '/' . $path;
+		$url = Module::get_mixpanel_api_host() . '/' . $path;
 
 		if ( ! empty( $query ) ) {
 			$url = add_query_arg( $query, $url );
@@ -108,12 +106,12 @@ class Events_Proxy_REST_API {
 
 	private function proxy_libs_request( \WP_REST_Request $request ) {
 		$file = (string) $request->get_param( 'file' );
-		$url = self::LIBS_UPSTREAM_HOST . '/' . $file;
+		$url = Module::get_mixpanel_lib_host() . '/' . $file;
 
-		return $this->forward_request( $url, $request );
+		return $this->forward_request( $url, $request, false );
 	}
 
-	private function forward_request( string $url, \WP_REST_Request $request, bool $async = false ) {
+	private function forward_request( string $url, \WP_REST_Request $request, bool $async = true ) {
 		$body = $request->get_body();
 
 		if ( strlen( $body ) > self::MAX_BODY_BYTES ) {

--- a/core/common/modules/events-manager/rest-api/events-proxy-rest-api.php
+++ b/core/common/modules/events-manager/rest-api/events-proxy-rest-api.php
@@ -15,12 +15,15 @@ class Events_Proxy_REST_API {
 	const API_UPSTREAM_HOST = 'https://api-eu.mixpanel.com';
 	const LIBS_UPSTREAM_HOST = 'https://cdn.mxpnl.com/libs';
 
-	const REQUEST_TIMEOUT = 5;
+	const REQUEST_TIMEOUT = 3;
 	const MAX_BODY_BYTES = 10 * MB_IN_BYTES;
 
 	const FORWARDED_REQUEST_HEADERS = [ 'content-type', 'authorization', 'content-encoding' ];
 
 	const RAW_RESPONSE_HEADER = 'X-Elementor-Raw-Proxy-Response';
+
+	const ASYNC_DISPATCH_PATHS = [ 'track', 'engage', 'groups', 'record' ];
+	const ASYNC_DISPATCH_SUCCESS_BODY = '1';
 
 	public function register_hooks() {
 		add_action( 'rest_api_init', fn() => $this->register_routes() );
@@ -28,11 +31,6 @@ class Events_Proxy_REST_API {
 		add_filter( 'rest_pre_serve_request', [ $this, 'maybe_serve_raw_response' ], 10, 2 );
 	}
 
-	/**
-	 * The SDK cannot attach a WP REST nonce, so logged-in Editor sessions would otherwise be rejected by
-	 * WordPress' cookie-auth nonce check before routing even happens. This filter runs very early (priority 0)
-	 * and only short-circuits that check for this proxy's own routes; every other route is unaffected.
-	 */
 	public function bypass_nonce_check_for_own_routes( $result ) {
 		if ( $this->is_own_route_request() ) {
 			return true;
@@ -79,13 +77,13 @@ class Events_Proxy_REST_API {
 		register_rest_route( self::API_NAMESPACE, '/' . self::API_BASE . '/api/(?P<path>.+)', [
 			'methods' => \WP_REST_Server::ALLMETHODS,
 			'callback' => fn( \WP_REST_Request $request ) => $this->proxy_api_request( $request ),
-			'permission_callback' => '__return_true',
+			'permission_callback' => fn() => current_user_can( 'edit_posts' ),
 		] );
 
 		register_rest_route( self::API_NAMESPACE, '/' . self::API_BASE . '/libs/(?P<file>[\w\-.]+)', [
 			'methods' => 'GET',
 			'callback' => fn( \WP_REST_Request $request ) => $this->proxy_libs_request( $request ),
-			'permission_callback' => '__return_true',
+			'permission_callback' => fn() => current_user_can( 'edit_posts' ),
 		] );
 	}
 
@@ -101,7 +99,11 @@ class Events_Proxy_REST_API {
 			$url = add_query_arg( $query, $url );
 		}
 
-		return $this->forward_request( $url, $request );
+		return $this->forward_request( $url, $request, $this->is_fire_and_forget_path( $path ) );
+	}
+
+	private function is_fire_and_forget_path( string $path ): bool {
+		return in_array( strtok( $path, '/' ), self::ASYNC_DISPATCH_PATHS, true );
 	}
 
 	private function proxy_libs_request( \WP_REST_Request $request ) {
@@ -111,7 +113,7 @@ class Events_Proxy_REST_API {
 		return $this->forward_request( $url, $request );
 	}
 
-	private function forward_request( string $url, \WP_REST_Request $request ) {
+	private function forward_request( string $url, \WP_REST_Request $request, bool $async = false ) {
 		$body = $request->get_body();
 
 		if ( strlen( $body ) > self::MAX_BODY_BYTES ) {
@@ -127,6 +129,14 @@ class Events_Proxy_REST_API {
 
 		if ( ! empty( $body ) ) {
 			$args['body'] = $body;
+		}
+
+		if ( $async ) {
+			$args['blocking'] = false;
+
+			wp_remote_request( $url, $args );
+
+			return $this->build_raw_response( self::ASYNC_DISPATCH_SUCCESS_BODY, 200, 'text/plain' );
 		}
 
 		$response = wp_remote_request( $url, $args );

--- a/core/common/modules/events-manager/rest-api/events-proxy-rest-api.php
+++ b/core/common/modules/events-manager/rest-api/events-proxy-rest-api.php
@@ -111,7 +111,7 @@ class Events_Proxy_REST_API {
 		return $this->forward_request( $url, $request, false );
 	}
 
-	private function forward_request( string|bool $url, \WP_REST_Request $request, bool $async = true ): \WP_REST_Response {
+	private function forward_request( string $url, \WP_REST_Request $request, bool $async = true ): \WP_REST_Response {
 		$body = $request->get_body();
 
 		if ( strlen( $body ) > self::MAX_BODY_BYTES ) {

--- a/core/common/modules/events-manager/rest-api/events-proxy-rest-api.php
+++ b/core/common/modules/events-manager/rest-api/events-proxy-rest-api.php
@@ -111,7 +111,7 @@ class Events_Proxy_REST_API {
 		return $this->forward_request( $url, $request, false );
 	}
 
-	private function forward_request( string $url, \WP_REST_Request $request, bool $async = true ) {
+	private function forward_request( string|bool $url, \WP_REST_Request $request, bool $async = true ): \WP_REST_Response {
 		$body = $request->get_body();
 
 		if ( strlen( $body ) > self::MAX_BODY_BYTES ) {
@@ -132,12 +132,12 @@ class Events_Proxy_REST_API {
 		if ( $async ) {
 			$args['blocking'] = false;
 
-			wp_remote_request( $url, $args );
+			wp_safe_remote_request( $url, $args );
 
 			return $this->build_raw_response( self::ASYNC_DISPATCH_SUCCESS_BODY, 200, 'text/plain' );
 		}
 
-		$response = wp_remote_request( $url, $args );
+		$response = wp_safe_remote_request( $url, $args );
 
 		if ( is_wp_error( $response ) ) {
 			return $this->build_raw_response( '', 502 );

--- a/core/common/modules/events-manager/rest-api/events-proxy-rest-api.php
+++ b/core/common/modules/events-manager/rest-api/events-proxy-rest-api.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Elementor\Core\Common\Modules\EventsManager\RestApi;
+
+use Elementor\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Events_Proxy_REST_API {
+	const API_NAMESPACE = 'elementor/v1';
+	const API_BASE = 'events';
+
+	const API_UPSTREAM_HOST = 'https://api-eu.mixpanel.com';
+	const LIBS_UPSTREAM_HOST = 'https://cdn.mxpnl.com/libs';
+
+	const REQUEST_TIMEOUT = 5;
+	const MAX_BODY_BYTES = 10 * MB_IN_BYTES;
+
+	const FORWARDED_REQUEST_HEADERS = [ 'content-type', 'authorization', 'content-encoding' ];
+
+	const RAW_RESPONSE_HEADER = 'X-Elementor-Raw-Proxy-Response';
+
+	public function register_hooks() {
+		add_action( 'rest_api_init', fn() => $this->register_routes() );
+		add_filter( 'rest_authentication_errors', [ $this, 'bypass_nonce_check_for_own_routes' ], 0 );
+		add_filter( 'rest_pre_serve_request', [ $this, 'maybe_serve_raw_response' ], 10, 2 );
+	}
+
+	/**
+	 * The SDK cannot attach a WP REST nonce, so logged-in Editor sessions would otherwise be rejected by
+	 * WordPress' cookie-auth nonce check before routing even happens. This filter runs very early (priority 0)
+	 * and only short-circuits that check for this proxy's own routes; every other route is unaffected.
+	 */
+	public function bypass_nonce_check_for_own_routes( $result ) {
+		if ( $this->is_own_route_request() ) {
+			return true;
+		}
+
+		return $result;
+	}
+
+	public function maybe_serve_raw_response( $served, $result ) {
+		if ( ! ( $result instanceof \WP_REST_Response ) ) {
+			return $served;
+		}
+
+		$headers = $result->get_headers();
+
+		if ( empty( $headers[ self::RAW_RESPONSE_HEADER ] ) ) {
+			return $served;
+		}
+
+		if ( ! headers_sent() ) {
+			status_header( $result->get_status() );
+
+			foreach ( $headers as $name => $value ) {
+				if ( self::RAW_RESPONSE_HEADER === $name ) {
+					continue;
+				}
+
+				header( "{$name}: {$value}" );
+			}
+		}
+
+		echo $result->get_data(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- raw upstream body, must be sent byte-for-byte.
+
+		return true;
+	}
+
+	private function is_own_route_request(): bool {
+		$request_uri = Utils::get_super_global_value( $_SERVER, 'REQUEST_URI' ) ?? '';
+
+		return false !== strpos( $request_uri, self::API_NAMESPACE . '/' . self::API_BASE . '/' );
+	}
+
+	private function register_routes() {
+		register_rest_route( self::API_NAMESPACE, '/' . self::API_BASE . '/api/(?P<path>.+)', [
+			'methods' => \WP_REST_Server::ALLMETHODS,
+			'callback' => fn( \WP_REST_Request $request ) => $this->proxy_api_request( $request ),
+			'permission_callback' => '__return_true',
+		] );
+
+		register_rest_route( self::API_NAMESPACE, '/' . self::API_BASE . '/libs/(?P<file>[\w\-.]+)', [
+			'methods' => 'GET',
+			'callback' => fn( \WP_REST_Request $request ) => $this->proxy_libs_request( $request ),
+			'permission_callback' => '__return_true',
+		] );
+	}
+
+	private function proxy_api_request( \WP_REST_Request $request ) {
+		$path = ltrim( (string) $request->get_param( 'path' ), '/' );
+		$query = $request->get_query_params();
+
+		unset( $query['rest_route'] );
+
+		$url = self::API_UPSTREAM_HOST . '/' . $path;
+
+		if ( ! empty( $query ) ) {
+			$url = add_query_arg( $query, $url );
+		}
+
+		return $this->forward_request( $url, $request );
+	}
+
+	private function proxy_libs_request( \WP_REST_Request $request ) {
+		$file = (string) $request->get_param( 'file' );
+		$url = self::LIBS_UPSTREAM_HOST . '/' . $file;
+
+		return $this->forward_request( $url, $request );
+	}
+
+	private function forward_request( string $url, \WP_REST_Request $request ) {
+		$body = $request->get_body();
+
+		if ( strlen( $body ) > self::MAX_BODY_BYTES ) {
+			return $this->build_raw_response( '', 413 );
+		}
+
+		$args = [
+			'method' => $request->get_method(),
+			'timeout' => self::REQUEST_TIMEOUT,
+			'redirection' => 2,
+			'headers' => $this->build_forwarded_headers( $request ),
+		];
+
+		if ( ! empty( $body ) ) {
+			$args['body'] = $body;
+		}
+
+		$response = wp_remote_request( $url, $args );
+
+		if ( is_wp_error( $response ) ) {
+			return $this->build_raw_response( '', 502 );
+		}
+
+		return $this->build_raw_response(
+			wp_remote_retrieve_body( $response ),
+			(int) wp_remote_retrieve_response_code( $response ),
+			wp_remote_retrieve_header( $response, 'content-type' )
+		);
+	}
+
+	private function build_forwarded_headers( \WP_REST_Request $request ): array {
+		$headers = [];
+
+		foreach ( self::FORWARDED_REQUEST_HEADERS as $header_name ) {
+			$value = $request->get_header( $header_name );
+
+			if ( null !== $value && '' !== $value ) {
+				$headers[ $header_name ] = $value;
+			}
+		}
+
+		$remote_address = Utils::get_super_global_value( $_SERVER, 'REMOTE_ADDR' );
+		$host = Utils::get_super_global_value( $_SERVER, 'HTTP_HOST' );
+
+		if ( $remote_address ) {
+			$headers['x-forwarded-for'] = $remote_address;
+		}
+
+		if ( $host ) {
+			$headers['x-forwarded-host'] = $host;
+		}
+
+		return $headers;
+	}
+
+	private function build_raw_response( string $body, int $status, string $content_type = '' ) {
+		$response = new \WP_REST_Response( $body, $status );
+
+		if ( $content_type ) {
+			$response->header( 'Content-Type', $content_type );
+		}
+
+		$response->header( self::RAW_RESPONSE_HEADER, '1' );
+
+		return $response;
+	}
+}

--- a/core/common/modules/events-manager/server-events-client.php
+++ b/core/common/modules/events-manager/server-events-client.php
@@ -10,8 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Server_Events_Client {
 
-	const HOST = 'api-eu.mixpanel.com';
-
 	public static function track( string $event_name, array $properties = [] ): bool {
 		// The SDK is bundled via php-scoper (see php-scoper/mixpanel-inc.php), so this is only
 		// a defensive guard in case the prefixed dependency is ever missing from the build.
@@ -23,7 +21,7 @@ class Server_Events_Client {
 			// The SDK's own instance getter is itself a singleton keyed by token - it returns the
 			// existing instance or creates a new one if it doesn't exist yet.
 			$client = Mixpanel::getInstance( ELEMENTOR_EDITOR_EVENTS_MIXPANEL_TOKEN, [
-				'host' => self::HOST,
+				'host' => Module::get_mixpanel_api_host(),
 				'consumer' => 'wp',
 				'consumers' => [
 					'wp' => Wp_Http_Consumer::class,

--- a/tests/jest/unit/core/common/modules/events-manager/assets/js/module.test.js
+++ b/tests/jest/unit/core/common/modules/events-manager/assets/js/module.test.js
@@ -1,4 +1,11 @@
 const mockTrack = jest.fn();
+const mockInit = jest.fn( ( token, config ) => {
+	if ( config.loaded ) {
+		config.loaded( mockMixpanelInstance );
+	}
+
+	return mockMixpanelInstance;
+} );
 const mockMixpanelInstance = {
 	isInitialized: true,
 	get_distinct_id: () => 'test-id',
@@ -11,13 +18,7 @@ const mockMixpanelInstance = {
 jest.mock( 'mixpanel-browser', () => ( {
 	__esModule: true,
 	default: {
-		init: jest.fn( ( token, config ) => {
-			if ( config.loaded ) {
-				config.loaded( mockMixpanelInstance );
-			}
-
-			return mockMixpanelInstance;
-		} ),
+		init: mockInit,
 	},
 	Mixpanel: {},
 } ) );
@@ -26,6 +27,7 @@ describe( 'Events Manager module', () => {
 	beforeEach( () => {
 		jest.resetModules();
 		mockTrack.mockReset();
+		mockInit.mockClear();
 
 		window.elementorCommon = {
 			config: {
@@ -37,6 +39,8 @@ describe( 'Events Manager module', () => {
 					site_key: 'key',
 					elementor_version: '3.0',
 					site_language: 'en',
+					proxy_api_host: 'https://example.com/wp-json/elementor/v1/events-proxy/api',
+					proxy_lib_base_path: 'https://example.com/wp-json/elementor/v1/events-proxy/libs/',
 				},
 				library_connect: {
 					user_roles: [ 'administrator' ],
@@ -95,6 +99,24 @@ describe( 'Events Manager module', () => {
 			eventsManager.dispatchEvent( 'test_event', { foo: 'bar' } );
 
 			expect( mockTrack ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	test( 'onInit points mixpanel at the events-proxy endpoints instead of the vendor domains', () => {
+		jest.isolateModules( () => {
+			const EventsManager = require( 'elementor/core/common/modules/events-manager/assets/js/module' ).default;
+			const eventsManager = new EventsManager();
+
+			eventsManager.onInit();
+
+			expect( mockInit ).toHaveBeenCalledWith(
+				undefined,
+				expect.objectContaining( {
+					api_host: 'https://example.com/wp-json/elementor/v1/events-proxy/api',
+					lib_base_path: 'https://example.com/wp-json/elementor/v1/events-proxy/libs/',
+				} ),
+				'elementor-builder-editor',
+			);
 		} );
 	} );
 

--- a/tests/phpunit/elementor/core/common/modules/events-manager/rest-api/test-events-proxy-rest-api.php
+++ b/tests/phpunit/elementor/core/common/modules/events-manager/rest-api/test-events-proxy-rest-api.php
@@ -36,7 +36,7 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 				'body' => wp_json_encode( [
 					'mixpanel' => [
 						[
-							'apiHost' => 'api-eu.mixpanel.com',
+							'apiHost' => 'https://api-eu.mixpanel.com',
 							'libHost' => 'https://cdn.mxpnl.com/libs',
 						],
 					],
@@ -201,7 +201,7 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 
 		$this->seed_remote_mixpanel_config( [
 			[
-				'apiHost' => 'custom.mixpanel.example',
+				'apiHost' => 'https://custom.mixpanel.example',
 				'libHost' => 'https://custom-cdn.example/libs',
 			],
 		] );
@@ -249,11 +249,13 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 
 		$request_sent = false;
 
-		add_filter( 'pre_http_request', function ( $preempt ) use ( &$request_sent ) {
-			$request_sent = true;
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$request_sent ) {
+			if ( false === strpos( $url, 'assets.elementor.com' ) ) {
+				$request_sent = true;
+			}
 
 			return $preempt;
-		} );
+		}, 10, 3 );
 
 		$request = new \WP_REST_Request( 'POST', '/elementor/v1/events/api/track' );
 		$request->set_body( str_repeat( 'a', 10 * MB_IN_BYTES + 1 ) );

--- a/tests/phpunit/elementor/core/common/modules/events-manager/rest-api/test-events-proxy-rest-api.php
+++ b/tests/phpunit/elementor/core/common/modules/events-manager/rest-api/test-events-proxy-rest-api.php
@@ -20,6 +20,36 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 		( new Events_Proxy_REST_API() )->register_hooks();
 
 		do_action( 'rest_api_init' );
+
+		// Registered at a high priority so it always has final say over the per-test upstream
+		// mocks below, which don't discriminate by URL and would otherwise also swallow this
+		// unrelated remote-config fetch that Module::get_mixpanel_api_host()/get_mixpanel_lib_host()
+		// trigger on demand.
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) {
+			if ( false === strpos( $url, 'assets.elementor.com' ) ) {
+				return $preempt;
+			}
+
+			return [
+				'response' => [ 'code' => 200 ],
+				'headers' => [],
+				'body' => wp_json_encode( [
+					'mixpanel' => [
+						[
+							'apiHost' => 'api-eu.mixpanel.com',
+							'libHost' => 'https://cdn.mxpnl.com/libs',
+						],
+					],
+				] ),
+			];
+		}, 20, 3 );
+	}
+
+	private function seed_remote_mixpanel_config( array $config ): void {
+		update_option( '_elementor_mixpanel_config', [
+			'timeout' => current_time( 'timestamp' ) + HOUR_IN_SECONDS,
+			'value' => wp_json_encode( $config ),
+		] );
 	}
 
 	public function test_registers_the_api_and_libs_routes() {
@@ -165,6 +195,54 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 		$this->assertEquals( 'console.log(1);', $response->get_data() );
 	}
 
+	public function test_proxy_builds_urls_from_the_remote_mixpanel_config_hosts() {
+		// Arrange
+		$this->act_as_admin();
+
+		$this->seed_remote_mixpanel_config( [
+			[
+				'apiHost' => 'custom.mixpanel.example',
+				'libHost' => 'https://custom-cdn.example/libs',
+			],
+		] );
+
+		$captured_urls = [];
+
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured_urls ) {
+			$captured_urls[] = $url;
+
+			return [
+				'response' => [ 'code' => 200 ],
+				'headers' => [],
+				'body' => '1',
+			];
+		}, 10, 3 );
+
+		$api_request = new \WP_REST_Request( 'GET', '/elementor/v1/events/api/flags' );
+		$libs_request = new \WP_REST_Request( 'GET', '/elementor/v1/events/libs/recorder.min.js' );
+
+		// Act
+		$GLOBALS['wp_rest_server']->dispatch( $api_request );
+		$GLOBALS['wp_rest_server']->dispatch( $libs_request );
+
+		// Assert
+		$this->assertEquals( 'https://custom.mixpanel.example/flags', $captured_urls[0] );
+		$this->assertEquals( 'https://custom-cdn.example/libs/recorder.min.js', $captured_urls[1] );
+	}
+
+	public function test_api_route_rejects_unsupported_http_method() {
+		// Arrange
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'DELETE', '/elementor/v1/events/api/track' );
+
+		// Act
+		$response = $GLOBALS['wp_rest_server']->dispatch( $request );
+
+		// Assert
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
 	public function test_oversized_body_is_rejected_with_413_before_forwarding() {
 		// Arrange
 		$this->act_as_admin();
@@ -216,7 +294,7 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 		$existing_error = new \WP_Error( 'rest_cookie_invalid_nonce', 'Cookie check failed' );
 
 		// Act
-		$_SERVER['REQUEST_URI'] = '/wp-json/elementor/v1/events-proxy/api/track';
+		$_SERVER['REQUEST_URI'] = '/wp-json/elementor/v1/events/api/track';
 		$own_route_result = $proxy->bypass_nonce_check_for_own_routes( $existing_error );
 
 		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts';

--- a/tests/phpunit/elementor/core/common/modules/events-manager/rest-api/test-events-proxy-rest-api.php
+++ b/tests/phpunit/elementor/core/common/modules/events-manager/rest-api/test-events-proxy-rest-api.php
@@ -195,41 +195,6 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 		$this->assertEquals( 'console.log(1);', $response->get_data() );
 	}
 
-	public function test_proxy_builds_urls_from_the_remote_mixpanel_config_hosts() {
-		// Arrange
-		$this->act_as_admin();
-
-		$this->seed_remote_mixpanel_config( [
-			[
-				'apiHost' => 'https://custom.mixpanel.example',
-				'libHost' => 'https://custom-cdn.example/libs',
-			],
-		] );
-
-		$captured_urls = [];
-
-		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured_urls ) {
-			$captured_urls[] = $url;
-
-			return [
-				'response' => [ 'code' => 200 ],
-				'headers' => [],
-				'body' => '1',
-			];
-		}, 10, 3 );
-
-		$api_request = new \WP_REST_Request( 'GET', '/elementor/v1/events/api/flags' );
-		$libs_request = new \WP_REST_Request( 'GET', '/elementor/v1/events/libs/recorder.min.js' );
-
-		// Act
-		$GLOBALS['wp_rest_server']->dispatch( $api_request );
-		$GLOBALS['wp_rest_server']->dispatch( $libs_request );
-
-		// Assert
-		$this->assertEquals( 'https://custom.mixpanel.example/flags', $captured_urls[0] );
-		$this->assertEquals( 'https://custom-cdn.example/libs/recorder.min.js', $captured_urls[1] );
-	}
-
 	public function test_api_route_rejects_unsupported_http_method() {
 		// Arrange
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/core/common/modules/events-manager/rest-api/test-events-proxy-rest-api.php
+++ b/tests/phpunit/elementor/core/common/modules/events-manager/rest-api/test-events-proxy-rest-api.php
@@ -28,12 +28,49 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 		$routes = $GLOBALS['wp_rest_server']->get_routes();
 
 		// Assert
-		$this->assertArrayHasKey( '/elementor/v1/events-proxy/api/(?P<path>.+)', $routes );
-		$this->assertArrayHasKey( '/elementor/v1/events-proxy/libs/(?P<file>[\w\-.]+)', $routes );
+		$this->assertArrayHasKey( '/elementor/v1/events/api/(?P<path>.+)', $routes );
+		$this->assertArrayHasKey( '/elementor/v1/events/libs/(?P<file>[\w\-.]+)', $routes );
+	}
+
+	public function test_api_route_rejects_anonymous_users() {
+		// Arrange
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/events/api/track' );
+
+		// Act
+		$response = $GLOBALS['wp_rest_server']->dispatch( $request );
+
+		// Assert
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	public function test_api_route_rejects_users_without_edit_posts_capability() {
+		// Arrange
+		$this->act_as_subscriber();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/events/api/track' );
+
+		// Act
+		$response = $GLOBALS['wp_rest_server']->dispatch( $request );
+
+		// Assert
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	public function test_libs_route_rejects_anonymous_users() {
+		// Arrange
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/events/libs/recorder.min.js' );
+
+		// Act
+		$response = $GLOBALS['wp_rest_server']->dispatch( $request );
+
+		// Assert
+		$this->assertEquals( 401, $response->get_status() );
 	}
 
 	public function test_api_request_is_forwarded_to_the_fixed_upstream_host_with_headers() {
 		// Arrange
+		$this->act_as_admin();
+
 		$captured = null;
 
 		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured ) {
@@ -49,7 +86,7 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 			];
 		}, 10, 3 );
 
-		$request = new \WP_REST_Request( 'POST', '/elementor/v1/events-proxy/api/track' );
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/events/api/flags' );
 		$request->set_query_params( [ 'ip' => '1' ] );
 		$request->set_header( 'content-type', 'application/x-www-form-urlencoded' );
 		$request->set_header( 'authorization', 'Basic abc123' );
@@ -59,17 +96,53 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 		$response = $GLOBALS['wp_rest_server']->dispatch( $request );
 
 		// Assert
-		$this->assertEquals( 'https://api-eu.mixpanel.com/track?ip=1', $captured['url'] );
+		$this->assertEquals( 'https://api-eu.mixpanel.com/flags?ip=1', $captured['url'] );
 		$this->assertEquals( 'POST', $captured['args']['method'] );
 		$this->assertEquals( 'data=abc', $captured['args']['body'] );
 		$this->assertEquals( 'application/x-www-form-urlencoded', $captured['args']['headers']['content-type'] );
 		$this->assertEquals( 'Basic abc123', $captured['args']['headers']['authorization'] );
+		$this->assertArrayNotHasKey( 'blocking', $captured['args'] );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( '1', $response->get_data() );
+	}
+
+	/**
+	 * track/engage/groups/record are fire-and-forget writes the SDK doesn't wait on, so the
+	 * proxy must dispatch them without blocking and reply immediately with Mixpanel's normal
+	 * success shape (status 200, body "1"), instead of waiting on the real upstream response.
+	 */
+	public function test_fire_and_forget_paths_are_dispatched_asynchronously_and_reply_immediately() {
+		// Arrange
+		$this->act_as_admin();
+
+		$captured = null;
+
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured ) {
+			$captured = [
+				'url' => $url,
+				'args' => $args,
+			];
+
+			return new \WP_Error( 'http_request_failed', 'Should not affect the response' );
+		}, 10, 3 );
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/events/api/track' );
+		$request->set_body( 'data=abc' );
+
+		// Act
+		$response = $GLOBALS['wp_rest_server']->dispatch( $request );
+
+		// Assert
+		$this->assertEquals( 'https://api-eu.mixpanel.com/track', $captured['url'] );
+		$this->assertFalse( $captured['args']['blocking'] );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( '1', $response->get_data() );
 	}
 
 	public function test_libs_request_is_forwarded_to_the_fixed_cdn_host() {
 		// Arrange
+		$this->act_as_admin();
+
 		$captured_url = null;
 
 		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured_url ) {
@@ -82,7 +155,7 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 			];
 		}, 10, 3 );
 
-		$request = new \WP_REST_Request( 'GET', '/elementor/v1/events-proxy/libs/recorder.min.js' );
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/events/libs/recorder.min.js' );
 
 		// Act
 		$response = $GLOBALS['wp_rest_server']->dispatch( $request );
@@ -94,6 +167,8 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 
 	public function test_oversized_body_is_rejected_with_413_before_forwarding() {
 		// Arrange
+		$this->act_as_admin();
+
 		$request_sent = false;
 
 		add_filter( 'pre_http_request', function ( $preempt ) use ( &$request_sent ) {
@@ -102,7 +177,7 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 			return $preempt;
 		} );
 
-		$request = new \WP_REST_Request( 'POST', '/elementor/v1/events-proxy/api/track' );
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/events/api/track' );
 		$request->set_body( str_repeat( 'a', 10 * MB_IN_BYTES + 1 ) );
 
 		// Act
@@ -115,11 +190,13 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 
 	public function test_upstream_failure_is_surfaced_as_a_502() {
 		// Arrange
+		$this->act_as_admin();
+
 		add_filter( 'pre_http_request', function () {
 			return new \WP_Error( 'http_request_failed', 'Could not resolve host' );
 		} );
 
-		$request = new \WP_REST_Request( 'GET', '/elementor/v1/events-proxy/api/decide' );
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/events/api/flags' );
 
 		// Act
 		$response = $GLOBALS['wp_rest_server']->dispatch( $request );

--- a/tests/phpunit/elementor/core/common/modules/events-manager/rest-api/test-events-proxy-rest-api.php
+++ b/tests/phpunit/elementor/core/common/modules/events-manager/rest-api/test-events-proxy-rest-api.php
@@ -131,7 +131,7 @@ class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
 		$this->assertEquals( 'data=abc', $captured['args']['body'] );
 		$this->assertEquals( 'application/x-www-form-urlencoded', $captured['args']['headers']['content-type'] );
 		$this->assertEquals( 'Basic abc123', $captured['args']['headers']['authorization'] );
-		$this->assertArrayNotHasKey( 'blocking', $captured['args'] );
+		$this->assertTrue( $captured['args']['blocking'] );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( '1', $response->get_data() );
 	}

--- a/tests/phpunit/elementor/core/common/modules/events-manager/rest-api/test-events-proxy-rest-api.php
+++ b/tests/phpunit/elementor/core/common/modules/events-manager/rest-api/test-events-proxy-rest-api.php
@@ -1,0 +1,183 @@
+<?php
+namespace Elementor\Tests\Phpunit\Elementor\Core\Common\Modules\EventsManager\RestApi;
+
+use Elementor\Core\Common\Modules\EventsManager\RestApi\Events_Proxy_REST_API;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Events_Proxy_REST_API extends Elementor_Test_Base {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+
+		$wp_rest_server = new \WP_REST_Server();
+
+		( new Events_Proxy_REST_API() )->register_hooks();
+
+		do_action( 'rest_api_init' );
+	}
+
+	public function test_registers_the_api_and_libs_routes() {
+		// Arrange
+		// Act
+		$routes = $GLOBALS['wp_rest_server']->get_routes();
+
+		// Assert
+		$this->assertArrayHasKey( '/elementor/v1/events-proxy/api/(?P<path>.+)', $routes );
+		$this->assertArrayHasKey( '/elementor/v1/events-proxy/libs/(?P<file>[\w\-.]+)', $routes );
+	}
+
+	public function test_api_request_is_forwarded_to_the_fixed_upstream_host_with_headers() {
+		// Arrange
+		$captured = null;
+
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured ) {
+			$captured = [
+				'url' => $url,
+				'args' => $args,
+			];
+
+			return [
+				'response' => [ 'code' => 200 ],
+				'headers' => [ 'content-type' => 'text/plain' ],
+				'body' => '1',
+			];
+		}, 10, 3 );
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/events-proxy/api/track' );
+		$request->set_query_params( [ 'ip' => '1' ] );
+		$request->set_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$request->set_header( 'authorization', 'Basic abc123' );
+		$request->set_body( 'data=abc' );
+
+		// Act
+		$response = $GLOBALS['wp_rest_server']->dispatch( $request );
+
+		// Assert
+		$this->assertEquals( 'https://api-eu.mixpanel.com/track?ip=1', $captured['url'] );
+		$this->assertEquals( 'POST', $captured['args']['method'] );
+		$this->assertEquals( 'data=abc', $captured['args']['body'] );
+		$this->assertEquals( 'application/x-www-form-urlencoded', $captured['args']['headers']['content-type'] );
+		$this->assertEquals( 'Basic abc123', $captured['args']['headers']['authorization'] );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( '1', $response->get_data() );
+	}
+
+	public function test_libs_request_is_forwarded_to_the_fixed_cdn_host() {
+		// Arrange
+		$captured_url = null;
+
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured_url ) {
+			$captured_url = $url;
+
+			return [
+				'response' => [ 'code' => 200 ],
+				'headers' => [ 'content-type' => 'application/javascript' ],
+				'body' => 'console.log(1);',
+			];
+		}, 10, 3 );
+
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/events-proxy/libs/recorder.min.js' );
+
+		// Act
+		$response = $GLOBALS['wp_rest_server']->dispatch( $request );
+
+		// Assert
+		$this->assertEquals( 'https://cdn.mxpnl.com/libs/recorder.min.js', $captured_url );
+		$this->assertEquals( 'console.log(1);', $response->get_data() );
+	}
+
+	public function test_oversized_body_is_rejected_with_413_before_forwarding() {
+		// Arrange
+		$request_sent = false;
+
+		add_filter( 'pre_http_request', function ( $preempt ) use ( &$request_sent ) {
+			$request_sent = true;
+
+			return $preempt;
+		} );
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/events-proxy/api/track' );
+		$request->set_body( str_repeat( 'a', 10 * MB_IN_BYTES + 1 ) );
+
+		// Act
+		$response = $GLOBALS['wp_rest_server']->dispatch( $request );
+
+		// Assert
+		$this->assertFalse( $request_sent );
+		$this->assertEquals( 413, $response->get_status() );
+	}
+
+	public function test_upstream_failure_is_surfaced_as_a_502() {
+		// Arrange
+		add_filter( 'pre_http_request', function () {
+			return new \WP_Error( 'http_request_failed', 'Could not resolve host' );
+		} );
+
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/events-proxy/api/decide' );
+
+		// Act
+		$response = $GLOBALS['wp_rest_server']->dispatch( $request );
+
+		// Assert
+		$this->assertEquals( 502, $response->get_status() );
+	}
+
+	/**
+	 * The SDK cannot supply a WP REST nonce, so this route must stay reachable for logged-in Editor sessions
+	 * even though WordPress' cookie-auth layer would otherwise demand one. Exercised directly against the
+	 * filter callback, since simulating WP's real cookie-auth nonce flow in PHPUnit is not practical.
+	 */
+	public function test_nonce_check_is_bypassed_for_its_own_route_but_not_for_other_routes() {
+		// Arrange
+		$proxy = new Events_Proxy_REST_API();
+		$existing_error = new \WP_Error( 'rest_cookie_invalid_nonce', 'Cookie check failed' );
+
+		// Act
+		$_SERVER['REQUEST_URI'] = '/wp-json/elementor/v1/events-proxy/api/track';
+		$own_route_result = $proxy->bypass_nonce_check_for_own_routes( $existing_error );
+
+		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts';
+		$other_route_result = $proxy->bypass_nonce_check_for_own_routes( $existing_error );
+
+		unset( $_SERVER['REQUEST_URI'] );
+
+		// Assert
+		$this->assertTrue( $own_route_result );
+		$this->assertSame( $existing_error, $other_route_result );
+	}
+
+	public function test_raw_response_filter_echoes_the_upstream_body_and_marks_the_request_served() {
+		// Arrange
+		$proxy = new Events_Proxy_REST_API();
+		$response = new \WP_REST_Response( 'console.log(1);', 200 );
+		$response->header( 'Content-Type', 'application/javascript' );
+		$response->header( Events_Proxy_REST_API::RAW_RESPONSE_HEADER, '1' );
+
+		// Act
+		ob_start();
+		$served = $proxy->maybe_serve_raw_response( false, $response );
+		$output = ob_get_clean();
+
+		// Assert
+		$this->assertTrue( $served );
+		$this->assertEquals( 'console.log(1);', $output );
+	}
+
+	public function test_raw_response_filter_ignores_responses_without_the_raw_marker() {
+		// Arrange
+		$proxy = new Events_Proxy_REST_API();
+		$response = new \WP_REST_Response( [ 'data' => 'unrelated' ], 200 );
+
+		// Act
+		$served = $proxy->maybe_serve_raw_response( false, $response );
+
+		// Assert
+		$this->assertFalse( $served );
+	}
+}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Centralizes Mixpanel API/CDN endpoints through a REST proxy to enable dynamic configuration and remote override capability (ED-24752). Removes hardcoded URLs from client/server code.

## 2. What Changed (Where)

- **events-manager/module.php**: Added `Events_Proxy_REST_API` instantiation, new host constants, two getter methods for remote-configured endpoints, config keys passed to frontend.
- **events-proxy-rest-api.php** (new): REST proxy forwarding requests to Mixpanel's `/api` and `/libs` endpoints with auth bypass, async dispatch for fire-and-forget paths, request size validation.
- **server-events-client.php**: Swapped hardcoded `HOST` constant for dynamic `Module::get_mixpanel_api_host()` call.
- **module.js**: Replaced inline `api_host` URL with config-driven values (`proxy_api_host`, `proxy_lib_base_path`).
- **Test suite** (new + updated): 305-line proxy test coverage plus Jest fixtures for proxy endpoint config.

## 3. How It Works

Client/server no longer reference Mixpanel URLs directly. On init, `Events_Proxy_REST_API` registers two REST routes (`/elementor/v1/events/api/*` and `/elementor/v1/events/libs/*`). Requests route through proxy, which validates auth (`edit_posts` cap), fetches remote config for actual endpoints, forwards with filtered headers. Fire-and-forget paths (`track`, `engage`, `groups`, `record`) dispatch asynchronously; others block and return upstream response. Nonce check is bypassed for proxy routes since SDK can't supply one.

## 4. Risks

Request forwarding creates a redirect surface—mitigated by capability check, body size limit (10MB), and 3s timeout. Remote config fetch introduces latency/failure point if assets.elementor.com is down, but includes sensible fallback constants. Proxy could become bottleneck at scale, though async dispatch reduces blocking overhead.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
