### PR TITLE
Fix: Better tool description [ED-24826]

### DIFF
--- a/modules/mcp/static-resources/abilities/build-composition.md
+++ b/modules/mcp/static-resources/abilities/build-composition.md
@@ -79,7 +79,7 @@ Match the widget schema shape:
 - **boolean**: plain boolean (`true`)
 - **html-v3** (title, paragraph, etc.): `{ "content": "Hello", "children": [] }` — `children` is a plain array of child node objects
 - **dynamic** (where schema allows): `{ "name": "<tag from elementor://dynamic-tags>", "settings": { ... } }` — settings use plain values per the tag schema; omit `group`
-- **image**: `{ "src": { "url": "https://example.com/photo.jpg" }, "size": "full" }`
+- **image**: `{ "src": { "url": "https://example.com/photo.jpg", "alt": "Description" }, "size": "full" }` — `url` alone is sufficient for any external or placeholder image (e.g. `https://placehold.co/300x400`). `id` is only required for images already in the WordPress media library; omit it for all other cases. `alt` is optional but recommended for accessibility.
 
 ## GLOBAL VARIABLES
 Read [elementor://global-variables] before styling. Create or update via `elementor/manage-global-variable`. Use variable **labels** from that list — not internal ids.


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Image field documentation was incomplete—missing guidance on `alt` attribute, `id` usage conditions, and external URL handling. This clarification improves developer experience and accessibility compliance for Elementor widget composition.

## 2. What Changed (Where)
`modules/mcp/static-resources/abilities/build-composition.md` — expanded image schema example with `alt` field, conditional `id` guidance, and URL flexibility notes.

## 3. How It Works
Documentation now specifies: `alt` is optional but recommended; `id` required only for WordPress media library images; external/placeholder URLs work without `id`.

## 4. Risks
None—documentation-only change with no behavioral impact on code execution or existing implementations.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
