### PR TITLE
Internal: Return to editor after editing theme part from app overlay [ED-25232]

### DIFF
--- a/app/modules/site-editor/assets/js/organisms/menu.js
+++ b/app/modules/site-editor/assets/js/organisms/menu.js
@@ -15,6 +15,12 @@ export default function Menu( props ) {
 			}
 
 			const goToCreate = () => {
+				if ( window.top !== window ) {
+					sessionStorage.setItem( 'elementor_app_return_to', window.top.location.href );
+					window.top.location.href = itemProps.urls.create;
+					return;
+				}
+
 				location.href = itemProps.urls.create;
 			};
 

--- a/packages/packages/core/editor-documents/src/sync/utils.ts
+++ b/packages/packages/core/editor-documents/src/sync/utils.ts
@@ -16,7 +16,47 @@ export function getV1DocumentsManager() {
 	return documentsManager;
 }
 
+const RETURN_TO_KEY = 'elementor_app_return_to';
+
+let appReturnToUrl: string | null | undefined;
+
+function getAppReturnToUrl(): string | null {
+	if ( appReturnToUrl !== undefined ) {
+		return appReturnToUrl;
+	}
+
+	appReturnToUrl = null;
+
+	const stored = sessionStorage.getItem( RETURN_TO_KEY );
+
+	if ( ! stored ) {
+		return appReturnToUrl;
+	}
+
+	sessionStorage.removeItem( RETURN_TO_KEY );
+
+	try {
+		const parsedUrl = new URL( stored );
+		const isSameOrigin = parsedUrl.hostname === window.location.hostname &&
+			( 'http:' === parsedUrl.protocol || 'https:' === parsedUrl.protocol );
+
+		if ( isSameOrigin ) {
+			appReturnToUrl = stored;
+		}
+	} catch ( e ) {
+		// Invalid URL, fall through to default behavior.
+	}
+
+	return appReturnToUrl;
+}
+
 export function getV1DocumentsExitTo( documentData: V1Document ) {
+	const returnTo = getAppReturnToUrl();
+
+	if ( returnTo ) {
+		return returnTo;
+	}
+
 	const exitPreference =
 		( window as unknown as ExtendedWindow ).elementor?.getPreferences?.( 'exit_to' ) || 'this_post';
 


### PR DESCRIPTION
## Summary
- Follow-up to #36845 (Theme Builder app overlay)
- When a user opens the Theme Builder as an overlay, clicks to edit/create a theme part, and then exits the template editor, they now return to the editor they came from instead of being redirected to the WordPress admin dashboard
- Uses `sessionStorage` to persist the return URL across the `elementor_new_post` redirect, with same-origin validation for security
- The original page's content is refreshed automatically since returning triggers a full page reload

## How it works
1. **`menu.js`** — When in iframe context (overlay), stores the parent editor URL in `sessionStorage` before navigating to the create URL via `window.top.location.href`
2. **`utils.ts`** — `getV1DocumentsExitTo()` checks `sessionStorage` for a return URL (lazy-initialized, read once per page load). If valid (same-origin), uses it as the exit URL instead of the user's exit preference

## Guard rails
- Only activates when `window.top !== window` (overlay iframe context)
- Same-origin validation prevents open redirect
- Module-level caching ensures `sessionStorage` is read once and cleared, preventing stale entries
- WP Admin → Theme Builder flow remains completely unchanged (no iframe = no sessionStorage write)

## Test plan
- [ ] Open editor for a page → open Theme Builder overlay → create a new header → exit editor → verify return to original page editor
- [ ] Open editor for a page → open Theme Builder overlay → create a new footer → save → exit → verify return to original page editor
- [ ] Open Theme Builder from WP Admin directly → edit a template → exit → verify default exit behavior (WP admin) is unchanged
- [ ] Verify exit preference (dashboard/all posts/this post) still works when no `sessionStorage` return URL is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

When editing theme parts from the app overlay, users need a way to return to the editor after completing edits. Currently there's no mechanism to restore the previous context (ED-25219).

## 2. What Changed (Where)

- `editor-documents/sync/utils.ts`: Added `getAppReturnToUrl()` that retrieves and validates a return URL from sessionStorage, integrated into `getV1DocumentsExitTo()` to prioritize app overlay returns
- `site-editor/menu.js`: Store parent window's location in sessionStorage before navigating to create flow when in iframe context

## 3. How It Works

When the menu's "Create" action fires from an iframe (`window.top !== window`), it stores the parent's URL in sessionStorage under `elementor_app_return_to` and navigates the parent window. On editor exit, `getAppReturnToUrl()` retrieves this URL (validating same-origin), clears sessionStorage, and uses it as the exit destination before falling back to user preferences.

## 4. Risks

URL validation relies on hostname and protocol matching, but doesn't verify the URL's legitimacy within the app ecosystem—a compromised sessionStorage could redirect to any same-origin URL. Mitigate by restricting stored URLs to known app paths in future iterations.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
