### PR TITLE
Internal: Return to editor after editing theme part from app overlay [ED-25232]

### DIFF
--- a/app/modules/site-editor/assets/js/organisms/menu.js
+++ b/app/modules/site-editor/assets/js/organisms/menu.js
@@ -5,6 +5,9 @@ import AddNewButton from 'elementor-app/ui/molecules/add-new-button';
 
 import './menu.scss';
 
+// Consumed by getAppReturnToUrl() in editor-documents/src/sync/utils.ts.
+const RETURN_TO_KEY = 'elementor_app_return_to';
+
 export default function Menu( props ) {
 	const { templateTypes } = React.useContext( TemplateTypesContext ),
 		actionButton = ( itemProps ) => {
@@ -16,7 +19,7 @@ export default function Menu( props ) {
 
 			const goToCreate = () => {
 				if ( window.top !== window ) {
-					sessionStorage.setItem( 'elementor_app_return_to', window.top.location.href );
+					sessionStorage.setItem( RETURN_TO_KEY, window.top.location.href );
 					window.top.location.href = itemProps.urls.create;
 					return;
 				}

--- a/app/modules/site-editor/assets/js/organisms/menu.js
+++ b/app/modules/site-editor/assets/js/organisms/menu.js
@@ -15,6 +15,12 @@ export default function Menu( props ) {
 			}
 
 			const goToCreate = () => {
+				if ( window.top !== window ) {
+					sessionStorage.setItem( 'elementor_app_return_to', window.top.location.href );
+					window.top.location.href = itemProps.urls.create;
+					return;
+				}
+
 				location.href = itemProps.urls.create;
 			};
 

--- a/packages/packages/core/editor-documents/src/sync/__tests__/utils.test.ts
+++ b/packages/packages/core/editor-documents/src/sync/__tests__/utils.test.ts
@@ -1,5 +1,6 @@
-import { getV1DocumentsManager } from '../utils';
 import { createMockDocumentData } from 'test-utils';
+
+import { getV1DocumentsManager } from '../utils';
 
 /**
  * This test exists only because this function is being used only inside event handlers,

--- a/packages/packages/core/editor-documents/src/sync/__tests__/utils.test.ts
+++ b/packages/packages/core/editor-documents/src/sync/__tests__/utils.test.ts
@@ -31,17 +31,17 @@ describe( '@elementor/editor-documents - getV1DocumentsExitTo with return URL', 
 
 		mockDocument = createMockDocumentData( { id: 1 } );
 
-		( window as Record< string, unknown > ).elementor = {
+		( window as unknown as Record< string, unknown > ).elementor = {
 			getPreferences: () => 'this_post',
 		};
 	} );
 
 	afterEach( () => {
-		delete ( window as Record< string, unknown > ).elementor;
+		delete ( window as unknown as Record< string, unknown > ).elementor;
 	} );
 
 	function getFreshExitTo( documentData: V1Document ): string {
-		let result: string;
+		let result = '';
 
 		jest.isolateModules( () => {
 			const { getV1DocumentsExitTo } = require( '../utils' );
@@ -110,8 +110,8 @@ describe( '@elementor/editor-documents - getV1DocumentsExitTo with return URL', 
 		sessionStorage.setItem( RETURN_TO_KEY, returnUrl );
 
 		// Act — use the same module instance for both calls.
-		let firstResult: string;
-		let secondResult: string;
+		let firstResult = '';
+		let secondResult = '';
 
 		jest.isolateModules( () => {
 			const { getV1DocumentsExitTo } = require( '../utils' );

--- a/packages/packages/core/editor-documents/src/sync/__tests__/utils.test.ts
+++ b/packages/packages/core/editor-documents/src/sync/__tests__/utils.test.ts
@@ -1,4 +1,5 @@
 import { getV1DocumentsManager } from '../utils';
+import { createMockDocumentData } from 'test-utils';
 
 /**
  * This test exists only because this function is being used only inside event handlers,
@@ -15,5 +16,112 @@ describe( '@elementor/editor-documents - Sync Utils', () => {
 		expect( () => {
 			getV1DocumentsManager();
 		} ).toThrow( 'Elementor Editor V1 documents manager not found' );
+	} );
+} );
+
+describe( '@elementor/editor-documents - getV1DocumentsExitTo with return URL', () => {
+	const RETURN_TO_KEY = 'elementor_app_return_to';
+
+	let mockDocument;
+
+	beforeEach( () => {
+		sessionStorage.clear();
+
+		mockDocument = createMockDocumentData( { id: 1 } );
+
+		window.elementor = {
+			getPreferences: () => 'this_post',
+		};
+	} );
+
+	afterEach( () => {
+		delete window.elementor;
+	} );
+
+	function getFreshExitTo( documentData ) {
+		let result;
+
+		jest.isolateModules( () => {
+			const { getV1DocumentsExitTo } = require( '../utils' );
+			result = getV1DocumentsExitTo( documentData );
+		} );
+
+		return result;
+	}
+
+	it( 'should return the sessionStorage URL when it is same-origin', () => {
+		// Arrange.
+		const returnUrl = 'http://localhost/site-editor/';
+		sessionStorage.setItem( RETURN_TO_KEY, returnUrl );
+
+		// Act.
+		const result = getFreshExitTo( mockDocument );
+
+		// Assert.
+		expect( result ).toBe( returnUrl );
+	} );
+
+	it( 'should remove the sessionStorage key after reading', () => {
+		// Arrange.
+		sessionStorage.setItem( RETURN_TO_KEY, 'http://localhost/site-editor/' );
+
+		// Act.
+		getFreshExitTo( mockDocument );
+
+		// Assert.
+		expect( sessionStorage.getItem( RETURN_TO_KEY ) ).toBeNull();
+	} );
+
+	it( 'should fall back to exit preference when sessionStorage URL is cross-origin', () => {
+		// Arrange.
+		sessionStorage.setItem( RETURN_TO_KEY, 'https://evil.com/phish' );
+
+		// Act.
+		const result = getFreshExitTo( mockDocument );
+
+		// Assert.
+		expect( result ).toBe( mockDocument.config.urls.exit_to_dashboard );
+	} );
+
+	it( 'should fall back to exit preference when sessionStorage URL is invalid', () => {
+		// Arrange.
+		sessionStorage.setItem( RETURN_TO_KEY, 'not-a-valid-url' );
+
+		// Act.
+		const result = getFreshExitTo( mockDocument );
+
+		// Assert.
+		expect( result ).toBe( mockDocument.config.urls.exit_to_dashboard );
+	} );
+
+	it( 'should fall back to exit preference when sessionStorage is empty', () => {
+		// Act.
+		const result = getFreshExitTo( mockDocument );
+
+		// Assert.
+		expect( result ).toBe( mockDocument.config.urls.exit_to_dashboard );
+	} );
+
+	it( 'should cache the result and not re-read sessionStorage', () => {
+		// Arrange.
+		const returnUrl = 'http://localhost/site-editor/';
+		sessionStorage.setItem( RETURN_TO_KEY, returnUrl );
+
+		// Act — use the same module instance for both calls.
+		let firstResult;
+		let secondResult;
+
+		jest.isolateModules( () => {
+			const { getV1DocumentsExitTo } = require( '../utils' );
+			firstResult = getV1DocumentsExitTo( mockDocument );
+
+			// Set a new value — should be ignored due to caching.
+			sessionStorage.setItem( RETURN_TO_KEY, 'http://localhost/other/' );
+			secondResult = getV1DocumentsExitTo( mockDocument );
+		} );
+
+		// Assert.
+		expect( firstResult ).toBe( returnUrl );
+		expect( secondResult ).toBe( returnUrl );
 	} );
 } );

--- a/packages/packages/core/editor-documents/src/sync/__tests__/utils.test.ts
+++ b/packages/packages/core/editor-documents/src/sync/__tests__/utils.test.ts
@@ -1,5 +1,6 @@
 import { createMockDocumentData } from 'test-utils';
 
+import { type V1Document } from '../../types';
 import { getV1DocumentsManager } from '../utils';
 
 /**
@@ -23,24 +24,24 @@ describe( '@elementor/editor-documents - Sync Utils', () => {
 describe( '@elementor/editor-documents - getV1DocumentsExitTo with return URL', () => {
 	const RETURN_TO_KEY = 'elementor_app_return_to';
 
-	let mockDocument;
+	let mockDocument: V1Document;
 
 	beforeEach( () => {
 		sessionStorage.clear();
 
 		mockDocument = createMockDocumentData( { id: 1 } );
 
-		window.elementor = {
+		( window as Record< string, unknown > ).elementor = {
 			getPreferences: () => 'this_post',
 		};
 	} );
 
 	afterEach( () => {
-		delete window.elementor;
+		delete ( window as Record< string, unknown > ).elementor;
 	} );
 
-	function getFreshExitTo( documentData ) {
-		let result;
+	function getFreshExitTo( documentData: V1Document ): string {
+		let result: string;
 
 		jest.isolateModules( () => {
 			const { getV1DocumentsExitTo } = require( '../utils' );
@@ -109,8 +110,8 @@ describe( '@elementor/editor-documents - getV1DocumentsExitTo with return URL', 
 		sessionStorage.setItem( RETURN_TO_KEY, returnUrl );
 
 		// Act — use the same module instance for both calls.
-		let firstResult;
-		let secondResult;
+		let firstResult: string;
+		let secondResult: string;
 
 		jest.isolateModules( () => {
 			const { getV1DocumentsExitTo } = require( '../utils' );

--- a/packages/packages/core/editor-documents/src/sync/utils.ts
+++ b/packages/packages/core/editor-documents/src/sync/utils.ts
@@ -16,7 +16,47 @@ export function getV1DocumentsManager() {
 	return documentsManager;
 }
 
+const RETURN_TO_KEY = 'elementor_app_return_to';
+
+let appReturnToUrl: string | null | undefined;
+
+function getAppReturnToUrl(): string | null {
+	if ( appReturnToUrl !== undefined ) {
+		return appReturnToUrl;
+	}
+
+	appReturnToUrl = null;
+
+	const stored = sessionStorage.getItem( RETURN_TO_KEY );
+
+	if ( ! stored ) {
+		return appReturnToUrl;
+	}
+
+	sessionStorage.removeItem( RETURN_TO_KEY );
+
+	try {
+		const parsedUrl = new URL( stored );
+		const isSameOrigin = parsedUrl.hostname === window.location.hostname &&
+			( 'http:' === parsedUrl.protocol || 'https:' === parsedUrl.protocol );
+
+		if ( isSameOrigin ) {
+			appReturnToUrl = stored;
+		}
+	} catch ( e ) {
+		// Invalid URL, fall through to default behavior.
+	}
+
+	return appReturnToUrl;
+}
+
 export function getV1DocumentsExitTo( documentData: V1Document ) {
+	const returnTo = getAppReturnToUrl();
+
+	if ( returnTo ) {
+		return returnTo;
+	}
+
 	const exitPreference =
 		( window as unknown as ExtendedWindow ).elementor?.getPreferences?.( 'exit_to' ) || 'this_post';
 

--- a/packages/packages/core/editor-documents/src/sync/utils.ts
+++ b/packages/packages/core/editor-documents/src/sync/utils.ts
@@ -16,7 +16,7 @@ export function getV1DocumentsManager() {
 	return documentsManager;
 }
 
-const RETURN_TO_KEY = 'elementor_app_return_to';
+export const RETURN_TO_KEY = 'elementor_app_return_to';
 
 let appReturnToUrl: string | null | undefined;
 
@@ -37,13 +37,12 @@ function getAppReturnToUrl(): string | null {
 
 	try {
 		const parsedUrl = new URL( stored );
-		const isSameOrigin = parsedUrl.hostname === window.location.hostname &&
-			( 'http:' === parsedUrl.protocol || 'https:' === parsedUrl.protocol );
+		const isSameOrigin = parsedUrl.origin === window.location.origin;
 
 		if ( isSameOrigin ) {
 			appReturnToUrl = stored;
 		}
-	} catch ( e ) {
+	} catch {
 		// Invalid URL, fall through to default behavior.
 	}
 


### PR DESCRIPTION
## Summary
- Follow-up to #36845 (Theme Builder app overlay)
- When a user opens the Theme Builder as an overlay, clicks to create a theme part, and then exits the template editor, they now return to the editor they came from instead of being redirected to the WordPress admin dashboard
- Uses `sessionStorage` to persist the return URL across the `elementor_new_post` redirect, with same-origin validation for security
- The original page's content is refreshed automatically since returning triggers a full page reload

## How it works
1. **`menu.js`** — When in iframe context (overlay), stores the parent editor URL in `sessionStorage` before navigating to the create URL via `window.top.location.href`
2. **`utils.ts`** — `getV1DocumentsExitTo()` checks `sessionStorage` for a return URL (lazy-initialized, read once per page load). If valid (same-origin), uses it as the exit URL instead of the user's exit preference

## Guard rails
- Only activates when `window.top !== window` (overlay iframe context)
- Same-origin validation prevents open redirect
- Module-level caching ensures `sessionStorage` is read once and cleared, preventing stale entries
- WP Admin → Theme Builder flow remains completely unchanged (no iframe = no sessionStorage write)

## Note
Pro counterpart needed for the "Edit" button on existing templates (`site-template-header.js`). The `sessionStorage` read side in `utils.ts` already supports both flows.

## Test plan
- [ ] Open editor for a page → open Theme Builder overlay → create a new header → exit editor → verify return to original page editor
- [ ] Open editor for a page → open Theme Builder overlay → create a new footer → save → exit → verify return to original page editor
- [ ] Open Theme Builder from WP Admin directly → edit a template → exit → verify default exit behavior (WP admin) is unchanged
- [ ] Verify exit preference (dashboard/all posts/this post) still works when no `sessionStorage` return URL is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

When users edit theme parts from the app overlay (iframe), they need to return to the editor rather than the default exit location. This requires passing the return URL through sessionStorage since cross-origin communication is limited.

## 2. What Changed (Where)

- **editor-documents/src/sync/utils.ts**: Added `getAppReturnToUrl()` helper with same-origin validation and caching; integrated into `getV1DocumentsExitTo()` as primary return path.
- **site-editor/menu.js**: Store parent window location in sessionStorage before navigating to create flow from iframe context.
- **utils.test.ts**: Added comprehensive test suite covering same-origin validation, cross-origin rejection, caching, and sessionStorage lifecycle.

## 3. How It Works

On iframe navigation (create button): store `window.top.location.href` in sessionStorage with key `elementor_app_return_to`. When exiting the editor, `getAppReturnToUrl()` retrieves and validates it (same-origin check), removes the key, caches the result, and returns it. Falls back to preference-based exit URL if invalid, cross-origin, or missing.

## 4. Risks

Minimal. Same-origin validation prevents open redirect attacks. SessionStorage scoping to origin provides implicit protection. Caching prevents repeated reads but requires module isolation in tests (already handled). Duplicate key constant across files is maintainability smell but not functional risk.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
