### PR TITLE
Fix: Cherry-pick PR 36695 to 4.02: Atomic media widgets fail to save when URL is not strict-valid [ED-25101]

### DIFF
--- a/modules/atomic-widgets/prop-types/url-prop-type.php
+++ b/modules/atomic-widgets/prop-types/url-prop-type.php
@@ -24,7 +24,7 @@ class Url_Prop_Type extends String_Prop_Type {
 			return true;
 		}
 
-		return (bool) wp_http_validate_url( $value );
+		return false !== filter_var( $value, FILTER_VALIDATE_URL );
 	}
 
 	protected function sanitize_value( $value ) {

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-image-prop-type.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-types/test-image-prop-type.php
@@ -217,6 +217,32 @@ class Test_Image_Prop_Type extends Elementor_Test_Base {
 		$this->assertFalse( $result );
 	}
 
+	public function test_validate__passes_for_uncommon_tld() {
+		// Arrange.
+		$prop_type = Image_Prop_Type::make();
+
+		// Act — https://google.c was rejected by wp_http_validate_url (see ED-25101).
+		$result = $prop_type->validate( [
+			'$$type' => 'image',
+			'value' => [
+				'src' => [
+					'$$type' => 'image-src',
+					'value' => [
+						'id' => null,
+						'url' => [
+							'$$type' => 'url',
+							'value' => 'https://google.c',
+						],
+					],
+				],
+				'size' => [ '$$type' => 'string', 'value' => 'full' ],
+			],
+		] );
+
+		// Assert.
+		$this->assertTrue( $result );
+	}
+
 	public function test_validate__fail_when_passing_non_string_size() {
 		// Arrange.
 		$prop_type = Image_Prop_Type::make();


### PR DESCRIPTION
## Summary

Cherry-pick of [#36695](https://github.com/elementor/elementor/pull/36695) to `4.02`.

Fixes a regression where saving an atomic image (or svg/video) with a user-typed URL like `https://google.c` fails with:

```
Settings validation failed. image: invalid_value
```

### Root cause

On save, `Url_Prop_Type::validate_value()` calls `wp_http_validate_url()`, which is stricter than users expect (rejects `https://google.c`, `http://localhost:8888`, etc.).

### Change

Replace `wp_http_validate_url()` with `filter_var( $value, FILTER_VALIDATE_URL )` in `Url_Prop_Type`. Sanitization via `esc_url_raw()` remains unchanged.

## PR Type
- [x] Bugfix

## Test plan

- [ ] CI PHPUnit passes on updated `test-image-prop-type.php`
- [ ] In editor: add atomic image, "Insert from URL", type `https://google.c`, save → no validation error
- [ ] In editor: same flow with a valid URL (`https://google.com`) → still saves

**Original PR:** [#36695](https://github.com/elementor/elementor/pull/36695)

Fixes ED-25101

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

ED-25101: `wp_http_validate_url()` rejects valid URLs with uncommon TLDs (e.g., `https://google.c`), preventing atomic media widgets from saving. Switching to `filter_var( FILTER_VALIDATE_URL )` uses PHP's native validation which is more permissive.

## 2. What Changed (Where)

- `url-prop-type.php`: Replaced `wp_http_validate_url()` with `filter_var( $value, FILTER_VALIDATE_URL )`
- `test-image-prop-type.php`: Added test case validating uncommon TLD URLs pass validation

## 3. How It Works

`validate_value()` now uses PHP's native URL filter instead of WordPress's stricter validation. Respects `skip_validation` setting; otherwise delegates to `filter_var()` which accepts RFC-compliant URLs that WordPress rejected. Sanitization via `esc_url_raw()` remains unchanged.

## 4. Risks

Trade-off: Increased URL acceptance surface may allow edge-case invalid URLs through validation (mitigated by `esc_url_raw()` sanitization on save). No breaking changes since this only relaxes validation constraints.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
