### PR TITLE
Fix: Render gradients when color-stop offset is missing [ED-24951]

### DIFF
--- a/modules/atomic-widgets/css-converter/value-parsers/background-image-value-parser.php
+++ b/modules/atomic-widgets/css-converter/value-parsers/background-image-value-parser.php
@@ -212,38 +212,65 @@ class Background_Image_Value_Parser {
 			return null;
 		}
 
-		$stops = [];
+		$parsed = [];
 
 		foreach ( $tokens as $token ) {
-			$stop = self::parse_color_stop( trim( $token ) );
+			$parts = self::parse_color_stop_parts( trim( $token ) );
 
-			if ( null === $stop ) {
+			if ( null === $parts ) {
 				return null;
 			}
 
-			$stops[] = $stop;
+			$parsed[] = $parts;
 		}
 
-		return $stops;
+		return self::build_color_stops_with_defaults( $parsed );
 	}
 
-	private static function parse_color_stop( string $token ): ?array {
+	private static function parse_color_stop_parts( string $token ): ?array {
 		$parts = Css_Token_Splitter::split_by_whitespace( $token );
 
 		if ( empty( $parts ) || count( $parts ) > 2 ) {
 			return null;
 		}
 
-		$stop_value = [ 'color' => Color_Prop_Type::generate( $parts[0] ) ];
+		$offset = null;
 
 		if ( isset( $parts[1] ) ) {
 			if ( ! preg_match( '/^(-?\d+(?:\.\d+)?)%$/', $parts[1], $m ) ) {
 				return null;
 			}
 
-			$stop_value['offset'] = Number_Prop_Type::generate( (float) $m[1] );
+			$offset = (float) $m[1];
 		}
 
-		return Color_Stop_Prop_Type::generate( $stop_value );
+		return [
+			'color' => $parts[0],
+			'offset' => $offset,
+		];
+	}
+
+	private static function build_color_stops_with_defaults( array $parsed ): array {
+		$count = count( $parsed );
+		$stops = [];
+
+		foreach ( $parsed as $index => $part ) {
+			$offset = $part['offset'] ?? self::default_offset_for_index( $index, $count );
+
+			$stops[] = Color_Stop_Prop_Type::generate( [
+				'color' => Color_Prop_Type::generate( $part['color'] ),
+				'offset' => Number_Prop_Type::generate( $offset ),
+			] );
+		}
+
+		return $stops;
+	}
+
+	private static function default_offset_for_index( int $index, int $count ): float {
+		if ( $count <= 1 ) {
+			return 0.0;
+		}
+
+		return ( $index / ( $count - 1 ) ) * 100;
 	}
 }

--- a/modules/atomic-widgets/props-resolver/transformers/styles/color-stop-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/styles/color-stop-transformer.php
@@ -12,8 +12,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Color_Stop_Transformer extends Transformer_Base {
 	public function transform( $value, Props_Resolver_Context $context ): string {
 		$color = $value['color'];
-		$offset = $value['offset'] . '%';
+		$offset = $value['offset'] ?? null;
 
-		return $color . ' ' . $offset;
+		if ( null === $offset || '' === $offset ) {
+			return (string) $color;
+		}
+
+		return $color . ' ' . $offset . '%';
 	}
 }

--- a/packages/packages/libs/editor-controls/src/controls/background-control/background-gradient-color-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/background-control/background-gradient-color-control.tsx
@@ -64,9 +64,9 @@ export const BackgroundGradientColorControl = createControl( () => {
 		return {
 			type: type.value,
 			angle: angle?.value || 0,
-			stops: stops.value.map( ( { value: { color, offset } }: ColorStop ) => ( {
+			stops: stops.value.map( ( { value: { color, offset } }: ColorStop, index: number, arr: ColorStop[] ) => ( {
 				color: color.value,
-				offset: offset.value,
+				offset: offset?.value ?? ( arr.length > 1 ? ( index / ( arr.length - 1 ) ) * 100 : 0 ),
 			} ) ),
 			positions: positions?.value.split( ' ' ),
 		};

--- a/packages/packages/libs/editor-controls/src/controls/background-control/background-overlay/background-overlay-repeater-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/background-control/background-overlay/background-overlay-repeater-control.tsx
@@ -305,7 +305,9 @@ const getGradientValue = ( value: BackgroundOverlayItemPropValue ) => {
 	const gradient = value.value;
 
 	const stops = gradient.stops.value
-		?.map( ( { value: { color, offset } }: ColorStop ) => `${ color.value } ${ offset.value ?? 0 }%` )
+		?.map( ( { value: { color, offset } }: ColorStop ) =>
+			offset ? `${ color.value } ${ offset.value ?? 0 }%` : `${ color.value }`
+		)
 		?.join( ',' );
 
 	if ( gradient.type.value === 'linear' ) {

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/value-parsers/test-background-image-value-parser.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/value-parsers/test-background-image-value-parser.php
@@ -124,4 +124,58 @@ class Test_Background_Image_Value_Parser extends TestCase {
 		// Assert.
 		$this->assertNull( $result );
 	}
+
+	public function test_parse__linear_gradient_without_stop_offsets_auto_distributes_two_stops() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'linear-gradient(135deg, #ff0000, #0000ff)' );
+
+		// Assert: CSS spec — first stop defaults to 0%, last to 100%.
+		$stops = $result[0]['value']['stops']['value'];
+		$this->assertCount( 2, $stops );
+		$this->assertSame( 0.0, $stops[0]['value']['offset']['value'] );
+		$this->assertSame( 100.0, $stops[1]['value']['offset']['value'] );
+	}
+
+	public function test_parse__linear_gradient_without_stop_offsets_auto_distributes_three_stops() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'linear-gradient(#ff0000, #00ff00, #0000ff)' );
+
+		// Assert: middle stop is placed evenly between first (0%) and last (100%).
+		$stops = $result[0]['value']['stops']['value'];
+		$this->assertCount( 3, $stops );
+		$this->assertSame( 0.0, $stops[0]['value']['offset']['value'] );
+		$this->assertSame( 50.0, $stops[1]['value']['offset']['value'] );
+		$this->assertSame( 100.0, $stops[2]['value']['offset']['value'] );
+	}
+
+	public function test_parse__linear_gradient_preserves_explicit_offsets_when_present() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'linear-gradient(#ff0000 10%, #0000ff 80%)' );
+
+		// Assert: explicit offsets are not overwritten by defaults.
+		$stops = $result[0]['value']['stops']['value'];
+		$this->assertSame( 10.0, $stops[0]['value']['offset']['value'] );
+		$this->assertSame( 80.0, $stops[1]['value']['offset']['value'] );
+	}
+
+	public function test_parse__linear_gradient_fills_only_missing_offsets_in_mixed_stops() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'linear-gradient(#ff0000, #00ff00 25%, #0000ff)' );
+
+		// Assert: explicit interior offset preserved; ends filled from index.
+		$stops = $result[0]['value']['stops']['value'];
+		$this->assertSame( 0.0, $stops[0]['value']['offset']['value'] );
+		$this->assertSame( 25.0, $stops[1]['value']['offset']['value'] );
+		$this->assertSame( 100.0, $stops[2]['value']['offset']['value'] );
+	}
+
+	public function test_parse__radial_gradient_without_stop_offsets_auto_distributes() {
+		// Act.
+		$result = Background_Image_Value_Parser::parse( 'radial-gradient(circle at center, #ff0000, #0000ff)' );
+
+		// Assert.
+		$stops = $result[0]['value']['stops']['value'];
+		$this->assertSame( 0.0, $stops[0]['value']['offset']['value'] );
+		$this->assertSame( 100.0, $stops[1]['value']['offset']['value'] );
+	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/props-resolver/transformers/styles/test-color-stop-transformer.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/props-resolver/transformers/styles/test-color-stop-transformer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\PropsResolver\Transformers\Styles;
+
+use Elementor\Modules\AtomicWidgets\PropsResolver\Props_Resolver_Context;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Styles\Color_Stop_Transformer;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Color_Stop_Transformer extends TestCase {
+	private Color_Stop_Transformer $transformer;
+	private Props_Resolver_Context $context;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->transformer = new Color_Stop_Transformer();
+		$this->context = Props_Resolver_Context::make();
+	}
+
+	public function test_transform__with_offset_emits_color_and_percent() {
+		// Act.
+		$result = $this->transformer->transform( [
+			'color' => '#ff0000',
+			'offset' => 25,
+		], $this->context );
+
+		// Assert.
+		$this->assertSame( '#ff0000 25%', $result );
+	}
+
+	public function test_transform__with_null_offset_emits_color_only() {
+		// Act.
+		$result = $this->transformer->transform( [
+			'color' => '#ff0000',
+			'offset' => null,
+		], $this->context );
+
+		// Assert: valid CSS — browser distributes stops automatically.
+		$this->assertSame( '#ff0000', $result );
+	}
+
+	public function test_transform__with_missing_offset_key_emits_color_only() {
+		// Act.
+		$result = $this->transformer->transform( [
+			'color' => '#ff0000',
+		], $this->context );
+
+		// Assert.
+		$this->assertSame( '#ff0000', $result );
+	}
+
+	public function test_transform__with_zero_offset_emits_zero_percent() {
+		// Act.
+		$result = $this->transformer->transform( [
+			'color' => '#ff0000',
+			'offset' => 0,
+		], $this->context );
+
+		// Assert: 0 is a valid position and must be preserved.
+		$this->assertSame( '#ff0000 0%', $result );
+	}
+}


### PR DESCRIPTION
## Summary

CSS allows gradients without explicit stop positions (e.g. `linear-gradient(135deg, red, blue)`) — the browser distributes stops evenly. The atomic-widgets pipeline assumed `offset` was always present, so offset-less color stops broke both frontend rendering and the editor UI.

**Reproduction:** any `background: linear-gradient(<angle>, <color>, <color>)` value (as commonly generated by the MCP composition builder) produced:
- Frontend: `Color_Stop_Transformer` emitted `<color> %` (invalid CSS) → browser dropped the whole gradient.
- Editor: `ItemIconGradient` in the background-overlay repeater crashed destructuring `offset.value` on `undefined`, tripping the repeater's `ErrorBoundary`.
- Editor: opening the gradient popover crashed the same way in `normalizeValue`.

## Fix (three targeted changes)

- **Source (parser):** `Background_Image_Value_Parser` now assigns evenly-distributed default offsets (0%, 100%, interior evenly) at parse time, so newly-generated PropValues are always well-formed.
- **Frontend transformer:** `Color_Stop_Transformer` omits the position when `offset` is null/absent — valid CSS, browser auto-distributes.
- **Editor guards:** `getGradientValue` (`ItemIconGradient`) and `normalizeValue` (`BackgroundGradientColorControl`) tolerate missing `offset` so pre-existing content no longer crashes; the popover falls back to evenly-distributed defaults.

## Test plan

- [ ] Build the composition from the MCP composition builder (or any existing content) containing `background: linear-gradient(<angle>, <color>, <color>)` without explicit stop positions.
- [ ] Verify the gradient renders correctly on the frontend.
- [ ] Verify the background-overlay item icon in the editor renders without triggering an error boundary.
- [ ] Verify opening the gradient popover shows both stops with the auto-distributed offsets (0 and 100 for two stops).
- [ ] Verify a gradient authored with explicit stop positions (e.g. `linear-gradient(90deg, red 10%, blue 80%)`) still round-trips unchanged.


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

CSS gradients with missing color-stop offsets were failing to render. The fix implements automatic offset distribution per CSS spec (first stop 0%, last 100%, intermediate stops evenly spaced) while preserving explicit offsets when present.

## 2. What Changed (Where)

- **background-image-value-parser.php**: Refactored color-stop parsing into three functions—`parse_color_stop_parts()` extracts color/offset pair, `build_color_stops_with_defaults()` injects missing offsets, `default_offset_for_index()` calculates even distribution.
- **color-stop-transformer.php**: Handles null offsets by emitting color-only (valid CSS, browser auto-distributes).
- **Test coverage**: Added 5 parser tests (2/3-stop distribution, mixed explicit/implicit offsets, radial gradient), 4 transformer tests (offset presence/absence edge cases).
- **Frontend gradient builders**: Updated to compute default offsets during serialization when offset is null/undefined.

## 3. How It Works

Parser collects raw color-stop tokens with optional offsets, defers offset resolution to `build_color_stops_with_defaults()`. For each stop: use explicit offset if present, else compute `(index / (count-1)) * 100` (handles single-stop edge case as 0%). Transformer outputs `color offset%` or bare `color` when offset is null, delegating to browser's default distribution algorithm.

## 4. Risks

Behavioral change: gradients with implicit offsets now produce valid CSS instead of failing silently. Existing explicit offsets unaffected. Frontend serialization mirrors backend logic (index-based distribution), but slight risk of client/server offset divergence if one path misses an update. Mitigate: tests validate both layers.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
