### PR TITLE
Internal: Atomic e-list - item markers [ED-25114]

### DIFF
--- a/modules/atomic-widgets/assets/js/editor/atomic-list-model.js
+++ b/modules/atomic-widgets/assets/js/editor/atomic-list-model.js
@@ -1,0 +1,292 @@
+import AtomicElementBaseModel from './atomic-element-base-model';
+
+const LIST_ITEM_ELEMENT_TYPE = 'e-list-item';
+const LIST_ITEM_MARKER_ELEMENT_TYPE = 'e-list-item-marker';
+const LIST_ITEM_CONTENT_ELEMENT_TYPE = 'e-list-item-content';
+const LIST_MARKER_STASH_PREFIX = 'elementor/editor-state';
+const LIST_MARKER_STASH_SEGMENT = 'children-deps';
+
+export default class AtomicListModel extends AtomicElementBaseModel {
+	initialize( attributes, options ) {
+		super.initialize( attributes, options );
+
+		this.bindListMarkersReconcile();
+
+		if ( ! this.isShowMarkersEnabledFromModel( this.get( 'settings' ) ) ) {
+			this.reconcileListMarkersWithModel( false );
+		}
+
+		this.once( 'destroy', () => this.unbindListMarkersReconcile?.() );
+	}
+
+	reconcileChildrenAgainstSchema( attributes ) {
+		attributes.elements = this.get( 'elements' );
+		this.reconcileListMarkersAgainstSchema( attributes );
+		this.set( 'elements', attributes.elements );
+
+		super.reconcileChildrenAgainstSchema( attributes );
+	}
+
+	reconcileListMarkersAgainstSchema( attributes ) {
+		const elements = [ ...( attributes.elements ?? [] ) ];
+		const showMarkers = this.isShowMarkersEnabled( attributes.settings );
+
+		attributes.elements = elements.map( ( child ) => {
+			if ( LIST_ITEM_ELEMENT_TYPE !== child.elType ) {
+				return child;
+			}
+
+			return {
+				...child,
+				elements: this.reconcileListItemMarkerData( child, showMarkers ),
+			};
+		} );
+	}
+
+	bindListMarkersReconcile() {
+		const adapter = AtomicElementBaseModel.childrenDependenciesAdapter;
+		const settingsModel = this.get( 'settings' );
+
+		if (
+			! adapter?.getContainer ||
+			! adapter?.addModelToParent ||
+			! adapter?.removeModelFromParent ||
+			! settingsModel?.on ||
+			! settingsModel?.off
+		) {
+			return;
+		}
+
+		this.unbindListMarkersReconcile?.();
+
+		let previousShowMarkers = this.isShowMarkersEnabledFromModel( settingsModel );
+
+		const onChange = () => {
+			const currentShowMarkers = this.isShowMarkersEnabledFromModel( settingsModel );
+
+			if ( previousShowMarkers === currentShowMarkers ) {
+				return;
+			}
+
+			previousShowMarkers = currentShowMarkers;
+			this.reconcileListMarkersWithModel( currentShowMarkers );
+		};
+
+		settingsModel.on( 'change', onChange );
+
+		this.unbindListMarkersReconcile = () => {
+			settingsModel.off?.( 'change', onChange );
+			this.clearListMarkerStash();
+		};
+	}
+
+	isShowMarkersEnabled( settings = {} ) {
+		return this.unwrapPropValue( settings.show_markers ) !== false;
+	}
+
+	isShowMarkersEnabledFromModel( settingsModel ) {
+		return this.unwrapPropValue( settingsModel?.get?.( 'show_markers' ) ) !== false;
+	}
+
+	unwrapPropValue( propValue ) {
+		if ( propValue && 'object' === typeof propValue && 'value' in propValue ) {
+			return propValue.value;
+		}
+
+		return propValue;
+	}
+
+	reconcileListMarkersWithModel( showMarkers ) {
+		const adapter = AtomicElementBaseModel.childrenDependenciesAdapter;
+		const listContainer = adapter?.getContainer?.( this.get( 'id' ) );
+
+		if ( ! listContainer ) {
+			return;
+		}
+
+		const listItemIds = ( listContainer.children ?? [] )
+			.filter( ( child ) => child.model.get( 'elType' ) === LIST_ITEM_ELEMENT_TYPE )
+			.map( ( child ) => child.id );
+
+		listItemIds.forEach( ( itemId ) => {
+			if ( showMarkers ) {
+				this.attachMarkerToItem( itemId );
+				return;
+			}
+
+			this.detachMarkerFromItem( itemId );
+		} );
+	}
+
+	reconcileListItemMarkerData( listItem, showMarkers ) {
+		const nextChildren = [ ...( listItem.elements ?? [] ) ];
+		const markerIndex = nextChildren.findIndex( ( child ) => child.elType === LIST_ITEM_MARKER_ELEMENT_TYPE );
+		const listItemId = listItem.id;
+
+		if ( showMarkers ) {
+			if ( markerIndex >= 0 ) {
+				return nextChildren;
+			}
+
+			const nextMarker = this.takeStashedMarker( listItemId ) ?? this.createDefaultMarkerModel();
+			nextChildren.splice( this.getMarkerInsertIndex( nextChildren ), 0, this.ensureModelId( nextMarker ) );
+
+			return nextChildren;
+		}
+
+		if ( markerIndex < 0 ) {
+			return nextChildren;
+		}
+
+		const [ removedMarker ] = nextChildren.splice( markerIndex, 1 );
+		this.saveMarkerToStash( listItemId, removedMarker );
+
+		return nextChildren;
+	}
+
+	attachMarkerToItem( listItemId ) {
+		const adapter = AtomicElementBaseModel.childrenDependenciesAdapter;
+		const listItem = adapter?.getContainer?.( listItemId );
+
+		if ( ! listItem ) {
+			return;
+		}
+
+		const currentChildren = listItem.children ?? [];
+		const hasMarker = currentChildren.some(
+			( child ) => child.model.get( 'elType' ) === LIST_ITEM_MARKER_ELEMENT_TYPE,
+		);
+
+		if ( hasMarker ) {
+			return;
+		}
+
+		const markerModel = this.ensureModelId(
+			this.takeStashedMarker( listItemId ) ?? this.createDefaultMarkerModel(),
+		);
+
+		const attached = adapter.addModelToParent(
+			listItemId,
+			markerModel,
+			{
+				at: this.getMarkerInsertIndex(
+					currentChildren.map( ( child ) => child.model.toJSON() ),
+				),
+			},
+		);
+
+		if ( ! attached ) {
+			this.saveMarkerToStash( listItemId, markerModel );
+			return;
+		}
+
+		this.requestNavigatorRefresh( listItemId );
+	}
+
+	detachMarkerFromItem( listItemId ) {
+		const adapter = AtomicElementBaseModel.childrenDependenciesAdapter;
+		const listItem = adapter?.getContainer?.( listItemId );
+		const markerChild = listItem?.children?.find(
+			( child ) => child.model.get( 'elType' ) === LIST_ITEM_MARKER_ELEMENT_TYPE,
+		);
+
+		if ( ! markerChild ) {
+			return;
+		}
+
+		if ( ! adapter.removeModelFromParent( listItemId, markerChild.id ) ) {
+			return;
+		}
+
+		const markerSnapshot = markerChild.model.toJSON();
+		this.saveMarkerToStash( listItemId, markerSnapshot );
+		this.requestNavigatorRefresh( listItemId );
+	}
+
+	getMarkerInsertIndex( children = [] ) {
+		const contentIndex = children.findIndex( ( child ) => child.elType === LIST_ITEM_CONTENT_ELEMENT_TYPE );
+
+		return contentIndex >= 0 ? contentIndex : 0;
+	}
+
+	createDefaultMarkerModel() {
+		return {
+			elType: LIST_ITEM_MARKER_ELEMENT_TYPE,
+			elements: [
+				{
+					elType: 'widget',
+					widgetType: 'e-svg',
+				},
+			],
+		};
+	}
+
+	ensureModelId( modelData ) {
+		if ( modelData?.id ) {
+			return modelData;
+		}
+
+		return {
+			...modelData,
+			id: elementorCommon.helpers.getUniqueId(),
+		};
+	}
+
+	saveMarkerToStash( listItemId, data ) {
+		if ( ! listItemId || ! data ) {
+			return;
+		}
+
+		sessionStorage.setItem(
+			this.buildListMarkerStashKey( listItemId ),
+			JSON.stringify( data ),
+		);
+	}
+
+	takeStashedMarker( listItemId ) {
+		if ( ! listItemId ) {
+			return undefined;
+		}
+
+		const key = this.buildListMarkerStashKey( listItemId );
+		const stashed = sessionStorage.getItem( key );
+
+		if ( ! stashed ) {
+			return undefined;
+		}
+
+		sessionStorage.removeItem( key );
+
+		try {
+			return JSON.parse( stashed );
+		} catch {
+			return undefined;
+		}
+	}
+
+	clearListMarkerStash() {
+		const listItems = this.get( 'elements' ) ?? [];
+
+		listItems.forEach( ( child ) => {
+			if ( child?.elType === LIST_ITEM_ELEMENT_TYPE && child.id ) {
+				sessionStorage.removeItem( this.buildListMarkerStashKey( child.id ) );
+			}
+		} );
+	}
+
+	buildListMarkerStashKey( listItemId ) {
+		return `${ LIST_MARKER_STASH_PREFIX }/${ listItemId }/${ LIST_MARKER_STASH_SEGMENT }/${ LIST_ITEM_MARKER_ELEMENT_TYPE }`;
+	}
+
+	requestNavigatorRefresh( parentId ) {
+		if ( 'undefined' === typeof window || typeof window.dispatchEvent !== 'function' ) {
+			return;
+		}
+
+		window.dispatchEvent(
+			new CustomEvent( 'elementor/navigator/refresh-children', {
+				detail: { elementId: parentId },
+			} ),
+		);
+	}
+}

--- a/tests/jest/unit/modules/atomic-widgets/assets/js/editor/atomic-list-model.test.js
+++ b/tests/jest/unit/modules/atomic-widgets/assets/js/editor/atomic-list-model.test.js
@@ -1,0 +1,119 @@
+describe( 'AtomicListModel', () => {
+	let AtomicElementBaseModel;
+	let AtomicListModel;
+
+	beforeAll( async () => {
+		jest.resetModules();
+
+		class BaseElementModel {
+			constructor() {
+				this._events = new Map();
+			}
+
+			get( key ) {
+				return this._data?.[ key ];
+			}
+
+			set( key, value ) {
+				this._data = this._data || {};
+				this._data[ key ] = value;
+			}
+
+			unset( key ) {
+				if ( this._data ) {
+					delete this._data[ key ];
+				}
+			}
+
+			initialize() {}
+
+			once( event, callback ) {
+				this._events.set( event, callback );
+			}
+
+			trigger( event, ...args ) {
+				this._events.get( event )?.( ...args );
+			}
+		}
+
+		global.elementor = {
+			modules: { elements: { models: { Element: BaseElementModel } } },
+			config: {
+				elements: {
+					'e-list': {
+						children_dependencies: [],
+					},
+				},
+			},
+		};
+
+		global.$e = { commands: { currentTrace: [] } };
+		global.elementorCommon = { helpers: { getUniqueId: () => 'uid' } };
+		global.sessionStorage = {
+			getItem: jest.fn(),
+			setItem: jest.fn(),
+			removeItem: jest.fn(),
+		};
+
+		AtomicElementBaseModel = ( await import( 'elementor/modules/atomic-widgets/assets/js/editor/atomic-element-base-model' ) ).default;
+		AtomicListModel = ( await import( 'elementor/modules/atomic-widgets/assets/js/editor/atomic-list-model' ) ).default;
+	} );
+
+	beforeEach( () => {
+		global.sessionStorage.getItem.mockReset();
+		global.sessionStorage.setItem.mockReset();
+		global.sessionStorage.removeItem.mockReset();
+		AtomicElementBaseModel.setChildrenDependenciesAdapter( null );
+	} );
+
+	afterAll( () => {
+		delete global.elementor;
+		delete global.$e;
+		delete global.elementorCommon;
+		delete global.sessionStorage;
+	} );
+
+	it( 'preserves list marker reconciliation when the base model resets attributes.elements', () => {
+		const marker = {
+			id: 'marker-1',
+			elType: 'e-list-item-marker',
+			elements: [],
+		};
+		const content = {
+			id: 'content-1',
+			elType: 'e-list-item-content',
+			elements: [],
+		};
+		const listItem = {
+			id: 'item-1',
+			elType: 'e-list-item',
+			elements: [ marker, content ],
+		};
+		const model = new AtomicListModel();
+
+		model.set( 'id', 'list-1' );
+		model.set( 'elType', 'e-list' );
+		model.set( 'elements', [ listItem ] );
+
+		model.initialize( {
+			elements: [ listItem ],
+			settings: {
+				show_markers: {
+					value: false,
+				},
+			},
+		}, {} );
+
+		expect( model.get( 'elements' ) ).toEqual( [
+			{
+				id: 'item-1',
+				elType: 'e-list-item',
+				elements: [ content ],
+			},
+		] );
+		expect( global.sessionStorage.setItem ).toHaveBeenCalledWith(
+			'elementor/editor-state/item-1/children-deps/e-list-item-marker',
+			JSON.stringify( marker ),
+		);
+	} );
+} );


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Implements atomic list marker lifecycle management: markers are now reconciled with the `show_markers` setting, persisted to sessionStorage when hidden, and restored when re-enabled. Addresses ED-25114.

## 2. What Changed (Where)

- **atomic-list-model.js** (292 lines): New model class extending `AtomicElementBaseModel` with marker attachment/detachment, stashing logic, and settings binding.
- **atomic-list-model.test.js** (119 lines): Unit test verifying marker removal and sessionStorage persistence when `show_markers` is disabled.

## 3. How It Works

On initialization, binds a listener to the `show_markers` setting. When toggled, `reconcileListMarkersWithModel()` iterates list items: attaching markers via adapter or stashing them to sessionStorage with a namespaced key (`elementor/editor-state/{itemId}/children-deps/e-list-item-marker`). On re-enable, `takeStashedMarker()` retrieves and restores the marker. Marker insertion position respects list-item-content precedence via `getMarkerInsertIndex()`. Cleanup fires on model destroy and on adapter failures (gracefully re-stashes).

## 4. Risks

- **SessionStorage scope collision**: Key structure assumes single-tab editor; concurrent tabs could lose marker state. Mitigated by namespace, but fragile for multi-tab workflows.
- **Adapter dependency**: No fallback if `childrenDependenciesAdapter` is null/incomplete; markers silently fail to attach. Test doesn't cover adapter absence scenarios.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
