### PR TITLE
Fix: Editor top bar responsiveness [ED-24890]

### DIFF
--- a/packages/packages/core/editor-app-bar/src/components/locations/__tests__/menus.test.tsx
+++ b/packages/packages/core/editor-app-bar/src/components/locations/__tests__/menus.test.tsx
@@ -7,6 +7,7 @@ jest.mock( '@elementor/editor-current-user', () => ( {
 	useCurrentUserCapabilities: () => ( { isAdmin: true, canUser: jest.fn(), capabilities: [] } ),
 } ) );
 
+import { DEFAULT_MAX_TOOLBAR_ACTIONS } from '../../../constants';
 import { AppBarSizeProvider } from '../../../contexts/app-bar-size-context';
 import { integrationsMenu, mainMenu, toolsMenu, utilitiesMenu } from '../../../locations';
 import MainMenuLocation from '../main-menu-location';
@@ -83,13 +84,13 @@ describe( 'Menus components', () => {
 		{
 			menuName: 'Tools',
 			menu: toolsMenu,
-			maxItems: 5,
+			maxItems: DEFAULT_MAX_TOOLBAR_ACTIONS.tools,
 			Component: ToolsMenuLocation,
 		},
 		{
 			menuName: 'Utilities',
 			menu: utilitiesMenu,
-			maxItems: 4,
+			maxItems: DEFAULT_MAX_TOOLBAR_ACTIONS.utilities,
 			Component: UtilitiesMenuLocation,
 		},
 	] )( '$menuName menu', ( { maxItems, menu, Component } ) => {
@@ -161,7 +162,7 @@ describe( 'Menus components', () => {
 	} );
 
 	describe( 'Utilities menu late registration', () => {
-		const maxUtilitiesItems = 4;
+		const maxUtilitiesItems = DEFAULT_MAX_TOOLBAR_ACTIONS.utilities;
 
 		it( 'should render a menu item registered after the location has mounted', () => {
 			// Arrange.
@@ -197,7 +198,7 @@ describe( 'Menus components', () => {
 			}
 
 			renderWithTheme(
-				<AppBarSizeProvider value={ { tools: 5, utilities: maxUtilitiesItems } }>
+				<AppBarSizeProvider value={ { tools: DEFAULT_MAX_TOOLBAR_ACTIONS.tools, utilities: maxUtilitiesItems } }>
 					<UtilitiesMenuLocation />
 				</AppBarSizeProvider>
 			);

--- a/packages/packages/core/editor-app-bar/src/components/locations/__tests__/menus.test.tsx
+++ b/packages/packages/core/editor-app-bar/src/components/locations/__tests__/menus.test.tsx
@@ -198,7 +198,9 @@ describe( 'Menus components', () => {
 			}
 
 			renderWithTheme(
-				<AppBarSizeProvider value={ { tools: DEFAULT_MAX_TOOLBAR_ACTIONS.tools, utilities: maxUtilitiesItems } }>
+				<AppBarSizeProvider
+					value={ { tools: DEFAULT_MAX_TOOLBAR_ACTIONS.tools, utilities: maxUtilitiesItems } }
+				>
 					<UtilitiesMenuLocation />
 				</AppBarSizeProvider>
 			);

--- a/packages/packages/core/editor-app-bar/src/constants.ts
+++ b/packages/packages/core/editor-app-bar/src/constants.ts
@@ -9,6 +9,6 @@ export type MaxToolbarActions = {
 };
 
 export const DEFAULT_MAX_TOOLBAR_ACTIONS: MaxToolbarActions = {
-	tools: 5,
-	utilities: 4,
+	tools: 6,
+	utilities: 5,
 };


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Increases toolbar action capacity (tools: 5→6, utilities: 4→5) to improve editor top bar responsiveness and reduce overflow popover usage. Ticket: ED-24890.

## 2. What Changed (Where)

- `constants.ts`: Updated `DEFAULT_MAX_TOOLBAR_ACTIONS` default values (+1 each)
- `menus.test.tsx`: Replaced hardcoded test values with constant references, maintains test coverage parity

## 3. How It Works

Tests now reference `DEFAULT_MAX_TOOLBAR_ACTIONS` instead of duplicating magic numbers, ensuring test assertions stay synchronized with actual configuration. Single source of truth prevents drift between implementation and validation.

## 4. Risks

None material. Change is backwards-compatible configuration increase; tests remain equivalent. AppBarSizeProvider will respect new defaults unless explicitly overridden.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
