### PR TITLE
[AI-6959] Feature: Expose system info via REST API 

### DIFF
--- a/modules/system-info/module.php
+++ b/modules/system-info/module.php
@@ -2,11 +2,12 @@
 namespace Elementor\Modules\System_Info;
 
 use Elementor\Core\Base\Module as BaseModule;
-use Elementor\Modules\System_Info\Reporters\Base;
-use Elementor\Modules\System_Info\Helpers\Model_Helper;
 use Elementor\Modules\EditorOne\Classes\Menu_Data_Provider;
 use Elementor\Modules\System_Info\AdminMenuItems\Editor_One_System_Info_Menu;
 use Elementor\Modules\System_Info\AdminMenuItems\Editor_One_System_Menu;
+use Elementor\Modules\System_Info\Helpers\Model_Helper;
+use Elementor\Modules\System_Info\Reporters\Base;
+use Elementor\Modules\System_Info\Rest\Rest_Api;
 use Elementor\Plugin;
 use Elementor\Settings;
 
@@ -125,6 +126,42 @@ class Module extends BaseModule {
 		} );
 
 		add_action( 'wp_ajax_elementor_system_info_download_file', [ $this, 'download_file' ] );
+		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
+	}
+
+	public function register_rest_routes(): void {
+		( new Rest_Api() )->register_routes();
+	}
+
+	public function get_reports_data(): array {
+		$reports = $this->load_reports( self::get_allowed_reports() );
+
+		return $this->build_reports_data( $reports );
+	}
+
+	private function build_reports_data( array $reports ): array {
+		$data = [];
+
+		foreach ( $reports as $report_name => $report_details ) {
+			$report = $report_details['report']->get_report();
+
+			if ( is_wp_error( $report ) ) {
+				continue;
+			}
+
+			$report_data = [
+				'label' => $report_details['label'],
+				'report' => $report,
+			];
+
+			if ( ! empty( $report_details['sub'] ) ) {
+				$report_data['sub'] = $this->build_reports_data( $report_details['sub'] );
+			}
+
+			$data[ $report_name ] = $report_data;
+		}
+
+		return $data;
 	}
 
 	private function register_editor_one_menu( Menu_Data_Provider $menu_data_provider ) {

--- a/modules/system-info/rest/rest-api.php
+++ b/modules/system-info/rest/rest-api.php
@@ -1,0 +1,31 @@
+<?php
+namespace Elementor\Modules\System_Info\Rest;
+
+use Elementor\Core\Utils\Api\Response_Builder;
+use Elementor\Plugin;
+use WP_REST_Server;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Rest_Api {
+	const API_NAMESPACE = 'elementor/v1';
+	const API_BASE = 'system-info';
+
+	public function register_routes(): void {
+		register_rest_route( self::API_NAMESPACE, '/' . self::API_BASE, [
+			'methods' => WP_REST_Server::READABLE,
+			'callback' => [ $this, 'get_system_info' ],
+			'permission_callback' => [ $this, 'check_permission' ],
+		] );
+	}
+
+	public function check_permission(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	public function get_system_info() {
+		return Response_Builder::make( Plugin::$instance->system_info->get_reports_data() )->build();
+	}
+}

--- a/tests/phpunit/elementor/modules/system-info/rest/test-rest-api.php
+++ b/tests/phpunit/elementor/modules/system-info/rest/test-rest-api.php
@@ -1,0 +1,76 @@
+<?php
+namespace Elementor\Tests\Phpunit\Elementor\Modules\System_Info\Rest;
+
+use Elementor\Modules\System_Info\Rest\Rest_Api;
+use ElementorEditorTesting\Elementor_Test_Base;
+use WP_REST_Request;
+
+class Test_Rest_Api extends Elementor_Test_Base {
+
+	private const ROUTE = '/elementor/v1/system-info';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		do_action( 'rest_api_init' );
+	}
+
+	public function test_register_routes__registers_system_info_endpoint() {
+		// Arrange
+		$routes = rest_get_server()->get_routes();
+
+		// Assert
+		$this->assertArrayHasKey( self::ROUTE, $routes );
+
+		$route = $routes[ self::ROUTE ][0];
+		$this->assertTrue( $route['methods']['GET'] );
+		$this->assertIsCallable( $route['callback'] );
+		$this->assertIsCallable( $route['permission_callback'] );
+	}
+
+	public function test_check_permission__requires_manage_options() {
+		// Arrange
+		$rest_api = new Rest_Api();
+
+		// Act + Assert
+		$this->act_as_subscriber();
+		$this->assertFalse( $rest_api->check_permission() );
+
+		$this->act_as_admin();
+		$this->assertTrue( $rest_api->check_permission() );
+	}
+
+	public function test_get_system_info__forbidden_for_subscriber() {
+		// Arrange
+		$this->act_as_subscriber();
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
+
+		// Act
+		$response = rest_get_server()->dispatch( $request );
+
+		// Assert
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_get_system_info__returns_reports_for_admin() {
+		// Arrange
+		$this->act_as_admin();
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
+
+		// Act
+		$response = rest_get_server()->dispatch( $request );
+
+		// Assert
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'data', $data );
+		$this->assertArrayHasKey( 'server', $data['data'] );
+		$this->assertArrayHasKey( 'wordpress', $data['data'] );
+		$this->assertArrayHasKey( 'label', $data['data']['server'] );
+		$this->assertArrayHasKey( 'report', $data['data']['server'] );
+		$this->assertNotEmpty( $data['data']['server']['report'] );
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
System info was only available through the admin UI / download ajax action, so admin-level tooling (e.g. Angie CX) could not fetch the same diagnostics over REST.

## Solution
Add a read-only `GET /elementor/v1/system-info` endpoint gated by `manage_options`, returning the existing system-info reports as structured JSON.

## Jira Link
https://elementor.atlassian.net/browse/AI-6959

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45f55c09-ae8f-449c-b54c-945575bfc4c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45f55c09-ae8f-449c-b54c-945575bfc4c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

