### PR TITLE
Internal: Map V3 allowlisted widget styles via CSS bridge [ED-25071]

### DIFF
--- a/modules/mcp/abilities/appliers/element-config-applier.php
+++ b/modules/mcp/abilities/appliers/element-config-applier.php
@@ -7,6 +7,7 @@ use Elementor\Modules\AtomicWidgets\Parsers\Props_Parser;
 use Elementor\Modules\AtomicWidgets\PlainResolvers\Plain_Values_Resolver;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\Components\Components_Repository;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Non_Style_Allowlist;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Widget_Type_Resolver;
 use Elementor\Modules\Mcp\Abilities\Prop_Canonicalizer;
 
@@ -52,6 +53,17 @@ class Element_Config_Applier {
 
 			if ( self::COMPONENT_INSTANCE_WIDGET_TYPE === $tag ) {
 				$component_entries[ $config_id ] = $settings;
+				continue;
+			}
+
+			if ( V3_Node_Bridge::is_v3_node( $node ) ) {
+				$filter = V3_Non_Style_Allowlist::filter( (string) $tag, $settings );
+				if ( $filter['error'] ) {
+					$errors[] = sprintf( '[%s] %s', $config_id, $filter['error']->get_error_message() );
+					continue;
+				}
+
+				$node['settings'] = $this->merge_with_clears( $node['settings'] ?? [], $filter['allowed'] );
 				continue;
 			}
 

--- a/modules/mcp/abilities/appliers/style-applier.php
+++ b/modules/mcp/abilities/appliers/style-applier.php
@@ -60,7 +60,7 @@ class Style_Applier {
 			$node = &$config_id_index[ $config_id ];
 
 			if ( V3_Node_Bridge::is_v3_node( $node ) ) {
-				$v3_warnings = $this->apply_v3_style( $node, $css_string, $widget_configs );
+				$v3_warnings = $this->apply_v3_style( $node, $css_string, $style_apply_mode, $widget_configs );
 				foreach ( $v3_warnings as $warning ) {
 					$warnings[] = sprintf( '[%s] %s', $config_id, $warning );
 				}
@@ -132,7 +132,7 @@ class Style_Applier {
 	 * @param array<string, array> $widget_configs
 	 * @return string[] Warnings (without config-id prefix).
 	 */
-	private function apply_v3_style( array &$node, string $css_string, array $widget_configs = [] ): array {
+	private function apply_v3_style( array &$node, string $css_string, string $style_apply_mode = 'patch', array $widget_configs = [] ): array {
 		$warnings = [];
 		$widget_type = $node['widgetType'] ?? '';
 		$widget_config = [];
@@ -141,6 +141,17 @@ class Style_Applier {
 			$widget_config = $widget_configs[ $widget_type ]
 				?? Widget_Context_Helper::get_widget_config( $widget_type )
 				?? [];
+		}
+
+		$is_empty_css = '' === trim( $css_string );
+		$is_replace = 'replace' === $style_apply_mode;
+
+		if ( $is_replace ) {
+			V3_Node_Bridge::clear_style_settings( $node, (string) $widget_type, $widget_config );
+		}
+
+		if ( $is_empty_css ) {
+			return $warnings;
 		}
 
 		$mapper = new V3_Style_Mapper( $this->css_converter, $this->get_active_breakpoints() );
@@ -155,14 +166,36 @@ class Style_Applier {
 		}
 
 		$unmapped = $result['unmapped_css'] ?? '';
-		$warning = V3_Node_Bridge::apply_custom_css( $node, $unmapped );
-		if ( null !== $warning ) {
-			$warnings[] = $warning;
-		} elseif ( '' !== trim( $unmapped ) ) {
-			$warnings[] = __( 'Some CSS could not be mapped to V3 settings and was written to custom_css.', 'elementor' );
+		$pro_warning = V3_Node_Bridge::apply_custom_css( $node, $unmapped );
+		if ( null !== $pro_warning ) {
+			$warnings[] = $pro_warning;
+		}
+
+		if ( '' !== trim( $unmapped ) ) {
+			$snippet = self::truncate_css_snippet( $unmapped );
+			$warnings[] = null !== $pro_warning
+				? sprintf(
+					/* translators: %s: CSS snippet that could not be mapped */
+					__( 'Some CSS could not be mapped to V3 settings and was dropped: %s', 'elementor' ),
+					$snippet
+				)
+				: sprintf(
+					/* translators: %s: CSS snippet that could not be mapped */
+					__( 'Some CSS could not be mapped to V3 settings and was written to custom_css: %s', 'elementor' ),
+					$snippet
+				);
 		}
 
 		return $warnings;
+	}
+
+	private static function truncate_css_snippet( string $css, int $max_length = 200 ): string {
+		$css = trim( preg_replace( '/\s+/', ' ', $css ) ?? $css );
+		if ( strlen( $css ) <= $max_length ) {
+			return $css;
+		}
+
+		return substr( $css, 0, $max_length - 3 ) . '...';
 	}
 
 	private function get_active_breakpoints(): array {

--- a/modules/mcp/abilities/appliers/style-applier.php
+++ b/modules/mcp/abilities/appliers/style-applier.php
@@ -3,8 +3,10 @@
 namespace Elementor\Modules\Mcp\Abilities\Appliers;
 
 use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Style_Mapper;
 use Elementor\Modules\Mcp\Abilities\Utils\Bulk_Operations_Result;
 use Elementor\Modules\Mcp\Abilities\Utils\Style_Variants_Merger;
+use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -29,9 +31,11 @@ class Style_Applier {
 	/**
 	 * @param array<string, array&> $config_id_index Index of subtree refs.
 	 * @param array<string, string> $styles          Per-config-id CSS strings.
+	 * @param string                $style_apply_mode `patch` or `replace`.
+	 * @param array<string, array>  $widget_configs  Optional widget_type => config map (used for V3 mapping).
 	 * @return array{error: \WP_Error|null, warnings: string[]}
 	 */
-	public function apply( array $config_id_index, array $styles, string $style_apply_mode = 'patch' ): array {
+	public function apply( array $config_id_index, array $styles, string $style_apply_mode = 'patch', array $widget_configs = [] ): array {
 		if ( empty( $styles ) ) {
 			return [
 				'error'    => null,
@@ -56,8 +60,8 @@ class Style_Applier {
 			$node = &$config_id_index[ $config_id ];
 
 			if ( V3_Node_Bridge::is_v3_node( $node ) ) {
-				$warning = V3_Node_Bridge::apply_custom_css( $node, $css_string );
-				if ( null !== $warning ) {
+				$v3_warnings = $this->apply_v3_style( $node, $css_string, $widget_configs );
+				foreach ( $v3_warnings as $warning ) {
 					$warnings[] = sprintf( '[%s] %s', $config_id, $warning );
 				}
 				unset( $node );
@@ -122,6 +126,43 @@ class Style_Applier {
 			) : null,
 			'warnings' => $warnings,
 		];
+	}
+
+	/**
+	 * @param array<string, array> $widget_configs
+	 * @return string[] Warnings (without config-id prefix).
+	 */
+	private function apply_v3_style( array &$node, string $css_string, array $widget_configs = [] ): array {
+		$warnings = [];
+		$widget_type = $node['widgetType'] ?? '';
+		$widget_config = [];
+
+		if ( is_string( $widget_type ) && '' !== $widget_type ) {
+			$widget_config = $widget_configs[ $widget_type ]
+				?? Widget_Context_Helper::get_widget_config( $widget_type )
+				?? [];
+		}
+
+		$mapper = new V3_Style_Mapper( $this->css_converter, $this->get_active_breakpoints() );
+		$result = $mapper->apply( $css_string, (string) $widget_type, $widget_config );
+
+		foreach ( $result['warnings'] as $warning ) {
+			$warnings[] = $warning;
+		}
+
+		if ( ! empty( $result['settings_patch'] ) ) {
+			$node['settings'] = array_merge( $node['settings'] ?? [], $result['settings_patch'] );
+		}
+
+		$unmapped = $result['unmapped_css'] ?? '';
+		$warning = V3_Node_Bridge::apply_custom_css( $node, $unmapped );
+		if ( null !== $warning ) {
+			$warnings[] = $warning;
+		} elseif ( '' !== trim( $unmapped ) ) {
+			$warnings[] = __( 'Some CSS could not be mapped to V3 settings and was written to custom_css.', 'elementor' );
+		}
+
+		return $warnings;
 	}
 
 	private function get_active_breakpoints(): array {

--- a/modules/mcp/abilities/appliers/style-applier.php
+++ b/modules/mcp/abilities/appliers/style-applier.php
@@ -129,6 +129,9 @@ class Style_Applier {
 	}
 
 	/**
+	 * @param array                $node
+	 * @param string               $css_string
+	 * @param string               $style_apply_mode
 	 * @param array<string, array> $widget_configs
 	 * @return string[] Warnings (without config-id prefix).
 	 */

--- a/modules/mcp/abilities/appliers/v3-node-bridge.php
+++ b/modules/mcp/abilities/appliers/v3-node-bridge.php
@@ -2,6 +2,8 @@
 
 namespace Elementor\Modules\Mcp\Abilities\Appliers;
 
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Style_Settings_Index;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Widget_Bridge_Registry;
 use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 use Elementor\Utils;
 
@@ -18,6 +20,28 @@ class V3_Node_Bridge {
 
 	const V3_CUSTOM_CSS_SETTING = 'custom_css';
 	const V3_CSS_CLASSES_SETTING = '_css_classes';
+
+	const RESPONSIVE_SUFFIXES = [ '_tablet', '_mobile' ];
+
+	const TYPOGRAPHY_SETTING_SUFFIXES = [
+		'typography',
+		'font_family',
+		'font_weight',
+		'font_style',
+		'text_transform',
+		'text_decoration',
+		'font_size',
+		'line_height',
+		'letter_spacing',
+		'word_spacing',
+	];
+
+	const TYPOGRAPHY_RESPONSIVE_SUFFIXES = [
+		'font_size',
+		'line_height',
+		'letter_spacing',
+		'word_spacing',
+	];
 
 	public static function is_v3_node( array $node ): bool {
 		// V3 non-widget elements (containers/sections) are intentionally not supported at this layer for now.
@@ -46,6 +70,21 @@ class V3_Node_Bridge {
 	}
 
 	/**
+	 * Clears all known mapped style settings and custom_css for a V3 widget.
+	 * Mirrors V4 replace semantics (wipe existing style before applying a new one).
+	 *
+	 * @param array<string, mixed> $widget_config
+	 */
+	public static function clear_style_settings( array &$node, string $widget_type, array $widget_config = [] ): void {
+		$keys = self::collect_style_setting_keys( $widget_type, $widget_config );
+		$keys[] = self::V3_CUSTOM_CSS_SETTING;
+
+		foreach ( array_unique( $keys ) as $key ) {
+			unset( $node['settings'][ $key ] );
+		}
+	}
+
+	/**
 	 * Writes a CSS string into V3's `custom_css`. Plain declaration lists (`color: red;`)
 	 * are wrapped in `selector { ... }` — the Pro custom-css module replaces `selector`
 	 * with the widget's wrapper at render.
@@ -67,6 +106,111 @@ class V3_Node_Bridge {
 		$node['settings'][ self::V3_CUSTOM_CSS_SETTING ] = self::wrap_with_selector( $css_string );
 
 		return null;
+	}
+
+	/**
+	 * @param array<string, mixed> $widget_config
+	 * @return string[]
+	 */
+	private static function collect_style_setting_keys( string $widget_type, array $widget_config ): array {
+		$keys = [];
+		$overrides = V3_Widget_Bridge_Registry::get_style_overrides( $widget_type );
+
+		foreach ( $overrides as $override ) {
+			$keys = array_merge( $keys, self::expand_override_keys( $override ) );
+		}
+
+		$generic = V3_Style_Settings_Index::build( $widget_config['controls'] ?? [], $overrides );
+		foreach ( $generic as $rule ) {
+			$setting = (string) ( $rule['setting'] ?? '' );
+			if ( '' === $setting ) {
+				continue;
+			}
+			$keys[] = $setting;
+			if ( ! empty( $rule['responsive'] ) ) {
+				foreach ( self::RESPONSIVE_SUFFIXES as $suffix ) {
+					$keys[] = $setting . $suffix;
+				}
+			}
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * @param array<string, mixed> $override
+	 * @return string[]
+	 */
+	private static function expand_override_keys( array $override ): array {
+		if ( isset( $override['typography_prefix'] ) ) {
+			return self::expand_typography_keys( (string) $override['typography_prefix'] );
+		}
+
+		if ( isset( $override['border_prefix'] ) ) {
+			return self::expand_border_keys( (string) $override['border_prefix'] );
+		}
+
+		if ( isset( $override['box_shadow_prefix'] ) ) {
+			$prefix = (string) $override['box_shadow_prefix'];
+			return [
+				$prefix . '_box_shadow_type',
+				$prefix . '_box_shadow',
+			];
+		}
+
+		$setting = $override['setting'] ?? null;
+		if ( ! is_string( $setting ) || '' === $setting ) {
+			return [];
+		}
+
+		$keys = [ $setting ];
+		if ( ! empty( $override['responsive'] ) ) {
+			foreach ( self::RESPONSIVE_SUFFIXES as $suffix ) {
+				$keys[] = $setting . $suffix;
+			}
+		}
+
+		if ( 'box_shadow' === ( $override['resolver'] ?? null ) ) {
+			$keys[] = $setting . '_type';
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private static function expand_typography_keys( string $prefix ): array {
+		$keys = [];
+
+		foreach ( self::TYPOGRAPHY_SETTING_SUFFIXES as $suffix ) {
+			$keys[] = $prefix . '_' . $suffix;
+			if ( ! in_array( $suffix, self::TYPOGRAPHY_RESPONSIVE_SUFFIXES, true ) ) {
+				continue;
+			}
+			foreach ( self::RESPONSIVE_SUFFIXES as $responsive_suffix ) {
+				$keys[] = $prefix . '_' . $suffix . $responsive_suffix;
+			}
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private static function expand_border_keys( string $prefix ): array {
+		$keys = [
+			$prefix . '_border',
+			$prefix . '_width',
+			$prefix . '_color',
+		];
+
+		foreach ( self::RESPONSIVE_SUFFIXES as $suffix ) {
+			$keys[] = $prefix . '_width' . $suffix;
+		}
+
+		return $keys;
 	}
 
 	private static function wrap_with_selector( string $css ): string {

--- a/modules/mcp/abilities/appliers/v3-node-bridge.php
+++ b/modules/mcp/abilities/appliers/v3-node-bridge.php
@@ -73,7 +73,9 @@ class V3_Node_Bridge {
 	 * Clears all known mapped style settings and custom_css for a V3 widget.
 	 * Mirrors V4 replace semantics (wipe existing style before applying a new one).
 	 *
-	 * @param array<string, mixed> $widget_config
+	 * @param array<string, mixed> $node           Subtree node (by reference).
+	 * @param string               $widget_type    V3 widget type name.
+	 * @param array<string, mixed> $widget_config  Widget config from Widget_Context_Helper::get_widget_config().
 	 */
 	public static function clear_style_settings( array &$node, string $widget_type, array $widget_config = [] ): void {
 		$keys = self::collect_style_setting_keys( $widget_type, $widget_config );
@@ -109,7 +111,8 @@ class V3_Node_Bridge {
 	}
 
 	/**
-	 * @param array<string, mixed> $widget_config
+	 * @param string               $widget_type    V3 widget type name.
+	 * @param array<string, mixed> $widget_config  Widget config from Widget_Context_Helper::get_widget_config().
 	 * @return string[]
 	 */
 	private static function collect_style_setting_keys( string $widget_type, array $widget_config ): array {

--- a/modules/mcp/abilities/appliers/v3/v3-non-style-allowlist.php
+++ b/modules/mcp/abilities/appliers/v3/v3-non-style-allowlist.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Validates V3 element_config settings against the per-widget non-style allowlist.
+ */
+class V3_Non_Style_Allowlist {
+
+	/**
+	 * @param string               $widget_type
+	 * @param array<string, mixed> $settings
+	 * @return array{allowed: array<string, mixed>, rejected: string[], error: \WP_Error|null}
+	 */
+	public static function filter( string $widget_type, array $settings ): array {
+		$allowed_keys = V3_Widget_Bridge_Registry::get_non_style_keys( $widget_type );
+		$allowed_lookup = array_fill_keys( $allowed_keys, true );
+
+		$allowed = [];
+		$rejected = [];
+
+		foreach ( $settings as $key => $value ) {
+			if ( ! is_string( $key ) || '' === $key ) {
+				continue;
+			}
+
+			if ( ! isset( $allowed_lookup[ $key ] ) ) {
+				$rejected[] = $key;
+				continue;
+			}
+
+			$allowed[ $key ] = $value;
+		}
+
+		if ( empty( $rejected ) ) {
+			return [
+				'allowed' => $allowed,
+				'rejected' => [],
+				'error' => null,
+			];
+		}
+
+		$available = empty( $allowed_keys )
+			? '(none — this V3 widget has no settable behavior keys; use style for visuals)'
+			: implode( ', ', $allowed_keys );
+
+		return [
+			'allowed' => $allowed,
+			'rejected' => $rejected,
+			'error' => new \WP_Error(
+				'elementor_invalid_settings',
+				sprintf(
+					'V3 widget "%s" does not allow settings: %s. Allowed non-style keys: %s. Visual styling must go through the style (CSS) input.',
+					$widget_type,
+					implode( ', ', $rejected ),
+					$available
+				),
+				[ 'status' => \WP_Http::BAD_REQUEST ]
+			),
+		];
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/v3-style-mapper.php
+++ b/modules/mcp/abilities/appliers/v3/v3-style-mapper.php
@@ -188,13 +188,10 @@ class V3_Style_Mapper {
 		$key = $setting;
 		if ( ! empty( $override['responsive'] ) && self::DESKTOP_BREAKPOINT !== $breakpoint ) {
 			$suffixed = $setting . '_' . $breakpoint;
-			if ( $this->control_exists( $widget_config, $suffixed ) ) {
-				$key = $suffixed;
-			} elseif ( $this->control_exists( $widget_config, $setting ) ) {
+			if ( ! $this->control_exists( $widget_config, $suffixed ) ) {
 				return null;
-			} else {
-				$key = $suffixed;
 			}
+			$key = $suffixed;
 		}
 
 		return [ $key => $resolved ];
@@ -213,13 +210,10 @@ class V3_Style_Mapper {
 		$key = $rule['setting'];
 		if ( self::DESKTOP_BREAKPOINT !== $breakpoint ) {
 			$suffixed = $key . '_' . $breakpoint;
-			if ( $this->control_exists( $widget_config, $suffixed ) ) {
-				$key = $suffixed;
-			} elseif ( empty( $rule['responsive'] ) ) {
-				return null;
-			} else {
+			if ( ! $this->control_exists( $widget_config, $suffixed ) ) {
 				return null;
 			}
+			$key = $suffixed;
 		}
 
 		return [ $key => $resolved ];

--- a/modules/mcp/abilities/appliers/v3/v3-style-mapper.php
+++ b/modules/mcp/abilities/appliers/v3/v3-style-mapper.php
@@ -1,0 +1,344 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Media_Splitter;
+use Elementor\Modules\Mcp\Abilities\Utils\Style_Variants_Merger;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Maps LLM CSS strings onto legacy V3 style settings; unmapped rules become custom_css.
+ */
+class V3_Style_Mapper {
+
+	const DESKTOP_BREAKPOINT = 'desktop';
+
+	private Css_Converter $css_converter;
+	private array $active_breakpoints;
+
+	public function __construct( Css_Converter $css_converter, array $active_breakpoints = [] ) {
+		$this->css_converter = $css_converter;
+		$this->active_breakpoints = $active_breakpoints;
+	}
+
+	/**
+	 * @param string $css_string
+	 * @param string $widget_type
+	 * @param array  $widget_config From Widget_Context_Helper::get_widget_config().
+	 * @return array{settings_patch: array<string, mixed>, unmapped_css: string, warnings: string[]}
+	 */
+	public function apply( string $css_string, string $widget_type, array $widget_config ): array {
+		$css_string = trim( $css_string );
+
+		if ( '' === $css_string ) {
+			return [
+				'settings_patch' => [],
+				'unmapped_css' => '',
+				'warnings' => [],
+			];
+		}
+
+		$overrides = V3_Widget_Bridge_Registry::get_style_overrides( $widget_type );
+		$generic_index = V3_Style_Settings_Index::build( $widget_config['controls'] ?? [], $overrides );
+
+		$split = ( new Css_Media_Splitter( $this->get_active_breakpoints() ) )->split( $css_string );
+		if ( null !== $split['error'] ) {
+			return [
+				'settings_patch' => [],
+				'unmapped_css' => $css_string,
+				'warnings' => [ $split['error'] ],
+			];
+		}
+
+		$settings_patch = [];
+		$unmapped = [];
+		$warnings = [];
+		$typography_buckets = [];
+
+		foreach ( $split['breakpoints'] as $breakpoint => $css ) {
+			if ( '' === trim( $css ) ) {
+				continue;
+			}
+
+			$parsed = $this->css_converter->parse_nested( $css );
+			if ( isset( $parsed['error'] ) ) {
+				$unmapped[] = $this->serialize_breakpoint_block( $breakpoint, $css );
+				$warnings[] = $parsed['error'];
+				continue;
+			}
+
+			foreach ( $parsed['blocks'] as $block ) {
+				$selector = $block['selector'] ?? null;
+				$block_css = $block['css'] ?? '';
+				$state = $this->normalize_state( $selector );
+
+				if ( null !== $selector && null === $state ) {
+					$unmapped[] = $this->serialize_nested_block( $breakpoint, $selector, $block_css );
+					continue;
+				}
+
+				foreach ( $this->parse_declarations( $block_css ) as $declaration ) {
+					$property = $declaration['property'];
+					$value = $declaration['value'];
+					$match_key = null === $state ? $property : $property . '@' . $state;
+
+					if ( isset( $overrides[ $match_key ] ) ) {
+						$override = $overrides[ $match_key ];
+
+						if ( isset( $override['typography_prefix'] ) ) {
+							$bucket_key = $breakpoint . '|' . ( $state ?? '' ) . '|' . $override['typography_prefix'];
+							$typography_buckets[ $bucket_key ]['prefix'] = $override['typography_prefix'];
+							$typography_buckets[ $bucket_key ]['breakpoint'] = $breakpoint;
+							$typography_buckets[ $bucket_key ]['responsive'] = ! empty( $override['responsive'] );
+							$typography_buckets[ $bucket_key ]['declarations'][ $property ] = $value;
+							continue;
+						}
+
+						$mapped = $this->apply_override( $override, $value, $breakpoint, $widget_config );
+						if ( null === $mapped ) {
+							$unmapped[] = $this->serialize_declaration( $breakpoint, $state, $property, $value );
+							continue;
+						}
+
+						$settings_patch = array_merge( $settings_patch, $mapped );
+						continue;
+					}
+
+					if ( isset( $generic_index[ $match_key ] ) ) {
+						$mapped = $this->apply_generic_rule( $generic_index[ $match_key ], $value, $breakpoint, $widget_config );
+						if ( null !== $mapped ) {
+							$settings_patch = array_merge( $settings_patch, $mapped );
+							continue;
+						}
+					}
+
+					$unmapped[] = $this->serialize_declaration( $breakpoint, $state, $property, $value );
+				}
+			}
+		}
+
+		foreach ( $typography_buckets as $bucket ) {
+			$group_patch = V3_Value_Resolvers::resolve_typography_group(
+				$bucket['declarations'],
+				$bucket['prefix']
+			);
+
+			if ( ! empty( $bucket['responsive'] ) && self::DESKTOP_BREAKPOINT !== $bucket['breakpoint'] ) {
+				$group_patch = $this->suffix_responsive_keys( $group_patch, $bucket['breakpoint'], $widget_config );
+			}
+
+			$settings_patch = array_merge( $settings_patch, $group_patch );
+		}
+
+		if ( ! empty( $split['custom_css'] ) ) {
+			$unmapped[] = trim( $split['custom_css'] );
+		}
+
+		return [
+			'settings_patch' => $settings_patch,
+			'unmapped_css' => $this->join_unmapped( $unmapped ),
+			'warnings' => $warnings,
+		];
+	}
+
+	/**
+	 * @param array<string, mixed> $override
+	 * @return array<string, mixed>|null
+	 */
+	private function apply_override( array $override, string $value, string $breakpoint, array $widget_config ): ?array {
+		if ( isset( $override['border_prefix'] ) ) {
+			$patch = V3_Value_Resolvers::resolve_border_shorthand( $value, $override['border_prefix'] );
+			return $patch;
+		}
+
+		if ( isset( $override['box_shadow_prefix'] ) ) {
+			$resolved = V3_Value_Resolvers::resolve_box_shadow( $value );
+			if ( null === $resolved ) {
+				return null;
+			}
+			$prefix = $override['box_shadow_prefix'];
+			return [
+				$prefix . '_box_shadow_type' => $resolved['box_shadow_type'],
+				$prefix . '_box_shadow' => $resolved['box_shadow'],
+			];
+		}
+
+		$resolver = $override['resolver'] ?? 'text';
+		$setting = $override['setting'] ?? null;
+		if ( ! is_string( $setting ) || '' === $setting ) {
+			return null;
+		}
+
+		$resolved = V3_Value_Resolvers::resolve( $resolver, $value );
+		if ( null === $resolved ) {
+			return null;
+		}
+
+		if ( 'box_shadow' === $resolver && is_array( $resolved ) ) {
+			return [
+				$setting . '_type' => $resolved['box_shadow_type'],
+				$setting => $resolved['box_shadow'],
+			];
+		}
+
+		$key = $setting;
+		if ( ! empty( $override['responsive'] ) && self::DESKTOP_BREAKPOINT !== $breakpoint ) {
+			$suffixed = $setting . '_' . $breakpoint;
+			if ( $this->control_exists( $widget_config, $suffixed ) ) {
+				$key = $suffixed;
+			} elseif ( $this->control_exists( $widget_config, $setting ) ) {
+				return null;
+			} else {
+				$key = $suffixed;
+			}
+		}
+
+		return [ $key => $resolved ];
+	}
+
+	/**
+	 * @param array{setting: string, resolver: string, responsive: bool} $rule
+	 * @return array<string, mixed>|null
+	 */
+	private function apply_generic_rule( array $rule, string $value, string $breakpoint, array $widget_config ): ?array {
+		$resolved = V3_Value_Resolvers::resolve( $rule['resolver'], $value );
+		if ( null === $resolved ) {
+			return null;
+		}
+
+		$key = $rule['setting'];
+		if ( self::DESKTOP_BREAKPOINT !== $breakpoint ) {
+			$suffixed = $key . '_' . $breakpoint;
+			if ( $this->control_exists( $widget_config, $suffixed ) ) {
+				$key = $suffixed;
+			} elseif ( empty( $rule['responsive'] ) ) {
+				return null;
+			} else {
+				return null;
+			}
+		}
+
+		return [ $key => $resolved ];
+	}
+
+	/**
+	 * @param array<string, mixed> $patch
+	 * @return array<string, mixed>
+	 */
+	private function suffix_responsive_keys( array $patch, string $breakpoint, array $widget_config ): array {
+		$suffixed = [];
+
+		foreach ( $patch as $key => $value ) {
+			if ( str_ends_with( (string) $key, '_typography' ) ) {
+				$suffixed[ $key ] = $value;
+				continue;
+			}
+
+			$candidate = $key . '_' . $breakpoint;
+			if ( $this->control_exists( $widget_config, $candidate ) ) {
+				$suffixed[ $candidate ] = $value;
+				continue;
+			}
+
+			$suffixed[ $key ] = $value;
+		}
+
+		return $suffixed;
+	}
+
+	private function control_exists( array $widget_config, string $key ): bool {
+		$controls = $widget_config['controls'] ?? [];
+
+		return is_array( $controls ) && array_key_exists( $key, $controls );
+	}
+
+	private function normalize_state( $selector ): ?string {
+		if ( null === $selector || '' === $selector ) {
+			return null;
+		}
+
+		$state = strtolower( ltrim( (string) $selector, ':' ) );
+
+		return in_array( $state, Style_Variants_Merger::PSEUDO_STATES, true ) ? $state : null;
+	}
+
+	/**
+	 * @return array<int, array{property: string, value: string}>
+	 */
+	private function parse_declarations( string $css ): array {
+		$rules = [];
+
+		foreach ( explode( ';', $css ) as $declaration ) {
+			$declaration = trim( $declaration );
+			$separator = strpos( $declaration, ':' );
+
+			if ( false === $separator ) {
+				continue;
+			}
+
+			$property = strtolower( trim( substr( $declaration, 0, $separator ) ) );
+			$value = trim( substr( $declaration, $separator + 1 ) );
+
+			if ( '' === $property || '' === $value || 'null' === $value ) {
+				continue;
+			}
+
+			$rules[] = [
+				'property' => $property,
+				'value' => $value,
+			];
+		}
+
+		return $rules;
+	}
+
+	private function serialize_declaration( string $breakpoint, ?string $state, string $property, string $value ): string {
+		$decl = $property . ': ' . $value . ';';
+
+		if ( null !== $state ) {
+			$decl = '&:' . $state . ' { ' . $decl . ' }';
+		}
+
+		return $this->serialize_breakpoint_block( $breakpoint, $decl );
+	}
+
+	private function serialize_nested_block( string $breakpoint, string $selector, string $css ): string {
+		$inner = '&' . $selector . ' { ' . trim( $css ) . ' }';
+
+		return $this->serialize_breakpoint_block( $breakpoint, $inner );
+	}
+
+	private function serialize_breakpoint_block( string $breakpoint, string $css ): string {
+		$css = trim( $css );
+		if ( '' === $css ) {
+			return '';
+		}
+
+		if ( self::DESKTOP_BREAKPOINT === $breakpoint ) {
+			return $css;
+		}
+
+		return '@media(--' . $breakpoint . ') { ' . $css . ' }';
+	}
+
+	/**
+	 * @param string[] $parts
+	 */
+	private function join_unmapped( array $parts ): string {
+		$parts = array_values( array_filter( array_map( 'trim', $parts ) ) );
+
+		return implode( ' ', $parts );
+	}
+
+	private function get_active_breakpoints(): array {
+		if ( ! empty( $this->active_breakpoints ) ) {
+			return $this->active_breakpoints;
+		}
+
+		return [ self::DESKTOP_BREAKPOINT ];
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/v3-style-serializer.php
+++ b/modules/mcp/abilities/appliers/v3/v3-style-serializer.php
@@ -1,0 +1,347 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Serializes a V3 widget's flat style settings back into a CSS string that
+ * V3_Style_Mapper can consume. Reverse of V3_Style_Mapper.
+ *
+ * The output is grouped by breakpoint / pseudo-state to match what the write path
+ * expects: base declarations, then `&:hover|focus|active { ... }`, then
+ * `@media(--breakpoint) { ... }` blocks with the same nesting inside.
+ */
+class V3_Style_Serializer {
+
+	const RESPONSIVE_SUFFIXES = [
+		'_tablet' => 'tablet',
+		'_mobile' => 'mobile',
+	];
+
+	const TYPOGRAPHY_PROPERTIES = [
+		'font-family' => 'font_family',
+		'font-weight' => 'font_weight',
+		'font-style' => 'font_style',
+		'text-transform' => 'text_transform',
+		'text-decoration' => 'text_decoration',
+		'font-size' => 'font_size',
+		'line-height' => 'line_height',
+		'letter-spacing' => 'letter_spacing',
+		'word-spacing' => 'word_spacing',
+	];
+
+	const TYPOGRAPHY_DIMENSION_PROPERTIES = [ 'font-size', 'line-height', 'letter-spacing', 'word-spacing' ];
+
+	const DEFAULT_BREAKPOINT = 'desktop';
+
+	public function serialize( array $settings, string $widget_type, array $widget_config ): string {
+		$overrides = V3_Widget_Bridge_Registry::get_style_overrides( $widget_type );
+		$controls = $widget_config['controls'] ?? [];
+		$generic = V3_Style_Settings_Index::build( is_array( $controls ) ? $controls : [], $overrides );
+
+		$blocks = [];
+
+		foreach ( $overrides as $match_key => $override ) {
+			[ $property, $state ] = $this->split_match_key( (string) $match_key );
+			$this->emit_override( $blocks, $settings, $property, $state, $override );
+		}
+
+		foreach ( $generic as $match_key => $rule ) {
+			[ $property, $state ] = $this->split_match_key( (string) $match_key );
+			$this->emit_simple( $blocks, $settings, $property, $state, (string) $rule['setting'], (string) $rule['resolver'], ! empty( $rule['responsive'] ) );
+		}
+
+		return $this->render_blocks( $blocks );
+	}
+
+	private function emit_override( array &$blocks, array $settings, string $property, ?string $state, array $override ): void {
+		if ( isset( $override['typography_prefix'] ) ) {
+			$this->emit_typography( $blocks, $settings, $property, $state, (string) $override['typography_prefix'], ! empty( $override['responsive'] ) );
+			return;
+		}
+
+		if ( isset( $override['border_prefix'] ) ) {
+			$this->emit_border( $blocks, $settings, $state, (string) $override['border_prefix'], ! empty( $override['responsive'] ) );
+			return;
+		}
+
+		if ( isset( $override['box_shadow_prefix'] ) ) {
+			$this->emit_box_shadow( $blocks, $settings, $state, (string) $override['box_shadow_prefix'] );
+			return;
+		}
+
+		if ( isset( $override['setting'], $override['resolver'] ) ) {
+			$this->emit_simple( $blocks, $settings, $property, $state, (string) $override['setting'], (string) $override['resolver'], ! empty( $override['responsive'] ) );
+		}
+	}
+
+	private function emit_simple( array &$blocks, array $settings, string $property, ?string $state, string $setting_key, string $resolver, bool $responsive ): void {
+		$this->emit_setting_at_breakpoint( $blocks, $settings, $property, $state, $setting_key, $resolver, self::DEFAULT_BREAKPOINT );
+
+		if ( ! $responsive ) {
+			return;
+		}
+
+		foreach ( self::RESPONSIVE_SUFFIXES as $suffix => $breakpoint ) {
+			$this->emit_setting_at_breakpoint( $blocks, $settings, $property, $state, $setting_key . $suffix, $resolver, $breakpoint );
+		}
+	}
+
+	private function emit_setting_at_breakpoint( array &$blocks, array $settings, string $property, ?string $state, string $setting_key, string $resolver, string $breakpoint ): void {
+		if ( ! array_key_exists( $setting_key, $settings ) ) {
+			return;
+		}
+
+		$css_value = $this->format_value( $resolver, $settings[ $setting_key ] );
+		if ( null === $css_value ) {
+			return;
+		}
+
+		$this->push( $blocks, $breakpoint, $state, $property, $css_value );
+	}
+
+	private function emit_typography( array &$blocks, array $settings, string $property, ?string $state, string $prefix, bool $responsive ): void {
+		$suffix = self::TYPOGRAPHY_PROPERTIES[ $property ] ?? null;
+		if ( null === $suffix ) {
+			return;
+		}
+
+		$is_dimension = in_array( $property, self::TYPOGRAPHY_DIMENSION_PROPERTIES, true );
+		$resolver = $is_dimension ? 'dimension' : 'text';
+		$setting_key = $prefix . '_' . $suffix;
+
+		$this->emit_setting_at_breakpoint( $blocks, $settings, $property, $state, $setting_key, $resolver, self::DEFAULT_BREAKPOINT );
+
+		if ( ! $responsive ) {
+			return;
+		}
+
+		foreach ( self::RESPONSIVE_SUFFIXES as $sfx => $breakpoint ) {
+			$this->emit_setting_at_breakpoint( $blocks, $settings, $property, $state, $setting_key . $sfx, $resolver, $breakpoint );
+		}
+	}
+
+	private function emit_border( array &$blocks, array $settings, ?string $state, string $prefix, bool $responsive ): void {
+		$style = $settings[ $prefix . '_border' ] ?? null;
+		if ( ! is_string( $style ) || '' === $style ) {
+			return;
+		}
+
+		$width_value = $this->format_value( 'sides', $settings[ $prefix . '_width' ] ?? null );
+		$color_value = $this->format_value( 'color', $settings[ $prefix . '_color' ] ?? null );
+
+		$parts = [];
+		if ( null !== $width_value ) {
+			$parts[] = $width_value;
+		}
+		$parts[] = $style;
+		if ( null !== $color_value ) {
+			$parts[] = $color_value;
+		}
+
+		$this->push( $blocks, self::DEFAULT_BREAKPOINT, $state, 'border', implode( ' ', $parts ) );
+
+		if ( ! $responsive ) {
+			return;
+		}
+
+		foreach ( self::RESPONSIVE_SUFFIXES as $suffix => $breakpoint ) {
+			$responsive_width = $this->format_value( 'sides', $settings[ $prefix . '_width' . $suffix ] ?? null );
+			if ( null === $responsive_width ) {
+				continue;
+			}
+			$this->push( $blocks, $breakpoint, $state, 'border-width', $responsive_width );
+		}
+	}
+
+	private function emit_box_shadow( array &$blocks, array $settings, ?string $state, string $prefix ): void {
+		$type = $settings[ $prefix . '_box_shadow_type' ] ?? null;
+		$shadow = $settings[ $prefix . '_box_shadow' ] ?? null;
+		if ( 'yes' !== $type || ! is_array( $shadow ) ) {
+			return;
+		}
+
+		$parts = [
+			$this->format_size( $shadow['horizontal'] ?? 0 ),
+			$this->format_size( $shadow['vertical'] ?? 0 ),
+			$this->format_size( $shadow['blur'] ?? 0 ),
+			$this->format_size( $shadow['spread'] ?? 0 ),
+		];
+		if ( isset( $shadow['color'] ) && '' !== $shadow['color'] ) {
+			$parts[] = $shadow['color'];
+		}
+		if ( isset( $shadow['position'] ) && 'inset' === $shadow['position'] ) {
+			array_unshift( $parts, 'inset' );
+		}
+
+		$this->push( $blocks, self::DEFAULT_BREAKPOINT, $state, 'box-shadow', implode( ' ', $parts ) );
+	}
+
+	/**
+	 * @param string $resolver Resolver name from V3_Value_Resolvers::resolve.
+	 * @param mixed  $value    Raw setting value.
+	 * @return string|null
+	 */
+	private function format_value( string $resolver, $value ): ?string {
+		if ( null === $value || '' === $value ) {
+			return null;
+		}
+
+		switch ( $resolver ) {
+			case 'text':
+			case 'color':
+				return is_scalar( $value ) ? (string) $value : null;
+
+			case 'dimension':
+			case 'slider':
+				return $this->format_dimension( $value );
+
+			case 'sides':
+				return $this->format_sides( $value );
+
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * @param mixed $value
+	 */
+	private function format_dimension( $value ): ?string {
+		if ( ! is_array( $value ) || ! array_key_exists( 'size', $value ) ) {
+			return null;
+		}
+
+		if ( '' === $value['size'] || null === $value['size'] ) {
+			return null;
+		}
+
+		return $this->format_size( $value['size'] ) . ( isset( $value['unit'] ) && 'px' !== $value['unit'] ? $value['unit'] : 'px' );
+	}
+
+	/**
+	 * @param mixed $value
+	 */
+	private function format_sides( $value ): ?string {
+		if ( ! is_array( $value ) ) {
+			return null;
+		}
+
+		$sides = [ 'top', 'right', 'bottom', 'left' ];
+		foreach ( $sides as $side ) {
+			if ( ! array_key_exists( $side, $value ) || '' === $value[ $side ] || null === $value[ $side ] ) {
+				return null;
+			}
+		}
+
+		$unit = isset( $value['unit'] ) && '' !== $value['unit'] ? $value['unit'] : 'px';
+		$top = $this->format_size( $value['top'] );
+		$right = $this->format_size( $value['right'] );
+		$bottom = $this->format_size( $value['bottom'] );
+		$left = $this->format_size( $value['left'] );
+
+		if ( ! empty( $value['isLinked'] ) && $top === $right && $right === $bottom && $bottom === $left ) {
+			return $top . $unit;
+		}
+
+		return sprintf( '%s%s %s%s %s%s %s%s', $top, $unit, $right, $unit, $bottom, $unit, $left, $unit );
+	}
+
+	/**
+	 * @param mixed $size
+	 */
+	private function format_size( $size ): string {
+		if ( is_int( $size ) ) {
+			return (string) $size;
+		}
+
+		if ( is_float( $size ) ) {
+			return rtrim( rtrim( sprintf( '%.4f', $size ), '0' ), '.' );
+		}
+
+		if ( is_string( $size ) && '' !== $size ) {
+			return $size;
+		}
+
+		return '0';
+	}
+
+	/**
+	 * @return array{0: string, 1: string|null}
+	 */
+	private function split_match_key( string $match_key ): array {
+		if ( false === strpos( $match_key, '@' ) ) {
+			return [ $match_key, null ];
+		}
+
+		[ $property, $state ] = explode( '@', $match_key, 2 );
+
+		return [ $property, '' === $state ? null : $state ];
+	}
+
+	private function push( array &$blocks, string $breakpoint, ?string $state, string $property, string $value ): void {
+		$state_key = $state ?? '';
+		$blocks[ $breakpoint ][ $state_key ][ $property ] = $value;
+	}
+
+	/**
+	 * @param array<string, array<string, array<string, string>>> $blocks
+	 */
+	private function render_blocks( array $blocks ): string {
+		$parts = [];
+
+		$default = $blocks[ self::DEFAULT_BREAKPOINT ] ?? [];
+		unset( $blocks[ self::DEFAULT_BREAKPOINT ] );
+
+		$rendered_default = $this->render_state_group( $default );
+		if ( '' !== $rendered_default ) {
+			$parts[] = $rendered_default;
+		}
+
+		foreach ( $blocks as $breakpoint => $state_group ) {
+			$rendered = $this->render_state_group( $state_group );
+			if ( '' === $rendered ) {
+				continue;
+			}
+			$parts[] = sprintf( '@media(--%s) { %s }', $breakpoint, $rendered );
+		}
+
+		return implode( ' ', $parts );
+	}
+
+	/**
+	 * @param array<string, array<string, string>> $state_group
+	 */
+	private function render_state_group( array $state_group ): string {
+		$parts = [];
+
+		$base = $state_group[''] ?? [];
+		unset( $state_group[''] );
+		if ( ! empty( $base ) ) {
+			$parts[] = $this->render_declarations( $base );
+		}
+
+		foreach ( $state_group as $state => $declarations ) {
+			if ( empty( $declarations ) ) {
+				continue;
+			}
+			$parts[] = sprintf( '&:%s { %s }', $state, $this->render_declarations( $declarations ) );
+		}
+
+		return implode( ' ', $parts );
+	}
+
+	/**
+	 * @param array<string, string> $declarations
+	 */
+	private function render_declarations( array $declarations ): string {
+		$parts = [];
+		foreach ( $declarations as $property => $value ) {
+			$parts[] = sprintf( '%s: %s;', $property, $value );
+		}
+		return implode( ' ', $parts );
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/v3-style-serializer.php
+++ b/modules/mcp/abilities/appliers/v3/v3-style-serializer.php
@@ -54,7 +54,38 @@ class V3_Style_Serializer {
 			$this->emit_simple( $blocks, $settings, $property, $state, (string) $rule['setting'], (string) $rule['resolver'], ! empty( $rule['responsive'] ) );
 		}
 
-		return $this->render_blocks( $blocks );
+		$mapped_css = $this->render_blocks( $blocks );
+		$custom_css = $this->unwrap_custom_css( $settings['custom_css'] ?? null );
+
+		if ( '' === $mapped_css ) {
+			return $custom_css;
+		}
+
+		if ( '' === $custom_css ) {
+			return $mapped_css;
+		}
+
+		return $mapped_css . ' ' . $custom_css;
+	}
+
+	/**
+	 * @param mixed $custom_css
+	 */
+	private function unwrap_custom_css( $custom_css ): string {
+		if ( ! is_string( $custom_css ) ) {
+			return '';
+		}
+
+		$custom_css = trim( $custom_css );
+		if ( '' === $custom_css ) {
+			return '';
+		}
+
+		if ( preg_match( '/^\s*selector\s*\{\s*([\s\S]*?)\s*\}\s*$/i', $custom_css, $matches ) ) {
+			return trim( $matches[1] );
+		}
+
+		return $custom_css;
 	}
 
 	private function emit_override( array &$blocks, array $settings, string $property, ?string $state, array $override ): void {
@@ -153,7 +184,13 @@ class V3_Style_Serializer {
 			if ( null === $responsive_width ) {
 				continue;
 			}
-			$this->push( $blocks, $breakpoint, $state, 'border-width', $responsive_width );
+
+			$parts = [ $responsive_width, $style ];
+			if ( null !== $color_value ) {
+				$parts[] = $color_value;
+			}
+
+			$this->push( $blocks, $breakpoint, $state, 'border', implode( ' ', $parts ) );
 		}
 	}
 

--- a/modules/mcp/abilities/appliers/v3/v3-style-settings-index.php
+++ b/modules/mcp/abilities/appliers/v3/v3-style-settings-index.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Indexes a V3 widget's controls for generic CSS-property → setting reverse lookup.
+ *
+ * Only considers simple selector-backed controls (not Group_Control_* siblings).
+ * Group controls are handled exclusively via registry style_overrides.
+ */
+class V3_Style_Settings_Index {
+
+	const GROUP_CONTROL_PREFIXES = [
+		'typography_',
+		'text_stroke_',
+		'text_shadow_',
+		'box_shadow_',
+		'border_',
+		'background_',
+		'css_filters_',
+		'image_border_',
+		'image_box_shadow_',
+		'caption_typography_',
+		'caption_text_shadow_',
+		'menu_typography_',
+		'dropdown_typography_',
+		'dropdown_border_',
+		'dropdown_box_shadow_',
+		'dropdown_divider_',
+	];
+
+	/**
+	 * @param array                $controls Widget controls from get_config()['controls'].
+	 * @param array<string, array> $style_overrides Registry overrides (excluded from generic index).
+	 * @return array<string, array{setting: string, resolver: string, responsive: bool}>
+	 *         Keyed by "property" or "property@state". Only unique matches are kept.
+	 */
+	public static function build( array $controls, array $style_overrides = [] ): array {
+		$candidates = [];
+
+		foreach ( $controls as $setting_key => $control ) {
+			if ( ! is_array( $control ) || ! is_string( $setting_key ) ) {
+				continue;
+			}
+
+			if ( self::is_group_control_key( $setting_key ) ) {
+				continue;
+			}
+
+			$selectors = $control['selectors'] ?? null;
+			if ( ! is_array( $selectors ) || empty( $selectors ) ) {
+				continue;
+			}
+
+			foreach ( $selectors as $selector_template => $css_template ) {
+				if ( ! is_string( $selector_template ) || ! is_string( $css_template ) ) {
+					continue;
+				}
+
+				$property = self::extract_css_property( $css_template );
+				if ( null === $property ) {
+					continue;
+				}
+
+				$state = self::extract_pseudo_state( $selector_template );
+				$match_key = null === $state ? $property : $property . '@' . $state;
+
+				if ( isset( $style_overrides[ $match_key ] ) ) {
+					continue;
+				}
+
+				$candidates[ $match_key ][] = [
+					'setting' => $setting_key,
+					'resolver' => self::infer_resolver( $control, $property ),
+					'responsive' => isset( $controls[ $setting_key . '_tablet' ] ) || isset( $controls[ $setting_key . '_mobile' ] ),
+				];
+			}
+		}
+
+		$index = [];
+		foreach ( $candidates as $match_key => $matches ) {
+			if ( 1 !== count( $matches ) ) {
+				continue;
+			}
+			$index[ $match_key ] = $matches[0];
+		}
+
+		return $index;
+	}
+
+	private static function is_group_control_key( string $setting_key ): bool {
+		foreach ( self::GROUP_CONTROL_PREFIXES as $prefix ) {
+			if ( str_starts_with( $setting_key, $prefix ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static function extract_css_property( string $css_template ): ?string {
+		if ( ! preg_match( '/^\s*([a-zA-Z-]+)\s*:/', $css_template, $matches ) ) {
+			return null;
+		}
+
+		return strtolower( $matches[1] );
+	}
+
+	private static function extract_pseudo_state( string $selector_template ): ?string {
+		if ( preg_match( '/:(hover|focus|active)\b/i', $selector_template, $matches ) ) {
+			return strtolower( $matches[1] );
+		}
+
+		return null;
+	}
+
+	private static function infer_resolver( array $control, string $property ): string {
+		$type = $control['type'] ?? null;
+
+		if ( 'color' === $type || str_ends_with( $property, 'color' ) || 'fill' === $property ) {
+			return 'color';
+		}
+
+		if ( in_array( $property, [ 'padding', 'margin', 'border-radius' ], true ) ) {
+			return 'sides';
+		}
+
+		if ( in_array( $type, [ 'slider', 'dimensions' ], true ) ) {
+			return 'dimensions' === $type ? 'sides' : 'dimension';
+		}
+
+		if ( in_array( $property, [ 'width', 'height', 'max-width', 'min-height', 'font-size', 'line-height', 'letter-spacing', 'word-spacing', 'opacity', 'top', 'right', 'bottom', 'left' ], true ) ) {
+			return 'dimension';
+		}
+
+		if ( 'box-shadow' === $property ) {
+			return 'box_shadow';
+		}
+
+		if ( 'border' === $property ) {
+			return 'border';
+		}
+
+		return 'text';
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/v3-value-resolvers.php
+++ b/modules/mcp/abilities/appliers/v3/v3-value-resolvers.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Pure functions that turn CSS values into legacy V3 control value shapes.
+ */
+class V3_Value_Resolvers {
+
+	const DEFAULT_UNIT = 'px';
+
+	/**
+	 * @return array{unit: string, size: float}|null
+	 */
+	public static function resolve_dimension( string $css_value ): ?array {
+		$parsed = self::parse_length( trim( $css_value ) );
+
+		if ( null === $parsed ) {
+			return null;
+		}
+
+		return [
+			'unit' => $parsed['unit'],
+			'size' => $parsed['size'],
+		];
+	}
+
+	/**
+	 * Parses padding/margin/border-radius shorthand into Elementor dimensions shape.
+	 *
+	 * @return array{top: string, right: string, bottom: string, left: string, unit: string, isLinked: bool}|null
+	 */
+	public static function resolve_sides_shorthand( string $css_value ): ?array {
+		$tokens = self::tokenize_css_values( trim( $css_value ) );
+
+		if ( empty( $tokens ) || count( $tokens ) > 4 ) {
+			return null;
+		}
+
+		$parsed = [];
+		foreach ( $tokens as $token ) {
+			$length = self::parse_length( $token );
+			if ( null === $length ) {
+				return null;
+			}
+			$parsed[] = $length;
+		}
+
+		$unit = $parsed[0]['unit'];
+		foreach ( $parsed as $item ) {
+			if ( $item['unit'] !== $unit ) {
+				return null;
+			}
+		}
+
+		$sizes = array_column( $parsed, 'size' );
+		$count = count( $sizes );
+
+		if ( 1 === $count ) {
+			$top = $right = $bottom = $left = $sizes[0];
+		} elseif ( 2 === $count ) {
+			$top = $bottom = $sizes[0];
+			$right = $left = $sizes[1];
+		} elseif ( 3 === $count ) {
+			$top = $sizes[0];
+			$right = $left = $sizes[1];
+			$bottom = $sizes[2];
+		} else {
+			[ $top, $right, $bottom, $left ] = $sizes;
+		}
+
+		$linked = $top === $right && $right === $bottom && $bottom === $left;
+
+		return [
+			'top' => (string) $top,
+			'right' => (string) $right,
+			'bottom' => (string) $bottom,
+			'left' => (string) $left,
+			'unit' => $unit,
+			'isLinked' => $linked,
+		];
+	}
+
+	public static function resolve_color( string $css_value ): string {
+		return trim( $css_value );
+	}
+
+	/**
+	 * Parses a single box-shadow declaration into Elementor's box_shadow control shape.
+	 *
+	 * @return array{box_shadow_type: string, box_shadow: array}|null
+	 */
+	public static function resolve_box_shadow( string $css_value ): ?array {
+		$value = trim( $css_value );
+
+		if ( '' === $value || 'none' === strtolower( $value ) ) {
+			return [
+				'box_shadow_type' => '',
+				'box_shadow' => [
+					'horizontal' => 0,
+					'vertical' => 0,
+					'blur' => 0,
+					'spread' => 0,
+					'color' => 'rgba(0,0,0,0.5)',
+				],
+			];
+		}
+
+		$position = 'outline';
+		if ( preg_match( '/\binset\b/i', $value ) ) {
+			$position = 'inset';
+			$value = trim( preg_replace( '/\binset\b/i', '', $value ) );
+		}
+
+		$color = null;
+		if ( preg_match( '/^(rgba?\([^)]+\)|hsla?\([^)]+\)|#[0-9a-fA-F]{3,8}|[a-zA-Z]+)\s+(.+)$/', $value, $matches ) ) {
+			$color = $matches[1];
+			$value = trim( $matches[2] );
+		} elseif ( preg_match( '/^(.+?)\s+(rgba?\([^)]+\)|hsla?\([^)]+\)|#[0-9a-fA-F]{3,8}|[a-zA-Z]+)$/', $value, $matches ) ) {
+			$value = trim( $matches[1] );
+			$color = $matches[2];
+		}
+
+		$lengths = self::tokenize_css_values( $value );
+		if ( count( $lengths ) < 2 || count( $lengths ) > 4 ) {
+			return null;
+		}
+
+		$parsed_lengths = [];
+		foreach ( $lengths as $token ) {
+			$length = self::parse_length( $token );
+			if ( null === $length ) {
+				return null;
+			}
+			$parsed_lengths[] = $length['size'];
+		}
+
+		return [
+			'box_shadow_type' => 'yes',
+			'box_shadow' => [
+				'horizontal' => $parsed_lengths[0],
+				'vertical' => $parsed_lengths[1],
+				'blur' => $parsed_lengths[2] ?? 0,
+				'spread' => $parsed_lengths[3] ?? 0,
+				'color' => $color ?? 'rgba(0,0,0,0.5)',
+				'position' => $position,
+			],
+		];
+	}
+
+	/**
+	 * Spreads typography-related CSS properties into legacy typography_* keys and
+	 * forces the group toggle to `custom`.
+	 *
+	 * @param array<string, string> $declarations property => css value
+	 * @param string                $prefix       Control group prefix, e.g. `typography` or `menu_typography`.
+	 * @return array<string, mixed>
+	 */
+	public static function resolve_typography_group( array $declarations, string $prefix = 'typography' ): array {
+		$patch = [
+			$prefix . '_typography' => 'custom',
+		];
+
+		$map = [
+			'font-family' => $prefix . '_font_family',
+			'font-weight' => $prefix . '_font_weight',
+			'text-transform' => $prefix . '_text_transform',
+			'font-style' => $prefix . '_font_style',
+			'text-decoration' => $prefix . '_text_decoration',
+			'line-height' => $prefix . '_line_height',
+			'letter-spacing' => $prefix . '_letter_spacing',
+			'word-spacing' => $prefix . '_word_spacing',
+			'font-size' => $prefix . '_font_size',
+		];
+
+		foreach ( $declarations as $property => $value ) {
+			$key = $map[ $property ] ?? null;
+			if ( null === $key ) {
+				continue;
+			}
+
+			if ( in_array( $property, [ 'font-size', 'line-height', 'letter-spacing', 'word-spacing' ], true ) ) {
+				$dimension = self::resolve_dimension( $value );
+				if ( null !== $dimension ) {
+					$patch[ $key ] = $dimension;
+				}
+				continue;
+			}
+
+			$patch[ $key ] = trim( $value );
+		}
+
+		return $patch;
+	}
+
+	/**
+	 * Parses `border: WIDTH STYLE COLOR` into Elementor border group keys.
+	 *
+	 * @param string $css_value
+	 * @param string $prefix    e.g. `border` or `image_border` or `dropdown_border`.
+	 * @return array<string, mixed>|null
+	 */
+	public static function resolve_border_shorthand( string $css_value, string $prefix = 'border' ): ?array {
+		$value = trim( $css_value );
+
+		if ( '' === $value || 'none' === strtolower( $value ) ) {
+			return [
+				$prefix . '_border' => '',
+			];
+		}
+
+		$style = null;
+		$styles = [ 'solid', 'dashed', 'dotted', 'double', 'groove', 'ridge', 'inset', 'outset', 'none', 'hidden' ];
+		foreach ( $styles as $candidate ) {
+			if ( preg_match( '/\b' . preg_quote( $candidate, '/' ) . '\b/i', $value ) ) {
+				$style = strtolower( $candidate );
+				$value = trim( preg_replace( '/\b' . preg_quote( $candidate, '/' ) . '\b/i', '', $value ) );
+				break;
+			}
+		}
+
+		$color = null;
+		if ( preg_match( '/(rgba?\([^)]+\)|hsla?\([^)]+\)|#[0-9a-fA-F]{3,8}|[a-zA-Z]+)$/', $value, $matches ) ) {
+			$color = $matches[1];
+			$value = trim( substr( $value, 0, -strlen( $color ) ) );
+		}
+
+		$width = null;
+		$tokens = self::tokenize_css_values( $value );
+		if ( ! empty( $tokens ) ) {
+			$width = self::resolve_sides_shorthand( implode( ' ', $tokens ) );
+		}
+
+		$patch = [
+			$prefix . '_border' => $style ?? 'solid',
+		];
+
+		if ( null !== $width ) {
+			$patch[ $prefix . '_width' ] = $width;
+		}
+
+		if ( null !== $color ) {
+			$patch[ $prefix . '_color' ] = $color;
+		}
+
+		return $patch;
+	}
+
+	/**
+	 * Dispatches a named resolver against a CSS value.
+	 *
+	 * @param string               $resolver_name One of: color, dimension, sides, box_shadow, border, text, slider.
+	 * @param string               $css_value
+	 * @param array<string, mixed> $args          Extra args (prefix for border/typography).
+	 * @return mixed|null
+	 */
+	public static function resolve( string $resolver_name, string $css_value, array $args = [] ) {
+		switch ( $resolver_name ) {
+			case 'color':
+				return self::resolve_color( $css_value );
+			case 'dimension':
+				return self::resolve_dimension( $css_value );
+			case 'sides':
+				return self::resolve_sides_shorthand( $css_value );
+			case 'box_shadow':
+				return self::resolve_box_shadow( $css_value );
+			case 'border':
+				return self::resolve_border_shorthand( $css_value, $args['prefix'] ?? 'border' );
+			case 'slider':
+				$dimension = self::resolve_dimension( $css_value );
+				return null === $dimension ? null : $dimension;
+			case 'text':
+				return trim( $css_value );
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * @return array{size: float, unit: string}|null
+	 */
+	private static function parse_length( string $token ): ?array {
+		$token = trim( $token );
+
+		if ( '' === $token ) {
+			return null;
+		}
+
+		if ( '0' === $token ) {
+			return [
+				'size' => 0.0,
+				'unit' => self::DEFAULT_UNIT,
+			];
+		}
+
+		if ( ! preg_match( '/^(-?\d*\.?\d+)(px|em|rem|%|vh|vw|vmin|vmax)?$/i', $token, $matches ) ) {
+			return null;
+		}
+
+		return [
+			'size' => (float) $matches[1],
+			'unit' => strtolower( $matches[2] ?? self::DEFAULT_UNIT ),
+		];
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private static function tokenize_css_values( string $value ): array {
+		if ( '' === $value ) {
+			return [];
+		}
+
+		preg_match_all( '/(?:rgba?\([^)]+\)|hsla?\([^)]+\)|[^\s]+)/', $value, $matches );
+
+		return $matches[0] ?? [];
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/v3-value-resolvers.php
+++ b/modules/mcp/abilities/appliers/v3/v3-value-resolvers.php
@@ -61,13 +61,19 @@ class V3_Value_Resolvers {
 		$count = count( $sizes );
 
 		if ( 1 === $count ) {
-			$top = $right = $bottom = $left = $sizes[0];
+			$top = $sizes[0];
+			$right = $sizes[0];
+			$bottom = $sizes[0];
+			$left = $sizes[0];
 		} elseif ( 2 === $count ) {
-			$top = $bottom = $sizes[0];
-			$right = $left = $sizes[1];
+			$top = $sizes[0];
+			$bottom = $sizes[0];
+			$right = $sizes[1];
+			$left = $sizes[1];
 		} elseif ( 3 === $count ) {
 			$top = $sizes[0];
-			$right = $left = $sizes[1];
+			$right = $sizes[1];
+			$left = $sizes[1];
 			$bottom = $sizes[2];
 		} else {
 			[ $top, $right, $bottom, $left ] = $sizes;

--- a/modules/mcp/abilities/appliers/v3/v3-value-resolvers.php
+++ b/modules/mcp/abilities/appliers/v3/v3-value-resolvers.php
@@ -189,6 +189,13 @@ class V3_Value_Resolvers {
 				continue;
 			}
 
+			if ( 'font-family' === $property ) {
+				$value = self::normalize_font_family( $value );
+				if ( '' === $value ) {
+					continue;
+				}
+			}
+
 			$patch[ $key ] = trim( $value );
 		}
 
@@ -309,6 +316,22 @@ class V3_Value_Resolvers {
 			'size' => (float) $matches[1],
 			'unit' => strtolower( $matches[2] ?? self::DEFAULT_UNIT ),
 		];
+	}
+
+	/**
+	 * V3 typography controls accept a single named font; CSS stacks are reduced to the first family.
+	 */
+	private static function normalize_font_family( string $value ): string {
+		$first = trim( explode( ',', $value, 2 )[0] );
+
+		if (
+			( str_starts_with( $first, '"' ) && str_ends_with( $first, '"' ) )
+			|| ( str_starts_with( $first, "'" ) && str_ends_with( $first, "'" ) )
+		) {
+			$first = substr( $first, 1, -1 );
+		}
+
+		return trim( $first );
 	}
 
 	/**

--- a/modules/mcp/abilities/appliers/v3/v3-value-resolvers.php
+++ b/modules/mcp/abilities/appliers/v3/v3-value-resolvers.php
@@ -161,9 +161,7 @@ class V3_Value_Resolvers {
 	 * @return array<string, mixed>
 	 */
 	public static function resolve_typography_group( array $declarations, string $prefix = 'typography' ): array {
-		$patch = [
-			$prefix . '_typography' => 'custom',
-		];
+		$patch = [];
 
 		$map = [
 			'font-family' => $prefix . '_font_family',
@@ -193,6 +191,12 @@ class V3_Value_Resolvers {
 
 			$patch[ $key ] = trim( $value );
 		}
+
+		if ( empty( $patch ) ) {
+			return [];
+		}
+
+		$patch[ $prefix . '_typography' ] = 'custom';
 
 		return $patch;
 	}

--- a/modules/mcp/abilities/appliers/v3/v3-widget-bridge-registry.php
+++ b/modules/mcp/abilities/appliers/v3/v3-widget-bridge-registry.php
@@ -101,15 +101,46 @@ class V3_Widget_Bridge_Registry {
 				self::typography_overrides( 'dropdown_typography' ),
 				self::typography_overrides( 'menu_typography' ),
 				[
-					'color' => [ 'setting' => 'color_menu_item', 'resolver' => 'color' ],
-					'color@hover' => [ 'setting' => 'color_menu_item_hover', 'resolver' => 'color' ],
-					'color@active' => [ 'setting' => 'color_menu_item_active', 'resolver' => 'color' ],
-					'background-color@hover' => [ 'setting' => 'pointer_color_menu_item_hover', 'resolver' => 'color' ],
-					'background-color@active' => [ 'setting' => 'pointer_color_menu_item_active', 'resolver' => 'color' ],
-					'padding-left' => [ 'setting' => 'padding_horizontal_menu_item', 'resolver' => 'dimension', 'responsive' => true ],
-					'padding-right' => [ 'setting' => 'padding_horizontal_menu_item', 'resolver' => 'dimension', 'responsive' => true ],
-					'padding-top' => [ 'setting' => 'padding_vertical_menu_item', 'resolver' => 'dimension', 'responsive' => true ],
-					'padding-bottom' => [ 'setting' => 'padding_vertical_menu_item', 'resolver' => 'dimension', 'responsive' => true ],
+					'color' => [
+						'setting' => 'color_menu_item',
+						'resolver' => 'color',
+					],
+					'color@hover' => [
+						'setting' => 'color_menu_item_hover',
+						'resolver' => 'color',
+					],
+					'color@active' => [
+						'setting' => 'color_menu_item_active',
+						'resolver' => 'color',
+					],
+					'background-color@hover' => [
+						'setting' => 'pointer_color_menu_item_hover',
+						'resolver' => 'color',
+					],
+					'background-color@active' => [
+						'setting' => 'pointer_color_menu_item_active',
+						'resolver' => 'color',
+					],
+					'padding-left' => [
+						'setting' => 'padding_horizontal_menu_item',
+						'resolver' => 'dimension',
+						'responsive' => true,
+					],
+					'padding-right' => [
+						'setting' => 'padding_horizontal_menu_item',
+						'resolver' => 'dimension',
+						'responsive' => true,
+					],
+					'padding-top' => [
+						'setting' => 'padding_vertical_menu_item',
+						'resolver' => 'dimension',
+						'responsive' => true,
+					],
+					'padding-bottom' => [
+						'setting' => 'padding_vertical_menu_item',
+						'resolver' => 'dimension',
+						'responsive' => true,
+					],
 				]
 			),
 		];
@@ -121,8 +152,14 @@ class V3_Widget_Bridge_Registry {
 			'style_overrides' => array_merge(
 				self::typography_overrides( 'typography' ),
 				[
-					'color' => [ 'setting' => 'text_color', 'resolver' => 'color' ],
-					'text-align' => [ 'setting' => 'align', 'resolver' => 'text' ],
+					'color' => [
+						'setting' => 'text_color',
+						'resolver' => 'color',
+					],
+					'text-align' => [
+						'setting' => 'align',
+						'resolver' => 'text',
+					],
 				]
 			),
 		];
@@ -160,9 +197,19 @@ class V3_Widget_Bridge_Registry {
 			'style_overrides' => array_merge(
 				self::typography_overrides( 'typography' ),
 				[
-					'color' => [ 'setting' => 'title_color', 'resolver' => 'color' ],
-					'text-align' => [ 'setting' => 'align', 'resolver' => 'text' ],
-					'margin-bottom' => [ 'setting' => 'paragraph_spacing', 'resolver' => 'dimension', 'responsive' => true ],
+					'color' => [
+						'setting' => 'title_color',
+						'resolver' => 'color',
+					],
+					'text-align' => [
+						'setting' => 'align',
+						'resolver' => 'text',
+					],
+					'margin-bottom' => [
+						'setting' => 'paragraph_spacing',
+						'resolver' => 'dimension',
+						'responsive' => true,
+					],
 				]
 			),
 		];
@@ -183,15 +230,46 @@ class V3_Widget_Bridge_Registry {
 			'style_overrides' => array_merge(
 				self::typography_overrides( 'caption_typography' ),
 				[
-					'text-align' => [ 'setting' => 'align', 'resolver' => 'text' ],
-					'width' => [ 'setting' => 'width', 'resolver' => 'dimension', 'responsive' => true ],
-					'max-width' => [ 'setting' => 'space', 'resolver' => 'dimension', 'responsive' => true ],
-					'height' => [ 'setting' => 'height', 'resolver' => 'dimension', 'responsive' => true ],
-					'object-fit' => [ 'setting' => 'object_fit', 'resolver' => 'text' ],
-					'object-position' => [ 'setting' => 'object_position', 'resolver' => 'text' ],
-					'opacity' => [ 'setting' => 'opacity', 'resolver' => 'text' ],
-					'opacity@hover' => [ 'setting' => 'opacity_hover', 'resolver' => 'text' ],
-					'border-radius' => [ 'setting' => 'image_border_radius', 'resolver' => 'sides', 'responsive' => true ],
+					'text-align' => [
+						'setting' => 'align',
+						'resolver' => 'text',
+					],
+					'width' => [
+						'setting' => 'width',
+						'resolver' => 'dimension',
+						'responsive' => true,
+					],
+					'max-width' => [
+						'setting' => 'space',
+						'resolver' => 'dimension',
+						'responsive' => true,
+					],
+					'height' => [
+						'setting' => 'height',
+						'resolver' => 'dimension',
+						'responsive' => true,
+					],
+					'object-fit' => [
+						'setting' => 'object_fit',
+						'resolver' => 'text',
+					],
+					'object-position' => [
+						'setting' => 'object_position',
+						'resolver' => 'text',
+					],
+					'opacity' => [
+						'setting' => 'opacity',
+						'resolver' => 'text',
+					],
+					'opacity@hover' => [
+						'setting' => 'opacity_hover',
+						'resolver' => 'text',
+					],
+					'border-radius' => [
+						'setting' => 'image_border_radius',
+						'resolver' => 'sides',
+						'responsive' => true,
+					],
 					'border' => [ 'border_prefix' => 'image_border' ],
 					'box-shadow' => [ 'box_shadow_prefix' => 'image_box_shadow' ],
 				]
@@ -208,10 +286,22 @@ class V3_Widget_Bridge_Registry {
 		return array_merge(
 			self::typography_overrides( 'typography' ),
 			[
-				'color' => [ 'setting' => 'title_color', 'resolver' => 'color' ],
-				'color@hover' => [ 'setting' => 'title_hover_color', 'resolver' => 'color' ],
-				'text-align' => [ 'setting' => 'align', 'resolver' => 'text' ],
-				'mix-blend-mode' => [ 'setting' => 'blend_mode', 'resolver' => 'text' ],
+				'color' => [
+					'setting' => 'title_color',
+					'resolver' => 'color',
+				],
+				'color@hover' => [
+					'setting' => 'title_hover_color',
+					'resolver' => 'color',
+				],
+				'text-align' => [
+					'setting' => 'align',
+					'resolver' => 'text',
+				],
+				'mix-blend-mode' => [
+					'setting' => 'blend_mode',
+					'resolver' => 'text',
+				],
 			]
 		);
 	}

--- a/modules/mcp/abilities/appliers/v3/v3-widget-bridge-registry.php
+++ b/modules/mcp/abilities/appliers/v3/v3-widget-bridge-registry.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Per-widget allowlists and CSS→legacy-setting overrides for MCP-allowlisted V3 widgets.
+ *
+ * Entry shape:
+ * [
+ *   'non_style_keys' => string[],
+ *   'style_overrides' => [
+ *     // Match key: "css-property" or "css-property@pseudo" (pseudo: hover|focus|active)
+ *     'color' => [
+ *       'setting' => 'title_color',          // single setting key
+ *       'resolver' => 'color',               // V3_Value_Resolvers::resolve name
+ *       'responsive' => true,               // write _tablet/_mobile suffix when breakpoint != desktop
+ *     ],
+ *     'font-size' => [
+ *       'typography_prefix' => 'typography', // expands via resolve_typography_group
+ *     ],
+ *     'border' => [
+ *       'border_prefix' => 'image_border',   // expands via resolve_border_shorthand
+ *     ],
+ *     'box-shadow' => [
+ *       'setting' => 'image_box_shadow',     // writes box_shadow_type + box_shadow under this prefix
+ *       'resolver' => 'box_shadow',
+ *     ],
+ *   ],
+ * ]
+ */
+class V3_Widget_Bridge_Registry {
+
+	/**
+	 * @return array{non_style_keys: string[], style_overrides: array<string, array>}|null
+	 */
+	public static function get( string $widget_type ): ?array {
+		$entries = self::entries();
+
+		return $entries[ $widget_type ] ?? null;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public static function get_non_style_keys( string $widget_type ): array {
+		$entry = self::get( $widget_type );
+
+		return $entry['non_style_keys'] ?? [];
+	}
+
+	/**
+	 * @return array<string, array>
+	 */
+	public static function get_style_overrides( string $widget_type ): array {
+		$entry = self::get( $widget_type );
+
+		return $entry['style_overrides'] ?? [];
+	}
+
+	/**
+	 * @return array<string, array{non_style_keys: string[], style_overrides: array<string, array>}>
+	 */
+	private static function entries(): array {
+		return [
+			'nav-menu' => self::nav_menu(),
+			'theme-post-content' => self::theme_post_content(),
+			'theme-post-title' => self::theme_post_title(),
+			'theme-post-featured-image' => self::theme_post_featured_image(),
+			'theme-post-excerpt' => self::theme_post_excerpt(),
+			'theme-archive-title' => self::theme_archive_title(),
+		];
+	}
+
+	private static function nav_menu(): array {
+		return [
+			'non_style_keys' => [
+				'menu_name',
+				'menu',
+				'layout',
+				'align_items',
+				'pointer',
+				'animation_line',
+				'animation_framed',
+				'animation_background',
+				'animation_text',
+				'submenu_icon',
+				'dropdown',
+				'full_width',
+				'text_align',
+				'toggle',
+				'toggle_icon_normal',
+				'toggle_icon_hover_animation',
+				'toggle_icon_active',
+				'toggle_align',
+			],
+			'style_overrides' => array_merge(
+				self::typography_overrides( 'dropdown_typography' ),
+				self::typography_overrides( 'menu_typography' ),
+				[
+					'color' => [ 'setting' => 'color_menu_item', 'resolver' => 'color' ],
+					'color@hover' => [ 'setting' => 'color_menu_item_hover', 'resolver' => 'color' ],
+					'color@active' => [ 'setting' => 'color_menu_item_active', 'resolver' => 'color' ],
+					'background-color@hover' => [ 'setting' => 'pointer_color_menu_item_hover', 'resolver' => 'color' ],
+					'background-color@active' => [ 'setting' => 'pointer_color_menu_item_active', 'resolver' => 'color' ],
+					'padding-left' => [ 'setting' => 'padding_horizontal_menu_item', 'resolver' => 'dimension', 'responsive' => true ],
+					'padding-right' => [ 'setting' => 'padding_horizontal_menu_item', 'resolver' => 'dimension', 'responsive' => true ],
+					'padding-top' => [ 'setting' => 'padding_vertical_menu_item', 'resolver' => 'dimension', 'responsive' => true ],
+					'padding-bottom' => [ 'setting' => 'padding_vertical_menu_item', 'resolver' => 'dimension', 'responsive' => true ],
+				]
+			),
+		];
+	}
+
+	private static function theme_post_content(): array {
+		return [
+			'non_style_keys' => [],
+			'style_overrides' => array_merge(
+				self::typography_overrides( 'typography' ),
+				[
+					'color' => [ 'setting' => 'text_color', 'resolver' => 'color' ],
+					'text-align' => [ 'setting' => 'align', 'resolver' => 'text' ],
+				]
+			),
+		];
+	}
+
+	private static function theme_post_title(): array {
+		return [
+			'non_style_keys' => [
+				'title',
+				'link',
+				'size',
+				'header_size',
+			],
+			'style_overrides' => self::heading_style_overrides(),
+		];
+	}
+
+	private static function theme_archive_title(): array {
+		return [
+			'non_style_keys' => [
+				'title',
+				'link',
+				'size',
+				'header_size',
+			],
+			'style_overrides' => self::heading_style_overrides(),
+		];
+	}
+
+	private static function theme_post_excerpt(): array {
+		return [
+			'non_style_keys' => [
+				'excerpt',
+			],
+			'style_overrides' => array_merge(
+				self::typography_overrides( 'typography' ),
+				[
+					'color' => [ 'setting' => 'title_color', 'resolver' => 'color' ],
+					'text-align' => [ 'setting' => 'align', 'resolver' => 'text' ],
+					'margin-bottom' => [ 'setting' => 'paragraph_spacing', 'resolver' => 'dimension', 'responsive' => true ],
+				]
+			),
+		];
+	}
+
+	private static function theme_post_featured_image(): array {
+		return [
+			'non_style_keys' => [
+				'image',
+				'image_size',
+				'image_custom_dimension',
+				'caption_source',
+				'caption',
+				'link_to',
+				'link',
+				'open_lightbox',
+			],
+			'style_overrides' => array_merge(
+				self::typography_overrides( 'caption_typography' ),
+				[
+					'text-align' => [ 'setting' => 'align', 'resolver' => 'text' ],
+					'width' => [ 'setting' => 'width', 'resolver' => 'dimension', 'responsive' => true ],
+					'max-width' => [ 'setting' => 'space', 'resolver' => 'dimension', 'responsive' => true ],
+					'height' => [ 'setting' => 'height', 'resolver' => 'dimension', 'responsive' => true ],
+					'object-fit' => [ 'setting' => 'object_fit', 'resolver' => 'text' ],
+					'object-position' => [ 'setting' => 'object_position', 'resolver' => 'text' ],
+					'opacity' => [ 'setting' => 'opacity', 'resolver' => 'text' ],
+					'opacity@hover' => [ 'setting' => 'opacity_hover', 'resolver' => 'text' ],
+					'border-radius' => [ 'setting' => 'image_border_radius', 'resolver' => 'sides', 'responsive' => true ],
+					'border' => [ 'border_prefix' => 'image_border' ],
+					'box-shadow' => [ 'box_shadow_prefix' => 'image_box_shadow' ],
+				]
+			),
+		];
+	}
+
+	/**
+	 * Shared heading-style overrides for theme-post-title / theme-archive-title.
+	 *
+	 * @return array<string, array>
+	 */
+	private static function heading_style_overrides(): array {
+		return array_merge(
+			self::typography_overrides( 'typography' ),
+			[
+				'color' => [ 'setting' => 'title_color', 'resolver' => 'color' ],
+				'color@hover' => [ 'setting' => 'title_hover_color', 'resolver' => 'color' ],
+				'text-align' => [ 'setting' => 'align', 'resolver' => 'text' ],
+				'mix-blend-mode' => [ 'setting' => 'blend_mode', 'resolver' => 'text' ],
+			]
+		);
+	}
+
+	/**
+	 * @return array<string, array{typography_prefix: string, responsive?: bool}>
+	 */
+	private static function typography_overrides( string $prefix ): array {
+		$props = [
+			'font-family',
+			'font-weight',
+			'font-style',
+			'text-transform',
+			'text-decoration',
+			'font-size',
+			'line-height',
+			'letter-spacing',
+			'word-spacing',
+		];
+
+		$overrides = [];
+		foreach ( $props as $prop ) {
+			$overrides[ $prop ] = [
+				'typography_prefix' => $prefix,
+				'responsive' => in_array( $prop, [ 'font-size', 'line-height', 'letter-spacing', 'word-spacing' ], true ),
+			];
+		}
+
+		return $overrides;
+	}
+}

--- a/modules/mcp/abilities/build-composition-ability.php
+++ b/modules/mcp/abilities/build-composition-ability.php
@@ -149,7 +149,7 @@ class Build_Composition_Ability extends Abstract_Ability {
 		}
 
 		$style_applier = new Style_Applier( $this->create_css_converter( $variables_service ), $this->get_active_breakpoints() );
-		$style_result = $style_applier->apply( $index, $this->as_map( $input['style'] ?? [] ), 'patch' );
+		$style_result = $style_applier->apply( $index, $this->as_map( $input['style'] ?? [] ), 'patch', $widget_configs );
 		if ( $style_result['error'] ) {
 			return $style_result['error'];
 		}

--- a/modules/mcp/abilities/get-structure-ability.php
+++ b/modules/mcp/abilities/get-structure-ability.php
@@ -7,6 +7,10 @@ use Elementor\Modules\AtomicWidgets\Styles\Local_Style_Serializer;
 use Elementor\Modules\AtomicWidgets\Utils\Element_Structure_Title;
 use Elementor\Modules\GlobalClasses\Utils\Atomic_Elements_Utils;
 use Elementor\Modules\Interactions\Props\Interaction_Item_Prop_Type;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3_Node_Bridge;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Non_Style_Allowlist;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Style_Serializer;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Widget_Bridge_Registry;
 use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 use Elementor\Plugin;
 use Elementor\Utils;
@@ -24,14 +28,14 @@ class Get_Structure_Ability extends Abstract_Ability {
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Get Elementor Page Structure', 'elementor' ),
-			__( 'Returns a lean Elementor element tree skeleton (id, elType, widgetType, version, title, nested elements) for a single post or page ID. Each node is tagged with version=3 (legacy) or version=4 (atomic). Only version=4 nodes can be modified via elementor/manage-elements or referenced by elementor/build-composition element_config; version=3 nodes are returned for context only and must be edited directly in the Elementor editor. Optionally scope to a subtree via element_id. Set include_content=true (requires element_id) to also return each V4 node\'s settings, styles, and interactions in the same shape that build-composition accepts as input; V3 nodes are returned with empty settings and styles. Only works for posts that were saved with Elementor.', 'elementor' ),
+			__( 'Returns a lean Elementor element tree skeleton (id, elType, widgetType, title, nested elements) for a single post or page ID. Optionally scope to a subtree via element_id. Set include_content=true (requires element_id) to also return each node\'s configurable state (settings, styles/style, interactions) in the same shape that build-composition and manage-elements accept as input. Widget types not returned by elementor/list-widget-schemas cannot be configured via this API and are returned with empty settings/styles for context only. Only works for posts that were saved with Elementor.', 'elementor' ),
 			'elementor',
 			[
 				'type' => 'object',
 				'properties' => [
 					'elements' => [
 						'type' => 'array',
-						'description' => 'Skeleton of Elementor elements (id, elType, widgetType, version, title, nested elements). When include_content is true, V4 nodes also include settings, styles, and interactions; V3 nodes always have empty settings and styles.',
+						'description' => 'Skeleton of Elementor elements (id, elType, widgetType, title, nested elements). When include_content is true, nodes also include settings, styles/style, and interactions. Widget types not returned by elementor/list-widget-schemas are returned with empty settings/styles.',
 					],
 				],
 			],
@@ -122,11 +126,6 @@ class Get_Structure_Ability extends Abstract_Ability {
 				$skeleton['widgetType'] = $node['widgetType'];
 			}
 
-			$version = $this->resolve_element_version( $node );
-			if ( null !== $version ) {
-				$skeleton['version'] = $version;
-			}
-
 			$title = Element_Structure_Title::resolve( $node );
 
 			if ( null !== $title ) {
@@ -138,43 +137,59 @@ class Get_Structure_Ability extends Abstract_Ability {
 			}
 
 			if ( $include_content ) {
-				if ( null !== $version && $version < 4 ) {
-					$skeleton['settings'] = (object) [];
-					$skeleton['styles'] = (object) [];
-					return $skeleton;
-				}
-
-				$settings = $node['settings'] ?? [];
-				$props_schema = $this->resolve_props_schema( $node );
-
-				if ( is_array( $settings ) && $props_schema ) {
-					$schema = array_intersect_key( $props_schema, $settings );
-					$settings = Render_Props_Resolver::for_settings()->resolve( $schema, $settings );
-				}
-
-				$skeleton['settings']     = $settings ? $settings : (object) [];
-				$skeleton['styles']       = Local_Style_Serializer::serialize( $node['styles'] ?? [] );
-				$skeleton['interactions'] = $this->normalize_interactions( $node['interactions'] ?? null );
+				$this->populate_content( $skeleton, $node );
 			}
 
 			return $skeleton;
 		} );
 	}
 
-	private function resolve_element_version( array $node ): ?int {
-		$type = Atomic_Elements_Utils::get_element_type( $node );
+	private function populate_content( array &$skeleton, array $node ): void {
+		$skeleton['interactions'] = $this->normalize_interactions( $node['interactions'] ?? null );
 
-		if ( ! $type ) {
-			return null;
+		if ( V3_Node_Bridge::is_v3_node( $node ) ) {
+			$this->populate_v3_content( $skeleton, $node );
+			return;
 		}
 
-		$instance = Atomic_Elements_Utils::get_element_instance( (string) $type );
+		$props_schema = $this->resolve_props_schema( $node );
+		$settings = $node['settings'] ?? [];
 
-		if ( ! $instance ) {
-			return null;
+		if ( ! $props_schema ) {
+			$skeleton['settings'] = (object) [];
+			$skeleton['styles'] = (object) [];
+			return;
 		}
 
-		return Atomic_Elements_Utils::is_atomic_element( $instance ) ? 4 : 3;
+		if ( is_array( $settings ) ) {
+			$schema = array_intersect_key( $props_schema, $settings );
+			$settings = Render_Props_Resolver::for_settings()->resolve( $schema, $settings );
+		}
+
+		$skeleton['settings'] = $settings ? $settings : (object) [];
+		$skeleton['styles'] = Local_Style_Serializer::serialize( $node['styles'] ?? [] );
+	}
+
+	private function populate_v3_content( array &$skeleton, array $node ): void {
+		$widget_type = (string) ( $node['widgetType'] ?? '' );
+		$raw_settings = is_array( $node['settings'] ?? null ) ? $node['settings'] : [];
+
+		$allowed = V3_Widget_Bridge_Registry::get_non_style_keys( $widget_type );
+
+		if ( empty( $allowed ) && empty( V3_Widget_Bridge_Registry::get_style_overrides( $widget_type ) ) ) {
+			$skeleton['settings'] = (object) [];
+			$skeleton['style'] = '';
+			return;
+		}
+
+		$filter = V3_Non_Style_Allowlist::filter( $widget_type, $raw_settings );
+		$allowed_settings = $filter['allowed'];
+
+		$widget_config = Widget_Context_Helper::get_widget_config( $widget_type );
+		$style = ( new V3_Style_Serializer() )->serialize( $raw_settings, $widget_type, $widget_config ?? [] );
+
+		$skeleton['settings'] = ! empty( $allowed_settings ) ? $allowed_settings : (object) [];
+		$skeleton['style'] = $style;
 	}
 
 	private function normalize_interactions( $interactions ): array {

--- a/modules/mcp/abilities/manage-elements-ability.php
+++ b/modules/mcp/abilities/manage-elements-ability.php
@@ -431,7 +431,7 @@ class Manage_Elements_Ability extends Abstract_Ability {
 
 		if ( $has_style ) {
 			$style_applier = new Style_Applier( $this->create_css_converter( $variables_service ), $this->get_active_breakpoints() );
-			$style_result = $style_applier->apply( $index, [ $element_id => $style ], $style_apply_mode );
+			$style_result = $style_applier->apply( $index, [ $element_id => $style ], $style_apply_mode, $widget_configs );
 			if ( $style_result['error'] ) {
 				return $style_result['error'];
 			}

--- a/modules/mcp/abilities/utils/v3-controls-metadata.php
+++ b/modules/mcp/abilities/utils/v3-controls-metadata.php
@@ -11,7 +11,7 @@ class V3_Controls_Metadata {
 	const LAYOUT_CONTROL_TYPES = [ 'section', 'tab', 'tabs' ];
 
 	/**
-	 * @param mixed       $controls     Widget controls stack.
+	 * @param mixed         $controls     Widget controls stack.
 	 * @param string[]|null $allowed_keys When provided, only these control keys are emitted.
 	 */
 	public static function extract( $controls, ?array $allowed_keys = null ): array {

--- a/modules/mcp/abilities/utils/v3-controls-metadata.php
+++ b/modules/mcp/abilities/utils/v3-controls-metadata.php
@@ -10,15 +10,27 @@ class V3_Controls_Metadata {
 
 	const LAYOUT_CONTROL_TYPES = [ 'section', 'tab', 'tabs' ];
 
-	public static function extract( $controls ): array {
+	/**
+	 * @param mixed       $controls     Widget controls stack.
+	 * @param string[]|null $allowed_keys When provided, only these control keys are emitted.
+	 */
+	public static function extract( $controls, ?array $allowed_keys = null ): array {
 		if ( ! is_array( $controls ) || empty( $controls ) ) {
 			return [];
 		}
+
+		$allowed_lookup = null === $allowed_keys
+			? null
+			: array_fill_keys( $allowed_keys, true );
 
 		$result = [];
 
 		foreach ( $controls as $control_key => $control ) {
 			if ( ! is_array( $control ) ) {
+				continue;
+			}
+
+			if ( null !== $allowed_lookup && ! isset( $allowed_lookup[ $control_key ] ) ) {
 				continue;
 			}
 

--- a/modules/mcp/abilities/utils/v3-json-schema-builder.php
+++ b/modules/mcp/abilities/utils/v3-json-schema-builder.php
@@ -111,8 +111,14 @@ class V3_Json_Schema_Builder {
 					'type' => 'object',
 					'properties' => [
 						'url' => [ 'type' => 'string' ],
-						'is_external' => [ 'type' => 'string', 'enum' => [ 'on', '' ] ],
-						'nofollow' => [ 'type' => 'string', 'enum' => [ 'on', '' ] ],
+						'is_external' => [
+							'type' => 'string',
+							'enum' => [ 'on', '' ],
+						],
+						'nofollow' => [
+							'type' => 'string',
+							'enum' => [ 'on', '' ],
+						],
 					],
 				];
 

--- a/modules/mcp/abilities/utils/v3-json-schema-builder.php
+++ b/modules/mcp/abilities/utils/v3-json-schema-builder.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Builds a JSON-Schema shaped object from a V3 widget's legacy controls stack,
+ * filtered to an allowlist of behavior keys.
+ *
+ * Legacy control types are mapped to plain JSON Schema:
+ *  - text / textarea / wysiwyg / code / hidden / color / date-time -> string
+ *  - number             -> number
+ *  - switcher           -> boolean-ish string ("yes" | "")
+ *  - select / choose    -> string with enum (from options keys or values)
+ *  - url                -> object { url, is_external, nofollow }
+ *  - media              -> object { url, id }
+ *  - icons              -> object { value, library }
+ *  - slider             -> object { size, unit }
+ *  - dimensions         -> object { top, right, bottom, left, unit, isLinked }
+ *  - repeater           -> array (item shape omitted; legacy repeater fields are not introspected)
+ *
+ * Layout wrappers (`section`, `tab`, `tabs`) are always dropped.
+ */
+class V3_Json_Schema_Builder {
+
+	const LAYOUT_CONTROL_TYPES = [ 'section', 'tab', 'tabs' ];
+
+	/**
+	 * @param mixed         $controls     Widget controls stack.
+	 * @param string[]|null $allowed_keys When provided, only these keys are emitted.
+	 * @return array{properties: array<string, array>, required: string[]}
+	 */
+	public static function build( $controls, ?array $allowed_keys = null ): array {
+		if ( ! is_array( $controls ) || empty( $controls ) ) {
+			return [
+				'properties' => [],
+				'required' => [],
+			];
+		}
+
+		$allowed_lookup = null === $allowed_keys
+			? null
+			: array_fill_keys( $allowed_keys, true );
+
+		$properties = [];
+
+		foreach ( $controls as $control_key => $control ) {
+			if ( ! is_array( $control ) || ! is_string( $control_key ) ) {
+				continue;
+			}
+
+			if ( null !== $allowed_lookup && ! isset( $allowed_lookup[ $control_key ] ) ) {
+				continue;
+			}
+
+			$control_type = is_string( $control['type'] ?? null ) ? $control['type'] : null;
+
+			if ( $control_type && in_array( $control_type, self::LAYOUT_CONTROL_TYPES, true ) ) {
+				continue;
+			}
+
+			$entry = self::build_entry( $control, $control_type );
+			if ( null === $entry ) {
+				continue;
+			}
+
+			$properties[ $control_key ] = $entry;
+		}
+
+		return [
+			'properties' => $properties,
+			'required' => [],
+		];
+	}
+
+	private static function build_entry( array $control, ?string $control_type ): ?array {
+		$entry = self::type_entry( $control, $control_type );
+
+		if ( array_key_exists( 'default', $control ) && ! self::has_object_shape( $entry ) ) {
+			$entry['default'] = $control['default'];
+		}
+
+		if ( isset( $control['description'] ) && is_string( $control['description'] ) ) {
+			$entry['description'] = trim( strip_tags( $control['description'] ) );
+		}
+
+		return $entry;
+	}
+
+	private static function type_entry( array $control, ?string $control_type ): array {
+		switch ( $control_type ) {
+			case 'number':
+				return [ 'type' => 'number' ];
+
+			case 'switcher':
+				return [
+					'type' => 'string',
+					'enum' => [ 'yes', '' ],
+				];
+
+			case 'select':
+			case 'select2':
+			case 'choose':
+				return self::enum_entry( $control );
+
+			case 'url':
+				return [
+					'type' => 'object',
+					'properties' => [
+						'url' => [ 'type' => 'string' ],
+						'is_external' => [ 'type' => 'string', 'enum' => [ 'on', '' ] ],
+						'nofollow' => [ 'type' => 'string', 'enum' => [ 'on', '' ] ],
+					],
+				];
+
+			case 'media':
+				return [
+					'type' => 'object',
+					'properties' => [
+						'url' => [ 'type' => 'string' ],
+						'id' => [ 'type' => 'number' ],
+					],
+				];
+
+			case 'icons':
+				return [
+					'type' => 'object',
+					'properties' => [
+						'value' => [ 'type' => 'string' ],
+						'library' => [ 'type' => 'string' ],
+					],
+				];
+
+			case 'slider':
+				return [
+					'type' => 'object',
+					'properties' => [
+						'size' => [ 'type' => 'number' ],
+						'unit' => [ 'type' => 'string' ],
+					],
+				];
+
+			case 'dimensions':
+				return [
+					'type' => 'object',
+					'properties' => [
+						'top' => [ 'type' => 'string' ],
+						'right' => [ 'type' => 'string' ],
+						'bottom' => [ 'type' => 'string' ],
+						'left' => [ 'type' => 'string' ],
+						'unit' => [ 'type' => 'string' ],
+						'isLinked' => [ 'type' => 'boolean' ],
+					],
+				];
+
+			case 'repeater':
+				return [
+					'type' => 'array',
+					'items' => [ 'type' => 'object' ],
+				];
+
+			default:
+				return [ 'type' => 'string' ];
+		}
+	}
+
+	private static function enum_entry( array $control ): array {
+		$entry = [ 'type' => 'string' ];
+
+		$options = $control['options'] ?? null;
+		if ( is_array( $options ) && ! empty( $options ) ) {
+			$entry['enum'] = self::is_associative_array( $options )
+				? array_keys( $options )
+				: array_values( $options );
+		}
+
+		return $entry;
+	}
+
+	private static function has_object_shape( array $entry ): bool {
+		$type = $entry['type'] ?? null;
+		return 'object' === $type || 'array' === $type;
+	}
+
+	private static function is_associative_array( array $arr ): bool {
+		return array_keys( $arr ) !== range( 0, count( $arr ) - 1 );
+	}
+}

--- a/modules/mcp/abilities/utils/widget-context-helper.php
+++ b/modules/mcp/abilities/utils/widget-context-helper.php
@@ -7,6 +7,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Utils\Plain_Llm_Schema_Converter;
 use Elementor\Modules\GlobalClasses\Utils\Atomic_Elements_Utils;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Widget_Bridge_Registry;
 use Elementor\Plugin;
 use Elementor\Utils;
 
@@ -37,9 +38,9 @@ class Widget_Context_Helper {
 		'theme-archive-title',
 	];
 
-	const V3_FALLBACK_MESSAGE = 'This widget exists in the editor but has no atomic props schema (V4). Use control_metadata as non-authoritative hints from legacy controls.';
+	const V3_FALLBACK_MESSAGE = '`properties` lists the only keys accepted in `element_config` / `manage-elements.settings` for this widget. Put all visual styling in the `style` (CSS) input.';
 
-	const V3_FALLBACK_FIELDS_NOTE = 'All settings are optional; there is no JSON schema for this widget type.';
+	const V3_FALLBACK_FIELDS_NOTE = 'All properties are optional. Object-typed properties describe common shapes but do not include exhaustive inner validation.';
 
 	/**
 	 * @return array<string, array> widget_type => config, filtered to widgets eligible for LLM use.
@@ -151,11 +152,17 @@ class Widget_Context_Helper {
 				return null;
 			}
 
+			$allowed_keys = V3_Widget_Bridge_Registry::get_non_style_keys( $widget_type );
+			$built = V3_Json_Schema_Builder::build( $config['controls'], $allowed_keys );
+
 			return [
+				'type' => 'object',
 				'widget_version' => self::VERSION_V3,
 				'message' => self::V3_FALLBACK_MESSAGE,
 				'fields_note' => self::V3_FALLBACK_FIELDS_NOTE,
-				'properties' => V3_Controls_Metadata::extract( $config['controls'] ),
+				'properties' => $built['properties'],
+				'required' => $built['required'],
+				'additionalProperties' => false,
 			];
 		}
 

--- a/modules/mcp/static-resources/abilities/build-composition.md
+++ b/modules/mcp/static-resources/abilities/build-composition.md
@@ -6,18 +6,12 @@ If the user asks about a header, footer, 404, single, archive, or search-results
 - [elementor://global-classes] - Reusable CSS classes from the active kit, ordered from highest to lowest CSS priority; check FIRST before adding inline styles
 - [elementor://global-variables] - Design tokens from the active kit; use labels in CSS as `var(--label)` or `var(--label, fallback)`; ONLY variables listed here are valid
 - [elementor://interactions/schema] - Native interaction item shape and allowed enums for `interactions`
-- [elementor/list-widget-schemas?summary=true] - Available v4 widgets plus the closed V3 allowlist (`nav-menu`, theme-post-* / theme-archive-title)
+- [elementor/list-widget-schemas?summary=true] - Available widget types this tool can configure
 - `elementor/list-assets` - Images and SVG icons already in the Media Library; call before placing an `e-image` (for real dimensions and `srcset`) and always before an `e-svg` (which needs an uploaded asset to render)
 - `elementor/list-components` - User-defined reusable widget compositions; only call when the user explicitly asks to use a component (see COMPONENTS below)
 
 # TOOL SUPPORT
-This tool supports v4 elements and a closed V3 allowlist (`nav-menu`, `theme-post-content`, `theme-post-title`, `theme-post-featured-image`, `theme-post-excerpt`, `theme-archive-title`).
-
-V3 mapping (same LLM contract as V4, translated internally):
-- `element_config` → raw V3 settings (no schema validation).
-- `classes` (global class labels) → V3 `_css_classes` (space-separated string).
-- `style` (plain CSS) → V3 `custom_css`, wrapped in `selector { ... }`. **Requires Elementor Pro**; without Pro the style is skipped and a warning is emitted.
-- Interactions and V4 nested `&:hover` / `@media (--mobile)` in `style` are not translated to V3 — keep V3 style inputs simple.
+Discover valid `widget_type` values via `elementor/list-widget-schemas?summary=true`. Any type it lists is workable through the same uniform contract (`element_config`, `style`, `classes`, `interactions`); anything it does not list must be edited manually in the Elementor editor.
 
 # WORKFLOW
 1. Check/create global variables via `elementor/manage-global-variable`

--- a/modules/mcp/static-resources/abilities/get-widget-schema.md
+++ b/modules/mcp/static-resources/abilities/get-widget-schema.md
@@ -1,7 +1,5 @@
-Returns the JSON Schema for a single V4 (atomic) widget type's settings, including default values and nesting guidance.
+Returns the JSON Schema for a single widget type's settings, including default values and nesting guidance.
 
-A closed V3 allowlist is also fetchable: `nav-menu`, `theme-post-content`, `theme-post-title`, `theme-post-featured-image`, `theme-post-excerpt`, `theme-archive-title`. Those return the V3 fallback shape (`widget_version: 'v3'`, `message`, `fields_note`, `properties` from legacy control metadata — non-authoritative). Other V3 (legacy) widget types are rejected with `elementor_v3_not_supported` and must be edited directly in the Elementor editor.
+Use `elementor/list-widget-schemas` with `summary=true` first to discover valid `widget_type` values. Types not returned by that endpoint are not supported by this tool and must be edited directly in the Elementor editor (call fails with `elementor_v3_not_supported`).
 
-Use elementor/list-widget-schemas with summary=true first to discover valid widget_type values.
-
-Values in the returned V4 schema are plain JSON. Send settings in `build-composition.element_config` and `manage-elements.settings` using this shape directly (scalars as scalars, dynamic tags as `{ name, settings }`). For allowlisted V3 widgets, send raw control keys as plain settings (no schema validation).
+Values in the returned schema are plain JSON. Send settings in `build-composition.element_config` and `manage-elements.settings` using this shape directly (scalars as scalars, dynamic tags as `{ name, settings }`). Only keys listed under `properties` are accepted; put all visual styling in the `style` (CSS) input.

--- a/modules/mcp/static-resources/abilities/list-widget-schemas.md
+++ b/modules/mcp/static-resources/abilities/list-widget-schemas.md
@@ -1,9 +1,7 @@
-Returns widget information for V4 (atomic) widgets and a closed V3 allowlist available to the LLM.
+Returns widget information for every widget type this tool can configure. Types absent from this list must be edited manually in the Elementor editor.
 
-V3 allowlist members: `nav-menu`, `theme-post-content`, `theme-post-title`, `theme-post-featured-image`, `theme-post-excerpt`, `theme-archive-title`. Allowlisted V3 entries use the V3 fallback shape (`widget_version: 'v3'`, control metadata hints — not a validated JSON Schema). Other V3 widgets are omitted.
+Default mode: Returns a map of `widget_type` to JSON Schema. Prefer `elementor/get-widget-schema` when only one widget type is needed.
 
-Default mode: Returns a map of widget_type to JSON Schema (or V3 fallback). Prefer elementor/get-widget-schema when only one widget type is needed.
+With `summary=true`: Returns `{ widgets: [{ type, description }, ...] }` for widget discovery. Use this mode first to discover which widget types exist before fetching full schemas or building compositions.
 
-With summary=true: Returns { widgets: [{ type, description }, ...] } for widget discovery. Use this mode first to discover which widget types exist before fetching full schemas or building compositions.
-
-Values in the returned V4 schemas are plain JSON. Send settings in `build-composition.element_config` and `manage-elements.settings` using this shape directly. For allowlisted V3 widgets, send raw control keys as plain settings (no schema validation).
+Values in the returned schemas are plain JSON. Send settings in `build-composition.element_config` and `manage-elements.settings` using this shape directly. Only keys listed under `properties` are accepted; put all visual styling in the `style` (CSS) input.

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-element-config-applier.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-element-config-applier.php
@@ -120,6 +120,67 @@ class Test_Element_Config_Applier extends TestCase {
 		$this->assertSame( [], $e_component_node['settings'] );
 	}
 
+	public function test_apply__v3_allowlisted_keys_merge_as_plain_settings() {
+		// Arrange
+		$type_resolver = new Widget_Type_Resolver( new Xml_Parser() );
+		$applier = new Element_Config_Applier( $type_resolver, $this->make_plain_values_resolver() );
+
+		$nav = [
+			'elType' => 'widget',
+			'widgetType' => 'nav-menu',
+			'settings' => [],
+		];
+		$index = [ 'main-nav' => &$nav ];
+
+		// Act
+		$result = $applier->apply(
+			$index,
+			[
+				'main-nav' => [
+					'menu' => 'primary',
+					'layout' => 'horizontal',
+				],
+			],
+			[]
+		);
+
+		// Assert
+		$this->assertNull( $result['error'] );
+		$this->assertSame( 'primary', $nav['settings']['menu'] );
+		$this->assertSame( 'horizontal', $nav['settings']['layout'] );
+	}
+
+	public function test_apply__v3_rejects_non_allowlisted_settings() {
+		// Arrange
+		$type_resolver = new Widget_Type_Resolver( new Xml_Parser() );
+		$applier = new Element_Config_Applier( $type_resolver, $this->make_plain_values_resolver() );
+
+		$nav = [
+			'elType' => 'widget',
+			'widgetType' => 'nav-menu',
+			'settings' => [],
+		];
+		$index = [ 'main-nav' => &$nav ];
+
+		// Act
+		$result = $applier->apply(
+			$index,
+			[
+				'main-nav' => [
+					'menu' => 'primary',
+					'color_menu_item' => '#ff0000',
+				],
+			],
+			[]
+		);
+
+		// Assert
+		$this->assertNotNull( $result['error'] );
+		$this->assertSame( 'elementor_invalid_settings', $result['error']->get_error_code() );
+		$this->assertStringContainsString( 'color_menu_item', $result['error']->get_error_message() );
+		$this->assertArrayNotHasKey( 'menu', $nav['settings'] );
+	}
+
 	public function test_apply__reports_settings_and_component_errors_together() {
 		// Arrange
 		$type_resolver = new Widget_Type_Resolver( new Xml_Parser() );

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-style-applier.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-style-applier.php
@@ -6,6 +6,10 @@ namespace Elementor {
 			public static function generate_random_string(): string {
 				return dechex( rand() );
 			}
+
+			public static function has_pro(): bool {
+				return true;
+			}
 		}
 	}
 }
@@ -21,7 +25,9 @@ namespace {
 		}
 	}
 
+	use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
 	use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+	use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
 	use Elementor\Modules\Mcp\Abilities\Appliers\Style_Applier;
 	use PHPUnit\Framework\TestCase;
 
@@ -248,6 +254,46 @@ namespace {
 			// Assert.
 			$this->assertInstanceOf( \WP_Error::class, $result['error'] );
 			$this->assertStringContainsString( 'nonexistent', $result['error']->get_error_message() );
+		}
+
+		public function test_apply__v3_maps_css_to_settings_and_falls_back_unmapped_to_custom_css() {
+			// Arrange.
+			$converter = new Css_Converter( new Converter_Registry(), new Null_Failure_Reporter() );
+			$applier = $this->make_applier( $converter );
+			$node = [
+				'id' => 'elem-1',
+				'elType' => 'widget',
+				'widgetType' => 'theme-post-title',
+				'settings' => [],
+				'styles' => [],
+			];
+			$index = [ 'post-title' => &$node ];
+			$widget_configs = [
+				'theme-post-title' => [
+					'controls' => [
+						'title_color' => [ 'type' => 'color' ],
+						'typography_typography' => [ 'type' => 'typography' ],
+						'typography_font_size' => [ 'type' => 'slider' ],
+					],
+				],
+			];
+
+			// Act.
+			$result = $applier->apply(
+				$index,
+				[ 'post-title' => 'color: #222222; font-size: 2rem; filter: blur(2px);' ],
+				'patch',
+				$widget_configs
+			);
+
+			// Assert.
+			$this->assertNull( $result['error'] );
+			$this->assertSame( '#222222', $node['settings']['title_color'] );
+			$this->assertSame( 'custom', $node['settings']['typography_typography'] );
+			$this->assertSame( [ 'unit' => 'rem', 'size' => 2.0 ], $node['settings']['typography_font_size'] );
+			$this->assertArrayHasKey( 'custom_css', $node['settings'] );
+			$this->assertStringContainsString( 'filter: blur(2px);', $node['settings']['custom_css'] );
+			$this->assertNotEmpty( $result['warnings'] );
 		}
 	}
 }

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-style-applier.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-style-applier.php
@@ -291,9 +291,104 @@ namespace {
 			$this->assertSame( '#222222', $node['settings']['title_color'] );
 			$this->assertSame( 'custom', $node['settings']['typography_typography'] );
 			$this->assertSame( [ 'unit' => 'rem', 'size' => 2.0 ], $node['settings']['typography_font_size'] );
-			$this->assertArrayHasKey( 'custom_css', $node['settings'] );
-			$this->assertStringContainsString( 'filter: blur(2px);', $node['settings']['custom_css'] );
 			$this->assertNotEmpty( $result['warnings'] );
+			$this->assertTrue(
+				(bool) array_filter(
+					$result['warnings'],
+					static fn( $warning ) => false !== strpos( (string) $warning, 'filter: blur(2px);' )
+				)
+			);
+
+			if ( \Elementor\Utils::has_pro() ) {
+				$this->assertArrayHasKey( 'custom_css', $node['settings'] );
+				$this->assertStringContainsString( 'filter: blur(2px);', $node['settings']['custom_css'] );
+			} else {
+				$this->assertArrayNotHasKey( 'custom_css', $node['settings'] );
+			}
+		}
+
+		public function test_apply__v3_replace_clears_mapped_settings_and_custom_css() {
+			// Arrange.
+			$converter = new Css_Converter( new Converter_Registry(), new Null_Failure_Reporter() );
+			$applier = $this->make_applier( $converter );
+			$node = [
+				'id' => 'elem-1',
+				'elType' => 'widget',
+				'widgetType' => 'theme-post-title',
+				'settings' => [
+					'title' => 'Keep me',
+					'title_color' => '#111111',
+					'typography_typography' => 'custom',
+					'typography_font_size' => [ 'unit' => 'px', 'size' => 40 ],
+					'custom_css' => 'selector { filter: blur(2px); }',
+				],
+				'styles' => [],
+			];
+			$index = [ 'post-title' => &$node ];
+			$widget_configs = [
+				'theme-post-title' => [
+					'controls' => [
+						'title_color' => [ 'type' => 'color' ],
+						'typography_typography' => [ 'type' => 'typography' ],
+						'typography_font_size' => [ 'type' => 'slider' ],
+					],
+				],
+			];
+
+			// Act.
+			$result = $applier->apply(
+				$index,
+				[ 'post-title' => 'color: #abcdef;' ],
+				'replace',
+				$widget_configs
+			);
+
+			// Assert.
+			$this->assertNull( $result['error'] );
+			$this->assertSame( 'Keep me', $node['settings']['title'] );
+			$this->assertSame( '#abcdef', $node['settings']['title_color'] );
+			$this->assertArrayNotHasKey( 'typography_typography', $node['settings'] );
+			$this->assertArrayNotHasKey( 'typography_font_size', $node['settings'] );
+			$this->assertArrayNotHasKey( 'custom_css', $node['settings'] );
+		}
+
+		public function test_apply__v3_replace_empty_css_wipes_styles() {
+			// Arrange.
+			$converter = new Css_Converter( new Converter_Registry(), new Null_Failure_Reporter() );
+			$applier = $this->make_applier( $converter );
+			$node = [
+				'id' => 'elem-1',
+				'elType' => 'widget',
+				'widgetType' => 'theme-post-title',
+				'settings' => [
+					'title' => 'Keep me',
+					'title_color' => '#111111',
+					'custom_css' => 'selector { filter: blur(2px); }',
+				],
+				'styles' => [],
+			];
+			$index = [ 'post-title' => &$node ];
+			$widget_configs = [
+				'theme-post-title' => [
+					'controls' => [
+						'title_color' => [ 'type' => 'color' ],
+					],
+				],
+			];
+
+			// Act.
+			$result = $applier->apply(
+				$index,
+				[ 'post-title' => '' ],
+				'replace',
+				$widget_configs
+			);
+
+			// Assert.
+			$this->assertNull( $result['error'] );
+			$this->assertSame( 'Keep me', $node['settings']['title'] );
+			$this->assertArrayNotHasKey( 'title_color', $node['settings'] );
+			$this->assertArrayNotHasKey( 'custom_css', $node['settings'] );
 		}
 	}
 }

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-non-style-allowlist.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-non-style-allowlist.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Non_Style_Allowlist;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Widget_Bridge_Registry;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Non_Style_Allowlist extends TestCase {
+
+	public function test_filter__allows_whitelisted_keys_for_nav_menu() {
+		// Arrange.
+		$settings = [
+			'menu' => 'primary',
+			'layout' => 'horizontal',
+		];
+
+		// Act.
+		$result = V3_Non_Style_Allowlist::filter( 'nav-menu', $settings );
+
+		// Assert.
+		$this->assertNull( $result['error'] );
+		$this->assertSame( $settings, $result['allowed'] );
+		$this->assertEmpty( $result['rejected'] );
+	}
+
+	public function test_filter__rejects_unknown_and_style_keys() {
+		// Arrange.
+		$settings = [
+			'menu' => 'primary',
+			'title_color' => '#ff0000',
+			'typography_font_size' => [ 'unit' => 'px', 'size' => 16 ],
+		];
+
+		// Act.
+		$result = V3_Non_Style_Allowlist::filter( 'nav-menu', $settings );
+
+		// Assert.
+		$this->assertNotNull( $result['error'] );
+		$this->assertSame( 'elementor_invalid_settings', $result['error']->get_error_code() );
+		$this->assertSame( [ 'menu' => 'primary' ], $result['allowed'] );
+		$this->assertContains( 'title_color', $result['rejected'] );
+		$this->assertContains( 'typography_font_size', $result['rejected'] );
+	}
+
+	public function test_filter__theme_post_content_has_no_non_style_keys() {
+		// Arrange / Act.
+		$result = V3_Non_Style_Allowlist::filter( 'theme-post-content', [ 'align' => 'center' ] );
+
+		// Assert.
+		$this->assertNotNull( $result['error'] );
+		$this->assertEmpty( $result['allowed'] );
+		$this->assertSame( [], V3_Widget_Bridge_Registry::get_non_style_keys( 'theme-post-content' ) );
+	}
+
+	public function test_registry__covers_all_allowlisted_widgets() {
+		$types = [
+			'nav-menu',
+			'theme-post-content',
+			'theme-post-title',
+			'theme-post-featured-image',
+			'theme-post-excerpt',
+			'theme-archive-title',
+		];
+
+		foreach ( $types as $type ) {
+			$this->assertNotNull( V3_Widget_Bridge_Registry::get( $type ), "Missing registry entry for {$type}" );
+			$this->assertIsArray( V3_Widget_Bridge_Registry::get_style_overrides( $type ) );
+		}
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-style-mapper.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-style-mapper.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Style_Mapper;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Style_Mapper extends TestCase {
+
+	private function make_mapper(): V3_Style_Mapper {
+		$converter = new Css_Converter( new Converter_Registry(), new Null_Failure_Reporter() );
+
+		return new V3_Style_Mapper( $converter, [ 'desktop', 'tablet', 'mobile' ] );
+	}
+
+	private function heading_config(): array {
+		return [
+			'controls' => [
+				'title_color' => [
+					'type' => 'color',
+					'selectors' => [
+						'{{WRAPPER}} .elementor-heading-title' => 'color: {{VALUE}};',
+					],
+				],
+				'title_hover_color' => [
+					'type' => 'color',
+					'selectors' => [
+						'{{WRAPPER}} .elementor-heading-title:hover' => 'color: {{VALUE}};',
+					],
+				],
+				'align' => [
+					'type' => 'choose',
+					'selectors' => [
+						'{{WRAPPER}}' => 'text-align: {{VALUE}};',
+					],
+				],
+				'typography_typography' => [ 'type' => 'typography' ],
+				'typography_font_size' => [ 'type' => 'slider' ],
+				'typography_font_size_tablet' => [ 'type' => 'slider' ],
+				'typography_font_weight' => [ 'type' => 'select' ],
+			],
+		];
+	}
+
+	public function test_apply__maps_color_via_override() {
+		// Arrange.
+		$mapper = $this->make_mapper();
+
+		// Act.
+		$result = $mapper->apply( 'color: #111111;', 'theme-post-title', $this->heading_config() );
+
+		// Assert.
+		$this->assertSame( '#111111', $result['settings_patch']['title_color'] );
+		$this->assertSame( '', $result['unmapped_css'] );
+	}
+
+	public function test_apply__maps_typography_group_and_forces_custom_toggle() {
+		// Arrange.
+		$mapper = $this->make_mapper();
+
+		// Act.
+		$result = $mapper->apply(
+			'font-size: 2rem; font-weight: 700;',
+			'theme-post-title',
+			$this->heading_config()
+		);
+
+		// Assert.
+		$this->assertSame( 'custom', $result['settings_patch']['typography_typography'] );
+		$this->assertSame( [ 'unit' => 'rem', 'size' => 2.0 ], $result['settings_patch']['typography_font_size'] );
+		$this->assertSame( '700', $result['settings_patch']['typography_font_weight'] );
+		$this->assertSame( '', $result['unmapped_css'] );
+	}
+
+	public function test_apply__maps_hover_color_via_override() {
+		// Arrange.
+		$mapper = $this->make_mapper();
+
+		// Act.
+		$result = $mapper->apply( '&:hover { color: blue; }', 'theme-post-title', $this->heading_config() );
+
+		// Assert.
+		$this->assertSame( 'blue', $result['settings_patch']['title_hover_color'] );
+		$this->assertSame( '', $result['unmapped_css'] );
+	}
+
+	public function test_apply__maps_padding_shorthand_via_override_on_featured_image() {
+		// Arrange.
+		$mapper = $this->make_mapper();
+		$config = [
+			'controls' => [
+				'image_border_radius' => [ 'type' => 'dimensions' ],
+				'image_border_border' => [ 'type' => 'select' ],
+				'image_border_width' => [ 'type' => 'dimensions' ],
+				'image_border_color' => [ 'type' => 'color' ],
+			],
+		];
+
+		// Act.
+		$result = $mapper->apply( 'border-radius: 8px;', 'theme-post-featured-image', $config );
+
+		// Assert.
+		$this->assertArrayHasKey( 'image_border_radius', $result['settings_patch'] );
+		$this->assertSame( '8', $result['settings_patch']['image_border_radius']['top'] );
+		$this->assertTrue( $result['settings_patch']['image_border_radius']['isLinked'] );
+	}
+
+	public function test_apply__unmapped_property_falls_back_to_unmapped_css() {
+		// Arrange.
+		$mapper = $this->make_mapper();
+
+		// Act.
+		$result = $mapper->apply(
+			'color: red; filter: blur(4px);',
+			'theme-post-title',
+			$this->heading_config()
+		);
+
+		// Assert.
+		$this->assertSame( 'red', $result['settings_patch']['title_color'] );
+		$this->assertStringContainsString( 'filter: blur(4px);', $result['unmapped_css'] );
+	}
+
+	public function test_apply__tablet_breakpoint_writes_responsive_suffix_when_control_exists() {
+		// Arrange.
+		$mapper = $this->make_mapper();
+
+		// Act.
+		$result = $mapper->apply(
+			'@media(--tablet) { font-size: 1.25rem; }',
+			'theme-post-title',
+			$this->heading_config()
+		);
+
+		// Assert.
+		$this->assertSame( 'custom', $result['settings_patch']['typography_typography'] );
+		$this->assertArrayHasKey( 'typography_font_size_tablet', $result['settings_patch'] );
+		$this->assertSame( [ 'unit' => 'rem', 'size' => 1.25 ], $result['settings_patch']['typography_font_size_tablet'] );
+	}
+
+	public function test_apply__generic_selector_reverse_for_unique_match() {
+		// Arrange — text-align is in heading overrides too; use a widget without that override
+		// and a unique selector-backed control not covered by overrides.
+		$mapper = $this->make_mapper();
+		$config = [
+			'controls' => [
+				'text_color' => [
+					'type' => 'color',
+					'selectors' => [
+						'{{WRAPPER}}' => 'color: {{VALUE}};',
+					],
+				],
+				'extra_gap' => [
+					'type' => 'slider',
+					'selectors' => [
+						'{{WRAPPER}}' => 'gap: {{SIZE}}{{UNIT}};',
+					],
+				],
+			],
+		];
+
+		// Act — theme-post-content has color override to text_color; gap is generic-only.
+		$result = $mapper->apply( 'gap: 12px;', 'theme-post-content', $config );
+
+		// Assert.
+		$this->assertSame( [ 'unit' => 'px', 'size' => 12.0 ], $result['settings_patch']['extra_gap'] );
+	}
+
+	public function test_apply__empty_css_returns_empty_patch() {
+		$mapper = $this->make_mapper();
+		$result = $mapper->apply( '   ', 'theme-post-title', $this->heading_config() );
+
+		$this->assertSame( [], $result['settings_patch'] );
+		$this->assertSame( '', $result['unmapped_css'] );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-style-serializer.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-style-serializer.php
@@ -132,4 +132,17 @@ class Test_V3_Style_Serializer extends TestCase {
 		$this->assertStringNotContainsString( 'random_unknown_key', $css );
 		$this->assertStringNotContainsString( 'Hello', $css );
 	}
+
+	public function test_serialize__appends_unwrapped_custom_css() {
+		$settings = [
+			'title_color' => '#ff0000',
+			'custom_css' => 'selector { filter: blur(2px); }',
+		];
+
+		$css = ( new V3_Style_Serializer() )->serialize( $settings, 'theme-post-title', $this->heading_config() );
+
+		$this->assertStringContainsString( 'color: #ff0000;', $css );
+		$this->assertStringContainsString( 'filter: blur(2px);', $css );
+		$this->assertStringNotContainsString( 'selector', $css );
+	}
 }

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-style-serializer.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-style-serializer.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\AtomicWidgets\CssConverter\Converter_Registry;
+use Elementor\Modules\AtomicWidgets\CssConverter\Css_Converter;
+use Elementor\Modules\AtomicWidgets\CssConverter\Metrics\Null_Failure_Reporter;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Style_Mapper;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Style_Serializer;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Style_Serializer extends TestCase {
+
+	private function heading_config(): array {
+		return [
+			'controls' => [
+				'title_color' => [
+					'type' => 'color',
+					'selectors' => [
+						'{{WRAPPER}} .elementor-heading-title' => 'color: {{VALUE}};',
+					],
+				],
+				'title_hover_color' => [
+					'type' => 'color',
+					'selectors' => [
+						'{{WRAPPER}} .elementor-heading-title:hover' => 'color: {{VALUE}};',
+					],
+				],
+				'align' => [
+					'type' => 'choose',
+					'selectors' => [ '{{WRAPPER}}' => 'text-align: {{VALUE}};' ],
+				],
+				'blend_mode' => [
+					'type' => 'select',
+					'selectors' => [ '{{WRAPPER}} .elementor-heading-title' => 'mix-blend-mode: {{VALUE}};' ],
+				],
+				'typography_typography' => [ 'type' => 'typography' ],
+				'typography_font_size' => [ 'type' => 'slider' ],
+				'typography_font_size_tablet' => [ 'type' => 'slider' ],
+				'typography_font_weight' => [ 'type' => 'select' ],
+				'typography_text_transform' => [ 'type' => 'select' ],
+				'typography_letter_spacing' => [ 'type' => 'slider' ],
+			],
+		];
+	}
+
+	private function make_mapper(): V3_Style_Mapper {
+		$converter = new Css_Converter( new Converter_Registry(), new Null_Failure_Reporter() );
+		return new V3_Style_Mapper( $converter, [ 'desktop', 'tablet', 'mobile' ] );
+	}
+
+	public function test_serialize__emits_color_and_typography_declarations() {
+		$settings = [
+			'title_color' => '#ff3355',
+			'typography_typography' => 'custom',
+			'typography_font_size' => [ 'unit' => 'px', 'size' => 42 ],
+			'typography_text_transform' => 'uppercase',
+			'typography_letter_spacing' => [ 'unit' => 'px', 'size' => 2 ],
+		];
+
+		$css = ( new V3_Style_Serializer() )->serialize( $settings, 'theme-post-title', $this->heading_config() );
+
+		$this->assertStringContainsString( 'color: #ff3355;', $css );
+		$this->assertStringContainsString( 'font-size: 42px;', $css );
+		$this->assertStringContainsString( 'text-transform: uppercase;', $css );
+		$this->assertStringContainsString( 'letter-spacing: 2px;', $css );
+	}
+
+	public function test_serialize__emits_hover_state() {
+		$settings = [
+			'title_color' => '#111',
+			'title_hover_color' => '#c00',
+		];
+
+		$css = ( new V3_Style_Serializer() )->serialize( $settings, 'theme-post-title', $this->heading_config() );
+
+		$this->assertStringContainsString( 'color: #111;', $css );
+		$this->assertStringContainsString( '&:hover { color: #c00; }', $css );
+	}
+
+	public function test_serialize__emits_responsive_breakpoint_block() {
+		$settings = [
+			'typography_typography' => 'custom',
+			'typography_font_size' => [ 'unit' => 'px', 'size' => 42 ],
+			'typography_font_size_tablet' => [ 'unit' => 'px', 'size' => 32 ],
+		];
+
+		$css = ( new V3_Style_Serializer() )->serialize( $settings, 'theme-post-title', $this->heading_config() );
+
+		$this->assertStringContainsString( 'font-size: 42px;', $css );
+		$this->assertStringContainsString( '@media(--tablet) { font-size: 32px; }', $css );
+	}
+
+	public function test_serialize__skips_empty_and_unset_settings() {
+		$settings = [
+			'title_color' => '',
+			'align' => 'center',
+			'typography_font_size' => [ 'unit' => 'px', 'size' => '' ],
+		];
+
+		$css = ( new V3_Style_Serializer() )->serialize( $settings, 'theme-post-title', $this->heading_config() );
+
+		$this->assertStringNotContainsString( 'color:', $css );
+		$this->assertStringNotContainsString( 'font-size:', $css );
+		$this->assertStringContainsString( 'text-align: center;', $css );
+	}
+
+	public function test_round_trip__mapper_serializer_mapper_is_idempotent() {
+		$css = 'color: #ff3355; font-size: 42px; text-transform: uppercase; letter-spacing: 2px; &:hover { color: #c00; } @media(--tablet) { font-size: 32px; }';
+
+		$mapped = $this->make_mapper()->apply( $css, 'theme-post-title', $this->heading_config() );
+		$serialized = ( new V3_Style_Serializer() )->serialize( $mapped['settings_patch'], 'theme-post-title', $this->heading_config() );
+		$remapped = $this->make_mapper()->apply( $serialized, 'theme-post-title', $this->heading_config() );
+
+		$this->assertEquals( $mapped['settings_patch'], $remapped['settings_patch'] );
+	}
+
+	public function test_serialize__ignores_style_settings_not_in_registry_or_index() {
+		$settings = [
+			'title_color' => '#ff0000',
+			'random_unknown_key' => 'foo',
+			'title' => 'Hello',
+		];
+
+		$css = ( new V3_Style_Serializer() )->serialize( $settings, 'theme-post-title', $this->heading_config() );
+
+		$this->assertStringContainsString( 'color: #ff0000;', $css );
+		$this->assertStringNotContainsString( 'random_unknown_key', $css );
+		$this->assertStringNotContainsString( 'Hello', $css );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-value-resolvers.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-value-resolvers.php
@@ -97,6 +97,20 @@ class Test_V3_Value_Resolvers extends TestCase {
 		$this->assertSame( [], $patch );
 	}
 
+	public function test_resolve_typography_group__takes_first_font_from_stack() {
+		// Arrange / Act.
+		$patch = V3_Value_Resolvers::resolve_typography_group(
+			[
+				'font-family' => '"Playfair Display", Georgia, serif',
+			],
+			'typography'
+		);
+
+		// Assert.
+		$this->assertSame( 'Playfair Display', $patch['typography_font_family'] );
+		$this->assertSame( 'custom', $patch['typography_typography'] );
+	}
+
 	public function test_resolve_border_shorthand__parses_width_style_color() {
 		// Arrange / Act.
 		$patch = V3_Value_Resolvers::resolve_border_shorthand( '2px solid #ccc', 'image_border' );

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-value-resolvers.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-value-resolvers.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Value_Resolvers;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Value_Resolvers extends TestCase {
+
+	public function test_resolve_dimension__parses_px_and_rem() {
+		// Arrange / Act / Assert.
+		$this->assertSame( [ 'unit' => 'px', 'size' => 16.0 ], V3_Value_Resolvers::resolve_dimension( '16px' ) );
+		$this->assertSame( [ 'unit' => 'rem', 'size' => 1.5 ], V3_Value_Resolvers::resolve_dimension( '1.5rem' ) );
+		$this->assertSame( [ 'unit' => 'px', 'size' => 0.0 ], V3_Value_Resolvers::resolve_dimension( '0' ) );
+		$this->assertNull( V3_Value_Resolvers::resolve_dimension( 'auto' ) );
+	}
+
+	public function test_resolve_sides_shorthand__expands_1_to_4_values() {
+		// Arrange / Act.
+		$one = V3_Value_Resolvers::resolve_sides_shorthand( '10px' );
+		$two = V3_Value_Resolvers::resolve_sides_shorthand( '10px 20px' );
+		$four = V3_Value_Resolvers::resolve_sides_shorthand( '1px 2px 3px 4px' );
+
+		// Assert.
+		$this->assertSame( '10', $one['top'] );
+		$this->assertSame( '10', $one['right'] );
+		$this->assertTrue( $one['isLinked'] );
+
+		$this->assertSame( '10', $two['top'] );
+		$this->assertSame( '20', $two['right'] );
+		$this->assertSame( '10', $two['bottom'] );
+		$this->assertFalse( $two['isLinked'] );
+
+		$this->assertSame( '1', $four['top'] );
+		$this->assertSame( '4', $four['left'] );
+		$this->assertFalse( $four['isLinked'] );
+	}
+
+	public function test_resolve_color__passthrough() {
+		$this->assertSame( '#ff0000', V3_Value_Resolvers::resolve_color( '  #ff0000  ' ) );
+		$this->assertSame( 'rgba(0,0,0,0.5)', V3_Value_Resolvers::resolve_color( 'rgba(0,0,0,0.5)' ) );
+	}
+
+	public function test_resolve_box_shadow__parses_lengths_and_color() {
+		// Arrange / Act.
+		$result = V3_Value_Resolvers::resolve_box_shadow( '0 20px 60px rgba(0,0,0,0.15)' );
+
+		// Assert.
+		$this->assertSame( 'yes', $result['box_shadow_type'] );
+		$this->assertSame( 0.0, $result['box_shadow']['horizontal'] );
+		$this->assertSame( 20.0, $result['box_shadow']['vertical'] );
+		$this->assertSame( 60.0, $result['box_shadow']['blur'] );
+		$this->assertSame( 'rgba(0,0,0,0.15)', $result['box_shadow']['color'] );
+		$this->assertSame( 'outline', $result['box_shadow']['position'] );
+	}
+
+	public function test_resolve_box_shadow__detects_inset() {
+		$result = V3_Value_Resolvers::resolve_box_shadow( 'inset 2px 2px 4px #000' );
+
+		$this->assertSame( 'inset', $result['box_shadow']['position'] );
+		$this->assertSame( 2.0, $result['box_shadow']['horizontal'] );
+	}
+
+	public function test_resolve_typography_group__sets_toggle_and_keys() {
+		// Arrange / Act.
+		$patch = V3_Value_Resolvers::resolve_typography_group(
+			[
+				'font-size' => '2rem',
+				'font-weight' => '700',
+				'font-family' => 'Georgia',
+			],
+			'typography'
+		);
+
+		// Assert.
+		$this->assertSame( 'custom', $patch['typography_typography'] );
+		$this->assertSame( [ 'unit' => 'rem', 'size' => 2.0 ], $patch['typography_font_size'] );
+		$this->assertSame( '700', $patch['typography_font_weight'] );
+		$this->assertSame( 'Georgia', $patch['typography_font_family'] );
+	}
+
+	public function test_resolve_border_shorthand__parses_width_style_color() {
+		// Arrange / Act.
+		$patch = V3_Value_Resolvers::resolve_border_shorthand( '2px solid #ccc', 'image_border' );
+
+		// Assert.
+		$this->assertSame( 'solid', $patch['image_border_border'] );
+		$this->assertSame( '#ccc', $patch['image_border_color'] );
+		$this->assertSame( '2', $patch['image_border_width']['top'] );
+		$this->assertSame( 'px', $patch['image_border_width']['unit'] );
+	}
+
+	public function test_resolve__dispatches_by_name() {
+		$this->assertSame( 'red', V3_Value_Resolvers::resolve( 'color', 'red' ) );
+		$this->assertSame( [ 'unit' => 'px', 'size' => 10.0 ], V3_Value_Resolvers::resolve( 'dimension', '10px' ) );
+		$this->assertNull( V3_Value_Resolvers::resolve( 'unknown', 'x' ) );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-value-resolvers.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-value-resolvers.php
@@ -83,6 +83,20 @@ class Test_V3_Value_Resolvers extends TestCase {
 		$this->assertSame( 'Georgia', $patch['typography_font_family'] );
 	}
 
+	public function test_resolve_typography_group__skips_toggle_when_nothing_resolves() {
+		// Arrange / Act.
+		$patch = V3_Value_Resolvers::resolve_typography_group(
+			[
+				'font-size' => 'potato',
+				'line-height' => 'banana',
+			],
+			'typography'
+		);
+
+		// Assert.
+		$this->assertSame( [], $patch );
+	}
+
 	public function test_resolve_border_shorthand__parses_width_style_color() {
 		// Arrange / Act.
 		$patch = V3_Value_Resolvers::resolve_border_shorthand( '2px solid #ccc', 'image_border' );

--- a/tests/phpunit/elementor/modules/mcp/abilities/utils/test-v3-controls-metadata.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/utils/test-v3-controls-metadata.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Modules\Mcp\Abilities\Utils\V3_Controls_Metadata;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Controls_Metadata extends TestCase {
+
+	public function test_extract__skips_layout_controls() {
+		// Arrange.
+		$controls = [
+			'section_content' => [ 'type' => 'section' ],
+			'title' => [ 'type' => 'text', 'default' => 'Hello' ],
+			'tab_style' => [ 'type' => 'tab' ],
+		];
+
+		// Act.
+		$result = V3_Controls_Metadata::extract( $controls );
+
+		// Assert.
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertArrayNotHasKey( 'section_content', $result );
+		$this->assertArrayNotHasKey( 'tab_style', $result );
+		$this->assertSame( 'Hello', $result['title']['default'] );
+		$this->assertSame( 'text', $result['title']['type'] );
+	}
+
+	public function test_extract__filters_to_allowed_keys() {
+		// Arrange.
+		$controls = [
+			'title' => [ 'type' => 'text', 'default' => 'Hello' ],
+			'title_color' => [ 'type' => 'color', 'default' => '#000' ],
+			'header_size' => [
+				'type' => 'select',
+				'options' => [
+					'h1' => 'H1',
+					'h2' => 'H2',
+				],
+			],
+		];
+
+		// Act.
+		$result = V3_Controls_Metadata::extract( $controls, [ 'title', 'header_size' ] );
+
+		// Assert.
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertArrayHasKey( 'header_size', $result );
+		$this->assertArrayNotHasKey( 'title_color', $result );
+		$this->assertSame( [ 'h1', 'h2' ], $result['header_size']['options'] );
+	}
+
+	public function test_extract__empty_allowlist_returns_empty() {
+		$result = V3_Controls_Metadata::extract(
+			[ 'title' => [ 'type' => 'text' ] ],
+			[]
+		);
+
+		$this->assertSame( [], $result );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/utils/test-v3-json-schema-builder.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/utils/test-v3-json-schema-builder.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Utils;
+
+use Elementor\Modules\Mcp\Abilities\Utils\V3_Json_Schema_Builder;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Json_Schema_Builder extends TestCase {
+
+	public function test_build__maps_select_to_string_enum() {
+		// Arrange.
+		$controls = [
+			'layout' => [
+				'type' => 'select',
+				'default' => 'horizontal',
+				'options' => [
+					'horizontal' => 'Horizontal',
+					'vertical' => 'Vertical',
+				],
+			],
+		];
+
+		// Act.
+		$result = V3_Json_Schema_Builder::build( $controls );
+
+		// Assert.
+		$this->assertSame( 'string', $result['properties']['layout']['type'] );
+		$this->assertSame( [ 'horizontal', 'vertical' ], $result['properties']['layout']['enum'] );
+		$this->assertSame( 'horizontal', $result['properties']['layout']['default'] );
+	}
+
+	public function test_build__maps_switcher_to_string_enum_yes_or_empty() {
+		$controls = [ 'open_lightbox' => [ 'type' => 'switcher' ] ];
+
+		$result = V3_Json_Schema_Builder::build( $controls );
+
+		$this->assertSame( 'string', $result['properties']['open_lightbox']['type'] );
+		$this->assertSame( [ 'yes', '' ], $result['properties']['open_lightbox']['enum'] );
+	}
+
+	public function test_build__maps_number_and_text() {
+		$controls = [
+			'count' => [ 'type' => 'number', 'default' => 3 ],
+			'title' => [ 'type' => 'text', 'default' => 'Hello' ],
+		];
+
+		$result = V3_Json_Schema_Builder::build( $controls );
+
+		$this->assertSame( 'number', $result['properties']['count']['type'] );
+		$this->assertSame( 3, $result['properties']['count']['default'] );
+		$this->assertSame( 'string', $result['properties']['title']['type'] );
+		$this->assertSame( 'Hello', $result['properties']['title']['default'] );
+	}
+
+	public function test_build__maps_media_and_icons_to_object_shapes() {
+		$controls = [
+			'image' => [ 'type' => 'media' ],
+			'icon' => [ 'type' => 'icons' ],
+		];
+
+		$result = V3_Json_Schema_Builder::build( $controls );
+
+		$this->assertSame( 'object', $result['properties']['image']['type'] );
+		$this->assertArrayHasKey( 'url', $result['properties']['image']['properties'] );
+		$this->assertArrayHasKey( 'id', $result['properties']['image']['properties'] );
+
+		$this->assertSame( 'object', $result['properties']['icon']['type'] );
+		$this->assertArrayHasKey( 'value', $result['properties']['icon']['properties'] );
+		$this->assertArrayHasKey( 'library', $result['properties']['icon']['properties'] );
+	}
+
+	public function test_build__maps_slider_and_dimensions_to_object_shapes() {
+		$controls = [
+			'gap' => [ 'type' => 'slider' ],
+			'padding' => [ 'type' => 'dimensions' ],
+		];
+
+		$result = V3_Json_Schema_Builder::build( $controls );
+
+		$this->assertSame( 'object', $result['properties']['gap']['type'] );
+		$this->assertArrayHasKey( 'size', $result['properties']['gap']['properties'] );
+		$this->assertArrayHasKey( 'unit', $result['properties']['gap']['properties'] );
+
+		$this->assertSame( 'object', $result['properties']['padding']['type'] );
+		$this->assertArrayHasKey( 'top', $result['properties']['padding']['properties'] );
+		$this->assertArrayHasKey( 'isLinked', $result['properties']['padding']['properties'] );
+	}
+
+	public function test_build__filters_by_allowed_keys_and_drops_layout_wrappers() {
+		$controls = [
+			'section' => [ 'type' => 'section' ],
+			'menu' => [ 'type' => 'select', 'options' => [ 'a' => 'A', 'b' => 'B' ] ],
+			'title_color' => [ 'type' => 'color' ],
+		];
+
+		$result = V3_Json_Schema_Builder::build( $controls, [ 'menu', 'title_color' ] );
+
+		$this->assertArrayHasKey( 'menu', $result['properties'] );
+		$this->assertArrayHasKey( 'title_color', $result['properties'] );
+		$this->assertArrayNotHasKey( 'section', $result['properties'] );
+
+		$filtered = V3_Json_Schema_Builder::build( $controls, [ 'menu' ] );
+		$this->assertArrayNotHasKey( 'title_color', $filtered['properties'] );
+	}
+
+	public function test_build__empty_allowlist_returns_empty_properties() {
+		$result = V3_Json_Schema_Builder::build( [ 'title' => [ 'type' => 'text' ] ], [] );
+
+		$this->assertSame( [], $result['properties'] );
+	}
+
+	public function test_build__preserves_description_stripped_of_tags() {
+		$controls = [
+			'menu' => [
+				'type' => 'select',
+				'description' => 'Go to the <a href="#">menus screen</a>',
+			],
+		];
+
+		$result = V3_Json_Schema_Builder::build( $controls );
+
+		$this->assertSame( 'Go to the menus screen', $result['properties']['menu']['description'] );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
@@ -1032,14 +1032,14 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 			'post_id' => $post_id,
 			'xml_structure' => '<nav-menu configuration-id="m1"/>',
 			'style' => [
-				'm1' => 'color: red;',
+				'm1' => 'filter: blur(2px);',
 			],
 		] );
 
 		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : 'unknown' );
 
 		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
-		$this->assertSame( 'selector { color: red; }', $elements[0]['settings']['custom_css'] ?? null );
+		$this->assertSame( 'selector { filter: blur(2px); }', $elements[0]['settings']['custom_css'] ?? null );
 	}
 
 	public function test_execute__allowlisted_v3_widget_style_warns_when_pro_missing() {
@@ -1055,13 +1055,18 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 			'post_id' => $post_id,
 			'xml_structure' => '<nav-menu configuration-id="m1"/>',
 			'style' => [
-				'm1' => 'color: red;',
+				'm1' => 'filter: blur(2px);',
 			],
 		] );
 
 		$this->assertIsArray( $result );
 		$this->assertNotEmpty( $result['warnings'] ?? [] );
-		$this->assertStringContainsString( 'Elementor Pro', $result['warnings'][0] );
+		$this->assertTrue(
+			(bool) array_filter(
+				$result['warnings'],
+				static fn( $warning ) => false !== strpos( (string) $warning, 'Elementor Pro' )
+			)
+		);
 
 		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
 		$this->assertArrayNotHasKey( 'custom_css', $elements[0]['settings'] );

--- a/tests/phpunit/elementor/modules/mcp/test-get-structure-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-get-structure-ability.php
@@ -163,14 +163,12 @@ class Test_Get_Structure_Ability extends Elementor_Test_Base {
 				[
 					'id' => 'container1',
 					'elType' => 'container',
-					'version' => 3,
 					'title' => 'Container',
 					'elements' => [
 						[
 							'id' => 'widget1',
 							'elType' => 'widget',
 							'widgetType' => 'e-heading',
-							'version' => 4,
 							'title' => 'Heading',
 						],
 					],
@@ -211,7 +209,7 @@ class Test_Get_Structure_Ability extends Elementor_Test_Base {
 		// Assert
 		$this->assertSame(
 			[
-				[ 'id' => 'widget2', 'elType' => 'widget', 'widgetType' => 'e-button', 'version' => 4, 'title' => 'Button' ],
+				[ 'id' => 'widget2', 'elType' => 'widget', 'widgetType' => 'e-button', 'title' => 'Button' ],
 			],
 			$result['elements']
 		);
@@ -691,7 +689,7 @@ class Test_Get_Structure_Ability extends Elementor_Test_Base {
 		$this->assertSame( 'Envelope Title', $result['elements'][0]['title'] );
 	}
 
-	public function test_execute__tags_v3_widget_and_v4_widget_with_version() {
+	public function test_execute__omits_version_from_skeleton() {
 		// Arrange
 		$this->act_as_admin();
 		$post_id = $this->factory()->post->create();
@@ -714,12 +712,12 @@ class Test_Get_Structure_Ability extends Elementor_Test_Base {
 
 		// Assert
 		$container = $result['elements'][0];
-		$this->assertSame( 3, $container['version'] );
-		$this->assertSame( 3, $container['elements'][0]['version'] );
-		$this->assertSame( 4, $container['elements'][1]['version'] );
+		$this->assertArrayNotHasKey( 'version', $container );
+		$this->assertArrayNotHasKey( 'version', $container['elements'][0] );
+		$this->assertArrayNotHasKey( 'version', $container['elements'][1] );
 	}
 
-	public function test_execute__strips_v3_settings_and_styles_when_include_content_true() {
+	public function test_execute__strips_non_allowlisted_v3_settings_and_styles_when_include_content_true() {
 		// Arrange
 		$this->act_as_admin();
 		$post_id = $this->factory()->post->create();
@@ -746,9 +744,46 @@ class Test_Get_Structure_Ability extends Elementor_Test_Base {
 
 		// Assert
 		$node = $result['elements'][0];
-		$this->assertSame( 3, $node['version'] );
+		$this->assertArrayNotHasKey( 'version', $node );
 		$this->assertEquals( (object) [], $node['settings'] );
 		$this->assertEquals( (object) [], $node['styles'] );
+	}
+
+	public function test_execute__serializes_allowlisted_v3_style_when_include_content_true() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->factory()->post->create();
+
+		$elements = [
+			[
+				'id' => 'post-title-1',
+				'elType' => 'widget',
+				'widgetType' => 'theme-post-title',
+				'settings' => [
+					'title' => 'Hello',
+					'title_color' => '#222222',
+					'custom_css' => 'selector { filter: blur(2px); }',
+				],
+				'elements' => [],
+			],
+		];
+
+		$this->mock_document_with_elements( $post_id, $elements );
+
+		// Act
+		$result = $this->ability->execute( [
+			'post_id' => $post_id,
+			'element_id' => 'post-title-1',
+			'include_content' => true,
+		] );
+
+		// Assert
+		$node = $result['elements'][0];
+		$this->assertArrayNotHasKey( 'version', $node );
+		$this->assertArrayNotHasKey( 'styles', $node );
+		$this->assertSame( [ 'title' => 'Hello' ], $node['settings'] );
+		$this->assertStringContainsString( 'color: #222222;', $node['style'] );
+		$this->assertStringContainsString( 'filter: blur(2px);', $node['style'] );
 	}
 
 	public function test_execute__omits_version_for_unknown_type() {

--- a/tests/phpunit/elementor/modules/mcp/test-get-widget-schema-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-get-widget-schema-ability.php
@@ -55,12 +55,14 @@ class Test_Get_Widget_Schema_Ability extends Elementor_Test_Base {
 		$result = $this->ability->execute( [ 'widget_type' => 'nav-menu' ] );
 
 		$this->assertIsArray( $result );
+		$this->assertSame( 'object', $result['type'] );
 		$this->assertSame( Widget_Context_Helper::VERSION_V3, $result['widget_version'] );
 		$this->assertSame( Widget_Context_Helper::V3_FALLBACK_MESSAGE, $result['message'] );
 		$this->assertSame( Widget_Context_Helper::V3_FALLBACK_FIELDS_NOTE, $result['fields_note'] );
 		$this->assertArrayHasKey( 'properties', $result );
 		$this->assertArrayHasKey( 'menu', $result['properties'] );
-		$this->assertSame( 'select', $result['properties']['menu']['type'] );
+		$this->assertSame( 'string', $result['properties']['menu']['type'] );
+		$this->assertSame( [ 'horizontal', 'vertical' ], $result['properties']['layout']['enum'] );
 	}
 
 	public function test_execute__returns_404_for_unknown_widget_type() {

--- a/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
@@ -864,7 +864,7 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 				[
 					'action' => 'update',
 					'element_id' => $v3_id,
-					'style' => 'font-size: 2rem;',
+					'style' => 'filter: blur(2px);',
 				],
 			],
 		] );
@@ -872,7 +872,7 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertOkOperation( $result, 0 );
 
 		$node = $this->find_element_in_document( $post_id, $v3_id );
-		$this->assertSame( 'selector { font-size: 2rem; }', $node['settings']['custom_css'] ?? null );
+		$this->assertSame( 'selector { filter: blur(2px); }', $node['settings']['custom_css'] ?? null );
 		$this->assertArrayNotHasKey( 'styles', $node );
 	}
 
@@ -892,7 +892,7 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 				[
 					'action' => 'update',
 					'element_id' => $v3_id,
-					'style' => 'font-size: 2rem;',
+					'style' => 'filter: blur(2px);',
 				],
 			],
 		] );
@@ -900,7 +900,12 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertOkOperation( $result, 0 );
 		$warnings = $result['results'][0]['warnings'] ?? [];
 		$this->assertNotEmpty( $warnings );
-		$this->assertStringContainsString( 'Elementor Pro', $warnings[0] );
+		$this->assertTrue(
+			(bool) array_filter(
+				$warnings,
+				static fn( $warning ) => false !== strpos( (string) $warning, 'Elementor Pro' )
+			)
+		);
 
 		$node = $this->find_element_in_document( $post_id, $v3_id );
 		$this->assertArrayNotHasKey( 'custom_css', $node['settings'] );


### PR DESCRIPTION
## Summary

Layer 2 of the [ED-25071 stacked series](https://github.com/elementor/elementor/pull/36801). Adds the V3 style read/write path so the six allowlisted V3 widgets accept plain-CSS `style` on `build-composition`/`manage-elements` and surface their current styles back through `get-page-structure`.

- `V3_Style_Mapper`: parses LLM CSS declarations, maps them onto legacy V3 style controls via a widget bridge registry, and wraps anything unmapped in `selector { ... }` for the Custom CSS module.
- `V3_Style_Serializer`: inverse path — reconstructs a CSS string from current V3 settings for `get-page-structure` output.
- `V3_Widget_Bridge_Registry` / `V3_Style_Settings_Index` / `V3_Value_Resolvers`: per-widget mapping tables (base + responsive + pseudo-state) with value resolvers for typography, borders, shadows, dimensions, etc.
- `V3_Json_Schema_Builder`: exposes the V3 shape via list/get-widget-schemas.
- `Style_Applier` / `Element_Config_Applier`: dispatch V3 style writes through the mapper; V4 atomic path unchanged.
- `get-structure-ability`: emits a `style` field for allowlisted V3 nodes.

## Depends on

- Base: #36829 (PR1 — V3 allowlist)

## Test plan

- [ ] PHPUnit: `test-v3-style-mapper.php`, `test-v3-style-serializer.php`, `test-v3-value-resolvers.php`, `test-v3-non-style-allowlist.php`, `test-v3-controls-metadata.php`, `test-v3-json-schema-builder.php`, `test-style-applier.php`, `test-element-config-applier.php`
- [ ] Manual: call `elementor/manage-elements` with a plain-CSS `style` payload on `theme-post-title` and observe the mapped V3 settings; verify `get-page-structure` round-trips the same CSS.

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

V3 allowlisted widgets (nav-menu, theme-post-*) now accept CSS via the same `style` input as V4 widgets, mapping declarative CSS to legacy settings (typography, border, color, etc.) with fallback to custom_css. Closes ED-25071.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `v3/v3-widget-bridge-registry.php` | New: per-widget CSS→setting override registry (6 allowlisted types, 335 LOC) |
| `v3/v3-style-mapper.php` | New: CSS parser mapping rules to V3 settings, handles responsive breakpoints (338 LOC) |
| `v3/v3-style-serializer.php` | New: reverse mapping—settings back to CSS for `get-structure` (384 LOC) |
| `v3/v3-value-resolvers.php` | New: pure functions resolving CSS values to V3 control shapes (355 LOC) |
| `v3/v3-style-settings-index.php` | New: generic CSS→setting reverse lookup from control selectors (150 LOC) |
| `v3/v3-non-style-allowlist.php` | New: per-widget non-style settings allowlist validator (66 LOC) |
| `appliers/v3-node-bridge.php` | Extended: `clear_style_settings()` wipes mapped settings on replace mode; introspection helpers for collecting/expanding override keys |
| `appliers/style-applier.php` | `apply()` signature: +`$style_apply_mode`, +`$widget_configs` params; new `apply_v3_style()` delegates to V3_Style_Mapper |
| `appliers/element-config-applier.php` | V3 nodes now filter settings through V3_Non_Style_Allowlist before merge |
| `get-structure-ability.php` | New `populate_v3_content()` serializes V3 styles + filters settings when `include_content=true`; dropped `version` field |
| `build-composition-ability.php`, `manage-elements-ability.php` | Pass `$widget_configs` to `style_applier->apply()` |
| Tests | 10 new test files covering mappers, serializers, resolvers, allowlist filtering; updated build/manage/get-structure tests |
| Docs | Updated `.md` guides—removed v3-specific caveats, unified contract language |

## 3. How It Works

**Entry:** V3 node + CSS string → Style_Applier detects `V3_Node_Bridge::is_v3_node()` → delegates to `apply_v3_style()`.

**Happy path:**
1. V3_Style_Mapper parses CSS, splits by breakpoint, matches selectors to pseudo-states
2. Per-widget registry overrides (typography_prefix, border_prefix, box_shadow_prefix, setting+resolver) apply first
3. Fallback to generic V3_Style_Settings_Index (reverse lookup from control selectors)
4. V3_Value_Resolvers converts CSS values to V3 shape (e.g., `2rem` → `{unit: 'rem', size: 2.0}`)
5. Responsive suffixes (`_tablet`, `_mobile`) written if control exists
6. Unmapped CSS accumulates, merged into custom_css (Pro only) or warning

**Edge cases:**
- Replace mode clears all known style settings + custom_css before applying new styles
- Empty CSS in replace mode wipes styles cleanly
- Unmapped CSS truncated (200 chars) in warnings
- Generic index excludes overridden keys; only unique 1:1 selector→setting mappings included

**Serialization (reverse):** V3 settings → CSS via V3_Style_Serializer for `get-structure` with `include_content=true`. Re-wraps custom_css if needed, groups by breakpoint/pseudo-state.

## 4. Risks

**Schema stability:** Registry is hand-curated per widget. Missing or incorrect CSS→setting mappings silently drop to unmapped. *Mitigation:* registry tests cover all 6 types; mapper tests verify round-trip idempotence.

**Responsive control existence:** Mapper checks control existence before applying breakpoint suffixes. Silently skips if control missing. *Mitigation:* intentional—avoids orphaned settings; test covers both cases.

**Pro dependency:** Unmapped CSS requires Pro custom_css module. Non-Pro warns but doesn't fail. *Mitigation:* explicit warning; tests mock Utils::has_pro() to verify both paths.

**Backward compat:** V3 widget get-structure no longer returns `version` field. *Mitigation:* docs updated; clients already ignore unknown fields; test corrected.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
