### PR TITLE
Fix: Preserve grouped options in v4 dynamic tag select settings [ED-25015]

### DIFF
--- a/modules/atomic-widgets/controls/types/select-control.php
+++ b/modules/atomic-widgets/controls/types/select-control.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Select_Control extends Atomic_Control_Base {
 	private array $options = [];
+	private array $groups = [];
 	private ?array $fallback_labels = null;
 	private ?string $collection_id = null;
 	private ?string $placeholder = null;
@@ -19,6 +20,12 @@ class Select_Control extends Atomic_Control_Base {
 
 	public function set_options( array $options ): self {
 		$this->options = $options;
+
+		return $this;
+	}
+
+	public function set_groups( array $groups ): self {
+		$this->groups = $groups;
 
 		return $this;
 	}
@@ -41,6 +48,10 @@ class Select_Control extends Atomic_Control_Base {
 			'fallbackLabels' => $this->fallback_labels,
 			'placeholder' => $this->placeholder,
 		];
+
+		if ( $this->groups ) {
+			$props['groups'] = $this->groups;
+		}
 
 		if ( $this->collection_id ) {
 			$props['collectionId'] = $this->collection_id;

--- a/modules/atomic-widgets/dynamic-tags/dynamic-tags-editor-config.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-tags-editor-config.php
@@ -180,27 +180,29 @@ class Dynamic_Tags_Editor_Config {
 	 * @throws \Exception If control is missing options.
 	 */
 	private function convert_select_control_to_atomic( $control, $tag = [] ) {
-		$options = $this->extract_select_options_from_control( $control );
-
-		if ( empty( $options ) ) {
-			throw new \Exception( 'Select control must have options' );
-		}
-
-		$options = apply_filters( 'elementor/atomic/dynamic_tags/select_control_options', $options, $control, $tag );
-
-		$options = array_map(
-			fn( $key, $value ) => [
-				'value' => $key,
-				'label' => $value,
-			],
-			array_keys( $options ),
-			$options
-		);
-
 		$select_control = Select_Control::bind_to( $control['name'] )
 			->set_placeholder( $control['placeholder'] ?? '' )
-			->set_options( $options )
 			->set_label( $control['atomic_label'] ?? $control['label'] );
+
+		if ( $this->has_select_control_groups( $control ) ) {
+			$groups = $this->extract_select_groups_from_control( $control, $tag );
+
+			if ( empty( $groups ) ) {
+				throw new \Exception( 'Select control must have options' );
+			}
+
+			$select_control->set_groups( $groups );
+		} else {
+			$options = $this->extract_select_options_from_control( $control );
+
+			if ( empty( $options ) ) {
+				throw new \Exception( 'Select control must have options' );
+			}
+
+			$options = apply_filters( 'elementor/atomic/dynamic_tags/select_control_options', $options, $control, $tag );
+
+			$select_control->set_options( $this->map_select_options( $options ) );
+		}
 
 		if ( isset( $control['collection_id'] ) ) {
 			$select_control->set_collection_id( $control['collection_id'] );
@@ -209,23 +211,28 @@ class Dynamic_Tags_Editor_Config {
 		return $select_control;
 	}
 
+	private function has_select_control_groups( $control ): bool {
+		if ( ! empty( $control['options'] ) ) {
+			return false;
+		}
+
+		return ! empty( $control['groups'] ) && is_array( $control['groups'] );
+	}
+
 	private function extract_select_options_from_control( $control ): array {
-		$options = $control['options'] ?? [];
+		return $control['options'] ?? [];
+	}
 
-		if ( ! empty( $options ) ) {
-			return $options;
-		}
-
-		if ( empty( $control['groups'] ) || ! is_array( $control['groups'] ) ) {
-			return $options;
-		}
+	private function extract_select_groups_from_control( $control, $tag = [] ): array {
+		$sanitized_groups = [];
+		$flat_options = [];
 
 		foreach ( $control['groups'] as $group ) {
 			if ( empty( $group['options'] ) || ! is_array( $group['options'] ) ) {
 				continue;
 			}
 
-			$filtered = array_filter(
+			$options = array_filter(
 				$group['options'],
 				static function ( $label, $key ) {
 					return is_string( $key );
@@ -233,10 +240,47 @@ class Dynamic_Tags_Editor_Config {
 				ARRAY_FILTER_USE_BOTH
 			);
 
-			$options = array_merge( $options, $filtered );
+			if ( empty( $options ) ) {
+				continue;
+			}
+
+			$sanitized_groups[] = [
+				'label'   => $group['label'] ?? '',
+				'options' => $options,
+			];
+
+			$flat_options = array_merge( $flat_options, $options );
 		}
 
-		return $options;
+		$filtered_options = apply_filters( 'elementor/atomic/dynamic_tags/select_control_options', $flat_options, $control, $tag );
+
+		$groups = [];
+
+		foreach ( $sanitized_groups as $group ) {
+			$group_options = array_intersect_key( $filtered_options, $group['options'] );
+
+			if ( empty( $group_options ) ) {
+				continue;
+			}
+
+			$groups[] = [
+				'label'   => $group['label'],
+				'options' => $this->map_select_options( $group_options ),
+			];
+		}
+
+		return apply_filters( 'elementor/atomic/dynamic_tags/select_control_groups', $groups, $control, $tag );
+	}
+
+	private function map_select_options( array $options ): array {
+		return array_map(
+			fn( $key, $value ) => [
+				'value' => $key,
+				'label' => $value,
+			],
+			array_keys( $options ),
+			$options
+		);
 	}
 
 	/**

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/select-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/select-control.test.tsx
@@ -296,4 +296,68 @@ describe( 'SelectControl', () => {
 		expect( screen.getByText( 'Option 1' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Option 2' ) ).toBeInTheDocument();
 	} );
+
+	describe( 'grouped options', () => {
+		const groups = [
+			{
+				label: 'Group A',
+				options: [
+					{ label: 'A Option 1', value: 'a1' },
+					{ label: 'A Option 2', value: 'a2' },
+				],
+			},
+			{
+				label: 'Group B',
+				options: [ { label: 'B Option 1', value: 'b1' } ],
+			},
+		];
+
+		it( 'should render a subheader per group with its own options', () => {
+			// Arrange.
+			const props = { setValue: jest.fn(), value: { $$type: 'string', value: 'a1' }, bind: 'tag', propType };
+
+			// Act.
+			renderControl( <SelectControl groups={ groups } />, props );
+
+			const select = screen.getByRole( 'combobox' );
+			fireEvent.mouseDown( select );
+
+			// Assert.
+			expect( screen.getByText( 'Group A' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Group B' ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'option', { name: 'A Option 1' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'option', { name: 'A Option 2' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'option', { name: 'B Option 1' } ) ).toBeInTheDocument();
+		} );
+
+		it( 'should resolve the selected value label across groups', () => {
+			// Arrange.
+			const props = { setValue: jest.fn(), value: { $$type: 'string', value: 'b1' }, bind: 'tag', propType };
+
+			// Act.
+			renderControl( <SelectControl groups={ groups } />, props );
+
+			// Assert.
+			expect( screen.getByRole( 'combobox' ) ).toHaveTextContent( 'B Option 1' );
+		} );
+
+		it( 'should select a value from a grouped option and call setValue', () => {
+			// Arrange.
+			const setValue = jest.fn();
+			const props = { setValue, value: { $$type: 'string', value: null }, bind: 'tag', propType };
+
+			// Act.
+			renderControl( <SelectControl groups={ groups } />, props );
+
+			const select = screen.getByRole( 'combobox' );
+			fireEvent.mouseDown( select );
+			fireEvent.click( screen.getByRole( 'option', { name: 'B Option 1' } ) );
+
+			// Assert.
+			expect( setValue ).toHaveBeenCalledWith( {
+				$$type: 'string',
+				value: 'b1',
+			} );
+		} );
+	} );
 } );

--- a/packages/packages/libs/editor-controls/src/controls/select-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/select-control.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { stringPropTypeUtil, type StringPropValue } from '@elementor/editor-props';
 import { MenuListItem } from '@elementor/editor-ui';
-import { Select, type SelectChangeEvent, type SelectProps, Typography } from '@elementor/ui';
+import { MenuSubheader, Select, type SelectChangeEvent, type SelectProps, Typography } from '@elementor/ui';
 
 import { useBoundProp } from '../bound-prop-context';
 import ControlActions from '../control-actions/control-actions';
@@ -13,8 +13,14 @@ export type SelectOption = {
 	disabled?: boolean;
 };
 
-type SelectControlProps = {
+export type SelectOptionGroup = {
+	label: string;
 	options: SelectOption[];
+};
+
+type SelectControlProps = {
+	options?: SelectOption[];
+	groups?: SelectOptionGroup[];
 	onChange?: ( newValue: string | null, previousValue: string | null | undefined ) => void;
 	MenuProps?: SelectProps[ 'MenuProps' ];
 	ariaLabel?: string;
@@ -29,7 +35,7 @@ const DEFAULT_MENU_PROPS = {
 };
 
 export const SelectControl = createControl(
-	( { options, onChange, MenuProps = DEFAULT_MENU_PROPS, ariaLabel }: SelectControlProps ) => {
+	( { options = [], groups = [], onChange, MenuProps = DEFAULT_MENU_PROPS, ariaLabel }: SelectControlProps ) => {
 		const { value, setValue, disabled, placeholder } = useBoundProp( stringPropTypeUtil );
 		const handleChange = ( event: SelectChangeEvent< StringPropValue[ 'value' ] > ) => {
 			const newValue = event.target.value || null;
@@ -37,7 +43,8 @@ export const SelectControl = createControl(
 			onChange?.( newValue, value );
 			setValue( newValue );
 		};
-		const isDisabled = disabled || options.length === 0;
+		const flatOptions = flattenGroupedOptions( options, groups );
+		const isDisabled = disabled || flatOptions.length === 0;
 
 		return (
 			<ControlActions>
@@ -48,23 +55,53 @@ export const SelectControl = createControl(
 					MenuProps={ MenuProps }
 					aria-label={ ariaLabel || placeholder }
 					renderValue={ ( selectedValue: string | null ) =>
-						getSelectRenderValue( options, placeholder, selectedValue )
+						getSelectRenderValue( flatOptions, placeholder, selectedValue )
 					}
 					value={ value ?? '' }
 					onChange={ handleChange }
 					disabled={ isDisabled }
 					fullWidth
 				>
-					{ options.map( ( { label, ...props } ) => (
-						<MenuListItem key={ props.value } { ...props } value={ props.value ?? '' }>
-							{ label }
-						</MenuListItem>
-					) ) }
+					{ groups.length
+						? groups.flatMap( ( group ) => renderGroup( group ) )
+						: options.map( ( option ) => renderOption( option ) ) }
 				</Select>
 			</ControlActions>
 		);
 	}
 );
+
+const GROUPED_OPTION_INDENT = 3.5;
+
+function renderGroup( group: SelectOptionGroup ): React.ReactNode[] {
+	return [
+		<MenuSubheader key={ `group-${ group.label }` } sx={ { fontWeight: 400, color: 'text.tertiary' } }>
+			{ group.label }
+		</MenuSubheader>,
+		...group.options.map( ( option ) => renderOption( option, true ) ),
+	];
+}
+
+function renderOption( { label, ...props }: SelectOption, isGrouped = false ): React.ReactNode {
+	return (
+		<MenuListItem
+			key={ props.value }
+			{ ...props }
+			value={ props.value ?? '' }
+			sx={ isGrouped ? { pl: GROUPED_OPTION_INDENT } : undefined }
+		>
+			{ label }
+		</MenuListItem>
+	);
+}
+
+function flattenGroupedOptions( options: SelectOption[], groups: SelectOptionGroup[] ): SelectOption[] {
+	if ( ! groups.length ) {
+		return options;
+	}
+
+	return groups.flatMap( ( group ) => group.options );
+}
 
 export function getSelectRenderValue(
 	options: SelectOption[],

--- a/tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/test-dynamic-tags-module.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/test-dynamic-tags-module.php
@@ -345,6 +345,72 @@ class Test_Dynamic_Tags_Module extends Elementor_Test_Base {
 		$tag->cleanup();
 	}
 
+	public function test_add_atomic_dynamic_tags_to_editor_settings__preserves_select_control_groups() {
+		// Arrange.
+		$tag = $this->make_mock_tag( [
+			'name' => 'acf-like',
+			'title' => 'ACF Like',
+			'categories' => [ 'text' ],
+			'register_controls' => function ( Tag $tag ) {
+				$tag->add_control(
+					'key',
+					[
+						'type' => 'select',
+						'label' => 'Key',
+						'groups' => [
+							[
+								'label' => 'Group A',
+								'options' => [
+									'field_1:name' => 'Name',
+								],
+							],
+							[
+								'label' => 'Group B',
+								'options' => [
+									'field_2:email' => 'Email',
+								],
+							],
+						],
+						'default' => '',
+					]
+				);
+			},
+		] );
+
+		Plugin::$instance->dynamic_tags->register( $tag );
+
+		$tags = Plugin::$instance->dynamic_tags->get_tags_config();
+
+		// Act.
+		$settings = apply_filters( 'elementor/editor/localize_settings', [ 'dynamicTags' => [ 'tags' => $tags ] ] );
+
+		$decoded_tags = json_decode( wp_json_encode( $settings['atomicDynamicTags']['tags'] ), true );
+		$key_control_props = $decoded_tags['acf-like']['atomic_controls'][0]['value']['items'][0]['value']['props'];
+
+		// Assert.
+		$this->assertEmpty( $key_control_props['options'] );
+		$this->assertEquals(
+			[
+				[
+					'label' => 'Group A',
+					'options' => [
+						[ 'value' => 'field_1:name', 'label' => 'Name' ],
+					],
+				],
+				[
+					'label' => 'Group B',
+					'options' => [
+						[ 'value' => 'field_2:email', 'label' => 'Email' ],
+					],
+				],
+			],
+			$key_control_props['groups']
+		);
+
+		// Cleanup.
+		$tag->cleanup();
+	}
+
 	public function test_add_dynamic_prop_type__skips_non_prop_types() {
 		// Act.
 		$schema = apply_filters( 'elementor/atomic-widgets/props-schema', [


### PR DESCRIPTION
## Summary
- Preserve legacy dynamic-tag select `groups` when converting to atomic controls, instead of flattening them into a single options list
- Add first-class `groups` support to atomic `Select_Control` and render grouped options in `SelectControl` with category headers and indented items (matching Dynamic tags picker styling)
- Keep backward compatibility for flat `options` and existing `elementor/atomic/dynamic_tags/select_control_options` filter behavior (including ACF URL filtering)

## Test plan
- [x] Jest: `packages/libs/editor-controls/src/controls/__tests__/select-control.test.tsx` (grouped options cases)
- [x] Jest: full `editor-controls` + `editor-editing-panel` suites pass
- [x] `tsc` (packages) passes
- [ ] PHPUnit: `tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/test-dynamic-tags-module.php`
- [ ] Manual: open a v4 widget with an ACF dynamic tag (e.g. in collection loop), open dynamic settings, verify field groups are categorized and indented like v3


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Dynamic tag select controls with grouped options weren't being preserved when converting to atomic format—groups were flattened into a single options array, losing the grouping structure needed for UI organization.

## 2. What Changed (Where)

- **Select_Control (PHP)**: Added `$groups` property and `set_groups()` method; conditionally includes groups in props output.
- **Dynamic_Tags_Editor_Config (PHP)**: Refactored `convert_select_control_to_atomic()` to branch on `has_select_control_groups()`; extracts and filters groups separately with new helper methods.
- **select-control.tsx (React)**: Updated component to accept both `options` and `groups` props; renders grouped options with `MenuSubheader` labels and indented items.
- **Tests**: Added PHP test validating group structure preservation and React tests covering group rendering and selection.

## 3. How It Works

When converting a select control, the code checks if groups exist in the source control. If so, it extracts groups (flattens options per group, applies filters, maps to value/label pairs), then passes the structured groups to the Select_Control. The React component flattens groups to check if disabled, but renders either grouped items with subheaders or flat options based on what's provided. Filters allow upstream customization without losing structure.

## 4. Risks

Minor: The filter `elementor/atomic/dynamic_tags/select_control_groups` is new—third-party code filtering flat options won't affect grouped output unless they also handle the new groups filter. Mitigation: Well-documented filter signature; groups are applied *after* flat filtering so existing option filters work transitively.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
