### PR TITLE
Internal: Add elementor/manage-component MCP ability [ED-24967]

### DIFF
--- a/modules/components/components-repository.php
+++ b/modules/components/components-repository.php
@@ -151,6 +151,10 @@ class Components_Repository {
 	 * If target status is publish:
 	 * - Will return the main document. If it's an autosave, it will be published later by the publish_component method.
 	 */
+	public function get_for_edit( int $component_id, string $target_status ): ?Component_Document {
+		return $this->get_component_for_edit( $component_id, $target_status );
+	}
+
 	private function get_component_for_edit( int $component_id, string $target_status ): ?Component_Document {
 		$component = $this->get( $component_id );
 

--- a/modules/mcp/abilities/appliers/component-instance-applier.php
+++ b/modules/mcp/abilities/appliers/component-instance-applier.php
@@ -38,10 +38,10 @@ class Component_Instance_Applier {
 	 *
 	 * @param array<string, array&>                                                 $config_id_index      Index of subtree refs (from Subtree_Builder).
 	 * @param array<string, array{component_id:int,overrides?:array<string,mixed>}> $component_instances  Per-config-id shorthand.
-	 * @param Document                                                              $document             Target document (used for circular-dep check).
+	 * @param Document|null                                                         $document             Target document, when one already exists.
 	 * @return \WP_Error|null
 	 */
-	public function apply( array &$config_id_index, array $component_instances, Document $document ): ?\WP_Error {
+	public function apply( array &$config_id_index, array $component_instances, ?Document $document ): ?\WP_Error {
 		if ( empty( $component_instances ) ) {
 			return null;
 		}
@@ -91,7 +91,7 @@ class Component_Instance_Applier {
 		);
 	}
 
-	private function build_envelope( string $config_id, array $shorthand, Document $document, array &$errors ): ?array {
+	private function build_envelope( string $config_id, array $shorthand, ?Document $document, array &$errors ): ?array {
 		$component_id = (int) ( $shorthand['component_id'] ?? 0 );
 
 		if ( ! $component_id ) {

--- a/modules/mcp/abilities/appliers/element-config-applier.php
+++ b/modules/mcp/abilities/appliers/element-config-applier.php
@@ -33,7 +33,7 @@ class Element_Config_Applier {
 	 * @param array<string, array&>               $config_id_index Index of subtree refs.
 	 * @param array<string, array<string, mixed>> $element_config  Per-config-id settings.
 	 * @param array<string, array>                $widget_configs  Resolved type configs.
-	 * @param Document|null                       $document        Target document (required for <e-component> entries).
+	 * @param Document|null                       $document        Target document, when one already exists.
 	 *
 	 * @return array{ error: ?\WP_Error, warnings: string[] }
 	 */
@@ -110,17 +110,6 @@ class Element_Config_Applier {
 	}
 
 	private function apply_component_entries( array &$config_id_index, array $component_entries, ?Document $document ): ?\WP_Error {
-		if ( ! $document ) {
-			return new \WP_Error(
-				'elementor_invalid_settings',
-				sprintf(
-					'<e-component> entries in element_config require document context, which was not provided. Config-ids: %s.',
-					implode( ', ', array_keys( $component_entries ) )
-				),
-				[ 'status' => \WP_Http::BAD_REQUEST ]
-			);
-		}
-
 		return $this->create_component_applier()->apply( $config_id_index, $component_entries, $document );
 	}
 

--- a/modules/mcp/abilities/list-components-ability.php
+++ b/modules/mcp/abilities/list-components-ability.php
@@ -34,7 +34,10 @@ class List_Components_Ability extends Abstract_Ability {
 								'id'          => [ 'type' => 'integer' ],
 								'name'        => [ 'type' => 'string' ],
 								'uid'         => [ 'type' => 'string' ],
-								'is_archived' => [ 'type' => 'boolean' ],
+								'is_archived' => [
+									'type' => 'boolean',
+									'description' => 'Only present for components requested via component_ids. The discovery list never includes archived components.',
+								],
 								'overridable_props' => [
 									'type' => 'object',
 									'description' => 'Only present for components requested via component_ids.',
@@ -91,6 +94,7 @@ class List_Components_Ability extends Abstract_Ability {
 
 		return array_values(
 			$repository->all()
+				->filter( fn( $component ) => ! ( $component['is_archived'] ?? false ) )
 				->map( fn( $component ) => [
 					'id'          => $component['id'],
 					'name'        => $component['title'],

--- a/modules/mcp/abilities/manage-component-ability.php
+++ b/modules/mcp/abilities/manage-component-ability.php
@@ -1,0 +1,637 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities;
+
+use Elementor\Core\Base\Document;
+use Elementor\Core\Utils\Collection;
+use Elementor\Core\Utils\Document\Document_Mutator;
+use Elementor\Modules\Components\Circular_Dependency_Validator;
+use Elementor\Modules\Components\Components_Access_Controller;
+use Elementor\Modules\Components\Components_Repository;
+use Elementor\Modules\Components\Documents\Component as Component_Document;
+use Elementor\Modules\Components\Non_Atomic_Widget_Validator;
+use Elementor\Modules\Components\Save_Components_Validator;
+use Elementor\Modules\Mcp\Abilities\Utils\Composition_Compiler;
+use Elementor\Modules\Mcp\Abilities\Utils\Insufficient_Permissions_Error;
+use Elementor\Modules\Mcp\Abilities\Utils\Overridable_Props_Builder;
+use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Manage_Component_Ability extends Abstract_Ability {
+
+	const ACTION_CREATE = 'create';
+	const ACTION_UPDATE = 'update';
+	const ACTION_RENAME = 'rename';
+	const ACTION_ARCHIVE = 'archive';
+	const ACTION_PUBLISH = 'publish';
+
+	private ?Components_Repository $repository;
+
+	public function __construct( ?Components_Repository $repository = null ) {
+		$this->repository = $repository;
+	}
+
+	protected function get_ability_id(): string {
+		return 'elementor/manage-component';
+	}
+
+	protected function get_definition(): Ability_Definition {
+		return new Ability_Definition(
+			__( 'Manage Elementor Component', 'elementor' ),
+			Prompt_Loader::load( 'manage-component' ),
+			'elementor',
+			$this->get_output_schema(),
+			[
+				'annotations' => [
+					'readonly' => false,
+					'idempotent' => false,
+					'destructive' => true,
+				],
+			],
+			fn() => current_user_can( 'manage_options' ),
+			$this->get_input_schema()
+		);
+	}
+
+	public function execute( $input = [] ) {
+		$input = is_array( $input ) ? $input : [];
+
+		switch ( $input['action'] ?? null ) {
+			case self::ACTION_CREATE:
+				return $this->handle_create( $input );
+			case self::ACTION_UPDATE:
+				return $this->handle_update( $input );
+			case self::ACTION_RENAME:
+				return $this->handle_rename( $input );
+			case self::ACTION_ARCHIVE:
+				return $this->handle_archive( $input );
+			case self::ACTION_PUBLISH:
+				return $this->handle_publish( $input );
+		}
+
+		return $this->invalid_input( __( 'action must be one of: create, update, rename, archive, publish.', 'elementor' ) );
+	}
+
+	private function handle_create( array $input ) {
+		$gate = $this->check_access( self::ACTION_CREATE, fn() => Components_Access_Controller::can_create() );
+		if ( $gate ) {
+			return $gate;
+		}
+
+		$title = isset( $input['title'] ) ? trim( (string) $input['title'] ) : '';
+		if ( strlen( $title ) < 2 ) {
+			return $this->invalid_input( __( 'create requires a title of at least 2 characters.', 'elementor' ) );
+		}
+
+		$source_result = $this->resolve_create_elements( $input );
+		if ( is_wp_error( $source_result ) ) {
+			return $source_result;
+		}
+		[ 'elements' => $elements, 'warnings' => $warnings ] = $source_result;
+
+		$settings = [];
+		$overridable_error = $this->apply_overridable_props( $elements, $input, $settings );
+		if ( is_wp_error( $overridable_error ) ) {
+			return $overridable_error;
+		}
+
+		$uid = $this->generate_uid();
+		$item = [
+			'uid' => $uid,
+			'title' => $title,
+			'elements' => $elements,
+			'settings' => $settings,
+		];
+		$items = Collection::make( [ $item ] );
+
+		$save_validation = Save_Components_Validator::make( $this->get_repository()->all() )->validate( $items );
+		if ( ! $save_validation['success'] ) {
+			return new \WP_Error(
+				'components_validation_failed',
+				__( 'Validation failed: ', 'elementor' ) . implode( ' ', $save_validation['messages'] ),
+				[ 'status' => \WP_Http::UNPROCESSABLE_ENTITY ]
+			);
+		}
+
+		$circular_validation = Circular_Dependency_Validator::make()->validate_new_components( $items );
+		if ( ! $circular_validation['success'] ) {
+			return new \WP_Error(
+				'circular_dependency_detected',
+				__( "Can't add this component - components that contain each other can't be nested.", 'elementor' ),
+				[
+					'status' => \WP_Http::UNPROCESSABLE_ENTITY,
+					'caused_by' => $circular_validation['messages'],
+				]
+			);
+		}
+
+		$non_atomic_validation = Non_Atomic_Widget_Validator::make()->validate_items( $items );
+		if ( ! $non_atomic_validation['success'] ) {
+			return new \WP_Error(
+				Non_Atomic_Widget_Validator::ERROR_CODE,
+				__( 'Components require atomic elements only. Remove widgets to create this component.', 'elementor' ),
+				[
+					'status' => \WP_Http::UNPROCESSABLE_ENTITY,
+					'non_atomic_elements' => $non_atomic_validation['non_atomic_elements'],
+				]
+			);
+		}
+
+		try {
+			$component_id = $this->get_repository()->create( $title, $elements, $this->resolve_status( $input ), $uid, $settings );
+		} catch ( \Exception $e ) {
+			return new \WP_Error( 'create_failed', $e->getMessage(), [ 'status' => \WP_Http::UNPROCESSABLE_ENTITY ] );
+		}
+
+		$component = $this->get_repository()->get( $component_id, false );
+
+		$response = [
+			'success' => true,
+			'component_id' => $component_id,
+			'uid' => $uid,
+		] + $this->document_links( $component );
+
+		if ( ! empty( $warnings ) ) {
+			$response['warnings'] = $warnings;
+		}
+
+		return $response;
+	}
+
+	private function handle_update( array $input ) {
+		$gate = $this->check_access( self::ACTION_UPDATE, fn() => Components_Access_Controller::can_edit() );
+		if ( $gate ) {
+			return $gate;
+		}
+
+		$component_id = isset( $input['component_id'] ) ? (int) $input['component_id'] : 0;
+		if ( $component_id <= 0 ) {
+			return $this->invalid_input( __( 'update requires component_id.', 'elementor' ) );
+		}
+
+		$component = $this->get_repository()->get_for_edit( $component_id, $this->resolve_status( $input ) );
+		if ( ! $component ) {
+			return $this->not_found( __( 'Component not found.', 'elementor' ) );
+		}
+
+		$has_xml = ! empty( $input['xml_structure'] ) && is_string( $input['xml_structure'] );
+
+		return $has_xml
+			? $this->update_with_xml( $component, $input )
+			: $this->update_overridable_props_only( $component, $input );
+	}
+
+	private function handle_rename( array $input ) {
+		$gate = $this->check_access( self::ACTION_RENAME, fn() => Components_Access_Controller::can_rename() );
+		if ( $gate ) {
+			return $gate;
+		}
+
+		$component_id = isset( $input['component_id'] ) ? (int) $input['component_id'] : 0;
+		$title = isset( $input['title'] ) ? trim( (string) $input['title'] ) : '';
+
+		if ( $component_id <= 0 || strlen( $title ) < 2 ) {
+			return $this->invalid_input( __( 'rename requires component_id and a title of at least 2 characters.', 'elementor' ) );
+		}
+
+		$success = $this->get_repository()->update_title( $component_id, $title, $this->resolve_status( $input ) );
+		if ( ! $success ) {
+			return $this->not_found( __( 'Component not found or title could not be updated.', 'elementor' ) );
+		}
+
+		return [
+			'success' => true,
+			'component_id' => $component_id,
+		];
+	}
+
+	private function handle_archive( array $input ) {
+		$gate = $this->check_access( self::ACTION_ARCHIVE, fn() => Components_Access_Controller::can_delete() );
+		if ( $gate ) {
+			return $gate;
+		}
+
+		$component_ids = $this->normalize_ids( $input['component_ids'] ?? [] );
+		if ( empty( $component_ids ) ) {
+			return $this->invalid_input( __( 'archive requires a non-empty component_ids array of positive integers.', 'elementor' ) );
+		}
+
+		$result = $this->get_repository()->archive( $component_ids, $this->resolve_status( $input ) );
+
+		return [
+			'success' => empty( $result['failedIds'] ),
+			'success_ids' => $result['successIds'],
+			'failed_ids' => $result['failedIds'],
+		];
+	}
+
+	private function handle_publish( array $input ) {
+		$gate = $this->check_access( self::ACTION_PUBLISH, fn() => Components_Access_Controller::can_publish() );
+		if ( $gate ) {
+			return $gate;
+		}
+
+		$component_id = isset( $input['component_id'] ) ? (int) $input['component_id'] : 0;
+		if ( $component_id <= 0 ) {
+			return $this->invalid_input( __( 'publish requires component_id.', 'elementor' ) );
+		}
+
+		$component = $this->get_repository()->get( $component_id );
+		if ( ! $component ) {
+			return $this->not_found( __( 'Component not found.', 'elementor' ) );
+		}
+
+		if ( ! $this->get_repository()->publish_component( $component ) ) {
+			return new \WP_Error(
+				'publish_failed',
+				__( 'Failed to publish component.', 'elementor' ),
+				[ 'status' => \WP_Http::INTERNAL_SERVER_ERROR ]
+			);
+		}
+
+		$published = $this->get_repository()->get( $component->get_main_id(), false );
+
+		return [
+			'success' => true,
+			'component_id' => $component->get_main_id(),
+		] + $this->document_links( $published );
+	}
+
+	private function update_overridable_props_only( Component_Document $component, array $input ) {
+		if ( ! is_array( $input['overridable_props'] ?? null ) ) {
+			return $this->invalid_input( __( 'update without xml_structure requires overridable_props.', 'elementor' ) );
+		}
+
+		$elements = $component->get_elements_data();
+		$settings = [];
+
+		$overridable_error = $this->apply_overridable_props( $elements, $input, $settings );
+		if ( is_wp_error( $overridable_error ) ) {
+			return $overridable_error;
+		}
+
+		return $this->save_component( $component, $elements, $settings );
+	}
+
+	private function update_with_xml( Component_Document $component, array $input ) {
+		$compiled = $this->compile_composition( $input, $component );
+		if ( is_wp_error( $compiled ) ) {
+			return $compiled;
+		}
+
+		$elements = $this->assign_element_ids( $compiled['elements'] );
+		$warnings = $compiled['warnings'];
+
+		$non_atomic_validation = Non_Atomic_Widget_Validator::make()->validate( $elements );
+		if ( ! $non_atomic_validation['success'] ) {
+			return new \WP_Error(
+				Non_Atomic_Widget_Validator::ERROR_CODE,
+				__( 'Components require atomic elements only. Remove widgets to create this component.', 'elementor' ),
+				[
+					'status' => \WP_Http::UNPROCESSABLE_ENTITY,
+					'non_atomic_elements' => $non_atomic_validation['non_atomic_elements'],
+				]
+			);
+		}
+
+		$settings = [];
+		$overridable_error = $this->apply_overridable_props( $elements, $input, $settings );
+		if ( is_wp_error( $overridable_error ) ) {
+			return $overridable_error;
+		}
+
+		$result = $this->save_component( $component, $elements, $settings );
+		if ( is_wp_error( $result ) || empty( $warnings ) ) {
+			return $result;
+		}
+
+		return $result + [ 'warnings' => $warnings ];
+	}
+
+	private function save_component( Component_Document $component, array $elements, array $settings ) {
+		try {
+			$saved = $component->save( [
+				'elements' => $elements,
+				'settings' => $settings,
+			] );
+		} catch ( \Exception $e ) {
+			return new \WP_Error( 'save_failed', $e->getMessage(), [ 'status' => \WP_Http::UNPROCESSABLE_ENTITY ] );
+		}
+
+		if ( ! $saved ) {
+			return new \WP_Error( 'save_failed', __( 'Failed to save component.', 'elementor' ), [ 'status' => \WP_Http::INTERNAL_SERVER_ERROR ] );
+		}
+
+		return [
+			'success' => true,
+			'component_id' => $component->get_main_id(),
+		] + $this->document_links( $component );
+	}
+
+	/**
+	 * @return array{elements: array[], warnings: string[]}|\WP_Error
+	 */
+	private function resolve_create_elements( array $input ) {
+		$has_xml = ! empty( $input['xml_structure'] ) && is_string( $input['xml_structure'] );
+		$has_source_element = ! empty( $input['source_post_id'] ) && ! empty( $input['element_id'] );
+
+		if ( $has_xml && $has_source_element ) {
+			return $this->invalid_input( __( 'create accepts either xml_structure or source_post_id/element_id, not both.', 'elementor' ) );
+		}
+
+		if ( $has_xml ) {
+			return $this->compile_elements_from_xml( $input );
+		}
+
+		if ( $has_source_element ) {
+			return $this->copy_elements_from_source( $input );
+		}
+
+		return [
+			'elements' => [],
+			'warnings' => [],
+		];
+	}
+
+	/**
+	 * @return array{elements: array[], warnings: string[]}|\WP_Error
+	 */
+	private function compile_elements_from_xml( array $input ) {
+		$compiled = $this->compile_composition( $input );
+
+		if ( is_wp_error( $compiled ) ) {
+			return $compiled;
+		}
+
+		return [
+			'elements' => $this->assign_element_ids( $compiled['elements'] ),
+			'warnings' => $compiled['warnings'],
+		];
+	}
+
+	/**
+	 * @return array{elements: array[], warnings: string[], dom: \DOMDocument, xml_parser: \Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser}|\WP_Error
+	 */
+	private function compile_composition( array $input, ?Document $document = null ) {
+		$compiled = Composition_Compiler::make()->compile( $input, $document );
+		if ( is_wp_error( $compiled ) ) {
+			return $compiled;
+		}
+
+		if ( 1 !== count( $compiled['elements'] ) ) {
+			return new \WP_Error(
+				'component_requires_single_root',
+				__( 'A component composition must contain exactly one root element.', 'elementor' ),
+				[ 'status' => \WP_Http::UNPROCESSABLE_ENTITY ]
+			);
+		}
+
+		return $compiled;
+	}
+
+	/**
+	 * @return array{elements: array[], warnings: string[]}|\WP_Error
+	 */
+	private function copy_elements_from_source( array $input ) {
+		$source_post_id = (int) $input['source_post_id'];
+		$element_id = (string) $input['element_id'];
+
+		if ( ! current_user_can( 'edit_post', $source_post_id ) ) {
+			return new \WP_Error(
+				'elementor_forbidden',
+				__( 'You do not have permission to read source_post_id.', 'elementor' ),
+				[ 'status' => \WP_Http::FORBIDDEN ]
+			);
+		}
+
+		$document = Plugin::$instance->documents->get_doc_or_auto_save( $source_post_id, get_current_user_id() )
+			?? Plugin::$instance->documents->get( $source_post_id );
+
+		if ( ! $document ) {
+			return $this->not_found( __( 'source_post_id not found.', 'elementor' ) );
+		}
+
+		$found = Document_Mutator::instance()->find_by_id( $document->get_elements_data(), $element_id );
+		if ( null === $found ) {
+			return $this->not_found( __( 'element_id was not found on source_post_id.', 'elementor' ) );
+		}
+
+		return [
+			'elements' => $this->assign_element_ids( [ $found ] ),
+			'warnings' => [],
+		];
+	}
+
+	/**
+	 * Builds the native overridable-props payload and stamps `overridable` envelopes
+	 * onto the referenced element settings. Validation and persistence of the native
+	 * payload itself is left to the component document's save hook, which already
+	 * parses and persists it for every component save.
+	 *
+	 * @return \WP_Error|null
+	 */
+	private function apply_overridable_props( array &$elements, array $input, array &$settings ) {
+		if ( ! is_array( $input['overridable_props'] ?? null ) || empty( $input['overridable_props'] ) ) {
+			return null;
+		}
+
+		$builder_result = Overridable_Props_Builder::make()->build( $elements, $input['overridable_props'] );
+		if ( is_wp_error( $builder_result ) ) {
+			return $builder_result;
+		}
+
+		$settings['overridable_props'] = $builder_result;
+
+		return null;
+	}
+
+	/**
+	 * Compiled subtrees have no ids yet (`Subtree_Builder` never sets one), and copied
+	 * subtrees carry ids from another document that would collide here. Both paths need
+	 * fresh, slug-safe machine ids; the caller's configuration-id stays on
+	 * `editor_settings.title` so `overridable_props.target` and other tools can still
+	 * address elements by the identifier the caller used in `xml_structure` — see
+	 * `Overridable_Props_Builder::find_element_ref`.
+	 */
+	private function assign_element_ids( array $elements ): array {
+		return array_map( fn( array $element ) => $this->assign_element_id( $element ), $elements );
+	}
+
+	private function assign_element_id( array $element ): array {
+		$element['id'] = Document_Mutator::instance()->generate_id();
+
+		if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
+			$element['elements'] = array_map( fn( array $child ) => $this->assign_element_id( $child ), $element['elements'] );
+		}
+
+		return $element;
+	}
+
+	private function document_links( Component_Document $component ): array {
+		$editor_url = $component->get_edit_url();
+
+		return [
+			'editor_url' => $editor_url,
+			'llm_instructions' => sprintf(
+				/* translators: %s: Component editor URL. */
+				__( 'You MUST show the user this link to review the component: %s', 'elementor' ),
+				$editor_url
+			),
+		];
+	}
+
+	private function resolve_status( array $input ): string {
+		return 'draft' === ( $input['publish_status'] ?? 'publish' ) ? Document::STATUS_DRAFT : Document::STATUS_PUBLISH;
+	}
+
+	private function generate_uid(): string {
+		return 'component-' . wp_generate_uuid4();
+	}
+
+	private function normalize_ids( $raw ): array {
+		if ( ! is_array( $raw ) ) {
+			return [];
+		}
+
+		$ids = [];
+		foreach ( $raw as $value ) {
+			$id = (int) $value;
+			if ( $id > 0 ) {
+				$ids[ $id ] = $id;
+			}
+		}
+
+		return array_values( $ids );
+	}
+
+	private function check_access( string $action, callable $can ): ?\WP_Error {
+		return $can() ? null : Insufficient_Permissions_Error::for_action( $action );
+	}
+
+	private function invalid_input( string $message ): \WP_Error {
+		return new \WP_Error( 'invalid_input', $message, [ 'status' => \WP_Http::BAD_REQUEST ] );
+	}
+
+	private function not_found( string $message ): \WP_Error {
+		return new \WP_Error( 'elementor_not_found', $message, [ 'status' => \WP_Http::NOT_FOUND ] );
+	}
+
+	private function get_repository(): Components_Repository {
+		if ( ! $this->repository ) {
+			$this->repository = new Components_Repository();
+		}
+
+		return $this->repository;
+	}
+
+	private function get_output_schema(): array {
+		return [
+			'type' => 'object',
+			'properties' => [
+				'success' => [ 'type' => 'boolean' ],
+				'component_id' => [ 'type' => 'integer' ],
+				'uid' => [
+					'type' => 'string',
+					'description' => 'Server-generated component uid, only present for create.',
+				],
+				'success_ids' => [
+					'type' => 'array',
+					'items' => [ 'type' => 'integer' ],
+					'description' => 'archive only.',
+				],
+				'failed_ids' => [
+					'type' => 'array',
+					'items' => [ 'type' => 'integer' ],
+					'description' => 'archive only.',
+				],
+				'editor_url' => [
+					'type' => 'string',
+					'description' => 'Component documents have no public permalink; this is the editor URL to review the change.',
+				],
+				'llm_instructions' => [
+					'type' => 'string',
+					'description' => 'Mandatory next step: include this text (with the editor link) in your reply to the user.',
+				],
+				'warnings' => [
+					'type' => 'array',
+					'items' => [ 'type' => 'string' ],
+					'description' => 'Non-fatal notices from XML compilation, e.g. props skipped or CSS that fell back to custom_css.',
+				],
+			],
+		];
+	}
+
+	private function get_input_schema(): array {
+		return [
+			'type' => 'object',
+			'required' => [ 'action' ],
+			'properties' => [
+				'action' => [
+					'type' => 'string',
+					'enum' => [ self::ACTION_CREATE, self::ACTION_UPDATE, self::ACTION_RENAME, self::ACTION_ARCHIVE, self::ACTION_PUBLISH ],
+				],
+				'title' => [
+					'type' => 'string',
+					'minLength' => 2,
+					'maxLength' => 200,
+					'description' => 'create: component title. rename: the new title.',
+				],
+				'source_post_id' => [
+					'type' => 'integer',
+					'description' => 'create: WordPress post id to copy an existing element subtree from. Requires element_id. Mutually exclusive with xml_structure.',
+				],
+				'element_id' => [
+					'type' => 'string',
+					'description' => 'create: id of the element (within source_post_id, from elementor/get-page-structure) to copy as the component root.',
+				],
+				'xml_structure' => [
+					'type' => 'string',
+					'description' => 'create/update: same tag language as elementor/build-composition, with exactly one root element. Mutually exclusive with source_post_id/element_id.',
+				],
+				'element_config' => [
+					'type' => 'object',
+					'default' => (object) [],
+					'description' => 'Same shape as elementor/build-composition element_config. Only used with xml_structure.',
+				],
+				'classes' => [
+					'type' => 'object',
+					'default' => (object) [],
+					'description' => 'Same shape as elementor/build-composition classes. Only used with xml_structure.',
+				],
+				'style' => [
+					'type' => 'object',
+					'default' => (object) [],
+					'description' => 'Same shape as elementor/build-composition style. Only used with xml_structure.',
+				],
+				'interactions' => [
+					'type' => 'object',
+					'default' => (object) [],
+					'description' => 'Same shape as elementor/build-composition interactions. Only used with xml_structure.',
+				],
+				'overridable_props' => [
+					'type' => 'object',
+					'description' => 'Record mapping override-key → { target, prop_key, label, group? }. target identifies the element to expose: for xml_structure, use the same configuration-id you set on that element; for source_post_id/element_id (create) or an update without xml_structure, use the real element id (from elementor/get-page-structure). override keys, groupIds, and origin values are generated server-side.',
+				],
+				'publish_status' => [
+					'type' => 'string',
+					'enum' => [ 'publish', 'draft' ],
+					'default' => 'publish',
+					'description' => 'create: initial document status. update/rename/archive: "draft" edits an autosave copy instead of the live document; the change is not visible on pages using this component until you publish it.',
+				],
+				'component_id' => [
+					'type' => 'integer',
+					'description' => 'update/rename/publish target component id.',
+				],
+				'component_ids' => [
+					'type' => 'array',
+					'items' => [ 'type' => 'integer' ],
+					'description' => 'archive targets.',
+				],
+			],
+		];
+	}
+}

--- a/modules/mcp/abilities/utils/insufficient-permissions-error.php
+++ b/modules/mcp/abilities/utils/insufficient-permissions-error.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Modules\Components\Components_Access_Controller;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Insufficient_Permissions_Error {
+
+	public static function for_action( string $action ): \WP_Error {
+		return new \WP_Error(
+			'insufficient_permissions',
+			__( 'You do not have permission to perform this action.', 'elementor' ),
+			[
+				'status' => \WP_Http::FORBIDDEN,
+				'action' => $action,
+				'tier' => Components_Access_Controller::get_access_tier(),
+			]
+		);
+	}
+}

--- a/modules/mcp/abilities/utils/overridable-props-builder.php
+++ b/modules/mcp/abilities/utils/overridable-props-builder.php
@@ -1,0 +1,562 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Modules\Components\Components_Repository;
+use Elementor\Modules\Components\Documents\Component_Overridable_Prop;
+use Elementor\Modules\Components\PropTypes\Component_Override_Parser;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Override_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Overrides_Prop_Type;
+use Elementor\Modules\Components\Utils\Parsing_Utils;
+use Elementor\Modules\Components\Widgets\Component_Instance;
+use WP_Http;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Enriches a friendly, LLM-authorable overridable-props input into the native
+ * `{ props, groups }` shape expected by `Component_Overridable_Props_Parser`,
+ * and rewrites the referenced element settings into `overridable` envelopes.
+ *
+ * Friendly input shape:
+ * ```
+ * [
+ *     '<override-key>' => [
+ *         'target'    => '<element id, or the configuration-id the element was compiled from>',
+ *         'prop_key'  => '<setting key on that element (raw widget target)
+ *                          OR nested override key exposed by the target component (e-component target)>',
+ *         'label'     => '<human label>',
+ *         'group'     => '<optional group label, defaults to "Default">',
+ *     ],
+ * ]
+ * ```
+ *
+ * When `target` is an `<e-component>` instance, the builder switches to the "expose further" flow:
+ * it reads the inner component's own `overridable_props`, threads any pre-existing `originPropFields`
+ * through for multi-hop composition, and splices an `overridable → override` envelope into the nested
+ * instance's `component_instance.value.overrides` list — matching what the editor's expose-further UI
+ * produces on save. Any override already addressing that inner key is absorbed into the envelope rather
+ * than left beside it, so a per-instance value set via `element_config` survives being exposed.
+ */
+class Overridable_Props_Builder {
+
+	const DEFAULT_GROUP_LABEL = 'Default';
+	const GROUP_ID_PREFIX = 'group';
+	const GROUP_ID_SUFFIX_LENGTH = 7;
+
+	private ?Components_Repository $repository;
+
+	public function __construct( ?Components_Repository $repository = null ) {
+		$this->repository = $repository;
+	}
+
+	public static function make( ?Components_Repository $repository = null ): self {
+		return new self( $repository );
+	}
+
+	/**
+	 * @param array $elements       Elements tree containing the referenced target ids. Mutated in place:
+	 *                              each referenced element's setting is rewritten into an `overridable` envelope
+	 *                              (raw widget target) or spliced into `component_instance.value.overrides`
+	 *                              (`<e-component>` target).
+	 * @param array $friendly_props Friendly overridable-props input, keyed by override key.
+	 *
+	 * @return array{props: array, groups: array{items: array, order: array}}|\WP_Error
+	 */
+	public function build( array &$elements, array $friendly_props ) {
+		if ( empty( $friendly_props ) ) {
+			return [
+				'props' => [],
+				'groups' => [
+					'items' => [],
+					'order' => [],
+				],
+			];
+		}
+
+		$props = [];
+		$groups = [];
+		$group_order = [];
+		$group_ids_by_label = [];
+		$errors = [];
+
+		foreach ( $friendly_props as $override_key => $definition ) {
+			$prop = $this->build_prop( (string) $override_key, $definition, $elements, $group_ids_by_label, $groups, $group_order );
+
+			if ( is_wp_error( $prop ) ) {
+				$errors[] = $prop->get_error_message();
+				continue;
+			}
+
+			$props[ $override_key ] = $prop;
+		}
+
+		if ( ! empty( $errors ) ) {
+			return new \WP_Error(
+				'invalid_overridable_props',
+				implode( ' ', $errors ),
+				[ 'status' => WP_Http::BAD_REQUEST ]
+			);
+		}
+
+		return [
+			'props' => $props,
+			'groups' => [
+				'items' => $groups,
+				'order' => $group_order,
+			],
+		];
+	}
+
+	/**
+	 * @return array|\WP_Error
+	 */
+	private function build_prop(
+		string $override_key,
+		$definition,
+		array &$elements,
+		array &$group_ids_by_label,
+		array &$groups,
+		array &$group_order
+	) {
+		$common = $this->validate_common_definition( $override_key, $definition );
+		if ( is_wp_error( $common ) ) {
+			return $common;
+		}
+		[ 'target' => $target, 'prop_key' => $prop_key, 'label' => $label, 'group_label' => $group_label ] = $common;
+
+		$element = &$this->find_element_ref( $elements, $target );
+
+		if ( null === $element ) {
+			return new \WP_Error( 'x', sprintf( '[%s] target "%s" was not found in the element tree.', $override_key, $target ) );
+		}
+
+		$widget_type = (string) ( $element['widgetType'] ?? '' );
+
+		if ( Component_Instance::get_element_type() === $widget_type ) {
+			return $this->build_nested_component_prop(
+				$override_key,
+				$prop_key,
+				$label,
+				$group_label,
+				$element,
+				$group_ids_by_label,
+				$groups,
+				$group_order
+			);
+		}
+
+		return $this->build_raw_widget_prop(
+			$override_key,
+			$prop_key,
+			$label,
+			$group_label,
+			$element,
+			$group_ids_by_label,
+			$groups,
+			$group_order
+		);
+	}
+
+	/**
+	 * @return array{target: string, prop_key: string, label: string, group_label: string}|\WP_Error
+	 */
+	private function validate_common_definition( string $override_key, $definition ) {
+		if ( ! is_array( $definition ) ) {
+			return new \WP_Error( 'x', sprintf( '[%s] overridable_props entry must be an object.', $override_key ) );
+		}
+
+		if ( sanitize_key( $override_key ) !== $override_key ) {
+			return new \WP_Error( 'x', sprintf( '[%s] override keys must be slugs: lowercase letters, digits, dashes and underscores only.', $override_key ) );
+		}
+
+		$target = $definition['target'] ?? null;
+		$prop_key = $definition['prop_key'] ?? null;
+		$label = $definition['label'] ?? null;
+		$group_label = is_string( $definition['group'] ?? null ) && '' !== $definition['group']
+			? $definition['group']
+			: self::DEFAULT_GROUP_LABEL;
+
+		if ( ! is_string( $target ) || '' === $target || ! is_string( $prop_key ) || '' === $prop_key || ! is_string( $label ) || '' === $label ) {
+			return new \WP_Error( 'x', sprintf( '[%s] overridable_props entries require a non-empty target, prop_key, and label.', $override_key ) );
+		}
+
+		return [
+			'target' => $target,
+			'prop_key' => $prop_key,
+			'label' => $label,
+			'group_label' => $group_label,
+		];
+	}
+
+	/**
+	 * @return array|\WP_Error
+	 */
+	private function build_raw_widget_prop(
+		string $override_key,
+		string $prop_key,
+		string $label,
+		string $group_label,
+		array &$element,
+		array &$group_ids_by_label,
+		array &$groups,
+		array &$group_order
+	) {
+		$el_type = (string) ( $element['elType'] ?? '' );
+		$widget_type = (string) ( $element['widgetType'] ?? '' );
+
+		try {
+			$prop_type = Parsing_Utils::get_prop_type( $el_type, $widget_type, $prop_key );
+		} catch ( \Exception $e ) {
+			return new \WP_Error( 'x', sprintf( '[%s] %s', $override_key, $e->getMessage() ) );
+		}
+
+		$origin_value = $element['settings'][ $prop_key ] ?? $prop_type->get_default();
+
+		$element['settings'][ $prop_key ] = [
+			'$$type' => Overridable_Prop_Type::get_key(),
+			'value' => [
+				'override_key' => $override_key,
+				'origin_value' => $origin_value,
+			],
+		];
+
+		$group_id = $this->resolve_group_id( $group_label, $group_ids_by_label, $groups, $group_order );
+		$groups[ $group_id ]['props'][] = $override_key;
+
+		return [
+			'overrideKey' => $override_key,
+			'label' => $label,
+			'elementId' => (string) $element['id'],
+			'elType' => $el_type,
+			'widgetType' => $this->resolve_widgets_cache_key( $el_type, $widget_type ),
+			'propKey' => $prop_key,
+			'originValue' => $origin_value,
+			'groupId' => $group_id,
+		];
+	}
+
+	/**
+	 * Expose-further path. `$prop_key` names the **inner component's** exposed override key,
+	 * not a real setting key on the `<e-component>` element (which only has `component_instance`).
+	 *
+	 * @return array|\WP_Error
+	 */
+	private function build_nested_component_prop(
+		string $override_key,
+		string $inner_override_key,
+		string $label,
+		string $group_label,
+		array &$element,
+		array &$group_ids_by_label,
+		array &$groups,
+		array &$group_order
+	) {
+		$inner_component_id = $this->extract_inner_component_id( $element );
+
+		if ( null === $inner_component_id ) {
+			return new \WP_Error(
+				'x',
+				sprintf(
+					'[%s] target "%s" is an <e-component> instance but has no valid component_instance settings. Set component_id on the instance (via element_config) before exposing an override through it.',
+					$override_key,
+					(string) ( $element['id'] ?? '' )
+				)
+			);
+		}
+
+		$inner_component = $this->get_repository()->get( $inner_component_id, false );
+
+		if ( ! $inner_component ) {
+			return new \WP_Error(
+				'x',
+				sprintf( '[%s] inner component %d referenced by target "%s" was not found.', $override_key, $inner_component_id, (string) $element['id'] )
+			);
+		}
+
+		$inner_props = $inner_component->get_overridable_props()->props;
+		$inner_prop = $inner_props[ $inner_override_key ] ?? null;
+
+		if ( ! $inner_prop ) {
+			$available = empty( $inner_props ) ? '(none)' : implode( ', ', array_keys( $inner_props ) );
+			return new \WP_Error(
+				'x',
+				sprintf(
+					'[%s] component %d has no exposed override "%s". Available: %s. Use one of these as prop_key when the target is an <e-component>, or expose the underlying raw widget on the inner component first.',
+					$override_key,
+					$inner_component_id,
+					$inner_override_key,
+					$available
+				)
+			);
+		}
+
+		$origin_prop_fields = $this->resolve_origin_prop_fields( $inner_prop );
+
+		$inner_override_value = $this->take_existing_override_value( $element, $inner_override_key );
+
+		$override_envelope = $this->build_override_envelope( $inner_override_key, $inner_component_id, $inner_override_value );
+
+		$overridable_envelope = [
+			'$$type' => Overridable_Prop_Type::get_key(),
+			'value' => [
+				'override_key' => $override_key,
+				'origin_value' => $override_envelope,
+			],
+		];
+
+		$this->upsert_component_instance_override( $element, $override_key, $overridable_envelope );
+
+		$group_id = $this->resolve_group_id( $group_label, $group_ids_by_label, $groups, $group_order );
+		$groups[ $group_id ]['props'][] = $override_key;
+
+		return [
+			'overrideKey' => $override_key,
+			'label' => $label,
+			'elementId' => (string) $element['id'],
+			'elType' => 'widget',
+			'widgetType' => Component_Instance::get_element_type(),
+			'propKey' => $inner_override_key,
+			'originValue' => $inner_override_value,
+			'groupId' => $group_id,
+			'originPropFields' => $origin_prop_fields,
+		];
+	}
+
+	private function extract_inner_component_id( array $element ): ?int {
+		$raw = $element['settings']['component_instance']['value']['component_id']['value'] ?? null;
+
+		if ( ! is_numeric( $raw ) || (int) $raw <= 0 ) {
+			return null;
+		}
+
+		return (int) $raw;
+	}
+
+	/**
+	 * N-level chaining: if the inner overridable prop is itself a chained expose (already carries
+	 * `origin_prop_fields`), thread those through so the outer entry points all the way at the raw
+	 * widget's schema. Otherwise, derive the fields from the inner prop's own element metadata.
+	 */
+	private function resolve_origin_prop_fields( Component_Overridable_Prop $inner_prop ): array {
+		if ( $inner_prop->origin_prop_fields ) {
+			return [
+				'elType' => (string) $inner_prop->origin_prop_fields['el_type'],
+				'widgetType' => (string) $inner_prop->origin_prop_fields['widget_type'],
+				'propKey' => (string) $inner_prop->origin_prop_fields['prop_key'],
+				'elementId' => (string) $inner_prop->origin_prop_fields['element_id'],
+			];
+		}
+
+		return [
+			'elType' => (string) $inner_prop->el_type,
+			'widgetType' => (string) $inner_prop->widget_type,
+			'propKey' => (string) $inner_prop->prop_key,
+			'elementId' => (string) $inner_prop->element_id,
+		];
+	}
+
+	/**
+	 * @param string     $inner_override_key   Override key exposed by the inner component.
+	 * @param int        $inner_component_id   Component the inner override key belongs to.
+	 * @param array|null $inner_override_value Per-instance value for the inner override, or null to inherit
+	 *                                         the inner component's own origin value.
+	 */
+	private function build_override_envelope( string $inner_override_key, int $inner_component_id, ?array $inner_override_value ): array {
+		return [
+			'$$type' => Override_Prop_Type::get_key(),
+			'value' => [
+				'override_key' => $inner_override_key,
+				'override_value' => $inner_override_value,
+				'schema_source' => [
+					'type' => Component_Override_Parser::get_override_type(),
+					'id' => $inner_component_id,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Both a literal `override` (placed via `element_config`) and the `overridable` envelope we are about to
+	 * write address the nested instance by the same inner override key. Two entries for one key make the
+	 * resolvers last-write-wins, silently discarding whichever came first, so the existing entry is consumed
+	 * here: its value moves into the new envelope's `override_value` and the old entry is dropped.
+	 *
+	 * @return array|null The value carried by the removed entry, or null when there was none.
+	 */
+	private function take_existing_override_value( array &$element, string $inner_override_key ): ?array {
+		$this->ensure_component_instance_shape( $element );
+
+		$overrides_list = &$element['settings']['component_instance']['value']['overrides']['value'];
+		$taken_value = null;
+
+		foreach ( $overrides_list as $index => $existing ) {
+			if ( $inner_override_key !== $this->resolve_inner_override_key( $existing ) ) {
+				continue;
+			}
+
+			$taken_value = $this->resolve_inner_override_value( $existing );
+			unset( $overrides_list[ $index ] );
+		}
+
+		$overrides_list = array_values( $overrides_list );
+
+		return $taken_value;
+	}
+
+	/**
+	 * An entry addresses the nested instance either directly (`override`) or through an already-exposed
+	 * wrapper (`overridable` whose `origin_value` is the `override`).
+	 */
+	private function resolve_inner_override( $entry ): ?array {
+		if ( ! is_array( $entry ) ) {
+			return null;
+		}
+
+		if ( Overridable_Prop_Type::get_key() === ( $entry['$$type'] ?? null ) ) {
+			$entry = $entry['value']['origin_value'] ?? null;
+		}
+
+		if ( ! is_array( $entry ) || Override_Prop_Type::get_key() !== ( $entry['$$type'] ?? null ) ) {
+			return null;
+		}
+
+		return $entry;
+	}
+
+	private function resolve_inner_override_key( $entry ): ?string {
+		$override = $this->resolve_inner_override( $entry );
+
+		return isset( $override['value']['override_key'] ) ? (string) $override['value']['override_key'] : null;
+	}
+
+	private function resolve_inner_override_value( $entry ): ?array {
+		$override = $this->resolve_inner_override( $entry );
+		$value = $override['value']['override_value'] ?? null;
+
+		return is_array( $value ) ? $value : null;
+	}
+
+	/**
+	 * Replace-or-append semantics on the nested instance's `overrides` list, keyed by the outer
+	 * override_key stored on the `Overridable_Prop_Type` envelope — mirrors how the editor's
+	 * `getMatchingOverride`/`setInstanceValue` flow keys entries when the user re-edits an
+	 * exposed-further prop.
+	 */
+	private function upsert_component_instance_override( array &$element, string $override_key, array $overridable_envelope ): void {
+		$this->ensure_component_instance_shape( $element );
+
+		$overrides_list = &$element['settings']['component_instance']['value']['overrides']['value'];
+
+		foreach ( $overrides_list as $index => $existing ) {
+			$is_overridable = ( $existing['$$type'] ?? null ) === Overridable_Prop_Type::get_key();
+			$existing_key = $existing['value']['override_key'] ?? null;
+
+			if ( $is_overridable && $existing_key === $override_key ) {
+				$overrides_list[ $index ] = $overridable_envelope;
+				return;
+			}
+		}
+
+		$overrides_list[] = $overridable_envelope;
+	}
+
+	private function ensure_component_instance_shape( array &$element ): void {
+		if ( ! isset( $element['settings']['component_instance']['value']['overrides'] ) ) {
+			$element['settings']['component_instance']['value']['overrides'] = [
+				'$$type' => Overrides_Prop_Type::get_key(),
+				'value' => [],
+			];
+			return;
+		}
+
+		if ( ! isset( $element['settings']['component_instance']['value']['overrides']['value'] )
+			|| ! is_array( $element['settings']['component_instance']['value']['overrides']['value'] ) ) {
+			$element['settings']['component_instance']['value']['overrides']['value'] = [];
+		}
+	}
+
+	private function get_repository(): Components_Repository {
+		if ( ! $this->repository ) {
+			$this->repository = new Components_Repository();
+		}
+
+		return $this->repository;
+	}
+
+	/**
+	 * The editor's `getWidgetsCache()` is keyed by the atomic widget/element type name (e.g. `e-heading`,
+	 * `e-flexbox`). Widgets carry it on `widgetType`; atomic elements carry it on `elType` and leave
+	 * `widgetType` unset. `OverrideControl` looks the persisted `widgetType` up in the cache to find the
+	 * origin prop type — it must be a real cache key, or the panel throws "Prop type not found".
+	 */
+	private function resolve_widgets_cache_key( string $el_type, string $widget_type ): string {
+		return '' !== $widget_type ? $widget_type : $el_type;
+	}
+
+	private function resolve_group_id( string $label, array &$group_ids_by_label, array &$groups, array &$group_order ): string {
+		if ( isset( $group_ids_by_label[ $label ] ) ) {
+			return $group_ids_by_label[ $label ];
+		}
+
+		$group_id = $this->generate_group_id();
+
+		$group_ids_by_label[ $label ] = $group_id;
+		$groups[ $group_id ] = [
+			'id' => $group_id,
+			'label' => $label,
+			'props' => [],
+		];
+		$group_order[] = $group_id;
+
+		return $group_id;
+	}
+
+	/**
+	 * Mirrors the editor's `generateUniqueId( 'group' )` format. Group ids must not be derived from the
+	 * label: `@elementor/ui`'s `SortableGroup` treats the id "default" as "no group id" and hands the
+	 * whole multi-group map back to the props panel, which then crashes on `items.map`.
+	 */
+	private function generate_group_id(): string {
+		return sprintf(
+			'%s-%d-%s',
+			self::GROUP_ID_PREFIX,
+			(int) round( microtime( true ) * 1000 ),
+			strtolower( wp_generate_password( self::GROUP_ID_SUFFIX_LENGTH, false, false ) )
+		);
+	}
+
+	/**
+	 * Matches the persisted element id, or the configuration-id the element was compiled from —
+	 * compiled trees get machine-generated ids, so the caller can only address them by the
+	 * configuration-id it already used in `xml_structure`.
+	 *
+	 * @return array|null
+	 */
+	private function &find_element_ref( array &$elements, string $target ) {
+		$not_found = null;
+
+		foreach ( $elements as &$element ) {
+			$configuration_id = $element['editor_settings']['title'] ?? null;
+
+			if ( ( $element['id'] ?? null ) === $target || $configuration_id === $target ) {
+				return $element;
+			}
+
+			if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
+				$found = &$this->find_element_ref( $element['elements'], $target );
+
+				if ( null !== $found ) {
+					unset( $element );
+					return $found;
+				}
+			}
+		}
+		unset( $element );
+
+		return $not_found;
+	}
+}

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -75,6 +75,7 @@ class Module extends BaseModule {
 
 		if ( $this->is_components_active() ) {
 			( new Abilities\List_Components_Ability() )->register();
+			( new Abilities\Manage_Component_Ability() )->register();
 		}
 		( new Abilities\Global_Variables_Resource_Ability() )->register();
 		( new Abilities\Interactions_Schema_Resource_Ability() )->register();
@@ -128,7 +129,7 @@ class Module extends BaseModule {
 			'elementor/list-assets',
 			'elementor/list-resources',
 			'elementor/read-resource',
-			...( $this->is_components_active() ? [ 'elementor/list-components' ] : [] ),
+			...( $this->is_components_active() ? [ 'elementor/list-components', 'elementor/manage-component' ] : [] ),
 		];
 
 		/**

--- a/modules/mcp/static-resources/abilities/build-composition.md
+++ b/modules/mcp/static-resources/abilities/build-composition.md
@@ -23,7 +23,7 @@ This tool supports v4 elements only.
 
 1. Call `elementor/list-components` with no arguments and find components whose names match what the user asked for (fuzzy match is fine: "Hero" → "Hero Section", etc.). If more than one component name is a plausible match, do NOT guess — ask the user which one before fetching the schema.
 2. If found, call `elementor/list-components` again with `component_ids` set to the id(s) you plan to use (batch multiple in one call) and verify each `overridable_props` covers the customizations the user needs.
-3. If a component is missing, archived (`is_archived: true`), or its overridable props do not cover the required customizations, fall back to raw widgets and tell the user why.
+3. If a component is not listed (archived components never are) or its overridable props do not cover the required customizations, fall back to raw widgets, save the composition as a new component, and inform the user about that.
 
 ## Placement
 - Use `<e-component configuration-id="my-hero">` in `xml_structure`. **Leaf tag — no child tags inside it.**
@@ -45,7 +45,6 @@ This tool supports v4 elements only.
 
 - `component_id` is required. `overrides` is optional — omit it entirely if you have no overrides to apply.
 - Only `override_key`s listed in `overridable_props` are valid. Unknown keys are rejected.
-- Do NOT place archived components (`is_archived: true`).
 - Components can be mixed with raw widgets in the same composition.
 
 # XML STRUCTURE

--- a/modules/mcp/static-resources/abilities/list-components.md
+++ b/modules/mcp/static-resources/abilities/list-components.md
@@ -2,7 +2,7 @@ Returns the components available on this site. Each component is a user-defined 
 
 Call in two steps, the same way `elementor/list-widget-schemas` works:
 
-1. **Discovery** — call with no arguments to list every component without its schema. Returns `id`, `name`, `uid`, `is_archived` per component.
+1. **Discovery** — call with no arguments to list every component without its schema. Returns `id`, `name`, `uid` per component. Archived components are never listed.
 2. **Schemas** — call again with `component_ids` set to the id(s) you actually intend to place (batch them in one call) to get each component's `overridable_props`.
 
 Always discover first. Requesting schemas for every component is wasteful on sites with many components.
@@ -10,7 +10,7 @@ Always discover first. Requesting schemas for every component is wasteful on sit
 - `id`: numeric post ID used to reference the component
 - `name`: the human-readable title the user gave the component
 - `uid`: stable string identifier
-- `is_archived`: archived components should not be placed in new compositions
+- `is_archived`: only returned for components requested via `component_ids` — an archived component cannot be placed, so pick another one
 - `overridable_props`: only returned for components requested via `component_ids`
 
 If any requested id is not a component, the call fails with `elementor_not_found` — no partial results.
@@ -20,54 +20,4 @@ Each entry in `overridable_props` maps an `override_key` to:
 - `group_id`: optional grouping for display
 - `origin_prop_schema`: plain-value JSON Schema for the override value (no `$$type` envelopes — same convention as `elementor/get-widget-schema`)
 
-# PLACING A COMPONENT IN build-composition
-
-1. Use `<e-component configuration-id="my-hero">` in `xml_structure` (leaf tag — no children allowed).
-2. Under `element_config`, map the configuration-id to `{ component_id, overrides? }`. Send each override value in the plain-value shape described by `origin_prop_schema`:
-
-```json
-{
-  "element_config": {
-    "my-hero": {
-      "component_id": 42,
-      "overrides": {
-        "title": "Welcome",
-        "cta_url": "https://example.com"
-      }
-    }
-  }
-}
-```
-
-Only include `override_key`s that appear in `overridable_props`. Unknown keys are rejected.
-Omit `overrides` entirely if you have no overrides to apply.
-Do NOT place `<e-component>` tags inside archived components.
-
-# UPDATING AN EXISTING COMPONENT INSTANCE via manage-elements
-
-Use `elementor/manage-elements` with `action=update` and `settings={ component_id?, overrides }`. Semantics:
-
-- `component_id` is optional — inferred from the existing instance if omitted.
-- Each `override_key` in `overrides` is deep-merged onto the existing overrides: only mentioned keys change.
-- Pass `null` for an `override_key` to remove that override (revert to component default).
-- Override keys not mentioned in the payload are preserved untouched — you do NOT need to re-send unchanged overrides.
-
-Example — change only the CTA URL and clear the title override:
-
-```json
-{
-  "post_id": 41870,
-  "operations": [
-    {
-      "action": "update",
-      "element_id": "1d367385",
-      "settings": {
-        "overrides": {
-          "cta_url": "https://new.example.com",
-          "title": null
-        }
-      }
-    }
-  ]
-}
-```
+Place components via `elementor/build-composition` (see its COMPONENTS section). Update an existing instance's overrides via `elementor/manage-elements` with `settings.overrides` — a deep-merge, and `null` clears a key.

--- a/modules/mcp/static-resources/abilities/manage-component.md
+++ b/modules/mcp/static-resources/abilities/manage-component.md
@@ -1,0 +1,103 @@
+Create and manage Elementor components — user-facing reusable compositions of widgets, placed elsewhere via `<e-component>` in `elementor/build-composition` (see `elementor/list-components`).
+
+Requires administrator access. `create`, `rename`, and `archive` additionally require an active Elementor Pro license; `publish` and `update` also work with an expired license. Without the required license, calls fail with `insufficient_permissions`.
+
+# ACTIONS
+Every call takes one `action`: `create`, `update`, `rename`, `archive`, `publish`.
+
+## create
+Requires `title` (2-200 chars). Choose ONE source for the initial content, or omit both to create an empty component:
+- **xml_structure**: same tag language as `elementor/build-composition` (`element_config`, `classes`, `style`, `interactions`). It must contain exactly one root element, and every element needs a unique `configuration-id`.
+- **source_post_id** + **element_id**: copy an existing element (and its children) from another document — get `element_id` from `elementor/get-page-structure`. All ids are regenerated on the copy.
+
+Optionally attach `overridable_props` (see below). Returns `component_id`, `uid`, `editor_url`.
+
+`xml_structure` may contain `<e-component configuration-id="…"></e-component>` nodes to instance other components (leaf tag; no children inside `<e-component>`). `configuration-id` identifies the instance within the request; configure the reusable component it references via `element_config` using the flat `{ component_id, overrides? }` shape documented in `build-composition.md` COMPONENTS section.
+
+```json
+{
+  "action": "create",
+  "title": "Two Cards",
+  "xml_structure": "<e-flexbox configuration-id=\"row\"><e-component configuration-id=\"card-a\"></e-component><e-component configuration-id=\"card-b\"></e-component></e-flexbox>",
+  "element_config": {
+    "card-a": { "component_id": 42, "overrides": { "title": "First Card", "image": { "src": { "url": "https://example.com/a.jpg" }, "size": "full" } } },
+    "card-b": { "component_id": 42, "overrides": { "title": "Second Card", "image": { "src": { "url": "https://example.com/b.jpg" }, "size": "full" } } }
+  }
+}
+```
+
+Prefer instancing an existing component over inlining its widgets. If a matching component exists (check via `elementor/list-components`), place `<e-component>` instead of duplicating the subtree.
+## update
+Requires `component_id`. Two modes:
+- **With `xml_structure`**: replaces the ENTIRE component tree (same params as `create`'s xml_structure path). Not a merge — re-send the full composition.
+- **Without `xml_structure`**: requires `overridable_props`; only overridable-props metadata changes, the element tree is untouched.
+
+## rename
+Requires `component_id` and `title` (2-200 chars).
+
+## archive
+Requires `component_ids` (array). Archived components stop being listed by `elementor/list-components` and can no longer be placed in compositions. Returns `success_ids` / `failed_ids` per id.
+
+## publish
+Requires `component_id`. Promotes a pending draft/autosave (created via `publish_status: "draft"`) to the live version.
+
+# publish_status
+Applies to `create`, `update`, `rename`, `archive`. Defaults to `"publish"` (operates on the live document immediately). Pass `"draft"` to stage changes in an autosave that does NOT affect pages already using this component until you call `action: "publish"`.
+
+# overridable_props
+Exposes per-instance customization points, surfaced later via `elementor/list-components`' `overridable_props` and set via `<e-component>` `element_config.overrides` in `elementor/build-composition`.
+
+Record mapping a caller-chosen override key → `{ target, prop_key, label, group? }`:
+- `target`: which element to expose a prop from.
+  - With `xml_structure` (create or update): the `configuration-id` you set on that element.
+  - With `source_post_id`/`element_id` (create), or `update` without `xml_structure`: the real element id (from `elementor/get-page-structure`).
+- `prop_key`: identifies WHICH setting to expose. Meaning depends on the target:
+  - Raw widget / atomic element (`<e-heading>`, `<e-image>`, `<e-flexbox>`, etc.): the setting name on that element (from `elementor/get-widget-schema`).
+  - Nested `<e-component>` instance (expose-further): the inner component's own exposed override key (from `elementor/list-components` `overridable_props` for that component). The inner component must already expose the prop before you can re-expose it through the wrapper.
+- `label`: human-readable name shown to whoever configures an instance.
+- `group` (optional): label used to group related overrides together; defaults to "Default".
+
+The current/default value of `prop_key` becomes the override's origin value automatically — do NOT try to set it yourself.
+
+Expose-further composes through any depth: if the inner component's exposed key was itself exposed from a grand-child, the wrapper's control still resolves to the underlying raw widget's schema.
+
+Example — a `Cards Grid` wrapper that re-exposes `caption`/`image` from each nested `<e-component>` instance of a `Card` component (which itself exposes `caption` from an `<e-paragraph>` and `image` from an `<e-image>`):
+
+```json
+{
+  "action": "create",
+  "title": "Cards Grid",
+  "xml_structure": "<e-flexbox configuration-id=\"grid\"><e-component configuration-id=\"card-1\"></e-component><e-component configuration-id=\"card-2\"></e-component></e-flexbox>",
+  "element_config": {
+    "card-1": { "component_id": 42 },
+    "card-2": { "component_id": 42 }
+  },
+  "overridable_props": {
+    "card_1_caption": { "target": "card-1", "prop_key": "caption", "label": "Card 1 Caption", "group": "Card 1" },
+    "card_1_image":   { "target": "card-1", "prop_key": "image",   "label": "Card 1 Image",   "group": "Card 1" },
+    "card_2_caption": { "target": "card-2", "prop_key": "caption", "label": "Card 2 Caption", "group": "Card 2" },
+    "card_2_image":   { "target": "card-2", "prop_key": "image",   "label": "Card 2 Image",   "group": "Card 2" }
+  }
+}
+```
+
+```json
+{
+  "action": "create",
+  "title": "Hero Section",
+  "xml_structure": "<e-flexbox configuration-id=\"hero\"><e-heading configuration-id=\"hero-title\"></e-heading></e-flexbox>",
+  "element_config": {
+    "hero-title": { "title": { "content": "Welcome", "children": [] } }
+  },
+  "overridable_props": {
+    "heading-text": {
+      "target": "hero-title",
+      "prop_key": "title",
+      "label": "Heading Text"
+    }
+  }
+}
+```
+
+# FURTHER INSTRUCTIONS
+Every successful response includes `editor_url` and `llm_instructions` — components have no public permalink, so you MUST share `editor_url` with the user to review the change.

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-element-config-applier.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-element-config-applier.php
@@ -87,39 +87,6 @@ class Test_Element_Config_Applier extends TestCase {
 		);
 	}
 
-	public function test_apply__errors_when_e_component_entry_has_no_document_context() {
-		// Arrange
-		$type_resolver = new Widget_Type_Resolver( new Xml_Parser() );
-		$applier = new Element_Config_Applier( $type_resolver, $this->make_plain_values_resolver() );
-
-		$e_component_node = [
-			'elType' => 'widget',
-			'widgetType' => 'e-component',
-			'settings' => [],
-		];
-
-		$index = [ 'my-hero' => &$e_component_node ];
-
-		// Act
-		$result = $applier->apply(
-			$index,
-			[
-				'my-hero' => [
-					'component_id' => 42,
-					'overrides' => [ 'title' => 'Welcome' ],
-				],
-			],
-			[]
-		);
-
-		// Assert
-		$this->assertNotNull( $result['error'] );
-		$this->assertSame( 'elementor_invalid_settings', $result['error']->get_error_code() );
-		$this->assertStringContainsString( 'my-hero', $result['error']->get_error_message() );
-		$this->assertStringContainsString( 'document context', $result['error']->get_error_message() );
-		$this->assertSame( [], $e_component_node['settings'] );
-	}
-
 	public function test_apply__reports_settings_and_component_errors_together() {
 		// Arrange
 		$type_resolver = new Widget_Type_Resolver( new Xml_Parser() );

--- a/tests/phpunit/elementor/modules/mcp/test-list-components-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-list-components-ability.php
@@ -87,17 +87,32 @@ class Test_List_Components_Ability extends Elementor_Test_Base {
 		$this->assertArrayNotHasKey( 'overridable_props', $result['components'][0] );
 	}
 
-	public function test_execute__returns_archived_flag_for_archived_components() {
+	public function test_execute__excludes_archived_components_from_the_discovery_list() {
 		// Arrange
 		$this->act_as_admin();
-		$component_id = $this->create_component( 'Old Header', 'publish' );
+		$archived_id = $this->create_component( 'Old Header', 'publish' );
+		$active_id = $this->create_component( 'Current Header', 'publish' );
 		$repository = new Components_Repository();
-		$component = $repository->get( $component_id, false );
-		$component->archive();
+		$repository->get( $archived_id, false )->archive();
 		$ability = new List_Components_Ability();
 
 		// Act
 		$result = $ability->execute();
+
+		// Assert
+		$this->assertSame( [ $active_id ], array_column( $result['components'], 'id' ) );
+	}
+
+	public function test_execute__returns_archived_flag_when_an_archived_component_is_requested_by_id() {
+		// Arrange
+		$this->act_as_admin();
+		$component_id = $this->create_component( 'Old Header', 'publish' );
+		$repository = new Components_Repository();
+		$repository->get( $component_id, false )->archive();
+		$ability = new List_Components_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'component_ids' => [ $component_id ] ] );
 
 		// Assert
 		$this->assertCount( 1, $result['components'] );

--- a/tests/phpunit/elementor/modules/mcp/test-manage-component-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-component-ability.php
@@ -1,0 +1,1406 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp;
+
+use Elementor\Core\Documents_Manager;
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Elements_Manager;
+use Elementor\Modules\Components\Components_Repository;
+use Elementor\Modules\Components\Documents\Component as Component_Document;
+use Elementor\Modules\Components\Non_Atomic_Widget_Validator;
+use Elementor\Modules\Interactions\Module as Interactions_Module;
+use Elementor\Modules\Mcp\Abilities\Manage_Component_Ability;
+use Elementor\Plugin;
+use Elementor\Widgets_Manager;
+use ElementorEditorTesting\Elementor_Test_Base;
+use Mock_Pro_License_API;
+use WP_Http;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once __DIR__ . '/../components/mocks/mock-pro-license-api.php';
+
+/**
+ * @group Elementor\Modules\Mcp
+ */
+class Test_Manage_Component_Ability extends Elementor_Test_Base {
+
+	private Documents_Manager $original_documents;
+	private Widgets_Manager $original_widgets_manager;
+	private Elements_Manager $original_elements_manager;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_scripts, $wp_styles;
+		$wp_scripts = new \WP_Scripts();
+		$wp_styles = new \WP_Styles();
+
+		$this->original_documents = Plugin::$instance->documents;
+		$this->original_widgets_manager = Plugin::$instance->widgets_manager;
+		$this->original_elements_manager = Plugin::$instance->elements_manager;
+
+		Plugin::$instance->documents->register_document_type(
+			Component_Document::TYPE,
+			Component_Document::get_class_full_name()
+		);
+
+		register_post_type( Component_Document::TYPE, [
+			'label' => Component_Document::get_title(),
+			'labels' => Component_Document::get_labels(),
+			'public' => false,
+			'supports' => Component_Document::get_supported_features(),
+		] );
+
+		Mock_Pro_License_API::reset();
+	}
+
+	public function tearDown(): void {
+		Plugin::$instance->documents = $this->original_documents;
+		Plugin::$instance->widgets_manager = $this->original_widgets_manager;
+		Plugin::$instance->elements_manager = $this->original_elements_manager;
+
+		global $wp_scripts, $wp_styles;
+		$wp_scripts = new \WP_Scripts();
+		$wp_styles = new \WP_Styles();
+
+		$this->delete_all_components();
+		Mock_Pro_License_API::reset();
+
+		parent::tearDown();
+	}
+
+	// ---------------------------------------------------------------------
+	// action routing
+	// ---------------------------------------------------------------------
+
+	public function test_execute__returns_invalid_input_for_missing_or_unknown_action() {
+		// Arrange
+		$this->act_as_admin();
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'delete_everything' ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	// ---------------------------------------------------------------------
+	// access gating (shared across all actions)
+	// ---------------------------------------------------------------------
+
+	/**
+	 * @dataProvider access_gate_cases
+	 */
+	public function test_execute__blocked_by_access_tier( array $input, bool $license_active, bool $license_expired ) {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( $license_active, $license_expired );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( $input );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'insufficient_permissions', $result->get_error_code() );
+		$this->assertSame( WP_Http::FORBIDDEN, $result->get_error_data()['status'] );
+		$this->assertSame( $input['action'], $result->get_error_data()['action'] );
+	}
+
+	public function access_gate_cases(): array {
+		return [
+			'create requires pro tier' => [ [ 'action' => 'create', 'title' => 'Hero' ], false, false ],
+			'create blocked even when expired' => [ [ 'action' => 'create', 'title' => 'Hero' ], false, true ],
+			'update requires pro or expired tier' => [ [ 'action' => 'update', 'component_id' => 1 ], false, false ],
+			'rename requires pro tier' => [ [ 'action' => 'rename', 'component_id' => 1, 'title' => 'Hero' ], false, false ],
+			'rename blocked even when expired' => [ [ 'action' => 'rename', 'component_id' => 1, 'title' => 'Hero' ], false, true ],
+			'archive requires pro tier' => [ [ 'action' => 'archive', 'component_ids' => [ 1 ] ], false, false ],
+			'archive blocked even when expired' => [ [ 'action' => 'archive', 'component_ids' => [ 1 ] ], false, true ],
+			'publish requires pro or expired tier' => [ [ 'action' => 'publish', 'component_id' => 1 ], false, false ],
+		];
+	}
+
+	// ---------------------------------------------------------------------
+	// create
+	// ---------------------------------------------------------------------
+
+	public function test_create__requires_a_title_of_at_least_two_characters() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'create', 'title' => 'X' ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	public function test_create__creates_an_empty_component_when_no_source_is_given() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'create', 'title' => 'Empty Hero' ] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertTrue( $result['success'] );
+		$this->assertArrayHasKey( 'component_id', $result );
+		$this->assertArrayHasKey( 'uid', $result );
+		$this->assertArrayHasKey( 'editor_url', $result );
+
+		$component = ( new Components_Repository() )->get( $result['component_id'], false );
+		$this->assertSame( [], $component->get_elements_data() );
+	}
+
+	public function test_create__compiles_elements_from_xml_structure_with_generated_ids() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Hero From Xml',
+			'xml_structure' => '<e-flexbox configuration-id="Hero Wrap"><e-heading configuration-id="Hero Title"/></e-flexbox>',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$elements = ( new Components_Repository() )->get( $result['component_id'], false )->get_elements_data();
+		$this->assertSame( 'e-flexbox', $elements[0]['elType'] );
+		$heading = $elements[0]['elements'][0];
+		$this->assertSame( 'e-heading', $heading['widgetType'] );
+		$this->assertSame( 'Hero Title', $heading['editor_settings']['title'] );
+		$this->assertNotSame( 'Hero Title', $heading['id'] );
+		$this->assertSame( $heading['id'], sanitize_key( $heading['id'] ) );
+	}
+
+	public function test_create__rejects_xml_structure_with_multiple_root_elements() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Multiple Roots',
+			'xml_structure' => '<e-heading configuration-id="heading"/><e-paragraph configuration-id="paragraph"/>',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'component_requires_single_root', $result->get_error_code() );
+		$this->assertSame( \WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	public function test_create__rejects_invalid_form_structure_from_xml() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Invalid Form',
+			'xml_structure' => '<e-flexbox configuration-id="wrapper"><e-form-input configuration-id="input"/></e-flexbox>',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_invalid_form_structure', $result->get_error_code() );
+	}
+
+	public function test_create__applies_interactions_from_xml() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $this->with_interactions_active(
+			fn() => $ability->execute( [
+				'action' => 'create',
+				'title' => 'Interactive Heading',
+				'xml_structure' => '<e-heading configuration-id="heading"/>',
+				'interactions' => [ 'heading' => [ $this->valid_interaction() ] ],
+			] )
+		);
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$elements = ( new Components_Repository() )->get( $result['component_id'], false )->get_elements_data();
+		$this->assertArrayHasKey( 'interactions', $elements[0], wp_json_encode( $elements[0] ) );
+		$this->assertCount( 1, $elements[0]['interactions']['items'] );
+		$interaction = $elements[0]['interactions']['items'][0];
+		$this->assertSame( 'interaction-item', $interaction['$$type'] );
+		$this->assertSame( 'load', $interaction['value']['trigger']['value'] );
+		$this->assertSame( 'fade', $interaction['value']['animation']['value']['effect']['value'] );
+	}
+
+	public function test_create__copies_an_existing_element_subtree_and_regenerates_ids() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$post_id = $this->create_real_document();
+		$this->given_document_with_elements( $post_id, [
+			[
+				'id' => 'source-container-id',
+				'elType' => 'e-flexbox',
+				'settings' => [],
+				'elements' => [
+					[ 'id' => 'source-heading-id', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+				],
+			],
+		] );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Hero From Source',
+			'source_post_id' => $post_id,
+			'element_id' => 'source-container-id',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$elements = ( new Components_Repository() )->get( $result['component_id'], false )->get_elements_data();
+		$this->assertSame( 'e-flexbox', $elements[0]['elType'] );
+		$this->assertNotSame( 'source-container-id', $elements[0]['id'] );
+		$this->assertSame( 'e-heading', $elements[0]['elements'][0]['widgetType'] );
+		$this->assertNotSame( 'source-heading-id', $elements[0]['elements'][0]['id'] );
+	}
+
+	public function test_create__keeps_widget_at_component_root_unwrapped() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Bare Heading Component',
+			'xml_structure' => '<e-heading configuration-id="Solo Heading"/>',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertEmpty( $result['warnings'] ?? [], 'A widget at root is valid and needs no warning.' );
+
+		$elements = ( new Components_Repository() )->get( $result['component_id'], false )->get_elements_data();
+		$this->assertCount( 1, $elements );
+		$this->assertSame( 'widget', $elements[0]['elType'] );
+		$this->assertSame( 'e-heading', $elements[0]['widgetType'] );
+		$this->assertSame( 'Solo Heading', $elements[0]['editor_settings']['title'] );
+	}
+
+	public function test_create__rejects_xml_structure_and_source_element_together() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Conflicting Source',
+			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'source_post_id' => 1,
+			'element_id' => 'whatever',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	public function test_create__forbids_copying_from_a_post_the_user_cannot_edit() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		$this->given_document_with_elements( $post_id, [
+			[ 'id' => 'source-heading-id', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		] );
+
+		Mock_Pro_License_API::set_license_state( true );
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'contributor' ] ) );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Forbidden Source',
+			'source_post_id' => $post_id,
+			'element_id' => 'source-heading-id',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_forbidden', $result->get_error_code() );
+	}
+
+	public function test_create__returns_not_found_when_element_id_does_not_exist_on_source() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$post_id = $this->create_real_document();
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Missing Source Element',
+			'source_post_id' => $post_id,
+			'element_id' => 'does-not-exist',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_not_found', $result->get_error_code() );
+	}
+
+	public function test_create__rejects_components_containing_non_atomic_widgets() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$post_id = $this->create_real_document();
+		$this->given_document_with_elements( $post_id, [
+			[ 'id' => 'legacy-heading-id', 'elType' => 'widget', 'widgetType' => 'heading', 'settings' => [], 'elements' => [] ],
+		] );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Legacy Widget Component',
+			'source_post_id' => $post_id,
+			'element_id' => 'legacy-heading-id',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( Non_Atomic_Widget_Validator::ERROR_CODE, $result->get_error_code() );
+	}
+
+	public function test_create__rejects_non_atomic_widget_from_xml() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Legacy Heading XML',
+			'xml_structure' => '<heading configuration-id="heading"/>',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( Non_Atomic_Widget_Validator::ERROR_CODE, $result->get_error_code() );
+	}
+
+	public function test_create__rejects_a_duplicate_title() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$this->create_component_with_content( [], 'Existing Hero' );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'create', 'title' => 'Existing Hero' ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'components_validation_failed', $result->get_error_code() );
+	}
+
+	public function test_create__applies_overridable_props_to_the_referenced_element() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Overridable Hero',
+			'xml_structure' => '<e-flexbox configuration-id="wrap"><e-heading configuration-id="h1"/></e-flexbox>',
+			'overridable_props' => [
+				'heading_tag' => [
+					'target' => 'h1',
+					'prop_key' => 'tag',
+					'label' => 'Heading Tag',
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$component = ( new Components_Repository() )->get( $result['component_id'], false );
+
+		$elements = $component->get_elements_data();
+		$heading = $elements[0]['elements'][0];
+		$this->assertSame( 'overridable', $heading['settings']['tag']['$$type'] );
+		$this->assertArrayHasKey( 'heading_tag', $component->get_overridable_props()->props );
+	}
+
+	public function test_create__persists_widgets_cache_key_as_widget_type_for_atomic_elements() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Linkable Flexbox',
+			'xml_structure' => '<e-flexbox configuration-id="card"/>',
+			'overridable_props' => [
+				'card_link' => [
+					'target' => 'card',
+					'prop_key' => 'link',
+					'label' => 'Card Link',
+				],
+			],
+		] );
+
+		// Assert - widgetType must be a real widgetsCache key (the element type), not '',
+		// otherwise the editor's OverrideControl throws "Prop type not found".
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$overridable = ( new Components_Repository() )->get( $result['component_id'], false )
+			->get_overridable_props()->props['card_link'];
+		$this->assertSame( 'e-flexbox', $overridable->widget_type );
+		$this->assertSame( 'e-flexbox', $overridable->el_type );
+	}
+
+	public function test_create__persists_an_overridable_prop_element_id_that_still_resolves_after_sanitization() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Human Labelled Hero',
+			'xml_structure' => '<e-flexbox configuration-id="wrap"><e-heading configuration-id="Hero Title"/></e-flexbox>',
+			'overridable_props' => [
+				'hero-title' => [
+					'target' => 'Hero Title',
+					'prop_key' => 'tag',
+					'label' => 'Heading Tag',
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$component = ( new Components_Repository() )->get( $result['component_id'], false );
+
+		$heading_id = $component->get_elements_data()[0]['elements'][0]['id'];
+		$this->assertSame( $heading_id, $component->get_overridable_props()->props['hero-title']->element_id );
+	}
+
+	public function test_create__generates_group_ids_that_do_not_collide_with_the_sortable_default_group() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Default Group Hero',
+			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'overridable_props' => [
+				'heading_tag' => [
+					'target' => 'h1',
+					'prop_key' => 'tag',
+					'label' => 'Heading Tag',
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$groups = ( new Components_Repository() )->get( $result['component_id'], false )->get_overridable_props()->groups;
+
+		$group_id = $groups['order'][0];
+		$this->assertNotSame( 'default', $group_id );
+		$this->assertStringStartsWith( 'group-', $group_id );
+		$this->assertSame( 'Default', $groups['items'][ $group_id ]['label'] );
+	}
+
+	public function test_create__returns_error_for_a_non_slug_override_key() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Non Slug Override Key',
+			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'overridable_props' => [
+				'Heading Tag' => [
+					'target' => 'h1',
+					'prop_key' => 'tag',
+					'label' => 'Heading Tag',
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_overridable_props', $result->get_error_code() );
+	}
+
+	public function test_create__returns_error_for_an_invalid_overridable_props_target() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Bad Overridable Target',
+			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'overridable_props' => [
+				'heading_tag' => [
+					'target' => 'does-not-exist',
+					'prop_key' => 'tag',
+					'label' => 'Heading Tag',
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_overridable_props', $result->get_error_code() );
+	}
+
+	public function test_create__creates_nested_component_instances_and_exposes_their_props() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+		$inner_component_id = $this->given_card_component( $ability );
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Cards Grid ' . uniqid(),
+			'xml_structure' => '<e-flexbox configuration-id="grid"><e-component configuration-id="card-1"/><e-component configuration-id="card-2"/></e-flexbox>',
+			'element_config' => [
+				'card-1' => [ 'component_id' => $inner_component_id ],
+				'card-2' => [ 'component_id' => $inner_component_id ],
+			],
+			'overridable_props' => [
+				'card_1_caption' => [
+					'target' => 'card-1',
+					'prop_key' => 'caption',
+					'label' => 'Card 1 Caption',
+				],
+				'card_2_caption' => [
+					'target' => 'card-2',
+					'prop_key' => 'caption',
+					'label' => 'Card 2 Caption',
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$component = ( new Components_Repository() )->get( $result['component_id'], false );
+		$instances = $component->get_elements_data()[0]['elements'];
+		$this->assertCount( 2, $instances );
+		$this->assertSame( 'e-component', $instances[0]['widgetType'] );
+		$this->assertSame( 'e-component', $instances[1]['widgetType'] );
+		$this->assertSame( $inner_component_id, $instances[0]['settings']['component_instance']['value']['component_id']['value'] );
+		$this->assertSame( $inner_component_id, $instances[1]['settings']['component_instance']['value']['component_id']['value'] );
+		$this->assertArrayHasKey( 'card_1_caption', $component->get_overridable_props()->props );
+		$this->assertArrayHasKey( 'card_2_caption', $component->get_overridable_props()->props );
+	}
+
+	public function test_update__exposes_further_from_nested_e_component_instance() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		$inner_component_id = $this->given_card_component( $ability );
+		$wrapper_component_id = $this->given_empty_wrapper( $ability, 'Cards Grid With Exposed Card Overrides' );
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $wrapper_component_id,
+			'xml_structure' => '<e-flexbox configuration-id="grid"><e-component configuration-id="card-1"/></e-flexbox>',
+			'element_config' => [
+				'card-1' => [ 'component_id' => $inner_component_id ],
+			],
+			'overridable_props' => [
+				'card_1_caption' => [
+					'target' => 'card-1',
+					'prop_key' => 'caption',
+					'label' => 'Card 1 Caption',
+					'group' => 'Card 1',
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$outer = ( new Components_Repository() )->get( $wrapper_component_id, false );
+
+		$exposed = $outer->get_overridable_props()->props;
+		$this->assertArrayHasKey( 'card_1_caption', $exposed );
+
+		$prop = $exposed['card_1_caption'];
+		$this->assertSame( 'e-component', $prop->widget_type );
+		$this->assertSame( 'caption', $prop->prop_key );
+		$this->assertSame( 'e-paragraph', $prop->origin_prop_fields['widget_type'] );
+		$this->assertSame( 'paragraph', $prop->origin_prop_fields['prop_key'] );
+		$this->assertNull( $prop->origin_value, 'Nothing was set per-instance, so there is no value to inherit.' );
+
+		$nested_instance = $this->find_nested_component_instance( $outer->get_elements_data() );
+		$overrides = $nested_instance['settings']['component_instance']['value']['overrides']['value'];
+		$this->assertCount( 1, $overrides );
+		$this->assertSame( 'overridable', $overrides[0]['$$type'] );
+		$this->assertSame( 'card_1_caption', $overrides[0]['value']['override_key'] );
+
+		$inner_override = $overrides[0]['value']['origin_value'];
+		$this->assertSame( 'override', $inner_override['$$type'] );
+		$this->assertSame( 'caption', $inner_override['value']['override_key'] );
+		$this->assertSame( $inner_component_id, $inner_override['value']['schema_source']['id'] );
+	}
+
+	public function test_update__expose_further_absorbs_an_existing_element_config_override() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		$inner_component_id = $this->given_card_component( $ability );
+		$wrapper_component_id = $this->given_empty_wrapper( $ability, 'Grid With Preset Caption' );
+		$preset_caption = [
+			'$$type' => 'html-v3',
+			'value' => [
+				'content' => [ '$$type' => 'string', 'value' => 'Preset Caption' ],
+				'children' => [],
+			],
+		];
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $wrapper_component_id,
+			'xml_structure' => '<e-flexbox configuration-id="grid"><e-component configuration-id="card-1"/></e-flexbox>',
+			'element_config' => [
+				'card-1' => [
+					'component_id' => $inner_component_id,
+					'overrides' => [ 'caption' => $preset_caption ],
+				],
+			],
+			'overridable_props' => [
+				'card_1_caption' => [
+					'target' => 'card-1',
+					'prop_key' => 'caption',
+					'label' => 'Card 1 Caption',
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$outer = ( new Components_Repository() )->get( $wrapper_component_id, false );
+
+		$nested_instance = $this->find_nested_component_instance( $outer->get_elements_data() );
+		$overrides = $nested_instance['settings']['component_instance']['value']['overrides']['value'];
+		$this->assertCount( 1, $overrides, 'The literal override must be absorbed, not left beside the exposed envelope.' );
+		$this->assertSame( 'overridable', $overrides[0]['$$type'] );
+
+		$inner_override = $overrides[0]['value']['origin_value'];
+		$this->assertSame( 'caption', $inner_override['value']['override_key'] );
+		$this->assertSame( 'Preset Caption', $inner_override['value']['override_value']['value']['content']['value'] );
+
+		$prop = $outer->get_overridable_props()->props['card_1_caption'];
+		$this->assertSame( 'Preset Caption', $prop->origin_value['value']['content']['value'], 'The absorbed value becomes the exposed prop\'s inherited default.' );
+	}
+
+	public function test_update__expose_further_threads_origin_prop_fields_through_multi_hop() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		$inner_component_id = $this->given_card_component( $ability );
+		$middle_component_id = $this->given_wrapper_exposing_from_inner( $ability, $inner_component_id, 'card_caption' );
+		$outer_component_id = $this->given_empty_wrapper( $ability, 'Outer Wrapper' );
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $outer_component_id,
+			'xml_structure' => '<e-flexbox configuration-id="root"><e-component configuration-id="middle"/></e-flexbox>',
+			'element_config' => [
+				'middle' => [ 'component_id' => $middle_component_id ],
+			],
+			'overridable_props' => [
+				'outer_caption' => [
+					'target' => 'middle',
+					'prop_key' => 'card_caption',
+					'label' => 'Outer Caption',
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$outer = ( new Components_Repository() )->get( $outer_component_id, false );
+
+		$prop = $outer->get_overridable_props()->props['outer_caption'];
+		$this->assertSame( 'e-paragraph', $prop->origin_prop_fields['widget_type'], 'origin_prop_fields must terminate at the raw widget, not at the middle e-component.' );
+		$this->assertSame( 'paragraph', $prop->origin_prop_fields['prop_key'] );
+
+		$this->assertSame( 'card_caption', $prop->prop_key, 'Outer must point at the middle component\'s override key, not the innermost one — the runtime resolves the chain one hop at a time.' );
+
+		$nested_instance = $this->find_nested_component_instance( $outer->get_elements_data() );
+		$inner_override = $nested_instance['settings']['component_instance']['value']['overrides']['value'][0]['value']['origin_value'];
+		$this->assertSame( 'card_caption', $inner_override['value']['override_key'] );
+		$this->assertSame( $middle_component_id, $inner_override['value']['schema_source']['id'] );
+	}
+
+	public function test_update__expose_further_fails_when_inner_override_key_does_not_exist() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		$inner_component_id = $this->given_card_component( $ability );
+		$wrapper_component_id = $this->given_empty_wrapper( $ability, 'Bad Inner Override Key' );
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $wrapper_component_id,
+			'xml_structure' => '<e-flexbox configuration-id="grid"><e-component configuration-id="card-1"/></e-flexbox>',
+			'element_config' => [
+				'card-1' => [ 'component_id' => $inner_component_id ],
+			],
+			'overridable_props' => [
+				'card_1_missing' => [
+					'target' => 'card-1',
+					'prop_key' => 'does_not_exist_on_card',
+					'label' => 'Missing',
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_overridable_props', $result->get_error_code() );
+		$this->assertStringContainsString( 'no exposed override', $result->get_error_message() );
+		$this->assertStringContainsString( 'caption', $result->get_error_message() );
+	}
+
+	public function test_create__expose_further_fails_when_e_component_has_no_component_id() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'No Inner Component',
+			'xml_structure' => '<e-flexbox configuration-id="grid"><e-component configuration-id="card-1"/></e-flexbox>',
+			'overridable_props' => [
+				'card_1_caption' => [
+					'target' => 'card-1',
+					'prop_key' => 'caption',
+					'label' => 'Card Caption',
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_overridable_props', $result->get_error_code() );
+		$this->assertStringContainsString( 'no valid component_instance settings', $result->get_error_message() );
+	}
+
+	private function given_card_component( Manage_Component_Ability $ability ): int {
+		$card = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Card ' . uniqid(),
+			'xml_structure' => '<e-flexbox configuration-id="card-root"><e-paragraph configuration-id="card-caption"/></e-flexbox>',
+			'overridable_props' => [
+				'caption' => [
+					'target' => 'card-caption',
+					'prop_key' => 'paragraph',
+					'label' => 'Caption',
+				],
+			],
+		] );
+
+		$this->assertIsArray( $card, 'Card fixture create must succeed but got: ' . $this->error_message( $card ) );
+
+		return (int) $card['component_id'];
+	}
+
+	private function given_empty_wrapper( Manage_Component_Ability $ability, string $title ): int {
+		$wrapper = $ability->execute( [
+			'action' => 'create',
+			'title' => $title . ' ' . uniqid(),
+		] );
+
+		$this->assertIsArray( $wrapper, 'Empty wrapper create must succeed but got: ' . $this->error_message( $wrapper ) );
+
+		return (int) $wrapper['component_id'];
+	}
+
+	private function given_wrapper_exposing_from_inner( Manage_Component_Ability $ability, int $inner_component_id, string $outer_key ): int {
+		$wrapper_id = $this->given_empty_wrapper( $ability, 'Middle Wrapper' );
+
+		$wrapper = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $wrapper_id,
+			'xml_structure' => '<e-flexbox configuration-id="wrap"><e-component configuration-id="nested"/></e-flexbox>',
+			'element_config' => [
+				'nested' => [ 'component_id' => $inner_component_id ],
+			],
+			'overridable_props' => [
+				$outer_key => [
+					'target' => 'nested',
+					'prop_key' => 'caption',
+					'label' => 'Wrapper Caption',
+				],
+			],
+		] );
+
+		$this->assertIsArray( $wrapper, 'Middle wrapper update must succeed but got: ' . $this->error_message( $wrapper ) );
+
+		return $wrapper_id;
+	}
+
+	private function find_nested_component_instance( array $elements ): ?array {
+		foreach ( $elements as $element ) {
+			if ( ( $element['widgetType'] ?? null ) === 'e-component' ) {
+				return $element;
+			}
+
+			if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
+				$found = $this->find_nested_component_instance( $element['elements'] );
+				if ( null !== $found ) {
+					return $found;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	// ---------------------------------------------------------------------
+	// update
+	// ---------------------------------------------------------------------
+
+	public function test_update__requires_component_id() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'update' ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	public function test_update__returns_not_found_for_unknown_component() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'update', 'component_id' => 999999 ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_not_found', $result->get_error_code() );
+	}
+
+	public function test_update__requires_overridable_props_or_xml_structure() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [
+			[ 'id' => 'h1', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		], 'Editable Hero' );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'update', 'component_id' => $component_id ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	public function test_update__overridable_props_only_updates_the_component_without_touching_elements() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [
+			[ 'id' => 'h1', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		], 'Editable Hero' );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $component_id,
+			'overridable_props' => [
+				'heading_tag' => [ 'target' => 'h1', 'prop_key' => 'tag', 'label' => 'Tag' ],
+			],
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$component = ( new Components_Repository() )->get( $component_id, false );
+		$this->assertArrayHasKey( 'heading_tag', $component->get_overridable_props()->props );
+		$this->assertSame( 'h1', $component->get_elements_data()[0]['id'] );
+	}
+
+	public function test_update__with_xml_structure_replaces_the_element_tree() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [
+			[ 'id' => 'h1', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		], 'Replaceable Hero' );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $component_id,
+			'xml_structure' => '<e-flexbox configuration-id="wrap"><e-paragraph configuration-id="p1"/></e-flexbox>',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$elements = ( new Components_Repository() )->get( $component_id, false )->get_elements_data();
+		$this->assertCount( 1, $elements );
+		$this->assertSame( 'e-flexbox', $elements[0]['elType'] );
+		$this->assertSame( 'e-paragraph', $elements[0]['elements'][0]['widgetType'] );
+		$this->assertSame( 'p1', $elements[0]['elements'][0]['editor_settings']['title'] );
+	}
+
+	public function test_update__rejects_invalid_form_structure_and_preserves_the_element_tree() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [
+			[ 'id' => 'h1', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		], 'Invalid Form Update' );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $component_id,
+			'xml_structure' => '<e-flexbox configuration-id="wrapper"><e-form-input configuration-id="input"/></e-flexbox>',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_invalid_form_structure', $result->get_error_code() );
+		$elements = ( new Components_Repository() )->get( $component_id, false )->get_elements_data();
+		$this->assertSame( 'h1', $elements[0]['id'] );
+	}
+
+	public function test_update__rejects_xml_structure_with_multiple_root_elements() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [
+			[ 'id' => 'h1', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		], 'Multiple Root Update' );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $component_id,
+			'xml_structure' => '<e-heading configuration-id="heading"/><e-paragraph configuration-id="paragraph"/>',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'component_requires_single_root', $result->get_error_code() );
+	}
+
+	public function test_update__applies_interactions_from_xml() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [
+			[ 'id' => 'h1', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		], 'Interactive Update' );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $this->with_interactions_active(
+			fn() => $ability->execute( [
+				'action' => 'update',
+				'component_id' => $component_id,
+				'xml_structure' => '<e-heading configuration-id="heading"/>',
+				'interactions' => [ 'heading' => [ $this->valid_interaction() ] ],
+			] )
+		);
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$elements = ( new Components_Repository() )->get( $component_id, false )->get_elements_data();
+		$this->assertArrayHasKey( 'interactions', $elements[0], wp_json_encode( $elements[0] ) );
+		$this->assertCount( 1, $elements[0]['interactions']['items'] );
+	}
+
+	public function test_update__with_draft_publish_status_creates_an_autosave_and_leaves_the_published_document_untouched() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [
+			[ 'id' => 'h1', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		], 'Draftable Hero' );
+		$this->set_main_doc_as_older_than_autosave( $component_id );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $component_id,
+			'xml_structure' => '<e-flexbox configuration-id="wrap"><e-paragraph configuration-id="p1"/></e-flexbox>',
+			'publish_status' => 'draft',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+
+		$published = ( new Components_Repository() )->get( $component_id, false );
+		$this->assertSame( 'e-heading', $published->get_elements_data()[0]['widgetType'] );
+
+		$with_autosave = ( new Components_Repository() )->get( $component_id, true );
+		$this->assertSame( 'e-flexbox', $with_autosave->get_elements_data()[0]['elType'] );
+		$this->assertSame( 'e-paragraph', $with_autosave->get_elements_data()[0]['elements'][0]['widgetType'] );
+	}
+
+	public function test_update__succeeds_when_license_is_expired() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [], 'Expired License Hero' );
+		Mock_Pro_License_API::set_license_state( false, true );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $component_id,
+			'xml_structure' => '<e-heading configuration-id="h1"/>',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertTrue( $result['success'] );
+	}
+
+	// ---------------------------------------------------------------------
+	// rename
+	// ---------------------------------------------------------------------
+
+	public function test_rename__requires_component_id_and_a_title_of_at_least_two_characters() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'rename', 'component_id' => 1, 'title' => 'X' ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	public function test_rename__updates_the_component_title() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [], 'Old Title' );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'rename', 'component_id' => $component_id, 'title' => 'New Title' ] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertTrue( $result['success'] );
+		$component = ( new Components_Repository() )->get( $component_id, false );
+		$this->assertSame( 'New Title', $component->get_post()->post_title );
+	}
+
+	public function test_rename__returns_not_found_for_unknown_component() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'rename', 'component_id' => 999999, 'title' => 'New Title' ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_not_found', $result->get_error_code() );
+	}
+
+	// ---------------------------------------------------------------------
+	// archive
+	// ---------------------------------------------------------------------
+
+	public function test_archive__requires_a_non_empty_component_ids_array() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'archive', 'component_ids' => [] ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	public function test_archive__archives_valid_ids_and_reports_failures_for_invalid_ones() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [], 'Archivable Hero' );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'archive', 'component_ids' => [ $component_id, 999999 ] ] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( [ $component_id ], $result['success_ids'] );
+		$this->assertSame( [ 999999 ], $result['failed_ids'] );
+
+		$component = ( new Components_Repository() )->get( $component_id, false );
+		$this->assertTrue( $component->get_is_archived() );
+	}
+
+	// ---------------------------------------------------------------------
+	// publish
+	// ---------------------------------------------------------------------
+
+	public function test_publish__requires_component_id() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'publish' ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	public function test_publish__returns_not_found_for_unknown_component() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'publish', 'component_id' => 999999 ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_not_found', $result->get_error_code() );
+	}
+
+	public function test_publish__promotes_a_draft_autosave_to_the_published_document() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [
+			[ 'id' => 'h1', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		], 'Publishable Hero' );
+		$this->set_main_doc_as_older_than_autosave( $component_id );
+
+		$ability = new Manage_Component_Ability();
+		$draft_result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $component_id,
+			'xml_structure' => '<e-flexbox configuration-id="wrap"><e-paragraph configuration-id="p1"/></e-flexbox>',
+			'publish_status' => 'draft',
+		] );
+		$this->assertIsArray( $draft_result, 'Fixture setup failed: ' . $this->error_message( $draft_result ) );
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'publish', 'component_id' => $component_id ] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertTrue( $result['success'] );
+		$published = ( new Components_Repository() )->get( $component_id, false );
+		$this->assertSame( 'e-flexbox', $published->get_elements_data()[0]['elType'] );
+		$this->assertSame( 'e-paragraph', $published->get_elements_data()[0]['elements'][0]['widgetType'] );
+	}
+
+	public function test_publish__succeeds_when_license_is_expired() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [], 'Expired Publish Hero', 'draft' );
+		Mock_Pro_License_API::set_license_state( false, true );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'publish', 'component_id' => $component_id ] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertTrue( $result['success'] );
+	}
+
+	// ---------------------------------------------------------------------
+	// helpers
+	// ---------------------------------------------------------------------
+
+	private function create_component_with_content( array $elements, string $title, string $status = 'publish', array $settings = [] ): int {
+		return ( new Components_Repository() )->create( $title, $elements, $status, uniqid( 'uid-', true ), $settings );
+	}
+
+	private function valid_interaction(): array {
+		return [
+			'trigger' => 'load',
+			'animation' => [
+				'effect' => 'fade',
+				'type' => 'in',
+				'direction' => '',
+				'timing_config' => [
+					'duration' => [ 'size' => 600, 'unit' => 'ms' ],
+					'delay' => [ 'size' => 0, 'unit' => 'ms' ],
+				],
+				'config' => [
+					'easing' => 'easeIn',
+				],
+			],
+			'breakpoints' => [
+				'excluded' => [],
+			],
+		];
+	}
+
+	private function with_interactions_active( callable $callback ) {
+		$experiments = Plugin::$instance->experiments;
+		$original_state = $experiments->get_features( Interactions_Module::EXPERIMENT_NAME )['state'];
+		$feature_option_key = $experiments->get_feature_option_key( Interactions_Module::EXPERIMENT_NAME );
+		update_option( $feature_option_key, Experiments_Manager::STATE_ACTIVE );
+		new Interactions_Module();
+
+		try {
+			return $callback();
+		} finally {
+			update_option( $feature_option_key, $original_state );
+		}
+	}
+
+	/**
+	 * Autosave detection requires the autosave's `post_modified_gmt` to be strictly newer than the
+	 * main document's, which second-precision MySQL timestamps can't guarantee within a single test run.
+	 */
+	private function set_main_doc_as_older_than_autosave( int $main_doc_id ): void {
+		global $wpdb;
+		$past_time = gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) );
+		$wpdb->update( $wpdb->posts, [ 'post_modified_gmt' => $past_time ], [ 'ID' => $main_doc_id ] );
+		clean_post_cache( $main_doc_id );
+		$this->clear_document_cache( $main_doc_id );
+	}
+
+	private function create_real_document(): int {
+		return $this->factory()->create_and_get_default_post()->ID;
+	}
+
+	private function given_document_with_elements( int $post_id, array $elements ): void {
+		$document = Plugin::$instance->documents->get( $post_id );
+		$document->save( [ 'elements' => $elements ] );
+
+		$this->clear_document_cache( $post_id );
+	}
+
+	private function clear_document_cache( int $post_id ): void {
+		$reflection = new \ReflectionProperty( Plugin::$instance->documents, 'documents' );
+		$reflection->setAccessible( true );
+		$documents = $reflection->getValue( Plugin::$instance->documents );
+		unset( $documents[ $post_id ] );
+		$reflection->setValue( Plugin::$instance->documents, $documents );
+	}
+
+	private function delete_all_components(): void {
+		$posts = get_posts( [
+			'post_type' => Component_Document::TYPE,
+			'post_status' => 'any',
+			'posts_per_page' => -1,
+		] );
+
+		foreach ( $posts as $post ) {
+			wp_delete_post( $post->ID, true );
+		}
+	}
+
+	private function error_message( $result ): string {
+		return is_wp_error( $result ) ? $result->get_error_message() : 'unknown';
+	}
+}


### PR DESCRIPTION
## Summary
- Add `elementor/manage-component` actions for creating, updating, renaming, archiving, and publishing components.
- Build recursive overridable-prop definitions and support composition-based component content.
- Exclude archived components from discovery while preserving direct lookup metadata.

## Dependency
- Stacked on [#36762](https://github.com/elementor/elementor/pull/36762).

## Test plan
- [x] Focused MCP PHPUnit suite (102 tests, 399 assertions)
- [x] PHPCS for all changed PHP files
- [ ] Repository-wide ESLint currently fails on unrelated unresolved `vite-plus` imports under `scripts/vite/`

## Jira
- [ED-24967](https://elementor.atlassian.net/browse/ED-24967)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds `elementor/manage-component` MCP ability to enable LLM-driven creation, editing, archiving, and publishing of Elementor components. Components now support full lifecycle management through structured API calls alongside existing read-only `list-components` ability.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `manage-component-ability.php` | New 637-line ability implementing create/update/rename/archive/publish actions with validation, overridable props, nested component support |
| `overridable-props-builder.php` | New 562-line utility building friendly→native overridable-props, handles raw widget and expose-further flows |
| `insufficient-permissions-error.php` | New 24-line utility for consistent permission denial responses |
| `components-repository.php` | Added `get_for_edit()` public wrapper around private `get_component_for_edit()` |
| `component-instance-applier.php` | Made `$document` parameter nullable; removed strict document requirement |
| `element-config-applier.php` | Removed document-context validation; now delegates to applier with optional document |
| `module.php` | Registered new ability; exposed in MCP server tools list |
| `list-components-ability.php` | Added description to `is_archived` schema field; filters archived from discovery list |
| `test-manage-component-ability.php` | New 1406-line comprehensive test suite covering all actions, permissions, validation |
| `test-list-components-ability.php` | Updated tests: split archived behavior into discovery exclusion + explicit archived-flag tests |
| Prompts & docs | New `manage-component.md` prompt; updated `build-composition.md` and `list-components.md` with component lifecycle guidance |

## 3. How It Works

**Entry point**: Five actions route through `execute()` with access gating via `Components_Access_Controller`. **Create** validates title, resolves elements from XML/source/empty, applies overridable-props via `Overridable_Props_Builder`, validates atomicity/circularity, persists. **Update** fetches target document (autosave or published), either replaces tree via XML or patches overridable-props only. **Rename/Archive/Publish** delegate to repository methods. 

**Overridable-props flow**: Builder recursively finds element refs by id or `configuration-id`, rewrites raw widget settings into `overridable` envelopes, or for nested `<e-component>` instances, splices `override` envelopes into component_instance overrides (expose-further). Absorbs existing per-instance overrides to prevent duplication.

**Document context**: Optional `Document` parameter now flows through appliers; removed hard requirement in `element-config-applier` so component instances can reference schemas without loaded document context.

## 4. Risks

**Circular dependency risk**: Validation happens pre-save; race conditions possible if components reference each other during concurrent edits. Mitigated by existing `Circular_Dependency_Validator` called on create/update.

**Permission boundary**: Expired Pro licenses grant update/publish but block create/rename/archive—asymmetry could confuse callers. Documented in prompt; tests cover all tier combinations.

**Expose-further depth**: Multi-hop chaining (`origin_prop_fields`) relies on correct threading through nested components. Tests verify chain termination at raw widget schema; no depth limit imposed.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
