### PR TITLE
Feature: Bulk operations for elementor/manage-elements MCP ability [ED-24951]

### DIFF
--- a/modules/mcp/abilities/manage-elements-ability.php
+++ b/modules/mcp/abilities/manage-elements-ability.php
@@ -17,6 +17,7 @@ use Elementor\Modules\Mcp\Abilities\Build_Composition\Element_Config_Applier;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Style_Applier;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Widget_Type_Resolver;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser;
+use Elementor\Modules\Mcp\Abilities\Utils\Bulk_Operations_Result;
 use Elementor\Modules\Variables\Module as Variables_Module;
 use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
 use Elementor\Modules\Variables\Services\Variables_Service;
@@ -28,6 +29,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Manage_Elements_Ability extends Abstract_Ability {
+
+	const MAX_BATCH_SIZE = 50;
 
 	private ?Document_Mutator $mutator;
 
@@ -42,20 +45,16 @@ class Manage_Elements_Ability extends Abstract_Ability {
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Manage Elements', 'elementor' ),
-			__( 'Surgical edits on existing V4 elements in a document. action=update merges partial plain settings, raw-CSS style, and global class labels; action=delete removes the element; action=move re-parents it under new_parent_id at optional index; action=duplicate clones the element (with fresh ids) right after the source.', 'elementor' ),
+			__( 'Bulk surgical edits on existing V4 elements in a document (up to 50 operations applied to a single document tree, saved once). Each operation: action=update merges partial plain settings, raw-CSS style, and global class labels; action=delete removes the element; action=move re-parents it under new_parent_id at optional index; action=duplicate clones the element (with fresh ids) right after the source.', 'elementor' ),
 			'elementor',
 			[
 				'type' => 'object',
-				'required' => [ 'status' ],
+				'required' => [ 'status', 'results', 'post_id' ],
 				'properties' => [
 					'status' => [ 'type' => 'string' ],
+					'results' => [ 'type' => 'array' ],
 					'post_id' => [ 'type' => 'integer' ],
-					'element_id' => [ 'type' => 'string' ],
 					'version' => [ 'type' => 'string' ],
-					'warnings' => [
-						'type' => 'array',
-						'items' => [ 'type' => 'string' ],
-					],
 				],
 			],
 			[
@@ -68,34 +67,44 @@ class Manage_Elements_Ability extends Abstract_Ability {
 			fn() => current_user_can( 'edit_posts' ),
 			[
 				'type' => 'object',
-				'required' => [ 'action', 'post_id', 'element_id' ],
+				'required' => [ 'post_id', 'operations' ],
 				'properties' => [
-					'action' => [
-						'type' => 'string',
-						'enum' => [ 'update', 'delete', 'move', 'duplicate' ],
-					],
 					'post_id' => [ 'type' => 'integer' ],
-					'element_id' => [ 'type' => 'string' ],
-					'settings' => [
-						'type' => 'object',
-						'description' => 'update only: partial plain settings map merged onto existing settings.',
-					],
-					'style' => [
-						'type' => 'object',
-						'description' => 'update only: raw CSS declarations (property → value); null resets a property.',
-					],
-					'classes' => [
+					'operations' => [
 						'type' => 'array',
-						'items' => [ 'type' => 'string' ],
-						'description' => 'update only: global class labels to attach (prepended to ex Fisting).',
-					],
-					'new_parent_id' => [
-						'type' => 'string',
-						'description' => "move only: target parent id or 'document' for root.",
-					],
-					'index' => [
-						'type' => [ 'integer', 'null' ],
-						'description' => 'move only: insertion index within new_parent_id (null = append).',
+						'description' => 'Bulk operations (1–50) applied in order to a single document tree, saved once at the end. Partial success is supported: failed ops return per-op errors while sibling valid ops still apply.',
+						'items' => [
+							'type' => 'object',
+							'required' => [ 'action', 'element_id' ],
+							'properties' => [
+								'action' => [
+									'type' => 'string',
+									'enum' => [ 'update', 'delete', 'move', 'duplicate' ],
+								],
+								'element_id' => [ 'type' => 'string' ],
+								'settings' => [
+									'type' => 'object',
+									'description' => 'update only: partial plain settings map merged onto existing settings.',
+								],
+								'style' => [
+									'type' => 'object',
+									'description' => 'update only: raw CSS declarations (property → value); null resets a property.',
+								],
+								'classes' => [
+									'type' => 'array',
+									'items' => [ 'type' => 'string' ],
+									'description' => 'update only: global class labels to attach (prepended to existing).',
+								],
+								'new_parent_id' => [
+									'type' => 'string',
+									'description' => "move only: target parent id or 'document' for root.",
+								],
+								'index' => [
+									'type' => [ 'integer', 'null' ],
+									'description' => 'move only: insertion index within new_parent_id (null = append).',
+								],
+							],
+						],
 					],
 				],
 			]
@@ -104,18 +113,36 @@ class Manage_Elements_Ability extends Abstract_Ability {
 
 	public function execute( $input = [] ) {
 		$input = is_array( $input ) ? $input : [];
-		$action = $input['action'] ?? '';
 
 		if ( empty( $input['post_id'] ) ) {
 			return $this->bad_request( __( 'post_id is required.', 'elementor' ) );
 		}
 
-		if ( empty( $input['element_id'] ) || ! is_string( $input['element_id'] ) ) {
-			return $this->bad_request( __( 'element_id is required.', 'elementor' ) );
+		$operations = $input['operations'] ?? null;
+		if ( ! is_array( $operations ) ) {
+			return $this->bad_request( __( 'operations array is required.', 'elementor' ) );
+		}
+
+		if ( empty( $operations ) ) {
+			return $this->bad_request( __( 'operations must not be empty.', 'elementor' ) );
+		}
+
+		if ( count( $operations ) > self::MAX_BATCH_SIZE ) {
+			return new \WP_Error(
+				'batch_size_exceeded',
+				sprintf(
+					/* translators: %d: maximum operations per request */
+					__( 'Maximum %d operations per request.', 'elementor' ),
+					self::MAX_BATCH_SIZE
+				),
+				[
+					'status' => \WP_Http::BAD_REQUEST,
+					'max_allowed' => self::MAX_BATCH_SIZE,
+				]
+			);
 		}
 
 		$post_id = (int) $input['post_id'];
-		$element_id = (string) $input['element_id'];
 
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return new \WP_Error(
@@ -130,89 +157,159 @@ class Manage_Elements_Ability extends Abstract_Ability {
 			return $document;
 		}
 
+		return $this->handle_bulk( $document, $operations );
+	}
+
+	private function handle_bulk( Document $document, array $operations ): array {
+		$results = new Bulk_Operations_Result();
+		$tree = $this->get_tree( $document );
+		$any_change = false;
+
+		foreach ( $operations as $index => $operation ) {
+			$index = (int) $index;
+
+			if ( ! is_array( $operation ) ) {
+				$results->add_error( $index, '', 'invalid_input', __( 'Invalid operation.', 'elementor' ) );
+				continue;
+			}
+
+			$action = $operation['action'] ?? '';
+			$element_id = $operation['element_id'] ?? '';
+
+			if ( ! is_string( $element_id ) || '' === $element_id ) {
+				$results->add_error( $index, $action, 'invalid_input', __( 'element_id is required.', 'elementor' ) );
+				continue;
+			}
+
+			$outcome = $this->apply_operation( $tree, $action, $element_id, $operation );
+
+			if ( is_wp_error( $outcome ) ) {
+				$results->add_error( $index, $action, $outcome->get_error_code(), $outcome->get_error_message() );
+				continue;
+			}
+
+			$tree = $outcome['tree'];
+			$any_change = true;
+
+			$extra = [ 'element_id' => $element_id ];
+			if ( ! empty( $outcome['warnings'] ) ) {
+				$extra['warnings'] = $outcome['warnings'];
+			}
+			$results->add_success( $index, $action, $extra );
+		}
+
+		$response = $results->to_array();
+		$response['post_id'] = (int) $document->get_main_id();
+
+		if ( ! $any_change ) {
+			return $response;
+		}
+
+		$save_result = $this->get_mutator()->save_as_draft( $document, $tree );
+		if ( is_wp_error( $save_result ) || ! $save_result ) {
+			$response['status'] = 'error';
+			$response['save_error'] = is_wp_error( $save_result )
+				? $save_result->get_error_message()
+				: __( 'Could not save document.', 'elementor' );
+			return $response;
+		}
+
+		Plugin::$instance->files_manager->clear_cache();
+
+		$post = get_post( $document->get_main_id() );
+		$response['version'] = $post ? $post->post_modified_gmt : current_time( 'mysql', true );
+
+		return $response;
+	}
+
+	private function apply_operation( array $tree, string $action, string $element_id, array $operation ) {
 		switch ( $action ) {
 			case 'update':
-				return $this->handle_update( $document, $element_id, $input );
+				return $this->apply_update( $tree, $element_id, $operation );
 			case 'delete':
-				return $this->handle_delete( $document, $element_id );
+				return $this->apply_delete( $tree, $element_id );
 			case 'move':
-				return $this->handle_move( $document, $element_id, $input );
+				return $this->apply_move( $tree, $element_id, $operation );
 			case 'duplicate':
-				return $this->handle_duplicate( $document, $element_id );
+				return $this->apply_duplicate( $tree, $element_id );
 			default:
-				return $this->bad_request( sprintf(
-					/* translators: %s: action name */
-					__( 'Unknown action: %s.', 'elementor' ),
-					$action
-				) );
+				return new \WP_Error(
+					'invalid_input',
+					sprintf(
+						/* translators: %s: action name */
+						__( 'Unknown action: %s.', 'elementor' ),
+						$action
+					)
+				);
 		}
 	}
 
-	private function handle_delete( Document $document, string $element_id ) {
-		$tree = $this->get_tree( $document );
+	private function apply_delete( array $tree, string $element_id ) {
 		$new_tree = $this->get_mutator()->remove( $tree, $element_id );
-
 		if ( is_wp_error( $new_tree ) ) {
 			return $this->to_public_error( $new_tree );
 		}
 
-		return $this->save_and_respond( $document, $new_tree, $element_id, [] );
+		return [
+			'tree' => $new_tree,
+			'warnings' => [],
+		];
 	}
 
-	private function handle_duplicate( Document $document, string $element_id ) {
-		$tree = $this->get_tree( $document );
+	private function apply_duplicate( array $tree, string $element_id ) {
 		$new_tree = $this->get_mutator()->duplicate( $tree, $element_id );
-
 		if ( is_wp_error( $new_tree ) ) {
 			return $this->to_public_error( $new_tree );
 		}
 
-		return $this->save_and_respond( $document, $new_tree, $element_id, [] );
+		return [
+			'tree' => $new_tree,
+			'warnings' => [],
+		];
 	}
 
-	private function handle_move( Document $document, string $element_id, array $input ) {
-		$new_parent_id = $input['new_parent_id'] ?? '';
+	private function apply_move( array $tree, string $element_id, array $operation ) {
+		$new_parent_id = $operation['new_parent_id'] ?? '';
 		if ( ! is_string( $new_parent_id ) || '' === $new_parent_id ) {
-			return $this->bad_request( __( 'new_parent_id is required for action=move.', 'elementor' ) );
+			return new \WP_Error( 'invalid_input', __( 'new_parent_id is required for action=move.', 'elementor' ) );
 		}
 
-		$index = array_key_exists( 'index', $input ) && null !== $input['index'] ? (int) $input['index'] : null;
+		$index = array_key_exists( 'index', $operation ) && null !== $operation['index'] ? (int) $operation['index'] : null;
 
-		$tree = $this->get_tree( $document );
 		$new_tree = $this->get_mutator()->move( $tree, $element_id, $new_parent_id, $index );
-
 		if ( is_wp_error( $new_tree ) ) {
 			return $this->to_public_error( $new_tree );
 		}
 
-		return $this->save_and_respond( $document, $new_tree, $element_id, [] );
+		return [
+			'tree' => $new_tree,
+			'warnings' => [],
+		];
 	}
 
-	private function handle_update( Document $document, string $element_id, array $input ) {
-		$settings = $this->as_map( $input['settings'] ?? [] );
-		$style = $this->as_map( $input['style'] ?? [] );
-		$classes = $input['classes'] ?? null;
+	private function apply_update( array $tree, string $element_id, array $operation ) {
+		$settings = $this->as_map( $operation['settings'] ?? [] );
+		$style = $this->as_map( $operation['style'] ?? [] );
+		$classes = $operation['classes'] ?? null;
 
 		$has_change = ! empty( $settings ) || ! empty( $style ) || ! empty( $classes );
 		if ( ! $has_change ) {
-			return $this->bad_request( __( 'update requires at least one of settings, style, or classes.', 'elementor' ) );
+			return new \WP_Error( 'invalid_input', __( 'update requires at least one of settings, style, or classes.', 'elementor' ) );
 		}
 
-		$tree = $this->get_tree( $document );
-
 		if ( null === $this->get_mutator()->find_by_id( $tree, $element_id ) ) {
-			return $this->not_found( __( 'Element not found.', 'elementor' ) );
+			return new \WP_Error( 'elementor_not_found', __( 'Element not found.', 'elementor' ) );
 		}
 
 		$index = $this->get_mutator()->build_ref_index( $tree, $element_id );
 		if ( empty( $index ) ) {
-			return $this->not_found( __( 'Element not found.', 'elementor' ) );
+			return new \WP_Error( 'elementor_not_found', __( 'Element not found.', 'elementor' ) );
 		}
 
 		$node_snapshot = $index[ $element_id ];
 		$element_type = $node_snapshot['widgetType'] ?? $node_snapshot['elType'] ?? null;
 		if ( ! $element_type ) {
-			return $this->bad_request( __( 'Element has no resolvable type.', 'elementor' ) );
+			return new \WP_Error( 'invalid_input', __( 'Element has no resolvable type.', 'elementor' ) );
 		}
 
 		$xml_parser = new Xml_Parser();
@@ -241,7 +338,7 @@ class Manage_Elements_Ability extends Abstract_Ability {
 
 		if ( ! empty( $classes ) ) {
 			if ( ! is_array( $classes ) ) {
-				return $this->bad_request( __( 'classes must be an array of global class labels.', 'elementor' ) );
+				return new \WP_Error( 'invalid_input', __( 'classes must be an array of global class labels.', 'elementor' ) );
 			}
 			$class_applier = new Class_Applier( $this->create_global_classes_repository() );
 			$class_error = $class_applier->apply( $index, [ $element_id => $classes ] );
@@ -259,40 +356,10 @@ class Manage_Elements_Ability extends Abstract_Ability {
 			$warnings = array_merge( $warnings, $style_result['warnings'] );
 		}
 
-		return $this->save_and_respond( $document, $tree, $element_id, $warnings );
-	}
-
-	private function save_and_respond( Document $document, array $tree, string $element_id, array $warnings ) {
-		$save_result = $this->get_mutator()->save_as_draft( $document, $tree );
-
-		if ( is_wp_error( $save_result ) ) {
-			return $save_result;
-		}
-
-		if ( ! $save_result ) {
-			return new \WP_Error(
-				'save_failed',
-				__( 'Could not save document.', 'elementor' ),
-				[ 'status' => \WP_Http::INTERNAL_SERVER_ERROR ]
-			);
-		}
-
-		Plugin::$instance->files_manager->clear_cache();
-
-		$post = get_post( $document->get_main_id() );
-
-		$response = [
-			'status' => 'ok',
-			'post_id' => (int) $document->get_main_id(),
-			'element_id' => $element_id,
-			'version' => $post ? $post->post_modified_gmt : current_time( 'mysql', true ),
+		return [
+			'tree' => $tree,
+			'warnings' => $warnings,
 		];
-
-		if ( ! empty( $warnings ) ) {
-			$response['warnings'] = $warnings;
-		}
-
-		return $response;
 	}
 
 	private function resolve_document( int $post_id ) {
@@ -329,10 +396,6 @@ class Manage_Elements_Ability extends Abstract_Ability {
 
 	private function bad_request( string $message ): \WP_Error {
 		return new \WP_Error( 'invalid_input', $message, [ 'status' => \WP_Http::BAD_REQUEST ] );
-	}
-
-	private function not_found( string $message ): \WP_Error {
-		return new \WP_Error( 'elementor_not_found', $message, [ 'status' => \WP_Http::NOT_FOUND ] );
 	}
 
 	private function as_map( $value ): array {

--- a/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
@@ -54,14 +54,13 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		parent::tearDown();
 	}
 
-	public function test_execute__unknown_action_returns_bad_request() {
+	public function test_execute__missing_post_id_returns_bad_request() {
 		$this->act_as_admin();
-		$post_id = $this->create_real_document();
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'noop',
-			'post_id' => $post_id,
-			'element_id' => 'anything',
+			'operations' => [
+				[ 'action' => 'delete', 'element_id' => 'x' ],
+			],
 		] );
 
 		$this->assertWPError( $result );
@@ -69,28 +68,60 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertSame( \WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
 	}
 
-	public function test_execute__missing_post_id_returns_bad_request() {
+	public function test_execute__missing_operations_returns_bad_request() {
 		$this->act_as_admin();
+		$post_id = $this->create_real_document();
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+		] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	public function test_execute__empty_operations_returns_bad_request() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => [],
+		] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	public function test_execute__batch_size_exceeded() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+
+		$operations = array_fill( 0, Manage_Elements_Ability::MAX_BATCH_SIZE + 1, [
 			'action' => 'delete',
 			'element_id' => 'x',
 		] );
 
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => $operations,
+		] );
+
 		$this->assertWPError( $result );
+		$this->assertSame( 'batch_size_exceeded', $result->get_error_code() );
 		$this->assertSame( \WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
 	}
 
-	public function test_execute__forbidden_user_returns_403() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+	public function test_execute__forbidden_user_returns_403_before_touching_ops() {
 		$this->act_as_admin();
 		$post_id = $this->create_real_document();
 		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'delete',
 			'post_id' => $post_id,
-			'element_id' => 'x',
+			'operations' => [
+				[ 'action' => 'delete', 'element_id' => 'x' ],
+			],
 		] );
 
 		$this->assertWPError( $result );
@@ -98,19 +129,37 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertSame( \WP_Http::FORBIDDEN, $result->get_error_data()['status'] );
 	}
 
-	public function test_execute__unknown_element_returns_not_found() {
+	public function test_execute__unknown_action_returns_per_op_error() {
 		$this->act_as_admin();
 		$post_id = $this->create_real_document();
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'delete',
 			'post_id' => $post_id,
-			'element_id' => 'ghost',
+			'operations' => [
+				[ 'action' => 'noop', 'element_id' => 'anything' ],
+			],
 		] );
 
-		$this->assertWPError( $result );
-		$this->assertSame( 'elementor_not_found', $result->get_error_code() );
-		$this->assertSame( \WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertSame( 'error', $result['results'][0]['status'] );
+		$this->assertSame( 'invalid_input', $result['results'][0]['code'] );
+	}
+
+	public function test_execute__unknown_element_returns_per_op_not_found() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => [
+				[ 'action' => 'delete', 'element_id' => 'ghost' ],
+			],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertSame( 'elementor_not_found', $result['results'][0]['code'] );
 	}
 
 	public function test_delete__removes_element_from_document() {
@@ -119,13 +168,15 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$root_id = $this->given_heading_on_document( $post_id );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'delete',
 			'post_id' => $post_id,
-			'element_id' => $root_id,
+			'operations' => [
+				[ 'action' => 'delete', 'element_id' => $root_id ],
+			],
 		] );
 
-		$this->assertNoErrors( $result );
-
+		$this->assertOkOperation( $result, 0 );
+		$this->assertSame( $root_id, $result['results'][0]['element_id'] );
+		$this->assertNotEmpty( $result['version'] );
 		$this->assertNull( $this->find_element_in_document( $post_id, $root_id ) );
 	}
 
@@ -135,12 +186,13 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		[ $container_id, $heading_id ] = $this->given_container_with_heading( $post_id );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'duplicate',
 			'post_id' => $post_id,
-			'element_id' => $container_id,
+			'operations' => [
+				[ 'action' => 'duplicate', 'element_id' => $container_id ],
+			],
 		] );
 
-		$this->assertNoErrors( $result );
+		$this->assertOkOperation( $result, 0 );
 
 		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
 		$this->assertCount( 2, $elements );
@@ -155,34 +207,39 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		[ $container_id, $heading_id ] = $this->given_container_with_heading( $post_id );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'move',
 			'post_id' => $post_id,
-			'element_id' => $heading_id,
-			'new_parent_id' => 'document',
-			'index' => 0,
+			'operations' => [
+				[
+					'action' => 'move',
+					'element_id' => $heading_id,
+					'new_parent_id' => 'document',
+					'index' => 0,
+				],
+			],
 		] );
 
-		$this->assertNoErrors( $result );
+		$this->assertOkOperation( $result, 0 );
 
 		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
 		$this->assertSame( $heading_id, $elements[0]['id'] );
 		$this->assertEmpty( $elements[1]['elements'] ?? [] );
 	}
 
-	public function test_move__missing_new_parent_id_returns_bad_request() {
+	public function test_move__missing_new_parent_id_returns_per_op_error() {
 		$this->act_as_admin();
 		$post_id = $this->create_real_document();
 		$heading_id = $this->given_heading_on_document( $post_id );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'move',
 			'post_id' => $post_id,
-			'element_id' => $heading_id,
+			'operations' => [
+				[ 'action' => 'move', 'element_id' => $heading_id ],
+			],
 		] );
 
-		$this->assertWPError( $result );
-		$this->assertSame( 'invalid_input', $result->get_error_code() );
-		$this->assertSame( \WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertSame( 'invalid_input', $result['results'][0]['code'] );
 	}
 
 	public function test_update__merges_partial_settings_into_existing_element() {
@@ -191,18 +248,22 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$heading_id = $this->given_heading_on_document( $post_id );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'update',
 			'post_id' => $post_id,
-			'element_id' => $heading_id,
-			'settings' => [
-				'title' => [
-					'content' => 'New Title',
-					'children' => [],
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $heading_id,
+					'settings' => [
+						'title' => [
+							'content' => 'New Title',
+							'children' => [],
+						],
+					],
 				],
 			],
 		] );
 
-		$this->assertNoErrors( $result );
+		$this->assertOkOperation( $result, 0 );
 
 		$node = $this->find_element_in_document( $post_id, $heading_id );
 		$this->assertNotNull( $node );
@@ -215,18 +276,21 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$heading_id = $this->given_heading_on_document( $post_id );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'update',
 			'post_id' => $post_id,
-			'element_id' => $heading_id,
-			'settings' => [
-				'nonexistent_prop' => 'x',
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $heading_id,
+					'settings' => [ 'nonexistent_prop' => 'x' ],
+				],
 			],
 		] );
 
-		$this->assertNoErrors( $result );
-		$this->assertNotEmpty( $result['warnings'] );
-		$this->assertStringContainsString( 'nonexistent_prop', $result['warnings'][0] );
-		$this->assertStringContainsString( 'skipped', $result['warnings'][0] );
+		$this->assertOkOperation( $result, 0 );
+		$warnings = $result['results'][0]['warnings'] ?? [];
+		$this->assertNotEmpty( $warnings );
+		$this->assertStringContainsString( 'nonexistent_prop', $warnings[0] );
+		$this->assertStringContainsString( 'skipped', $warnings[0] );
 	}
 
 	public function test_update__unhandled_style_declaration_warns_with_declaration_and_url_hint() {
@@ -235,18 +299,23 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$heading_id = $this->given_heading_on_document( $post_id );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'update',
 			'post_id' => $post_id,
-			'element_id' => $heading_id,
-			'style' => [
-				'background' => 'url(/wp-content/uploads/x.png) center/cover no-repeat',
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $heading_id,
+					'style' => [
+						'background' => 'url(/wp-content/uploads/x.png) center/cover no-repeat',
+					],
+				],
 			],
 		] );
 
-		$this->assertNoErrors( $result );
-		$this->assertNotEmpty( $result['warnings'] ?? [] );
+		$this->assertOkOperation( $result, 0 );
+		$warnings = $result['results'][0]['warnings'] ?? [];
+		$this->assertNotEmpty( $warnings );
 
-		$warning = $result['warnings'][0];
+		$warning = $warnings[0];
 		$this->assertStringContainsString( 'background:', $warning );
 		$this->assertStringContainsString( 'url(', $warning );
 		$this->assertStringContainsString( 'URLs must be absolute', $warning );
@@ -260,14 +329,18 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$class_id = $this->given_kit_global_class( 'hero-heading', '#111111' );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'update',
 			'post_id' => $post_id,
-			'element_id' => $heading_id,
-			'style' => [ 'font-size' => '2rem' ],
-			'classes' => [ 'hero-heading' ],
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $heading_id,
+					'style' => [ 'font-size' => '2rem' ],
+					'classes' => [ 'hero-heading' ],
+				],
+			],
 		] );
 
-		$this->assertNoErrors( $result );
+		$this->assertOkOperation( $result, 0 );
 
 		$node = $this->find_element_in_document( $post_id, $heading_id );
 		$this->assertNotNull( $node );
@@ -277,20 +350,25 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertNotEmpty( $node['styles'] ?? [] );
 	}
 
-	public function test_update__rejects_unknown_class_label() {
+	public function test_update__rejects_unknown_class_label_as_per_op_error() {
 		$this->act_as_admin();
 		$post_id = $this->create_real_document();
 		$heading_id = $this->given_heading_on_document( $post_id );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'update',
 			'post_id' => $post_id,
-			'element_id' => $heading_id,
-			'classes' => [ 'missing-class' ],
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $heading_id,
+					'classes' => [ 'missing-class' ],
+				],
+			],
 		] );
 
-		$this->assertWPError( $result );
-		$this->assertSame( 'elementor_unknown_global_class', $result->get_error_code() );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertSame( 'elementor_unknown_global_class', $result['results'][0]['code'] );
 	}
 
 	public function test_update__applies_plain_dynamic_title() {
@@ -311,18 +389,22 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		] );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'update',
 			'post_id' => $post_id,
-			'element_id' => $heading_id,
-			'settings' => [
-				'title' => [
-					'name' => 'post-excerpt',
-					'settings' => [ 'length' => '120' ],
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $heading_id,
+					'settings' => [
+						'title' => [
+							'name' => 'post-excerpt',
+							'settings' => [ 'length' => '120' ],
+						],
+					],
 				],
 			],
 		] );
 
-		$this->assertNoErrors( $result );
+		$this->assertOkOperation( $result, 0 );
 
 		$node = $this->find_element_in_document( $post_id, $heading_id );
 		$this->assertNotNull( $node );
@@ -331,27 +413,105 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertSame( '120', $node['settings']['title']['value']['settings']['length']['value'] ?? null );
 	}
 
-	public function test_update__rejects_invalid_title_shape() {
+	public function test_update__rejects_invalid_title_shape_as_per_op_error() {
 		$this->act_as_admin();
 		$post_id = $this->create_real_document();
 		$heading_id = $this->given_heading_on_document( $post_id );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
-			'action' => 'update',
 			'post_id' => $post_id,
-			'element_id' => $heading_id,
-			'settings' => [
-				'title' => 'plain string title',
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $heading_id,
+					'settings' => [ 'title' => 'plain string title' ],
+				],
 			],
 		] );
 
-		$this->assertWPError( $result );
-		$this->assertSame( 'elementor_invalid_settings', $result->get_error_code() );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertSame( 'elementor_invalid_settings', $result['results'][0]['code'] );
 	}
 
-	private function assertNoErrors( $result ): void {
+	public function test_bulk__multiple_ops_persisted_in_single_save() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		[ $container_id, $heading_id ] = $this->given_container_with_heading( $post_id );
+
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $heading_id,
+					'settings' => [
+						'title' => [ 'content' => 'Bulk Title', 'children' => [] ],
+					],
+				],
+				[
+					'action' => 'duplicate',
+					'element_id' => $container_id,
+				],
+				[
+					'action' => 'move',
+					'element_id' => $heading_id,
+					'new_parent_id' => 'document',
+					'index' => 0,
+				],
+			],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'ok', $result['status'] );
+		$this->assertCount( 3, $result['results'] );
+		foreach ( $result['results'] as $row ) {
+			$this->assertSame( 'ok', $row['status'] );
+		}
+		$this->assertNotEmpty( $result['version'] );
+
+		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
+		$this->assertSame( $heading_id, $elements[0]['id'] );
+		$this->assertCount( 3, $elements );
+
+		$node = $this->find_element_in_document( $post_id, $heading_id );
+		$this->assertSame( 'Bulk Title', $node['settings']['title']['value']['content']['value'] );
+	}
+
+	public function test_bulk__partial_failure_still_saves_valid_ops() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		$heading_id = $this->given_heading_on_document( $post_id );
+
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => [
+				[ 'action' => 'delete', 'element_id' => 'ghost' ],
+				[
+					'action' => 'update',
+					'element_id' => $heading_id,
+					'settings' => [
+						'title' => [ 'content' => 'Survived', 'children' => [] ],
+					],
+				],
+			],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'partial_error', $result['status'] );
+		$this->assertSame( 'error', $result['results'][0]['status'] );
+		$this->assertSame( 'elementor_not_found', $result['results'][0]['code'] );
+		$this->assertSame( 'ok', $result['results'][1]['status'] );
+		$this->assertNotEmpty( $result['version'] );
+
+		$node = $this->find_element_in_document( $post_id, $heading_id );
+		$this->assertSame( 'Survived', $node['settings']['title']['value']['content']['value'] );
+	}
+
+	private function assertOkOperation( $result, int $index ): void {
 		$this->assertIsArray( $result, 'Expected success but got: ' . ( is_wp_error( $result ) ? $result->get_error_message() : 'unknown' ) );
 		$this->assertSame( 'ok', $result['status'] );
+		$this->assertSame( 'ok', $result['results'][ $index ]['status'] ?? null );
 	}
 
 	private function create_real_document(): int {


### PR DESCRIPTION
## Summary

- Rewrites the `elementor/manage-elements` MCP ability to accept an `operations[]` array (1-50) under a single `post_id`, matching the bulk shape already used by `manage-classes` and `manage-global-variable`.
- Operations mutate a single in-memory document tree and are saved once at the end. Failed ops become per-op errors while sibling valid ops still apply and persist (partial success via `Bulk_Operations_Result`).
- Extracts per-action logic into pure `apply_update` / `apply_delete` / `apply_move` / `apply_duplicate` helpers that take and return the tree without saving, reusing the existing `Element_Config_Applier`, `Class_Applier`, `Style_Applier`, and `Document_Mutator`.

## Contract

Input:
- `post_id: integer` (required)
- `operations: array` (required, 1-50) — each item: `{ action: update|delete|move|duplicate, element_id, settings?, style?, classes?, new_parent_id?, index? }`

Output (mirrors the other bulk abilities):
- `status: ok|partial_error|error`
- `results: [{ index, action, status, element_id?, warnings?, code?, message? }]`
- `post_id: integer`
- `version: string` (only when at least one op saved)

## Backward compatibility

Breaking schema change on this MCP tool surface — same clean cutover as when `manage-classes` and `manage-global-variable` moved to bulk. No JS-side callers pin the input shape.

## Test plan

- [x] PHP syntax check on modified files
- [x] `phpcs` on modified files
- [ ] CI: `Test_Manage_Elements_Ability` phpunit suite (migrated single-op tests + new coverage: multi-op single-save, partial failure, empty operations, `batch_size_exceeded`, capability denial before ops)


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Converting single-element operations to bulk batch API (up to 50 ops/request, ED-24951). Enables efficient multi-step edits with partial-success semantics—failed ops don't block valid siblings.

## 2. What Changed (Where)

- **manage-elements-ability.php**: Refactored `execute()` to accept `operations[]` array instead of single `action`/`element_id`; decomposed handlers into `apply_operation()` delegates; added `handle_bulk()` orchestrator with `Bulk_Operations_Result` for per-op error tracking; removed `save_and_respond()` in favor of unified bulk save.
- **test-manage-elements-ability.php**: Migrated 12+ tests from single-op to bulk syntax; added batch-size, partial-failure, and multi-op persistence tests; replaced `assertNoErrors()` with `assertOkOperation(index)` for result indexing.

## 3. How It Works

Entry: validate post_id → operations array (1–50 items, non-empty). Iterate ops, apply each (`update`/`delete`/`move`/`duplicate`) to tree clone; collect per-op success/error in `Bulk_Operations_Result`. On any valid change, save once at end. Return aggregated response with `status` (`ok`/`error`/`partial_error`) and `results[]` array indexed by operation order—failed ops include error code/message, succeeded ops include element_id and warnings.

## 4. Risks

**Batch atomicity trade-off**: Saves on first valid change, not all-or-nothing. Mitigated by per-op error capture and clear `partial_error` status. **Index stability**: tree mutations during iteration could corrupt refs; mitigated by fresh index per operation. **Schema break**: response format changed from single-element (`element_id` → `results[]`); old clients will fail—expected for MCP versioning.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
