### PR TITLE
Internal: Resolve usage of global variables in gradients to actual values [ED-25143]

### DIFF
--- a/modules/atomic-widgets/css-converter/css-converter.php
+++ b/modules/atomic-widgets/css-converter/css-converter.php
@@ -59,6 +59,11 @@ class Css_Converter {
 			$props = $ejected['props'];
 			$leftover = array_merge( $leftover, $ejected['custom_css'] );
 			$rejected = array_merge( $rejected, $ejected['rejected'] );
+
+			// Post-processing: handle edge cases that the general transform pipeline cannot cover.
+			$gradient_color_stops_leftovers = $this->variable_transformer->normalize_gradient_color_stops( $props, $rules );
+			$leftover = array_merge( $leftover, $gradient_color_stops_leftovers );
+
 			$props = $this->validate_props( $props, $schema );
 		}
 

--- a/modules/atomic-widgets/css-converter/variable-prop-value-transformer.php
+++ b/modules/atomic-widgets/css-converter/variable-prop-value-transformer.php
@@ -12,6 +12,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
 use Elementor\Modules\AtomicWidgets\Styles\Size_Constants;
 use Elementor\Modules\Variables\Adapters\Prop_Type_Adapter;
+use Elementor\Modules\Variables\PropTypes\Color_Variable_Prop_Type;
 use Elementor\Modules\Variables\PropTypes\Size_Variable_Prop_Type;
 use Elementor\Modules\Variables\Services\Variables_Service;
 use Elementor\Modules\Variables\Utils\Variable_Type_Keys;
@@ -25,6 +26,61 @@ class Variable_Prop_Value_Transformer {
 
 	public function __construct( Variables_Service $variables_service ) {
 		$this->variables_service = $variables_service;
+	}
+
+	/**
+	 * Resolves global-color-variable references inside gradient color stops to their actual color values.
+	 * Variables cannot be used inside gradient stops because the gradient UI control does not support them.
+	 * If a variable cannot be resolved, the entire background prop is ejected to custom CSS.
+	 *
+	 * @param array                                                                   $props  Mutated in place.
+	 * @param array<int, array{property: string, value: string, declaration: string}> $rules
+	 * @return string[] Extra custom CSS declarations produced by ejected props.
+	 */
+	public function normalize_gradient_color_stops( array &$props, array $rules ): array {
+		$background = $props['background'] ?? null;
+
+		if ( ! is_array( $background ) || 'background' !== ( $background['$$type'] ?? null ) ) {
+			return [];
+		}
+
+		$overlays = $background['value']['background-overlay']['value'] ?? null;
+
+		if ( ! is_array( $overlays ) ) {
+			return [];
+		}
+
+		foreach ( $overlays as $i => $overlay ) {
+			if ( 'background-gradient-overlay' !== ( $overlay['$$type'] ?? null ) ) {
+				continue;
+			}
+
+			$stops = $overlay['value']['stops']['value'] ?? [];
+
+			foreach ( $stops as $j => $stop ) {
+				if ( 'color-stop' !== ( $stop['$$type'] ?? null ) ) {
+					continue;
+				}
+
+				$color = $stop['value']['color'] ?? null;
+
+				if ( ! is_array( $color ) || Color_Variable_Prop_Type::get_key() !== ( $color['$$type'] ?? null ) ) {
+					continue;
+				}
+
+				$variable = $this->variables_service->find_by_label_or_id( $color['value'] ?? '' );
+
+				if ( null === $variable || '' === ( $variable['value'] ?? '' ) ) {
+					unset( $props['background'] );
+					$declaration = $this->declaration_for_ejected_prop( $rules, 'background' );
+					return null !== $declaration ? [ $declaration . ';' ] : [];
+				}
+
+				$props['background']['value']['background-overlay']['value'][ $i ]['value']['stops']['value'][ $j ]['value']['color'] = Color_Prop_Type::generate( $variable['value'] );
+			}
+		}
+
+		return [];
 	}
 
 	/**

--- a/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-variable-prop-value-transformer.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/css-converter/test-variable-prop-value-transformer.php
@@ -4,13 +4,14 @@ namespace Elementor\Testing\Modules\AtomicWidgets\CssConverter;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Variable_Prop_Value_Transformer;
 use Elementor\Modules\AtomicWidgets\PropTypes\Color_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Union_Prop_Type;
 use Elementor\Modules\Variables\Adapters\Prop_Type_Adapter;
 use Elementor\Modules\Variables\PropTypes\Color_Variable_Prop_Type;
 use Elementor\Modules\Variables\PropTypes\Font_Variable_Prop_Type;
 use Elementor\Modules\Variables\PropTypes\Size_Variable_Prop_Type;
-use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\Variables\Services\Variables_Service;
 use PHPUnit\Framework\TestCase;
 
@@ -238,6 +239,105 @@ class Test_Variable_Prop_Value_Transformer extends TestCase {
 			],
 			$result['width']
 		);
+	}
+
+	public function test_normalize_background_gradient_stops__resolves_variable_to_actual_color() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->with( 'e-gv-1' )->willReturn( [
+			'id' => 'e-gv-1',
+			'type' => Color_Variable_Prop_Type::get_key(),
+			'label' => 'brand-primary',
+			'value' => '#ff0000',
+		] );
+
+		$transformer = new Variable_Prop_Value_Transformer( $service );
+
+		$props = $this->build_gradient_props_with_color_stop( [
+			'$$type' => Color_Variable_Prop_Type::get_key(),
+			'value' => 'e-gv-1',
+		] );
+
+		$custom_css = $transformer->normalize_gradient_color_stops( $props, [] );
+
+		$stop_color = $props['background']['value']['background-overlay']['value'][0]['value']['stops']['value'][0]['value']['color'];
+
+		$this->assertSame( Color_Prop_Type::generate( '#ff0000' ), $stop_color );
+		$this->assertSame( [], $custom_css );
+	}
+
+	public function test_normalize_background_gradient_stops__ejects_background_when_variable_unresolvable() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->method( 'find_by_label_or_id' )->willReturn( null );
+
+		$transformer = new Variable_Prop_Value_Transformer( $service );
+
+		$props = $this->build_gradient_props_with_color_stop( [
+			'$$type' => Color_Variable_Prop_Type::get_key(),
+			'value' => 'e-gv-missing',
+		] );
+
+		$rules = [
+			[
+				'property' => 'background-image',
+				'value' => 'linear-gradient(180deg, var(--brand-primary) 0%, #fff 100%)',
+				'declaration' => 'background-image: linear-gradient(180deg, var(--brand-primary) 0%, #fff 100%)',
+			],
+		];
+
+		$custom_css = $transformer->normalize_gradient_color_stops( $props, $rules );
+
+		$this->assertArrayNotHasKey( 'background', $props );
+		$this->assertSame( [ 'background-image: linear-gradient(180deg, var(--brand-primary) 0%, #fff 100%);' ], $custom_css );
+	}
+
+	public function test_normalize_background_gradient_stops__skips_non_variable_color_stops() {
+		$service = $this->createMock( Variables_Service::class );
+		$service->expects( $this->never() )->method( 'find_by_label_or_id' );
+
+		$transformer = new Variable_Prop_Value_Transformer( $service );
+
+		$props = $this->build_gradient_props_with_color_stop( Color_Prop_Type::generate( '#00ff00' ) );
+
+		$custom_css = $transformer->normalize_gradient_color_stops( $props, [] );
+
+		$stop_color = $props['background']['value']['background-overlay']['value'][0]['value']['stops']['value'][0]['value']['color'];
+
+		$this->assertSame( Color_Prop_Type::generate( '#00ff00' ), $stop_color );
+		$this->assertSame( [], $custom_css );
+	}
+
+	private function build_gradient_props_with_color_stop( array $color_value ): array {
+		return [
+			'background' => [
+				'$$type' => 'background',
+				'value' => [
+					'background-overlay' => [
+						'$$type' => 'background-overlay',
+						'value' => [
+							[
+								'$$type' => 'background-gradient-overlay',
+								'value' => [
+									'type' => String_Prop_Type::generate( 'linear' ),
+									'angle' => Number_Prop_Type::generate( 180 ),
+									'stops' => [
+										'$$type' => 'gradient-color-stop',
+										'value' => [
+											[
+												'$$type' => 'color-stop',
+												'value' => [
+													'color' => $color_value,
+													'offset' => Number_Prop_Type::generate( 0 ),
+												],
+											],
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
 	}
 
 	public function test_transform__promotes_size_var_custom_unit_reference() {


### PR DESCRIPTION
Requirement by product team

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Gradient color stops don't support CSS variables in the UI control, so global color variable references must be resolved to actual values during CSS conversion or the entire background property gets ejected to custom CSS as fallback.

## 2. What Changed (Where)

- **css-converter.php**: Added post-processing step calling `normalize_gradient_color_stops()` after variable transformation
- **variable-prop-value-transformer.php**: Implemented `normalize_gradient_color_stops()` method that traverses gradient overlays, resolves color variables, or ejects background if unresolvable
- **test file**: Added 3 test cases covering variable resolution, unresolvable variables, and non-variable color stops

## 3. How It Works

Entry point is the new `normalize_gradient_color_stops()` call in the CSS conversion pipeline. The method traverses the nested background → overlay → gradient stops structure, identifies color-stop entries with `Color_Variable_Prop_Type`, looks up the variable via `Variables_Service`, and replaces it with the resolved color value. If lookup fails, the entire background prop is removed and the original declaration is pushed to custom CSS, preserving the gradient via fallback.

## 4. Risks

Edge case: deeply nested prop structure mutations could fail silently if schema changes. Mitigated by type guards (`$$type` checks) at each level and returning empty array on safe exits.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
