### PR TITLE
Fix: PHP 8.4 deprecation notice for implicit nullable param [ED-00000]

### DIFF
--- a/modules/global-classes/atomic-global-styles.php
+++ b/modules/global-classes/atomic-global-styles.php
@@ -407,7 +407,7 @@ class Atomic_Global_Styles {
 		return Plugin::$instance->preview->is_editor_or_preview();
 	}
 
-	private function get_cache_root_key( string $key = null ): string {
+	private function get_cache_root_key( ?string $key = null ): string {
 		return $key ? self::STYLES_KEY . '_' . $key : self::STYLES_KEY;
 	}
 }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines

## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Fixed PHP 8.4+ deprecation notice in `Atomic_Global_Styles::get_cache_root_key()` caused by an implicitly nullable parameter.

## Description

`Atomic_Global_Styles::get_cache_root_key()` declared its `$key` parameter as non-nullable `string` with a `null` default value. PHP 8.4 deprecates implicitly nullable parameters, so the declaration is updated to explicitly nullable `?string`.

```diff
- private function get_cache_root_key( string $key = null ): string {
+ private function get_cache_root_key( ?string $key = null ): string {
```

The method is `private` and all call sites already pass a `string` constant or nothing, so this is behavior-preserving.

## Test instructions

1. Install Elementor from this branch.
2. Run WordPress with PHP 8.4+ and deprecation reporting enabled.
3. Execute `wp eval 'echo "WordPress loaded.\n";'` and confirm no deprecation notice for `get_cache_root_key()` is logged.
4. Run `php -l modules/global-classes/atomic-global-styles.php` to confirm valid syntax.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #36627
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

PHP 8.4 deprecated implicit nullable parameters — adding explicit `?` type hint to match the runtime behavior and silence the deprecation notice.

## 2. What Changed (Where)

`atomic-global-styles.php`: `get_cache_root_key()` parameter changed from `string $key = null` to `?string $key = null`.

## 3. How It Works

Explicit nullable type declaration aligns the signature with the default `null` value, eliminating the implicit-to-explicit conversion warning in PHP 8.4+.

## 4. Risks

None — purely a type hint clarification with zero behavioral impact. Backward compatible across all PHP versions.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
