### PR TITLE
Feat: Self-heal CSS files from the filesystem, not the DB [ED-24868]

### DIFF
--- a/core/experiments/manager.php
+++ b/core/experiments/manager.php
@@ -377,6 +377,16 @@ class Manager extends Base_Object {
 				'minimum_installation_version' => '3.30.0',
 			],
 		] );
+
+		$this->add_feature( [
+			'name' => 'e_optimized_css_files',
+			'title' => esc_html__( 'Optimized CSS Files', 'elementor' ),
+			'tag' => esc_html__( 'Performance', 'elementor' ),
+			'description' => esc_html__( 'Keeps external CSS files available and consistent for sites behind page caching or a CDN.', 'elementor' ),
+			'release_status' => self::RELEASE_STATUS_ALPHA,
+			'default' => self::STATE_INACTIVE,
+			'generator_tag' => true,
+		] );
 	}
 
 	/**

--- a/core/files/base.php
+++ b/core/files/base.php
@@ -175,15 +175,20 @@ abstract class Base {
 	/**
 	 * @since 2.1.0
 	 * @access public
+	 *
+	 * @return bool True if the content was written successfully, or if there was no
+	 *              content to write. False if a write was attempted and failed.
 	 */
 	public function update_file() {
 		$this->content = $this->parse_content();
 
 		if ( $this->content ) {
-			$this->write();
-		} else {
-			$this->delete();
+			return false !== $this->write();
 		}
+
+		$this->delete();
+
+		return true;
 	}
 
 	/**
@@ -191,7 +196,49 @@ abstract class Base {
 	 * @access public
 	 */
 	public function write() {
-		return file_put_contents( $this->path, $this->content );
+		if ( ! Plugin::$instance->experiments->is_feature_active( 'e_optimized_css_files' ) ) {
+			return file_put_contents( $this->path, $this->content );
+		}
+
+		return $this->write_atomically();
+	}
+
+	/**
+	 * Write the file atomically.
+	 *
+	 * Writes to a temporary file first and then renames it into place, so a concurrent
+	 * request can never read a half-written or zero-byte file. Falls back to a direct
+	 * write if the temp file could not be created or the rename fails.
+	 *
+	 * @since 3.33.0
+	 * @access protected
+	 *
+	 * @return bool True if the write succeeded, False otherwise.
+	 */
+	protected function write_atomically() {
+		$tmp_path = $this->path . '.tmp-' . wp_generate_password( 8, false, false );
+
+		$is_written = false !== file_put_contents( $tmp_path, $this->content );
+
+		if ( ! $is_written ) {
+			if ( file_exists( $tmp_path ) ) {
+				unlink( $tmp_path );
+			}
+
+			return false;
+		}
+
+		if ( ! rename( $tmp_path, $this->path ) ) {
+			$fallback = false !== file_put_contents( $this->path, $this->content );
+
+			if ( file_exists( $tmp_path ) ) {
+				unlink( $tmp_path );
+			}
+
+			return $fallback;
+		}
+
+		return true;
 	}
 
 	/**

--- a/core/files/css/base.php
+++ b/core/files/css/base.php
@@ -131,7 +131,7 @@ abstract class Base extends Base_File {
 	 * @access public
 	 */
 	public function update() {
-		$this->update_file();
+		$write_succeeded = $this->update_file();
 
 		$meta = $this->get_meta();
 
@@ -144,10 +144,14 @@ abstract class Base extends Base_File {
 			$meta['css'] = '';
 		} else {
 			$use_external_file = $this->use_external_file();
+			$is_optimized_css_files_active = Plugin::$instance->experiments->is_feature_active( 'e_optimized_css_files' );
 
-			if ( $use_external_file ) {
+			if ( $use_external_file && ( ! $is_optimized_css_files_active || $write_succeeded ) ) {
 				$meta['status'] = self::CSS_STATUS_FILE;
 			} else {
+				// Either the print method is internal, or (when the experiment is active) the
+				// external file write failed — fall back to inline CSS rather than recording a
+				// `file` status that points at a file that doesn't exist.
 				$meta['status'] = self::CSS_STATUS_INLINE;
 				$meta['css'] = $content;
 			}
@@ -164,8 +168,10 @@ abstract class Base extends Base_File {
 	 */
 	public function write() {
 		if ( $this->use_external_file() ) {
-			parent::write();
+			return parent::write();
 		}
+
+		return true;
 	}
 
 	/**
@@ -231,6 +237,18 @@ abstract class Base extends Base_File {
 
 		// First time after clear cache and etc.
 		if ( '' === $meta['status'] || $this->is_update_required() ) {
+			$this->update();
+
+			$meta = $this->get_meta();
+		}
+
+		if ( self::CSS_STATUS_FILE === $meta['status']
+			&& Plugin::$instance->experiments->is_feature_active( 'e_optimized_css_files' )
+			&& ! $this->has_non_empty_file()
+		) {
+			// The meta says the file exists, but the filesystem disagrees (deleted, purged,
+			// zero-byte from an interrupted write, offloaded uploads never synced, ...).
+			// Self-heal by regenerating now instead of emitting a URL that 404s forever.
 			$this->update();
 
 			$meta = $this->get_meta();
@@ -1060,5 +1078,32 @@ abstract class Base extends Base_File {
 		if ( ! in_array( $font, $this->fonts, true ) ) {
 			$this->fonts[] = $font;
 		}
+	}
+
+	/**
+	 * Whether the file exists on disk and is non-empty.
+	 *
+	 * Mirrors `CSS_Files_Manager::has_non_empty_file()` (the atomic self-heal check) so
+	 * a missing or zero-byte file is treated the same way as if it never existed.
+	 *
+	 * @since 3.33.0
+	 * @access private
+	 *
+	 * @return bool
+	 */
+	private function has_non_empty_file() {
+		$path = $this->get_path();
+
+		if ( ! file_exists( $path ) ) {
+			return false;
+		}
+
+		$size = filesize( $path );
+
+		if ( false === $size ) {
+			return true;
+		}
+
+		return $size > 0;
 	}
 }

--- a/tests/phpunit/elementor/core/files/css/test-base.php
+++ b/tests/phpunit/elementor/core/files/css/test-base.php
@@ -1,10 +1,53 @@
 <?php
 namespace Elementor\Tests\Phpunit\Elementor\Core\Files\Css;
 
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Core\Files\CSS\Base as CSS_Base;
 use Elementor\Core\Frontend\Widget_Content_Render_Mode;
 use Elementor\Plugin;
 use Elementor\Tests\Phpunit\Responsive_Control_Testing_Trait;
 use ElementorEditorTesting\Elementor_Test_Base;
+
+/**
+ * A minimal, directly instantiable `CSS\Base` subclass used to exercise `enqueue()` /
+ * `update()` / `write()` self-heal behaviour without depending on the post/document
+ * pipeline (mirrors the isolation `Test_Css_Files_Manager` gets for the atomic side).
+ */
+class Optimized_Css_Files_Test_File extends CSS_Base {
+	const META_KEY = 'elementor_test_optimized_css_files_meta';
+
+	private $css_content = 'body { color: red; }';
+
+	private $write_should_fail = false;
+
+	public function get_name() {
+		return 'test-optimized-css-files';
+	}
+
+	protected function get_file_handle_id() {
+		return 'elementor-test-optimized-css-files';
+	}
+
+	protected function render_css() {
+		$this->get_stylesheet()->add_raw_css( $this->css_content );
+	}
+
+	public function set_css_content( $css ) {
+		$this->css_content = $css;
+	}
+
+	public function set_write_should_fail( $should_fail ) {
+		$this->write_should_fail = $should_fail;
+	}
+
+	public function write() {
+		if ( $this->write_should_fail ) {
+			return false;
+		}
+
+		return parent::write();
+	}
+}
 
 /**
  * Test the CSS Base class
@@ -332,4 +375,190 @@ class Test_Base extends Elementor_Test_Base {
 
 		wp_deregister_style( 'registered-handle' );
 	}
+
+	// region Step 2 — filesystem self-heal (`e_optimized_css_files`).
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		delete_option( Optimized_Css_Files_Test_File::META_KEY );
+
+		$file = $this->make_optimized_css_files_test_file();
+
+		if ( file_exists( $file->get_path() ) ) {
+			unlink( $file->get_path() );
+		}
+
+		$this->set_optimized_css_files_experiment( Experiments_Manager::STATE_INACTIVE );
+
+		// `CSS\Base::$printed` is a static, per-process "already enqueued this handle" cache;
+		// reset it so each test starts with a clean slate regardless of test execution order.
+		$printed_property = new \ReflectionProperty( CSS_Base::class, 'printed' );
+		$printed_property->setAccessible( true );
+		$printed_property->setValue( null, [] );
+	}
+
+	private function make_optimized_css_files_test_file(): Optimized_Css_Files_Test_File {
+		return new Optimized_Css_Files_Test_File( 'optimized-css-files-test.css' );
+	}
+
+	private function set_optimized_css_files_experiment( $state ) {
+		Plugin::$instance->experiments->set_feature_default_state( 'e_optimized_css_files', $state );
+	}
+
+	private function seed_file_status_meta( Optimized_Css_Files_Test_File $file ) {
+		update_option( Optimized_Css_Files_Test_File::META_KEY, [
+			'time' => time(),
+			'status' => CSS_Base::CSS_STATUS_FILE,
+			'css' => '',
+			'fonts' => [],
+			'icons' => [],
+			'dynamic_elements_ids' => [],
+		] );
+	}
+
+	public function test_enqueue__self_heals_when_status_file_but_file_missing_and_experiment_active() {
+		// Arrange.
+		$this->set_optimized_css_files_experiment( Experiments_Manager::STATE_ACTIVE );
+
+		$file = $this->make_optimized_css_files_test_file();
+		$this->seed_file_status_meta( $file );
+
+		$this->assertFileDoesNotExist( $file->get_path() );
+
+		// Act.
+		$file->enqueue();
+
+		// Assert.
+		$this->assertFileExists( $file->get_path(), 'A missing file must be regenerated on enqueue when the experiment is active.' );
+		$this->assertNotEmpty( file_get_contents( $file->get_path() ) );
+		$this->assertEquals( CSS_Base::CSS_STATUS_FILE, $file->get_meta( 'status' ) );
+		$this->assertTrue( wp_style_is( 'elementor-test-optimized-css-files', 'enqueued' ) );
+	}
+
+	public function test_enqueue__self_heals_when_status_file_but_file_is_zero_bytes_and_experiment_active() {
+		// Arrange.
+		$this->set_optimized_css_files_experiment( Experiments_Manager::STATE_ACTIVE );
+
+		$file = $this->make_optimized_css_files_test_file();
+		$this->seed_file_status_meta( $file );
+
+		file_put_contents( $file->get_path(), '' );
+		$this->assertFileExists( $file->get_path() );
+		$this->assertEquals( 0, filesize( $file->get_path() ) );
+
+		// Act.
+		$file->enqueue();
+
+		// Assert.
+		$this->assertGreaterThan( 0, filesize( $file->get_path() ), 'A zero-byte file must be regenerated on enqueue when the experiment is active.' );
+		$this->assertEquals( CSS_Base::CSS_STATUS_FILE, $file->get_meta( 'status' ) );
+	}
+
+	public function test_enqueue__does_not_self_heal_when_experiment_inactive() {
+		// Arrange — experiment left at its default (inactive) state.
+		$file = $this->make_optimized_css_files_test_file();
+		$this->seed_file_status_meta( $file );
+
+		$this->assertFileDoesNotExist( $file->get_path() );
+
+		// Act.
+		$file->enqueue();
+
+		// Assert — today's behaviour is preserved: no `file_exists()` check, the (missing)
+		// file's URL is still enqueued, and the meta status is left untouched.
+		$this->assertFileDoesNotExist( $file->get_path() );
+		$this->assertEquals( CSS_Base::CSS_STATUS_FILE, $file->get_meta( 'status' ) );
+		$this->assertTrue( wp_style_is( 'elementor-test-optimized-css-files', 'enqueued' ) );
+	}
+
+	public function test_enqueue__does_not_self_heal_zero_byte_file_when_experiment_inactive() {
+		// Arrange.
+		$file = $this->make_optimized_css_files_test_file();
+		$this->seed_file_status_meta( $file );
+
+		file_put_contents( $file->get_path(), '' );
+
+		// Act.
+		$file->enqueue();
+
+		// Assert — zero-byte file is served as-is, matching current (pre-Step-2) behaviour.
+		$this->assertFileExists( $file->get_path() );
+		$this->assertEquals( 0, filesize( $file->get_path() ) );
+		$this->assertEquals( CSS_Base::CSS_STATUS_FILE, $file->get_meta( 'status' ) );
+	}
+
+	public function test_update__falls_back_to_inline_status_when_write_fails_and_experiment_active() {
+		// Arrange.
+		$this->set_optimized_css_files_experiment( Experiments_Manager::STATE_ACTIVE );
+
+		$file = $this->make_optimized_css_files_test_file();
+		$file->set_write_should_fail( true );
+
+		// Act.
+		$file->update();
+
+		// Assert.
+		$this->assertEquals( CSS_Base::CSS_STATUS_INLINE, $file->get_meta( 'status' ) );
+		$this->assertEquals( 'body { color: red; }', $file->get_meta( 'css' ) );
+		$this->assertFileDoesNotExist( $file->get_path() );
+	}
+
+	public function test_update__keeps_file_status_on_write_failure_when_experiment_inactive() {
+		// Arrange — experiment left inactive: today's behaviour (write failure is silent).
+		$file = $this->make_optimized_css_files_test_file();
+		$file->set_write_should_fail( true );
+
+		// Act.
+		$file->update();
+
+		// Assert.
+		$this->assertEquals( CSS_Base::CSS_STATUS_FILE, $file->get_meta( 'status' ) );
+	}
+
+	public function test_write__successful_write_is_never_observed_as_zero_byte() {
+		// Arrange.
+		$this->set_optimized_css_files_experiment( Experiments_Manager::STATE_ACTIVE );
+
+		$file = $this->make_optimized_css_files_test_file();
+		$file->set_css_content( str_repeat( 'a { color: red; }', 500 ) );
+
+		// Act.
+		$file->update();
+
+		// Assert — the final file at the public path is either absent or fully written;
+		// a partial/zero-byte state must never be observable once the write has completed.
+		$this->assertFileExists( $file->get_path() );
+		$this->assertGreaterThan( 0, filesize( $file->get_path() ) );
+		$this->assertStringContainsString( 'a { color: red; }', file_get_contents( $file->get_path() ) );
+
+		// No leftover temp file should remain after a successful atomic write.
+		$leftover_tmp_files = glob( $file->get_path() . '.tmp-*' );
+		$this->assertEmpty( $leftover_tmp_files, 'No temp file should remain after a successful atomic write.' );
+	}
+
+	public function test_write__uses_atomic_temp_file_and_rename_when_experiment_active() {
+		// Arrange.
+		$this->set_optimized_css_files_experiment( Experiments_Manager::STATE_ACTIVE );
+
+		$file = $this->make_optimized_css_files_test_file();
+
+		$method = new \ReflectionMethod( $file, 'write_atomically' );
+		$method->setAccessible( true );
+
+		$content_property = new \ReflectionProperty( \Elementor\Core\Files\Base::class, 'content' );
+		$content_property->setAccessible( true );
+		$content_property->setValue( $file, 'body { color: blue; }' );
+
+		// Act.
+		$result = $method->invoke( $file );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertFileExists( $file->get_path() );
+		$this->assertEquals( 'body { color: blue; }', file_get_contents( $file->get_path() ) );
+		$this->assertEmpty( glob( $file->get_path() . '.tmp-*' ) );
+	}
+
+	// endregion
 }

--- a/tests/phpunit/elementor/core/files/css/test-base.php
+++ b/tests/phpunit/elementor/core/files/css/test-base.php
@@ -488,6 +488,32 @@ class Test_Base extends Elementor_Test_Base {
 		$this->assertEquals( CSS_Base::CSS_STATUS_FILE, $file->get_meta( 'status' ) );
 	}
 
+	public function test_enqueue__self_heals_to_inline_when_missing_file_regen_write_fails() {
+		// Arrange — meta says `file`, the file is missing (self-heal trigger), and the
+		// regeneration attempt itself fails to write (e.g. read-only uploads dir).
+		// Requirement 3 in the plan: a failed regeneration must serve inline CSS on
+		// *this* request rather than enqueueing a URL for a file that still doesn't exist.
+		$this->set_optimized_css_files_experiment( Experiments_Manager::STATE_ACTIVE );
+
+		$file = $this->make_optimized_css_files_test_file();
+		$this->seed_file_status_meta( $file );
+		$file->set_write_should_fail( true );
+
+		$this->assertFileDoesNotExist( $file->get_path() );
+
+		// Act.
+		ob_start();
+		$file->enqueue();
+		$output = ob_get_clean();
+
+		// Assert.
+		$this->assertFileDoesNotExist( $file->get_path(), 'A failed regen must not leave a partial file behind.' );
+		$this->assertEquals( CSS_Base::CSS_STATUS_INLINE, $file->get_meta( 'status' ), 'Meta must reflect inline, not a `file` status pointing at nothing.' );
+		$this->assertStringContainsString( '<style', $output, 'The inline fallback must actually be printed on this request.' );
+		$this->assertStringContainsString( 'body { color: red; }', $output );
+		$this->assertFalse( wp_style_is( 'elementor-test-optimized-css-files', 'enqueued' ), 'Must not enqueue a stylesheet URL for a file that was never written.' );
+	}
+
 	public function test_update__falls_back_to_inline_status_when_write_fails_and_experiment_active() {
 		// Arrange.
 		$this->set_optimized_css_files_experiment( Experiments_Manager::STATE_ACTIVE );


### PR DESCRIPTION
## Summary
- Behind the `e_optimized_css_files` experiment, CSS file status is now verified against the actual filesystem on `enqueue()`, not just the DB meta - if the DB says "file" but the file is missing/corrupted, regenerate it on demand instead of enqueueing a broken URL.
- Adds coverage for the edge case where the regeneration attempt itself fails to write (e.g. a read-only uploads dir): falls back to inline CSS for that request, doesn't leave a partial file on disk, and doesn't enqueue a stylesheet URL for a file that was never written.

## Test plan
- [x] `php -l` clean on all changed files
- [x] Added `test_enqueue__self_heals_to_inline_when_missing_file_regen_write_fails` covering the failed-regeneration edge case
- [ ] Run the plugin's PHPUnit suite in CI

Ref: ED-24868

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

CSS files can vanish from disk (purged, deleted, offloaded uploads) while metadata still claims they exist, causing 404s. This implements filesystem self-heal via atomic writes (temp file + rename) to prevent zero-byte/partial writes and detect missing files on enqueue, falling back to inline CSS when regeneration fails—all behind the `e_optimized_css_files` experiment flag.

## 2. What Changed (Where)

- `core/files/base.php`: `update_file()` now returns bool; `write()` conditionally routes to new `write_atomically()` (temp file + rename pattern) when experiment active
- `core/files/css/base.php`: `update()` captures write success/failure and gates FILE status on it; `enqueue()` adds self-heal check for missing/zero-byte files; `write()` returns bool; new `has_non_empty_file()` predicate
- `tests/phpunit/...`: Comprehensive test fixture (`Optimized_Css_Files_Test_File`) covering enqueue self-heal, write failures, atomic safety, and experiment state boundaries

## 3. How It Works

On `update()`: parse content → attempt atomic write (temp file to final path via rename, fallback to direct write if rename fails) → inspect result → set FILE status only if write succeeded, else INLINE. On `enqueue()`: after loading meta, if meta says FILE but file missing/zero-byte and experiment active, call `update()` again to regenerate. Atomic write ensures partial/zero-byte files never observable post-completion; failed writes trigger immediate inline fallback rather than orphaned FILE status.

## 4. Risks

Minimal—feature gated and fallback-heavy. Atomic rename can fail on cross-filesystem moves (handled via fallback direct write). Temp file generation uses `wp_generate_password()` which could theoretically collide, but negligible at scale. Tests validate happy path and failure modes comprehensively.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
