### PR TITLE
Internal: Seed V3 dynamic defaults during composition build [ED-25071]

### DIFF
--- a/modules/mcp/abilities/appliers/v3-node-bridge.php
+++ b/modules/mcp/abilities/appliers/v3-node-bridge.php
@@ -20,6 +20,47 @@ class V3_Node_Bridge {
 
 	const V3_CUSTOM_CSS_SETTING = 'custom_css';
 	const V3_CSS_CLASSES_SETTING = '_css_classes';
+	const V3_DYNAMIC_SETTING = '__dynamic__';
+
+	/**
+	 * Seeds each control's `dynamic.default` into the node's `__dynamic__` settings map when the
+	 * caller did not provide one. Without this, controls whose default is a dynamic tag (e.g.
+	 * `theme-post-title.title` -> post-title tag) render as their static fallback in the editor
+	 * canvas immediately after mutation and only pick up the dynamic value on a full refresh.
+	 *
+	 * @param array $node          Subtree node (by reference).
+	 * @param array $widget_config Widget config from Widget_Context_Helper::get_widget_config().
+	 */
+	public static function seed_dynamic_defaults( array &$node, array $widget_config ): void {
+		if ( ! self::is_v3_node( $node ) ) {
+			return;
+		}
+
+		$controls = $widget_config['controls'] ?? [];
+		if ( empty( $controls ) || ! is_array( $controls ) ) {
+			return;
+		}
+
+		$existing = $node['settings'][ self::V3_DYNAMIC_SETTING ] ?? [];
+
+		foreach ( $controls as $name => $control ) {
+			$dynamic_default = $control['dynamic']['default'] ?? null;
+
+			if ( ! is_string( $dynamic_default ) || '' === $dynamic_default ) {
+				continue;
+			}
+
+			if ( array_key_exists( $name, $existing ) ) {
+				continue;
+			}
+
+			$existing[ $name ] = $dynamic_default;
+		}
+
+		if ( ! empty( $existing ) ) {
+			$node['settings'][ self::V3_DYNAMIC_SETTING ] = $existing;
+		}
+	}
 
 	const RESPONSIVE_SUFFIXES = [ '_tablet', '_mobile' ];
 

--- a/modules/mcp/abilities/appliers/v3-node-bridge.php
+++ b/modules/mcp/abilities/appliers/v3-node-bridge.php
@@ -28,19 +28,10 @@ class V3_Node_Bridge {
 	 * `theme-post-title.title` -> post-title tag) render as their static fallback in the editor
 	 * canvas immediately after mutation and only pick up the dynamic value on a full refresh.
 	 *
-	 * @param array $node          Subtree node (by reference).
-	 * @param array $widget_config Widget config from Widget_Context_Helper::get_widget_config().
+	 * @param array $node     Subtree node (by reference).
+	 * @param array $controls Widget controls from Widget_Base::get_controls().
 	 */
-	public static function seed_dynamic_defaults( array &$node, array $widget_config ): void {
-		if ( ! self::is_v3_node( $node ) ) {
-			return;
-		}
-
-		$controls = $widget_config['controls'] ?? [];
-		if ( empty( $controls ) || ! is_array( $controls ) ) {
-			return;
-		}
-
+	public static function seed_dynamic_defaults( array &$node, array $controls ): void {
 		$existing = $node['settings'][ self::V3_DYNAMIC_SETTING ] ?? [];
 
 		foreach ( $controls as $name => $control ) {

--- a/modules/mcp/abilities/build-composition/subtree-builder.php
+++ b/modules/mcp/abilities/build-composition/subtree-builder.php
@@ -85,8 +85,8 @@ class Subtree_Builder {
 			$element['editor_settings']['title'] = $configuration_id;
 		}
 
-		if ( ! empty( $config['controls'] ) ) {
-			V3_Node_Bridge::seed_dynamic_defaults( $element, [ 'controls' => $config['controls'] ] );
+		if ( ! empty( $config['controls'] ) && V3_Node_Bridge::is_v3_node( $element ) ) {
+			V3_Node_Bridge::seed_dynamic_defaults( $element, $config['controls'] );
 		}
 
 		return $element;

--- a/modules/mcp/abilities/build-composition/subtree-builder.php
+++ b/modules/mcp/abilities/build-composition/subtree-builder.php
@@ -2,6 +2,8 @@
 
 namespace Elementor\Modules\Mcp\Abilities\Build_Composition;
 
+use Elementor\Modules\Mcp\Abilities\Appliers\V3_Node_Bridge;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -81,6 +83,10 @@ class Subtree_Builder {
 		$configuration_id = $this->xml_parser->get_configuration_id( $node );
 		if ( null !== $configuration_id ) {
 			$element['editor_settings']['title'] = $configuration_id;
+		}
+
+		if ( ! empty( $config['controls'] ) ) {
+			V3_Node_Bridge::seed_dynamic_defaults( $element, [ 'controls' => $config['controls'] ] );
 		}
 
 		return $element;

--- a/modules/mcp/abilities/build-composition/widget-type-resolver.php
+++ b/modules/mcp/abilities/build-composition/widget-type-resolver.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities\Build_Composition;
 
+use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -76,18 +77,24 @@ class Widget_Type_Resolver {
 	}
 
 	/**
-	 * @return array|\WP_Error  ['elType', 'widgetType', 'allowed_child_types', 'class']
+	 * @return array|\WP_Error  ['elType', 'widgetType', 'allowed_child_types', 'class', 'controls']
 	 */
 	public function resolve_type_config( string $type ) {
 		$widget = Plugin::$instance->widgets_manager->get_widget_types( $type );
 		if ( $widget ) {
 			$config = $widget->get_config();
-			return [
+			$resolved = [
 				'elType' => 'widget',
 				'widgetType' => $type,
 				'allowed_child_types' => $config['allowed_child_types'] ?? [],
 				'class' => get_class( $widget ),
 			];
+
+			if ( Widget_Context_Helper::is_v3_allowlisted( $type ) && method_exists( $widget, 'get_controls' ) ) {
+				$resolved['controls'] = (array) $widget->get_controls();
+			}
+
+			return $resolved;
 		}
 
 		$element = Plugin::$instance->elements_manager->get_element_types( $type );

--- a/modules/mcp/abilities/build-composition/widget-type-resolver.php
+++ b/modules/mcp/abilities/build-composition/widget-type-resolver.php
@@ -90,7 +90,7 @@ class Widget_Type_Resolver {
 				'class' => get_class( $widget ),
 			];
 
-			if ( Widget_Context_Helper::is_v3_allowlisted( $type ) && method_exists( $widget, 'get_controls' ) ) {
+			if ( Widget_Context_Helper::is_v3_allowlisted( $type ) ) {
 				$resolved['controls'] = (array) $widget->get_controls();
 			}
 

--- a/tests/phpunit/elementor/modules/mcp/abilities/build-composition/test-subtree-builder-v3-seed.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/build-composition/test-subtree-builder-v3-seed.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Build_Composition;
+
+use Elementor\Modules\Mcp\Abilities\Build_Composition\Subtree_Builder;
+use Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Subtree_Builder_V3_Seed extends TestCase {
+
+	public function test_build__seeds_v3_dynamic_defaults_from_widget_config_controls() {
+		$xml_parser = new Xml_Parser();
+		$builder = new Subtree_Builder( $xml_parser );
+
+		$dom = $xml_parser->parse( '<theme-post-title configuration-id="t1"></theme-post-title>' );
+
+		$widget_configs = [
+			'theme-post-title' => [
+				'elType' => 'widget',
+				'widgetType' => 'theme-post-title',
+				'allowed_child_types' => [],
+				'class' => 'FakeThemePostTitleWidget',
+				'controls' => [
+					'title' => [
+						'type' => 'text',
+						'dynamic' => [ 'default' => '[elementor-tag id="post-title"]' ],
+					],
+					'body' => [ 'type' => 'text' ],
+				],
+			],
+		];
+
+		$subtrees = $builder->build( $dom, $widget_configs );
+
+		$this->assertCount( 1, $subtrees );
+		$this->assertSame(
+			[ 'title' => '[elementor-tag id="post-title"]' ],
+			$subtrees[0]['settings']['__dynamic__'] ?? []
+		);
+	}
+
+	public function test_build__leaves_v4_atomic_widgets_untouched() {
+		$xml_parser = new Xml_Parser();
+		$builder = new Subtree_Builder( $xml_parser );
+
+		$dom = $xml_parser->parse( '<e-heading configuration-id="h1"></e-heading>' );
+
+		$widget_configs = [
+			'e-heading' => [
+				'elType' => 'widget',
+				'widgetType' => 'e-heading',
+				'allowed_child_types' => [],
+				'class' => 'FakeAtomicHeadingWidget',
+			],
+		];
+
+		$subtrees = $builder->build( $dom, $widget_configs );
+
+		$this->assertSame( [], $subtrees[0]['settings'] );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/build-composition/test-subtree-builder-v3-seed.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/build-composition/test-subtree-builder-v3-seed.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Testing\Modules\Mcp\Abilities\Build_Composition;
 
+use Elementor\Modules\Mcp\Abilities\Appliers\V3_Node_Bridge;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Subtree_Builder;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser;
 use PHPUnit\Framework\TestCase;
@@ -43,7 +44,30 @@ class Test_Subtree_Builder_V3_Seed extends TestCase {
 		);
 	}
 
-	public function test_build__leaves_v4_atomic_widgets_untouched() {
+	public function test_seed_dynamic_defaults__preserves_caller_provided_dynamic_overrides() {
+		$node = [
+			'elType' => 'widget',
+			'widgetType' => 'theme-post-title',
+			'settings' => [
+				'__dynamic__' => [ 'title' => '[elementor-tag id="custom-title"]' ],
+			],
+		];
+		$controls = [
+			'title' => [
+				'type' => 'text',
+				'dynamic' => [ 'default' => '[elementor-tag id="post-title"]' ],
+			],
+		];
+
+		V3_Node_Bridge::seed_dynamic_defaults( $node, $controls );
+
+		$this->assertSame(
+			[ 'title' => '[elementor-tag id="custom-title"]' ],
+			$node['settings']['__dynamic__']
+		);
+	}
+
+	public function test_build__skips_v4_atomic_widgets_even_when_controls_are_present() {
 		$xml_parser = new Xml_Parser();
 		$builder = new Subtree_Builder( $xml_parser );
 
@@ -55,6 +79,12 @@ class Test_Subtree_Builder_V3_Seed extends TestCase {
 				'widgetType' => 'e-heading',
 				'allowed_child_types' => [],
 				'class' => 'FakeAtomicHeadingWidget',
+				'controls' => [
+					'title' => [
+						'type' => 'text',
+						'dynamic' => [ 'default' => '[elementor-tag id="post-title"]' ],
+					],
+				],
 			],
 		];
 


### PR DESCRIPTION
## Summary

Layer 3 of the [ED-25071 stacked series](https://github.com/elementor/elementor/pull/36801). Seeds V3 widget dynamic defaults into `settings.__dynamic__` at composition time so the editor's initial render uses the dynamic value (post-title, post-content, etc.) instead of the static fallback.

Design: seed happens directly during element construction in `Subtree_Builder::build_subtree()` — not as a post-pass on the ability output.

- `V3_Node_Bridge::seed_dynamic_defaults`: reads `dynamic.default` for each control and writes non-empty dynamic tags into `settings.__dynamic__`; caller-provided `__dynamic__.<name>` values are preserved.
- `Widget_Type_Resolver`: attaches `controls` (via `Widget_Base::get_controls()`, which forces stack init) to the resolved config for V3 allowlisted widgets only.
- `Subtree_Builder::build_subtree`: invokes the bridge whenever `controls` is present.

## Depends on

- Base: #36830 (PR2 — V3 style bridge)

## Test plan

- [ ] PHPUnit: `tests/phpunit/elementor/modules/mcp/abilities/build-composition/test-subtree-builder-v3-seed.php`
- [ ] Manual: build a `theme-post-title` widget via `elementor/build-composition` with empty `settings` and verify the editor's initial render shows the post title (not the static fallback).

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

V3 widgets with dynamic tag defaults (e.g., post-title) render as static fallbacks immediately after mutation in the editor canvas, only acquiring dynamic values on full refresh. This seeds those defaults into the composition build to match LLM contract expectations.

## 2. What Changed (Where)

- **V3_Node_Bridge**: New `seed_dynamic_defaults()` method + `V3_DYNAMIC_SETTING` constant for populating `__dynamic__` settings map
- **Subtree_Builder**: Invokes seeding post-element-build when v3 node with controls present
- **Widget_Type_Resolver**: Returns widget `controls` array for v3-allowlisted types; updated docstring
- **Test file**: New comprehensive test coverage for seeding behavior, caller overrides, v4 skipping

## 3. How It Works

Entry point is `Subtree_Builder::build()` → after element construction, checks `is_v3_node()` and calls `seed_dynamic_defaults()` → iterates control definitions, extracts `dynamic.default` strings, merges into `__dynamic__` settings (respecting existing caller-provided values) → preserves LLM's expected contract for immediate dynamic rendering.

## 4. Risks

None identified. Logic defensively skips non-v3 nodes via `is_v3_node()` check; allowlist gating prevents accidental v4 inclusion; caller overrides respected via early-exit on existing keys.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
