### PR TITLE
Internal: Extract reusable MCP composition compiler [ED-24967]

### DIFF
--- a/modules/mcp/abilities/build-composition-ability.php
+++ b/modules/mcp/abilities/build-composition-ability.php
@@ -4,30 +4,11 @@ namespace Elementor\Modules\Mcp\Abilities;
 
 use Elementor\Core\Base\Document;
 use Elementor\Core\Utils\Document\Document_Mutator;
-use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry_Factory;
-use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
-use Elementor\Modules\AtomicWidgets\CssConverter\Expander_Registry_Factory;
-use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
-use Elementor\Modules\AtomicWidgets\CssConverter\Variable_Prop_Value_Transformer;
-use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
-use Elementor\Modules\AtomicWidgets\PlainResolvers\Plain_Values_Resolver;
-use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
-use Elementor\Modules\Interactions\Module as Interactions_Module;
-use Elementor\Modules\Mcp\Abilities\Appliers\Class_Applier;
-use Elementor\Modules\Mcp\Abilities\Appliers\Element_Config_Applier;
-use Elementor\Modules\Mcp\Abilities\Appliers\Interactions_Applier;
-use Elementor\Modules\Mcp\Abilities\Appliers\Style_Applier;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Composition_Persister;
-use Elementor\Modules\Mcp\Abilities\Build_Composition\Form_Structure_Validator;
-use Elementor\Modules\Mcp\Abilities\Build_Composition\Subtree_Builder;
-use Elementor\Modules\Mcp\Abilities\Build_Composition\Widget_Type_Resolver;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser;
+use Elementor\Modules\Mcp\Abilities\Utils\Composition_Compiler;
 use Elementor\Modules\Mcp\Abilities\Utils\Document_Mutation_Links;
 use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
-use Elementor\Modules\Variables\Module as Variables_Module;
-use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
-use Elementor\Modules\Variables\Services\Variables_Service;
-use Elementor\Modules\Variables\Storage\Variables_Repository;
 use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -95,72 +76,21 @@ class Build_Composition_Ability extends Abstract_Ability {
 			return $document;
 		}
 
-		$xml_parser = new Xml_Parser();
-		$type_resolver = new Widget_Type_Resolver( $xml_parser );
-		$subtree_builder = new Subtree_Builder( $xml_parser );
-
-		$dom = $xml_parser->parse( (string) $input['xml_structure'] );
-		if ( is_wp_error( $dom ) ) {
-			return $dom;
-		}
-
 		$elements_data = $document->get_elements_data();
-		$form_structure_error = ( new Form_Structure_Validator( $xml_parser ) )->validate(
-			$dom,
+		$compiled = Composition_Compiler::make()->compile(
+			$input,
+			$document,
 			is_array( $elements_data ) ? $elements_data : [],
 			$parent_id
 		);
-
-		if ( $form_structure_error ) {
-			return $form_structure_error;
+		if ( is_wp_error( $compiled ) ) {
+			return $compiled;
 		}
 
-		$widget_configs = $type_resolver->collect_used( $dom );
-		if ( is_wp_error( $widget_configs ) ) {
-			return $widget_configs;
-		}
-
-		$child_type_error = $type_resolver->validate_child_types( $dom, $widget_configs );
-		if ( $child_type_error ) {
-			return $child_type_error;
-		}
-
-		$subtrees = $subtree_builder->build( $dom, $widget_configs );
-		if ( empty( $subtrees ) ) {
-			return new \WP_Error(
-				'empty_composition',
-				__( 'xml_structure did not contain any elements. Pass raw XML tags (e.g. <e-flexbox configuration-id="..."></e-flexbox>) — do not wrap the value in <![CDATA[...]]> or other text-only content.', 'elementor' ),
-				[ 'status' => \WP_Http::BAD_REQUEST ]
-			);
-		}
-		$index = $subtree_builder->index_by_config_id( $subtrees, $dom );
-
-		$variables_service = $this->create_variables_service();
-
-		$config_applier = new Element_Config_Applier( $type_resolver, $this->get_plain_values_resolver() );
-		$config_result = $config_applier->apply( $index, $this->as_map( $input['element_config'] ?? [] ), $widget_configs, $document );
-		if ( $config_result['error'] ) {
-			return $config_result['error'];
-		}
-
-		$class_applier = new Class_Applier( $this->create_global_classes_repository() );
-		$class_error = $class_applier->apply( $index, $this->as_map( $input['classes'] ?? [] ) );
-		if ( $class_error ) {
-			return $class_error;
-		}
-
-		$style_applier = new Style_Applier( $this->create_css_converter( $variables_service ) );
-		$style_result = $style_applier->apply( $index, $this->as_map( $input['style'] ?? [] ), $this->element_types_from_index( $index ) );
-		if ( $style_result['error'] ) {
-			return $style_result['error'];
-		}
-
-		$interactions_result = $this->apply_interactions( $index, $this->as_map( $input['interactions'] ?? [] ) );
-		if ( $interactions_result['error'] ) {
-			return $interactions_result['error'];
-		}
-
-		$warnings = array_merge( $config_result['warnings'], $style_result['warnings'], $interactions_result['warnings'] );
+		$subtrees = $compiled['elements'];
+		$warnings = $compiled['warnings'];
+		$dom = $compiled['dom'];
+		$xml_parser = $compiled['xml_parser'];
 
 		if ( $dry_run ) {
 			return $this->build_response( $post_id, $document, $xml_parser, $dom, [], $warnings, $mode, [] );
@@ -359,98 +289,7 @@ class Build_Composition_Ability extends Abstract_Ability {
 		return $response;
 	}
 
-	private function as_map( $value ): array {
-		if ( is_object( $value ) ) {
-			$value = (array) $value;
-		}
-		return is_array( $value ) ? $value : [];
-	}
-
-	private function element_types_from_index( array $index ): array {
-		$element_types = [];
-		foreach ( $index as $config_id => $node ) {
-			$element_type = $node['widgetType'] ?? $node['elType'] ?? null;
-			if ( is_string( $element_type ) && '' !== $element_type ) {
-				$element_types[ $config_id ] = $element_type;
-			}
-		}
-		return $element_types;
-	}
-
 	private function get_mutator(): Document_Mutator {
 		return $this->mutator ?? Document_Mutator::instance();
-	}
-
-	private function create_css_converter( ?Variables_Service $variables_service ): Css_Converter {
-		$variable_transformer = $variables_service
-			? new Variable_Prop_Value_Transformer( $variables_service )
-			: null;
-
-		return new Css_Converter(
-			Converter_Registry_Factory::create( $variables_service ),
-			new Null_Failure_Reporter(),
-			Expander_Registry_Factory::create( $variables_service ),
-			$variable_transformer
-		);
-	}
-
-	private function create_variables_service(): ?Variables_Service {
-		if ( ! $this->is_variables_active() ) {
-			return null;
-		}
-
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-
-		if ( ! $kit ) {
-			return null;
-		}
-
-		return new Variables_Service(
-			new Variables_Repository( $kit ),
-			new Batch_Processor()
-		);
-	}
-
-	private function get_plain_values_resolver(): Plain_Values_Resolver {
-		return AtomicWidgetsModule::instance()->get_settings_plain_values_resolver();
-	}
-
-	/**
-	 * @param array<string, array&>            $index
-	 * @param array<string, array<int, array>> $interactions
-	 *
-	 * @return array{error: \WP_Error|null, warnings: string[]}
-	 */
-	private function apply_interactions( array &$index, array $interactions ): array {
-		if ( empty( $interactions ) ) {
-			return [
-				'error' => null,
-				'warnings' => [],
-			];
-		}
-
-		if ( ! Plugin::$instance->experiments->is_feature_active( Interactions_Module::EXPERIMENT_NAME ) ) {
-			return [
-				'error' => null,
-				'warnings' => [ __( 'Interactions experiment is not active. Interactions were not applied.', 'elementor' ) ],
-			];
-		}
-
-		$applier = new Interactions_Applier( $this->get_plain_values_resolver() );
-
-		return $applier->apply( $index, $interactions );
-	}
-
-	private function is_variables_active(): bool {
-		$experiments = Plugin::$instance->experiments;
-
-		return $experiments->is_feature_active( Variables_Module::EXPERIMENT_NAME )
-			&& $experiments->is_feature_active( AtomicWidgetsModule::EXPERIMENT_NAME );
-	}
-
-	private function create_global_classes_repository(): Global_Classes_Repository {
-		$kit = Plugin::$instance->kits_manager->get_active_kit();
-
-		return Global_Classes_Repository::make( $kit );
 	}
 }

--- a/modules/mcp/abilities/utils/composition-compiler.php
+++ b/modules/mcp/abilities/utils/composition-compiler.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Core\Base\Document;
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry_Factory;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Expander_Registry_Factory;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Variable_Prop_Value_Transformer;
+use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
+use Elementor\Modules\AtomicWidgets\PlainResolvers\Plain_Values_Resolver;
+use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
+use Elementor\Modules\Interactions\Module as Interactions_Module;
+use Elementor\Modules\Mcp\Abilities\Appliers\Class_Applier;
+use Elementor\Modules\Mcp\Abilities\Appliers\Element_Config_Applier;
+use Elementor\Modules\Mcp\Abilities\Appliers\Interactions_Applier;
+use Elementor\Modules\Mcp\Abilities\Appliers\Style_Applier;
+use Elementor\Modules\Mcp\Abilities\Build_Composition\Form_Structure_Validator;
+use Elementor\Modules\Mcp\Abilities\Build_Composition\Subtree_Builder;
+use Elementor\Modules\Mcp\Abilities\Build_Composition\Widget_Type_Resolver;
+use Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser;
+use Elementor\Modules\Variables\Module as Variables_Module;
+use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
+use Elementor\Modules\Variables\Services\Variables_Service;
+use Elementor\Modules\Variables\Storage\Variables_Repository;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class Composition_Compiler {
+
+	private const DEFAULT_PARENT_ID = 'document';
+
+	public static function make(): self {
+		return new self();
+	}
+
+	/**
+	 * @param array     $input         Composition input using the `elementor/build-composition` shapes.
+	 * @param ?Document $document      Context for resolving dynamic values, when a target document exists.
+	 * @param array     $document_tree Existing document tree used for insertion-context validation.
+	 * @param string    $parent_id     Target parent used for insertion-context validation.
+	 *
+	 * @return array{elements: array[], warnings: string[], dom: \DOMDocument, xml_parser: Xml_Parser}|\WP_Error
+	 */
+	public function compile(
+		array $input,
+		?Document $document = null,
+		array $document_tree = [],
+		string $parent_id = self::DEFAULT_PARENT_ID
+	) {
+		$xml_parser = new Xml_Parser();
+		$type_resolver = new Widget_Type_Resolver( $xml_parser );
+		$subtree_builder = new Subtree_Builder( $xml_parser );
+
+		$dom = $xml_parser->parse( (string) ( $input['xml_structure'] ?? '' ) );
+		if ( is_wp_error( $dom ) ) {
+			return $dom;
+		}
+
+		$form_structure_error = ( new Form_Structure_Validator( $xml_parser ) )->validate(
+			$dom,
+			$document_tree,
+			$parent_id
+		);
+		if ( $form_structure_error ) {
+			return $form_structure_error;
+		}
+
+		$widget_configs = $type_resolver->collect_used( $dom );
+		if ( is_wp_error( $widget_configs ) ) {
+			return $widget_configs;
+		}
+
+		$child_type_error = $type_resolver->validate_child_types( $dom, $widget_configs );
+		if ( $child_type_error ) {
+			return $child_type_error;
+		}
+
+		$subtrees = $subtree_builder->build( $dom, $widget_configs );
+		if ( empty( $subtrees ) ) {
+			return new \WP_Error(
+				'empty_composition',
+				__( 'xml_structure did not contain any elements. Pass raw XML tags (e.g. <e-flexbox configuration-id="..."></e-flexbox>) — do not wrap the value in <![CDATA[...]]> or other text-only content.', 'elementor' ),
+				[ 'status' => \WP_Http::BAD_REQUEST ]
+			);
+		}
+
+		$index = $subtree_builder->index_by_config_id( $subtrees, $dom );
+
+		$variables_service = $this->create_variables_service();
+
+		$config_applier = new Element_Config_Applier( $type_resolver, $this->get_plain_values_resolver() );
+		$config_result = $config_applier->apply( $index, $this->as_map( $input['element_config'] ?? [] ), $widget_configs, $document );
+		if ( $config_result['error'] ) {
+			return $config_result['error'];
+		}
+
+		$class_applier = new Class_Applier( $this->create_global_classes_repository() );
+		$class_error = $class_applier->apply( $index, $this->as_map( $input['classes'] ?? [] ) );
+		if ( $class_error ) {
+			return $class_error;
+		}
+
+		$style_applier = new Style_Applier( $this->create_css_converter( $variables_service ) );
+		$style_result = $style_applier->apply( $index, $this->as_map( $input['style'] ?? [] ), $this->element_types_from_index( $index ) );
+		if ( $style_result['error'] ) {
+			return $style_result['error'];
+		}
+
+		$interactions_result = $this->apply_interactions( $index, $this->as_map( $input['interactions'] ?? [] ) );
+		if ( $interactions_result['error'] ) {
+			return $interactions_result['error'];
+		}
+
+		return [
+			'elements' => $subtrees,
+			'warnings' => array_merge( $config_result['warnings'], $style_result['warnings'], $interactions_result['warnings'] ),
+			'dom' => $dom,
+			'xml_parser' => $xml_parser,
+		];
+	}
+
+	private function as_map( $value ): array {
+		if ( is_object( $value ) ) {
+			$value = (array) $value;
+		}
+
+		return is_array( $value ) ? $value : [];
+	}
+
+	private function element_types_from_index( array $index ): array {
+		$element_types = [];
+
+		foreach ( $index as $config_id => $node ) {
+			$element_type = $node['widgetType'] ?? $node['elType'] ?? null;
+
+			if ( is_string( $element_type ) && '' !== $element_type ) {
+				$element_types[ $config_id ] = $element_type;
+			}
+		}
+
+		return $element_types;
+	}
+
+	private function create_css_converter( ?Variables_Service $variables_service ): Css_Converter {
+		$variable_transformer = $variables_service
+			? new Variable_Prop_Value_Transformer( $variables_service )
+			: null;
+
+		return new Css_Converter(
+			Converter_Registry_Factory::create( $variables_service ),
+			new Null_Failure_Reporter(),
+			Expander_Registry_Factory::create( $variables_service ),
+			$variable_transformer
+		);
+	}
+
+	private function create_variables_service(): ?Variables_Service {
+		if ( ! $this->is_variables_active() ) {
+			return null;
+		}
+
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+
+		if ( ! $kit ) {
+			return null;
+		}
+
+		return new Variables_Service(
+			new Variables_Repository( $kit ),
+			new Batch_Processor()
+		);
+	}
+
+	private function get_plain_values_resolver(): Plain_Values_Resolver {
+		return AtomicWidgetsModule::instance()->get_settings_plain_values_resolver();
+	}
+
+	/**
+	 * @param array<string, array&>            $index
+	 * @param array<string, array<int, array>> $interactions
+	 *
+	 * @return array{error: \WP_Error|null, warnings: string[]}
+	 */
+	private function apply_interactions( array &$index, array $interactions ): array {
+		if ( empty( $interactions ) ) {
+			return [
+				'error' => null,
+				'warnings' => [],
+			];
+		}
+
+		if ( ! Plugin::$instance->experiments->is_feature_active( Interactions_Module::EXPERIMENT_NAME ) ) {
+			return [
+				'error' => null,
+				'warnings' => [ __( 'Interactions experiment is not active. Interactions were not applied.', 'elementor' ) ],
+			];
+		}
+
+		$applier = new Interactions_Applier( $this->get_plain_values_resolver() );
+
+		return $applier->apply( $index, $interactions );
+	}
+
+	private function is_variables_active(): bool {
+		$experiments = Plugin::$instance->experiments;
+
+		return $experiments->is_feature_active( Variables_Module::EXPERIMENT_NAME )
+			&& $experiments->is_feature_active( AtomicWidgetsModule::EXPERIMENT_NAME );
+	}
+
+	private function create_global_classes_repository(): Global_Classes_Repository {
+		$kit = Plugin::$instance->kits_manager->get_active_kit();
+
+		return Global_Classes_Repository::make( $kit );
+	}
+}


### PR DESCRIPTION
## Summary
- Extract composition parsing and configuration application into a reusable `Composition_Compiler`.
- Keep document persistence and response formatting in `Build_Composition_Ability`.

## Test plan
- [x] `composer test -- --filter Test_Build_Composition_Ability` (33 tests, 147 assertions)
- [x] PHPCS for changed PHP files

## Jira
- [ED-24967](https://elementor.atlassian.net/browse/ED-24967)

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Extracted composition compilation logic into a reusable `Composition_Compiler` utility class to decouple XML parsing, validation, and applier orchestration from the ability layer, enabling reuse across MCP modules (ED-24967).

## 2. What Changed (Where)

- **build-composition-ability.php**: Removed 18 imports and 100+ lines of compilation/helper methods; now delegates via `Composition_Compiler::make()->compile()`.
- **composition-compiler.php** (new): Encapsulates all compilation steps: XML parsing → validation → applier pipeline → result aggregation.

## 3. How It Works

`Composition_Compiler::compile()` accepts input array and optional document context, returns structured result `{elements, warnings, dom, xml_parser}` or `WP_Error`. Internally chains: XML parse → form validation → type resolution → subtree building → config/class/style/interactions appliers with unified error handling. Single public method with private helpers mirrors original logic—zero behavioral change, pure extraction.

## 4. Risks

None material. Logic is identical to original; only encapsulation changes. Public API is narrowly scoped (`compile()` returns keyed array, easy to consume). If downstream code expects specific error messages or warning format, integration tests cover that.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
