### PR TITLE
Fix: Flex-* converters missing in css-converters [ED-25140]

### DIFF
--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -223,8 +223,9 @@ class Converter_Registry_Factory {
 	 */
 	public static function flex_longhand_specs(): array {
 		return [
-			'flex-grow'  => 'flexGrow',
-			'flex-basis' => 'flexBasis',
+			'flex-grow'   => 'flexGrow',
+			'flex-shrink' => 'flexShrink',
+			'flex-basis'  => 'flexBasis',
 		];
 	}
 
@@ -454,6 +455,17 @@ class Converter_Registry_Factory {
 		$converters['flex-grow'] = new Flex_Longhand_Converter(
 			'flex-grow',
 			'flexGrow',
+			static function ( string $v ): ?array {
+				if ( ! is_numeric( $v ) ) {
+					return null;
+				}
+				return Number_Prop_Type::generate( (float) $v );
+			}
+		);
+
+		$converters['flex-shrink'] = new Flex_Longhand_Converter(
+			'flex-shrink',
+			'flexShrink',
 			static function ( string $v ): ?array {
 				if ( ! is_numeric( $v ) ) {
 					return null;

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -11,6 +11,7 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Border_Radius_Proper
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Color_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Dimensions_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Filter_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Flex_Longhand_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Flex_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Transform_Origin_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Transform_Property_Converter;
@@ -23,13 +24,16 @@ use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Object_Side_Merge_Co
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Size_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Span_Property_Converter;
 use Elementor\Modules\AtomicWidgets\CssConverter\Converters\String_Property_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
 use Elementor\Modules\AtomicWidgets\PropTypes\Background_Image_Overlay_Size_Scale_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Background_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Border_Radius_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Dimensions_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Border_Width_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Style_Schema;
 use Elementor\Modules\Variables\Services\Variables_Service;
 
@@ -211,6 +215,26 @@ class Converter_Registry_Factory {
 	];
 
 	/**
+	 * Flex longhands that each contribute one field to the aggregate `flex` prop
+	 * (Flex_Prop_Type). Not Style_Schema properties themselves; accumulated into
+	 * the schema aggregate by Flex_Longhand_Converter.
+	 *
+	 * @return array<string, string> input property -> Flex_Prop_Type field key
+	 */
+	public static function flex_longhand_specs(): array {
+		return [
+			'flex-grow'  => 'flexGrow',
+			'flex-basis' => 'flexBasis',
+		];
+	}
+
+	/**
+	 * CSS-wide keywords accepted as `custom` size values for flex-basis. The UI exposes a free
+	 * "custom" input for flex-basis, so these are stored verbatim as {size: "<keyword>", unit: "custom"}.
+	 */
+	const FLEX_BASIS_CUSTOM_KEYWORDS = [ 'initial', 'inherit', 'unset', 'revert', 'revert-layer' ];
+
+	/**
 	 * Filter-function lists backed by Array(Css_Filter_Func) (filter, backdrop-filter). Handled
 	 * uniformly by Filter_Property_Converter + Filter_Value_Parser; the two share inner items and
 	 * differ only by the wrapping $$type, which is sourced from the live schema.
@@ -320,6 +344,7 @@ class Converter_Registry_Factory {
 			self::FILTER_PROPERTIES,
 			self::OTHER_PROPERTIES,
 			array_keys( self::border_side_specs() ),
+			array_keys( self::flex_longhand_specs() ),
 			self::BACKGROUND_FIELD_PROPERTIES,
 			self::BACKGROUND_LAYER_PROPERTIES,
 			self::NOOP_PROPERTIES,
@@ -425,6 +450,29 @@ class Converter_Registry_Factory {
 		$converters['border-width'] = new Dimensions_Property_Converter( 'border-width', Border_Width_Prop_Type::class );
 		$converters['object-position'] = new Object_Position_Property_Converter();
 		$converters['flex'] = new Flex_Property_Converter();
+
+		$converters['flex-grow'] = new Flex_Longhand_Converter(
+			'flex-grow',
+			'flexGrow',
+			static function ( string $v ): ?array {
+				if ( ! is_numeric( $v ) ) {
+					return null;
+				}
+				return Number_Prop_Type::generate( (float) $v );
+			}
+		);
+
+		$converters['flex-basis'] = new Flex_Longhand_Converter(
+			'flex-basis',
+			'flexBasis',
+			static function ( string $v ): ?array {
+				if ( in_array( strtolower( $v ), self::FLEX_BASIS_CUSTOM_KEYWORDS, true ) ) {
+					return Size_Prop_Type::generate( [ 'size' => $v, 'unit' => 'custom' ] );
+				}
+				$parsed = Size_Value_Parser::parse( $v );
+				return null !== $parsed ? Size_Prop_Type::generate( $parsed ) : null;
+			}
+		);
 		$converters['transition'] = new Transition_Property_Converter();
 		$converters['transform'] = new Transform_Property_Converter();
 		$converters['transform-origin'] = new Transform_Origin_Property_Converter();

--- a/modules/atomic-widgets/css-converter/converter-registry-factory.php
+++ b/modules/atomic-widgets/css-converter/converter-registry-factory.php
@@ -479,7 +479,10 @@ class Converter_Registry_Factory {
 			'flexBasis',
 			static function ( string $v ): ?array {
 				if ( in_array( strtolower( $v ), self::FLEX_BASIS_CUSTOM_KEYWORDS, true ) ) {
-					return Size_Prop_Type::generate( [ 'size' => $v, 'unit' => 'custom' ] );
+					return Size_Prop_Type::generate( [
+						'size' => $v,
+						'unit' => 'custom',
+					] );
 				}
 				$parsed = Size_Value_Parser::parse( $v );
 				return null !== $parsed ? Size_Prop_Type::generate( $parsed ) : null;

--- a/modules/atomic-widgets/css-converter/converters/flex-longhand-converter.php
+++ b/modules/atomic-widgets/css-converter/converters/flex-longhand-converter.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Property_Converter_Base;
+use Elementor\Modules\AtomicWidgets\PropTypes\Flex_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converter for individual flex longhands (flex-grow, flex-basis) that contribute one field to
+ * the aggregate `flex` prop. Reads the existing flex prop from context (if any), updates the
+ * target field, then writes the merged result back.
+ *
+ * Value parsing is delegated to an injected callable so each instance can apply the correct
+ * parser (numeric for flex-grow, size for flex-basis) without duplicating merge logic.
+ */
+class Flex_Longhand_Converter extends Property_Converter_Base {
+	private string $property;
+	private string $field_key;
+
+	/** @var callable(string): ?array */
+	private $value_parser;
+
+	public function __construct( string $property, string $field_key, callable $value_parser ) {
+		$this->property     = $property;
+		$this->field_key    = $field_key;
+		$this->value_parser = $value_parser;
+	}
+
+	protected function get_supported_properties(): array {
+		return [ $this->property ];
+	}
+
+	protected function convert_null( Conversion_Context $context, array $rule ): bool {
+		$fields                     = $this->current_flex_fields( $context->get_prop( 'flex' ) );
+		$fields[ $this->field_key ] = null;
+
+		$context->set_prop( 'flex', Flex_Prop_Type::generate( $fields ) );
+
+		return true;
+	}
+
+	protected function do_convert( Conversion_Context $context, array $rule ): bool {
+		$parsed = ( $this->value_parser )( trim( $rule['value'] ) );
+
+		if ( null === $parsed ) {
+			return false;
+		}
+
+		$fields                     = $this->current_flex_fields( $context->get_prop( 'flex' ) );
+		$fields[ $this->field_key ] = $parsed;
+
+		$context->set_prop( 'flex', Flex_Prop_Type::generate( $fields ) );
+
+		return true;
+	}
+
+	private function current_flex_fields( $existing ): array {
+		if (
+			is_array( $existing ) &&
+			Flex_Prop_Type::get_key() === ( $existing['$$type'] ?? null ) &&
+			is_array( $existing['value'] ?? null )
+		) {
+			return $existing['value'];
+		}
+
+		return [];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-flex-longhand-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-flex-longhand-converter.php
@@ -1,0 +1,387 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter\Converters;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Conversion_Context;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry_Factory;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converters\Flex_Longhand_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\CssConverter\ValueParsers\Size_Value_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Flex_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Flex_Longhand_Converter extends TestCase {
+	private Conversion_Context $context;
+
+	public function setUp(): void {
+		$this->context = new Conversion_Context( [] );
+	}
+
+	// --- flex-grow: unit tests ---
+
+	public function test_flex_grow__converts_integer() {
+		// Arrange.
+		$converter = $this->flex_grow_converter();
+
+		// Act.
+		$result = $converter->convert( $this->context, [ 'property' => 'flex-grow', 'value' => '2' ] );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertSame( 2.0, $this->context->get_prop( 'flex' )['value']['flexGrow']['value'] );
+	}
+
+	public function test_flex_grow__converts_float() {
+		// Arrange.
+		$converter = $this->flex_grow_converter();
+
+		// Act.
+		$result = $converter->convert( $this->context, [ 'property' => 'flex-grow', 'value' => '1.5' ] );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertSame( 1.5, $this->context->get_prop( 'flex' )['value']['flexGrow']['value'] );
+	}
+
+	public function test_flex_grow__merges_into_existing_flex() {
+		// Arrange.
+		$converter = $this->flex_grow_converter();
+
+		$this->context->set_prop( 'flex', Flex_Prop_Type::generate( [
+			'flexGrow'   => Number_Prop_Type::generate( 1.0 ),
+			'flexShrink' => Number_Prop_Type::generate( 1.0 ),
+			'flexBasis'  => Size_Prop_Type::generate( [ 'size' => 50, 'unit' => '%' ] ),
+		] ) );
+
+		// Act.
+		$converter->convert( $this->context, [ 'property' => 'flex-grow', 'value' => '3' ] );
+
+		// Assert.
+		$flex = $this->context->get_prop( 'flex' );
+		$this->assertSame( 3.0, $flex['value']['flexGrow']['value'] );
+		$this->assertSame( 1.0, $flex['value']['flexShrink']['value'] );
+		$this->assertEquals( 50, $flex['value']['flexBasis']['value']['size'] );
+	}
+
+	// --- flex-grow: null resets ---
+
+	/** @dataProvider flex_grow_null_reset_provider */
+	public function test_flex_grow__null_resets_flexGrow_and_preserves_other_fields(
+		array $initial_fields,
+		array $expected_preserved
+	) {
+		// Arrange.
+		$converter = $this->flex_grow_converter();
+
+		if ( ! empty( $initial_fields ) ) {
+			$this->context->set_prop( 'flex', Flex_Prop_Type::generate( $initial_fields ) );
+		}
+
+		// Act.
+		$result = $converter->convert( $this->context, [ 'property' => 'flex-grow', 'value' => null ] );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$flex = $this->context->get_prop( 'flex' );
+		$this->assertNull( $flex['value']['flexGrow'] );
+
+		foreach ( $expected_preserved as $field => $expected_value ) {
+			$this->assertEquals( $expected_value, $flex['value'][ $field ]['value'] );
+		}
+	}
+
+	public static function flex_grow_null_reset_provider(): array {
+		return [
+			'no existing flex'                    => [ [], [] ],
+			'flexGrow was set (now nulled)'       => [
+				[ 'flexGrow' => Number_Prop_Type::generate( 2.0 ) ],
+				[],
+			],
+			'flexShrink preserved'                => [
+				[ 'flexShrink' => Number_Prop_Type::generate( 1.5 ) ],
+				[ 'flexShrink' => 1.5 ],
+			],
+			'flexBasis preserved'                 => [
+				[ 'flexBasis' => Size_Prop_Type::generate( [ 'size' => 100, 'unit' => 'px' ] ) ],
+				[],
+			],
+			'all fields set — non-targets kept'   => [
+				[
+					'flexGrow'   => Number_Prop_Type::generate( 3.0 ),
+					'flexShrink' => Number_Prop_Type::generate( 1.0 ),
+					'flexBasis'  => Size_Prop_Type::generate( [ 'size' => 50, 'unit' => '%' ] ),
+				],
+				[ 'flexShrink' => 1.0 ],
+			],
+			'all fields zero — non-targets kept'  => [
+				[
+					'flexGrow'   => Number_Prop_Type::generate( 0.0 ),
+					'flexShrink' => Number_Prop_Type::generate( 0.0 ),
+					'flexBasis'  => Size_Prop_Type::generate( [ 'size' => 0, 'unit' => 'px' ] ),
+				],
+				[ 'flexShrink' => 0.0 ],
+			],
+		];
+	}
+
+	// --- flex-grow: decline → customCss integration ---
+
+	public function test_flex_grow__non_numeric_falls_to_custom_css() {
+		// Arrange.
+		$css       = 'flex-grow: auto';
+		$converter = $this->make_css_converter( $this->flex_grow_converter() );
+
+		// Act.
+		$result = $converter->convert( $css );
+
+		// Assert.
+		$this->assertEmpty( $result['props'] );
+		$this->assertSame( 'flex-grow: auto;', $result['customCss'] );
+	}
+
+	/** @dataProvider css_wide_keywords_provider */
+	public function test_flex_grow__css_wide_keywords_fall_to_custom_css( string $keyword ) {
+		// Arrange.
+		$converter = $this->make_css_converter( $this->flex_grow_converter() );
+
+		// Act.
+		$result = $converter->convert( "flex-grow: {$keyword}" );
+
+		// Assert.
+		$this->assertEmpty( $result['props'] );
+		$this->assertSame( "flex-grow: {$keyword};", $result['customCss'] );
+	}
+
+	public function test_flex_grow__valid_then_invalid_keeps_prop_and_adds_custom_css() {
+		// flex-grow: 2 → sets flex prop; flex-grow: auto (invalid) → customCss; last-wins dedup means
+		// only the last declaration is processed, so the invalid one wins and goes to customCss.
+		// Arrange.
+		$converter = $this->make_css_converter( $this->flex_grow_converter() );
+
+		// Act.
+		$result = $converter->convert( 'flex-grow: 2; flex-grow: auto' );
+
+		// Assert.
+		$this->assertEmpty( $result['props'] );
+		$this->assertSame( 'flex-grow: auto;', $result['customCss'] );
+	}
+
+	public function test_flex_grow_and_flex_basis__one_valid_one_invalid_splits_to_prop_and_custom_css() {
+		// Arrange.
+		$converter = $this->make_css_converter( $this->flex_grow_converter(), $this->flex_basis_converter() );
+
+		// Act.
+		$result = $converter->convert( 'flex-grow: 2; flex-basis: banana' );
+
+		// Assert.
+		$this->assertSame( 2.0, $result['props']['flex']['value']['flexGrow']['value'] );
+		$this->assertSame( 'flex-basis: banana;', $result['customCss'] );
+	}
+
+	// --- flex-basis: unit tests ---
+
+	public function test_flex_basis__converts_pixel_value() {
+		// Arrange.
+		$converter = $this->flex_basis_converter();
+
+		// Act.
+		$result = $converter->convert( $this->context, [ 'property' => 'flex-basis', 'value' => '100px' ] );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$basis = $this->context->get_prop( 'flex' )['value']['flexBasis']['value'];
+		$this->assertEquals( 100, $basis['size'] );
+		$this->assertSame( 'px', $basis['unit'] );
+	}
+
+	public function test_flex_basis__converts_percentage() {
+		// Arrange.
+		$converter = $this->flex_basis_converter();
+
+		// Act.
+		$result = $converter->convert( $this->context, [ 'property' => 'flex-basis', 'value' => '50%' ] );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$basis = $this->context->get_prop( 'flex' )['value']['flexBasis']['value'];
+		$this->assertEquals( 50, $basis['size'] );
+		$this->assertSame( '%', $basis['unit'] );
+	}
+
+	public function test_flex_basis__converts_auto() {
+		// Arrange.
+		$converter = $this->flex_basis_converter();
+
+		// Act.
+		$result = $converter->convert( $this->context, [ 'property' => 'flex-basis', 'value' => 'auto' ] );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$basis = $this->context->get_prop( 'flex' )['value']['flexBasis']['value'];
+		$this->assertNull( $basis['size'] );
+		$this->assertSame( 'auto', $basis['unit'] );
+	}
+
+	public function test_flex_basis__merges_into_existing_flex() {
+		// Arrange.
+		$converter = $this->flex_basis_converter();
+
+		$this->context->set_prop( 'flex', Flex_Prop_Type::generate( [
+			'flexGrow'   => Number_Prop_Type::generate( 2.0 ),
+			'flexShrink' => Number_Prop_Type::generate( 1.0 ),
+			'flexBasis'  => Size_Prop_Type::generate( [ 'size' => 0, 'unit' => 'px' ] ),
+		] ) );
+
+		// Act.
+		$converter->convert( $this->context, [ 'property' => 'flex-basis', 'value' => '200px' ] );
+
+		// Assert.
+		$flex = $this->context->get_prop( 'flex' );
+		$this->assertSame( 2.0, $flex['value']['flexGrow']['value'] );
+		$this->assertEquals( 200, $flex['value']['flexBasis']['value']['size'] );
+	}
+
+	// --- flex-basis: null resets ---
+
+	/** @dataProvider flex_basis_null_reset_provider */
+	public function test_flex_basis__null_resets_flexBasis_and_preserves_other_fields(
+		array $initial_fields,
+		array $expected_preserved
+	) {
+		// Arrange.
+		$converter = $this->flex_basis_converter();
+
+		if ( ! empty( $initial_fields ) ) {
+			$this->context->set_prop( 'flex', Flex_Prop_Type::generate( $initial_fields ) );
+		}
+
+		// Act.
+		$result = $converter->convert( $this->context, [ 'property' => 'flex-basis', 'value' => null ] );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$flex = $this->context->get_prop( 'flex' );
+		$this->assertNull( $flex['value']['flexBasis'] );
+
+		foreach ( $expected_preserved as $field => $expected_value ) {
+			$this->assertEquals( $expected_value, $flex['value'][ $field ]['value'] );
+		}
+	}
+
+	public static function flex_basis_null_reset_provider(): array {
+		return [
+			'no existing flex'                    => [ [], [] ],
+			'flexGrow preserved'                  => [
+				[ 'flexGrow' => Number_Prop_Type::generate( 2.0 ) ],
+				[ 'flexGrow' => 2.0 ],
+			],
+			'flexShrink preserved'                => [
+				[ 'flexShrink' => Number_Prop_Type::generate( 1.5 ) ],
+				[ 'flexShrink' => 1.5 ],
+			],
+			'flexBasis was set (now nulled)'      => [
+				[ 'flexBasis' => Size_Prop_Type::generate( [ 'size' => 100, 'unit' => 'px' ] ) ],
+				[],
+			],
+			'all fields set — non-targets kept'   => [
+				[
+					'flexGrow'   => Number_Prop_Type::generate( 3.0 ),
+					'flexShrink' => Number_Prop_Type::generate( 1.0 ),
+					'flexBasis'  => Size_Prop_Type::generate( [ 'size' => 50, 'unit' => '%' ] ),
+				],
+				[ 'flexGrow' => 3.0, 'flexShrink' => 1.0 ],
+			],
+			'all fields zero — non-targets kept'  => [
+				[
+					'flexGrow'   => Number_Prop_Type::generate( 0.0 ),
+					'flexShrink' => Number_Prop_Type::generate( 0.0 ),
+					'flexBasis'  => Size_Prop_Type::generate( [ 'size' => 0, 'unit' => 'px' ] ),
+				],
+				[ 'flexGrow' => 0.0, 'flexShrink' => 0.0 ],
+			],
+		];
+	}
+
+	// --- flex-basis: css-wide keywords ---
+
+	/** @dataProvider css_wide_keywords_provider */
+	public function test_flex_basis__accepts_css_wide_keywords_as_custom( string $keyword ) {
+		// Arrange.
+		$converter = $this->flex_basis_converter();
+
+		// Act.
+		$result = $converter->convert( $this->context, [ 'property' => 'flex-basis', 'value' => $keyword ] );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$basis = $this->context->get_prop( 'flex' )['value']['flexBasis']['value'];
+		$this->assertSame( $keyword, $basis['size'] );
+		$this->assertSame( 'custom', $basis['unit'] );
+	}
+
+	// --- flex-basis: decline → customCss integration ---
+
+	public function test_flex_basis__invalid_value_falls_to_custom_css() {
+		// Arrange.
+		$converter = $this->make_css_converter( $this->flex_basis_converter() );
+
+		// Act.
+		$result = $converter->convert( 'flex-basis: banana' );
+
+		// Assert.
+		$this->assertEmpty( $result['props'] );
+		$this->assertSame( 'flex-basis: banana;', $result['customCss'] );
+	}
+
+	public static function css_wide_keywords_provider(): array {
+		return array_combine(
+			Converter_Registry_Factory::FLEX_BASIS_CUSTOM_KEYWORDS,
+			array_map( fn( $k ) => [ $k ], Converter_Registry_Factory::FLEX_BASIS_CUSTOM_KEYWORDS )
+		);
+	}
+
+	private function flex_grow_converter(): Flex_Longhand_Converter {
+		return new Flex_Longhand_Converter(
+			'flex-grow',
+			'flexGrow',
+			static function ( string $v ): ?array {
+				if ( ! is_numeric( $v ) ) {
+					return null;
+				}
+				return Number_Prop_Type::generate( (float) $v );
+			}
+		);
+	}
+
+	private function flex_basis_converter(): Flex_Longhand_Converter {
+		return new Flex_Longhand_Converter(
+			'flex-basis',
+			'flexBasis',
+			static function ( string $v ): ?array {
+				if ( in_array( strtolower( $v ), Converter_Registry_Factory::FLEX_BASIS_CUSTOM_KEYWORDS, true ) ) {
+					return Size_Prop_Type::generate( [ 'size' => $v, 'unit' => 'custom' ] );
+				}
+				$parsed = Size_Value_Parser::parse( $v );
+				return null !== $parsed ? Size_Prop_Type::generate( $parsed ) : null;
+			}
+		);
+	}
+
+	private function make_css_converter( Flex_Longhand_Converter ...$converters ): Css_Converter {
+		$registry = new Converter_Registry();
+
+		foreach ( $converters as $converter ) {
+			$registry->register( $converter );
+		}
+
+		return new Css_Converter( $registry, new Null_Failure_Reporter() );
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-flex-longhand-converter.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/converters/test-flex-longhand-converter.php
@@ -26,7 +26,6 @@ class Test_Flex_Longhand_Converter extends TestCase {
 	}
 
 	// --- flex-grow: unit tests ---
-
 	public function test_flex_grow__converts_integer() {
 		// Arrange.
 		$converter = $this->flex_grow_converter();
@@ -186,8 +185,52 @@ class Test_Flex_Longhand_Converter extends TestCase {
 		$this->assertSame( 'flex-basis: banana;', $result['customCss'] );
 	}
 
-	// --- flex-basis: unit tests ---
+	// --- flex-shrink: unit + integration (mirrors flex-grow; same numeric parser) ---
 
+	public function test_flex_shrink__converts_numeric() {
+		// Arrange.
+		$converter = $this->flex_shrink_converter();
+
+		// Act.
+		$result = $converter->convert( $this->context, [ 'property' => 'flex-shrink', 'value' => '2' ] );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertSame( 2.0, $this->context->get_prop( 'flex' )['value']['flexShrink']['value'] );
+	}
+
+	public function test_flex_shrink__merges_into_existing_flex() {
+		// Arrange.
+		$converter = $this->flex_shrink_converter();
+
+		$this->context->set_prop( 'flex', Flex_Prop_Type::generate( [
+			'flexGrow'   => Number_Prop_Type::generate( 1.0 ),
+			'flexShrink' => Number_Prop_Type::generate( 1.0 ),
+			'flexBasis'  => Size_Prop_Type::generate( [ 'size' => 50, 'unit' => '%' ] ),
+		] ) );
+
+		// Act.
+		$converter->convert( $this->context, [ 'property' => 'flex-shrink', 'value' => '0' ] );
+
+		// Assert.
+		$flex = $this->context->get_prop( 'flex' );
+		$this->assertSame( 1.0, $flex['value']['flexGrow']['value'] );
+		$this->assertSame( 0.0, $flex['value']['flexShrink']['value'] );
+	}
+
+	public function test_flex_shrink__non_numeric_falls_to_custom_css() {
+		// Arrange.
+		$converter = $this->make_css_converter( $this->flex_shrink_converter() );
+
+		// Act.
+		$result = $converter->convert( 'flex-shrink: auto' );
+
+		// Assert.
+		$this->assertEmpty( $result['props'] );
+		$this->assertSame( 'flex-shrink: auto;', $result['customCss'] );
+	}
+
+	// --- flex-basis: unit tests ---
 	public function test_flex_basis__converts_pixel_value() {
 		// Arrange.
 		$converter = $this->flex_basis_converter();
@@ -352,6 +395,19 @@ class Test_Flex_Longhand_Converter extends TestCase {
 		return new Flex_Longhand_Converter(
 			'flex-grow',
 			'flexGrow',
+			static function ( string $v ): ?array {
+				if ( ! is_numeric( $v ) ) {
+					return null;
+				}
+				return Number_Prop_Type::generate( (float) $v );
+			}
+		);
+	}
+
+	private function flex_shrink_converter(): Flex_Longhand_Converter {
+		return new Flex_Longhand_Converter(
+			'flex-shrink',
+			'flexShrink',
 			static function ( string $v ): ?array {
 				if ( ! is_numeric( $v ) ) {
 					return null;


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The CSS converter was missing handlers for flex longhands (`flex-grow`, `flex-shrink`, `flex-basis`), causing these individual properties to be silently dropped instead of merging into the aggregate `flex` prop. ED-25140.

## 2. What Changed (Where)

- **converter-registry-factory.php**: Added imports for `Flex_Longhand_Converter`, `Size_Value_Parser`, `Number_Prop_Type`, `Size_Prop_Type`; registered three longhand converters; added `flex_longhand_specs()` method and `FLEX_BASIS_CUSTOM_KEYWORDS` constant
- **flex-longhand-converter.php** (new): Converter merges individual flex longhands into aggregate `flex` prop via injected value parsers
- **test-flex-longhand-converter.php** (new): 443-line test suite covering numeric parsing, size parsing, merging, null resets, CSS-wide keywords, and customCss fallback

## 3. How It Works

Each longhand converter reads the current `flex` prop from context, updates its target field via injected parser, and writes back merged result. `flex-grow` and `flex-shrink` parse numerically; `flex-basis` accepts size units or CSS-wide keywords (`initial`, `inherit`, etc.) as custom values. Invalid values return null, causing the converter to decline and route to customCss instead.

## 4. Risks

Low. Parser injection pattern is sound and tested. One edge case: case-insensitive keyword matching for `flex-basis` could theoretically collide with malformed input, but the explicit keyword list mitigates this.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
