### PR TITLE
Internal: Validate V3 element_config settings and coerce dynamic tags [ED-TBD]

### DIFF
--- a/modules/mcp/abilities/appliers/element-config-applier.php
+++ b/modules/mcp/abilities/appliers/element-config-applier.php
@@ -7,7 +7,7 @@ use Elementor\Modules\AtomicWidgets\Parsers\Props_Parser;
 use Elementor\Modules\AtomicWidgets\PlainResolvers\Plain_Values_Resolver;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\Components\Components_Repository;
-use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Non_Style_Allowlist;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Settings_Validator;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Widget_Type_Resolver;
 use Elementor\Modules\Mcp\Abilities\Prop_Canonicalizer;
 
@@ -57,13 +57,26 @@ class Element_Config_Applier {
 			}
 
 			if ( V3_Node_Bridge::is_v3_node( $node ) ) {
-				$filter = V3_Non_Style_Allowlist::filter( (string) $tag, $settings );
-				if ( $filter['error'] ) {
-					$errors[] = sprintf( '[%s] %s', $config_id, $filter['error']->get_error_message() );
+				$widget_type = (string) $tag;
+				$widget_config = is_array( $widget_configs[ $widget_type ] ?? null ) ? $widget_configs[ $widget_type ] : [];
+
+				$validated = V3_Settings_Validator::validate( $widget_type, $settings, $widget_config );
+
+				if ( $validated['error'] ) {
+					$errors[] = sprintf( '[%s] %s', $config_id, $validated['error']->get_error_message() );
 					continue;
 				}
 
-				$node['settings'] = $this->merge_with_clears( $node['settings'] ?? [], $filter['allowed'] );
+				$node['settings'] = $this->merge_with_clears( $node['settings'] ?? [], $validated['allowed'] );
+
+				if ( ! empty( $validated['dynamic_patch'] ) ) {
+					$existing_dynamic = $node['settings']['__dynamic__'] ?? [];
+					$node['settings']['__dynamic__'] = array_merge(
+						is_array( $existing_dynamic ) ? $existing_dynamic : [],
+						$validated['dynamic_patch']
+					);
+				}
+
 				continue;
 			}
 

--- a/modules/mcp/abilities/appliers/v3/v3-dynamic-resolver.php
+++ b/modules/mcp/abilities/appliers/v3/v3-dynamic-resolver.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Translates the LLM-facing dynamic-tag idiom (`{ name, settings }`) into V3's on-disk
+ * `__dynamic__[key] = <shortcode>` sibling map. Accepts two input shapes so the LLM can use
+ * the same contract it uses on V4:
+ *
+ *   1. Top-level:  `{ name, settings }` at the allowlisted key.
+ *   2. Nested:     `{ <control.dynamic.property>: { name, settings } }` (e.g. `url` on a URL control).
+ *
+ * Validation is strict:
+ *   - Tag must be registered.
+ *   - Tag's categories must intersect the control's `dynamic.categories` (when declared).
+ *
+ * Two callable seams (`$tag_info_resolver`, `$shortcode_builder`) exist so unit tests can
+ * exercise the resolver without booting WordPress.
+ */
+class V3_Dynamic_Resolver {
+
+	/** @var callable|null */
+	private static $tag_info_resolver = null;
+
+	/** @var callable|null */
+	private static $shortcode_builder = null;
+
+	public static function set_tag_info_resolver( ?callable $resolver ): void {
+		self::$tag_info_resolver = $resolver;
+	}
+
+	public static function set_shortcode_builder( ?callable $builder ): void {
+		self::$shortcode_builder = $builder;
+	}
+
+	/**
+	 * @param string               $key     Allowlisted setting key (control name on the V3 widget).
+	 * @param mixed                $value   Raw value from element_config for this key.
+	 * @param array<string, mixed> $control Control config from `Widget_Base::get_controls()[$key]`.
+	 *
+	 * @return array{
+	 *     matched: bool,
+	 *     shortcode?: string,
+	 *     primitive?: mixed,
+	 *     error?: \WP_Error,
+	 * }
+	 */
+	public static function try_resolve( string $key, $value, array $control ): array {
+		if ( ! self::is_dynamic_capable( $control ) ) {
+			return [ 'matched' => false ];
+		}
+
+		$dynamic_input = self::extract_dynamic_input( $value, $control['dynamic']['property'] ?? null );
+		if ( null === $dynamic_input ) {
+			return [ 'matched' => false ];
+		}
+
+		$tag_info = self::resolve_tag_info( $dynamic_input['name'] );
+		if ( null === $tag_info ) {
+			return [
+				'matched' => true,
+				'error' => new \WP_Error(
+					'elementor_invalid_settings',
+					sprintf( 'dynamic tag "%s" is not registered.', $dynamic_input['name'] )
+				),
+			];
+		}
+
+		$category_error = self::validate_categories( $key, $dynamic_input['name'], $tag_info, $control['dynamic']['categories'] ?? [] );
+		if ( $category_error ) {
+			return [
+				'matched' => true,
+				'error' => $category_error,
+			];
+		}
+
+		$shortcode = self::build_shortcode( $dynamic_input['name'], $dynamic_input['settings'] );
+		if ( '' === $shortcode ) {
+			return [
+				'matched' => true,
+				'error' => new \WP_Error(
+					'elementor_invalid_settings',
+					sprintf( 'failed to serialize dynamic tag "%s".', $dynamic_input['name'] )
+				),
+			];
+		}
+
+		return [
+			'matched' => true,
+			'shortcode' => $shortcode,
+			'primitive' => self::empty_primitive_for_control( $control ),
+		];
+	}
+
+	public static function is_dynamic_capable( array $control ): bool {
+		return true === ( $control['dynamic']['active'] ?? false );
+	}
+
+	/**
+	 * @return array{name: string, settings: array<string, mixed>}|null
+	 */
+	private static function extract_dynamic_input( $value, ?string $property ): ?array {
+		if ( ! is_array( $value ) ) {
+			return null;
+		}
+
+		$top = self::pluck_dynamic_shape( $value );
+		if ( null !== $top ) {
+			return $top;
+		}
+
+		if ( ! is_string( $property ) || '' === $property ) {
+			return null;
+		}
+
+		$nested = $value[ $property ] ?? null;
+		if ( ! is_array( $nested ) ) {
+			return null;
+		}
+
+		return self::pluck_dynamic_shape( $nested );
+	}
+
+	/**
+	 * @return array{name: string, settings: array<string, mixed>}|null
+	 */
+	private static function pluck_dynamic_shape( array $value ): ?array {
+		$name = $value['name'] ?? null;
+		if ( ! is_string( $name ) || '' === $name ) {
+			return null;
+		}
+
+		$settings = $value['settings'] ?? [];
+		if ( ! is_array( $settings ) ) {
+			$settings = [];
+		}
+
+		return [
+			'name' => $name,
+			'settings' => $settings,
+		];
+	}
+
+	private static function validate_categories( string $key, string $tag_name, array $tag_info, array $control_categories ): ?\WP_Error {
+		if ( empty( $control_categories ) ) {
+			return null;
+		}
+
+		$tag_categories = self::extract_tag_categories( $tag_info );
+		if ( empty( $tag_categories ) ) {
+			return null;
+		}
+
+		if ( ! empty( array_intersect( $tag_categories, $control_categories ) ) ) {
+			return null;
+		}
+
+		return new \WP_Error(
+			'elementor_invalid_settings',
+			sprintf(
+				'dynamic tag "%s" (categories: [%s]) is not compatible with field "%s" (allowed categories: [%s]).',
+				$tag_name,
+				implode( ', ', $tag_categories ),
+				$key,
+				implode( ', ', $control_categories )
+			)
+		);
+	}
+
+	private static function extract_tag_categories( array $tag_info ): array {
+		if ( isset( $tag_info['categories'] ) && is_array( $tag_info['categories'] ) ) {
+			return $tag_info['categories'];
+		}
+
+		$class = $tag_info['class'] ?? null;
+		if ( ! is_string( $class ) || ! class_exists( $class ) ) {
+			return [];
+		}
+
+		try {
+			$instance = new $class();
+			if ( method_exists( $instance, 'get_categories' ) ) {
+				$categories = $instance->get_categories();
+				return is_array( $categories ) ? $categories : [];
+			}
+		} catch ( \Throwable $e ) {
+			return [];
+		}
+
+		return [];
+	}
+
+	private static function resolve_tag_info( string $name ): ?array {
+		if ( is_callable( self::$tag_info_resolver ) ) {
+			$info = ( self::$tag_info_resolver )( $name );
+			return is_array( $info ) ? $info : null;
+		}
+
+		if ( ! isset( Plugin::$instance->dynamic_tags ) ) {
+			return null;
+		}
+
+		$info = Plugin::$instance->dynamic_tags->get_tag_info( $name );
+		return is_array( $info ) ? $info : null;
+	}
+
+	private static function build_shortcode( string $name, array $settings ): string {
+		$id = self::generate_tag_id();
+
+		if ( is_callable( self::$shortcode_builder ) ) {
+			$built = ( self::$shortcode_builder )( $id, $name, $settings );
+			return is_string( $built ) ? $built : '';
+		}
+
+		if ( ! isset( Plugin::$instance->dynamic_tags ) ) {
+			return '';
+		}
+
+		$built = Plugin::$instance->dynamic_tags->tag_data_to_tag_text( $id, $name, $settings );
+		return is_string( $built ) ? $built : '';
+	}
+
+	private static function generate_tag_id(): string {
+		return substr( md5( uniqid( 'mcp-v3-dyn', true ) ), 0, 7 );
+	}
+
+	private static function empty_primitive_for_control( array $control ): mixed {
+		$type = $control['type'] ?? null;
+
+		if ( 'url' === $type ) {
+			return [
+				'url' => '',
+				'is_external' => '',
+				'nofollow' => '',
+			];
+		}
+
+		if ( 'media' === $type ) {
+			return [
+				'url' => '',
+				'id' => 0,
+			];
+		}
+
+		return '';
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/v3-dynamic-resolver.php
+++ b/modules/mcp/abilities/appliers/v3/v3-dynamic-resolver.php
@@ -56,7 +56,9 @@ class V3_Dynamic_Resolver {
 			return [ 'matched' => false ];
 		}
 
-		$dynamic_input = self::extract_dynamic_input( $value, $control['dynamic']['property'] ?? null );
+		$dynamic = self::resolve_dynamic_config( $control );
+		$property = $dynamic['property'] ?? self::default_dynamic_property_for_type( $control['type'] ?? null );
+		$dynamic_input = self::extract_dynamic_input( $value, $property );
 		if ( null === $dynamic_input ) {
 			return [ 'matched' => false ];
 		}
@@ -72,7 +74,7 @@ class V3_Dynamic_Resolver {
 			];
 		}
 
-		$category_error = self::validate_categories( $key, $dynamic_input['name'], $tag_info, $control['dynamic']['categories'] ?? [] );
+		$category_error = self::validate_categories( $key, $dynamic_input['name'], $tag_info, $dynamic['categories'] ?? [] );
 		if ( $category_error ) {
 			return [
 				'matched' => true,
@@ -99,7 +101,53 @@ class V3_Dynamic_Resolver {
 	}
 
 	public static function is_dynamic_capable( array $control ): bool {
-		return true === ( $control['dynamic']['active'] ?? false );
+		$dynamic = self::resolve_dynamic_config( $control );
+
+		if ( true === ( $dynamic['active'] ?? false ) ) {
+			return true;
+		}
+
+		if ( ! empty( $dynamic['categories'] ) ) {
+			return true;
+		}
+
+		return is_string( $dynamic['default'] ?? null ) && '' !== $dynamic['default'];
+	}
+
+	/**
+	 * Merges per-control `dynamic` args with the control-type defaults from Controls_Manager.
+	 * Widget stacks often only set `dynamic.active` or `dynamic.default`; URL controls rely on
+	 * the type default for `categories` + `property` (`url`).
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function resolve_dynamic_config( array $control ): array {
+		$dynamic = is_array( $control['dynamic'] ?? null ) ? $control['dynamic'] : [];
+		$type = $control['type'] ?? null;
+
+		if ( ! is_string( $type ) || '' === $type || ! isset( Plugin::$instance->controls_manager ) ) {
+			return $dynamic;
+		}
+
+		$control_obj = Plugin::$instance->controls_manager->get_control( $type );
+		if ( ! $control_obj || ! method_exists( $control_obj, 'get_settings' ) ) {
+			return $dynamic;
+		}
+
+		$type_dynamic = $control_obj->get_settings( 'dynamic' );
+		if ( ! is_array( $type_dynamic ) || empty( $type_dynamic ) ) {
+			return $dynamic;
+		}
+
+		return array_merge( $type_dynamic, $dynamic );
+	}
+
+	private static function default_dynamic_property_for_type( ?string $control_type ): ?string {
+		if ( 'url' === $control_type ) {
+			return 'url';
+		}
+
+		return null;
 	}
 
 	/**

--- a/modules/mcp/abilities/appliers/v3/v3-settings-validator.php
+++ b/modules/mcp/abilities/appliers/v3/v3-settings-validator.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\Mcp\Abilities\Utils\V3_Json_Schema_Builder;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Value-level gate for V3 element_config entries. Composes three concerns:
+ *
+ *   1. `V3_Non_Style_Allowlist`  — key gate (which keys the widget accepts at all).
+ *   2. `V3_Dynamic_Resolver`     — routes `{ name, settings }` (or its nested variant on
+ *                                  URL/media controls) into `__dynamic__[key]` shortcodes
+ *                                  so the LLM cannot smuggle a V4-shaped dynamic into a
+ *                                  V3 primitive slot.
+ *   3. Shape check               — validates remaining primitive values against the JSON
+ *                                  Schema entry emitted by `V3_Json_Schema_Builder` so
+ *                                  the applier never merges an array into a scalar field
+ *                                  (the original bug: `link` merged as `{name, settings}`
+ *                                  and `esc_url()` blew up on the array).
+ */
+class V3_Settings_Validator {
+
+	/**
+	 * @param string               $widget_type   V3 widget type (e.g. `theme-post-title`).
+	 * @param array<string, mixed> $settings      Raw settings for a single element_config entry.
+	 * @param array<string, mixed> $widget_config Widget config from `Widget_Type_Resolver::resolve_type_config()`.
+	 *
+	 * @return array{
+	 *     allowed: array<string, mixed>,
+	 *     dynamic_patch: array<string, string>,
+	 *     error: \WP_Error|null,
+	 * }
+	 */
+	public static function validate( string $widget_type, array $settings, array $widget_config ): array {
+		$key_filter = V3_Non_Style_Allowlist::filter( $widget_type, $settings );
+
+		$errors = [];
+		if ( $key_filter['error'] ) {
+			$errors[] = $key_filter['error']->get_error_message();
+		}
+
+		$controls = is_array( $widget_config['controls'] ?? null ) ? $widget_config['controls'] : [];
+		$schema = V3_Json_Schema_Builder::build( $controls, array_keys( $key_filter['allowed'] ) );
+
+		$allowed = [];
+		$dynamic_patch = [];
+
+		foreach ( $key_filter['allowed'] as $key => $value ) {
+			$control = is_array( $controls[ $key ] ?? null ) ? $controls[ $key ] : [];
+
+			$dynamic_outcome = V3_Dynamic_Resolver::try_resolve( $key, $value, $control );
+			if ( $dynamic_outcome['matched'] ) {
+				if ( isset( $dynamic_outcome['error'] ) ) {
+					$errors[] = self::format_error( $widget_type, $key, $dynamic_outcome['error']->get_error_message() );
+					continue;
+				}
+
+				$dynamic_patch[ $key ] = $dynamic_outcome['shortcode'];
+				$allowed[ $key ] = $dynamic_outcome['primitive'];
+				continue;
+			}
+
+			$shape_error = self::validate_primitive( $value, $schema['properties'][ $key ] ?? null );
+			if ( null !== $shape_error ) {
+				$errors[] = self::format_error( $widget_type, $key, $shape_error );
+				continue;
+			}
+
+			$allowed[ $key ] = $value;
+		}
+
+		return [
+			'allowed' => $allowed,
+			'dynamic_patch' => $dynamic_patch,
+			'error' => empty( $errors ) ? null : new \WP_Error(
+				'elementor_invalid_settings',
+				implode( ' ', $errors ),
+				[ 'status' => \WP_Http::BAD_REQUEST ]
+			),
+		];
+	}
+
+	private static function format_error( string $widget_type, string $key, string $reason ): string {
+		return sprintf( 'V3 widget "%s" property "%s": %s', $widget_type, $key, $reason );
+	}
+
+	/**
+	 * Best-effort JSON-Schema shape check. Unlike `Props_Parser` (V4), V3 has no runtime
+	 * parser, so we walk one level deep — enough to catch the array-vs-scalar and unknown
+	 * enum-value classes of bugs, without inventing a general JSON-Schema validator.
+	 */
+	private static function validate_primitive( $value, ?array $entry_schema ): ?string {
+		if ( ! is_array( $entry_schema ) ) {
+			return null;
+		}
+
+		$primitive_schema = self::unwrap_primitive_branch( $entry_schema );
+
+		return self::validate_against_schema( $value, $primitive_schema );
+	}
+
+	private static function unwrap_primitive_branch( array $entry_schema ): array {
+		if ( ! isset( $entry_schema['anyOf'] ) || ! is_array( $entry_schema['anyOf'] ) ) {
+			return $entry_schema;
+		}
+
+		foreach ( $entry_schema['anyOf'] as $branch ) {
+			if ( is_array( $branch ) && ! self::is_dynamic_branch( $branch ) ) {
+				return $branch;
+			}
+		}
+
+		return $entry_schema;
+	}
+
+	private static function is_dynamic_branch( array $branch ): bool {
+		if ( 'object' !== ( $branch['type'] ?? null ) ) {
+			return false;
+		}
+
+		$required = $branch['required'] ?? [];
+		if ( ! is_array( $required ) || ! in_array( 'name', $required, true ) ) {
+			return false;
+		}
+
+		return isset( $branch['properties']['name'] );
+	}
+
+	private static function validate_against_schema( $value, array $schema ): ?string {
+		$expected_type = $schema['type'] ?? null;
+		$actual_type = self::json_type_of( $value );
+
+		if ( $expected_type && $expected_type !== $actual_type ) {
+			return sprintf( 'invalid shape (expected %s, got %s).', $expected_type, $actual_type );
+		}
+
+		if ( isset( $schema['enum'] ) && is_array( $schema['enum'] ) && ! in_array( $value, $schema['enum'], true ) ) {
+			return sprintf( 'value must be one of [%s].', implode( ', ', array_map( 'strval', $schema['enum'] ) ) );
+		}
+
+		if ( 'object' === $expected_type && is_array( $value ) && isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
+			foreach ( $schema['properties'] as $prop_key => $prop_schema ) {
+				if ( ! is_string( $prop_key ) || ! array_key_exists( $prop_key, $value ) ) {
+					continue;
+				}
+
+				$sub_expected = $prop_schema['type'] ?? null;
+				$sub_actual = self::json_type_of( $value[ $prop_key ] );
+				if ( $sub_expected && $sub_expected !== $sub_actual ) {
+					return sprintf( 'invalid shape at "%s" (expected %s, got %s).', $prop_key, $sub_expected, $sub_actual );
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static function json_type_of( $value ): string {
+		if ( is_string( $value ) ) {
+			return 'string';
+		}
+		if ( is_bool( $value ) ) {
+			return 'boolean';
+		}
+		if ( is_int( $value ) || is_float( $value ) ) {
+			return 'number';
+		}
+		if ( null === $value ) {
+			return 'null';
+		}
+		if ( is_array( $value ) ) {
+			if ( empty( $value ) ) {
+				return 'object';
+			}
+			return array_keys( $value ) === range( 0, count( $value ) - 1 ) ? 'array' : 'object';
+		}
+		return gettype( $value );
+	}
+}

--- a/modules/mcp/abilities/utils/v3-json-schema-builder.php
+++ b/modules/mcp/abilities/utils/v3-json-schema-builder.php
@@ -2,6 +2,8 @@
 
 namespace Elementor\Modules\Mcp\Abilities\Utils;
 
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Dynamic_Resolver;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -87,7 +89,7 @@ class V3_Json_Schema_Builder {
 			? trim( strip_tags( $control['description'] ) )
 			: null;
 
-		if ( ! self::is_dynamic_capable( $control ) ) {
+		if ( ! V3_Dynamic_Resolver::is_dynamic_capable( $control ) ) {
 			if ( null !== $description ) {
 				$entry['description'] = $description;
 			}
@@ -95,11 +97,13 @@ class V3_Json_Schema_Builder {
 			return $entry;
 		}
 
-		return self::wrap_with_dynamic_branch( $entry, $control['dynamic']['categories'] ?? [], $description );
+		$dynamic = V3_Dynamic_Resolver::resolve_dynamic_config( $control );
+
+		return self::wrap_with_dynamic_branch( $entry, $dynamic['categories'] ?? [], $description );
 	}
 
 	private static function is_dynamic_capable( array $control ): bool {
-		return true === ( $control['dynamic']['active'] ?? false );
+		return V3_Dynamic_Resolver::is_dynamic_capable( $control );
 	}
 
 	/**

--- a/modules/mcp/abilities/utils/v3-json-schema-builder.php
+++ b/modules/mcp/abilities/utils/v3-json-schema-builder.php
@@ -83,11 +83,69 @@ class V3_Json_Schema_Builder {
 			$entry['default'] = $control['default'];
 		}
 
-		if ( isset( $control['description'] ) && is_string( $control['description'] ) ) {
-			$entry['description'] = trim( strip_tags( $control['description'] ) );
+		$description = isset( $control['description'] ) && is_string( $control['description'] )
+			? trim( strip_tags( $control['description'] ) )
+			: null;
+
+		if ( ! self::is_dynamic_capable( $control ) ) {
+			if ( null !== $description ) {
+				$entry['description'] = $description;
+			}
+
+			return $entry;
 		}
 
-		return $entry;
+		return self::wrap_with_dynamic_branch( $entry, $control['dynamic']['categories'] ?? [], $description );
+	}
+
+	private static function is_dynamic_capable( array $control ): bool {
+		return true === ( $control['dynamic']['active'] ?? false );
+	}
+
+	/**
+	 * Wraps a primitive schema entry in an `anyOf` union with the plain dynamic-tag shape,
+	 * mirroring how V4 atomic prop types advertise dynamic bindings. Kept aligned with the
+	 * static resource `elementor://dynamic-tags`: the LLM picks a tag from there whose
+	 * categories intersect the ones declared on this control.
+	 *
+	 * @param array<string, mixed> $primitive_entry Primitive schema entry.
+	 * @param array<int, string>   $categories      Dynamic-tag categories accepted by this control.
+	 * @param string|null          $description     Optional shared description hoisted to the wrapper.
+	 */
+	private static function wrap_with_dynamic_branch( array $primitive_entry, array $categories, ?string $description ): array {
+		$dynamic_entry = [
+			'type' => 'object',
+			'required' => [ 'name' ],
+			'properties' => [
+				'name' => [ 'type' => 'string' ],
+				'settings' => [ 'type' => 'object' ],
+			],
+			'description' => self::dynamic_branch_description( $categories ),
+		];
+
+		$wrapped = [
+			'anyOf' => [
+				$primitive_entry,
+				$dynamic_entry,
+			],
+		];
+
+		if ( null !== $description ) {
+			$wrapped['description'] = $description;
+		}
+
+		return $wrapped;
+	}
+
+	private static function dynamic_branch_description( array $categories ): string {
+		if ( empty( $categories ) ) {
+			return 'Bind THIS value to a dynamic tag from elementor://dynamic-tags. Shape: { "name": "<tag>", "settings": { ... } }.';
+		}
+
+		return sprintf(
+			'Bind THIS value to a dynamic tag from elementor://dynamic-tags whose categories intersect [%s]. Shape: { "name": "<tag>", "settings": { ... } }.',
+			implode( ', ', array_map( 'strval', $categories ) )
+		);
 	}
 
 	private static function type_entry( array $control, ?string $control_type ): array {

--- a/modules/mcp/static-resources/abilities/build-composition.md
+++ b/modules/mcp/static-resources/abilities/build-composition.md
@@ -115,10 +115,12 @@ Read [elementor://global-classes] before composing. Create or update via `elemen
 - Global classes are prepended before any local styles from `style`; local styles still win on conflicts
 
 # DYNAMIC TAGS
-- A value can be made dynamic wherever the widget schema allows a dynamic variant (often a union on the prop or a nested field such as an image's `src`).
+- A value can be made dynamic wherever the widget schema allows a dynamic variant (often an `anyOf` on the prop or a nested field such as an image's `src`).
 - Put the plain dynamic object at that node, in place of the static variant. Read [elementor://dynamic-tags] for allowed tag names and each tag's settings schema.
 - Plain dynamic shape: `{ "name": "<allowed tag>", "settings": { ... } }`
 - Example (image `src`): `"image": { "src": { "name": "<image tag>", "settings": { ... } }, "size": "full" }`
+- V3 widgets (e.g. `theme-post-title`, `theme-post-featured-image`) accept the SAME dynamic shape at the field's slot. On URL controls the dynamic goes on the inner `url` slot: `"link": { "url": { "name": "post-url", "settings": {} } }`. The server rewrites it into V3's `__dynamic__` map — do NOT hand-craft `__dynamic__` shortcodes yourself.
+- The tag's categories must intersect the categories declared by the field (visible in the widget schema's dynamic branch). Pick a tag from [elementor://dynamic-tags] whose category list overlaps.
 - Do NOT send `group` (resolved automatically). Populate `settings` strictly per the tag's schema; use `{}` only when it has none.
 
 Note about configuration ids: These names are visible to the end-user, make sure they make sense, related and relevant.

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-element-config-applier.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-element-config-applier.php
@@ -12,6 +12,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Boolean_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Modules\Mcp\Abilities\Appliers\Element_Config_Applier;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Dynamic_Resolver;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Widget_Type_Resolver;
 use Elementor\Modules\Mcp\Abilities\Build_Composition\Xml_Parser;
 use PHPUnit\Framework\TestCase;
@@ -179,6 +180,99 @@ class Test_Element_Config_Applier extends TestCase {
 		$this->assertSame( 'elementor_invalid_settings', $result['error']->get_error_code() );
 		$this->assertStringContainsString( 'color_menu_item', $result['error']->get_error_message() );
 		$this->assertArrayNotHasKey( 'menu', $nav['settings'] );
+	}
+
+	public function test_apply__v3_dynamic_tag_on_url_control_is_hoisted_into__dynamic__() {
+		// Arrange — reproduces the reported bug: LLM sent { url: { name, settings } } on the
+		// V3 `link` control of theme-post-title. The old path merged the array into the primitive
+		// slot, causing esc_url() to receive an array at render.
+		V3_Dynamic_Resolver::set_tag_info_resolver( function ( $name ) {
+			return 'post-url' === $name ? [ 'name' => 'post-url', 'categories' => [ 'url' ] ] : null;
+		} );
+		V3_Dynamic_Resolver::set_shortcode_builder( function ( $id, $name, $settings ) {
+			return sprintf( '[elementor-tag id="%s" name="%s"]', $id, $name );
+		} );
+
+		try {
+			$type_resolver = new Widget_Type_Resolver( new Xml_Parser() );
+			$applier = new Element_Config_Applier( $type_resolver, $this->make_plain_values_resolver() );
+
+			$node = [
+				'elType' => 'widget',
+				'widgetType' => 'theme-post-title',
+				'settings' => [],
+			];
+			$index = [ 'title' => &$node ];
+
+			$widget_configs = [
+				'theme-post-title' => [
+					'controls' => [
+						'link' => [
+							'type' => 'url',
+							'dynamic' => [ 'active' => true, 'categories' => [ 'url' ], 'property' => 'url' ],
+						],
+					],
+				],
+			];
+
+			// Act.
+			$result = $applier->apply(
+				$index,
+				[
+					'title' => [
+						'link' => [ 'url' => [ 'name' => 'post-url', 'settings' => [] ] ],
+					],
+				],
+				$widget_configs
+			);
+
+			// Assert.
+			$this->assertNull( $result['error'] );
+			$this->assertSame( [ 'url' => '', 'is_external' => '', 'nofollow' => '' ], $node['settings']['link'] );
+			$this->assertArrayHasKey( '__dynamic__', $node['settings'] );
+			$this->assertStringContainsString( 'name="post-url"', $node['settings']['__dynamic__']['link'] );
+		} finally {
+			V3_Dynamic_Resolver::set_tag_info_resolver( null );
+			V3_Dynamic_Resolver::set_shortcode_builder( null );
+		}
+	}
+
+	public function test_apply__v3_rejects_array_value_on_scalar_slot_shape_check() {
+		// Arrange.
+		$type_resolver = new Widget_Type_Resolver( new Xml_Parser() );
+		$applier = new Element_Config_Applier( $type_resolver, $this->make_plain_values_resolver() );
+
+		$node = [
+			'elType' => 'widget',
+			'widgetType' => 'theme-post-title',
+			'settings' => [],
+		];
+		$index = [ 'title' => &$node ];
+
+		$widget_configs = [
+			'theme-post-title' => [
+				'controls' => [
+					'title' => [ 'type' => 'text' ],
+				],
+			],
+		];
+
+		// Act — array without a `name` key is neither dynamic nor a valid string.
+		$result = $applier->apply(
+			$index,
+			[
+				'title' => [
+					'title' => [ 'not' => 'a scalar' ],
+				],
+			],
+			$widget_configs
+		);
+
+		// Assert.
+		$this->assertNotNull( $result['error'] );
+		$this->assertStringContainsString( 'title', $result['error']->get_error_message() );
+		$this->assertStringContainsString( 'invalid shape', $result['error']->get_error_message() );
+		$this->assertArrayNotHasKey( 'title', $node['settings'] );
 	}
 
 	public function test_apply__reports_settings_and_component_errors_together() {

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-dynamic-resolver.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-dynamic-resolver.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Dynamic_Resolver;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Dynamic_Resolver extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		V3_Dynamic_Resolver::set_tag_info_resolver( function ( $name ) {
+			$catalog = [
+				'post-title' => [ 'name' => 'post-title', 'categories' => [ 'text' ] ],
+				'post-url' => [ 'name' => 'post-url', 'categories' => [ 'url' ] ],
+				'wrong-cat' => [ 'name' => 'wrong-cat', 'categories' => [ 'gallery' ] ],
+			];
+			return $catalog[ $name ] ?? null;
+		} );
+		V3_Dynamic_Resolver::set_shortcode_builder( function ( $id, $name, $settings ) {
+			return sprintf( '[elementor-tag id="%s" name="%s" settings="%s"]', $id, $name, rawurlencode( json_encode( $settings ) ) );
+		} );
+	}
+
+	protected function tearDown(): void {
+		V3_Dynamic_Resolver::set_tag_info_resolver( null );
+		V3_Dynamic_Resolver::set_shortcode_builder( null );
+		parent::tearDown();
+	}
+
+	public function test_try_resolve__returns_unmatched_when_control_is_not_dynamic_capable() {
+		// Arrange.
+		$control = [ 'type' => 'text' ];
+
+		// Act.
+		$result = V3_Dynamic_Resolver::try_resolve( 'title', [ 'name' => 'post-title' ], $control );
+
+		// Assert.
+		$this->assertFalse( $result['matched'] );
+	}
+
+	public function test_try_resolve__returns_unmatched_when_value_is_a_plain_scalar() {
+		// Arrange.
+		$control = [ 'type' => 'text', 'dynamic' => [ 'active' => true, 'categories' => [ 'text' ] ] ];
+
+		// Act.
+		$result = V3_Dynamic_Resolver::try_resolve( 'title', 'Hello world', $control );
+
+		// Assert.
+		$this->assertFalse( $result['matched'] );
+	}
+
+	public function test_try_resolve__coerces_top_level_dynamic_into_shortcode_and_neutral_primitive() {
+		// Arrange.
+		$control = [ 'type' => 'text', 'dynamic' => [ 'active' => true, 'categories' => [ 'text' ] ] ];
+
+		// Act.
+		$result = V3_Dynamic_Resolver::try_resolve( 'title', [ 'name' => 'post-title', 'settings' => [] ], $control );
+
+		// Assert.
+		$this->assertTrue( $result['matched'] );
+		$this->assertArrayNotHasKey( 'error', $result );
+		$this->assertStringContainsString( 'name="post-title"', $result['shortcode'] );
+		$this->assertSame( '', $result['primitive'] );
+	}
+
+	public function test_try_resolve__accepts_nested_dynamic_on_url_control_property() {
+		// Arrange.
+		$control = [
+			'type' => 'url',
+			'dynamic' => [
+				'active' => true,
+				'categories' => [ 'url' ],
+				'property' => 'url',
+			],
+		];
+
+		$value = [
+			'url' => [ 'name' => 'post-url', 'settings' => [] ],
+		];
+
+		// Act.
+		$result = V3_Dynamic_Resolver::try_resolve( 'link', $value, $control );
+
+		// Assert.
+		$this->assertTrue( $result['matched'] );
+		$this->assertArrayNotHasKey( 'error', $result );
+		$this->assertStringContainsString( 'name="post-url"', $result['shortcode'] );
+		$this->assertSame(
+			[ 'url' => '', 'is_external' => '', 'nofollow' => '' ],
+			$result['primitive']
+		);
+	}
+
+	public function test_try_resolve__errors_when_tag_is_not_registered() {
+		// Arrange.
+		$control = [ 'type' => 'text', 'dynamic' => [ 'active' => true, 'categories' => [ 'text' ] ] ];
+
+		// Act.
+		$result = V3_Dynamic_Resolver::try_resolve( 'title', [ 'name' => 'not-a-tag' ], $control );
+
+		// Assert.
+		$this->assertTrue( $result['matched'] );
+		$this->assertInstanceOf( \WP_Error::class, $result['error'] );
+		$this->assertStringContainsString( 'not registered', $result['error']->get_error_message() );
+	}
+
+	public function test_try_resolve__errors_when_tag_categories_do_not_intersect_control() {
+		// Arrange.
+		$control = [ 'type' => 'text', 'dynamic' => [ 'active' => true, 'categories' => [ 'text' ] ] ];
+
+		// Act.
+		$result = V3_Dynamic_Resolver::try_resolve( 'title', [ 'name' => 'wrong-cat' ], $control );
+
+		// Assert.
+		$this->assertTrue( $result['matched'] );
+		$this->assertInstanceOf( \WP_Error::class, $result['error'] );
+		$this->assertStringContainsString( 'not compatible', $result['error']->get_error_message() );
+	}
+
+	public function test_try_resolve__accepts_any_registered_tag_when_control_declares_no_categories() {
+		// Arrange.
+		$control = [ 'type' => 'text', 'dynamic' => [ 'active' => true ] ];
+
+		// Act.
+		$result = V3_Dynamic_Resolver::try_resolve( 'title', [ 'name' => 'post-title' ], $control );
+
+		// Assert.
+		$this->assertTrue( $result['matched'] );
+		$this->assertArrayNotHasKey( 'error', $result );
+		$this->assertStringContainsString( 'name="post-title"', $result['shortcode'] );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-dynamic-resolver.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-dynamic-resolver.php
@@ -96,6 +96,27 @@ class Test_V3_Dynamic_Resolver extends TestCase {
 		);
 	}
 
+	public function test_try_resolve__accepts_nested_dynamic_on_url_control_without_explicit_property_in_stack() {
+		// Arrange — mirrors real widget stacks: only `dynamic.active` is set on the control;
+		// `property` and `categories` come from the URL control type defaults at runtime.
+		$control = [
+			'type' => 'url',
+			'dynamic' => [ 'active' => true ],
+		];
+
+		$value = [
+			'url' => [ 'name' => 'post-url', 'settings' => [] ],
+		];
+
+		// Act.
+		$result = V3_Dynamic_Resolver::try_resolve( 'link', $value, $control );
+
+		// Assert — without WP boot, property is still inferred from the nested `url` key shape.
+		$this->assertTrue( $result['matched'] );
+		$this->assertArrayNotHasKey( 'error', $result );
+		$this->assertStringContainsString( 'name="post-url"', $result['shortcode'] );
+	}
+
 	public function test_try_resolve__errors_when_tag_is_not_registered() {
 		// Arrange.
 		$control = [ 'type' => 'text', 'dynamic' => [ 'active' => true, 'categories' => [ 'text' ] ] ];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-settings-validator.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-settings-validator.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Dynamic_Resolver;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Settings_Validator;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Settings_Validator extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		V3_Dynamic_Resolver::set_tag_info_resolver( function ( $name ) {
+			$catalog = [
+				'post-title' => [ 'name' => 'post-title', 'categories' => [ 'text' ] ],
+				'post-url' => [ 'name' => 'post-url', 'categories' => [ 'url' ] ],
+			];
+			return $catalog[ $name ] ?? null;
+		} );
+		V3_Dynamic_Resolver::set_shortcode_builder( function ( $id, $name, $settings ) {
+			return sprintf( '[elementor-tag id="%s" name="%s"]', $id, $name );
+		} );
+	}
+
+	protected function tearDown(): void {
+		V3_Dynamic_Resolver::set_tag_info_resolver( null );
+		V3_Dynamic_Resolver::set_shortcode_builder( null );
+		parent::tearDown();
+	}
+
+	private function theme_post_title_config(): array {
+		return [
+			'controls' => [
+				'title' => [
+					'type' => 'text',
+					'dynamic' => [ 'active' => true, 'categories' => [ 'text' ] ],
+				],
+				'link' => [
+					'type' => 'url',
+					'dynamic' => [ 'active' => true, 'categories' => [ 'url' ], 'property' => 'url' ],
+				],
+				'size' => [
+					'type' => 'select',
+					'options' => [ 'default' => 'Default', 'small' => 'Small', 'large' => 'Large' ],
+				],
+				'header_size' => [
+					'type' => 'select',
+					'options' => [ 'h1' => 'H1', 'h2' => 'H2', 'h3' => 'H3' ],
+				],
+			],
+		];
+	}
+
+	public function test_validate__coerces_nested_url_dynamic_into_dynamic_patch_and_empty_url_primitive() {
+		// Arrange — reproduces the original bug: LLM sends { url: { name, settings } } for link.
+		$settings = [
+			'link' => [ 'url' => [ 'name' => 'post-url', 'settings' => [] ] ],
+		];
+
+		// Act.
+		$result = V3_Settings_Validator::validate( 'theme-post-title', $settings, $this->theme_post_title_config() );
+
+		// Assert.
+		$this->assertNull( $result['error'] );
+		$this->assertSame(
+			[ 'url' => '', 'is_external' => '', 'nofollow' => '' ],
+			$result['allowed']['link']
+		);
+		$this->assertArrayHasKey( 'link', $result['dynamic_patch'] );
+		$this->assertStringContainsString( 'name="post-url"', $result['dynamic_patch']['link'] );
+	}
+
+	public function test_validate__coerces_top_level_text_dynamic_on_title() {
+		// Arrange.
+		$settings = [
+			'title' => [ 'name' => 'post-title', 'settings' => [] ],
+		];
+
+		// Act.
+		$result = V3_Settings_Validator::validate( 'theme-post-title', $settings, $this->theme_post_title_config() );
+
+		// Assert.
+		$this->assertNull( $result['error'] );
+		$this->assertSame( '', $result['allowed']['title'] );
+		$this->assertArrayHasKey( 'title', $result['dynamic_patch'] );
+	}
+
+	public function test_validate__rejects_array_value_on_a_scalar_slot_with_shape_error() {
+		// Arrange — array smuggled into a scalar slot (no `name` key, so not dynamic).
+		$settings = [
+			'title' => [ 'not' => 'a scalar' ],
+		];
+
+		// Act.
+		$result = V3_Settings_Validator::validate( 'theme-post-title', $settings, $this->theme_post_title_config() );
+
+		// Assert.
+		$this->assertInstanceOf( \WP_Error::class, $result['error'] );
+		$this->assertStringContainsString( 'title', $result['error']->get_error_message() );
+		$this->assertStringContainsString( 'invalid shape', $result['error']->get_error_message() );
+		$this->assertArrayNotHasKey( 'title', $result['allowed'] );
+	}
+
+	public function test_validate__rejects_enum_violation() {
+		// Arrange.
+		$settings = [ 'header_size' => 'h9' ];
+
+		// Act.
+		$result = V3_Settings_Validator::validate( 'theme-post-title', $settings, $this->theme_post_title_config() );
+
+		// Assert.
+		$this->assertInstanceOf( \WP_Error::class, $result['error'] );
+		$this->assertStringContainsString( 'header_size', $result['error']->get_error_message() );
+	}
+
+	public function test_validate__passes_plain_valid_primitive_through() {
+		// Arrange.
+		$settings = [
+			'title' => 'Hello world',
+			'header_size' => 'h2',
+		];
+
+		// Act.
+		$result = V3_Settings_Validator::validate( 'theme-post-title', $settings, $this->theme_post_title_config() );
+
+		// Assert.
+		$this->assertNull( $result['error'] );
+		$this->assertSame( 'Hello world', $result['allowed']['title'] );
+		$this->assertSame( 'h2', $result['allowed']['header_size'] );
+		$this->assertEmpty( $result['dynamic_patch'] );
+	}
+
+	public function test_validate__errors_when_dynamic_tag_category_does_not_match_slot() {
+		// Arrange — post-url is a URL tag, but we bind it on the text slot `title` (categories: [text]).
+		$settings = [
+			'title' => [ 'name' => 'post-url', 'settings' => [] ],
+		];
+
+		// Act.
+		$result = V3_Settings_Validator::validate( 'theme-post-title', $settings, $this->theme_post_title_config() );
+
+		// Assert.
+		$this->assertInstanceOf( \WP_Error::class, $result['error'] );
+		$this->assertStringContainsString( 'not compatible', $result['error']->get_error_message() );
+	}
+
+	public function test_validate__rejects_unknown_key_via_allowlist() {
+		// Arrange.
+		$settings = [
+			'title_color' => '#ff0000',
+			'title' => 'Hello',
+		];
+
+		// Act.
+		$result = V3_Settings_Validator::validate( 'theme-post-title', $settings, $this->theme_post_title_config() );
+
+		// Assert — allowlist error is folded into the aggregate.
+		$this->assertInstanceOf( \WP_Error::class, $result['error'] );
+		$this->assertStringContainsString( 'title_color', $result['error']->get_error_message() );
+		$this->assertSame( 'Hello', $result['allowed']['title'] );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/utils/test-v3-json-schema-builder.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/utils/test-v3-json-schema-builder.php
@@ -113,6 +113,69 @@ class Test_V3_Json_Schema_Builder extends TestCase {
 		$this->assertSame( [], $result['properties'] );
 	}
 
+	public function test_build__wraps_dynamic_capable_control_in_anyOf_union() {
+		// Arrange.
+		$controls = [
+			'title' => [
+				'type' => 'text',
+				'default' => 'Hello',
+				'dynamic' => [ 'active' => true, 'categories' => [ 'text', 'post_meta' ] ],
+			],
+		];
+
+		// Act.
+		$result = V3_Json_Schema_Builder::build( $controls );
+
+		// Assert.
+		$entry = $result['properties']['title'];
+		$this->assertArrayHasKey( 'anyOf', $entry );
+		$this->assertCount( 2, $entry['anyOf'] );
+
+		$this->assertSame( 'string', $entry['anyOf'][0]['type'] );
+		$this->assertSame( 'Hello', $entry['anyOf'][0]['default'] );
+
+		$this->assertSame( 'object', $entry['anyOf'][1]['type'] );
+		$this->assertSame( [ 'name' ], $entry['anyOf'][1]['required'] );
+		$this->assertSame( 'string', $entry['anyOf'][1]['properties']['name']['type'] );
+		$this->assertStringContainsString( 'text', $entry['anyOf'][1]['description'] );
+		$this->assertStringContainsString( 'post_meta', $entry['anyOf'][1]['description'] );
+	}
+
+	public function test_build__does_not_wrap_non_dynamic_control() {
+		// Arrange.
+		$controls = [
+			'size' => [
+				'type' => 'select',
+				'options' => [ 'a' => 'A', 'b' => 'B' ],
+			],
+		];
+
+		// Act.
+		$result = V3_Json_Schema_Builder::build( $controls );
+
+		// Assert.
+		$this->assertArrayNotHasKey( 'anyOf', $result['properties']['size'] );
+		$this->assertSame( 'string', $result['properties']['size']['type'] );
+	}
+
+	public function test_build__hoists_description_above_anyOf_when_control_is_dynamic() {
+		// Arrange.
+		$controls = [
+			'title' => [
+				'type' => 'text',
+				'description' => 'Heading text.',
+				'dynamic' => [ 'active' => true ],
+			],
+		];
+
+		// Act.
+		$result = V3_Json_Schema_Builder::build( $controls );
+
+		// Assert.
+		$this->assertSame( 'Heading text.', $result['properties']['title']['description'] );
+		$this->assertArrayHasKey( 'anyOf', $result['properties']['title'] );
+	}
+
 	public function test_build__preserves_description_stripped_of_tags() {
 		$controls = [
 			'menu' => [


### PR DESCRIPTION
## Summary

Value-level validation for the V3 branch of the MCP element-config applier, plus explicit support for the plain `{ name, settings }` dynamic-tag shape so the LLM's V4 idiom no longer crashes V3 render.

## Bug

`build-composition` and `manage-elements` accepted arbitrary values for allowlisted V3 keys: the old V3 branch in [`Element_Config_Applier::apply()`](modules/mcp/abilities/appliers/element-config-applier.php) filtered keys via `V3_Non_Style_Allowlist` and merged the resulting map into the node as-is.

When the LLM sent a V4-shaped dynamic tag on `theme-post-title.link` — the exact idiom that works everywhere else in MCP:

```json
{ "link": { "url": { "name": "post-url", "settings": {} } } }
```

...the array flowed straight into `settings.link.url` and `esc_url()` blew up at render (`element-base.php:443`). This is a rational LLM mistake: `build-composition.md` frames dynamic tags as a universal idiom, and `theme-post-title` is the natural choice for post-driven pages.

## Fix

Three additions plus a wire-in:

- [`V3_Json_Schema_Builder`](modules/mcp/abilities/utils/v3-json-schema-builder.php) emits an `anyOf(primitive, dynamic)` union for every control with `dynamic.active === true`, mirroring how V4 atomic prop types advertise dynamic bindings.
- [`V3_Dynamic_Resolver`](modules/mcp/abilities/appliers/v3/v3-dynamic-resolver.php) detects `{ name, settings }` (top-level or nested under the control's `dynamic.property`, e.g. `url` on URL controls). It validates the tag is registered and its categories intersect the control's, then rewrites into V3's native `__dynamic__[key]` shortcode via `Plugin::$instance->dynamic_tags->tag_data_to_tag_text()`. Two callable seams (`set_tag_info_resolver`, `set_shortcode_builder`) keep the class unit-testable without booting WordPress.
- [`V3_Settings_Validator`](modules/mcp/abilities/appliers/v3/v3-settings-validator.php) composes the allowlist filter, dynamic resolver, and a one-level JSON-Schema primitive shape check so array-in-scalar-slot is a hard `elementor_invalid_settings` error instead of a runtime crash.
- [`Element_Config_Applier`](modules/mcp/abilities/appliers/element-config-applier.php) routes V3 nodes through the validator, merging the neutral primitive back into `settings` and the resolved shortcodes into `settings.__dynamic__`.

The [`build-composition` prompt](modules/mcp/static-resources/abilities/build-composition.md) is updated so the LLM knows V3 fields accept the same `{ name, settings }` contract (with a concrete example for URL controls).

## Design notes

- Dynamic-tag category validation is enforced strictly: a `post-url` tag cannot be bound to a `text`-category slot.
- The applier preserves any pre-existing `__dynamic__` map and only patches keys resolved from `element_config`.
- Primitive shape validation only walks one level deep — enough to catch array-vs-scalar and unknown-enum bugs without inventing a general JSON-Schema validator (V3 has no runtime `Props_Parser`).

## Test plan

- [x] `tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-dynamic-resolver.php` — 7 cases (top-level, nested, category mismatch, unregistered tag, non-dynamic control, scalar passthrough, no-categories fallback).
- [x] `tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-settings-validator.php` — 7 cases including the original bug regression (`link: { url: { name, settings } }` on `theme-post-title`).
- [x] `tests/phpunit/elementor/modules/mcp/abilities/utils/test-v3-json-schema-builder.php` — 3 new cases for the `anyOf` wrapper (dynamic-capable, non-dynamic, description hoisting).
- [x] `tests/phpunit/elementor/modules/mcp/abilities/appliers/test-element-config-applier.php` — 2 new applier-level cases: dynamic-tag hoisting into `__dynamic__` and array-on-scalar-slot rejection.
- [x] `vendor/bin/phpcs --standard=ruleset.xml` on the 4 changed source files — clean (one pre-existing `strip_tags` warning on unchanged code).

19 new tests, 62 new assertions, all green under the unit bootstrap. No pre-existing behaviour changed for V4/atomic elements.

> Note: the `[ED-TBD]` marker needs to be replaced with a real Jira key before this can pass the PR-linter and Jira-check gates.

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

LLM was sending V4-shaped dynamic tags (`{ name, settings }`) into V3 element_config slots, causing arrays to be merged into scalar fields and breaking downstream rendering (e.g., `esc_url()` receiving an array). Need strict validation that coerces dynamic tags into V3's `__dynamic__` shortcode map while rejecting malformed/incompatible values.

## 2. What Changed (Where)

- `element-config-applier.php`: Replaced `V3_Non_Style_Allowlist` call with new `V3_Settings_Validator` composition (allowlist + dynamic resolver + shape check).
- `v3-settings-validator.php`: New orchestrator combining key filtering, dynamic tag coercion, and JSON schema validation.
- `v3-dynamic-resolver.php`: New resolver translating `{ name, settings }` into `__dynamic__[key]` shortcodes with category intersection checks.
- `v3-json-schema-builder.php`: Extended to wrap dynamic-capable controls in `anyOf` unions, advertising dynamic bindings in schema.
- Tests + docs updated (2 new test files, 3 integration tests, build-composition.md clarified).

## 3. How It Works

Entry: `apply()` detects V3 node → calls `V3_Settings_Validator::validate()` with widget type, raw settings, and widget config.

Validator chains:
1. **Key gate**: `V3_Non_Style_Allowlist` rejects unknown keys.
2. **Dynamic coercion**: `V3_Dynamic_Resolver::try_resolve()` matches `{ name, settings }` (or nested on URL/media controls), validates tag registration + category intersection, builds shortcode, stashes in `dynamic_patch`, returns empty primitive.
3. **Shape check**: Remaining values validated against JSON schema (type, enum, nested object properties) to catch array-in-scalar bugs.

Result: `{ allowed, dynamic_patch, error }` → merged into node with `__dynamic__` sibling map.

Schema building now detects dynamic-capable controls and wraps in `anyOf` [primitive | dynamic-tag-shape] so LLM sees both variants.

## 4. Risks

**Category validation on unknown tags**: If tag resolver fails (WP not booted in tests), category check is skipped—acceptable for test hermiticity, but production must have Plugin singleton. Mitigated by test seams.

**Nested dynamic property inference**: Assumes `url` property for URL controls when not explicit; could diverge from future type defaults. Minor—inherits from existing control-type logic.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
