### PR TITLE
Internal: Add list-resources catalog filter for MCP contributors [ED-25078]

### DIFF
--- a/modules/mcp/abilities/list-resources-ability.php
+++ b/modules/mcp/abilities/list-resources-ability.php
@@ -48,8 +48,32 @@ class List_Resources_Ability extends Abstract_Ability {
 	}
 
 	public function execute( $input = [] ) {
+		$catalog = $this->get_resource_catalog();
+
+		/**
+		 * Filters the MCP list-resources catalog.
+		 *
+		 * Contributors should append associative arrays keyed by `uri`, `name`, `description`, `mimeType`.
+		 * Entries with a duplicate `uri` are deduped (last write wins).
+		 *
+		 * @since 4.3.0
+		 * @param array $catalog List of catalog entries.
+		 */
+		$filtered = apply_filters( 'elementor/mcp/list-resources/catalog', $catalog );
+
+		if ( ! is_array( $filtered ) ) {
+			$filtered = $catalog;
+		}
+
+		$deduped = [];
+		foreach ( $filtered as $entry ) {
+			if ( is_array( $entry ) && isset( $entry['uri'] ) && is_string( $entry['uri'] ) ) {
+				$deduped[ $entry['uri'] ] = $entry;
+			}
+		}
+
 		return [
-			'resources' => $this->get_resource_catalog(),
+			'resources' => array_values( $deduped ),
 		];
 	}
 


### PR DESCRIPTION
## Summary
- Wraps the MCP `list-resources` catalog in a new public filter `elementor/mcp/list-resources/catalog` so Pro (and other modules) can contribute resource entries.
- Dedupes catalog entries by `uri` (last write wins); non-array filter returns fall back to defaults.

## Test plan
- [ ] With no external filters attached, `elementor/list-resources` output is unchanged from before.
- [ ] When Pro attaches catalog entries (companion PR), the two site-parts resources appear in the catalog.
- [ ] PHPCS passes on `modules/mcp/abilities/list-resources-ability.php`.

**Companion PR:** elementor/elementor-pro (ED-25078 discovery resources) — should merge after or alongside this.


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds extensibility to MCP list-resources endpoint by allowing external contributors to inject custom catalog entries via a WordPress filter hook, with deduplication logic to handle conflicts.

## 2. What Changed (Where)

`list-resources-ability.php`: `execute()` method now retrieves base catalog, applies `elementor/mcp/list-resources/catalog` filter, validates returned data, dedupes entries by URI, and returns filtered results.

## 3. How It Works

Flow: get base catalog → apply filter hook → validate is_array() fallback to original → iterate entries, dedupe by URI (last-write-wins) → return array_values() as resources. Deduping uses associative array keyed on URI, preventing duplicate URIs in output.

## 4. Risks

Filter could return non-array data (mitigated by validation fallback). Malformed entries (missing/non-string URI) are silently skipped—consider logging for debugging. Last-write-wins dedup may mask conflicts unexpectedly.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
