### PR TITLE
Internal: Better document handling [ED-24156]

### DIFF
--- a/core/base/document.php
+++ b/core/base/document.php
@@ -854,9 +854,7 @@ abstract class Document extends Controls_Stack {
 		do_action( 'elementor/document/before_save', $this, $data );
 
 		if ( ! current_user_can( 'unfiltered_html' ) ) {
-			$data = map_deep( $data, function ( $value ) {
-				return is_bool( $value ) || is_null( $value ) ? $value : wp_kses_post( $value );
-			} );
+			$data = Utils::kses_post_deep( $data );
 		}
 
 		if ( ! empty( $data['settings'] ) ) {

--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -25,7 +25,6 @@ use Elementor\Modules\System_Info\Module as System_Info_Module;
 use Elementor\Data\Manager as Data_Manager;
 use Elementor\Data\V2\Manager as Data_Manager_V2;
 use Elementor\Core\Files\Uploads_Manager;
-use WP_REST_Request;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -42,12 +41,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Plugin {
 
 	const ELEMENTOR_DEFAULT_POST_TYPES = [ 'page', 'post' ];
-
-	private const SANITIZABLE_META_KEYS = [
-		'_elementor_data',
-		'_elementor_page_settings',
-		'_elementor_global_class_data',
-	];
 
 	/**
 	 * Instance.
@@ -832,44 +825,10 @@ class Plugin {
 
 		add_action( 'init', [ $this, 'init' ], 0 );
 		add_action( 'rest_api_init', [ $this, 'on_rest_api_init' ], 9 );
-		add_filter( 'rest_pre_insert_post', [ $this, 'sanitize_post_data' ], 10, 2 );
 	}
 
 	final public static function get_title() {
 		return esc_html__( 'Elementor', 'elementor' );
-	}
-
-	public function sanitize_post_data( $post, WP_REST_Request $request ) {
-		if ( current_user_can( 'unfiltered_html' ) ) {
-			return $post;
-		}
-
-		$meta = $request->get_param( 'meta' );
-		if ( empty( $meta ) || ! is_array( $meta ) ) {
-			return $post;
-		}
-
-		foreach ( self::SANITIZABLE_META_KEYS as $meta_key ) {
-			$elementor_data = $meta[ $meta_key ] ?? null;
-			if ( is_null( $elementor_data ) ) {
-				continue;
-			}
-			if ( is_string( $elementor_data ) ) {
-				$elementor_data = json_decode( $elementor_data, true );
-			}
-			if ( empty( $elementor_data ) ) {
-				continue;
-			}
-
-			$elementor_data = map_deep($elementor_data, function ( $value ) {
-				return is_bool( $value ) || is_null( $value ) ? $value : wp_kses_post( $value );
-			});
-
-			$meta[ $meta_key ] = wp_json_encode( $elementor_data );
-		}
-
-		$request->set_param( 'meta', $meta );
-		return $post;
 	}
 }
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -840,6 +840,12 @@ class Utils {
 		echo wp_kses( $text, $allowed_html );
 	}
 
+	public static function kses_post_deep( $data ) {
+		return map_deep( $data, function ( $value ) {
+			return is_string( $value ) ? wp_kses_post( $value ) : $value;
+		} );
+	}
+
 	public static function is_elementor_path( $path ) {
 		$path = wp_normalize_path( $path );
 

--- a/modules/kit-elements-defaults/utils/settings-sanitizer.php
+++ b/modules/kit-elements-defaults/utils/settings-sanitizer.php
@@ -5,6 +5,7 @@ use Elementor\Core\Breakpoints\Manager as Breakpoints_Manager;
 use Elementor\Element_Base;
 use Elementor\Elements_Manager;
 use Elementor\Core\Base\Document;
+use Elementor\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -121,13 +122,7 @@ class Settings_Sanitizer {
 			return $this;
 		}
 
-		$this->pending_settings = map_deep( $this->pending_settings, function( $value ) {
-			if ( ! is_string( $value ) ) {
-				return $value;
-			}
-
-			return wp_kses_post( $value );
-		} );
+		$this->pending_settings = Utils::kses_post_deep( $this->pending_settings );
 
 		return $this;
 	}

--- a/modules/wp-rest/classes/elementor-post-meta.php
+++ b/modules/wp-rest/classes/elementor-post-meta.php
@@ -78,7 +78,27 @@ class Elementor_Post_Meta {
 				],
 			],
 			'auth_callback' => [ $this, 'check_edit_permission' ],
+			'sanitize_callback' => [ $this, 'sanitize_elementor_data' ],
 		]);
+	}
+
+	public function sanitize_elementor_data( $value ) {
+		if ( current_user_can( 'unfiltered_html' ) ) {
+			return $value;
+		}
+
+		if ( ! is_string( $value ) ) {
+			return Utils::kses_post_deep( $value );
+		}
+
+		$elementor_data = json_decode( $value, true );
+
+		if ( JSON_ERROR_NONE !== json_last_error() || empty( $elementor_data ) ) {
+			// Not valid Elementor JSON (or empty): treat the whole string as HTML to be safe.
+			return wp_kses_post( $value );
+		}
+
+		return wp_json_encode( Utils::kses_post_deep( $elementor_data ) );
 	}
 
 	private function register_page_settings_meta( string $post_type ): void {
@@ -104,7 +124,16 @@ class Elementor_Post_Meta {
 				],
 			],
 			'auth_callback' => [ $this, 'check_edit_permission' ],
+			'sanitize_callback' => [ $this, 'sanitize_page_settings' ],
 		]);
+	}
+
+	public function sanitize_page_settings( $value ) {
+		if ( current_user_can( 'unfiltered_html' ) ) {
+			return $value;
+		}
+
+		return Utils::kses_post_deep( $value );
 	}
 
 	private function register_conditions_meta( string $post_type ): void {

--- a/tests/phpunit/elementor/includes/test-utils.php
+++ b/tests/phpunit/elementor/includes/test-utils.php
@@ -369,6 +369,59 @@ class Elementor_Test_Utils extends Elementor_Test_Base {
 		$this->assertEquals( $sanitized_files, $result );
 	}
 
+	public function test_kses_post_deep__strips_disallowed_html_from_strings() {
+		// Arrange
+		$value = '<iframe src="https://evil.example"></iframe><strong>Bold</strong>';
+
+		// Act
+		$result = Utils::kses_post_deep( $value );
+
+		// Assert
+		$this->assertEquals( '<strong>Bold</strong>', $result );
+	}
+
+	public function test_kses_post_deep__preserves_non_string_scalars() {
+		// Arrange
+		$data = [
+			'bool_true' => true,
+			'bool_false' => false,
+			'null_value' => null,
+			'int_value' => 5,
+			'float_value' => 1.5,
+		];
+
+		// Act
+		$result = Utils::kses_post_deep( $data );
+
+		// Assert
+		$this->assertSame( $data, $result );
+	}
+
+	public function test_kses_post_deep__sanitizes_strings_inside_nested_arrays() {
+		// Arrange
+		$data = [
+			'title' => '<iframe src="https://evil.example"></iframe>Title',
+			'nested' => [
+				'description' => '<iframe src="evil"></iframe><em>Description</em>',
+				'z_index' => 10,
+				'is_visible' => false,
+			],
+		];
+
+		// Act
+		$result = Utils::kses_post_deep( $data );
+
+		// Assert
+		$this->assertEquals( [
+			'title' => 'Title',
+			'nested' => [
+				'description' => '<em>Description</em>',
+				'z_index' => 10,
+				'is_visible' => false,
+			],
+		], $result );
+	}
+
 	private function create_mocked_elements_data( $url ) {
 		return [
 			(object) [


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Consolidates HTML sanitization logic for Elementor data into a reusable utility, eliminating scattered `map_deep` implementations and removing overly complex REST API filtering that duplicated document-level sanitization.

## 2. What Changed (Where)

- `Utils::kses_post_deep()` — new utility method wrapping `map_deep` to sanitize strings while preserving non-string scalars
- `Document::save()` — uses new utility instead of inline `map_deep` logic
- `Plugin` — removed `sanitize_post_data` method and `SANITIZABLE_META_KEYS` constant; REST filtering delegated to individual meta registrations
- `Settings_Sanitizer::kses_deep()` — uses `Utils::kses_post_deep()` instead of inline implementation
- `Elementor_Post_Meta` — adds `sanitize_callback` to `_elementor_data` and `_elementor_page_settings` meta registrations with matching logic
- Tests — added comprehensive unit tests for `kses_post_deep()`

## 3. How It Works

Sanitization now flows per meta field during REST registration rather than at plugin level. When unprivileged users POST/PUT data, each meta field's `sanitize_callback` applies `Utils::kses_post_deep()`: JSON strings decode → recursively sanitize leaf strings via `wp_kses_post()` → re-encode. Non-strings (bools, ints, nulls) pass through untouched. This approach is safer (immutable per-field) and clearer than the previous global filter.

## 4. Risks

Removed unused import `WP_REST_Request` in `Plugin` (no impact). The shift from centralized to per-meta sanitization assumes all Elementor meta fields flow through REST (true in current codebase). If direct meta updates bypass REST, they won't be sanitized — mitigate by enforcing REST for all data entry or adding filters at `update_post_meta` level if needed.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
