### PR TITLE
Feature: Support image dynamic tags on the atomic SVG element

### DIFF
--- a/modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-prop-types-mapping.php
@@ -61,7 +61,11 @@ class Dynamic_Prop_Types_Mapping extends Prop_Types_Schema_Extender {
 		}
 
 		if ( $prop_type instanceof Svg_Src_Prop_Type ) {
-			return [ V1_Dynamic_Tags_Module::SVG_CATEGORY ];
+			// SVGs are stored as attachments in the media library, so image tags are supported as well.
+			return [
+				V1_Dynamic_Tags_Module::SVG_CATEGORY,
+				V1_Dynamic_Tags_Module::IMAGE_CATEGORY,
+			];
 		}
 
 		if ( $prop_type instanceof Image_Src_Prop_Type ) {

--- a/modules/atomic-widgets/dynamic-tags/dynamic-transformer.php
+++ b/modules/atomic-widgets/dynamic-tags/dynamic-transformer.php
@@ -3,8 +3,13 @@
 namespace Elementor\Modules\AtomicWidgets\DynamicTags;
 
 use Elementor\Core\DynamicTags\Manager as Dynamic_Tags_Manager;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Props_Resolver_Context;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Render_Props_Resolver;
 use Elementor\Modules\AtomicWidgets\PropsResolver\Transformer_Base;
+use Elementor\Modules\AtomicWidgets\PropTypes\Image_Attachment_Id_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Svg_Src_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Url_Prop_Type;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -25,7 +30,7 @@ class Dynamic_Transformer extends Transformer_Base {
 		$this->props_resolver = $props_resolver;
 	}
 
-	public function transform( $value, $key ) {
+	public function transform( $value, Props_Resolver_Context $context ) {
 		if ( ! isset( $value['name'] ) || ! is_string( $value['name'] ) ) {
 			throw new \Exception( 'Dynamic tag name must be a string' );
 		}
@@ -41,6 +46,45 @@ class Dynamic_Transformer extends Transformer_Base {
 			$value['settings'] ?? []
 		);
 
-		return $this->dynamic_tags_manager->get_tag_data_content( null, $value['name'], $settings );
+		$content = $this->dynamic_tags_manager->get_tag_data_content( null, $value['name'], $settings );
+
+		return $this->maybe_wrap_as_svg_src( $content, $context );
+	}
+
+	/**
+	 * Tags from the image category resolve into an attachment array (`[ 'id' => .., 'url' => .. ]`).
+	 * When such a tag is bound to an SVG prop, the result is wrapped back into an `svg-src` value,
+	 * so it will be resolved again by the SVG transformer and rendered as inline SVG markup.
+	 *
+	 * @param mixed $content
+	 *
+	 * @return mixed
+	 */
+	private function maybe_wrap_as_svg_src( $content, Props_Resolver_Context $context ) {
+		if ( ! is_array( $content ) || ! $this->is_svg_src_prop( $context ) ) {
+			return $content;
+		}
+
+		$id = ! empty( $content['id'] ) ? (int) $content['id'] : null;
+		$url = ( ! empty( $content['url'] ) && is_string( $content['url'] ) ) ? $content['url'] : null;
+
+		if ( ! $id && ! $url ) {
+			return null;
+		}
+
+		return Svg_Src_Prop_Type::generate( [
+			'id' => $id ? Image_Attachment_Id_Prop_Type::generate( $id ) : null,
+			'url' => $url ? Url_Prop_Type::generate( $url ) : null,
+		] );
+	}
+
+	private function is_svg_src_prop( Props_Resolver_Context $context ): bool {
+		$schema_prop_type = $context->get_schema_prop_type();
+
+		if ( ! ( $schema_prop_type instanceof Union_Prop_Type ) ) {
+			return false;
+		}
+
+		return $schema_prop_type->get_prop_type( Svg_Src_Prop_Type::get_key() ) instanceof Svg_Src_Prop_Type;
 	}
 }

--- a/modules/atomic-widgets/props-resolver/props-resolver-context.php
+++ b/modules/atomic-widgets/props-resolver/props-resolver-context.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\AtomicWidgets\PropsResolver;
 
+use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Transformable_Prop_Type;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -12,6 +13,12 @@ class Props_Resolver_Context {
 	private ?string $key = null;
 
 	private ?Transformable_Prop_Type $prop_type;
+
+	/**
+	 * The prop type as it is defined in the schema, before resolving a union into
+	 * the specific prop type that matches the value.
+	 */
+	private ?Prop_Type $schema_prop_type = null;
 
 	private bool $disabled = false;
 
@@ -35,6 +42,16 @@ class Props_Resolver_Context {
 		$this->prop_type = $prop_type;
 
 		return $this;
+	}
+
+	public function set_schema_prop_type( ?Prop_Type $prop_type ): self {
+		$this->schema_prop_type = $prop_type;
+
+		return $this;
+	}
+
+	public function get_schema_prop_type(): ?Prop_Type {
+		return $this->schema_prop_type;
 	}
 
 	public function get_key(): ?string {

--- a/modules/atomic-widgets/props-resolver/props-resolver-context.php
+++ b/modules/atomic-widgets/props-resolver/props-resolver-context.php
@@ -17,6 +17,8 @@ class Props_Resolver_Context {
 	/**
 	 * The prop type as it is defined in the schema, before resolving a union into
 	 * the specific prop type that matches the value.
+	 *
+	 * @var Prop_Type|null
 	 */
 	private ?Prop_Type $schema_prop_type = null;
 

--- a/modules/atomic-widgets/props-resolver/props-resolver.php
+++ b/modules/atomic-widgets/props-resolver/props-resolver.php
@@ -46,6 +46,8 @@ abstract class Props_Resolver {
 	}
 
 	protected function transform( $value, $key, Prop_Type $prop_type ) {
+		$schema_prop_type = $prop_type;
+
 		if ( $prop_type instanceof Union_Prop_Type ) {
 			$prop_type = $prop_type->get_prop_type( $value['$$type'] );
 
@@ -97,7 +99,8 @@ abstract class Props_Resolver {
 			$context = Props_Resolver_Context::make()
 				->set_key( $key )
 				->set_disabled( (bool) ( $value['disabled'] ?? false ) )
-				->set_prop_type( $prop_type );
+				->set_prop_type( $prop_type )
+				->set_schema_prop_type( $schema_prop_type );
 
 			return $transformer->transform( $value['value'], $context );
 		} catch ( Exception $e ) {

--- a/modules/atomic-widgets/props-resolver/transformers/svg-src-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/svg-src-transformer.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Svg_Src_Transformer extends Transformer_Base {
 	const SVG_INLINE_STYLES = 'width: 100%; height: 100%; overflow: unset;';
+	const SVG_MIME_TYPE = 'image/svg+xml';
 
 	public function transform( $value, Props_Resolver_Context $context ) {
 		$id = isset( $value['id'] ) ? (int) $value['id'] : null;
@@ -36,6 +37,10 @@ class Svg_Src_Transformer extends Transformer_Base {
 	}
 
 	private function fetch_svg_content( ?int $id, ?string $url ): ?string {
+		if ( $id && ! $this->is_svg_attachment( $id ) ) {
+			return null;
+		}
+
 		if ( $id ) {
 			$path = get_attached_file( $id );
 			$content = $path ? Utils::file_get_contents( $path ) : null;
@@ -61,11 +66,36 @@ class Svg_Src_Transformer extends Transformer_Base {
 
 		$response = wp_safe_remote_get( $url );
 
-		if ( ! is_wp_error( $response ) ) {
+		if ( ! is_wp_error( $response ) && $this->is_svg_response( $response ) ) {
 			return $response['body'];
 		}
 
 		return null;
+	}
+
+	/**
+	 * Image dynamic tags may resolve into a non-SVG attachment (e.g. JPG/PNG),
+	 * which should not be inlined into the document.
+	 */
+	private function is_svg_attachment( int $id ): bool {
+		$mime_type = get_post_mime_type( $id );
+
+		// Unknown mime types are not blocked, to keep supporting ids that are resolved by third parties.
+		return ! $mime_type || self::SVG_MIME_TYPE === $mime_type;
+	}
+
+	private function is_svg_response( $response ): bool {
+		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+
+		if ( is_array( $content_type ) ) {
+			$content_type = reset( $content_type );
+		}
+
+		if ( ! is_string( $content_type ) || '' === $content_type ) {
+			return true;
+		}
+
+		return false !== strpos( $content_type, 'svg' ) || false !== strpos( $content_type, 'xml' );
 	}
 
 	private function resolve_local_path( string $url ): ?string {

--- a/packages/packages/core/editor-editing-panel/src/dynamics/__tests__/dynamic-transformer.test.ts
+++ b/packages/packages/core/editor-editing-panel/src/dynamics/__tests__/dynamic-transformer.test.ts
@@ -128,6 +128,63 @@ describe( 'dynamicTransformer', () => {
 		expect( value ).toBe( 'default-value' );
 	} );
 
+	it( 'should wrap an image tag value as an svg-src value when bound to an svg prop', async () => {
+		// Arrange.
+		window.elementor = {
+			...ELEMENTOR_MOCK,
+			dynamicTags: mockDynamicTagsManager( { id: 5, url: 'https://example.com/icon.svg' } ),
+		};
+
+		const propType = {
+			kind: 'union',
+			prop_types: {
+				'svg-src': { kind: 'object', key: 'svg-src' },
+				dynamic: { kind: 'plain', key: 'dynamic' },
+			},
+		} as unknown as PropType;
+
+		const expected = {
+			$$type: 'svg-src',
+			value: {
+				id: { $$type: 'image-attachment-id', value: 5 },
+				url: { $$type: 'url', value: 'https://example.com/icon.svg' },
+			},
+		};
+
+		// Act & Assert - resolved from the server.
+		await expect(
+			dynamicTransformer( { name: 'test-tag', settings: {} }, { key: 'test', propType } )
+		).resolves.toEqual( expected );
+
+		// Act & Assert - resolved from the cache.
+		expect( dynamicTransformer( { name: 'test-tag', settings: {} }, { key: 'test', propType } ) ).toEqual(
+			expected
+		);
+	} );
+
+	it( 'should not wrap an image tag value when the prop is not an svg prop', async () => {
+		// Arrange.
+		const tagValue = { id: 5, url: 'https://example.com/icon.svg' };
+
+		window.elementor = {
+			...ELEMENTOR_MOCK,
+			dynamicTags: mockDynamicTagsManager( tagValue ),
+		};
+
+		const propType = {
+			kind: 'union',
+			prop_types: {
+				'image-src': { kind: 'object', key: 'image-src' },
+				dynamic: { kind: 'plain', key: 'dynamic' },
+			},
+		} as unknown as PropType;
+
+		// Act & Assert.
+		await expect(
+			dynamicTransformer( { name: 'test-tag', settings: {} }, { key: 'test', propType } )
+		).resolves.toEqual( tagValue );
+	} );
+
 	it( 'should return default value for null dynamic values', async () => {
 		// Arrange & Act.
 		const value = dynamicTransformer( null as never, {
@@ -140,7 +197,7 @@ describe( 'dynamicTransformer', () => {
 	} );
 } );
 
-function mockDynamicTagsManager(): DynamicTagsManager {
+function mockDynamicTagsManager( tagValue?: unknown ): DynamicTagsManager {
 	const tags: Record< string, TagInstance > = {};
 	const cache: Record< string, unknown > = {};
 
@@ -170,7 +227,7 @@ function mockDynamicTagsManager(): DynamicTagsManager {
 			}
 
 			// Populate for next "fetch".
-			cache[ cacheKey ] = cacheKey;
+			cache[ cacheKey ] = tagValue ?? cacheKey;
 
 			return null;
 		},

--- a/packages/packages/core/editor-editing-panel/src/dynamics/dynamic-transformer.ts
+++ b/packages/packages/core/editor-editing-panel/src/dynamics/dynamic-transformer.ts
@@ -1,5 +1,12 @@
 import { createTransformer } from '@elementor/editor-canvas';
-import { isTransformable, type Props } from '@elementor/editor-props';
+import {
+	imageAttachmentIdPropType,
+	isTransformable,
+	type PropType,
+	type Props,
+	svgSrcPropTypeUtil,
+	urlPropTypeUtil,
+} from '@elementor/editor-props';
 
 import { DynamicTagsManagerNotFoundError } from './errors';
 import { isDynamicTagSupported } from './utils';
@@ -9,6 +16,11 @@ type Dynamic = {
 	settings?: Props;
 };
 
+type ImageTagValue = {
+	id?: unknown;
+	url?: unknown;
+};
+
 export const dynamicTransformer = createTransformer< Dynamic >( ( value, { propType, renderContext } ) => {
 	if ( ! value?.name || ! isDynamicTagSupported( value.name ) ) {
 		return propType?.default ?? null;
@@ -16,8 +28,45 @@ export const dynamicTransformer = createTransformer< Dynamic >( ( value, { propT
 
 	const renderPostId = ( renderContext as { currentPostId?: number } | undefined )?.currentPostId;
 
-	return getDynamicValue( value.name, simpleTransform( value?.settings ?? {} ), renderPostId );
+	const dynamicValue = getDynamicValue( value.name, simpleTransform( value?.settings ?? {} ), renderPostId );
+
+	if ( dynamicValue instanceof Promise ) {
+		return dynamicValue.then( ( resolved ) => maybeWrapAsSvgSrc( resolved, propType ) );
+	}
+
+	return maybeWrapAsSvgSrc( dynamicValue, propType );
 } );
+
+/**
+ * Tags from the image category resolve into an attachment object (`{ id, url }`).
+ * When such a tag is bound to an SVG prop, the result is wrapped back into an `svg-src` value,
+ * so it will be resolved again by the SVG transformer and rendered as inline SVG markup.
+ */
+function maybeWrapAsSvgSrc( dynamicValue: unknown, propType?: PropType ) {
+	if ( ! isSvgSrcProp( propType ) || ! isImageTagValue( dynamicValue ) ) {
+		return dynamicValue;
+	}
+
+	const id = Number( dynamicValue.id ) || null;
+	const url = typeof dynamicValue.url === 'string' && dynamicValue.url ? dynamicValue.url : null;
+
+	if ( ! id ) {
+		return url ? svgSrcPropTypeUtil.create( { id: null, url: urlPropTypeUtil.create( url ) } ) : null;
+	}
+
+	return svgSrcPropTypeUtil.create( {
+		id: imageAttachmentIdPropType.create( id ),
+		url: url ? urlPropTypeUtil.create( url ) : null,
+	} );
+}
+
+function isSvgSrcProp( propType?: PropType ): boolean {
+	return propType?.kind === 'union' && !! propType.prop_types[ svgSrcPropTypeUtil.key ];
+}
+
+function isImageTagValue( value: unknown ): value is ImageTagValue {
+	return !! value && typeof value === 'object' && ( 'id' in value || 'url' in value );
+}
 
 // Temporary naive transformation until we'll have a `backendTransformer` that
 // will replace the `dynamicTransformer` client implementation.

--- a/packages/packages/core/editor-editing-panel/src/dynamics/dynamic-transformer.ts
+++ b/packages/packages/core/editor-editing-panel/src/dynamics/dynamic-transformer.ts
@@ -2,8 +2,8 @@ import { createTransformer } from '@elementor/editor-canvas';
 import {
 	imageAttachmentIdPropType,
 	isTransformable,
-	type PropType,
 	type Props,
+	type PropType,
 	svgSrcPropTypeUtil,
 	urlPropTypeUtil,
 } from '@elementor/editor-props';
@@ -41,6 +41,8 @@ export const dynamicTransformer = createTransformer< Dynamic >( ( value, { propT
  * Tags from the image category resolve into an attachment object (`{ id, url }`).
  * When such a tag is bound to an SVG prop, the result is wrapped back into an `svg-src` value,
  * so it will be resolved again by the SVG transformer and rendered as inline SVG markup.
+ * @param dynamicValue
+ * @param propType
  */
 function maybeWrapAsSvgSrc( dynamicValue: unknown, propType?: PropType ) {
 	if ( ! isSvgSrcProp( propType ) || ! isImageTagValue( dynamicValue ) ) {

--- a/tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/mocks/mock-image-dynamic-tag.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/mocks/mock-image-dynamic-tag.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\DynamicTags\Mocks;
+
+use Elementor\Core\DynamicTags\Data_Tag;
+use Elementor\Modules\DynamicTags\Module as DynamicTagsModule;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Mock_Image_Dynamic_Tag extends Data_Tag {
+
+	const ATTACHMENT_ID = 123;
+	const ATTACHMENT_URL = 'https://example.com/icon.svg';
+
+	/**
+	 * The value that the tag resolves into, so tests can simulate different tag results.
+	 *
+	 * @var mixed
+	 */
+	public static $value = [
+		'id' => self::ATTACHMENT_ID,
+		'url' => self::ATTACHMENT_URL,
+	];
+
+	public static function reset() {
+		static::$value = [
+			'id' => self::ATTACHMENT_ID,
+			'url' => self::ATTACHMENT_URL,
+		];
+	}
+
+	public function get_name() {
+		return 'mock-image-dynamic-tag';
+	}
+
+	public function get_title() {
+		return 'Mock Image Dynamic Tag';
+	}
+
+	public function get_group() {
+		return DynamicTagsModule::BASE_GROUP;
+	}
+
+	public function get_categories() {
+		return [ DynamicTagsModule::IMAGE_CATEGORY ];
+	}
+
+	protected function get_value( array $options = [] ) {
+		return static::$value;
+	}
+
+	protected function register_controls() {}
+
+	protected function register_advanced_section() {}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/test-dynamic-tags-module.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/test-dynamic-tags-module.php
@@ -10,6 +10,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Image_Src_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Svg_Src_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Url_Prop_Type;
 use Elementor\Modules\DynamicTags\Module as V1DynamicTags;
@@ -562,6 +563,11 @@ class Test_Dynamic_Tags_Module extends Elementor_Test_Base {
 			'image-src' => [
 				Image_Src_Prop_Type::make(),
 				[ V1DynamicTags::IMAGE_CATEGORY ],
+			],
+
+			'svg-src' => [
+				Svg_Src_Prop_Type::make(),
+				[ V1DynamicTags::SVG_CATEGORY, V1DynamicTags::IMAGE_CATEGORY ],
 			],
 
 			'string' => [

--- a/tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/test-dynamic-transformer.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/dynamic-tags/test-dynamic-transformer.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\DynamicTags;
+
+use Elementor\Core\DynamicTags\Manager as Dynamic_Tags_Manager;
+use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Prop_Type;
+use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Tags_Module;
+use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Tags_Schemas;
+use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Transformer;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Props_Resolver_Context;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Render_Props_Resolver;
+use Elementor\Modules\AtomicWidgets\PropTypes\Image_Src_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Svg_Src_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
+use Elementor\Plugin;
+use Elementor\Testing\Modules\AtomicWidgets\DynamicTags\Mocks\Mock_Image_Dynamic_Tag;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+require_once __DIR__ . '/mocks/mock-image-dynamic-tag.php';
+
+/**
+ * @group props-resolver
+ */
+class Test_Dynamic_Transformer extends Elementor_Test_Base {
+
+	private Dynamic_Transformer $transformer;
+
+	private Dynamic_Tags_Manager $original_dynamic_tags;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_dynamic_tags = Plugin::$instance->dynamic_tags;
+
+		Plugin::$instance->dynamic_tags = new Dynamic_Tags_Manager();
+
+		remove_all_actions( 'elementor/dynamic_tags/register_tags' );
+		remove_all_actions( 'elementor/dynamic_tags/register' );
+
+		Mock_Image_Dynamic_Tag::reset();
+
+		Plugin::$instance->dynamic_tags->register( new Mock_Image_Dynamic_Tag() );
+
+		Dynamic_Tags_Module::fresh();
+
+		$this->transformer = new Dynamic_Transformer(
+			Plugin::$instance->dynamic_tags,
+			new Dynamic_Tags_Schemas(),
+			Render_Props_Resolver::for_settings()
+		);
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		Mock_Image_Dynamic_Tag::reset();
+
+		Plugin::$instance->dynamic_tags = $this->original_dynamic_tags;
+	}
+
+	public function test_transform__wraps_image_tag_value_as_svg_src() {
+		// Act.
+		$result = $this->transformer->transform(
+			[ 'name' => 'mock-image-dynamic-tag', 'settings' => [] ],
+			$this->make_context( Svg_Src_Prop_Type::make() )
+		);
+
+		// Assert.
+		$this->assertSame( [
+			'$$type' => 'svg-src',
+			'value' => [
+				'id' => [ '$$type' => 'image-attachment-id', 'value' => Mock_Image_Dynamic_Tag::ATTACHMENT_ID ],
+				'url' => [ '$$type' => 'url', 'value' => Mock_Image_Dynamic_Tag::ATTACHMENT_URL ],
+			],
+		], $result );
+	}
+
+	public function test_transform__wraps_image_tag_value_as_svg_src_when_only_a_url_is_returned() {
+		// Arrange.
+		Mock_Image_Dynamic_Tag::$value = [
+			'id' => null,
+			'url' => Mock_Image_Dynamic_Tag::ATTACHMENT_URL,
+		];
+
+		// Act.
+		$result = $this->transformer->transform(
+			[ 'name' => 'mock-image-dynamic-tag', 'settings' => [] ],
+			$this->make_context( Svg_Src_Prop_Type::make() )
+		);
+
+		// Assert.
+		$this->assertSame( [
+			'$$type' => 'svg-src',
+			'value' => [
+				'id' => null,
+				'url' => [ '$$type' => 'url', 'value' => Mock_Image_Dynamic_Tag::ATTACHMENT_URL ],
+			],
+		], $result );
+	}
+
+	public function test_transform__returns_null_when_the_image_tag_has_no_value() {
+		// Arrange.
+		Mock_Image_Dynamic_Tag::$value = [
+			'id' => null,
+			'url' => null,
+		];
+
+		// Act.
+		$result = $this->transformer->transform(
+			[ 'name' => 'mock-image-dynamic-tag', 'settings' => [] ],
+			$this->make_context( Svg_Src_Prop_Type::make() )
+		);
+
+		// Assert.
+		$this->assertNull( $result );
+	}
+
+	public function test_transform__does_not_wrap_non_array_values() {
+		// Arrange.
+		Mock_Image_Dynamic_Tag::$value = 'https://example.com/icon.svg';
+
+		// Act.
+		$result = $this->transformer->transform(
+			[ 'name' => 'mock-image-dynamic-tag', 'settings' => [] ],
+			$this->make_context( Svg_Src_Prop_Type::make() )
+		);
+
+		// Assert.
+		$this->assertSame( 'https://example.com/icon.svg', $result );
+	}
+
+	public function test_transform__does_not_wrap_when_the_prop_is_not_an_svg_prop() {
+		// Act.
+		$result = $this->transformer->transform(
+			[ 'name' => 'mock-image-dynamic-tag', 'settings' => [] ],
+			$this->make_context( Image_Src_Prop_Type::make() )
+		);
+
+		// Assert.
+		$this->assertSame( [
+			'id' => Mock_Image_Dynamic_Tag::ATTACHMENT_ID,
+			'url' => Mock_Image_Dynamic_Tag::ATTACHMENT_URL,
+		], $result );
+	}
+
+	public function test_transform__does_not_wrap_when_there_is_no_schema_prop_type() {
+		// Act.
+		$result = $this->transformer->transform(
+			[ 'name' => 'mock-image-dynamic-tag', 'settings' => [] ],
+			Props_Resolver_Context::make()
+		);
+
+		// Assert.
+		$this->assertSame( [
+			'id' => Mock_Image_Dynamic_Tag::ATTACHMENT_ID,
+			'url' => Mock_Image_Dynamic_Tag::ATTACHMENT_URL,
+		], $result );
+	}
+
+	private function make_context( $prop_type ): Props_Resolver_Context {
+		$union = Union_Prop_Type::create_from( $prop_type )
+			->add_prop_type( Dynamic_Prop_Type::make() );
+
+		return Props_Resolver_Context::make()->set_schema_prop_type( $union );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/props-resolver/transformers/test-svg-src-transformer.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/props-resolver/transformers/test-svg-src-transformer.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\PropsResolver\Transformers;
+
+use Elementor\Modules\AtomicWidgets\PropsResolver\Props_Resolver_Context;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Svg_Src_Transformer;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * @group props-resolver
+ */
+class Test_Svg_Src_Transformer extends Elementor_Test_Base {
+
+	const SVG_URL = 'https://not-a-real-site.test/icon.svg';
+	const SVG_CONTENT = '<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h100v100H0z"/></svg>';
+
+	private Svg_Src_Transformer $transformer;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->transformer = new Svg_Src_Transformer();
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'pre_http_request' );
+
+		parent::tearDown();
+	}
+
+	public function test_transform__inlines_the_svg_content_of_a_remote_svg() {
+		// Arrange.
+		$this->mock_http_response( 'image/svg+xml', self::SVG_CONTENT );
+
+		// Act.
+		$result = $this->transformer->transform(
+			[ 'id' => null, 'url' => self::SVG_URL ],
+			Props_Resolver_Context::make()
+		);
+
+		// Assert.
+		$this->assertSame( self::SVG_URL, $result['url'] );
+		$this->assertStringContainsString( '<svg', $result['html'] );
+		$this->assertStringContainsString( 'fill="currentColor"', $result['html'] );
+	}
+
+	public function test_transform__does_not_inline_a_response_that_is_not_an_svg() {
+		// Arrange.
+		$this->mock_http_response( 'image/jpeg', 'not-an-svg' );
+
+		// Act.
+		$result = $this->transformer->transform(
+			[ 'id' => null, 'url' => self::SVG_URL ],
+			Props_Resolver_Context::make()
+		);
+
+		// Assert.
+		$this->assertSame( '', $result['html'] );
+		$this->assertSame( self::SVG_URL, $result['url'] );
+	}
+
+	public function test_transform__does_not_inline_an_attachment_that_is_not_an_svg() {
+		// Arrange.
+		$attachment_id = $this->factory()->post->create( [
+			'post_type' => 'attachment',
+			'post_mime_type' => 'image/jpeg',
+		] );
+
+		$this->mock_http_response( 'image/jpeg', 'not-an-svg' );
+
+		// Act.
+		$result = $this->transformer->transform(
+			[ 'id' => $attachment_id, 'url' => null ],
+			Props_Resolver_Context::make()
+		);
+
+		// Assert.
+		$this->assertSame( '', $result['html'] );
+	}
+
+	private function mock_http_response( string $content_type, string $body ) {
+		add_filter( 'pre_http_request', function () use ( $content_type, $body ) {
+			return [
+				'body' => $body,
+				'headers' => [ 'content-type' => $content_type ],
+				'response' => [ 'code' => 200, 'message' => 'OK' ],
+			];
+		} );
+	}
+}


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Tags from the `image` dynamic tags category can now be used on the atomic SVG element (`e-svg`), and are resolved into inline SVG markup.

## Description

Today `Dynamic_Prop_Types_Mapping::get_related_categories()` only returns `SVG_CATEGORY` for `Svg_Src_Prop_Type`. In practice there are almost no tags registered in that category, while SVG files are regular attachments in the WordPress media library and are therefore delivered by `image` category tags (for example an ACF "Image" field that points to an uploaded `.svg`).

Concrete scenario this unlocks: an ACF Image field holding an SVG icon can be bound to an `e-svg` element. That matters because `e-image` renders an `<img>` that cannot be recolored with CSS, while `e-svg` inlines the SVG and is fully stylable (`fill: currentColor`). Without this, a dynamic (ACF) icon can never follow the site's colors.

Adding the category alone is not enough: an image tag resolves into an attachment array (`[ 'id' => .., 'url' => .. ]`), while the SVG element's Twig template renders `settings.svg.html`, which is produced by `Svg_Src_Transformer`. Because the dynamic transformer's output was returned as-is, the element rendered nothing. So the value resolution had to be fixed as well.

### Changes

**Front-end (PHP)**
* `dynamic-prop-types-mapping.php` — `Svg_Src_Prop_Type` now accepts `SVG_CATEGORY` **and** `IMAGE_CATEGORY`.
* `props-resolver-context.php` / `props-resolver.php` — the context now also carries the prop type as defined in the schema (the union), next to the resolved prop type. This mirrors what the editor-side props resolver already passes to its transformers (`propType: type`).
* `dynamic-transformer.php` — when the resolved tag value is an attachment array and the prop is an `svg-src` prop, the value is re-wrapped into an `svg-src` value. The props resolver then transforms it again (it already re-resolves transformer output up to `TRANSFORM_DEPTH_LIMIT`), so `Svg_Src_Transformer` produces the sanitized inline markup. Values that are not arrays, and props that are not SVG props, are returned untouched.

**Editor preview (TS)**
* `dynamic-transformer.ts` — the same wrapping, so the canvas resolves the value through the existing `svgSrcTransformer`. The transformer stays synchronous when the tag value comes from the cache, and only chains on the promise when the value has to be fetched.

**Media type safety**

An image tag can just as well point to a JPG/PNG. That is handled gracefully, no fatals and no broken markup:
* `Svg_Src_Transformer` no longer reads the attachment file when the attachment's mime type is known and is not `image/svg+xml`. Unknown/empty mime types are still allowed through, so ids resolved by third parties keep working.
* Remote responses whose `content-type` is present but is not svg/xml are ignored (mirrors the content-type check the editor-side transformer already does).
* Anything that slips through still passes the existing `WP_HTML_Tag_Processor` + `Svg_Sanitizer` guard, which returns an empty string when no `<svg>` root is found. The result is an empty SVG container, not a broken or unsafe render.
* If the tag returns neither an id nor a url, the prop resolves to `null`.

### Related

Companion PR on branch `ucs/pr1` allows tags from the `url` category on image/SVG props. The two are independent; this one only concerns the `image` category and the `svg-src` value resolution.

## Test instructions
This PR can be tested by following these steps:

1. Upload an `.svg` file to the media library (SVG uploads enabled).
2. Create an ACF (or any other) Image field on a post/page and select that SVG.
3. Add an atomic **SVG** element (`e-svg`) to that page, open the SVG control and pick the dynamic tag (the image tags are now listed).
4. The SVG renders inline in the editor preview and on the front-end, and follows the element's `color` (`fill: currentColor`).
5. Point the same field to a JPG/PNG and reload: the element renders empty instead of injecting a non-SVG file.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Added tests:
* `tests/phpunit/.../dynamic-tags/test-dynamic-transformer.php` — wrapping of an image tag value into `svg-src` (id + url, url-only, empty value), plus non-array values and non-SVG props being left alone.
* `tests/phpunit/.../props-resolver/transformers/test-svg-src-transformer.php` — inlining a remote SVG, and ignoring a non-SVG response / non-SVG attachment.
* `tests/phpunit/.../dynamic-tags/test-dynamic-tags-module.php` — `svg-src` maps to the svg + image categories.
* `packages/.../dynamics/__tests__/dynamic-transformer.test.ts` — editor-side wrapping, from server and from cache, and no wrapping for non-SVG props.

### Verification

**Environment used:** PHPUnit 9.6.35 on PHP 8.3 / WordPress 7.0.2 / MySQL 8.0 (`bin/install-wp-tests.sh`), Jest on Node 26, ESLint 8.57 and PHPCS with `ruleset.xml`.

Note on the pre-existing failures below: running `--filter AtomicWidgets` on an unmodified `main` in the same environment yields **1045 tests, 10 errors, 2 failures** (all in `Test_Has_Template` / `Test_Template_Renderer` / `Test_Render_Element_Action`, i.e. Twig template rendering). Those numbers are quoted as the baseline; this branch does not add to them.

* `vendor/bin/phpunit --filter AtomicWidgets` → 1055 tests, 10 errors, 2 failures — the same 10/2 as the `main` baseline (1045 tests), so the 10 added tests pass and nothing regressed.
* `npx jest --config=./packages/jest.config.js packages/packages/core/editor-editing-panel` → **405 passed, 0 failed**.
* ESLint (packages config) and `vendor/bin/phpcs --standard=./ruleset.xml` on the changed files → clean.

Not done: no manual run-through with a live ACF install and no Playwright run.
