### PR TITLE
Internal: Atomic e-list - item management [ED-25114]

### DIFF
--- a/modules/atomic-widgets/controls/types/elements/list-items-control.php
+++ b/modules/atomic-widgets/controls/types/elements/list-items-control.php
@@ -1,0 +1,18 @@
+<?php
+namespace Elementor\Modules\AtomicWidgets\Controls\Types\Elements;
+
+use Elementor\Modules\AtomicWidgets\Controls\Base\Element_Control_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class List_Items_Control extends Element_Control_Base {
+	public function get_type(): string {
+		return 'list-items';
+	}
+
+	public function get_props(): array {
+		return [];
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list-item-content/atomic-list-item-content.html.twig
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list-item-content/atomic-list-item-content.html.twig
@@ -1,0 +1,6 @@
+{% import 'elementor/macros' as m %}
+<div class="{{ m.render_base_classes(id, base_styles, settings) }} {{ editor_classes | default('') }}"
+	{{- ' ' }}{{ m.render_data_attributes(id, type, interaction_id) }}
+	{{- m.render_custom_attributes(settings, editor_attributes) }}>
+	<!-- elementor-children-placeholder -->
+</div>

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list-item-content/atomic-list-item-content.php
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list-item-content/atomic-list-item-content.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item_Content;
+
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Atomic_List_Item_Content extends Atomic_Element_Base {
+	use Has_Element_Template;
+
+	const BASE_STYLE_KEY = 'base';
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'is_container', true );
+		$this->meta( 'permanently_locked', true );
+	}
+
+	public static function get_type() {
+		return 'e-list-item-content';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-list-item-content';
+	}
+
+	public function get_title() {
+		return esc_html__( 'List item content', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'list', 'content' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-text-area';
+	}
+
+	public function should_show_in_panel() {
+		return false;
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()
+				->default( [] ),
+			'attributes' => Attributes_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [] ),
+		];
+	}
+
+	protected function define_base_styles(): array {
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+						->add_props( [
+							'display' => String_Prop_Type::generate( 'block' ),
+							'flex-grow' => String_Prop_Type::generate( '1' ),
+							'min-width' => String_Prop_Type::generate( '0' ),
+						] )
+				),
+		];
+	}
+
+	protected function define_default_html_tag() {
+		return 'div';
+	}
+
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-list-item-content' => __DIR__ . '/atomic-list-item-content.html.twig',
+		];
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list-item-marker/atomic-list-item-marker.html.twig
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list-item-marker/atomic-list-item-marker.html.twig
@@ -1,0 +1,7 @@
+{% import 'elementor/macros' as m %}
+<span class="{{ m.render_base_classes(id, base_styles, settings) }} {{ editor_classes | default('') }}"
+	{{- ' ' }}{{ m.render_data_attributes(id, type, interaction_id) }}
+	aria-hidden="true"
+	{{- m.render_custom_attributes(settings, editor_attributes) }}>
+	<!-- elementor-children-placeholder -->
+</span>

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list-item-marker/atomic-list-item-marker.php
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list-item-marker/atomic-list-item-marker.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item_Marker;
+
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Atomic_List_Item_Marker extends Atomic_Element_Base {
+	use Has_Element_Template;
+
+	const BASE_STYLE_KEY = 'base';
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'is_container', true );
+		$this->meta( 'permanently_locked', true );
+	}
+
+	public static function get_type() {
+		return 'e-list-item-marker';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-list-item-marker';
+	}
+
+	public function get_title() {
+		return esc_html__( 'List item marker', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'list', 'marker' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-bullet-list';
+	}
+
+	public function should_show_in_panel() {
+		return false;
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()
+				->default( [] ),
+			'attributes' => Attributes_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [] ),
+		];
+	}
+
+	protected function define_base_styles(): array {
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+						->add_props( [
+							'display' => String_Prop_Type::generate( 'flex' ),
+							'align-items' => String_Prop_Type::generate( 'center' ),
+							'flex-shrink' => String_Prop_Type::generate( '0' ),
+						] )
+				),
+		];
+	}
+
+	protected function define_default_html_tag() {
+		return 'span';
+	}
+
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-list-item-marker' => __DIR__ . '/atomic-list-item-marker.html.twig',
+		];
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list-item/atomic-list-item.html.twig
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list-item/atomic-list-item.html.twig
@@ -1,0 +1,6 @@
+{% import 'elementor/macros' as m %}
+<li class="{{ m.render_base_classes(id, base_styles, settings) }} {{ editor_classes | default('') }}"
+	{{- ' ' }}{{ m.render_data_attributes(id, type, interaction_id) }}
+	{{- m.render_custom_attributes(settings, editor_attributes) }}>
+	<!-- elementor-children-placeholder -->
+</li>

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list-item/atomic-list-item.php
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list-item/atomic-list-item.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item;
+
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item_Content\Atomic_List_Item_Content;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item_Marker\Atomic_List_Item_Marker;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
+use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
+use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Atomic_List_Item extends Atomic_Element_Base {
+	use Has_Element_Template;
+
+	const BASE_STYLE_KEY = 'base';
+
+	public function __construct( $data = [], $args = null ) {
+		parent::__construct( $data, $args );
+		$this->meta( 'is_container', true );
+		$this->meta( 'permanently_locked', true );
+	}
+
+	public static function get_type() {
+		return 'e-list-item';
+	}
+
+	public static function get_element_type(): string {
+		return 'e-list-item';
+	}
+
+	public function get_title() {
+		return esc_html__( 'List item', 'elementor' );
+	}
+
+	public function get_keywords() {
+		return [ 'ato', 'atom', 'atoms', 'atomic', 'list', 'item' ];
+	}
+
+	public function get_icon() {
+		return 'eicon-bullet-list';
+	}
+
+	public function should_show_in_panel() {
+		return false;
+	}
+
+	protected static function define_props_schema(): array {
+		return [
+			'classes' => Classes_Prop_Type::make()
+				->default( [] ),
+			'attributes' => Attributes_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() ),
+		];
+	}
+
+	protected function define_atomic_controls(): array {
+		return [
+			Section::make()
+				->set_label( __( 'Settings', 'elementor' ) )
+				->set_id( 'settings' )
+				->set_items( [] ),
+		];
+	}
+
+	protected function define_base_styles(): array {
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+						->add_props( [
+							'display' => String_Prop_Type::generate( 'flex' ),
+							'align-items' => String_Prop_Type::generate( 'flex-start' ),
+							'gap' => Size_Prop_Type::generate( [
+								'size' => 12,
+								'unit' => 'px',
+							] ),
+						] )
+				),
+		];
+	}
+
+	protected function define_allowed_child_types() {
+		return [
+			Atomic_List_Item_Marker::get_element_type(),
+			Atomic_List_Item_Content::get_element_type(),
+		];
+	}
+
+	protected function define_default_html_tag() {
+		return 'li';
+	}
+
+	protected function get_templates(): array {
+		return [
+			'elementor/elements/atomic-list-item' => __DIR__ . '/atomic-list-item.html.twig',
+		];
+	}
+}

--- a/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.php
+++ b/modules/atomic-widgets/elements/atomic-list/atomic-list/atomic-list.php
@@ -3,12 +3,23 @@
 namespace Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List;
 
 use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Elements\List_Items_Control;
 use Elementor\Modules\AtomicWidgets\Controls\Types\Text_Control;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item\Atomic_List_Item;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item_Content\Atomic_List_Item_Content;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item_Marker\Atomic_List_Item_Marker;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Paragraph\Atomic_Paragraph;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Svg\Atomic_Svg;
 use Elementor\Modules\AtomicWidgets\Elements\Base\Atomic_Element_Base;
+use Elementor\Modules\AtomicWidgets\Elements\Base\Widget_Builder;
 use Elementor\Modules\AtomicWidgets\Elements\Base\Has_Element_Template;
 use Elementor\Modules\AtomicWidgets\PropTypes\Attributes_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Classes_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Html_V3_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Size_Prop_Type;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Definition;
+use Elementor\Modules\AtomicWidgets\Styles\Style_Variant;
 use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -17,6 +28,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Atomic_List extends Atomic_Element_Base {
 	use Has_Element_Template;
+
+	const BASE_STYLE_KEY = 'base';
 
 	public function __construct( $data = [], $args = null ) {
 		parent::__construct( $data, $args );
@@ -57,6 +70,16 @@ class Atomic_List extends Atomic_Element_Base {
 	protected function define_atomic_controls(): array {
 		return [
 			Section::make()
+				->set_label( __( 'Content', 'elementor' ) )
+				->set_id( 'content' )
+				->set_items( [
+					List_Items_Control::make()
+						->set_label( __( 'List Items', 'elementor' ) )
+						->set_meta( [
+							'layout' => 'custom',
+						] ),
+				] ),
+			Section::make()
 				->set_label( __( 'Settings', 'elementor' ) )
 				->set_id( 'settings' )
 				->set_items( [
@@ -64,6 +87,66 @@ class Atomic_List extends Atomic_Element_Base {
 						->set_label( __( 'ID', 'elementor' ) )
 						->set_meta( $this->get_css_id_control_meta() ),
 				] ),
+		];
+	}
+
+	protected function define_base_styles(): array {
+		return [
+			static::BASE_STYLE_KEY => Style_Definition::make()
+				->add_variant(
+					Style_Variant::make()
+						->add_props( [
+							'display' => String_Prop_Type::generate( 'flex' ),
+							'flex-direction' => String_Prop_Type::generate( 'column' ),
+							'list-style-type' => String_Prop_Type::generate( 'none' ),
+							'margin' => Size_Prop_Type::generate( [
+								'size' => 0,
+								'unit' => 'px',
+							] ),
+							'padding' => Size_Prop_Type::generate( [
+								'size' => 0,
+								'unit' => 'px',
+							] ),
+							'gap' => Size_Prop_Type::generate( [
+								'size' => 12,
+								'unit' => 'px',
+							] ),
+						] )
+				),
+		];
+	}
+
+	protected function define_allowed_child_types() {
+		return [ Atomic_List_Item::get_element_type() ];
+	}
+
+	protected function define_default_children() {
+		return [
+			Atomic_List_Item::generate()
+				->editor_settings( [
+					'label' => 'Item 1',
+					'initial_position' => 1,
+				] )
+				->children( [
+					Atomic_List_Item_Marker::generate()
+						->children( [
+							Widget_Builder::make( Atomic_Svg::get_element_type() )->build(),
+						] )
+						->build(),
+					Atomic_List_Item_Content::generate()
+						->children( [
+							Widget_Builder::make( Atomic_Paragraph::get_element_type() )
+								->settings( [
+									'paragraph' => Html_V3_Prop_Type::generate( [
+										'content' => String_Prop_Type::generate( __( 'List item', 'elementor' ) ),
+										'children' => [],
+									] ),
+								] )
+								->build(),
+						] )
+						->build(),
+				] )
+				->build(),
 		];
 	}
 

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -28,6 +28,9 @@ use Elementor\Modules\AtomicWidgets\Elements\Atomic_Paragraph\Atomic_Paragraph;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Button\Atomic_Button;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Divider\Atomic_Divider;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List\Atomic_List;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item\Atomic_List_Item;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item_Content\Atomic_List_Item_Content;
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_List\Atomic_List_Item_Marker\Atomic_List_Item_Marker;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Svg\Atomic_Svg;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Tabs\Atomic_Tabs\Atomic_Tabs;
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Tabs\Atomic_Tabs_Menu\Atomic_Tabs_Menu;
@@ -357,6 +360,9 @@ class Module extends BaseModule {
 
 		if ( Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_LIST ) ) {
 			$elements_manager->register_element_type( new Atomic_List() );
+			$elements_manager->register_element_type( new Atomic_List_Item() );
+			$elements_manager->register_element_type( new Atomic_List_Item_Marker() );
+			$elements_manager->register_element_type( new Atomic_List_Item_Content() );
 		}
 
 		$elements_manager->register_element_type( new Atomic_Tabs() );

--- a/modules/atomic-widgets/utils/element-structure-title.php
+++ b/modules/atomic-widgets/utils/element-structure-title.php
@@ -11,9 +11,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Element_Structure_Title {
 
 	public static function resolve( array $element ): ?string {
-		$editor_title = $element['editor_settings']['title'] ?? null;
+		$editor_label = self::extract_plain_string( $element['editor_settings']['label'] ?? null );
 
-		if ( is_string( $editor_title ) && '' !== $editor_title ) {
+		if ( null !== $editor_label ) {
+			return $editor_label;
+		}
+
+		$editor_title = self::extract_plain_string( $element['editor_settings']['title'] ?? null );
+
+		if ( null !== $editor_title ) {
 			return $editor_title;
 		}
 

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/__tests__/list-items-control.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/__tests__/list-items-control.test.tsx
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { ListItemsControlContent } from '../list-items-control';
+
+const mockRepeater = jest.fn( ( _props: unknown ) => null );
+const mockGetContainer = jest.fn();
+const mockGetElementChildren = jest.fn();
+const mockUseElementEditorSettings = jest.fn(
+	( _elementId: string ): { label?: string } => ( { label: 'Item 1' } )
+);
+
+jest.mock( '@elementor/editor-v1-adapters', () => ( {
+	__privateUseListenTo: ( _events: unknown[], getValue: () => unknown ) => getValue(),
+	commandEndEvent: ( command: string ) => command,
+	v1ReadyEvent: () => 'ready',
+	windowEvent: ( event: string ) => event,
+} ) );
+
+jest.mock( '@elementor/editor-controls', () => ( {
+	Repeater: ( props: unknown ) => {
+		mockRepeater( props );
+		return null;
+	},
+	ControlFormLabel: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
+} ) );
+
+jest.mock( '@elementor/editor-elements', () => ( {
+	getContainer: ( ...args: unknown[] ) => mockGetContainer( ...args ),
+	getElementChildrenWithFallback: ( ...args: unknown[] ) => mockGetElementChildren( ...args ),
+	updateElementEditorSettings: jest.fn(),
+	useElementEditorSettings: ( elementId: string ) => mockUseElementEditorSettings( elementId ),
+} ) );
+
+jest.mock( '../../../../contexts/element-context', () => ( {
+	useElement: () => ( { element: { id: 'list-1' } } ),
+} ) );
+
+jest.mock( '../use-actions', () => ( {
+	LIST_ITEM_ELEMENT_TYPE: 'e-list-item',
+	useActions: () => ( {
+		addItem: jest.fn(),
+		duplicateItem: jest.fn(),
+		moveItem: jest.fn(),
+		removeItem: jest.fn(),
+	} ),
+} ) );
+
+describe( 'ListItemsControlContent', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetContainer.mockReturnValue( { id: 'list-1', model: {} } );
+		mockUseElementEditorSettings.mockReturnValue( { label: 'Item 1' } );
+	} );
+
+	it( 'hides remove when only one item exists', () => {
+		mockGetElementChildren.mockReturnValue( [
+			{
+				model: {
+					get: ( key: string ) => {
+						if ( key === 'id' ) {
+							return 'item-1';
+						}
+
+						if ( key === 'editor_settings' ) {
+							return { label: 'Item 1' };
+						}
+
+						return undefined;
+					},
+				},
+			},
+		] );
+
+		render( <ListItemsControlContent label="List Items" /> );
+
+		expect( mockRepeater ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				showRemove: false,
+			} )
+		);
+	} );
+
+	it( 'shows remove when multiple items exist', () => {
+		mockGetElementChildren.mockReturnValue( [
+			{
+				model: {
+					get: ( key: string ) => {
+						if ( key === 'id' ) {
+							return 'item-1';
+						}
+
+						if ( key === 'editor_settings' ) {
+							return { label: 'Item 1' };
+						}
+
+						return undefined;
+					},
+				},
+			},
+			{
+				model: {
+					get: ( key: string ) => {
+						if ( key === 'id' ) {
+							return 'item-2';
+						}
+
+						if ( key === 'editor_settings' ) {
+							return { label: 'Item 2' };
+						}
+
+						return undefined;
+					},
+				},
+			},
+		] );
+
+		render( <ListItemsControlContent label="List Items" /> );
+
+		expect( mockRepeater ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				showRemove: true,
+			} )
+		);
+	} );
+
+	it( 'populates the popover input with the effective item label when editor settings are empty', () => {
+		mockGetElementChildren.mockReturnValue( [
+			{
+				model: {
+					get: ( key: string ) => {
+						if ( key === 'id' ) {
+							return 'item-1';
+						}
+
+						if ( key === 'editor_settings' ) {
+							return {};
+						}
+
+						return undefined;
+					},
+				},
+			},
+		] );
+		mockUseElementEditorSettings.mockReturnValue( {} );
+
+		render( <ListItemsControlContent label="List Items" /> );
+
+		const repeaterProps = mockRepeater.mock.calls[ 0 ][ 0 ] as {
+			itemSettings: {
+				Content: React.ComponentType< {
+					value: { id: string; title: string };
+					index: number;
+					anchorEl: HTMLElement | null;
+					bind: string;
+				} >;
+			};
+		};
+
+		const Content = repeaterProps.itemSettings.Content;
+
+		render( <Content value={ { id: 'item-1', title: 'Item 1' } } index={ 0 } anchorEl={ null } bind="ignored" /> );
+
+		expect( screen.getByDisplayValue( 'Item 1' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/__tests__/use-actions.test.ts
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/__tests__/use-actions.test.ts
@@ -1,0 +1,121 @@
+import { createMockElement } from 'test-utils';
+import {
+	createElements,
+	duplicateElements,
+	getContainer,
+	moveElements,
+	removeElements,
+	type V1Element,
+} from '@elementor/editor-elements';
+import { renderHook } from '@testing-library/react';
+
+import { useActions } from '../use-actions';
+
+jest.mock( '@elementor/editor-elements' );
+
+describe( 'list-items-control actions', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'creates a full default list-item subtree when adding an item', () => {
+		const listContainer = createMockElement( {
+			model: { id: 'list-1', elType: 'e-list' },
+		} ) as unknown as V1Element;
+		const { result } = renderHook( () => useActions() );
+
+		result.current.addItem( {
+			listContainer,
+			items: [ { index: 1, item: { id: '', title: 'Item' } } ],
+		} );
+
+		expect( createElements ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				title: 'List Items',
+				elements: [
+					expect.objectContaining( {
+						container: listContainer,
+						model: expect.objectContaining( {
+							elType: 'e-list-item',
+							editor_settings: { label: 'Item 2', initial_position: 2 },
+							elements: [
+								expect.objectContaining( {
+									elType: 'e-list-item-marker',
+									elements: [ expect.objectContaining( { elType: 'widget', widgetType: 'e-svg' } ) ],
+								} ),
+								expect.objectContaining( {
+									elType: 'e-list-item-content',
+									elements: [
+										expect.objectContaining( {
+											elType: 'widget',
+											widgetType: 'e-paragraph',
+										} ),
+									],
+								} ),
+							],
+						} ),
+					} ),
+				],
+			} )
+		);
+	} );
+
+	it( 'removes the selected list items by root id', () => {
+		const { result } = renderHook( () => useActions() );
+
+		result.current.removeItem( {
+			items: [
+				{ index: 0, item: { id: 'item-1', title: 'Item 1' } },
+				{ index: 1, item: { id: 'item-2', title: 'Item 2' } },
+			],
+		} );
+
+		expect( removeElements ).toHaveBeenCalledWith( {
+			title: 'List Items',
+			elementIds: [ 'item-1', 'item-2' ],
+		} );
+	} );
+
+	it( 'duplicates the selected list item roots', () => {
+		const { result } = renderHook( () => useActions() );
+
+		result.current.duplicateItem( {
+			items: [ { index: 0, item: { id: 'item-1', title: 'Item 1' } } ],
+		} );
+
+		expect( duplicateElements ).toHaveBeenCalledWith( {
+			elementIds: [ 'item-1' ],
+			title: 'Duplicate List Item',
+		} );
+	} );
+
+	it( 'reorders a list item inside the root list container', () => {
+		const listContainer = createMockElement( {
+			model: { id: 'list-1', elType: 'e-list' },
+		} ) as unknown as V1Element;
+		const movedElement = createMockElement( {
+			model: { id: 'item-2', elType: 'e-list-item' },
+		} ) as unknown as V1Element;
+
+		jest.mocked( getContainer ).mockReturnValue( movedElement );
+
+		const { result } = renderHook( () => useActions() );
+
+		result.current.moveItem( {
+			listContainer,
+			toIndex: 0,
+			movedElementId: 'item-2',
+		} );
+
+		expect( moveElements ).toHaveBeenCalledWith( {
+			title: 'Reorder List Items',
+			moves: [
+				{
+					element: movedElement,
+					targetContainer: listContainer,
+					options: { at: 0 },
+				},
+			],
+		} );
+	} );
+} );

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/list-items-control.tsx
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/list-items-control.tsx
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import { ControlFormLabel, Repeater, type RepeaterItem, type SetRepeaterValuesMeta } from '@elementor/editor-controls';
+import {
+	getContainer,
+	getElementChildrenWithFallback,
+	updateElementEditorSettings,
+	useElementEditorSettings,
+	type V1Element,
+} from '@elementor/editor-elements';
+import { type CreateOptions } from '@elementor/editor-props';
+import {
+	__privateUseListenTo as useListenTo,
+	commandEndEvent,
+	v1ReadyEvent,
+	windowEvent,
+} from '@elementor/editor-v1-adapters';
+import { Stack, TextField } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import { useElement } from '../../../contexts/element-context';
+import { LIST_ITEM_ELEMENT_TYPE, type ListItem, useActions } from './use-actions';
+
+type ElementModel = {
+	id: string;
+	editorSettings: {
+		label?: string;
+		title?: string;
+	};
+};
+
+const useListItems = ( elementId: string ): ElementModel[] => {
+	return useListenTo(
+		[
+			v1ReadyEvent(),
+			commandEndEvent( 'document/elements/create' ),
+			commandEndEvent( 'document/elements/delete' ),
+			commandEndEvent( 'document/elements/update' ),
+			commandEndEvent( 'document/elements/set-settings' ),
+			windowEvent( 'elementor/element/update_editor_settings' ),
+		],
+		() => {
+			const container = getContainer( elementId );
+			const model = container?.model;
+
+			if ( ! model ) {
+				return [];
+			}
+
+			return getElementChildrenWithFallback(
+				model,
+				( childModel ) => childModel.get( 'elType' ) === LIST_ITEM_ELEMENT_TYPE
+			).map( ( { model: childModel } ) => ( {
+				id: childModel.get( 'id' ) as string,
+				editorSettings: ( childModel.get( 'editor_settings' ) ?? {} ) as ElementModel[ 'editorSettings' ],
+			} ) );
+		},
+		[ elementId ]
+	);
+};
+
+export const ListItemsControl = ( { label }: { label: string } ) => {
+	return <ListItemsControlContent label={ label } />;
+};
+
+export const ListItemsControlContent = ( { label }: { label: string } ) => {
+	const { element } = useElement();
+	const { addItem, duplicateItem, moveItem, removeItem } = useActions();
+	const listItems = useListItems( element.id );
+	const listContainer = getContainer( element.id ) as V1Element;
+
+	const repeaterValues: RepeaterItem< ListItem >[] = listItems.map( ( item, index ) => ( {
+		id: item.id,
+		title: item.editorSettings.label ?? `Item ${ index + 1 }`,
+		index,
+	} ) );
+
+	const setValue = (
+		_newValues: RepeaterItem< ListItem >[],
+		_options: CreateOptions,
+		meta?: SetRepeaterValuesMeta< RepeaterItem< ListItem > >
+	) => {
+		if ( ! listContainer ) {
+			throw new Error( 'List container not found' );
+		}
+
+		if ( meta?.action?.type === 'add' ) {
+			return addItem( { items: meta.action.payload, listContainer } );
+		}
+
+		if ( meta?.action?.type === 'remove' ) {
+			return removeItem( { items: meta.action.payload } );
+		}
+
+		if ( meta?.action?.type === 'duplicate' ) {
+			return duplicateItem( { items: meta.action.payload } );
+		}
+
+		if ( meta?.action?.type === 'reorder' ) {
+			const { from, to } = meta.action.payload;
+
+			return moveItem( {
+				listContainer,
+				toIndex: to,
+				movedElementId: listItems[ from ]?.id,
+			} );
+		}
+	};
+
+	return (
+		<Repeater
+			showToggle={ false }
+			values={ repeaterValues }
+			setValues={ setValue }
+			showRemove={ repeaterValues.length > 1 }
+			label={ label }
+			itemSettings={ {
+				getId: ( { item } ) => item.id,
+				initialValues: { id: '', title: 'Item' },
+				Label: ItemLabel,
+				Content: ItemContent,
+				Icon: () => null,
+			} }
+		/>
+	);
+};
+
+const ItemLabel = ( { value }: { value: ListItem } ) => {
+	return (
+		<Stack sx={ { minHeight: 20 } } direction="row" alignItems="center" gap={ 1.5 }>
+			<span>{ value.title }</span>
+		</Stack>
+	);
+};
+
+const ItemContent = ( { value }: { value: ListItem } ) => {
+	if ( ! value.id ) {
+		return null;
+	}
+
+	return (
+		<Stack p={ 2 } gap={ 1.5 }>
+			<ListItemLabelControl elementId={ value.id } initialLabel={ value.title ?? '' } />
+		</Stack>
+	);
+};
+
+const ListItemLabelControl = ( { elementId, initialLabel }: { elementId: string; initialLabel: string } ) => {
+	const editorSettings = useElementEditorSettings( elementId );
+	const label = editorSettings?.label ?? initialLabel;
+
+	return (
+		<Stack gap={ 1 }>
+			<ControlFormLabel>{ __( 'Item name', 'elementor' ) }</ControlFormLabel>
+			<TextField
+				size="tiny"
+				value={ label }
+				onChange={ ( { target }: React.ChangeEvent< HTMLInputElement > ) => {
+					updateElementEditorSettings( {
+						elementId,
+						settings: { label: target.value },
+					} );
+				} }
+			/>
+		</Stack>
+	);
+};

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/use-actions.ts
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/list-items-control/use-actions.ts
@@ -1,0 +1,142 @@
+import { type ItemsActionPayload } from '@elementor/editor-controls';
+import {
+	type CreateElementParams,
+	createElements,
+	duplicateElements,
+	getContainer,
+	moveElements,
+	removeElements,
+	type V1Element,
+} from '@elementor/editor-elements';
+import { __ } from '@wordpress/i18n';
+
+export type ListItem = {
+	id: string;
+	title?: string;
+};
+
+export const LIST_ITEM_ELEMENT_TYPE = 'e-list-item';
+const LIST_ITEM_MARKER_ELEMENT_TYPE = 'e-list-item-marker';
+const LIST_ITEM_CONTENT_ELEMENT_TYPE = 'e-list-item-content';
+const SVG_WIDGET_TYPE = 'e-svg';
+const PARAGRAPH_WIDGET_TYPE = 'e-paragraph';
+
+type ListItemModel = Omit< NonNullable< CreateElementParams[ 'model' ] >, 'elements' > & {
+	elements?: ListItemModel[];
+};
+
+const createDefaultListItemModel = ( position: number ): ListItemModel => ( {
+	elType: LIST_ITEM_ELEMENT_TYPE,
+	editor_settings: {
+		label: `Item ${ position }`,
+		initial_position: position,
+	},
+	elements: [
+		{
+			elType: LIST_ITEM_MARKER_ELEMENT_TYPE,
+			elements: [
+				{
+					elType: 'widget',
+					widgetType: SVG_WIDGET_TYPE,
+				},
+			],
+		},
+		{
+			elType: LIST_ITEM_CONTENT_ELEMENT_TYPE,
+			elements: [
+				{
+					elType: 'widget',
+					widgetType: PARAGRAPH_WIDGET_TYPE,
+					settings: {
+						paragraph: {
+							$$type: 'html-v3',
+							value: {
+								content: {
+									$$type: 'string',
+									value: __( 'List item', 'elementor' ),
+								},
+								children: [],
+							},
+						},
+					},
+				},
+			],
+		},
+	],
+} );
+
+export const useActions = () => {
+	const duplicateItem = ( { items }: { items: ItemsActionPayload< ListItem > } ) => {
+		duplicateElements( {
+			elementIds: items.map( ( { item } ) => item.id as string ),
+			title: __( 'Duplicate List Item', 'elementor' ),
+		} );
+	};
+
+	const moveItem = ( {
+		listContainer,
+		toIndex,
+		movedElementId,
+	}: {
+		listContainer: V1Element;
+		toIndex: number;
+		movedElementId?: string;
+	} ) => {
+		if ( ! movedElementId ) {
+			throw new Error( 'List item is required' );
+		}
+
+		const movedElement = getContainer( movedElementId );
+
+		if ( ! movedElement ) {
+			throw new Error( 'List item not found' );
+		}
+
+		moveElements( {
+			title: __( 'Reorder List Items', 'elementor' ),
+			moves: [
+				{
+					element: movedElement,
+					targetContainer: listContainer,
+					options: { at: toIndex },
+				},
+			],
+		} );
+	};
+
+	const removeItem = ( { items }: { items: ItemsActionPayload< ListItem > } ) => {
+		removeElements( {
+			title: __( 'List Items', 'elementor' ),
+			elementIds: items.map( ( { item } ) => item.id as string ),
+		} );
+	};
+
+	const addItem = ( {
+		listContainer,
+		items,
+	}: {
+		listContainer: V1Element;
+		items: ItemsActionPayload< ListItem >;
+	} ) => {
+		items.forEach( ( { index } ) => {
+			const position = index + 1;
+
+			createElements( {
+				title: __( 'List Items', 'elementor' ),
+				elements: [
+					{
+						container: listContainer,
+						model: createDefaultListItemModel( position ) as CreateElementParams[ 'model' ],
+					},
+				],
+			} );
+		} );
+	};
+
+	return {
+		duplicateItem,
+		moveItem,
+		removeItem,
+		addItem,
+	};
+};

--- a/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/registry.ts
+++ b/packages/packages/core/editor-editing-panel/src/controls-registry/element-controls/registry.ts
@@ -1,9 +1,11 @@
 import { type ControlComponent } from '@elementor/editor-controls';
 
 import { type ControlRegistry, controlsRegistry } from '../controls-registry';
+import { ListItemsControl } from './list-items-control/list-items-control';
 import { TabsControl } from './tabs-control/tabs-control';
 
 const controlTypes = {
+	'list-items': { component: ListItemsControl as ControlComponent, layout: 'full' },
 	tabs: { component: TabsControl as ControlComponent, layout: 'full' },
 } as const satisfies ControlRegistry;
 

--- a/packages/packages/libs/editor-elements/src/hooks/__tests__/use-element-children.test.ts
+++ b/packages/packages/libs/editor-elements/src/hooks/__tests__/use-element-children.test.ts
@@ -179,6 +179,36 @@ describe( 'useElementChildren', () => {
 		expect( result.current.tab.map( ( e ) => e.id ) ).toEqual( [ 'child-1', 'child-2' ] );
 	} );
 
+	it( 'should update when editor settings change event is dispatched', () => {
+		// Arrange.
+		const tabs = [ createMockChild( { id: 'child-1', elType: 'tab' } ) ];
+		const tabsParent = createMockContainer( 'tabs-parent', tabs, 'tabs' );
+		const mockContainer = createMockContainer( 'element-1', [ tabsParent ] );
+		mockGetContainer.mockReturnValue( mockContainer );
+
+		// Act.
+		const { result } = renderHook( () => useElementChildren( 'element-1', { tabs: 'tab' } ) );
+
+		// Assert.
+		expect( result.current.tab[ 0 ]?.editorSettings?.title ).toBeUndefined();
+
+		// Arrange.
+		const updatedTabs = [
+			createMockChild( { id: 'child-1', elType: 'tab', editor_settings: { title: 'Updated' } } ),
+		];
+		const updatedTabsParent = createMockContainer( 'tabs-parent', updatedTabs, 'tabs' );
+		const updatedContainer = createMockContainer( 'element-1', [ updatedTabsParent ] );
+		mockGetContainer.mockReturnValue( updatedContainer );
+
+		// Act.
+		act( () => {
+			window.dispatchEvent( new CustomEvent( 'elementor/element/update_editor_settings' ) );
+		} );
+
+		// Assert.
+		expect( result.current.tab[ 0 ]?.editorSettings?.title ).toBe( 'Updated' );
+	} );
+
 	it( 'should re-compute when elementId dependency changes', () => {
 		// Arrange.
 		const tabs1 = [ createMockChild( { id: 'child-1', elType: 'tab' } ) ];

--- a/packages/packages/libs/editor-elements/src/hooks/use-element-children.ts
+++ b/packages/packages/libs/editor-elements/src/hooks/use-element-children.ts
@@ -1,4 +1,9 @@
-import { __privateUseListenTo as useListenTo, commandEndEvent, v1ReadyEvent } from '@elementor/editor-v1-adapters';
+import {
+	__privateUseListenTo as useListenTo,
+	commandEndEvent,
+	v1ReadyEvent,
+	windowEvent,
+} from '@elementor/editor-v1-adapters';
 
 import { getContainer } from '../sync/get-container';
 import { findChildRecursive, getElementChildren, type ModelResult } from '../sync/model-utils';
@@ -30,6 +35,7 @@ export function useElementChildren< T extends ElementChildren >(
 			commandEndEvent( 'document/elements/delete' ),
 			commandEndEvent( 'document/elements/update' ),
 			commandEndEvent( 'document/elements/set-settings' ),
+			windowEvent( 'elementor/element/update_editor_settings' ),
 		],
 		() => {
 			const container = getContainer( elementId );

--- a/packages/packages/libs/editor-elements/src/sync/__tests__/get-element-title.test.ts
+++ b/packages/packages/libs/editor-elements/src/sync/__tests__/get-element-title.test.ts
@@ -35,6 +35,24 @@ describe( 'getElementTitle', () => {
 		expect( title ).toBe( 'Custom Editor Title' );
 	} );
 
+	it( 'should return editor_settings.label when set', () => {
+		// Arrange.
+		jest.mocked( getContainer ).mockReturnValue(
+			createMockElement( {
+				model: {
+					widgetType: 'test-widget',
+					editor_settings: { label: 'Custom Editor Label' },
+				},
+			} )
+		);
+
+		// Act.
+		const title = getElementTitle( 'test-id' );
+
+		// Assert.
+		expect( title ).toBe( 'Custom Editor Label' );
+	} );
+
 	it( 'should return _title setting when editor_settings.title is not set', () => {
 		// Arrange.
 		jest.mocked( getContainer ).mockReturnValue(
@@ -125,5 +143,23 @@ describe( 'getElementTitle', () => {
 
 		// Assert.
 		expect( title ).toBe( 'Editor Title' );
+	} );
+
+	it( 'should prefer editor_settings.label over editor_settings.title', () => {
+		// Arrange.
+		jest.mocked( getContainer ).mockReturnValue(
+			createMockElement( {
+				model: {
+					widgetType: 'test-widget',
+					editor_settings: { label: 'Editor Label', title: 'Editor Title' },
+				},
+			} )
+		);
+
+		// Act.
+		const title = getElementTitle( 'test-id' );
+
+		// Assert.
+		expect( title ).toBe( 'Editor Label' );
 	} );
 } );

--- a/packages/packages/libs/editor-elements/src/sync/__tests__/update-element-editor-settings.test.ts
+++ b/packages/packages/libs/editor-elements/src/sync/__tests__/update-element-editor-settings.test.ts
@@ -7,8 +7,15 @@ jest.mock( '../get-container' );
 jest.mock( '@elementor/editor-v1-adapters' );
 
 describe( 'updateElementEditorSettings', () => {
+	let dispatchEventSpy: jest.SpyInstance;
+
 	beforeEach( () => {
 		jest.clearAllMocks();
+		dispatchEventSpy = jest.spyOn( window, 'dispatchEvent' ).mockImplementation( () => true );
+	} );
+
+	afterEach( () => {
+		dispatchEventSpy.mockRestore();
 	} );
 
 	it( 'should update element editor settings successfully', () => {
@@ -32,6 +39,9 @@ describe( 'updateElementEditorSettings', () => {
 			...existingSettings,
 			...newSettings,
 		} );
+		expect( dispatchEventSpy ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'elementor/element/update_editor_settings' } )
+		);
 		expect( runCommandSync ).toHaveBeenCalledWith(
 			'document/save/set-is-modified',
 			{ status: true },

--- a/packages/packages/libs/editor-elements/src/sync/get-element-title.ts
+++ b/packages/packages/libs/editor-elements/src/sync/get-element-title.ts
@@ -22,6 +22,12 @@ function extractString( value: unknown ): string | null {
 
 export function getElementTitle( elementId: ElementID ): string | null {
 	const editorSettings = getElementEditorSettings( elementId );
+	const editorLabel = extractString( editorSettings?.label );
+
+	if ( editorLabel ) {
+		return editorLabel;
+	}
+
 	const editorTitle = extractString( editorSettings?.title );
 
 	if ( editorTitle ) {

--- a/packages/packages/libs/editor-elements/src/sync/types.ts
+++ b/packages/packages/libs/editor-elements/src/sync/types.ts
@@ -178,6 +178,7 @@ export type ElementPosition = {
 };
 
 export type V1ElementEditorSettingsProps = {
+	label?: string;
 	title?: string;
 	initial_position?: number;
 	component_uid?: string;
@@ -207,7 +208,9 @@ export type V1ElementConfig< T = object, TChild = unknown > = {
 	allowed_child_types?: string[];
 	default_children?: Array< Record< string, TChild > >;
 	children_dependencies?: ChildDependencyRule[];
-	meta?: { [ key: string ]: string | number | boolean | null | NonNullable< V1ElementConfig[ 'meta' ] > };
+	meta?: {
+		[ key: string ]: string | number | boolean | null | NonNullable< V1ElementConfig[ 'meta' ] >;
+	};
 } & T;
 
 type V1Model< T > = {

--- a/packages/packages/libs/editor-elements/src/sync/update-element-editor-settings.ts
+++ b/packages/packages/libs/editor-elements/src/sync/update-element-editor-settings.ts
@@ -19,6 +19,7 @@ export const updateElementEditorSettings = ( {
 	const editorSettings = element.model.get( 'editor_settings' ) ?? {};
 
 	element.model.set( 'editor_settings', { ...editorSettings, ...settings } );
+	window.dispatchEvent( new CustomEvent( 'elementor/element/update_editor_settings' ) );
 
 	runCommandSync( 'document/save/set-is-modified', { status: true }, { internal: true } );
 };

--- a/tests/phpunit/elementor/modules/atomic-widgets/utils/test-element-structure-title.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/utils/test-element-structure-title.php
@@ -11,6 +11,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Test_Element_Structure_Title extends TestCase {
 
+	public function test_resolve__returns_editor_settings_label() {
+		// Arrange.
+		$element = [
+			'elType' => 'widget',
+			'widgetType' => 'e-heading',
+			'editor_settings' => [ 'label' => 'List Item Label' ],
+		];
+
+		// Act.
+		$title = Element_Structure_Title::resolve( $element );
+
+		// Assert.
+		$this->assertSame( 'List Item Label', $title );
+	}
+
 	public function test_resolve__returns_editor_settings_title() {
 		// Arrange.
 		$element = [
@@ -70,6 +85,24 @@ class Test_Element_Structure_Title extends TestCase {
 
 		// Assert.
 		$this->assertSame( 'Editor Title', $title );
+	}
+
+	public function test_resolve__prefers_editor_settings_label_over_title() {
+		// Arrange.
+		$element = [
+			'elType' => 'widget',
+			'widgetType' => 'e-heading',
+			'editor_settings' => [
+				'label' => 'Editor Label',
+				'title' => 'Editor Title',
+			],
+		];
+
+		// Act.
+		$title = Element_Structure_Title::resolve( $element );
+
+		// Assert.
+		$this->assertSame( 'Editor Label', $title );
 	}
 
 	public function test_resolve__extracts_title_from_envelope_setting() {

--- a/tests/phpunit/elementor/modules/mcp/test-get-structure-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-get-structure-ability.php
@@ -571,6 +571,30 @@ class Test_Get_Structure_Ability extends Elementor_Test_Base {
 		$this->assertSame( 'Hero Section', $result['elements'][0]['title'] );
 	}
 
+	public function test_execute__includes_editor_settings_label_in_skeleton() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->factory()->post->create();
+
+		$elements = [
+			[
+				'id' => 'widget1',
+				'elType' => 'widget',
+				'widgetType' => 'e-heading',
+				'editor_settings' => [ 'label' => 'Renamed List Item' ],
+				'elements' => [],
+			],
+		];
+
+		$this->mock_document_with_elements( $post_id, $elements );
+
+		// Act
+		$result = $this->ability->execute( [ 'post_id' => $post_id ] );
+
+		// Assert
+		$this->assertSame( 'Renamed List Item', $result['elements'][0]['title'] );
+	}
+
 	public function test_execute__falls_back_to_title_setting() {
 		// Arrange
 		$this->act_as_admin();
@@ -665,6 +689,34 @@ class Test_Get_Structure_Ability extends Elementor_Test_Base {
 
 		// Assert
 		$this->assertSame( 'Editor Title', $result['elements'][0]['title'] );
+	}
+
+	public function test_execute__prefers_editor_settings_label_over_title() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->factory()->post->create();
+
+		$elements = [
+			[
+				'id' => 'widget1',
+				'elType' => 'widget',
+				'widgetType' => 'e-heading',
+				'editor_settings' => [
+					'label' => 'Editor Label',
+					'title' => 'Editor Title',
+				],
+				'settings' => [ '_title' => 'Legacy Title' ],
+				'elements' => [],
+			],
+		];
+
+		$this->mock_document_with_elements( $post_id, $elements );
+
+		// Act
+		$result = $this->ability->execute( [ 'post_id' => $post_id ] );
+
+		// Assert
+		$this->assertSame( 'Editor Label', $result['elements'][0]['title'] );
 	}
 
 	public function test_execute__extracts_title_from_envelope_setting() {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Implements list item management for atomic e-list widget (ED-25114). Adds child elements (marker, content) with UI controls for add/remove/reorder/duplicate operations and editor labeling.

## 2. What Changed (Where)

| Component | Change |
|-----------|--------|
| PHP Elements | New `Atomic_List_Item`, `Atomic_List_Item_Marker`, `Atomic_List_Item_Content` classes with base styles and templates |
| Control Layer | New `List_Items_Control` + TypeScript `ListItemsControl` repeater UI with item management actions |
| Editor Settings | Added `label` field to `V1ElementEditorSettingsProps`; refactored title resolution to prefer `label` over `title` |
| Module Registration | Three new element types registered when LIST experiment active |
| Event System | Dispatches custom event on editor settings update; extends hook dependencies |

## 3. How It Works

List items render as `<li>` containers with flex layout (12px gap). Each item contains marker (`<span>`) and content (`<div>`) sub-elements. TypeScript control uses repeater UI to manage items: add creates full subtree (marker→SVG, content→paragraph), remove/duplicate/reorder delegate to v1 element APIs. Editor label stored in `editor_settings.label` with fallback to generated "Item N" on missing label. Custom event triggers reactive updates in hooks.

## 4. Risks

Minor: title resolution change deprioritizes `title` field (now only fallback after `label`), could break legacy code expecting `title` as primary source—mitigated by existing `title` fallback to `_title` setting. Event dispatch on every settings update may cause thrashing in large trees—acceptable given typical usage. No schema breaking changes.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
