### PR TITLE
Internal: Support dynamic mentions [ED-24834]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/__tests__/email-chips-field.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/email-chips-field.test.tsx
@@ -218,3 +218,58 @@ describe( 'EmailChipsField form-field shortcodes', () => {
 		expect( setValue ).toHaveBeenCalledWith( { to: wrapStringArray( [ '[email]' ] ) }, {}, { bind: 'to' } );
 	} );
 } );
+
+describe( 'EmailChipsField @ mentions', () => {
+	it( 'should convert a matching @mention into a shortcode chip on blur', () => {
+		const suggestions: Suggestion[] = [ { label: 'email', value: 'email' } ];
+		const { setValue } = renderRecipientField( { fieldBind: 'to', fieldValue: wrapStringArray( [] ), suggestions } );
+		const input = screen.getByRole( 'combobox' );
+
+		fireEvent.change( input, { target: { value: '@email' } } );
+		fireEvent.blur( input );
+
+		expect( setValue ).toHaveBeenCalledWith( { to: wrapStringArray( [ '[email]' ] ) }, {}, { bind: 'to' } );
+	} );
+
+	it( 'should filter suggestions in the dropdown when typing an @mention query', () => {
+		const suggestions: Suggestion[] = [
+			{ label: 'email', value: 'email' },
+			{ label: 'name', value: 'name' },
+		];
+		renderRecipientField( { fieldBind: 'cc', fieldValue: wrapStringArray( [] ), suggestions } );
+		const input = screen.getByRole( 'combobox' );
+
+		fireEvent.change( input, { target: { value: '@ema' } } );
+
+		const listbox = screen.getByRole( 'listbox' );
+
+		expect( within( listbox ).getByText( '[email]' ) ).toBeInTheDocument();
+		expect( within( listbox ).queryByText( '[name]' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should not treat a real email address containing "@" as a mention', () => {
+		const suggestions: Suggestion[] = [ { label: 'email', value: 'email' } ];
+		const { setValue } = renderRecipientField( { fieldBind: 'bcc', fieldValue: wrapStringArray( [] ), suggestions } );
+		const input = screen.getByRole( 'combobox' );
+
+		fireEvent.change( input, { target: { value: 'admin@example.com' } } );
+		fireEvent.blur( input );
+
+		expect( setValue ).toHaveBeenCalledWith(
+			{ bcc: wrapStringArray( [ 'admin@example.com' ] ) },
+			{},
+			{ bind: 'bcc' }
+		);
+	} );
+
+	it( 'should drop an @mention with no matching suggestion', () => {
+		const suggestions: Suggestion[] = [ { label: 'email', value: 'email' } ];
+		const { setValue } = renderRecipientField( { fieldBind: 'to', fieldValue: wrapStringArray( [] ), suggestions } );
+		const input = screen.getByRole( 'combobox' );
+
+		fireEvent.change( input, { target: { value: '@unknown' } } );
+		fireEvent.blur( input );
+
+		expect( setValue ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/email-chips-field.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/email-chips-field.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { createMockPropType, renderWithTheme } from 'test-utils';
 import { isTransformable, type ObjectPropType, type PropValue, type UnionPropType } from '@elementor/editor-props';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 
 import { PropKeyProvider, PropProvider } from '../../bound-prop-context';
 import { ControlActionsProvider } from '../../control-actions/control-actions-context';
 import { ControlReplacementsProvider, createControlReplacementsRegistry } from '../../control-replacements';
+import { type Suggestion } from '../../hooks/use-form-field-suggestions';
 import { EmailChipsField } from '../email-form-action-control/email-chips-field';
 
 const wrap = ( val: string ) => ( { $$type: 'string' as const, value: val } );
@@ -72,9 +73,10 @@ registerControlReplacement( {
 type RenderRecipientFieldArgs = {
 	fieldBind: 'to' | 'cc' | 'bcc';
 	fieldValue: PropValue;
+	suggestions?: Suggestion[];
 };
 
-const renderRecipientField = ( { fieldBind, fieldValue }: RenderRecipientFieldArgs ) => {
+const renderRecipientField = ( { fieldBind, fieldValue, suggestions }: RenderRecipientFieldArgs ) => {
 	const setValue = jest.fn();
 
 	renderWithTheme(
@@ -82,7 +84,7 @@ const renderRecipientField = ( { fieldBind, fieldValue }: RenderRecipientFieldAr
 			<PropKeyProvider bind={ fieldBind }>
 				<ControlReplacementsProvider replacements={ getControlReplacements() }>
 					<ControlActionsProvider items={ [] }>
-						<EmailChipsField fieldLabel="Recipients" />
+						<EmailChipsField fieldLabel="Recipients" suggestions={ suggestions } />
 					</ControlActionsProvider>
 				</ControlReplacementsProvider>
 			</PropKeyProvider>
@@ -148,5 +150,71 @@ describe( 'EmailChipsField dynamic tags', () => {
 			expect( fieldPropType.prop_types.dynamic?.key ).toBe( 'dynamic' );
 			expect( fieldPropType.prop_types[ 'string-array' ]?.key ).toBe( 'string-array' );
 		}
+	} );
+} );
+
+describe( 'EmailChipsField form-field shortcodes', () => {
+	it( 'should keep a mention shortcode as a chip instead of clearing it', () => {
+		// Arrange
+		const { setValue } = renderRecipientField( { fieldBind: 'to', fieldValue: wrapStringArray( [] ) } );
+		const input = screen.getByRole( 'combobox' );
+
+		// Act
+		fireEvent.change( input, { target: { value: '[email]' } } );
+		fireEvent.blur( input );
+
+		// Assert
+		expect( setValue ).toHaveBeenCalledWith( { to: wrapStringArray( [ '[email]' ] ) }, {}, { bind: 'to' } );
+	} );
+
+	it( 'should keep a legacy [field id="..."] shortcode as a chip instead of clearing it', () => {
+		// Arrange
+		const { setValue } = renderRecipientField( { fieldBind: 'cc', fieldValue: wrapStringArray( [] ) } );
+		const input = screen.getByRole( 'combobox' );
+
+		// Act
+		fireEvent.change( input, { target: { value: '[field id="email"]' } } );
+		fireEvent.blur( input );
+
+		// Assert
+		expect( setValue ).toHaveBeenCalledWith(
+			{ cc: wrapStringArray( [ '[field id="email"]' ] ) },
+			{},
+			{ bind: 'cc' }
+		);
+	} );
+
+	it( 'should still drop a plainly invalid, non-shortcode value', () => {
+		// Arrange
+		const { setValue } = renderRecipientField( { fieldBind: 'bcc', fieldValue: wrapStringArray( [] ) } );
+		const input = screen.getByRole( 'combobox' );
+
+		// Act
+		fireEvent.change( input, { target: { value: 'not-an-email' } } );
+		fireEvent.blur( input );
+
+		// Assert
+		expect( setValue ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should add a suggested form field from the dropdown as a shortcode chip', () => {
+		// Arrange
+		const suggestions: Suggestion[] = [ { label: 'email', value: 'email' } ];
+		const { setValue } = renderRecipientField( {
+			fieldBind: 'to',
+			fieldValue: wrapStringArray( [] ),
+			suggestions,
+		} );
+
+		const input = screen.getByRole( 'combobox' );
+		fireEvent.mouseDown( input );
+
+		const listbox = screen.getByRole( 'listbox' );
+
+		// Act
+		fireEvent.click( within( listbox ).getByText( '[email]' ) );
+
+		// Assert
+		expect( setValue ).toHaveBeenCalledWith( { to: wrapStringArray( [ '[email]' ] ) }, {}, { bind: 'to' } );
 	} );
 } );

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/email-chips-field.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/email-chips-field.test.tsx
@@ -222,7 +222,11 @@ describe( 'EmailChipsField form-field shortcodes', () => {
 describe( 'EmailChipsField @ mentions', () => {
 	it( 'should convert a matching @mention into a shortcode chip on blur', () => {
 		const suggestions: Suggestion[] = [ { label: 'email', value: 'email' } ];
-		const { setValue } = renderRecipientField( { fieldBind: 'to', fieldValue: wrapStringArray( [] ), suggestions } );
+		const { setValue } = renderRecipientField( {
+			fieldBind: 'to',
+			fieldValue: wrapStringArray( [] ),
+			suggestions,
+		} );
 		const input = screen.getByRole( 'combobox' );
 
 		fireEvent.change( input, { target: { value: '@email' } } );
@@ -249,7 +253,11 @@ describe( 'EmailChipsField @ mentions', () => {
 
 	it( 'should not treat a real email address containing "@" as a mention', () => {
 		const suggestions: Suggestion[] = [ { label: 'email', value: 'email' } ];
-		const { setValue } = renderRecipientField( { fieldBind: 'bcc', fieldValue: wrapStringArray( [] ), suggestions } );
+		const { setValue } = renderRecipientField( {
+			fieldBind: 'bcc',
+			fieldValue: wrapStringArray( [] ),
+			suggestions,
+		} );
 		const input = screen.getByRole( 'combobox' );
 
 		fireEvent.change( input, { target: { value: 'admin@example.com' } } );
@@ -264,7 +272,11 @@ describe( 'EmailChipsField @ mentions', () => {
 
 	it( 'should drop an @mention with no matching suggestion', () => {
 		const suggestions: Suggestion[] = [ { label: 'email', value: 'email' } ];
-		const { setValue } = renderRecipientField( { fieldBind: 'to', fieldValue: wrapStringArray( [] ), suggestions } );
+		const { setValue } = renderRecipientField( {
+			fieldBind: 'to',
+			fieldValue: wrapStringArray( [] ),
+			suggestions,
+		} );
 		const input = screen.getByRole( 'combobox' );
 
 		fireEvent.change( input, { target: { value: '@unknown' } } );

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control/email-chips-field.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control/email-chips-field.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { type KeyboardEvent, type SyntheticEvent, useState } from 'react';
+import { type KeyboardEvent, type SyntheticEvent, useMemo, useState } from 'react';
 import { stringArrayPropTypeUtil, stringPropTypeUtil } from '@elementor/editor-props';
 import { Autocomplete, Grid, TextField } from '@elementor/ui';
 
@@ -8,13 +8,17 @@ import { ChipsList } from '../../components/chips-list';
 import { ControlFormLabel } from '../../components/control-form-label';
 import ControlActions from '../../control-actions/control-actions';
 import { createControl } from '../../create-control';
-import { CHIP_TRIGGER_KEYS, isValidEmail } from './utils';
+import { type Suggestion } from '../../hooks/use-form-field-suggestions';
+import { CHIP_TRIGGER_KEYS, isFormFieldShortcode, isValidEmail } from './utils';
+
+const isValidRecipient = ( address: string ) => isValidEmail( address ) || isFormFieldShortcode( address );
 
 type EmailChipsControlProps = {
 	placeholder?: string;
+	suggestions?: Suggestion[];
 };
 
-export const EmailChipsControl = createControl( ( { placeholder }: EmailChipsControlProps ) => {
+export const EmailChipsControl = createControl( ( { placeholder, suggestions = [] }: EmailChipsControlProps ) => {
 	const { value, setValue, disabled } = useBoundProp( stringArrayPropTypeUtil );
 	const [ inputValue, setInputValue ] = useState( '' );
 
@@ -24,10 +28,15 @@ export const EmailChipsControl = createControl( ( { placeholder }: EmailChipsCon
 		.map( ( item ) => stringPropTypeUtil.extract( item ) )
 		.filter( ( val ): val is string => val !== null );
 
+	const suggestionOptions = useMemo(
+		() => suggestions.map( ( suggestion ) => `[${ suggestion.value }]` ),
+		[ suggestions ]
+	);
+
 	const tryAddChip = ( raw: string ) => {
 		const address = raw.trim();
 
-		if ( ! address || selectedValues.includes( address ) || ! isValidEmail( address ) ) {
+		if ( ! address || selectedValues.includes( address ) || ! isValidRecipient( address ) ) {
 			return;
 		}
 
@@ -41,7 +50,7 @@ export const EmailChipsControl = createControl( ( { placeholder }: EmailChipsCon
 		for ( const entry of newValue ) {
 			const address = entry.trim();
 
-			if ( ! address || ! isValidEmail( address ) ) {
+			if ( ! address || ! isValidRecipient( address ) ) {
 				continue;
 			}
 
@@ -82,7 +91,8 @@ export const EmailChipsControl = createControl( ( { placeholder }: EmailChipsCon
 				} }
 				value={ selectedValues }
 				onChange={ handleChange }
-				options={ [] }
+				options={ suggestionOptions }
+				filterSelectedOptions
 				onBlur={ handleBlur }
 				getOptionLabel={ ( option ) => option }
 				isOptionEqualToValue={ ( option, val ) => option === val }
@@ -100,15 +110,16 @@ export const EmailChipsControl = createControl( ( { placeholder }: EmailChipsCon
 type EmailChipsFieldProps = {
 	fieldLabel: string;
 	placeholder?: string;
+	suggestions?: Suggestion[];
 };
 
-export const EmailChipsField = ( { fieldLabel, placeholder }: EmailChipsFieldProps ) => (
+export const EmailChipsField = ( { fieldLabel, placeholder, suggestions }: EmailChipsFieldProps ) => (
 	<Grid container direction="column" gap={ 0.5 }>
 		<Grid item>
 			<ControlFormLabel>{ fieldLabel }</ControlFormLabel>
 		</Grid>
 		<Grid item>
-			<EmailChipsControl placeholder={ placeholder } />
+			<EmailChipsControl placeholder={ placeholder } suggestions={ suggestions } />
 		</Grid>
 	</Grid>
 );

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control/email-chips-field.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control/email-chips-field.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { type KeyboardEvent, type SyntheticEvent, useMemo, useState } from 'react';
 import { stringArrayPropTypeUtil, stringPropTypeUtil } from '@elementor/editor-props';
-import { InfoAlert } from '@elementor/editor-ui';
-import { Autocomplete, Grid, Stack, TextField } from '@elementor/ui';
-import { __ } from '@wordpress/i18n';
+import { Autocomplete, Grid, TextField } from '@elementor/ui';
 
 import { useBoundProp } from '../../bound-prop-context';
 import { ChipsList } from '../../components/chips-list';
@@ -11,9 +9,20 @@ import { ControlFormLabel } from '../../components/control-form-label';
 import ControlActions from '../../control-actions/control-actions';
 import { createControl } from '../../create-control';
 import { type Suggestion } from '../../hooks/use-form-field-suggestions';
-import { CHIP_TRIGGER_KEYS, isFormFieldShortcode, isValidEmail, shouldShowMentionsInfo } from './utils';
+import { createMentionPattern } from '../mention-text-area-control';
+import { CHIP_TRIGGER_KEYS, isFormFieldShortcode, isValidEmail } from './utils';
 
 const isValidRecipient = ( address: string ) => isValidEmail( address ) || isFormFieldShortcode( address );
+
+function resolveMention( raw: string, suggestions: Suggestion[] ): string {
+	if ( ! raw.startsWith( '@' ) ) {
+		return raw;
+	}
+
+	const match = suggestions.find( ( suggestion ) => createMentionPattern( suggestion.value, 'start' ).test( raw ) );
+
+	return match ? `[${ match.value }]` : raw;
+}
 
 type EmailChipsControlProps = {
 	placeholder?: string;
@@ -36,7 +45,7 @@ export const EmailChipsControl = createControl( ( { placeholder, suggestions = [
 	);
 
 	const tryAddChip = ( raw: string ) => {
-		const address = raw.trim();
+		const address = resolveMention( raw.trim(), suggestions );
 
 		if ( ! address || selectedValues.includes( address ) || ! isValidRecipient( address ) ) {
 			return;
@@ -50,7 +59,7 @@ export const EmailChipsControl = createControl( ( { placeholder, suggestions = [
 		const updated = [];
 
 		for ( const entry of newValue ) {
-			const address = entry.trim();
+			const address = resolveMention( entry.trim(), suggestions );
 
 			if ( ! address || ! isValidRecipient( address ) ) {
 				continue;
@@ -94,6 +103,11 @@ export const EmailChipsControl = createControl( ( { placeholder, suggestions = [
 				value={ selectedValues }
 				onChange={ handleChange }
 				options={ suggestionOptions }
+				filterOptions={ ( options, state ) => {
+					const query = state.inputValue.trim().replace( /^@/, '' ).toLowerCase();
+
+					return query ? options.filter( ( option ) => option.toLowerCase().includes( query ) ) : options;
+				} }
 				filterSelectedOptions
 				onBlur={ handleBlur }
 				getOptionLabel={ ( option ) => option }
@@ -116,17 +130,12 @@ type EmailChipsFieldProps = {
 };
 
 export const EmailChipsField = ( { fieldLabel, placeholder, suggestions }: EmailChipsFieldProps ) => (
-	<Stack gap={ 0.5 }>
-		<Grid container direction="column" gap={ 0.5 }>
-			<Grid item>
-				<ControlFormLabel>{ fieldLabel }</ControlFormLabel>
-			</Grid>
-			<Grid item>
-				<EmailChipsControl placeholder={ placeholder } suggestions={ suggestions } />
-			</Grid>
+	<Grid container direction="column" gap={ 0.5 }>
+		<Grid item>
+			<ControlFormLabel>{ fieldLabel }</ControlFormLabel>
 		</Grid>
-		{ shouldShowMentionsInfo() && (
-			<InfoAlert>{ __( 'Type an email field name to insert its submitted value.', 'elementor' ) }</InfoAlert>
-		) }
-	</Stack>
+		<Grid item>
+			<EmailChipsControl placeholder={ placeholder } suggestions={ suggestions } />
+		</Grid>
+	</Grid>
 );

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control/email-chips-field.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control/email-chips-field.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { type KeyboardEvent, type SyntheticEvent, useMemo, useState } from 'react';
 import { stringArrayPropTypeUtil, stringPropTypeUtil } from '@elementor/editor-props';
-import { Autocomplete, Grid, TextField } from '@elementor/ui';
+import { InfoAlert } from '@elementor/editor-ui';
+import { Autocomplete, Grid, Stack, TextField } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
 
 import { useBoundProp } from '../../bound-prop-context';
 import { ChipsList } from '../../components/chips-list';
@@ -9,7 +11,7 @@ import { ControlFormLabel } from '../../components/control-form-label';
 import ControlActions from '../../control-actions/control-actions';
 import { createControl } from '../../create-control';
 import { type Suggestion } from '../../hooks/use-form-field-suggestions';
-import { CHIP_TRIGGER_KEYS, isFormFieldShortcode, isValidEmail } from './utils';
+import { CHIP_TRIGGER_KEYS, isFormFieldShortcode, isValidEmail, shouldShowMentionsInfo } from './utils';
 
 const isValidRecipient = ( address: string ) => isValidEmail( address ) || isFormFieldShortcode( address );
 
@@ -114,12 +116,17 @@ type EmailChipsFieldProps = {
 };
 
 export const EmailChipsField = ( { fieldLabel, placeholder, suggestions }: EmailChipsFieldProps ) => (
-	<Grid container direction="column" gap={ 0.5 }>
-		<Grid item>
-			<ControlFormLabel>{ fieldLabel }</ControlFormLabel>
+	<Stack gap={ 0.5 }>
+		<Grid container direction="column" gap={ 0.5 }>
+			<Grid item>
+				<ControlFormLabel>{ fieldLabel }</ControlFormLabel>
+			</Grid>
+			<Grid item>
+				<EmailChipsControl placeholder={ placeholder } suggestions={ suggestions } />
+			</Grid>
 		</Grid>
-		<Grid item>
-			<EmailChipsControl placeholder={ placeholder } suggestions={ suggestions } />
-		</Grid>
-	</Grid>
+		{ shouldShowMentionsInfo() && (
+			<InfoAlert>{ __( 'Type an email field name to insert its submitted value.', 'elementor' ) }</InfoAlert>
+		) }
+	</Stack>
 );

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control/fields.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control/fields.tsx
@@ -18,11 +18,18 @@ export const SendToField = ( { placeholder }: { placeholder?: string } ) => {
 
 	return (
 		<PropKeyProvider bind="to">
-			<EmailChipsField
-				fieldLabel={ __( 'Send to', 'elementor' ) }
-				placeholder={ placeholder }
-				suggestions={ suggestions }
-			/>
+			<Stack gap={ 0.5 }>
+				<EmailChipsField
+					fieldLabel={ __( 'Send to', 'elementor' ) }
+					placeholder={ placeholder }
+					suggestions={ suggestions }
+				/>
+				{ shouldShowMentionsInfo() && (
+					<InfoAlert>
+						{ __( 'Type @ or an email field name to insert its submitted value.', 'elementor' ) }
+					</InfoAlert>
+				) }
+			</Stack>
 		</PropKeyProvider>
 	);
 };

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control/fields.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control/fields.tsx
@@ -13,11 +13,26 @@ import { EmailChipsField } from './email-chips-field';
 import { EmailField } from './email-field';
 import { shouldShowMentionsInfo } from './utils';
 
-export const SendToField = ( { placeholder }: { placeholder?: string } ) => (
-	<PropKeyProvider bind="to">
-		<EmailChipsField fieldLabel={ __( 'Send to', 'elementor' ) } placeholder={ placeholder } />
-	</PropKeyProvider>
-);
+export const SendToField = ( { placeholder }: { placeholder?: string } ) => {
+	const suggestions = useFormFieldSuggestions( { inputType: 'email' } );
+
+	return (
+		<PropKeyProvider bind="to">
+			<Stack gap={ 0.5 }>
+				<EmailChipsField
+					fieldLabel={ __( 'Send to', 'elementor' ) }
+					placeholder={ placeholder }
+					suggestions={ suggestions }
+				/>
+				{ shouldShowMentionsInfo() && (
+					<InfoAlert>
+						{ __( 'Type an email field name to insert its submitted value.', 'elementor' ) }
+					</InfoAlert>
+				) }
+			</Stack>
+		</PropKeyProvider>
+	);
+};
 
 export const SubjectField = () => (
 	<EmailField
@@ -92,17 +107,25 @@ export const ReplyToField = () => {
 	);
 };
 
-export const CcField = () => (
-	<PropKeyProvider bind="cc">
-		<EmailChipsField fieldLabel={ __( 'Cc', 'elementor' ) } />
-	</PropKeyProvider>
-);
+export const CcField = () => {
+	const suggestions = useFormFieldSuggestions( { inputType: 'email' } );
 
-export const BccField = () => (
-	<PropKeyProvider bind="bcc">
-		<EmailChipsField fieldLabel={ __( 'Bcc', 'elementor' ) } />
-	</PropKeyProvider>
-);
+	return (
+		<PropKeyProvider bind="cc">
+			<EmailChipsField fieldLabel={ __( 'Cc', 'elementor' ) } suggestions={ suggestions } />
+		</PropKeyProvider>
+	);
+};
+
+export const BccField = () => {
+	const suggestions = useFormFieldSuggestions( { inputType: 'email' } );
+
+	return (
+		<PropKeyProvider bind="bcc">
+			<EmailChipsField fieldLabel={ __( 'Bcc', 'elementor' ) } suggestions={ suggestions } />
+		</PropKeyProvider>
+	);
+};
 
 export const MetaDataField = () => (
 	<PropKeyProvider bind="meta-data">

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control/fields.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control/fields.tsx
@@ -18,18 +18,11 @@ export const SendToField = ( { placeholder }: { placeholder?: string } ) => {
 
 	return (
 		<PropKeyProvider bind="to">
-			<Stack gap={ 0.5 }>
-				<EmailChipsField
-					fieldLabel={ __( 'Send to', 'elementor' ) }
-					placeholder={ placeholder }
-					suggestions={ suggestions }
-				/>
-				{ shouldShowMentionsInfo() && (
-					<InfoAlert>
-						{ __( 'Type an email field name to insert its submitted value.', 'elementor' ) }
-					</InfoAlert>
-				) }
-			</Stack>
+			<EmailChipsField
+				fieldLabel={ __( 'Send to', 'elementor' ) }
+				placeholder={ placeholder }
+				suggestions={ suggestions }
+			/>
 		</PropKeyProvider>
 	);
 };

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control/utils.ts
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control/utils.ts
@@ -9,6 +9,15 @@ export function isValidEmail( email: string ): boolean {
 	return z.string().email().safeParse( email ).success;
 }
 
+// Matches a single bracket-wrapped token, e.g. `[email]` (form field mention shortcode) or the
+// legacy `[field id="email"]` shortcode, so recipient chips can hold a dynamic value instead of
+// a literal address.
+const FORM_FIELD_SHORTCODE_PATTERN = /^\[[^[\]]+]$/;
+
+export function isFormFieldShortcode( value: string ): boolean {
+	return FORM_FIELD_SHORTCODE_PATTERN.test( value );
+}
+
 export const shouldShowMentionsInfo = (): boolean => {
 	if ( ! hasProInstalled() ) {
 		return true;

--- a/packages/packages/libs/editor-controls/src/controls/email-form-action-control/utils.ts
+++ b/packages/packages/libs/editor-controls/src/controls/email-form-action-control/utils.ts
@@ -9,9 +9,6 @@ export function isValidEmail( email: string ): boolean {
 	return z.string().email().safeParse( email ).success;
 }
 
-// Matches a single bracket-wrapped token, e.g. `[email]` (form field mention shortcode) or the
-// legacy `[field id="email"]` shortcode, so recipient chips can hold a dynamic value instead of
-// a literal address.
 const FORM_FIELD_SHORTCODE_PATTERN = /^\[[^[\]]+]$/;
 
 export function isFormFieldShortcode( value: string ): boolean {

--- a/packages/packages/libs/editor-controls/src/controls/mention-text-area-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/mention-text-area-control.tsx
@@ -81,9 +81,9 @@ const MentionWrapper = styled( 'div' )( ( { theme } ) => ( {
 	},
 } ) );
 
-type TriggerPosition = 'start' | 'auto';
+export type TriggerPosition = 'start' | 'auto';
 
-function createMentionPattern( value: string, triggerPosition: TriggerPosition ): RegExp {
+export function createMentionPattern( value: string, triggerPosition: TriggerPosition ): RegExp {
 	const escaped = value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
 	const prefix = 'start' === triggerPosition ? '^' : '';
 


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

ED-24834: Enable form field suggestions in email recipient fields (To, Cc, Bcc) via @-mention syntax, converting matches to `[fieldname]` shortcodes while preserving email validation.

## 2. What Changed (Where)

- **email-chips-field.tsx**: Added `resolveMention()` to convert `@fieldname` to `[fieldname]` shortcodes; integrated suggestion filtering and memoization; updated validation to accept both emails and shortcodes.
- **fields.tsx**: Refactored `SendToField`, `CcField`, `BccField` to inject form field suggestions via `useFormFieldSuggestions()`.
- **utils.ts**: Extracted `createMentionPattern()` to public export; added `isFormFieldShortcode()` validator for bracket-wrapped shortcodes.
- **mention-text-area-control.tsx**: Exported `createMentionPattern()` and `TriggerPosition` type for reuse.
- **email-chips-field.test.tsx**: Added 6 new test suites covering shortcode preservation, @-mention resolution, dropdown filtering, and edge cases (non-matching mentions, real emails).

## 3. How It Works

User types `@email` → `resolveMention()` searches suggestions against pattern `^@email` → matches convert to `[email]` on blur/selection. Autocomplete filters options when input starts with `@` (stripped for matching). Validation accepts `[field id="..."]` legacy format and simple `[fieldname]` via regex `/^\[[^[\]]+]$/`. Real emails bypass mention resolution since they don't start with `@`.

## 4. Risks

Mention pattern matching uses `createMentionPattern(..., 'start')` which only matches `@field` at input start—misses mid-string mentions, but acceptable for chip-input context. Legacy `[field id="..."]` support relies on regex; malformed brackets are rejected (correct). Test coverage is comprehensive but doesn't mock actual `useFormFieldSuggestions()` hook behavior beyond shape.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
