### PR TITLE
CI: Always deploy Playground preview after successful PR build [ED-25240]

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -1,75 +1,40 @@
-name: Playground PR Preview Deployments
+name: Playground PR Preview
+
 on:
-  workflow_run:
-    workflows: ["PR"]
-    types: [completed]
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: Core build artifact name from the PR build job
+        required: true
+        type: string
+      pr_number:
+        description: Pull request number
+        required: true
+        type: string
+      head_sha:
+        description: PR head commit SHA
+        required: true
+        type: string
+
 permissions:
   contents: read
-  pull-requests: write
   actions: read
   deployments: write
 
 jobs:
   preview:
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
 
-      - name: Resolve PR context and Build run
-        id: runctx
-        uses: actions/github-script@v9
-        with:
-          script: |
-            console.log('context:${JSON.stringify(context)}');
-            const run = context.payload.workflow_run;
-            const prs = run.pull_requests || [];
-            if (!prs.length) {
-              core.setFailed('No pull request found for this workflow run');
-              return;
-            }
-
-            const prNumber = prs[0].number;
-            const headSha = run.head_sha;
-            const buildRunId = run.id;
-
-            core.setOutput('pr-number', String(prNumber));
-            core.setOutput('head-sha', headSha);
-            core.setOutput('build-run-id', String(buildRunId));
-
       - name: Download plugin artifact
-        id: artifact
-        uses: actions/github-script@v9
+        uses: actions/download-artifact@v8
         with:
-          script: |
-            const artifacts = await github.paginate(
-              github.rest.actions.listWorkflowRunArtifacts,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: Number('${{ steps.runctx.outputs.build-run-id }}'),
-                per_page: 100,
-              },
-            );
-            const hit = artifacts.find(a => a.name.startsWith('elementor-'));
-            if (!hit) {
-              core.setFailed('No elementor artifact found in resolved PR workflow run');
-              return;
-            }
-            const dl = await github.rest.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: hit.id,
-              archive_format: 'zip',
-            });
-            require('fs').writeFileSync('build-artifact.zip', Buffer.from(dl.data));
-            core.setOutput('artifact-name', hit.name);
+          name: ${{ inputs.artifact_name }}
+          path: build-artifact
 
       - name: Repack build artifact for Playground
         run: |
-          unzip -oq build-artifact.zip -d build-artifact
           if [ ! -f build-artifact/elementor.php ]; then
             echo "Downloaded artifact does not look like Elementor plugin root (missing elementor.php)"
             exit 1
@@ -83,7 +48,7 @@ jobs:
         id: playground-artifact
         uses: actions/upload-artifact@v7
         with:
-          name: playground-plugin-pr${{ steps.runctx.outputs.pr-number }}-${{ steps.runctx.outputs.head-sha }}
+          name: playground-plugin-pr${{ inputs.pr_number }}-${{ inputs.head_sha }}
           path: plugin-root
           if-no-files-found: error
           retention-days: 3
@@ -91,7 +56,7 @@ jobs:
       - name: Prepare blueprint JSON
         id: blueprint
         env:
-          ARTIFACT_NAME: playground-plugin-pr${{ steps.runctx.outputs.pr-number }}-${{ steps.runctx.outputs.head-sha }}
+          ARTIFACT_NAME: playground-plugin-pr${{ inputs.pr_number }}-${{ inputs.head_sha }}
         run: |
           node <<'NODE'
           const fs = require('fs');
@@ -111,8 +76,8 @@ jobs:
       - name: Create PR deployment
         uses: actions/github-script@v9
         env:
-          HEAD_SHA: ${{ steps.runctx.outputs.head-sha }}
-          PR_NUMBER: ${{ steps.runctx.outputs.pr-number }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          PR_NUMBER: ${{ inputs.pr_number }}
           PREVIEW_URL: ${{ steps.blueprint.outputs.playground-url }}
         with:
           script: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,7 @@ permissions:
   id-token: write
   actions: read
   statuses: write
+  deployments: write
 
 jobs:
   set-pending-playwright-on-draft:
@@ -211,6 +212,22 @@ jobs:
           echo "  Path: elementor"
           echo "  Size: $(du -sh elementor | cut -f1)"
           echo "  URL: https://github.com/elementor/elementor/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload-artifact.outputs.artifact-id }}"
+
+  playground-preview:
+    needs: [build]
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      startsWith(github.repository, 'elementor/')
+    permissions:
+      contents: read
+      actions: read
+      deployments: write
+    uses: ./.github/workflows/playground-preview.yml
+    with:
+      artifact_name: ${{ needs.build.outputs.artifact_name }}
+      pr_number: ${{ github.event.pull_request.number }}
+      head_sha: ${{ github.event.pull_request.head.sha }}
 
   lint-js:
     name: Lint JS


### PR DESCRIPTION
## Summary
- Convert Playground preview from a `workflow_run` (requires full `PR` success) to a `workflow_call` invoked right after `build`.
- Deploy whenever build succeeds, including draft PRs and when later lint/test jobs fail.
- Use `actions/download-artifact` with the build artifact name (removes the fragile artifact-list pagination path).

## Test plan
- [ ] Open a **draft** PR with a successful build and confirm a Playground deployment is created
- [ ] Push a change that fails Playwright/Jest after build succeeds and confirm Playground still deploys
- [ ] Confirm Playground still deploys on a ready-for-review PR with green CI
- [ ] Confirm no Playground job runs when build itself fails

## Jira
[ED-25240](https://elementor.atlassian.net/browse/ED-25240)

[ED-25240]: https://elementor.atlassian.net/browse/ED-25240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Playground preview deployment was coupled to an external workflow trigger (`workflow_run`), making it unreliable and hard to debug. Refactoring to `workflow_call` decouples concerns and ensures deployment runs consistently after successful PR builds (ED-25240).

## 2. What Changed (Where)

- `.github/workflows/playground-preview.yml`: Converted from `workflow_run` event to `workflow_call` with explicit inputs; removed complex GitHub Script context resolution and artifact discovery logic.
- `.github/workflows/pr.yml`: Added `playground-preview` job that calls the refactored workflow; added `deployments: write` permission.

## 3. How It Works

PR build completes successfully → `playground-preview` job triggered with build artifact name and PR metadata as inputs → workflow downloads artifact, repacks it, uploads to Playground, deploys. Direct parameter passing replaces the previous cross-workflow event inspection and artifact search.

## 4. Risks

If `pr.yml` ever filters the playground job incorrectly (e.g., condition `startsWith(github.repository, 'elementor/')` could exclude forks), deployments won't occur. Mitigation: condition is intentional for org repos only; monitor first few merged PRs for successful deployments.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
