### PR TITLE
Internal: Atomic e-list - widget [ED-25114]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.html.twig
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.html.twig
@@ -3,5 +3,5 @@
 <{{ tag }} class="{{ m.render_base_classes(id, base_styles, settings) }} {{ editor_classes | default('') }}"
 	{{- ' ' }}{{ m.render_data_attributes(id, type, interaction_id) }}
 	{{- m.render_custom_attributes(settings, editor_attributes) }}>
-	<li>List scaffold</li>
+	<!-- elementor-children-placeholder -->
 </{{ tag }}>

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.html.twig
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.html.twig
@@ -1,0 +1,7 @@
+{% import 'elementor/macros' as m %}
+{%- set tag = settings.tag | default('ul') -%}
+<{{ tag }} class="{{ m.render_base_classes(id, base_styles, settings) }} {{ editor_classes | default('') }}"
+	{{- ' ' }}{{ m.render_data_attributes(id, type, interaction_id) }}
+	{{- m.render_custom_attributes(settings, editor_attributes) }}>
+	<li>List scaffold</li>
+</{{ tag }}>

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.php
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List;
+
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Atomic_List extends Atomic_Element_Base {
+	use Has_Element_Template;
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'is_container', true );
+	}
+
+	public static function get_type() {
+		return 'e-list';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-list';
+	}
+
+	public function get_title() {
+		return esc_html__( 'List', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'list' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-bullet-list';
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()
+				->default( [] ),
+			'tag' => String_Prop_Type::make()
+				->enum( [ 'ul', 'ol' ] )
+				->default( 'ul' ),
+			'attributes' => Attributes_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [
+					Text_Control::bind_to( '_cssid' )
+						->set_label( __( 'ID', 'elementor' ) )
+						->set_meta( $this->get_css_id_control_meta() ),
+				] ),
+		];
+	}
+
+	protected function define_default_html_tag() {
+		return 'ul';
+	}
+
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-list' => __DIR__ . '/atomic-list.html.twig',
+		];
+	}
+}

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -27,6 +27,7 @@ use Elementor\Modules\AtomicWidgets\Elements\Atomic_Image\Atomic_Image;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Paragraph\Atomic_Paragraph;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Button\Atomic_Button;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Divider\Atomic_Divider;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List\Atomic_List;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Svg\Atomic_Svg;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Tabs\Atomic_Tabs\Atomic_Tabs;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Tabs\Atomic_Tabs_Menu\Atomic_Tabs_Menu;
@@ -353,6 +354,10 @@ class Module extends BaseModule {
 		$elements_manager->register_element_type( new Div_Block() );
 		$elements_manager->register_element_type( new Flexbox() );
 		$elements_manager->register_element_type( new Grid() );
+
+		if ( Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_LIST ) ) {
+			$elements_manager->register_element_type( new Atomic_List() );
+		}
 
 		$elements_manager->register_element_type( new Atomic_Tabs() );
 		$elements_manager->register_element_type( new Atomic_Tabs_Menu() );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Introduces the atomic list widget (`e-list`) as a new container element for the atomic widgets framework, gated behind an experimental feature flag (ED-25114).

## 2. What Changed (Where)

- **atomic-list.php**: New 79-line widget class extending `Atomic_Element_Base` with props schema (tag, classes, attributes) and template binding.
- **atomic-list.html.twig**: Template rendering `<ul>` or `<ol>` with base classes and data attributes.
- **module.php**: Imported `Atomic_List` class and conditionally registered it behind `EXPERIMENT_LIST` feature gate.

## 3. How It Works

Widget registers as `e-list` element type when experiment active. Supports `ul`/`ol` tag switching via props schema, renders as container with template placeholder for child elements. Uses macro utilities for class/attribute rendering.

## 4. Risks

None significant — feature-flagged registration prevents premature exposure; follows established atomic widget patterns; twig template is minimal/standard. Ensure `EXPERIMENT_LIST` constant exists in module context.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
