### PR TITLE
Internal: Add manage-component MCP ability CRUD [ED-24967] (3/4)

### DIFF
--- a/modules/components/components-repository.php
+++ b/modules/components/components-repository.php
@@ -107,7 +107,7 @@ class Components_Repository {
 
 		foreach ( $ids as $id ) {
 			try {
-				$component = $this->get_component_for_edit( $id, $status );
+				$component = $this->get_for_edit( $id, $status );
 
 				if ( ! $component ) {
 					$failed_ids[] = $id;
@@ -128,7 +128,7 @@ class Components_Repository {
 	}
 
 	public function update_title( int $component_id, string $title, string $status ): bool {
-		$component = $this->get_component_for_edit( $component_id, $status );
+		$component = $this->get_for_edit( $component_id, $status );
 
 		if ( ! $component ) {
 			return false;
@@ -151,7 +151,7 @@ class Components_Repository {
 	 * If target status is publish:
 	 * - Will return the main document. If it's an autosave, it will be published later by the publish_component method.
 	 */
-	private function get_component_for_edit( int $component_id, string $target_status ): ?Component_Document {
+	public function get_for_edit( int $component_id, string $target_status ): ?Component_Document {
 		$component = $this->get( $component_id );
 
 		if ( ! $component ) {

--- a/modules/mcp/abilities/list-components-ability.php
+++ b/modules/mcp/abilities/list-components-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\Components\Components_Access_Controller;
 use Elementor\Modules\Components\Components_Repository;
 use Elementor\Modules\Components\Documents\Component_Overridable_Prop;
 use Elementor\Modules\Components\Utils\Parsing_Utils;
@@ -34,12 +35,24 @@ class List_Components_Ability extends Abstract_Ability {
 								'id'          => [ 'type' => 'integer' ],
 								'name'        => [ 'type' => 'string' ],
 								'uid'         => [ 'type' => 'string' ],
-								'is_archived' => [ 'type' => 'boolean' ],
+								'is_archived' => [
+									'type' => 'boolean',
+									'description' => 'Only present for components requested via component_ids. The discovery list never includes archived components.',
+								],
 								'overridable_props' => [
 									'type' => 'object',
 									'description' => 'Only present for components requested via component_ids.',
 								],
 							],
+						],
+					],
+					'capabilities' => [
+						'type' => 'object',
+						'description' => 'Component operations available to the current user and license tier.',
+						'properties' => [
+							'can_create' => [ 'type' => 'boolean' ],
+							'can_edit' => [ 'type' => 'boolean' ],
+							'can_add_to_page' => [ 'type' => 'boolean' ],
 						],
 					],
 				],
@@ -70,7 +83,7 @@ class List_Components_Ability extends Abstract_Ability {
 		$requested_ids = is_array( $input['component_ids'] ?? null ) ? $input['component_ids'] : [];
 
 		if ( empty( $requested_ids ) ) {
-			return [ 'components' => $this->build_summaries() ];
+			return $this->build_response( $this->build_summaries() );
 		}
 
 		$component_ids = $this->normalize_ids( $requested_ids );
@@ -83,7 +96,26 @@ class List_Components_Ability extends Abstract_Ability {
 			);
 		}
 
-		return $this->build_schemas( $component_ids );
+		$result = $this->build_schemas( $component_ids );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return $this->build_response( $result['components'] );
+	}
+
+	private function build_response( array $components ): array {
+		$can_manage_components = current_user_can( 'manage_options' );
+
+		return [
+			'components' => $components,
+			'capabilities' => [
+				'can_create' => $can_manage_components && Components_Access_Controller::can_create(),
+				'can_edit' => $can_manage_components && Components_Access_Controller::can_edit(),
+				'can_add_to_page' => current_user_can( 'edit_posts' ) && Components_Access_Controller::can_add_to_page(),
+			],
+		];
 	}
 
 	private function build_summaries(): array {
@@ -91,11 +123,11 @@ class List_Components_Ability extends Abstract_Ability {
 
 		return array_values(
 			$repository->all()
+				->filter( fn( $component ) => ! ( $component['is_archived'] ?? false ) )
 				->map( fn( $component ) => [
 					'id'          => $component['id'],
 					'name'        => $component['title'],
 					'uid'         => $component['uid'],
-					'is_archived' => $component['is_archived'] ?? false,
 				] )
 				->all()
 		);

--- a/modules/mcp/abilities/manage-component-ability.php
+++ b/modules/mcp/abilities/manage-component-ability.php
@@ -1,0 +1,588 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities;
+
+use Elementor\Core\Base\Document;
+use Elementor\Core\Utils\Collection;
+use Elementor\Core\Utils\Document\Document_Mutator;
+use Elementor\Modules\Components\Circular_Dependency_Validator;
+use Elementor\Modules\Components\Components_Access_Controller;
+use Elementor\Modules\Components\Components_Repository;
+use Elementor\Modules\Components\Documents\Component as Component_Document;
+use Elementor\Modules\Components\Non_Atomic_Widget_Validator;
+use Elementor\Modules\Components\Save_Components_Validator;
+use Elementor\Modules\Mcp\Abilities\Utils\Composition_Compiler;
+use Elementor\Modules\Mcp\Abilities\Utils\Insufficient_Permissions_Error;
+use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Manage_Component_Ability extends Abstract_Ability {
+
+	const ACTION_CREATE = 'create';
+	const ACTION_UPDATE = 'update';
+	const ACTION_RENAME = 'rename';
+	const ACTION_ARCHIVE = 'archive';
+	const ACTION_PUBLISH = 'publish';
+
+	private ?Components_Repository $repository;
+
+	public function __construct( ?Components_Repository $repository = null ) {
+		$this->repository = $repository;
+	}
+
+	protected function get_ability_id(): string {
+		return 'elementor/manage-component';
+	}
+
+	protected function get_definition(): Ability_Definition {
+		return new Ability_Definition(
+			__( 'Manage Elementor Component', 'elementor' ),
+			Prompt_Loader::load( 'manage-component' ),
+			'elementor',
+			$this->get_output_schema(),
+			[
+				'annotations' => [
+					'readonly' => false,
+					'idempotent' => false,
+					'destructive' => true,
+				],
+			],
+			fn() => current_user_can( 'manage_options' ),
+			$this->get_input_schema()
+		);
+	}
+
+	public function execute( $input = [] ) {
+		$input = is_array( $input ) ? $input : [];
+
+		switch ( $input['action'] ?? null ) {
+			case self::ACTION_CREATE:
+				return $this->handle_create( $input );
+			case self::ACTION_UPDATE:
+				return $this->handle_update( $input );
+			case self::ACTION_RENAME:
+				return $this->handle_rename( $input );
+			case self::ACTION_ARCHIVE:
+				return $this->handle_archive( $input );
+			case self::ACTION_PUBLISH:
+				return $this->handle_publish( $input );
+		}
+
+		return $this->invalid_input( __( 'action must be one of: create, update, rename, archive, publish.', 'elementor' ) );
+	}
+
+	private function handle_create( array $input ) {
+		$gate = $this->check_access( self::ACTION_CREATE, fn() => Components_Access_Controller::can_create() );
+		if ( $gate ) {
+			return $gate;
+		}
+
+		$title = isset( $input['title'] ) ? trim( (string) $input['title'] ) : '';
+		if ( strlen( $title ) < 2 ) {
+			return $this->invalid_input( __( 'create requires a title of at least 2 characters.', 'elementor' ) );
+		}
+
+		$source_result = $this->resolve_create_elements( $input );
+		if ( is_wp_error( $source_result ) ) {
+			return $source_result;
+		}
+		[ 'elements' => $elements, 'warnings' => $warnings ] = $source_result;
+
+		$settings = [];
+
+		$uid = $this->generate_uid();
+		$item = [
+			'uid' => $uid,
+			'title' => $title,
+			'elements' => $elements,
+			'settings' => $settings,
+		];
+		$items = Collection::make( [ $item ] );
+
+		$save_validation = Save_Components_Validator::make( $this->get_repository()->all() )->validate( $items );
+		if ( ! $save_validation['success'] ) {
+			return new \WP_Error(
+				'components_validation_failed',
+				__( 'Validation failed: ', 'elementor' ) . implode( ' ', $save_validation['messages'] ),
+				[ 'status' => \WP_Http::UNPROCESSABLE_ENTITY ]
+			);
+		}
+
+		$circular_validation = Circular_Dependency_Validator::make()->validate_new_components( $items );
+		if ( ! $circular_validation['success'] ) {
+			return new \WP_Error(
+				'circular_dependency_detected',
+				__( "Can't add this component - components that contain each other can't be nested.", 'elementor' ),
+				[
+					'status' => \WP_Http::UNPROCESSABLE_ENTITY,
+					'caused_by' => $circular_validation['messages'],
+				]
+			);
+		}
+
+		$non_atomic_error = $this->validate_atomic_elements( $elements );
+		if ( $non_atomic_error ) {
+			return $non_atomic_error;
+		}
+
+		try {
+			$component_id = $this->get_repository()->create( $title, $elements, $this->resolve_status( $input ), $uid, $settings );
+		} catch ( \Exception $e ) {
+			return new \WP_Error( 'create_failed', $e->getMessage(), [ 'status' => \WP_Http::UNPROCESSABLE_ENTITY ] );
+		}
+
+		$component = $this->get_repository()->get( $component_id, false );
+
+		$response = [
+			'success' => true,
+			'component_id' => $component_id,
+			'uid' => $uid,
+		] + $this->document_links( $component );
+
+		if ( ! empty( $warnings ) ) {
+			$response['warnings'] = $warnings;
+		}
+
+		return $response;
+	}
+
+	private function handle_update( array $input ) {
+		$gate = $this->check_access( self::ACTION_UPDATE, fn() => Components_Access_Controller::can_edit() );
+		if ( $gate ) {
+			return $gate;
+		}
+
+		$component_id = isset( $input['component_id'] ) ? (int) $input['component_id'] : 0;
+		if ( $component_id <= 0 ) {
+			return $this->invalid_input( __( 'update requires component_id.', 'elementor' ) );
+		}
+
+		$component = $this->get_repository()->get_for_edit( $component_id, $this->resolve_status( $input ) );
+		if ( ! $component ) {
+			return $this->not_found( __( 'Component not found.', 'elementor' ) );
+		}
+
+		$has_xml = ! empty( $input['xml_structure'] ) && is_string( $input['xml_structure'] );
+		if ( ! $has_xml ) {
+			return $this->invalid_input( __( 'update requires xml_structure.', 'elementor' ) );
+		}
+
+		return $this->update_with_xml( $component, $input );
+	}
+
+	private function handle_rename( array $input ) {
+		$gate = $this->check_access( self::ACTION_RENAME, fn() => Components_Access_Controller::can_rename() );
+		if ( $gate ) {
+			return $gate;
+		}
+
+		$component_id = isset( $input['component_id'] ) ? (int) $input['component_id'] : 0;
+		$title = isset( $input['title'] ) ? trim( (string) $input['title'] ) : '';
+
+		if ( $component_id <= 0 || strlen( $title ) < 2 ) {
+			return $this->invalid_input( __( 'rename requires component_id and a title of at least 2 characters.', 'elementor' ) );
+		}
+
+		$success = $this->get_repository()->update_title( $component_id, $title, $this->resolve_status( $input ) );
+		if ( ! $success ) {
+			return $this->not_found( __( 'Component not found or title could not be updated.', 'elementor' ) );
+		}
+
+		return [
+			'success' => true,
+			'component_id' => $component_id,
+		];
+	}
+
+	private function handle_archive( array $input ) {
+		$gate = $this->check_access( self::ACTION_ARCHIVE, fn() => Components_Access_Controller::can_delete() );
+		if ( $gate ) {
+			return $gate;
+		}
+
+		$component_ids = $this->normalize_ids( $input['component_ids'] ?? [] );
+		if ( empty( $component_ids ) ) {
+			return $this->invalid_input( __( 'archive requires a non-empty component_ids array of positive integers.', 'elementor' ) );
+		}
+
+		$result = $this->get_repository()->archive( $component_ids, $this->resolve_status( $input ) );
+
+		return [
+			'success' => empty( $result['failedIds'] ),
+			'success_ids' => $result['successIds'],
+			'failed_ids' => $result['failedIds'],
+		];
+	}
+
+	private function handle_publish( array $input ) {
+		$gate = $this->check_access( self::ACTION_PUBLISH, fn() => Components_Access_Controller::can_publish() );
+		if ( $gate ) {
+			return $gate;
+		}
+
+		$component_id = isset( $input['component_id'] ) ? (int) $input['component_id'] : 0;
+		if ( $component_id <= 0 ) {
+			return $this->invalid_input( __( 'publish requires component_id.', 'elementor' ) );
+		}
+
+		$component = $this->get_repository()->get( $component_id );
+		if ( ! $component ) {
+			return $this->not_found( __( 'Component not found.', 'elementor' ) );
+		}
+
+		if ( ! $this->get_repository()->publish_component( $component ) ) {
+			return new \WP_Error(
+				'publish_failed',
+				__( 'Failed to publish component.', 'elementor' ),
+				[ 'status' => \WP_Http::INTERNAL_SERVER_ERROR ]
+			);
+		}
+
+		$published = $this->get_repository()->get( $component->get_main_id(), false );
+
+		return [
+			'success' => true,
+			'component_id' => $component->get_main_id(),
+		] + $this->document_links( $published );
+	}
+
+
+	private function update_with_xml( Component_Document $component, array $input ) {
+		$compiled = $this->compile_composition( $input, $component );
+		if ( is_wp_error( $compiled ) ) {
+			return $compiled;
+		}
+
+		$elements = $this->assign_element_ids( $compiled['elements'] );
+		$warnings = $compiled['warnings'];
+
+		$non_atomic_error = $this->validate_atomic_elements( $elements );
+		if ( $non_atomic_error ) {
+			return $non_atomic_error;
+		}
+
+		$result = $this->save_component( $component, $elements, [] );
+		if ( is_wp_error( $result ) || empty( $warnings ) ) {
+			return $result;
+		}
+
+		return $result + [ 'warnings' => $warnings ];
+	}
+
+	private function save_component( Component_Document $component, array $elements, array $settings ) {
+		try {
+			$saved = $component->save( [
+				'elements' => $elements,
+				'settings' => $settings,
+			] );
+		} catch ( \Exception $e ) {
+			return new \WP_Error( 'save_failed', $e->getMessage(), [ 'status' => \WP_Http::UNPROCESSABLE_ENTITY ] );
+		}
+
+		if ( ! $saved ) {
+			return new \WP_Error( 'save_failed', __( 'Failed to save component.', 'elementor' ), [ 'status' => \WP_Http::INTERNAL_SERVER_ERROR ] );
+		}
+
+		return [
+			'success' => true,
+			'component_id' => $component->get_main_id(),
+		] + $this->document_links( $component );
+	}
+
+	private function validate_atomic_elements( array $elements ): ?\WP_Error {
+		$validation = Non_Atomic_Widget_Validator::make()->validate( $elements );
+
+		if ( $validation['success'] ) {
+			return null;
+		}
+
+		return new \WP_Error(
+			Non_Atomic_Widget_Validator::ERROR_CODE,
+			__( 'Components require atomic elements only. Remove widgets to create this component.', 'elementor' ),
+			[
+				'status' => \WP_Http::UNPROCESSABLE_ENTITY,
+				'non_atomic_elements' => $validation['non_atomic_elements'],
+			]
+		);
+	}
+
+	/**
+	 * @return array{elements: array[], warnings: string[]}|\WP_Error
+	 */
+	private function resolve_create_elements( array $input ) {
+		$has_xml = ! empty( $input['xml_structure'] ) && is_string( $input['xml_structure'] );
+		$has_source_element = ! empty( $input['source_post_id'] ) && ! empty( $input['element_id'] );
+
+		if ( $has_xml && $has_source_element ) {
+			return $this->invalid_input( __( 'create accepts either xml_structure or source_post_id/element_id, not both.', 'elementor' ) );
+		}
+
+		if ( $has_xml ) {
+			return $this->compile_elements_from_xml( $input );
+		}
+
+		if ( $has_source_element ) {
+			return $this->copy_elements_from_source( $input );
+		}
+
+		return [
+			'elements' => [],
+			'warnings' => [],
+		];
+	}
+
+	/**
+	 * @return array{elements: array[], warnings: string[]}|\WP_Error
+	 */
+	private function compile_elements_from_xml( array $input ) {
+		$compiled = $this->compile_composition( $input );
+
+		if ( is_wp_error( $compiled ) ) {
+			return $compiled;
+		}
+
+		return [
+			'elements' => $this->assign_element_ids( $compiled['elements'] ),
+			'warnings' => $compiled['warnings'],
+		];
+	}
+
+	/**
+	 * @return array{elements: array[], warnings: string[], dom: \DOMDocument, xml_parser: \Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser}|\WP_Error
+	 */
+	private function compile_composition( array $input, ?Document $document = null ) {
+		$compiled = Composition_Compiler::make()->compile( $input, $document );
+		if ( is_wp_error( $compiled ) ) {
+			return $compiled;
+		}
+
+		if ( 1 !== count( $compiled['elements'] ) ) {
+			return new \WP_Error(
+				'component_requires_single_root',
+				__( 'A component composition must contain exactly one root element.', 'elementor' ),
+				[ 'status' => \WP_Http::UNPROCESSABLE_ENTITY ]
+			);
+		}
+
+		return $compiled;
+	}
+
+	/**
+	 * @return array{elements: array[], warnings: string[]}|\WP_Error
+	 */
+	private function copy_elements_from_source( array $input ) {
+		$source_post_id = (int) $input['source_post_id'];
+		$element_id = (string) $input['element_id'];
+
+		if ( ! current_user_can( 'edit_post', $source_post_id ) ) {
+			return new \WP_Error(
+				'elementor_forbidden',
+				__( 'You do not have permission to read source_post_id.', 'elementor' ),
+				[ 'status' => \WP_Http::FORBIDDEN ]
+			);
+		}
+
+		$document = Plugin::$instance->documents->get_doc_or_auto_save( $source_post_id, get_current_user_id() )
+			?? Plugin::$instance->documents->get( $source_post_id );
+
+		if ( ! $document ) {
+			return $this->not_found( __( 'source_post_id not found.', 'elementor' ) );
+		}
+
+		$found = Document_Mutator::instance()->find_by_id( $document->get_elements_data(), $element_id );
+		if ( null === $found ) {
+			return $this->not_found( __( 'element_id was not found on source_post_id.', 'elementor' ) );
+		}
+
+		return [
+			'elements' => $this->assign_element_ids( [ $found ] ),
+			'warnings' => [],
+		];
+	}
+
+
+	/**
+	 * Compiled subtrees have no ids yet (`Subtree_Builder` never sets one), and copied
+	 * subtrees carry ids from another document that would collide here. Both paths need
+	 * fresh, slug-safe machine ids; the caller's configuration-id stays on
+	 * `editor_settings.title` so `overridable_props.target` and other tools can still
+	 * address elements by the identifier the caller used in `xml_structure`.
+	 */
+	private function assign_element_ids( array $elements ): array {
+		return array_map( fn( array $element ) => $this->assign_element_id( $element ), $elements );
+	}
+
+	private function assign_element_id( array $element ): array {
+		$element['id'] = Document_Mutator::instance()->generate_id();
+
+		if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
+			$element['elements'] = array_map( fn( array $child ) => $this->assign_element_id( $child ), $element['elements'] );
+		}
+
+		return $element;
+	}
+
+	private function document_links( Component_Document $component ): array {
+		$editor_url = $component->get_edit_url();
+
+		return [
+			'editor_url' => $editor_url,
+			'llm_instructions' => sprintf(
+				/* translators: %s: Component editor URL. */
+				__( 'You MUST show the user this link to review the component: %s', 'elementor' ),
+				$editor_url
+			),
+		];
+	}
+
+	private function resolve_status( array $input ): string {
+		return 'draft' === ( $input['publish_status'] ?? 'publish' ) ? Document::STATUS_DRAFT : Document::STATUS_PUBLISH;
+	}
+
+	private function generate_uid(): string {
+		return 'component-' . wp_generate_uuid4();
+	}
+
+	private function normalize_ids( $raw ): array {
+		if ( ! is_array( $raw ) ) {
+			return [];
+		}
+
+		$ids = [];
+		foreach ( $raw as $value ) {
+			$id = (int) $value;
+			if ( $id > 0 ) {
+				$ids[ $id ] = $id;
+			}
+		}
+
+		return array_values( $ids );
+	}
+
+	private function check_access( string $action, callable $can ): ?\WP_Error {
+		return $can() ? null : Insufficient_Permissions_Error::for_action( $action );
+	}
+
+	private function invalid_input( string $message ): \WP_Error {
+		return new \WP_Error( 'invalid_input', $message, [ 'status' => \WP_Http::BAD_REQUEST ] );
+	}
+
+	private function not_found( string $message ): \WP_Error {
+		return new \WP_Error( 'elementor_not_found', $message, [ 'status' => \WP_Http::NOT_FOUND ] );
+	}
+
+	private function get_repository(): Components_Repository {
+		if ( ! $this->repository ) {
+			$this->repository = new Components_Repository();
+		}
+
+		return $this->repository;
+	}
+
+	private function get_output_schema(): array {
+		return [
+			'type' => 'object',
+			'properties' => [
+				'success' => [ 'type' => 'boolean' ],
+				'component_id' => [ 'type' => 'integer' ],
+				'uid' => [
+					'type' => 'string',
+					'description' => 'Server-generated component uid, only present for create.',
+				],
+				'success_ids' => [
+					'type' => 'array',
+					'items' => [ 'type' => 'integer' ],
+					'description' => 'archive only.',
+				],
+				'failed_ids' => [
+					'type' => 'array',
+					'items' => [ 'type' => 'integer' ],
+					'description' => 'archive only.',
+				],
+				'editor_url' => [
+					'type' => 'string',
+					'description' => 'Component documents have no public permalink; this is the editor URL to review the change.',
+				],
+				'llm_instructions' => [
+					'type' => 'string',
+					'description' => 'Mandatory next step: include this text (with the editor link) in your reply to the user.',
+				],
+				'warnings' => [
+					'type' => 'array',
+					'items' => [ 'type' => 'string' ],
+					'description' => 'Non-fatal notices from XML compilation, e.g. props skipped or CSS that fell back to custom_css.',
+				],
+			],
+		];
+	}
+
+	private function get_input_schema(): array {
+		return [
+			'type' => 'object',
+			'required' => [ 'action' ],
+			'properties' => [
+				'action' => [
+					'type' => 'string',
+					'enum' => [ self::ACTION_CREATE, self::ACTION_UPDATE, self::ACTION_RENAME, self::ACTION_ARCHIVE, self::ACTION_PUBLISH ],
+				],
+				'title' => [
+					'type' => 'string',
+					'minLength' => 2,
+					'maxLength' => 200,
+					'description' => 'create: component title. rename: the new title.',
+				],
+				'source_post_id' => [
+					'type' => 'integer',
+					'description' => 'create: WordPress post id to copy an existing element subtree from. Requires element_id. Mutually exclusive with xml_structure.',
+				],
+				'element_id' => [
+					'type' => 'string',
+					'description' => 'create: id of the element (within source_post_id, from elementor/get-page-structure) to copy as the component root.',
+				],
+				'xml_structure' => [
+					'type' => 'string',
+					'description' => 'create/update: same tag language as elementor/build-composition, with exactly one root element. Mutually exclusive with source_post_id/element_id.',
+				],
+				'element_config' => [
+					'type' => 'object',
+					'default' => (object) [],
+					'description' => 'Same shape as elementor/build-composition element_config. Only used with xml_structure.',
+				],
+				'classes' => [
+					'type' => 'object',
+					'default' => (object) [],
+					'description' => 'Same shape as elementor/build-composition classes. Only used with xml_structure.',
+				],
+				'style' => [
+					'type' => 'object',
+					'default' => (object) [],
+					'description' => 'Same shape as elementor/build-composition style. Only used with xml_structure.',
+				],
+				'interactions' => [
+					'type' => 'object',
+					'default' => (object) [],
+					'description' => 'Same shape as elementor/build-composition interactions. Only used with xml_structure.',
+				],
+				'publish_status' => [
+					'type' => 'string',
+					'enum' => [ 'publish', 'draft' ],
+					'default' => 'publish',
+					'description' => 'create: initial document status. update/rename/archive: "draft" edits an autosave copy instead of the live document; the change is not visible on pages using this component until you publish it.',
+				],
+				'component_id' => [
+					'type' => 'integer',
+					'description' => 'update/rename/publish target component id.',
+				],
+				'component_ids' => [
+					'type' => 'array',
+					'items' => [ 'type' => 'integer' ],
+					'description' => 'archive targets.',
+				],
+			],
+		];
+	}
+}

--- a/modules/mcp/abilities/manage-component-ability.php
+++ b/modules/mcp/abilities/manage-component-ability.php
@@ -112,16 +112,11 @@ class Manage_Component_Ability extends Abstract_Ability {
 			);
 		}
 
-		$circular_validation = Circular_Dependency_Validator::make()->validate_new_components( $items );
-		if ( ! $circular_validation['success'] ) {
-			return new \WP_Error(
-				'circular_dependency_detected',
-				__( "Can't add this component - components that contain each other can't be nested.", 'elementor' ),
-				[
-					'status' => \WP_Http::UNPROCESSABLE_ENTITY,
-					'caused_by' => $circular_validation['messages'],
-				]
-			);
+		$circular_error = $this->validate_circular_dependency(
+			fn() => Circular_Dependency_Validator::make()->validate_new_components( $items )
+		);
+		if ( $circular_error ) {
+			return $circular_error;
 		}
 
 		$non_atomic_error = $this->validate_atomic_elements( $elements );
@@ -265,6 +260,13 @@ class Manage_Component_Ability extends Abstract_Ability {
 			return $non_atomic_error;
 		}
 
+		$circular_error = $this->validate_circular_dependency(
+			fn() => Circular_Dependency_Validator::make()->validate( $component->get_main_id(), $elements )
+		);
+		if ( $circular_error ) {
+			return $circular_error;
+		}
+
 		$result = $this->save_component( $component, $elements, [] );
 		if ( is_wp_error( $result ) || empty( $warnings ) ) {
 			return $result;
@@ -280,6 +282,14 @@ class Manage_Component_Ability extends Abstract_Ability {
 				'settings' => $settings,
 			] );
 		} catch ( \Exception $e ) {
+			if ( str_contains( $e->getMessage(), 'components that contain each other' ) ) {
+				return new \WP_Error(
+					'circular_dependency_detected',
+					__( "Can't add this component - components that contain each other can't be nested.", 'elementor' ),
+					[ 'status' => \WP_Http::UNPROCESSABLE_ENTITY ]
+				);
+			}
+
 			return new \WP_Error( 'save_failed', $e->getMessage(), [ 'status' => \WP_Http::UNPROCESSABLE_ENTITY ] );
 		}
 
@@ -291,6 +301,23 @@ class Manage_Component_Ability extends Abstract_Ability {
 			'success' => true,
 			'component_id' => $component->get_main_id(),
 		] + $this->document_links( $component );
+	}
+
+	private function validate_circular_dependency( callable $validate ): ?\WP_Error {
+		$circular_validation = $validate();
+
+		if ( $circular_validation['success'] ) {
+			return null;
+		}
+
+		return new \WP_Error(
+			'circular_dependency_detected',
+			__( "Can't add this component - components that contain each other can't be nested.", 'elementor' ),
+			[
+				'status' => \WP_Http::UNPROCESSABLE_ENTITY,
+				'caused_by' => $circular_validation['messages'],
+			]
+		);
 	}
 
 	private function validate_atomic_elements( array $elements ): ?\WP_Error {

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -75,6 +75,7 @@ class Module extends BaseModule {
 
 		if ( $this->is_components_active() ) {
 			( new Abilities\List_Components_Ability() )->register();
+			( new Abilities\Manage_Component_Ability() )->register();
 		}
 		( new Abilities\Global_Variables_Resource_Ability() )->register();
 		( new Abilities\Interactions_Schema_Resource_Ability() )->register();
@@ -128,7 +129,7 @@ class Module extends BaseModule {
 			'elementor/list-assets',
 			'elementor/list-resources',
 			'elementor/read-resource',
-			...( $this->is_components_active() ? [ 'elementor/list-components' ] : [] ),
+			...( $this->is_components_active() ? [ 'elementor/list-components', 'elementor/manage-component' ] : [] ),
 		];
 
 		/**

--- a/modules/mcp/static-resources/abilities/list-components.md
+++ b/modules/mcp/static-resources/abilities/list-components.md
@@ -1,8 +1,13 @@
 Returns the components available on this site. Each component is a user-defined reusable composition of widgets stored as a post, embeddable in any document via the `<e-component>` XML tag in `elementor/build-composition`.
 
+Every successful response includes `capabilities` for the current user and license tier:
+- `can_create`: new components may be created.
+- `can_edit`: existing components may be updated.
+- `can_add_to_page`: components may be placed in page compositions.
+
 Call in two steps, the same way `elementor/list-widget-schemas` works:
 
-1. **Discovery** — call with no arguments to list every component without its schema. Returns `id`, `name`, `uid`, `is_archived` per component.
+1. **Discovery** — call with no arguments to list every component without its schema. Returns `id`, `name`, `uid` per component. Archived components are never listed.
 2. **Schemas** — call again with `component_ids` set to the id(s) you actually intend to place (batch them in one call) to get each component's `overridable_props`.
 
 Always discover first. Requesting schemas for every component is wasteful on sites with many components.
@@ -10,7 +15,7 @@ Always discover first. Requesting schemas for every component is wasteful on sit
 - `id`: numeric post ID used to reference the component
 - `name`: the human-readable title the user gave the component
 - `uid`: stable string identifier
-- `is_archived`: archived components should not be placed in new compositions
+- `is_archived`: only returned for components requested via `component_ids` — an archived component cannot be placed, so pick another one
 - `overridable_props`: only returned for components requested via `component_ids`
 
 If any requested id is not a component, the call fails with `elementor_not_found` — no partial results.
@@ -20,54 +25,4 @@ Each entry in `overridable_props` maps an `override_key` to:
 - `group_id`: optional grouping for display
 - `origin_prop_schema`: plain-value JSON Schema for the override value (no `$$type` envelopes — same convention as `elementor/get-widget-schema`)
 
-# PLACING A COMPONENT IN build-composition
-
-1. Use `<e-component configuration-id="my-hero">` in `xml_structure` (leaf tag — no children allowed).
-2. Under `element_config`, map the configuration-id to `{ component_id, overrides? }`. Send each override value in the plain-value shape described by `origin_prop_schema`:
-
-```json
-{
-  "element_config": {
-    "my-hero": {
-      "component_id": 42,
-      "overrides": {
-        "title": "Welcome",
-        "cta_url": "https://example.com"
-      }
-    }
-  }
-}
-```
-
-Only include `override_key`s that appear in `overridable_props`. Unknown keys are rejected.
-Omit `overrides` entirely if you have no overrides to apply.
-Do NOT place `<e-component>` tags inside archived components.
-
-# UPDATING AN EXISTING COMPONENT INSTANCE via manage-elements
-
-Use `elementor/manage-elements` with `action=update` and `settings={ component_id?, overrides }`. Semantics:
-
-- `component_id` is optional — inferred from the existing instance if omitted.
-- Each `override_key` in `overrides` is deep-merged onto the existing overrides: only mentioned keys change.
-- Pass `null` for an `override_key` to remove that override (revert to component default).
-- Override keys not mentioned in the payload are preserved untouched — you do NOT need to re-send unchanged overrides.
-
-Example — change only the CTA URL and clear the title override:
-
-```json
-{
-  "post_id": 41870,
-  "operations": [
-    {
-      "action": "update",
-      "element_id": "1d367385",
-      "settings": {
-        "overrides": {
-          "cta_url": "https://new.example.com",
-          "title": null
-        }
-      }
-    }
-  ]
-}
-```
+Place components via `elementor/build-composition` (see its COMPONENTS section). Update an existing instance's overrides via `elementor/manage-elements` with `settings.overrides` — a deep-merge, and `null` clears a key.

--- a/modules/mcp/static-resources/abilities/manage-component.md
+++ b/modules/mcp/static-resources/abilities/manage-component.md
@@ -1,0 +1,54 @@
+Create and manage Elementor components — user-facing reusable compositions of widgets, placed elsewhere via `<e-component>` in `elementor/build-composition` (see `elementor/list-components`).
+
+Requires administrator access. `create`, `rename`, and `archive` additionally require an active Elementor Pro license; `publish` and `update` also work with an expired license. Without the required license, calls fail with `insufficient_permissions`.
+
+# COMPONENT INTENT
+An Elementor component is a persistent, reusable widget composition. It is not a global CSS class and is not merely a group of raw widgets placed on one page.
+
+Treat "create/build components", "with components", "basic components", and "component library/design system" as requests to create missing Elementor components. When a request separately names variables, classes, and components, all three are distinct deliverables.
+
+Before creating a component, call `elementor/list-components` and reuse a matching component when its exposed properties cover the requested customization. If component creation fails, report the failure instead of substituting a global class and claiming that it is a component.
+
+# ACTIONS
+Every call takes one `action`: `create`, `update`, `rename`, `archive`, `publish`.
+
+## create
+Requires `title` (2-200 chars). Choose ONE source for the initial content, or omit both to create an empty component:
+- **xml_structure**: same tag language as `elementor/build-composition` (`element_config`, `classes`, `style`, `interactions`). It must contain exactly one root element, and every element needs a unique `configuration-id`.
+- **source_post_id** + **element_id**: copy an existing element (and its children) from another document — get `element_id` from `elementor/get-page-structure`. All ids are regenerated on the copy.
+
+Returns `component_id`, `uid`, `editor_url`.
+
+`xml_structure` may contain self-closing `<e-component configuration-id="…"/>` nodes to instance other components (leaf tag; no children inside `<e-component>`). `configuration-id` identifies the instance within the request; configure the reusable component it references via `element_config` using the flat `{ component_id, overrides? }` shape documented in `build-composition.md` COMPONENTS section.
+
+```json
+{
+  "action": "create",
+  "title": "Two Cards",
+  "xml_structure": "<e-flexbox configuration-id=\"row\"><e-component configuration-id=\"card-a\"/><e-component configuration-id=\"card-b\"/></e-flexbox>",
+  "element_config": {
+    "card-a": { "component_id": 42, "overrides": { "title": "First Card", "image": { "src": { "url": "https://example.com/a.jpg" }, "size": "full" } } },
+    "card-b": { "component_id": 42, "overrides": { "title": "Second Card", "image": { "src": { "url": "https://example.com/b.jpg" }, "size": "full" } } }
+  }
+}
+```
+
+Prefer instancing an existing component over inlining its widgets. If a matching component exists (check via `elementor/list-components`), place `<e-component>` instead of duplicating the subtree.
+## update
+Requires `component_id` and `xml_structure`. Replaces the ENTIRE component tree (same params as `create`'s xml_structure path). Not a merge — re-send the full composition.
+
+## rename
+Requires `component_id` and `title` (2-200 chars).
+
+## archive
+Requires `component_ids` (array). Archived components stop being listed by `elementor/list-components` and can no longer be placed in compositions. Returns `success_ids` / `failed_ids` per id.
+
+## publish
+Requires `component_id`. Promotes a pending draft/autosave (created via `publish_status: "draft"`) to the live version.
+
+# publish_status
+Applies to `create`, `update`, `rename`, `archive`. Defaults to `"publish"` (operates on the live document immediately). Pass `"draft"` to stage changes in an autosave that does NOT affect pages already using this component until you call `action: "publish"`.
+
+
+# FURTHER INSTRUCTIONS
+Every successful response includes `editor_url` and `llm_instructions` — components have no public permalink, so you MUST share `editor_url` with the user to review the change.

--- a/tests/phpunit/elementor/modules/mcp/test-list-components-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-list-components-ability.php
@@ -8,12 +8,15 @@ use Elementor\Modules\Mcp\Abilities\List_Components_Ability;
 use Elementor\Plugin;
 use Elementor\Testing\Modules\Components\Mocks\Component_Overrides_Mocks;
 use ElementorEditorTesting\Elementor_Test_Base;
+use Mock_Pro_License_API;
+use WP_Http;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 require_once __DIR__ . '/../components/mocks/component-overrides-mocks.php';
+require_once __DIR__ . '/../components/mocks/mock-pro-license-api.php';
 
 /**
  * @group Elementor\Modules\Mcp
@@ -34,11 +37,82 @@ class Test_List_Components_Ability extends Elementor_Test_Base {
 			'public'   => false,
 			'supports' => Component_Document::get_supported_features(),
 		] );
+
+		Mock_Pro_License_API::reset();
 	}
 
 	public function tearDown(): void {
 		$this->delete_all_components();
+		Mock_Pro_License_API::reset();
 		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider access_capability_cases
+	 */
+	public function test_execute__returns_component_access_capabilities( bool $active, bool $expired, array $expected ) {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( $active, $expired );
+		$ability = new List_Components_Ability();
+
+		// Act
+		$result = $ability->execute();
+
+		// Assert
+		$this->assertSame( $expected, $result['capabilities'] );
+	}
+
+	public function access_capability_cases(): array {
+		return [
+			'pro' => [
+				true,
+				false,
+				[
+					'can_create' => true,
+					'can_edit' => true,
+					'can_add_to_page' => true,
+				],
+			],
+			'expired' => [
+				false,
+				true,
+				[
+					'can_create' => false,
+					'can_edit' => true,
+					'can_add_to_page' => false,
+				],
+			],
+			'core' => [
+				false,
+				false,
+				[
+					'can_create' => false,
+					'can_edit' => false,
+					'can_add_to_page' => false,
+				],
+			],
+		];
+	}
+
+	public function test_execute__includes_user_permissions_in_component_capabilities() {
+		// Arrange
+		Mock_Pro_License_API::set_license_state( true );
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'editor' ] ) );
+		$ability = new List_Components_Ability();
+
+		// Act
+		$result = $ability->execute();
+
+		// Assert
+		$this->assertSame(
+			[
+				'can_create' => false,
+				'can_edit' => false,
+				'can_add_to_page' => true,
+			],
+			$result['capabilities']
+		);
 	}
 
 	public function test_execute__returns_empty_list_when_no_components_exist() {
@@ -70,7 +144,7 @@ class Test_List_Components_Ability extends Elementor_Test_Base {
 		$this->assertSame( $component_id, $component['id'] );
 		$this->assertSame( 'My Hero', $component['name'] );
 		$this->assertArrayHasKey( 'uid', $component );
-		$this->assertFalse( $component['is_archived'] );
+		$this->assertArrayNotHasKey( 'is_archived', $component );
 	}
 
 	public function test_execute__omits_overridable_props_from_the_discovery_list() {
@@ -87,17 +161,32 @@ class Test_List_Components_Ability extends Elementor_Test_Base {
 		$this->assertArrayNotHasKey( 'overridable_props', $result['components'][0] );
 	}
 
-	public function test_execute__returns_archived_flag_for_archived_components() {
+	public function test_execute__excludes_archived_components_from_the_discovery_list() {
 		// Arrange
 		$this->act_as_admin();
-		$component_id = $this->create_component( 'Old Header', 'publish' );
+		$archived_id = $this->create_component( 'Old Header', 'publish' );
+		$active_id = $this->create_component( 'Current Header', 'publish' );
 		$repository = new Components_Repository();
-		$component = $repository->get( $component_id, false );
-		$component->archive();
+		$repository->get( $archived_id, false )->archive();
 		$ability = new List_Components_Ability();
 
 		// Act
 		$result = $ability->execute();
+
+		// Assert
+		$this->assertSame( [ $active_id ], array_column( $result['components'], 'id' ) );
+	}
+
+	public function test_execute__returns_archived_flag_when_an_archived_component_is_requested_by_id() {
+		// Arrange
+		$this->act_as_admin();
+		$component_id = $this->create_component( 'Old Header', 'publish' );
+		$repository = new Components_Repository();
+		$repository->get( $component_id, false )->archive();
+		$ability = new List_Components_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'component_ids' => [ $component_id ] ] );
 
 		// Assert
 		$this->assertCount( 1, $result['components'] );
@@ -130,7 +219,7 @@ class Test_List_Components_Ability extends Elementor_Test_Base {
 		// Assert
 		$this->assertWPError( $result );
 		$this->assertSame( 'invalid_input', $result->get_error_code() );
-		$this->assertSame( \WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
+		$this->assertSame( WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
 	}
 
 	public function test_execute__returns_404_when_any_requested_component_is_missing() {
@@ -145,7 +234,7 @@ class Test_List_Components_Ability extends Elementor_Test_Base {
 		// Assert
 		$this->assertWPError( $result );
 		$this->assertSame( 'elementor_not_found', $result->get_error_code() );
-		$this->assertSame( \WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
+		$this->assertSame( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
 	}
 
 	public function test_execute__returns_404_when_id_points_to_non_component_post() {

--- a/tests/phpunit/elementor/modules/mcp/test-manage-component-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-component-ability.php
@@ -484,6 +484,52 @@ class Test_Manage_Component_Ability extends Elementor_Test_Base {
 		$this->assertSame( 'p1', $elements[0]['elements'][0]['editor_settings']['title'] );
 	}
 
+	public function test_save_component__maps_circular_dependency_exception_to_circular_dependency_detected() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [], 'Self Referencing Hero' );
+		$component = ( new Components_Repository() )->get( $component_id, false );
+		$ability = new Manage_Component_Ability();
+		$save_component = new \ReflectionMethod( Manage_Component_Ability::class, 'save_component' );
+		$save_component->setAccessible( true );
+
+		// Act
+		$result = $save_component->invoke(
+			$ability,
+			$component,
+			[ $this->self_referencing_component_element( $component_id ) ],
+			[]
+		);
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'circular_dependency_detected', $result->get_error_code() );
+	}
+
+	public function test_update__rejects_circular_nesting_with_circular_dependency_detected() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [], 'Self Referencing Hero' );
+		$ability = new Manage_Component_Ability();
+		$validate_circular_dependency = new \ReflectionMethod( Manage_Component_Ability::class, 'validate_circular_dependency' );
+		$validate_circular_dependency->setAccessible( true );
+
+		// Act
+		$result = $validate_circular_dependency->invoke(
+			$ability,
+			fn() => \Elementor\Modules\Components\Circular_Dependency_Validator::make()->validate(
+				$component_id,
+				[ $this->self_referencing_component_element( $component_id ) ]
+			)
+		);
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'circular_dependency_detected', $result->get_error_code() );
+	}
+
 	public function test_update__rejects_invalid_form_structure_and_preserves_the_element_tree() {
 		// Arrange
 		$this->act_as_admin();
@@ -740,6 +786,26 @@ class Test_Manage_Component_Ability extends Elementor_Test_Base {
 		foreach ( $posts as $post ) {
 			wp_delete_post( $post->ID, true );
 		}
+	}
+
+	private function self_referencing_component_element( int $component_id ): array {
+		return [
+			'id' => 'component-instance-' . $component_id,
+			'elType' => 'widget',
+			'widgetType' => 'e-component',
+			'settings' => [
+				'component_instance' => [
+					'$$type' => 'component-instance',
+					'value' => [
+						'component_id' => [
+							'$$type' => 'number',
+							'value' => $component_id,
+						],
+					],
+				],
+			],
+			'elements' => [],
+		];
 	}
 
 	private function error_message( $result ): string {

--- a/tests/phpunit/elementor/modules/mcp/test-manage-component-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-component-ability.php
@@ -1,0 +1,748 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp;
+
+use Elementor\Core\Documents_Manager;
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Elements_Manager;
+use Elementor\Modules\Components\Components_Repository;
+use Elementor\Modules\Components\Documents\Component as Component_Document;
+use Elementor\Modules\Components\Non_Atomic_Widget_Validator;
+use Elementor\Modules\Interactions\Module as Interactions_Module;
+use Elementor\Modules\Mcp\Abilities\Manage_Component_Ability;
+use Elementor\Plugin;
+use Elementor\Widgets_Manager;
+use ElementorEditorTesting\Elementor_Test_Base;
+use Mock_Pro_License_API;
+use WP_Http;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once __DIR__ . '/../components/mocks/mock-pro-license-api.php';
+
+/**
+ * @group Elementor\Modules\Mcp
+ */
+class Test_Manage_Component_Ability extends Elementor_Test_Base {
+
+	private Documents_Manager $original_documents;
+	private Widgets_Manager $original_widgets_manager;
+	private Elements_Manager $original_elements_manager;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_scripts, $wp_styles;
+		$wp_scripts = new \WP_Scripts();
+		$wp_styles = new \WP_Styles();
+
+		$this->original_documents = Plugin::$instance->documents;
+		$this->original_widgets_manager = Plugin::$instance->widgets_manager;
+		$this->original_elements_manager = Plugin::$instance->elements_manager;
+
+		Plugin::$instance->documents->register_document_type(
+			Component_Document::TYPE,
+			Component_Document::get_class_full_name()
+		);
+
+		register_post_type( Component_Document::TYPE, [
+			'label' => Component_Document::get_title(),
+			'labels' => Component_Document::get_labels(),
+			'public' => false,
+			'supports' => Component_Document::get_supported_features(),
+		] );
+
+		Mock_Pro_License_API::reset();
+	}
+
+	public function tearDown(): void {
+		Plugin::$instance->documents = $this->original_documents;
+		Plugin::$instance->widgets_manager = $this->original_widgets_manager;
+		Plugin::$instance->elements_manager = $this->original_elements_manager;
+
+		global $wp_scripts, $wp_styles;
+		$wp_scripts = new \WP_Scripts();
+		$wp_styles = new \WP_Styles();
+
+		$this->delete_all_components();
+		Mock_Pro_License_API::reset();
+
+		parent::tearDown();
+	}
+
+	// ---------------------------------------------------------------------
+	// action routing
+	// ---------------------------------------------------------------------
+
+	public function test_execute__returns_invalid_input_for_unknown_action() {
+		// Arrange
+		$this->act_as_admin();
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'delete_everything' ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	/**
+	 * @dataProvider invalid_action_input_cases
+	 */
+
+	public function test_execute__validates_action_specific_required_fields( array $input ) {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( $input );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	public function invalid_action_input_cases(): array {
+		return [
+			'create requires a valid title' => [ [ 'action' => 'create', 'title' => 'X' ] ],
+			'update requires component_id' => [ [ 'action' => 'update' ] ],
+			'rename requires component_id and a valid title' => [ [ 'action' => 'rename', 'component_id' => 1, 'title' => 'X' ] ],
+			'archive requires component_ids' => [ [ 'action' => 'archive', 'component_ids' => [] ] ],
+			'publish requires component_id' => [ [ 'action' => 'publish' ] ],
+		];
+	}
+
+	/**
+	 * @dataProvider unknown_component_action_cases
+	 */
+
+	public function test_execute__returns_not_found_for_unknown_component( array $input ) {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( $input );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_not_found', $result->get_error_code() );
+	}
+
+	public function unknown_component_action_cases(): array {
+		return [
+			'update' => [ [ 'action' => 'update', 'component_id' => 999999 ] ],
+			'rename' => [ [ 'action' => 'rename', 'component_id' => 999999, 'title' => 'New Title' ] ],
+			'publish' => [ [ 'action' => 'publish', 'component_id' => 999999 ] ],
+		];
+	}
+
+	// ---------------------------------------------------------------------
+	// access gating (shared across all actions)
+	// ---------------------------------------------------------------------
+
+	/**
+	 * @dataProvider access_gate_cases
+	 */
+
+	public function test_execute__blocked_by_access_tier( array $input, bool $license_active, bool $license_expired ) {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( $license_active, $license_expired );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( $input );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'insufficient_permissions', $result->get_error_code() );
+		$this->assertSame( WP_Http::FORBIDDEN, $result->get_error_data()['status'] );
+		$this->assertSame( $input['action'], $result->get_error_data()['action'] );
+	}
+
+	public function access_gate_cases(): array {
+		return [
+			'create requires pro tier' => [ [ 'action' => 'create', 'title' => 'Hero' ], false, false ],
+			'create blocked even when expired' => [ [ 'action' => 'create', 'title' => 'Hero' ], false, true ],
+			'update requires pro or expired tier' => [ [ 'action' => 'update', 'component_id' => 1 ], false, false ],
+			'rename requires pro tier' => [ [ 'action' => 'rename', 'component_id' => 1, 'title' => 'Hero' ], false, false ],
+			'rename blocked even when expired' => [ [ 'action' => 'rename', 'component_id' => 1, 'title' => 'Hero' ], false, true ],
+			'archive requires pro tier' => [ [ 'action' => 'archive', 'component_ids' => [ 1 ] ], false, false ],
+			'archive blocked even when expired' => [ [ 'action' => 'archive', 'component_ids' => [ 1 ] ], false, true ],
+			'publish requires pro or expired tier' => [ [ 'action' => 'publish', 'component_id' => 1 ], false, false ],
+		];
+	}
+
+	// ---------------------------------------------------------------------
+	// create
+	// ---------------------------------------------------------------------
+
+	public function test_create__creates_an_empty_component_when_no_source_is_given() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'create', 'title' => 'Empty Hero' ] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertTrue( $result['success'] );
+		$this->assertArrayHasKey( 'component_id', $result );
+		$this->assertArrayHasKey( 'uid', $result );
+		$this->assertArrayHasKey( 'editor_url', $result );
+
+		$component = ( new Components_Repository() )->get( $result['component_id'], false );
+		$this->assertSame( [], $component->get_elements_data() );
+	}
+
+	public function test_create__compiles_elements_from_xml_structure_with_generated_ids() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Hero From Xml',
+			'xml_structure' => '<e-flexbox configuration-id="Hero Wrap"><e-heading configuration-id="Hero Title"/></e-flexbox>',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$elements = ( new Components_Repository() )->get( $result['component_id'], false )->get_elements_data();
+		$this->assertSame( 'e-flexbox', $elements[0]['elType'] );
+		$heading = $elements[0]['elements'][0];
+		$this->assertSame( 'e-heading', $heading['widgetType'] );
+		$this->assertSame( 'Hero Title', $heading['editor_settings']['title'] );
+		$this->assertNotSame( 'Hero Title', $heading['id'] );
+		$this->assertSame( $heading['id'], sanitize_key( $heading['id'] ) );
+	}
+
+	public function test_create__rejects_xml_structure_with_multiple_root_elements() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Multiple Roots',
+			'xml_structure' => '<e-heading configuration-id="heading"/><e-paragraph configuration-id="paragraph"/>',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'component_requires_single_root', $result->get_error_code() );
+		$this->assertSame( \WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	public function test_create__applies_interactions_from_xml() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $this->with_interactions_active(
+			fn() => $ability->execute( [
+				'action' => 'create',
+				'title' => 'Interactive Heading',
+				'xml_structure' => '<e-heading configuration-id="heading"/>',
+				'interactions' => [ 'heading' => [ $this->valid_interaction() ] ],
+			] )
+		);
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$elements = ( new Components_Repository() )->get( $result['component_id'], false )->get_elements_data();
+		$this->assertArrayHasKey( 'interactions', $elements[0], wp_json_encode( $elements[0] ) );
+		$this->assertCount( 1, $elements[0]['interactions']['items'] );
+		$interaction = $elements[0]['interactions']['items'][0];
+		$this->assertSame( 'interaction-item', $interaction['$$type'] );
+		$this->assertSame( 'load', $interaction['value']['trigger']['value'] );
+		$this->assertSame( 'fade', $interaction['value']['animation']['value']['effect']['value'] );
+	}
+
+	public function test_create__copies_an_existing_element_subtree_and_regenerates_ids() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$post_id = $this->create_real_document();
+		$this->given_document_with_elements( $post_id, [
+			[
+				'id' => 'source-container-id',
+				'elType' => 'e-flexbox',
+				'settings' => [],
+				'elements' => [
+					[ 'id' => 'source-heading-id', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+				],
+			],
+		] );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Hero From Source',
+			'source_post_id' => $post_id,
+			'element_id' => 'source-container-id',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$elements = ( new Components_Repository() )->get( $result['component_id'], false )->get_elements_data();
+		$this->assertSame( 'e-flexbox', $elements[0]['elType'] );
+		$this->assertNotSame( 'source-container-id', $elements[0]['id'] );
+		$this->assertSame( 'e-heading', $elements[0]['elements'][0]['widgetType'] );
+		$this->assertNotSame( 'source-heading-id', $elements[0]['elements'][0]['id'] );
+	}
+
+	public function test_create__keeps_widget_at_component_root_unwrapped() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Bare Heading Component',
+			'xml_structure' => '<e-heading configuration-id="Solo Heading"/>',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertEmpty( $result['warnings'] ?? [], 'A widget at root is valid and needs no warning.' );
+
+		$elements = ( new Components_Repository() )->get( $result['component_id'], false )->get_elements_data();
+		$this->assertCount( 1, $elements );
+		$this->assertSame( 'widget', $elements[0]['elType'] );
+		$this->assertSame( 'e-heading', $elements[0]['widgetType'] );
+		$this->assertSame( 'Solo Heading', $elements[0]['editor_settings']['title'] );
+	}
+
+	public function test_create__rejects_xml_structure_and_source_element_together() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Conflicting Source',
+			'xml_structure' => '<e-heading configuration-id="h1"/>',
+			'source_post_id' => 1,
+			'element_id' => 'whatever',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	public function test_create__forbids_copying_from_a_post_the_user_cannot_edit() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		$this->given_document_with_elements( $post_id, [
+			[ 'id' => 'source-heading-id', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		] );
+
+		Mock_Pro_License_API::set_license_state( true );
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'contributor' ] ) );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Forbidden Source',
+			'source_post_id' => $post_id,
+			'element_id' => 'source-heading-id',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_forbidden', $result->get_error_code() );
+	}
+
+	public function test_create__returns_not_found_when_element_id_does_not_exist_on_source() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$post_id = $this->create_real_document();
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Missing Source Element',
+			'source_post_id' => $post_id,
+			'element_id' => 'does-not-exist',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_not_found', $result->get_error_code() );
+	}
+
+	public function test_create__rejects_components_containing_non_atomic_widgets() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$post_id = $this->create_real_document();
+		$this->given_document_with_elements( $post_id, [
+			[ 'id' => 'legacy-heading-id', 'elType' => 'widget', 'widgetType' => 'heading', 'settings' => [], 'elements' => [] ],
+		] );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Legacy Widget Component',
+			'source_post_id' => $post_id,
+			'element_id' => 'legacy-heading-id',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( Non_Atomic_Widget_Validator::ERROR_CODE, $result->get_error_code() );
+	}
+
+	public function test_create__rejects_non_atomic_widget_from_xml() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Legacy Heading XML',
+			'xml_structure' => '<heading configuration-id="heading"/>',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( Non_Atomic_Widget_Validator::ERROR_CODE, $result->get_error_code() );
+	}
+
+	public function test_create__rejects_a_duplicate_title() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$this->create_component_with_content( [], 'Existing Hero' );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'create', 'title' => 'Existing Hero' ] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'components_validation_failed', $result->get_error_code() );
+	}
+
+	public function test_update__with_xml_structure_replaces_the_element_tree() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [
+			[ 'id' => 'h1', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		], 'Replaceable Hero' );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $component_id,
+			'xml_structure' => '<e-flexbox configuration-id="wrap"><e-paragraph configuration-id="p1"/></e-flexbox>',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$elements = ( new Components_Repository() )->get( $component_id, false )->get_elements_data();
+		$this->assertCount( 1, $elements );
+		$this->assertSame( 'e-flexbox', $elements[0]['elType'] );
+		$this->assertSame( 'e-paragraph', $elements[0]['elements'][0]['widgetType'] );
+		$this->assertSame( 'p1', $elements[0]['elements'][0]['editor_settings']['title'] );
+	}
+
+	public function test_update__rejects_invalid_form_structure_and_preserves_the_element_tree() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [
+			[ 'id' => 'h1', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		], 'Invalid Form Update' );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $component_id,
+			'xml_structure' => '<e-flexbox configuration-id="wrapper"><e-form-input configuration-id="input"/></e-flexbox>',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_invalid_form_structure', $result->get_error_code() );
+		$elements = ( new Components_Repository() )->get( $component_id, false )->get_elements_data();
+		$this->assertSame( 'h1', $elements[0]['id'] );
+	}
+
+	public function test_update__with_draft_publish_status_creates_an_autosave_and_leaves_the_published_document_untouched() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [
+			[ 'id' => 'h1', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		], 'Draftable Hero' );
+		$this->set_main_doc_as_older_than_autosave( $component_id );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $component_id,
+			'xml_structure' => '<e-flexbox configuration-id="wrap"><e-paragraph configuration-id="p1"/></e-flexbox>',
+			'publish_status' => 'draft',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+
+		$published = ( new Components_Repository() )->get( $component_id, false );
+		$this->assertSame( 'e-heading', $published->get_elements_data()[0]['widgetType'] );
+
+		$with_autosave = ( new Components_Repository() )->get( $component_id, true );
+		$this->assertSame( 'e-flexbox', $with_autosave->get_elements_data()[0]['elType'] );
+		$this->assertSame( 'e-paragraph', $with_autosave->get_elements_data()[0]['elements'][0]['widgetType'] );
+	}
+
+	public function test_update__succeeds_when_license_is_expired() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [], 'Expired License Hero' );
+		Mock_Pro_License_API::set_license_state( false, true );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $component_id,
+			'xml_structure' => '<e-heading configuration-id="h1"/>',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertTrue( $result['success'] );
+	}
+
+	// ---------------------------------------------------------------------
+	// rename
+	// ---------------------------------------------------------------------
+
+	public function test_rename__updates_the_component_title() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [], 'Old Title' );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'rename', 'component_id' => $component_id, 'title' => 'New Title' ] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertTrue( $result['success'] );
+		$component = ( new Components_Repository() )->get( $component_id, false );
+		$this->assertSame( 'New Title', $component->get_post()->post_title );
+	}
+
+	// ---------------------------------------------------------------------
+	// archive
+	// ---------------------------------------------------------------------
+
+	public function test_archive__archives_valid_ids_and_reports_failures_for_invalid_ones() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [], 'Archivable Hero' );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'archive', 'component_ids' => [ $component_id, 999999 ] ] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( [ $component_id ], $result['success_ids'] );
+		$this->assertSame( [ 999999 ], $result['failed_ids'] );
+
+		$component = ( new Components_Repository() )->get( $component_id, false );
+		$this->assertTrue( $component->get_is_archived() );
+	}
+
+	// ---------------------------------------------------------------------
+	// publish
+	// ---------------------------------------------------------------------
+
+	public function test_publish__promotes_a_draft_autosave_to_the_published_document() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [
+			[ 'id' => 'h1', 'elType' => 'widget', 'widgetType' => 'e-heading', 'settings' => [], 'elements' => [] ],
+		], 'Publishable Hero' );
+		$this->set_main_doc_as_older_than_autosave( $component_id );
+
+		$ability = new Manage_Component_Ability();
+		$draft_result = $ability->execute( [
+			'action' => 'update',
+			'component_id' => $component_id,
+			'xml_structure' => '<e-flexbox configuration-id="wrap"><e-paragraph configuration-id="p1"/></e-flexbox>',
+			'publish_status' => 'draft',
+		] );
+		$this->assertIsArray( $draft_result, 'Fixture setup failed: ' . $this->error_message( $draft_result ) );
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'publish', 'component_id' => $component_id ] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertTrue( $result['success'] );
+		$published = ( new Components_Repository() )->get( $component_id, false );
+		$this->assertSame( 'e-flexbox', $published->get_elements_data()[0]['elType'] );
+		$this->assertSame( 'e-paragraph', $published->get_elements_data()[0]['elements'][0]['widgetType'] );
+	}
+
+	public function test_publish__succeeds_when_license_is_expired() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$component_id = $this->create_component_with_content( [], 'Expired Publish Hero', 'draft' );
+		Mock_Pro_License_API::set_license_state( false, true );
+
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [ 'action' => 'publish', 'component_id' => $component_id ] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$this->assertTrue( $result['success'] );
+	}
+
+	// ---------------------------------------------------------------------
+
+	// helpers
+	// ---------------------------------------------------------------------
+
+	private function create_component_with_content( array $elements, string $title, string $status = 'publish', array $settings = [] ): int {
+		return ( new Components_Repository() )->create( $title, $elements, $status, uniqid( 'uid-', true ), $settings );
+	}
+
+	private function valid_interaction(): array {
+		return [
+			'trigger' => 'load',
+			'animation' => [
+				'effect' => 'fade',
+				'type' => 'in',
+				'direction' => '',
+				'timing_config' => [
+					'duration' => [ 'size' => 600, 'unit' => 'ms' ],
+					'delay' => [ 'size' => 0, 'unit' => 'ms' ],
+				],
+				'config' => [
+					'easing' => 'easeIn',
+				],
+			],
+			'breakpoints' => [
+				'excluded' => [],
+			],
+		];
+	}
+
+	private function with_interactions_active( callable $callback ) {
+		$experiments = Plugin::$instance->experiments;
+		$original_state = $experiments->get_features( Interactions_Module::EXPERIMENT_NAME )['state'];
+		$feature_option_key = $experiments->get_feature_option_key( Interactions_Module::EXPERIMENT_NAME );
+		update_option( $feature_option_key, Experiments_Manager::STATE_ACTIVE );
+		new Interactions_Module();
+
+		try {
+			return $callback();
+		} finally {
+			update_option( $feature_option_key, $original_state );
+		}
+	}
+
+	/**
+	 * Autosave detection requires the autosave's `post_modified_gmt` to be strictly newer than the
+	 * main document's, which second-precision MySQL timestamps can't guarantee within a single test run.
+	 */
+	private function set_main_doc_as_older_than_autosave( int $main_doc_id ): void {
+		global $wpdb;
+		$past_time = gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) );
+		$wpdb->update( $wpdb->posts, [ 'post_modified_gmt' => $past_time ], [ 'ID' => $main_doc_id ] );
+		clean_post_cache( $main_doc_id );
+		$this->clear_document_cache( $main_doc_id );
+	}
+
+	private function create_real_document(): int {
+		return $this->factory()->create_and_get_default_post()->ID;
+	}
+
+	private function given_document_with_elements( int $post_id, array $elements ): void {
+		$document = Plugin::$instance->documents->get( $post_id );
+		$document->save( [ 'elements' => $elements ] );
+
+		$this->clear_document_cache( $post_id );
+	}
+
+	private function clear_document_cache( int $post_id ): void {
+		$reflection = new \ReflectionProperty( Plugin::$instance->documents, 'documents' );
+		$reflection->setAccessible( true );
+		$documents = $reflection->getValue( Plugin::$instance->documents );
+		unset( $documents[ $post_id ] );
+		$reflection->setValue( Plugin::$instance->documents, $documents );
+	}
+
+	private function delete_all_components(): void {
+		$posts = get_posts( [
+			'post_type' => Component_Document::TYPE,
+			'post_status' => 'any',
+			'posts_per_page' => -1,
+		] );
+
+		foreach ( $posts as $post ) {
+			wp_delete_post( $post->ID, true );
+		}
+	}
+
+	private function error_message( $result ): string {
+		return is_wp_error( $result ) ? $result->get_error_message() : 'unknown';
+	}
+}


### PR DESCRIPTION
## Summary
Register `elementor/manage-component` for create/update/rename/archive/publish, reuse the composition compiler for XML sources, and expose list-components capabilities for agent discovery. Overridable props land in 4/4.

## Stack
- **Base:** `feat/ED-24967-2-doc-applier` (2/4)
- **This PR:** 3/4 in the ED-24967 stack
- **Follow-up:** overridable props (4/4)

## Jira
[ED-24967](https://elementor.atlassian.net/browse/ED-24967)

## Test plan
- [ ] PHPUnit: `test-manage-component-ability.php` and list-components capability updates
- [ ] Exercise create/update/rename/archive/publish via the ability (or MCP client smoke)

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Implements the third part of component CRUD operations for the MCP server (ED-24967). Exposes `manage-component` ability alongside existing `list-components`, enabling AI to create, update, rename, archive, and publish components with proper license gating and validation.

## 2. What Changed (Where)

- **components-repository.php**: Renamed `get_component_for_edit()` private method to public `get_for_edit()` to support external access patterns.
- **list-components-ability.php**: Refactored response structure—now returns top-level `capabilities` object; filters archived components from discovery list; only includes `is_archived` flag when explicitly requested by ID.
- **manage-component-ability.php**: New 615-line ability implementing all five actions (create/update/rename/archive/publish) with comprehensive input validation, circular dependency detection, atomic widget enforcement, and license-tier access control.
- **mcp/module.php**: Registered `Manage_Component_Ability` alongside `List_Components_Ability`; added `elementor/manage-component` to exposed abilities.
- **Tests & docs**: 814 test cases covering all actions, access gates, error paths; updated markdown docs with capability schema and component creation patterns.

## 3. How It Works

**Entry point**: `Manage_Component_Ability::execute()` routes on `action` field. Each handler (create/update/rename/archive/publish) checks `Components_Access_Controller` against license state—Pro required for mutations, expired license allows read/publish only.

**Create/update flow**: XML compilation via `Composition_Compiler` → element ID regeneration → circular dependency validation → atomic widget validation → repository persistence. Draft mode uses autosave without touching live document.

**Archive**: Bulk archive with partial failure reporting. **Publish**: Promotes autosave to main document.

**Response shape**: All success responses include `editor_url` + `llm_instructions` (components lack public permalinks). Capabilities now returned at response root level rather than per-component.

## 4. Risks

**License gating asymmetry**: Create/rename/archive blocked on core; update/publish allowed on expired. Risk: confusion if license lapses mid-workflow. Mitigation: error messages explicitly state license requirement; tests cover all tiers.

**Circular dependency detection**: Validates post-compilation before save. Edge case: self-referencing component XML accepted during create but fails on save. Acceptable since error is caught and reported with clear message.

**Autosave collision**: Draft mode creates autosave; race condition if two requests collide. Mitigation: WordPress autosave semantics handle this (last-write-wins), acceptable for this use case.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
