### PR TITLE
Internal: Fix preview url [ED-24995]

### DIFF
--- a/modules/mcp/abilities/build-composition-ability.php
+++ b/modules/mcp/abilities/build-composition-ability.php
@@ -19,6 +19,7 @@ use Elementor\Modules\Mcp\Abilities\Build_Composition\Style_Applier;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Subtree_Builder;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Widget_Type_Resolver;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser;
+use Elementor\Modules\Mcp\Abilities\Utils\Document_Mutation_Links;
 use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
 use Elementor\Modules\Variables\Module as Variables_Module;
 use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
@@ -163,7 +164,7 @@ class Build_Composition_Ability extends Abstract_Ability {
 	private function get_output_schema(): array {
 		return [
 			'type' => 'object',
-			'required' => [ 'success', 'post_id', 'root_element_ids', 'preview_url', 'version' ],
+			'required' => [ 'success', 'post_id', 'root_element_ids', 'preview_url', 'render_url', 'llm_instructions', 'version' ],
 			'properties' => [
 				'success' => [ 'type' => 'boolean' ],
 				'post_id' => [ 'type' => 'integer' ],
@@ -172,18 +173,13 @@ class Build_Composition_Ability extends Abstract_Ability {
 					'items' => [ 'type' => 'string' ],
 					'description' => 'IDs of the created root-level elements.',
 				],
-				'preview_url' => [
-					'type' => 'string',
-					'format' => 'uri',
-				],
+				'preview_url' => Document_Mutation_Links::preview_schema_property(),
+				'render_url' => Document_Mutation_Links::render_schema_property(),
+				'llm_instructions' => Document_Mutation_Links::llm_instructions_schema_property(),
 				'version' => [ 'type' => 'string' ],
 				'resolved_xml' => [
 					'type' => 'string',
 					'description' => 'The XML with element IDs embedded.',
-				],
-				'llm_instructions' => [
-					'type' => 'string',
-					'description' => 'Next-step instructions for the LLM.',
 				],
 				'warnings' => [
 					'type' => 'array',
@@ -317,11 +313,13 @@ class Build_Composition_Ability extends Abstract_Ability {
 			'success' => true,
 			'post_id' => $post_id,
 			'root_element_ids' => $root_ids,
-			'preview_url' => $document->get_preview_url(),
 			'version' => $post ? $post->post_modified_gmt : current_time( 'mysql', true ),
 			'resolved_xml' => $xml_parser->serialize_children( $dom ),
-			'llm_instructions' => __( 'The composition was built successfully. Reload the editor to see the result.', 'elementor' ),
-		];
+		] + Document_Mutation_Links::for_document(
+			$document,
+			null,
+			__( 'The composition was built successfully.', 'elementor' )
+		);
 
 		if ( ! empty( $warnings ) ) {
 			$response['warnings'] = $warnings;

--- a/modules/mcp/abilities/create-page-ability.php
+++ b/modules/mcp/abilities/create-page-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\Mcp\Abilities\Utils\Document_Mutation_Links;
 use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -24,6 +25,9 @@ class Create_Page_Ability extends Abstract_Ability {
 				'properties' => [
 					'id' => [ 'type' => 'integer' ],
 					'edit_url' => [ 'type' => 'string' ],
+					'preview_url' => Document_Mutation_Links::preview_schema_property(),
+					'render_url' => Document_Mutation_Links::render_schema_property(),
+					'llm_instructions' => Document_Mutation_Links::llm_instructions_schema_property(),
 					'status' => [ 'type' => 'string' ],
 					'type' => [ 'type' => 'string' ],
 				],
@@ -132,6 +136,10 @@ class Create_Page_Ability extends Abstract_Ability {
 			'edit_url' => $document->get_edit_url(),
 			'status' => get_post_status( $post_id ),
 			'type' => $post_type,
-		];
+		] + Document_Mutation_Links::for_document(
+			$document,
+			null,
+			__( 'Page created successfully.', 'elementor' )
+		);
 	}
 }

--- a/modules/mcp/abilities/manage-elements-ability.php
+++ b/modules/mcp/abilities/manage-elements-ability.php
@@ -17,6 +17,7 @@ use Elementor\Modules\Mcp\Abilities\Build_Composition\Element_Config_Applier;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Style_Applier;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Widget_Type_Resolver;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser;
+use Elementor\Modules\Mcp\Abilities\Utils\Document_Mutation_Links;
 use Elementor\Modules\Variables\Module as Variables_Module;
 use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
 use Elementor\Modules\Variables\Services\Variables_Service;
@@ -46,11 +47,14 @@ class Manage_Elements_Ability extends Abstract_Ability {
 			'elementor',
 			[
 				'type' => 'object',
-				'required' => [ 'status' ],
+				'required' => [ 'status', 'preview_url', 'render_url', 'llm_instructions' ],
 				'properties' => [
 					'status' => [ 'type' => 'string' ],
 					'post_id' => [ 'type' => 'integer' ],
 					'element_id' => [ 'type' => 'string' ],
+					'preview_url' => Document_Mutation_Links::preview_schema_property(),
+					'render_url' => Document_Mutation_Links::render_schema_property(),
+					'llm_instructions' => Document_Mutation_Links::llm_instructions_schema_property(),
 					'version' => [ 'type' => 'string' ],
 					'warnings' => [
 						'type' => 'array',
@@ -286,7 +290,7 @@ class Manage_Elements_Ability extends Abstract_Ability {
 			'post_id' => (int) $document->get_main_id(),
 			'element_id' => $element_id,
 			'version' => $post ? $post->post_modified_gmt : current_time( 'mysql', true ),
-		];
+		] + Document_Mutation_Links::for_document( $document, $element_id );
 
 		if ( ! empty( $warnings ) ) {
 			$response['warnings'] = $warnings;

--- a/modules/mcp/abilities/render-page-ability.php
+++ b/modules/mcp/abilities/render-page-ability.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities;
+
+use Elementor\Modules\Mcp\Abilities\Utils\Document_Renderer;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Render_Page_Ability extends Abstract_Ability {
+
+	protected function get_ability_id(): string {
+		return 'elementor/render-page';
+	}
+
+	protected function get_definition(): Ability_Definition {
+		return new Ability_Definition(
+			__( 'Render Elementor Page', 'elementor' ),
+			__( 'Returns server-rendered HTML and plain text for a document or element subtree. Use after mutating tools to verify the visual result with MCP credentials instead of opening preview_url in a browser.', 'elementor' ),
+			'elementor',
+			[
+				'type' => 'object',
+				'required' => [ 'post_id', 'html', 'text' ],
+				'properties' => [
+					'post_id' => [ 'type' => 'integer' ],
+					'element_id' => [ 'type' => [ 'string', 'null' ] ],
+					'html' => [ 'type' => 'string' ],
+					'text' => [ 'type' => 'string' ],
+				],
+			],
+			[
+				'annotations' => [
+					'readonly' => true,
+					'idempotent' => true,
+					'destructive' => false,
+				],
+			],
+			fn() => current_user_can( 'edit_posts' ),
+			[
+				'type' => 'object',
+				'required' => [ 'post_id' ],
+				'properties' => [
+					'post_id' => [
+						'type' => 'integer',
+						'description' => 'WordPress post ID of the Elementor document.',
+					],
+					'element_id' => [
+						'type' => 'string',
+						'description' => 'Optional element id to render only that subtree.',
+					],
+					'text_limit' => [
+						'type' => 'integer',
+						'description' => 'Optional maximum length of the returned plain-text excerpt.',
+					],
+				],
+			]
+		);
+	}
+
+	public function execute( $input = [] ) {
+		$input = is_array( $input ) ? $input : [];
+		$post_id = isset( $input['post_id'] ) ? absint( $input['post_id'] ) : 0;
+
+		if ( ! $post_id ) {
+			return new \WP_Error(
+				'invalid_post_id',
+				__( 'A valid post_id is required.', 'elementor' ),
+				[ 'status' => \WP_Http::BAD_REQUEST ]
+			);
+		}
+
+		$element_id = isset( $input['element_id'] ) && is_string( $input['element_id'] ) && '' !== $input['element_id']
+			? $input['element_id']
+			: null;
+		$text_limit = isset( $input['text_limit'] ) ? absint( $input['text_limit'] ) : null;
+		$text_limit = $text_limit > 0 ? $text_limit : null;
+
+		return ( new Document_Renderer() )->render( $post_id, $element_id, $text_limit );
+	}
+}

--- a/modules/mcp/abilities/update-settings-ability.php
+++ b/modules/mcp/abilities/update-settings-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\Mcp\Abilities\Utils\Document_Mutation_Links;
 use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -24,6 +25,9 @@ class Update_Settings_Ability extends Abstract_Ability {
 				'properties' => [
 					'success' => [ 'type' => 'boolean' ],
 					'post_id' => [ 'type' => 'integer' ],
+					'preview_url' => Document_Mutation_Links::preview_schema_property(),
+					'render_url' => Document_Mutation_Links::render_schema_property(),
+					'llm_instructions' => Document_Mutation_Links::llm_instructions_schema_property(),
 				],
 			],
 			[
@@ -85,6 +89,10 @@ class Update_Settings_Ability extends Abstract_Ability {
 		return [
 			'success' => true,
 			'post_id' => $post_id,
-		];
+		] + Document_Mutation_Links::for_document(
+			$document,
+			null,
+			__( 'Page settings updated successfully.', 'elementor' )
+		);
 	}
 }

--- a/modules/mcp/abilities/utils/document-mutation-links.php
+++ b/modules/mcp/abilities/utils/document-mutation-links.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Core\Base\Document;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Document_Mutation_Links {
+
+	public static function preview_schema_property(): array {
+		return Document_Preview_Url::output_schema_property();
+	}
+
+	public static function render_schema_property(): array {
+		return Document_Render_Url::output_schema_property();
+	}
+
+	public static function llm_instructions_schema_property(): array {
+		return [
+			'type' => 'string',
+			'description' => 'Mandatory next step: include this text (with the preview link) in your reply to the user.',
+		];
+	}
+
+	public static function for_document( Document $document, ?string $element_id = null, ?string $success_message = null ): array {
+		$post_id = (int) $document->get_main_id();
+		$preview_url = Document_Preview_Url::for_document( $document );
+		$render_url = Document_Render_Url::for_post( $post_id, $element_id );
+
+		return [
+			'preview_url' => $preview_url,
+			'render_url' => $render_url,
+			'llm_instructions' => self::build_llm_instructions( $preview_url, $success_message ),
+		];
+	}
+
+	private static function build_llm_instructions( string $preview_url, ?string $success_message = null ): string {
+		$prefix = $success_message ?? __( 'Change saved.', 'elementor' );
+
+		return sprintf(
+			/* translators: 1: Success message, 2: Preview URL the LLM must share with the user. */
+			__( '%1$s You MUST show the human this preview link in your reply (they must be logged into WordPress as an editor): %2$s Fetch render_url with MCP credentials to verify the rendered result yourself.', 'elementor' ),
+			$prefix,
+			$preview_url
+		);
+	}
+}

--- a/modules/mcp/abilities/utils/document-preview-html.php
+++ b/modules/mcp/abilities/utils/document-preview-html.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Document_Preview_Html {
+
+	public function wrap( int $post_id, string $html, string $css, array $fonts = [] ): string {
+		$html = trim( $html );
+		$css = trim( $css );
+
+		if ( '' === $html && '' === $css ) {
+			return '';
+		}
+
+		$head = $this->build_head( $css, $fonts );
+		$body = sprintf(
+			'<div class="elementor elementor-%1$d">%2$s</div>',
+			$post_id,
+			$html
+		);
+
+		return '<!DOCTYPE html><html><head><meta charset="utf-8">' . $head . '</head><body>' . $body . '</body></html>';
+	}
+
+	private function build_head( string $css, array $fonts ): string {
+		$output = '';
+
+		if ( ! empty( $fonts ) ) {
+			$font_url = Plugin::$instance->frontend->get_stable_google_fonts_url( $fonts );
+
+			$output .= sprintf(
+				'<link rel="stylesheet" href="%s">',
+				esc_url( $font_url )
+			);
+		}
+
+		if ( '' !== $css ) {
+			$output .= '<style>' . $css . '</style>';
+		}
+
+		return $output;
+	}
+}

--- a/modules/mcp/abilities/utils/document-preview-html.php
+++ b/modules/mcp/abilities/utils/document-preview-html.php
@@ -29,21 +29,15 @@ class Document_Preview_Html {
 	}
 
 	private function build_head( string $css, array $fonts ): string {
-		$output = '';
-
 		if ( ! empty( $fonts ) ) {
 			$font_url = Plugin::$instance->frontend->get_stable_google_fonts_url( $fonts );
-
-			$output .= sprintf(
-				'<link rel="stylesheet" href="%s">',
-				esc_url( $font_url )
-			);
+			$css = '@import url("' . esc_url( $font_url ) . '");' . $css;
 		}
 
-		if ( '' !== $css ) {
-			$output .= '<style>' . $css . '</style>';
+		if ( '' === $css ) {
+			return '';
 		}
 
-		return $output;
+		return '<style>' . $css . '</style>';
 	}
 }

--- a/modules/mcp/abilities/utils/document-preview-styles.php
+++ b/modules/mcp/abilities/utils/document-preview-styles.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Core\Base\Document;
+use Elementor\Core\Breakpoints\Breakpoint;
+use Elementor\Core\Utils\Collection;
+use Elementor\Modules\AtomicWidgets\Styles\Atomic_Widget_Styles;
+use Elementor\Modules\AtomicWidgets\Styles\Styles_Renderer;
+use Elementor\Modules\AtomicWidgets\Utils\Utils as Atomic_Utils;
+use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
+use Elementor\Modules\GlobalClasses\Global_Classes_Relations;
+use Elementor\Modules\GlobalClasses\Utils\Atomic_Elements_Utils;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Document_Preview_Styles {
+
+	private const DEFAULT_BREAKPOINT = 'desktop';
+
+	private array $fonts = [];
+
+	public function collect( Document $document ): string {
+		$this->fonts = [];
+
+		$post_id = $document->get_main_id();
+		$css_chunks = [
+			$this->get_static_css(),
+			$this->render_style_set( $this->get_base_styles() ),
+			$this->render_style_set( $this->get_local_styles( $document ) ),
+			$this->render_style_set( $this->get_global_styles( $post_id ) ),
+			$this->get_design_system_css(),
+		];
+
+		return implode( '', array_filter( $css_chunks ) );
+	}
+
+	public function get_collected_fonts(): array {
+		return array_values( array_unique( $this->fonts ) );
+	}
+
+	private function get_static_css(): string {
+		return '.e-heading-base a, .e-paragraph-base a { all: unset; cursor: pointer; }'
+			. 'form[data-element_type="e-form"].form-state-success [data-element_type="e-form-success-message"],'
+			. 'form[data-element_type="e-form"].form-state-error [data-element_type="e-form-error-message"]'
+			. '{ display: block; }';
+	}
+
+	private function get_base_styles(): array {
+		$elements = Plugin::$instance->elements_manager->get_element_types();
+		$widgets = Plugin::$instance->widgets_manager->get_widget_types();
+
+		return Collection::make( $elements )
+			->merge( $widgets )
+			->filter( fn( $element ) => Atomic_Utils::is_atomic( $element ) )
+			->map( fn( $element ) => $element->get_base_styles() )
+			->flatten()
+			->all();
+	}
+
+	private function get_local_styles( Document $document ): array {
+		$post_styles = [];
+		$elements = $document->get_elements_data();
+
+		if ( empty( $elements ) ) {
+			return [];
+		}
+
+		Plugin::$instance->db->iterate_data(
+			$elements,
+			function ( array $element_data ) use ( &$post_styles ) {
+				$post_styles = array_merge( $post_styles, $this->parse_element_styles( $element_data ) );
+			}
+		);
+
+		return Atomic_Widget_Styles::get_license_based_filtered_styles( $post_styles );
+	}
+
+	private function parse_element_styles( array $element_data ): array {
+		$element_type = Atomic_Elements_Utils::get_element_type( $element_data );
+		$element_instance = Atomic_Elements_Utils::get_element_instance( $element_type );
+
+		if ( ! Atomic_Utils::is_atomic( $element_instance ) ) {
+			return [];
+		}
+
+		return $element_data['styles'] ?? [];
+	}
+
+	private function get_global_styles( int $post_id ): array {
+		$aggregate_ids = $this->get_aggregate_post_ids( $post_id );
+
+		$class_ids = [];
+		$relations = ( new Global_Classes_Relations() )->set_preview( true );
+
+		foreach ( $aggregate_ids as $aggregate_id ) {
+			$class_ids = array_merge( $class_ids, $relations->get_styles_by_post( $aggregate_id ) );
+		}
+
+		$class_ids = array_values( array_unique( $class_ids ) );
+
+		if ( empty( $class_ids ) ) {
+			return [];
+		}
+
+		$repository = Global_Classes_Repository::make()->set_preview( true );
+		$global_order = $repository->all_labels();
+		$ordered_class_ids = array_values( array_intersect( array_keys( $global_order ), $class_ids ) );
+
+		if ( empty( $ordered_class_ids ) ) {
+			return [];
+		}
+
+		$items = $repository->get_by_ids( $ordered_class_ids );
+		$styles = [];
+
+		foreach ( array_reverse( $ordered_class_ids ) as $class_id ) {
+			$item = $items[ $class_id ] ?? null;
+
+			if ( ! $item ) {
+				continue;
+			}
+
+			$resolved_label = $global_order[ $class_id ] ?? $item['label'];
+			$item['id'] = $resolved_label;
+			$item['label'] = $resolved_label;
+			$styles[] = $item;
+		}
+
+		return $styles;
+	}
+
+	private function get_aggregate_post_ids( int $post_id ): array {
+		$parent_to_embedded = [];
+		$visited = [];
+
+		$this->resolve_embedded_post_descendants( $post_id, $parent_to_embedded, $visited );
+
+		$embedded_ids = $parent_to_embedded[ $post_id ] ?? [];
+
+		return array_values( array_unique( array_merge( [ $post_id ], $embedded_ids ) ) );
+	}
+
+	private function resolve_embedded_post_descendants( int $post_id, array &$parent_to_embedded, array &$visited ): array {
+		if ( isset( $visited[ $post_id ] ) ) {
+			return $parent_to_embedded[ $post_id ] ?? [];
+		}
+
+		$visited[ $post_id ] = true;
+
+		$related = (array) apply_filters( 'elementor/document/related_posts', [], $post_id );
+		$related = array_values( array_unique( array_map( 'intval', array_filter( $related, 'is_numeric' ) ) ) );
+
+		$all_related = $related;
+
+		foreach ( $related as $related_post ) {
+			$further_related = $this->resolve_embedded_post_descendants( $related_post, $parent_to_embedded, $visited );
+			$all_related = array_values( array_unique( array_merge( $all_related, $further_related ) ) );
+		}
+
+		$parent_to_embedded[ $post_id ] = $all_related;
+
+		return $all_related;
+	}
+
+	private function get_design_system_css(): string {
+		if ( ! class_exists( '\Elementor\Modules\DesignSystemSync\Classes\Stylesheet_Manager' ) ) {
+			return '';
+		}
+
+		$manager = new \Elementor\Modules\DesignSystemSync\Classes\Stylesheet_Manager();
+		$method = new \ReflectionMethod( $manager, 'parse_content' );
+		$method->setAccessible( true );
+
+		return (string) $method->invoke( $manager );
+	}
+
+	private function render_style_set( array $styles ): string {
+		if ( empty( $styles ) ) {
+			return '';
+		}
+
+		$grouped_styles = $this->group_by_breakpoint( $styles );
+		$css = '';
+
+		foreach ( $this->get_breakpoints() as $breakpoint_key ) {
+			$breakpoint_styles = array_values( $grouped_styles[ $breakpoint_key ] ?? [] );
+
+			if ( empty( $breakpoint_styles ) ) {
+				continue;
+			}
+
+			$css .= Styles_Renderer::make(
+				Plugin::$instance->breakpoints->get_breakpoints_config()
+			)->on_font_enqueue( function ( string $font ) {
+				$this->fonts[] = $font;
+			} )->render( $breakpoint_styles );
+		}
+
+		return $css;
+	}
+
+	private function group_by_breakpoint( array $styles ): array {
+		return Collection::make( $styles )->reduce(
+			function ( array $group, array $style ) {
+				Collection::make( $style['variants'] ?? [] )->each(
+					function ( array $variant ) use ( &$group, $style ) {
+						$breakpoint = $variant['meta']['breakpoint'] ?? self::DEFAULT_BREAKPOINT;
+
+						if ( ! isset( $group[ $breakpoint ][ $style['id'] ] ) ) {
+							$group[ $breakpoint ][ $style['id'] ] = [
+								'id' => $style['id'],
+								'type' => $style['type'],
+								'variants' => [],
+							];
+						}
+
+						$group[ $breakpoint ][ $style['id'] ]['variants'][] = $variant;
+					}
+				);
+
+				return $group;
+			},
+			[]
+		);
+	}
+
+	private function get_breakpoints(): array {
+		return Collection::make( Plugin::$instance->breakpoints->get_breakpoints() )
+			->map( fn( Breakpoint $breakpoint ) => $breakpoint->get_name() )
+			->reverse()
+			->prepend( self::DEFAULT_BREAKPOINT )
+			->all();
+	}
+}

--- a/modules/mcp/abilities/utils/document-preview-url.php
+++ b/modules/mcp/abilities/utils/document-preview-url.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Core\Base\Document;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Document_Preview_Url {
+
+	public static function output_schema_property(): array {
+		return [
+			'type' => 'string',
+			'format' => 'uri',
+			'description' => 'Human preview URL. Open in a browser while logged into WordPress as an editor; relies on session cookies, not preview_nonce.',
+		];
+	}
+
+	public static function for_document( Document $document ): string {
+		return remove_query_arg( 'preview_nonce', $document->get_wp_preview_url() );
+	}
+}

--- a/modules/mcp/abilities/utils/document-render-url.php
+++ b/modules/mcp/abilities/utils/document-render-url.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Document_Render_Url {
+
+	public static function output_schema_property(): array {
+		return [
+			'type' => 'string',
+			'format' => 'uri',
+			'description' => 'Authenticated REST URL that returns rendered HTML and text for LLM verification. Fetch with the same MCP credentials.',
+		];
+	}
+
+	public static function for_post( int $post_id, ?string $element_id = null ): string {
+		$url = rest_url( 'elementor/v1/mcp/documents/' . $post_id . '/render' );
+
+		if ( null !== $element_id && '' !== $element_id ) {
+			$url = add_query_arg( 'element_id', $element_id, $url );
+		}
+
+		return $url;
+	}
+}

--- a/modules/mcp/abilities/utils/document-renderer.php
+++ b/modules/mcp/abilities/utils/document-renderer.php
@@ -81,7 +81,6 @@ class Document_Renderer {
 	}
 
 	private function resolve_preview_document( int $post_id ) {
-		$user_id = get_current_user_id();
 		$main = Plugin::$instance->documents->get( $post_id );
 
 		if ( ! $main ) {
@@ -92,12 +91,10 @@ class Document_Renderer {
 			);
 		}
 
-		if ( $main->get_autosave_id( $user_id ) ) {
-			$autosave = $main->get_autosave( $user_id );
+		$newer_autosave = $main->get_newer_autosave();
 
-			if ( $autosave ) {
-				return $autosave;
-			}
+		if ( $newer_autosave ) {
+			return $newer_autosave;
 		}
 
 		$status = get_post_status( $post_id );

--- a/modules/mcp/abilities/utils/document-renderer.php
+++ b/modules/mcp/abilities/utils/document-renderer.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Core\Base\Document;
+use Elementor\Core\Frontend\Widget_Content_Render_Mode;
+use Elementor\Plugin;
+use Elementor\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Document_Renderer {
+
+	const DEFAULT_TEXT_LIMIT = 8000;
+
+	private const DRAFT_STATUSES = [ 'draft', 'pending', 'auto-draft', 'future' ];
+
+	public function render( int $post_id, ?string $element_id = null, ?int $text_limit = null ) {
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return new \WP_Error(
+				'rest_cannot_view',
+				__( 'Sorry, you are not allowed to access this document.', 'elementor' ),
+				[ 'status' => \WP_Http::FORBIDDEN ]
+			);
+		}
+
+		$document = $this->resolve_preview_document( $post_id );
+
+		if ( is_wp_error( $document ) ) {
+			return $document;
+		}
+
+		if ( ! $document->is_built_with_elementor() ) {
+			return new \WP_Error(
+				'not_elementor',
+				__( 'This post is not built with Elementor.', 'elementor' ),
+				[ 'status' => \WP_Http::BAD_REQUEST ]
+			);
+		}
+
+		$elements = $document->get_elements_data();
+		$elements = is_array( $elements ) ? $elements : [];
+
+		if ( null !== $element_id && '' !== $element_id ) {
+			$subtree = Utils::find_element_recursive( $elements, $element_id );
+
+			if ( ! $subtree ) {
+				return new \WP_Error(
+					'element_not_found',
+					__( 'Element not found in this document.', 'elementor' ),
+					[ 'status' => \WP_Http::NOT_FOUND ]
+				);
+			}
+
+			$elements = [ $subtree ];
+		}
+
+		$html = Widget_Content_Render_Mode::execute_as(
+			Widget_Content_Render_Mode::MARKDOWN,
+			fn() => $this->render_elements( $document, $elements, $post_id )
+		);
+
+		$styles_collector = new Document_Preview_Styles();
+		$css = $styles_collector->collect( $document );
+		$html = ( new Document_Preview_Html() )->wrap(
+			$post_id,
+			$html,
+			$css,
+			$styles_collector->get_collected_fonts()
+		);
+		$text = $this->html_to_text( $html, $text_limit ?? self::DEFAULT_TEXT_LIMIT );
+
+		return [
+			'post_id' => $post_id,
+			'element_id' => $element_id,
+			'html' => $html,
+			'text' => $text,
+		];
+	}
+
+	private function resolve_preview_document( int $post_id ) {
+		$user_id = get_current_user_id();
+		$main = Plugin::$instance->documents->get( $post_id );
+
+		if ( ! $main ) {
+			return new \WP_Error(
+				'document_not_found',
+				__( 'Document not found.', 'elementor' ),
+				[ 'status' => \WP_Http::NOT_FOUND ]
+			);
+		}
+
+		if ( $main->get_autosave_id( $user_id ) ) {
+			$autosave = $main->get_autosave( $user_id );
+
+			if ( $autosave ) {
+				return $autosave;
+			}
+		}
+
+		$status = get_post_status( $post_id );
+
+		if ( in_array( $status, self::DRAFT_STATUSES, true ) ) {
+			return $main;
+		}
+
+		return new \WP_Error(
+			'no_draft_preview',
+			__( 'No draft preview is available for this document.', 'elementor' ),
+			[ 'status' => \WP_Http::NOT_FOUND ]
+		);
+	}
+
+	private function render_elements( Document $document, array $elements, int $post_id ): string {
+		$editor = Plugin::$instance->editor;
+		$is_edit_mode = $editor->is_edit_mode();
+		$editor->set_edit_mode( true );
+
+		Plugin::$instance->db->switch_to_query( [
+			'p' => $post_id,
+			'post_type' => 'any',
+		], true );
+
+		Plugin::$instance->documents->switch_to_document( $document );
+
+		do_action( 'elementor/atomic_widgets/before_render', $document );
+
+		$output = '';
+
+		try {
+			foreach ( $elements as $element_data ) {
+				$instance = Plugin::$instance->elements_manager->create_element_instance( $element_data );
+
+				if ( ! $instance ) {
+					continue;
+				}
+
+				ob_start();
+				$instance->print_element();
+				$output .= ob_get_clean() . "\n";
+			}
+		} finally {
+			do_action( 'elementor/atomic_widgets/after_render', $document );
+			Plugin::$instance->documents->restore_document();
+			$editor->set_edit_mode( $is_edit_mode );
+			Plugin::$instance->db->restore_current_query();
+		}
+
+		return trim( $output );
+	}
+
+	private function html_to_text( string $html, int $limit ): string {
+		$text = wp_strip_all_tags( $html );
+		$text = preg_replace( '/\s+/u', ' ', $text );
+		$text = trim( (string) $text );
+
+		if ( strlen( $text ) > $limit ) {
+			$text = substr( $text, 0, $limit );
+		}
+
+		return $text;
+	}
+}

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\Mcp;
 
 use Elementor\Core\Base\Module as BaseModule;
+use Elementor\Modules\Mcp\RestApi\Document_Render_REST_API;
 use Elementor\Modules\Mcp\RestApi\Mcp_Proxy_REST_API;
 use WP\MCP\Core\McpAdapter;
 
@@ -25,6 +26,7 @@ class Module extends BaseModule {
 		parent::__construct();
 
 		( new Mcp_Proxy_REST_API() )->register_hooks();
+		( new Document_Render_REST_API() )->register_hooks();
 
 		if ( ! $this->is_active() ) {
 			return;
@@ -56,6 +58,7 @@ class Module extends BaseModule {
 			return;
 		}
 
+		( new Abilities\Render_Page_Ability() )->register();
 		( new Abilities\Get_Structure_Ability() )->register();
 		( new Abilities\Update_Settings_Ability() )->register();
 		( new Abilities\Create_Page_Ability() )->register();
@@ -90,6 +93,7 @@ class Module extends BaseModule {
 			\WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler::class,
 			\WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class,
 			[
+				'elementor/render-page',
 				'elementor/get-page-structure',
 				'elementor/update-page-settings',
 				'elementor/create-page',

--- a/modules/mcp/rest-api/document-render-rest-api.php
+++ b/modules/mcp/rest-api/document-render-rest-api.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Elementor\Modules\Mcp\RestApi;
+
+use Elementor\Core\Utils\Api\Error_Builder;
+use Elementor\Core\Utils\Api\Response_Builder;
+use Elementor\Modules\Mcp\Abilities\Utils\Document_Renderer;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Document_Render_REST_API {
+	const API_NAMESPACE = 'elementor/v1';
+	const API_BASE = 'mcp/documents/(?P<post_id>\d+)/render';
+
+	public function register_hooks() {
+		add_action( 'rest_api_init', fn() => $this->register_routes() );
+	}
+
+	private function register_routes() {
+		register_rest_route( self::API_NAMESPACE, '/' . self::API_BASE, [
+			'methods' => 'GET',
+			'callback' => fn( \WP_REST_Request $request ) => $this->route_wrapper( fn() => $this->handle_render( $request ) ),
+			'permission_callback' => fn( \WP_REST_Request $request ) => current_user_can( 'edit_post', (int) $request->get_param( 'post_id' ) ),
+			'args' => [
+				'post_id' => [
+					'type' => 'integer',
+					'required' => true,
+				],
+				'element_id' => [
+					'type' => 'string',
+					'required' => false,
+				],
+				'text_limit' => [
+					'type' => 'integer',
+					'required' => false,
+				],
+			],
+		] );
+	}
+
+	private function handle_render( \WP_REST_Request $request ) {
+		$post_id = (int) $request->get_param( 'post_id' );
+		$element_id = $request->get_param( 'element_id' );
+		$element_id = is_string( $element_id ) && '' !== $element_id ? $element_id : null;
+		$text_limit = $request->get_param( 'text_limit' );
+		$text_limit = null !== $text_limit ? (int) $text_limit : null;
+
+		$result = ( new Document_Renderer() )->render( $post_id, $element_id, $text_limit );
+
+		return $this->build_response( $result );
+	}
+
+	private function build_response( $result ) {
+		if ( is_wp_error( $result ) ) {
+			$data = $result->get_error_data();
+			$status = is_array( $data ) && isset( $data['status'] ) ? $data['status'] : 400;
+
+			return Error_Builder::make( $result->get_error_code() )
+				->set_status( $status )
+				->set_message( $result->get_error_message() )
+				->build();
+		}
+
+		return Response_Builder::make( $result )->build();
+	}
+
+	private function route_wrapper( callable $cb ) {
+		try {
+			return $cb();
+		} catch ( \Exception $e ) {
+			return Error_Builder::make( 'unexpected_error' )
+				->set_message( __( 'Something went wrong', 'elementor' ) )
+				->build();
+		}
+	}
+}

--- a/modules/mcp/rest-api/mcp-proxy-rest-api.php
+++ b/modules/mcp/rest-api/mcp-proxy-rest-api.php
@@ -15,6 +15,7 @@ use Elementor\Modules\Mcp\Abilities\List_Widget_Schemas_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Classes_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Elements_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Variable_Ability;
+use Elementor\Modules\Mcp\Abilities\Render_Page_Ability;
 use Elementor\Modules\Mcp\Abilities\Read_Resource_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Variable_Guide_Ability;
 use Elementor\Modules\Mcp\Abilities\Style_Best_Practices_Ability;
@@ -38,6 +39,7 @@ class Mcp_Proxy_REST_API {
 			'list-widget-schemas' => fn( array $input ) => ( new List_Widget_Schemas_Ability() )->execute( $input ),
 			'list-dynamic-tags' => fn( array $input ) => ( new List_Dynamic_Tags_Ability() )->execute( $input ),
 			'build-composition' => fn( array $input ) => ( new Build_Composition_Ability() )->execute( $input ),
+			'render-page' => fn( array $input ) => ( new Render_Page_Ability() )->execute( $input ),
 			'get-page-structure' => fn( array $input ) => ( new Get_Structure_Ability() )->execute( $input ),
 			'manage-elements' => fn( array $input ) => ( new Manage_Elements_Ability() )->execute( $input ),
 			'list-resources' => fn( array $input ) => ( new List_Resources_Ability() )->execute( $input ),

--- a/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
@@ -148,7 +148,7 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		$this->assertStringContainsString( $result['preview_url'], $result['llm_instructions'] );
 		$this->assertStringNotContainsString( 'preview_nonce=', $result['preview_url'] );
 		$this->assertStringContainsString( 'preview=true', $result['preview_url'] );
-		$this->assertStringContainsString( '/mcp/documents/' . $post_id . '/render', $result['render_url'] );
+		$this->assertStringContainsString( '/mcp/documents/' . $post_id . '/render', urldecode( $result['render_url'] ) );
 		$this->assertNotEmpty( $result['warnings'] );
 		$this->assertStringContainsString( 'custom_css', implode( ' ', $result['warnings'] ) );
 

--- a/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
@@ -142,6 +142,13 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		$this->assertIsArray( $result, 'Expected success array but got: ' . ( is_wp_error( $result ) ? $result->get_error_message() : 'unknown' ) );
 		$this->assertTrue( $result['success'] );
 		$this->assertCount( 1, $result['root_element_ids'] );
+		$this->assertArrayHasKey( 'preview_url', $result );
+		$this->assertArrayHasKey( 'render_url', $result );
+		$this->assertArrayHasKey( 'llm_instructions', $result );
+		$this->assertStringContainsString( $result['preview_url'], $result['llm_instructions'] );
+		$this->assertStringNotContainsString( 'preview_nonce=', $result['preview_url'] );
+		$this->assertStringContainsString( 'preview=true', $result['preview_url'] );
+		$this->assertStringContainsString( '/mcp/documents/' . $post_id . '/render', $result['render_url'] );
 		$this->assertNotEmpty( $result['warnings'] );
 		$this->assertStringContainsString( 'custom_css', implode( ' ', $result['warnings'] ) );
 

--- a/tests/phpunit/elementor/modules/mcp/test-create-page-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-create-page-ability.php
@@ -81,6 +81,7 @@ class Test_Create_Page_Ability extends Elementor_Test_Base {
 
 		$mock_document = $this->createMock( \Elementor\Core\Base\Document::class );
 		$mock_document->method( 'get_edit_url' )->willReturn( 'https://example.com/edit/1' );
+		$mock_document->method( 'get_wp_preview_url' )->willReturn( 'https://example.com/?p=1&preview_id=1&preview_nonce=abc&preview=true' );
 
 		$mock_docs = $this->createMock( Documents_Manager::class );
 		$mock_docs->method( 'get' )->willReturn( $mock_document );
@@ -93,6 +94,13 @@ class Test_Create_Page_Ability extends Elementor_Test_Base {
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'id', $result );
 		$this->assertArrayHasKey( 'edit_url', $result );
+		$this->assertArrayHasKey( 'preview_url', $result );
+		$this->assertArrayHasKey( 'render_url', $result );
+		$this->assertArrayHasKey( 'llm_instructions', $result );
+		$this->assertStringContainsString( $result['preview_url'], $result['llm_instructions'] );
+		$this->assertStringNotContainsString( 'preview_nonce=', $result['preview_url'] );
+		$this->assertStringContainsString( 'preview=true', $result['preview_url'] );
+		$this->assertStringContainsString( '/mcp/documents/', $result['render_url'] );
 		$this->assertArrayHasKey( 'status', $result );
 		$this->assertArrayHasKey( 'type', $result );
 		$this->assertSame( 'page', $result['type'] );
@@ -107,6 +115,7 @@ class Test_Create_Page_Ability extends Elementor_Test_Base {
 
 		$mock_document = $this->createMock( \Elementor\Core\Base\Document::class );
 		$mock_document->method( 'get_edit_url' )->willReturn( 'https://example.com/edit/1' );
+		$mock_document->method( 'get_wp_preview_url' )->willReturn( 'https://example.com/?p=1&preview_id=1&preview_nonce=abc&preview=true' );
 
 		$mock_docs = $this->createMock( Documents_Manager::class );
 		$mock_docs->method( 'get' )->willReturnCallback( function ( $post_id ) use ( &$captured_post_id, $mock_document ) {

--- a/tests/phpunit/elementor/modules/mcp/test-create-page-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-create-page-ability.php
@@ -100,7 +100,7 @@ class Test_Create_Page_Ability extends Elementor_Test_Base {
 		$this->assertStringContainsString( $result['preview_url'], $result['llm_instructions'] );
 		$this->assertStringNotContainsString( 'preview_nonce=', $result['preview_url'] );
 		$this->assertStringContainsString( 'preview=true', $result['preview_url'] );
-		$this->assertStringContainsString( '/mcp/documents/', $result['render_url'] );
+		$this->assertStringContainsString( '/mcp/documents/', urldecode( $result['render_url'] ) );
 		$this->assertArrayHasKey( 'status', $result );
 		$this->assertArrayHasKey( 'type', $result );
 		$this->assertSame( 'page', $result['type'] );

--- a/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
@@ -126,6 +126,15 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 
 		$this->assertNoErrors( $result );
 
+		$this->assertArrayHasKey( 'preview_url', $result );
+		$this->assertArrayHasKey( 'render_url', $result );
+		$this->assertArrayHasKey( 'llm_instructions', $result );
+		$this->assertStringContainsString( $result['preview_url'], $result['llm_instructions'] );
+		$this->assertStringNotContainsString( 'preview_nonce=', $result['preview_url'] );
+		$this->assertStringContainsString( 'preview=true', $result['preview_url'] );
+		$this->assertStringContainsString( '/mcp/documents/' . $post_id . '/render', $result['render_url'] );
+		$this->assertStringContainsString( 'element_id=' . $root_id, $result['render_url'] );
+
 		$this->assertNull( $this->find_element_in_document( $post_id, $root_id ) );
 	}
 

--- a/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
@@ -132,7 +132,7 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertStringContainsString( $result['preview_url'], $result['llm_instructions'] );
 		$this->assertStringNotContainsString( 'preview_nonce=', $result['preview_url'] );
 		$this->assertStringContainsString( 'preview=true', $result['preview_url'] );
-		$this->assertStringContainsString( '/mcp/documents/' . $post_id . '/render', $result['render_url'] );
+		$this->assertStringContainsString( '/mcp/documents/' . $post_id . '/render', urldecode( $result['render_url'] ) );
 		$this->assertStringContainsString( 'element_id=' . $root_id, $result['render_url'] );
 
 		$this->assertNull( $this->find_element_in_document( $post_id, $root_id ) );

--- a/tests/phpunit/elementor/modules/mcp/test-render-page-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-render-page-ability.php
@@ -4,7 +4,6 @@ namespace Elementor\Tests\Phpunit\Modules\Mcp;
 
 use Elementor\Modules\Mcp\Abilities\Build_Composition_Ability;
 use Elementor\Modules\Mcp\Abilities\Render_Page_Ability;
-use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -15,6 +14,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @group Elementor\Modules\Mcp
  */
 class Test_Render_Page_Ability extends Elementor_Test_Base {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_scripts, $wp_styles;
+		$wp_scripts = new \WP_Scripts();
+		$wp_styles = new \WP_Styles();
+	}
 
 	public function test_execute__returns_rendered_text_for_document() {
 		$this->act_as_admin();
@@ -94,5 +101,9 @@ class Test_Render_Page_Ability extends Elementor_Test_Base {
 		$this->assertIsArray( $result );
 
 		return $result['root_element_ids'][0];
+	}
+
+	private function create_real_document(): int {
+		return $this->factory()->create_and_get_default_post()->ID;
 	}
 }

--- a/tests/phpunit/elementor/modules/mcp/test-render-page-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-render-page-ability.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp;
+
+use Elementor\Modules\Mcp\Abilities\Build_Composition_Ability;
+use Elementor\Modules\Mcp\Abilities\Render_Page_Ability;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @group Elementor\Modules\Mcp
+ */
+class Test_Render_Page_Ability extends Elementor_Test_Base {
+
+	public function test_execute__returns_rendered_text_for_document() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+
+		( new Build_Composition_Ability() )->execute( [
+			'post_id' => $post_id,
+			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'element_config' => [
+				'h1' => [
+					'title' => [
+						'content' => 'Render Snapshot Heading',
+						'children' => [],
+					],
+				],
+			],
+		] );
+
+		$result = ( new Render_Page_Ability() )->execute( [
+			'post_id' => $post_id,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertNotEmpty( $result['html'] );
+		$this->assertStringContainsString( '<style>', $result['html'] );
+		$this->assertStringContainsString( 'Render Snapshot Heading', $result['text'] );
+		$this->assertStringContainsString( 'Render Snapshot Heading', $result['html'] );
+	}
+
+	public function test_execute__rejects_published_document_without_draft() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+
+		wp_update_post( [
+			'ID' => $post_id,
+			'post_status' => 'publish',
+		] );
+
+		$result = ( new Render_Page_Ability() )->execute( [
+			'post_id' => $post_id,
+		] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'no_draft_preview', $result->get_error_code() );
+	}
+
+	public function test_execute__scopes_render_to_element_id() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		$root_id = $this->given_heading_on_document( $post_id, 'Scoped Heading Text' );
+
+		$result = ( new Render_Page_Ability() )->execute( [
+			'post_id' => $post_id,
+			'element_id' => $root_id,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $root_id, $result['element_id'] );
+		$this->assertStringContainsString( 'Scoped Heading Text', $result['text'] );
+	}
+
+	private function given_heading_on_document( int $post_id, string $title ): string {
+		$result = ( new Build_Composition_Ability() )->execute( [
+			'post_id' => $post_id,
+			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'element_config' => [
+				'h1' => [
+					'title' => [
+						'content' => $title,
+						'children' => [],
+					],
+				],
+			],
+		] );
+
+		$this->assertIsArray( $result );
+
+		return $result['root_element_ids'][0];
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-update-settings-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-update-settings-ability.php
@@ -144,7 +144,7 @@ class Test_Update_Settings_Ability extends Elementor_Test_Base {
 		$this->assertStringContainsString( $result['preview_url'], $result['llm_instructions'] );
 		$this->assertStringNotContainsString( 'preview_nonce=', $result['preview_url'] );
 		$this->assertStringContainsString( 'preview=true', $result['preview_url'] );
-		$this->assertStringContainsString( '/mcp/documents/', $result['render_url'] );
+		$this->assertStringContainsString( '/mcp/documents/', urldecode( $result['render_url'] ) );
 	}
 
 	public function test_execute__passes_settings_to_document_save() {

--- a/tests/phpunit/elementor/modules/mcp/test-update-settings-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-update-settings-ability.php
@@ -125,6 +125,7 @@ class Test_Update_Settings_Ability extends Elementor_Test_Base {
 		$mock_document = $this->createMock( \Elementor\Core\Base\Document::class );
 		$mock_document->method( 'is_editable_by_current_user' )->willReturn( true );
 		$mock_document->method( 'save' )->willReturn( true );
+		$mock_document->method( 'get_wp_preview_url' )->willReturn( 'https://example.com/?p=1&preview_id=1&preview_nonce=abc&preview=true' );
 
 		$mock_docs = $this->createMock( Documents_Manager::class );
 		$mock_docs->method( 'get' )->willReturn( $mock_document );
@@ -137,6 +138,13 @@ class Test_Update_Settings_Ability extends Elementor_Test_Base {
 		$this->assertIsArray( $result );
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertArrayHasKey( 'preview_url', $result );
+		$this->assertArrayHasKey( 'render_url', $result );
+		$this->assertArrayHasKey( 'llm_instructions', $result );
+		$this->assertStringContainsString( $result['preview_url'], $result['llm_instructions'] );
+		$this->assertStringNotContainsString( 'preview_nonce=', $result['preview_url'] );
+		$this->assertStringContainsString( 'preview=true', $result['preview_url'] );
+		$this->assertStringContainsString( '/mcp/documents/', $result['render_url'] );
 	}
 
 	public function test_execute__passes_settings_to_document_save() {


### PR DESCRIPTION
Co-authored-by: Cursor <cursoragent@cursor.com>

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Preview URLs were being returned with preview nonces, which fail when fetched via MCP credentials. Extracted URL generation logic into reusable utility to standardize preview/render URLs and LLM instructions across mutation abilities (ED-24995).

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `document-mutation-links.php` | New utility centralizes preview_url, render_url, llm_instructions generation |
| `document-preview-url.php` | New utility strips preview_nonce from preview URLs |
| `document-render-url.php` | New REST endpoint URL builder for MCP render calls |
| `document-renderer.php` | New server-side HTML/text renderer for documents/elements |
| `render-page-ability.php` | New ability wraps Document_Renderer |
| `build-composition-ability.php` | Updated schema, response uses Document_Mutation_Links |
| `create-page-ability.php`, `update-settings-ability.php`, `manage-elements-ability.php` | Same pattern: schema updated, responses merged with mutation links |
| `document-render-rest-api.php` | New REST route for /mcp/documents/{id}/render |
| Test files | Added assertions for preview_url, render_url, llm_instructions presence |

## 3. How It Works

When mutation completes → `Document_Mutation_Links::for_document()` merges three fields into response: (1) preview_url strips nonce, relies on session cookies; (2) render_url points to REST endpoint for MCP-authenticated verification; (3) llm_instructions embeds preview link with mandatory user-facing text. New Render_Page_Ability invokes Document_Renderer to server-render HTML/text for element subtrees, used for post-mutation verification without browser.

## 4. Risks

URL generation now centralized—single point of failure for all mutation responses. REST render endpoint added without apparent rate limiting or caching; could strain on large documents. Schema updates require LLM consumer adaptation; llm_instructions is now mandatory in responses.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
