### PR TITLE
Internal: Implement and register Icon Button element [ED-25008]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.php
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.php
@@ -19,7 +19,9 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
 use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -42,6 +44,14 @@ class Atomic_Button extends Atomic_Widget_Base {
 
 	public function get_icon() {
 		return 'eicon-e-button';
+	}
+
+	/**
+	 * The V4 Icon Button element replaces this leaf button in the widgets panel. The widget stays
+	 * registered so existing documents keep rendering — only the panel tile is hidden.
+	 */
+	public function show_in_panel() {
+		return ! Plugin::$instance->experiments->is_feature_active( Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON );
 	}
 
 	protected static function define_props_schema(): array {

--- a/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-content/atomic-icon-button-content.html.twig
+++ b/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-content/atomic-icon-button-content.html.twig
@@ -1,0 +1,11 @@
+{% set classes = ['e-icon-button__content', 'e-con', 'e-atomic-element'] | merge(settings.classes | default([])) | join(' ') %}
+<span class="{{ classes }} {{ editor_classes | default('') }}"
+	data-id="{{ id }}"
+	data-element_type="{{ type }}"
+	data-e-type="{{ type }}"
+	data-interaction-id="{{ interaction_id }}"
+	data-interactions="{{ interactions | json_encode | e('html_attr') }}"
+	{% if settings.attributes is defined and settings.attributes is not empty %}
+		{{ settings.attributes | raw }}
+	{% endif %}
+	{{ editor_attributes | default('') | raw }}><!-- elementor-children-placeholder --></span>

--- a/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-content/atomic-icon-button-content.php
+++ b/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-content/atomic-icon-button-content.php
@@ -19,6 +19,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Atomic_Icon_Button_Content extends Atomic_Element_Base {
 	use Has_Element_Template;
 
+	public static $widget_description = 'Content slot for the Icon Button element. Holds the button label; drop any V4 element here to replace the default paragraph.';
+
 	public function __construct( $data = [], $args = null ) {
 		parent::__construct( $data, $args );
 		$this->meta( 'permanently_locked', true );

--- a/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-content/atomic-icon-button-content.php
+++ b/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-content/atomic-icon-button-content.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button_Content;
+
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Paragraph\Atomic_Paragraph;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Html_V3_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Atomic_Icon_Button_Content extends Atomic_Element_Base {
+	use Has_Element_Template;
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'permanently_locked', true );
+	}
+
+	public static function get_type() {
+		return 'e-icon-button-content';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-icon-button-content';
+	}
+
+	public function get_title() {
+		return esc_html__( 'Content', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'button', 'content' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-layout';
+	}
+
+	public function should_show_in_panel() {
+		return false;
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()->default( [] ),
+			'attributes' => Attributes_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	public static function get_props_schema(): array {
+		$schema = parent::get_props_schema();
+
+		// Locked sub-element: Display Conditions belong on the Icon Button root only.
+		unset( $schema['display-conditions'] );
+
+		return $schema;
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [] ),
+		];
+	}
+
+	protected function define_default_html_tag() {
+		return 'span';
+	}
+
+	protected function define_default_children() {
+		return [
+			Atomic_Paragraph::generate()
+				->settings( [
+					'paragraph' => Html_V3_Prop_Type::generate( [
+						'content' => String_Prop_Type::generate( esc_html__( 'Click here', 'elementor' ) ),
+						'children' => [],
+					] ),
+					'tag' => String_Prop_Type::generate( 'span' ),
+				] )
+				->build(),
+		];
+	}
+
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-icon-button-content' => __DIR__ . '/atomic-icon-button-content.html.twig',
+		];
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-icon/atomic-icon-button-icon.html.twig
+++ b/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-icon/atomic-icon-button-icon.html.twig
@@ -1,0 +1,12 @@
+{% set classes = ['e-icon-button__icon', 'e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+<span class="{{ classes }} {{ editor_classes | default('') }}"
+	data-id="{{ id }}"
+	data-element_type="{{ type }}"
+	data-e-type="{{ type }}"
+	data-interaction-id="{{ interaction_id }}"
+	data-interactions="{{ interactions | json_encode | e('html_attr') }}"
+	aria-hidden="true"
+	{% if settings.attributes is defined and settings.attributes is not empty %}
+		{{ settings.attributes | raw }}
+	{% endif %}
+	{{ editor_attributes | default('') | raw }}><!-- elementor-children-placeholder --></span>

--- a/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-icon/atomic-icon-button-icon.php
+++ b/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-icon/atomic-icon-button-icon.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button_Icon;
+
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Svg\Atomic_Svg;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Flex_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Atomic_Icon_Button_Icon extends Atomic_Element_Base {
+	use Has_Element_Template;
+
+	const BASE_STYLE_KEY = 'base';
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'permanently_locked', true );
+	}
+
+	public static function get_type() {
+		return 'e-icon-button-icon';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-icon-button-icon';
+	}
+
+	public function get_title() {
+		return esc_html__( 'Icon', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'button', 'icon' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-svg';
+	}
+
+	public function should_show_in_panel() {
+		return false;
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()->default( [] ),
+			'attributes' => Attributes_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	public static function get_props_schema(): array {
+		$schema = parent::get_props_schema();
+
+		// Locked sub-element: Display Conditions belong on the Icon Button root only.
+		unset( $schema['display-conditions'] );
+
+		return $schema;
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [] ),
+		];
+	}
+
+	protected function define_default_html_tag() {
+		return 'span';
+	}
+
+	protected function define_base_styles(): array {
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+						->add_props( [
+							// `flex-shrink: 0` — there is no standalone `flex-shrink` entry in the style
+							// schema, so it is expressed through the `flex` shorthand with the CSS
+							// initial values for grow (0) and basis (auto), which renders `flex: 0 0 auto`.
+							'flex' => Flex_Prop_Type::generate( [
+								'flexGrow' => Number_Prop_Type::generate( 0 ),
+								'flexShrink' => Number_Prop_Type::generate( 0 ),
+								'flexBasis' => Size_Prop_Type::generate( [
+									'size' => 'auto',
+									'unit' => 'custom',
+								] ),
+							] ),
+						] )
+				),
+		];
+	}
+
+	protected function define_default_children() {
+		return [
+			Atomic_Svg::generate()->build(),
+		];
+	}
+
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-icon-button-icon' => __DIR__ . '/atomic-icon-button-icon.html.twig',
+		];
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-icon/atomic-icon-button-icon.php
+++ b/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-icon/atomic-icon-button-icon.php
@@ -24,6 +24,8 @@ class Atomic_Icon_Button_Icon extends Atomic_Element_Base {
 
 	const BASE_STYLE_KEY = 'base';
 
+	public static $widget_description = 'Icon slot for the Icon Button element. Holds the decorative icon; drop any V4 element here to replace the default SVG.';
+
 	public function __construct( $data = [], $args = null ) {
 		parent::__construct( $data, $args );
 		$this->meta( 'permanently_locked', true );

--- a/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button.html.twig
+++ b/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button.html.twig
@@ -1,0 +1,13 @@
+{% import 'elementor/macros' as m %}
+{%- set tag = settings.tag | default('button') -%}
+{%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
+	{%- set tag = settings.link.tag | default('a') -%}
+{%- endif -%}
+<{{ tag | e('html_tag') }} class="{{ m.render_base_classes(id, base_styles, settings) }} {{ editor_classes | default('') }}"
+	{{- ' ' }}{{ m.render_data_attributes(id, type, interaction_id) }}
+	{#- A bare <button> defaults to type=submit, which would submit an enclosing e-form. -#}
+	{%- if 'button' == tag %} type="button"{% endif -%}
+	{{- m.render_link_attributes(settings.link | default(null)) }}
+	{{- m.render_custom_attributes(settings, editor_attributes) }}>
+	<!-- elementor-children-placeholder -->
+</{{ tag | e('html_tag') }}>

--- a/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button.php
+++ b/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button.php
@@ -39,6 +39,8 @@ class Atomic_Icon_Button extends Atomic_Element_Base {
 	const ELEMENT_TYPE_CONTENT = 'e-icon-button-content';
 	const ELEMENT_TYPE_ICON = 'e-icon-button-icon';
 
+	public static $widget_description = 'A pre-composed button with an icon and a text label. Structure: e-icon-button contains e-icon-button-content (holds the label, any V4 element) and e-icon-button-icon (holds the icon, any V4 element). Renders as a <button>, or as an <a> when a link is set.';
+
 	public function __construct( $data = [], $args = null ) {
 		parent::__construct( $data, $args );
 		$this->meta( 'is_container', true );
@@ -86,16 +88,21 @@ class Atomic_Icon_Button extends Atomic_Element_Base {
 
 		return [
 			'classes' => Classes_Prop_Type::make()
-				->default( [] ),
+				->default( [] )
+				->description( 'The CSS classes applied to the button.' ),
 			'tag' => String_Prop_Type::make()
 				->enum( [ 'button', 'a', 'div', 'header', 'section', 'article', 'aside', 'footer' ] )
 				->default( 'button' )
-				->set_dependencies( $tag_dependencies ),
-			'link' => Link_Prop_Type::make(),
+				->set_dependencies( $tag_dependencies )
+				->description( 'The HTML tag for the button. Defaults to button, and switches to a automatically when a link is set. Could be button, a, div, header, section, article, aside, or footer.' ),
+			'link' => Link_Prop_Type::make()
+				->description( 'The link destination of the button. When set, the button is rendered as an anchor with an href.' ),
 			'show_icon' => Boolean_Prop_Type::make()
-				->default( true ),
+				->default( true )
+				->description( 'Whether the icon slot is rendered. When false, the icon element is removed from the markup entirely and the button shows text only.' ),
 			'attributes' => Attributes_Prop_Type::make()
-				->meta( Overridable_Prop_Type::ignore() ),
+				->meta( Overridable_Prop_Type::ignore() )
+				->description( 'Custom HTML attributes added to the button.' ),
 		];
 	}
 
@@ -258,5 +265,21 @@ class Atomic_Icon_Button extends Atomic_Element_Base {
 		return [
 			'elementor/elements/atomic-icon-button' => __DIR__ . '/atomic-icon-button.html.twig',
 		];
+	}
+
+	public function render_markdown(): string {
+		$text = trim( wp_strip_all_tags( parent::render_markdown() ) );
+
+		if ( empty( $text ) ) {
+			return '';
+		}
+
+		$settings = $this->get_atomic_settings();
+
+		if ( ! empty( $settings['link']['href'] ) ) {
+			return '[' . $text . '](' . esc_url( $settings['link']['href'] ) . ')';
+		}
+
+		return '**' . $text . '**';
 	}
 }

--- a/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button.php
+++ b/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button;
+
+use Elementor\Modules\AtomicWidgets\ChildrenDependencies\Child_Dependency;
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Html_Tag_Control;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Link_Control;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Switch_Control;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button_Content\Atomic_Icon_Button_Content;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button_Icon\Atomic_Icon_Button_Icon;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Element_Builder;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
+use Elementor\Modules\AtomicWidgets\PropDependencies\Manager as Dependency_Manager;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Background_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Dimensions_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Link_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Boolean_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\AtomicWidgets\Utils\Element_Position;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Atomic_Icon_Button extends Atomic_Element_Base {
+	use Has_Element_Template;
+
+	const BASE_STYLE_KEY = 'base';
+	const ELEMENT_TYPE_CONTENT = 'e-icon-button-content';
+	const ELEMENT_TYPE_ICON = 'e-icon-button-icon';
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'is_container', true );
+	}
+
+	public static function get_type() {
+		return 'e-icon-button';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-icon-button';
+	}
+
+	public function get_title() {
+		return esc_html__( 'Button', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'button', 'icon' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-e-button';
+	}
+
+	protected static function define_props_schema(): array {
+		$tag_dependencies = Dependency_Manager::make( Dependency_Manager::RELATION_AND )
+			->where( [
+				'operator' => 'ne',
+				'path' => [ 'link', 'destination' ],
+				'nestedPath' => [ 'group' ],
+				'value' => 'action',
+				'newValue' => [
+					'$$type' => 'string',
+					'value' => 'button',
+				],
+			] )->where( [
+				'operator' => 'not_exist',
+				'path' => [ 'link', 'destination' ],
+				'newValue' => [
+					'$$type' => 'string',
+					'value' => 'a',
+				],
+			] )->get();
+
+		return [
+			'classes' => Classes_Prop_Type::make()
+				->default( [] ),
+			'tag' => String_Prop_Type::make()
+				->enum( [ 'button', 'a', 'div', 'header', 'section', 'article', 'aside', 'footer' ] )
+				->default( 'button' )
+				->set_dependencies( $tag_dependencies ),
+			'link' => Link_Prop_Type::make(),
+			'show_icon' => Boolean_Prop_Type::make()
+				->default( true ),
+			'attributes' => Attributes_Prop_Type::make()
+				->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [
+					Switch_Control::bind_to( 'show_icon' )
+						->set_label( esc_html__( 'Show Icon', 'elementor' ) ),
+					Html_Tag_Control::bind_to( 'tag' )
+						->set_options( [
+							[
+								'value' => 'button',
+								'label' => 'Button',
+							],
+							[
+								'value' => 'div',
+								'label' => 'Div',
+							],
+							[
+								'value' => 'header',
+								'label' => 'Header',
+							],
+							[
+								'value' => 'section',
+								'label' => 'Section',
+							],
+							[
+								'value' => 'article',
+								'label' => 'Article',
+							],
+							[
+								'value' => 'aside',
+								'label' => 'Aside',
+							],
+							[
+								'value' => 'footer',
+								'label' => 'Footer',
+							],
+						] )
+						->set_fallback_labels( [
+							'a' => 'a (link)',
+							'button' => 'Button',
+						] )
+						->set_label( esc_html__( 'HTML Tag', 'elementor' ) ),
+					Link_Control::bind_to( 'link' )
+						->set_placeholder( __( 'Type or paste your URL', 'elementor' ) )
+						->set_label( __( 'Link', 'elementor' ) )
+						->set_meta( [
+							'topDivider' => true,
+						] ),
+					Text_Control::bind_to( '_cssid' )
+						->set_label( __( 'ID', 'elementor' ) )
+						->set_meta( $this->get_css_id_control_meta() ),
+				] ),
+		];
+	}
+
+	protected function define_base_styles(): array {
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+						->add_props( [
+							// `inline-flex` also reveals the Style tab flex controls, so the icon can be
+							// moved before/after the label without any dedicated setting.
+							'display' => String_Prop_Type::generate( 'inline-flex' ),
+							'align-items' => String_Prop_Type::generate( 'center' ),
+							'gap' => Size_Prop_Type::generate( [
+								'size' => 8,
+								'unit' => 'px',
+							] ),
+							'padding' => Dimensions_Prop_Type::generate( [
+								'block-start' => Size_Prop_Type::generate( [
+									'size' => 12,
+									'unit' => 'px',
+								] ),
+								'inline-end' => Size_Prop_Type::generate( [
+									'size' => 24,
+									'unit' => 'px',
+								] ),
+								'block-end' => Size_Prop_Type::generate( [
+									'size' => 12,
+									'unit' => 'px',
+								] ),
+								'inline-start' => Size_Prop_Type::generate( [
+									'size' => 24,
+									'unit' => 'px',
+								] ),
+							] ),
+							'background' => Background_Prop_Type::generate( [
+								'color' => Color_Prop_Type::generate( '#375EFB' ),
+							] ),
+							'border-radius' => Size_Prop_Type::generate( [
+								'size' => 2,
+								'unit' => 'px',
+							] ),
+							'border-width' => Size_Prop_Type::generate( [
+								'size' => 0,
+								'unit' => 'px',
+							] ),
+							'text-align' => String_Prop_Type::generate( 'center' ),
+						] )
+				),
+		];
+	}
+
+	protected function define_default_children() {
+		return [
+			Atomic_Icon_Button_Content::generate()
+				->editor_settings( [
+					'title' => esc_html__( 'Content', 'elementor' ),
+				] )
+				->hydrate_default_children( true )
+				->build(),
+			Atomic_Icon_Button_Icon::generate()
+				->editor_settings( [
+					'title' => esc_html__( 'Icon', 'elementor' ),
+				] )
+				->hydrate_default_children( true )
+				->build(),
+		];
+	}
+
+	protected function define_children_dependencies(): array {
+		return [
+			Child_Dependency::for( self::ELEMENT_TYPE_ICON )
+				->when(
+					Dependency_Manager::make()->where( [
+						'operator' => 'ne',
+						'path' => [ 'show_icon' ],
+						'value' => false,
+					] )
+				)
+				->position( Element_Position::last() )
+				->stash( true )
+				->default_model(
+					Element_Builder::make( self::ELEMENT_TYPE_ICON )
+						->is_locked( true )
+						->hydrate_default_children( true )
+						->build()
+				),
+		];
+	}
+
+	protected function define_allowed_child_types() {
+		return [
+			self::ELEMENT_TYPE_CONTENT,
+			self::ELEMENT_TYPE_ICON,
+		];
+	}
+
+	protected function define_default_html_tag() {
+		return 'button';
+	}
+
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-icon-button' => __DIR__ . '/atomic-icon-button.html.twig',
+		];
+	}
+}

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -128,6 +128,9 @@ use Elementor\Modules\AtomicWidgets\Elements\Atomic_Background_Video\Atomic_Back
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Background_Video\Atomic_Background_Video_Controls\Atomic_Background_Video_Controls;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Background_Video\Atomic_Background_Video_Pause\Atomic_Background_Video_Pause;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Background_Video\Atomic_Background_Video_Play\Atomic_Background_Video_Play;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button_Content\Atomic_Icon_Button_Content;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button_Icon\Atomic_Icon_Button_Icon;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Tabs\Atomic_Tab_Content\Atomic_Tab_Content;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Collection_Loop\Collection_Loop_Promotion;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Form\Atomic_Form;
@@ -195,6 +198,7 @@ class Module extends BaseModule {
 		add_filter( 'elementor/editor/localize_settings', fn ( $settings ) => $this->add_styles_schema( $settings ) );
 		add_filter( 'elementor/editor/localize_settings', fn ( $settings ) => $this->add_supported_units( $settings ) );
 		add_filter( 'elementor/editor/localize_settings', fn ( $settings ) => $this->move_background_video_to_panel_end( $settings ) );
+		add_filter( 'elementor/editor/localize_settings', fn ( $settings ) => $this->move_icon_button_to_button_position( $settings ) );
 		add_filter( 'elementor/widgets/register', fn ( Widgets_Manager $widgets_manager ) => $this->register_widgets( $widgets_manager ) );
 		add_filter( 'elementor/usage/elements/element_title', fn ( $title, $type ) => $this->get_element_usage_name( $title, $type ), 10, 2 );
 
@@ -307,6 +311,53 @@ class Module extends BaseModule {
 		return $settings;
 	}
 
+	/**
+	 * Icon Button is a container element, so core lists it among the atomic *elements*, which always
+	 * precede the atomic *widgets* in the widgets panel — `Document::get_config()` builds the panel
+	 * list as `array_merge( $elements_config, $widget_types_config )` (see `core/base/document.php`),
+	 * and the panel renders tiles in that insertion order (there is no per-tile ordering field). Left
+	 * alone, a nested element therefore always sorts ahead of every atomic widget. The spec requires
+	 * the Icon Button tile to take the old Button's slot, which sits among the widgets (Heading,
+	 * Image, Paragraph, SVG, Button, Video...), so we re-insert its config right after SVG — Button's
+	 * historical neighbour — in the initial document's widget list that seeds the editor cache.
+	 */
+	private function move_icon_button_to_button_position( $settings ) {
+		if ( ! Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_ICON_BUTTON ) ) {
+			return $settings;
+		}
+
+		$type = Atomic_Icon_Button::get_element_type();
+
+		if ( empty( $settings['initial_document']['widgets'][ $type ] ) ) {
+			return $settings;
+		}
+
+		$widgets = $settings['initial_document']['widgets'];
+		$anchor = Atomic_Svg::get_element_type();
+
+		if ( ! isset( $widgets[ $anchor ] ) ) {
+			return $settings;
+		}
+
+		$config = $widgets[ $type ];
+
+		unset( $widgets[ $type ] );
+
+		$reordered = [];
+
+		foreach ( $widgets as $key => $widget ) {
+			$reordered[ $key ] = $widget;
+
+			if ( $anchor === $key ) {
+				$reordered[ $type ] = $config;
+			}
+		}
+
+		$settings['initial_document']['widgets'] = $reordered;
+
+		return $settings;
+	}
+
 	private function register_widgets( Widgets_Manager $widgets_manager ) {
 		$widgets_manager->register( new Atomic_Heading() );
 		$widgets_manager->register( new Atomic_Image() );
@@ -334,6 +385,12 @@ class Module extends BaseModule {
 		$elements_manager->register_element_type( new Atomic_Background_Video_Controls() );
 		$elements_manager->register_element_type( new Atomic_Background_Video_Play() );
 		$elements_manager->register_element_type( new Atomic_Background_Video_Pause() );
+
+		if ( Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_ICON_BUTTON ) ) {
+			$elements_manager->register_element_type( new Atomic_Icon_Button() );
+			$elements_manager->register_element_type( new Atomic_Icon_Button_Content() );
+			$elements_manager->register_element_type( new Atomic_Icon_Button_Icon() );
+		}
 
 		if ( \Elementor\Utils::has_pro() && Plugin::$instance->experiments->is_feature_active( 'e_pro_atomic_form' ) ) {
 			$elements_manager->register_element_type( new Atomic_Form() );

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -161,6 +161,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Module extends BaseModule {
 	const EXPERIMENT_NAME = 'e_atomic_elements';
+	const EXPERIMENT_ICON_BUTTON = 'e_icon_button';
 
 	const PACKAGES = [
 		'editor-canvas',
@@ -185,6 +186,8 @@ class Module extends BaseModule {
 		if ( ! self::is_active() ) {
 			return;
 		}
+
+		$this->register_icon_button_experiment();
 
 		$this->register_hooks();
 
@@ -226,6 +229,21 @@ class Module extends BaseModule {
 				'minimum_installation_version' => '4.0.0',
 			],
 		];
+	}
+
+	/**
+	 * Dev-only gate that keeps the V4 Icon Button element off trunk while it is built across
+	 * several pull requests. Remove it once the element passes QA.
+	 */
+	private function register_icon_button_experiment() {
+		Plugin::$instance->experiments->add_feature( [
+			'name' => self::EXPERIMENT_ICON_BUTTON,
+			'title' => esc_html__( 'Icon Button', 'elementor' ),
+			'description' => esc_html__( 'Enable the V4 Icon Button element.', 'elementor' ),
+			'hidden' => true,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,
+		] );
 	}
 
 	private function register_hooks() {

--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-icon-button.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-icon-button.php
@@ -1,0 +1,451 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\Elements;
+
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Button\Atomic_Button;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button_Content\Atomic_Icon_Button_Content;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button_Icon\Atomic_Icon_Button_Icon;
+use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Link_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Boolean_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Minimal stand-in for a rendered child element. `Element_Base::render_markdown()` only ever
+ * calls `render_markdown()` on the members of `get_children()`, so this is enough to drive the
+ * Icon Button's markdown wrapper without registering the whole element tree.
+ */
+class Icon_Button_Markdown_Child {
+	private $markdown;
+
+	public function __construct( string $markdown ) {
+		$this->markdown = $markdown;
+	}
+
+	public function render_markdown(): string {
+		return $this->markdown;
+	}
+}
+
+class Icon_Button_With_Stub_Children extends Atomic_Icon_Button {
+	public $stub_children = [];
+
+	public function get_children() {
+		return $this->stub_children;
+	}
+}
+
+class Test_Atomic_Icon_Button extends Elementor_Test_Base {
+
+	/**
+	 * @var string|null
+	 */
+	private $original_icon_button_experiment_default = null;
+
+	/**
+	 * @var bool
+	 */
+	private $registered_icon_button_experiment = false;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$feature = Plugin::$instance->experiments->get_features( Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON );
+
+		if ( $feature ) {
+			$this->original_icon_button_experiment_default = $feature['default'];
+		}
+	}
+
+	public function tearDown(): void {
+		if ( $this->registered_icon_button_experiment ) {
+			Plugin::$instance->experiments->remove_feature( Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON );
+			$this->registered_icon_button_experiment = false;
+		} elseif ( null !== $this->original_icon_button_experiment_default ) {
+			Plugin::$instance->experiments->set_feature_default_state(
+				Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON,
+				$this->original_icon_button_experiment_default
+			);
+		}
+
+		parent::tearDown();
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Props schema
+	// -----------------------------------------------------------------------------------------
+
+	public function test_props_schema__contains_the_expected_props_with_the_expected_types() {
+		// Act.
+		$schema = $this->get_defined_props_schema( Atomic_Icon_Button::class );
+
+		// Assert.
+		$this->assertSame(
+			[ 'classes', 'tag', 'link', 'show_icon', 'attributes' ],
+			array_keys( $schema )
+		);
+
+		$this->assertInstanceOf( Classes_Prop_Type::class, $schema['classes'] );
+		$this->assertInstanceOf( String_Prop_Type::class, $schema['tag'] );
+		$this->assertInstanceOf( Link_Prop_Type::class, $schema['link'] );
+		$this->assertInstanceOf( Boolean_Prop_Type::class, $schema['show_icon'] );
+		$this->assertInstanceOf( Attributes_Prop_Type::class, $schema['attributes'] );
+	}
+
+	public function test_props_schema__show_icon_defaults_to_true() {
+		// Act.
+		$default = $this->get_defined_props_schema( Atomic_Icon_Button::class )['show_icon']->get_default();
+
+		// Assert.
+		$this->assertTrue( $default['value'] );
+	}
+
+	public function test_props_schema__tag_defaults_to_button_and_enum_allows_button_and_anchor() {
+		// Act.
+		$tag = $this->get_defined_props_schema( Atomic_Icon_Button::class )['tag'];
+
+		// Assert.
+		$this->assertSame( 'button', $tag->get_default()['value'] );
+		$this->assertContains( 'button', $tag->get_enum() );
+		$this->assertContains( 'a', $tag->get_enum() );
+	}
+
+	public function test_props_schema__tag_carries_dependencies_driven_by_the_link_prop() {
+		// Act.
+		$dependencies = $this->get_defined_props_schema( Atomic_Icon_Button::class )['tag']->get_dependencies();
+
+		// Assert.
+		$this->assertNotEmpty( $dependencies );
+		$this->assertSame( 'and', $dependencies['relation'] );
+		$this->assertCount( 2, $dependencies['terms'] );
+		$this->assertSame( [ 'link', 'destination' ], $dependencies['terms'][0]['path'] );
+		$this->assertSame( 'button', $dependencies['terms'][0]['newValue']['value'] );
+		$this->assertSame( 'not_exist', $dependencies['terms'][1]['operator'] );
+		$this->assertSame( 'a', $dependencies['terms'][1]['newValue']['value'] );
+	}
+
+	public function test_props_schema__show_icon_and_link_stay_overridable_for_components() {
+		// Act.
+		$schema = $this->get_defined_props_schema( Atomic_Icon_Button::class );
+
+		// Assert.
+		$this->assertArrayNotHasKey( Overridable_Prop_Type::META_KEY, $schema['show_icon']->get_meta() );
+		$this->assertArrayNotHasKey( Overridable_Prop_Type::META_KEY, $schema['link']->get_meta() );
+	}
+
+	public function test_props_schema__attributes_is_not_overridable() {
+		// Act.
+		$meta = $this->get_defined_props_schema( Atomic_Icon_Button::class )['attributes']->get_meta();
+
+		// Assert.
+		$this->assertArrayHasKey( Overridable_Prop_Type::META_KEY, $meta );
+		$this->assertFalse( $meta[ Overridable_Prop_Type::META_KEY ] );
+	}
+
+	public function test_props_schema__cssid_is_auto_injected_and_not_overridable() {
+		// Act.
+		$defined = $this->get_defined_props_schema( Atomic_Icon_Button::class );
+		$schema = Atomic_Icon_Button::get_props_schema();
+
+		// Assert.
+		$this->assertArrayNotHasKey( '_cssid', $defined );
+		$this->assertArrayHasKey( '_cssid', $schema );
+		$this->assertFalse( $schema['_cssid']->get_meta_item( Overridable_Prop_Type::META_KEY ) );
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Children dependencies
+	// -----------------------------------------------------------------------------------------
+
+	public function test_children_dependencies__declare_a_single_stashing_rule_for_the_icon_slot() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_icon_button() );
+
+		// Assert.
+		$this->assertCount( 1, $config['children_dependencies'] );
+
+		$rule = $config['children_dependencies'][0];
+
+		$this->assertSame( 'e-icon-button-icon', $rule['child_type'] );
+		$this->assertSame( 'last', $rule['position']['kind'] );
+		$this->assertTrue( $rule['stash'] );
+	}
+
+	public function test_children_dependencies__default_model_is_a_locked_hydrated_icon_slot() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_icon_button() );
+
+		// Assert.
+		$default_model = $config['children_dependencies'][0]['default_model'];
+
+		$this->assertNotEmpty( $default_model );
+		$this->assertSame( 'e-icon-button-icon', $default_model['elType'] );
+		$this->assertTrue( $default_model['isLocked'] );
+		$this->assertTrue( $default_model['hydrateDefaultChildren'] );
+	}
+
+	public function test_children_dependencies__condition_is_show_icon_not_equal_false() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_icon_button() );
+
+		// Assert.
+		$term = $config['children_dependencies'][0]['when']['terms'][0];
+
+		$this->assertSame( 'ne', $term['operator'] );
+		$this->assertSame( [ 'show_icon' ], $term['path'] );
+		$this->assertFalse( $term['value'] );
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Default children / allowed children
+	// -----------------------------------------------------------------------------------------
+
+	public function test_default_children__are_the_content_slot_then_the_icon_slot() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_icon_button() );
+
+		// Assert.
+		$children = $config['default_children'];
+
+		$this->assertCount( 2, $children );
+		$this->assertSame( 'e-icon-button-content', $children[0]['elType'] );
+		$this->assertSame( 'e-icon-button-icon', $children[1]['elType'] );
+		$this->assertTrue( $children[0]['hydrateDefaultChildren'] );
+		$this->assertTrue( $children[1]['hydrateDefaultChildren'] );
+	}
+
+	public function test_default_children__content_slot_seeds_a_paragraph_rendered_as_a_span() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_content_slot() );
+
+		// Assert.
+		$children = $config['default_children'];
+
+		$this->assertCount( 1, $children );
+		$this->assertSame( 'widget', $children[0]['elType'] );
+		$this->assertSame( 'e-paragraph', $children[0]['widgetType'] );
+		$this->assertSame( 'span', $children[0]['settings']['tag']['value'] );
+	}
+
+	public function test_default_children__icon_slot_seeds_an_svg() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_icon_slot() );
+
+		// Assert.
+		$children = $config['default_children'];
+
+		$this->assertCount( 1, $children );
+		$this->assertSame( 'widget', $children[0]['elType'] );
+		$this->assertSame( 'e-svg', $children[0]['widgetType'] );
+	}
+
+	public function test_allowed_child_types__root_accepts_only_its_two_slots() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_icon_button() );
+
+		// Assert.
+		$this->assertSame(
+			[ 'e-icon-button-content', 'e-icon-button-icon' ],
+			$config['allowed_child_types']
+		);
+	}
+
+	public function test_allowed_child_types__slots_impose_no_restriction() {
+		// Act.
+		$content_config = $this->get_initial_config( $this->make_content_slot() );
+		$icon_config = $this->get_initial_config( $this->make_icon_slot() );
+
+		// Assert.
+		$this->assertSame( [], $content_config['allowed_child_types'] );
+		$this->assertSame( [], $icon_config['allowed_child_types'] );
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Root / slot element config
+	// -----------------------------------------------------------------------------------------
+
+	public function test_root__renders_as_a_button_and_is_a_container() {
+		// Arrange.
+		$icon_button = $this->make_icon_button();
+
+		// Act.
+		$config = $this->get_initial_config( $icon_button );
+
+		// Assert.
+		$this->assertSame( 'e-icon-button', Atomic_Icon_Button::get_element_type() );
+		$this->assertSame( 'button', $config['default_html_tag'] );
+		$this->assertSame( 'eicon-e-button', $icon_button->get_icon() );
+		$this->assertSame( 'Button', $icon_button->get_title() );
+		$this->assertTrue( $config['show_in_panel'] );
+		$this->assertTrue( (bool) $icon_button->get_meta_item( 'is_container' ) );
+	}
+
+	/**
+	 * @dataProvider slot_provider
+	 */
+	public function test_slots__are_hidden_locked_spans_without_display_conditions( string $class ) {
+		// Arrange.
+		$slot = $this->make_slot( $class );
+
+		// Act.
+		$config = $this->get_initial_config( $slot );
+
+		// Assert.
+		$this->assertFalse( $slot->should_show_in_panel() );
+		$this->assertFalse( $config['show_in_panel'] );
+		$this->assertTrue( $config['meta']['permanently_locked'] );
+		$this->assertSame( 'span', $config['default_html_tag'] );
+		$this->assertArrayNotHasKey( 'display-conditions', $class::get_props_schema() );
+	}
+
+	public function slot_provider(): array {
+		return [
+			'content slot' => [ Atomic_Icon_Button_Content::class ],
+			'icon slot' => [ Atomic_Icon_Button_Icon::class ],
+		];
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Markdown
+	// -----------------------------------------------------------------------------------------
+
+	public function test_render_markdown__returns_empty_string_when_there_is_no_child_text() {
+		// Arrange.
+		$icon_button = $this->make_icon_button_with_children( [] );
+
+		// Act & Assert.
+		$this->assertSame( '', $icon_button->render_markdown() );
+	}
+
+	public function test_render_markdown__returns_bold_text_when_there_is_no_link() {
+		// Arrange.
+		$icon_button = $this->make_icon_button_with_children( [ new Icon_Button_Markdown_Child( 'Click here' ) ] );
+
+		// Act & Assert.
+		$this->assertSame( '**Click here**', $icon_button->render_markdown() );
+	}
+
+	public function test_render_markdown__returns_a_markdown_link_when_a_link_is_set() {
+		// Arrange.
+		$icon_button = $this->make_icon_button_with_children(
+			[ new Icon_Button_Markdown_Child( 'Click here' ) ],
+			[
+				'link' => [
+					'href' => 'https://example.com/',
+					'target' => '_blank',
+					'tag' => 'a',
+				],
+			]
+		);
+
+		// Act & Assert.
+		$this->assertSame( '[Click here](https://example.com/)', $icon_button->render_markdown() );
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Legacy button panel visibility
+	// -----------------------------------------------------------------------------------------
+
+	public function test_legacy_button__is_hidden_from_the_panel_when_the_icon_button_experiment_is_active() {
+		// Arrange.
+		$this->set_icon_button_experiment( Experiments_Manager::STATE_ACTIVE );
+
+		// Act & Assert.
+		$this->assertFalse( ( new Atomic_Button() )->show_in_panel() );
+	}
+
+	public function test_legacy_button__is_shown_in_the_panel_when_the_icon_button_experiment_is_inactive() {
+		// Arrange.
+		$this->set_icon_button_experiment( Experiments_Manager::STATE_INACTIVE );
+
+		// Act & Assert.
+		$this->assertTrue( ( new Atomic_Button() )->show_in_panel() );
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------------------------
+
+	/**
+	 * The authored schema, before `Has_Atomic_Base::get_props_schema()` injects `_cssid` and before
+	 * the `elementor/atomic-widgets/props-schema` filter wraps props in unions (dynamic tags,
+	 * component overrides). Those wrappers preserve meta/default/dependencies but change the
+	 * concrete prop-type class, so type assertions have to run against the raw definition.
+	 */
+	private function get_defined_props_schema( string $class ): array {
+		$reflection = new \ReflectionMethod( $class, 'define_props_schema' );
+		$reflection->setAccessible( true );
+
+		return $reflection->invoke( null );
+	}
+
+	private function get_initial_config( $element ): array {
+		$reflection = new \ReflectionMethod( get_class( $element ), 'get_initial_config' );
+		$reflection->setAccessible( true );
+
+		return $reflection->invoke( $element );
+	}
+
+	private function make_icon_button(): Atomic_Icon_Button {
+		return new Atomic_Icon_Button( $this->make_element_data( Atomic_Icon_Button::get_element_type() ), null );
+	}
+
+	private function make_content_slot(): Atomic_Icon_Button_Content {
+		return $this->make_slot( Atomic_Icon_Button_Content::class );
+	}
+
+	private function make_icon_slot(): Atomic_Icon_Button_Icon {
+		return $this->make_slot( Atomic_Icon_Button_Icon::class );
+	}
+
+	private function make_slot( string $class ) {
+		return new $class( $this->make_element_data( $class::get_element_type() ), null );
+	}
+
+	private function make_icon_button_with_children( array $children, array $settings = [] ): Icon_Button_With_Stub_Children {
+		$icon_button = new Icon_Button_With_Stub_Children(
+			$this->make_element_data( Atomic_Icon_Button::get_element_type(), $settings ),
+			null
+		);
+
+		$icon_button->stub_children = $children;
+
+		return $icon_button;
+	}
+
+	private function make_element_data( string $el_type, array $settings = [] ): array {
+		return [
+			'id' => 'test',
+			'elType' => $el_type,
+			'settings' => $settings,
+		];
+	}
+
+	private function set_icon_button_experiment( string $state ): void {
+		$experiments = Plugin::$instance->experiments;
+
+		if ( ! $experiments->get_features( Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON ) ) {
+			$experiments->add_feature( [
+				'name' => Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON,
+				'title' => 'Icon Button',
+				'hidden' => true,
+				'default' => Experiments_Manager::STATE_INACTIVE,
+			] );
+
+			$this->registered_icon_button_experiment = true;
+		}
+
+		$experiments->set_feature_default_state( Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON, $state );
+	}
+}

--- a/tests/playwright/sanity/modules/v4-tests/atomic-icon-button.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-icon-button.test.ts
@@ -1,0 +1,197 @@
+import { expect, type BrowserContext, type Locator, type Page } from '@playwright/test';
+import { parallelTest as test } from '../../../parallelTest';
+import WpAdminPage from '../../../pages/wp-admin-page';
+import EditorPage from '../../../pages/editor-page';
+import EditorSelectors from '../../../selectors/editor-selectors';
+import TopBarSelectors from '../../../selectors/top-bar-selectors';
+
+const ICON_BUTTON_TYPE = 'e-icon-button';
+const CONTENT_SLOT_TYPE = 'e-icon-button-content';
+const ICON_SLOT_TYPE = 'e-icon-button-icon';
+const PARAGRAPH_TYPE = 'e-paragraph';
+const SVG_TYPE = 'e-svg';
+const LEGACY_BUTTON_TYPE = 'e-button';
+
+test.describe( 'Atomic Icon Button @v4-tests', () => {
+	let context: BrowserContext;
+	let page: Page;
+	let wpAdmin: WpAdminPage;
+	let editor: EditorPage;
+
+	const panelTile = ( elementType: string ): Locator =>
+		page.locator( `#elementor-panel-page-elements [data-library-element-type="${ elementType }"]` );
+
+	const previewLocator = ( selector: string ): Locator => editor.getPreviewFrame().locator( selector );
+
+	const elementById = ( elementId: string ): Locator => previewLocator( `[data-id="${ elementId }"]` );
+
+	const tagNameOf = async ( elementId: string ): Promise<string> =>
+		elementById( elementId ).evaluate( ( element ) => element.tagName );
+
+	const descendantId = async ( rootId: string, selector: string ): Promise<string> =>
+		elementById( rootId ).locator( selector ).first().getAttribute( 'data-id' );
+
+	/**
+	 * Adds the Icon Button by clicking its tile in the Atomic Elements panel section — the same
+	 * path a user takes, so the client-side default-children hydration runs.
+	 */
+	const addIconButtonFromPanel = async (): Promise<string> => {
+		await editor.openElementsPanel();
+
+		const tile = panelTile( ICON_BUTTON_TYPE );
+		await tile.waitFor( { state: 'visible' } );
+		await tile.click();
+
+		const root = previewLocator( `[data-element_type="${ ICON_BUTTON_TYPE }"]` ).first();
+		await root.waitFor( { state: 'visible' } );
+
+		return await root.getAttribute( 'data-id' );
+	};
+
+	const openNavigator = async (): Promise<void> => {
+		await editor.waitForPreviewFrame();
+
+		const isOpen = await editor.getPreviewFrame().evaluate( () => elementor.navigator.isOpen() );
+
+		if ( ! isOpen ) {
+			await editor.clickTopBarItem( TopBarSelectors.navigator );
+		}
+
+		await page.locator( EditorSelectors.panels.navigator.wrapper ).waitFor();
+	};
+
+	const navigatorEntry = ( elementId: string ): Locator =>
+		page.locator( EditorSelectors.panels.navigator.getElement( elementId ) );
+
+	const showIconSwitch = (): Locator =>
+		page.locator( 'span' ).filter( { hasText: 'Show Icon' } ).getByRole( 'checkbox' );
+
+	const toggleLinkButton = (): Locator => page.locator( '[aria-label="Toggle link"]' );
+
+	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
+		context = await browser.newContext();
+		page = await context.newPage();
+		wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+
+		await wpAdmin.setExperiments( {
+			e_atomic_elements: 'active',
+			e_icon_button: 'active',
+		} );
+	} );
+
+	test.afterAll( async () => {
+		await wpAdmin?.resetExperiments();
+		await context.close();
+	} );
+
+	test.beforeEach( async () => {
+		editor = await wpAdmin.openNewPage();
+	} );
+
+	// QA row 11.
+	test( 'The Button tile lives in the Atomic Elements section and the legacy button tile is gone', async () => {
+		// Act.
+		await editor.openElementsPanel();
+
+		const v4Section = page.locator( EditorSelectors.panels.elements.v4elements );
+
+		// Assert.
+		await expect( v4Section.locator( `[data-library-element-type="${ ICON_BUTTON_TYPE }"]` ) ).toBeVisible();
+		await expect( v4Section.locator( `[data-library-element-type="${ ICON_BUTTON_TYPE }"]` ) ).toContainText( 'Button' );
+		await expect( panelTile( LEGACY_BUTTON_TYPE ) ).toHaveCount( 0 );
+	} );
+
+	// QA row 1.
+	test( 'Dropping the Button renders an icon and the "Click here" label inside a <button>', async () => {
+		// Act.
+		const rootId = await addIconButtonFromPanel();
+		const root = elementById( rootId );
+
+		// Assert.
+		await expect.poll( () => tagNameOf( rootId ) ).toBe( 'BUTTON' );
+		await expect( root.locator( `[data-element_type="${ CONTENT_SLOT_TYPE }"]` ) ).toHaveCount( 1 );
+		await expect( root.locator( `[data-element_type="${ ICON_SLOT_TYPE }"]` ) ).toHaveCount( 1 );
+		await expect( root.locator( `[data-widget_type="${ PARAGRAPH_TYPE }.default"]` ) ).toContainText( 'Click here' );
+		await expect( root.locator( `[data-widget_type="${ SVG_TYPE }.default"] svg` ).first() ).toBeVisible();
+	} );
+
+	// QA row 5.
+	test( 'The content slot label can be edited on the canvas', async () => {
+		// Arrange.
+		const rootId = await addIconButtonFromPanel();
+		const root = elementById( rootId );
+		const paragraphId = await descendantId( rootId, `[data-widget_type="${ PARAGRAPH_TYPE }.default"]` );
+
+		// Act.
+		const inlineEditor = await editor.triggerEditingElement( paragraphId );
+		await inlineEditor.click();
+		await page.keyboard.press( 'ControlOrMeta+A' );
+		await page.keyboard.type( 'Buy now' );
+		await page.keyboard.press( 'Escape' );
+
+		// Assert.
+		await expect( root.locator( `[data-widget_type="${ PARAGRAPH_TYPE }.default"]` ) ).toContainText( 'Buy now' );
+	} );
+
+	// QA rows 6 + 7.
+	test( 'Setting a link switches the root to an <a>, clearing it switches back to a <button>', async () => {
+		// Arrange.
+		const rootId = await addIconButtonFromPanel();
+		const root = elementById( rootId );
+		const url = 'https://elementor.com/';
+
+		await editor.selectElement( rootId );
+		await editor.v4Panel.openTab( 'general' );
+
+		// Act - set a link.
+		const urlInput = page.getByPlaceholder( 'Type or paste your URL' );
+
+		if ( ! await urlInput.isVisible() ) {
+			await toggleLinkButton().click();
+		}
+
+		await urlInput.fill( url );
+
+		// Assert - the root became an anchor.
+		await expect.poll( () => tagNameOf( rootId ) ).toBe( 'A' );
+		await expect( root ).toHaveAttribute( 'href', url );
+
+		// Act - clear the link.
+		await toggleLinkButton().click();
+
+		// Assert - the root is a button again.
+		await expect.poll( () => tagNameOf( rootId ) ).toBe( 'BUTTON' );
+		await expect( root ).not.toHaveAttribute( 'href', url );
+	} );
+
+	// QA rows 8 + 9.
+	test( 'Show Icon removes the icon from the canvas and the Structure panel, and restores it', async () => {
+		// Arrange.
+		const rootId = await addIconButtonFromPanel();
+		const root = elementById( rootId );
+		const iconSlotId = await descendantId( rootId, `[data-element_type="${ ICON_SLOT_TYPE }"]` );
+
+		await openNavigator();
+		await expect( navigatorEntry( iconSlotId ) ).toHaveCount( 1 );
+
+		await editor.selectElement( rootId );
+		await editor.v4Panel.openTab( 'general' );
+
+		// Act - turn Show Icon off.
+		await showIconSwitch().click();
+
+		// Assert - gone from both the canvas and the Structure panel.
+		await expect( root.locator( `[data-element_type="${ ICON_SLOT_TYPE }"]` ) ).toHaveCount( 0 );
+		await expect( navigatorEntry( iconSlotId ) ).toHaveCount( 0 );
+
+		// Act - turn Show Icon back on.
+		await showIconSwitch().click();
+
+		// Assert - restored in both.
+		await expect( root.locator( `[data-element_type="${ ICON_SLOT_TYPE }"]` ) ).toHaveCount( 1 );
+		await expect( root.locator( `[data-widget_type="${ SVG_TYPE }.default"] svg` ).first() ).toBeVisible();
+
+		const restoredIconSlotId = await descendantId( rootId, `[data-element_type="${ ICON_SLOT_TYPE }"]` );
+		await expect( navigatorEntry( restoredIconSlotId ) ).toHaveCount( 1 );
+	} );
+} );


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Feature (behind a hidden dev experiment)

> **Stacked on #36717** — review/merge that one first; base will retarget to `main` automatically.

## Summary

This PR can be summarized in the following changelog entry:

* Internal: Add the V4 Icon Button element (`e-icon-button`) with locked content and icon slots, behind the `e_icon_button` experiment

## Description

Second of three PRs for [ED-25008](https://elementor.atlassian.net/browse/ED-25008), per the [Icon Button spec](https://elementor.atlassian.net/wiki/spaces/RDDEP/pages/2758574093/Icon+Button+Spec).

Introduces `e-icon-button`, a nested V4 container element that replaces the leaf `e-button` in the widgets panel. It ships with two permanently locked slots — content (paragraph "Click here") and icon (default SVG) — so users get a working icon button out of the box and can drop any V4 element into either slot.

- Root `e-icon-button` renders `<button>`, auto-switching to `<a>` when a link is set, reusing the Div Block tag/link dependency coupling.
- `Show Icon` toggle removes the icon slot from the DOM and the Structure panel via `Child_Dependency::stash( true )`, mirroring Background Video's `show_controls`. No new client-side code — the generic reconciler in `@elementor/editor-elements` already handles attach/detach and stashing.
- Base styles match the current button with `display: inline-flex`, `align-items: center` and `gap: 8px`, which also auto-reveals the Style tab's flex controls so the icon can be moved before/after the text.
- `Atomic_Button` stays registered unconditionally and only hides from the panel via `show_in_panel()`, so existing pages keep rendering. No data migration.
- Elements are merged ahead of widgets in `Document::get_config()`, so a `localize_settings` filter re-seats the tile in the old Button slot.

Out of scope per spec: icon-only mode, icon library, hover/active presets. Agent Ready metadata and tests land in the follow-up PR.

## Test instructions

1. `wp elementor experiments activate e_icon_button`
2. Open the editor — the Button tile sits in its usual place and drops an `e-icon-button` with a label and an icon; the legacy Button tile is gone.
3. Set a link — the root renders as `<a href>`; clear it — back to `<button>`.
4. Toggle `Show Icon` off — the icon disappears from the canvas and the Structure panel; toggle back on — the same icon element returns.
5. Open a page built with the legacy `e-button` — it still renders unchanged.
6. Deactivate the experiment — the panel is back to its previous state.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended (in the follow-up PR)
- [ ] Docs have been added / updated (for bug fixes / features)


[ED-25008]: https://elementor.atlassian.net/browse/ED-25008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Implementing Icon Button (V4 atomic element) to replace the legacy Button widget in the panel. The old Button remains registered for backward compatibility with existing documents, but is hidden when the feature flag is active.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `atomic-button.php` | Added `show_in_panel()` method gated by experiment flag |
| `atomic-icon-button/` | New element with two child slots (content, icon) and link support |
| `module.php` | Registered Icon Button elements; reordered panel position after SVG via `move_icon_button_to_button_position()` |
| Tests & E2E | 450+ lines coverage (props, children, markdown, markdown rendering) |

## 3. How It Works

Icon Button is a container with two locked, permanently-hidden child slots: `Atomic_Icon_Button_Content` (holds label) and `Atomic_Icon_Button_Icon` (holds SVG). Root renders as `<button>` or `<a>` depending on link prop; icon slot conditionally stashed via `show_icon` boolean. Panel ordering happens in `get_config()` by extracting Icon Button from elements list and reinserting after SVG to sit where legacy Button lived—avoids core list-building race.

## 4. Risks

Panel reordering via settings mutation (line 324–359) is fragile if core changes `initial_document.widgets` structure. Mitigation: defensive checks for key existence; experiment gate prevents execution on inactive installs. Child stashing logic depends on proper `define_children_dependencies()` wiring—validated by comprehensive tests.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
