### PR TITLE
Fix: Assert sidebar menu event payloads by subset [ED-25104]

### DIFF
--- a/tests/jest/unit/assets/dev/js/editor/utils/editor-one-events-sidebar-menu.test.js
+++ b/tests/jest/unit/assets/dev/js/editor/utils/editor-one-events-sidebar-menu.test.js
@@ -31,14 +31,14 @@ describe( 'EditorOneEventManager sidebar menu events', () => {
 		EditorOneEventManager.sendSidebarMenuItemClicked( { eventId: 'settings' } );
 
 		// Assert
-		expect( dispatchEvent ).toHaveBeenCalledWith( 'sidebar_menu_item_clicked', {
+		expect( dispatchEvent ).toHaveBeenCalledWith( 'sidebar_menu_item_clicked', expect.objectContaining( {
 			window_name: 'sidebar_menu',
 			interaction_type: 'click',
 			target_type: 'link',
 			target_name: 'settings',
 			interaction_result: 'page_opened',
 			target_location: 'sidebar',
-		} );
+		} ) );
 		expect( dispatchEvent.mock.calls[ 0 ][ 1 ] ).not.toHaveProperty( 'location_l1' );
 	} );
 
@@ -50,7 +50,7 @@ describe( 'EditorOneEventManager sidebar menu events', () => {
 		} );
 
 		// Assert
-		expect( dispatchEvent ).toHaveBeenCalledWith( 'sidebar_menu_item_clicked', {
+		expect( dispatchEvent ).toHaveBeenCalledWith( 'sidebar_menu_item_clicked', expect.objectContaining( {
 			window_name: 'sidebar_menu',
 			interaction_type: 'click',
 			target_type: 'link',
@@ -58,7 +58,7 @@ describe( 'EditorOneEventManager sidebar menu events', () => {
 			interaction_result: 'page_opened',
 			target_location: 'sidebar',
 			location_l1: 'system',
-		} );
+		} ) );
 	} );
 
 	test( 'sendSidebarMenuGroupToggled dispatches expanded when group opens', () => {
@@ -69,14 +69,14 @@ describe( 'EditorOneEventManager sidebar menu events', () => {
 		} );
 
 		// Assert
-		expect( dispatchEvent ).toHaveBeenCalledWith( 'sidebar_menu_group_toggled', {
+		expect( dispatchEvent ).toHaveBeenCalledWith( 'sidebar_menu_group_toggled', expect.objectContaining( {
 			window_name: 'sidebar_menu',
 			interaction_type: 'click',
 			target_type: 'toggle',
 			target_name: 'templates',
 			interaction_result: 'expanded',
 			target_location: 'sidebar',
-		} );
+		} ) );
 	} );
 
 	test( 'sendSidebarMenuGroupToggled dispatches collapsed when group closes', () => {
@@ -87,14 +87,14 @@ describe( 'EditorOneEventManager sidebar menu events', () => {
 		} );
 
 		// Assert
-		expect( dispatchEvent ).toHaveBeenCalledWith( 'sidebar_menu_group_toggled', {
+		expect( dispatchEvent ).toHaveBeenCalledWith( 'sidebar_menu_group_toggled', expect.objectContaining( {
 			window_name: 'sidebar_menu',
 			interaction_type: 'click',
 			target_type: 'toggle',
 			target_name: 'custom_elements',
 			interaction_result: 'collapsed',
 			target_location: 'sidebar',
-		} );
+		} ) );
 	} );
 
 	test( 'does not dispatch when events cannot be sent', () => {


### PR DESCRIPTION
## Summary
- Assert sidebar menu event payloads with `expect.objectContaining` instead of exact object equality, so the tests verify only the properties this feature owns
- Keeps the explicit `not.toHaveProperty( 'location_l1' )` check that covers the top-level item requirement
- Fixes the cherry-pick to `4.02`, where `createBasePayload` still adds an extra property that made the strict payload comparison fail

## Test plan
- [ ] `npm run test:jest -- --testPathPattern="editor-one-events-sidebar-menu"` passes on `main`
- [ ] Same suite passes when the base payload carries the additional property present on `4.02`
- [ ] Cherry-pick to `4.02` reports a green Jest run

## Jira
[ED-25104](https://elementor.atlassian.net/browse/ED-25104)


[ED-25104]: https://elementor.atlassian.net/browse/ED-25104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Tests were brittle due to exact payload matching; switching to subset assertions makes them resilient to payload additions (ED-25104).

## 2. What Changed (Where)

- `editor-one-events-sidebar-menu.test.js`: Four test assertions wrapped with `expect.objectContaining()` for loose payload matching.

## 3. How It Works

Replaces strict equality checks with `expect.objectContaining()`, verifying only essential event properties while ignoring extra fields. Maintains existing supplementary assertion for `location_l1` absence.

## 4. Risks

None—pure test improvement. Subset matching is stricter than no assertion but looser than exact equality, striking the right balance for event contract testing.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
