### PR TITLE
Internal: Cherry-pick PR 36687 to 4.02: Improve Template Library handling [ED-24736]

### DIFF
--- a/includes/template-library/manager.php
+++ b/includes/template-library/manager.php
@@ -27,6 +27,7 @@ class Manager {
 
 	const ERROR_TEMPLATE_SOURCE_NOT_FOUND = 'Template source not found.';
 	const ERROR_TEMPLATE_IDS_MISSING = 'Template IDs are missing.';
+	const ERROR_JSON_UPLOAD_NOT_ALLOWED = 'Uploading JSON files is not allowed for this user.';
 
 	/**
 	 * Registered template sources.
@@ -600,6 +601,10 @@ class Manager {
 	 * @return mixed Whether the export succeeded or failed.
 	 */
 	public function import_template( array $data ) {
+		if ( ! User::is_current_user_can_upload_json() ) {
+			return new \WP_Error( 'template_error', self::ERROR_JSON_UPLOAD_NOT_ALLOWED );
+		}
+
 		// If the template is a JSON file, allow uploading it.
 		add_filter( 'elementor/files/allow-file-type/json', [ $this, 'enable_json_template_upload' ] );
 		add_filter( 'elementor/files/allow_unfiltered_upload', [ $this, 'enable_json_template_upload' ] );
@@ -897,6 +902,10 @@ class Manager {
 	 */
 	private function handle_ajax_request( $ajax_request, array $data ) {
 		if ( ! User::is_current_user_can_edit_post_type( Source_Local::CPT ) ) {
+			throw new \Exception( 'Access denied.' );
+		}
+
+		if ( 'import_template' === $ajax_request && ! User::is_current_user_can_upload_json() ) {
 			throw new \Exception( 'Access denied.' );
 		}
 

--- a/tests/phpunit/elementor/includes/template-library/test-manager-general.php
+++ b/tests/phpunit/elementor/includes/template-library/test-manager-general.php
@@ -3,6 +3,8 @@ namespace Elementor\Testing\Includes\TemplateLibrary;
 
 use Elementor\Core\Base\Document;
 use Elementor\Core\Isolation\Elementor_Adapter_Interface;
+use Elementor\Core\RoleManager\Role_Manager;
+use Elementor\Plugin;
 use Elementor\TemplateLibrary\Manager;
 use ElementorEditorTesting\Elementor_Test_Base;
 use Elementor\TemplateLibrary\Source_Local;
@@ -652,5 +654,63 @@ class Elementor_Test_Manager_General extends Elementor_Test_Base {
 
 		// Assert
 		$this->assertArrayNotHasKey( 'htmlCache', $result[0]['elements'][0] );
+	}
+
+	private function mock_json_upload_capability_revoked() {
+		// Role_Manager::user_can() returns true when the capability is restricted
+		// (i.e. the "Enable the option to upload JSON files" checkbox is unchecked).
+		$role_manager_mock = $this->getMockBuilder( Role_Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'user_can' ] )
+			->getMock();
+
+		$role_manager_mock->method( 'user_can' )->willReturn( true );
+
+		return $role_manager_mock;
+	}
+
+	public function test_import_template__denies_upload_when_json_upload_capability_revoked() {
+		// Arrange
+		$this->act_as_editor();
+
+		$original_role_manager = Plugin::$instance->role_manager;
+		Plugin::$instance->role_manager = $this->mock_json_upload_capability_revoked();
+
+		// Act
+		$result = self::$manager->import_template( [ 'source' => 'local' ] );
+
+		// Cleanup
+		Plugin::$instance->role_manager = $original_role_manager;
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertEquals( Manager::ERROR_JSON_UPLOAD_NOT_ALLOWED, $result->get_error_message() );
+	}
+
+	public function test_handle_ajax_request__denies_import_template_when_json_upload_capability_revoked() {
+		// Arrange
+		$this->act_as_editor();
+
+		$original_role_manager = Plugin::$instance->role_manager;
+		Plugin::$instance->role_manager = $this->mock_json_upload_capability_revoked();
+
+		$reflection = new \ReflectionClass( self::$manager );
+		$method = $reflection->getMethod( 'handle_ajax_request' );
+		$method->setAccessible( true );
+
+		// Act
+		try {
+			$method->invoke( self::$manager, 'import_template', [] );
+			$exception = null;
+		} catch ( \Exception $exception ) {
+			// Caught below, after the role manager is restored.
+		}
+
+		// Cleanup
+		Plugin::$instance->role_manager = $original_role_manager;
+
+		// Assert
+		$this->assertInstanceOf( \Exception::class, $exception );
+		$this->assertEquals( 'Access denied.', $exception->getMessage() );
 	}
 }


### PR DESCRIPTION
Cherry-pick of #36687 to the 4.02 release branch.

## Changes
- Improve template library handling
- Add test coverage in `tests/phpunit/elementor/includes/template-library/test-manager-general.php`

## Original PR
#36687

## Jira
[ED-24736](https://elementor.atlassian.net/browse/ED-24736)

Made with [Cursor](https://cursor.com)

[ED-24736]: https://elementor.atlassian.net/browse/ED-24736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Template library now enforces JSON upload permissions via role manager, blocking users without explicit capability to import templates. Cherry-pick from main branch (ED-24736).

## 2. What Changed (Where)

- `manager.php`: Added `ERROR_JSON_UPLOAD_NOT_ALLOWED` constant; gated `import_template()` and `handle_ajax_request()` with permission checks.
- `test-manager-general.php`: Added Role_Manager mock helper and two test cases validating upload denial.

## 3. How It Works

`import_template()` early-returns WP_Error if `User::is_current_user_can_upload_json()` fails. AJAX handler mirrors check to prevent bypass. Tests mock Role_Manager to return restricted capability state.

## 4. Risks

None material. Permission logic delegates to User utility (scope outside this diff). Tests properly mock and restore Plugin state.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
