### PR TITLE
Fix: Paginate artifact listing for Playground and Lighthouse previews [ED-25239]

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -59,11 +59,16 @@ jobs:
               return;
             }
 
-            const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: run.id,
-            });
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+                per_page: 100,
+              },
+              (response) => response.data.artifacts,
+            );
 
             const pluginArtifact = artifacts.find((artifact) => artifact.name.startsWith('elementor-'));
             if (!pluginArtifact) {

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -44,11 +44,16 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: Number('${{ steps.runctx.outputs.build-run-id }}'),
-            });
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: Number('${{ steps.runctx.outputs.build-run-id }}'),
+                per_page: 100,
+              },
+              (response) => response.data.artifacts,
+            );
             const hit = artifacts.find(a => a.name.startsWith('elementor-'));
             if (!hit) {
               core.setFailed('No elementor artifact found in resolved PR workflow run');


### PR DESCRIPTION
## Summary
- Paginate `listWorkflowRunArtifacts` in Playground preview and Lighthouse so the `elementor-*` plugin zip is found when the unified `PR` workflow uploads more than 30 artifacts (Playwright/Allure fill the first page).
- Fixes deterministic `No elementor artifact found in resolved PR workflow run` failures (e.g. https://github.com/elementor/elementor/actions/runs/31673691114).

## Test plan
- [ ] Merge or push this branch, open/re-run a PR whose `PR` workflow succeeds with 30+ artifacts
- [ ] Confirm Playground PR Preview Deployments finds `elementor-*` and posts a deployment
- [ ] With `run-tests` label, confirm Lighthouse resolve step still locates the plugin artifact

## Jira
[ED-25239](https://elementor.atlassian.net/browse/ED-25239)

[ED-25239]: https://elementor.atlassian.net/browse/ED-25239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

GitHub API's `listWorkflowRunArtifacts` endpoint paginates results (100 per page default), but the old code only fetched the first page. This breaks artifact discovery for builds that generate >100 artifacts. ED-25239.

## 2. What Changed (Where)

- `.github/workflows/lighthouse.yml`: Replaced direct API call with `github.paginate()` wrapper, added `per_page: 100` param
- `.github/workflows/playground-preview.yml`: Same pagination fix for artifact listing in playground preview workflow

## 3. How It Works

`github.paginate()` automatically handles multi-page responses by making sequential requests and aggregating results via the callback `(response) => response.data.artifacts`. The `per_page: 100` is explicit but matches the API default.

## 4. Risks

None. The `paginate()` utility is idiomatic in GitHub Actions scripting and backward-compatible—collects *all* artifacts instead of just the first batch.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
