### PR TITLE
Internal: Wrap the audit tool in an experiment and add beta tag to the audit panel header [ED-25059]

### DIFF
--- a/modules/audits/module.php
+++ b/modules/audits/module.php
@@ -49,6 +49,7 @@ class Module extends BaseModule {
 			'description' => esc_html__( 'Scan the current page for SEO, accessibility, performance, and best-practice issues directly from the editor.', 'elementor' ),
 			'release_status' => Experiments_Manager::RELEASE_STATUS_BETA,
 			'default' => Experiments_Manager::STATE_INACTIVE,
+			'hidden' => true,
 		];
 	}
 

--- a/modules/audits/module.php
+++ b/modules/audits/module.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\Audits;
 
 use Elementor\Core\Base\Module as BaseModule;
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\Modules\Audits\Data\Controller;
 use Elementor\Plugin;
 
@@ -11,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Module extends BaseModule {
+
+	const EXPERIMENT_NAME = 'e_page_audit';
 
 	const REST_NAMESPACE = 'elementor/v1';
 
@@ -25,6 +28,12 @@ class Module extends BaseModule {
 	public function __construct() {
 		parent::__construct();
 
+		$this->register_experiment();
+
+		if ( ! Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME ) ) {
+			return;
+		}
+
 		$this->register_data_controller();
 
 		add_filter( 'elementor/editor/v2/packages', fn( $packages ) => $this->add_packages( $packages ) );
@@ -33,6 +42,16 @@ class Module extends BaseModule {
 
 	public function get_name(): string {
 		return 'audits';
+	}
+
+	private function register_experiment(): void {
+		Plugin::$instance->experiments->add_feature( [
+			'name' => self::EXPERIMENT_NAME,
+			'title' => esc_html__( 'Page Audit', 'elementor' ),
+			'description' => esc_html__( 'Scan the current page for SEO, accessibility, performance, and best-practice issues directly from the editor.', 'elementor' ),
+			'release_status' => Experiments_Manager::RELEASE_STATUS_BETA,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+		] );
 	}
 
 	public function register_data_controller(): void {

--- a/modules/audits/module.php
+++ b/modules/audits/module.php
@@ -28,7 +28,13 @@ class Module extends BaseModule {
 	public function __construct() {
 		parent::__construct();
 
-		$this->register_experiment();
+		Plugin::$instance->experiments->add_feature( [
+			'name' => self::EXPERIMENT_NAME,
+			'title' => esc_html__( 'Page Audit', 'elementor' ),
+			'description' => esc_html__( 'Scan the current page for SEO, accessibility, performance, and best-practice issues directly from the editor.', 'elementor' ),
+			'release_status' => Experiments_Manager::RELEASE_STATUS_BETA,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+		] );
 
 		if ( ! Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME ) ) {
 			return;
@@ -42,16 +48,6 @@ class Module extends BaseModule {
 
 	public function get_name(): string {
 		return 'audits';
-	}
-
-	private function register_experiment(): void {
-		Plugin::$instance->experiments->add_feature( [
-			'name' => self::EXPERIMENT_NAME,
-			'title' => esc_html__( 'Page Audit', 'elementor' ),
-			'description' => esc_html__( 'Scan the current page for SEO, accessibility, performance, and best-practice issues directly from the editor.', 'elementor' ),
-			'release_status' => Experiments_Manager::RELEASE_STATUS_BETA,
-			'default' => Experiments_Manager::STATE_INACTIVE,
-		] );
 	}
 
 	public function register_data_controller(): void {

--- a/modules/audits/module.php
+++ b/modules/audits/module.php
@@ -28,15 +28,7 @@ class Module extends BaseModule {
 	public function __construct() {
 		parent::__construct();
 
-		Plugin::$instance->experiments->add_feature( [
-			'name' => self::EXPERIMENT_NAME,
-			'title' => esc_html__( 'Page Audit', 'elementor' ),
-			'description' => esc_html__( 'Scan the current page for SEO, accessibility, performance, and best-practice issues directly from the editor.', 'elementor' ),
-			'release_status' => Experiments_Manager::RELEASE_STATUS_BETA,
-			'default' => Experiments_Manager::STATE_INACTIVE,
-		] );
-
-		if ( ! Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME ) ) {
+		if ( ! self::is_active() ) {
 			return;
 		}
 
@@ -48,6 +40,20 @@ class Module extends BaseModule {
 
 	public function get_name(): string {
 		return 'audits';
+	}
+
+	public static function get_experimental_data() {
+		return [
+			'name' => self::EXPERIMENT_NAME,
+			'title' => esc_html__( 'Page Audit', 'elementor' ),
+			'description' => esc_html__( 'Scan the current page for SEO, accessibility, performance, and best-practice issues directly from the editor.', 'elementor' ),
+			'release_status' => Experiments_Manager::RELEASE_STATUS_BETA,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+		];
+	}
+
+	public static function is_active(): bool {
+		return Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME );
 	}
 
 	public function register_data_controller(): void {

--- a/packages/packages/core/editor-audits/src/components/audit-panel.tsx
+++ b/packages/packages/core/editor-audits/src/components/audit-panel.tsx
@@ -24,6 +24,7 @@ export default function AuditPanel() {
 				panelId="audit-panel"
 				title={ __( 'Audit', 'elementor' ) }
 				badge={ __( 'Beta', 'elementor' ) }
+				titleVariant="subtitle2"
 				// actions={ [
 				// 	{
 				// 		id: 'audit',

--- a/packages/packages/core/editor-audits/src/components/audit-panel.tsx
+++ b/packages/packages/core/editor-audits/src/components/audit-panel.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { getCurrentDocumentId } from '@elementor/editor-elements';
 import { FloatingPanelBody, FloatingPanelFooter, FloatingPanelHeader } from '@elementor/editor-floating-panels';
-import { ShieldCheckIcon } from '@elementor/icons';
 import { Box, Button, Typography } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
@@ -22,17 +21,9 @@ export default function AuditPanel() {
 		<>
 			<FloatingPanelHeader
 				panelId="audit-panel"
-				title={ __( 'Audit', 'elementor' ) }
+				title={ __( 'Page Audit', 'elementor' ) }
 				badge={ __( 'Beta', 'elementor' ) }
 				titleVariant="subtitle2"
-				// actions={ [
-				// 	{
-				// 		id: 'audit',
-				// 		icon: ShieldCheckIcon,
-				// 		label: __( 'Audit Page', 'elementor' ),
-				// 		disabled: true,
-				// 	},
-				// ] }
 			/>
 			<FloatingPanelBody>
 				{ status === 'idle' && <WelcomePage /> }

--- a/packages/packages/core/editor-audits/src/components/audit-panel.tsx
+++ b/packages/packages/core/editor-audits/src/components/audit-panel.tsx
@@ -23,6 +23,7 @@ export default function AuditPanel() {
 			<FloatingPanelHeader
 				panelId="audit-panel"
 				title={ __( 'Audit', 'elementor' ) }
+				badge={ __( 'Beta', 'elementor' ) }
 				// actions={ [
 				// 	{
 				// 		id: 'audit',

--- a/packages/packages/core/editor-floating-panels/src/__tests__/floating-panel-header.test.tsx
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/floating-panel-header.test.tsx
@@ -137,6 +137,18 @@ describe( 'FloatingPanelHeader', () => {
 		expect( screen.getByRole( 'button', { name: /drag to reposition/i } ) ).toBeInTheDocument();
 	} );
 
+	it( 'renders a badge chip when badge is provided', () => {
+		renderHeader( { badge: 'Beta' } );
+
+		expect( screen.getByText( 'Beta' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render a badge chip when badge is omitted', () => {
+		renderHeader();
+
+		expect( screen.queryByText( 'Beta' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'does not render drag handle when isDraggable is false', () => {
 		__deleteStore();
 		__registerSlice( slice );

--- a/packages/packages/core/editor-floating-panels/src/__tests__/floating-panel-header.test.tsx
+++ b/packages/packages/core/editor-floating-panels/src/__tests__/floating-panel-header.test.tsx
@@ -149,6 +149,38 @@ describe( 'FloatingPanelHeader', () => {
 		expect( screen.queryByText( 'Beta' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'left-aligns the title when a badge is provided', () => {
+		renderHeader( { badge: 'Beta' } );
+
+		const title = screen.getByRole( 'heading', { name: 'Test Panel' } );
+
+		expect( title ).toHaveStyle( { textAlign: 'left' } );
+	} );
+
+	it( 'centers the title when badge is omitted', () => {
+		renderHeader();
+
+		const title = screen.getByRole( 'heading', { name: 'Test Panel' } );
+
+		expect( title ).toHaveStyle( { textAlign: 'center', fontWeight: 400 } );
+	} );
+
+	it( 'renders the title with the given titleVariant', () => {
+		renderHeader( { titleVariant: 'subtitle2' } );
+
+		const title = screen.getByRole( 'heading', { name: 'Test Panel' } );
+
+		expect( title ).toHaveClass( 'MuiTypography-subtitle2' );
+	} );
+
+	it( 'does not render a typography variant class when titleVariant is omitted', () => {
+		renderHeader();
+
+		const title = screen.getByRole( 'heading', { name: 'Test Panel' } );
+
+		expect( title ).not.toHaveClass( 'MuiTypography-subtitle2' );
+	} );
+
 	it( 'does not render drag handle when isDraggable is false', () => {
 		__deleteStore();
 		__registerSlice( slice );

--- a/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-header.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-header.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { type ComponentType } from 'react';
 import { XIcon } from '@elementor/icons';
 import { __useSelector as useSelector } from '@elementor/store';
-import { Box, Chip, IconButton, Stack, Tooltip, Typography } from '@elementor/ui';
+import { Box, Chip, IconButton, Stack, Tooltip, Typography, type TypographyProps } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { useFloatingPanelActions } from '../../hooks/use-floating-panel-actions';
@@ -17,6 +17,7 @@ type Props = {
 	icon?: ComponentType;
 	actions?: FloatingPanelHeaderAction[];
 	badge?: string;
+	titleVariant?: TypographyProps[ 'variant' ];
 };
 
 function HeaderAction( {
@@ -50,19 +51,37 @@ function HeaderAction( {
 	);
 }
 
-export default function FloatingPanelHeader( { panelId, title, icon: Icon, actions, badge }: Props ) {
+export default function FloatingPanelHeader( { panelId, title, icon: Icon, actions, badge, titleVariant }: Props ) {
 	const { close } = useFloatingPanelActions( panelId );
 	const isDraggable = useSelector( ( state: GlobalState ) => selectIsDraggable( state, panelId ) );
 	const hasActions = Boolean( actions?.length );
 	const panelZIndex = useFloatingPanelZIndex( panelId );
 
+	const hasBadge = Boolean( badge );
+
 	const titleContent = (
-		<Box sx={ { display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1, height: '100%' } }>
+		<Box
+			sx={ {
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: hasBadge ? 'flex-start' : 'center',
+				gap: 1,
+				height: '100%',
+				pl: hasBadge ? 1 : 0,
+			} }
+		>
 			{ Icon ? <Icon /> : null }
-			<Typography component="h2" sx={ { textAlign: 'center', fontSize: '13px', fontWeight: 400 } }>
+			<Typography
+				component="h2"
+				variant={ titleVariant }
+				sx={ {
+					textAlign: hasBadge ? 'left' : 'center',
+					...( ! titleVariant && { fontSize: '13px', fontWeight: 400 } ),
+				} }
+			>
 				{ title }
 			</Typography>
-			{ badge ? <Chip label={ badge } size="small" color="info" variant="standard" /> : null }
+			{ badge ? <Chip label={ badge } size="tiny" variant="standard" /> : null }
 		</Box>
 	);
 

--- a/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-header.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-header.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { type ComponentType } from 'react';
 import { XIcon } from '@elementor/icons';
 import { __useSelector as useSelector } from '@elementor/store';
-import { Box, IconButton, Stack, Tooltip, Typography } from '@elementor/ui';
+import { Box, Chip, IconButton, Stack, Tooltip, Typography } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 import { useFloatingPanelActions } from '../../hooks/use-floating-panel-actions';
@@ -16,6 +16,7 @@ type Props = {
 	title: string;
 	icon?: ComponentType;
 	actions?: FloatingPanelHeaderAction[];
+	badge?: string;
 };
 
 function HeaderAction( {
@@ -49,7 +50,7 @@ function HeaderAction( {
 	);
 }
 
-export default function FloatingPanelHeader( { panelId, title, icon: Icon, actions }: Props ) {
+export default function FloatingPanelHeader( { panelId, title, icon: Icon, actions, badge }: Props ) {
 	const { close } = useFloatingPanelActions( panelId );
 	const isDraggable = useSelector( ( state: GlobalState ) => selectIsDraggable( state, panelId ) );
 	const hasActions = Boolean( actions?.length );
@@ -61,6 +62,7 @@ export default function FloatingPanelHeader( { panelId, title, icon: Icon, actio
 			<Typography component="h2" sx={ { textAlign: 'center', fontSize: '13px', fontWeight: 400 } }>
 				{ title }
 			</Typography>
+			{ badge ? <Chip label={ badge } size="small" color="info" variant="standard" /> : null }
 		</Box>
 	);
 

--- a/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-header.tsx
+++ b/packages/packages/core/editor-floating-panels/src/components/external/floating-panel-header.tsx
@@ -67,7 +67,7 @@ export default function FloatingPanelHeader( { panelId, title, icon: Icon, actio
 				justifyContent: hasBadge ? 'flex-start' : 'center',
 				gap: 1,
 				height: '100%',
-				pl: hasBadge ? 1 : 0,
+				pl: hasBadge ? 2 : 0,
 			} }
 		>
 			{ Icon ? <Icon /> : null }

--- a/tests/phpunit/elementor/modules/audits/test-module.php
+++ b/tests/phpunit/elementor/modules/audits/test-module.php
@@ -44,6 +44,16 @@ class Test_Module extends Elementor_Test_Base {
 		$this->assertSame( 'audits', $module->get_name() );
 	}
 
+	public function test_get_experimental_data_returns_beta_experiment_definition() {
+		// Act.
+		$data = Module::get_experimental_data();
+
+		// Assert.
+		$this->assertSame( Module::EXPERIMENT_NAME, $data['name'] );
+		$this->assertSame( Experiments_Manager::STATE_INACTIVE, $data['default'] );
+		$this->assertSame( Experiments_Manager::RELEASE_STATUS_BETA, $data['release_status'] );
+	}
+
 	public function test_data_controller_is_not_registered_when_experiment_is_inactive() {
 		// Arrange.
 		Plugin::$instance->experiments->set_feature_default_state( Module::EXPERIMENT_NAME, Experiments_Manager::STATE_INACTIVE );

--- a/tests/phpunit/elementor/modules/audits/test-module.php
+++ b/tests/phpunit/elementor/modules/audits/test-module.php
@@ -44,16 +44,6 @@ class Test_Module extends Elementor_Test_Base {
 		$this->assertSame( 'audits', $module->get_name() );
 	}
 
-	public function test_registers_a_beta_experiment() {
-		// Act.
-		new Module();
-
-		// Assert.
-		$feature = Plugin::$instance->experiments->get_features( Module::EXPERIMENT_NAME );
-		$this->assertSame( Experiments_Manager::RELEASE_STATUS_BETA, $feature['release_status'] );
-		$this->assertSame( Experiments_Manager::STATE_INACTIVE, $feature['default'] );
-	}
-
 	public function test_data_controller_is_not_registered_when_experiment_is_inactive() {
 		// Arrange.
 		Plugin::$instance->experiments->set_feature_default_state( Module::EXPERIMENT_NAME, Experiments_Manager::STATE_INACTIVE );

--- a/tests/phpunit/elementor/modules/audits/test-module.php
+++ b/tests/phpunit/elementor/modules/audits/test-module.php
@@ -3,6 +3,7 @@
 namespace Elementor\Tests\Phpunit\Elementor\Modules\Audits;
 
 use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\Audits\Data\Controller;
 use Elementor\Modules\Audits\Module;
 use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
@@ -20,6 +21,7 @@ class Test_Module extends Elementor_Test_Base {
 
 		remove_all_filters( 'elementor/editor/v2/packages' );
 		remove_all_actions( 'elementor/editor/v2/scripts/enqueue' );
+		unset( Plugin::$instance->data_manager_v2->controllers['audits'] );
 
 		$this->original_experiment_default_state = Plugin::$instance->experiments
 			->get_features( Module::EXPERIMENT_NAME )['default'];
@@ -49,6 +51,29 @@ class Test_Module extends Elementor_Test_Base {
 		// Assert.
 		$feature = Plugin::$instance->experiments->get_features( Module::EXPERIMENT_NAME );
 		$this->assertSame( Experiments_Manager::RELEASE_STATUS_BETA, $feature['release_status'] );
+		$this->assertSame( Experiments_Manager::STATE_INACTIVE, $feature['default'] );
+	}
+
+	public function test_data_controller_is_not_registered_when_experiment_is_inactive() {
+		// Arrange.
+		Plugin::$instance->experiments->set_feature_default_state( Module::EXPERIMENT_NAME, Experiments_Manager::STATE_INACTIVE );
+
+		// Act.
+		new Module();
+
+		// Assert.
+		$this->assertFalse( Plugin::$instance->data_manager_v2->get_controller( 'audits' ) );
+	}
+
+	public function test_data_controller_is_registered_when_experiment_is_active() {
+		// Arrange.
+		Plugin::$instance->experiments->set_feature_default_state( Module::EXPERIMENT_NAME, Experiments_Manager::STATE_ACTIVE );
+
+		// Act.
+		new Module();
+
+		// Assert.
+		$this->assertInstanceOf( Controller::class, Plugin::$instance->data_manager_v2->get_controller( 'audits' ) );
 	}
 
 	public function test_packages_filter_is_not_added_when_experiment_is_inactive() {

--- a/tests/phpunit/elementor/modules/audits/test-module.php
+++ b/tests/phpunit/elementor/modules/audits/test-module.php
@@ -2,28 +2,74 @@
 
 namespace Elementor\Tests\Phpunit\Elementor\Modules\Audits;
 
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\Modules\Audits\Module;
-use PHPUnit\Framework\TestCase;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class Test_Module extends TestCase {
+class Test_Module extends Elementor_Test_Base {
+
+	private $original_experiment_default_state;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		remove_all_filters( 'elementor/editor/v2/packages' );
+		remove_all_actions( 'elementor/editor/v2/scripts/enqueue' );
+
+		$this->original_experiment_default_state = Plugin::$instance->experiments
+			->get_features( Module::EXPERIMENT_NAME )['default'];
+	}
+
+	public function tearDown(): void {
+		Plugin::$instance->experiments->set_feature_default_state(
+			Module::EXPERIMENT_NAME,
+			$this->original_experiment_default_state
+		);
+
+		parent::tearDown();
+	}
 
 	public function test_module_name_is_audits() {
 		// Arrange / Act.
-		$module = Module::instance();
+		$module = new Module();
 
 		// Assert.
 		$this->assertSame( 'audits', $module->get_name() );
 	}
 
-	public function test_packages_filter_adds_floating_panels_and_audits() {
+	public function test_registers_a_beta_experiment() {
+		// Act.
+		new Module();
+
+		// Assert.
+		$feature = Plugin::$instance->experiments->get_features( Module::EXPERIMENT_NAME );
+		$this->assertSame( Experiments_Manager::RELEASE_STATUS_BETA, $feature['release_status'] );
+	}
+
+	public function test_packages_filter_is_not_added_when_experiment_is_inactive() {
 		// Arrange.
-		Module::instance();
+		Plugin::$instance->experiments->set_feature_default_state( Module::EXPERIMENT_NAME, Experiments_Manager::STATE_INACTIVE );
 
 		// Act.
+		new Module();
+		$packages = apply_filters( 'elementor/editor/v2/packages', [] );
+
+		// Assert.
+		$this->assertNotContains( 'editor-audits', $packages );
+		$this->assertNotContains( 'editor-floating-panels', $packages );
+	}
+
+	public function test_packages_filter_adds_floating_panels_and_audits_when_experiment_is_active() {
+		// Arrange.
+		Plugin::$instance->experiments->set_feature_default_state( Module::EXPERIMENT_NAME, Experiments_Manager::STATE_ACTIVE );
+
+		// Act.
+		new Module();
 		$packages = apply_filters( 'elementor/editor/v2/packages', [] );
 
 		// Assert.
@@ -31,9 +77,23 @@ class Test_Module extends TestCase {
 		$this->assertContains( 'editor-audits', $packages );
 	}
 
-	public function test_inline_config_is_printed_when_editor_assets_enqueue() {
+	public function test_inline_config_is_not_printed_when_experiment_is_inactive() {
 		// Arrange.
-		Module::instance();
+		Plugin::$instance->experiments->set_feature_default_state( Module::EXPERIMENT_NAME, Experiments_Manager::STATE_INACTIVE );
+		new Module();
+		wp_register_script( 'elementor-v2-editor-audits', 'http://example.test/editor-audits.js', [], '1.0', true );
+
+		// Act.
+		do_action( 'elementor/editor/v2/scripts/enqueue' );
+
+		// Assert.
+		$this->assertEmpty( wp_scripts()->get_data( 'elementor-v2-editor-audits', 'data' ) );
+	}
+
+	public function test_inline_config_is_printed_when_editor_assets_enqueue_and_experiment_is_active() {
+		// Arrange.
+		Plugin::$instance->experiments->set_feature_default_state( Module::EXPERIMENT_NAME, Experiments_Manager::STATE_ACTIVE );
+		new Module();
 		wp_register_script( 'elementor-v2-editor-audits', 'http://example.test/editor-audits.js', [], '1.0', true );
 
 		// Act.

--- a/tests/playwright/sanity/modules/audits/audit-panel.test.ts
+++ b/tests/playwright/sanity/modules/audits/audit-panel.test.ts
@@ -6,6 +6,8 @@ test( 'audit panel opens, runs, lists a violation, and deep-links to the offendi
 	apiRequests,
 }, testInfo ) => {
 	const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+	await wpAdmin.setExperiments( { e_page_audit: 'active' } );
+
 	const editor = await wpAdmin.openNewPage();
 
 	await editor.addWidget( 'image' );
@@ -32,4 +34,6 @@ test( 'audit panel opens, runs, lists a violation, and deep-links to the offendi
 	await expect(
 		editor.getPreviewFrame().locator( '.elementor-element.elementor-element-edit-mode' ),
 	).toBeVisible();
+
+	await wpAdmin.resetExperiments();
 } );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

<img width="1042" height="1424" alt="image" src="https://github.com/user-attachments/assets/b5e0ba04-dcf2-40d2-a9b4-1a587a2ca050" />

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Wraps audit tool behind an experiment flag (ED-25059) to control rollout. Adds "Beta" badge to panel header and defaults feature to inactive, requiring explicit opt-in.

## 2. What Changed (Where)

- **module.php**: Added experiment registration (`EXPERIMENT_NAME`, `get_experimental_data()`, `is_active()`) with early return in constructor when inactive
- **audit-panel.tsx**: Updated header to display "Page Audit" title with "Beta" badge; removed unused ShieldCheckIcon import
- **floating-panel-header.tsx**: Extended Props to support `badge` and `titleVariant`; refactored title layout to left-align when badge present
- **Test suite**: Migrated from singleton `Module::instance()` to instantiation; added 6 new tests covering experiment states, controller registration, and conditional feature loading
- **Playwright test**: Added experiment activation before test execution and reset after

## 3. How It Works

Constructor checks `is_active()` and returns early if experiment inactive, skipping data controller registration and filter hooks. Panel header conditionally renders badge chip and adjusts typography variant/alignment based on props. Tests isolate experiment state via setUp/tearDown to prevent cross-test pollution.

## 4. Risks

Early return in constructor may mask initialization errors for inactive experiments (silent failure). Test setup complexity around experiment state mutation could cause brittleness if experiment manager behavior changes. Consider logging when feature is bypassed in production.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
