### PR TITLE
Internal: Unify MCP ability registration through a single registry [ED-25196]

### DIFF
--- a/modules/mcp/abilities/abstract-ability.php
+++ b/modules/mcp/abilities/abstract-ability.php
@@ -8,6 +8,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 abstract class Abstract_Ability {
 
+	const KIND_TOOL = 'tool';
+	const KIND_RESOURCE = 'resource';
+	const ABILITY_ID_PREFIX = 'elementor/';
+
+	private ?Ability_Definition $cached_definition = null;
+
 	abstract protected function get_ability_id(): string;
 
 	abstract protected function get_definition(): Ability_Definition;
@@ -15,12 +21,70 @@ abstract class Abstract_Ability {
 	abstract public function execute( $input = [] );
 
 	public function check_permission(): bool {
-		return (bool) call_user_func( $this->get_definition()->permission_callback );
+		return (bool) call_user_func( $this->definition()->permission_callback );
 	}
 
 	public function register(): void {
-		$definition = $this->get_definition()->to_array();
+		$definition = $this->definition()->to_array();
 		$definition['execute_callback'] = [ $this, 'execute' ];
-		wp_register_ability( $this->get_ability_id(), $definition );
+		wp_register_ability( $this->get_id(), $definition );
+	}
+
+	public function get_id(): string {
+		return $this->get_ability_id();
+	}
+
+	public function get_kind(): string {
+		return $this->is_resource() ? self::KIND_RESOURCE : self::KIND_TOOL;
+	}
+
+	public function get_uri(): ?string {
+		return $this->mcp_meta()['uri'] ?? null;
+	}
+
+	public function get_mime_type(): ?string {
+		return $this->mcp_meta()['mimeType'] ?? null;
+	}
+
+	public function get_resource_description(): ?string {
+		return $this->mcp_meta()['description'] ?? null;
+	}
+
+	public function get_display_name(): string {
+		return $this->definition()->label;
+	}
+
+	public function get_proxy_slug(): string {
+		if ( self::KIND_RESOURCE === $this->get_kind() ) {
+			return (string) $this->get_uri();
+		}
+
+		return substr( $this->get_id(), strlen( self::ABILITY_ID_PREFIX ) );
+	}
+
+	public function is_exposed_via_proxy(): bool {
+		return true;
+	}
+
+	public function is_exposed_on_server(): bool {
+		return true;
+	}
+
+	private function is_resource(): bool {
+		return self::KIND_RESOURCE === ( $this->mcp_meta()['type'] ?? null );
+	}
+
+	protected function definition(): Ability_Definition {
+		if ( null === $this->cached_definition ) {
+			$this->cached_definition = $this->get_definition();
+		}
+
+		return $this->cached_definition;
+	}
+
+	private function mcp_meta(): array {
+		$meta = $this->definition()->meta;
+
+		return is_array( $meta['mcp'] ?? null ) ? $meta['mcp'] : [];
 	}
 }

--- a/modules/mcp/abilities/abstract-ability.php
+++ b/modules/mcp/abilities/abstract-ability.php
@@ -47,11 +47,11 @@ abstract class Abstract_Ability {
 	}
 
 	public function get_resource_description(): ?string {
-		return $this->mcp_meta()['description'] ?? null;
+		return $this->mcp_meta()['description'] ?? $this->definition()->description;
 	}
 
 	public function get_display_name(): string {
-		return $this->definition()->label;
+		return (string) ( $this->mcp_meta()['name'] ?? $this->definition()->label );
 	}
 
 	public function get_proxy_slug(): string {

--- a/modules/mcp/abilities/build-composition-ability.php
+++ b/modules/mcp/abilities/build-composition-ability.php
@@ -50,6 +50,10 @@ class Build_Composition_Ability extends Abstract_Ability {
 		return 'elementor/build-composition';
 	}
 
+	public function is_exposed_via_proxy(): bool {
+		return false;
+	}
+
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Build Composition', 'elementor' ),

--- a/modules/mcp/abilities/create-page-ability.php
+++ b/modules/mcp/abilities/create-page-ability.php
@@ -15,6 +15,10 @@ class Create_Page_Ability extends Abstract_Ability {
 		return 'elementor/create-page';
 	}
 
+	public function is_exposed_via_proxy(): bool {
+		return false;
+	}
+
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Create Elementor Page', 'elementor' ),

--- a/modules/mcp/abilities/create-preview-link-ability.php
+++ b/modules/mcp/abilities/create-preview-link-ability.php
@@ -18,6 +18,10 @@ class Create_Preview_Link_Ability extends Abstract_Ability {
 		return 'elementor/create-preview-link';
 	}
 
+	public function is_exposed_via_proxy(): bool {
+		return false;
+	}
+
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Create Elementor Public Preview Link', 'elementor' ),

--- a/modules/mcp/abilities/global-classes-resource-ability.php
+++ b/modules/mcp/abilities/global-classes-resource-ability.php
@@ -34,7 +34,7 @@ class Global_Classes_Resource_Ability extends Abstract_Ability {
 					'uri'         => self::URI,
 					'public'      => true,
 					'mimeType'    => 'application/json',
-					'description' => __( 'Global class IDs and labels from the active kit, ordered from highest to lowest CSS priority.', 'elementor' ),
+					'description' => __( 'Reusable CSS classes from the active kit, ordered from highest to lowest CSS priority. Check first before adding inline styles.', 'elementor' ),
 				],
 			],
 			fn() => current_user_can( 'edit_posts' )

--- a/modules/mcp/abilities/global-variables-resource-ability.php
+++ b/modules/mcp/abilities/global-variables-resource-ability.php
@@ -30,7 +30,7 @@ class Global_Variables_Resource_Ability extends Abstract_Ability {
 					'uri'         => self::URI,
 					'public'      => true,
 					'mimeType'    => 'application/json',
-					'description' => __( 'Variables list, total count, and watermark from the active kit.', 'elementor' ),
+					'description' => __( 'Design tokens (colors, fonts, sizes) from the active kit; check before styling with variables.', 'elementor' ),
 				],
 			],
 			fn() => current_user_can( 'edit_posts' )

--- a/modules/mcp/abilities/interactions-schema-resource-ability.php
+++ b/modules/mcp/abilities/interactions-schema-resource-ability.php
@@ -28,7 +28,7 @@ class Interactions_Schema_Resource_Ability extends Abstract_Ability {
 					'uri'         => self::URI,
 					'public'      => true,
 					'mimeType'    => 'application/json',
-					'description' => __( 'Native interaction item shape, enums, and defaults for build-composition.', 'elementor' ),
+					'description' => __( 'Interaction item shape, enums, and defaults for build-composition.', 'elementor' ),
 				],
 			],
 			fn() => current_user_can( 'edit_posts' )

--- a/modules/mcp/abilities/list-components-ability.php
+++ b/modules/mcp/abilities/list-components-ability.php
@@ -18,6 +18,10 @@ class List_Components_Ability extends Abstract_Ability {
 		return 'elementor/list-components';
 	}
 
+	public function is_exposed_via_proxy(): bool {
+		return false;
+	}
+
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'List Elementor Components', 'elementor' ),

--- a/modules/mcp/abilities/list-dynamic-tags-ability.php
+++ b/modules/mcp/abilities/list-dynamic-tags-ability.php
@@ -31,6 +31,7 @@ class List_Dynamic_Tags_Ability extends Abstract_Ability {
 					'uri'         => self::URI,
 					'public'      => true,
 					'mimeType'    => 'application/json',
+					'name'        => 'Dynamic Tags',
 					'description' => self::DESCRIPTION,
 				],
 			],

--- a/modules/mcp/abilities/list-resources-ability.php
+++ b/modules/mcp/abilities/list-resources-ability.php
@@ -3,12 +3,20 @@
 namespace Elementor\Modules\Mcp\Abilities;
 
 use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
+use Elementor\Modules\Mcp\Registry\Ability_Registry;
+use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 class List_Resources_Ability extends Abstract_Ability {
+
+	private ?Ability_Registry $registry;
+
+	public function __construct( ?Ability_Registry $registry = null ) {
+		$this->registry = $registry;
+	}
 
 	protected function get_ability_id(): string {
 		return 'elementor/list-resources';
@@ -49,54 +57,42 @@ class List_Resources_Ability extends Abstract_Ability {
 
 	public function execute( $input = [] ) {
 		return [
-			'resources' => $this->get_resource_catalog(),
+			'resources' => $this->build_catalog(),
 		];
 	}
 
-	private function get_resource_catalog(): array {
-		return [
-			[
-				'uri' => Style_Best_Practices_Ability::URI,
-				'name' => 'Style Best Practices',
-				'description' => 'Design quality guidelines for creating distinctive, intentional aesthetics. Covers typography, color strategy, spacing, motion, and visual hierarchy.',
-				'mimeType' => 'text/markdown',
-			],
-			[
-				'uri' => Wordpress_Best_Practices_Ability::URI,
-				'name' => 'WordPress Best Practices',
-				'description' => 'Opinionated WordPress patterns for Elementor builds: repeating layouts (single template vs N pages), include-all + exclude-exceptions condition scoping, Post Content placement, dynamic tags.',
-				'mimeType' => 'text/markdown',
-			],
-			[
-				'uri' => Manage_Variable_Guide_Ability::URI,
-				'name' => 'Manage Global Variable Guide',
-				'description' => 'Detailed guide for using the manage-global-variable tool. Covers available types, naming rules, value rules, and operation examples.',
-				'mimeType' => 'text/plain',
-			],
-			[
-				'uri' => Global_Classes_Resource_Ability::URI,
-				'name' => 'Global Classes',
-				'description' => 'Reusable CSS classes from the active kit, ordered from highest to lowest CSS priority. Check first before adding inline styles.',
-				'mimeType' => 'application/json',
-			],
-			[
-				'uri' => Global_Variables_Resource_Ability::URI,
-				'name' => 'Global Variables',
-				'description' => 'Design tokens (colors, fonts, sizes) from the active kit; check before styling with variables.',
-				'mimeType' => 'application/json',
-			],
-			[
-				'uri' => List_Dynamic_Tags_Ability::URI,
-				'name' => 'Dynamic Tags',
-				'description' => List_Dynamic_Tags_Ability::DESCRIPTION,
-				'mimeType' => 'application/json',
-			],
-			[
-				'uri' => Interactions_Schema_Resource_Ability::URI,
-				'name' => 'Interactions Schema',
-				'description' => 'Interaction item shape, enums, and defaults for build-composition.',
-				'mimeType' => 'application/json',
-			],
-		];
+	private function build_catalog(): array {
+		$registry = $this->resolve_registry();
+
+		if ( null === $registry ) {
+			return [];
+		}
+
+		$catalog = [];
+
+		foreach ( $registry->resources() as $ability ) {
+			if ( ! $ability->is_exposed_via_proxy() ) {
+				continue;
+			}
+
+			$catalog[] = [
+				'uri' => (string) $ability->get_uri(),
+				'name' => $ability->get_display_name(),
+				'description' => (string) ( $ability->get_resource_description() ?? '' ),
+				'mimeType' => (string) ( $ability->get_mime_type() ?? '' ),
+			];
+		}
+
+		return $catalog;
+	}
+
+	private function resolve_registry(): ?Ability_Registry {
+		if ( $this->registry instanceof Ability_Registry ) {
+			return $this->registry;
+		}
+
+		$module = Plugin::$instance->modules_manager->get_modules( 'mcp' );
+
+		return $module && method_exists( $module, 'registry' ) ? $module->registry() : null;
 	}
 }

--- a/modules/mcp/abilities/list-resources-ability.php
+++ b/modules/mcp/abilities/list-resources-ability.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\Mcp\Abilities;
 
 use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
+use Elementor\Modules\Mcp\Module as Mcp_Module;
 use Elementor\Modules\Mcp\Registry\Ability_Registry;
 use Elementor\Plugin;
 
@@ -62,15 +63,9 @@ class List_Resources_Ability extends Abstract_Ability {
 	}
 
 	private function build_catalog(): array {
-		$registry = $this->resolve_registry();
-
-		if ( null === $registry ) {
-			return [];
-		}
-
 		$catalog = [];
 
-		foreach ( $registry->resources() as $ability ) {
+		foreach ( $this->resolve_registry()->resources() as $ability ) {
 			if ( ! $ability->is_exposed_via_proxy() ) {
 				continue;
 			}
@@ -86,13 +81,17 @@ class List_Resources_Ability extends Abstract_Ability {
 		return $catalog;
 	}
 
-	private function resolve_registry(): ?Ability_Registry {
+	private function resolve_registry(): Ability_Registry {
 		if ( $this->registry instanceof Ability_Registry ) {
 			return $this->registry;
 		}
 
 		$module = Plugin::$instance->modules_manager->get_modules( 'mcp' );
 
-		return $module && method_exists( $module, 'registry' ) ? $module->registry() : null;
+		$this->registry = $module instanceof Mcp_Module
+			? $module->registry()
+			: Mcp_Module::build_core_registry();
+
+		return $this->registry;
 	}
 }

--- a/modules/mcp/abilities/manage-variable-guide-ability.php
+++ b/modules/mcp/abilities/manage-variable-guide-ability.php
@@ -18,7 +18,7 @@ class Manage_Variable_Guide_Ability extends Abstract_Ability {
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Manage Global Variable Guide', 'elementor' ),
-			__( 'Detailed guide for using the manage-global-variable tool.', 'elementor' ),
+			__( 'Detailed guide for using the manage-global-variable tool. Covers available types, naming rules, value rules, and operation examples.', 'elementor' ),
 			'elementor',
 			[ 'type' => 'string' ],
 			[
@@ -27,7 +27,7 @@ class Manage_Variable_Guide_Ability extends Abstract_Ability {
 					'uri' => self::URI,
 					'public' => true,
 					'mimeType' => 'text/plain',
-					'description' => __( 'Detailed guide for using the manage-global-variable tool', 'elementor' ),
+					'description' => __( 'Detailed guide for using the manage-global-variable tool. Covers available types, naming rules, value rules, and operation examples.', 'elementor' ),
 				],
 			],
 			fn() => current_user_can( 'manage_options' )

--- a/modules/mcp/abilities/publish-document-ability.php
+++ b/modules/mcp/abilities/publish-document-ability.php
@@ -15,6 +15,10 @@ class Publish_Document_Ability extends Abstract_Ability {
 		return 'elementor/publish-document';
 	}
 
+	public function is_exposed_via_proxy(): bool {
+		return false;
+	}
+
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Publish Elementor Document', 'elementor' ),

--- a/modules/mcp/abilities/read-resource-ability.php
+++ b/modules/mcp/abilities/read-resource-ability.php
@@ -3,12 +3,20 @@
 namespace Elementor\Modules\Mcp\Abilities;
 
 use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
+use Elementor\Modules\Mcp\Registry\Ability_Registry;
+use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 class Read_Resource_Ability extends Abstract_Ability {
+
+	private ?Ability_Registry $registry;
+
+	public function __construct( ?Ability_Registry $registry = null ) {
+		$this->registry = $registry;
+	}
 
 	protected function get_ability_id(): string {
 		return 'elementor/read-resource';
@@ -60,9 +68,10 @@ class Read_Resource_Ability extends Abstract_Ability {
 			);
 		}
 
-		$executors = $this->get_resource_executors();
+		$registry = $this->resolve_registry();
+		$resource = $registry ? $registry->find_resource_by_uri( $uri ) : null;
 
-		if ( ! isset( $executors[ $uri ] ) ) {
+		if ( null === $resource ) {
 			return new \WP_Error(
 				'resource_not_found',
 				sprintf(
@@ -74,11 +83,7 @@ class Read_Resource_Ability extends Abstract_Ability {
 			);
 		}
 
-		$executor = $executors[ $uri ];
-		/** @var Abstract_Ability $ability */
-		$ability = $executor['ability'];
-
-		if ( ! $ability->check_permission() ) {
+		if ( ! $resource->check_permission() ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'Sorry, you are not allowed to perform this action.', 'elementor' ),
@@ -86,7 +91,7 @@ class Read_Resource_Ability extends Abstract_Ability {
 			);
 		}
 
-		$content = $ability->execute();
+		$content = $resource->execute();
 
 		if ( is_wp_error( $content ) ) {
 			return $content;
@@ -94,41 +99,18 @@ class Read_Resource_Ability extends Abstract_Ability {
 
 		return [
 			'uri' => $uri,
-			'mimeType' => $executor['mimeType'],
+			'mimeType' => (string) ( $resource->get_mime_type() ?? '' ),
 			'content' => is_string( $content ) ? $content : wp_json_encode( $content ),
 		];
 	}
 
-	private function get_resource_executors(): array {
-		return [
-			Style_Best_Practices_Ability::URI => [
-				'ability' => new Style_Best_Practices_Ability(),
-				'mimeType' => 'text/markdown',
-			],
-			Wordpress_Best_Practices_Ability::URI => [
-				'ability' => new Wordpress_Best_Practices_Ability(),
-				'mimeType' => 'text/markdown',
-			],
-			Manage_Variable_Guide_Ability::URI => [
-				'ability' => new Manage_Variable_Guide_Ability(),
-				'mimeType' => 'text/plain',
-			],
-			Global_Classes_Resource_Ability::URI => [
-				'ability' => new Global_Classes_Resource_Ability(),
-				'mimeType' => 'application/json',
-			],
-			Global_Variables_Resource_Ability::URI => [
-				'ability' => new Global_Variables_Resource_Ability(),
-				'mimeType' => 'application/json',
-			],
-			List_Dynamic_Tags_Ability::URI => [
-				'ability' => new List_Dynamic_Tags_Ability(),
-				'mimeType' => 'application/json',
-			],
-			Interactions_Schema_Resource_Ability::URI => [
-				'ability' => new Interactions_Schema_Resource_Ability(),
-				'mimeType' => 'application/json',
-			],
-		];
+	private function resolve_registry(): ?Ability_Registry {
+		if ( $this->registry instanceof Ability_Registry ) {
+			return $this->registry;
+		}
+
+		$module = Plugin::$instance->modules_manager->get_modules( 'mcp' );
+
+		return $module && method_exists( $module, 'registry' ) ? $module->registry() : null;
 	}
 }

--- a/modules/mcp/abilities/read-resource-ability.php
+++ b/modules/mcp/abilities/read-resource-ability.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\Mcp\Abilities;
 
 use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
+use Elementor\Modules\Mcp\Module as Mcp_Module;
 use Elementor\Modules\Mcp\Registry\Ability_Registry;
 use Elementor\Plugin;
 
@@ -68,8 +69,7 @@ class Read_Resource_Ability extends Abstract_Ability {
 			);
 		}
 
-		$registry = $this->resolve_registry();
-		$resource = $registry ? $registry->find_resource_by_uri( $uri ) : null;
+		$resource = $this->resolve_registry()->find_resource_by_uri( $uri );
 
 		if ( null === $resource ) {
 			return new \WP_Error(
@@ -104,13 +104,17 @@ class Read_Resource_Ability extends Abstract_Ability {
 		];
 	}
 
-	private function resolve_registry(): ?Ability_Registry {
+	private function resolve_registry(): Ability_Registry {
 		if ( $this->registry instanceof Ability_Registry ) {
 			return $this->registry;
 		}
 
 		$module = Plugin::$instance->modules_manager->get_modules( 'mcp' );
 
-		return $module && method_exists( $module, 'registry' ) ? $module->registry() : null;
+		$this->registry = $module instanceof Mcp_Module
+			? $module->registry()
+			: Mcp_Module::build_core_registry();
+
+		return $this->registry;
 	}
 }

--- a/modules/mcp/abilities/style-best-practices-ability.php
+++ b/modules/mcp/abilities/style-best-practices-ability.php
@@ -17,7 +17,7 @@ class Style_Best_Practices_Ability extends Abstract_Ability {
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Style Best Practices', 'elementor' ),
-			__( 'Style Best Practices', 'elementor' ),
+			__( 'Design quality guidelines for creating distinctive, intentional aesthetics. Covers typography, color strategy, spacing, motion, and visual hierarchy.', 'elementor' ),
 			'elementor',
 			[ 'type' => 'string' ],
 			[
@@ -26,7 +26,7 @@ class Style_Best_Practices_Ability extends Abstract_Ability {
 					'uri'         => self::URI,
 					'public'      => true,
 					'mimeType'    => 'text/markdown',
-					'description' => __( 'Style Best Practices', 'elementor' ),
+					'description' => __( 'Design quality guidelines for creating distinctive, intentional aesthetics. Covers typography, color strategy, spacing, motion, and visual hierarchy.', 'elementor' ),
 				],
 			],
 			fn() => current_user_can( 'edit_posts' )

--- a/modules/mcp/abilities/update-settings-ability.php
+++ b/modules/mcp/abilities/update-settings-ability.php
@@ -15,6 +15,10 @@ class Update_Settings_Ability extends Abstract_Ability {
 		return 'elementor/update-page-settings';
 	}
 
+	public function is_exposed_via_proxy(): bool {
+		return false;
+	}
+
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Update Elementor Page Settings', 'elementor' ),

--- a/modules/mcp/abilities/wordpress-best-practices-ability.php
+++ b/modules/mcp/abilities/wordpress-best-practices-ability.php
@@ -17,7 +17,7 @@ class Wordpress_Best_Practices_Ability extends Abstract_Ability {
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'WordPress Best Practices', 'elementor' ),
-			__( 'Opinionated WordPress patterns for Elementor builds: repeating layouts, condition scoping, Post Content placement, dynamic tags.', 'elementor' ),
+			__( 'Opinionated WordPress patterns for Elementor builds: repeating layouts (single template vs N pages), include-all + exclude-exceptions condition scoping, Post Content placement, dynamic tags.', 'elementor' ),
 			'elementor',
 			[ 'type' => 'string' ],
 			[
@@ -26,7 +26,7 @@ class Wordpress_Best_Practices_Ability extends Abstract_Ability {
 					'uri'         => self::URI,
 					'public'      => true,
 					'mimeType'    => 'text/markdown',
-					'description' => __( 'WordPress Best Practices', 'elementor' ),
+					'description' => __( 'Opinionated WordPress patterns for Elementor builds: repeating layouts (single template vs N pages), include-all + exclude-exceptions condition scoping, Post Content placement, dynamic tags.', 'elementor' ),
 				],
 			],
 			fn() => current_user_can( 'edit_posts' )

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -30,8 +30,7 @@ class Module extends BaseModule {
 	public function __construct() {
 		parent::__construct();
 
-		$this->registry = new Ability_Registry();
-		$this->populate_registry();
+		$this->registry = self::build_core_registry();
 
 		( new Mcp_Proxy_REST_API( $this->registry ) )->register_hooks();
 		( new Public_Preview_Handler() )->register();
@@ -102,14 +101,18 @@ class Module extends BaseModule {
 		}
 	}
 
-	private function populate_registry(): void {
-		foreach ( $this->get_core_abilities() as $ability ) {
-			$this->registry->add( $ability );
+	public static function build_core_registry(): Ability_Registry {
+		$registry = new Ability_Registry();
+
+		foreach ( self::get_core_abilities( $registry ) as $ability ) {
+			$registry->add( $ability );
 		}
+
+		return $registry;
 	}
 
 	/** @return Abstract_Ability[] */
-	private function get_core_abilities(): array {
+	private static function get_core_abilities( Ability_Registry $registry ): array {
 		$abilities = [
 			new Abilities\Get_Structure_Ability(),
 			new Abilities\Update_Settings_Ability(),
@@ -131,18 +134,18 @@ class Module extends BaseModule {
 			new Abilities\List_Assets_Ability(),
 			new Abilities\Global_Variables_Resource_Ability(),
 			new Abilities\Interactions_Schema_Resource_Ability(),
-			new Abilities\List_Resources_Ability( $this->registry ),
-			new Abilities\Read_Resource_Ability( $this->registry ),
+			new Abilities\List_Resources_Ability( $registry ),
+			new Abilities\Read_Resource_Ability( $registry ),
 		];
 
-		if ( $this->is_components_active() ) {
+		if ( self::is_components_active() ) {
 			$abilities[] = new Abilities\List_Components_Ability();
 		}
 
 		return $abilities;
 	}
 
-	private function is_components_active(): bool {
+	private static function is_components_active(): bool {
 		return class_exists( Components_Module::class ) && Components_Module::is_experiment_active();
 	}
 

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -4,7 +4,9 @@ namespace Elementor\Modules\Mcp;
 
 use Elementor\Core\Base\Module as BaseModule;
 use Elementor\Modules\Components\Module as Components_Module;
+use Elementor\Modules\Mcp\Abilities\Abstract_Ability;
 use Elementor\Modules\Mcp\Preview\Public_Preview_Handler;
+use Elementor\Modules\Mcp\Registry\Ability_Registry;
 use Elementor\Modules\Mcp\RestApi\Mcp_Proxy_REST_API;
 use WP\MCP\Core\McpAdapter;
 
@@ -13,6 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Module extends BaseModule {
+
+	private Ability_Registry $registry;
 
 	public function get_name() {
 		return 'mcp';
@@ -26,7 +30,10 @@ class Module extends BaseModule {
 	public function __construct() {
 		parent::__construct();
 
-		( new Mcp_Proxy_REST_API() )->register_hooks();
+		$this->registry = new Ability_Registry();
+		$this->populate_registry();
+
+		( new Mcp_Proxy_REST_API( $this->registry ) )->register_hooks();
 		( new Public_Preview_Handler() )->register();
 
 		if ( ! $this->is_active() ) {
@@ -38,6 +45,10 @@ class Module extends BaseModule {
 		add_action( 'wp_abilities_api_categories_init', [ $this, 'register_ability_category' ] );
 		add_action( 'wp_abilities_api_init', [ $this, 'register_abilities' ] );
 		add_action( 'mcp_adapter_init', [ $this, 'register_server' ] );
+	}
+
+	public function registry(): Ability_Registry {
+		return $this->registry;
 	}
 
 	public function register_ability_category() {
@@ -59,32 +70,9 @@ class Module extends BaseModule {
 			return;
 		}
 
-		( new Abilities\Get_Structure_Ability() )->register();
-		( new Abilities\Update_Settings_Ability() )->register();
-		( new Abilities\Create_Page_Ability() )->register();
-		( new Abilities\Create_Preview_Link_Ability() )->register();
-		( new Abilities\Publish_Document_Ability() )->register();
-		( new Abilities\Style_Best_Practices_Ability() )->register();
-		( new Abilities\Wordpress_Best_Practices_Ability() )->register();
-		( new Abilities\Manage_Variable_Ability() )->register();
-		( new Abilities\Manage_Classes_Ability() )->register();
-		( new Abilities\Reorder_Classes_Ability() )->register();
-		( new Abilities\Manage_Variable_Guide_Ability() )->register();
-		( new Abilities\Get_Widget_Schema_Ability() )->register();
-		( new Abilities\List_Widget_Schemas_Ability() )->register();
-		( new Abilities\List_Dynamic_Tags_Ability() )->register();
-		( new Abilities\Build_Composition_Ability() )->register();
-		( new Abilities\Manage_Elements_Ability() )->register();
-		( new Abilities\Global_Classes_Resource_Ability() )->register();
-		( new Abilities\List_Assets_Ability() )->register();
-
-		if ( $this->is_components_active() ) {
-			( new Abilities\List_Components_Ability() )->register();
+		foreach ( $this->registry->all() as $ability ) {
+			$ability->register();
 		}
-		( new Abilities\Global_Variables_Resource_Ability() )->register();
-		( new Abilities\Interactions_Schema_Resource_Ability() )->register();
-		( new Abilities\List_Resources_Ability() )->register();
-		( new Abilities\Read_Resource_Ability() )->register();
 	}
 
 	public function register_server( $adapter ) {
@@ -114,37 +102,59 @@ class Module extends BaseModule {
 		}
 	}
 
+	private function populate_registry(): void {
+		foreach ( $this->get_core_abilities() as $ability ) {
+			$this->registry->add( $ability );
+		}
+	}
+
+	/** @return Abstract_Ability[] */
+	private function get_core_abilities(): array {
+		$abilities = [
+			new Abilities\Get_Structure_Ability(),
+			new Abilities\Update_Settings_Ability(),
+			new Abilities\Create_Page_Ability(),
+			new Abilities\Create_Preview_Link_Ability(),
+			new Abilities\Publish_Document_Ability(),
+			new Abilities\Style_Best_Practices_Ability(),
+			new Abilities\Wordpress_Best_Practices_Ability(),
+			new Abilities\Manage_Variable_Ability(),
+			new Abilities\Manage_Classes_Ability(),
+			new Abilities\Reorder_Classes_Ability(),
+			new Abilities\Manage_Variable_Guide_Ability(),
+			new Abilities\Get_Widget_Schema_Ability(),
+			new Abilities\List_Widget_Schemas_Ability(),
+			new Abilities\List_Dynamic_Tags_Ability(),
+			new Abilities\Build_Composition_Ability(),
+			new Abilities\Manage_Elements_Ability(),
+			new Abilities\Global_Classes_Resource_Ability(),
+			new Abilities\List_Assets_Ability(),
+			new Abilities\Global_Variables_Resource_Ability(),
+			new Abilities\Interactions_Schema_Resource_Ability(),
+			new Abilities\List_Resources_Ability( $this->registry ),
+			new Abilities\Read_Resource_Ability( $this->registry ),
+		];
+
+		if ( $this->is_components_active() ) {
+			$abilities[] = new Abilities\List_Components_Ability();
+		}
+
+		return $abilities;
+	}
+
 	private function is_components_active(): bool {
 		return class_exists( Components_Module::class ) && Components_Module::is_experiment_active();
 	}
 
 	private function get_server_tools(): array {
-		$tools = [
-			'elementor/get-page-structure',
-			'elementor/update-page-settings',
-			'elementor/create-page',
-			'elementor/create-preview-link',
-			'elementor/publish-document',
-			'elementor/manage-global-variable',
-			'elementor/manage-classes',
-			'elementor/reorder-classes',
-			'elementor/get-widget-schema',
-			'elementor/list-widget-schemas',
-			'elementor/build-composition',
-			'elementor/manage-elements',
-			'elementor/list-assets',
-			'elementor/list-resources',
-			'elementor/read-resource',
-			...( $this->is_components_active() ? [ 'elementor/list-components' ] : [] ),
-		];
+		$tools = $this->collect_server_ids( $this->registry->tools() );
 
 		/**
 		 * Filters additional MCP tool ability slugs to expose on the Elementor MCP server.
 		 *
-		 * Use this filter to add tool abilities (registered via `wp_register_ability` on the
-		 * `wp_abilities_api_init` hook) to the `elementor-mcp-server`. Slugs must match the
-		 * ability id returned by the ability's `get_ability_id()`. Core defaults are always
-		 * included and cannot be removed via this filter.
+		 * Preferred integration path: add abilities directly to the Ability_Registry via
+		 * `Plugin::$instance->modules_manager->get_modules( 'mcp' )->registry()->add( ... )`.
+		 * This filter is retained for backward compatibility with third-party extensions.
 		 *
 		 * @since 4.3.0
 		 *
@@ -156,23 +166,14 @@ class Module extends BaseModule {
 	}
 
 	private function get_server_resources(): array {
-		$resources = [
-			'elementor/style-best-practices',
-			'elementor/wordpress-best-practices',
-			'elementor/manage-global-variable-guide',
-			'elementor/global-classes-resource',
-			'elementor/global-variables-resource',
-			'elementor/list-dynamic-tags',
-			'elementor/interactions-schema-resource',
-		];
+		$resources = $this->collect_server_ids( $this->registry->resources() );
 
 		/**
 		 * Filters additional MCP resource ability slugs to expose on the Elementor MCP server.
 		 *
-		 * Use this filter to add resource abilities (registered via `wp_register_ability` on the
-		 * `wp_abilities_api_init` hook) to the `elementor-mcp-server`. Slugs must match the
-		 * ability id returned by the ability's `get_ability_id()`. Core defaults are always
-		 * included and cannot be removed via this filter.
+		 * Preferred integration path: add abilities directly to the Ability_Registry via
+		 * `Plugin::$instance->modules_manager->get_modules( 'mcp' )->registry()->add( ... )`.
+		 * This filter is retained for backward compatibility with third-party extensions.
 		 *
 		 * @since 4.3.0
 		 *
@@ -181,6 +182,22 @@ class Module extends BaseModule {
 		$additional_resources = apply_filters( 'elementor/mcp/server/resources', [] );
 
 		return $this->normalize_slugs( $resources, $additional_resources );
+	}
+
+	/**
+	 * @param Abstract_Ability[] $abilities
+	 * @return string[]
+	 */
+	private function collect_server_ids( array $abilities ): array {
+		$ids = [];
+
+		foreach ( $abilities as $ability ) {
+			if ( $ability->is_exposed_on_server() ) {
+				$ids[] = $ability->get_id();
+			}
+		}
+
+		return $ids;
 	}
 
 	private function normalize_slugs( array $defaults, $additional ): array {

--- a/modules/mcp/registry/ability-registry.php
+++ b/modules/mcp/registry/ability-registry.php
@@ -56,10 +56,6 @@ class Ability_Registry {
 				continue;
 			}
 
-			if ( ! $ability->is_exposed_via_proxy() ) {
-				continue;
-			}
-
 			if ( $ability->get_uri() === $uri ) {
 				return $ability;
 			}

--- a/modules/mcp/registry/ability-registry.php
+++ b/modules/mcp/registry/ability-registry.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Registry;
+
+use Elementor\Modules\Mcp\Abilities\Abstract_Ability;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Ability_Registry {
+
+	/** @var array<string, Abstract_Ability> */
+	private array $abilities = [];
+
+	public function add( Abstract_Ability $ability ): void {
+		$this->abilities[ $ability->get_id() ] = $ability;
+	}
+
+	/** @return Abstract_Ability[] */
+	public function all(): array {
+		return array_values( $this->abilities );
+	}
+
+	/** @return Abstract_Ability[] */
+	public function tools(): array {
+		return $this->filter_by_kind( Abstract_Ability::KIND_TOOL );
+	}
+
+	/** @return Abstract_Ability[] */
+	public function resources(): array {
+		return $this->filter_by_kind( Abstract_Ability::KIND_RESOURCE );
+	}
+
+	public function find_by_id( string $id ): ?Abstract_Ability {
+		return $this->abilities[ $id ] ?? null;
+	}
+
+	public function find_by_proxy_slug( string $slug ): ?Abstract_Ability {
+		foreach ( $this->abilities as $ability ) {
+			if ( ! $ability->is_exposed_via_proxy() ) {
+				continue;
+			}
+
+			if ( Abstract_Ability::KIND_TOOL === $ability->get_kind() && $ability->get_proxy_slug() === $slug ) {
+				return $ability;
+			}
+		}
+
+		return null;
+	}
+
+	public function find_resource_by_uri( string $uri ): ?Abstract_Ability {
+		foreach ( $this->abilities as $ability ) {
+			if ( Abstract_Ability::KIND_RESOURCE !== $ability->get_kind() ) {
+				continue;
+			}
+
+			if ( ! $ability->is_exposed_via_proxy() ) {
+				continue;
+			}
+
+			if ( $ability->get_uri() === $uri ) {
+				return $ability;
+			}
+		}
+
+		return null;
+	}
+
+	/** @return Abstract_Ability[] */
+	private function filter_by_kind( string $kind ): array {
+		return array_values( array_filter(
+			$this->abilities,
+			fn( Abstract_Ability $ability ) => $kind === $ability->get_kind()
+		) );
+	}
+}

--- a/modules/mcp/rest-api/mcp-proxy-rest-api.php
+++ b/modules/mcp/rest-api/mcp-proxy-rest-api.php
@@ -4,23 +4,9 @@ namespace Elementor\Modules\Mcp\RestApi;
 
 use Elementor\Core\Utils\Api\Error_Builder;
 use Elementor\Core\Utils\Api\Response_Builder;
-use Elementor\Modules\Mcp\Abilities\Abstract_Ability;
-use Elementor\Modules\Mcp\Abilities\Get_Structure_Ability;
-use Elementor\Modules\Mcp\Abilities\Get_Widget_Schema_Ability;
-use Elementor\Modules\Mcp\Abilities\Global_Classes_Resource_Ability;
-use Elementor\Modules\Mcp\Abilities\Global_Variables_Resource_Ability;
-use Elementor\Modules\Mcp\Abilities\List_Assets_Ability;
-use Elementor\Modules\Mcp\Abilities\List_Dynamic_Tags_Ability;
-use Elementor\Modules\Mcp\Abilities\List_Resources_Ability;
-use Elementor\Modules\Mcp\Abilities\List_Widget_Schemas_Ability;
-use Elementor\Modules\Mcp\Abilities\Manage_Classes_Ability;
-use Elementor\Modules\Mcp\Abilities\Manage_Elements_Ability;
-use Elementor\Modules\Mcp\Abilities\Manage_Variable_Ability;
-use Elementor\Modules\Mcp\Abilities\Manage_Variable_Guide_Ability;
-use Elementor\Modules\Mcp\Abilities\Read_Resource_Ability;
-use Elementor\Modules\Mcp\Abilities\Reorder_Classes_Ability;
-use Elementor\Modules\Mcp\Abilities\Style_Best_Practices_Ability;
-use Elementor\Modules\Mcp\Abilities\Wordpress_Best_Practices_Ability;
+use Elementor\Modules\Mcp\Module as Mcp_Module;
+use Elementor\Modules\Mcp\Registry\Ability_Registry;
+use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -30,34 +16,10 @@ class Mcp_Proxy_REST_API {
 	const API_NAMESPACE = 'elementor/v1';
 	const API_BASE      = 'mcp-proxy';
 
-	/** @var array<string, callable(): Abstract_Ability> */
-	private array $tools = [];
+	private ?Ability_Registry $registry;
 
-	/** @var array<string, callable(): Abstract_Ability> */
-	private array $resources = [];
-
-	public function __construct() {
-		$this->tools = [
-			'manage-global-variable' => fn() => new Manage_Variable_Ability(),
-			'manage-classes' => fn() => new Manage_Classes_Ability(),
-			'reorder-classes' => fn() => new Reorder_Classes_Ability(),
-			'get-widget-schema' => fn() => new Get_Widget_Schema_Ability(),
-			'list-widget-schemas' => fn() => new List_Widget_Schemas_Ability(),
-			'get-page-structure' => fn() => new Get_Structure_Ability(),
-			'manage-elements' => fn() => new Manage_Elements_Ability(),
-			'list-assets' => fn() => new List_Assets_Ability(),
-			'list-resources' => fn() => new List_Resources_Ability(),
-			'read-resource' => fn() => new Read_Resource_Ability(),
-		];
-
-		$this->resources = [
-			Style_Best_Practices_Ability::URI => fn() => new Style_Best_Practices_Ability(),
-			Wordpress_Best_Practices_Ability::URI => fn() => new Wordpress_Best_Practices_Ability(),
-			Manage_Variable_Guide_Ability::URI => fn() => new Manage_Variable_Guide_Ability(),
-			Global_Classes_Resource_Ability::URI => fn() => new Global_Classes_Resource_Ability(),
-			Global_Variables_Resource_Ability::URI => fn() => new Global_Variables_Resource_Ability(),
-			List_Dynamic_Tags_Ability::URI => fn() => new List_Dynamic_Tags_Ability(),
-		];
+	public function __construct( ?Ability_Registry $registry = null ) {
+		$this->registry = $registry;
 	}
 
 	public function register_hooks() {
@@ -99,15 +61,16 @@ class Mcp_Proxy_REST_API {
 		$tool  = $request->get_param( 'tool' );
 		$input = $request->get_param( 'input' );
 
-		if ( ! isset( $this->tools[ $tool ] ) ) {
+		$registry = $this->resolve_registry();
+		$ability = $registry ? $registry->find_by_proxy_slug( (string) $tool ) : null;
+
+		if ( null === $ability ) {
 			return Error_Builder::make( 'unknown_tool' )
 				->set_status( 404 )
 				// translators: By tool name
 				->set_message( sprintf( __( 'Unknown tool: %s', 'elementor' ), $tool ) )
 				->build();
 		}
-
-		$ability = ( $this->tools[ $tool ] )();
 
 		if ( ! $ability->check_permission() ) {
 			return $this->build_response( $this->forbidden_error() );
@@ -121,15 +84,16 @@ class Mcp_Proxy_REST_API {
 	private function handle_resource( \WP_REST_Request $request ) {
 		$uri = $request->get_param( 'uri' );
 
-		if ( ! isset( $this->resources[ $uri ] ) ) {
+		$registry = $this->resolve_registry();
+		$ability = $registry ? $registry->find_resource_by_uri( (string) $uri ) : null;
+
+		if ( null === $ability ) {
 			return Error_Builder::make( 'unknown_resource' )
 				->set_status( 404 )
 				// translators: By resource URI
 				->set_message( sprintf( __( 'Unknown resource: %s', 'elementor' ), $uri ) )
 				->build();
 		}
-
-		$ability = ( $this->resources[ $uri ] )();
 
 		if ( ! $ability->check_permission() ) {
 			return $this->build_response( $this->forbidden_error() );
@@ -138,6 +102,16 @@ class Mcp_Proxy_REST_API {
 		$result = $ability->execute();
 
 		return $this->build_response( $result );
+	}
+
+	private function resolve_registry(): ?Ability_Registry {
+		if ( $this->registry instanceof Ability_Registry ) {
+			return $this->registry;
+		}
+
+		$module = Plugin::$instance->modules_manager->get_modules( 'mcp' );
+
+		return $module instanceof Mcp_Module ? $module->registry() : null;
 	}
 
 	private function forbidden_error(): \WP_Error {

--- a/modules/mcp/rest-api/mcp-proxy-rest-api.php
+++ b/modules/mcp/rest-api/mcp-proxy-rest-api.php
@@ -61,8 +61,7 @@ class Mcp_Proxy_REST_API {
 		$tool  = $request->get_param( 'tool' );
 		$input = $request->get_param( 'input' );
 
-		$registry = $this->resolve_registry();
-		$ability = $registry ? $registry->find_by_proxy_slug( (string) $tool ) : null;
+		$ability = $this->resolve_registry()->find_by_proxy_slug( (string) $tool );
 
 		if ( null === $ability ) {
 			return Error_Builder::make( 'unknown_tool' )
@@ -84,8 +83,7 @@ class Mcp_Proxy_REST_API {
 	private function handle_resource( \WP_REST_Request $request ) {
 		$uri = $request->get_param( 'uri' );
 
-		$registry = $this->resolve_registry();
-		$ability = $registry ? $registry->find_resource_by_uri( (string) $uri ) : null;
+		$ability = $this->resolve_registry()->find_resource_by_uri( (string) $uri );
 
 		if ( null === $ability ) {
 			return Error_Builder::make( 'unknown_resource' )
@@ -104,14 +102,18 @@ class Mcp_Proxy_REST_API {
 		return $this->build_response( $result );
 	}
 
-	private function resolve_registry(): ?Ability_Registry {
+	private function resolve_registry(): Ability_Registry {
 		if ( $this->registry instanceof Ability_Registry ) {
 			return $this->registry;
 		}
 
 		$module = Plugin::$instance->modules_manager->get_modules( 'mcp' );
 
-		return $module instanceof Mcp_Module ? $module->registry() : null;
+		$this->registry = $module instanceof Mcp_Module
+			? $module->registry()
+			: Mcp_Module::build_core_registry();
+
+		return $this->registry;
 	}
 
 	private function forbidden_error(): \WP_Error {

--- a/tests/phpunit/elementor/modules/mcp/registry/test-ability-registry.php
+++ b/tests/phpunit/elementor/modules/mcp/registry/test-ability-registry.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp\Registry;
+
+use Elementor\Modules\Mcp\Abilities\Ability_Definition;
+use Elementor\Modules\Mcp\Abilities\Abstract_Ability;
+use Elementor\Modules\Mcp\Registry\Ability_Registry;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @group Elementor\Modules\Mcp
+ */
+class Test_Ability_Registry extends TestCase {
+
+	public function test_add__stores_ability_and_returns_via_all() {
+		// Arrange
+		$registry = new Ability_Registry();
+		$tool = $this->make_tool( 'elementor/test-tool' );
+
+		// Act
+		$registry->add( $tool );
+
+		// Assert
+		$this->assertSame( [ $tool ], $registry->all() );
+	}
+
+	public function test_add__deduplicates_by_id() {
+		// Arrange
+		$registry = new Ability_Registry();
+		$first = $this->make_tool( 'elementor/test-tool' );
+		$second = $this->make_tool( 'elementor/test-tool' );
+
+		// Act
+		$registry->add( $first );
+		$registry->add( $second );
+
+		// Assert
+		$this->assertCount( 1, $registry->all() );
+		$this->assertSame( $second, $registry->all()[0] );
+	}
+
+	public function test_tools_and_resources__partition_by_kind() {
+		// Arrange
+		$registry = new Ability_Registry();
+		$tool = $this->make_tool( 'elementor/tool-a' );
+		$resource = $this->make_resource( 'elementor/resource-a', 'elementor://res/a' );
+
+		// Act
+		$registry->add( $tool );
+		$registry->add( $resource );
+
+		// Assert
+		$this->assertSame( [ $tool ], $registry->tools() );
+		$this->assertSame( [ $resource ], $registry->resources() );
+	}
+
+	public function test_find_by_proxy_slug__matches_tool_by_short_slug() {
+		// Arrange
+		$registry = new Ability_Registry();
+		$tool = $this->make_tool( 'elementor/get-thing' );
+		$registry->add( $tool );
+
+		// Act
+		$found = $registry->find_by_proxy_slug( 'get-thing' );
+
+		// Assert
+		$this->assertSame( $tool, $found );
+	}
+
+	public function test_find_by_proxy_slug__skips_tools_not_exposed_via_proxy() {
+		// Arrange
+		$registry = new Ability_Registry();
+		$tool = $this->make_tool( 'elementor/hidden', false );
+		$registry->add( $tool );
+
+		// Act
+		$found = $registry->find_by_proxy_slug( 'hidden' );
+
+		// Assert
+		$this->assertNull( $found );
+	}
+
+	public function test_find_resource_by_uri__matches_resource() {
+		// Arrange
+		$registry = new Ability_Registry();
+		$resource = $this->make_resource( 'elementor/res', 'elementor://res/x' );
+		$registry->add( $resource );
+
+		// Act
+		$found = $registry->find_resource_by_uri( 'elementor://res/x' );
+
+		// Assert
+		$this->assertSame( $resource, $found );
+	}
+
+	public function test_find_resource_by_uri__returns_null_for_unknown_uri() {
+		// Arrange
+		$registry = new Ability_Registry();
+
+		// Act
+		$found = $registry->find_resource_by_uri( 'elementor://missing' );
+
+		// Assert
+		$this->assertNull( $found );
+	}
+
+	private function make_tool( string $id, bool $exposed = true ): Abstract_Ability {
+		return new class( $id, $exposed ) extends Abstract_Ability {
+			private string $id_value;
+			private bool $exposed;
+
+			public function __construct( string $id, bool $exposed ) {
+				$this->id_value = $id;
+				$this->exposed = $exposed;
+			}
+
+			protected function get_ability_id(): string {
+				return $this->id_value;
+			}
+
+			protected function get_definition(): Ability_Definition {
+				return new Ability_Definition(
+					'Test',
+					'Test',
+					'elementor',
+					[ 'type' => 'object' ],
+					[],
+					fn() => true
+				);
+			}
+
+			public function execute( $input = [] ) {
+				return [];
+			}
+
+			public function is_exposed_via_proxy(): bool {
+				return $this->exposed;
+			}
+		};
+	}
+
+	private function make_resource( string $id, string $uri ): Abstract_Ability {
+		return new class( $id, $uri ) extends Abstract_Ability {
+			private string $id_value;
+			private string $uri_value;
+
+			public function __construct( string $id, string $uri ) {
+				$this->id_value = $id;
+				$this->uri_value = $uri;
+			}
+
+			protected function get_ability_id(): string {
+				return $this->id_value;
+			}
+
+			protected function get_definition(): Ability_Definition {
+				return new Ability_Definition(
+					'Test Resource',
+					'Desc',
+					'elementor',
+					[ 'type' => 'string' ],
+					[
+						'mcp' => [
+							'type' => 'resource',
+							'uri' => $this->uri_value,
+							'mimeType' => 'text/plain',
+							'description' => 'Desc',
+						],
+					],
+					fn() => true
+				);
+			}
+
+			public function execute( $input = [] ) {
+				return '';
+			}
+		};
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/registry/test-core-resources-metadata.php
+++ b/tests/phpunit/elementor/modules/mcp/registry/test-core-resources-metadata.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp\Registry;
+
+use Elementor\Modules\Mcp\Abilities\Global_Classes_Resource_Ability;
+use Elementor\Modules\Mcp\Abilities\Global_Variables_Resource_Ability;
+use Elementor\Modules\Mcp\Abilities\Interactions_Schema_Resource_Ability;
+use Elementor\Modules\Mcp\Abilities\List_Dynamic_Tags_Ability;
+use Elementor\Modules\Mcp\Abilities\Manage_Variable_Guide_Ability;
+use Elementor\Modules\Mcp\Abilities\Style_Best_Practices_Ability;
+use Elementor\Modules\Mcp\Abilities\Wordpress_Best_Practices_Ability;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Guards against silently losing per-resource metadata (URI or mime type) when
+ * changing ability definitions. Each core resource must expose a URI and a
+ * non-empty mimeType that read-resource returns to callers.
+ *
+ * @group Elementor\Modules\Mcp
+ */
+class Test_Core_Resources_Metadata extends TestCase {
+
+	/**
+	 * @dataProvider core_resource_abilities
+	 */
+	public function test_resource__has_non_empty_uri_and_mime_type( string $class, string $expected_uri, string $expected_mime ) {
+		// Arrange
+		$ability = new $class();
+
+		// Act
+		$uri = $ability->get_uri();
+		$mime = $ability->get_mime_type();
+
+		// Assert
+		$this->assertSame( 'resource', $ability->get_kind() );
+		$this->assertSame( $expected_uri, $uri );
+		$this->assertSame( $expected_mime, $mime );
+		$this->assertNotEmpty( $ability->get_display_name() );
+		$this->assertNotEmpty( $ability->get_resource_description() );
+	}
+
+	public function core_resource_abilities(): array {
+		return [
+			'style-best-practices' => [
+				Style_Best_Practices_Ability::class,
+				Style_Best_Practices_Ability::URI,
+				'text/markdown',
+			],
+			'wordpress-best-practices' => [
+				Wordpress_Best_Practices_Ability::class,
+				Wordpress_Best_Practices_Ability::URI,
+				'text/markdown',
+			],
+			'manage-global-variable-guide' => [
+				Manage_Variable_Guide_Ability::class,
+				Manage_Variable_Guide_Ability::URI,
+				'text/plain',
+			],
+			'global-classes' => [
+				Global_Classes_Resource_Ability::class,
+				Global_Classes_Resource_Ability::URI,
+				'application/json',
+			],
+			'global-variables' => [
+				Global_Variables_Resource_Ability::class,
+				Global_Variables_Resource_Ability::URI,
+				'application/json',
+			],
+			'dynamic-tags' => [
+				List_Dynamic_Tags_Ability::class,
+				List_Dynamic_Tags_Ability::URI,
+				'application/json',
+			],
+			'interactions-schema' => [
+				Interactions_Schema_Resource_Ability::class,
+				Interactions_Schema_Resource_Ability::URI,
+				'application/json',
+			],
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/registry/test-list-resources-catalog-parity.php
+++ b/tests/phpunit/elementor/modules/mcp/registry/test-list-resources-catalog-parity.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp\Registry;
+
+use Elementor\Modules\Mcp\Abilities\Global_Classes_Resource_Ability;
+use Elementor\Modules\Mcp\Abilities\Global_Variables_Resource_Ability;
+use Elementor\Modules\Mcp\Abilities\Interactions_Schema_Resource_Ability;
+use Elementor\Modules\Mcp\Abilities\List_Dynamic_Tags_Ability;
+use Elementor\Modules\Mcp\Abilities\List_Resources_Ability;
+use Elementor\Modules\Mcp\Abilities\Manage_Variable_Guide_Ability;
+use Elementor\Modules\Mcp\Abilities\Style_Best_Practices_Ability;
+use Elementor\Modules\Mcp\Abilities\Wordpress_Best_Practices_Ability;
+use Elementor\Modules\Mcp\Registry\Ability_Registry;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Guards against drift in the `list-resources` catalog output. The name,
+ * description, uri, and mimeType for each core resource must match the
+ * expected values that consumers (editor, external agents) rely on.
+ *
+ * @group Elementor\Modules\Mcp
+ */
+class Test_List_Resources_Catalog_Parity extends TestCase {
+
+	public function test_execute__returns_expected_catalog_entries_for_core_resources() {
+		// Arrange
+		$registry = new Ability_Registry();
+		foreach ( $this->core_resource_abilities() as $ability ) {
+			$registry->add( $ability );
+		}
+
+		// Act
+		$catalog = ( new List_Resources_Ability( $registry ) )->execute()['resources'];
+		$by_uri = array_column( $catalog, null, 'uri' );
+
+		// Assert
+		foreach ( $this->expected_catalog_entries() as $entry ) {
+			$this->assertArrayHasKey( $entry['uri'], $by_uri, "Resource {$entry['uri']} missing from catalog" );
+			$this->assertSame( $entry, $by_uri[ $entry['uri'] ], "Catalog entry drift for {$entry['uri']}" );
+		}
+	}
+
+	private function core_resource_abilities(): array {
+		return [
+			new Style_Best_Practices_Ability(),
+			new Wordpress_Best_Practices_Ability(),
+			new Manage_Variable_Guide_Ability(),
+			new Global_Classes_Resource_Ability(),
+			new Global_Variables_Resource_Ability(),
+			new List_Dynamic_Tags_Ability(),
+			new Interactions_Schema_Resource_Ability(),
+		];
+	}
+
+	private function expected_catalog_entries(): array {
+		return [
+			[
+				'uri' => Style_Best_Practices_Ability::URI,
+				'name' => 'Style Best Practices',
+				'description' => 'Design quality guidelines for creating distinctive, intentional aesthetics. Covers typography, color strategy, spacing, motion, and visual hierarchy.',
+				'mimeType' => 'text/markdown',
+			],
+			[
+				'uri' => Wordpress_Best_Practices_Ability::URI,
+				'name' => 'WordPress Best Practices',
+				'description' => 'Opinionated WordPress patterns for Elementor builds: repeating layouts (single template vs N pages), include-all + exclude-exceptions condition scoping, Post Content placement, dynamic tags.',
+				'mimeType' => 'text/markdown',
+			],
+			[
+				'uri' => Manage_Variable_Guide_Ability::URI,
+				'name' => 'Manage Global Variable Guide',
+				'description' => 'Detailed guide for using the manage-global-variable tool. Covers available types, naming rules, value rules, and operation examples.',
+				'mimeType' => 'text/plain',
+			],
+			[
+				'uri' => Global_Classes_Resource_Ability::URI,
+				'name' => 'Global Classes',
+				'description' => 'Reusable CSS classes from the active kit, ordered from highest to lowest CSS priority. Check first before adding inline styles.',
+				'mimeType' => 'application/json',
+			],
+			[
+				'uri' => Global_Variables_Resource_Ability::URI,
+				'name' => 'Global Variables',
+				'description' => 'Design tokens (colors, fonts, sizes) from the active kit; check before styling with variables.',
+				'mimeType' => 'application/json',
+			],
+			[
+				'uri' => List_Dynamic_Tags_Ability::URI,
+				'name' => 'Dynamic Tags',
+				'description' => List_Dynamic_Tags_Ability::DESCRIPTION,
+				'mimeType' => 'application/json',
+			],
+			[
+				'uri' => Interactions_Schema_Resource_Ability::URI,
+				'name' => 'Interactions Schema',
+				'description' => 'Interaction item shape, enums, and defaults for build-composition.',
+				'mimeType' => 'application/json',
+			],
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-abstract-ability-accessors.php
+++ b/tests/phpunit/elementor/modules/mcp/test-abstract-ability-accessors.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp;
+
+use Elementor\Modules\Mcp\Abilities\Ability_Definition;
+use Elementor\Modules\Mcp\Abilities\Abstract_Ability;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @group Elementor\Modules\Mcp
+ */
+class Test_Abstract_Ability_Accessors extends TestCase {
+
+	public function test_get_kind__defaults_to_tool_when_no_mcp_meta() {
+		// Arrange
+		$ability = $this->tool_ability();
+
+		// Act / Assert
+		$this->assertSame( Abstract_Ability::KIND_TOOL, $ability->get_kind() );
+	}
+
+	public function test_get_kind__returns_resource_when_mcp_type_is_resource() {
+		// Arrange
+		$ability = $this->resource_ability();
+
+		// Act / Assert
+		$this->assertSame( Abstract_Ability::KIND_RESOURCE, $ability->get_kind() );
+	}
+
+	public function test_get_uri__returns_null_for_tool() {
+		// Arrange
+		$ability = $this->tool_ability();
+
+		// Act / Assert
+		$this->assertNull( $ability->get_uri() );
+	}
+
+	public function test_get_uri__returns_meta_uri_for_resource() {
+		// Arrange
+		$ability = $this->resource_ability();
+
+		// Act / Assert
+		$this->assertSame( 'elementor://test/thing', $ability->get_uri() );
+	}
+
+	public function test_get_mime_type__returns_meta_mime_for_resource() {
+		// Arrange
+		$ability = $this->resource_ability();
+
+		// Act / Assert
+		$this->assertSame( 'application/json', $ability->get_mime_type() );
+	}
+
+	public function test_get_proxy_slug__strips_elementor_prefix_for_tool() {
+		// Arrange
+		$ability = $this->tool_ability();
+
+		// Act / Assert
+		$this->assertSame( 'do-thing', $ability->get_proxy_slug() );
+	}
+
+	public function test_get_proxy_slug__returns_uri_for_resource() {
+		// Arrange
+		$ability = $this->resource_ability();
+
+		// Act / Assert
+		$this->assertSame( 'elementor://test/thing', $ability->get_proxy_slug() );
+	}
+
+	public function test_is_exposed_via_proxy__defaults_to_true() {
+		// Arrange
+		$ability = $this->tool_ability();
+
+		// Act / Assert
+		$this->assertTrue( $ability->is_exposed_via_proxy() );
+	}
+
+	public function test_is_exposed_on_server__defaults_to_true() {
+		// Arrange
+		$ability = $this->tool_ability();
+
+		// Act / Assert
+		$this->assertTrue( $ability->is_exposed_on_server() );
+	}
+
+	public function test_get_display_name__returns_definition_label() {
+		// Arrange
+		$ability = $this->tool_ability();
+
+		// Act / Assert
+		$this->assertSame( 'Test Tool', $ability->get_display_name() );
+	}
+
+	public function test_get_resource_description__returns_meta_description_for_resource() {
+		// Arrange
+		$ability = $this->resource_ability();
+
+		// Act / Assert
+		$this->assertSame( 'A test resource.', $ability->get_resource_description() );
+	}
+
+	private function tool_ability(): Abstract_Ability {
+		return new class() extends Abstract_Ability {
+			protected function get_ability_id(): string {
+				return 'elementor/do-thing';
+			}
+
+			protected function get_definition(): Ability_Definition {
+				return new Ability_Definition(
+					'Test Tool',
+					'Does a thing.',
+					'elementor',
+					[ 'type' => 'object' ],
+					[],
+					fn() => true
+				);
+			}
+
+			public function execute( $input = [] ) {
+				return [];
+			}
+		};
+	}
+
+	private function resource_ability(): Abstract_Ability {
+		return new class() extends Abstract_Ability {
+			protected function get_ability_id(): string {
+				return 'elementor/test-thing';
+			}
+
+			protected function get_definition(): Ability_Definition {
+				return new Ability_Definition(
+					'Test Resource',
+					'A test resource.',
+					'elementor',
+					[ 'type' => 'string' ],
+					[
+						'mcp' => [
+							'type' => 'resource',
+							'uri' => 'elementor://test/thing',
+							'mimeType' => 'application/json',
+							'description' => 'A test resource.',
+						],
+					],
+					fn() => true
+				);
+			}
+
+			public function execute( $input = [] ) {
+				return '';
+			}
+		};
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-list-dynamic-tags-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-list-dynamic-tags-ability.php
@@ -65,12 +65,12 @@ class Test_List_Dynamic_Tags_Ability extends TestCase {
 
 	public function test_dynamic_tags_uri_is_in_resource_catalog() {
 		// Arrange
-		$ability = new List_Resources_Ability();
-		$reflection = new \ReflectionMethod( $ability, 'get_resource_catalog' );
-		$reflection->setAccessible( true );
+		$registry = new \Elementor\Modules\Mcp\Registry\Ability_Registry();
+		$registry->add( new List_Dynamic_Tags_Ability() );
+		$ability = new List_Resources_Ability( $registry );
 
 		// Act
-		$catalog = $reflection->invoke( $ability );
+		$catalog = $ability->execute()['resources'];
 		$uris = array_column( $catalog, 'uri' );
 
 		// Assert


### PR DESCRIPTION
## Summary

Consolidates MCP ability registration into a single `Ability_Registry` so each ability is declared once (in its `*Ability` class) and automatically shows up on:

1. `wp_register_ability()` (WP Abilities API)
2. The Elementor MCP server tool/resource lists
3. The editor `/elementor/v1/mcp-proxy` REST route
4. `list-resources` / `read-resource` catalogs

Ticket: [ED-25196](https://elementor.atlassian.net/browse/ED-25196)

## What changed

- **New:** `modules/mcp/registry/ability-registry.php` — single source of truth. Methods: `add()`, `all()`, `tools()`, `resources()`, `find_by_id()`, `find_by_proxy_slug()`, `find_resource_by_uri()`.
- **`Abstract_Ability`** — new accessors: `get_id`, `get_kind`, `get_uri`, `get_mime_type`, `get_resource_description`, `get_display_name`, `get_proxy_slug`, `is_exposed_via_proxy`, `is_exposed_on_server`. All derived from the ability's existing `Ability_Definition` (kind/URI/mime read from `meta.mcp`). `get_definition()` is memoized.
- **`Module`** — builds the registry in its constructor, exposes `registry()` for extensions, and drives both server slug lists and the proxy REST from the registry. The two legacy `apply_filters` hooks (`elementor/mcp/server/tools`, `elementor/mcp/server/resources`) are kept as backward-compat additive extension points.
- **`Mcp_Proxy_REST_API`** — hardcoded maps deleted. Registry injected; falls back to `Module::registry()` when constructed without args (keeps existing tests working).
- **`List_Resources_Ability` / `Read_Resource_Ability`** — hardcoded catalog and executor map deleted; both walk the registry now, pulling name/description/mimeType straight from each resource's `meta.mcp`.
- **Preserve current proxy scope byte-for-byte:** six abilities that were not in the proxy REST map before (`Update_Settings_Ability`, `Create_Page_Ability`, `Create_Preview_Link_Ability`, `Publish_Document_Ability`, `Build_Composition_Ability`, `List_Components_Ability`) override `is_exposed_via_proxy()` to return `false`.
- **Gap fix:** `elementor://interactions/schema` is now reachable via the proxy REST GET (it was missing from the hardcoded map).

## Duplication before/after (per resource)

Before, a single resource had metadata repeated in up to 5 places (ability class, server slug list, proxy REST map, list-resources catalog, read-resource executor map). After, the metadata lives only in the ability class.

## Non-goals (deferred to follow-ups)

- JS-side `@elementor/editor-mcp` registration — separate concern, not in the ticket's three surfaces.
- Deprecating the two legacy `apply_filters` hooks — kept for third-party BC.
- Aligning `Manage_Variable_Guide_Ability`'s `manage_options` permission with the rest of the resource catalog — flagged in ticket, needs product confirmation.

## Pro side

Companion PR: `elementor-pro` — Pro's `Abstract_Ability` / `Ability_Definition` now extend Core's, and Pro's `Module` adds its abilities directly to the Core registry when available (falls back to the legacy filter path for BC with older Core).

## Test plan

- [x] Unit tests for `Ability_Registry` (add/dedup, tools/resources partition, find-by-proxy-slug incl. exposure filter, find-by-uri) — `tests/phpunit/elementor/modules/mcp/registry/test-ability-registry.php`
- [x] Unit tests for `Abstract_Ability` accessors (kind/uri/mime/proxy-slug/name/exposure defaults) — `tests/phpunit/elementor/modules/mcp/test-abstract-ability-accessors.php`
- [x] Metadata guard for every core resource — asserts URI + mimeType + name + description are non-empty and match expectations — `tests/phpunit/elementor/modules/mcp/registry/test-core-resources-metadata.php`
- [ ] Existing `test-mcp-proxy-rest-api.php` still passes (proxy scope preserved)
- [ ] `list-resources` output identical to previous hardcoded catalog for the 6 pre-existing resources; `interactions-schema` newly appears
- [ ] MCP server `tools`/`resources` slug lists identical to previous output
- [ ] Manual: editor tool invocation via `/elementor/v1/mcp-proxy` still works for the 10 previously-exposed tools

Made with [Cursor](https://cursor.com)

[ED-25196]: https://elementor.atlassian.net/browse/ED-25196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Centralizes scattered ability registration through a single `Ability_Registry` instead of hardcoded arrays, reducing coupling and enabling dynamic ability composition. Ticket: ED-25196.

## 2. What Changed (Where)

| Module | Change |
|--------|--------|
| `Abstract_Ability` | Added constants, caching, metadata accessors (`get_kind()`, `get_uri()`, `get_proxy_slug()`, etc.) |
| `Ability_Registry` (new) | Central registry with filtering by kind and lookup by ID/URI |
| `Module` | Builds core registry once, passes to `Mcp_Proxy_REST_API`; abilities register via loop |
| `Mcp_Proxy_REST_API` | Accepts registry, queries by slug/URI instead of array lookup |
| `List_Resources_Ability`, `Read_Resource_Ability` | Accept registry dependency, query dynamically instead of hardcoded catalog |
| 7 abilities | Added `is_exposed_via_proxy() = false` override (tools hidden from proxy) |
| Resource abilities | Enriched descriptions in metadata; removed from hardcoded lists |
| Tests (new) | 3 suites: registry behavior, metadata parity, catalog consistency |

## 3. How It Works

Entry point: `Module.__construct()` calls `build_core_registry()`, instantiating all abilities and populating `Ability_Registry`. On `wp_abilities_api_init`, loop over `registry->all()` calling `register()`. REST proxy queries registry: `find_by_proxy_slug()` for tools, `find_resource_by_uri()` for resources. `is_exposed_via_proxy()` controls proxy visibility; `is_exposed_on_server()` controls MCP server exposure. Resources now expose metadata (URI, MIME, name, description) through ability methods rather than separate maps—enables consistent catalog generation and individual resource execution.

## 4. Risks

**Missing: Abilities require registry dependency injection or lazy-load fallback.** `List_Resources_Ability` and `Read_Resource_Ability` accept optional `?Ability_Registry` and resolve dynamically if null—guards test isolation but risks stale cache if registry changes post-instantiation. **Visibility split (`is_exposed_via_proxy` vs `is_exposed_on_server`)** could diverge; tests verify parity but no runtime enforcement. **Hardcoded ability list still in `Module::get_core_abilities()`**—filters remain on plugin hook; no mechanism prevents stale slugs in filters if abilities added/removed.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
