### PR TITLE
Fix/svg sanitizer filter primitive casing

### DIFF
--- a/core/utils/svg/svg-sanitizer.php
+++ b/core/utils/svg/svg-sanitizer.php
@@ -178,7 +178,7 @@ class Svg_Sanitizer {
 	private function is_allowed_tag( $element ) {
 		static $allowed_tags = false;
 		if ( false === $allowed_tags ) {
-			$allowed_tags = $this->get_allowed_elements();
+			$allowed_tags = array_map( 'strtolower', $this->get_allowed_elements() );
 		}
 
 		$tag_name = $element->tagName; // phpcs:ignore -- php DomDocument

--- a/tests/phpunit/elementor/core/files/file-types/test-svg.php
+++ b/tests/phpunit/elementor/core/files/file-types/test-svg.php
@@ -86,4 +86,33 @@ class Test_Svg extends Elementor_Test_Base {
 			[ 'javascri&#10;pt:alert(origin)', false ],
 		];
 	}
+
+	public function test_sanitizer__preserves_filter_primitives_and_animations() {
+        $svg_handler = Plugin::$instance->uploads_manager->get_file_type_handlers( 'svg' );
+
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120" fill="none">'
+            . '<g filter="url(#f0)"><path d="M10 10 H100 V100 H10 Z" fill="#F09EBA"/></g>'
+            . '<rect x="0" y="0" width="10" height="10"><animateTransform attributeName="transform" type="rotate" from="0" to="360" dur="2s"repeatCount="indefinite"/></rect>'
+            . '<defs><filter id="f0" x="0" y="0" width="120" height="120" filterUnits="userSpaceOnUse">'
+            . '<feFlood flood-opacity="0" result="bg"/>'
+            . '<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>'
+            . '<feOffset dy="4"/>'
+            . '<feGaussianBlur stdDeviation="2"/>'
+            . '<feComposite in2="hardAlpha" operator="out"/>'
+            . '<feBlend mode="normal" in2="bg" result="shadow"/>'
+            . '</filter></defs></svg>';
+
+        $sanitized = $svg_handler->sanitizer( $svg );
+
+        $this->assertStringContainsString( '<feFlood', $sanitized );
+        $this->assertStringContainsString( '<feColorMatrix', $sanitized );
+        $this->assertStringContainsString( '<feOffset', $sanitized );
+        $this->assertStringContainsString( '<feGaussianBlur', $sanitized );
+        $this->assertStringContainsString( '<feComposite', $sanitized );
+        $this->assertStringContainsString( '<feBlend', $sanitized );
+
+        $this->assertStringContainsString( 'stdDeviation', $sanitized );
+
+        $this->assertStringContainsString( '<animateTransform', $sanitized );
+    }
 }


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: SVG filter primitives (`feGaussianBlur`, `feDropShadow`, etc.) and `animate*` elements were stripped on upload, leaving empty `<filter>` elements and hiding filtered artwork.

## Description
An explanation of what is done in this PR

* `Svg_Sanitizer::is_allowed_tag()` compares `strtolower( $tag_name )` against the allow-list, but the SVG filter primitives and SMIL animation elements are stored in `get_allowed_elements()` in camelCase (`feBlend`…`feTurbulence`, `animateMotion`, `animateTransform`). After `strtolower` they never match, so every `<fe*>` / `<animate*>` element is removed even though it's listed as allowed. The enclosing `<filter>` survives but empty, and per the SVG spec an element referencing an empty filter renders transparent — so artwork inside `<g filter="url(#…)">` (e.g. Figma exports with drop shadows) uploads invisible.
* Fix: normalize the allow-list once with `array_map( 'strtolower', … )` so it matches the existing comparison.

## Test instructions
This PR can be tested by following these steps:

* Upload the following SVG and open the sanitized copy from `wp-content/uploads/`:
  ```svg
  <svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120" fill="none"><g filter="url(#f0)"><path d="M10 10 H100 V100 H10 Z" fill="#F09EBA"/></g><defs><filter id="f0" x="0" y="0" width="120" height="120" filterUnits="userSpaceOnUse"><feFlood flood-opacity="0" result="bg"/><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/><feOffset dy="4"/><feGaussianBlur stdDeviation="2"/><feComposite in2="hardAlpha" operator="out"/><feBlend mode="normal" in2="bg" result="shadow"/></filter></defs></svg>
  ```
* Before this fix: all `<fe*>` elements are stripped, `<filter>` is empty, the shape is invisible. After: the primitives are preserved and the shape renders with its drop shadow.
* Automated: `npm run test:php` — see `Test_Svg::test_sanitizer__preserves_filter_primitives_and_animations`.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #31662
