### PR TITLE
Internal: Register `e_icon_button` experiment [ED-25131]

### DIFF
--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -161,6 +161,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Module extends BaseModule {
 	const EXPERIMENT_NAME = 'e_atomic_elements';
+	const EXPERIMENT_ICON_BUTTON = 'e_icon_button';
 
 	const PACKAGES = [
 		'editor-canvas',
@@ -185,6 +186,8 @@ class Module extends BaseModule {
 		if ( ! self::is_active() ) {
 			return;
 		}
+
+		$this->register_icon_button_experiment();
 
 		$this->register_hooks();
 
@@ -226,6 +229,21 @@ class Module extends BaseModule {
 				'minimum_installation_version' => '4.0.0',
 			],
 		];
+	}
+
+	/**
+	 * Dev-only gate that keeps the V4 Icon Button element off trunk while it is built across
+	 * several pull requests. Remove it once the element passes QA.
+	 */
+	private function register_icon_button_experiment() {
+		Plugin::$instance->experiments->add_feature( [
+			'name' => self::EXPERIMENT_ICON_BUTTON,
+			'title' => esc_html__( 'Icon Button', 'elementor' ),
+			'description' => esc_html__( 'Enable the V4 Icon Button element.', 'elementor' ),
+			'hidden' => true,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,
+		] );
 	}
 
 	private function register_hooks() {


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Other... Please describe: Internal — feature flag only, no user-facing change.

## Summary

This PR can be summarized in the following changelog entry:

* Internal: Register the hidden `e_icon_button` experiment for the upcoming V4 Icon Button element

## Description

First of three PRs for [ED-25008](https://elementor.atlassian.net/browse/ED-25008). Adds a hidden, dev-only experiment (`RELEASE_STATUS_DEV`, default inactive) that gates the V4 Icon Button element while it is built across several PRs. Nothing changes until the flag is switched on.

The flag is registered from the module constructor, the same way `site-navigation` and `site-builder` register their secondary flags — `get_experimental_data()` is already taken by the module's own `e_atomic_elements` gate, and hidden experiments cannot be used as `dependencies`.

The flag is temporary and gets removed after QA sign-off (tracked in a dedicated sub-task).

Stack:
1. **This PR** — register the experiment
2. `ED-25008-element` — implement and register the element
3. `ED-25008-agent-ready` — Agent Ready metadata and tests

## Test instructions

1. `wp elementor experiments list` — `e_icon_button` is present and inactive.
2. `wp elementor experiments activate e_icon_button` succeeds; the editor is unaffected either way.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)


[ED-25008]: https://elementor.atlassian.net/browse/ED-25008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Gating the V4 Icon Button element behind a hidden dev experiment during development across multiple PRs to prevent premature trunk exposure.

## 2. What Changed (Where)

- `modules/atomic-widgets/module.php`: Added `EXPERIMENT_ICON_BUTTON` constant, new `register_icon_button_experiment()` method, and integration call in constructor.

## 3. How It Works

Constructor now calls `register_icon_button_experiment()` which registers a hidden, dev-only feature flag via `Plugin::$instance->experiments->add_feature()` with `STATE_INACTIVE` default and `RELEASE_STATUS_DEV` status.

## 4. Risks

None — hidden experiment with inactive default poses no surface risk. Element remains inaccessible until explicitly enabled.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
