### PR TITLE
Internal: Expose element titles in get-page-structure [D-24993]

### DIFF
--- a/modules/atomic-widgets/utils/element-structure-title.php
+++ b/modules/atomic-widgets/utils/element-structure-title.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\Utils;
+
+use Elementor\Modules\GlobalClasses\Utils\Atomic_Elements_Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Element_Structure_Title {
+
+	public static function resolve( array $element ): ?string {
+		$editor_title = $element['editor_settings']['title'] ?? null;
+
+		if ( is_string( $editor_title ) && '' !== $editor_title ) {
+			return $editor_title;
+		}
+
+		$settings = $element['settings'] ?? [];
+
+		if ( is_array( $settings ) ) {
+			foreach ( [ '_title', 'presetTitle' ] as $key ) {
+				$plain = self::extract_plain_string( $settings[ $key ] ?? null );
+
+				if ( null !== $plain ) {
+					return $plain;
+				}
+			}
+		}
+
+		$type = $element['widgetType'] ?? $element['elType'] ?? null;
+
+		if ( ! $type ) {
+			return null;
+		}
+
+		$instance = Atomic_Elements_Utils::get_element_instance( (string) $type );
+
+		if ( ! $instance ) {
+			return null;
+		}
+
+		$label = $instance->get_title();
+
+		if ( ! is_string( $label ) || '' === $label ) {
+			return null;
+		}
+
+		return $label;
+	}
+
+	private static function extract_plain_string( $value ): ?string {
+		if ( is_string( $value ) && '' !== $value ) {
+			return $value;
+		}
+
+		if (
+			is_array( $value )
+			&& isset( $value['value'] )
+			&& is_string( $value['value'] )
+			&& '' !== $value['value']
+		) {
+			return $value['value'];
+		}
+
+		return null;
+	}
+}

--- a/modules/mcp/abilities/get-structure-ability.php
+++ b/modules/mcp/abilities/get-structure-ability.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\Mcp\Abilities;
 
 use Elementor\Modules\AtomicWidgets\Styles\Local_Style_Serializer;
+use Elementor\Modules\GlobalClasses\Utils\Atomic_Elements_Utils;
 use Elementor\Plugin;
 use Elementor\Utils;
 
@@ -19,14 +20,14 @@ class Get_Structure_Ability extends Abstract_Ability {
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Get Elementor Page Structure', 'elementor' ),
-			__( 'Returns a lean Elementor element tree skeleton (id, elType, widgetType, nested elements) for a single post or page ID. Optionally scope to a subtree via element_id. Set include_content=true (requires element_id) to also return each node\'s settings and styles in the same shape that build-composition accepts as input. Only works for posts that were saved with Elementor.', 'elementor' ),
+			__( 'Returns a lean Elementor element tree skeleton (id, elType, widgetType, title, nested elements) for a single post or page ID. Optionally scope to a subtree via element_id. Set include_content=true (requires element_id) to also return each node\'s settings and styles in the same shape that build-composition accepts as input. Only works for posts that were saved with Elementor.', 'elementor' ),
 			'elementor',
 			[
 				'type' => 'object',
 				'properties' => [
 					'elements' => [
 						'type' => 'array',
-						'description' => 'Skeleton of Elementor elements (id, elType, widgetType, nested elements). When include_content is true, each node also includes settings and styles.',
+						'description' => 'Skeleton of Elementor elements (id, elType, widgetType, title, nested elements). When include_content is true, each node also includes settings and styles.',
 					],
 				],
 			],
@@ -117,6 +118,12 @@ class Get_Structure_Ability extends Abstract_Ability {
 				$skeleton['widgetType'] = $node['widgetType'];
 			}
 
+			$title = $this->resolve_element_title( $node );
+
+			if ( null !== $title ) {
+				$skeleton['title'] = $title;
+			}
+
 			if ( ! empty( $node['elements'] ) ) {
 				$skeleton['elements'] = $node['elements'];
 			}
@@ -128,6 +135,63 @@ class Get_Structure_Ability extends Abstract_Ability {
 
 			return $skeleton;
 		} );
+	}
+
+	private function resolve_element_title( array $node ): ?string {
+		$editor_title = $node['editor_settings']['title'] ?? null;
+
+		if ( is_string( $editor_title ) && '' !== $editor_title ) {
+			return $editor_title;
+		}
+
+		$settings = $node['settings'] ?? [];
+
+		if ( is_array( $settings ) ) {
+			foreach ( [ '_title', 'presetTitle' ] as $key ) {
+				$plain = $this->extract_plain_string( $settings[ $key ] ?? null );
+
+				if ( null !== $plain ) {
+					return $plain;
+				}
+			}
+		}
+
+		$type = $node['widgetType'] ?? $node['elType'] ?? null;
+
+		if ( ! $type ) {
+			return null;
+		}
+
+		$instance = Atomic_Elements_Utils::get_element_instance( (string) $type );
+
+		if ( ! $instance ) {
+			return null;
+		}
+
+		$label = $instance->get_title();
+
+		if ( ! is_string( $label ) || '' === $label ) {
+			return null;
+		}
+
+		return $label;
+	}
+
+	private function extract_plain_string( $value ): ?string {
+		if ( is_string( $value ) && '' !== $value ) {
+			return $value;
+		}
+
+		if (
+			is_array( $value )
+			&& isset( $value['value'] )
+			&& is_string( $value['value'] )
+			&& '' !== $value['value']
+		) {
+			return $value['value'];
+		}
+
+		return null;
 	}
 
 	private function resolve_post_id( $input ) {

--- a/modules/mcp/abilities/get-structure-ability.php
+++ b/modules/mcp/abilities/get-structure-ability.php
@@ -3,7 +3,7 @@
 namespace Elementor\Modules\Mcp\Abilities;
 
 use Elementor\Modules\AtomicWidgets\Styles\Local_Style_Serializer;
-use Elementor\Modules\GlobalClasses\Utils\Atomic_Elements_Utils;
+use Elementor\Modules\AtomicWidgets\Utils\Element_Structure_Title;
 use Elementor\Plugin;
 use Elementor\Utils;
 
@@ -118,7 +118,7 @@ class Get_Structure_Ability extends Abstract_Ability {
 				$skeleton['widgetType'] = $node['widgetType'];
 			}
 
-			$title = $this->resolve_element_title( $node );
+			$title = Element_Structure_Title::resolve( $node );
 
 			if ( null !== $title ) {
 				$skeleton['title'] = $title;
@@ -135,63 +135,6 @@ class Get_Structure_Ability extends Abstract_Ability {
 
 			return $skeleton;
 		} );
-	}
-
-	private function resolve_element_title( array $node ): ?string {
-		$editor_title = $node['editor_settings']['title'] ?? null;
-
-		if ( is_string( $editor_title ) && '' !== $editor_title ) {
-			return $editor_title;
-		}
-
-		$settings = $node['settings'] ?? [];
-
-		if ( is_array( $settings ) ) {
-			foreach ( [ '_title', 'presetTitle' ] as $key ) {
-				$plain = $this->extract_plain_string( $settings[ $key ] ?? null );
-
-				if ( null !== $plain ) {
-					return $plain;
-				}
-			}
-		}
-
-		$type = $node['widgetType'] ?? $node['elType'] ?? null;
-
-		if ( ! $type ) {
-			return null;
-		}
-
-		$instance = Atomic_Elements_Utils::get_element_instance( (string) $type );
-
-		if ( ! $instance ) {
-			return null;
-		}
-
-		$label = $instance->get_title();
-
-		if ( ! is_string( $label ) || '' === $label ) {
-			return null;
-		}
-
-		return $label;
-	}
-
-	private function extract_plain_string( $value ): ?string {
-		if ( is_string( $value ) && '' !== $value ) {
-			return $value;
-		}
-
-		if (
-			is_array( $value )
-			&& isset( $value['value'] )
-			&& is_string( $value['value'] )
-			&& '' !== $value['value']
-		) {
-			return $value['value'];
-		}
-
-		return null;
 	}
 
 	private function resolve_post_id( $input ) {

--- a/packages/packages/core/editor-canvas/src/mcp/tools/get-page-structure/tool.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/tools/get-page-structure/tool.ts
@@ -17,7 +17,7 @@ export const initGetPageStructureTool = ( reg: MCPRegistryEntry ) => {
 	addTool( {
 		name: 'get-page-structure',
 		description:
-			'Returns a lean Elementor element tree skeleton (id, elType, widgetType, nested elements) for a post or page. ' +
+			'Returns a lean Elementor element tree skeleton (id, elType, widgetType, title, nested elements) for a post or page. ' +
 			'If no postId is provided, uses the currently open document. Optionally scope to a subtree with elementId. ' +
 			"Set includeContent=true (requires elementId) to also return each node's settings and styles.",
 		schema: {
@@ -42,7 +42,7 @@ export const initGetPageStructureTool = ( reg: MCPRegistryEntry ) => {
 			elements: z
 				.array( z.any() )
 				.describe(
-					'Skeleton of Elementor elements (id, elType, widgetType, nested elements). When includeContent is true, each node also includes settings and styles.'
+					'Skeleton of Elementor elements (id, elType, widgetType, title, nested elements). When includeContent is true, each node also includes settings and styles.'
 				),
 		},
 		handler: async ( { postId, elementId, includeContent } ) => {

--- a/tests/phpunit/elementor/modules/atomic-widgets/utils/test-element-structure-title.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/utils/test-element-structure-title.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\Utils;
+
+use Elementor\Modules\AtomicWidgets\Utils\Element_Structure_Title;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Element_Structure_Title extends TestCase {
+
+	public function test_resolve__returns_editor_settings_title() {
+		// Arrange.
+		$element = [
+			'elType' => 'widget',
+			'widgetType' => 'e-heading',
+			'editor_settings' => [ 'title' => 'Hero Section' ],
+		];
+
+		// Act.
+		$title = Element_Structure_Title::resolve( $element );
+
+		// Assert.
+		$this->assertSame( 'Hero Section', $title );
+	}
+
+	public function test_resolve__falls_back_to_title_setting() {
+		// Arrange.
+		$element = [
+			'elType' => 'widget',
+			'widgetType' => 'e-heading',
+			'settings' => [ '_title' => 'Legacy Custom Title' ],
+		];
+
+		// Act.
+		$title = Element_Structure_Title::resolve( $element );
+
+		// Assert.
+		$this->assertSame( 'Legacy Custom Title', $title );
+	}
+
+	public function test_resolve__falls_back_to_preset_title() {
+		// Arrange.
+		$element = [
+			'elType' => 'widget',
+			'widgetType' => 'e-heading',
+			'settings' => [ 'presetTitle' => 'Preset Title' ],
+		];
+
+		// Act.
+		$title = Element_Structure_Title::resolve( $element );
+
+		// Assert.
+		$this->assertSame( 'Preset Title', $title );
+	}
+
+	public function test_resolve__prefers_editor_settings_title_over_title_setting() {
+		// Arrange.
+		$element = [
+			'elType' => 'widget',
+			'widgetType' => 'e-heading',
+			'editor_settings' => [ 'title' => 'Editor Title' ],
+			'settings' => [ '_title' => 'Legacy Title' ],
+		];
+
+		// Act.
+		$title = Element_Structure_Title::resolve( $element );
+
+		// Assert.
+		$this->assertSame( 'Editor Title', $title );
+	}
+
+	public function test_resolve__extracts_title_from_envelope_setting() {
+		// Arrange.
+		$element = [
+			'elType' => 'widget',
+			'widgetType' => 'e-heading',
+			'settings' => [
+				'_title' => [
+					'$$type' => 'string',
+					'value' => 'Envelope Title',
+				],
+			],
+		];
+
+		// Act.
+		$title = Element_Structure_Title::resolve( $element );
+
+		// Assert.
+		$this->assertSame( 'Envelope Title', $title );
+	}
+
+	public function test_resolve__returns_null_when_no_title_sources_and_unknown_type() {
+		// Arrange.
+		$element = [
+			'elType' => 'widget',
+			'widgetType' => 'unknown-widget-type-xyz',
+		];
+
+		// Act.
+		$title = Element_Structure_Title::resolve( $element );
+
+		// Assert.
+		$this->assertNull( $title );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-get-structure-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-get-structure-ability.php
@@ -163,11 +163,13 @@ class Test_Get_Structure_Ability extends Elementor_Test_Base {
 				[
 					'id' => 'container1',
 					'elType' => 'container',
+					'title' => 'Container',
 					'elements' => [
 						[
 							'id' => 'widget1',
 							'elType' => 'widget',
 							'widgetType' => 'e-heading',
+							'title' => 'Heading',
 						],
 					],
 				],
@@ -207,7 +209,7 @@ class Test_Get_Structure_Ability extends Elementor_Test_Base {
 		// Assert
 		$this->assertSame(
 			[
-				[ 'id' => 'widget2', 'elType' => 'widget', 'widgetType' => 'e-button' ],
+				[ 'id' => 'widget2', 'elType' => 'widget', 'widgetType' => 'e-button', 'title' => 'Button' ],
 			],
 			$result['elements']
 		);
@@ -518,5 +520,165 @@ class Test_Get_Structure_Ability extends Elementor_Test_Base {
 		$this->assertArrayNotHasKey( '__custom_css', $styles );
 		$this->assertCount( 1, $styles['__variants'] );
 		$this->assertSame( 'mobile', $styles['__variants'][0]['meta']['breakpoint'] );
+	}
+
+	public function test_execute__includes_editor_settings_title_in_skeleton() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->factory()->post->create();
+
+		$elements = [
+			[
+				'id' => 'widget1',
+				'elType' => 'widget',
+				'widgetType' => 'e-heading',
+				'editor_settings' => [ 'title' => 'Hero Section' ],
+				'elements' => [],
+			],
+		];
+
+		$this->mock_document_with_elements( $post_id, $elements );
+
+		// Act
+		$result = $this->ability->execute( [ 'post_id' => $post_id ] );
+
+		// Assert
+		$this->assertSame( 'Hero Section', $result['elements'][0]['title'] );
+	}
+
+	public function test_execute__falls_back_to_title_setting() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->factory()->post->create();
+
+		$elements = [
+			[
+				'id' => 'widget1',
+				'elType' => 'widget',
+				'widgetType' => 'e-heading',
+				'settings' => [ '_title' => 'Legacy Custom Title' ],
+				'elements' => [],
+			],
+		];
+
+		$this->mock_document_with_elements( $post_id, $elements );
+
+		// Act
+		$result = $this->ability->execute( [ 'post_id' => $post_id ] );
+
+		// Assert
+		$this->assertSame( 'Legacy Custom Title', $result['elements'][0]['title'] );
+	}
+
+	public function test_execute__falls_back_to_preset_title() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->factory()->post->create();
+
+		$elements = [
+			[
+				'id' => 'widget1',
+				'elType' => 'widget',
+				'widgetType' => 'e-heading',
+				'settings' => [ 'presetTitle' => 'Preset Title' ],
+				'elements' => [],
+			],
+		];
+
+		$this->mock_document_with_elements( $post_id, $elements );
+
+		// Act
+		$result = $this->ability->execute( [ 'post_id' => $post_id ] );
+
+		// Assert
+		$this->assertSame( 'Preset Title', $result['elements'][0]['title'] );
+	}
+
+	public function test_execute__falls_back_to_widget_type_label() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->factory()->post->create();
+
+		$elements = [
+			[
+				'id' => 'widget1',
+				'elType' => 'widget',
+				'widgetType' => 'e-heading',
+				'elements' => [],
+			],
+		];
+
+		$this->mock_document_with_elements( $post_id, $elements );
+
+		// Act
+		$result = $this->ability->execute( [ 'post_id' => $post_id ] );
+
+		// Assert
+		$this->assertSame( 'Heading', $result['elements'][0]['title'] );
+	}
+
+	public function test_execute__prefers_editor_settings_title_over_title_setting() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->factory()->post->create();
+
+		$elements = [
+			[
+				'id' => 'widget1',
+				'elType' => 'widget',
+				'widgetType' => 'e-heading',
+				'editor_settings' => [ 'title' => 'Editor Title' ],
+				'settings' => [ '_title' => 'Legacy Title' ],
+				'elements' => [],
+			],
+		];
+
+		$this->mock_document_with_elements( $post_id, $elements );
+
+		// Act
+		$result = $this->ability->execute( [ 'post_id' => $post_id ] );
+
+		// Assert
+		$this->assertSame( 'Editor Title', $result['elements'][0]['title'] );
+	}
+
+	public function test_execute__extracts_title_from_envelope_setting() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->factory()->post->create();
+
+		$elements = [
+			[
+				'id' => 'widget1',
+				'elType' => 'widget',
+				'widgetType' => 'e-heading',
+				'settings' => [
+					'_title' => [
+						'$$type' => 'string',
+						'value' => 'Envelope Title',
+					],
+				],
+				'elements' => [],
+			],
+		];
+
+		$this->mock_document_with_elements( $post_id, $elements );
+
+		// Act
+		$result = $this->ability->execute( [ 'post_id' => $post_id ] );
+
+		// Assert
+		$this->assertSame( 'Envelope Title', $result['elements'][0]['title'] );
+	}
+
+	private function mock_document_with_elements( int $post_id, array $elements ): void {
+		$mock_document = $this->createMock( \Elementor\Core\Base\Document::class );
+		$mock_document->method( 'is_built_with_elementor' )->willReturn( true );
+		$mock_document->method( 'is_editable_by_current_user' )->willReturn( true );
+		$mock_document->method( 'get_elements_data' )->willReturn( $elements );
+
+		$mock_docs = $this->createMock( Documents_Manager::class );
+		$mock_docs->method( 'get' )->willReturn( $mock_document );
+		Plugin::$instance->documents = $mock_docs;
 	}
 }


### PR DESCRIPTION
## Summary
- Add a `title` field to each node returned by `elementor/get-page-structure`
- Resolve titles using the editor fallback chain: `editor_settings.title` → `_title` → `presetTitle` → widget/element type label
- Update MCP tool descriptions and add PHPUnit coverage for all resolution paths

## Test plan
- [x] `vendor/bin/phpunit --filter Test_Get_Structure_Ability` — 20 tests, 48 assertions, all passing
- [ ] Call `get-page-structure` on a page with renamed navigator labels and verify titles appear in the skeleton
- [ ] Confirm nodes without custom titles still receive widget type labels (e.g. "Heading", "Container")
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

MCP's get-page-structure ability didn't expose element titles, limiting client visibility into page hierarchy. This adds title resolution with priority fallback (editor settings → legacy _title → presetTitle → widget type label).

## 2. What Changed (Where)

- New utility class `Element_Structure_Title` resolves titles with cascading fallback logic
- `Get_Structure_Ability` integrates title resolution into skeleton generation
- Updated MCP ability definition and TypeScript tool schema to document title field
- Test coverage for all title resolution paths and integration scenarios

## 3. How It Works

When building the page skeleton, `resolve()` checks: (1) `editor_settings.title`, (2) `settings._title` or `settings.presetTitle` (extracting from envelope if nested), (3) instantiates widget by type and calls `get_title()`. Returns null if no source found. Title is conditionally added to skeleton only when non-null.

## 4. Risks

None identified—purely additive field, fallback is safe, test coverage is comprehensive. Backwards compatible since title is optional in output.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
