### PR TITLE
Internal: Fix local wp-playground blueprint to match wp-env dev environment setup [ED-25185]

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "restart:testing": "bash scripts/setup-testing.sh --restart",
     "packages:version": "npm run version -w elementor-packages",
     "packages:release": "turbo build && npm run release -w elementor-packages",
-    "wp-playground": "npx -y @wp-playground/cli server --mount=.:/wordpress/wp-content/plugins/elementor --blueprint=./tests/playwright/blueprints/local.json",
+    "wp-playground": "npx -y @wp-playground/cli server --workers=1 --mount=.:/wordpress/wp-content/plugins/elementor --blueprint=./tests/playwright/blueprints/local.json",
     "wp-playground:ci": "npx -y @wp-playground/cli server --mount=./build:/wordpress/wp-content/plugins/elementor --blueprint=./tests/playwright/blueprints/ci.json",
     "full-e2e-local": "npx concurrently \"npm run watch\" \"npm run wp-playground\" \"npm run test:playwright -- --ui\"",
     "prepare": "husky"

--- a/tests/playwright/blueprints/local.json
+++ b/tests/playwright/blueprints/local.json
@@ -11,10 +11,8 @@
 		{
             "step": "defineWpConfigConsts",
             "consts": {
-                "WP_DISABLE_FATAL_ERROR_HANDLER": true,
-                "WP_DEBUG": true,
-                "WP_DEBUG_DISPLAY": true,
-                "SCRIPT_DEBUG": true,
+                "WP_DEBUG": false,
+                "SCRIPT_DEBUG": false,
                 "ELEMENTOR_SHOW_HIDDEN_EXPERIMENTS": true
             }
         },
@@ -25,14 +23,21 @@
 				"slug": "hello-elementor"
 			}
 		},
+		{
+			"step": "installPlugin",
+			"pluginData": { "resource": "wordpress.org/plugins", "slug": "wordpress-importer" },
+			"options": { "activate": true }
+		},
 		{ "step": "activatePlugin", "pluginPath": "/wordpress/wp-content/plugins/elementor" },
         { "step": "activateTheme", "themeFolderName": "hello-elementor" },
-        { "step": "wp-cli", "command": "wp option add 'elementor_onboarded' 1" },
-        { "step": "wp-cli", "command": "wp elementor experiments activate e_atomic_elements,container,e_opt_in_v4" },
         { "step": "updateUserMeta", "meta": { "announcements_user_counter": 999, "elementor_enable_ai": 0, "_e_welcome_popover_displayed": 1 }, "userId": 1 },
         {
             "step": "wp-cli",
-            "command": "wp --user=admin elementor library import-dir /wordpress/wp-content/plugins/elementor/tests/playwright/templates || echo 'Template import failed or already imported'"
+            "command": "wp eval 'update_option(\"elementor_onboarded\", 1); update_option(\"e_editor_counter\", 10); update_option(\"elementor_checklist\", json_encode(array(\"last_opened_timestamp\"=>null,\"first_closed_checklist_in_editor\"=>true,\"is_popup_minimized\"=>false,\"steps\"=>array(),\"should_open_in_editor\"=>false,\"editor_visit_count\"=>10))); update_option(\"elementor_experiment-e_atomic_elements\", \"active\"); update_option(\"elementor_experiment-container\", \"active\"); update_option(\"elementor_experiment-e_opt_in_v4\", \"active\"); wp_cache_flush();'"
+        },
+        {
+            "step": "wp-cli",
+            "command": "wp --user=admin elementor library import-dir /wordpress/wp-content/plugins/elementor/tests/playwright/templates"
         }
 	]
 }


### PR DESCRIPTION
## Summary
- Mirrors the Pro fix from https://github.com/elementor/elementor-pro/pull/7418 for Core's `tests/playwright/blueprints/local.json`.
- Sets `WP_DEBUG`/`SCRIPT_DEBUG` to `false` (matching `.wp-env.json`) so PHP debug output no longer corrupts editor REST API JSON responses.
- Removes unsupported shell operators (`|| echo ...`) from `wp-cli` steps — the blueprint parses args directly, not through a shell.
- Consolidates onboarding/experiment/checklist option updates into a single `wp eval` (aligned with `tests/wp-env/config/setup.sh` plus the existing playground experiment set).
- Installs `wordpress-importer` to match core's `setup.sh` path.

Core-specific differences vs Pro PR (intentional):
- No ACF / ACF WP-CLI / Pro sample-data imports (those are Pro-only).
- No `e_font_icon_svg` / `additional_custom_breakpoints` seeding (Pro gets those from `setup-experiments.sh`; Core has no equivalent).
- No `blogname=elementor` (Pro `setup.sh` only).

## Test plan
- [ ] `npm run wp-playground` boots cleanly
- [ ] Elementor + Hello Elementor active; wordpress-importer installed
- [ ] Editor loads on an existing published page with no console/JSON errors and no infinite spinner
- [ ] Checklist/announcement popovers do not auto-open on first editor visit

Jira: [ED-25185](https://elementor.atlassian.net/browse/ED-25185)


Made with [Cursor](https://cursor.com)

[ED-25185]: https://elementor.atlassian.net/browse/ED-25185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

ED-25185: Local wp-playground blueprint was misconfigured for development—had debugging flags enabled and outdated wp-cli commands that don't match the wp-env setup. This aligns local and CI environments.

## 2. What Changed (Where)

- `package.json`: Added `--workers=1` flag to `wp-playground` npm script for single-worker consistency
- `tests/playwright/blueprints/local.json`: Disabled debug flags, installed wordpress-importer plugin, refactored wp-cli setup commands into consolidated option/experiment management

## 3. How It Works

Debug settings now match production (WP_DEBUG/SCRIPT_DEBUG false), wordpress-importer installs upfront, consolidates onboarding options and experiment activation into single wp-cli eval command, then imports templates—eliminating individual wp-cli steps and reducing failures.

## 4. Risks

Minor: Template import failure silenced by removing `|| echo` fallback—import errors now fail hard instead of logging. Verify `tests/playwright/templates` directory exists and wp-cli eval command syntax is compatible with target WordPress version.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
