### PR TITLE
Internal: Document flex-direction default gotcha in MCP composition best practices [ED-25153]

### DIFF
--- a/modules/mcp/static-resources/style/best-practices.md
+++ b/modules/mcp/static-resources/style/best-practices.md
@@ -102,6 +102,14 @@ When in doubt between "safe" and "distinctive," choose distinctive - users can a
 - Space: Primary gets 2x+ surrounding white space vs. secondary
 
 
+## 7. Flexbox Gotcha (CAPABILITY-AWARE)
+
+`e-flexbox` defaults to `flex-direction: row`, not `column` — stacked content
+(heading + paragraph, footer columns, etc.) needs `"display": "flex",
+"flex-direction": "column"` set explicitly, or children render side-by-side with
+no warning. Set `flex-direction` explicitly on every multi-child container.
+
+
 # IMPLEMENTATION WORKFLOW
 
 When building a composition:


### PR DESCRIPTION
## Summary
- Adds a "Flexbox Gotcha" section to the MCP build-composition best-practices guide, noting that `e-flexbox` defaults to `flex-direction: row`, so multi-child containers meant to stack vertically must set `flex-direction: column` explicitly, or children render side-by-side with no warning.

## Test plan
- [ ] Review the updated `modules/mcp/static-resources/style/best-practices.md` for accuracy and clarity.
- [ ] Confirm MCP-generated compositions with stacked multi-child containers explicitly set `flex-direction: column`.

## Jira
[ED-25153](https://elementor.atlassian.net/browse/ED-25153)

Made with [Cursor](https://cursor.com)

[ED-25153]: https://elementor.atlassian.net/browse/ED-25153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Developers building MCP compositions were unknowingly nesting content side-by-side due to `e-flexbox`'s default `flex-direction: row` behavior. This documents the gotcha to prevent layout bugs.

## 2. What Changed (Where)

Added section 7 to `modules/mcp/static-resources/style/best-practices.md` documenting the flexbox direction requirement with explicit guidance.

## 3. How It Works

New section warns that `e-flexbox` defaults to row direction; stacked layouts (heading+paragraph, footer columns) require explicit `flex-direction: column` or children render horizontally unintentionally.

## 4. Risks

None — purely documentation adding clarity to prevent future bugs.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
