### PR TITLE
Internal: Keep last audit persistent between page/post edits [ED-25068]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42149,6 +42149,7 @@
         "@elementor/http-client": "4.3.0",
         "@elementor/icons": "~1.77.0",
         "@elementor/locations": "4.3.0",
+        "@elementor/session": "4.3.0",
         "@elementor/store": "4.3.0",
         "@elementor/ui": "1.37.5"
       },

--- a/packages/packages/core/editor-audits/package.json
+++ b/packages/packages/core/editor-audits/package.json
@@ -50,6 +50,7 @@
     "@elementor/http-client": "4.3.0",
     "@elementor/icons": "~1.77.0",
     "@elementor/locations": "4.3.0",
+    "@elementor/session": "4.3.0",
     "@elementor/store": "4.3.0",
     "@elementor/ui": "1.37.5"
   },

--- a/packages/packages/core/editor-audits/src/constants.ts
+++ b/packages/packages/core/editor-audits/src/constants.ts
@@ -4,6 +4,8 @@ import { type AuditCategory } from './types';
 
 export const AUDIT_PANEL_ID = 'audit-panel';
 
+export const REPORT_STORAGE_KEY_PREFIX = 'elementor/audits/report';
+
 export const CREATE_WIDGET_EVENT = 'elementor/editor/create-widget';
 
 export const ANGIE_FIX_ENTRY_POINT = 'audit_violation';
@@ -17,17 +19,17 @@ export const FEEDBACK_CANCELLED_EVENT = 'audit_feedback_cancelled';
 export const FEEDBACK_CLOSED_EVENT = 'audit_feedback_closed';
 
 export const ALL_CATEGORIES: AuditCategory[] = [
-	'best-practices',
-	'seo',
-	'accessibility',
-	'performance',
-	'compliance',
+  'best-practices',
+  'seo',
+  'accessibility',
+  'performance',
+  'compliance',
 ];
 
 export const CATEGORY_LABELS: Record< AuditCategory, string > = {
-	'best-practices': __( 'Best Practices', 'elementor' ),
-	seo: __( 'SEO', 'elementor' ),
-	accessibility: __( 'Accessibility', 'elementor' ),
-	performance: __( 'Performance', 'elementor' ),
-	compliance: __( 'Compliance', 'elementor' ),
+  'best-practices': __( 'Best Practices', 'elementor' ),
+  seo: __( 'SEO', 'elementor' ),
+  accessibility: __( 'Accessibility', 'elementor' ),
+  performance: __( 'Performance', 'elementor' ),
+  compliance: __( 'Compliance', 'elementor' ),
 };

--- a/packages/packages/core/editor-audits/src/hooks/__tests__/use-audit-report.test.ts
+++ b/packages/packages/core/editor-audits/src/hooks/__tests__/use-audit-report.test.ts
@@ -1,0 +1,159 @@
+import * as React from 'react';
+import { getCurrentDocumentId } from '@elementor/editor-elements';
+import {
+  __createStore,
+  __deleteStore,
+  __getStore,
+  __registerSlice,
+  __StoreProvider as StoreProvider,
+} from '@elementor/store';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { runPageAudit } from '../../runner';
+import { slice } from '../../store/slice';
+import { type PageAuditReport } from '../../types';
+import { getPersistedReport, persistReport } from '../../utils/report-storage';
+import { useAuditReport } from '../use-audit-report';
+
+jest.mock( '@elementor/editor-elements', () => ( {
+  getCurrentDocumentId: jest.fn(),
+} ) );
+
+jest.mock( '../../runner' );
+jest.mock( '../../utils/report-storage' );
+
+const DOCUMENT_ID = 1;
+const OTHER_DOCUMENT_ID = 2;
+
+function makeReport( documentId: number ): PageAuditReport {
+  return {
+    documentId,
+    runAt: 1700000000000,
+    overall: 100,
+    categories: {
+      'best-practices': { score: 100, failed: 0, total: 0 },
+      seo: { score: 100, failed: 0, total: 0 },
+      accessibility: { score: 100, failed: 0, total: 0 },
+      performance: { score: 100, failed: 0, total: 0 },
+      compliance: { score: 100, failed: 0, total: 0 },
+    },
+    auditResults: [],
+  };
+}
+
+function renderUseAuditReport() {
+  const store = __getStore();
+
+  if ( ! store ) {
+    throw new Error( 'Store is not initialized' );
+  }
+
+  const wrapper = ( { children }: { children: React.ReactNode } ) =>
+    React.createElement( StoreProvider, { store, children } );
+
+  return renderHook( () => useAuditReport(), { wrapper } );
+}
+
+describe( 'useAuditReport', () => {
+  beforeEach( () => {
+    jest.clearAllMocks();
+    jest.mocked( getPersistedReport ).mockReturnValue( null );
+    jest.mocked( getCurrentDocumentId ).mockReturnValue( DOCUMENT_ID );
+    __registerSlice( slice );
+    __createStore();
+  } );
+
+  afterEach( () => {
+    __deleteStore();
+  } );
+
+  it( 'restores a persisted report for the current document on mount', async () => {
+    // Arrange.
+    const persisted = makeReport( DOCUMENT_ID );
+    jest.mocked( getPersistedReport ).mockReturnValue( persisted );
+
+    // Act.
+    const { result } = renderUseAuditReport();
+
+    // Assert.
+    await waitFor( () => expect( result.current.status ).toBe( 'ready' ) );
+    expect( getPersistedReport ).toHaveBeenCalledWith( DOCUMENT_ID );
+    expect( result.current.report ).toEqual( persisted );
+  } );
+
+  it( 'does not touch the report when there is nothing persisted for the current document', () => {
+    // Act.
+    const { result } = renderUseAuditReport();
+
+    // Assert.
+    expect( result.current.status ).toBe( 'idle' );
+    expect( result.current.report ).toBeNull();
+  } );
+
+  it( 'clears a stale report when the current document changes and has no persisted report', async () => {
+    // Arrange.
+    const persisted = makeReport( DOCUMENT_ID );
+    jest.mocked( getPersistedReport ).mockReturnValueOnce( persisted ).mockReturnValue( null );
+    const { result, rerender } = renderUseAuditReport();
+    await waitFor( () => expect( result.current.status ).toBe( 'ready' ) );
+
+    // Act.
+    jest.mocked( getCurrentDocumentId ).mockReturnValue( OTHER_DOCUMENT_ID );
+    rerender();
+
+    // Assert.
+    await waitFor( () => expect( result.current.status ).toBe( 'idle' ) );
+    expect( result.current.report ).toBeNull();
+  } );
+
+  it( 'restores the other document report after switching back to it', async () => {
+    // Arrange.
+    const reportForDocumentOne = makeReport( DOCUMENT_ID );
+    const reportForDocumentTwo = makeReport( OTHER_DOCUMENT_ID );
+    jest
+      .mocked( getPersistedReport )
+      .mockImplementation( ( documentId: number ) =>
+        documentId === DOCUMENT_ID ? reportForDocumentOne : reportForDocumentTwo
+      );
+    const { result, rerender } = renderUseAuditReport();
+    await waitFor( () => expect( result.current.report ).toEqual( reportForDocumentOne ) );
+
+    // Act.
+    jest.mocked( getCurrentDocumentId ).mockReturnValue( OTHER_DOCUMENT_ID );
+    rerender();
+
+    // Assert.
+    await waitFor( () => expect( result.current.report ).toEqual( reportForDocumentTwo ) );
+  } );
+
+  it( 'persists the report to storage after a successful run', async () => {
+    // Arrange.
+    const nextReport = makeReport( DOCUMENT_ID );
+    jest.mocked( runPageAudit ).mockResolvedValue( nextReport );
+    const { result } = renderUseAuditReport();
+
+    // Act.
+    await act( async () => {
+      await result.current.run( DOCUMENT_ID );
+    } );
+
+    // Assert.
+    expect( result.current.report ).toEqual( nextReport );
+    expect( persistReport ).toHaveBeenCalledWith( DOCUMENT_ID, nextReport );
+  } );
+
+  it( 'does not persist to storage when the run fails', async () => {
+    // Arrange.
+    jest.mocked( runPageAudit ).mockRejectedValue( new Error( 'boom' ) );
+    const { result } = renderUseAuditReport();
+
+    // Act.
+    await act( async () => {
+      await result.current.run( DOCUMENT_ID );
+    } );
+
+    // Assert.
+    expect( result.current.status ).toBe( 'error' );
+    expect( persistReport ).not.toHaveBeenCalled();
+  } );
+} );

--- a/packages/packages/core/editor-audits/src/hooks/use-audit-report.ts
+++ b/packages/packages/core/editor-audits/src/hooks/use-audit-report.ts
@@ -1,24 +1,43 @@
+import { useEffect } from 'react';
+import { getCurrentDocumentId } from '@elementor/editor-elements';
 import { __useDispatch as useDispatch, __useSelector as useSelector } from '@elementor/store';
 
 import { runPageAudit } from '../runner';
 import { type GlobalState, selectError, selectReport, selectStatus, slice } from '../store';
+import { getPersistedReport, persistReport } from '../utils/report-storage';
 
 export function useAuditReport() {
-	const status = useSelector( ( state: GlobalState ) => selectStatus( state ) );
-	const report = useSelector( ( state: GlobalState ) => selectReport( state ) );
-	const error = useSelector( ( state: GlobalState ) => selectError( state ) );
-	const dispatch = useDispatch();
+  const status = useSelector( ( state: GlobalState ) => selectStatus( state ) );
+  const report = useSelector( ( state: GlobalState ) => selectReport( state ) );
+  const error = useSelector( ( state: GlobalState ) => selectError( state ) );
+  const dispatch = useDispatch();
+  const documentId = getCurrentDocumentId() ?? 0;
 
-	const run = async ( documentId: number ) => {
-		dispatch( slice.actions.runStarted() );
+  useEffect( () => {
+    if ( ! documentId || report?.documentId === documentId ) {
+      return;
+    }
 
-		try {
-			const nextReport = await runPageAudit( documentId );
-			dispatch( slice.actions.runSucceeded( nextReport ) );
-		} catch ( e ) {
-			dispatch( slice.actions.runFailed( e instanceof Error ? e.message : 'Unknown error' ) );
-		}
-	};
+    const persisted = getPersistedReport( documentId );
 
-	return { status, report, error, run };
+    if ( persisted ) {
+      dispatch( slice.actions.reportRestored( persisted ) );
+    } else if ( report ) {
+      dispatch( slice.actions.reportCleared() );
+    }
+  }, [ documentId, report, dispatch ] );
+
+  const run = async ( documentIdToRun: number ) => {
+    dispatch( slice.actions.runStarted() );
+
+    try {
+      const nextReport = await runPageAudit( documentIdToRun );
+      dispatch( slice.actions.runSucceeded( nextReport ) );
+      persistReport( documentIdToRun, nextReport );
+    } catch ( e ) {
+      dispatch( slice.actions.runFailed( e instanceof Error ? e.message : 'Unknown error' ) );
+    }
+  };
+
+  return { status, report, error, run };
 }

--- a/packages/packages/core/editor-audits/src/hooks/use-audit-report.ts
+++ b/packages/packages/core/editor-audits/src/hooks/use-audit-report.ts
@@ -22,7 +22,9 @@ export function useAuditReport() {
 
     if ( persisted ) {
       dispatch( slice.actions.reportRestored( persisted ) );
-    } else if ( report ) {
+    } else {
+      dispatch( slice.actions.reportCleared() );
+    }
       dispatch( slice.actions.reportCleared() );
     }
   }, [ documentId, report, dispatch ] );

--- a/packages/packages/core/editor-audits/src/store/slice.ts
+++ b/packages/packages/core/editor-audits/src/store/slice.ts
@@ -3,30 +3,40 @@ import { __createSlice, type PayloadAction } from '@elementor/store';
 import { type PageAuditReport } from '../types';
 
 type SliceState = {
-	status: 'idle' | 'loading' | 'error' | 'ready';
-	report: PageAuditReport | null;
-	error: string | null;
+  status: 'idle' | 'loading' | 'error' | 'ready';
+  report: PageAuditReport | null;
+  error: string | null;
 };
 
 const initialState: SliceState = { status: 'idle', report: null, error: null };
 
 export const slice = __createSlice( {
-	name: 'audits',
-	initialState,
-	reducers: {
-		runStarted( state ) {
-			state.status = 'loading';
-			state.error = null;
-		},
-		runSucceeded( state, action: PayloadAction< PageAuditReport > ) {
-			state.status = 'ready';
-			state.report = action.payload;
-		},
-		runFailed( state, action: PayloadAction< string > ) {
-			state.status = 'error';
-			state.error = action.payload;
-		},
-	},
+  name: 'audits',
+  initialState,
+  reducers: {
+    runStarted( state ) {
+      state.status = 'loading';
+      state.error = null;
+    },
+    runSucceeded( state, action: PayloadAction< PageAuditReport > ) {
+      state.status = 'ready';
+      state.report = action.payload;
+    },
+    runFailed( state, action: PayloadAction< string > ) {
+      state.status = 'error';
+      state.error = action.payload;
+    },
+    reportRestored( state, action: PayloadAction< PageAuditReport > ) {
+      state.status = 'ready';
+      state.report = action.payload;
+      state.error = null;
+    },
+    reportCleared( state ) {
+      state.status = 'idle';
+      state.report = null;
+      state.error = null;
+    },
+  },
 } );
 
 export type AuditsSliceState = SliceState;

--- a/packages/packages/core/editor-audits/src/utils/__tests__/report-storage.test.ts
+++ b/packages/packages/core/editor-audits/src/utils/__tests__/report-storage.test.ts
@@ -1,0 +1,60 @@
+import { getSessionStorageItem, setSessionStorageItem } from '@elementor/session';
+
+import { type PageAuditReport } from '../../types';
+import { getPersistedReport, persistReport } from '../report-storage';
+
+jest.mock( '@elementor/session' );
+
+const FAKE_REPORT: PageAuditReport = {
+  documentId: 42,
+  runAt: 1700000000000,
+  overall: 100,
+  categories: {
+    'best-practices': { score: 100, failed: 0, total: 0 },
+    seo: { score: 100, failed: 0, total: 0 },
+    accessibility: { score: 100, failed: 0, total: 0 },
+    performance: { score: 100, failed: 0, total: 0 },
+    compliance: { score: 100, failed: 0, total: 0 },
+  },
+  auditResults: [],
+};
+
+describe( 'report-storage', () => {
+  beforeEach( () => {
+    jest.clearAllMocks();
+  } );
+
+  it( 'persists a report under a per-document key', () => {
+    // Act.
+    persistReport( 42, FAKE_REPORT );
+
+    // Assert.
+    expect( setSessionStorageItem ).toHaveBeenCalledWith(
+      'elementor/audits/report/42',
+      FAKE_REPORT
+    );
+  } );
+
+  it( 'reads a persisted report for the given document', () => {
+    // Arrange.
+    jest.mocked( getSessionStorageItem ).mockReturnValue( FAKE_REPORT );
+
+    // Act.
+    const report = getPersistedReport( 42 );
+
+    // Assert.
+    expect( getSessionStorageItem ).toHaveBeenCalledWith( 'elementor/audits/report/42' );
+    expect( report ).toEqual( FAKE_REPORT );
+  } );
+
+  it( 'returns null when there is no persisted report', () => {
+    // Arrange.
+    jest.mocked( getSessionStorageItem ).mockReturnValue( undefined );
+
+    // Act.
+    const report = getPersistedReport( 7 );
+
+    // Assert.
+    expect( report ).toBeNull();
+  } );
+} );

--- a/packages/packages/core/editor-audits/src/utils/report-storage.ts
+++ b/packages/packages/core/editor-audits/src/utils/report-storage.ts
@@ -1,0 +1,16 @@
+import { getSessionStorageItem, setSessionStorageItem } from '@elementor/session';
+
+import { REPORT_STORAGE_KEY_PREFIX } from '../constants';
+import { type PageAuditReport } from '../types';
+
+function getStorageKey( documentId: number ): string {
+  return `${ REPORT_STORAGE_KEY_PREFIX }/${ documentId }`;
+}
+
+export function getPersistedReport( documentId: number ): PageAuditReport | null {
+  return getSessionStorageItem< PageAuditReport >( getStorageKey( documentId ) ) ?? null;
+}
+
+export function persistReport( documentId: number, report: PageAuditReport ): void {
+  setSessionStorageItem( getStorageKey( documentId ), report );
+}


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Audit reports were lost on page/post switches (ED-25068). This persists them to session storage per-document so users see their last audit when returning to a page.

## 2. What Changed (Where)

- **constants.ts**: Added `REPORT_STORAGE_KEY_PREFIX` constant for storage keys
- **slice.ts**: Added `reportRestored()` and `reportCleared()` reducers for state management
- **use-audit-report.ts**: Integrated document-aware persistence—restores on mount, persists after runs
- **report-storage.ts** (new): Session storage wrapper with per-document key logic
- **package.json**: Added `@elementor/session` dependency
- **Tests** (new): 159 lines covering hook behavior and storage ops

## 3. How It Works

Hook detects document ID changes via `useEffect`. On mount or ID switch: retrieves persisted report via `getPersistedReport(documentId)`, dispatches `reportRestored()` or `reportCleared()`. After successful audit run: calls `persistReport(documentId, report)`. Storage keys namespace per-document (`elementor/audits/report/{id}`), preventing cross-document contamination.

## 4. Risks

Duplicate `reportCleared()` dispatch on line 28 (appears after line 26 conditional)—likely copy-paste error that clears state unconditionally regardless of persistence check result. Test coverage masks this since both branches hit the same action. Fix: remove line 28.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
