### PR TITLE
Fix: Correct duplicate-title detection operator precedence in Save_Components_Validator

### DIFF
--- a/modules/components/save-components-validator.php
+++ b/modules/components/save-components-validator.php
@@ -61,7 +61,7 @@ class Save_Components_Validator {
 				$is_title_exists = $this->components->some(
 					fn ( $component ) => ! $component['is_archived'] && $component['title'] === $title
 				) || $data->filter(
-					fn ( $component ) => ! $component['title'] === $title
+					fn ( $component ) => $component['title'] === $title
 				)->count() > 1;
 
 				if ( $is_title_exists ) {

--- a/tests/phpunit/elementor/modules/components/test-save-components-validator.php
+++ b/tests/phpunit/elementor/modules/components/test-save-components-validator.php
@@ -188,7 +188,7 @@ class Test_Save_Components_Validator extends Elementor_Test_Base {
 
 		// Assert
 		$this->assertFalse( $result['success'], 'Validation should fail when two components in the same batch share a title' );
-		$this->assertContains( "Component title 'Duplicate Title' is duplicated.", $result['messages'] );
+		$this->assertContains( "Component title &#039;Duplicate Title&#039; is duplicated.", $result['messages'] );
 	}
 
 	public function test_validate_duplicated_values__passes_when_titles_are_unique() {

--- a/tests/phpunit/elementor/modules/components/test-save-components-validator.php
+++ b/tests/phpunit/elementor/modules/components/test-save-components-validator.php
@@ -166,6 +166,56 @@ class Test_Save_Components_Validator extends Elementor_Test_Base {
 		$this->assertEmpty( $result['messages'] );
 	}
 
+	public function test_validate_duplicated_values__fails_when_two_new_components_share_a_title() {
+		// Arrange
+		$existing_components = Collection::make( [] );
+		$new_components = Collection::make( [
+			[
+				'uid' => 'new-component-1',
+				'title' => 'Duplicate Title',
+				'elements' => [],
+			],
+			[
+				'uid' => 'new-component-2',
+				'title' => 'Duplicate Title',
+				'elements' => [],
+			],
+		] );
+
+		// Act
+		$validator = Save_Components_Validator::make( $existing_components );
+		$result = $validator->validate( $new_components );
+
+		// Assert
+		$this->assertFalse( $result['success'], 'Validation should fail when two components in the same batch share a title' );
+		$this->assertContains( "Component title 'Duplicate Title' is duplicated.", $result['messages'] );
+	}
+
+	public function test_validate_duplicated_values__passes_when_titles_are_unique() {
+		// Arrange
+		$existing_components = Collection::make( [] );
+		$new_components = Collection::make( [
+			[
+				'uid' => 'new-component-1',
+				'title' => 'First Title',
+				'elements' => [],
+			],
+			[
+				'uid' => 'new-component-2',
+				'title' => 'Second Title',
+				'elements' => [],
+			],
+		] );
+
+		// Act
+		$validator = Save_Components_Validator::make( $existing_components );
+		$result = $validator->validate( $new_components );
+
+		// Assert
+		$this->assertTrue( $result['success'], 'Validation should pass when all titles in the batch are unique' );
+		$this->assertEmpty( $result['messages'] );
+	}
+
 	// Helpers
 	private function create_mock_components( int $count, bool $is_archived = false ): array {
 		$components = [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`Save_Components_Validator::validate_duplicated_values()` checks for duplicate component titles two ways: against existing (non-archived) components, and within the batch of components being submitted in the same request. The within-batch check has an operator-precedence bug:

```php
$data->filter(
    fn ( $component ) => ! $component['title'] === $title
)->count() > 1;
```

PHP's `!` binds tighter than `===`, so this evaluates as `( ! $component['title'] ) === $title` — a boolean compared to a string with strict equality, which is never `true`. The within-batch duplicate-title check has been silently dead code: submitting two components with the same title in a single save request was never flagged.

## Fix

Removes the stray `!`, matching the pattern already used two lines below for the uid-duplicate check (`fn ( $component ) => $component['uid'] === $uid`).

## Tests

Added two PHPUnit cases to `test-save-components-validator.php`:
- `test_validate_duplicated_values__fails_when_two_new_components_share_a_title` — fails against the pre-fix code (the bug), passes after the fix.
- `test_validate_duplicated_values__passes_when_titles_are_unique` — regression guard.

**Not run in this environment** — no `composer`/`vendor` available here. Please confirm in CI that the new test fails on the pre-fix code and passes after.

Found while fact-checking the v4 docs plan against source. Tracked in [ED-25069](https://elementor.atlassian.net/browse/ED-25069).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b21e1e9-fc27-4896-9e4d-6ae8fd9fee1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b21e1e9-fc27-4896-9e4d-6ae8fd9fee1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ED-25069]: https://elementor.atlassian.net/browse/ED-25069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ