### PR TITLE
Fix local Saved Templates when Template Library data is unavailable

### DIFF
--- a/includes/template-library/data/endpoints/templates.php
+++ b/includes/template-library/data/endpoints/templates.php
@@ -58,18 +58,30 @@ class Templates extends Endpoint {
 	 * @return array
 	 */
 	private function reorder_categories( array $library_data ): array {
-		$not_found_category = '404 page';
+	$not_found_category = '404 page';
 
-		$key = array_search( $not_found_category, $library_data['config']['block']['categories'] );
-		if ( false === $key ) {
-			return $library_data;
-		}
-
-		array_splice( $library_data['config']['block']['categories'], $key, 1 );
-		$library_data['config']['block']['categories'][] = $not_found_category;
-
+	if (
+		empty( $library_data['config']['block']['categories'] ) ||
+		! is_array( $library_data['config']['block']['categories'] )
+	) {
 		return $library_data;
 	}
+
+	$key = array_search(
+		$not_found_category,
+		$library_data['config']['block']['categories'],
+		true
+	);
+
+	if ( false === $key ) {
+		return $library_data;
+	}
+
+	array_splice( $library_data['config']['block']['categories'], $key, 1 );
+	$library_data['config']['block']['categories'][] = $not_found_category;
+
+	return $library_data;
+}
 
 	public function create_items( $request ) {
 		/** @var Source_Local $source */

--- a/includes/template-library/manager.php
+++ b/includes/template-library/manager.php
@@ -226,9 +226,11 @@ class Manager {
 
 		$library_data = Api::get_library_data( $force_update );
 
-		if ( empty( $library_data ) ) {
-			return $library_data;
-		}
+	if ( empty( $library_data ) ) {
+		$library_data = [
+			'types_data' => [],
+		];
+	}
 
 		// Ensure all document are registered.
 		Plugin::$instance->documents->get_document_types();
@@ -237,7 +239,7 @@ class Manager {
 
 		$full_library_data = [
 			'templates' => $this->get_templates( $filter_sources, $force_update ),
-			'config' => $library_data['types_data'],
+			'config' => $library_data['types_data'] ?? [],
 		];
 
 		/**


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

- Fix local Saved Templates not being displayed when remote Template Library data is unavailable or empty.

## Description

This PR fixes an issue where local Saved Templates are not displayed in the Elementor editor when `Api::get_library_data()` returns an empty value.

Currently, `Templates_Manager::get_library_data()` returns early when the remote Template Library data is empty:

```php
$library_data = Api::get_library_data( $force_update );

if ( empty( $library_data ) ) {
	return $library_data;
}
```

Because of this early return, Elementor never reaches:

```php
$this->get_templates( $filter_sources, $force_update )
```

As a result, local Saved Templates are not returned even when the requested template source is `local`.

The templates themselves are not lost. They remain available in WordPress Admin, and new local templates can still be saved successfully. However, they are not displayed in the Elementor editor's Saved Templates interface.

Additionally, the REST endpoint:

`/wp-json/elementor/v1/template-library/templates?source=local`

can fail when `reorder_categories()` attempts to access:

```php
$library_data['config']['block']['categories']
```

while the library configuration is unavailable.

This can result in errors such as:

```text
Undefined array key "config"

array_search(): Argument #2 ($haystack) must be of type array, null given
```

This PR allows local templates to be retrieved even when remote Template Library metadata is unavailable.

It also adds a defensive check to prevent `reorder_categories()` from attempting to reorder categories when the categories configuration is missing or is not an array.

No database changes are required.

## Test instructions

This PR can be tested by following these steps:

1. Install and activate Elementor.
2. Activate the Hello Elementor theme.
3. Disable all third-party plugins.
4. Create and save one or more local Saved Templates.
5. Verify that the templates are visible in WordPress Admin under Saved Templates.
6. Reproduce an environment where `Api::get_library_data()` returns an empty value or the remote Template Library data is unavailable.
7. Open a page in the Elementor editor.
8. Open the Template Library and view Saved Templates.

### Before this PR

- Local Saved Templates are not displayed in the Elementor editor.
- The templates are still present in WordPress Admin.
- New templates can still be saved.
- The REST endpoint may return an HTTP 500 error.
- `reorder_categories()` may call `array_search()` with a null value.

### After this PR

- Existing local Saved Templates are displayed in the Elementor editor.
- Newly saved local templates are displayed normally.
- Local templates remain accessible when remote Template Library data is unavailable.
- Missing Template Library configuration no longer causes the REST endpoint to fail.

### Tested environment

- WordPress 7.0.2
- PHP 8.4.24
- MariaDB 10.11
- LiteSpeed
- Hello Elementor theme
- Only Elementor active during reproduction

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Template Library API failures were breaking local Saved Templates functionality. PR adds defensive handling to gracefully degrade when remote config is unavailable.

## 2. What Changed (Where)

- `manager.php`: Returns minimal fallback structure (`types_data: []`) instead of bailing when API fails; adds null-coalescing for config access
- `templates.php`: Adds safety checks for empty/invalid category arrays before reordering to prevent undefined array access

## 3. How It Works

When `Api::get_library_data()` returns empty/null, `get_library_data()` now initializes a minimal structure containing empty `types_data` rather than short-circuiting. The `reorder_categories()` method validates category structure exists and is traversable before attempting array operations. This ensures local templates remain functional even when remote Library API is down.

## 4. Risks

Minimal risk. Fallback to empty config is safe and preserves existing behavior for working API calls. Only concern: if category reordering logic elsewhere assumes non-empty categories array, but the defensive check mitigates this.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
