### PR TITLE
Fix: Trimming values to avoid control ui break [ED-25142]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/aspect-ratio-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/aspect-ratio-control.tsx
@@ -51,8 +51,8 @@ export const AspectRatioControl = createControl( ( { label }: { label: string } 
 
 		if ( isCustomValue ) {
 			const [ width, height ] = aspectRatioValue.split( '/' );
-			setCustomWidth( width || '' );
-			setCustomHeight( height || '' );
+			setCustomWidth( width.trim() || '' );
+			setCustomHeight( height.trim() || '' );
 			setSelectedValue( CUSTOM_RATIO );
 			setIsCustom( true );
 		} else {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Custom aspect ratio values were retaining leading/trailing whitespace when split, causing UI layout breaks. Trimming ensures clean numeric inputs.

## 2. What Changed (Where)

`AspectRatioControl` (aspect-ratio-control.tsx): Added `.trim()` calls on width/height values after splitting custom ratio string.

## 3. How It Works

When custom aspect ratio detected, the `"width/height"` string splits into components. `.trim()` removes whitespace before passing to state setters, preventing rendering artifacts.

## 4. Risks

None — trim is idempotent on already-clean input. Backward compatible.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
