### PR TITLE
Fix: Enforce MCP ability permissions on proxy path [ED-25102]

### DIFF
--- a/modules/mcp/abilities/abstract-ability.php
+++ b/modules/mcp/abilities/abstract-ability.php
@@ -14,6 +14,22 @@ abstract class Abstract_Ability {
 
 	abstract public function execute( $input = [] );
 
+	public function check_permission(): bool {
+		return (bool) call_user_func( $this->get_definition()->permission_callback );
+	}
+
+	public function permission_error(): ?\WP_Error {
+		if ( $this->check_permission() ) {
+			return null;
+		}
+
+		return new \WP_Error(
+			'rest_forbidden',
+			__( 'Sorry, you are not allowed to perform this action.', 'elementor' ),
+			[ 'status' => \WP_Http::FORBIDDEN ]
+		);
+	}
+
 	public function register(): void {
 		$definition = $this->get_definition()->to_array();
 		$definition['execute_callback'] = [ $this, 'execute' ];

--- a/modules/mcp/abilities/abstract-ability.php
+++ b/modules/mcp/abilities/abstract-ability.php
@@ -18,18 +18,6 @@ abstract class Abstract_Ability {
 		return (bool) call_user_func( $this->get_definition()->permission_callback );
 	}
 
-	public function permission_error(): ?\WP_Error {
-		if ( $this->check_permission() ) {
-			return null;
-		}
-
-		return new \WP_Error(
-			'rest_forbidden',
-			__( 'Sorry, you are not allowed to perform this action.', 'elementor' ),
-			[ 'status' => \WP_Http::FORBIDDEN ]
-		);
-	}
-
 	public function register(): void {
 		$definition = $this->get_definition()->to_array();
 		$definition['execute_callback'] = [ $this, 'execute' ];

--- a/modules/mcp/abilities/read-resource-ability.php
+++ b/modules/mcp/abilities/read-resource-ability.php
@@ -75,7 +75,15 @@ class Read_Resource_Ability extends Abstract_Ability {
 		}
 
 		$executor = $executors[ $uri ];
-		$content = $executor['execute']();
+		/** @var Abstract_Ability $ability */
+		$ability = $executor['ability'];
+		$permission_error = $ability->permission_error();
+
+		if ( $permission_error ) {
+			return $permission_error;
+		}
+
+		$content = $ability->execute();
 
 		if ( is_wp_error( $content ) ) {
 			return $content;
@@ -91,27 +99,27 @@ class Read_Resource_Ability extends Abstract_Ability {
 	private function get_resource_executors(): array {
 		return [
 			Style_Best_Practices_Ability::URI => [
-				'execute' => fn() => ( new Style_Best_Practices_Ability() )->execute(),
+				'ability' => new Style_Best_Practices_Ability(),
 				'mimeType' => 'text/markdown',
 			],
 			Manage_Variable_Guide_Ability::URI => [
-				'execute' => fn() => ( new Manage_Variable_Guide_Ability() )->execute(),
+				'ability' => new Manage_Variable_Guide_Ability(),
 				'mimeType' => 'text/plain',
 			],
 			Global_Classes_Resource_Ability::URI => [
-				'execute' => fn() => ( new Global_Classes_Resource_Ability() )->execute(),
+				'ability' => new Global_Classes_Resource_Ability(),
 				'mimeType' => 'application/json',
 			],
 			Global_Variables_Resource_Ability::URI => [
-				'execute' => fn() => ( new Global_Variables_Resource_Ability() )->execute(),
+				'ability' => new Global_Variables_Resource_Ability(),
 				'mimeType' => 'application/json',
 			],
 			List_Dynamic_Tags_Ability::URI => [
-				'execute' => fn() => ( new List_Dynamic_Tags_Ability() )->execute(),
+				'ability' => new List_Dynamic_Tags_Ability(),
 				'mimeType' => 'application/json',
 			],
 			Interactions_Schema_Resource_Ability::URI => [
-				'execute' => fn() => ( new Interactions_Schema_Resource_Ability() )->execute(),
+				'ability' => new Interactions_Schema_Resource_Ability(),
 				'mimeType' => 'application/json',
 			],
 		];

--- a/modules/mcp/abilities/read-resource-ability.php
+++ b/modules/mcp/abilities/read-resource-ability.php
@@ -77,10 +77,13 @@ class Read_Resource_Ability extends Abstract_Ability {
 		$executor = $executors[ $uri ];
 		/** @var Abstract_Ability $ability */
 		$ability = $executor['ability'];
-		$permission_error = $ability->permission_error();
 
-		if ( $permission_error ) {
-			return $permission_error;
+		if ( ! $ability->check_permission() ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to perform this action.', 'elementor' ),
+				[ 'status' => \WP_Http::FORBIDDEN ]
+			);
 		}
 
 		$content = $ability->execute();

--- a/modules/mcp/rest-api/mcp-proxy-rest-api.php
+++ b/modules/mcp/rest-api/mcp-proxy-rest-api.php
@@ -104,10 +104,9 @@ class Mcp_Proxy_REST_API {
 		}
 
 		$ability = ( $this->tools[ $tool ] )();
-		$permission_error = $ability->permission_error();
 
-		if ( $permission_error ) {
-			return $this->build_response( $permission_error );
+		if ( ! $ability->check_permission() ) {
+			return $this->build_response( $this->forbidden_error() );
 		}
 
 		$result = $ability->execute( is_array( $input ) ? $input : [] );
@@ -127,15 +126,22 @@ class Mcp_Proxy_REST_API {
 		}
 
 		$ability = ( $this->resources[ $uri ] )();
-		$permission_error = $ability->permission_error();
 
-		if ( $permission_error ) {
-			return $this->build_response( $permission_error );
+		if ( ! $ability->check_permission() ) {
+			return $this->build_response( $this->forbidden_error() );
 		}
 
 		$result = $ability->execute();
 
 		return $this->build_response( $result );
+	}
+
+	private function forbidden_error(): \WP_Error {
+		return new \WP_Error(
+			'rest_forbidden',
+			__( 'Sorry, you are not allowed to perform this action.', 'elementor' ),
+			[ 'status' => \WP_Http::FORBIDDEN ]
+		);
 	}
 
 	private function build_response( $result ) {

--- a/modules/mcp/rest-api/mcp-proxy-rest-api.php
+++ b/modules/mcp/rest-api/mcp-proxy-rest-api.php
@@ -4,6 +4,7 @@ namespace Elementor\Modules\Mcp\RestApi;
 
 use Elementor\Core\Utils\Api\Error_Builder;
 use Elementor\Core\Utils\Api\Response_Builder;
+use Elementor\Modules\Mcp\Abilities\Abstract_Ability;
 use Elementor\Modules\Mcp\Abilities\Get_Structure_Ability;
 use Elementor\Modules\Mcp\Abilities\Get_Widget_Schema_Ability;
 use Elementor\Modules\Mcp\Abilities\Global_Classes_Resource_Ability;
@@ -15,8 +16,8 @@ use Elementor\Modules\Mcp\Abilities\List_Widget_Schemas_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Classes_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Elements_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Variable_Ability;
-use Elementor\Modules\Mcp\Abilities\Read_Resource_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Variable_Guide_Ability;
+use Elementor\Modules\Mcp\Abilities\Read_Resource_Ability;
 use Elementor\Modules\Mcp\Abilities\Style_Best_Practices_Ability;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -27,28 +28,31 @@ class Mcp_Proxy_REST_API {
 	const API_NAMESPACE = 'elementor/v1';
 	const API_BASE      = 'mcp-proxy';
 
-	private array $tools     = [];
+	/** @var array<string, callable(): Abstract_Ability> */
+	private array $tools = [];
+
+	/** @var array<string, callable(): Abstract_Ability> */
 	private array $resources = [];
 
 	public function __construct() {
 		$this->tools = [
-			'manage-global-variable' => fn( array $input ) => ( new Manage_Variable_Ability() )->execute( $input ),
-			'manage-classes' => fn( array $input ) => ( new Manage_Classes_Ability() )->execute( $input ),
-			'get-widget-schema' => fn( array $input ) => ( new Get_Widget_Schema_Ability() )->execute( $input ),
-			'list-widget-schemas' => fn( array $input ) => ( new List_Widget_Schemas_Ability() )->execute( $input ),
-			'get-page-structure' => fn( array $input ) => ( new Get_Structure_Ability() )->execute( $input ),
-			'manage-elements' => fn( array $input ) => ( new Manage_Elements_Ability() )->execute( $input ),
-			'list-assets' => fn( array $input ) => ( new List_Assets_Ability() )->execute( $input ),
-			'list-resources' => fn( array $input ) => ( new List_Resources_Ability() )->execute( $input ),
-			'read-resource' => fn( array $input ) => ( new Read_Resource_Ability() )->execute( $input ),
+			'manage-global-variable' => fn() => new Manage_Variable_Ability(),
+			'manage-classes' => fn() => new Manage_Classes_Ability(),
+			'get-widget-schema' => fn() => new Get_Widget_Schema_Ability(),
+			'list-widget-schemas' => fn() => new List_Widget_Schemas_Ability(),
+			'get-page-structure' => fn() => new Get_Structure_Ability(),
+			'manage-elements' => fn() => new Manage_Elements_Ability(),
+			'list-assets' => fn() => new List_Assets_Ability(),
+			'list-resources' => fn() => new List_Resources_Ability(),
+			'read-resource' => fn() => new Read_Resource_Ability(),
 		];
 
 		$this->resources = [
-			Style_Best_Practices_Ability::URI => fn() => ( new Style_Best_Practices_Ability() )->execute(),
-			Manage_Variable_Guide_Ability::URI => fn() => ( new Manage_Variable_Guide_Ability() )->execute(),
-			Global_Classes_Resource_Ability::URI => fn() => ( new Global_Classes_Resource_Ability() )->execute(),
-			Global_Variables_Resource_Ability::URI => fn() => ( new Global_Variables_Resource_Ability() )->execute(),
-			List_Dynamic_Tags_Ability::URI => fn() => ( new List_Dynamic_Tags_Ability() )->execute(),
+			Style_Best_Practices_Ability::URI => fn() => new Style_Best_Practices_Ability(),
+			Manage_Variable_Guide_Ability::URI => fn() => new Manage_Variable_Guide_Ability(),
+			Global_Classes_Resource_Ability::URI => fn() => new Global_Classes_Resource_Ability(),
+			Global_Variables_Resource_Ability::URI => fn() => new Global_Variables_Resource_Ability(),
+			List_Dynamic_Tags_Ability::URI => fn() => new List_Dynamic_Tags_Ability(),
 		];
 	}
 
@@ -99,7 +103,14 @@ class Mcp_Proxy_REST_API {
 				->build();
 		}
 
-		$result = ( $this->tools[ $tool ] )( is_array( $input ) ? $input : [] );
+		$ability = ( $this->tools[ $tool ] )();
+		$permission_error = $ability->permission_error();
+
+		if ( $permission_error ) {
+			return $this->build_response( $permission_error );
+		}
+
+		$result = $ability->execute( is_array( $input ) ? $input : [] );
 
 		return $this->build_response( $result );
 	}
@@ -115,7 +126,14 @@ class Mcp_Proxy_REST_API {
 				->build();
 		}
 
-		$result = ( $this->resources[ $uri ] )();
+		$ability = ( $this->resources[ $uri ] )();
+		$permission_error = $ability->permission_error();
+
+		if ( $permission_error ) {
+			return $this->build_response( $permission_error );
+		}
+
+		$result = $ability->execute();
 
 		return $this->build_response( $result );
 	}

--- a/tests/phpunit/elementor/modules/mcp/test-abstract-ability-permissions.php
+++ b/tests/phpunit/elementor/modules/mcp/test-abstract-ability-permissions.php
@@ -34,30 +34,7 @@ class Test_Abstract_Ability_Permissions extends Elementor_Test_Base {
 		$this->assertTrue( $ability->check_permission() );
 	}
 
-	public function test_permission_error__returns_null_when_allowed() {
-		// Arrange
-		$this->act_as_admin();
-		$ability = new Manage_Variable_Ability();
-
-		// Act / Assert
-		$this->assertNull( $ability->permission_error() );
-	}
-
-	public function test_permission_error__returns_forbidden_wp_error_when_denied() {
-		// Arrange
-		$this->act_as_editor();
-		$ability = new Manage_Variable_Ability();
-
-		// Act
-		$error = $ability->permission_error();
-
-		// Assert
-		$this->assertInstanceOf( \WP_Error::class, $error );
-		$this->assertSame( 'rest_forbidden', $error->get_error_code() );
-		$this->assertSame( \WP_Http::FORBIDDEN, $error->get_error_data()['status'] );
-	}
-
-	public function test_permission_error__uses_definition_callback() {
+	public function test_check_permission__uses_definition_callback() {
 		// Arrange
 		$ability = new class() extends Abstract_Ability {
 			protected function get_ability_id(): string {
@@ -80,11 +57,7 @@ class Test_Abstract_Ability_Permissions extends Elementor_Test_Base {
 			}
 		};
 
-		// Act
-		$error = $ability->permission_error();
-
-		// Assert
-		$this->assertInstanceOf( \WP_Error::class, $error );
-		$this->assertSame( 'rest_forbidden', $error->get_error_code() );
+		// Act / Assert
+		$this->assertFalse( $ability->check_permission() );
 	}
 }

--- a/tests/phpunit/elementor/modules/mcp/test-abstract-ability-permissions.php
+++ b/tests/phpunit/elementor/modules/mcp/test-abstract-ability-permissions.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp;
+
+use Elementor\Modules\Mcp\Abilities\Ability_Definition;
+use Elementor\Modules\Mcp\Abilities\Abstract_Ability;
+use Elementor\Modules\Mcp\Abilities\Manage_Variable_Ability;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @group Elementor\Modules\Mcp
+ */
+class Test_Abstract_Ability_Permissions extends Elementor_Test_Base {
+
+	public function test_check_permission__returns_false_when_callback_denies() {
+		// Arrange
+		$this->act_as_editor();
+		$ability = new Manage_Variable_Ability();
+
+		// Act / Assert
+		$this->assertFalse( $ability->check_permission() );
+	}
+
+	public function test_check_permission__returns_true_when_callback_allows() {
+		// Arrange
+		$this->act_as_admin();
+		$ability = new Manage_Variable_Ability();
+
+		// Act / Assert
+		$this->assertTrue( $ability->check_permission() );
+	}
+
+	public function test_permission_error__returns_null_when_allowed() {
+		// Arrange
+		$this->act_as_admin();
+		$ability = new Manage_Variable_Ability();
+
+		// Act / Assert
+		$this->assertNull( $ability->permission_error() );
+	}
+
+	public function test_permission_error__returns_forbidden_wp_error_when_denied() {
+		// Arrange
+		$this->act_as_editor();
+		$ability = new Manage_Variable_Ability();
+
+		// Act
+		$error = $ability->permission_error();
+
+		// Assert
+		$this->assertInstanceOf( \WP_Error::class, $error );
+		$this->assertSame( 'rest_forbidden', $error->get_error_code() );
+		$this->assertSame( \WP_Http::FORBIDDEN, $error->get_error_data()['status'] );
+	}
+
+	public function test_permission_error__uses_definition_callback() {
+		// Arrange
+		$ability = new class() extends Abstract_Ability {
+			protected function get_ability_id(): string {
+				return 'elementor/test-permission-ability';
+			}
+
+			protected function get_definition(): Ability_Definition {
+				return new Ability_Definition(
+					'Test',
+					'Test',
+					'elementor',
+					[ 'type' => 'object' ],
+					[],
+					fn() => false
+				);
+			}
+
+			public function execute( $input = [] ) {
+				return [];
+			}
+		};
+
+		// Act
+		$error = $ability->permission_error();
+
+		// Assert
+		$this->assertInstanceOf( \WP_Error::class, $error );
+		$this->assertSame( 'rest_forbidden', $error->get_error_code() );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-mcp-proxy-rest-api.php
+++ b/tests/phpunit/elementor/modules/mcp/test-mcp-proxy-rest-api.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp;
+
+use Elementor\Modules\GlobalClasses\Database\Migrations\Add_Capabilities;
+use Elementor\Modules\Mcp\Abilities\Manage_Variable_Ability;
+use Elementor\Modules\Mcp\Abilities\Manage_Variable_Guide_Ability;
+use Elementor\Modules\Mcp\Abilities\Read_Resource_Ability;
+use Elementor\Modules\Mcp\RestApi\Mcp_Proxy_REST_API;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @group Elementor\Modules\Mcp
+ */
+class Test_Mcp_Proxy_REST_API extends Elementor_Test_Base {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+
+		$wp_rest_server = new \WP_REST_Server();
+
+		( new Mcp_Proxy_REST_API() )->register_hooks();
+
+		do_action( 'rest_api_init' );
+	}
+
+	public function test_post__rejects_manage_global_variable_for_editor() {
+		// Arrange
+		$this->act_as_editor();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/mcp-proxy' );
+		$request->set_body_params( [
+			'tool' => 'manage-global-variable',
+			'input' => [
+				'operations' => [
+					[
+						'action' => 'create',
+						'type' => Manage_Variable_Ability::TYPE_COLOR,
+						'label' => 'brand-primary',
+						'value' => '#000000',
+					],
+				],
+			],
+		] );
+
+		// Act
+		$response = rest_do_request( $request );
+
+		// Assert
+		$this->assertSame( \WP_Http::FORBIDDEN, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	public function test_post__allows_manage_global_variable_permission_for_admin() {
+		// Arrange
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/mcp-proxy' );
+		$request->set_body_params( [
+			'tool' => 'manage-global-variable',
+			'input' => [],
+		] );
+
+		// Act
+		$response = rest_do_request( $request );
+
+		// Assert — permission passed; empty input fails validation, not auth
+		$this->assertNotSame( \WP_Http::FORBIDDEN, $response->get_status() );
+		$this->assertSame( 'invalid_input', $response->get_data()['code'] );
+	}
+
+	public function test_post__rejects_manage_classes_for_editor() {
+		// Arrange
+		$this->act_as_editor();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/mcp-proxy' );
+		$request->set_body_params( [
+			'tool' => 'manage-classes',
+			'input' => [
+				'operations' => [
+					[
+						'action' => 'delete',
+						'id' => 'g-abc1234',
+					],
+				],
+			],
+		] );
+
+		// Act
+		$response = rest_do_request( $request );
+
+		// Assert
+		$this->assertSame( \WP_Http::FORBIDDEN, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	public function test_post__allows_manage_classes_permission_for_admin() {
+		// Arrange
+		$role = get_role( 'administrator' );
+		$role->add_cap( Add_Capabilities::UPDATE_CLASS );
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'POST', '/elementor/v1/mcp-proxy' );
+		$request->set_body_params( [
+			'tool' => 'manage-classes',
+			'input' => [],
+		] );
+
+		// Act
+		$response = rest_do_request( $request );
+
+		// Assert — permission passed; empty input fails validation, not auth
+		$this->assertNotSame( \WP_Http::FORBIDDEN, $response->get_status() );
+		$this->assertSame( 'invalid_input', $response->get_data()['code'] );
+	}
+
+	public function test_get__rejects_manage_global_variable_guide_for_editor() {
+		// Arrange
+		$this->act_as_editor();
+
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/mcp-proxy' );
+		$request->set_param( 'uri', Manage_Variable_Guide_Ability::URI );
+
+		// Act
+		$response = rest_do_request( $request );
+
+		// Assert
+		$this->assertSame( \WP_Http::FORBIDDEN, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	public function test_get__allows_manage_global_variable_guide_for_admin() {
+		// Arrange
+		$this->act_as_admin();
+
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/mcp-proxy' );
+		$request->set_param( 'uri', Manage_Variable_Guide_Ability::URI );
+
+		// Act
+		$response = rest_do_request( $request );
+
+		// Assert
+		$this->assertSame( \WP_Http::OK, $response->get_status() );
+	}
+
+	public function test_read_resource__rejects_manage_global_variable_guide_for_editor() {
+		// Arrange
+		$this->act_as_editor();
+		$ability = new Read_Resource_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'uri' => Manage_Variable_Guide_Ability::URI,
+		] );
+
+		// Assert
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+		$this->assertSame( \WP_Http::FORBIDDEN, $result->get_error_data()['status'] );
+	}
+
+	public function test_read_resource__allows_manage_global_variable_guide_for_admin() {
+		// Arrange
+		$this->act_as_admin();
+		$ability = new Read_Resource_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'uri' => Manage_Variable_Guide_Ability::URI,
+		] );
+
+		// Assert
+		$this->assertIsArray( $result );
+		$this->assertSame( Manage_Variable_Guide_Ability::URI, $result['uri'] );
+		$this->assertNotEmpty( $result['content'] );
+	}
+}


### PR DESCRIPTION
## Summary
- The in-editor `mcp-proxy` REST endpoint only checked `edit_posts` before calling ability `execute()`, bypassing each ability's `permission_callback`.
- Enforce per-ability permissions in the proxy (tools + resources) and in `read-resource` delegation so Editors cannot mutate global variables/classes or read admin-only resources.
- Add PHPUnit coverage for editor vs admin on proxy tools/resources and for `Abstract_Ability` permission helpers.

## Jira
[ED-25102](https://elementor.atlassian.net/browse/ED-25102)

## Test plan
- [ ] As Editor: `POST /elementor/v1/mcp-proxy` with `manage-global-variable` returns 403
- [ ] As Editor: `POST /elementor/v1/mcp-proxy` with `manage-classes` returns 403
- [ ] As Editor: `GET /elementor/v1/mcp-proxy?uri=elementor://variables/tools/manage-global-variable-guide` returns 403
- [ ] As Admin: same calls proceed past auth (validation/success as appropriate)
- [ ] As Editor: `read-resource` for the manage-global-variable guide returns 403
- [ ] Run: `vendor/bin/phpunit --filter 'Test_Mcp_Proxy_REST_API|Test_Abstract_Ability_Permissions'`

[ED-25102]: https://elementor.atlassian.net/browse/ED-25102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

MCP proxy endpoints weren't enforcing ability-level permissions—they only called execute() directly. ED-25102 requires permission checks at the proxy layer to deny unauthorized access before execution.

## 2. What Changed (Where)

- **abstract-ability.php**: Added `check_permission()` method that invokes the ability definition's permission callback
- **read-resource-ability.php**: Refactored executor map to store ability instances instead of lambdas; added permission check before execute()
- **mcp-proxy-rest-api.php**: Restructured tools/resources maps to return ability factories; added permission checks in both `handle_tool()` and `handle_resource()` paths with shared `forbidden_error()` helper
- **test-abstract-ability-permissions.php** (new): Unit tests for permission callback invocation with editor/admin contexts
- **test-mcp-proxy-rest-api.php** (new): Integration tests verifying REST endpoint rejection/allowance by role across manage-variable, manage-classes, and resource endpoints

## 3. How It Works

Permission check flow: request → route handler instantiates ability via factory → `check_permission()` calls ability definition's callback → if denied, returns 403 before execute() runs. Both tool and resource paths follow identical pattern. Tests confirm editors get FORBIDDEN (403) while admins proceed.

## 4. Risks

Permission callback execution now happens twice for resources (once in proxy, once in Read_Resource_Ability internally)—minor redundancy but functionally safe since callbacks are idempotent guards. No breaking changes to existing ability contracts.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
