### PR TITLE
Feature: Add default-styles PHP module and REST API [ED-22046]

### DIFF
--- a/core/modules-manager.php
+++ b/core/modules-manager.php
@@ -126,6 +126,7 @@ class Modules_Manager {
 			'content-sanitizer',
 			'atomic-widgets',
 			'global-classes',
+			'default-styles',
 			'variables',
 			'design-system-sync',
 			'wc-product-editor',

--- a/modules/atomic-widgets/styles/atomic-styles-manager.php
+++ b/modules/atomic-widgets/styles/atomic-styles-manager.php
@@ -179,12 +179,22 @@ class Atomic_Styles_Manager {
 			Collection::make( $style['variants'] )->each( function( $variant ) use ( &$group, $style ) {
 				$breakpoint = $variant['meta']['breakpoint'] ?? self::DEFAULT_BREAKPOINT;
 
+				if ( empty( $breakpoint ) ) {
+					$breakpoint = self::DEFAULT_BREAKPOINT;
+				}
+
 				if ( ! isset( $group[ $breakpoint ][ $style['id'] ] ) ) {
-					$group[ $breakpoint ][ $style['id'] ] = [
+					$style_for_breakpoint = [
 						'id' => $style['id'],
 						'type' => $style['type'],
 						'variants' => [],
 					];
+
+					if ( isset( $style['cssName'] ) ) {
+						$style_for_breakpoint['cssName'] = $style['cssName'];
+					}
+
+					$group[ $breakpoint ][ $style['id'] ] = $style_for_breakpoint;
 				}
 
 				$group[ $breakpoint ][ $style['id'] ]['variants'][] = $variant;

--- a/modules/default-styles/atomic-default-styles.php
+++ b/modules/default-styles/atomic-default-styles.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+use Elementor\Modules\AtomicWidgets\Styles\Atomic_Styles_Manager;
+use Elementor\Plugin;
+
+class Atomic_Default_Styles {
+	const STYLES_KEY = 'default';
+
+	public function register_hooks() {
+		add_action(
+			'elementor/atomic-widgets/styles/register',
+			fn( Atomic_Styles_Manager $styles_manager ) => $this->register_styles( $styles_manager ),
+			15,
+			1
+		);
+
+		add_action(
+			'elementor/default_styles/update',
+			fn() => $this->invalidate_cache(),
+			10,
+			0
+		);
+
+		add_action(
+			'elementor/core/files/clear_cache',
+			fn() => $this->invalidate_cache(),
+		);
+
+		add_action(
+			'deleted_post',
+			fn( $post_id ) => $this->on_kit_delete( $post_id ),
+		);
+	}
+
+	private function register_styles( Atomic_Styles_Manager $styles_manager ) {
+		$styles_manager->register(
+			[ self::STYLES_KEY ],
+			fn () => $this->get_all_default_styles(),
+		);
+	}
+
+	private function get_all_default_styles(): array {
+		$items = Default_Styles_Repository::make()->all();
+
+		return array_values( $items );
+	}
+
+	private function invalidate_cache(): void {
+		do_action( 'elementor/atomic-widgets/styles/clear', [ self::STYLES_KEY ] );
+	}
+
+	private function on_kit_delete( $post_id ): void {
+		if ( ! Plugin::$instance->kits_manager->is_kit( $post_id ) ) {
+			return;
+		}
+
+		$this->invalidate_cache();
+	}
+}

--- a/modules/default-styles/concerns/has-kit-dependency.php
+++ b/modules/default-styles/concerns/has-kit-dependency.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles\Concerns;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+trait Has_Kit_Dependency {
+	private ?Kit $kit = null;
+
+	public function set_kit( Kit $kit ): self {
+		$this->kit = $kit;
+
+		return $this;
+	}
+
+	protected function get_kit(): ?Kit {
+		if ( ! $this->kit ) {
+			$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+		}
+
+		return $this->kit;
+	}
+}

--- a/modules/default-styles/concerns/has-preview-context.php
+++ b/modules/default-styles/concerns/has-preview-context.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles\Concerns;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+trait Has_Preview_Context {
+	private bool $is_preview = false;
+
+	public function set_preview( bool $is_preview = true ): self {
+		if ( $is_preview === $this->is_preview ) {
+			return $this;
+		}
+
+		$this->is_preview = $is_preview;
+		$this->on_preview_change();
+
+		return $this;
+	}
+
+	protected function is_preview(): bool {
+		return $this->is_preview;
+	}
+
+	protected function get_context_key( string $key ): string {
+		$map = $this->get_context_keys()[ $key ] ?? null;
+
+		if ( null === $map ) {
+			throw new \InvalidArgumentException( sprintf( 'Unknown context key: %s', esc_html( $key ) ) );
+		}
+
+		return $this->is_preview ? $map['preview'] : $map['frontend'];
+	}
+
+	protected function get_context_keys(): array {
+		if ( empty( $this->context_keys ) ) {
+			return [];
+		}
+
+		return $this->context_keys;
+	}
+
+	protected function on_preview_change(): void {
+	}
+}

--- a/modules/default-styles/default-style-post-type.php
+++ b/modules/default-styles/default-style-post-type.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Style_Post_Type {
+	const CPT = 'e_default_style';
+
+	public function register() {
+		add_action( 'init', [ $this, 'register_post_type' ] );
+	}
+
+	public function register_post_type() {
+		register_post_type( self::CPT, [
+			'label' => esc_html__( 'Default Style', 'elementor' ),
+			'labels' => [
+				'name' => esc_html__( 'Default Styles', 'elementor' ),
+				'singular_name' => esc_html__( 'Default Style', 'elementor' ),
+			],
+			'public' => false,
+			'show_ui' => false,
+			'supports' => [ 'title' ],
+		] );
+	}
+
+	public static function ensure_registered(): void {
+		if ( ! post_type_exists( self::CPT ) ) {
+			( new self() )->register_post_type();
+		}
+	}
+}

--- a/modules/default-styles/default-style-post.php
+++ b/modules/default-styles/default-style-post.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\AtomicWidgets\PropTypeMigrations\Migrations_Orchestrator;
+use Elementor\Modules\DefaultStyles\Utils\Default_Style_Data_Normalizer;
+use Elementor\Plugin;
+use WP_Post;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Style_Post {
+	const META_KEY_VERSION = '_elementor_version';
+	const META_KEY_TAG = '_elementor_default_style_tag';
+	const META_KEY_DATA = '_elementor_default_style_data';
+
+	private WP_Post $post;
+
+	private function __construct( WP_Post $post ) {
+		$this->post = $post;
+	}
+
+	public static function from_post( WP_Post $post ): self {
+		return new static( $post );
+	}
+
+	public static function from_post_id( int $post_id ): ?self {
+		$post = get_post( $post_id );
+
+		if ( ! $post || Default_Style_Post_Type::CPT !== $post->post_type ) {
+			return null;
+		}
+
+		return new static( $post );
+	}
+
+	public static function find_by_tag( string $tag, ?Kit $kit = null ): ?self {
+		$kit = $kit ?? Plugin::$instance->kits_manager->get_active_kit();
+
+		if ( ! $kit ) {
+			return null;
+		}
+
+		$post_id = Default_Styles_Tag_Post_IDs::make( $kit )->get_post_id( $tag );
+
+		if ( ! $post_id ) {
+			return null;
+		}
+
+		return self::from_post_id( $post_id );
+	}
+
+	public function get_post_id(): int {
+		return $this->post->ID;
+	}
+
+	public function get_tag(): string {
+		$tag = get_post_meta( $this->post->ID, self::META_KEY_TAG, true );
+
+		return is_string( $tag ) ? $tag : '';
+	}
+
+	public function get_data( bool $skip_migration = false ): array {
+		$data = get_post_meta( $this->post->ID, self::META_KEY_DATA, true );
+		$data = is_array( $data ) ? $data : [];
+
+		if ( ! empty( $data ) && ! $skip_migration ) {
+			$this->migrate_data( $data );
+		}
+
+		return $data;
+	}
+
+	private function migrate_data( array &$data ): void {
+		$post_id = $this->post->ID;
+		$meta_key = self::META_KEY_DATA;
+
+		Migrations_Orchestrator::make()->migrate(
+			$data,
+			$post_id,
+			$meta_key,
+			function ( $migrated ) use ( $post_id, $meta_key ) {
+				update_post_meta( $post_id, $meta_key, $migrated );
+				clean_post_cache( $post_id );
+			}
+		);
+	}
+
+	public function to_array( bool $skip_migration = false ): array {
+		$data = $this->get_data( $skip_migration );
+		$tag = $this->get_tag();
+
+		return Default_Style_Data_Normalizer::normalize_style( $tag, $data );
+	}
+
+	public function update_data( array $data, string $version = ELEMENTOR_VERSION ): bool {
+		$normalized_data = Default_Style_Data_Normalizer::normalize_style_fields( $data );
+
+		$result = update_post_meta( $this->post->ID, self::META_KEY_DATA, $normalized_data );
+
+		update_post_meta( $this->post->ID, self::META_KEY_VERSION, $version );
+
+		return false !== $result;
+	}
+
+	public static function create( string $tag, array $data, ?Kit $kit = null, string $version = ELEMENTOR_VERSION ): ?self {
+		$post_id = wp_insert_post( [
+			'post_type' => Default_Style_Post_Type::CPT,
+			'post_title' => $tag,
+			'post_status' => 'publish',
+		] );
+
+		if ( is_wp_error( $post_id ) || ! $post_id ) {
+			return null;
+		}
+
+		$normalized_data = Default_Style_Data_Normalizer::normalize_style_fields( $data );
+
+		update_post_meta( $post_id, self::META_KEY_TAG, $tag );
+		update_post_meta( $post_id, self::META_KEY_DATA, $normalized_data );
+		update_post_meta( $post_id, self::META_KEY_VERSION, $version );
+
+		$kit = $kit ?? Plugin::$instance->kits_manager->get_active_kit();
+
+		if ( $kit ) {
+			Default_Styles_Tag_Post_IDs::make( $kit )->set( $tag, (int) $post_id );
+		}
+
+		return self::from_post_id( $post_id );
+	}
+
+	public function delete(): bool {
+		$result = wp_delete_post( $this->post->ID, true );
+
+		return false !== $result;
+	}
+
+	public static function clone_to_other_kit( string $tag, Kit $source_kit, Kit $target_kit ): ?self {
+		$source_post = self::find_by_tag( $tag, $source_kit );
+
+		if ( ! $source_post ) {
+			return null;
+		}
+
+		$new_post_id = wp_insert_post( [
+			'post_type' => Default_Style_Post_Type::CPT,
+			'post_title' => $tag,
+			'post_status' => 'publish',
+		] );
+
+		if ( is_wp_error( $new_post_id ) || ! $new_post_id ) {
+			return null;
+		}
+
+		update_post_meta( $new_post_id, self::META_KEY_TAG, $tag );
+		update_post_meta( $new_post_id, self::META_KEY_VERSION, get_post_meta( $source_post->get_post_id(), self::META_KEY_VERSION, true ) );
+
+		$source_data = $source_post->get_data();
+
+		if ( ! empty( $source_data ) ) {
+			update_post_meta( $new_post_id, self::META_KEY_DATA, $source_data );
+		}
+
+		Default_Styles_Tag_Post_IDs::make( $target_kit )->set( $tag, (int) $new_post_id );
+
+		return self::from_post_id( $new_post_id );
+	}
+}

--- a/modules/default-styles/default-styles-repository.php
+++ b/modules/default-styles/default-styles-repository.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\DefaultStyles\Concerns\Has_Kit_Dependency;
+use Elementor\Modules\DefaultStyles\Utils\Default_Style_Data_Normalizer;
+use Elementor\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Styles_Repository {
+	use Has_Kit_Dependency;
+
+	private ?array $cache = null;
+
+	public function __construct( ?Kit $kit = null ) {
+		if ( null !== $kit ) {
+			$this->set_kit( $kit );
+		}
+	}
+
+	public static function make( ?Kit $kit = null ): self {
+		return new self( $kit );
+	}
+
+	public function all( bool $force = false ): array {
+		if ( ! $force && null !== $this->cache ) {
+			return $this->cache;
+		}
+
+		$items = [];
+		$tag_post_ids = Default_Styles_Tag_Post_IDs::make( $this->get_kit() )->get_all();
+
+		foreach ( $tag_post_ids as $tag => $post_id ) {
+			$post = Default_Style_Post::from_post_id( $post_id );
+
+			if ( $post ) {
+				$items[ $tag ] = $post->to_array();
+			}
+		}
+
+		$this->cache = $items;
+
+		return $items;
+	}
+
+	public function get( string $tag ): ?array {
+		$post = Default_Style_Post::find_by_tag( $tag, $this->get_kit() );
+
+		return $post ? $post->to_array() : null;
+	}
+
+	public function put( string $tag, array $data ): void {
+		if ( ! self::is_allowed_tag( $tag ) ) {
+			return;
+		}
+
+		$post = Default_Style_Post::find_by_tag( $tag, $this->get_kit() );
+		$normalized = Default_Style_Data_Normalizer::normalize_style_fields( $data );
+
+		if ( $post ) {
+			$post->update_data( $normalized );
+			clean_post_cache( $post->get_post_id() );
+		} else {
+			$created = Default_Style_Post::create( $tag, [], $this->get_kit() );
+
+			if ( $created ) {
+				$created->update_data( $normalized );
+				clean_post_cache( $created->get_post_id() );
+			}
+		}
+
+		$this->cache = null;
+
+		do_action( 'elementor/default_styles/update', [ 'tag' => $tag ] );
+	}
+
+	public function delete( string $tag ): void {
+		$post = Default_Style_Post::find_by_tag( $tag, $this->get_kit() );
+
+		if ( ! $post ) {
+			return;
+		}
+
+		Default_Styles_Tag_Post_IDs::make( $this->get_kit() )->remove_tag( $tag );
+		$post->delete();
+
+		$this->cache = null;
+
+		do_action( 'elementor/default_styles/update', [ 'tag' => $tag, 'deleted' => true ] );
+	}
+
+	public static function is_allowed_tag( string $tag ): bool {
+		return in_array( $tag, Utils::ALLOWED_HTML_WRAPPER_TAGS, true );
+	}
+}

--- a/modules/default-styles/default-styles-rest-api.php
+++ b/modules/default-styles/default-styles-rest-api.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Core\Utils\Api\Error_Builder;
+use Elementor\Core\Utils\Api\Response_Builder;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Styles_REST_API {
+	const API_NAMESPACE = 'elementor/v1';
+	const API_BASE = 'default-styles';
+
+	private ?Default_Styles_Repository $repository = null;
+	private ?Kit $kit = null;
+
+	public function register_hooks() {
+		add_action( 'rest_api_init', fn() => $this->register_routes() );
+	}
+
+	private function get_kit(): ?Kit {
+		if ( ! $this->kit ) {
+			$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+		}
+
+		return $this->kit;
+	}
+
+	private function get_repository(): Default_Styles_Repository {
+		if ( ! $this->repository ) {
+			$this->repository = new Default_Styles_Repository( $this->get_kit() );
+		}
+
+		return $this->repository;
+	}
+
+	private function register_routes() {
+		$this->repository = null;
+		$this->kit = null;
+
+		register_rest_route( self::API_NAMESPACE, '/' . self::API_BASE, [
+			[
+				'methods' => 'GET',
+				'callback' => fn( $request ) => $this->route_wrapper( fn() => $this->all( $request ) ),
+				'permission_callback' => fn() => current_user_can( 'manage_options' ),
+			],
+		] );
+
+		register_rest_route( self::API_NAMESPACE, '/' . self::API_BASE . '/(?P<tag>[a-z0-9]+)', [
+			[
+				'methods' => 'GET',
+				'callback' => fn( $request ) => $this->route_wrapper( fn() => $this->get_one( $request ) ),
+				'permission_callback' => fn() => current_user_can( 'manage_options' ),
+				'args' => [
+					'tag' => [
+						'type' => 'string',
+						'required' => true,
+					],
+				],
+			],
+			[
+				'methods' => 'PUT',
+				'callback' => fn( $request ) => $this->route_wrapper( fn() => $this->put( $request ) ),
+				'permission_callback' => fn() => current_user_can( 'manage_options' ),
+				'args' => [
+					'tag' => [
+						'type' => 'string',
+						'required' => true,
+					],
+					'variants' => [
+						'type' => 'array',
+						'required' => true,
+					],
+					'type' => [
+						'type' => 'string',
+						'enum' => [ 'class' ],
+						'required' => false,
+					],
+				],
+			],
+			[
+				'methods' => 'DELETE',
+				'callback' => fn( $request ) => $this->route_wrapper( fn() => $this->delete( $request ) ),
+				'permission_callback' => fn() => current_user_can( 'manage_options' ),
+				'args' => [
+					'tag' => [
+						'type' => 'string',
+						'required' => true,
+					],
+				],
+			],
+		] );
+	}
+
+	private function all( \WP_REST_Request $request ) {
+		$items = $this->get_repository()->all();
+
+		return Response_Builder::make( (object) $items )->build();
+	}
+
+	private function get_one( \WP_REST_Request $request ) {
+		$tag = $request->get_param( 'tag' );
+
+		if ( ! Default_Styles_Repository::is_allowed_tag( $tag ) ) {
+			return Error_Builder::make( 'invalid_tag' )
+				->set_status( 400 )
+				->set_message( 'Invalid HTML tag.' )
+				->build();
+		}
+
+		$item = $this->get_repository()->get( $tag );
+
+		if ( ! $item ) {
+			return Error_Builder::make( 'not_found' )
+				->set_status( 404 )
+				->set_message( 'Default style not found.' )
+				->build();
+		}
+
+		return Response_Builder::make( $item )->build();
+	}
+
+	private function put( \WP_REST_Request $request ) {
+		$tag = $request->get_param( 'tag' );
+
+		if ( ! Default_Styles_Repository::is_allowed_tag( $tag ) ) {
+			return Error_Builder::make( 'invalid_tag' )
+				->set_status( 400 )
+				->set_message( 'Invalid HTML tag.' )
+				->build();
+		}
+
+		$this->get_repository()->put(
+			$tag,
+			[
+				'type' => 'class',
+				'variants' => $request->get_param( 'variants' ),
+			]
+		);
+
+		$item = $this->get_repository()->get( $tag );
+
+		return Response_Builder::make( $item )->build();
+	}
+
+	private function delete( \WP_REST_Request $request ) {
+		$tag = $request->get_param( 'tag' );
+
+		if ( ! Default_Styles_Repository::is_allowed_tag( $tag ) ) {
+			return Error_Builder::make( 'invalid_tag' )
+				->set_status( 400 )
+				->set_message( 'Invalid HTML tag.' )
+				->build();
+		}
+
+		$this->get_repository()->delete( $tag );
+
+		return Response_Builder::make( [ 'deleted' => true ] )->build();
+	}
+
+	private function route_wrapper( callable $callback ) {
+		try {
+			return $callback();
+		} catch ( \Throwable $e ) {
+			return Error_Builder::make( 'default_styles_error' )
+				->set_status( 500 )
+				->set_message( $e->getMessage() )
+				->build();
+		}
+	}
+}

--- a/modules/default-styles/default-styles-tag-post-ids.php
+++ b/modules/default-styles/default-styles-tag-post-ids.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\DefaultStyles\Concerns\Has_Kit_Dependency;
+use Elementor\Modules\GlobalClasses\Utils\Kit_Utils;
+use WP_Post;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Styles_Tag_Post_IDs {
+	use Has_Kit_Dependency;
+
+	const META_KEY = '_elementor_default_styles_post_ids';
+
+	private ?array $cache = null;
+
+	public static function make( ?Kit $kit = null ): self {
+		$instance = new self();
+
+		if ( null !== $kit ) {
+			$instance->set_kit( $kit );
+		}
+
+		return $instance;
+	}
+
+	public function register_hooks(): void {
+		add_action( 'deleted_post', [ self::class, 'on_deleted_post' ], 10, 2 );
+	}
+
+	public static function on_deleted_post( int $post_id, WP_Post $post ): void {
+		if ( Default_Style_Post_Type::CPT !== $post->post_type ) {
+			return;
+		}
+
+		foreach ( Kit_Utils::get_all_kit_documents() as $kit ) {
+			self::make( $kit )->remove_post_id( $post_id );
+		}
+	}
+
+	public function get_post_id( string $tag ): ?int {
+		$map = $this->read_map();
+
+		if ( ! isset( $map[ $tag ] ) ) {
+			return null;
+		}
+
+		$post_id = (int) $map[ $tag ];
+
+		if ( get_post( $post_id ) ) {
+			return $post_id;
+		}
+
+		$this->remove_post_id( $post_id );
+
+		return null;
+	}
+
+	public function get_all(): array {
+		$map = $this->read_map();
+		$resolved = [];
+
+		foreach ( $map as $tag => $post_id ) {
+			$post_id = (int) $post_id;
+
+			if ( get_post( $post_id ) ) {
+				$resolved[ $tag ] = $post_id;
+			} else {
+				$this->remove_post_id( $post_id );
+			}
+		}
+
+		return $resolved;
+	}
+
+	public function set( string $tag, int $post_id ): void {
+		$map = $this->read_map();
+
+		if ( $post_id <= 0 || '' === $tag ) {
+			return;
+		}
+
+		$map[ $tag ] = $post_id;
+		$this->write_map( $map );
+	}
+
+	public function remove_tag( string $tag ): void {
+		$map = $this->read_map();
+
+		if ( ! isset( $map[ $tag ] ) ) {
+			return;
+		}
+
+		unset( $map[ $tag ] );
+		$this->write_map( $map );
+	}
+
+	public function remove_post_id( int $post_id ): void {
+		$map = $this->read_map();
+		$filtered = array_filter( $map, fn( $id ) => (int) $id !== $post_id );
+
+		if ( count( $filtered ) === count( $map ) ) {
+			return;
+		}
+
+		$this->write_map( $filtered );
+	}
+
+	private function read_map(): array {
+		if ( null !== $this->cache ) {
+			return $this->cache;
+		}
+
+		$kit = $this->get_kit();
+
+		if ( ! $kit ) {
+			$this->cache = [];
+
+			return [];
+		}
+
+		$raw = $kit->get_meta( self::META_KEY );
+		$this->cache = is_array( $raw ) ? $raw : [];
+
+		return $this->cache;
+	}
+
+	private function write_map( array $map ): bool {
+		$kit = $this->get_kit();
+
+		if ( ! $kit ) {
+			return false;
+		}
+
+		$result = $kit->update_meta( self::META_KEY, $map );
+		$this->cache = $map;
+
+		return false !== $result;
+	}
+}

--- a/modules/default-styles/module.php
+++ b/modules/default-styles/module.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+use Elementor\Core\Base\Module as BaseModule;
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Module extends BaseModule {
+	const EXPERIMENT_NAME = 'e_default_styles';
+
+	public function get_name() {
+		return 'default-styles';
+	}
+
+	public static function get_experimental_data() {
+		return [
+			'name' => self::EXPERIMENT_NAME,
+			'title' => esc_html__( 'HTML Tag Default Styles', 'elementor' ),
+			'description' => esc_html__( 'Enable site-wide default styles for HTML tags.', 'elementor' ),
+			'hidden' => true,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,
+		];
+	}
+
+	public function __construct() {
+		parent::__construct();
+
+		if ( ! Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME ) ) {
+			return;
+		}
+
+		if ( ! Plugin::$instance->experiments->is_feature_active( Atomic_Widgets_Module::EXPERIMENT_NAME ) ) {
+			return;
+		}
+
+		( new Default_Style_Post_Type() )->register();
+		( new Default_Styles_Tag_Post_IDs() )->register_hooks();
+
+		( new Default_Styles_REST_API() )->register_hooks();
+		( new Atomic_Default_Styles() )->register_hooks();
+
+		add_filter(
+			'elementor/kit/meta_to_preserve_on_kit_import',
+			[ $this, 'add_meta_to_preserve_on_kit_import' ]
+		);
+
+		add_action( 'elementor/kit/after_new_kit_created', [ $this, 'clone_default_styles_for_new_kit' ], 10, 1 );
+	}
+
+	public function add_meta_to_preserve_on_kit_import( array $meta_keys ): array {
+		return array_merge( $meta_keys, [
+			Default_Styles_Tag_Post_IDs::META_KEY,
+		] );
+	}
+
+	public function clone_default_styles_for_new_kit( array $params ): void {
+		[ 'new_kit_id' => $new_kit_id, 'previous_kit_id' => $previous_kit_id ] = $params;
+
+		$previous_kit = Plugin::$instance->kits_manager->get_kit( $previous_kit_id );
+		$new_kit = Plugin::$instance->kits_manager->get_kit( $new_kit_id );
+
+		if ( ! $previous_kit || ! $new_kit ) {
+			return;
+		}
+
+		$tags = Default_Styles_Tag_Post_IDs::make( $previous_kit )->get_all();
+
+		foreach ( array_keys( $tags ) as $tag ) {
+			Default_Style_Post::clone_to_other_kit( $tag, $previous_kit, $new_kit );
+		}
+	}
+}

--- a/modules/default-styles/utils/default-style-data-normalizer.php
+++ b/modules/default-styles/utils/default-style-data-normalizer.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Style_Data_Normalizer {
+	const CSS_NAME_PREFIX = 'e-default-';
+
+	public static function normalize_style( string $tag, array $data ): array {
+		return array_merge(
+			[
+				'id' => $tag,
+				'label' => $tag,
+				'cssName' => self::CSS_NAME_PREFIX . $tag,
+			],
+			self::normalize_style_fields( $data )
+		);
+	}
+
+	public static function normalize_style_fields( array $item ): array {
+		return [
+			'type' => $item['type'] ?? 'class',
+			'variants' => $item['variants'] ?? [],
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/test-atomic-styles-manager.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/test-atomic-styles-manager.php
@@ -116,6 +116,50 @@ class Test_Atomic_Styles_Manager extends Elementor_Test_Base {
 		];
 	}
 
+	public function test_enqueue__uses_css_name_when_distinct_from_id() {
+		// Arrange.
+		$styles_manager = new Atomic_Styles_Manager();
+		$styles_manager->register_hooks();
+
+		$get_style_defs = function () {
+			return [
+				[
+					'id' => 'h2',
+					'type' => 'class',
+					'cssName' => 'e-default-h2',
+					'variants' => [
+						[
+							'meta' => [
+								'breakpoint' => 'desktop',
+							],
+							'props' => [
+								'color' => 'red',
+							],
+						],
+					],
+				],
+			];
+		};
+
+		$this->filesystemMock->method( 'put_contents' )->willReturn( true );
+
+		$this->filesystemMock->expects( $this->once() )
+			->method( 'put_contents' )
+			->with(
+				$this->anything(),
+				'.elementor .e-default-h2{color:red;}'
+			);
+
+		add_action( 'elementor/atomic-widgets/styles/register', function ( $styles_manager ) use ( $get_style_defs ) {
+			$styles_manager->register( [ $this->test_style_key ], $get_style_defs );
+		}, 100, 1 );
+
+		do_action( 'elementor/post/render', 1 );
+
+		// Act
+		do_action( 'elementor/frontend/after_enqueue_post_styles' );
+	}
+
 	public function test_enqueue__enqueues_styles() {
 		// Arrange.
 		$styles_manager = new Atomic_Styles_Manager();

--- a/tests/phpunit/elementor/modules/default-styles/test-default-styles.php
+++ b/tests/phpunit/elementor/modules/default-styles/test-default-styles.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Elementor\Testing\Modules\DefaultStyles;
+
+use Elementor\Modules\DefaultStyles\Default_Style_Post_Type;
+use Elementor\Modules\DefaultStyles\Default_Styles_Repository;
+use Elementor\Modules\DefaultStyles\Atomic_Default_Styles;
+use Elementor\Modules\AtomicWidgets\Styles\Atomic_Styles_Manager;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+use PHPUnit\Framework\MockObject\MockObject;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Default_Styles_Repository extends Elementor_Test_Base {
+	private ?\Elementor\Core\Kits\Documents\Kit $kit = null;
+
+	public function set_up() {
+		parent::set_up();
+
+		Default_Style_Post_Type::ensure_registered();
+
+		$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+	}
+
+	public function test_put_and_get_style() {
+		$repository = Default_Styles_Repository::make( $this->kit );
+
+		$repository->put( 'h1', [
+			'type' => 'class',
+			'variants' => [
+				[
+					'props' => [ 'color' => 'red' ],
+					'meta' => [ 'breakpoint' => null, 'state' => null ],
+				],
+			],
+		] );
+
+		$item = $repository->get( 'h1' );
+
+		$this->assertNotNull( $item );
+		$this->assertSame( 'h1', $item['id'] );
+		$this->assertSame( 'class', $item['type'] );
+		$this->assertCount( 1, $item['variants'] );
+	}
+
+	public function test_is_allowed_tag_rejects_invalid_tag() {
+		$this->assertTrue( Default_Styles_Repository::is_allowed_tag( 'h1' ) );
+		$this->assertFalse( Default_Styles_Repository::is_allowed_tag( 'script' ) );
+	}
+}
+
+class Test_Default_Styles_Rendering extends Elementor_Test_Base {
+	private ?\Elementor\Core\Kits\Documents\Kit $kit = null;
+
+	public function set_up() {
+		parent::set_up();
+
+		Default_Style_Post_Type::ensure_registered();
+
+		$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+	}
+
+	public function test_default_styles_use_prefixed_css_class_in_selector() {
+		$repository = Default_Styles_Repository::make( $this->kit );
+
+		$repository->put( 'h2', [
+			'type' => 'class',
+			'variants' => [
+				[
+					'props' => [
+						'color' => [
+							'$$type' => 'color',
+							'value' => 'red',
+						],
+					],
+					'meta' => [ 'breakpoint' => 'desktop', 'state' => null ],
+				],
+			],
+		] );
+
+		$item = $repository->get( 'h2' );
+
+		$this->assertSame( 'e-default-h2', $item['cssName'] );
+
+		$css = \Elementor\Modules\AtomicWidgets\Styles\Styles_Renderer::make(
+			Plugin::$instance->breakpoints->get_breakpoints_config()
+		)->render( [ $item ] );
+
+		$this->assertStringContainsString( '.elementor .e-default-h2', $css );
+		$this->assertStringNotContainsString( '.elementor .h2', $css );
+	}
+}
+
+class Test_Atomic_Default_Styles extends Elementor_Test_Base {
+	private MockObject $mock_styles_manager;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->mock_styles_manager = $this->createMock( Atomic_Styles_Manager::class );
+		remove_all_actions( 'elementor/atomic-widgets/styles/register' );
+	}
+
+	public function test_register_styles__uses_default_path_without_post_id() {
+		( new Atomic_Default_Styles() )->register_hooks();
+
+		$this->mock_styles_manager
+			->expects( $this->once() )
+			->method( 'register' )
+			->with(
+				[ Atomic_Default_Styles::STYLES_KEY ],
+				$this->isCallable()
+			);
+
+		do_action( 'elementor/atomic-widgets/styles/register', $this->mock_styles_manager, [] );
+	}
+}


### PR DESCRIPTION
## Summary

- Registers the hidden `e_default_styles` experiment with kit-scoped CPT storage and REST API.
- Hooks default styles into `Atomic_Styles_Manager` for frontend CSS emission.
- Fixes `Atomic_Styles_Manager::group_by_breakpoint()` to preserve `cssName` so class-based selectors (e.g. `.e-default-h2`) render correctly on the frontend.

## Jira

[ED-22046](https://elementor.atlassian.net/browse/ED-22046)

## Stack

Part of a 3-PR stack for HTML tag default styles. Merge via the top PR (`feat/ED-22046-default-styles-editor`).

1. **This PR** — PHP backend + `Atomic_Styles_Manager` fix
2. `feat/ED-22046-atomic-twig-default-tag-class` — Twig `e-default-<tag>` class emission
3. `feat/ED-22046-default-styles-editor` — Editor package + panel

## Test plan

- [ ] Run `tests/phpunit/elementor/modules/default-styles/test-default-styles.php`
- [ ] Run `tests/phpunit/elementor/modules/atomic-widgets/styles/test-atomic-styles-manager.php --filter test_enqueue__uses_css_name_when_distinct_from_id`

[ED-22046]: https://elementor.atlassian.net/browse/ED-22046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

ED-22046: Adds site-wide default styles for HTML tags via a new PHP module and REST API, enabling consistent styling across Elementor sites using the atomic widgets infrastructure.

## 2. What Changed (Where)

- **core/modules-manager.php**: Registered `default-styles` module in load sequence
- **modules/default-styles/**: New module with 8 core files (post type, repository, REST API, data normalizer, traits)
- **modules/atomic-widgets/styles/atomic-styles-manager.php**: Fixed breakpoint fallback and added optional `cssName` field preservation
- **tests/**: Added unit tests for repository, rendering, and styles manager integration

## 3. How It Works

Entry point is `Module::__construct()` which registers hooks when both experiments are active. `Default_Style_Post_Type` creates custom post type for storage. `Default_Styles_Repository` manages CRUD via `Default_Style_Post` (wraps WP_Post), keyed by `Default_Styles_Tag_Post_IDs` (stored in kit meta). `Atomic_Default_Styles` registers styles with `Atomic_Styles_Manager` via callback, which pulls from repository and renders with prefixed CSS class names (`e-default-{tag}`). REST API exposes GET/PUT/DELETE endpoints with tag validation against `Utils::ALLOWED_HTML_WRAPPER_TAGS`. Atomic styles manager fix ensures empty breakpoints default to desktop and cssName persists through grouping.

## 4. Risks

Minor: breakpoint fallback logic (lines 182–184) duplicates the coalescing operator but adds defensive check—acceptable. Empty kit scenario handled safely in repository. Tag validation via allowlist mitigates injection. No backward compatibility concerns (new feature, gated by experiment flag).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
