### PR TITLE
Fix: Persist "Don't show again" for the sync to global fonts dialog

### DIFF
--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
@@ -7,6 +7,7 @@ import {
 	mockTracking,
 	renderWithStore,
 } from 'test-utils';
+import { useSuppressedMessage } from '@elementor/editor-current-user';
 import { getCurrentDocument } from '@elementor/editor-documents';
 import { __privateRunCommand } from '@elementor/editor-v1-adapters';
 import { QueryClient, QueryClientProvider } from '@elementor/query';
@@ -45,11 +46,30 @@ jest.mock( '@tanstack/react-virtual', () => ( {
 jest.mock( '@elementor/editor-documents' );
 jest.mock( '../class-manager-introduction' );
 jest.mock( '../start-sync-to-v3-modal', () => ( {
-	StartSyncToV3Modal: ( { onConfirm, externalOpen }: { onConfirm?: () => void; externalOpen?: boolean } ) =>
+	StartSyncToV3Modal: ( {
+		onConfirm,
+		onSuppressMessage,
+		externalOpen,
+	}: {
+		onConfirm?: () => void;
+		onSuppressMessage?: () => void;
+		externalOpen?: boolean;
+	} ) =>
 		externalOpen ? (
-			<button type="button" onClick={ onConfirm }>
-				Confirm sync
-			</button>
+			<>
+				<button type="button" onClick={ onConfirm }>
+					Confirm sync
+				</button>
+				<button
+					type="button"
+					onClick={ () => {
+						onSuppressMessage?.();
+						onConfirm?.();
+					} }
+				>
+					Confirm sync and suppress
+				</button>
+			</>
 		) : null,
 } ) );
 
@@ -114,6 +134,8 @@ describe( 'ClassManagerPanel', () => {
 		);
 
 		jest.mocked( getCurrentDocument ).mockReturnValue( createMockDocument( { id: 1 } ) );
+		mockSuppressedMessages( {} );
+		jest.mocked( loadExistingClasses ).mockResolvedValue( undefined );
 	} );
 
 	it( 'should render embedded panel structure correctly', () => {
@@ -654,4 +676,72 @@ describe( 'ClassManagerPanel', () => {
 			variants: unloadedClass.variants,
 		} );
 	} );
+
+	it( 'should suppress the start sync message when it is dismissed from the modal', async () => {
+		// Arrange.
+		const suppressStartSyncMessage = jest.fn();
+
+		mockSuppressedMessages( { 'start-sync-class': [ false, suppressStartSyncMessage ] as SuppressedMessage } );
+
+		renderWithStore(
+			<ThemeProvider>
+				<QueryClientProvider client={ queryClient }>
+					<ClassManagerPanelEmbedded onRequestClose={ jest.fn() } onExposeCloseAttempt={ jest.fn() } />
+				</QueryClientProvider>
+			</ThemeProvider>,
+			store
+		);
+
+		const [ classItem ] = screen.getAllByRole( 'listitem' );
+
+		// Act.
+		fireEvent.click( within( classItem ).getByRole( 'button', { name: 'More actions' } ) );
+		fireEvent.click( screen.getByRole( 'menuitem', { name: /Sync to Global Fonts/i } ) );
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'button', { name: 'Confirm sync and suppress' } ) ).toBeInTheDocument();
+		} );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Confirm sync and suppress' } ) );
+
+		// Assert.
+		expect( suppressStartSyncMessage ).toHaveBeenCalled();
+	} );
+
+	it( 'should not show the start sync modal again once the message is suppressed', async () => {
+		// Arrange.
+		mockSuppressedMessages( { 'start-sync-class': [ true, jest.fn() ] as SuppressedMessage } );
+
+		renderWithStore(
+			<ThemeProvider>
+				<QueryClientProvider client={ queryClient }>
+					<ClassManagerPanelEmbedded onRequestClose={ jest.fn() } onExposeCloseAttempt={ jest.fn() } />
+				</QueryClientProvider>
+			</ThemeProvider>,
+			store
+		);
+
+		const [ classItem ] = screen.getAllByRole( 'listitem' );
+
+		// Act.
+		fireEvent.click( within( classItem ).getByRole( 'button', { name: 'More actions' } ) );
+		fireEvent.click( screen.getByRole( 'menuitem', { name: /Sync to Global Fonts/i } ) );
+
+		// Assert.
+		await waitFor( () => {
+			expect( store.getState().globalClasses.data.items[ 'class-2' ] ).toMatchObject( {
+				sync_to_v3: true,
+			} );
+		} );
+
+		expect( screen.queryByRole( 'button', { name: 'Confirm sync' } ) ).not.toBeInTheDocument();
+	} );
 } );
+
+type SuppressedMessage = readonly [ boolean, () => void ];
+
+function mockSuppressedMessages( messages: Record< string, SuppressedMessage > ) {
+	jest.mocked( useSuppressedMessage ).mockImplementation( ( messageKey: string ): SuppressedMessage => {
+		return messages[ messageKey ] ?? [ false, jest.fn() ];
+	} );
+}

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/start-sync-to-v3-modal.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/start-sync-to-v3-modal.test.tsx
@@ -13,6 +13,7 @@ const renderModal = ( props = {} ) => {
 		classId: 'class-1',
 		onExternalClose: jest.fn(),
 		onConfirm: jest.fn(),
+		onSuppressMessage: jest.fn(),
 	};
 
 	return {
@@ -73,6 +74,34 @@ describe( 'StartSyncToV3Modal', () => {
 
 		expect( props.onExternalClose ).toHaveBeenCalled();
 		expect( props.onConfirm ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should suppress the message when confirming with "Don\'t show again" checked', () => {
+		const { props } = renderModal();
+
+		fireEvent.click( screen.getByRole( 'checkbox' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Sync to Global Fonts' } ) );
+
+		expect( props.onSuppressMessage ).toHaveBeenCalledTimes( 1 );
+		expect( props.onConfirm ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should not suppress the message when confirming without "Don\'t show again" checked', () => {
+		const { props } = renderModal();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Sync to Global Fonts' } ) );
+
+		expect( props.onSuppressMessage ).not.toHaveBeenCalled();
+		expect( props.onConfirm ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should not suppress the message when cancelling with "Don\'t show again" checked', () => {
+		const { props } = renderModal();
+
+		fireEvent.click( screen.getByRole( 'checkbox' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( props.onSuppressMessage ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should not track when modal is closed', () => {

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/class-manager-panel.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/class-manager-panel.tsx
@@ -28,6 +28,7 @@ import { blockPanelInteractions, unblockPanelInteractions } from './panel-intera
 import { StartSyncToV3Modal } from './start-sync-to-v3-modal';
 
 const STOP_SYNC_MESSAGE_KEY = 'stop-sync-class';
+const START_SYNC_MESSAGE_KEY = 'start-sync-class';
 
 type StopSyncConfirmationDialogProps = {
 	open: boolean;
@@ -71,6 +72,7 @@ function ClassManagerPanelContent( {
 	const [ stopSyncConfirmation, setStopSyncConfirmation ] = useState< string | null >( null );
 	const [ startSyncConfirmation, setStartSyncConfirmation ] = useState< string | null >( null );
 	const [ isStopSyncSuppressed ] = useSuppressedMessage( STOP_SYNC_MESSAGE_KEY );
+	const [ isStartSyncSuppressed, suppressStartSyncMessage ] = useSuppressedMessage( START_SYNC_MESSAGE_KEY );
 	const [ scrollElement, setScrollElement ] = useState< HTMLElement | null >( null );
 
 	const { mutateAsync: publish, isPending: isPublishing } = usePublish();
@@ -148,6 +150,17 @@ function ClassManagerPanelContent( {
 		[ isStopSyncSuppressed, handleStopSync ]
 	);
 
+	const handleStartSyncRequest = useCallback(
+		( classId: string ) => {
+			if ( ! isStartSyncSuppressed ) {
+				setStartSyncConfirmation( classId );
+			} else {
+				handleStartSync( classId );
+			}
+		},
+		[ isStartSyncSuppressed, handleStartSync ]
+	);
+
 	usePreventUnload();
 
 	return (
@@ -194,7 +207,7 @@ function ClassManagerPanelContent( {
 								disabled={ isPublishing }
 								scrollElement={ scrollElement }
 								onStopSyncRequest={ handleStopSyncRequest }
-								onStartSyncRequest={ ( classId ) => setStartSyncConfirmation( classId ) }
+								onStartSyncRequest={ handleStartSyncRequest }
 							/>
 						</Box>
 						<PanelFooter>
@@ -220,6 +233,7 @@ function ClassManagerPanelContent( {
 					classId={ startSyncConfirmation }
 					onExternalClose={ () => setStartSyncConfirmation( null ) }
 					onConfirm={ () => handleStartSync( startSyncConfirmation ) }
+					onSuppressMessage={ suppressStartSyncMessage }
 				/>
 			) }
 			{ stopSyncConfirmation && (

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/start-sync-to-v3-modal.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/start-sync-to-v3-modal.tsx
@@ -21,6 +21,7 @@ type StartSyncToV3ModalProps = {
 	classId?: string;
 	onExternalClose?: () => void;
 	onConfirm?: () => void;
+	onSuppressMessage?: () => void;
 };
 
 export const StartSyncToV3Modal = ( {
@@ -28,6 +29,7 @@ export const StartSyncToV3Modal = ( {
 	classId,
 	onExternalClose,
 	onConfirm,
+	onSuppressMessage,
 }: StartSyncToV3ModalProps = {} ) => {
 	const [ shouldShowAgain, setShouldShowAgain ] = useState( true );
 	const hasTrackedExposure = useRef( false );
@@ -54,6 +56,11 @@ export const StartSyncToV3Modal = ( {
 		if ( classId ) {
 			trackGlobalClasses( { event: 'classSyncToV3PopupClick', classId, action: 'sync' } );
 		}
+
+		if ( ! shouldShowAgain ) {
+			onSuppressMessage?.();
+		}
+
 		onConfirm?.();
 		onExternalClose?.();
 	};


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: The "Sync to Global Fonts" confirmation dialog kept reappearing after checking "Don't show again".

## Description
An explanation of what is done in this PR

* In `StartSyncToV3Modal` (Class Manager > class row > "Sync to Global Fonts") the "Don't show again" checkbox was wired to a component-local `useState( shouldShowAgain )` only. The value was read nowhere: `handleConfirm()` fired tracking, `onConfirm()` and `onExternalClose()`, and the state was thrown away when the modal unmounted. `ClassManagerPanelContent` also opened the modal unconditionally via `onStartSyncRequest={ ( classId ) => setStartSyncConfirmation( classId ) }`, so the dialog showed on every sync action.
* This is the mirror image of the already working "stop sync" flow in the same panel, which persists the preference through `useSuppressedMessage( 'stop-sync-class' )` and skips the dialog in `handleStopSyncRequest` when suppressed.
* The fix follows that existing pattern:
  * `StartSyncToV3Modal` accepts an optional `onSuppressMessage` callback and invokes it on confirm when "Don't show again" is checked (same semantics as `ConfirmationDialog.Actions`: suppression only happens on confirm, not on cancel).
  * `ClassManagerPanelContent` registers a new suppressed-message key `start-sync-class` and adds `handleStartSyncRequest`, which starts the sync directly when the message is suppressed and only opens the modal otherwise.
* The preference is stored per user through the existing `useSuppressedMessage` / current-user mechanism, so it survives reloads.

## Test instructions
This PR can be tested by following these steps:

1. Open a page in the Editor V4 and open the **Class Manager** panel.
2. On a class that is not synced yet, open the "More actions" menu and choose **Sync to Global Fonts**.
3. In the dialog, tick **Don't show again** and press **Sync to Global Fonts**.
4. Un-sync the class (More actions > Stop syncing to Global Fonts) and choose **Sync to Global Fonts** again — optionally reload the editor first.
5. Expected: the dialog no longer appears and the class is synced immediately. Before this PR the dialog reappeared every single time.
6. Regression check: with a fresh user (nothing suppressed), leaving the checkbox unticked, or pressing **Cancel** with the checkbox ticked, must keep showing the dialog on the next attempt.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

### Verification

**Environment used:** PHPUnit 9.6.35 on PHP 8.3 / WordPress 7.0.2 / MySQL 8.0 (`bin/install-wp-tests.sh`), Jest on Node 26, ESLint 8.57 and PHPCS with `ruleset.xml`.

Note on the pre-existing failures below: running `--filter AtomicWidgets` on an unmodified `main` in the same environment yields **1045 tests, 10 errors, 2 failures** (all in `Test_Has_Template` / `Test_Template_Renderer` / `Test_Render_Element_Action`, i.e. Twig template rendering). Those numbers are quoted as the baseline; this branch does not add to them.

* `npx jest --config=./packages/jest.config.js packages/packages/core/editor-global-classes` → **110 passed, 0 failed**, including the 5 new tests covering (a) `onSuppressMessage` firing only on confirm with the checkbox ticked, and (b) the panel skipping the dialog and syncing directly once the message is suppressed.
* ESLint (packages config) on all four changed files → clean.

Not done: no manual run-through in a live editor and no Playwright run, so the checkbox above reflects automated coverage only.
