### PR TITLE
test: verify border-radius type migration runs when key conditions fail

### DIFF
--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-border-logical-properties-orchestrator.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-border-logical-properties-orchestrator.php
@@ -126,6 +126,51 @@ class Test_Border_Logical_Properties_Orchestrator extends Elementor_Test_Base {
 		$this->assertArrayNotHasKey( 'top', $border_width['value'] );
 	}
 
+	public function test_migrate__legacy_type_with_logical_keys_still_gets_type_bumped() {
+		// Arrange
+		$orchestrator = Migrations_Orchestrator::make( dirname( __DIR__, 6 ) . '/migrations/' );
+		$global_classes_data = [
+			'items' => [
+				[
+					'id' => 'gc_1',
+					'type' => 'class',
+					'label' => 'Logical Keys Legacy Type',
+					'variants' => [
+						[
+							'meta' => [
+								'breakpoint' => 'desktop',
+								'state' => null,
+							],
+							'props' => [
+								'border-radius' => [
+									'$$type' => 'border-radius',
+									'value' => [
+										'start-start' => $this->make_size( 12 ),
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+			'order' => [ 'gc_1' ],
+		];
+
+		$save_callback_called = false;
+		$save_callback = function () use ( &$save_callback_called ) {
+			$save_callback_called = true;
+		};
+
+		// Act
+		$orchestrator->migrate( $global_classes_data, 2004, 'test_border_radius_logical_keys_legacy_type', $save_callback );
+
+		// Assert
+		$this->assertTrue( $save_callback_called );
+		$border_radius = $global_classes_data['items'][0]['variants'][0]['props']['border-radius'];
+		$this->assertSame( 'border-radius-v2', $border_radius['$$type'] );
+		$this->assertSame( 12, $border_radius['value']['start-start']['value']['size'] );
+	}
+
 	public function test_migrate__logical_border_radius_is_unchanged() {
 		// Arrange
 		$orchestrator = Migrations_Orchestrator::make( dirname( __DIR__, 6 ) . '/migrations/' );

--- a/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-border-radius-to-border-radius-v2-migration.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/prop-type-migrations/test-border-radius-to-border-radius-v2-migration.php
@@ -41,6 +41,58 @@ class Test_Border_Radius_To_Border_Radius_V2_Migration extends TestCase {
 		$this->assertSame( 40, $result['value']['end-start']['value']['size'] );
 	}
 
+	public function test_up__still_updates_type_when_no_physical_keys_exist() {
+		// Arrange
+		$data = [
+			'$$type' => 'border-radius',
+			'value' => [
+				'start-start' => $this->make_size( 10 ),
+				'start-end' => $this->make_size( 20 ),
+			],
+		];
+
+		// Act
+		$result = Migration_Interpreter::run( $this->migration, $data, 'up' );
+
+		// Assert
+		$this->assertSame( 'border-radius-v2', $result['$$type'] );
+		$this->assertSame( 10, $result['value']['start-start']['value']['size'] );
+		$this->assertSame( 20, $result['value']['start-end']['value']['size'] );
+	}
+
+	public function test_up__still_updates_type_when_value_is_empty() {
+		// Arrange
+		$data = [
+			'$$type' => 'border-radius',
+			'value' => [],
+		];
+
+		// Act
+		$result = Migration_Interpreter::run( $this->migration, $data, 'up' );
+
+		// Assert
+		$this->assertSame( 'border-radius-v2', $result['$$type'] );
+		$this->assertSame( [], $result['value'] );
+	}
+
+	public function test_up__skipping_key_rename_conditions_does_not_block_type_change() {
+		// Arrange
+		$data = [
+			'$$type' => 'border-radius',
+			'value' => [
+				'start-end' => $this->make_size( 5 ),
+			],
+		];
+
+		// Act
+		$result = Migration_Interpreter::run( $this->migration, $data, 'up' );
+
+		// Assert
+		$this->assertSame( 'border-radius-v2', $result['$$type'] );
+		$this->assertArrayNotHasKey( 'top-left', $result['value'] );
+		$this->assertSame( 5, $result['value']['start-end']['value']['size'] );
+	}
+
 	public function test_up__renames_only_existing_corners() {
 		// Arrange
 		$data = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds regression tests for ED-24073 covering the scenario where physical-key rename conditions are not met but the `$$type` bump to `border-radius-v2` must still run.

## Tests

- `test_up__still_updates_type_when_no_physical_keys_exist`
- `test_up__still_updates_type_when_value_is_empty`
- `test_up__skipping_key_rename_conditions_does_not_block_type_change`
- `test_migrate__legacy_type_with_logical_keys_still_gets_type_bumped` (orchestrator; needs WP PHPUnit)

Ref: https://elementor.atlassian.net/browse/ED-24073
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4afd1453-520c-4ba7-be1f-cfbb41cfd85f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4afd1453-520c-4ba7-be1f-cfbb41cfd85f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

