### PR TITLE
Fix: Harden legacy Post CSS file writes and self-heal on enqueue [ED-24903]

### DIFF
--- a/core/files/css/base.php
+++ b/core/files/css/base.php
@@ -159,12 +159,52 @@ abstract class Base extends Base_File {
 	}
 
 	/**
+	 * Write the generated CSS to disk.
+	 *
+	 * Overrides {@see Base_File::write()} to perform an atomic write-then-rename instead of
+	 * a direct `file_put_contents()` on the final path. Because `rename()` is atomic on POSIX
+	 * filesystems, an anonymous request or a downstream page-cache snapshot cannot capture a
+	 * zero-byte or half-written state while regeneration is in flight. This directly closes
+	 * the concurrent-write race documented in ED-24903.
+	 *
+	 * On unusual filesystems where the atomic move fails (some symlinked/overlay setups, or
+	 * a `wp_upload_dir()` that is not writable in the same way as the temp sibling), the
+	 * method transparently falls back to the previous behaviour: a direct write to the final
+	 * path plus a cleanup of the tmp file. That fallback is byte-for-byte the pre-fix
+	 * behaviour, so no site regresses.
+	 *
 	 * @since 2.1.0
 	 * @access public
 	 */
 	public function write() {
-		if ( $this->use_external_file() ) {
-			parent::write();
+		if ( ! $this->use_external_file() ) {
+			return;
+		}
+
+		$path    = $this->get_path();
+		$content = $this->get_content();
+
+		// The tmp file lives next to the target so `rename()` is a single-inode swap on the
+		// same filesystem. The random suffix avoids collisions between concurrent renders of
+		// the same file.
+		$tmp_path = $path . '.tmp-' . wp_generate_password( 8, false, false );
+
+		$bytes = @file_put_contents( $tmp_path, $content );
+
+		if ( false === $bytes ) {
+			return;
+		}
+
+		if ( @rename( $tmp_path, $path ) ) {
+			return;
+		}
+
+		// Rename failed: fall back to a direct write (the pre-ED-24903 behaviour) and clean
+		// up the tmp file so we don't leave `.tmp-*` siblings around.
+		@file_put_contents( $path, $content );
+
+		if ( file_exists( $tmp_path ) ) {
+			@unlink( $tmp_path );
 		}
 	}
 
@@ -229,8 +269,11 @@ abstract class Base extends Base_File {
 		 */
 		do_action( 'elementor/css-file/before_enqueue', $this );
 
-		// First time after clear cache and etc.
-		if ( '' === $meta['status'] || $this->is_update_required() ) {
+		// First time after clear cache, when an update is explicitly required, or when the
+		// meta says an external CSS file should exist but the file on disk is missing or
+		// zero-byte (ED-24903: repairs stale meta that references a broken/purged file so
+		// the next request self-heals instead of emitting a `<link>` to an empty asset).
+		if ( '' === $meta['status'] || $this->is_update_required() || $this->is_external_file_missing_or_empty( $meta ) ) {
 			$this->update();
 
 			$meta = $this->get_meta();
@@ -696,6 +739,47 @@ abstract class Base extends Base_File {
 	 */
 	protected function is_update_required() {
 		return false;
+	}
+
+	/**
+	 * Whether the meta says an external CSS file should be present, but the file on disk is
+	 * missing or zero-byte.
+	 *
+	 * Guarded by {@see self::use_external_file()} so inline installs are never affected, and
+	 * gated on `meta['status'] === CSS_STATUS_FILE` so healthy sites (and legit empty CSS,
+	 * i.e. `CSS_STATUS_EMPTY`) short-circuit before the filesystem stat. In practice this
+	 * costs one `stat()` per external-file enqueue when the meta claims a file exists.
+	 *
+	 * Introduced for ED-24903 to close the reader-side of the "cache says file, file is
+	 * missing/empty" failure mode. A `true` return in {@see self::enqueue()} triggers a
+	 * regeneration before the `<link>` is emitted, so the next anonymous request self-heals
+	 * instead of serving an empty asset.
+	 *
+	 * @since 4.3.0
+	 * @access protected
+	 *
+	 * @param array $meta The current CSS file meta. Passed in rather than re-fetched to
+	 *                    keep the fast path of {@see self::enqueue()} free of extra option
+	 *                    reads.
+	 *
+	 * @return bool True when a regeneration is needed to repair a broken/empty on-disk file.
+	 */
+	protected function is_external_file_missing_or_empty( array $meta ) {
+		if ( ! $this->use_external_file() ) {
+			return false;
+		}
+
+		if ( empty( $meta['status'] ) || self::CSS_STATUS_FILE !== $meta['status'] ) {
+			return false;
+		}
+
+		$path = $this->get_path();
+
+		if ( ! file_exists( $path ) ) {
+			return true;
+		}
+
+		return 0 === (int) @filesize( $path );
 	}
 
 	/**

--- a/tests/phpunit/elementor/core/files/css/test-base.php
+++ b/tests/phpunit/elementor/core/files/css/test-base.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elementor\Tests\Phpunit\Elementor\Core\Files\Css;
 
+use Elementor\Core\Files\CSS\Base as CSS_Base;
+use Elementor\Core\Files\CSS\Post as CSS_Post;
 use Elementor\Core\Frontend\Widget_Content_Render_Mode;
 use Elementor\Plugin;
 use Elementor\Tests\Phpunit\Responsive_Control_Testing_Trait;
@@ -331,5 +333,191 @@ class Test_Base extends Elementor_Test_Base {
 		$this->assertSame( [ 'registered-handle' ], $method->invoke( $css ) );
 
 		wp_deregister_style( 'registered-handle' );
+	}
+
+	/**
+	 * ED-24903: `write()` should write CSS via a tmp-file + atomic rename so the public
+	 * URL never serves a zero-byte or partial asset. On success no `.tmp-*` sibling is left
+	 * behind.
+	 */
+	public function test_write__uses_atomic_rename_and_leaves_no_tmp_sibling() {
+		$dir       = $this->make_isolated_tmp_dir();
+		$target    = $dir . '/atomic-write-target.css';
+		$content   = ".elementor-999 { color: rebeccapurple; }";
+
+		$css = $this->build_css_mock( [
+			'use_external_file' => true,
+			'get_path'          => $target,
+			'get_content'       => $content,
+		] );
+
+		$css->write();
+
+		$this->assertFileExists( $target );
+		$this->assertSame( $content, file_get_contents( $target ) );
+		$this->assertSame( [], glob( $dir . '/*.tmp-*' ), 'No tmp sibling should remain after a successful atomic write.' );
+
+		$this->cleanup_isolated_tmp_dir( $dir );
+	}
+
+	/**
+	 * ED-24903: `write()` must be a no-op when the site is on the inline print method, so
+	 * inline installs are strictly unaffected.
+	 */
+	public function test_write__is_a_noop_when_not_using_external_file() {
+		$dir    = $this->make_isolated_tmp_dir();
+		$target = $dir . '/noop-target.css';
+
+		$css = $this->build_css_mock( [
+			'use_external_file' => false,
+			'get_path'          => $target,
+			'get_content'       => 'body {}',
+		] );
+
+		$css->write();
+
+		$this->assertFileDoesNotExist( $target );
+		$this->assertSame( [], glob( $dir . '/*.tmp-*' ) );
+
+		$this->cleanup_isolated_tmp_dir( $dir );
+	}
+
+	/**
+	 * ED-24903: reader-side self-heal helper returns `false` for inline installs.
+	 */
+	public function test_is_external_file_missing_or_empty__returns_false_when_inline_print_method() {
+		$css = $this->build_css_mock( [
+			'use_external_file' => false,
+			'get_path'          => '/definitely-does-not-exist/foo.css',
+			'get_content'       => '',
+		] );
+
+		$this->assertFalse( $this->invoke_missing_or_empty( $css, [ 'status' => 'file' ] ) );
+	}
+
+	/**
+	 * ED-24903: reader-side self-heal helper returns `false` unless the meta explicitly
+	 * says `CSS_STATUS_FILE`. Legit-empty CSS (`empty`), inline meta, and un-generated
+	 * meta must not trigger a regeneration.
+	 */
+	public function test_is_external_file_missing_or_empty__returns_false_when_status_not_file() {
+		$css = $this->build_css_mock( [
+			'use_external_file' => true,
+			'get_path'          => '/definitely-does-not-exist/foo.css',
+			'get_content'       => '',
+		] );
+
+		$this->assertFalse( $this->invoke_missing_or_empty( $css, [ 'status' => '' ] ) );
+		$this->assertFalse( $this->invoke_missing_or_empty( $css, [ 'status' => CSS_Base::CSS_STATUS_EMPTY ] ) );
+		$this->assertFalse( $this->invoke_missing_or_empty( $css, [ 'status' => CSS_Base::CSS_STATUS_INLINE ] ) );
+	}
+
+	/**
+	 * ED-24903: reader-side self-heal helper returns `true` when meta says CSS_STATUS_FILE
+	 * but the file is missing from disk. This is the exact 10 July occurrence.
+	 */
+	public function test_is_external_file_missing_or_empty__returns_true_when_file_missing() {
+		$dir    = $this->make_isolated_tmp_dir();
+		$target = $dir . '/never-created.css';
+
+		$css = $this->build_css_mock( [
+			'use_external_file' => true,
+			'get_path'          => $target,
+			'get_content'       => '',
+		] );
+
+		$this->assertTrue( $this->invoke_missing_or_empty( $css, [ 'status' => CSS_Base::CSS_STATUS_FILE ] ) );
+
+		$this->cleanup_isolated_tmp_dir( $dir );
+	}
+
+	/**
+	 * ED-24903: reader-side self-heal helper returns `true` when the file exists but is
+	 * zero bytes (the concurrent-write / truncated-by-host-cleanup case).
+	 */
+	public function test_is_external_file_missing_or_empty__returns_true_when_file_zero_bytes() {
+		$dir    = $this->make_isolated_tmp_dir();
+		$target = $dir . '/empty.css';
+		touch( $target );
+
+		$css = $this->build_css_mock( [
+			'use_external_file' => true,
+			'get_path'          => $target,
+			'get_content'       => '',
+		] );
+
+		$this->assertTrue( $this->invoke_missing_or_empty( $css, [ 'status' => CSS_Base::CSS_STATUS_FILE ] ) );
+
+		$this->cleanup_isolated_tmp_dir( $dir );
+	}
+
+	/**
+	 * ED-24903: healthy sites must not trigger a regeneration on every enqueue. When the
+	 * meta and disk agree on a non-empty file, the helper returns `false`.
+	 */
+	public function test_is_external_file_missing_or_empty__returns_false_when_file_healthy() {
+		$dir    = $this->make_isolated_tmp_dir();
+		$target = $dir . '/healthy.css';
+		file_put_contents( $target, '.elementor-1 { color: red; }' );
+
+		$css = $this->build_css_mock( [
+			'use_external_file' => true,
+			'get_path'          => $target,
+			'get_content'       => '',
+		] );
+
+		$this->assertFalse( $this->invoke_missing_or_empty( $css, [ 'status' => CSS_Base::CSS_STATUS_FILE ] ) );
+
+		$this->cleanup_isolated_tmp_dir( $dir );
+	}
+
+	/**
+	 * Build a mock `Core\Files\CSS\Post` with the three methods that the write()/self-heal
+	 * paths depend on stubbed to controllable values, so we can test file behaviour without
+	 * booting the full document/element stack.
+	 *
+	 * @param array{use_external_file: bool, get_path: string, get_content: string} $stubs
+	 * @return \Elementor\Core\Files\CSS\Post
+	 */
+	private function build_css_mock( array $stubs ) {
+		$css = $this->getMockBuilder( CSS_Post::class )
+			->setConstructorArgs( [ 0 ] )
+			->onlyMethods( [ 'use_external_file', 'get_path', 'get_content' ] )
+			->getMock();
+
+		$css->method( 'use_external_file' )->willReturn( $stubs['use_external_file'] );
+		$css->method( 'get_path' )->willReturn( $stubs['get_path'] );
+		$css->method( 'get_content' )->willReturn( $stubs['get_content'] );
+
+		return $css;
+	}
+
+	/**
+	 * Invoke the protected `is_external_file_missing_or_empty()` helper via reflection.
+	 */
+	private function invoke_missing_or_empty( $css, array $meta ) {
+		$method = new \ReflectionMethod( $css, 'is_external_file_missing_or_empty' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $css, $meta );
+	}
+
+	private function make_isolated_tmp_dir() {
+		$dir = sys_get_temp_dir() . '/elementor-ed24903-' . wp_generate_password( 8, false, false );
+		wp_mkdir_p( $dir );
+
+		return $dir;
+	}
+
+	private function cleanup_isolated_tmp_dir( $dir ) {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+
+		foreach ( glob( $dir . '/*' ) as $file ) {
+			@unlink( $file );
+		}
+
+		@rmdir( $dir );
 	}
 }


### PR DESCRIPTION
## Summary

Addresses the second half of ED-24903: hardening the **legacy** (v3) `Core\Files\CSS\Post` pipeline that produces `post-<id>.css` files. The v4 atomic pipeline is already covered by #<atomic-styles PR>. This PR is opened against `main` and is intentionally independent so it can be reviewed, tested and shipped on its own risk profile — the legacy pipeline is used by every Elementor v3 site (millions of installs), so the fix is deliberately as surgical as possible.

The customer evidence (see the PDF on the Jira ticket) shows two distinct failure modes on the v3 pipeline:

1. **10 July occurrence** — `post-907.css` served **empty** at its own URL to anonymous visitors, with no Elementor update event, while the four sibling `post-*.css` files were healthy. This is the reader side: `meta['status'] === CSS_STATUS_FILE`, but the on-disk file is missing or truncated, and today's `enqueue()` blindly emits a `<link>` to it.
2. **28 May / 3 June + the write-side of the 10 July occurrence** — non-atomic `file_put_contents($path, $content)` opens → truncates → writes, so there is a real window where the public URL serves a 0-byte asset that a full-page cache (or a downstream CSS combiner) can freeze.

## What changed

All changes live in **`core/files/css/base.php` only**. No changes to the shared `Core\Files\Base` parent (the "used by EVERYTHING" concern from the earlier review), no changes to any other subclass, no changes to `manager.php`, no changes to any v4 code.

### Writer side — atomic write-then-rename in `CSS\Base::write()`

- Writes CSS to a random `.tmp-*` sibling in the same directory, then `rename()`s into place. On POSIX filesystems this is a single-inode swap so the public URL cannot capture a partial or zero-byte state mid-render.
- Falls back to a direct `file_put_contents($final_path, $content)` + tmp cleanup if `rename()` fails (rare edge cases on some overlay/symlinked mounts). The fallback is byte-for-byte the pre-fix behaviour, so no adapter can regress.
- Inline print method (`!use_external_file()`) short-circuits before touching disk, identical to before.

### Reader side — self-heal in `CSS\Base::enqueue()`

- Extends the existing update condition (`'' === $meta['status'] || $this->is_update_required()`) with a new `is_external_file_missing_or_empty($meta)` guard.
- The guard returns `true` only when all of: external-file mode is on, `meta['status'] === CSS_STATUS_FILE`, and the file is missing or 0 bytes on disk. In that case the next enqueue triggers `update()` before the `<link>` is emitted, so the request self-heals instead of serving a broken asset.
- Healthy sites see one extra `stat()` per external-file enqueue and nothing else changes.

## Compatibility & risk

| Concern | Assessment |
|---|---|
| `rename()` failing on unusual filesystems | Fallback path replays the pre-fix behaviour |
| Mass regeneration on upgrade | Impossible on healthy sites — trigger requires `status=file` **and** file physically missing/empty |
| Extra syscall on healthy sites | 1 `stat()` per external-file enqueue when meta claims a file. Negligible; `stat` is one of the cheapest syscalls |
| Inline installs | `is_external_file_missing_or_empty()` returns `false` immediately when `!use_external_file()`. Unchanged |
| Multisite | No global state involved; tmp path is per-file per-random |
| Third-party subclasses | `Core\Files\Base` is untouched; `CSS\Base::write()` still has the same signature and behaviour surface (returns `null` in both paths) |

Explicitly **out of scope** for this branch (kept for follow-ups if we want them):
- `Core\Files\Base::write()` — untouched (shared parent, used by non-CSS callers).
- `modules/design-system-sync/classes/stylesheet-manager.php` — untouched (not the failing artifact; separate follow-up ticket if we want the same fix there).
- V4 atomic pipeline — handled in the sibling PR.

## Tests

Seven new tests added to `tests/phpunit/elementor/core/files/css/test-base.php`:

- `test_write__uses_atomic_rename_and_leaves_no_tmp_sibling` — happy path, tmp sibling cleaned up.
- `test_write__is_a_noop_when_not_using_external_file` — inline installs untouched.
- `test_is_external_file_missing_or_empty__returns_false_when_inline_print_method`
- `test_is_external_file_missing_or_empty__returns_false_when_status_not_file`
- `test_is_external_file_missing_or_empty__returns_true_when_file_missing` — matches the 10 July occurrence exactly.
- `test_is_external_file_missing_or_empty__returns_true_when_file_zero_bytes`
- `test_is_external_file_missing_or_empty__returns_false_when_file_healthy` — no thrash on healthy sites.

Existing tests in `test-base.php` are untouched.

### Test plan

- [ ] `vendor/bin/phpunit tests/phpunit/elementor/core/files/css/test-base.php` green
- [ ] Full PHPUnit suite green
- [ ] Playwright frontend smoke on a page built with v3 widgets (`post-<id>.css` link present, HTTP 200, non-empty body)
- [ ] Manual: with `elementor_css_print_method = external`, delete a `post-<id>.css` from disk, load the page anonymously → next request regenerates and serves a full file
- [ ] Manual: `truncate -s 0 post-<id>.css`, load anonymously → next request regenerates
- [ ] Manual: healthy site, load 100 anonymous requests → no unnecessary `update()` calls (verify via Query Monitor / logging)
- [ ] Confirm no `.tmp-*` files leak into `wp-content/uploads/elementor/css/` after normal editing

## Semver label

`patch` — behaviour-preserving bug fix, no API change, no schema change.

Ref: ED-24903

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

ED-24903 documents a race condition where concurrent CSS regenerations produce zero-byte or partial files that get cached, then served stale. The fix hardens writes via atomic rename and adds reader-side self-healing to repair broken cached metadata on enqueue.

## 2. What Changed (Where)

- `core/files/css/base.php`: `write()` now uses tmp-file + atomic rename instead of direct write; new `is_external_file_missing_or_empty()` method detects broken files; `enqueue()` triggers regeneration when meta claims file but disk is empty/missing.
- `tests/phpunit/elementor/core/files/css/test-base.php`: 8 new tests covering atomic writes, fallback behavior, inline-mode safety, and self-heal detection.

## 3. How It Works

Write path: Create `.tmp-{random}.css` → write content → atomic `rename()` to final path. If rename fails (overlay FS), fall back to direct write + cleanup tmp file.

Enqueue path: Check if meta says file exists but disk is missing/zero-byte → trigger `update()` before emitting `<link>` tag → next request self-heals automatically.

Guarded by `use_external_file()` so inline installs bypass all logic; status check ensures legitimate empty CSS (`CSS_STATUS_EMPTY`) doesn't trigger false regenerations.

## 4. Risks

Fallback path restores pre-fix behavior (direct write), so no regression on unusual filesystems. One additional `stat()` per external-file enqueue on healthy sites—negligible cost for the self-heal guarantee.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
