### PR TITLE
CI: Use generated GitHub token in Playwright suite

### DIFF
--- a/.github/workflows/playwright-suite.yml
+++ b/.github/workflows/playwright-suite.yml
@@ -397,7 +397,7 @@ jobs:
         with:
           github_user: ${{ github.actor }}
         env:
-          GH_TOKEN: ${{ secrets.PUBLIC_CLOUD_DEVOPS_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           SLACK_TOKEN: ${{ secrets.CLOUD_SLACK_BOT_TOKEN }}
       - name: Send slack message
         if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) }}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Migrating from static `PUBLIC_CLOUD_DEVOPS_TOKEN` secret to dynamically generated GitHub App token for improved security posture and reduced credential sprawl.

## 2. What Changed (Where)

`.github/workflows/playwright-suite.yml`: Replaced hardcoded secret with generated token in the `map_user` step's `GH_TOKEN` environment variable (line 400).

## 3. How It Works

The workflow now references `steps.generate-token.outputs.token` (presumably created by an earlier step) instead of retrieving credentials from GitHub Secrets, enabling short-lived token lifecycle.

## 4. Risks

Ensure `generate-token` step exists upstream and completes successfully before this step runs; workflow will fail silently if missing.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
