### PR TITLE
Internal: Document-root validity + component-instance access [ED-24967] (2/4)

### DIFF
--- a/core/utils/document/document-mutator.php
+++ b/core/utils/document/document-mutator.php
@@ -14,6 +14,8 @@ class Document_Mutator {
 
 	const DOCUMENT_ROOT = 'document';
 
+	const WIDGET_EL_TYPE = 'widget';
+
 	/** @var \Elementor\Elements_Manager */
 	private $element_manager;
 
@@ -91,7 +93,13 @@ class Document_Mutator {
 			$element['id'] = $this->generate_id();
 		}
 
-		if ( 'document' === $parent_id ) {
+		if ( self::DOCUMENT_ROOT === $parent_id ) {
+			$root_child_error = $this->check_document_root_child_allowed( $element );
+
+			if ( is_wp_error( $root_child_error ) ) {
+				return $root_child_error;
+			}
+
 			return $this->splice_into( $tree, $index, $element );
 		}
 
@@ -283,7 +291,7 @@ class Document_Mutator {
 	private function insert_into_tree( array $tree, string $parent_id, ?int $index, array $element ) {
 		foreach ( $tree as $i => $node ) {
 			if ( isset( $node['id'] ) && $node['id'] === $parent_id ) {
-				if ( isset( $node['elType'] ) && 'widget' === $node['elType'] ) {
+				if ( isset( $node['elType'] ) && self::WIDGET_EL_TYPE === $node['elType'] ) {
 					return new \WP_Error(
 						'elementor_invalid_parent',
 						__( 'Cannot insert into a widget element.', 'elementor' ),
@@ -339,6 +347,28 @@ class Document_Mutator {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Mirrors the editor's `Document.isValidChild`: only element types may sit at the document
+	 * root, so widgets inserted here would produce a tree the editor itself refuses to create.
+	 *
+	 * @return null|\WP_Error
+	 */
+	private function check_document_root_child_allowed( array $element ): ?\WP_Error {
+		if ( self::WIDGET_EL_TYPE !== ( $element['elType'] ?? '' ) ) {
+			return null;
+		}
+
+		return new \WP_Error(
+			'elementor_invalid_parent',
+			sprintf(
+				/* translators: %s: widget type */
+				__( '"%s" is a widget and cannot be a direct child of the document. Wrap it in a container element such as e-flexbox or e-div-block.', 'elementor' ),
+				$element['widgetType'] ?? self::WIDGET_EL_TYPE
+			),
+			[ 'status' => \WP_Http::BAD_REQUEST ]
+		);
 	}
 
 	/**

--- a/modules/mcp/abilities/appliers/component-instance-applier.php
+++ b/modules/mcp/abilities/appliers/component-instance-applier.php
@@ -7,6 +7,7 @@ use Elementor\Modules\AtomicWidgets\PlainResolvers\Plain_Values_Resolver;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\Components\Circular_Dependency_Validator;
+use Elementor\Modules\Components\Components_Access_Controller;
 use Elementor\Modules\Components\Components_Repository;
 use Elementor\Modules\Components\Documents\Component as Component_Document;
 use Elementor\Modules\Components\Documents\Component_Overridable_Prop;
@@ -16,6 +17,7 @@ use Elementor\Modules\Components\PropTypes\Override_Prop_Type;
 use Elementor\Modules\Components\PropTypes\Overrides_Prop_Type;
 use Elementor\Modules\Components\Utils\Parsing_Utils;
 use Elementor\Modules\Components\Widgets\Component_Instance;
+use Elementor\Modules\Mcp\Abilities\Utils\Insufficient_Permissions_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -38,12 +40,17 @@ class Component_Instance_Applier {
 	 *
 	 * @param array<string, array&>                                                 $config_id_index      Index of subtree refs (from Subtree_Builder).
 	 * @param array<string, array{component_id:int,overrides?:array<string,mixed>}> $component_instances  Per-config-id shorthand.
-	 * @param Document                                                              $document             Target document (used for circular-dep check).
+	 * @param Document|null                                                         $document             Target document, when one already exists.
 	 * @return \WP_Error|null
 	 */
-	public function apply( array &$config_id_index, array $component_instances, Document $document ): ?\WP_Error {
+	public function apply( array &$config_id_index, array $component_instances, ?Document $document ): ?\WP_Error {
 		if ( empty( $component_instances ) ) {
 			return null;
+		}
+
+		$access_error = $this->get_access_error( $document );
+		if ( $access_error ) {
+			return $access_error;
 		}
 
 		$errors = [];
@@ -91,7 +98,7 @@ class Component_Instance_Applier {
 		);
 	}
 
-	private function build_envelope( string $config_id, array $shorthand, Document $document, array &$errors ): ?array {
+	private function build_envelope( string $config_id, array $shorthand, ?Document $document, array &$errors ): ?array {
 		$component_id = (int) ( $shorthand['component_id'] ?? 0 );
 
 		if ( ! $component_id ) {
@@ -107,28 +114,9 @@ class Component_Instance_Applier {
 			return null;
 		}
 
-		$component = $this->repository->get( $component_id, false );
-
+		$component = $this->load_valid_component( $config_id, $component_id, $document, $errors );
 		if ( ! $component ) {
-			$errors[] = sprintf( '[%s] Component %d not found.', $config_id, $component_id );
 			return null;
-		}
-
-		if ( $component->get_is_archived() ) {
-			$errors[] = sprintf( '[%s] Component %d is archived and cannot be placed.', $config_id, $component_id );
-			return null;
-		}
-
-		if ( $document instanceof Component_Document ) {
-			$circular_result = Circular_Dependency_Validator::make()->validate(
-				$document->get_main_id(),
-				[ $this->make_placeholder_element( $component_id ) ]
-			);
-
-			if ( ! $circular_result['success'] ) {
-				$errors[] = sprintf( '[%s] %s', $config_id, implode( ' ', $circular_result['messages'] ) );
-				return null;
-			}
 		}
 
 		$overridable_props = $component->get_overridable_props()->props;
@@ -163,6 +151,11 @@ class Component_Instance_Applier {
 	public function apply_partial( array &$config_id_index, array $partial_shorthands, Document $document ): ?\WP_Error {
 		if ( empty( $partial_shorthands ) ) {
 			return null;
+		}
+
+		$access_error = $this->get_access_error( $document );
+		if ( $access_error ) {
+			return $access_error;
 		}
 
 		$errors = [];
@@ -238,6 +231,24 @@ class Component_Instance_Applier {
 			implode( ' ', $errors ),
 			[ 'status' => \WP_Http::BAD_REQUEST ]
 		);
+	}
+
+	private function get_access_error( ?Document $document ): ?\WP_Error {
+		if ( $document instanceof Component_Document ) {
+			return Components_Access_Controller::can_edit()
+				? null
+				: Insufficient_Permissions_Error::for_action( 'update' );
+		}
+
+		if ( null === $document ) {
+			return Components_Access_Controller::can_create()
+				? null
+				: Insufficient_Permissions_Error::for_action( 'create' );
+		}
+
+		return Components_Access_Controller::can_add_to_page()
+			? null
+			: Insufficient_Permissions_Error::for_action( 'add_to_page' );
 	}
 
 	private function assemble_envelope( int $component_id, array $overrides_list ): array {
@@ -317,7 +328,7 @@ class Component_Instance_Applier {
 		return $merged;
 	}
 
-	private function load_valid_component( string $config_id, int $component_id, Document $document, array &$errors ) {
+	private function load_valid_component( string $config_id, int $component_id, ?Document $document, array &$errors ) {
 		$component = $this->repository->get( $component_id, false );
 
 		if ( ! $component ) {

--- a/modules/mcp/abilities/appliers/element-config-applier.php
+++ b/modules/mcp/abilities/appliers/element-config-applier.php
@@ -33,7 +33,7 @@ class Element_Config_Applier {
 	 * @param array<string, array&>               $config_id_index Index of subtree refs.
 	 * @param array<string, array<string, mixed>> $element_config  Per-config-id settings.
 	 * @param array<string, array>                $widget_configs  Resolved type configs.
-	 * @param Document|null                       $document        Target document (required for <e-component> entries).
+	 * @param Document|null                       $document        Target document, when one already exists.
 	 *
 	 * @return array{ error: ?\WP_Error, warnings: string[] }
 	 */
@@ -110,17 +110,6 @@ class Element_Config_Applier {
 	}
 
 	private function apply_component_entries( array &$config_id_index, array $component_entries, ?Document $document ): ?\WP_Error {
-		if ( ! $document ) {
-			return new \WP_Error(
-				'elementor_invalid_settings',
-				sprintf(
-					'<e-component> entries in element_config require document context, which was not provided. Config-ids: %s.',
-					implode( ', ', array_keys( $component_entries ) )
-				),
-				[ 'status' => \WP_Http::BAD_REQUEST ]
-			);
-		}
-
 		return $this->create_component_applier()->apply( $config_id_index, $component_entries, $document );
 	}
 

--- a/modules/mcp/abilities/utils/composition-compiler.php
+++ b/modules/mcp/abilities/utils/composition-compiler.php
@@ -33,6 +33,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class Composition_Compiler {
 
 	private const DEFAULT_PARENT_ID = 'document';
+	private const DOCUMENT_ROOT_WRAPPER = 'e-div-block';
 
 	public static function make(): self {
 		return new self();
@@ -74,6 +75,13 @@ final class Composition_Compiler {
 		if ( is_wp_error( $widget_configs ) ) {
 			return $widget_configs;
 		}
+
+		$wrapping_result = $this->wrap_document_root_content( $dom, $widget_configs, $parent_id, $type_resolver, $xml_parser );
+		if ( is_wp_error( $wrapping_result ) ) {
+			return $wrapping_result;
+		}
+
+		$widget_configs = $wrapping_result['widget_configs'];
 
 		$child_type_error = $type_resolver->validate_child_types( $dom, $widget_configs );
 		if ( $child_type_error ) {
@@ -118,9 +126,68 @@ final class Composition_Compiler {
 
 		return [
 			'elements' => $subtrees,
-			'warnings' => array_merge( $config_result['warnings'], $style_result['warnings'], $interactions_result['warnings'] ),
+			'warnings' => array_merge( $wrapping_result['warnings'], $config_result['warnings'], $style_result['warnings'], $interactions_result['warnings'] ),
 			'dom' => $dom,
 			'xml_parser' => $xml_parser,
+		];
+	}
+
+	private function wrap_document_root_content(
+		\DOMDocument $dom,
+		array $widget_configs,
+		string $parent_id,
+		Widget_Type_Resolver $type_resolver,
+		Xml_Parser $xml_parser
+	) {
+		if ( self::DEFAULT_PARENT_ID !== $parent_id ) {
+			return [
+				'widget_configs' => $widget_configs,
+				'warnings' => [],
+			];
+		}
+
+		$root = $xml_parser->get_root( $dom );
+		if ( ! $root ) {
+			return [
+				'widget_configs' => $widget_configs,
+				'warnings' => [],
+			];
+		}
+
+		$root_children = $xml_parser->get_child_elements( $root );
+		$has_widget = false;
+		foreach ( $root_children as $child ) {
+			$tag = $xml_parser->get_tag_name( $child );
+			if ( 'widget' === ( $widget_configs[ $tag ]['elType'] ?? null ) ) {
+				$has_widget = true;
+				break;
+			}
+		}
+
+		if ( ! $has_widget ) {
+			return [
+				'widget_configs' => $widget_configs,
+				'warnings' => [],
+			];
+		}
+
+		$wrapper_config = $type_resolver->resolve_type_config( self::DOCUMENT_ROOT_WRAPPER );
+		if ( is_wp_error( $wrapper_config ) ) {
+			return $wrapper_config;
+		}
+
+		$widget_configs[ self::DOCUMENT_ROOT_WRAPPER ] = $wrapper_config;
+
+		$wrapper = $dom->createElement( self::DOCUMENT_ROOT_WRAPPER );
+		$root->appendChild( $wrapper );
+
+		foreach ( $root_children as $child ) {
+			$wrapper->appendChild( $child );
+		}
+
+		return [
+			'widget_configs' => $widget_configs,
+			'warnings' => [ __( 'Direct document-root content was wrapped in an e-div-block element.', 'elementor' ) ],
 		];
 	}
 

--- a/modules/mcp/abilities/utils/insufficient-permissions-error.php
+++ b/modules/mcp/abilities/utils/insufficient-permissions-error.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Modules\Components\Components_Access_Controller;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Insufficient_Permissions_Error {
+
+	public static function for_action( string $action ): \WP_Error {
+		return new \WP_Error(
+			'insufficient_permissions',
+			__( 'You do not have permission to perform this action.', 'elementor' ),
+			[
+				'status' => \WP_Http::FORBIDDEN,
+				'action' => $action,
+				'tier' => Components_Access_Controller::get_access_tier(),
+			]
+		);
+	}
+}

--- a/modules/mcp/static-resources/abilities/build-composition.md
+++ b/modules/mcp/static-resources/abilities/build-composition.md
@@ -7,7 +7,7 @@ If the user asks about a header, footer, 404, single, archive, or search-results
 - [elementor://interactions/schema] - Native interaction item shape and allowed enums for `interactions`
 - [elementor/list-widget-schemas?summary=true] - Available v4 widgets
 - `elementor/list-assets` - Images and SVG icons already in the Media Library; call before placing an `e-image` (for real dimensions and `srcset`) and always before an `e-svg` (which needs an uploaded asset to render)
-- `elementor/list-components` - User-defined reusable widget compositions; only call when the user explicitly asks to use a component (see COMPONENTS below)
+- `elementor/list-components` - Discover reusable widget compositions and the component capabilities available for the current license tier (see COMPONENTS)
 
 # TOOL SUPPORT
 This tool supports v4 elements only.
@@ -15,41 +15,19 @@ This tool supports v4 elements only.
 # WORKFLOW
 1. Check/create global variables via `elementor/manage-global-variable`
 2. Check/create global classes via `elementor/manage-classes`
-3. Build composition (THIS TOOL) - minimal inline styles; attach existing global classes via `classes`
-4. Use returned element IDs for subsequent configuration changes
+3. When component capabilities permit, prefer reusable components for cohesive structures that are repeated or likely to be reused
+4. Build composition (THIS TOOL) - minimal inline styles; attach existing global classes via `classes`
+5. Use returned element IDs for subsequent configuration changes
 
-# COMPONENTS (only when explicitly requested)
+# COMPONENTS
+Elementor components are reusable widget compositions; global classes are reusable styles. Do not substitute one for the other.
 
-**Do NOT call `elementor/list-components` by default.** Compose from raw widgets unless the user explicitly asks to use a component (e.g. "use my Hero component", "insert the Product Card component", "reuse the CTA component I made").
+Call `elementor/list-components` before building a repeated, named, or otherwise reusable structure. Use its `capabilities` response to decide the flow:
+- When `can_add_to_page` is true, reuse a matching component whose `overridable_props` cover the required customization.
+- When no suitable component exists and `can_create` is true, create one through `elementor/manage-component`, then place it.
+- When the required capability is false, build with raw widgets. Do not claim that a component was created or placed.
 
-## When the user explicitly asks for a component
-
-1. Call `elementor/list-components` with no arguments and find components whose names match what the user asked for (fuzzy match is fine: "Hero" → "Hero Section", etc.). If more than one component name is a plausible match, do NOT guess — ask the user which one before fetching the schema.
-2. If found, call `elementor/list-components` again with `component_ids` set to the id(s) you plan to use (batch multiple in one call) and verify each `overridable_props` covers the customizations the user needs.
-3. If a component is missing, archived (`is_archived: true`), or its overridable props do not cover the required customizations, fall back to raw widgets and tell the user why.
-
-## Placement
-- Use `<e-component configuration-id="my-hero">` in `xml_structure`. **Leaf tag — no child tags inside it.**
-- Configure it under `element_config` like any other widget. The value has the flat shape `{ component_id, overrides? }` (the widget has no other settings). Each override value uses the plain-value shape from `origin_prop_schema` — no `$$type` envelopes, same convention as regular widget settings:
-
-```json
-{
-  "element_config": {
-    "my-hero": {
-      "component_id": 42,
-      "overrides": {
-        "title": "Welcome",
-        "cta_url": "https://example.com"
-      }
-    }
-  }
-}
-```
-
-- `component_id` is required. `overrides` is optional — omit it entirely if you have no overrides to apply.
-- Only `override_key`s listed in `overridable_props` are valid. Unknown keys are rejected.
-- Do NOT place archived components (`is_archived: true`).
-- Components can be mixed with raw widgets in the same composition.
+Place a component as the self-closing leaf tag `<e-component configuration-id="my-hero"/>`. Configure it through `element_config` with `{ component_id, overrides? }`. Override values use the plain-value shape from `origin_prop_schema`; only listed override keys are valid. Components can be mixed with raw widgets.
 
 # XML STRUCTURE
 - Use widget tags: `<e-button configuration-id="btn1"></e-button>`
@@ -233,3 +211,5 @@ Note: No height/width specified on any element - flexbox handles layout automati
 
 # FURTHER INSTRUCTIONS
 Element IDs in the returned XML represent actual widgets. Use these IDs for subsequent styling or configuration changes.
+
+If components were requested or used, verify that each was created or placed successfully before reporting completion.

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-component-instance-applier.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-component-instance-applier.php
@@ -12,12 +12,15 @@ use Elementor\Modules\Mcp\Abilities\Build_Composition_Ability;
 use Elementor\Plugin;
 use Elementor\Testing\Modules\Components\Mocks\Component_Overrides_Mocks;
 use ElementorEditorTesting\Elementor_Test_Base;
+use Mock_Pro_License_API;
+use WP_Http;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 require_once __DIR__ . '/../../../components/mocks/component-overrides-mocks.php';
+require_once __DIR__ . '/../../../components/mocks/mock-pro-license-api.php';
 
 /**
  * @group Elementor\Modules\Mcp
@@ -42,12 +45,15 @@ class Test_Component_Instance_Applier extends Elementor_Test_Base {
 			'public'   => false,
 			'supports' => Component_Document::get_supported_features(),
 		] );
+
+		Mock_Pro_License_API::reset();
 	}
 
 	public function tearDown(): void {
 		Plugin::$instance->documents = $this->original_documents;
 
 		$this->delete_all_components();
+		Mock_Pro_License_API::reset();
 		parent::tearDown();
 	}
 
@@ -281,6 +287,122 @@ class Test_Component_Instance_Applier extends Elementor_Test_Base {
 		$this->assertNotNull( $ci );
 		$this->assertSame( 'component-instance', $ci['$$type'] );
 		$this->assertSame( $component_id, $ci['value']['component_id']['value'] );
+	}
+
+	/**
+	 * @dataProvider restricted_placement_tiers
+	 */
+	public function test_build_composition__rejects_component_placement_without_pro_access( bool $expired, string $expected_tier ) {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( false, $expired );
+		$component_id = $this->create_component( 'Restricted Component' );
+		$post_id = $this->create_real_document();
+		$ability = new Build_Composition_Ability( Document_Mutator::instance() );
+
+		// Act
+		$result = $ability->execute( [
+			'post_id' => $post_id,
+			'xml_structure' => '<e-flexbox configuration-id="section"><e-component configuration-id="restricted"></e-component></e-flexbox>',
+			'element_config' => [
+				'restricted' => [
+					'component_id' => $component_id,
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'insufficient_permissions', $result->get_error_code() );
+		$this->assertSame( WP_Http::FORBIDDEN, $result->get_error_data()['status'] );
+		$this->assertSame( 'add_to_page', $result->get_error_data()['action'] );
+		$this->assertSame( $expected_tier, $result->get_error_data()['tier'] );
+	}
+
+	public function restricted_placement_tiers(): array {
+		return [
+			'core' => [ false, 'core' ],
+			'expired' => [ true, 'expired' ],
+		];
+	}
+
+	public function test_build_composition__allows_raw_widgets_without_pro_access() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( false );
+		$post_id = $this->create_real_document();
+		$ability = new Build_Composition_Ability( Document_Mutator::instance() );
+
+		// Act
+		$result = $ability->execute( [
+			'post_id' => $post_id,
+			'xml_structure' => '<e-flexbox configuration-id="section"><e-heading configuration-id="heading"></e-heading></e-flexbox>',
+			'element_config' => [
+				'heading' => [
+					'title' => [
+						'content' => 'Raw heading',
+						'children' => [],
+					],
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+
+		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
+		$this->assertSame( 'e-heading', $elements[0]['elements'][0]['widgetType'] );
+	}
+
+	public function test_build_composition__rejects_component_instance_as_direct_document_child() {
+		// Arrange
+		$this->act_as_admin();
+		$component_id = $this->create_component( 'Hero Component' );
+		$post_id = $this->create_real_document();
+		$ability = new Build_Composition_Ability( Document_Mutator::instance() );
+
+		// Act
+		$result = $ability->execute( [
+			'post_id' => $post_id,
+			'xml_structure' => '<e-component configuration-id="hero-instance"/>',
+			'element_config' => [
+				'hero-instance' => [
+					'component_id' => $component_id,
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_invalid_parent', $result->get_error_code() );
+		$this->assertStringContainsString( 'e-component', $result->get_error_message() );
+		$this->assertEmpty( Plugin::$instance->documents->get( $post_id )->get_elements_data() );
+	}
+
+	public function test_apply__allows_expired_tier_to_edit_a_component_document() {
+		// Arrange
+		$this->act_as_admin();
+		$nested_component_id = $this->create_component( 'Nested Component' );
+		$host_component_id = $this->create_component( 'Host Component' );
+		$host_component = ( new Components_Repository() )->get( $host_component_id, false );
+		Mock_Pro_License_API::set_license_state( false, true );
+		$applier = $this->make_applier();
+		$index = [ 'nested' => [ 'elType' => 'widget', 'widgetType' => 'e-component', 'settings' => [] ] ];
+
+		// Act
+		$error = $applier->apply(
+			$index,
+			[ 'nested' => [ 'component_id' => $nested_component_id ] ],
+			$host_component
+		);
+
+		// Assert
+		$this->assertNull( $error );
+		$this->assertSame(
+			$nested_component_id,
+			$index['nested']['settings']['component_instance']['value']['component_id']['value']
+		);
 	}
 
 	public function test_apply_partial__preserves_untouched_overrides_and_replaces_specified_key() {

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-element-config-applier.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-element-config-applier.php
@@ -87,39 +87,6 @@ class Test_Element_Config_Applier extends TestCase {
 		);
 	}
 
-	public function test_apply__errors_when_e_component_entry_has_no_document_context() {
-		// Arrange
-		$type_resolver = new Widget_Type_Resolver( new Xml_Parser() );
-		$applier = new Element_Config_Applier( $type_resolver, $this->make_plain_values_resolver() );
-
-		$e_component_node = [
-			'elType' => 'widget',
-			'widgetType' => 'e-component',
-			'settings' => [],
-		];
-
-		$index = [ 'my-hero' => &$e_component_node ];
-
-		// Act
-		$result = $applier->apply(
-			$index,
-			[
-				'my-hero' => [
-					'component_id' => 42,
-					'overrides' => [ 'title' => 'Welcome' ],
-				],
-			],
-			[]
-		);
-
-		// Assert
-		$this->assertNotNull( $result['error'] );
-		$this->assertSame( 'elementor_invalid_settings', $result['error']->get_error_code() );
-		$this->assertStringContainsString( 'my-hero', $result['error']->get_error_message() );
-		$this->assertStringContainsString( 'document context', $result['error']->get_error_message() );
-		$this->assertSame( [], $e_component_node['settings'] );
-	}
-
 	public function test_apply__reports_settings_and_component_errors_together() {
 		// Arrange
 		$type_resolver = new Widget_Type_Resolver( new Xml_Parser() );

--- a/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
@@ -661,7 +661,7 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		return $html;
 	}
 
-	public function test_execute__rejects_widget_as_direct_document_child() {
+	public function test_execute__wraps_direct_document_children_in_single_div_block() {
 		// Arrange
 		$this->act_as_admin();
 		$post_id = $this->create_real_document();
@@ -671,15 +671,21 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		// Act
 		$result = $ability->execute( [
 			'post_id' => $post_id,
-			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'xml_structure' => '<e-heading configuration-id="h1"/><e-button configuration-id="cta"/>',
 		] );
 
 		// Assert
-		$this->assertWPError( $result );
-		$this->assertSame( 'elementor_invalid_parent', $result->get_error_code() );
-		$this->assertSame( \WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
-		$this->assertStringContainsString( 'e-heading', $result->get_error_message() );
-		$this->assertEmpty( Plugin::$instance->documents->get( $post_id )->get_elements_data() );
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 1, $result['warnings'] );
+		$this->assertStringContainsString( 'e-div-block', $result['warnings'][0] );
+		$this->assertStringContainsString( '<e-div-block', $result['resolved_xml'] );
+
+		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
+		$this->assertSame( 'e-div-block', $elements[0]['elType'] );
+		$this->assertCount( 2, $elements[0]['elements'] );
+		$this->assertSame( 'e-heading', $elements[0]['elements'][0]['widgetType'] );
+		$this->assertSame( 'e-button', $elements[0]['elements'][1]['widgetType'] );
 	}
 
 	public function test_execute__mode_omitted_behaves_as_append() {

--- a/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
@@ -361,7 +361,7 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		// Act
 		$result = $ability->execute( [
 			'post_id' => $post_id,
-			'xml_structure' => '<e-divider configuration-id="d1"/>',
+			'xml_structure' => '<e-flexbox configuration-id="section"><e-divider configuration-id="d1"/></e-flexbox>',
 			'element_config' => [
 				'd1' => [
 					'link' => [
@@ -448,7 +448,7 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 
 		$result = ( new Build_Composition_Ability() )->execute( [
 			'post_id' => $post_id,
-			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'xml_structure' => '<e-flexbox configuration-id="section"><e-heading configuration-id="h1"/></e-flexbox>',
 			'element_config' => [
 				'h1' => [
 					'title' => [
@@ -497,7 +497,7 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		// Act
 		$result = $ability->execute( [
 			'post_id' => $post_id,
-			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'xml_structure' => '<e-flexbox configuration-id="section"><e-heading configuration-id="h1"/></e-flexbox>',
 			'style' => [
 				'h1' => [ 'border-top' => '1px solid red' ],
 			],
@@ -522,7 +522,7 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		// Act
 		$result = $ability->execute( [
 			'post_id' => $post_id,
-			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'xml_structure' => '<e-flexbox configuration-id="section"><e-heading configuration-id="h1"/></e-flexbox>',
 			'classes' => [
 				'h1' => [ 'hero-heading' ],
 			],
@@ -537,7 +537,7 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 
 		$document = Plugin::$instance->documents->get( $post_id );
 		$elements = $document->get_elements_data();
-		$heading = $elements[0] ?? null;
+		$heading = $elements[0]['elements'][0] ?? null;
 		$this->assertNotNull( $heading );
 
 		$class_values = $heading['settings']['classes']['value'] ?? [];
@@ -581,7 +581,7 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		// Act
 		$result = $ability->execute( [
 			'post_id' => $post_id,
-			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'xml_structure' => '<e-flexbox configuration-id="section"><e-heading configuration-id="h1"/></e-flexbox>',
 			'style' => [
 				'h1' => [ 'color' => 'var(--wc26-gold)' ],
 			],
@@ -593,7 +593,7 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 
 		$document = Plugin::$instance->documents->get( $post_id );
 		$elements = $document->get_elements_data();
-		$heading = $elements[0] ?? null;
+		$heading = $elements[0]['elements'][0] ?? null;
 		$this->assertNotNull( $heading );
 
 		$style = reset( $heading['styles'] );
@@ -661,6 +661,27 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		return $html;
 	}
 
+	public function test_execute__rejects_widget_as_direct_document_child() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+
+		$ability = new Build_Composition_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'post_id' => $post_id,
+			'xml_structure' => '<e-heading configuration-id="h1"/>',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_invalid_parent', $result->get_error_code() );
+		$this->assertSame( \WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
+		$this->assertStringContainsString( 'e-heading', $result->get_error_message() );
+		$this->assertEmpty( Plugin::$instance->documents->get( $post_id )->get_elements_data() );
+	}
+
 	public function test_execute__mode_omitted_behaves_as_append() {
 		// Arrange
 		$this->act_as_admin();
@@ -674,7 +695,7 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		// Act
 		$result = $ability->execute( [
 			'post_id' => $post_id,
-			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'xml_structure' => '<e-flexbox configuration-id="section"/>',
 		] );
 
 		// Assert
@@ -701,7 +722,7 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		// Act
 		$result = $ability->execute( [
 			'post_id' => $post_id,
-			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'xml_structure' => '<e-flexbox configuration-id="section"/>',
 			'mode' => 'append',
 		] );
 
@@ -809,7 +830,7 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		// Act
 		$result = $ability->execute( [
 			'post_id' => $post_id,
-			'xml_structure' => '<e-heading configuration-id="new-heading"/>',
+			'xml_structure' => '<e-flexbox configuration-id="new-section"><e-heading configuration-id="new-heading"/></e-flexbox>',
 			'parent_id' => 'document',
 			'mode' => 'replace_children',
 		] );
@@ -823,8 +844,8 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		$document = Plugin::$instance->documents->get( $post_id );
 		$elements = $document->get_elements_data();
 		$this->assertCount( 1, $elements );
-		$this->assertSame( 'widget', $elements[0]['elType'] );
-		$this->assertSame( 'e-heading', $elements[0]['widgetType'] );
+		$this->assertSame( 'e-flexbox', $elements[0]['elType'] );
+		$this->assertSame( 'e-heading', $elements[0]['elements'][0]['widgetType'] );
 	}
 
 	public function test_execute__mode_replace_children_with_nonexistent_parent_returns_error() {

--- a/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
@@ -209,6 +209,30 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 	public function test_move__reparents_element_to_document_root_at_index() {
 		$this->act_as_admin();
 		$post_id = $this->create_real_document();
+		[ , $inner_id ] = $this->given_nested_containers( $post_id );
+
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => [
+				[
+					'action' => 'move',
+					'element_id' => $inner_id,
+					'new_parent_id' => 'document',
+					'index' => 0,
+				],
+			],
+		] );
+
+		$this->assertOkOperation( $result, 0 );
+
+		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
+		$this->assertSame( $inner_id, $elements[0]['id'] );
+		$this->assertEmpty( $elements[1]['elements'] ?? [] );
+	}
+
+	public function test_move__rejects_reparenting_widget_to_document_root() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
 		[ $container_id, $heading_id ] = $this->given_container_with_heading( $post_id );
 
 		$result = ( new Manage_Elements_Ability() )->execute( [
@@ -223,11 +247,12 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 			],
 		] );
 
-		$this->assertOkOperation( $result, 0 );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertSame( 'elementor_invalid_parent', $result['results'][0]['code'] );
 
-		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
-		$this->assertSame( $heading_id, $elements[0]['id'] );
-		$this->assertEmpty( $elements[1]['elements'] ?? [] );
+		$container = $this->find_element_in_document( $post_id, $container_id );
+		$this->assertSame( $heading_id, $container['elements'][0]['id'] ?? null );
 	}
 
 	public function test_move__missing_new_parent_id_returns_per_op_error() {
@@ -632,13 +657,15 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 
 		$build_result = ( new Build_Composition_Ability() )->execute( [
 			'post_id' => $post_id,
-			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'xml_structure' => '<e-flexbox configuration-id="section"><e-heading configuration-id="h1"/></e-flexbox>',
 			'parent_id' => 'document',
 			'style' => [ 'h1' => [ 'color' => '#ff0000' ] ],
 		] );
 		$this->assertIsArray( $build_result, 'build-composition failed: ' . ( is_wp_error( $build_result ) ? $build_result->get_error_message() : 'unknown' ) );
 		$this->assertTrue( $build_result['success'] ?? false );
-		$heading_id = $build_result['root_element_ids'][0];
+		$section_id = $build_result['root_element_ids'][0];
+		$heading_id = $this->find_element_in_document( $post_id, $section_id )['elements'][0]['id'] ?? null;
+		$this->assertNotNull( $heading_id );
 
 		$update_result = ( new Manage_Elements_Ability() )->execute( [
 			'post_id' => $post_id,
@@ -685,9 +712,9 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 				],
 				[
 					'action' => 'move',
-					'element_id' => $heading_id,
+					'element_id' => $container_id,
 					'new_parent_id' => 'document',
-					'index' => 0,
+					'index' => 1,
 				],
 			],
 		] );
@@ -701,8 +728,8 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertNotEmpty( $result['version'] );
 
 		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
-		$this->assertSame( $heading_id, $elements[0]['id'] );
-		$this->assertCount( 3, $elements );
+		$this->assertCount( 2, $elements );
+		$this->assertSame( $container_id, $elements[1]['id'] );
 
 		$node = $this->find_element_in_document( $post_id, $heading_id );
 		$this->assertSame( 'Bulk Title', $node['settings']['title']['value']['content']['value'] );
@@ -848,11 +875,17 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 	}
 
 	private function given_heading_on_document( int $post_id ): string {
+		[ , $heading_id ] = $this->given_container_with_heading( $post_id );
+
+		return $heading_id;
+	}
+
+	private function given_nested_containers( int $post_id ): array {
 		$this->act_as_admin();
 
 		$result = ( new Build_Composition_Ability() )->execute( [
 			'post_id' => $post_id,
-			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'xml_structure' => '<e-flexbox configuration-id="outer"><e-flexbox configuration-id="inner"/></e-flexbox>',
 			'parent_id' => 'document',
 		] );
 
@@ -860,7 +893,11 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 			$this->fail( 'Fixture setup failed: ' . $result->get_error_message() );
 		}
 
-		return $result['root_element_ids'][0];
+		$outer_id = $result['root_element_ids'][0];
+		$inner_id = $this->find_element_in_document( $post_id, $outer_id )['elements'][0]['id'] ?? null;
+		$this->assertNotNull( $inner_id );
+
+		return [ $outer_id, $inner_id ];
 	}
 
 	private function given_container_with_heading( int $post_id ): array {


### PR DESCRIPTION
## Summary
Enforce document-root validity (reject widgets as direct document children), allow composition against a null document during component create, and centralize insufficient-permissions errors for component instance placement.

## Stack
- **Base:** `feat/ED-24967-1-composition-compiler` (1/4)
- **This PR:** 2/4 in the ED-24967 stack
- **Follow-ups:** manage-component CRUD (3/4), overridable props (4/4)

## Jira
[ED-24967](https://elementor.atlassian.net/browse/ED-24967)

## Test plan
- [ ] PHPUnit: component-instance / element-config / build-composition / manage-elements coverage for the new gates
- [ ] Confirm widget-as-document-root is rejected; component create with null document still works

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
ED-24967: Prevents invalid document trees by forbidding widgets as direct root children and enforces license-based access control for component instance placement.

## 2. What Changed (Where)

| File | Change |
| :--- | :--- |
| `document-mutator.php` | Added root-level child validity checks; restricted widgets at document root. |
| `component-instance-applier.php` | Integrated `Components_Access_Controller` for create/update/add permissions. |
| `element-config-applier.php` | Removed mandatory document context requirement for component entries. |
| `composition-compiler.php` | Implemented auto-wrapping of root widgets into `e-div-block` containers. |
| `insufficient-permissions-error.php` | New utility for standardized permission error responses. |
| `tests/...` | Added coverage for root wrapping, permission tiers, and invalid reparenting. |
| `build-composition.md` | Updated LLM instructions for component usage and capability checks. |

## 3. How It Works
`Composition_Compiler` now intercepts the DOM; if widgets are found at the root, it wraps them in an `e-div-block` to maintain editor compatibility. `Component_Instance_Applier` calls `get_access_error` to verify the user's license tier against the action (create/update/add) before placing components. `Document_Mutator` acts as the final guard, returning a `WP_Error` if any operation attempts to place a widget directly under the document root.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
