### PR TITLE
Internal: Fix preview url [ED-24995]

### DIFF
--- a/modules/mcp/abilities/build-composition-ability.php
+++ b/modules/mcp/abilities/build-composition-ability.php
@@ -19,6 +19,7 @@ use Elementor\Modules\Mcp\Abilities\Build_Composition\Style_Applier;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Subtree_Builder;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Widget_Type_Resolver;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser;
+use Elementor\Modules\Mcp\Abilities\Utils\Document_Mutation_Links;
 use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
 use Elementor\Modules\Variables\Module as Variables_Module;
 use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
@@ -163,7 +164,7 @@ class Build_Composition_Ability extends Abstract_Ability {
 	private function get_output_schema(): array {
 		return [
 			'type' => 'object',
-			'required' => [ 'success', 'post_id', 'root_element_ids', 'preview_url', 'version' ],
+			'required' => [ 'success', 'post_id', 'root_element_ids', 'preview_url', 'llm_instructions', 'version' ],
 			'properties' => [
 				'success' => [ 'type' => 'boolean' ],
 				'post_id' => [ 'type' => 'integer' ],
@@ -172,19 +173,13 @@ class Build_Composition_Ability extends Abstract_Ability {
 					'items' => [ 'type' => 'string' ],
 					'description' => 'IDs of the created root-level elements.',
 				],
-				'preview_url' => [
-					'type' => 'string',
-					'format' => 'uri',
-				],
+				'preview_url' => Document_Mutation_Links::preview_schema_property(),
 				'version' => [ 'type' => 'string' ],
 				'resolved_xml' => [
 					'type' => 'string',
 					'description' => 'The XML with element IDs embedded.',
 				],
-				'llm_instructions' => [
-					'type' => 'string',
-					'description' => 'Next-step instructions for the LLM.',
-				],
+				'llm_instructions' => Document_Mutation_Links::llm_instructions_schema_property(),
 				'warnings' => [
 					'type' => 'array',
 					'items' => [ 'type' => 'string' ],
@@ -317,11 +312,12 @@ class Build_Composition_Ability extends Abstract_Ability {
 			'success' => true,
 			'post_id' => $post_id,
 			'root_element_ids' => $root_ids,
-			'preview_url' => $document->get_preview_url(),
 			'version' => $post ? $post->post_modified_gmt : current_time( 'mysql', true ),
 			'resolved_xml' => $xml_parser->serialize_children( $dom ),
-			'llm_instructions' => __( 'The composition was built successfully. Reload the editor to see the result.', 'elementor' ),
-		];
+		] + Document_Mutation_Links::for_document(
+			$document,
+			__( 'The composition was built successfully.', 'elementor' )
+		);
 
 		if ( ! empty( $warnings ) ) {
 			$response['warnings'] = $warnings;

--- a/modules/mcp/abilities/create-page-ability.php
+++ b/modules/mcp/abilities/create-page-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\Mcp\Abilities\Utils\Document_Mutation_Links;
 use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -26,6 +27,8 @@ class Create_Page_Ability extends Abstract_Ability {
 					'edit_url' => [ 'type' => 'string' ],
 					'status' => [ 'type' => 'string' ],
 					'type' => [ 'type' => 'string' ],
+					'preview_url' => Document_Mutation_Links::preview_schema_property(),
+					'llm_instructions' => Document_Mutation_Links::llm_instructions_schema_property(),
 				],
 			],
 			[
@@ -132,6 +135,9 @@ class Create_Page_Ability extends Abstract_Ability {
 			'edit_url' => $document->get_edit_url(),
 			'status' => get_post_status( $post_id ),
 			'type' => $post_type,
-		];
+		] + Document_Mutation_Links::for_document(
+			$document,
+			__( 'Page created.', 'elementor' )
+		);
 	}
 }

--- a/modules/mcp/abilities/manage-elements-ability.php
+++ b/modules/mcp/abilities/manage-elements-ability.php
@@ -18,6 +18,7 @@ use Elementor\Modules\Mcp\Abilities\Build_Composition\Style_Applier;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Widget_Type_Resolver;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser;
 use Elementor\Modules\Mcp\Abilities\Utils\Bulk_Operations_Result;
+use Elementor\Modules\Mcp\Abilities\Utils\Document_Mutation_Links;
 use Elementor\Modules\Variables\Module as Variables_Module;
 use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
 use Elementor\Modules\Variables\Services\Variables_Service;
@@ -49,11 +50,13 @@ class Manage_Elements_Ability extends Abstract_Ability {
 			'elementor',
 			[
 				'type' => 'object',
-				'required' => [ 'status', 'results', 'post_id' ],
+				'required' => [ 'status', 'results', 'post_id', 'preview_url', 'llm_instructions' ],
 				'properties' => [
 					'status' => [ 'type' => 'string' ],
 					'results' => [ 'type' => 'array' ],
 					'post_id' => [ 'type' => 'integer' ],
+					'preview_url' => Document_Mutation_Links::preview_schema_property(),
+					'llm_instructions' => Document_Mutation_Links::llm_instructions_schema_property(),
 					'version' => [ 'type' => 'string' ],
 				],
 			],
@@ -202,7 +205,7 @@ class Manage_Elements_Ability extends Abstract_Ability {
 		$response['post_id'] = (int) $document->get_main_id();
 
 		if ( ! $any_change ) {
-			return $response;
+			return $this->with_mutation_links( $response, $document );
 		}
 
 		$save_result = $this->get_mutator()->save_as_draft( $document, $tree );
@@ -211,7 +214,8 @@ class Manage_Elements_Ability extends Abstract_Ability {
 			$response['save_error'] = is_wp_error( $save_result )
 				? $save_result->get_error_message()
 				: __( 'Could not save document.', 'elementor' );
-			return $response;
+
+			return $this->with_mutation_links( $response, $document );
 		}
 
 		Plugin::$instance->files_manager->clear_cache();
@@ -219,7 +223,11 @@ class Manage_Elements_Ability extends Abstract_Ability {
 		$post = get_post( $document->get_main_id() );
 		$response['version'] = $post ? $post->post_modified_gmt : current_time( 'mysql', true );
 
-		return $response;
+		return $this->with_mutation_links( $response, $document );
+	}
+
+	private function with_mutation_links( array $response, Document $document ): array {
+		return array_merge( $response, Document_Mutation_Links::for_document( $document ) );
 	}
 
 	private function apply_operation( array $tree, string $action, string $element_id, array $operation ) {

--- a/modules/mcp/abilities/update-settings-ability.php
+++ b/modules/mcp/abilities/update-settings-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\Mcp\Abilities\Utils\Document_Mutation_Links;
 use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -24,6 +25,8 @@ class Update_Settings_Ability extends Abstract_Ability {
 				'properties' => [
 					'success' => [ 'type' => 'boolean' ],
 					'post_id' => [ 'type' => 'integer' ],
+					'preview_url' => Document_Mutation_Links::preview_schema_property(),
+					'llm_instructions' => Document_Mutation_Links::llm_instructions_schema_property(),
 				],
 			],
 			[
@@ -85,6 +88,6 @@ class Update_Settings_Ability extends Abstract_Ability {
 		return [
 			'success' => true,
 			'post_id' => $post_id,
-		];
+		] + Document_Mutation_Links::for_document( $document );
 	}
 }

--- a/modules/mcp/abilities/utils/document-mutation-links.php
+++ b/modules/mcp/abilities/utils/document-mutation-links.php
@@ -35,7 +35,7 @@ class Document_Mutation_Links {
 
 		return sprintf(
 			/* translators: 1: Success message, 2: Preview URL the LLM must share with the user. */
-			__( '%1$s You MUST show the human this preview link in your reply (they must be logged into WordPress as an editor): %2$s', 'elementor' ),
+			__( '%1$s You MUST show the user this preview link in your reply (they must be logged into WordPress as an editor): %2$s', 'elementor' ),
 			$prefix,
 			$preview_url
 		);

--- a/modules/mcp/abilities/utils/document-mutation-links.php
+++ b/modules/mcp/abilities/utils/document-mutation-links.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Core\Base\Document;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Document_Mutation_Links {
+
+	public static function preview_schema_property(): array {
+		return Document_Preview_Url::output_schema_property();
+	}
+
+	public static function llm_instructions_schema_property(): array {
+		return [
+			'type' => 'string',
+			'description' => 'Mandatory next step: include this text (with the preview link) in your reply to the user.',
+		];
+	}
+
+	public static function for_document( Document $document, ?string $success_message = null ): array {
+		$preview_url = Document_Preview_Url::for_document( $document );
+
+		return [
+			'preview_url' => $preview_url,
+			'llm_instructions' => self::build_llm_instructions( $preview_url, $success_message ),
+		];
+	}
+
+	private static function build_llm_instructions( string $preview_url, ?string $success_message = null ): string {
+		$prefix = $success_message ?? __( 'Change saved.', 'elementor' );
+
+		return sprintf(
+			/* translators: 1: Success message, 2: Preview URL the LLM must share with the user. */
+			__( '%1$s You MUST show the human this preview link in your reply (they must be logged into WordPress as an editor): %2$s', 'elementor' ),
+			$prefix,
+			$preview_url
+		);
+	}
+}

--- a/modules/mcp/abilities/utils/document-preview-url.php
+++ b/modules/mcp/abilities/utils/document-preview-url.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Core\Base\Document;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Document_Preview_Url {
+
+	public static function output_schema_property(): array {
+		return [
+			'type' => 'string',
+			'format' => 'uri',
+			'description' => 'Human preview URL. Open in a browser while logged into WordPress as an editor; relies on session cookies, not preview_nonce.',
+		];
+	}
+
+	public static function for_document( Document $document ): string {
+		return remove_query_arg( 'preview_nonce', $document->get_wp_preview_url() );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
@@ -142,6 +142,11 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		$this->assertIsArray( $result, 'Expected success array but got: ' . ( is_wp_error( $result ) ? $result->get_error_message() : 'unknown' ) );
 		$this->assertTrue( $result['success'] );
 		$this->assertCount( 1, $result['root_element_ids'] );
+		$this->assertArrayHasKey( 'preview_url', $result );
+		$this->assertArrayHasKey( 'llm_instructions', $result );
+		$this->assertStringContainsString( $result['preview_url'], $result['llm_instructions'] );
+		$this->assertStringNotContainsString( 'preview_nonce=', $result['preview_url'] );
+		$this->assertStringContainsString( 'preview=true', $result['preview_url'] );
 		$this->assertNotEmpty( $result['warnings'] );
 		$this->assertStringContainsString( 'custom_css', implode( ' ', $result['warnings'] ) );
 

--- a/tests/phpunit/elementor/modules/mcp/test-create-page-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-create-page-ability.php
@@ -81,6 +81,7 @@ class Test_Create_Page_Ability extends Elementor_Test_Base {
 
 		$mock_document = $this->createMock( \Elementor\Core\Base\Document::class );
 		$mock_document->method( 'get_edit_url' )->willReturn( 'https://example.com/edit/1' );
+		$mock_document->method( 'get_wp_preview_url' )->willReturn( 'https://example.com/?p=1&preview_id=1&preview_nonce=abc&preview=true' );
 
 		$mock_docs = $this->createMock( Documents_Manager::class );
 		$mock_docs->method( 'get' )->willReturn( $mock_document );
@@ -97,6 +98,11 @@ class Test_Create_Page_Ability extends Elementor_Test_Base {
 		$this->assertArrayHasKey( 'type', $result );
 		$this->assertSame( 'page', $result['type'] );
 		$this->assertSame( 'draft', $result['status'] );
+		$this->assertArrayHasKey( 'preview_url', $result );
+		$this->assertArrayHasKey( 'llm_instructions', $result );
+		$this->assertStringContainsString( $result['preview_url'], $result['llm_instructions'] );
+		$this->assertStringNotContainsString( 'preview_nonce=', $result['preview_url'] );
+		$this->assertStringContainsString( 'preview=true', $result['preview_url'] );
 	}
 
 	public function test_execute__uses_default_title_when_not_provided() {
@@ -107,6 +113,7 @@ class Test_Create_Page_Ability extends Elementor_Test_Base {
 
 		$mock_document = $this->createMock( \Elementor\Core\Base\Document::class );
 		$mock_document->method( 'get_edit_url' )->willReturn( 'https://example.com/edit/1' );
+		$mock_document->method( 'get_wp_preview_url' )->willReturn( 'https://example.com/?p=1&preview_id=1&preview_nonce=abc&preview=true' );
 
 		$mock_docs = $this->createMock( Documents_Manager::class );
 		$mock_docs->method( 'get' )->willReturnCallback( function ( $post_id ) use ( &$captured_post_id, $mock_document ) {

--- a/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
@@ -177,6 +177,11 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertOkOperation( $result, 0 );
 		$this->assertSame( $root_id, $result['results'][0]['element_id'] );
 		$this->assertNotEmpty( $result['version'] );
+		$this->assertArrayHasKey( 'preview_url', $result );
+		$this->assertArrayHasKey( 'llm_instructions', $result );
+		$this->assertStringContainsString( $result['preview_url'], $result['llm_instructions'] );
+		$this->assertStringNotContainsString( 'preview_nonce=', $result['preview_url'] );
+		$this->assertStringContainsString( 'preview=true', $result['preview_url'] );
 		$this->assertNull( $this->find_element_in_document( $post_id, $root_id ) );
 	}
 

--- a/tests/phpunit/elementor/modules/mcp/test-update-settings-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-update-settings-ability.php
@@ -125,6 +125,7 @@ class Test_Update_Settings_Ability extends Elementor_Test_Base {
 		$mock_document = $this->createMock( \Elementor\Core\Base\Document::class );
 		$mock_document->method( 'is_editable_by_current_user' )->willReturn( true );
 		$mock_document->method( 'save' )->willReturn( true );
+		$mock_document->method( 'get_wp_preview_url' )->willReturn( 'https://example.com/?p=1&preview_id=1&preview_nonce=abc&preview=true' );
 
 		$mock_docs = $this->createMock( Documents_Manager::class );
 		$mock_docs->method( 'get' )->willReturn( $mock_document );
@@ -137,6 +138,11 @@ class Test_Update_Settings_Ability extends Elementor_Test_Base {
 		$this->assertIsArray( $result );
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertArrayHasKey( 'preview_url', $result );
+		$this->assertArrayHasKey( 'llm_instructions', $result );
+		$this->assertStringContainsString( $result['preview_url'], $result['llm_instructions'] );
+		$this->assertStringNotContainsString( 'preview_nonce=', $result['preview_url'] );
+		$this->assertStringContainsString( 'preview=true', $result['preview_url'] );
 	}
 
 	public function test_execute__passes_settings_to_document_save() {


### PR DESCRIPTION
## Summary
- Return human-facing MCP preview URLs without `preview_nonce` so logged-in WordPress editors can open them via session cookies.
- Add `llm_instructions` on mutating MCP abilities telling the LLM to share the preview link with the user.
- Scope is intentionally minimal: no server-side render endpoint or preview ability.

## Test plan
- [ ] PHPUnit: MCP ability tests for build-composition, manage-elements, create-page, update-settings
- [ ] Manual: mutate a page via MCP, open returned `preview_url` while logged in as editor (no nonce in URL)
- [ ] Confirm LLM guidance text appears in ability responses

Supersedes #36670 (dropped render/preview-ability work per scope reduction).


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Preview URLs included nonce parameters that couldn't be reused across sessions, breaking LLM ability to generate shareable preview links for users. Centralizes preview URL and LLM instruction generation to ensure consistency across all document mutation endpoints (ED-24995).

## 2. What Changed (Where)
- New utility classes: `Document_Mutation_Links` and `Document_Preview_Url` handle preview URL generation and schema definitions
- Four abilities updated: `Build_Composition`, `Create_Page`, `Manage_Elements`, `Update_Settings` now use centralized utility
- Schema updated to mark `preview_url` and `llm_instructions` as required fields
- Tests enhanced to verify nonce stripping and preview link inclusion in LLM instructions

## 3. How It Works
`Document_Preview_Url::for_document()` calls `get_wp_preview_url()` then strips the `preview_nonce` query param via `remove_query_arg()`, creating a session-agnostic preview URL. Abilities merge response arrays with `Document_Mutation_Links::for_document()` output, which pairs the clean preview URL with formatted LLM instructions directing the model to include it in replies. Schema properties centralize the documentation: preview_url as uri format, llm_instructions with mandatory-share directive.

## 4. Risks
Query param removal assumes `preview_nonce` is always present and safe to strip—verify all preview URL sources consistently include it. LLM instructions now mandatory in all responses; test that legacy or edge-case paths don't return malformed responses. No backward compatibility layer for clients expecting old schema.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
