### PR TITLE
Tweak: Add stable DOM id to Add Element button [ED-25202]

### DIFF
--- a/packages/packages/core/editor-app-bar/src/components/actions/toggle-action.tsx
+++ b/packages/packages/core/editor-app-bar/src/components/actions/toggle-action.tsx
@@ -8,6 +8,7 @@ import ToolbarMenuToggleItem from '../ui/toolbar-menu-toggle-item';
 export type Props = {
 	title: string;
 	icon: ElementType;
+	id?: string;
 	selected?: boolean;
 	disabled?: boolean;
 	visible?: boolean;

--- a/packages/packages/core/editor-app-bar/src/extensions/elements/hooks/__tests__/use-action-props.test.ts
+++ b/packages/packages/core/editor-app-bar/src/extensions/elements/hooks/__tests__/use-action-props.test.ts
@@ -34,4 +34,12 @@ describe( '@elementor/editor-app-bar - useElementsPanelActionProps', () => {
 		expect( useRouteStatus ).toHaveBeenCalledTimes( 1 );
 		expect( useRouteStatus ).toHaveBeenCalledWith( 'panel/elements' );
 	} );
+
+	it( 'should expose a stable untranslated DOM id', () => {
+		// Act.
+		const { result } = renderHook( () => useActionProps() );
+
+		// Assert.
+		expect( result.current.id ).toBe( 'ele-add-element' );
+	} );
 } );

--- a/packages/packages/core/editor-app-bar/src/extensions/elements/hooks/use-action-props.ts
+++ b/packages/packages/core/editor-app-bar/src/extensions/elements/hooks/use-action-props.ts
@@ -13,6 +13,7 @@ export default function useActionProps() {
 	return {
 		title: __( 'Add Element', 'elementor' ),
 		icon: PlusIcon,
+		id: 'ele-add-element',
 		onClick: () => {
 			const extendedWindow = window as unknown as ExtendedWindow;
 			const config = extendedWindow?.elementorCommon?.eventsManager?.config;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add untranslated HTML `id="ele-add-element"` to the Add Element top-bar toggle button so integrations can find it without relying on translated `aria-label`.
- Extends `ToggleAction` props to accept an optional `id`.

## Test plan
- [ ] Open the Elementor editor and inspect the Add Element button in the top bar
- [ ] Confirm the button has `id="ele-add-element"`
- [ ] Confirm the visible title / tooltip remains the translated "Add Element" string
- [ ] Confirm clicking still opens the elements panel and selected/disabled states still work
- [x] Unit test covers the stable id on `useActionProps`

## Jira
[ED-25202](https://elementor.atlassian.net/browse/ED-25202)

Related: [AI-8870](https://elementor.atlassian.net/browse/AI-8870)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f466787-9521-4189-b920-567f064635fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f466787-9521-4189-b920-567f064635fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ED-25202]: https://elementor.atlassian.net/browse/ED-25202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-8870]: https://elementor.atlassian.net/browse/AI-8870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ