### PR TITLE
Internal: Detect Hello Theme settings page in conversion banner [TMZ-1064]

### DIFF
--- a/modules/promotions/conversion-banner.php
+++ b/modules/promotions/conversion-banner.php
@@ -22,8 +22,15 @@ class Conversion_Banner {
 	const CONTAINER_ID = 'e-conversion-banner';
 	const BIRTHDAY_PROMOTION_URL = 'https://go.elementor.com/go-pro-wp-admin-upgrad-notice/';
 
+	const HELLO_THEME_CONFIG_FILTER = 'hello-plus-theme/rest/admin-config';
+	const THEME_SLUGS = [ 'hello-elementor', 'hello-biz', 'hello-commerce' ];
+	const THEME_SETTINGS_PAGE_SUFFIX = '-settings';
+	const GO_PRO_TITLE_PREFIX = 'Go Pro';
+
 	public function __construct() {
 		add_action( 'wp_ajax_' . self::AJAX_ACTION, [ $this, 'ajax_dismiss_banner' ] );
+
+		add_filter( self::HELLO_THEME_CONFIG_FILTER, [ $this, 'suppress_hello_theme_banner' ] );
 
 		add_action( 'current_screen', [ $this, 'maybe_register_banner_hooks' ] );
 	}
@@ -47,6 +54,43 @@ class Conversion_Banner {
 			<?php $this->print_banner_markup( true ); ?>
 		</div>
 		<?php
+	}
+
+	public function suppress_hello_theme_banner( $config ) {
+		if ( $this->is_request_from_theme_admin_page()
+			|| ! ( is_array( $config ) && isset( $config['welcome'] ) )
+			|| Utils::has_pro()
+		) {
+			return $config;
+		}
+
+		$title = $config['welcome']['title'] ?? '';
+
+		if ( is_string( $title ) && substr( $title, 0, strlen( self::GO_PRO_TITLE_PREFIX ) ) === self::GO_PRO_TITLE_PREFIX ) {
+			$config['welcome'] = [];
+		}
+
+		return $config;
+	}
+
+	private function is_request_from_theme_admin_page(): bool {
+		$referer = wp_get_referer();
+
+		if ( ! $referer ) {
+			return false;
+		}
+
+		parse_str( (string) wp_parse_url( $referer, PHP_URL_QUERY ), $query_args );
+
+		$page = $query_args['page'] ?? '';
+
+		foreach ( self::THEME_SLUGS as $theme_slug ) {
+			if ( $page === $theme_slug || $page === $theme_slug . self::THEME_SETTINGS_PAGE_SUFFIX ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public function ajax_dismiss_banner(): void {

--- a/modules/promotions/conversion-banner.php
+++ b/modules/promotions/conversion-banner.php
@@ -22,14 +22,8 @@ class Conversion_Banner {
 	const CONTAINER_ID = 'e-conversion-banner';
 	const BIRTHDAY_PROMOTION_URL = 'https://go.elementor.com/go-pro-wp-admin-upgrad-notice/';
 
-	const HELLO_THEME_CONFIG_FILTER = 'hello-plus-theme/rest/admin-config';
-	const THEME_SLUGS = [ 'hello-elementor', 'hello-biz', 'hello-commerce' ];
-	const GO_PRO_TITLE_PREFIX = 'Go Pro';
-
 	public function __construct() {
 		add_action( 'wp_ajax_' . self::AJAX_ACTION, [ $this, 'ajax_dismiss_banner' ] );
-
-		add_filter( self::HELLO_THEME_CONFIG_FILTER, [ $this, 'suppress_hello_theme_banner' ] );
 
 		add_action( 'current_screen', [ $this, 'maybe_register_banner_hooks' ] );
 	}
@@ -53,35 +47,6 @@ class Conversion_Banner {
 			<?php $this->print_banner_markup( true ); ?>
 		</div>
 		<?php
-	}
-
-	public function suppress_hello_theme_banner( $config ) {
-		if ( $this->is_request_from_theme_admin_page()
-			|| ! ( is_array( $config ) && isset( $config['welcome'] ) )
-			|| Utils::has_pro()
-		) {
-			return $config;
-		}
-
-		$title = $config['welcome']['title'] ?? '';
-
-		if ( is_string( $title ) && substr( $title, 0, strlen( self::GO_PRO_TITLE_PREFIX ) ) === self::GO_PRO_TITLE_PREFIX ) {
-			$config['welcome'] = [];
-		}
-
-		return $config;
-	}
-
-	private function is_request_from_theme_admin_page(): bool {
-		$referer = wp_get_referer();
-
-		if ( ! $referer ) {
-			return false;
-		}
-
-		parse_str( (string) wp_parse_url( $referer, PHP_URL_QUERY ), $query_args );
-
-		return in_array( $query_args['page'] ?? '', self::THEME_SLUGS );
 	}
 
 	public function ajax_dismiss_banner(): void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Hello Theme Home screen is being removed and its menu now redirects to Settings, so the conversion banner's theme admin page detection has to recognize the Settings page.

## Changes

`is_request_from_theme_admin_page()` now matches both a theme slug and its `-settings` page, so `hello-elementor-settings` counts as a Hello admin page. Without this, `suppress_hello_theme_banner()` would strip Hello's Go Pro welcome box while the user is sitting on the Hello Settings screen.

The banner itself, the `hello-plus-theme/rest/admin-config` filter and the suppression logic are unchanged.

## Jira

[TMZ-1064](https://elementor.atlassian.net/browse/TMZ-1064)

Companion PR: [elementor/hello-theme#677](https://github.com/elementor/hello-theme/pull/677)

Spec: https://elementor.atlassian.net/wiki/spaces/RDDEP/pages/2754740246/Remove+Hello+Theme+Home+Screen
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11e4367d-5314-4f03-849a-0034bc76042e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11e4367d-5314-4f03-849a-0034bc76042e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMZ-1064]: https://elementor.atlassian.net/browse/TMZ-1064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ