### PR TITLE
Feature: Add HTML tag default styles editor panel [ED-22046]

### DIFF
--- a/core/modules-manager.php
+++ b/core/modules-manager.php
@@ -126,6 +126,7 @@ class Modules_Manager {
 			'content-sanitizer',
 			'atomic-widgets',
 			'global-classes',
+			'default-styles',
 			'variables',
 			'design-system-sync',
 			'wc-product-editor',

--- a/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video-content/atomic-background-video-content.html.twig
+++ b/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video-content/atomic-background-video-content.html.twig
@@ -1,4 +1,4 @@
-{% set classes = ['e-background-video__content', 'e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{% set classes = ['e-background-video__content', 'e-con', 'e-atomic-element', base_styles.base, 'e-default-div'] | merge(settings.classes | default([])) | join(' ') %}
 <div class="{{ classes }} {{ editor_classes | default('') }}"
 	data-id="{{ id }}"
 	data-element_type="{{ type }}"

--- a/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video-controls/atomic-background-video-controls.html.twig
+++ b/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video-controls/atomic-background-video-controls.html.twig
@@ -1,4 +1,4 @@
-{% set classes = ['e-background-video__controls', 'e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{% set classes = ['e-background-video__controls', 'e-con', 'e-atomic-element', base_styles.base, 'e-default-div'] | merge(settings.classes | default([])) | join(' ') %}
 <div class="{{ classes }} {{ editor_classes | default('') }}"
 	data-id="{{ id }}"
 	data-element_type="{{ type }}"

--- a/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video-pause/atomic-background-video-pause.html.twig
+++ b/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video-pause/atomic-background-video-pause.html.twig
@@ -1,4 +1,4 @@
-{% set classes = ['e-background-video__pause', 'e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{% set classes = ['e-background-video__pause', 'e-con', 'e-atomic-element', base_styles.base, 'e-default-button'] | merge(settings.classes | default([])) | join(' ') %}
 <button class="{{ classes }} {{ editor_classes | default('') }}"
 	data-id="{{ id }}"
 	data-element_type="{{ type }}"

--- a/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video-play/atomic-background-video-play.html.twig
+++ b/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video-play/atomic-background-video-play.html.twig
@@ -1,4 +1,4 @@
-{% set classes = ['e-background-video__play', 'e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{% set classes = ['e-background-video__play', 'e-con', 'e-atomic-element', base_styles.base, 'e-default-button'] | merge(settings.classes | default([])) | join(' ') %}
 <button class="{{ classes }} {{ editor_classes | default('') }}"
 	data-id="{{ id }}"
 	data-element_type="{{ type }}"

--- a/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video.html.twig
+++ b/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video.html.twig
@@ -1,9 +1,8 @@
 {% set state_class = '' %}
 {% if settings.state == 'playing' %}{% set state_class = 'e-background-video--playing' %}{% endif %}
 {% if settings.state == 'paused' %}{% set state_class = 'e-background-video--paused' %}{% endif %}
-{% set tag = settings.tag | default('div') %}
-{% set classes = ['e-background-video', 'e-con', 'e-atomic-element', base_styles.base, state_class] | merge(settings.classes | default([])) | join(' ') %}
-<{{ tag | e('html_tag') }} class="{{ classes }} {{ editor_classes | default('') }}"
+{% set classes = ['e-background-video', 'e-con', 'e-atomic-element', base_styles.base, state_class, 'e-default-div'] | merge(settings.classes | default([])) | join(' ') %}
+<div class="{{ classes }} {{ editor_classes | default('') }}"
 	data-id="{{ id }}"
 	data-element_type="{{ type }}"
 	data-e-type="{{ type }}"
@@ -31,4 +30,4 @@
 		</video>
 	{% endif %}
 	<!-- elementor-children-placeholder -->
-</{{ tag | e('html_tag') }}>
+</div>

--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.html.twig
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.html.twig
@@ -1,12 +1,14 @@
 {% import 'elementor/macros' as m %}
 {%- set allowed_tags = '<b><strong><sup><sub><s><em><i><u><del><span><br>' -%}
-{%- set classes = settings.classes | merge( [ base_styles.base ] ) | join(' ') -%}
-{%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
-	<{{ settings.link.tag | default('a') | e('html_tag') }}
+{%- set has_link = settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
+{%- set effective_tag = has_link ? (settings.link.tag | default('a')) : 'button' -%}
+{%- set classes = settings.classes | merge( [ base_styles.base, m.default_tag_class(effective_tag) ] ) | join(' ') -%}
+{%- if has_link -%}
+	<{{ effective_tag | e('html_tag') }}
 		{{- m.render_link_attributes(settings.link) }} class="{{ classes }}" data-interaction-id="{{ interaction_id }}"
 		{{- m.render_custom_attributes(settings) }}>
 		{{ settings.text | striptags(allowed_tags) | raw }}
-	</{{ settings.link.tag | default('a') | e('html_tag') }}>
+	</{{ effective_tag | e('html_tag') }}>
 {%- else -%}
 	<button class="{{ classes }}" data-interaction-id="{{ interaction_id }}"
 		{{- m.render_custom_attributes(settings) }}>

--- a/modules/atomic-widgets/elements/atomic-collection-loop/collection-loop-promotion.html.twig
+++ b/modules/atomic-widgets/elements/atomic-collection-loop/collection-loop-promotion.html.twig
@@ -1,4 +1,4 @@
-{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base, 'e-default-div'] | merge(settings.classes | default([])) | join(' ') %}
 <div class="{{ classes }} {{ editor_classes | default('') }}"
      data-id="{{ id }}"
      data-element_type="{{ type }}"

--- a/modules/atomic-widgets/elements/atomic-form/atomic-form-promotion.html.twig
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form-promotion.html.twig
@@ -1,4 +1,4 @@
-{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base, 'e-default-div'] | merge(settings.classes | default([])) | join(' ') %}
 <div class="{{ classes }} {{ editor_classes | default('') }}"
      data-id="{{ id }}"
      data-element_type="{{ type }}"

--- a/modules/atomic-widgets/elements/atomic-form/atomic-form.html.twig
+++ b/modules/atomic-widgets/elements/atomic-form/atomic-form.html.twig
@@ -1,5 +1,5 @@
 {%- set form_state = form_state | default(settings['form-state']) | default('default') -%}
-{%- set classes = ['e-con', 'e-atomic-element', base_styles.base, 'form-state-' ~ form_state] | merge(settings.classes | default([])) | join(' ') -%}
+{%- set classes = ['e-con', 'e-atomic-element', base_styles.base, 'form-state-' ~ form_state, 'e-default-form'] | merge(settings.classes | default([])) | join(' ') -%}
 <form class="{{ classes }} {{ editor_classes | default('') }}"
       data-id="{{ id }}"
       data-element_type="{{ type }}"

--- a/modules/atomic-widgets/elements/atomic-form/form-message/form-message.html.twig
+++ b/modules/atomic-widgets/elements/atomic-form/form-message/form-message.html.twig
@@ -1,4 +1,4 @@
-{%- set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{%- set classes = ['e-con', 'e-atomic-element', base_styles.base, 'e-default-div'] | merge(settings.classes | default([])) | join(' ') %}
 {%- set message_type = type == 'e-form-success-message' ? 'message-success' : 'message-error' %}
 {%- set aria_attr = type == 'e-form-success-message' ? 'aria-live="polite"'  : 'role="alert"' %}
 <div class="{{ classes }} {{ message_type }} {{ editor_classes | default('') }}"

--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -1,11 +1,11 @@
 {% import 'elementor/macros' as m %}
-{%- set classes = settings.classes | merge( [ base_styles.base ] ) | join(' ') -%}
+{%- set classes = settings.classes | merge( [ base_styles.base, m.default_tag_class(settings.tag) ] ) | join(' ') -%}
 <{{ settings.tag | e('html_tag') }} data-interaction-id="{{ interaction_id }}" class="{{ classes }}"
 	{{- m.render_custom_attributes(settings) }}>
 {%- set allowed_tags = '<b><strong><sup><sub><s><em><i><u><a><del><span><br>' -%}
 {%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
 	<{{ settings.link.tag | default('a') | e('html_tag') }}
-		{{- m.render_link_attributes(settings.link) }} class="{{ base_styles['link-base'] }}">
+		{{- m.render_link_attributes(settings.link) }} class="{{ base_styles['link-base'] }} {{ m.default_tag_class(settings.link.tag | default('a')) }}">
 		{{ settings.title | striptags(allowed_tags) | raw }}
 	</{{ settings.link.tag | default('a') | e('html_tag') }}>
 {%- else -%}

--- a/modules/atomic-widgets/elements/atomic-image/atomic-image.html.twig
+++ b/modules/atomic-widgets/elements/atomic-image/atomic-image.html.twig
@@ -1,8 +1,9 @@
 {% import 'elementor/macros' as m %}
 {%- set has_link = settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
+{%- set link_tag = settings.link.tag | default('a') -%}
 {%- if has_link -%}
-	<{{ settings.link.tag | default('a') | e('html_tag') }}
-		{{- m.render_link_attributes(settings.link) }} class="{{ base_styles['link-base'] }}" data-interaction-id="{{ interaction_id }}"
+	<{{ link_tag | e('html_tag') }}
+		{{- m.render_link_attributes(settings.link) }} class="{{ base_styles['link-base'] }} {{ m.default_tag_class(link_tag) }}" data-interaction-id="{{ interaction_id }}"
 	>
 {%- endif %}
 <img class="{{ base_styles['base'] }} {{ settings.classes | join(' ') }}"

--- a/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.html.twig
+++ b/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.html.twig
@@ -1,10 +1,10 @@
 {% import 'elementor/macros' as m %}
-{%- set classes = settings.classes | merge( [ base_styles.base ] ) | join(' ') -%}
+{%- set classes = settings.classes | merge( [ base_styles.base, m.default_tag_class(settings.tag) ] ) | join(' ') -%}
 <{{ settings.tag | e('html_tag') }} class="{{ classes }}" data-interaction-id="{{ interaction_id }}"
 	{{- m.render_custom_attributes(settings) }}>
 {%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
 	<{{ settings.link.tag | default('a') | e('html_tag') }}
-		{{- m.render_link_attributes(settings.link) }} class="{{ base_styles['link-base'] }}">
+		{{- m.render_link_attributes(settings.link) }} class="{{ base_styles['link-base'] }} {{ m.default_tag_class(settings.link.tag | default('a')) }}">
 		{{ settings.paragraph | striptags('<b><strong><sup><sub><s><em><u><ul><ol><li><blockquote><a><del><span><br>') | raw }}
 	</{{ settings.link.tag | default('a') | e('html_tag') }}>
 {%- else -%}

--- a/modules/atomic-widgets/elements/atomic-svg/atomic-svg.html.twig
+++ b/modules/atomic-widgets/elements/atomic-svg/atomic-svg.html.twig
@@ -1,8 +1,10 @@
 {% import 'elementor/macros' as m %}
-{%- set classes = settings.classes | merge([base_styles.base]) | join(' ') -%}
-{%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
-	<{{ settings.link.tag | default('a') | e('html_tag') }}{{ m.render_link_attributes(settings.link) }} class="{{ classes }}" data-interaction-id="{{ interaction_id }}"
-		{{- m.render_custom_attributes(settings) }}>{{ settings.svg.html | raw }}</{{ settings.link.tag | default('a') | e('html_tag') }}>
+{%- set has_link = settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
+{%- set effective_tag = has_link ? (settings.link.tag | default('a')) : 'div' -%}
+{%- set classes = settings.classes | merge([base_styles.base, m.default_tag_class(effective_tag)]) | join(' ') -%}
+{%- if has_link -%}
+	<{{ effective_tag | e('html_tag') }}{{ m.render_link_attributes(settings.link) }} class="{{ classes }}" data-interaction-id="{{ interaction_id }}"
+		{{- m.render_custom_attributes(settings) }}>{{ settings.svg.html | raw }}</{{ effective_tag | e('html_tag') }}>
 {%- else -%}
 	<div class="{{ classes }}" data-interaction-id="{{ interaction_id }}"
 		{{- m.render_custom_attributes(settings) }}>{{ settings.svg.html | raw }}</div>

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tab-content/atomic-tab-content.html.twig
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tab-content/atomic-tab-content.html.twig
@@ -1,4 +1,4 @@
-{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base, 'e-default-div'] | merge(settings.classes | default([])) | join(' ') %}
 <div class="{{ classes }} {{ editor_classes | default('') }}{{ is_active ? ' e--selected' : '' }}"
     data-id="{{ id }}"
     data-element_type="{{ type }}"

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tab/atomic-tab.html.twig
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tab/atomic-tab.html.twig
@@ -1,4 +1,4 @@
-{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base, 'e-default-button'] | merge(settings.classes | default([])) | join(' ') %}
 <button class="{{ classes }} {{ editor_classes | default('') }}{{ is_active ? ' e--selected' : '' }}"
     data-id="{{ id }}"
     data-element_type="{{ type }}"

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-content-area/atomic-tabs-content-area.html.twig
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-content-area/atomic-tabs-content-area.html.twig
@@ -1,4 +1,4 @@
-{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base, 'e-default-div'] | merge(settings.classes | default([])) | join(' ') %}
 <div class="{{ classes }} {{ editor_classes | default('') }}"
     data-id="{{ id }}"
     data-element_type="{{ type }}"

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-menu/atomic-tabs-menu.html.twig
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs-menu/atomic-tabs-menu.html.twig
@@ -1,4 +1,4 @@
-{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base, 'e-default-div'] | merge(settings.classes | default([])) | join(' ') %}
 <div class="{{ classes }} {{ editor_classes | default('') }}"
     data-id="{{ id }}"
     data-element_type="{{ type }}"

--- a/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs/atomic-tabs.html.twig
+++ b/modules/atomic-widgets/elements/atomic-tabs/atomic-tabs/atomic-tabs.html.twig
@@ -3,7 +3,7 @@
 {% set e_settings = {
     'default-active-tab': default_active_tab_id,
 } %}
-{% set classes = ['e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | join(' ') %}
+{% set classes = ['e-con', 'e-atomic-element', base_styles.base, 'e-default-div'] | merge(settings.classes | default([])) | join(' ') %}
 <div class="{{ classes }} {{ editor_classes | default('') }}"
     data-id="{{ id }}"
     data-element_type="{{ type }}"

--- a/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.html.twig
+++ b/modules/atomic-widgets/elements/atomic-youtube/atomic-youtube.html.twig
@@ -1,5 +1,5 @@
 {% set id_attribute = settings._cssid is not empty ? 'id=' ~ settings._cssid | e('html_attr') : '' %}
-{% set classes = settings.classes | merge( [ base_styles.base ] ) | join(' ') %}
+{% set classes = settings.classes | merge( [ base_styles.base, 'e-default-div' ] ) | join(' ') %}
 {% set data_settings = {
 	'source': settings.source,
 	'autoplay': settings.autoplay,

--- a/modules/atomic-widgets/elements/base/_macros.html.twig
+++ b/modules/atomic-widgets/elements/base/_macros.html.twig
@@ -1,5 +1,10 @@
-{%- macro render_base_classes(id, base_styles, settings, extra_classes) -%}
-{{- ['elementor-element', 'elementor-element-' ~ id, 'e-con', 'e-atomic-element', base_styles.base] | merge(settings.classes | default([])) | merge(extra_classes | default([])) | join(' ') -}}
+{%- macro default_tag_class(tag) -%}
+{%- if tag %}e-default-{{ tag | e('html_attr') }}{% endif -%}
+{%- endmacro -%}
+
+{%- macro render_base_classes(id, base_styles, settings, extra_classes, tag) -%}
+{%- import _self as self -%}
+{{- ['elementor-element', 'elementor-element-' ~ id, 'e-con', 'e-atomic-element', base_styles.base, self.default_tag_class(tag)] | merge(settings.classes | default([])) | merge(extra_classes | default([])) | join(' ') -}}
 {%- endmacro -%}
 
 {%- macro render_data_attributes(id, type, interaction_id) -%}

--- a/modules/atomic-widgets/elements/div-block/div-block.html.twig
+++ b/modules/atomic-widgets/elements/div-block/div-block.html.twig
@@ -3,7 +3,7 @@
 {%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
     {%- set tag = settings.link.tag | default('a') -%}
 {%- endif -%}
-<{{ tag }} class="{{ m.render_base_classes(id, base_styles, settings) }} {{ editor_classes | default('') }}"
+<{{ tag }} class="{{ m.render_base_classes(id, base_styles, settings, [], tag) }} {{ editor_classes | default('') }}"
     {{- ' ' }}{{ m.render_data_attributes(id, type, interaction_id) }}
     {{- m.render_link_attributes(settings.link | default(null)) }}
     {{- m.render_custom_attributes(settings, editor_attributes) }}>

--- a/modules/atomic-widgets/elements/flexbox/flexbox.html.twig
+++ b/modules/atomic-widgets/elements/flexbox/flexbox.html.twig
@@ -3,7 +3,7 @@
 {%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
     {%- set tag = settings.link.tag | default('a') -%}
 {%- endif -%}
-<{{ tag }} class="{{ m.render_base_classes(id, base_styles, settings) }} {{ editor_classes | default('') }}"
+<{{ tag }} class="{{ m.render_base_classes(id, base_styles, settings, [], tag) }} {{ editor_classes | default('') }}"
     {{- ' ' }}{{ m.render_data_attributes(id, type, interaction_id) }}
     {{- m.render_link_attributes(settings.link | default(null)) }}
     {{- m.render_custom_attributes(settings, editor_attributes) }}>

--- a/modules/atomic-widgets/elements/grid/grid.html.twig
+++ b/modules/atomic-widgets/elements/grid/grid.html.twig
@@ -3,7 +3,7 @@
 {%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
     {%- set tag = settings.link.tag | default('a') -%}
 {%- endif -%}
-<{{ tag }} class="{{ m.render_base_classes(id, base_styles, settings) }} {{ editor_classes | default('') }}"
+<{{ tag }} class="{{ m.render_base_classes(id, base_styles, settings, [], tag) }} {{ editor_classes | default('') }}"
     {{- ' ' }}{{ m.render_data_attributes(id, type, interaction_id) }}
     {{- m.render_link_attributes(settings.link | default(null)) }}
     {{- m.render_custom_attributes(settings, editor_attributes) }}>

--- a/modules/atomic-widgets/styles/atomic-styles-manager.php
+++ b/modules/atomic-widgets/styles/atomic-styles-manager.php
@@ -179,12 +179,22 @@ class Atomic_Styles_Manager {
 			Collection::make( $style['variants'] )->each( function( $variant ) use ( &$group, $style ) {
 				$breakpoint = $variant['meta']['breakpoint'] ?? self::DEFAULT_BREAKPOINT;
 
+				if ( empty( $breakpoint ) ) {
+					$breakpoint = self::DEFAULT_BREAKPOINT;
+				}
+
 				if ( ! isset( $group[ $breakpoint ][ $style['id'] ] ) ) {
-					$group[ $breakpoint ][ $style['id'] ] = [
+					$style_for_breakpoint = [
 						'id' => $style['id'],
 						'type' => $style['type'],
 						'variants' => [],
 					];
+
+					if ( isset( $style['cssName'] ) ) {
+						$style_for_breakpoint['cssName'] = $style['cssName'];
+					}
+
+					$group[ $breakpoint ][ $style['id'] ] = $style_for_breakpoint;
 				}
 
 				$group[ $breakpoint ][ $style['id'] ]['variants'][] = $variant;

--- a/modules/default-styles/atomic-default-styles.php
+++ b/modules/default-styles/atomic-default-styles.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+use Elementor\Modules\AtomicWidgets\Styles\Atomic_Styles_Manager;
+use Elementor\Plugin;
+
+class Atomic_Default_Styles {
+	const STYLES_KEY = 'default';
+
+	public function register_hooks() {
+		add_action(
+			'elementor/atomic-widgets/styles/register',
+			fn( Atomic_Styles_Manager $styles_manager ) => $this->register_styles( $styles_manager ),
+			15,
+			1
+		);
+
+		add_action(
+			'elementor/default_styles/update',
+			fn() => $this->invalidate_cache(),
+			10,
+			0
+		);
+
+		add_action(
+			'elementor/core/files/clear_cache',
+			fn() => $this->invalidate_cache(),
+		);
+
+		add_action(
+			'deleted_post',
+			fn( $post_id ) => $this->on_kit_delete( $post_id ),
+		);
+	}
+
+	private function register_styles( Atomic_Styles_Manager $styles_manager ) {
+		$styles_manager->register(
+			[ self::STYLES_KEY ],
+			fn () => $this->get_all_default_styles(),
+		);
+	}
+
+	private function get_all_default_styles(): array {
+		$items = Default_Styles_Repository::make()->all();
+
+		return array_values( $items );
+	}
+
+	private function invalidate_cache(): void {
+		do_action( 'elementor/atomic-widgets/styles/clear', [ self::STYLES_KEY ] );
+	}
+
+	private function on_kit_delete( $post_id ): void {
+		if ( ! Plugin::$instance->kits_manager->is_kit( $post_id ) ) {
+			return;
+		}
+
+		$this->invalidate_cache();
+	}
+}

--- a/modules/default-styles/concerns/has-kit-dependency.php
+++ b/modules/default-styles/concerns/has-kit-dependency.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles\Concerns;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+trait Has_Kit_Dependency {
+	private ?Kit $kit = null;
+
+	public function set_kit( Kit $kit ): self {
+		$this->kit = $kit;
+
+		return $this;
+	}
+
+	protected function get_kit(): ?Kit {
+		if ( ! $this->kit ) {
+			$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+		}
+
+		return $this->kit;
+	}
+}

--- a/modules/default-styles/concerns/has-preview-context.php
+++ b/modules/default-styles/concerns/has-preview-context.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles\Concerns;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+trait Has_Preview_Context {
+	private bool $is_preview = false;
+
+	public function set_preview( bool $is_preview = true ): self {
+		if ( $is_preview === $this->is_preview ) {
+			return $this;
+		}
+
+		$this->is_preview = $is_preview;
+		$this->on_preview_change();
+
+		return $this;
+	}
+
+	protected function is_preview(): bool {
+		return $this->is_preview;
+	}
+
+	protected function get_context_key( string $key ): string {
+		$map = $this->get_context_keys()[ $key ] ?? null;
+
+		if ( null === $map ) {
+			throw new \InvalidArgumentException( sprintf( 'Unknown context key: %s', esc_html( $key ) ) );
+		}
+
+		return $this->is_preview ? $map['preview'] : $map['frontend'];
+	}
+
+	protected function get_context_keys(): array {
+		if ( empty( $this->context_keys ) ) {
+			return [];
+		}
+
+		return $this->context_keys;
+	}
+
+	protected function on_preview_change(): void {
+	}
+}

--- a/modules/default-styles/default-style-post-type.php
+++ b/modules/default-styles/default-style-post-type.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Style_Post_Type {
+	const CPT = 'e_default_style';
+
+	public function register() {
+		add_action( 'init', [ $this, 'register_post_type' ] );
+	}
+
+	public function register_post_type() {
+		register_post_type( self::CPT, [
+			'label' => esc_html__( 'Default Style', 'elementor' ),
+			'labels' => [
+				'name' => esc_html__( 'Default Styles', 'elementor' ),
+				'singular_name' => esc_html__( 'Default Style', 'elementor' ),
+			],
+			'public' => false,
+			'show_ui' => false,
+			'supports' => [ 'title' ],
+		] );
+	}
+
+	public static function ensure_registered(): void {
+		if ( ! post_type_exists( self::CPT ) ) {
+			( new self() )->register_post_type();
+		}
+	}
+}

--- a/modules/default-styles/default-style-post.php
+++ b/modules/default-styles/default-style-post.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\AtomicWidgets\PropTypeMigrations\Migrations_Orchestrator;
+use Elementor\Modules\DefaultStyles\Utils\Default_Style_Data_Normalizer;
+use Elementor\Plugin;
+use WP_Post;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Style_Post {
+	const META_KEY_VERSION = '_elementor_version';
+	const META_KEY_TAG = '_elementor_default_style_tag';
+	const META_KEY_DATA = '_elementor_default_style_data';
+
+	private WP_Post $post;
+
+	private function __construct( WP_Post $post ) {
+		$this->post = $post;
+	}
+
+	public static function from_post( WP_Post $post ): self {
+		return new static( $post );
+	}
+
+	public static function from_post_id( int $post_id ): ?self {
+		$post = get_post( $post_id );
+
+		if ( ! $post || Default_Style_Post_Type::CPT !== $post->post_type ) {
+			return null;
+		}
+
+		return new static( $post );
+	}
+
+	public static function find_by_tag( string $tag, ?Kit $kit = null ): ?self {
+		$kit = $kit ?? Plugin::$instance->kits_manager->get_active_kit();
+
+		if ( ! $kit ) {
+			return null;
+		}
+
+		$post_id = Default_Styles_Tag_Post_IDs::make( $kit )->get_post_id( $tag );
+
+		if ( ! $post_id ) {
+			return null;
+		}
+
+		return self::from_post_id( $post_id );
+	}
+
+	public function get_post_id(): int {
+		return $this->post->ID;
+	}
+
+	public function get_tag(): string {
+		$tag = get_post_meta( $this->post->ID, self::META_KEY_TAG, true );
+
+		return is_string( $tag ) ? $tag : '';
+	}
+
+	public function get_data( bool $skip_migration = false ): array {
+		$data = get_post_meta( $this->post->ID, self::META_KEY_DATA, true );
+		$data = is_array( $data ) ? $data : [];
+
+		if ( ! empty( $data ) && ! $skip_migration ) {
+			$this->migrate_data( $data );
+		}
+
+		return $data;
+	}
+
+	private function migrate_data( array &$data ): void {
+		$post_id = $this->post->ID;
+		$meta_key = self::META_KEY_DATA;
+
+		Migrations_Orchestrator::make()->migrate(
+			$data,
+			$post_id,
+			$meta_key,
+			function ( $migrated ) use ( $post_id, $meta_key ) {
+				update_post_meta( $post_id, $meta_key, $migrated );
+				clean_post_cache( $post_id );
+			}
+		);
+	}
+
+	public function to_array( bool $skip_migration = false ): array {
+		$data = $this->get_data( $skip_migration );
+		$tag = $this->get_tag();
+
+		return Default_Style_Data_Normalizer::normalize_style( $tag, $data );
+	}
+
+	public function update_data( array $data, string $version = ELEMENTOR_VERSION ): bool {
+		$normalized_data = Default_Style_Data_Normalizer::normalize_style_fields( $data );
+
+		$result = update_post_meta( $this->post->ID, self::META_KEY_DATA, $normalized_data );
+
+		update_post_meta( $this->post->ID, self::META_KEY_VERSION, $version );
+
+		return false !== $result;
+	}
+
+	public static function create( string $tag, array $data, ?Kit $kit = null, string $version = ELEMENTOR_VERSION ): ?self {
+		$post_id = wp_insert_post( [
+			'post_type' => Default_Style_Post_Type::CPT,
+			'post_title' => $tag,
+			'post_status' => 'publish',
+		] );
+
+		if ( is_wp_error( $post_id ) || ! $post_id ) {
+			return null;
+		}
+
+		$normalized_data = Default_Style_Data_Normalizer::normalize_style_fields( $data );
+
+		update_post_meta( $post_id, self::META_KEY_TAG, $tag );
+		update_post_meta( $post_id, self::META_KEY_DATA, $normalized_data );
+		update_post_meta( $post_id, self::META_KEY_VERSION, $version );
+
+		$kit = $kit ?? Plugin::$instance->kits_manager->get_active_kit();
+
+		if ( $kit ) {
+			Default_Styles_Tag_Post_IDs::make( $kit )->set( $tag, (int) $post_id );
+		}
+
+		return self::from_post_id( $post_id );
+	}
+
+	public function delete(): bool {
+		$result = wp_delete_post( $this->post->ID, true );
+
+		return false !== $result;
+	}
+
+	public static function clone_to_other_kit( string $tag, Kit $source_kit, Kit $target_kit ): ?self {
+		$source_post = self::find_by_tag( $tag, $source_kit );
+
+		if ( ! $source_post ) {
+			return null;
+		}
+
+		$new_post_id = wp_insert_post( [
+			'post_type' => Default_Style_Post_Type::CPT,
+			'post_title' => $tag,
+			'post_status' => 'publish',
+		] );
+
+		if ( is_wp_error( $new_post_id ) || ! $new_post_id ) {
+			return null;
+		}
+
+		update_post_meta( $new_post_id, self::META_KEY_TAG, $tag );
+		update_post_meta( $new_post_id, self::META_KEY_VERSION, get_post_meta( $source_post->get_post_id(), self::META_KEY_VERSION, true ) );
+
+		$source_data = $source_post->get_data();
+
+		if ( ! empty( $source_data ) ) {
+			update_post_meta( $new_post_id, self::META_KEY_DATA, $source_data );
+		}
+
+		Default_Styles_Tag_Post_IDs::make( $target_kit )->set( $tag, (int) $new_post_id );
+
+		return self::from_post_id( $new_post_id );
+	}
+}

--- a/modules/default-styles/default-styles-repository.php
+++ b/modules/default-styles/default-styles-repository.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\DefaultStyles\Concerns\Has_Kit_Dependency;
+use Elementor\Modules\DefaultStyles\Utils\Default_Style_Data_Normalizer;
+use Elementor\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Styles_Repository {
+	use Has_Kit_Dependency;
+
+	private ?array $cache = null;
+
+	public function __construct( ?Kit $kit = null ) {
+		if ( null !== $kit ) {
+			$this->set_kit( $kit );
+		}
+	}
+
+	public static function make( ?Kit $kit = null ): self {
+		return new self( $kit );
+	}
+
+	public function all( bool $force = false ): array {
+		if ( ! $force && null !== $this->cache ) {
+			return $this->cache;
+		}
+
+		$items = [];
+		$tag_post_ids = Default_Styles_Tag_Post_IDs::make( $this->get_kit() )->get_all();
+
+		foreach ( $tag_post_ids as $tag => $post_id ) {
+			$post = Default_Style_Post::from_post_id( $post_id );
+
+			if ( $post ) {
+				$items[ $tag ] = $post->to_array();
+			}
+		}
+
+		$this->cache = $items;
+
+		return $items;
+	}
+
+	public function get( string $tag ): ?array {
+		$post = Default_Style_Post::find_by_tag( $tag, $this->get_kit() );
+
+		return $post ? $post->to_array() : null;
+	}
+
+	public function put( string $tag, array $data ): void {
+		if ( ! self::is_allowed_tag( $tag ) ) {
+			return;
+		}
+
+		$post = Default_Style_Post::find_by_tag( $tag, $this->get_kit() );
+		$normalized = Default_Style_Data_Normalizer::normalize_style_fields( $data );
+
+		if ( $post ) {
+			$post->update_data( $normalized );
+			clean_post_cache( $post->get_post_id() );
+		} else {
+			$created = Default_Style_Post::create( $tag, [], $this->get_kit() );
+
+			if ( $created ) {
+				$created->update_data( $normalized );
+				clean_post_cache( $created->get_post_id() );
+			}
+		}
+
+		$this->cache = null;
+
+		do_action( 'elementor/default_styles/update', [ 'tag' => $tag ] );
+	}
+
+	public function delete( string $tag ): void {
+		$post = Default_Style_Post::find_by_tag( $tag, $this->get_kit() );
+
+		if ( ! $post ) {
+			return;
+		}
+
+		Default_Styles_Tag_Post_IDs::make( $this->get_kit() )->remove_tag( $tag );
+		$post->delete();
+
+		$this->cache = null;
+
+		do_action( 'elementor/default_styles/update', [ 'tag' => $tag, 'deleted' => true ] );
+	}
+
+	public static function is_allowed_tag( string $tag ): bool {
+		return in_array( $tag, Utils::ALLOWED_HTML_WRAPPER_TAGS, true );
+	}
+}

--- a/modules/default-styles/default-styles-rest-api.php
+++ b/modules/default-styles/default-styles-rest-api.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Core\Utils\Api\Error_Builder;
+use Elementor\Core\Utils\Api\Response_Builder;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Styles_REST_API {
+	const API_NAMESPACE = 'elementor/v1';
+	const API_BASE = 'default-styles';
+
+	private ?Default_Styles_Repository $repository = null;
+	private ?Kit $kit = null;
+
+	public function register_hooks() {
+		add_action( 'rest_api_init', fn() => $this->register_routes() );
+	}
+
+	private function get_kit(): ?Kit {
+		if ( ! $this->kit ) {
+			$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+		}
+
+		return $this->kit;
+	}
+
+	private function get_repository(): Default_Styles_Repository {
+		if ( ! $this->repository ) {
+			$this->repository = new Default_Styles_Repository( $this->get_kit() );
+		}
+
+		return $this->repository;
+	}
+
+	private function register_routes() {
+		$this->repository = null;
+		$this->kit = null;
+
+		register_rest_route( self::API_NAMESPACE, '/' . self::API_BASE, [
+			[
+				'methods' => 'GET',
+				'callback' => fn( $request ) => $this->route_wrapper( fn() => $this->all( $request ) ),
+				'permission_callback' => fn() => current_user_can( 'manage_options' ),
+			],
+		] );
+
+		register_rest_route( self::API_NAMESPACE, '/' . self::API_BASE . '/(?P<tag>[a-z0-9]+)', [
+			[
+				'methods' => 'GET',
+				'callback' => fn( $request ) => $this->route_wrapper( fn() => $this->get_one( $request ) ),
+				'permission_callback' => fn() => current_user_can( 'manage_options' ),
+				'args' => [
+					'tag' => [
+						'type' => 'string',
+						'required' => true,
+					],
+				],
+			],
+			[
+				'methods' => 'PUT',
+				'callback' => fn( $request ) => $this->route_wrapper( fn() => $this->put( $request ) ),
+				'permission_callback' => fn() => current_user_can( 'manage_options' ),
+				'args' => [
+					'tag' => [
+						'type' => 'string',
+						'required' => true,
+					],
+					'variants' => [
+						'type' => 'array',
+						'required' => true,
+					],
+					'type' => [
+						'type' => 'string',
+						'enum' => [ 'class' ],
+						'required' => false,
+					],
+				],
+			],
+			[
+				'methods' => 'DELETE',
+				'callback' => fn( $request ) => $this->route_wrapper( fn() => $this->delete( $request ) ),
+				'permission_callback' => fn() => current_user_can( 'manage_options' ),
+				'args' => [
+					'tag' => [
+						'type' => 'string',
+						'required' => true,
+					],
+				],
+			],
+		] );
+	}
+
+	private function all( \WP_REST_Request $request ) {
+		$items = $this->get_repository()->all();
+
+		return Response_Builder::make( (object) $items )->build();
+	}
+
+	private function get_one( \WP_REST_Request $request ) {
+		$tag = $request->get_param( 'tag' );
+
+		if ( ! Default_Styles_Repository::is_allowed_tag( $tag ) ) {
+			return Error_Builder::make( 'invalid_tag' )
+				->set_status( 400 )
+				->set_message( 'Invalid HTML tag.' )
+				->build();
+		}
+
+		$item = $this->get_repository()->get( $tag );
+
+		if ( ! $item ) {
+			return Error_Builder::make( 'not_found' )
+				->set_status( 404 )
+				->set_message( 'Default style not found.' )
+				->build();
+		}
+
+		return Response_Builder::make( $item )->build();
+	}
+
+	private function put( \WP_REST_Request $request ) {
+		$tag = $request->get_param( 'tag' );
+
+		if ( ! Default_Styles_Repository::is_allowed_tag( $tag ) ) {
+			return Error_Builder::make( 'invalid_tag' )
+				->set_status( 400 )
+				->set_message( 'Invalid HTML tag.' )
+				->build();
+		}
+
+		$this->get_repository()->put(
+			$tag,
+			[
+				'type' => 'class',
+				'variants' => $request->get_param( 'variants' ),
+			]
+		);
+
+		$item = $this->get_repository()->get( $tag );
+
+		return Response_Builder::make( $item )->build();
+	}
+
+	private function delete( \WP_REST_Request $request ) {
+		$tag = $request->get_param( 'tag' );
+
+		if ( ! Default_Styles_Repository::is_allowed_tag( $tag ) ) {
+			return Error_Builder::make( 'invalid_tag' )
+				->set_status( 400 )
+				->set_message( 'Invalid HTML tag.' )
+				->build();
+		}
+
+		$this->get_repository()->delete( $tag );
+
+		return Response_Builder::make( [ 'deleted' => true ] )->build();
+	}
+
+	private function route_wrapper( callable $callback ) {
+		try {
+			return $callback();
+		} catch ( \Throwable $e ) {
+			return Error_Builder::make( 'default_styles_error' )
+				->set_status( 500 )
+				->set_message( $e->getMessage() )
+				->build();
+		}
+	}
+}

--- a/modules/default-styles/default-styles-tag-post-ids.php
+++ b/modules/default-styles/default-styles-tag-post-ids.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\DefaultStyles\Concerns\Has_Kit_Dependency;
+use Elementor\Modules\GlobalClasses\Utils\Kit_Utils;
+use WP_Post;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Styles_Tag_Post_IDs {
+	use Has_Kit_Dependency;
+
+	const META_KEY = '_elementor_default_styles_post_ids';
+
+	private ?array $cache = null;
+
+	public static function make( ?Kit $kit = null ): self {
+		$instance = new self();
+
+		if ( null !== $kit ) {
+			$instance->set_kit( $kit );
+		}
+
+		return $instance;
+	}
+
+	public function register_hooks(): void {
+		add_action( 'deleted_post', [ self::class, 'on_deleted_post' ], 10, 2 );
+	}
+
+	public static function on_deleted_post( int $post_id, WP_Post $post ): void {
+		if ( Default_Style_Post_Type::CPT !== $post->post_type ) {
+			return;
+		}
+
+		foreach ( Kit_Utils::get_all_kit_documents() as $kit ) {
+			self::make( $kit )->remove_post_id( $post_id );
+		}
+	}
+
+	public function get_post_id( string $tag ): ?int {
+		$map = $this->read_map();
+
+		if ( ! isset( $map[ $tag ] ) ) {
+			return null;
+		}
+
+		$post_id = (int) $map[ $tag ];
+
+		if ( get_post( $post_id ) ) {
+			return $post_id;
+		}
+
+		$this->remove_post_id( $post_id );
+
+		return null;
+	}
+
+	public function get_all(): array {
+		$map = $this->read_map();
+		$resolved = [];
+
+		foreach ( $map as $tag => $post_id ) {
+			$post_id = (int) $post_id;
+
+			if ( get_post( $post_id ) ) {
+				$resolved[ $tag ] = $post_id;
+			} else {
+				$this->remove_post_id( $post_id );
+			}
+		}
+
+		return $resolved;
+	}
+
+	public function set( string $tag, int $post_id ): void {
+		$map = $this->read_map();
+
+		if ( $post_id <= 0 || '' === $tag ) {
+			return;
+		}
+
+		$map[ $tag ] = $post_id;
+		$this->write_map( $map );
+	}
+
+	public function remove_tag( string $tag ): void {
+		$map = $this->read_map();
+
+		if ( ! isset( $map[ $tag ] ) ) {
+			return;
+		}
+
+		unset( $map[ $tag ] );
+		$this->write_map( $map );
+	}
+
+	public function remove_post_id( int $post_id ): void {
+		$map = $this->read_map();
+		$filtered = array_filter( $map, fn( $id ) => (int) $id !== $post_id );
+
+		if ( count( $filtered ) === count( $map ) ) {
+			return;
+		}
+
+		$this->write_map( $filtered );
+	}
+
+	private function read_map(): array {
+		if ( null !== $this->cache ) {
+			return $this->cache;
+		}
+
+		$kit = $this->get_kit();
+
+		if ( ! $kit ) {
+			$this->cache = [];
+
+			return [];
+		}
+
+		$raw = $kit->get_meta( self::META_KEY );
+		$this->cache = is_array( $raw ) ? $raw : [];
+
+		return $this->cache;
+	}
+
+	private function write_map( array $map ): bool {
+		$kit = $this->get_kit();
+
+		if ( ! $kit ) {
+			return false;
+		}
+
+		$result = $kit->update_meta( self::META_KEY, $map );
+		$this->cache = $map;
+
+		return false !== $result;
+	}
+}

--- a/modules/default-styles/module.php
+++ b/modules/default-styles/module.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+use Elementor\Core\Base\Module as BaseModule;
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Module extends BaseModule {
+	const EXPERIMENT_NAME = 'e_default_styles';
+
+	public function get_name() {
+		return 'default-styles';
+	}
+
+	public static function get_experimental_data() {
+		return [
+			'name' => self::EXPERIMENT_NAME,
+			'title' => esc_html__( 'HTML Tag Default Styles', 'elementor' ),
+			'description' => esc_html__( 'Enable site-wide default styles for HTML tags.', 'elementor' ),
+			'hidden' => true,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,
+		];
+	}
+
+	public function __construct() {
+		parent::__construct();
+
+		if ( ! Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_NAME ) ) {
+			return;
+		}
+
+		if ( ! Plugin::$instance->experiments->is_feature_active( Atomic_Widgets_Module::EXPERIMENT_NAME ) ) {
+			return;
+		}
+
+		( new Default_Style_Post_Type() )->register();
+		( new Default_Styles_Tag_Post_IDs() )->register_hooks();
+
+		( new Default_Styles_REST_API() )->register_hooks();
+		( new Atomic_Default_Styles() )->register_hooks();
+
+		add_filter(
+			'elementor/kit/meta_to_preserve_on_kit_import',
+			[ $this, 'add_meta_to_preserve_on_kit_import' ]
+		);
+
+		add_action( 'elementor/kit/after_new_kit_created', [ $this, 'clone_default_styles_for_new_kit' ], 10, 1 );
+	}
+
+	public function add_meta_to_preserve_on_kit_import( array $meta_keys ): array {
+		return array_merge( $meta_keys, [
+			Default_Styles_Tag_Post_IDs::META_KEY,
+		] );
+	}
+
+	public function clone_default_styles_for_new_kit( array $params ): void {
+		[ 'new_kit_id' => $new_kit_id, 'previous_kit_id' => $previous_kit_id ] = $params;
+
+		$previous_kit = Plugin::$instance->kits_manager->get_kit( $previous_kit_id );
+		$new_kit = Plugin::$instance->kits_manager->get_kit( $new_kit_id );
+
+		if ( ! $previous_kit || ! $new_kit ) {
+			return;
+		}
+
+		$tags = Default_Styles_Tag_Post_IDs::make( $previous_kit )->get_all();
+
+		foreach ( array_keys( $tags ) as $tag ) {
+			Default_Style_Post::clone_to_other_kit( $tag, $previous_kit, $new_kit );
+		}
+	}
+}

--- a/modules/default-styles/module.php
+++ b/modules/default-styles/module.php
@@ -14,6 +14,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Module extends BaseModule {
 	const EXPERIMENT_NAME = 'e_default_styles';
 
+	const PACKAGES = [
+		'editor-default-styles',
+	];
+
 	public function get_name() {
 		return 'default-styles';
 	}
@@ -42,6 +46,8 @@ class Module extends BaseModule {
 
 		( new Default_Style_Post_Type() )->register();
 		( new Default_Styles_Tag_Post_IDs() )->register_hooks();
+
+		add_filter( 'elementor/editor/v2/packages', fn( $packages ) => $this->add_packages( $packages ) );
 
 		( new Default_Styles_REST_API() )->register_hooks();
 		( new Atomic_Default_Styles() )->register_hooks();
@@ -75,5 +81,9 @@ class Module extends BaseModule {
 		foreach ( array_keys( $tags ) as $tag ) {
 			Default_Style_Post::clone_to_other_kit( $tag, $previous_kit, $new_kit );
 		}
+	}
+
+	private function add_packages( $packages ) {
+		return array_merge( $packages, self::PACKAGES );
 	}
 }

--- a/modules/default-styles/utils/default-style-data-normalizer.php
+++ b/modules/default-styles/utils/default-style-data-normalizer.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Style_Data_Normalizer {
+	const CSS_NAME_PREFIX = 'e-default-';
+
+	public static function normalize_style( string $tag, array $data ): array {
+		return array_merge(
+			[
+				'id' => $tag,
+				'label' => $tag,
+				'cssName' => self::CSS_NAME_PREFIX . $tag,
+			],
+			self::normalize_style_fields( $data )
+		);
+	}
+
+	public static function normalize_style_fields( array $item ): array {
+		return [
+			'type' => $item['type'] ?? 'class',
+			'variants' => $item['variants'] ?? [],
+		];
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3797,6 +3797,10 @@
       "resolved": "packages/packages/libs/editor-current-user",
       "link": true
     },
+    "node_modules/@elementor/editor-default-styles": {
+      "resolved": "packages/packages/core/editor-default-styles",
+      "link": true
+    },
     "node_modules/@elementor/editor-design-system": {
       "resolved": "packages/packages/core/editor-design-system",
       "link": true
@@ -7924,9 +7928,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7941,9 +7942,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7958,9 +7956,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7975,9 +7970,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7992,9 +7984,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8009,9 +7998,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8026,9 +8012,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8043,9 +8026,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8250,9 +8230,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8270,9 +8247,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8290,9 +8264,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8310,9 +8281,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8330,9 +8298,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8350,9 +8315,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8370,9 +8332,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8390,9 +8349,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8677,9 +8633,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8697,9 +8650,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8717,9 +8667,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8737,9 +8684,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8757,9 +8701,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8777,9 +8718,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8797,9 +8735,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8817,9 +8752,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9033,9 +8965,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9057,9 +8986,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9081,9 +9007,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9105,9 +9028,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9129,9 +9049,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9153,9 +9070,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9923,9 +9837,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9943,9 +9854,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9963,9 +9871,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9983,9 +9888,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10003,9 +9905,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10023,9 +9922,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10234,9 +10130,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10251,9 +10144,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10268,9 +10158,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10285,9 +10172,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10302,9 +10186,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10319,9 +10200,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10336,9 +10214,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10353,9 +10228,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10370,9 +10242,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10387,9 +10256,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10404,9 +10270,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10421,9 +10284,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10438,9 +10298,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11331,9 +11188,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -11351,9 +11205,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -11371,9 +11222,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -11391,9 +11239,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -13858,9 +13703,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13875,9 +13717,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13892,9 +13731,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13909,9 +13745,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13926,9 +13759,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13943,9 +13773,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13960,9 +13787,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13977,9 +13801,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13994,9 +13815,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14011,9 +13829,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14319,9 +14134,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14339,9 +14151,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14359,9 +14168,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14379,9 +14185,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21237,9 +21040,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -21253,9 +21053,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -21269,9 +21066,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -21285,9 +21079,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -21301,9 +21092,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -21317,9 +21105,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -21396,9 +21181,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -21412,9 +21194,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -21428,9 +21207,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -21444,9 +21220,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -21460,9 +21233,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -21476,9 +21246,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -31574,9 +31341,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31598,9 +31362,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31622,9 +31383,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31646,9 +31404,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -42401,6 +42156,41 @@
       },
       "devDependencies": {
         "tsup": "^8.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      }
+    },
+    "packages/packages/core/editor-default-styles": {
+      "name": "@elementor/editor-default-styles",
+      "version": "4.3.0",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@elementor/editor": "4.3.0",
+        "@elementor/editor-app-bar": "4.3.0",
+        "@elementor/editor-controls": "4.3.0",
+        "@elementor/editor-documents": "4.3.0",
+        "@elementor/editor-editing-panel": "4.3.0",
+        "@elementor/editor-elements": "4.3.0",
+        "@elementor/editor-panels": "4.3.0",
+        "@elementor/editor-props": "4.3.0",
+        "@elementor/editor-responsive": "4.3.0",
+        "@elementor/editor-styles": "4.3.0",
+        "@elementor/editor-styles-repository": "4.3.0",
+        "@elementor/editor-ui": "4.3.0",
+        "@elementor/editor-v1-adapters": "4.3.0",
+        "@elementor/http-client": "4.3.0",
+        "@elementor/icons": "~1.75.1",
+        "@elementor/menus": "4.3.0",
+        "@elementor/session": "4.3.0",
+        "@elementor/store": "4.3.0",
+        "@elementor/ui": "1.37.5",
+        "@elementor/utils": "4.3.0",
+        "@wordpress/i18n": "^5.13.0"
+      },
+      "devDependencies": {
+        "tsup": "^8.3.5"
       },
       "peerDependencies": {
         "react": "^18.3.1",

--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -1,8 +1,8 @@
 import { injectIntoLogic } from '@elementor/editor';
 import {
-	type CreateTemplatedElementTypeOptions,
-	registerElementType,
-	settingsTransformersRegistry,
+  type CreateTemplatedElementTypeOptions,
+  registerElementType,
+  settingsTransformersRegistry,
 } from '@elementor/editor-canvas';
 import { getV1CurrentDocument } from '@elementor/editor-documents';
 import { registerEditingPanelReplacement } from '@elementor/editor-editing-panel';
@@ -32,62 +32,71 @@ import { initLoadComponentDataAfterInstanceAdded } from './sync/load-component-d
 import { type ExtendedWindow } from './types';
 
 export function init() {
-	registerSlice( slice );
+  registerSlice( slice );
 
-	registerElementType( COMPONENT_WIDGET_TYPE, ( options: CreateTemplatedElementTypeOptions ) =>
-		createComponentType( {
-			...options,
-			showLockedByModal: openEditModeDialog,
-			showDetachConfirmDialog: openDetachConfirmDialog,
-		} )
-	);
+  registerElementType( COMPONENT_WIDGET_TYPE, ( options: CreateTemplatedElementTypeOptions ) =>
+    createComponentType( {
+      ...options,
+      showLockedByModal: openEditModeDialog,
+      showDetachConfirmDialog: openDetachConfirmDialog,
+    } )
+  );
 
-	( window as unknown as ExtendedWindow ).elementorCommon.__beforeSave = beforeSave;
+  const extendedWindow = window as unknown as ExtendedWindow;
+  const previousBeforeSave = extendedWindow.elementorCommon.__beforeSave as
+    | ( ( options: Parameters< typeof beforeSave >[ 0 ] ) => unknown )
+    | undefined;
+  extendedWindow.elementorCommon.__beforeSave = async (
+    options: Parameters< typeof beforeSave >[ 0 ]
+  ) => {
+    await previousBeforeSave?.( options );
+    await beforeSave( options );
+  };
 
-	injectTab( {
-		id: 'components',
-		label: __( 'Components', 'elementor' ),
-		component: Components,
-		position: 1,
-	} );
+  injectTab( {
+    id: 'components',
+    label: __( 'Components', 'elementor' ),
+    component: Components,
+    position: 1,
+  } );
 
-	injectIntoLogic( {
-		id: 'components-populate-store',
-		component: PopulateStore,
-	} );
+  injectIntoLogic( {
+    id: 'components-populate-store',
+    component: PopulateStore,
+  } );
 
-	registerDataHook( 'after', 'editor/documents/attach-preview', () => {
-		const { id, config } = getV1CurrentDocument() ?? {};
+  registerDataHook( 'after', 'editor/documents/attach-preview', () => {
+    const { id, config } = getV1CurrentDocument() ?? {};
 
-		if ( ! id ) {
-			return;
-		}
+    if ( ! id ) {
+      return;
+    }
 
-		removeComponentStyles( id );
+    removeComponentStyles( id );
 
-		void loadComponentsAssets( ( config?.elements as V1ElementData[] ) ?? [] );
-	} );
+    void loadComponentsAssets( ( config?.elements as V1ElementData[] ) ?? [] );
+  } );
 
-	embeddedDocumentsManager.onDocumentLoad( ( _documentId, data ) => {
-		void loadComponentsAssets( data.elements ?? [] );
-	} );
+  embeddedDocumentsManager.onDocumentLoad( ( _documentId, data ) => {
+    void loadComponentsAssets( data.elements ?? [] );
+  } );
 
-	injectIntoLogic( {
-		id: 'templates',
-		component: LoadTemplateComponents,
-	} );
+  injectIntoLogic( {
+    id: 'templates',
+    component: LoadTemplateComponents,
+  } );
 
-	registerEditingPanelReplacement( {
-		id: 'component-instance-edit-panel',
-		condition: ( _, elementType ) => elementType.key === 'e-component',
-		component: InstanceEditingPanel,
-	} );
+  registerEditingPanelReplacement( {
+    id: 'component-instance-edit-panel',
+    condition: ( _, elementType ) => elementType.key === 'e-component',
+    component: InstanceEditingPanel,
+  } );
 
-	settingsTransformersRegistry.register( 'component-instance', componentInstanceTransformer );
-	settingsTransformersRegistry.register( 'overridable', componentOverridableTransformer );
-	settingsTransformersRegistry.register( 'override', componentOverrideTransformer );
+  settingsTransformersRegistry.register( 'component-instance', componentInstanceTransformer );
+  settingsTransformersRegistry.register( 'overridable', componentOverridableTransformer );
+  settingsTransformersRegistry.register( 'override', componentOverrideTransformer );
 
-	initCircularNestingPrevention();
+  initCircularNestingPrevention();
 
-	initLoadComponentDataAfterInstanceAdded();
+  initLoadComponentDataAfterInstanceAdded();
 }

--- a/packages/packages/core/editor-default-styles/package.json
+++ b/packages/packages/core/editor-default-styles/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@elementor/editor-default-styles",
+  "version": "4.3.0",
+  "private": false,
+  "author": "Elementor Team",
+  "homepage": "https://elementor.com/",
+  "license": "GPL-3.0-or-later",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elementor/elementor.git",
+    "directory": "packages/core/editor-default-styles"
+  },
+  "bugs": {
+    "url": "https://github.com/elementor/elementor/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    "CHANGELOG.md",
+    "/dist",
+    "/src",
+    "!**/__tests__"
+  ],
+  "scripts": {
+    "build": "tsup --config=../../tsup.build.ts",
+    "dev": "tsup --config=../../tsup.dev.ts"
+  },
+  "dependencies": {
+    "@elementor/editor": "4.3.0",
+    "@elementor/editor-app-bar": "4.3.0",
+    "@elementor/editor-controls": "4.3.0",
+    "@elementor/editor-documents": "4.3.0",
+    "@elementor/editor-editing-panel": "4.3.0",
+    "@elementor/editor-elements": "4.3.0",
+    "@elementor/editor-panels": "4.3.0",
+    "@elementor/editor-props": "4.3.0",
+    "@elementor/editor-responsive": "4.3.0",
+    "@elementor/editor-styles": "4.3.0",
+    "@elementor/editor-styles-repository": "4.3.0",
+    "@elementor/editor-ui": "4.3.0",
+    "@elementor/editor-v1-adapters": "4.3.0",
+    "@elementor/http-client": "4.3.0",
+    "@elementor/icons": "~1.75.1",
+    "@elementor/menus": "4.3.0",
+    "@elementor/query": "4.3.0",
+    "@elementor/session": "4.3.0",
+    "@elementor/store": "4.3.0",
+    "@elementor/ui": "1.37.5",
+    "@elementor/utils": "4.3.0",
+    "@wordpress/i18n": "^5.13.0"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5"
+  }
+}

--- a/packages/packages/core/editor-default-styles/src/__tests__/default-styles-styles-provider.test.ts
+++ b/packages/packages/core/editor-default-styles/src/__tests__/default-styles-styles-provider.test.ts
@@ -1,0 +1,35 @@
+import { stylesRepository } from '@elementor/editor-styles-repository';
+import { __createStore as createStore, __registerSlice as registerSlice } from '@elementor/store';
+
+import {
+  DEFAULT_STYLES_PROVIDER_KEY,
+  defaultStylesStylesProvider,
+} from '../default-styles-styles-provider';
+import { slice } from '../store';
+
+describe( 'defaultStylesStylesProvider', () => {
+  beforeEach( () => {
+    registerSlice( slice );
+    createStore();
+    stylesRepository.register( defaultStylesStylesProvider );
+  } );
+  it( 'registers with priority between base and global', () => {
+    const provider = stylesRepository
+      .getProviders()
+      .find( ( entry ) => entry.getKey() === DEFAULT_STYLES_PROVIDER_KEY );
+
+    expect( provider ).toBeDefined();
+    expect( provider?.priority ).toBe( 15 );
+  } );
+
+  it( 'returns class style definitions with prefixed cssName from all()', () => {
+    const all = defaultStylesStylesProvider.actions.all();
+
+    expect( all.length ).toBeGreaterThan( 0 );
+    expect( all[ 0 ].type ).toBe( 'class' );
+    expect( all[ 0 ].id ).toBeTruthy();
+    expect( defaultStylesStylesProvider.actions.resolveCssName( all[ 0 ].id ) ).toBe(
+      `e-default-${ all[ 0 ].id }`
+    );
+  } );
+} );

--- a/packages/packages/core/editor-default-styles/src/__tests__/save-default-styles.test.ts
+++ b/packages/packages/core/editor-default-styles/src/__tests__/save-default-styles.test.ts
@@ -1,0 +1,80 @@
+import { createMockStyleDefinitionWithVariants } from 'test-utils';
+import {
+  __createStore as createStore,
+  __dispatch as dispatch,
+  __getState as getState,
+  __registerSlice as registerSlice,
+} from '@elementor/store';
+
+import { apiClient } from '../api';
+import { saveDefaultStyles } from '../save-default-styles';
+import { selectInitialData, selectIsDirty, slice } from '../store';
+
+jest.mock( '../api' );
+
+describe( 'saveDefaultStyles', () => {
+  beforeEach( () => {
+    registerSlice( slice );
+    createStore();
+
+    jest.mocked( apiClient.put ).mockResolvedValue( {} as never );
+    jest.mocked( apiClient.delete ).mockResolvedValue( {} as never );
+  } );
+
+  it( 'should persist changed tags and commit the store', async () => {
+    const style = createMockStyleDefinitionWithVariants( {
+      id: 'h2',
+      variants: [
+        {
+          meta: { breakpoint: 'desktop', state: null },
+          props: { 'font-size': '12px' },
+          custom_css: null,
+        },
+      ],
+    } );
+
+    dispatch(
+      slice.actions.load( {
+        data: {},
+      } )
+    );
+
+    dispatch( slice.actions.update( { style } ) );
+
+    await saveDefaultStyles();
+
+    expect( apiClient.put ).toHaveBeenCalledWith( 'h2', style.variants );
+    expect( selectIsDirty( getState() ) ).toBe( false );
+    expect( selectInitialData( getState() ) ).toEqual( { h2: style } );
+  } );
+
+  it( 'should delete tags removed from the store', async () => {
+    const style = createMockStyleDefinitionWithVariants( { id: 'h2' } );
+
+    dispatch(
+      slice.actions.load( {
+        data: { h2: style },
+      } )
+    );
+
+    dispatch( slice.actions.deleteTag( 'h2' ) );
+
+    await saveDefaultStyles();
+
+    expect( apiClient.delete ).toHaveBeenCalledWith( 'h2' );
+    expect( selectIsDirty( getState() ) ).toBe( false );
+  } );
+
+  it( 'should not call the API when the store is clean', async () => {
+    dispatch(
+      slice.actions.load( {
+        data: {},
+      } )
+    );
+
+    await saveDefaultStyles();
+
+    expect( apiClient.put ).not.toHaveBeenCalled();
+    expect( apiClient.delete ).not.toHaveBeenCalled();
+  } );
+} );

--- a/packages/packages/core/editor-default-styles/src/allowed-tags.ts
+++ b/packages/packages/core/editor-default-styles/src/allowed-tags.ts
@@ -1,0 +1,23 @@
+export const ALLOWED_HTML_WRAPPER_TAGS = [
+	'a',
+	'article',
+	'aside',
+	'button',
+	'form',
+	'div',
+	'footer',
+	'h1',
+	'h2',
+	'h3',
+	'h4',
+	'h5',
+	'h6',
+	'header',
+	'main',
+	'nav',
+	'p',
+	'section',
+	'span',
+] as const;
+
+export type AllowedHtmlTag = ( typeof ALLOWED_HTML_WRAPPER_TAGS )[ number ];

--- a/packages/packages/core/editor-default-styles/src/api.ts
+++ b/packages/packages/core/editor-default-styles/src/api.ts
@@ -1,0 +1,24 @@
+import { type StyleDefinition, type StyleDefinitionID } from '@elementor/editor-styles';
+import { type HttpResponse, httpService } from '@elementor/http-client';
+
+import { type AllowedHtmlTag } from './allowed-tags';
+
+const RESOURCE_URL = '/default-styles';
+const BASE_URL = 'elementor/v1';
+
+export type DefaultStylesMap = Record< StyleDefinitionID, StyleDefinition >;
+
+type DefaultStylesHttpResponse = HttpResponse< DefaultStylesMap >;
+
+export const apiClient = {
+  all: () => httpService().get< DefaultStylesHttpResponse >( `${ BASE_URL }${ RESOURCE_URL }` ),
+
+  put: ( tag: AllowedHtmlTag, variants: StyleDefinition[ 'variants' ] ) =>
+    httpService().put( `${ BASE_URL }${ RESOURCE_URL }/${ tag }`, {
+      type: 'class',
+      variants,
+    } ),
+
+  delete: ( tag: AllowedHtmlTag ) =>
+    httpService().delete( `${ BASE_URL }${ RESOURCE_URL }/${ tag }` ),
+};

--- a/packages/packages/core/editor-default-styles/src/components/default-styles-panel-content.tsx
+++ b/packages/packages/core/editor-default-styles/src/components/default-styles-panel-content.tsx
@@ -1,0 +1,205 @@
+import * as React from 'react';
+import { useState } from 'react';
+import {
+  ControlActionsProvider,
+  ControlReplacementsProvider,
+  getControlReplacements,
+} from '@elementor/editor-controls';
+import {
+  ClassesPropProvider,
+  CreatableAutocomplete,
+  ElementProvider,
+  type Option,
+  SectionsList,
+  StyleInheritanceProvider,
+  StyleProvider,
+  StyleSections,
+} from '@elementor/editor-editing-panel';
+import { type Element, type ElementType } from '@elementor/editor-elements';
+import {
+  Panel,
+  PanelBody,
+  PanelFooter,
+  PanelHeader,
+  PanelHeaderTitle,
+} from '@elementor/editor-panels';
+import { useActiveBreakpoint } from '@elementor/editor-responsive';
+import { type StyleDefinitionID, type StyleDefinitionState } from '@elementor/editor-styles';
+import { ThemeProvider } from '@elementor/editor-ui';
+import { controlActionsMenu } from '@elementor/menus';
+import { useMutation } from '@elementor/query';
+import { SessionStorageProvider } from '@elementor/session';
+import { __useSelector as useSelector } from '@elementor/store';
+import {
+  type AutocompleteChangeReason,
+  Box,
+  Button,
+  CloseButton,
+  ErrorBoundary,
+  FormControl,
+  FormLabel,
+  Stack,
+} from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import { ALLOWED_HTML_WRAPPER_TAGS, type AllowedHtmlTag } from '../allowed-tags';
+import { saveDefaultStyles } from '../save-default-styles';
+import { selectIsDirty } from '../store';
+import { TagChip } from './tag-chip';
+
+const { useMenuItems } = controlActionsMenu;
+
+const SHIM_ELEMENT_ID = 'default-styles-editor-shim';
+const SHIM_CLASSES_PROP = '__default_styles_classes__';
+const TAG_SELECTOR_ID = 'default-styles-tag-selector';
+
+const TAG_OPTIONS: Option[] = ALLOWED_HTML_WRAPPER_TAGS.map( ( tag ) => ( {
+  label: tag,
+  value: tag,
+} ) );
+
+function toTagChip( tag: AllowedHtmlTag ): Option {
+  return { label: tag, value: tag, fixed: true };
+}
+
+const shimElement: Element = {
+  id: SHIM_ELEMENT_ID,
+  type: 'default-style',
+};
+
+const shimElementType: ElementType = {
+  key: 'default-style',
+  controls: [],
+  propsSchema: {},
+  title: __( 'Default Style', 'elementor' ),
+};
+
+type DefaultStylesPanelContentProps = {
+  onRequestClose: () => void;
+};
+
+export function DefaultStylesPanelContent( { onRequestClose }: DefaultStylesPanelContentProps ) {
+  const [ selectedTag, setSelectedTag ] = useState< AllowedHtmlTag >( 'h1' );
+  const [ activeStyleState, setActiveStyleState ] = useState< StyleDefinitionState | null >( null );
+  const breakpoint = useActiveBreakpoint();
+  const menuItems = useMenuItems().default;
+  const controlReplacements = getControlReplacements();
+  const isDirty = useSelector( selectIsDirty );
+  const { mutateAsync: save, isPending: isSaving } = useSave();
+
+  const handleTagSelect = (
+    _selected: Option[],
+    reason: AutocompleteChangeReason,
+    option: Option
+  ) => {
+    if ( reason !== 'selectOption' || ! option.value ) {
+      return;
+    }
+
+    setSelectedTag( option.value as AllowedHtmlTag );
+    setActiveStyleState( null );
+  };
+
+  return (
+    <ErrorBoundary fallback={ null }>
+      <ThemeProvider>
+        <ControlActionsProvider items={ menuItems }>
+          <ControlReplacementsProvider replacements={ controlReplacements }>
+            <Panel>
+              <PanelHeader>
+                <Stack
+                  p={ 1 }
+                  pl={ 2 }
+                  width="100%"
+                  direction="row"
+                  alignItems="center"
+                  justifyContent="space-between"
+                  spacing={ 0.5 }
+                >
+                  <PanelHeaderTitle sx={ { flex: 1, minWidth: 0 } }>
+                    { __( 'Default Styles', 'elementor' ) }
+                  </PanelHeaderTitle>
+                  <CloseButton
+                    aria-label={ __( 'Close', 'elementor' ) }
+                    sx={ { flexShrink: 0 } }
+                    onClick={ onRequestClose }
+                  />
+                </Stack>
+              </PanelHeader>
+              <PanelBody>
+                <Stack sx={ { px: 2, pt: 1, gap: 1 } }>
+                  <FormControl fullWidth size="small">
+                    <FormLabel htmlFor={ TAG_SELECTOR_ID } size="small" sx={ { mb: 1 } }>
+                      { __( 'Tag', 'elementor' ) }
+                    </FormLabel>
+                    <CreatableAutocomplete< Option >
+                      id={ TAG_SELECTOR_ID }
+                      size="tiny"
+                      placeholder={ __( 'Type tag name', 'elementor' ) }
+                      options={ TAG_OPTIONS }
+                      selected={ [ toTagChip( selectedTag ) ] }
+                      onSelect={ handleTagSelect }
+                      renderTags={ ( values, getTagProps ) =>
+                        values.map( ( value, index ) => (
+                          <TagChip
+                            key={ value.value ?? value.label }
+                            label={ value.label }
+                            chipProps={ getTagProps( { index } ) }
+                            activeState={ activeStyleState }
+                            onSelectState={ setActiveStyleState }
+                          />
+                        ) )
+                      }
+                    />
+                  </FormControl>
+                </Stack>
+                <ElementProvider
+                  element={ shimElement }
+                  elementType={ shimElementType }
+                  settings={ {} }
+                >
+                  <ClassesPropProvider prop={ SHIM_CLASSES_PROP }>
+                    <StyleProvider
+                      meta={ { breakpoint, state: activeStyleState } }
+                      id={ selectedTag as StyleDefinitionID }
+                      setId={ () => {} }
+                      setMetaState={ setActiveStyleState }
+                    >
+                      <SessionStorageProvider prefix={ selectedTag }>
+                        <StyleInheritanceProvider>
+                          <SectionsList>
+                            <StyleSections />
+                          </SectionsList>
+                          <Box sx={ { height: '150px' } } />
+                        </StyleInheritanceProvider>
+                      </SessionStorageProvider>
+                    </StyleProvider>
+                  </ClassesPropProvider>
+                </ElementProvider>
+              </PanelBody>
+              <PanelFooter>
+                <Button
+                  fullWidth
+                  size="small"
+                  color="global"
+                  variant="contained"
+                  onClick={ () => void save() }
+                  disabled={ ! isDirty }
+                  loading={ isSaving }
+                >
+                  { __( 'Save changes', 'elementor' ) }
+                </Button>
+              </PanelFooter>
+            </Panel>
+          </ControlReplacementsProvider>
+        </ControlActionsProvider>
+      </ThemeProvider>
+    </ErrorBoundary>
+  );
+}
+
+function useSave() {
+  return useMutation( {
+    mutationFn: () => saveDefaultStyles(),
+  } );
+}

--- a/packages/packages/core/editor-default-styles/src/components/populate-store.tsx
+++ b/packages/packages/core/editor-default-styles/src/components/populate-store.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { useEffect } from 'react';
+import { registerDataHook } from '@elementor/editor-v1-adapters';
+
+import { loadDefaultStyles } from '../load-default-styles';
+
+export function PopulateStore() {
+	useEffect( () => {
+		void loadDefaultStyles();
+
+		registerDataHook( 'after', 'editor/documents/attach-preview', async () => {
+			await loadDefaultStyles();
+		} );
+	}, [] );
+
+	return null;
+}

--- a/packages/packages/core/editor-default-styles/src/components/tag-chip.tsx
+++ b/packages/packages/core/editor-default-styles/src/components/tag-chip.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { type StyleDefinitionState } from '@elementor/editor-styles';
+import { DotsVerticalIcon } from '@elementor/icons';
+import {
+  type AutocompleteRenderGetTagProps,
+  bindTrigger,
+  Chip,
+  Stack,
+  type Theme,
+  Typography,
+  UnstableChipGroup,
+  usePopupState,
+} from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import { TagStateMenu } from './tag-state-menu';
+
+const CHIP_SIZE = 'tiny';
+
+type TagChipProps = {
+  label: string;
+  chipProps: ReturnType< AutocompleteRenderGetTagProps >;
+  activeState: StyleDefinitionState | null;
+  onSelectState: ( state: StyleDefinitionState | null ) => void;
+};
+
+export function TagChip( { label, chipProps, activeState, onSelectState }: TagChipProps ) {
+  const popupState = usePopupState( { variant: 'popover', popupId: 'tag-state-menu' } );
+  const [ chipRef, setChipRef ] = useState< HTMLElement | null >( null );
+
+  const { onDelete: _onDelete, ...chipGroupProps } = chipProps;
+  const isShowingState = Boolean( activeState );
+
+  return (
+    <>
+      <UnstableChipGroup
+        ref={ setChipRef }
+        { ...chipGroupProps }
+        aria-label={ `Edit ${ label }` }
+        role="group"
+        sx={ ( theme: Theme ) => ( {
+          '&.MuiChipGroup-root.MuiAutocomplete-tag': { margin: theme.spacing( 0.125 ) },
+        } ) }
+      >
+        <Chip
+          size={ CHIP_SIZE }
+          label={ label }
+          variant={ isShowingState ? 'standard' : 'filled' }
+          shape="rounded"
+          color="default"
+          onClick={ () => {
+            if ( isShowingState ) {
+              onSelectState( null );
+            }
+          } }
+          sx={ ( theme: Theme ) => ( {
+            lineHeight: 1,
+            borderRadius: `${ theme.shape.borderRadius * 0.75 }px`,
+          } ) }
+        />
+        <Chip
+          icon={ isShowingState ? undefined : <DotsVerticalIcon fontSize="tiny" /> }
+          size={ CHIP_SIZE }
+          label={
+            isShowingState ? (
+              <Stack direction="row" gap={ 0.5 } alignItems="center">
+                <Typography variant="inherit">{ activeState }</Typography>
+                <DotsVerticalIcon fontSize="tiny" />
+              </Stack>
+            ) : undefined
+          }
+          variant="filled"
+          shape="rounded"
+          color="default"
+          { ...bindTrigger( popupState ) }
+          aria-label={ __( 'Open tag state menu', 'elementor' ) }
+          sx={ ( theme: Theme ) => ( {
+            borderRadius: `${ theme.shape.borderRadius * 0.75 }px`,
+            paddingRight: 0,
+            ...( ! isShowingState ? { paddingLeft: 0 } : {} ),
+            '.MuiChip-label': isShowingState ? { paddingRight: 0 } : { padding: 0 },
+          } ) }
+        />
+      </UnstableChipGroup>
+      <TagStateMenu
+        popupState={ popupState }
+        anchorEl={ chipRef }
+        activeState={ activeState }
+        onSelectState={ onSelectState }
+      />
+    </>
+  );
+}

--- a/packages/packages/core/editor-default-styles/src/components/tag-state-menu.tsx
+++ b/packages/packages/core/editor-default-styles/src/components/tag-state-menu.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { type StyleDefinitionState } from '@elementor/editor-styles';
+import { MenuListItem } from '@elementor/editor-ui';
+import { bindMenu, Menu, MenuSubheader, type PopupState } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+type PseudoState = {
+  value: StyleDefinitionState | null;
+  label: string;
+};
+
+const PSEUDO_STATES: PseudoState[] = [
+  { value: null, label: __( 'normal', 'elementor' ) },
+  { value: 'hover', label: __( 'hover', 'elementor' ) },
+  { value: 'focus', label: __( 'focus', 'elementor' ) },
+  { value: 'active', label: __( 'active', 'elementor' ) },
+];
+
+type TagStateMenuProps = {
+  popupState: PopupState;
+  anchorEl: HTMLElement | null;
+  activeState: StyleDefinitionState | null;
+  onSelectState: ( state: StyleDefinitionState | null ) => void;
+};
+
+export function TagStateMenu( {
+  popupState,
+  anchorEl,
+  activeState,
+  onSelectState,
+}: TagStateMenuProps ) {
+  return (
+    <Menu
+      MenuListProps={ { dense: true, sx: { minWidth: '160px' } } }
+      { ...bindMenu( popupState ) }
+      anchorEl={ anchorEl }
+      anchorOrigin={ { vertical: 'bottom', horizontal: 'left' } }
+      transformOrigin={ { horizontal: 'left', vertical: -4 } }
+      disableAutoFocusItem
+    >
+      <MenuSubheader sx={ { typography: 'caption', color: 'text.secondary', pb: 0.5, pt: 1 } }>
+        { __( 'States', 'elementor' ) }
+      </MenuSubheader>
+      { PSEUDO_STATES.map( ( state ) => (
+        <MenuListItem
+          key={ state.value ?? 'normal' }
+          selected={ state.value === activeState }
+          sx={ { textTransform: 'capitalize' } }
+          onClick={ () => {
+            onSelectState( state.value );
+            popupState.close();
+          } }
+        >
+          { state.label }
+        </MenuListItem>
+      ) ) }
+    </Menu>
+  );
+}

--- a/packages/packages/core/editor-default-styles/src/default-styles-panel.tsx
+++ b/packages/packages/core/editor-default-styles/src/default-styles-panel.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react';
+import { useCallback, useEffect } from 'react';
+import { __createPanel as createPanel } from '@elementor/editor-panels';
+import { SaveChangesDialog, useDialog } from '@elementor/editor-ui';
+import {
+  __privateListenTo as listenTo,
+  __privateOpenRoute as openRoute,
+  routeCloseEvent,
+} from '@elementor/editor-v1-adapters';
+import {
+  __dispatch as dispatch,
+  __getState as getState,
+  __useSelector as useSelector,
+} from '@elementor/store';
+import { DialogHeader } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import { DefaultStylesPanelContent } from './components/default-styles-panel-content';
+import { saveDefaultStyles } from './save-default-styles';
+import { selectIsDirty, slice } from './store';
+
+const PANEL_ID = 'default-styles';
+const V2_PANEL_ROUTE = 'panel/v2';
+
+export const { panel, usePanelStatus, usePanelActions } = createPanel( {
+  id: PANEL_ID,
+  component: DefaultStylesPanelRoot,
+} );
+
+function DefaultStylesPanelRoot() {
+  const { close } = usePanelActions();
+  const isDirty = useSelector( selectIsDirty );
+  const {
+    open: openSaveChangesDialog,
+    close: closeSaveChangesDialog,
+    isOpen: isSaveChangesDialogOpen,
+  } = useDialog();
+
+  const resetAndClosePanel = useCallback( () => {
+    dispatch( slice.actions.reset() );
+    closeSaveChangesDialog();
+    void close();
+  }, [ close, closeSaveChangesDialog ] );
+
+  const handleClosePanel = useCallback( () => {
+    if ( selectIsDirty( getState() ) ) {
+      openSaveChangesDialog();
+      return;
+    }
+
+    void close();
+  }, [ close, openSaveChangesDialog ] );
+
+  usePreventUnload( isDirty );
+
+  useEffect( () => {
+    const unsubscribe = listenTo( routeCloseEvent( V2_PANEL_ROUTE ), () => {
+      if ( ! selectIsDirty( getState() ) ) {
+        return;
+      }
+
+      openRoute( V2_PANEL_ROUTE );
+      openSaveChangesDialog();
+    } );
+
+    return unsubscribe;
+  }, [ openSaveChangesDialog ] );
+
+  return (
+    <>
+      <DefaultStylesPanelContent onRequestClose={ handleClosePanel } />
+      { isSaveChangesDialogOpen && (
+        <SaveChangesDialog>
+          <DialogHeader onClose={ closeSaveChangesDialog } logo={ false }>
+            <SaveChangesDialog.Title>
+              { __( 'You have unsaved changes', 'elementor' ) }
+            </SaveChangesDialog.Title>
+          </DialogHeader>
+          <SaveChangesDialog.Content>
+            <SaveChangesDialog.ContentText>
+              { __( 'You have unsaved changes in Default Styles.', 'elementor' ) }
+            </SaveChangesDialog.ContentText>
+            <SaveChangesDialog.ContentText>
+              { __(
+                'To avoid losing your updates, save your changes before leaving.',
+                'elementor'
+              ) }
+            </SaveChangesDialog.ContentText>
+          </SaveChangesDialog.Content>
+          <SaveChangesDialog.Actions
+            actions={ {
+              discard: {
+                label: __( 'Discard', 'elementor' ),
+                action: resetAndClosePanel,
+              },
+              confirm: {
+                label: __( 'Save & Continue', 'elementor' ),
+                action: async () => {
+                  await saveDefaultStyles();
+                  closeSaveChangesDialog();
+                  void close();
+                },
+              },
+            } }
+          />
+        </SaveChangesDialog>
+      ) }
+    </>
+  );
+}
+
+function usePreventUnload( isDirty: boolean ) {
+  useEffect( () => {
+    const handleBeforeUnload = ( event: BeforeUnloadEvent ) => {
+      if ( isDirty ) {
+        event.preventDefault();
+      }
+    };
+
+    window.addEventListener( 'beforeunload', handleBeforeUnload );
+
+    return () => {
+      window.removeEventListener( 'beforeunload', handleBeforeUnload );
+    };
+  }, [ isDirty ] );
+}

--- a/packages/packages/core/editor-default-styles/src/default-styles-styles-provider.ts
+++ b/packages/packages/core/editor-default-styles/src/default-styles-styles-provider.ts
@@ -1,0 +1,99 @@
+import {
+	type StyleDefinition,
+	type StyleDefinitionID,
+} from '@elementor/editor-styles';
+import { createStylesProvider } from '@elementor/editor-styles-repository';
+import {
+	__dispatch as dispatch,
+	__getState as getState,
+	__subscribeWithSelector as subscribeWithSelector,
+} from '@elementor/store';
+import { __ } from '@wordpress/i18n';
+
+import { ALLOWED_HTML_WRAPPER_TAGS } from './allowed-tags';
+import { selectData, slice } from './store';
+
+export const DEFAULT_STYLES_PROVIDER_KEY = 'default-styles';
+export const DEFAULT_STYLES_CSS_NAME_PREFIX = 'e-default-';
+
+const resolveCssName = ( id: StyleDefinitionID ) => `${ DEFAULT_STYLES_CSS_NAME_PREFIX }${ id }`;
+
+const placeholderDefinition = ( id: StyleDefinitionID ): StyleDefinition => ( {
+	id,
+	label: id,
+	type: 'class',
+	variants: [],
+} );
+
+const asClassDefinition = ( style: StyleDefinition ): StyleDefinition => ( {
+	...style,
+	type: 'class',
+} );
+
+export const defaultStylesStylesProvider = createStylesProvider( {
+	key: DEFAULT_STYLES_PROVIDER_KEY,
+	priority: 15,
+	labels: {
+		singular: __( 'tag', 'elementor' ),
+		plural: __( 'tags', 'elementor' ),
+	},
+	subscribe: ( cb ) => subscribeWithStates( cb ),
+	actions: {
+		all: () =>
+			ALLOWED_HTML_WRAPPER_TAGS.map( ( tag ) => {
+				const style = selectData( getState() )[ tag ];
+
+				return style ? asClassDefinition( style ) : placeholderDefinition( tag );
+			} ),
+		get: ( id ) => {
+			const style = selectData( getState() )[ id ];
+
+			return style ? asClassDefinition( style ) : placeholderDefinition( id );
+		},
+		resolveCssName,
+		update: ( payload ) => {
+			dispatch(
+				slice.actions.update( {
+					style: payload,
+				} )
+			);
+		},
+		delete: ( id ) => {
+			dispatch( slice.actions.deleteTag( id ) );
+		},
+		updateProps: ( args ) => {
+			dispatch(
+				slice.actions.updateProps( {
+					id: args.id,
+					meta: args.meta,
+					props: args.props,
+					mode: args.mode,
+				} )
+			);
+		},
+		updateCustomCss: ( args ) => {
+			dispatch(
+				slice.actions.updateProps( {
+					id: args.id,
+					meta: args.meta,
+					custom_css: args.custom_css,
+					props: {},
+				} )
+			);
+		},
+	},
+} );
+
+const subscribeWithStates = (
+	cb: ( previous: Record< string, StyleDefinition >, current: Record< string, StyleDefinition > ) => void
+) => {
+	let previousState = selectData( getState() );
+
+	return subscribeWithSelector(
+		( state ) => selectData( state ),
+		( currentState ) => {
+			cb( previousState, currentState );
+			previousState = currentState;
+		}
+	);
+};

--- a/packages/packages/core/editor-default-styles/src/hooks/use-default-styles-action-props.ts
+++ b/packages/packages/core/editor-default-styles/src/hooks/use-default-styles-action-props.ts
@@ -1,0 +1,17 @@
+import { type ActionProps } from '@elementor/editor-app-bar';
+import { TextIcon } from '@elementor/icons';
+import { __ } from '@wordpress/i18n';
+
+import { usePanelActions } from '../default-styles-panel';
+
+export function useDefaultStylesActionProps(): ActionProps {
+  const { open } = usePanelActions();
+
+  return {
+    title: __( 'Default Styles', 'elementor' ),
+    icon: TextIcon,
+    onClick: () => {
+      void open();
+    },
+  };
+}

--- a/packages/packages/core/editor-default-styles/src/index.ts
+++ b/packages/packages/core/editor-default-styles/src/index.ts
@@ -1,0 +1,1 @@
+export { init } from './init';

--- a/packages/packages/core/editor-default-styles/src/init.ts
+++ b/packages/packages/core/editor-default-styles/src/init.ts
@@ -1,0 +1,49 @@
+import { injectIntoLogic } from '@elementor/editor';
+import { toolsMenu } from '@elementor/editor-app-bar';
+import { registerElementPanelDefaults } from '@elementor/editor-editing-panel';
+import { __registerPanel as registerPanel } from '@elementor/editor-panels';
+import { stylesRepository } from '@elementor/editor-styles-repository';
+import { __registerSlice as registerSlice } from '@elementor/store';
+
+import { PopulateStore } from './components/populate-store';
+import { panel } from './default-styles-panel';
+import { defaultStylesStylesProvider } from './default-styles-styles-provider';
+import { useDefaultStylesActionProps } from './hooks/use-default-styles-action-props';
+import { slice } from './store';
+
+const DEFAULT_STYLE_SECTION_NAMES = [
+  'Layout',
+  'Spacing',
+  'Size',
+  'Position',
+  'Typography',
+  'Background',
+  'Border',
+  'Effects',
+] as const;
+
+export function init() {
+  registerSlice( slice );
+
+  registerElementPanelDefaults( 'default-style', {
+    defaultTab: 'style',
+    defaultSectionsExpanded: {
+      style: [ ...DEFAULT_STYLE_SECTION_NAMES ],
+    },
+  } );
+
+  registerPanel( panel );
+
+  stylesRepository.register( defaultStylesStylesProvider );
+
+  toolsMenu.registerAction( {
+    id: 'default-styles-button',
+    priority: 4,
+    useProps: useDefaultStylesActionProps,
+  } );
+
+  injectIntoLogic( {
+    id: 'default-styles-populate-store',
+    component: PopulateStore,
+  } );
+}

--- a/packages/packages/core/editor-default-styles/src/load-default-styles.ts
+++ b/packages/packages/core/editor-default-styles/src/load-default-styles.ts
@@ -1,0 +1,16 @@
+import { __dispatch as dispatch } from '@elementor/store';
+
+import { apiClient } from './api';
+import { slice } from './store';
+
+export async function loadDefaultStyles() {
+  const response = await apiClient.all();
+
+  const items = response.data.data;
+
+  dispatch(
+    slice.actions.load( {
+      data: items,
+    } )
+  );
+}

--- a/packages/packages/core/editor-default-styles/src/save-default-styles.ts
+++ b/packages/packages/core/editor-default-styles/src/save-default-styles.ts
@@ -1,0 +1,63 @@
+import { __dispatch as dispatch, __getState as getState } from '@elementor/store';
+import { hash } from '@elementor/utils';
+
+import { type AllowedHtmlTag } from './allowed-tags';
+import { apiClient } from './api';
+import {
+  selectData,
+  selectInitialData,
+  selectIsDirty,
+  slice,
+  type StateWithDefaultStyles,
+} from './store';
+
+function getChangedTags( state: StateWithDefaultStyles ): AllowedHtmlTag[] {
+  const current = selectData( state );
+  const initial = selectInitialData( state );
+
+  const changed: AllowedHtmlTag[] = [];
+
+  Object.keys( current ).forEach( ( tag ) => {
+    const currentStyle = current[ tag ];
+    const initialStyle = initial[ tag ];
+
+    if ( ! initialStyle || hash( currentStyle ) !== hash( initialStyle ) ) {
+      changed.push( tag as AllowedHtmlTag );
+    }
+  } );
+
+  Object.keys( initial ).forEach( ( tag ) => {
+    if ( ! current[ tag ] ) {
+      changed.push( tag as AllowedHtmlTag );
+    }
+  } );
+
+  return changed;
+}
+
+export async function saveDefaultStyles() {
+  const state = getState() as StateWithDefaultStyles;
+
+  if ( ! selectIsDirty( state ) ) {
+    return;
+  }
+
+  const data = selectData( state );
+  const changedTags = getChangedTags( state );
+
+  await Promise.all(
+    changedTags.map( async ( tag ) => {
+      const style = data[ tag ];
+
+      if ( ! style || style.variants.length === 0 ) {
+        await apiClient.delete( tag );
+
+        return;
+      }
+
+      await apiClient.put( tag, style.variants );
+    } )
+  );
+
+  dispatch( slice.actions.commit() );
+}

--- a/packages/packages/core/editor-default-styles/src/store.ts
+++ b/packages/packages/core/editor-default-styles/src/store.ts
@@ -1,0 +1,134 @@
+import { type Props } from '@elementor/editor-props';
+import {
+  type CustomCss,
+  getVariantByMeta,
+  type StyleDefinition,
+  type StyleDefinitionID,
+  type StyleDefinitionVariant,
+} from '@elementor/editor-styles';
+import { type UpdateActionPayload } from '@elementor/editor-styles-repository';
+import {
+  __createSelector as createSelector,
+  __createSlice as createSlice,
+  type PayloadAction,
+  type SliceState,
+} from '@elementor/store';
+
+type DefaultStylesState = {
+  data: Record< StyleDefinitionID, StyleDefinition >;
+  initialData: Record< StyleDefinitionID, StyleDefinition >;
+  isDirty: boolean;
+};
+
+const initialState: DefaultStylesState = {
+  data: {},
+  initialData: {},
+  isDirty: false,
+};
+
+export type StateWithDefaultStyles = SliceState< typeof slice >;
+
+const SLICE_NAME = 'defaultStyles';
+
+export const slice = createSlice( {
+  name: SLICE_NAME,
+  initialState,
+  reducers: {
+    load(
+      state,
+      { payload: { data } }: PayloadAction< { data: Record< StyleDefinitionID, StyleDefinition > } >
+    ) {
+      state.initialData = data;
+      state.data = data;
+      state.isDirty = false;
+    },
+
+    update( state, { payload }: PayloadAction< { style: UpdateActionPayload } > ) {
+      state.data[ payload.style.id ] = {
+        ...state.data[ payload.style.id ],
+        ...payload.style,
+      } as StyleDefinition;
+      state.isDirty = true;
+    },
+
+    updateProps(
+      state,
+      {
+        payload,
+      }: PayloadAction< {
+        id: StyleDefinitionID;
+        meta: StyleDefinitionVariant[ 'meta' ];
+        props: Props;
+        custom_css?: CustomCss | null;
+        mode?: 'merge' | 'replace';
+      } >
+    ) {
+      const style = state.data[ payload.id ] ?? {
+        id: payload.id,
+        label: payload.id,
+        type: 'class' as const,
+        variants: [],
+      };
+
+      const variant = getVariantByMeta( style, payload.meta );
+      let customCss =
+        ( 'custom_css' in payload ? payload.custom_css : variant?.custom_css ) ?? null;
+      customCss = customCss?.raw ? customCss : null;
+
+      if ( variant ) {
+        const payloadProps = JSON.parse( JSON.stringify( payload.props ) ) as Props;
+        const mode = payload.mode ?? 'merge';
+
+        if ( mode === 'replace' ) {
+          variant.props = payloadProps;
+        } else {
+          const variantProps = JSON.parse( JSON.stringify( variant.props ) ) as Props;
+          variant.props = { ...variantProps, ...payloadProps };
+        }
+
+        variant.custom_css = customCss;
+      } else {
+        style.variants.push( { meta: payload.meta, props: payload.props, custom_css: customCss } );
+      }
+
+      state.data[ payload.id ] = style;
+      state.isDirty = true;
+    },
+
+    reset( state ) {
+      state.data = state.initialData;
+      state.isDirty = false;
+    },
+
+    commit( state ) {
+      state.initialData = state.data;
+      state.isDirty = false;
+    },
+
+    deleteTag( state, { payload }: PayloadAction< StyleDefinitionID > ) {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete state.data[ payload ];
+      state.isDirty = true;
+    },
+  },
+} );
+
+export const selectData = createSelector(
+  ( state: StateWithDefaultStyles ) => state.defaultStyles.data,
+  ( data ) => data
+);
+
+export const selectIsDirty = createSelector(
+  ( state: StateWithDefaultStyles ) => state.defaultStyles.isDirty,
+  ( isDirty ) => isDirty
+);
+
+export const selectInitialData = createSelector(
+  ( state: StateWithDefaultStyles ) => state.defaultStyles.initialData,
+  ( initialData ) => initialData
+);
+
+export const selectTagStyle = createSelector(
+  [ selectData, ( _state: StateWithDefaultStyles, id: StyleDefinitionID ) => id ],
+  ( data, id ) => data[ id ]
+);

--- a/packages/packages/core/editor-editing-panel/src/components/style-sections.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-sections.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { __ } from '@wordpress/i18n';
+
+import { BackgroundSection } from './style-sections/background-section/background-section';
+import { BorderSection } from './style-sections/border-section/border-section';
+import { EffectsSection } from './style-sections/effects-section/effects-section';
+import { LayoutSection } from './style-sections/layout-section/layout-section';
+import { PositionSection } from './style-sections/position-section/position-section';
+import { SizeSection } from './style-sections/size-section/size-section';
+import { SpacingSection } from './style-sections/spacing-section/spacing-section';
+import { TypographySection } from './style-sections/typography-section/typography-section';
+import { StyleTabSection } from './style-tab-section';
+
+export const StyleSections = () => {
+	return (
+		<>
+			<StyleTabSection
+				section={ {
+					component: LayoutSection,
+					name: 'Layout',
+					title: __( 'Layout', 'elementor' ),
+				} }
+				fields={ [
+					'display',
+					'flex-direction',
+					'flex-wrap',
+					'justify-content',
+					'align-items',
+					'align-content',
+					'align-self',
+					'gap',
+					'order',
+					'grid-column',
+					'grid-row',
+					'grid-auto-rows',
+					'grid-auto-columns',
+				] }
+			/>
+			<StyleTabSection
+				section={ {
+					component: SpacingSection,
+					name: 'Spacing',
+					title: __( 'Spacing', 'elementor' ),
+				} }
+				fields={ [ 'margin', 'padding' ] }
+			/>
+			<StyleTabSection
+				section={ {
+					component: SizeSection,
+					name: 'Size',
+					title: __( 'Size', 'elementor' ),
+				} }
+				fields={ [
+					'width',
+					'min-width',
+					'max-width',
+					'height',
+					'min-height',
+					'max-height',
+					'overflow',
+					'aspect-ratio',
+					'object-fit',
+				] }
+			/>
+			<StyleTabSection
+				section={ {
+					component: PositionSection,
+					name: 'Position',
+					title: __( 'Position', 'elementor' ),
+				} }
+				fields={ [ 'position', 'z-index', 'scroll-margin-top' ] }
+			/>
+			<StyleTabSection
+				section={ {
+					component: TypographySection,
+					name: 'Typography',
+					title: __( 'Typography', 'elementor' ),
+				} }
+				fields={ [
+					'font-family',
+					'font-weight',
+					'font-size',
+					'text-align',
+					'color',
+					'line-height',
+					'letter-spacing',
+					'word-spacing',
+					'column-count',
+					'text-decoration',
+					'text-transform',
+					'direction',
+					'font-style',
+					'stroke',
+				] }
+			/>
+			<StyleTabSection
+				section={ {
+					component: BackgroundSection,
+					name: 'Background',
+					title: __( 'Background', 'elementor' ),
+				} }
+				fields={ [ 'background' ] }
+			/>
+			<StyleTabSection
+				section={ {
+					component: BorderSection,
+					name: 'Border',
+					title: __( 'Border', 'elementor' ),
+				} }
+				fields={ [ 'border-radius', 'border-width', 'border-color', 'border-style' ] }
+			/>
+			<StyleTabSection
+				section={ {
+					component: EffectsSection,
+					name: 'Effects',
+					title: __( 'Effects', 'elementor' ),
+				} }
+				fields={ [
+					'mix-blend-mode',
+					'box-shadow',
+					'opacity',
+					'transform',
+					'filter',
+					'backdrop-filter',
+					'transform-origin',
+					'transition',
+				] }
+			/>
+		</>
+	);
+};

--- a/packages/packages/core/editor-editing-panel/src/components/style-tab.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/style-tab.tsx
@@ -6,7 +6,6 @@ import { type StyleDefinitionID, type StyleDefinitionState } from '@elementor/ed
 import { createLocation } from '@elementor/locations';
 import { SessionStorageProvider } from '@elementor/session';
 import { Box, Divider, Stack } from '@elementor/ui';
-import { __ } from '@wordpress/i18n';
 
 import { ClassesPropProvider } from '../contexts/classes-prop-context';
 import { useElement } from '../contexts/element-context';
@@ -16,15 +15,7 @@ import { StyleInheritanceProvider } from '../contexts/styles-inheritance-context
 import { useActiveStyleDefId } from '../hooks/use-active-style-def-id';
 import { CssClassSelector } from './css-classes/css-class-selector';
 import { SectionsList } from './sections-list';
-import { BackgroundSection } from './style-sections/background-section/background-section';
-import { BorderSection } from './style-sections/border-section/border-section';
-import { EffectsSection } from './style-sections/effects-section/effects-section';
-import { LayoutSection } from './style-sections/layout-section/layout-section';
-import { PositionSection } from './style-sections/position-section/position-section';
-import { SizeSection } from './style-sections/size-section/size-section';
-import { SpacingSection } from './style-sections/spacing-section/spacing-section';
-import { TypographySection } from './style-sections/typography-section/typography-section';
-import { StyleTabSection } from './style-tab-section';
+import { StyleSections } from './style-sections';
 
 const TABS_HEADER_HEIGHT = '37px';
 
@@ -66,118 +57,7 @@ export const StyleTab = () => {
 							<Divider />
 						</ClassesHeader>
 						<SectionsList>
-							<StyleTabSection
-								section={ {
-									component: LayoutSection,
-									name: 'Layout',
-									title: __( 'Layout', 'elementor' ),
-								} }
-								fields={ [
-									'display',
-									'flex-direction',
-									'flex-wrap',
-									'justify-content',
-									'align-items',
-									'align-content',
-									'align-self',
-									'gap',
-									'order',
-									'grid-column',
-									'grid-row',
-									'grid-auto-rows',
-									'grid-auto-columns',
-								] }
-							/>
-							<StyleTabSection
-								section={ {
-									component: SpacingSection,
-									name: 'Spacing',
-									title: __( 'Spacing', 'elementor' ),
-								} }
-								fields={ [ 'margin', 'padding' ] }
-							/>
-							<StyleTabSection
-								section={ {
-									component: SizeSection,
-									name: 'Size',
-									title: __( 'Size', 'elementor' ),
-								} }
-								fields={ [
-									'width',
-									'min-width',
-									'max-width',
-									'height',
-									'min-height',
-									'max-height',
-									'overflow',
-									'aspect-ratio',
-									'object-fit',
-								] }
-							/>
-							<StyleTabSection
-								section={ {
-									component: PositionSection,
-									name: 'Position',
-									title: __( 'Position', 'elementor' ),
-								} }
-								fields={ [ 'position', 'z-index', 'scroll-margin-top' ] }
-							/>
-							<StyleTabSection
-								section={ {
-									component: TypographySection,
-									name: 'Typography',
-									title: __( 'Typography', 'elementor' ),
-								} }
-								fields={ [
-									'font-family',
-									'font-weight',
-									'font-size',
-									'text-align',
-									'color',
-									'line-height',
-									'letter-spacing',
-									'word-spacing',
-									'column-count',
-									'text-decoration',
-									'text-transform',
-									'direction',
-									'font-style',
-									'stroke',
-								] }
-							/>
-							<StyleTabSection
-								section={ {
-									component: BackgroundSection,
-									name: 'Background',
-									title: __( 'Background', 'elementor' ),
-								} }
-								fields={ [ 'background' ] }
-							/>
-							<StyleTabSection
-								section={ {
-									component: BorderSection,
-									name: 'Border',
-									title: __( 'Border', 'elementor' ),
-								} }
-								fields={ [ 'border-radius', 'border-width', 'border-color', 'border-style' ] }
-							/>
-							<StyleTabSection
-								section={ {
-									component: EffectsSection,
-									name: 'Effects',
-									title: __( 'Effects', 'elementor' ),
-								} }
-								fields={ [
-									'mix-blend-mode',
-									'box-shadow',
-									'opacity',
-									'transform',
-									'filter',
-									'backdrop-filter',
-									'transform-origin',
-									'transition',
-								] }
-							/>
+							<StyleSections />
 							<StyleTabSlot />
 						</SectionsList>
 						<Box sx={ { height: '150px' } } />

--- a/packages/packages/core/editor-editing-panel/src/contexts/styles-inheritance-context.tsx
+++ b/packages/packages/core/editor-editing-panel/src/contexts/styles-inheritance-context.tsx
@@ -1,17 +1,22 @@
 import * as React from 'react';
 import { createContext, type PropsWithChildren, useContext, useMemo } from 'react';
 import { getWidgetsCache } from '@elementor/editor-elements';
-import { classesPropTypeUtil, type ClassesPropValue, type PropValue } from '@elementor/editor-props';
+import {
+  classesPropTypeUtil,
+  type ClassesPropValue,
+  type PropValue,
+} from '@elementor/editor-props';
 import { getBreakpointsTree } from '@elementor/editor-responsive';
 import { getStylesSchema } from '@elementor/editor-styles';
 import { stylesRepository } from '@elementor/editor-styles-repository';
 
+import { useDefaultStyleTagFromPreview } from '../hooks/use-default-style-tag-from-preview';
 import { useStylesRerender } from '../hooks/use-styles-rerender';
 import { createStylesInheritance } from '../styles-inheritance/create-styles-inheritance';
 import {
-	type SnapshotPropValue,
-	type StylesInheritanceAPI,
-	type StylesInheritanceSnapshot,
+  type SnapshotPropValue,
+  type StylesInheritanceAPI,
+  type StylesInheritanceSnapshot,
 } from '../styles-inheritance/types';
 import { useClassesProp } from './classes-prop-context';
 import { useElement, usePanelElementSetting } from './element-context';
@@ -20,81 +25,103 @@ import { useStyle } from './style-context';
 const Context = createContext< StylesInheritanceAPI | null >( null );
 
 export function StyleInheritanceProvider( { children }: PropsWithChildren ) {
-	const styleDefs = useAppliedStyles();
+  const styleDefs = useAppliedStyles();
 
-	const breakpointsTree = getBreakpointsTree();
+  const breakpointsTree = getBreakpointsTree();
 
-	const { getSnapshot, getInheritanceChain } = createStylesInheritance( styleDefs, breakpointsTree );
+  const { getSnapshot, getInheritanceChain } = createStylesInheritance(
+    styleDefs,
+    breakpointsTree
+  );
 
-	return <Context.Provider value={ { getSnapshot, getInheritanceChain } }>{ children }</Context.Provider>;
+  return (
+    <Context.Provider value={ { getSnapshot, getInheritanceChain } }>{ children }</Context.Provider>
+  );
 }
 
 export function useStylesInheritanceSnapshot(): StylesInheritanceSnapshot | null {
-	const context = useContext( Context );
-	const { meta } = useStyle();
+  const context = useContext( Context );
+  const { meta } = useStyle();
 
-	if ( ! context ) {
-		throw new Error( 'useStylesInheritanceSnapshot must be used within a StyleInheritanceProvider' );
-	}
+  if ( ! context ) {
+    throw new Error(
+      'useStylesInheritanceSnapshot must be used within a StyleInheritanceProvider'
+    );
+  }
 
-	if ( ! meta ) {
-		return null;
-	}
+  if ( ! meta ) {
+    return null;
+  }
 
-	return context.getSnapshot( meta ) ?? null;
+  return context.getSnapshot( meta ) ?? null;
 }
 
 export function useStylesInheritanceChain( path: string[] ): SnapshotPropValue[] {
-	const context = useContext( Context );
+  const context = useContext( Context );
 
-	if ( ! context ) {
-		throw new Error( 'useStylesInheritanceChain must be used within a StyleInheritanceProvider' );
-	}
+  if ( ! context ) {
+    throw new Error( 'useStylesInheritanceChain must be used within a StyleInheritanceProvider' );
+  }
 
-	const schema = getStylesSchema();
+  const schema = getStylesSchema();
 
-	const topLevelPropType = schema?.[ path[ 0 ] ];
+  const topLevelPropType = schema?.[ path[ 0 ] ];
 
-	const snapshot = useStylesInheritanceSnapshot();
+  const snapshot = useStylesInheritanceSnapshot();
 
-	if ( ! snapshot ) {
-		return [];
-	}
+  if ( ! snapshot ) {
+    return [];
+  }
 
-	return context.getInheritanceChain( snapshot, path, topLevelPropType );
+  return context.getInheritanceChain( snapshot, path, topLevelPropType );
 }
 
 const EMPTY_INHERITED_VALUES: Record< string, PropValue > = {};
 
 export function useInheritedValues( propKeys: string[] ): Record< string, PropValue > {
-	const snapshot = useStylesInheritanceSnapshot();
+  const snapshot = useStylesInheritanceSnapshot();
 
-	return useMemo( () => {
-		if ( ! snapshot || propKeys.length === 0 ) {
-			return EMPTY_INHERITED_VALUES;
-		}
+  return useMemo( () => {
+    if ( ! snapshot || propKeys.length === 0 ) {
+      return EMPTY_INHERITED_VALUES;
+    }
 
-		return Object.fromEntries( propKeys.map( ( key ) => [ key, snapshot[ key ]?.[ 0 ]?.value ?? null ] ) );
-	}, [ snapshot, propKeys ] );
+    return Object.fromEntries(
+      propKeys.map( ( key ) => [ key, snapshot[ key ]?.[ 0 ]?.value ?? null ] )
+    );
+  }, [ snapshot, propKeys ] );
 }
 
 const useAppliedStyles = () => {
-	const currentClassesProp = useClassesProp();
-	const baseStyles = useBaseStyles();
+  const currentClassesProp = useClassesProp();
+  const baseStyles = useBaseStyles();
+  const defaultTagStyleId = useDefaultTagStyleId();
 
-	useStylesRerender();
+  useStylesRerender();
 
-	const classesProp = usePanelElementSetting< ClassesPropValue >( currentClassesProp );
+  const classesProp = usePanelElementSetting< ClassesPropValue >( currentClassesProp );
 
-	const appliedStyles = classesPropTypeUtil.extract( classesProp ) ?? [];
+  const appliedStyles = classesPropTypeUtil.extract( classesProp ) ?? [];
 
-	return stylesRepository.all().filter( ( style ) => [ ...baseStyles, ...appliedStyles ].includes( style.id ) );
+  const applicableIds = [
+    ...baseStyles,
+    ...appliedStyles,
+    ...( defaultTagStyleId ? [ defaultTagStyleId ] : [] ),
+  ];
+
+  return stylesRepository.all().filter( ( style ) => applicableIds.includes( style.id ) );
 };
 
 const useBaseStyles = () => {
-	const { elementType } = useElement();
-	const widgetsCache = getWidgetsCache();
-	const widgetCache = widgetsCache?.[ elementType.key ];
+  const { elementType } = useElement();
+  const widgetsCache = getWidgetsCache();
+  const widgetCache = widgetsCache?.[ elementType.key ];
 
-	return Object.keys( widgetCache?.base_styles ?? {} );
+  return Object.keys( widgetCache?.base_styles ?? {} );
+};
+
+const useDefaultTagStyleId = () => {
+  const { element } = useElement();
+
+  return useDefaultStyleTagFromPreview( element.id );
 };

--- a/packages/packages/core/editor-editing-panel/src/hooks/use-default-style-tag-from-preview.ts
+++ b/packages/packages/core/editor-editing-panel/src/hooks/use-default-style-tag-from-preview.ts
@@ -1,0 +1,18 @@
+import { getDefaultStyleTagFromPreviewElement } from '@elementor/editor-elements';
+import {
+  __privateUseListenTo as useListenTo,
+  commandEndEvent,
+  windowEvent,
+} from '@elementor/editor-v1-adapters';
+
+export function useDefaultStyleTagFromPreview( elementId: string ) {
+  return useListenTo(
+    [
+      windowEvent( 'elementor/preview/atomic-widget/render' ),
+      commandEndEvent( 'document/elements/settings' ),
+      commandEndEvent( 'document/elements/set-settings' ),
+      commandEndEvent( 'document/elements/select' ),
+    ],
+    () => getDefaultStyleTagFromPreviewElement( elementId )
+  );
+}

--- a/packages/packages/core/editor-editing-panel/src/index.ts
+++ b/packages/packages/core/editor-editing-panel/src/index.ts
@@ -1,20 +1,28 @@
-export { type ValidationEvent, type ValidationResult } from './components/creatable-autocomplete';
+export {
+  CreatableAutocomplete,
+  type CreatableAutocompleteProps,
+  type Option,
+  type ValidationEvent,
+  type ValidationResult,
+} from './components/creatable-autocomplete';
 export { injectIntoCssClassConvert } from './components/css-classes/css-class-convert-local';
 export { ControlLabel } from './components/control-label';
 export { injectIntoClassSelectorActions } from './components/css-classes/css-class-selector';
 export { CustomCssIndicator } from './components/custom-css-indicator';
 export { injectIntoPanelHeaderTop } from './components/editing-panel';
 export { EditingPanelTabs } from './components/editing-panel-tabs';
-export { SectionContent } from './components/section-content';
+export { SectionsList } from './components/sections-list';
 export { SettingsControl } from './components/settings-control';
 export { SettingsField } from './controls-registry/settings-field';
 export { StyleIndicator } from './components/style-indicator';
 export { injectIntoStyleTab } from './components/style-tab';
+export { StyleSections } from './components/style-sections';
 export { injectIntoGridFields } from './components/style-sections/layout-section/layout-section';
 export { StyleTabSection } from './components/style-tab-section';
-export { useClassesProp } from './contexts/classes-prop-context';
+export { ClassesPropProvider, useClassesProp } from './contexts/classes-prop-context';
 export { ElementProvider, useElement } from './contexts/element-context';
-export { useStyle } from './contexts/style-context';
+export { StyleProvider, useStyle } from './contexts/style-context';
+export { StyleInheritanceProvider } from './contexts/styles-inheritance-context';
 export { Control as BaseControl } from './controls-registry/control';
 export { ControlTypeContainer } from './controls-registry/control-type-container';
 export { controlsRegistry, type ControlType } from './controls-registry/controls-registry';
@@ -27,18 +35,25 @@ export { useStylesRerender } from './hooks/use-styles-rerender';
 export { init } from './init';
 export { usePanelActions, usePanelStatus } from './panel';
 export { registerStyleProviderToColors } from './provider-colors-registry';
-export { getFieldIndicators, registerFieldIndicator, FIELD_TYPE } from './field-indicators-registry';
+export {
+  getFieldIndicators,
+  registerFieldIndicator,
+  FIELD_TYPE,
+} from './field-indicators-registry';
 export { registerEditingPanelReplacement } from './editing-panel-replacement-registry';
-export { registerElementPanelDefaults, type ElementPanelDefaults } from './hooks/use-default-panel-settings';
+export {
+  registerElementPanelDefaults,
+  type ElementPanelDefaults,
+} from './hooks/use-default-panel-settings';
 
 export { doApplyClasses, doGetAppliedClasses, doUnapplyClass } from './apply-unapply-actions';
 export { setLicenseConfig } from './hooks/use-license-config';
 export { type DynamicTag, type DynamicTags, type DynamicTagsManager } from './dynamics/types';
 export { isDynamicPropValue } from './dynamics/utils';
 export {
-	extractDependencyEffect,
-	type DependencyEffect,
-	getElementSettingsWithDefaults,
-	getUpdatedValues,
-	extractOrderedDependencies,
+  extractDependencyEffect,
+  type DependencyEffect,
+  getElementSettingsWithDefaults,
+  getUpdatedValues,
+  extractOrderedDependencies,
 } from './utils/prop-dependency-utils';

--- a/packages/packages/libs/editor-elements/src/index.ts
+++ b/packages/packages/libs/editor-elements/src/index.ts
@@ -4,15 +4,19 @@ export type * from './sync/types';
 
 // children dependencies (schema-driven settings <-> children sync)
 export {
-	bindSettingsReconcile,
-	type ChildDependenciesConfig,
-	type ChildDependencyRule,
-	evaluateWhen,
-	reconcileInitialChildren,
+  bindSettingsReconcile,
+  type ChildDependenciesConfig,
+  type ChildDependencyRule,
+  evaluateWhen,
+  reconcileInitialChildren,
 } from './children-dependencies';
 
 // hooks
-export { useElementChildren, type ElementChildren, type ElementModel } from './hooks/use-element-children';
+export {
+  useElementChildren,
+  type ElementChildren,
+  type ElementModel,
+} from './hooks/use-element-children';
 export { useElementEditorSettings } from './hooks/use-element-editor-settings';
 export { useParentElement } from './hooks/use-parent-element';
 export { useSelectedElement } from './hooks/use-selected-element';
@@ -25,14 +29,20 @@ export { deleteElement } from './sync/delete-element';
 export { dropElement, type DropElementParams } from './sync/drop-element';
 export { duplicateElement, type DuplicateElementParams } from './sync/duplicate-element';
 export {
-	duplicateElements,
-	type DuplicatedElement,
-	type DuplicatedElementsResult,
-	type DuplicateElementsParams,
+  duplicateElements,
+  type DuplicatedElement,
+  type DuplicatedElementsResult,
+  type DuplicateElementsParams,
 } from './sync/duplicate-elements';
 export { generateElementId } from './sync/generate-element-id';
 export { getContainer, selectElement } from './sync/get-container';
-export { addModelToParent, findModelInDocument, removeModelFromParent, resolveContainer } from './sync/resolve-element';
+export { getPreviewElementDOM } from './sync/get-preview-element-dom';
+export {
+  addModelToParent,
+  findModelInDocument,
+  removeModelFromParent,
+  resolveContainer,
+} from './sync/resolve-element';
 export { getCurrentDocumentContainer } from './sync/get-current-document-container';
 export { getCurrentDocumentId } from './sync/get-current-document-id';
 export { getElementEditorSettings } from './sync/get-element-editor-settings';
@@ -44,9 +54,9 @@ export { getElementStyles } from './sync/get-element-styles';
 export { getElementType } from './sync/get-element-type';
 export { getAllDescendants } from './sync/get-all-descendants';
 export {
-	findChildRecursive,
-	getElementChildren as getElementChildrenWithFallback,
-	type ModelResult,
+  findChildRecursive,
+  getElementChildren as getElementChildrenWithFallback,
+  type ModelResult,
 } from './sync/model-utils';
 export { getElements } from './sync/get-elements';
 export { getSelectedElements } from './sync/get-selected-elements';
@@ -57,23 +67,34 @@ export { removeElements } from './sync/remove-elements';
 export { replaceElement } from './sync/replace-element';
 export { resolveInsertIndex } from './sync/resolve-insert-index';
 export { updateElementEditorSettings } from './sync/update-element-editor-settings';
-export { updateElementSettings, type UpdateElementSettingsArgs } from './sync/update-element-settings';
+export {
+  updateElementSettings,
+  type UpdateElementSettingsArgs,
+} from './sync/update-element-settings';
 
 export {
-	getAnchoredAncestorId,
-	getAnchoredDescendantId,
-	getLinkInLinkRestriction,
-	isElementAnchored,
-	type LinkInLinkRestriction,
+  getAnchoredAncestorId,
+  getAnchoredDescendantId,
+  getLinkInLinkRestriction,
+  isElementAnchored,
+  type LinkInLinkRestriction,
 } from './link-restriction';
 export { ELEMENT_STYLE_CHANGE_EVENT, styleRerenderEvents } from './styles/consts';
 export {
-	createElementStyle,
-	shouldCreateNewLocalStyle,
-	type CreateElementStyleArgs,
+  createElementStyle,
+  shouldCreateNewLocalStyle,
+  type CreateElementStyleArgs,
 } from './styles/create-element-style';
 export { deleteElementStyle } from './styles/delete-element-style';
 export { updateElementStyle, type UpdateElementStyleArgs } from './styles/update-element-style';
 
 export { getElementInteractions } from './sync/get-element-interactions';
-export { playElementInteractions, updateElementInteractions } from './sync/update-element-interactions';
+export {
+  DEFAULT_STYLE_CLASS_PREFIX,
+  getDefaultStyleTagFromPreviewElement,
+  parseDefaultStyleTagFromClassList,
+} from './utils/get-default-style-tag-from-preview';
+export {
+  playElementInteractions,
+  updateElementInteractions,
+} from './sync/update-element-interactions';

--- a/packages/packages/libs/editor-elements/src/link-restriction.ts
+++ b/packages/packages/libs/editor-elements/src/link-restriction.ts
@@ -1,177 +1,155 @@
 import { type LinkPropValue } from '@elementor/editor-props';
 
-import { getContainer } from './sync/get-container';
 import { getElementSetting } from './sync/get-element-setting';
-import { type ExtendedWindow } from './sync/types';
+import { getPreviewElementDOM } from './sync/get-preview-element-dom';
 
 const ANCHOR_SELECTOR = 'a, [data-action-link]';
 
 type LinkValue = LinkPropValue[ 'value' ];
 
 export type LinkInLinkRestriction =
-	| {
-			shouldRestrict: true;
-			reason: 'ancestor' | 'descendant';
-			elementId: string | null;
-	  }
-	| {
-			shouldRestrict: false;
-			reason?: never;
-			elementId?: never;
-	  };
+  | {
+      shouldRestrict: true;
+      reason: 'ancestor' | 'descendant';
+      elementId: string | null;
+    }
+  | {
+      shouldRestrict: false;
+      reason?: never;
+      elementId?: never;
+    };
 
-export function getLinkInLinkRestriction( elementId: string, resolvedValue?: LinkValue ): LinkInLinkRestriction {
-	const anchoredDescendantId = getAnchoredDescendantId( elementId );
+export function getLinkInLinkRestriction(
+  elementId: string,
+  resolvedValue?: LinkValue
+): LinkInLinkRestriction {
+  const anchoredDescendantId = getAnchoredDescendantId( elementId );
 
-	if ( anchoredDescendantId ) {
-		return {
-			shouldRestrict: true as const,
-			reason: 'descendant' as const,
-			elementId: anchoredDescendantId,
-		};
-	}
+  if ( anchoredDescendantId ) {
+    return {
+      shouldRestrict: true as const,
+      reason: 'descendant' as const,
+      elementId: anchoredDescendantId,
+    };
+  }
 
-	const hasInlineLink = checkForInlineLink( elementId, resolvedValue );
+  const hasInlineLink = checkForInlineLink( elementId, resolvedValue );
 
-	if ( hasInlineLink ) {
-		return {
-			shouldRestrict: true as const,
-			reason: 'descendant' as const,
-			elementId,
-		};
-	}
+  if ( hasInlineLink ) {
+    return {
+      shouldRestrict: true as const,
+      reason: 'descendant' as const,
+      elementId,
+    };
+  }
 
-	const ancestor = getAnchoredAncestorId( elementId );
+  const ancestor = getAnchoredAncestorId( elementId );
 
-	if ( ancestor ) {
-		return {
-			shouldRestrict: true as const,
-			reason: 'ancestor' as const,
-			elementId: ancestor,
-		};
-	}
+  if ( ancestor ) {
+    return {
+      shouldRestrict: true as const,
+      reason: 'ancestor' as const,
+      elementId: ancestor,
+    };
+  }
 
-	return {
-		shouldRestrict: false,
-	};
+  return {
+    shouldRestrict: false,
+  };
 }
 
 export function getAnchoredDescendantId( elementId: string ): string | null {
-	const element = getElementDOM( elementId );
+  const element = getElementDOM( elementId );
 
-	if ( ! element ) {
-		return null;
-	}
+  if ( ! element ) {
+    return null;
+  }
 
-	for ( const childAnchorElement of Array.from( element.querySelectorAll( ANCHOR_SELECTOR ) ) ) {
-		// Ensure the child is not in the current element's scope
-		const childElementId = findElementIdOf( childAnchorElement );
+  for ( const childAnchorElement of Array.from( element.querySelectorAll( ANCHOR_SELECTOR ) ) ) {
+    // Ensure the child is not in the current element's scope
+    const childElementId = findElementIdOf( childAnchorElement );
 
-		if ( childElementId !== elementId ) {
-			return childElementId;
-		}
-	}
+    if ( childElementId !== elementId ) {
+      return childElementId;
+    }
+  }
 
-	return null;
+  return null;
 }
 
 export function getAnchoredAncestorId( elementId: string ): string | null {
-	const element = getElementDOM( elementId );
+  const element = getElementDOM( elementId );
 
-	if ( ! element || element.parentElement === null ) {
-		return null;
-	}
+  if ( ! element || element.parentElement === null ) {
+    return null;
+  }
 
-	const parentAnchor = element.parentElement.closest( ANCHOR_SELECTOR );
+  const parentAnchor = element.parentElement.closest( ANCHOR_SELECTOR );
 
-	return parentAnchor ? findElementIdOf( parentAnchor ) : null;
+  return parentAnchor ? findElementIdOf( parentAnchor ) : null;
 }
 
 export function isElementAnchored( elementId: string ): boolean {
-	const element = getElementDOM( elementId ) as HTMLElement;
+  const element = getElementDOM( elementId ) as HTMLElement;
 
-	if ( ! element ) {
-		return false;
-	}
+  if ( ! element ) {
+    return false;
+  }
 
-	if ( element.matches( ANCHOR_SELECTOR ) ) {
-		return true;
-	}
+  if ( element.matches( ANCHOR_SELECTOR ) ) {
+    return true;
+  }
 
-	return doesElementContainAnchor( element );
+  return doesElementContainAnchor( element );
 }
 
 function doesElementContainAnchor( element: Element ): boolean {
-	for ( const child of Array.from( element.children ) as HTMLElement[] ) {
-		if ( isElementorElement( child ) ) {
-			continue;
-		}
+  for ( const child of Array.from( element.children ) as HTMLElement[] ) {
+    if ( isElementorElement( child ) ) {
+      continue;
+    }
 
-		if ( child.matches( ANCHOR_SELECTOR ) ) {
-			return true;
-		}
+    if ( child.matches( ANCHOR_SELECTOR ) ) {
+      return true;
+    }
 
-		if ( doesElementContainAnchor( child ) ) {
-			return true;
-		}
-	}
+    if ( doesElementContainAnchor( child ) ) {
+      return true;
+    }
+  }
 
-	return false;
+  return false;
 }
 
 function findElementIdOf( element: Element ): string | null {
-	return element.closest< HTMLElement >( '[data-id]' )?.dataset.id || null;
+  return element.closest< HTMLElement >( '[data-id]' )?.dataset.id || null;
 }
 
 function checkForInlineLink( elementId: string, resolvedValue?: LinkValue ): boolean {
-	const element = getElementDOM( elementId );
+  const element = getElementDOM( elementId );
 
-	if ( ! element ) {
-		return false;
-	}
+  if ( ! element ) {
+    return false;
+  }
 
-	if ( element.matches( ANCHOR_SELECTOR ) ) {
-		return false;
-	}
+  if ( element.matches( ANCHOR_SELECTOR ) ) {
+    return false;
+  }
 
-	const linkSetting = resolvedValue ?? getElementSetting< LinkPropValue >( elementId, 'link' )?.value;
+  const linkSetting =
+    resolvedValue ?? getElementSetting< LinkPropValue >( elementId, 'link' )?.value;
 
-	if ( linkSetting?.destination ) {
-		return false;
-	}
+  if ( linkSetting?.destination ) {
+    return false;
+  }
 
-	return element.querySelector( ANCHOR_SELECTOR ) !== null;
+  return element.querySelector( ANCHOR_SELECTOR ) !== null;
 }
 
 function getElementDOM( id: string ) {
-	try {
-		const fromContainer = getContainer( id )?.view?.el;
-
-		if ( fromContainer ) {
-			return fromContainer;
-		}
-
-		// Inner elements of component instances are rendered from Twig and have
-		// no V1 Backbone view, so getContainer(id) returns null. Fall back to
-		// querying the preview iframe document directly so link-in-link
-		// restriction still works for those elements.
-		return queryPreviewDOMByElementId( id );
-	} catch {
-		return null;
-	}
-}
-
-function queryPreviewDOMByElementId( id: string ): HTMLElement | null {
-	const previewDocument = ( window as unknown as ExtendedWindow ).elementor?.getPreviewContainer?.()?.view?.el
-		?.ownerDocument;
-
-	if ( ! previewDocument ) {
-		return null;
-	}
-
-	return previewDocument.querySelector< HTMLElement >( `[data-id="${ id }"]` );
+  return getPreviewElementDOM( id );
 }
 
 function isElementorElement( element: Element ): boolean {
-	return element.hasAttribute( 'data-id' );
+  return element.hasAttribute( 'data-id' );
 }

--- a/packages/packages/libs/editor-elements/src/sync/get-preview-element-dom.ts
+++ b/packages/packages/libs/editor-elements/src/sync/get-preview-element-dom.ts
@@ -1,0 +1,32 @@
+import { getContainer } from './get-container';
+
+type ExtendedWindow = Window & {
+  elementor?: {
+    getPreviewContainer?: () => { view?: { el?: HTMLElement } } | undefined;
+  };
+};
+
+export function getPreviewElementDOM( id: string ): HTMLElement | null {
+  try {
+    const fromContainer = getContainer( id )?.view?.el;
+
+    if ( fromContainer ) {
+      return fromContainer;
+    }
+
+    return queryPreviewDOMByElementId( id );
+  } catch {
+    return null;
+  }
+}
+
+function queryPreviewDOMByElementId( id: string ): HTMLElement | null {
+  const previewDocument = ( window as unknown as ExtendedWindow ).elementor?.getPreviewContainer?.()
+    ?.view?.el?.ownerDocument;
+
+  if ( ! previewDocument ) {
+    return null;
+  }
+
+  return previewDocument.querySelector< HTMLElement >( `[data-id="${ id }"]` );
+}

--- a/packages/packages/libs/editor-elements/src/utils/__tests__/get-default-style-tag-from-preview.test.ts
+++ b/packages/packages/libs/editor-elements/src/utils/__tests__/get-default-style-tag-from-preview.test.ts
@@ -1,0 +1,77 @@
+import {
+  getDefaultStyleTagFromPreviewElement,
+  parseDefaultStyleTagFromClassList,
+} from '../get-default-style-tag-from-preview';
+
+jest.mock( '../../sync/get-container', () => ( {
+  getContainer: jest.fn(),
+} ) );
+
+jest.mock( '../../sync/get-preview-element-dom', () => ( {
+  getPreviewElementDOM: jest.fn(),
+} ) );
+
+import { getContainer } from '../../sync/get-container';
+import { getPreviewElementDOM } from '../../sync/get-preview-element-dom';
+
+const mockGetContainer = jest.mocked( getContainer );
+const mockGetPreviewElementDOM = jest.mocked( getPreviewElementDOM );
+
+describe( 'parseDefaultStyleTagFromClassList', () => {
+  it( 'should extract the tag from an e-default-* class', () => {
+    const classList = {
+      *[ Symbol.iterator ]() {
+        yield 'elementor-element';
+        yield 'e-default-button';
+      },
+    } as DOMTokenList;
+
+    expect( parseDefaultStyleTagFromClassList( classList ) ).toBe( 'button' );
+  } );
+
+  it( 'should return null when no default style class exists', () => {
+    const classList = {
+      *[ Symbol.iterator ]() {
+        yield 'elementor-element';
+      },
+    } as DOMTokenList;
+
+    expect( parseDefaultStyleTagFromClassList( classList ) ).toBeNull();
+  } );
+} );
+
+describe( 'getDefaultStyleTagFromPreviewElement', () => {
+  afterEach( () => {
+    jest.clearAllMocks();
+  } );
+
+  it( 'should read the default style tag from the atomic render root', () => {
+    const button = document.createElement( 'button' );
+    button.className = 'e-button-base e-default-button';
+
+    const wrapper = document.createElement( 'div' );
+    wrapper.appendChild( button );
+
+    mockGetContainer.mockReturnValue( {
+      view: {
+        el: wrapper,
+        getDomElement: () => ( {
+          get: () => button,
+        } ),
+      },
+    } as never );
+
+    expect( getDefaultStyleTagFromPreviewElement( 'element-1' ) ).toBe( 'button' );
+  } );
+
+  it( 'should read the default style tag from a preview element with data-id', () => {
+    const div = document.createElement( 'div' );
+    div.dataset.id = 'element-2';
+    div.className = 'elementor-element e-default-div';
+
+    mockGetContainer.mockReturnValue( null );
+    mockGetPreviewElementDOM.mockReturnValue( div );
+
+    expect( getDefaultStyleTagFromPreviewElement( 'element-2' ) ).toBe( 'div' );
+  } );
+} );

--- a/packages/packages/libs/editor-elements/src/utils/get-default-style-tag-from-preview.ts
+++ b/packages/packages/libs/editor-elements/src/utils/get-default-style-tag-from-preview.ts
@@ -1,0 +1,63 @@
+import { getContainer } from '../sync/get-container';
+import { getPreviewElementDOM } from '../sync/get-preview-element-dom';
+
+export const DEFAULT_STYLE_CLASS_PREFIX = 'e-default-';
+
+type AtomicElementView = {
+  getDomElement?: () => { get: ( index: number ) => HTMLElement | undefined };
+  el?: HTMLElement;
+};
+
+export function parseDefaultStyleTagFromClassList( classList: DOMTokenList ): string | null {
+  for ( const className of classList ) {
+    if ( className.startsWith( DEFAULT_STYLE_CLASS_PREFIX ) ) {
+      return className.slice( DEFAULT_STYLE_CLASS_PREFIX.length );
+    }
+  }
+
+  return null;
+}
+
+export function getDefaultStyleTagFromPreviewElement( elementId: string ): string | null {
+  const renderRoot = getAtomicElementRenderRoot( elementId );
+
+  if ( ! renderRoot ) {
+    return null;
+  }
+
+  return parseDefaultStyleTagFromClassList( renderRoot.classList );
+}
+
+function getAtomicElementRenderRoot( elementId: string ): HTMLElement | null {
+  const view = getContainerView( elementId );
+
+  if ( view?.getDomElement ) {
+    const domElement = view.getDomElement().get( 0 );
+
+    if ( domElement ) {
+      return domElement;
+    }
+  }
+
+  const wrapper = view?.el ?? getPreviewElementDOM( elementId );
+
+  if ( ! wrapper ) {
+    return null;
+  }
+
+  if ( wrapper.hasAttribute( 'data-id' ) ) {
+    return wrapper;
+  }
+
+  const firstChild = wrapper.firstElementChild;
+
+  if ( firstChild instanceof HTMLElement ) {
+    return firstChild;
+  }
+
+  return wrapper;
+}
+
+function getContainerView( elementId: string ): AtomicElementView | null {
+  return getContainer( elementId )?.view ?? null;
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/test-atomic-styles-manager.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/test-atomic-styles-manager.php
@@ -116,6 +116,50 @@ class Test_Atomic_Styles_Manager extends Elementor_Test_Base {
 		];
 	}
 
+	public function test_enqueue__uses_css_name_when_distinct_from_id() {
+		// Arrange.
+		$styles_manager = new Atomic_Styles_Manager();
+		$styles_manager->register_hooks();
+
+		$get_style_defs = function () {
+			return [
+				[
+					'id' => 'h2',
+					'type' => 'class',
+					'cssName' => 'e-default-h2',
+					'variants' => [
+						[
+							'meta' => [
+								'breakpoint' => 'desktop',
+							],
+							'props' => [
+								'color' => 'red',
+							],
+						],
+					],
+				],
+			];
+		};
+
+		$this->filesystemMock->method( 'put_contents' )->willReturn( true );
+
+		$this->filesystemMock->expects( $this->once() )
+			->method( 'put_contents' )
+			->with(
+				$this->anything(),
+				'.elementor .e-default-h2{color:red;}'
+			);
+
+		add_action( 'elementor/atomic-widgets/styles/register', function ( $styles_manager ) use ( $get_style_defs ) {
+			$styles_manager->register( [ $this->test_style_key ], $get_style_defs );
+		}, 100, 1 );
+
+		do_action( 'elementor/post/render', 1 );
+
+		// Act
+		do_action( 'elementor/frontend/after_enqueue_post_styles' );
+	}
+
 	public function test_enqueue__enqueues_styles() {
 		// Arrange.
 		$styles_manager = new Atomic_Styles_Manager();

--- a/tests/phpunit/elementor/modules/default-styles/test-default-styles.php
+++ b/tests/phpunit/elementor/modules/default-styles/test-default-styles.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Elementor\Testing\Modules\DefaultStyles;
+
+use Elementor\Modules\DefaultStyles\Default_Style_Post_Type;
+use Elementor\Modules\DefaultStyles\Default_Styles_Repository;
+use Elementor\Modules\DefaultStyles\Atomic_Default_Styles;
+use Elementor\Modules\AtomicWidgets\Styles\Atomic_Styles_Manager;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+use PHPUnit\Framework\MockObject\MockObject;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Default_Styles_Repository extends Elementor_Test_Base {
+	private ?\Elementor\Core\Kits\Documents\Kit $kit = null;
+
+	public function set_up() {
+		parent::set_up();
+
+		Default_Style_Post_Type::ensure_registered();
+
+		$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+	}
+
+	public function test_put_and_get_style() {
+		$repository = Default_Styles_Repository::make( $this->kit );
+
+		$repository->put( 'h1', [
+			'type' => 'class',
+			'variants' => [
+				[
+					'props' => [ 'color' => 'red' ],
+					'meta' => [ 'breakpoint' => null, 'state' => null ],
+				],
+			],
+		] );
+
+		$item = $repository->get( 'h1' );
+
+		$this->assertNotNull( $item );
+		$this->assertSame( 'h1', $item['id'] );
+		$this->assertSame( 'class', $item['type'] );
+		$this->assertCount( 1, $item['variants'] );
+	}
+
+	public function test_is_allowed_tag_rejects_invalid_tag() {
+		$this->assertTrue( Default_Styles_Repository::is_allowed_tag( 'h1' ) );
+		$this->assertFalse( Default_Styles_Repository::is_allowed_tag( 'script' ) );
+	}
+}
+
+class Test_Default_Styles_Rendering extends Elementor_Test_Base {
+	private ?\Elementor\Core\Kits\Documents\Kit $kit = null;
+
+	public function set_up() {
+		parent::set_up();
+
+		Default_Style_Post_Type::ensure_registered();
+
+		$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+	}
+
+	public function test_default_styles_use_prefixed_css_class_in_selector() {
+		$repository = Default_Styles_Repository::make( $this->kit );
+
+		$repository->put( 'h2', [
+			'type' => 'class',
+			'variants' => [
+				[
+					'props' => [
+						'color' => [
+							'$$type' => 'color',
+							'value' => 'red',
+						],
+					],
+					'meta' => [ 'breakpoint' => 'desktop', 'state' => null ],
+				],
+			],
+		] );
+
+		$item = $repository->get( 'h2' );
+
+		$this->assertSame( 'e-default-h2', $item['cssName'] );
+
+		$css = \Elementor\Modules\AtomicWidgets\Styles\Styles_Renderer::make(
+			Plugin::$instance->breakpoints->get_breakpoints_config()
+		)->render( [ $item ] );
+
+		$this->assertStringContainsString( '.elementor .e-default-h2', $css );
+		$this->assertStringNotContainsString( '.elementor .h2', $css );
+	}
+}
+
+class Test_Atomic_Default_Styles extends Elementor_Test_Base {
+	private MockObject $mock_styles_manager;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->mock_styles_manager = $this->createMock( Atomic_Styles_Manager::class );
+		remove_all_actions( 'elementor/atomic-widgets/styles/register' );
+	}
+
+	public function test_register_styles__uses_default_path_without_post_id() {
+		( new Atomic_Default_Styles() )->register_hooks();
+
+		$this->mock_styles_manager
+			->expects( $this->once() )
+			->method( 'register' )
+			->with(
+				[ Atomic_Default_Styles::STYLES_KEY ],
+				$this->isCallable()
+			);
+
+		do_action( 'elementor/atomic-widgets/styles/register', $this->mock_styles_manager, [] );
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces `@elementor/editor-default-styles` editor package: tools-menu panel, Redux store, styles-repository provider (live canvas updates), and save-on-close UX.
- Extracts `StyleSections` from `editor-editing-panel` for reuse in the default-styles panel.
- Refactors `editor-components/init.ts` to support extension registration.
- Resolves default tag inheritance from preview `e-default-*` classes via `editor-elements` utilities.

## Jira

[ED-22046](https://elementor.atlassian.net/browse/ED-22046)

## Stack

Part of a 3-PR stack for HTML tag default styles. **Merge this PR via GitHub stacked-PRs to land the full stack.**

1. #36878 — PHP backend + `Atomic_Styles_Manager` `cssName` fix (`feat/ED-22046-default-styles-backend`)
2. #36879 — Twig `e-default-<tag>` class emission (`feat/ED-22046-atomic-twig-default-tag-class`)
3. **This PR** — Editor package + panel (`feat/ED-22046-default-styles-editor`)

Supersedes #36864 (kept open for reference).

## Test plan

- [ ] Enable `e_default_styles` and atomic widgets experiments
- [ ] Open Default Styles from the editor tools menu; set styles on a tag (e.g. `h2` background)
- [ ] Click **Save changes** — confirm REST PUT succeeds and panel `isDirty` clears
- [ ] Add an atomic heading with that tag — verify `e-default-h2` class and styles apply live in the canvas
- [ ] Add a linked heading — verify outer `e-default-h*` and inner `e-default-a` classes
- [ ] Reload the published frontend page — verify `.elementor .e-default-*` rules are enqueued and applied
- [ ] Close the panel with unsaved edits — confirm Save Changes dialog appears
- [ ] Run `npm run test:packages -w @elementor/editor-default-styles`
- [ ] Run `tests/phpunit/elementor/modules/default-styles/test-default-styles.php`
- [ ] Run `tests/phpunit/elementor/modules/atomic-widgets/styles/test-atomic-styles-manager.php --filter test_enqueue__uses_css_name_when_distinct_from_id`

[ED-22046]: https://elementor.atlassian.net/browse/ED-22046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds site-wide default HTML tag styling (e.g., `<h1>`, `<button>`, `<div>`) configurable through a new editor panel. Enables consistent typography/layout defaults across atomic widgets via the styles repository.

## 2. What Changed (Where)

| Component | Purpose |
|-----------|---------|
| **Backend** | New `default-styles` module: post type CPT, REST API endpoints, repository/normalizer for CRUD operations |
| **Frontend** | New `editor-default-styles` package: panel UI, state management, API client, styles provider integration |
| **Atomic Widgets** | Fixed `group_by_breakpoint` to preserve `cssName` field; updated 15+ Twig templates to inject `e-default-{tag}` classes |
| **Editing Panel** | Refactored style sections into reusable component; wired default tag inheritance into styles context |
| **Editor Elements** | Added `getDefaultStyleTagFromPreviewElement` utility to detect tag from element's class list |

## 3. How It Works

Panel → user selects HTML tag + styles (breakpoints/states) → saves via REST API → backend persists to post meta → `Atomic_Styles_Manager.register()` loads as `'default'` provider → styles applied to elements with matching `e-default-{tag}` class → inheritance chain includes default tag styles. CSS name prefix (`e-default-`) ensures no collision with element-scoped styles.

Twig templates auto-inject the tag class via new `default_tag_class()` macro. `StyleInheritanceProvider` queries preview DOM to detect element's tag and includes corresponding default style in inheritance chain.

## 4. Risks

**cssName preservation in `group_by_breakpoint`**: Guard condition added (`if (empty($breakpoint))`) prevents null breakpoint bugs, but behavior change for existing code passing undefined breakpoints—audit callers. **Template changes across 15+ files**: Mass addition of `e-default-{tag}` classes could mask styling inconsistencies if defaults are too broad; recommend conservative initial defaults. **Post type cleanup**: Orphaned default style posts on kit deletion rely on meta sync—verify kit import/export handles `Default_Styles_Tag_Post_IDs::META_KEY` preservation.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
