### PR TITLE
Fix: Allow URL dynamic tags on the atomic image and SVG props

### DIFF
--- a/modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php
@@ -61,11 +61,11 @@ class Dynamic_Prop_Types_Mapping extends Prop_Types_Schema_Extender {
 		}
 
 		if ( $prop_type instanceof Svg_Src_Prop_Type ) {
-			return [ V1_Dynamic_Tags_Module::SVG_CATEGORY ];
+			return [ V1_Dynamic_Tags_Module::SVG_CATEGORY, V1_Dynamic_Tags_Module::URL_CATEGORY ];
 		}
 
 		if ( $prop_type instanceof Image_Src_Prop_Type ) {
-			return [ V1_Dynamic_Tags_Module::IMAGE_CATEGORY ];
+			return [ V1_Dynamic_Tags_Module::IMAGE_CATEGORY, V1_Dynamic_Tags_Module::URL_CATEGORY ];
 		}
 
 		if ( $prop_type instanceof Url_Prop_Type ) {

--- a/modules/atomic-widgets/props-resolver/render-props-resolver.php
+++ b/modules/atomic-widgets/props-resolver/render-props-resolver.php
@@ -6,6 +6,8 @@ use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Array_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Image_Src_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Svg_Src_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
 use Elementor\Plugin;
 use Exception;
@@ -81,7 +83,35 @@ class Render_Props_Resolver extends Props_Resolver {
 
 		$transformed = $this->transform( $value, $key, $prop_type );
 
+		if ( Dynamic_Prop_Type::is_dynamic_prop_value( $value ) ) {
+			$transformed = $this->wrap_dynamic_url( $transformed, $prop_type );
+		}
+
 		return $this->resolve_item( $transformed, $key, $prop_type, $depth + 1 );
+	}
+
+	/**
+	 * Dynamic tags of the URL category resolve into a plain string, while the image & SVG
+	 * props expect an `{ id, url }` structure. Wrapping the string back into the prop type
+	 * it is bound to lets the matching transformer resolve it into a usable src.
+	 */
+	private function wrap_dynamic_url( $value, Prop_Type $prop_type ) {
+		if ( ! is_string( $value ) || '' === $value || ! ( $prop_type instanceof Union_Prop_Type ) ) {
+			return $value;
+		}
+
+		$src_prop_type_keys = [ Image_Src_Prop_Type::get_key(), Svg_Src_Prop_Type::get_key() ];
+
+		foreach ( $src_prop_type_keys as $src_prop_type_key ) {
+			if ( $prop_type->get_prop_type( $src_prop_type_key ) ) {
+				return [
+					'$$type' => $src_prop_type_key,
+					'value' => [ 'url' => $value ],
+				];
+			}
+		}
+
+		return $value;
 	}
 
 	private function get_validated_value( Prop_Type $prop_type, $prop_value ) {

--- a/packages/packages/core/editor-editing-panel/src/dynamics/__tests__/dynamic-transformer.test.ts
+++ b/packages/packages/core/editor-editing-panel/src/dynamics/__tests__/dynamic-transformer.test.ts
@@ -128,6 +128,56 @@ describe( 'dynamicTransformer', () => {
 		expect( value ).toBe( 'default-value' );
 	} );
 
+	it( 'should wrap a resolved url in the src prop type it is bound to', async () => {
+		// Arrange.
+		window.elementor = ELEMENTOR_MOCK;
+
+		const propType = {
+			kind: 'union',
+			prop_types: { 'image-src': {}, dynamic: {} },
+		} as unknown as PropType;
+
+		// Act.
+		const valueFromServer = dynamicTransformer(
+			{ name: 'test-tag', settings: { url: 'a' } },
+			{ key: 'test', propType }
+		);
+
+		// Assert.
+		await expect( valueFromServer ).resolves.toEqual( {
+			$$type: 'image-src',
+			value: { url: 'test-tag-{"url":"a"}' },
+		} );
+
+		// Act - the second call is resolved synchronously from the cache.
+		const valueFromCache = dynamicTransformer(
+			{ name: 'test-tag', settings: { url: 'a' } },
+			{ key: 'test', propType }
+		);
+
+		// Assert.
+		expect( valueFromCache ).toEqual( {
+			$$type: 'image-src',
+			value: { url: 'test-tag-{"url":"a"}' },
+		} );
+	} );
+
+	it( 'should not wrap a resolved url when the prop is not a src prop', async () => {
+		// Arrange.
+		window.elementor = ELEMENTOR_MOCK;
+
+		const propType = {
+			kind: 'union',
+			prop_types: { string: {}, dynamic: {} },
+		} as unknown as PropType;
+
+		// Act.
+		const value = dynamicTransformer( { name: 'test-tag', settings: { url: 'b' } }, { key: 'test', propType } );
+
+		// Assert.
+		await expect( value ).resolves.toBe( 'test-tag-{"url":"b"}' );
+	} );
+
 	it( 'should return default value for null dynamic values', async () => {
 		// Arrange & Act.
 		const value = dynamicTransformer( null as never, {

--- a/packages/packages/core/editor-editing-panel/src/dynamics/dynamic-transformer.ts
+++ b/packages/packages/core/editor-editing-panel/src/dynamics/dynamic-transformer.ts
@@ -1,5 +1,5 @@
 import { createTransformer } from '@elementor/editor-canvas';
-import { isTransformable, type Props } from '@elementor/editor-props';
+import { isTransformable, type Props, type PropType } from '@elementor/editor-props';
 
 import { DynamicTagsManagerNotFoundError } from './errors';
 import { isDynamicTagSupported } from './utils';
@@ -9,6 +9,8 @@ type Dynamic = {
 	settings?: Props;
 };
 
+const SRC_PROP_TYPE_KEYS = [ 'image-src', 'svg-src' ];
+
 export const dynamicTransformer = createTransformer< Dynamic >( ( value, { propType, renderContext } ) => {
 	if ( ! value?.name || ! isDynamicTagSupported( value.name ) ) {
 		return propType?.default ?? null;
@@ -16,8 +18,29 @@ export const dynamicTransformer = createTransformer< Dynamic >( ( value, { propT
 
 	const renderPostId = ( renderContext as { currentPostId?: number } | undefined )?.currentPostId;
 
-	return getDynamicValue( value.name, simpleTransform( value?.settings ?? {} ), renderPostId );
+	const dynamicValue = getDynamicValue( value.name, simpleTransform( value?.settings ?? {} ), renderPostId );
+
+	if ( dynamicValue instanceof Promise ) {
+		return dynamicValue.then( ( resolved ) => wrapDynamicUrl( resolved, propType ) );
+	}
+
+	return wrapDynamicUrl( dynamicValue, propType );
 } );
+
+/**
+ * Dynamic tags of the URL category resolve into a plain string, while the image & SVG props
+ * expect an `{ id, url }` structure. Wrapping the string back into the prop type it is bound
+ * to lets the matching transformer resolve it into a usable src.
+ */
+function wrapDynamicUrl( value: unknown, propType?: PropType ) {
+	if ( typeof value !== 'string' || ! value || propType?.kind !== 'union' ) {
+		return value;
+	}
+
+	const srcPropTypeKey = SRC_PROP_TYPE_KEYS.find( ( key ) => key in propType.prop_types );
+
+	return srcPropTypeKey ? { $$type: srcPropTypeKey, value: { url: value } } : value;
+}
 
 // Temporary naive transformation until we'll have a `backendTransformer` that
 // will replace the `dynamicTransformer` client implementation.

--- a/packages/packages/core/editor-editing-panel/src/dynamics/dynamic-transformer.ts
+++ b/packages/packages/core/editor-editing-panel/src/dynamics/dynamic-transformer.ts
@@ -31,6 +31,8 @@ export const dynamicTransformer = createTransformer< Dynamic >( ( value, { propT
  * Dynamic tags of the URL category resolve into a plain string, while the image & SVG props
  * expect an `{ id, url }` structure. Wrapping the string back into the prop type it is bound
  * to lets the matching transformer resolve it into a usable src.
+ * @param value
+ * @param propType
  */
 function wrapDynamicUrl( value: unknown, propType?: PropType ) {
 	if ( typeof value !== 'string' || ! value || propType?.kind !== 'union' ) {

--- a/tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/test-dynamic-tags-module.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/test-dynamic-tags-module.php
@@ -10,6 +10,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Image_Src_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Svg_Src_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Url_Prop_Type;
 use Elementor\Modules\DynamicTags\Module as V1DynamicTags;
@@ -561,7 +562,12 @@ class Test_Dynamic_Tags_Module extends Elementor_Test_Base {
 
 			'image-src' => [
 				Image_Src_Prop_Type::make(),
-				[ V1DynamicTags::IMAGE_CATEGORY ],
+				[ V1DynamicTags::IMAGE_CATEGORY, V1DynamicTags::URL_CATEGORY ],
+			],
+
+			'svg-src' => [
+				Svg_Src_Prop_Type::make(),
+				[ V1DynamicTags::SVG_CATEGORY, V1DynamicTags::URL_CATEGORY ],
 			],
 
 			'string' => [

--- a/tests/phpunit/elementor/modules/atomic-widgets/props-resolver/test-render-props-resolver-dynamic-url.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/props-resolver/test-render-props-resolver-dynamic-url.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\PropsResolver;
+
+use Elementor\Core\DynamicTags\Data_Tag;
+use Elementor\Core\DynamicTags\Manager as Dynamic_Tags_Manager;
+use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Prop_Type;
+use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Tags_Module;
+use Elementor\Modules\AtomicWidgets\PropTypes\Image_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Svg_Src_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Render_Props_Resolver;
+use Elementor\Modules\DynamicTags\Module as V1_Dynamic_Tags_Module;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * @group props-resolver
+ */
+class Test_Render_Props_Resolver_Dynamic_Url extends Elementor_Test_Base {
+
+	const URL = 'https://example.com/wp-content/uploads/dynamic.svg';
+
+	private ?Dynamic_Tags_Manager $original_dynamic_tags = null;
+
+	private $url_tag;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_dynamic_tags = Plugin::$instance->dynamic_tags;
+		Plugin::$instance->dynamic_tags = new Dynamic_Tags_Manager();
+
+		$this->url_tag = $this->make_url_tag();
+
+		Plugin::$instance->dynamic_tags->register( $this->url_tag );
+
+		Dynamic_Tags_Module::fresh()->register_hooks();
+
+		Render_Props_Resolver::reset();
+	}
+
+	public function tearDown(): void {
+		Plugin::$instance->controls_manager->delete_stack( $this->url_tag );
+		Plugin::$instance->dynamic_tags = $this->original_dynamic_tags;
+
+		Render_Props_Resolver::reset();
+
+		parent::tearDown();
+	}
+
+	public function test_resolve__image_src_bound_to_a_url_dynamic_tag() {
+		// Arrange.
+		$schema = $this->get_extended_schema( [
+			'image' => Image_Prop_Type::make()->default_size( 'full' ),
+		] );
+
+		$props = [
+			'image' => Image_Prop_Type::generate( [
+				'src' => $this->generate_url_tag_value(),
+				'size' => 'full',
+			] ),
+		];
+
+		// Act.
+		$result = Render_Props_Resolver::for_settings()->resolve( $schema, $props );
+
+		// Assert.
+		$this->assertSame( self::URL, $result['image']['src'] );
+	}
+
+	public function test_resolve__svg_src_bound_to_a_url_dynamic_tag() {
+		// Arrange.
+		add_filter( 'pre_http_request', [ $this, 'mock_svg_http_response' ], 1 );
+
+		$schema = $this->get_extended_schema( [
+			'svg' => Svg_Src_Prop_Type::make(),
+		] );
+
+		$props = [
+			'svg' => $this->generate_url_tag_value(),
+		];
+
+		// Act.
+		$result = Render_Props_Resolver::for_settings()->resolve( $schema, $props );
+
+		// Cleanup.
+		remove_filter( 'pre_http_request', [ $this, 'mock_svg_http_response' ], 1 );
+
+		// Assert.
+		$this->assertSame( self::URL, $result['svg']['url'] );
+		$this->assertStringContainsString( '<svg', $result['svg']['html'] );
+	}
+
+	public function mock_svg_http_response() {
+		return [
+			'body' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></svg>',
+			'response' => [
+				'code' => 200,
+				'message' => 'OK',
+			],
+		];
+	}
+
+	private function get_extended_schema( array $schema ): array {
+		return apply_filters( 'elementor/atomic-widgets/props-schema', $schema );
+	}
+
+	private function generate_url_tag_value(): array {
+		return Dynamic_Prop_Type::generate( [
+			'name' => 'mock-url-tag',
+			'group' => V1_Dynamic_Tags_Module::BASE_GROUP,
+			'settings' => [],
+		] );
+	}
+
+	private function make_url_tag(): Data_Tag {
+		return new class extends Data_Tag {
+			public function get_name() {
+				return 'mock-url-tag';
+			}
+
+			public function get_title() {
+				return 'Mock Url Tag';
+			}
+
+			public function get_group() {
+				return V1_Dynamic_Tags_Module::BASE_GROUP;
+			}
+
+			public function get_categories() {
+				return [ V1_Dynamic_Tags_Module::URL_CATEGORY ];
+			}
+
+			protected function get_value( array $options = [] ) {
+				return Test_Render_Props_Resolver_Dynamic_Url::URL;
+			}
+
+			protected function register_controls() {}
+
+			protected function register_advanced_section() {}
+		};
+	}
+}


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Dynamic tags of the URL category can now be used on the Image (`e-image`) and SVG (`e-svg`) atomic elements.

## Description
An explanation of what is done in this PR

* `Dynamic_Prop_Types_Mapping::get_related_categories()` only allowed `IMAGE_CATEGORY` on `Image_Src_Prop_Type` and `SVG_CATEGORY` on `Svg_Src_Prop_Type`. A dynamic tag that returns a plain URL (for example Elementor Pro's ACF "URL" tag, `acf-url`, pointing at an image or file field) therefore never shows up in the dynamic tag picker of the Image / SVG controls, even though the value it produces is a perfectly usable `src`. Today the only way around this is a custom `elementor/atomic/dynamic_tags/select_control_options` filter in a site plugin.
* Both prop types now additionally accept `URL_CATEGORY`.
* Adding the category on its own is not enough: URL tags resolve into a plain string, while `Image_Src_Prop_Type` / `Svg_Src_Prop_Type` expect an `{ id, url }` structure, so `Image_Transformer` would throw `Invalid image URL.` and the SVG transformer would not run at all (the twig template reads `settings.svg.html`). The resolvers now wrap the resolved string back into the src prop type the value is bound to, so the existing `image-src` / `svg-src` transformers pick it up through the regular "a transformer may return another transformable value" flow:
  * server-side render: `Render_Props_Resolver::resolve_item()`
  * editor preview: `dynamicTransformer` in `@elementor/editor-editing-panel`, which already receives the union prop type
* No behaviour change for tags of the image / SVG categories, or for any other prop type: the wrapping only kicks in for a string result on a union that contains `image-src` or `svg-src`.

Files touched:
* `modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php`
* `modules/atomic-widgets/props-resolver/render-props-resolver.php`
* `packages/packages/core/editor-editing-panel/src/dynamics/dynamic-transformer.ts`
* tests (PHPUnit + Jest)

A companion PR adds `IMAGE_CATEGORY` to the SVG src prop so that image dynamic tags can be used on `e-svg` as well.

## Test instructions
This PR can be tested by following these steps:

1. Install Elementor Pro + ACF, and add an ACF field of type `URL` (or an image/file field exposed through the ACF `URL` dynamic tag) to a post type.
2. Edit a page with the v4 (atomic) editor and add an **Image** element. Open the dynamic tag picker on the image control - the ACF "URL" tag is now listed. Pick it and confirm the image renders in the editor preview and on the front end.
3. Repeat with an **SVG** element and a URL pointing at an `.svg` file - the SVG is fetched, sanitized and rendered inline.
4. Verify that image-category tags on the Image element and SVG-category tags on the SVG element still behave exactly as before.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

### Verification

**Environment used:** PHPUnit 9.6.35 on PHP 8.3 / WordPress 7.0.2 / MySQL 8.0 (`bin/install-wp-tests.sh`), Jest on Node 26, ESLint 8.57 and PHPCS with `ruleset.xml`.

Note on the pre-existing failures below: running `--filter AtomicWidgets` on an unmodified `main` in the same environment yields **1045 tests, 10 errors, 2 failures** (all in `Test_Has_Template` / `Test_Template_Renderer` / `Test_Render_Element_Action`, i.e. Twig template rendering). Those numbers are quoted as the baseline; this branch does not add to them.

* `vendor/bin/phpunit --filter AtomicWidgets` → 1048 tests, 10 errors, 2 failures — the same 10/2 as the `main` baseline (1045 tests), so the 3 added tests pass and nothing regressed.
* `npx jest --config=./packages/jest.config.js packages/packages/core/editor-editing-panel` → **405 passed, 0 failed**.
* ESLint (packages config) and `vendor/bin/phpcs --standard=./ruleset.xml` on the changed files → clean.

Not done: no manual run-through with a live ACF install and no Playwright run.
