### PR TITLE
Internal: Icon Button Agent Ready and tests [ED-25008]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-content/atomic-icon-button-content.php
+++ b/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-content/atomic-icon-button-content.php
@@ -19,6 +19,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Atomic_Icon_Button_Content extends Atomic_Element_Base {
 	use Has_Element_Template;
 
+	public static $widget_description = 'Content slot for the Icon Button element. Holds the button label; drop any V4 element here to replace the default paragraph.';
+
 	public function __construct( $data = [], $args = null ) {
 		parent::__construct( $data, $args );
 		$this->meta( 'permanently_locked', true );

--- a/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-icon/atomic-icon-button-icon.php
+++ b/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button-icon/atomic-icon-button-icon.php
@@ -24,6 +24,8 @@ class Atomic_Icon_Button_Icon extends Atomic_Element_Base {
 
 	const BASE_STYLE_KEY = 'base';
 
+	public static $widget_description = 'Icon slot for the Icon Button element. Holds the decorative icon; drop any V4 element here to replace the default SVG.';
+
 	public function __construct( $data = [], $args = null ) {
 		parent::__construct( $data, $args );
 		$this->meta( 'permanently_locked', true );

--- a/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button.php
+++ b/modules/atomic-widgets/elements/atomic-icon-button/atomic-icon-button.php
@@ -39,6 +39,8 @@ class Atomic_Icon_Button extends Atomic_Element_Base {
 	const ELEMENT_TYPE_CONTENT = 'e-icon-button-content';
 	const ELEMENT_TYPE_ICON = 'e-icon-button-icon';
 
+	public static $widget_description = 'A pre-composed button with an icon and a text label. Structure: e-icon-button contains e-icon-button-content (holds the label, any V4 element) and e-icon-button-icon (holds the icon, any V4 element). Renders as a <button>, or as an <a> when a link is set.';
+
 	public function __construct( $data = [], $args = null ) {
 		parent::__construct( $data, $args );
 		$this->meta( 'is_container', true );
@@ -86,16 +88,21 @@ class Atomic_Icon_Button extends Atomic_Element_Base {
 
 		return [
 			'classes' => Classes_Prop_Type::make()
-				->default( [] ),
+				->default( [] )
+				->description( 'The CSS classes applied to the button.' ),
 			'tag' => String_Prop_Type::make()
 				->enum( [ 'button', 'a', 'div', 'header', 'section', 'article', 'aside', 'footer' ] )
 				->default( 'button' )
-				->set_dependencies( $tag_dependencies ),
-			'link' => Link_Prop_Type::make(),
+				->set_dependencies( $tag_dependencies )
+				->description( 'The HTML tag for the button. Defaults to button, and switches to a automatically when a link is set. Could be button, a, div, header, section, article, aside, or footer.' ),
+			'link' => Link_Prop_Type::make()
+				->description( 'The link destination of the button. When set, the button is rendered as an anchor with an href.' ),
 			'show_icon' => Boolean_Prop_Type::make()
-				->default( true ),
+				->default( true )
+				->description( 'Whether the icon slot is rendered. When false, the icon element is removed from the markup entirely and the button shows text only.' ),
 			'attributes' => Attributes_Prop_Type::make()
-				->meta( Overridable_Prop_Type::ignore() ),
+				->meta( Overridable_Prop_Type::ignore() )
+				->description( 'Custom HTML attributes added to the button.' ),
 		];
 	}
 
@@ -258,5 +265,21 @@ class Atomic_Icon_Button extends Atomic_Element_Base {
 		return [
 			'elementor/elements/atomic-icon-button' => __DIR__ . '/atomic-icon-button.html.twig',
 		];
+	}
+
+	public function render_markdown(): string {
+		$text = trim( wp_strip_all_tags( parent::render_markdown() ) );
+
+		if ( empty( $text ) ) {
+			return '';
+		}
+
+		$settings = $this->get_atomic_settings();
+
+		if ( ! empty( $settings['link']['href'] ) ) {
+			return '[' . $text . '](' . esc_url( $settings['link']['href'] ) . ')';
+		}
+
+		return '**' . $text . '**';
 	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-icon-button.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-icon-button.php
@@ -1,0 +1,451 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\Elements;
+
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Button\Atomic_Button;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button_Content\Atomic_Icon_Button_Content;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Icon_Button\Atomic_Icon_Button_Icon\Atomic_Icon_Button_Icon;
+use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Link_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Boolean_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Minimal stand-in for a rendered child element. `Element_Base::render_markdown()` only ever
+ * calls `render_markdown()` on the members of `get_children()`, so this is enough to drive the
+ * Icon Button's markdown wrapper without registering the whole element tree.
+ */
+class Icon_Button_Markdown_Child {
+	private $markdown;
+
+	public function __construct( string $markdown ) {
+		$this->markdown = $markdown;
+	}
+
+	public function render_markdown(): string {
+		return $this->markdown;
+	}
+}
+
+class Icon_Button_With_Stub_Children extends Atomic_Icon_Button {
+	public $stub_children = [];
+
+	public function get_children() {
+		return $this->stub_children;
+	}
+}
+
+class Test_Atomic_Icon_Button extends Elementor_Test_Base {
+
+	/**
+	 * @var string|null
+	 */
+	private $original_icon_button_experiment_default = null;
+
+	/**
+	 * @var bool
+	 */
+	private $registered_icon_button_experiment = false;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$feature = Plugin::$instance->experiments->get_features( Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON );
+
+		if ( $feature ) {
+			$this->original_icon_button_experiment_default = $feature['default'];
+		}
+	}
+
+	public function tearDown(): void {
+		if ( $this->registered_icon_button_experiment ) {
+			Plugin::$instance->experiments->remove_feature( Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON );
+			$this->registered_icon_button_experiment = false;
+		} elseif ( null !== $this->original_icon_button_experiment_default ) {
+			Plugin::$instance->experiments->set_feature_default_state(
+				Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON,
+				$this->original_icon_button_experiment_default
+			);
+		}
+
+		parent::tearDown();
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Props schema
+	// -----------------------------------------------------------------------------------------
+
+	public function test_props_schema__contains_the_expected_props_with_the_expected_types() {
+		// Act.
+		$schema = $this->get_defined_props_schema( Atomic_Icon_Button::class );
+
+		// Assert.
+		$this->assertSame(
+			[ 'classes', 'tag', 'link', 'show_icon', 'attributes' ],
+			array_keys( $schema )
+		);
+
+		$this->assertInstanceOf( Classes_Prop_Type::class, $schema['classes'] );
+		$this->assertInstanceOf( String_Prop_Type::class, $schema['tag'] );
+		$this->assertInstanceOf( Link_Prop_Type::class, $schema['link'] );
+		$this->assertInstanceOf( Boolean_Prop_Type::class, $schema['show_icon'] );
+		$this->assertInstanceOf( Attributes_Prop_Type::class, $schema['attributes'] );
+	}
+
+	public function test_props_schema__show_icon_defaults_to_true() {
+		// Act.
+		$default = $this->get_defined_props_schema( Atomic_Icon_Button::class )['show_icon']->get_default();
+
+		// Assert.
+		$this->assertTrue( $default['value'] );
+	}
+
+	public function test_props_schema__tag_defaults_to_button_and_enum_allows_button_and_anchor() {
+		// Act.
+		$tag = $this->get_defined_props_schema( Atomic_Icon_Button::class )['tag'];
+
+		// Assert.
+		$this->assertSame( 'button', $tag->get_default()['value'] );
+		$this->assertContains( 'button', $tag->get_enum() );
+		$this->assertContains( 'a', $tag->get_enum() );
+	}
+
+	public function test_props_schema__tag_carries_dependencies_driven_by_the_link_prop() {
+		// Act.
+		$dependencies = $this->get_defined_props_schema( Atomic_Icon_Button::class )['tag']->get_dependencies();
+
+		// Assert.
+		$this->assertNotEmpty( $dependencies );
+		$this->assertSame( 'and', $dependencies['relation'] );
+		$this->assertCount( 2, $dependencies['terms'] );
+		$this->assertSame( [ 'link', 'destination' ], $dependencies['terms'][0]['path'] );
+		$this->assertSame( 'button', $dependencies['terms'][0]['newValue']['value'] );
+		$this->assertSame( 'not_exist', $dependencies['terms'][1]['operator'] );
+		$this->assertSame( 'a', $dependencies['terms'][1]['newValue']['value'] );
+	}
+
+	public function test_props_schema__show_icon_and_link_stay_overridable_for_components() {
+		// Act.
+		$schema = $this->get_defined_props_schema( Atomic_Icon_Button::class );
+
+		// Assert.
+		$this->assertArrayNotHasKey( Overridable_Prop_Type::META_KEY, $schema['show_icon']->get_meta() );
+		$this->assertArrayNotHasKey( Overridable_Prop_Type::META_KEY, $schema['link']->get_meta() );
+	}
+
+	public function test_props_schema__attributes_is_not_overridable() {
+		// Act.
+		$meta = $this->get_defined_props_schema( Atomic_Icon_Button::class )['attributes']->get_meta();
+
+		// Assert.
+		$this->assertArrayHasKey( Overridable_Prop_Type::META_KEY, $meta );
+		$this->assertFalse( $meta[ Overridable_Prop_Type::META_KEY ] );
+	}
+
+	public function test_props_schema__cssid_is_auto_injected_and_not_overridable() {
+		// Act.
+		$defined = $this->get_defined_props_schema( Atomic_Icon_Button::class );
+		$schema = Atomic_Icon_Button::get_props_schema();
+
+		// Assert.
+		$this->assertArrayNotHasKey( '_cssid', $defined );
+		$this->assertArrayHasKey( '_cssid', $schema );
+		$this->assertFalse( $schema['_cssid']->get_meta_item( Overridable_Prop_Type::META_KEY ) );
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Children dependencies
+	// -----------------------------------------------------------------------------------------
+
+	public function test_children_dependencies__declare_a_single_stashing_rule_for_the_icon_slot() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_icon_button() );
+
+		// Assert.
+		$this->assertCount( 1, $config['children_dependencies'] );
+
+		$rule = $config['children_dependencies'][0];
+
+		$this->assertSame( 'e-icon-button-icon', $rule['child_type'] );
+		$this->assertSame( 'last', $rule['position']['kind'] );
+		$this->assertTrue( $rule['stash'] );
+	}
+
+	public function test_children_dependencies__default_model_is_a_locked_hydrated_icon_slot() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_icon_button() );
+
+		// Assert.
+		$default_model = $config['children_dependencies'][0]['default_model'];
+
+		$this->assertNotEmpty( $default_model );
+		$this->assertSame( 'e-icon-button-icon', $default_model['elType'] );
+		$this->assertTrue( $default_model['isLocked'] );
+		$this->assertTrue( $default_model['hydrateDefaultChildren'] );
+	}
+
+	public function test_children_dependencies__condition_is_show_icon_not_equal_false() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_icon_button() );
+
+		// Assert.
+		$term = $config['children_dependencies'][0]['when']['terms'][0];
+
+		$this->assertSame( 'ne', $term['operator'] );
+		$this->assertSame( [ 'show_icon' ], $term['path'] );
+		$this->assertFalse( $term['value'] );
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Default children / allowed children
+	// -----------------------------------------------------------------------------------------
+
+	public function test_default_children__are_the_content_slot_then_the_icon_slot() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_icon_button() );
+
+		// Assert.
+		$children = $config['default_children'];
+
+		$this->assertCount( 2, $children );
+		$this->assertSame( 'e-icon-button-content', $children[0]['elType'] );
+		$this->assertSame( 'e-icon-button-icon', $children[1]['elType'] );
+		$this->assertTrue( $children[0]['hydrateDefaultChildren'] );
+		$this->assertTrue( $children[1]['hydrateDefaultChildren'] );
+	}
+
+	public function test_default_children__content_slot_seeds_a_paragraph_rendered_as_a_span() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_content_slot() );
+
+		// Assert.
+		$children = $config['default_children'];
+
+		$this->assertCount( 1, $children );
+		$this->assertSame( 'widget', $children[0]['elType'] );
+		$this->assertSame( 'e-paragraph', $children[0]['widgetType'] );
+		$this->assertSame( 'span', $children[0]['settings']['tag']['value'] );
+	}
+
+	public function test_default_children__icon_slot_seeds_an_svg() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_icon_slot() );
+
+		// Assert.
+		$children = $config['default_children'];
+
+		$this->assertCount( 1, $children );
+		$this->assertSame( 'widget', $children[0]['elType'] );
+		$this->assertSame( 'e-svg', $children[0]['widgetType'] );
+	}
+
+	public function test_allowed_child_types__root_accepts_only_its_two_slots() {
+		// Act.
+		$config = $this->get_initial_config( $this->make_icon_button() );
+
+		// Assert.
+		$this->assertSame(
+			[ 'e-icon-button-content', 'e-icon-button-icon' ],
+			$config['allowed_child_types']
+		);
+	}
+
+	public function test_allowed_child_types__slots_impose_no_restriction() {
+		// Act.
+		$content_config = $this->get_initial_config( $this->make_content_slot() );
+		$icon_config = $this->get_initial_config( $this->make_icon_slot() );
+
+		// Assert.
+		$this->assertSame( [], $content_config['allowed_child_types'] );
+		$this->assertSame( [], $icon_config['allowed_child_types'] );
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Root / slot element config
+	// -----------------------------------------------------------------------------------------
+
+	public function test_root__renders_as_a_button_and_is_a_container() {
+		// Arrange.
+		$icon_button = $this->make_icon_button();
+
+		// Act.
+		$config = $this->get_initial_config( $icon_button );
+
+		// Assert.
+		$this->assertSame( 'e-icon-button', Atomic_Icon_Button::get_element_type() );
+		$this->assertSame( 'button', $config['default_html_tag'] );
+		$this->assertSame( 'eicon-e-button', $icon_button->get_icon() );
+		$this->assertSame( 'Button', $icon_button->get_title() );
+		$this->assertTrue( $config['show_in_panel'] );
+		$this->assertTrue( (bool) $icon_button->get_meta_item( 'is_container' ) );
+	}
+
+	/**
+	 * @dataProvider slot_provider
+	 */
+	public function test_slots__are_hidden_locked_spans_without_display_conditions( string $class ) {
+		// Arrange.
+		$slot = $this->make_slot( $class );
+
+		// Act.
+		$config = $this->get_initial_config( $slot );
+
+		// Assert.
+		$this->assertFalse( $slot->should_show_in_panel() );
+		$this->assertFalse( $config['show_in_panel'] );
+		$this->assertTrue( $config['meta']['permanently_locked'] );
+		$this->assertSame( 'span', $config['default_html_tag'] );
+		$this->assertArrayNotHasKey( 'display-conditions', $class::get_props_schema() );
+	}
+
+	public function slot_provider(): array {
+		return [
+			'content slot' => [ Atomic_Icon_Button_Content::class ],
+			'icon slot' => [ Atomic_Icon_Button_Icon::class ],
+		];
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Markdown
+	// -----------------------------------------------------------------------------------------
+
+	public function test_render_markdown__returns_empty_string_when_there_is_no_child_text() {
+		// Arrange.
+		$icon_button = $this->make_icon_button_with_children( [] );
+
+		// Act & Assert.
+		$this->assertSame( '', $icon_button->render_markdown() );
+	}
+
+	public function test_render_markdown__returns_bold_text_when_there_is_no_link() {
+		// Arrange.
+		$icon_button = $this->make_icon_button_with_children( [ new Icon_Button_Markdown_Child( 'Click here' ) ] );
+
+		// Act & Assert.
+		$this->assertSame( '**Click here**', $icon_button->render_markdown() );
+	}
+
+	public function test_render_markdown__returns_a_markdown_link_when_a_link_is_set() {
+		// Arrange.
+		$icon_button = $this->make_icon_button_with_children(
+			[ new Icon_Button_Markdown_Child( 'Click here' ) ],
+			[
+				'link' => [
+					'href' => 'https://example.com/',
+					'target' => '_blank',
+					'tag' => 'a',
+				],
+			]
+		);
+
+		// Act & Assert.
+		$this->assertSame( '[Click here](https://example.com/)', $icon_button->render_markdown() );
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Legacy button panel visibility
+	// -----------------------------------------------------------------------------------------
+
+	public function test_legacy_button__is_hidden_from_the_panel_when_the_icon_button_experiment_is_active() {
+		// Arrange.
+		$this->set_icon_button_experiment( Experiments_Manager::STATE_ACTIVE );
+
+		// Act & Assert.
+		$this->assertFalse( ( new Atomic_Button() )->show_in_panel() );
+	}
+
+	public function test_legacy_button__is_shown_in_the_panel_when_the_icon_button_experiment_is_inactive() {
+		// Arrange.
+		$this->set_icon_button_experiment( Experiments_Manager::STATE_INACTIVE );
+
+		// Act & Assert.
+		$this->assertTrue( ( new Atomic_Button() )->show_in_panel() );
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------------------------
+
+	/**
+	 * The authored schema, before `Has_Atomic_Base::get_props_schema()` injects `_cssid` and before
+	 * the `elementor/atomic-widgets/props-schema` filter wraps props in unions (dynamic tags,
+	 * component overrides). Those wrappers preserve meta/default/dependencies but change the
+	 * concrete prop-type class, so type assertions have to run against the raw definition.
+	 */
+	private function get_defined_props_schema( string $class ): array {
+		$reflection = new \ReflectionMethod( $class, 'define_props_schema' );
+		$reflection->setAccessible( true );
+
+		return $reflection->invoke( null );
+	}
+
+	private function get_initial_config( $element ): array {
+		$reflection = new \ReflectionMethod( get_class( $element ), 'get_initial_config' );
+		$reflection->setAccessible( true );
+
+		return $reflection->invoke( $element );
+	}
+
+	private function make_icon_button(): Atomic_Icon_Button {
+		return new Atomic_Icon_Button( $this->make_element_data( Atomic_Icon_Button::get_element_type() ), null );
+	}
+
+	private function make_content_slot(): Atomic_Icon_Button_Content {
+		return $this->make_slot( Atomic_Icon_Button_Content::class );
+	}
+
+	private function make_icon_slot(): Atomic_Icon_Button_Icon {
+		return $this->make_slot( Atomic_Icon_Button_Icon::class );
+	}
+
+	private function make_slot( string $class ) {
+		return new $class( $this->make_element_data( $class::get_element_type() ), null );
+	}
+
+	private function make_icon_button_with_children( array $children, array $settings = [] ): Icon_Button_With_Stub_Children {
+		$icon_button = new Icon_Button_With_Stub_Children(
+			$this->make_element_data( Atomic_Icon_Button::get_element_type(), $settings ),
+			null
+		);
+
+		$icon_button->stub_children = $children;
+
+		return $icon_button;
+	}
+
+	private function make_element_data( string $el_type, array $settings = [] ): array {
+		return [
+			'id' => 'test',
+			'elType' => $el_type,
+			'settings' => $settings,
+		];
+	}
+
+	private function set_icon_button_experiment( string $state ): void {
+		$experiments = Plugin::$instance->experiments;
+
+		if ( ! $experiments->get_features( Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON ) ) {
+			$experiments->add_feature( [
+				'name' => Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON,
+				'title' => 'Icon Button',
+				'hidden' => true,
+				'default' => Experiments_Manager::STATE_INACTIVE,
+			] );
+
+			$this->registered_icon_button_experiment = true;
+		}
+
+		$experiments->set_feature_default_state( Atomic_Widgets_Module::EXPERIMENT_ICON_BUTTON, $state );
+	}
+}

--- a/tests/playwright/sanity/modules/v4-tests/atomic-icon-button.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-icon-button.test.ts
@@ -1,0 +1,197 @@
+import { expect, type BrowserContext, type Locator, type Page } from '@playwright/test';
+import { parallelTest as test } from '../../../parallelTest';
+import WpAdminPage from '../../../pages/wp-admin-page';
+import EditorPage from '../../../pages/editor-page';
+import EditorSelectors from '../../../selectors/editor-selectors';
+import TopBarSelectors from '../../../selectors/top-bar-selectors';
+
+const ICON_BUTTON_TYPE = 'e-icon-button';
+const CONTENT_SLOT_TYPE = 'e-icon-button-content';
+const ICON_SLOT_TYPE = 'e-icon-button-icon';
+const PARAGRAPH_TYPE = 'e-paragraph';
+const SVG_TYPE = 'e-svg';
+const LEGACY_BUTTON_TYPE = 'e-button';
+
+test.describe( 'Atomic Icon Button @v4-tests', () => {
+	let context: BrowserContext;
+	let page: Page;
+	let wpAdmin: WpAdminPage;
+	let editor: EditorPage;
+
+	const panelTile = ( elementType: string ): Locator =>
+		page.locator( `#elementor-panel-page-elements [data-library-element-type="${ elementType }"]` );
+
+	const previewLocator = ( selector: string ): Locator => editor.getPreviewFrame().locator( selector );
+
+	const elementById = ( elementId: string ): Locator => previewLocator( `[data-id="${ elementId }"]` );
+
+	const tagNameOf = async ( elementId: string ): Promise<string> =>
+		elementById( elementId ).evaluate( ( element ) => element.tagName );
+
+	const descendantId = async ( rootId: string, selector: string ): Promise<string> =>
+		elementById( rootId ).locator( selector ).first().getAttribute( 'data-id' );
+
+	/**
+	 * Adds the Icon Button by clicking its tile in the Atomic Elements panel section — the same
+	 * path a user takes, so the client-side default-children hydration runs.
+	 */
+	const addIconButtonFromPanel = async (): Promise<string> => {
+		await editor.openElementsPanel();
+
+		const tile = panelTile( ICON_BUTTON_TYPE );
+		await tile.waitFor( { state: 'visible' } );
+		await tile.click();
+
+		const root = previewLocator( `[data-element_type="${ ICON_BUTTON_TYPE }"]` ).first();
+		await root.waitFor( { state: 'visible' } );
+
+		return await root.getAttribute( 'data-id' );
+	};
+
+	const openNavigator = async (): Promise<void> => {
+		await editor.waitForPreviewFrame();
+
+		const isOpen = await editor.getPreviewFrame().evaluate( () => elementor.navigator.isOpen() );
+
+		if ( ! isOpen ) {
+			await editor.clickTopBarItem( TopBarSelectors.navigator );
+		}
+
+		await page.locator( EditorSelectors.panels.navigator.wrapper ).waitFor();
+	};
+
+	const navigatorEntry = ( elementId: string ): Locator =>
+		page.locator( EditorSelectors.panels.navigator.getElement( elementId ) );
+
+	const showIconSwitch = (): Locator =>
+		page.locator( 'span' ).filter( { hasText: 'Show Icon' } ).getByRole( 'checkbox' );
+
+	const toggleLinkButton = (): Locator => page.locator( '[aria-label="Toggle link"]' );
+
+	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
+		context = await browser.newContext();
+		page = await context.newPage();
+		wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+
+		await wpAdmin.setExperiments( {
+			e_atomic_elements: 'active',
+			e_icon_button: 'active',
+		} );
+	} );
+
+	test.afterAll( async () => {
+		await wpAdmin?.resetExperiments();
+		await context.close();
+	} );
+
+	test.beforeEach( async () => {
+		editor = await wpAdmin.openNewPage();
+	} );
+
+	// QA row 11.
+	test( 'The Button tile lives in the Atomic Elements section and the legacy button tile is gone', async () => {
+		// Act.
+		await editor.openElementsPanel();
+
+		const v4Section = page.locator( EditorSelectors.panels.elements.v4elements );
+
+		// Assert.
+		await expect( v4Section.locator( `[data-library-element-type="${ ICON_BUTTON_TYPE }"]` ) ).toBeVisible();
+		await expect( v4Section.locator( `[data-library-element-type="${ ICON_BUTTON_TYPE }"]` ) ).toContainText( 'Button' );
+		await expect( panelTile( LEGACY_BUTTON_TYPE ) ).toHaveCount( 0 );
+	} );
+
+	// QA row 1.
+	test( 'Dropping the Button renders an icon and the "Click here" label inside a <button>', async () => {
+		// Act.
+		const rootId = await addIconButtonFromPanel();
+		const root = elementById( rootId );
+
+		// Assert.
+		await expect.poll( () => tagNameOf( rootId ) ).toBe( 'BUTTON' );
+		await expect( root.locator( `[data-element_type="${ CONTENT_SLOT_TYPE }"]` ) ).toHaveCount( 1 );
+		await expect( root.locator( `[data-element_type="${ ICON_SLOT_TYPE }"]` ) ).toHaveCount( 1 );
+		await expect( root.locator( `[data-widget_type="${ PARAGRAPH_TYPE }.default"]` ) ).toContainText( 'Click here' );
+		await expect( root.locator( `[data-widget_type="${ SVG_TYPE }.default"] svg` ).first() ).toBeVisible();
+	} );
+
+	// QA row 5.
+	test( 'The content slot label can be edited on the canvas', async () => {
+		// Arrange.
+		const rootId = await addIconButtonFromPanel();
+		const root = elementById( rootId );
+		const paragraphId = await descendantId( rootId, `[data-widget_type="${ PARAGRAPH_TYPE }.default"]` );
+
+		// Act.
+		const inlineEditor = await editor.triggerEditingElement( paragraphId );
+		await inlineEditor.click();
+		await page.keyboard.press( 'ControlOrMeta+A' );
+		await page.keyboard.type( 'Buy now' );
+		await page.keyboard.press( 'Escape' );
+
+		// Assert.
+		await expect( root.locator( `[data-widget_type="${ PARAGRAPH_TYPE }.default"]` ) ).toContainText( 'Buy now' );
+	} );
+
+	// QA rows 6 + 7.
+	test( 'Setting a link switches the root to an <a>, clearing it switches back to a <button>', async () => {
+		// Arrange.
+		const rootId = await addIconButtonFromPanel();
+		const root = elementById( rootId );
+		const url = 'https://elementor.com/';
+
+		await editor.selectElement( rootId );
+		await editor.v4Panel.openTab( 'general' );
+
+		// Act - set a link.
+		const urlInput = page.getByPlaceholder( 'Type or paste your URL' );
+
+		if ( ! await urlInput.isVisible() ) {
+			await toggleLinkButton().click();
+		}
+
+		await urlInput.fill( url );
+
+		// Assert - the root became an anchor.
+		await expect.poll( () => tagNameOf( rootId ) ).toBe( 'A' );
+		await expect( root ).toHaveAttribute( 'href', url );
+
+		// Act - clear the link.
+		await toggleLinkButton().click();
+
+		// Assert - the root is a button again.
+		await expect.poll( () => tagNameOf( rootId ) ).toBe( 'BUTTON' );
+		await expect( root ).not.toHaveAttribute( 'href', url );
+	} );
+
+	// QA rows 8 + 9.
+	test( 'Show Icon removes the icon from the canvas and the Structure panel, and restores it', async () => {
+		// Arrange.
+		const rootId = await addIconButtonFromPanel();
+		const root = elementById( rootId );
+		const iconSlotId = await descendantId( rootId, `[data-element_type="${ ICON_SLOT_TYPE }"]` );
+
+		await openNavigator();
+		await expect( navigatorEntry( iconSlotId ) ).toHaveCount( 1 );
+
+		await editor.selectElement( rootId );
+		await editor.v4Panel.openTab( 'general' );
+
+		// Act - turn Show Icon off.
+		await showIconSwitch().click();
+
+		// Assert - gone from both the canvas and the Structure panel.
+		await expect( root.locator( `[data-element_type="${ ICON_SLOT_TYPE }"]` ) ).toHaveCount( 0 );
+		await expect( navigatorEntry( iconSlotId ) ).toHaveCount( 0 );
+
+		// Act - turn Show Icon back on.
+		await showIconSwitch().click();
+
+		// Assert - restored in both.
+		await expect( root.locator( `[data-element_type="${ ICON_SLOT_TYPE }"]` ) ).toHaveCount( 1 );
+		await expect( root.locator( `[data-widget_type="${ SVG_TYPE }.default"] svg` ).first() ).toBeVisible();
+
+		const restoredIconSlotId = await descendantId( rootId, `[data-element_type="${ ICON_SLOT_TYPE }"]` );
+		await expect( navigatorEntry( restoredIconSlotId ) ).toHaveCount( 1 );
+	} );
+} );


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Feature (Agent Ready metadata)
- [x] Other... Please describe: test coverage

> **Stacked on #36718** — review/merge that one first.

## Summary

This PR can be summarized in the following changelog entry:

* Internal: Make the V4 Icon Button element Agent Ready and cover it with PHPUnit and Playwright tests

## Description

Third of three PRs for [ED-25008](https://elementor.atlassian.net/browse/ED-25008).

Makes the Icon Button legible to the editor agent and locks the behaviour down with tests:

- `$widget_description` on the root and on both locked slots, describing the element tree so the agent knows where the label and the icon live.
- `->description()` on every root prop, including the automatic `<button>`/`<a>` switch and what `show_icon` removes from the markup.
- `render_markdown()` renders the label as a bold run, or as a markdown link when the button carries one.
- PHPUnit covers props schema, controls, base styles, default children, the `show_icon` child dependency and `Atomic_Button` panel BC.
- Playwright covers dropping the element, the tag switch and the icon toggle.

## Test instructions

1. `tests/phpunit/.../elements/test-atomic-icon-button.php` passes in CI.
2. `tests/playwright/sanity/modules/v4-tests/atomic-icon-button.test.ts` passes in CI.
3. In the editor with `e_icon_button` active, ask the agent to add a button with an icon — it picks `e-icon-button` and targets the correct slots.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)


[ED-25008]: https://elementor.atlassian.net/browse/ED-25008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Marks Icon Button as agent-ready per ED-25008. Adds widget descriptions for discovery, props documentation for schema clarity, and markdown rendering for content export. Includes comprehensive test coverage across PHP unit tests and Playwright E2E scenarios.

## 2. What Changed (Where)

- **atomic-icon-button.php**: Added `$widget_description`, enriched props schema with descriptions/dependencies, implemented `render_markdown()` method.
- **atomic-icon-button-content.php** & **atomic-icon-button-icon.php**: Added slot-level `$widget_description`.
- **test-atomic-icon-button.php**: New 451-line unit test suite covering props schema, children dependencies, markdown rendering, experiment states.
- **atomic-icon-button.test.ts**: New 197-line E2E test covering UI interactions, link toggling, icon visibility, content editing.

## 3. How It Works

Icon Button now exports markdown by recursively calling `render_markdown()` on children, stripping tags, and wrapping output as bold text (`**text**`) or a markdown link (`[text](url)`) when href exists. Props schema now declares all controls with descriptions and the `link` prop gains `tag` dependencies that auto-switch between `button` and `a` based on href presence. Slot elements remain hidden from panel but locked and non-overridable. Tests verify schema structure, defaults, dependencies, markdown edge cases, and legacy button visibility under experiment states.

## 4. Risks

Minor: `render_markdown()` assumes children implement the interface but gracefully handles empty text. Icon visibility toggled via `show_icon` uses conditional children logic already in place. No regression risk—new code paths isolated to markdown export and props declarations.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
