### PR TITLE
Fix: Remove wrong paginate map function for artifact listing [ED-25239]

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -67,7 +67,6 @@ jobs:
                 run_id: run.id,
                 per_page: 100,
               },
-              (response) => response.data.artifacts,
             );
 
             const pluginArtifact = artifacts.find((artifact) => artifact.name.startsWith('elementor-'));

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -52,7 +52,6 @@ jobs:
                 run_id: Number('${{ steps.runctx.outputs.build-run-id }}'),
                 per_page: 100,
               },
-              (response) => response.data.artifacts,
             );
             const hit = artifacts.find(a => a.name.startsWith('elementor-'));
             if (!hit) {


### PR DESCRIPTION
## Summary
- Follow-up to #36893, which broke Playground preview with `TypeError: Cannot read properties of undefined (reading 'name')` (e.g. https://github.com/elementor/elementor/actions/runs/31678199796).
- Octokit's `normalizePaginatedListResponse` already replaces `response.data` with the artifacts array, so the `(response) => response.data.artifacts` map function returned `undefined` per page and `.find(a => a.name...)` threw.
- Dropping the map function makes `github.paginate` return the flat artifact list, keeping the intended pagination fix from #36893.

## Verification
Reproduced against real run `31671794861` (37 artifacts) with `@octokit/rest`:

```
old (mapFn):   1 entries, first = undefined  -> TypeError: Cannot read properties of undefined (reading 'name')
new (no mapFn): 37 entries                   -> found elementor-4.3.0-20260813.0552
```

## Test plan
- [ ] After merge, confirm Playground PR Preview Deployments resolves `elementor-*` and posts a deployment
- [ ] With `run-tests` label, confirm the Lighthouse resolve step locates the plugin artifact

## Jira
[ED-25239](https://elementor.atlassian.net/browse/ED-25239)

[ED-25239]: https://elementor.atlassian.net/browse/ED-25239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The `paginate()` calls were incorrectly passing a map function `(response) => response.data.artifacts` that filtered the paginated results to only artifacts, but `github.rest.actions.listWorkflowRunArtifacts` already returns the artifacts array directly—the map function was redundant and likely caused issues with pagination.

## 2. What Changed (Where)

- `.github/workflows/lighthouse.yml`: Removed map function from `paginate()` call (line 70)
- `.github/workflows/playground-preview.yml`: Removed map function from `paginate()` call (line 55)

## 3. How It Works

The Octokit paginate helper handles data extraction automatically based on the API response structure. Passing an explicit map function overrides that behavior and breaks pagination logic. Removing it restores correct iteration over all artifacts across pages.

## 4. Risks

None—this is a bug fix. The map function was incorrect; removal aligns code with Octokit's intended usage pattern.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
