### PR TITLE
Internal: Add empty_state_preview to element editor settings types [ED-23851]

### DIFF
--- a/packages/packages/libs/editor-elements/src/sync/types.ts
+++ b/packages/packages/libs/editor-elements/src/sync/types.ts
@@ -182,6 +182,7 @@ export type V1ElementEditorSettingsProps = {
 	initial_position?: number;
 	component_uid?: string;
 	grid_outline?: boolean;
+	empty_state_preview?: boolean;
 };
 
 export type V1ElementSettingsProps = Record< string, PropValue >;


### PR DESCRIPTION
## Summary
- Adds `empty_state_preview?: boolean` to `V1ElementEditorSettingsProps` so the collection loop empty-state editor preview control is typed when syncing element editor settings.
- Companion to elementor-pro PR: https://github.com/elementor/elementor-pro/pull/7439

## Test plan
- [ ] Typecheck passes for `@elementor/editor-elements` package
- [ ] Pro empty-state preview control updates `editor_settings.empty_state_preview` without type errors


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding `empty_state_preview` flag to element editor settings to control empty state preview behavior in the editor UI (ED-23851).

## 2. What Changed (Where)

- `packages/libs/editor-elements/src/sync/types.ts`: Added optional `empty_state_preview?: boolean` property to `V1ElementEditorSettingsProps` type.

## 3. How It Works

New boolean flag integrates into existing settings type definition; consumers can now pass this property when configuring element editor behavior for empty state previews.

## 4. Risks

None—purely additive type change with backward compatibility via optional property.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
