### PR TITLE
Fix: Border radius logical parser [ED-24826]

### DIFF
--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -336,7 +336,7 @@ class Converter_Registry_Factory {
 	 *
 	 * @return array<string, array{0: string, 1: string}>
 	 */
-	private static function border_side_specs(): array {
+	public static function border_side_specs(): array {
 		return [
 			'border-top-width' => [ 'border-width', 'block-start' ],
 			'border-right-width' => [ 'border-width', 'inline-end' ],

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -346,6 +346,10 @@ class Converter_Registry_Factory {
 			'border-top-right-radius' => [ 'border-radius', 'start-end' ],
 			'border-bottom-right-radius' => [ 'border-radius', 'end-end' ],
 			'border-bottom-left-radius' => [ 'border-radius', 'end-start' ],
+			'border-start-start-radius' => [ 'border-radius', 'start-start' ],
+			'border-start-end-radius' => [ 'border-radius', 'start-end' ],
+			'border-end-end-radius' => [ 'border-radius', 'end-end' ],
+			'border-end-start-radius' => [ 'border-radius', 'end-start' ],
 		];
 	}
 

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-logical-border-radius-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-logical-border-radius-converter.php
@@ -3,6 +3,7 @@
 namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry_Factory;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Side_Merge_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
@@ -130,26 +131,18 @@ class Test_Logical_Border_Radius_Converter extends TestCase {
 	private function make_registry(): Converter_Registry {
 		$registry = new Converter_Registry();
 
-		$corners = [
-			'border-start-start-radius'  => 'start-start',
-			'border-start-end-radius'    => 'start-end',
-			'border-end-end-radius'      => 'end-end',
-			'border-end-start-radius'    => 'end-start',
-			'border-top-left-radius'     => 'start-start',
-			'border-top-right-radius'    => 'start-end',
-			'border-bottom-right-radius' => 'end-end',
-			'border-bottom-left-radius'  => 'end-start',
-		];
+		$border_radius_specs = array_filter(
+			Converter_Registry_Factory::border_side_specs(),
+			fn( $spec ) => 'border-radius' === $spec[0]
+		);
 
-		$all_corner_keys = [ 'start-start', 'start-end', 'end-end', 'end-start' ];
-
-		foreach ( $corners as $property => $side_key ) {
+		foreach ( $border_radius_specs as $property => [ , $side_key ] ) {
 			$registry->register( new Object_Side_Merge_Converter(
 				$property,
 				'border-radius',
 				Border_Radius_Prop_Type::get_key(),
 				$side_key,
-				$all_corner_keys,
+				Converter_Registry_Factory::BORDER_RADIUS_CORNER_KEYS,
 				Border_Radius_Prop_Type::class
 			) );
 		}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-logical-border-radius-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-logical-border-radius-converter.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Side_Merge_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\PropTypes\Border_Radius_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Logical_Border_Radius_Converter extends TestCase {
+
+	/**
+	 * @dataProvider logical_border_radius_cases
+	 */
+	public function test_logical_longhand__converts_to_border_radius_prop(
+		string $css,
+		array $expected_corners
+	): void {
+		// Arrange.
+		$converter = new Css_Converter(
+			$this->make_registry(),
+			new Null_Failure_Reporter()
+		);
+
+		// Act.
+		$result = $converter->convert( $css );
+
+		// Assert.
+		$this->assertSame( '', $result['customCss'], 'Expected no customCss fallback.' );
+		$this->assertArrayHasKey( 'border-radius', $result['props'] );
+
+		$actual_corners = $result['props']['border-radius']['value'];
+
+		foreach ( $expected_corners as $corner_key => $expected_size ) {
+			$this->assertArrayHasKey( $corner_key, $actual_corners, "Missing corner: {$corner_key}" );
+			$this->assertSame( $expected_size, $actual_corners[ $corner_key ]['value']['size'], "Wrong size for {$corner_key}" );
+		}
+	}
+
+	public static function logical_border_radius_cases(): array {
+		return [
+			// Group A — single logical corner (4 cases).
+			'single_start_start' => [
+				'border-start-start-radius: 10px',
+				[ 'start-start' => 10 ],
+			],
+			'single_start_end' => [
+				'border-start-end-radius: 10px',
+				[ 'start-end' => 10 ],
+			],
+			'single_end_end' => [
+				'border-end-end-radius: 10px',
+				[ 'end-end' => 10 ],
+			],
+			'single_end_start' => [
+				'border-end-start-radius: 10px',
+				[ 'end-start' => 10 ],
+			],
+
+			// Group B — two logical corners, all C(4,2) pairs (6 cases).
+			'two_ss_se' => [
+				'border-start-start-radius: 10px; border-start-end-radius: 20px',
+				[ 'start-start' => 10, 'start-end' => 20 ],
+			],
+			'two_ss_ee' => [
+				'border-start-start-radius: 10px; border-end-end-radius: 20px',
+				[ 'start-start' => 10, 'end-end' => 20 ],
+			],
+			'two_ss_es' => [
+				'border-start-start-radius: 10px; border-end-start-radius: 20px',
+				[ 'start-start' => 10, 'end-start' => 20 ],
+			],
+			'two_se_ee' => [
+				'border-start-end-radius: 10px; border-end-end-radius: 20px',
+				[ 'start-end' => 10, 'end-end' => 20 ],
+			],
+			'two_se_es' => [
+				'border-start-end-radius: 10px; border-end-start-radius: 20px',
+				[ 'start-end' => 10, 'end-start' => 20 ],
+			],
+			'two_ee_es' => [
+				'border-end-end-radius: 10px; border-end-start-radius: 20px',
+				[ 'end-end' => 10, 'end-start' => 20 ],
+			],
+
+			// Group C — mixed three corners: 1 logical + 2 physical (8 cases).
+			// Physical pair: border-top-right-radius (→ start-end, 20px)
+			//              + border-bottom-left-radius (→ end-start, 30px).
+			'mixed_ss_logical_first' => [
+				'border-start-start-radius: 10px; border-top-right-radius: 20px; border-bottom-left-radius: 30px',
+				[ 'start-start' => 10, 'start-end' => 20, 'end-start' => 30 ],
+			],
+			'mixed_se_logical_first' => [
+				'border-start-end-radius: 10px; border-top-right-radius: 20px; border-bottom-left-radius: 30px',
+				[ 'start-end' => 20, 'end-start' => 30 ],
+			],
+			'mixed_ee_logical_first' => [
+				'border-end-end-radius: 10px; border-top-right-radius: 20px; border-bottom-left-radius: 30px',
+				[ 'end-end' => 10, 'start-end' => 20, 'end-start' => 30 ],
+			],
+			'mixed_es_logical_first' => [
+				'border-end-start-radius: 10px; border-top-right-radius: 20px; border-bottom-left-radius: 30px',
+				[ 'start-end' => 20, 'end-start' => 30 ],
+			],
+			'mixed_ss_logical_last' => [
+				'border-top-right-radius: 20px; border-bottom-left-radius: 30px; border-start-start-radius: 10px',
+				[ 'start-start' => 10, 'start-end' => 20, 'end-start' => 30 ],
+			],
+			'mixed_se_logical_last' => [
+				'border-top-right-radius: 20px; border-bottom-left-radius: 30px; border-start-end-radius: 10px',
+				[ 'start-end' => 10, 'end-start' => 30 ],
+			],
+			'mixed_ee_logical_last' => [
+				'border-top-right-radius: 20px; border-bottom-left-radius: 30px; border-end-end-radius: 10px',
+				[ 'start-end' => 20, 'end-end' => 10, 'end-start' => 30 ],
+			],
+			'mixed_es_logical_last' => [
+				'border-top-right-radius: 20px; border-bottom-left-radius: 30px; border-end-start-radius: 10px',
+				[ 'start-end' => 20, 'end-start' => 10 ],
+			],
+		];
+	}
+
+	private function make_registry(): Converter_Registry {
+		$registry = new Converter_Registry();
+
+		$corners = [
+			'border-start-start-radius'  => 'start-start',
+			'border-start-end-radius'    => 'start-end',
+			'border-end-end-radius'      => 'end-end',
+			'border-end-start-radius'    => 'end-start',
+			'border-top-left-radius'     => 'start-start',
+			'border-top-right-radius'    => 'start-end',
+			'border-bottom-right-radius' => 'end-end',
+			'border-bottom-left-radius'  => 'end-start',
+		];
+
+		$all_corner_keys = [ 'start-start', 'start-end', 'end-end', 'end-start' ];
+
+		foreach ( $corners as $property => $side_key ) {
+			$registry->register( new Object_Side_Merge_Converter(
+				$property,
+				'border-radius',
+				Border_Radius_Prop_Type::get_key(),
+				$side_key,
+				$all_corner_keys,
+				Border_Radius_Prop_Type::class
+			) );
+		}
+
+		return $registry;
+	}
+}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Logical border-radius properties (`border-start-start-radius`, etc.) weren't recognized by the CSS converter. This PR exposes the border side specs and adds logical radius mappings to support CSS Logical Properties spec.

## 2. What Changed (Where)

- **converter-registry-factory.php**: Changed `border_side_specs()` from `private` to `public`, added 4 logical border-radius mappings alongside physical ones
- **test-logical-border-radius-converter.php**: New test file with 18 comprehensive cases covering single, multiple, and mixed logical/physical radius combinations

## 3. How It Works

Logical radius properties now route through `Object_Side_Merge_Converter` like physical ones. The mapping translates `border-start-start-radius` → `['border-radius', 'start-start']`, allowing the converter to merge them into the aggregated `border-radius` prop with directional keys instead of falling back to custom CSS.

## 4. Risks

Low risk—purely additive. Test coverage is thorough (18 cases including collision scenarios). Visibility change (`private` → `public`) is safe since the method's return type is stable. Verify no other code relied on `border_side_specs()` remaining private.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
