### PR TITLE
Tweak: Expose panel APIs publicly [ED-25224]

### DIFF
--- a/.cursor/skills/extend-editor-v2/SKILL.md
+++ b/.cursor/skills/extend-editor-v2/SKILL.md
@@ -26,7 +26,7 @@ Optional env: `elementor/editor/v2/scripts/env` → `$env['@elementor/my-editor-
    - App bar: `injectIntoPageIndication`, `toolsMenu` (`@elementor/editor-app-bar`)
    - Editing panel: `injectIntoStyleTab`, `registerEditingPanelReplacement` (`@elementor/editor-editing-panel`)
    - Elements panel: `injectTab` (`@elementor/editor-elements-panel`)
-   - Slide-in panels: `__registerPanel` (`@elementor/editor-panels`)
+   - Slide-in panels: `registerPanel` (`@elementor/editor-panels`)
    - Styles: `stylesRepository.register` (`@elementor/editor-styles-repository`)
    - Legacy bridge: `registerDataHook`, `blockCommand`, `listenTo( v1ReadyEvent() )` (`@elementor/editor-v1-adapters`)
 5. **MCP (in-editor only)** — in `init()`:

--- a/docs/atomic-builder/editor-packages/extending-editor.md
+++ b/docs/atomic-builder/editor-packages/extending-editor.md
@@ -20,7 +20,7 @@ Durable extension surface for Editor V2:
 | `injectIntoStyleTab`, `registerEditingPanelReplacement` | `@elementor/editor-editing-panel` | Editing panel |
 | `injectTab` | `@elementor/editor-elements-panel` | Elements panel tabs |
 | `injectSiteSettingsTab` | `@elementor/editor-site-settings` | Site Settings tabs |
-| `__registerPanel` | `@elementor/editor-panels` | Slide-in panels |
+| `registerPanel` | `@elementor/editor-panels` | Slide-in panels |
 | `getMCPByDomain` | `@elementor/editor-mcp` | In-editor MCP domain |
 | `__registerSlice` | `@elementor/store` | Redux slice registration |
 | `stylesRepository.register` | `@elementor/editor-styles-repository` | Style provider |
@@ -99,7 +99,7 @@ Reference: `packages/packages/core/editor-site-navigation/src/init.ts`.
 
 ```ts
 import { injectIntoStyleTab, registerEditingPanelReplacement } from '@elementor/editor-editing-panel';
-import { __registerPanel as registerPanel } from '@elementor/editor-panels';
+import { registerPanel } from '@elementor/editor-panels';
 
 injectIntoStyleTab( { id: 'my-style-section', component: MyStyleSection } );
 registerPanel( { id: 'my-panel', component: MyPanel } );

--- a/packages/packages/core/editor-design-system/src/design-system-panel.tsx
+++ b/packages/packages/core/editor-design-system/src/design-system-panel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { reloadCurrentDocument } from '@elementor/editor-documents';
-import { __createPanel as createPanel } from '@elementor/editor-panels';
+import { createPanel } from '@elementor/editor-panels';
 import { changeEditMode } from '@elementor/editor-v1-adapters';
 
 import { DesignSystemPanelContent } from './components/design-system-panel-content';

--- a/packages/packages/core/editor-design-system/src/init.ts
+++ b/packages/packages/core/editor-design-system/src/init.ts
@@ -1,6 +1,6 @@
 import { injectIntoLogic } from '@elementor/editor';
 import { toolsMenu } from '@elementor/editor-app-bar';
-import { __registerPanel as registerPanel } from '@elementor/editor-panels';
+import { registerPanel } from '@elementor/editor-panels';
 
 import { DesignSystemEntrypoints } from './components/design-system-entrypoints';
 import { panel } from './design-system-panel';

--- a/packages/packages/core/editor-editing-panel/src/init.ts
+++ b/packages/packages/core/editor-editing-panel/src/init.ts
@@ -1,5 +1,5 @@
 import { injectIntoLogic } from '@elementor/editor';
-import { __registerPanel as registerPanel } from '@elementor/editor-panels';
+import { registerPanel } from '@elementor/editor-panels';
 import { blockCommand } from '@elementor/editor-v1-adapters';
 
 import { EditingPanelHooks } from './components/editing-panel-hooks';

--- a/packages/packages/core/editor-editing-panel/src/panel.ts
+++ b/packages/packages/core/editor-editing-panel/src/panel.ts
@@ -1,4 +1,4 @@
-import { __createPanel as createPanel } from '@elementor/editor-panels';
+import { createPanel } from '@elementor/editor-panels';
 
 import { EditingPanel } from './components/editing-panel';
 

--- a/packages/packages/core/editor-panels/src/__tests__/index.test.ts
+++ b/packages/packages/core/editor-panels/src/__tests__/index.test.ts
@@ -1,0 +1,13 @@
+import {
+	__createPanel,
+	__registerPanel,
+	createPanel,
+	registerPanel,
+} from '../index';
+
+describe( 'editor-panels exports', () => {
+	it( 'should expose public and compatibility aliases', () => {
+		expect( createPanel ).toBe( __createPanel );
+		expect( registerPanel ).toBe( __registerPanel );
+	} );
+} );

--- a/packages/packages/core/editor-panels/src/__tests__/index.test.ts
+++ b/packages/packages/core/editor-panels/src/__tests__/index.test.ts
@@ -1,9 +1,4 @@
-import {
-	__createPanel,
-	__registerPanel,
-	createPanel,
-	registerPanel,
-} from '../index';
+import { __createPanel, __registerPanel, createPanel, registerPanel } from '../index';
 
 describe( 'editor-panels exports', () => {
 	it( 'should expose public and compatibility aliases', () => {

--- a/packages/packages/core/editor-panels/src/index.ts
+++ b/packages/packages/core/editor-panels/src/index.ts
@@ -1,5 +1,6 @@
 export { init } from './init';
 
+export { createPanel, registerPanel } from './api';
 export { createPanel as __createPanel, registerPanel as __registerPanel } from './api';
 
 export * from './components/external';

--- a/packages/packages/core/editor-site-navigation/src/components/panel/panel.ts
+++ b/packages/packages/core/editor-site-navigation/src/components/panel/panel.ts
@@ -1,8 +1,8 @@
-import { __createPanel } from '@elementor/editor-panels';
+import { createPanel } from '@elementor/editor-panels';
 
 import Shell from './shell';
 
-export const { panel, usePanelStatus, usePanelActions } = __createPanel( {
+export const { panel, usePanelStatus, usePanelActions } = createPanel( {
 	id: 'site-navigation-panel',
 	component: Shell,
 } );

--- a/packages/packages/core/editor-site-navigation/src/init.ts
+++ b/packages/packages/core/editor-site-navigation/src/init.ts
@@ -1,5 +1,5 @@
 import { injectIntoPageIndication, toolsMenu } from '@elementor/editor-app-bar';
-import { __registerPanel } from '@elementor/editor-panels';
+import { registerPanel } from '@elementor/editor-panels';
 
 import { panel } from './components/panel/panel';
 import RecentlyEdited from './components/top-bar/recently-edited';
@@ -10,7 +10,7 @@ export function init() {
 	registerTopBarMenuItems();
 	// TODO 06/06/2023 :  remove if when we are production ready
 	if ( env.is_pages_panel_active ) {
-		__registerPanel( panel );
+		registerPanel( panel );
 		registerButton();
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Expose `createPanel` and `registerPanel` as public editor-panels APIs while retaining compatibility aliases.

## Description
An explanation of what is done in this PR

* Adds public exports for the existing panel creation and registration implementations.
* Keeps `__createPanel` and `__registerPanel` as aliases to preserve compatibility.
* Migrates Core package consumers to the public names.
* Updates docs (`extending-editor.md`, `extend-editor-v2` skill) to reference the public panel APIs.

Jira: [ED-25224](https://elementor.atlassian.net/browse/ED-25224)

## Test instructions
This PR can be tested by following these steps:

* Run `npx jest --config='./jest.config.js' packages/core/editor-panels/src/__tests__/index.test.ts packages/core/editor-panels/src/__tests__/api.test.tsx --runInBand` from `packages`.
* Run `npm run build:packages`.
* Run `npm run lint`.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fef70-8c73-78fb-bf55-7966198d3ffb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fef70-8c73-78fb-bf55-7966198d3ffb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ED-25224]: https://elementor.atlassian.net/browse/ED-25224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Promoting internal panel APIs (`__createPanel`, `__registerPanel`) to public exports in `@elementor/editor-panels`. This enables external packages to build slide-in panels without relying on unstable internal APIs. Ticket: ED-25224.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `editor-panels/src/index.ts` | Export public APIs alongside deprecated aliases for backward compatibility |
| 4 consumer packages | Migrate from `__createPanel`/`__registerPanel` to public `createPanel`/`registerPanel` |
| Documentation | Update extension guides to reference public APIs |
| New test | Verify public and legacy exports are identical |

## 3. How It Works

Public APIs are re-exported alongside compatibility aliases (`__createPanel` and `__registerPanel` now point to the same functions). All existing call sites updated to use public names; the dual exports ensure zero breakage during transition period.

## 4. Risks

None identified. Backward-compatible dual exports allow gradual migration; test confirms API equivalence. Existing code using underscored variants continues working.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
