### PR TITLE
Fix: Accept null breakpoint as the base style variant

### DIFF
--- a/modules/atomic-widgets/parsers/style-parser.php
+++ b/modules/atomic-widgets/parsers/style-parser.php
@@ -6,6 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use Elementor\Core\Breakpoints\Manager as Breakpoints_Manager;
 use Elementor\Modules\AtomicWidgets\OptIn\Opt_In;
 use Elementor\Plugin;
 use Elementor\Utils;
@@ -169,8 +170,9 @@ class Style_Parser {
 			return $result;
 		}
 
+		// A `null` breakpoint is the base (desktop) variant - it is normalized on sanitization.
 		// TODO: Validate breakpoint based on the existing breakpoints in the system [EDS-528]
-		if ( ! isset( $meta['breakpoint'] ) || ! is_string( $meta['breakpoint'] ) ) {
+		if ( ! array_key_exists( 'breakpoint', $meta ) || ( null !== $meta['breakpoint'] && ! is_string( $meta['breakpoint'] ) ) ) {
 			$result->errors()->add( 'breakpoint', 'missing_or_invalid_value' );
 
 			return $result;
@@ -198,8 +200,10 @@ class Style_Parser {
 			return [];
 		}
 
-		if ( isset( $meta['breakpoint'] ) ) {
-			$meta['breakpoint'] = sanitize_key( $meta['breakpoint'] );
+		if ( array_key_exists( 'breakpoint', $meta ) ) {
+			$meta['breakpoint'] = null === $meta['breakpoint']
+				? Breakpoints_Manager::BREAKPOINT_KEY_DESKTOP
+				: sanitize_key( $meta['breakpoint'] );
 		}
 
 		return $meta;

--- a/tests/phpunit/elementor/modules/atomic-widgets/parsers/test-style-parser.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/parsers/test-style-parser.php
@@ -161,7 +161,7 @@ class Test_Style_Parser extends Elementor_Test_Base {
 				[
 					'meta' => [
 						'state' => null,
-						'breakpoint' => null,
+						'breakpoint' => [ 'desktop' ],
 					],
 					'props' => [],
 				],
@@ -173,6 +173,57 @@ class Test_Style_Parser extends Elementor_Test_Base {
 
         // Assert.
         $this->assert_parse_result_invalid ( $result, [ 'meta.breakpoint' ] );
+	}
+
+	public function test_parse__missing_meta_breakpoint_fails_validation() {
+		// Arrange.
+		$style = [
+			'id' => 'test-style',
+			'type' => 'class',
+			'label' => 'test-style',
+			'variants' => [
+				[
+					'meta' => [
+						'state' => null,
+					],
+					'props' => [],
+				],
+			],
+		];
+
+		// Act.
+		$result = $this->parser->parse( $style );
+
+		// Assert.
+		$this->assert_parse_result_invalid( $result, [ 'meta.breakpoint' ] );
+	}
+
+	public function test_parse__null_meta_breakpoint_is_valid_and_normalized_to_desktop() {
+		// Arrange.
+		$style = [
+			'id' => 'test-style',
+			'type' => 'class',
+			'label' => 'test-style',
+			'variants' => [
+				[
+					'meta' => [
+						'state' => null,
+						'breakpoint' => null,
+					],
+					'props' => [],
+				],
+			],
+		];
+
+		// Act.
+		$result = $this->parser->parse( $style );
+		$parsed = $result->unwrap();
+
+		// Assert.
+		$this->assertTrue( $result->is_valid() );
+		$this->assertCount( 0, $result->errors()->all() );
+		$this->assertEquals( 'desktop', $parsed['variants'][0]['meta']['breakpoint'] );
+		$this->assertNull( $parsed['variants'][0]['meta']['state'] );
 	}
 
 	public function test_parse__validates_and_sanitizes() {

--- a/tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php
@@ -236,6 +236,42 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		], $classes );
 	}
 
+	public function test_put__accepts_null_breakpoint_and_normalizes_it_to_desktop() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$class = $this->create_global_class( 'g-1' );
+		$class['sync_to_v3'] = true;
+		$class['variants'][0]['meta']['breakpoint'] = null;
+
+		$this->seed_global_classes_posts( [
+			'items' => [ 'g-1' => $this->create_global_class( 'g-1' ) ],
+			'order' => [ 'g-1' ],
+		] );
+
+		// Act.
+		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
+
+		$request->set_body_params( [
+			'items' => [ 'g-1' => $class ],
+			'order' => [ 'g-1' ],
+			'changes' => [
+				'added' => [],
+				'deleted' => [],
+				'modified' => [ 'g-1' ],
+			],
+		] );
+
+		$response = rest_do_request( $request );
+
+		// Assert.
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
+
+		$this->assertSame( 204, $response->get_status() );
+		$this->assertSame( 'desktop', $classes['items']['g-1']['variants'][0]['meta']['breakpoint'] );
+		$this->assertTrue( $classes['items']['g-1']['sync_to_v3'] );
+	}
+
 	public function test_put__updates_based_on_changes() {
 		// Arrange.
 		$this->act_as_admin();


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Saving global classes failed with `invalid_items` when a style variant used `null` as its breakpoint (base variant), which broke "Sync with global fonts".

## Description
An explanation of what is done in this PR

**Symptom** — In the Class Manager, toggling "Sync with global fonts" on a class issues a `PUT /wp-json/elementor/v1/global-classes`. When one of the class variants carries `meta.breakpoint = null`, the request is rejected:

```
HTTP/1.1 400 Bad Request
{
  "code": "invalid_items",
  "message": "Invalid items: items.<class-id>.meta.breakpoint: missing_or_invalid_value",
  "data": { "status": 400 }
}
```

**Root cause** — `null` is an accepted representation of the base (desktop) variant almost everywhere in the codebase, but the write-path validator is the one place that rejects it:

* `packages/packages/libs/editor-styles/src/types.ts` — `StyleDefinitionVariant['meta'].breakpoint: null | BreakpointId`.
* `StyleTab` passes `useActiveBreakpoint()` straight into the variant meta, and `useActiveBreakpoint()` returns `null` when `elementor.channels.deviceMode` has no current mode yet — so the editor can legitimately produce a `null` breakpoint.
* `Style_Variant::build()` emits `'breakpoint' => null` when no breakpoint was set.
* Every reader coalesces `null`/missing to desktop: `Atomic_Styles_Manager::group_by_breakpoint()` (`?? self::DEFAULT_BREAKPOINT`), `Local_Style_Serializer` (`?? self::DESKTOP_BREAKPOINT`), `Classes_Provider::get_all_normal_state_variant_props()` (`null === $breakpoint ? desktop`), and on the JS side `create-styles-renderer.ts` (`|| 'desktop'`) and `getBreakpointKey()` (`breakpoint ?? DEFAULT_BREAKPOINT`).
* In the very same validator, `meta.state` explicitly accepts `null` (`Style_States::is_valid_state()`), so the two meta keys were handled asymmetrically.

Once such a variant exists in storage, *any* subsequent `PUT` of that class fails — the sync toggle just happens to be the flow that reliably re-submits a full, previously untouched item (`loadExistingClasses()` → `slice.actions.update({ sync_to_v3: true })`), which is why the bug surfaces there.

**Chosen fix layer** — the PHP parser (`Style_Parser`), i.e. the persistence boundary, rather than the editor payload producer:

1. It is the only place that disagrees with the rest of the codebase; changing it makes `breakpoint` consistent with `state` in the same method.
2. It fixes every producer at once (editor, REST clients, imports, `Style_Variant`), not just one call site.
3. Data is *normalized*, not merely tolerated: `null` is stored as `desktop`, so persisted data converges on the canonical value instead of staying ambiguous.

Diff: `validate_meta()` now accepts `null` (a missing key or a non-string, non-null value is still an error), and `sanitize_meta()` maps `null` to `Breakpoints_Manager::BREAKPOINT_KEY_DESKTOP`.

Not changed on purpose, to keep the diff minimal: `StyleTab` still passes `useActiveBreakpoint()` (possibly `null`) into the variant meta. With server-side normalization the stored data is canonical after the first save; making the editor default to `desktop` at the source would be a reasonable follow-up.

## Test instructions
This PR can be tested by following these steps:

1. Create a global class that has a variant with `meta.breakpoint = null`, e.g. via:
   ```
   PUT /wp-json/elementor/v1/global-classes
   {
     "items": { "g-1": { "id": "g-1", "label": "my-class", "type": "class",
       "variants": [ { "meta": { "breakpoint": null, "state": null },
                       "props": { "font-size": { "$$type": "size", "value": { "size": 24, "unit": "px" } } } } ] } },
     "order": [ "g-1" ],
     "changes": { "added": [ "g-1" ], "deleted": [], "modified": [] }
   }
   ```
   Before this PR this returns `400 invalid_items`; after it returns `204` and the variant is stored with `"breakpoint": "desktop"`.
2. In the editor, open the Class Manager and toggle **Sync with global fonts** on a class whose stored variant has `breakpoint: null`, then save. Before: the `PUT` fails with `400 invalid_items` and the sync does not stick. After: the save succeeds and the class shows up under Site Settings → Global Fonts → Atomic Classes.
3. Regression check: variants with an explicit `"breakpoint": "mobile"` etc. still validate and are still stored unchanged; a variant with a missing `breakpoint` key, or a non-string value such as `["desktop"]`, still fails validation.

Automated coverage added:
* `tests/phpunit/elementor/modules/atomic-widgets/parsers/test-style-parser.php` — `null` is valid and normalized to `desktop`; missing key still fails; non-string value still fails (the previous test used `null` as its "invalid" example and now uses an array).
* `tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php` — end-to-end `PUT` with `sync_to_v3: true` and `breakpoint: null` returns `204` and persists `desktop`.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

### Verification

**Environment used:** PHPUnit 9.6.35 on PHP 8.3 / WordPress 7.0.2 / MySQL 8.0 (`bin/install-wp-tests.sh`), Jest on Node 26, ESLint 8.57 and PHPCS with `ruleset.xml`.

Note on the pre-existing failures below: running `--filter AtomicWidgets` on an unmodified `main` in the same environment yields **1045 tests, 10 errors, 2 failures** (all in `Test_Has_Template` / `Test_Template_Renderer` / `Test_Render_Element_Action`, i.e. Twig template rendering). Those numbers are quoted as the baseline; this branch does not add to them.

* `vendor/bin/phpunit --filter Style_Parser` → **OK (19 tests, 50 assertions)**.
* `vendor/bin/phpunit --filter GlobalClasses` → **OK (182 tests, 585 assertions)**; the same filter on unmodified `main` gives 181 tests, so the new end-to-end REST test is the only delta and it passes.
* `vendor/bin/phpunit --filter AtomicWidgets` → 1047 tests, 10 errors, 2 failures — identical to the `main` baseline, i.e. no regressions.
* `vendor/bin/phpcs --standard=./ruleset.xml` on the changed file → clean.

The original 400 was also reproduced on a live 4.2.0 site, where the equivalent `rest_pre_dispatch` workaround resolves it.

Not done: no Playwright run.
