### PR TITLE
Internal: Add V3 widget allowlist to MCP schema abilities [ED-25071]

### DIFF
--- a/modules/mcp/abilities/appliers/class-applier.php
+++ b/modules/mcp/abilities/appliers/class-applier.php
@@ -42,8 +42,15 @@ class Class_Applier {
 				continue;
 			}
 
+			$node = &$config_id_index[ $config_id ];
+
+			if ( V3_Node_Bridge::is_v3_node( $node ) ) {
+				$this->apply_v3_classes( $node, $labels, $id_by_label, $config_id, $errors );
+				unset( $node );
+				continue;
+			}
+
 			if ( empty( $labels ) ) {
-				$node = &$config_id_index[ $config_id ];
 				$node['settings'] = $this->clear_global_classes( $node['settings'] ?? [] );
 				unset( $node );
 				continue;
@@ -71,13 +78,13 @@ class Class_Applier {
 			}
 
 			if ( empty( $resolved_ids ) ) {
+				unset( $node );
 				continue;
 			}
 
-			$node = &$config_id_index[ $config_id ];
 			$node['settings'] = $this->prepend_global_classes( $node['settings'] ?? [], $resolved_ids );
+			unset( $node );
 		}
-		unset( $node );
 
 		if ( empty( $errors ) ) {
 			return null;
@@ -88,6 +95,47 @@ class Class_Applier {
 			implode( ' ', $errors ),
 			[ 'status' => \WP_Http::BAD_REQUEST ]
 		);
+	}
+
+	/**
+	 * @param array                $node        Reference to a subtree node.
+	 * @param string[]             $labels      Global class labels input for this node.
+	 * @param array<string,string> $id_by_label Map of label => class id (for validation).
+	 * @param string               $config_id   Identifier used in error messages.
+	 * @param string[]             $errors      Collected error messages (by reference).
+	 */
+	private function apply_v3_classes( array &$node, array $labels, array $id_by_label, string $config_id, array &$errors ): void {
+		if ( empty( $labels ) ) {
+			V3_Node_Bridge::clear_classes( $node );
+			return;
+		}
+
+		$resolved_labels = [];
+
+		foreach ( $labels as $label ) {
+			if ( ! is_string( $label ) || '' === $label ) {
+				$errors[] = sprintf( '[%s] Each global class label must be a non-empty string.', $config_id );
+				continue;
+			}
+
+			if ( ! isset( $id_by_label[ $label ] ) ) {
+				$errors[] = sprintf(
+					'[%s] Unknown global class label "%s". Available labels: %s',
+					$config_id,
+					$label,
+					! empty( $id_by_label ) ? implode( ', ', array_keys( $id_by_label ) ) : '(none)'
+				);
+				continue;
+			}
+
+			$resolved_labels[] = $label;
+		}
+
+		if ( empty( $resolved_labels ) ) {
+			return;
+		}
+
+		V3_Node_Bridge::apply_classes( $node, $resolved_labels );
 	}
 
 	private function build_label_to_id_map( array $label_by_id ): array {

--- a/modules/mcp/abilities/appliers/class-applier.php
+++ b/modules/mcp/abilities/appliers/class-applier.php
@@ -43,9 +43,15 @@ class Class_Applier {
 			}
 
 			$node = &$config_id_index[ $config_id ];
+			$resolved_labels = $this->resolve_labels( $labels, $id_by_label, $config_id, $errors );
 
 			if ( V3_Node_Bridge::is_v3_node( $node ) ) {
-				$this->apply_v3_classes( $node, $labels, $id_by_label, $config_id, $errors );
+				if ( empty( $labels ) ) {
+					V3_Node_Bridge::clear_classes( $node );
+				} elseif ( ! empty( $resolved_labels ) ) {
+					V3_Node_Bridge::apply_classes( $node, $resolved_labels );
+				}
+
 				unset( $node );
 				continue;
 			}
@@ -56,31 +62,15 @@ class Class_Applier {
 				continue;
 			}
 
-			$resolved_ids = [];
-
-			foreach ( $labels as $label ) {
-				if ( ! is_string( $label ) || '' === $label ) {
-					$errors[] = sprintf( '[%s] Each global class label must be a non-empty string.', $config_id );
-					continue;
-				}
-
-				if ( ! isset( $id_by_label[ $label ] ) ) {
-					$errors[] = sprintf(
-						'[%s] Unknown global class label "%s". Available labels: %s',
-						$config_id,
-						$label,
-						! empty( $id_by_label ) ? implode( ', ', array_keys( $id_by_label ) ) : '(none)'
-					);
-					continue;
-				}
-
-				$resolved_ids[] = $id_by_label[ $label ];
-			}
-
-			if ( empty( $resolved_ids ) ) {
+			if ( empty( $resolved_labels ) ) {
 				unset( $node );
 				continue;
 			}
+
+			$resolved_ids = array_map(
+				static fn( string $label ) => $id_by_label[ $label ],
+				$resolved_labels
+			);
 
 			$node['settings'] = $this->prepend_global_classes( $node['settings'] ?? [], $resolved_ids );
 			unset( $node );
@@ -98,18 +88,13 @@ class Class_Applier {
 	}
 
 	/**
-	 * @param array                $node        Reference to a subtree node.
 	 * @param string[]             $labels      Global class labels input for this node.
 	 * @param array<string,string> $id_by_label Map of label => class id (for validation).
 	 * @param string               $config_id   Identifier used in error messages.
 	 * @param string[]             $errors      Collected error messages (by reference).
+	 * @return string[] Validated labels.
 	 */
-	private function apply_v3_classes( array &$node, array $labels, array $id_by_label, string $config_id, array &$errors ): void {
-		if ( empty( $labels ) ) {
-			V3_Node_Bridge::clear_classes( $node );
-			return;
-		}
-
+	private function resolve_labels( array $labels, array $id_by_label, string $config_id, array &$errors ): array {
 		$resolved_labels = [];
 
 		foreach ( $labels as $label ) {
@@ -131,11 +116,7 @@ class Class_Applier {
 			$resolved_labels[] = $label;
 		}
 
-		if ( empty( $resolved_labels ) ) {
-			return;
-		}
-
-		V3_Node_Bridge::apply_classes( $node, $resolved_labels );
+		return $resolved_labels;
 	}
 
 	private function build_label_to_id_map( array $label_by_id ): array {

--- a/modules/mcp/abilities/appliers/style-applier.php
+++ b/modules/mcp/abilities/appliers/style-applier.php
@@ -41,6 +41,7 @@ class Style_Applier {
 
 		$active_breakpoints = $this->get_active_breakpoints();
 		$errors             = [];
+		$warnings           = [];
 
 		foreach ( $styles as $config_id => $css_string ) {
 			if ( ! is_string( $css_string ) ) {
@@ -52,7 +53,17 @@ class Style_Applier {
 				continue;
 			}
 
-			$node         = &$config_id_index[ $config_id ];
+			$node = &$config_id_index[ $config_id ];
+
+			if ( V3_Node_Bridge::is_v3_node( $node ) ) {
+				$warning = V3_Node_Bridge::apply_custom_css( $node, $css_string );
+				if ( null !== $warning ) {
+					$warnings[] = sprintf( '[%s] %s', $config_id, $warning );
+				}
+				unset( $node );
+				continue;
+			}
+
 			$is_empty_css = '' === trim( $css_string );
 
 			if ( $is_empty_css ) {
@@ -109,7 +120,7 @@ class Style_Applier {
 				implode( ' ', $errors ),
 				[ 'status' => \WP_Http::BAD_REQUEST ]
 			) : null,
-			'warnings' => [],
+			'warnings' => $warnings,
 		];
 	}
 

--- a/modules/mcp/abilities/appliers/v3-node-bridge.php
+++ b/modules/mcp/abilities/appliers/v3-node-bridge.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers;
+
+use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
+use Elementor\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Bridges V4-shape MCP inputs (global-class labels, plain CSS strings) onto the V3
+ * settings shape (`_css_classes`, `custom_css`) for allowlisted V3 widgets so the
+ * same LLM contract works for both widget generations.
+ */
+class V3_Node_Bridge {
+
+	const V3_CUSTOM_CSS_SETTING = 'custom_css';
+	const V3_CSS_CLASSES_SETTING = '_css_classes';
+
+	public static function is_v3_node( array $node ): bool {
+		if ( 'widget' !== ( $node['elType'] ?? null ) ) {
+			return false;
+		}
+
+		$type = $node['widgetType'] ?? null;
+
+		return is_string( $type ) && Widget_Context_Helper::is_v3_allowlisted( $type );
+	}
+
+	/**
+	 * Writes labels directly to V3's `_css_classes` (space-separated, deduped).
+	 * V4 global class labels are the CSS class names themselves.
+	 */
+	public static function apply_classes( array &$node, array $labels ): void {
+		$existing = self::split_css_classes( $node['settings'][ self::V3_CSS_CLASSES_SETTING ] ?? '' );
+		$merged = array_values( array_unique( array_merge( $labels, $existing ) ) );
+
+		if ( empty( $merged ) ) {
+			unset( $node['settings'][ self::V3_CSS_CLASSES_SETTING ] );
+			return;
+		}
+
+		$node['settings'][ self::V3_CSS_CLASSES_SETTING ] = implode( ' ', $merged );
+	}
+
+	public static function clear_classes( array &$node ): void {
+		unset( $node['settings'][ self::V3_CSS_CLASSES_SETTING ] );
+	}
+
+	/**
+	 * Writes a CSS string into V3's `custom_css`. Plain declaration lists (`color: red;`)
+	 * are wrapped in `selector { ... }` — the Pro custom-css module replaces `selector`
+	 * with the widget's wrapper at render.
+	 *
+	 * @return string|null Warning message when Pro is missing, otherwise null.
+	 */
+	public static function apply_custom_css( array &$node, string $css_string ): ?string {
+		$css_string = trim( $css_string );
+
+		if ( '' === $css_string ) {
+			unset( $node['settings'][ self::V3_CUSTOM_CSS_SETTING ] );
+			return null;
+		}
+
+		if ( ! Utils::has_pro() ) {
+			return __( 'V3 widget styles require Elementor Pro (Custom CSS module). Style not applied.', 'elementor' );
+		}
+
+		$node['settings'][ self::V3_CUSTOM_CSS_SETTING ] = self::wrap_with_selector( $css_string );
+
+		return null;
+	}
+
+	private static function wrap_with_selector( string $css ): string {
+		if ( false !== strpos( $css, '{' ) ) {
+			return $css;
+		}
+
+		return 'selector { ' . rtrim( $css, "; \t\n\r" ) . '; }';
+	}
+
+	private static function split_css_classes( string $value ): array {
+		if ( '' === trim( $value ) ) {
+			return [];
+		}
+
+		return array_values( array_filter(
+			preg_split( '/\s+/', trim( $value ) ),
+			static fn( $token ) => '' !== $token
+		) );
+	}
+}

--- a/modules/mcp/abilities/appliers/v3-node-bridge.php
+++ b/modules/mcp/abilities/appliers/v3-node-bridge.php
@@ -20,6 +20,7 @@ class V3_Node_Bridge {
 	const V3_CSS_CLASSES_SETTING = '_css_classes';
 
 	public static function is_v3_node( array $node ): bool {
+		// V3 non-widget elements (containers/sections) are intentionally not supported at this layer for now.
 		if ( 'widget' !== ( $node['elType'] ?? null ) ) {
 			return false;
 		}
@@ -36,11 +37,6 @@ class V3_Node_Bridge {
 	public static function apply_classes( array &$node, array $labels ): void {
 		$existing = self::split_css_classes( $node['settings'][ self::V3_CSS_CLASSES_SETTING ] ?? '' );
 		$merged = array_values( array_unique( array_merge( $labels, $existing ) ) );
-
-		if ( empty( $merged ) ) {
-			unset( $node['settings'][ self::V3_CSS_CLASSES_SETTING ] );
-			return;
-		}
 
 		$node['settings'][ self::V3_CSS_CLASSES_SETTING ] = implode( ' ', $merged );
 	}
@@ -74,7 +70,7 @@ class V3_Node_Bridge {
 	}
 
 	private static function wrap_with_selector( string $css ): string {
-		if ( false !== strpos( $css, '{' ) ) {
+		if ( 1 === preg_match( '/^\s*[^{}]+\{\s*[\s\S]*\}\s*$/', $css ) ) {
 			return $css;
 		}
 

--- a/modules/mcp/abilities/get-widget-schema-ability.php
+++ b/modules/mcp/abilities/get-widget-schema-ability.php
@@ -67,7 +67,10 @@ class Get_Widget_Schema_Ability extends Abstract_Ability {
 			);
 		}
 
-		if ( Widget_Context_Helper::VERSION_V3 === Widget_Context_Helper::get_widget_version( $config ) ) {
+		if (
+			Widget_Context_Helper::VERSION_V3 === Widget_Context_Helper::get_widget_version( $config )
+			&& ! Widget_Context_Helper::is_v3_allowlisted( $widget_type )
+		) {
 			return new \WP_Error(
 				'elementor_v3_not_supported',
 				__( 'This is a legacy V3 widget and cannot be modified through this MCP. Edit V3 widgets directly in the Elementor editor.', 'elementor' ),
@@ -77,6 +80,10 @@ class Get_Widget_Schema_Ability extends Abstract_Ability {
 					'version' => 'v3',
 				]
 			);
+		}
+
+		if ( Widget_Context_Helper::VERSION_V3 === Widget_Context_Helper::get_widget_version( $config ) ) {
+			return Widget_Context_Helper::build_widget_schema( $widget_type, $config );
 		}
 
 		$all_widget_configs = Widget_Context_Helper::get_llm_eligible_widgets();

--- a/modules/mcp/abilities/get-widget-schema-ability.php
+++ b/modules/mcp/abilities/get-widget-schema-ability.php
@@ -67,10 +67,9 @@ class Get_Widget_Schema_Ability extends Abstract_Ability {
 			);
 		}
 
-		if (
-			Widget_Context_Helper::VERSION_V3 === Widget_Context_Helper::get_widget_version( $config )
-			&& ! Widget_Context_Helper::is_v3_allowlisted( $widget_type )
-		) {
+		$is_v3 = Widget_Context_Helper::VERSION_V3 === Widget_Context_Helper::get_widget_version( $config );
+
+		if ( $is_v3 && ! Widget_Context_Helper::is_v3_allowlisted( $widget_type ) ) {
 			return new \WP_Error(
 				'elementor_v3_not_supported',
 				__( 'This is a legacy V3 widget and cannot be modified through this MCP. Edit V3 widgets directly in the Elementor editor.', 'elementor' ),
@@ -82,7 +81,7 @@ class Get_Widget_Schema_Ability extends Abstract_Ability {
 			);
 		}
 
-		if ( Widget_Context_Helper::VERSION_V3 === Widget_Context_Helper::get_widget_version( $config ) ) {
+		if ( $is_v3 ) {
 			return Widget_Context_Helper::build_widget_schema( $widget_type, $config );
 		}
 

--- a/modules/mcp/abilities/list-widget-schemas-ability.php
+++ b/modules/mcp/abilities/list-widget-schemas-ability.php
@@ -50,7 +50,14 @@ class List_Widget_Schemas_Ability extends Abstract_Ability {
 
 		$widgets = array_filter(
 			Widget_Context_Helper::get_llm_eligible_widgets(),
-			fn( $config ) => Widget_Context_Helper::VERSION_V4 === Widget_Context_Helper::get_widget_version( $config )
+			static function ( $config, $type ) {
+				if ( Widget_Context_Helper::VERSION_V4 === Widget_Context_Helper::get_widget_version( $config ) ) {
+					return true;
+				}
+
+				return Widget_Context_Helper::is_v3_allowlisted( (string) $type );
+			},
+			ARRAY_FILTER_USE_BOTH
 		);
 
 		if ( $summary ) {

--- a/modules/mcp/abilities/manage-elements-ability.php
+++ b/modules/mcp/abilities/manage-elements-ability.php
@@ -23,6 +23,7 @@ use Elementor\Modules\Mcp\Abilities\Appliers\Style_Applier;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Widget_Type_Resolver;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser;
 use Elementor\Modules\Mcp\Abilities\Utils\Bulk_Operations_Result;
+use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 use Elementor\Modules\Variables\Module as Variables_Module;
 use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
 use Elementor\Modules\Variables\Services\Variables_Service;
@@ -50,7 +51,7 @@ class Manage_Elements_Ability extends Abstract_Ability {
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Manage Elements', 'elementor' ),
-			__( 'Bulk surgical edits on existing V4 (atomic) elements in a document (up to 50 operations applied to a single document tree, saved once). Only V4 elements (see elementor/get-page-structure -> version) can be the operation target; targeting a V3 legacy element_id returns elementor_v3_not_supported per-op and must be edited directly in the Elementor editor. new_parent_id on action=move may reference either V3 or V4 containers. Each operation: action=update merges partial plain settings, plain-CSS string style (with pseudo-state and breakpoint support; breakpoints use @media (--mobile) syntax — NOT pixel queries), global class labels, and native-shape interactions; action=delete removes the element; action=move re-parents it under new_parent_id at optional index; action=duplicate clones the element (with fresh ids) right after the source. WARNING: This tool performs a read-modify-write on the current document. Do NOT use element IDs obtained from a prior get-page-structure read if build-composition was called in between — use only IDs from the build-composition resolved_xml response to avoid silently overwriting its changes.', 'elementor' ),
+			__( 'Bulk surgical edits on existing V4 (atomic) elements in a document (up to 50 operations applied to a single document tree, saved once). V4 elements and a closed V3 allowlist (nav-menu, theme-post-content, theme-post-title, theme-post-featured-image, theme-post-excerpt, theme-archive-title — see elementor/list-widget-schemas) can be operation targets. Allowlisted V3 updates: settings merge raw without schema validation; classes are written to V3\'s space-separated _css_classes; style CSS is wrapped in `selector { ... }` and stored in V3\'s custom_css (requires Elementor Pro, otherwise emits a warning). Other V3 targets return elementor_v3_not_supported per-op and must be edited directly in the Elementor editor. new_parent_id on action=move may reference either V3 or V4 containers. Each operation: action=update merges partial plain settings, plain-CSS string style (with pseudo-state and breakpoint support; breakpoints use @media (--mobile) syntax — NOT pixel queries), global class labels, and native-shape interactions; action=delete removes the element; action=move re-parents it under new_parent_id at optional index; action=duplicate clones the element (with fresh ids) right after the source. WARNING: This tool performs a read-modify-write on the current document. Do NOT use element IDs obtained from a prior get-page-structure read if build-composition was called in between — use only IDs from the build-composition resolved_xml response to avoid silently overwriting its changes.', 'elementor' ),
 			'elementor',
 			[
 				'type' => 'object',
@@ -285,6 +286,10 @@ class Manage_Elements_Ability extends Abstract_Ability {
 
 		$type = $node['widgetType'] ?? $node['elType'] ?? null;
 		if ( ! is_string( $type ) || '' === $type ) {
+			return null;
+		}
+
+		if ( Widget_Context_Helper::is_v3_allowlisted( $type ) ) {
 			return null;
 		}
 

--- a/modules/mcp/abilities/utils/widget-context-helper.php
+++ b/modules/mcp/abilities/utils/widget-context-helper.php
@@ -53,6 +53,10 @@ class Widget_Context_Helper {
 		$eligible = [];
 
 		foreach ( $all_types as $type => $instance ) {
+			if ( self::is_v3_allowlisted( (string) $type ) && method_exists( $instance, 'get_stack' ) ) {
+				$instance->get_stack();
+			}
+
 			$config = $instance->get_config();
 
 			if ( self::is_widget_eligible_for_llm( $config ) ) {
@@ -66,7 +70,15 @@ class Widget_Context_Helper {
 	public static function get_widget_config( string $widget_type ): ?array {
 		$instance = Atomic_Elements_Utils::get_element_instance( $widget_type );
 
-		return $instance ? $instance->get_config() : null;
+		if ( ! $instance ) {
+			return null;
+		}
+
+		if ( self::is_v3_allowlisted( $widget_type ) && method_exists( $instance, 'get_stack' ) ) {
+			$instance->get_stack();
+		}
+
+		return $instance->get_config();
 	}
 
 	public static function is_widget_eligible_for_llm( array $config ): bool {

--- a/modules/mcp/abilities/utils/widget-context-helper.php
+++ b/modules/mcp/abilities/utils/widget-context-helper.php
@@ -28,6 +28,15 @@ class Widget_Context_Helper {
 
 	const VERSION_V4 = 'v4';
 
+	const V3_ALLOWLIST = [
+		'nav-menu',
+		'theme-post-content',
+		'theme-post-title',
+		'theme-post-featured-image',
+		'theme-post-excerpt',
+		'theme-archive-title',
+	];
+
 	const V3_FALLBACK_MESSAGE = 'This widget exists in the editor but has no atomic props schema (V4). Use control_metadata as non-authoritative hints from legacy controls.';
 
 	const V3_FALLBACK_FIELDS_NOTE = 'All settings are optional; there is no JSON schema for this widget type.';
@@ -82,6 +91,10 @@ class Widget_Context_Helper {
 
 	public static function get_widget_version( array $config ): string {
 		return empty( $config['atomic_props_schema'] ) ? self::VERSION_V3 : self::VERSION_V4;
+	}
+
+	public static function is_v3_allowlisted( string $widget_type ): bool {
+		return in_array( $widget_type, self::V3_ALLOWLIST, true );
 	}
 
 	public static function build_widget_summary( string $widget_type, array $config ): array {

--- a/modules/mcp/static-resources/abilities/build-composition.md
+++ b/modules/mcp/static-resources/abilities/build-composition.md
@@ -6,12 +6,18 @@ If the user asks about a header, footer, 404, single, archive, or search-results
 - [elementor://global-classes] - Reusable CSS classes from the active kit, ordered from highest to lowest CSS priority; check FIRST before adding inline styles
 - [elementor://global-variables] - Design tokens from the active kit; use labels in CSS as `var(--label)` or `var(--label, fallback)`; ONLY variables listed here are valid
 - [elementor://interactions/schema] - Native interaction item shape and allowed enums for `interactions`
-- [elementor/list-widget-schemas?summary=true] - Available v4 widgets
+- [elementor/list-widget-schemas?summary=true] - Available v4 widgets plus the closed V3 allowlist (`nav-menu`, theme-post-* / theme-archive-title)
 - `elementor/list-assets` - Images and SVG icons already in the Media Library; call before placing an `e-image` (for real dimensions and `srcset`) and always before an `e-svg` (which needs an uploaded asset to render)
 - `elementor/list-components` - User-defined reusable widget compositions; only call when the user explicitly asks to use a component (see COMPONENTS below)
 
 # TOOL SUPPORT
-This tool supports v4 elements only.
+This tool supports v4 elements and a closed V3 allowlist (`nav-menu`, `theme-post-content`, `theme-post-title`, `theme-post-featured-image`, `theme-post-excerpt`, `theme-archive-title`).
+
+V3 mapping (same LLM contract as V4, translated internally):
+- `element_config` → raw V3 settings (no schema validation).
+- `classes` (global class labels) → V3 `_css_classes` (space-separated string).
+- `style` (plain CSS) → V3 `custom_css`, wrapped in `selector { ... }`. **Requires Elementor Pro**; without Pro the style is skipped and a warning is emitted.
+- Interactions and V4 nested `&:hover` / `@media (--mobile)` in `style` are not translated to V3 — keep V3 style inputs simple.
 
 # WORKFLOW
 1. Check/create global variables via `elementor/manage-global-variable`

--- a/modules/mcp/static-resources/abilities/get-widget-schema.md
+++ b/modules/mcp/static-resources/abilities/get-widget-schema.md
@@ -1,3 +1,7 @@
-Returns the JSON Schema for a single V4 (atomic) widget type's settings, including default values and nesting guidance. V3 (legacy) widget types are rejected with elementor_v3_not_supported and must be edited directly in the Elementor editor. Use elementor/list-widget-schemas with summary=true first to discover valid widget_type values.
+Returns the JSON Schema for a single V4 (atomic) widget type's settings, including default values and nesting guidance.
 
-Values in the returned schema are plain JSON. Send settings in `build-composition.element_config` and `manage-elements.settings` using this shape directly (scalars as scalars, dynamic tags as `{ name, settings }`).
+A closed V3 allowlist is also fetchable: `nav-menu`, `theme-post-content`, `theme-post-title`, `theme-post-featured-image`, `theme-post-excerpt`, `theme-archive-title`. Those return the V3 fallback shape (`widget_version: 'v3'`, `message`, `fields_note`, `properties` from legacy control metadata — non-authoritative). Other V3 (legacy) widget types are rejected with `elementor_v3_not_supported` and must be edited directly in the Elementor editor.
+
+Use elementor/list-widget-schemas with summary=true first to discover valid widget_type values.
+
+Values in the returned V4 schema are plain JSON. Send settings in `build-composition.element_config` and `manage-elements.settings` using this shape directly (scalars as scalars, dynamic tags as `{ name, settings }`). For allowlisted V3 widgets, send raw control keys as plain settings (no schema validation).

--- a/modules/mcp/static-resources/abilities/list-widget-schemas.md
+++ b/modules/mcp/static-resources/abilities/list-widget-schemas.md
@@ -1,7 +1,9 @@
-Returns widget information for all V4 (atomic) widgets available to the LLM.
+Returns widget information for V4 (atomic) widgets and a closed V3 allowlist available to the LLM.
 
-Default mode: Returns a map of widget_type to JSON Schema. Prefer elementor/get-widget-schema when only one widget type is needed.
+V3 allowlist members: `nav-menu`, `theme-post-content`, `theme-post-title`, `theme-post-featured-image`, `theme-post-excerpt`, `theme-archive-title`. Allowlisted V3 entries use the V3 fallback shape (`widget_version: 'v3'`, control metadata hints — not a validated JSON Schema). Other V3 widgets are omitted.
+
+Default mode: Returns a map of widget_type to JSON Schema (or V3 fallback). Prefer elementor/get-widget-schema when only one widget type is needed.
 
 With summary=true: Returns { widgets: [{ type, description }, ...] } for widget discovery. Use this mode first to discover which widget types exist before fetching full schemas or building compositions.
 
-Values in the returned schemas are plain JSON. Send settings in `build-composition.element_config` and `manage-elements.settings` using this shape directly.
+Values in the returned V4 schemas are plain JSON. Send settings in `build-composition.element_config` and `manage-elements.settings` using this shape directly. For allowlisted V3 widgets, send raw control keys as plain settings (no schema validation).

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-v3-node-bridge.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-v3-node-bridge.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Elementor {
+	if ( ! class_exists( 'Elementor\\Utils', false ) ) {
+		class Utils {
+			public static bool $force_pro = false;
+
+			public static function has_pro(): bool {
+				return self::$force_pro;
+			}
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+	}
+
+	if ( ! function_exists( '__' ) ) {
+		function __( $text, $domain = null ) {
+			return $text;
+		}
+	}
+
+	use Elementor\Modules\Mcp\Abilities\Appliers\V3_Node_Bridge;
+	use Elementor\Utils;
+	use PHPUnit\Framework\TestCase;
+
+	class Test_V3_Node_Bridge extends TestCase {
+
+		protected function setUp(): void {
+			parent::setUp();
+
+			if ( property_exists( Utils::class, 'force_pro' ) ) {
+				Utils::$force_pro = false;
+			}
+		}
+
+		public function test_is_v3_node__true_for_allowlisted_widget() {
+			// Arrange.
+			$node = [
+				'elType' => 'widget',
+				'widgetType' => 'nav-menu',
+				'settings' => [],
+			];
+
+			// Act & Assert.
+			$this->assertTrue( V3_Node_Bridge::is_v3_node( $node ) );
+		}
+
+		public function test_is_v3_node__false_for_non_widget_element() {
+			// Arrange.
+			$node = [
+				'elType' => 'container',
+				'widgetType' => 'nav-menu',
+				'settings' => [],
+			];
+
+			// Act & Assert.
+			$this->assertFalse( V3_Node_Bridge::is_v3_node( $node ) );
+		}
+
+		public function test_is_v3_node__false_for_non_allowlisted_widget() {
+			// Arrange.
+			$node = [
+				'elType' => 'widget',
+				'widgetType' => 'button',
+				'settings' => [],
+			];
+
+			// Act & Assert.
+			$this->assertFalse( V3_Node_Bridge::is_v3_node( $node ) );
+		}
+
+		public function test_apply_classes__merges_with_existing_and_dedupes() {
+			// Arrange.
+			$node = [
+				'elType' => 'widget',
+				'widgetType' => 'nav-menu',
+				'settings' => [
+					V3_Node_Bridge::V3_CSS_CLASSES_SETTING => 'existing shared',
+				],
+			];
+
+			// Act.
+			V3_Node_Bridge::apply_classes( $node, [ 'new', 'shared' ] );
+
+			// Assert.
+			$this->assertSame(
+				'new shared existing',
+				$node['settings'][ V3_Node_Bridge::V3_CSS_CLASSES_SETTING ]
+			);
+		}
+
+		public function test_clear_classes__removes_css_classes_setting() {
+			// Arrange.
+			$node = [
+				'settings' => [
+					V3_Node_Bridge::V3_CSS_CLASSES_SETTING => 'menu-primary',
+				],
+			];
+
+			// Act.
+			V3_Node_Bridge::clear_classes( $node );
+
+			// Assert.
+			$this->assertArrayNotHasKey( V3_Node_Bridge::V3_CSS_CLASSES_SETTING, $node['settings'] );
+		}
+
+		public function test_apply_custom_css__empty_string_clears_setting() {
+			// Arrange.
+			$node = [
+				'settings' => [
+					V3_Node_Bridge::V3_CUSTOM_CSS_SETTING => 'selector { color: red; }',
+				],
+			];
+
+			// Act.
+			$warning = V3_Node_Bridge::apply_custom_css( $node, '   ' );
+
+			// Assert.
+			$this->assertNull( $warning );
+			$this->assertArrayNotHasKey( V3_Node_Bridge::V3_CUSTOM_CSS_SETTING, $node['settings'] );
+		}
+
+		public function test_apply_custom_css__warns_and_skips_when_pro_missing() {
+			if ( ! property_exists( Utils::class, 'force_pro' ) && Utils::has_pro() ) {
+				$this->markTestSkipped( 'Applies only when Pro is inactive.' );
+			}
+
+			// Arrange.
+			$node = [ 'settings' => [] ];
+
+			// Act.
+			$warning = V3_Node_Bridge::apply_custom_css( $node, 'color: red;' );
+
+			// Assert.
+			$this->assertIsString( $warning );
+			$this->assertStringContainsString( 'Elementor Pro', $warning );
+			$this->assertArrayNotHasKey( V3_Node_Bridge::V3_CUSTOM_CSS_SETTING, $node['settings'] );
+		}
+
+		public function test_apply_custom_css__wraps_plain_declarations_when_pro_active() {
+			if ( ! property_exists( Utils::class, 'force_pro' ) && ! Utils::has_pro() ) {
+				$this->markTestSkipped( 'Requires Elementor Pro for custom_css bridge.' );
+			}
+
+			if ( property_exists( Utils::class, 'force_pro' ) ) {
+				Utils::$force_pro = true;
+			}
+
+			// Arrange.
+			$node = [ 'settings' => [] ];
+
+			// Act.
+			$warning = V3_Node_Bridge::apply_custom_css( $node, 'font-size: 2rem;' );
+
+			// Assert.
+			$this->assertNull( $warning );
+			$this->assertSame(
+				'selector { font-size: 2rem; }',
+				$node['settings'][ V3_Node_Bridge::V3_CUSTOM_CSS_SETTING ]
+			);
+		}
+
+		public function test_wrap_with_selector__does_not_double_wrap_selector_block() {
+			// Arrange.
+			$method = new \ReflectionMethod( V3_Node_Bridge::class, 'wrap_with_selector' );
+			$method->setAccessible( true );
+
+			// Act.
+			$result = $method->invoke( null, 'selector { color: blue; }' );
+
+			// Assert.
+			$this->assertSame( 'selector { color: blue; }', $result );
+		}
+
+		public function test_wrap_with_selector__wraps_declarations_that_contain_brace_in_value() {
+			// Arrange.
+			$method = new \ReflectionMethod( V3_Node_Bridge::class, 'wrap_with_selector' );
+			$method->setAccessible( true );
+
+			// Act.
+			$result = $method->invoke( null, 'content: "{";' );
+
+			// Assert.
+			$this->assertSame( 'selector { content: "{"; }', $result );
+		}
+
+		public function test_wrap_with_selector__wraps_plain_declaration_list() {
+			// Arrange.
+			$method = new \ReflectionMethod( V3_Node_Bridge::class, 'wrap_with_selector' );
+			$method->setAccessible( true );
+
+			// Act.
+			$result = $method->invoke( null, 'color: red; font-size: 16px' );
+
+			// Assert.
+			$this->assertSame( 'selector { color: red; font-size: 16px; }', $result );
+		}
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/fixtures/fake-v3-widget.php
+++ b/tests/phpunit/elementor/modules/mcp/fixtures/fake-v3-widget.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp;
+
+use Elementor\Controls_Manager;
+use Elementor\Widget_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Minimal V3 Widget_Base stub used by MCP tests to exercise the V3 widget
+ * allowlist end-to-end without depending on Elementor Pro.
+ *
+ * Elementor's element manager clones registrations by calling `new $class( $data, $args )`,
+ * so the widget name must live on the class itself, not on constructor input. Subclass
+ * per V3 widget name.
+ */
+abstract class Fake_V3_Widget extends Widget_Base {
+
+	public function get_title() {
+		return 'Fake ' . $this->get_name();
+	}
+
+	protected function register_controls() {
+		$this->start_controls_section( 'section', [ 'label' => 'Section' ] );
+		$this->add_control( 'menu', [ 'label' => 'Menu', 'type' => Controls_Manager::TEXT ] );
+		$this->add_control( 'layout', [ 'label' => 'Layout', 'type' => Controls_Manager::TEXT ] );
+		$this->end_controls_section();
+	}
+
+	protected function render() {
+	}
+}
+
+class Fake_V3_Nav_Menu_Widget extends Fake_V3_Widget {
+	public function get_name() {
+		return 'nav-menu';
+	}
+}
+
+class Fake_V3_Theme_Post_Content_Widget extends Fake_V3_Widget {
+	public function get_name() {
+		return 'theme-post-content';
+	}
+}
+
+class Fake_V3_Widget_Factory {
+
+	public static function create( string $widget_name ): Widget_Base {
+		switch ( $widget_name ) {
+			case 'nav-menu':
+				return new Fake_V3_Nav_Menu_Widget();
+			case 'theme-post-content':
+				return new Fake_V3_Theme_Post_Content_Widget();
+		}
+
+		throw new \InvalidArgumentException( 'Unknown fake V3 widget: ' . $widget_name );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
@@ -24,6 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once __DIR__ . '/fixtures/fake-v3-widget.php';
+
 /**
  * @group Elementor\Modules\Mcp
  */
@@ -965,6 +967,108 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 		$this->assertStringContainsString( 'invalid_mode', $result->get_error_message() );
 		$this->assertStringContainsString( 'append', $result->get_error_message() );
 		$this->assertStringContainsString( 'replace_children', $result->get_error_message() );
+	}
+
+	public function test_execute__allowlisted_v3_widget_accepts_raw_settings() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		$this->given_fake_v3_widget_registered( 'nav-menu' );
+
+		$result = ( new Build_Composition_Ability() )->execute( [
+			'post_id' => $post_id,
+			'xml_structure' => '<nav-menu configuration-id="m1"/>',
+			'element_config' => [
+				'm1' => [
+					'menu' => '3',
+					'layout' => 'horizontal',
+				],
+			],
+		] );
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : 'unknown' );
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 1, $result['root_element_ids'] );
+
+		$document = Plugin::$instance->documents->get( $post_id );
+		$elements = $document->get_elements_data();
+		$this->assertCount( 1, $elements );
+		$this->assertSame( 'widget', $elements[0]['elType'] );
+		$this->assertSame( 'nav-menu', $elements[0]['widgetType'] );
+		$this->assertSame( '3', $elements[0]['settings']['menu'] );
+		$this->assertSame( 'horizontal', $elements[0]['settings']['layout'] );
+	}
+
+	public function test_execute__allowlisted_v3_widget_classes_are_written_to_css_classes() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		$this->given_fake_v3_widget_registered( 'nav-menu' );
+		$this->given_kit_global_class( 'hero-menu', '#111111' );
+
+		$result = ( new Build_Composition_Ability() )->execute( [
+			'post_id' => $post_id,
+			'xml_structure' => '<nav-menu configuration-id="m1"/>',
+			'classes' => [
+				'm1' => [ 'hero-menu' ],
+			],
+		] );
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : 'unknown' );
+
+		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
+		$this->assertSame( 'hero-menu', $elements[0]['settings']['_css_classes'] ?? null );
+		$this->assertArrayNotHasKey( 'classes', $elements[0]['settings'] );
+	}
+
+	public function test_execute__allowlisted_v3_widget_style_wraps_in_selector_when_pro_active() {
+		if ( ! \Elementor\Utils::has_pro() ) {
+			$this->markTestSkipped( 'Requires Elementor Pro for custom_css bridge.' );
+		}
+
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		$this->given_fake_v3_widget_registered( 'nav-menu' );
+
+		$result = ( new Build_Composition_Ability() )->execute( [
+			'post_id' => $post_id,
+			'xml_structure' => '<nav-menu configuration-id="m1"/>',
+			'style' => [
+				'm1' => 'color: red;',
+			],
+		] );
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : 'unknown' );
+
+		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
+		$this->assertSame( 'selector { color: red; }', $elements[0]['settings']['custom_css'] ?? null );
+	}
+
+	public function test_execute__allowlisted_v3_widget_style_warns_when_pro_missing() {
+		if ( \Elementor\Utils::has_pro() ) {
+			$this->markTestSkipped( 'Applies only when Pro is inactive.' );
+		}
+
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		$this->given_fake_v3_widget_registered( 'nav-menu' );
+
+		$result = ( new Build_Composition_Ability() )->execute( [
+			'post_id' => $post_id,
+			'xml_structure' => '<nav-menu configuration-id="m1"/>',
+			'style' => [
+				'm1' => 'color: red;',
+			],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result['warnings'] ?? [] );
+		$this->assertStringContainsString( 'Elementor Pro', $result['warnings'][0] );
+
+		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
+		$this->assertArrayNotHasKey( 'custom_css', $elements[0]['settings'] );
+	}
+
+	private function given_fake_v3_widget_registered( string $type ): void {
+		Plugin::$instance->widgets_manager->register( Fake_V3_Widget_Factory::create( $type ) );
 	}
 
 	private function given_document_with_elements( int $post_id, array $elements ): void {

--- a/tests/phpunit/elementor/modules/mcp/test-get-widget-schema-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-get-widget-schema-ability.php
@@ -3,6 +3,7 @@
 namespace Elementor\Tests\Phpunit\Modules\Mcp;
 
 use Elementor\Modules\Mcp\Abilities\Get_Widget_Schema_Ability;
+use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 use Elementor\Plugin;
 use Elementor\Widgets_Manager;
 use ElementorEditorTesting\Elementor_Test_Base;
@@ -44,6 +45,24 @@ class Test_Get_Widget_Schema_Ability extends Elementor_Test_Base {
 		$this->assertSame( 'v3', $data['version'] );
 	}
 
+	public function test_execute__returns_v3_fallback_for_allowlisted_widget() {
+		$this->act_as_admin();
+		$this->given_widget_manager_with_fake_v3_widget( 'nav-menu', [
+			'menu' => [ 'type' => 'select', 'default' => '' ],
+			'layout' => [ 'type' => 'select', 'options' => [ 'horizontal' => 'Horizontal', 'vertical' => 'Vertical' ] ],
+		] );
+
+		$result = $this->ability->execute( [ 'widget_type' => 'nav-menu' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( Widget_Context_Helper::VERSION_V3, $result['widget_version'] );
+		$this->assertSame( Widget_Context_Helper::V3_FALLBACK_MESSAGE, $result['message'] );
+		$this->assertSame( Widget_Context_Helper::V3_FALLBACK_FIELDS_NOTE, $result['fields_note'] );
+		$this->assertArrayHasKey( 'properties', $result );
+		$this->assertArrayHasKey( 'menu', $result['properties'] );
+		$this->assertSame( 'select', $result['properties']['menu']['type'] );
+	}
+
 	public function test_execute__returns_404_for_unknown_widget_type() {
 		$this->act_as_admin();
 
@@ -63,11 +82,19 @@ class Test_Get_Widget_Schema_Ability extends Elementor_Test_Base {
 		$this->assertSame( \WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
 	}
 
-	private function given_widget_manager_with_fake_v3_widget( string $type ): void {
-		$widget = new class() {
+	private function given_widget_manager_with_fake_v3_widget( string $type, array $controls = null ): void {
+		$controls = $controls ?? [ 'title' => [ 'type' => 'text' ] ];
+
+		$widget = new class( $controls ) {
+			private array $controls;
+
+			public function __construct( array $controls ) {
+				$this->controls = $controls;
+			}
+
 			public function get_config(): array {
 				return [
-					'controls' => [ 'title' => [ 'type' => 'text' ] ],
+					'controls' => $this->controls,
 					'atomic_props_schema' => null,
 					'title' => 'Fake V3',
 				];

--- a/tests/phpunit/elementor/modules/mcp/test-list-widget-schemas-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-list-widget-schemas-ability.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp;
+
+use Elementor\Elements_Manager;
+use Elementor\Modules\Mcp\Abilities\List_Widget_Schemas_Ability;
+use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
+use Elementor\Plugin;
+use Elementor\Widgets_Manager;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @group Elementor\Modules\Mcp
+ */
+class Test_List_Widget_Schemas_Ability extends Elementor_Test_Base {
+
+	private List_Widget_Schemas_Ability $ability;
+	private Widgets_Manager $original_widgets_manager;
+	private Elements_Manager $original_elements_manager;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->ability = new List_Widget_Schemas_Ability();
+		$this->original_widgets_manager = Plugin::$instance->widgets_manager;
+		$this->original_elements_manager = Plugin::$instance->elements_manager;
+	}
+
+	public function tearDown(): void {
+		Plugin::$instance->widgets_manager = $this->original_widgets_manager;
+		Plugin::$instance->elements_manager = $this->original_elements_manager;
+		parent::tearDown();
+	}
+
+	public function test_execute__includes_allowlisted_v3_and_excludes_other_v3() {
+		$this->act_as_admin();
+		$this->given_widget_manager_with_v3_widgets( [
+			'nav-menu' => [ 'menu' => [ 'type' => 'select' ] ],
+			'fake-v3' => [ 'title' => [ 'type' => 'text' ] ],
+		] );
+
+		$result = $this->ability->execute( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'nav-menu', $result );
+		$this->assertSame( Widget_Context_Helper::VERSION_V3, $result['nav-menu']['widget_version'] );
+		$this->assertArrayNotHasKey( 'fake-v3', $result );
+	}
+
+	public function test_execute__summary_includes_allowlisted_v3_type() {
+		$this->act_as_admin();
+		$this->given_widget_manager_with_v3_widgets( [
+			'nav-menu' => [ 'menu' => [ 'type' => 'select' ] ],
+			'fake-v3' => [ 'title' => [ 'type' => 'text' ] ],
+		] );
+
+		$result = $this->ability->execute( [ 'summary' => true ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'widgets', $result );
+
+		$types = array_column( $result['widgets'], 'type' );
+		$this->assertContains( 'nav-menu', $types );
+		$this->assertNotContains( 'fake-v3', $types );
+	}
+
+	/**
+	 * @param array<string, array> $widgets_by_type widget_type => controls
+	 */
+	private function given_widget_manager_with_v3_widgets( array $widgets_by_type ): void {
+		$instances = [];
+
+		foreach ( $widgets_by_type as $type => $controls ) {
+			$instances[ $type ] = new class( $controls ) {
+				private array $controls;
+
+				public function __construct( array $controls ) {
+					$this->controls = $controls;
+				}
+
+				public function get_config(): array {
+					return [
+						'controls' => $this->controls,
+						'atomic_props_schema' => null,
+						'title' => 'Fake V3',
+						'meta' => [ 'description' => 'Fake V3 widget' ],
+					];
+				}
+			};
+		}
+
+		$widgets_manager = $this->createMock( Widgets_Manager::class );
+		$widgets_manager->method( 'get_widget_types' )->willReturnCallback(
+			static function ( $name = null ) use ( $instances ) {
+				if ( null === $name ) {
+					return $instances;
+				}
+
+				return $instances[ $name ] ?? null;
+			}
+		);
+		Plugin::$instance->widgets_manager = $widgets_manager;
+
+		$elements_manager = $this->createMock( Elements_Manager::class );
+		$elements_manager->method( 'get_element_types' )->willReturn( [] );
+		Plugin::$instance->elements_manager = $elements_manager;
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
@@ -21,6 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once __DIR__ . '/fixtures/fake-v3-widget.php';
+
 /**
  * @group Elementor\Modules\Mcp
  */
@@ -796,6 +798,131 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertSame( 'Survived', $node['settings']['title']['value']['content']['value'] );
 	}
 
+	public function test_execute__allowlisted_v3_update_merges_raw_settings() {
+		$this->act_as_admin();
+		$this->given_fake_v3_widget_registered( 'nav-menu' );
+		$post_id = $this->create_real_document();
+		$v3_id = $this->given_allowlisted_v3_widget_on_document( $post_id, 'nav-menu' );
+
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $v3_id,
+					'settings' => [ 'menu' => '3', 'layout' => 'horizontal' ],
+				],
+			],
+		] );
+
+		$this->assertOkOperation( $result, 0 );
+
+		$node = $this->find_element_in_document( $post_id, $v3_id );
+		$this->assertNotNull( $node );
+		$this->assertSame( '3', $node['settings']['menu'] );
+		$this->assertSame( 'horizontal', $node['settings']['layout'] );
+	}
+
+	public function test_execute__allowlisted_v3_classes_write_to_css_classes() {
+		$this->act_as_admin();
+		$this->given_fake_v3_widget_registered( 'nav-menu' );
+		$post_id = $this->create_real_document();
+		$v3_id = $this->given_allowlisted_v3_widget_on_document( $post_id, 'nav-menu' );
+		$this->given_kit_global_class( 'menu-primary', '#111111' );
+
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $v3_id,
+					'classes' => [ 'menu-primary' ],
+				],
+			],
+		] );
+
+		$this->assertOkOperation( $result, 0 );
+
+		$node = $this->find_element_in_document( $post_id, $v3_id );
+		$this->assertSame( 'menu-primary', $node['settings']['_css_classes'] ?? null );
+		$this->assertArrayNotHasKey( 'classes', $node['settings'] );
+	}
+
+	public function test_execute__allowlisted_v3_style_bridged_to_custom_css_when_pro_active() {
+		if ( ! \Elementor\Utils::has_pro() ) {
+			$this->markTestSkipped( 'Requires Elementor Pro for custom_css bridge.' );
+		}
+
+		$this->act_as_admin();
+		$this->given_fake_v3_widget_registered( 'nav-menu' );
+		$post_id = $this->create_real_document();
+		$v3_id = $this->given_allowlisted_v3_widget_on_document( $post_id, 'nav-menu' );
+
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $v3_id,
+					'style' => 'font-size: 2rem;',
+				],
+			],
+		] );
+
+		$this->assertOkOperation( $result, 0 );
+
+		$node = $this->find_element_in_document( $post_id, $v3_id );
+		$this->assertSame( 'selector { font-size: 2rem; }', $node['settings']['custom_css'] ?? null );
+		$this->assertArrayNotHasKey( 'styles', $node );
+	}
+
+	public function test_execute__allowlisted_v3_style_warns_when_pro_missing() {
+		if ( \Elementor\Utils::has_pro() ) {
+			$this->markTestSkipped( 'Applies only when Pro is inactive.' );
+		}
+
+		$this->act_as_admin();
+		$this->given_fake_v3_widget_registered( 'nav-menu' );
+		$post_id = $this->create_real_document();
+		$v3_id = $this->given_allowlisted_v3_widget_on_document( $post_id, 'nav-menu' );
+
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $v3_id,
+					'style' => 'font-size: 2rem;',
+				],
+			],
+		] );
+
+		$this->assertOkOperation( $result, 0 );
+		$warnings = $result['results'][0]['warnings'] ?? [];
+		$this->assertNotEmpty( $warnings );
+		$this->assertStringContainsString( 'Elementor Pro', $warnings[0] );
+
+		$node = $this->find_element_in_document( $post_id, $v3_id );
+		$this->assertArrayNotHasKey( 'custom_css', $node['settings'] );
+	}
+
+	public function test_execute__allowlisted_v3_delete_succeeds() {
+		$this->act_as_admin();
+		$this->given_fake_v3_widget_registered( 'theme-post-content' );
+		$post_id = $this->create_real_document();
+		$v3_id = $this->given_allowlisted_v3_widget_on_document( $post_id, 'theme-post-content' );
+
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => [
+				[ 'action' => 'delete', 'element_id' => $v3_id ],
+			],
+		] );
+
+		$this->assertOkOperation( $result, 0 );
+		$this->assertNull( $this->find_element_in_document( $post_id, $v3_id ) );
+	}
+
 	public function test_bulk__partial_failure_still_saves_valid_ops() {
 		$this->act_as_admin();
 		$post_id = $this->create_real_document();
@@ -990,6 +1117,26 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		] );
 
 		return $id;
+	}
+
+	private function given_allowlisted_v3_widget_on_document( int $post_id, string $widget_type ): string {
+		$id = $this->random_element_id();
+
+		$this->append_elements_to_document( $post_id, [
+			[
+				'id' => $id,
+				'elType' => 'widget',
+				'widgetType' => $widget_type,
+				'settings' => [],
+				'elements' => [],
+			],
+		] );
+
+		return $id;
+	}
+
+	private function given_fake_v3_widget_registered( string $type ): void {
+		Plugin::$instance->widgets_manager->register( Fake_V3_Widget_Factory::create( $type ) );
 	}
 
 	private function given_v3_container_on_document( int $post_id ): string {


### PR DESCRIPTION
## Summary

Layer 1 of the [ED-25071 stacked series](https://github.com/elementor/elementor/pull/36801). Opens a closed V3 allowlist (`nav-menu`, `theme-post-content`, `theme-post-title`, `theme-post-featured-image`, `theme-post-excerpt`, `theme-archive-title`) to `elementor/list-widget-schemas` and `elementor/get-widget-schema` (V3 fallback shape), and permits allowlisted V3 targets in `build-composition` and `manage-elements`.

Same LLM contract as V4; internal V3 shape bridge:
- `classes`: labels → `settings._css_classes` (space-separated string).
- `style`: CSS wrapped as `selector { ... }` into `settings.custom_css` (requires Elementor Pro; otherwise a warning is emitted and the style is skipped).
- `settings`: raw merge (no schema validation, matching V3 fallback behavior in `Element_Config_Applier`).

Also forces V3 widget stack initialization in `Widget_Context_Helper` so `get_config()` surfaces controls for the six allowlisted types via the V3 fallback shape.

## Depends on

- Base: `main`
- Top of stack: [PR4 registry refactor](../pull/) (see other PRs in the ED-25071 chain)

## Test plan

- [ ] PHPUnit: allowlist behavior in `test-list-widget-schemas-ability.php`, `test-get-widget-schema-ability.php`, `test-build-composition-ability.php`, `test-manage-elements-ability.php`
- [ ] Manual: call `elementor/list-widget-schemas` and confirm the six V3 types are present

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
ED-25071: Extends MCP schema abilities to support a closed allowlist of V3 widgets (nav-menu, theme-post-*) with the same V4 contract, enabling LLM interactions with legacy widgets without editor modification. Bridges V4-shape inputs (global class labels, CSS strings) onto V3 settings format.

## 2. What Changed (Where)
- **Class_Applier**: Refactored label validation into `resolve_labels()` method; added V3_Node_Bridge detection for allowlisted widgets to write to `_css_classes`.
- **Style_Applier**: Moved `$node` assignment conditionally; added V3_Node_Bridge detection to write CSS to `custom_css` with Pro check; tracks warnings separately.
- **V3_Node_Bridge** (new): Bridges V4 inputs onto V3 `_css_classes` and `custom_css` settings; wraps plain CSS in `selector { ... }` blocks; guards Pro requirement for custom_css.
- **Get_Widget_Schema_Ability**: Returns V3 fallback schema (control metadata) for allowlisted V3 widgets instead of rejection.
- **List_Widget_Schemas_Ability**: Filter now includes allowlisted V3 widgets alongside V4 candidates.
- **Manage_Elements_Ability**: Added V3 allowlist check before atomic element validation; updated docstring and imports.
- **Widget_Context_Helper**: Added V3_ALLOWLIST constant; `is_v3_allowlisted()` method; calls `get_stack()` on V3 widgets before config fetch to populate control metadata.
- **Tests**: New test classes for V3_Node_Bridge, List_Widget_Schemas_Ability; new fake V3 widget fixture; expanded Manage_Elements and Get_Widget_Schema tests with allowlist coverage.
- **Docs**: Updated schema ability markdown to document V3 allowlist behavior, settings merge, class mapping, style wrapping with Pro requirement.

## 3. How It Works
Entry point: Get_Widget_Schema_Ability now detects allowlisted V3 via `is_v3_allowlisted()` and returns V3 fallback; List_Widget_Schemas_Ability filters to include both V4 and allowlisted V3. Build/Manage operations detect V3 nodes and route through V3_Node_Bridge: global class labels → `_css_classes` (space-separated, deduped); plain CSS → `custom_css` wrapped in `selector { ... }` (warns if Pro missing); raw settings merge without schema validation. Non-allowlisted V3 still reject with `elementor_v3_not_supported`.

## 4. Risks
**Pro dependency assumption**: Style bridging silently fails with warning if Pro absent—ensure docs surface this clearly. **V3 widget discovery timing**: `get_stack()` call required to populate control metadata; verify this doesn't break lazy-loaded widgets or cause perf regression. **Allowlist maintenance**: Hardcoded constant requires coordination if new V3 widgets are added—document process. **Edge case: empty/null settings**: Defensive null-coalescing throughout; edge cases (missing `_css_classes`, malformed CSS) appear handled via unset/trim.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
