### PR TITLE
Internal: Load wp-admin post helpers before wp_check_post_lock in MCP guard [ED-00000]

### DIFF
--- a/modules/mcp/utils/editor-sync-state.php
+++ b/modules/mcp/utils/editor-sync-state.php
@@ -47,6 +47,10 @@ class Editor_Sync_State {
 			return null;
 		}
 
+		if ( ! function_exists( 'wp_check_post_lock' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/post.php';
+		}
+
 		$has_lock    = (bool) wp_check_post_lock( $post_id );
 		$has_unsaved = self::has_editor_unsaved( $post_id );
 


### PR DESCRIPTION
## Summary

The MCP `pre_execute_guard` filter calls `wp_check_post_lock()` unconditionally in `Editor_Sync_State::check_mutation_guard()`. That function is defined in `wp-admin/includes/post.php`, which WordPress does not autoload on REST/CLI/front-end requests. As a result, every MCP tool call that carries a `post_id` (e.g. `elementor/build-composition`, and any other ability routed through the guard) throws a fatal before it can validate input:

> Ability \"elementor/build-composition\" callback threw an exception: Call to undefined function Elementor\\Modules\\Mcp\\Utils\\wp_check_post_lock()

## Fix

Lazily `require_once ABSPATH . 'wp-admin/includes/post.php'` right before the call, guarded by `function_exists()`. This matches the pattern WordPress core itself uses when admin-only helpers are invoked from non-admin contexts, and is a no-op when the file has already been loaded (e.g. when the guard runs from inside an actual admin request).

Smallest possible change — one 3-line guard, same call site, same behavior once the helper is available.

## Reproduction

1. From any MCP client (Cursor MCP, Claude Desktop, etc.), invoke `elementor/build-composition` with a valid `post_id` and any `xml_structure`.
2. Before this patch: fatal \"Call to undefined function ... wp_check_post_lock()\".
3. After this patch: the guard runs, returns either `null` (no conflict) or the `elementor_editor_unsaved_changes` `WP_Error` (409) as designed.

Verified locally by re-running `elementor/build-composition` after the patch — the fatal is gone and the ability proceeds into normal schema validation.

## Jira

ED-00000 (placeholder — will update with the real ticket before merge).

## Test plan

- [ ] Trigger any MCP ability that carries `post_id` (e.g. `build-composition`, `manage-elements`) on a REST request and confirm it no longer fatals.
- [ ] Trigger the same ability while the target post is locked *and* has an unsaved editor signal, and confirm the guard still returns the `elementor_editor_unsaved_changes` 409 (behavior unchanged when the helper is available).
- [ ] Confirm the existing admin-side flows (editor bootstrap) are unaffected — `require_once` on an already-loaded file is a no-op.


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
`wp_check_post_lock()` requires wp-admin post utilities, which may not be loaded in MCP contexts. This guards against undefined function errors by conditionally requiring the dependency before use.

## 2. What Changed (Where)
- `modules/mcp/utils/editor-sync-state.php`: Added conditional require for `wp-admin/includes/post.php` before calling `wp_check_post_lock()` (lines 50–52)

## 3. How It Works
Before invoking `wp_check_post_lock()`, the code checks if the function exists; if missing, it requires the wp-admin post helpers file. Subsequent calls proceed normally with the function available.

## 4. Risks
Minimal. File already exists in standard WordPress structure. Conditional loading prevents double-inclusion. No performance impact—only executes once per request in affected code path.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
