### PR TITLE
Fix: MCP Style_Applier creates duplicate local styles on subsequent updates [ED-25035]

### DIFF
--- a/modules/mcp/abilities/build-composition/style-applier.php
+++ b/modules/mcp/abilities/build-composition/style-applier.php
@@ -13,7 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Style_Applier {
 
 	const LOCAL_STYLE_ID_PREFIX = 'e-';
-	const LOCAL_STYLE_MARKER_PREFIX = 's-';
 	const DESKTOP_BREAKPOINT = 'desktop';
 	const LOCAL_STYLE_LABEL = 'local';
 	const LOCAL_STYLE_TYPE = 'class';
@@ -212,7 +211,7 @@ class Style_Applier {
 
 	private function find_existing_local_style_id( array $node ): ?string {
 		foreach ( $node['styles'] ?? [] as $style_id => $_style ) {
-			if ( str_starts_with( $style_id, self::LOCAL_STYLE_MARKER_PREFIX ) ) {
+			if ( str_starts_with( (string) $style_id, self::LOCAL_STYLE_ID_PREFIX ) ) {
 				return $style_id;
 			}
 		}

--- a/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
@@ -349,6 +349,40 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertSame( 'elementor_invalid_settings', $result->get_error_code() );
 	}
 
+	public function test_update__style_merges_into_existing_local_style_from_build_composition() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+
+		$build_result = ( new Build_Composition_Ability() )->execute( [
+			'post_id' => $post_id,
+			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'parent_id' => 'document',
+			'style' => [ 'h1' => [ 'color' => '#ff0000' ] ],
+		] );
+		$this->assertIsArray( $build_result, 'build-composition failed: ' . ( is_wp_error( $build_result ) ? $build_result->get_error_message() : 'unknown' ) );
+		$this->assertTrue( $build_result['success'] ?? false );
+		$heading_id = $build_result['root_element_ids'][0];
+
+		$update_result = ( new Manage_Elements_Ability() )->execute( [
+			'action' => 'update',
+			'post_id' => $post_id,
+			'element_id' => $heading_id,
+			'style' => [ 'font-size' => '24px' ],
+		] );
+		$this->assertNoErrors( $update_result );
+
+		$node = $this->find_element_in_document( $post_id, $heading_id );
+		$this->assertNotNull( $node );
+
+		$this->assertCount( 1, $node['styles'] ?? [], 'Expected a single local style entry, got: ' . wp_json_encode( array_keys( $node['styles'] ?? [] ) ) );
+		$this->assertCount( 1, $node['settings']['classes']['value'] ?? [], 'Expected settings.classes.value to hold a single local style id.' );
+
+		$style = reset( $node['styles'] );
+		$desktop_variant = $style['variants'][0] ?? [];
+		$this->assertArrayHasKey( 'color', $desktop_variant['props'] ?? [] );
+		$this->assertArrayHasKey( 'font-size', $desktop_variant['props'] ?? [] );
+	}
+
 	private function assertNoErrors( $result ): void {
 		$this->assertIsArray( $result, 'Expected success but got: ' . ( is_wp_error( $result ) ? $result->get_error_message() : 'unknown' ) );
 		$this->assertSame( 'ok', $result['status'] );


### PR DESCRIPTION
## Summary

Fixes [ED-25035](https://elementor.atlassian.net/browse/ED-25035): using `elementor/build-composition` followed by `elementor/manage-elements` (or a second `build-composition`) with a `style` block on the same element produced **two separate local styles** on the element instead of merging into the existing one.

## Root cause

`Style_Applier` used two constants that did not agree:

```php
const LOCAL_STYLE_ID_PREFIX     = 'e-';   // used to generate ids
const LOCAL_STYLE_MARKER_PREFIX = 's-';   // used to detect existing local styles
```

`find_existing_local_style_id()` searched `node['styles']` for a key starting with `'s-'`, but the ids it (and the editor client's `createElementStyle` at `packages/packages/libs/editor-elements/src/styles/create-element-style.ts`) generate always start with `'e-'`. So the lookup always returned `null`, `apply_conversion_to_node()` fell through to the "create new" branch, and a fresh local style id was pushed into `settings.classes.value` each time.

Introduced in the original build-composition ability commit (`92529c6e53`, ED-24826); never actually worked.

## Fix

- Use `LOCAL_STYLE_ID_PREFIX` in `find_existing_local_style_id()` (single source of truth).
- Remove the unused `LOCAL_STYLE_MARKER_PREFIX` constant.

## Reproduction / verification

Live-verified against a local Elementor document (post 37307):

Before the fix (from post 37304):
```json
"classes": { "value": ["e-702ab5bb-d971", "e-164966fc-a94b"] },
"styles":  { "e-702ab5bb-d971": { "color": "#ff0000" }, "e-164966fc-a94b": { "font-size": 24px } }
```

After the fix:
```json
"classes": { "value": ["e-142fa79a-c9c2"] },
"styles":  { "e-142fa79a-c9c2": { "props": { "color": "#ff0000", "font-size": 24px } } }
```

## Test plan

- [x] New PHPUnit test `test_update__style_merges_into_existing_local_style_from_build_composition` in `tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php` asserts a single local style entry, a single id in `classes.value`, and that both properties end up on the desktop variant.
- [x] Live MCP reproduction confirmed pre-fix (duplicate style) and post-fix (merged).
- [x] `phpcs` clean on the changed files.
- [ ] CI runs full PHP/JS test suites.

## Ref

ED-25035

Made with [Cursor](https://cursor.com)

[ED-25035]: https://elementor.atlassian.net/browse/ED-25035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Subsequent style updates on MCP-created elements duplicated local styles instead of merging into the existing one. The marker was checking `LOCAL_STYLE_MARKER_PREFIX` ('s-') instead of `LOCAL_STYLE_ID_PREFIX` ('e-'), causing new local styles to be created on each update rather than reusing the existing one.

## 2. What Changed (Where)

- `style-applier.php`: Removed unused `LOCAL_STYLE_MARKER_PREFIX` constant; fixed `find_existing_local_style_id()` to check correct prefix and cast `$style_id` to string.
- Test file: Added comprehensive test validating that multiple updates merge into single local style entry.

## 3. How It Works

The fix corrects the style lookup logic to match how local styles are actually prefixed ('e-' not 's-'). When updating an element, `find_existing_local_style_id()` now correctly identifies and reuses the existing local style rather than creating duplicates on subsequent calls.

## 4. Risks

None. The prefix constant removal and logic correction are straightforward; test coverage validates the fix prevents regression.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
