### PR TITLE
CI: Unzip new created build before validation[ED-24452]

### DIFF
--- a/.github/workflows/build-draft-release.yml
+++ b/.github/workflows/build-draft-release.yml
@@ -131,6 +131,9 @@ jobs:
           BUILD_ZIP_FILE_PATH: ${{ github.event.repository.name }}-${{ inputs.version }}.zip
           PLUGIN_NAME: ${{ github.event.repository.name }}
 
+      - name: Unzip build artifact
+        run: unzip -o ${{ github.event.repository.name }}-${{ inputs.version }}.zip -d $GITHUB_WORKSPACE
+
       - name: Validate build files
         if: github.repository_owner == 'elementor'
         env:

--- a/.github/workflows/controlled-release.yml
+++ b/.github/workflows/controlled-release.yml
@@ -30,6 +30,7 @@ jobs:
     with:
       version: ${{ inputs.version }}
       dry_run: true
+      prerelease: ${{ inputs.prerelease }}
     secrets:
       MAINTAIN_USERNAME: ${{ secrets.MAINTAIN_USERNAME }}
       MAINTAIN_EMAIL: ${{ secrets.MAINTAIN_EMAIL }}
@@ -81,6 +82,11 @@ jobs:
         run: |
           {
             echo "### 📦 Draft release created: \`${{ inputs.version }}\`"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| **Version** | \`${{ inputs.version }}\` |"
+            echo "| **Pre-release** | ${{ inputs.prerelease && '✅ Yes (publish workflow skipped)' || 'No' }} |"
             echo ""
             echo "[View draft release](https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }})"
             echo ""

--- a/.github/workflows/release-tag-creation.yml
+++ b/.github/workflows/release-tag-creation.yml
@@ -12,6 +12,11 @@ on:
         type: boolean
         default: true
         description: Dry run — validate everything but do not push commits or create tag.
+      prerelease:
+        required: false
+        type: boolean
+        default: false
+        description: 'Mark as pre-release on GitHub (skips the publish workflow).'
 
   workflow_call:
     inputs:
@@ -24,6 +29,11 @@ on:
         type: boolean
         default: true
         description: Dry run — validate everything but do not push commits or create tag.
+      prerelease:
+        required: false
+        type: boolean
+        default: false
+        description: 'Mark as pre-release on GitHub (skips the publish workflow).'
     secrets:
       MAINTAIN_USERNAME:
         required: true
@@ -64,3 +74,8 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
           maintain_username: ${{ secrets.MAINTAIN_USERNAME }}
           maintain_email: ${{ secrets.MAINTAIN_EMAIL }}
+
+      - name: Append prerelease to summary
+        if: ${{ inputs.prerelease }}
+        run: |
+          echo "| **Pre-release** | ✅ Yes (publish workflow skipped) |" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Build validation was failing because artifacts weren't extracted before validation checks ran. Adding unzip step + prerelease flag support to control workflow behavior in controlled-release pipelines (ED-24452).

## 2. What Changed (Where)

- **build-draft-release.yml**: Added unzip step before validation to extract build artifact
- **controlled-release.yml**: Pass prerelease flag to tag-creation workflow; enhanced summary with version/prerelease table
- **release-tag-creation.yml**: Added prerelease input parameter (both workflow_dispatch and workflow_call); appends prerelease status to summary

## 3. How It Works

Unzip runs after get-release-name step extracts version, then validation uses extracted files. Prerelease flag flows through controlled-release → tag-creation workflows, controlling GitHub release classification and downstream publish logic via conditional summary append.

## 4. Risks

Unzip silently overwrites existing files (-o flag) — benign in CI but document if local testing needed. Prerelease flag defaults to false but no validation prevents conflicting version patterns (e.g., "4.1.0" marked prerelease); rely on input validation upstream.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
