### PR TITLE
Internal: Migrate 'list-dynamic-tags' as a resource [ED-24844]

### DIFF
--- a/modules/mcp/abilities/list-dynamic-tags-ability.php
+++ b/modules/mcp/abilities/list-dynamic-tags-ability.php
@@ -5,7 +5,6 @@ namespace Elementor\Modules\Mcp\Abilities;
 use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Tags_Module;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Transformable_Prop_Type;
 use Elementor\Modules\Mcp\Abilities\Dynamic_Tag_Llm_Resolver;
-use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
 use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class List_Dynamic_Tags_Ability extends Abstract_Ability {
+	const URI = 'elementor://dynamic-tags';
+	const DESCRIPTION = 'List of available dynamic tags for binding properties to dynamic sources.';
 
 	protected function get_ability_id(): string {
 		return 'elementor/list-dynamic-tags';
@@ -21,45 +22,32 @@ class List_Dynamic_Tags_Ability extends Abstract_Ability {
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'List Elementor Dynamic Tags', 'elementor' ),
-			Prompt_Loader::load( 'list-dynamic-tags' ),
+			__( 'List of available dynamic tags for binding properties to dynamic sources.', 'elementor' ),
 			'elementor',
+			[ 'type' => 'string' ],
 			[
-				'type' => 'array',
-				'items' => [
-					'type' => 'object',
-					'properties' => [
-						'name' => [ 'type' => 'string' ],
-						'label' => [ 'type' => 'string' ],
-						'categories' => [
-							'type' => 'array',
-							'items' => [ 'type' => 'string' ],
-						],
-						'settings' => [ 'type' => 'object' ],
-					],
+				'mcp' => [
+					'type'        => 'resource',
+					'uri'         => self::URI,
+					'public'      => true,
+					'mimeType'    => 'application/json',
+					'description' => self::DESCRIPTION,
 				],
 			],
-			[
-				'annotations' => [
-					'readonly' => true,
-					'idempotent' => true,
-					'destructive' => false,
-				],
-			],
-			function () {
-				return current_user_can( 'edit_posts' );
-			}
+			fn() => current_user_can( 'edit_posts' )
 		);
 	}
 
-	public function execute( $input = [] ) {
-		$tags = Dynamic_Tags_Module::instance()->registry->get_tags();
+	public function execute( $input = [], $tags_module = null ) {
+		$tags_module = $tags_module ?? Dynamic_Tags_Module::instance();
+		$tags = $tags_module->registry->get_tags();
 
 		$entries = [];
 		foreach ( $tags as $tag ) {
 			$entries[] = $this->build_tag_entry( $tag );
 		}
 
-		return $entries;
+		return wp_json_encode( $entries );
 	}
 
 	private function build_tag_entry( array $tag ): array {

--- a/modules/mcp/abilities/list-resources-ability.php
+++ b/modules/mcp/abilities/list-resources-ability.php
@@ -79,6 +79,12 @@ class List_Resources_Ability extends Abstract_Ability {
 				'description' => 'Design tokens (colors, fonts, sizes) from the active kit; check before styling with variables.',
 				'mimeType' => 'application/json',
 			],
+			[
+				'uri' => List_Dynamic_Tags_Ability::URI,
+				'name' => 'Dynamic Tags',
+				'description' => List_Dynamic_Tags_Ability::DESCRIPTION,
+				'mimeType' => 'application/json',
+			],
 		];
 	}
 }

--- a/modules/mcp/abilities/read-resource-ability.php
+++ b/modules/mcp/abilities/read-resource-ability.php
@@ -106,6 +106,10 @@ class Read_Resource_Ability extends Abstract_Ability {
 				'execute' => fn() => ( new Global_Variables_Resource_Ability() )->execute(),
 				'mimeType' => 'application/json',
 			],
+			List_Dynamic_Tags_Ability::URI => [
+				'execute' => fn() => ( new List_Dynamic_Tags_Ability() )->execute(),
+				'mimeType' => 'application/json',
+			],
 		];
 	}
 }

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -97,7 +97,6 @@ class Module extends BaseModule {
 				'elementor/manage-classes',
 				'elementor/get-widget-schema',
 				'elementor/list-widget-schemas',
-				'elementor/list-dynamic-tags',
 				'elementor/build-composition',
 				'elementor/manage-elements',
 				'elementor/list-resources',
@@ -108,6 +107,7 @@ class Module extends BaseModule {
 				'elementor/manage-global-variable-guide',
 				'elementor/global-classes-resource',
 				'elementor/global-variables-resource',
+				'elementor/list-dynamic-tags',
 			],
 			[]
 		);

--- a/modules/mcp/rest-api/mcp-proxy-rest-api.php
+++ b/modules/mcp/rest-api/mcp-proxy-rest-api.php
@@ -36,7 +36,6 @@ class Mcp_Proxy_REST_API {
 			'manage-classes' => fn( array $input ) => ( new Manage_Classes_Ability() )->execute( $input ),
 			'get-widget-schema' => fn( array $input ) => ( new Get_Widget_Schema_Ability() )->execute( $input ),
 			'list-widget-schemas' => fn( array $input ) => ( new List_Widget_Schemas_Ability() )->execute( $input ),
-			'list-dynamic-tags' => fn( array $input ) => ( new List_Dynamic_Tags_Ability() )->execute( $input ),
 			'build-composition' => fn( array $input ) => ( new Build_Composition_Ability() )->execute( $input ),
 			'get-page-structure' => fn( array $input ) => ( new Get_Structure_Ability() )->execute( $input ),
 			'manage-elements' => fn( array $input ) => ( new Manage_Elements_Ability() )->execute( $input ),
@@ -49,6 +48,7 @@ class Mcp_Proxy_REST_API {
 			Manage_Variable_Guide_Ability::URI => fn() => ( new Manage_Variable_Guide_Ability() )->execute(),
 			Global_Classes_Resource_Ability::URI => fn() => ( new Global_Classes_Resource_Ability() )->execute(),
 			Global_Variables_Resource_Ability::URI => fn() => ( new Global_Variables_Resource_Ability() )->execute(),
+			List_Dynamic_Tags_Ability::URI => fn() => ( new List_Dynamic_Tags_Ability() )->execute(),
 		];
 	}
 

--- a/modules/mcp/static-resources/abilities/list-dynamic-tags.md
+++ b/modules/mcp/static-resources/abilities/list-dynamic-tags.md
@@ -1,1 +1,0 @@
-Returns the available dynamic tags. To bind a property to a dynamic source, set its value to `{ "name": "<tag name>", "settings": { ... } }` using a tag whose name appears here. Populate `settings` with plain values per the tag entry's schema. Do not send `group`.

--- a/packages/packages/core/editor-canvas/src/mcp/resources/__tests__/dynamic-tags-resource.test.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/__tests__/dynamic-tags-resource.test.ts
@@ -19,7 +19,7 @@ const captureHandler = (): ResourceHandler => {
 const readCatalog = async () => {
 	const handler = captureHandler();
 	const result = await handler( new URL( DYNAMIC_TAGS_URI ) );
-	return JSON.parse( result.contents[ 0 ].text );
+	return result.contents[ 0 ].text;
 };
 
 describe( 'dynamic-tags-resource', () => {
@@ -27,31 +27,9 @@ describe( 'dynamic-tags-resource', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'returns the flat tag list fetched from the server', async () => {
+	it( 'returns the json string fetched from the server', async () => {
 		// Arrange
-		const post = jest.fn().mockResolvedValue( {
-			data: {
-				data: [
-					{
-						name: 'post-custom-field',
-						label: 'Post Custom Field',
-						categories: [ 'text', 'url' ],
-						settings: { key: { mocked: true }, before: { mocked: true } },
-					},
-				],
-			},
-		} );
-		mockedHttpService.mockReturnValue( { post } as never );
-
-		// Act
-		const catalog = await readCatalog();
-
-		// Assert
-		expect( post ).toHaveBeenCalledWith( 'elementor/v1/mcp-proxy', {
-			tool: 'list-dynamic-tags',
-			input: {},
-		} );
-		expect( catalog ).toEqual( [
+		const serverJson = JSON.stringify( [
 			{
 				name: 'post-custom-field',
 				label: 'Post Custom Field',
@@ -59,17 +37,31 @@ describe( 'dynamic-tags-resource', () => {
 				settings: { key: { mocked: true }, before: { mocked: true } },
 			},
 		] );
-	} );
 
-	it( 'returns an empty list when the server returns no data', async () => {
-		// Arrange
-		const post = jest.fn().mockResolvedValue( { data: {} } );
-		mockedHttpService.mockReturnValue( { post } as never );
+		const get = jest.fn().mockResolvedValue( {
+			data: { data: serverJson },
+		} );
+		mockedHttpService.mockReturnValue( { get } as never );
 
 		// Act
-		const catalog = await readCatalog();
+		const text = await readCatalog();
 
 		// Assert
-		expect( catalog ).toEqual( [] );
+		expect( get ).toHaveBeenCalledWith( 'elementor/v1/mcp-proxy', {
+			params: { uri: DYNAMIC_TAGS_URI },
+		} );
+		expect( text ).toBe( serverJson );
+	} );
+
+	it( 'returns an empty json array string when the server returns no data', async () => {
+		// Arrange
+		const get = jest.fn().mockResolvedValue( { data: {} } );
+		mockedHttpService.mockReturnValue( { get } as never );
+
+		// Act
+		const text = await readCatalog();
+
+		// Assert
+		expect( text ).toBe( '[]' );
 	} );
 } );

--- a/packages/packages/core/editor-canvas/src/mcp/resources/dynamic-tags-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/dynamic-tags-resource.ts
@@ -5,20 +5,13 @@ export const DYNAMIC_TAGS_URI = 'elementor://dynamic-tags';
 
 const MCP_PROXY_URL = 'elementor/v1/mcp-proxy';
 
-type DynamicTagEntry = {
-	name: string;
-	label: string;
-	categories: string[];
-	settings: Record< string, unknown >;
-};
-
-const fetchDynamicTags = async (): Promise< DynamicTagEntry[] > => {
-	const { data } = await httpService().post< HttpResponse< DynamicTagEntry[] > >( MCP_PROXY_URL, {
-		tool: 'list-dynamic-tags',
-		input: {},
+// NOTE: JSON-encoded array of dynamic tag entries; shape defined by List_Dynamic_Tags_Ability::execute() in modules/mcp/abilities/list-dynamic-tags-ability.php
+const fetchDynamicTags = async (): Promise< string > => {
+	const { data } = await httpService().get< HttpResponse< string > >( MCP_PROXY_URL, {
+		params: { uri: DYNAMIC_TAGS_URI },
 	} );
 
-	return data.data ?? [];
+	return data.data ?? '[]';
 };
 
 export const initDynamicTagsResource = ( reg: MCPRegistryEntry ) => {
@@ -35,14 +28,12 @@ export const initDynamicTagsResource = ( reg: MCPRegistryEntry ) => {
 			mimeType: 'application/json',
 		},
 		async ( uri: URL ) => {
-			const tags = await fetchDynamicTags();
-
 			return {
 				contents: [
 					{
 						uri: uri.href,
 						mimeType: 'application/json',
-						text: JSON.stringify( tags ),
+						text: await fetchDynamicTags(),
 					},
 				],
 			};

--- a/tests/phpunit/elementor/modules/mcp/test-list-dynamic-tags-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-list-dynamic-tags-ability.php
@@ -3,6 +3,7 @@
 namespace Elementor\Tests\Phpunit\Modules\Mcp;
 
 use Elementor\Modules\Mcp\Abilities\List_Dynamic_Tags_Ability;
+use Elementor\Modules\Mcp\Abilities\List_Resources_Ability;
 use PHPUnit\Framework\TestCase;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -60,5 +61,19 @@ class Test_List_Dynamic_Tags_Ability extends TestCase {
 		$reflection = new \ReflectionMethod( $ability, 'get_ability_id' );
 		$reflection->setAccessible( true );
 		return $reflection->invoke( $ability );
+	}
+
+	public function test_dynamic_tags_uri_is_in_resource_catalog() {
+		// Arrange
+		$ability = new List_Resources_Ability();
+		$reflection = new \ReflectionMethod( $ability, 'get_resource_catalog' );
+		$reflection->setAccessible( true );
+
+		// Act
+		$catalog = $reflection->invoke( $ability );
+		$uris = array_column( $catalog, 'uri' );
+
+		// Assert
+		$this->assertContains( List_Dynamic_Tags_Ability::URI, $uris );
 	}
 }

--- a/tests/phpunit/elementor/modules/mcp/test-list-dynamic-tags-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-list-dynamic-tags-ability.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp;
+
+use Elementor\Modules\Mcp\Abilities\List_Dynamic_Tags_Ability;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @group Elementor\Modules\Mcp
+ */
+class Test_List_Dynamic_Tags_Ability extends TestCase {
+
+	public function test_uri_constant() {
+		// Arrange
+		$ability = new List_Dynamic_Tags_Ability();
+
+		// Assert
+		$this->assertSame( 'elementor://dynamic-tags', List_Dynamic_Tags_Ability::URI );
+		$this->assertSame( 'elementor/list-dynamic-tags', $this->get_ability_id( $ability ) );
+	}
+
+	public function test_execute_with_mock_returns_json_with_expected_shape() {
+		// Arrange
+		$tag = [
+			'name'        => 'post-title',
+			'label'       => 'Post Title',
+			'categories'  => [ 'text' ],
+			'props_schema' => [],
+		];
+
+		$registry = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_tags' ] )
+			->getMock();
+		$registry->method( 'get_tags' )->willReturn( [ $tag ] );
+
+		$tags_module          = new \stdClass();
+		$tags_module->registry = $registry;
+
+		$ability = new List_Dynamic_Tags_Ability();
+
+		// Act
+		$result  = $ability->execute( [], $tags_module );
+		$decoded = json_decode( $result, true );
+
+		// Assert
+		$this->assertIsString( $result );
+		$this->assertCount( 1, $decoded );
+		$this->assertArrayHasKey( 'name', $decoded[0] );
+		$this->assertArrayHasKey( 'label', $decoded[0] );
+		$this->assertArrayHasKey( 'categories', $decoded[0] );
+		$this->assertArrayHasKey( 'settings', $decoded[0] );
+		$this->assertSame( 'post-title', $decoded[0]['name'] );
+	}
+
+	private function get_ability_id( List_Dynamic_Tags_Ability $ability ): string {
+		$reflection = new \ReflectionMethod( $ability, 'get_ability_id' );
+		$reflection->setAccessible( true );
+		return $reflection->invoke( $ability );
+	}
+}

--- a/tests/phpunit/unit-bootstrap.php
+++ b/tests/phpunit/unit-bootstrap.php
@@ -18,6 +18,12 @@ if ( ! function_exists( 'esc_html' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data ) {
+		return json_encode( $data );
+	}
+}
+
 $root = dirname( __DIR__, 2 ) . '/';
 
 require $root . 'vendor/autoload.php';


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Migrating `list-dynamic-tags` from a tool-based ability to a resource-based ability within the MCP (Model Context Protocol) infrastructure, aligning with architectural changes and enabling proper resource discovery/cataloging.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `list-dynamic-tags-ability.php` | Added URI/description constants; refactored `get_definition()` to use resource schema; changed `execute()` to return JSON string instead of array |
| `list-resources-ability.php` | Registered dynamic tags resource in catalog |
| `read-resource-ability.php` | Added handler for dynamic tags resource URI |
| `module.php` | Moved ability from tools array to resources array |
| `mcp-proxy-rest-api.php` | Moved handler from tools to resources map |
| `dynamic-tags-resource.ts` | Switched from POST tool call to GET resource request; returns JSON string directly |
| Test files | Added unit tests; updated integration tests to verify resource registration |

## 3. How It Works

Client calls `/mcp-proxy?uri=elementor://dynamic-tags` (GET resource) → `Read_Resource_Ability` routes to `List_Dynamic_Tags_Ability::execute()` → returns `wp_json_encode($entries)` as string → TypeScript receives JSON string and passes through MCP resource protocol. Removed intermediate tool mechanism and prompt-loader dependency.

## 4. Risks

**Return type change (array → JSON string):** Consumers must parse JSON. TypeScript test updated correctly, but verify all client-side callers handle string response. Prompt file deletion should be confirmed as unused elsewhere.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
