### PR TITLE
Internal: Add keepMounted option to editor panels [ED-25222]

### DIFF
--- a/packages/packages/core/editor-panels/src/__tests__/api.test.tsx
+++ b/packages/packages/core/editor-panels/src/__tests__/api.test.tsx
@@ -103,6 +103,36 @@ describe( 'panels api', () => {
 		expect( screen.queryByText( 'Test Panel Body' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'should keep the panel mounted when keepMounted is true', () => {
+		// Arrange.
+		const mockPanel = createMockPanel( { keepMounted: true } );
+
+		registerPanel( mockPanel.panel );
+
+		jest.mocked( useRouteStatus ).mockReturnValue( {
+			isActive: true,
+			isBlocked: false,
+		} );
+
+		// Act.
+		renderPanel( mockPanel );
+
+		// Assert.
+		expect( screen.queryByText( 'Test Panel Body', { hidden: true } ) ).toBeInTheDocument();
+
+		// Act.
+		fireEvent.click( screen.getByText( 'Open Panel' ) );
+
+		// Assert.
+		expect( screen.getByText( 'Test Panel Body' ) ).toBeInTheDocument();
+
+		// Act.
+		fireEvent.click( screen.getByText( 'Close Panel' ) );
+
+		// Assert.
+		expect( screen.getByText( 'Test Panel Body', { hidden: true } ) ).toBeInTheDocument();
+	} );
+
 	it( 'should not open the panel if the panel was not registered', () => {
 		// Arrange.
 		const mockPanel = createMockPanel();

--- a/packages/packages/core/editor-panels/src/__tests__/api.test.tsx
+++ b/packages/packages/core/editor-panels/src/__tests__/api.test.tsx
@@ -118,19 +118,22 @@ describe( 'panels api', () => {
 		renderPanel( mockPanel );
 
 		// Assert.
-		expect( screen.queryByText( 'Test Panel Body', { hidden: true } ) ).toBeInTheDocument();
+		const mountedPanelBody = screen.getByText( 'Test Panel Body' );
+		expect( mountedPanelBody ).toBeInTheDocument();
+		expect( mountedPanelBody ).not.toBeVisible();
 
 		// Act.
 		fireEvent.click( screen.getByText( 'Open Panel' ) );
 
 		// Assert.
-		expect( screen.getByText( 'Test Panel Body' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Test Panel Body' ) ).toBeVisible();
 
 		// Act.
 		fireEvent.click( screen.getByText( 'Close Panel' ) );
 
 		// Assert.
-		expect( screen.getByText( 'Test Panel Body', { hidden: true } ) ).toBeInTheDocument();
+		expect( mountedPanelBody ).toBeInTheDocument();
+		expect( mountedPanelBody ).not.toBeVisible();
 	} );
 
 	it( 'should not open the panel if the panel was not registered', () => {

--- a/packages/packages/core/editor-panels/src/api.ts
+++ b/packages/packages/core/editor-panels/src/api.ts
@@ -14,6 +14,7 @@ export type PanelDeclaration< TOnOpenReturn = unknown > = {
 	id: string;
 	component: ComponentType;
 	isOpenPreviousElement?: boolean;
+	keepMounted?: boolean;
 } & UseActionsOptions< TOnOpenReturn > &
 	UseRouteStatusOptions;
 
@@ -25,6 +26,7 @@ export function createPanel< TOnOpenReturn >( {
 	allowedEditModes,
 	blockOnKitRoutes,
 	isOpenPreviousElement = false,
+	keepMounted = false,
 }: PanelDeclaration< TOnOpenReturn > ) {
 	const usePanelStatus = createUseStatus( id, {
 		allowedEditModes,
@@ -45,16 +47,22 @@ export function createPanel< TOnOpenReturn >( {
 		panel: {
 			id,
 			component,
+			keepMounted,
 		},
 		usePanelStatus,
 		usePanelActions,
 	};
 }
 
-export function registerPanel( { id, component }: Pick< PanelDeclaration, 'id' | 'component' > ) {
+export function registerPanel( {
+	id,
+	component,
+	keepMounted,
+}: Pick< PanelDeclaration, 'id' | 'component' | 'keepMounted' > ) {
 	injectIntoPanels( {
 		id,
 		component,
+		keepMounted,
 	} );
 }
 

--- a/packages/packages/core/editor-panels/src/components/internal/panels.tsx
+++ b/packages/packages/core/editor-panels/src/components/internal/panels.tsx
@@ -1,19 +1,29 @@
 import * as React from 'react';
+import { __useSelector as useSelector } from '@elementor/store';
 
-import useOpenPanelInjection from '../../hooks/use-open-panel-injection';
+import { usePanelsInjections } from '../../location';
+import { selectOpenId } from '../../store';
 import Portal from './portal';
 
 export default function Panels() {
-	const openPanel = useOpenPanelInjection();
-	const Component = openPanel?.component ?? null;
+	const injections = usePanelsInjections();
+	const openId = useSelector( selectOpenId );
 
-	if ( ! Component ) {
+	const persistentInjections = injections.filter( ( injection ) => injection.keepMounted );
+	const openInjection = injections.find( ( injection ) => openId === injection.id );
+
+	if ( ! persistentInjections.length && ! openInjection ) {
 		return null;
 	}
 
 	return (
 		<Portal>
-			<Component />
+			{ persistentInjections.map( ( { id, component: Component } ) => (
+				<div key={ id } style={ { display: openId === id ? 'contents' : 'none' } }>
+					<Component />
+				</div>
+			) ) }
+			{ openInjection && ! openInjection.keepMounted && <openInjection.component /> }
 		</Portal>
 	);
 }

--- a/packages/packages/core/editor-panels/src/components/internal/portal.tsx
+++ b/packages/packages/core/editor-panels/src/components/internal/portal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { Portal as BasePortal, type PortalProps } from '@elementor/ui';
 
 import { getPortalContainer } from '../../sync';
@@ -7,11 +7,32 @@ import { getPortalContainer } from '../../sync';
 type Props = Omit< PortalProps, 'container' >;
 
 export default function Portal( props: Props ) {
-	const containerRef = useRef( getPortalContainer );
+	const [ container, setContainer ] = useState( () => getPortalContainer() );
 
-	if ( ! containerRef.current ) {
+	useEffect( () => {
+		if ( container ) {
+			return;
+		}
+
+		const resolveContainer = () => {
+			const portalContainer = getPortalContainer();
+
+			if ( portalContainer ) {
+				setContainer( portalContainer );
+			}
+		};
+
+		window.addEventListener( 'elementor/panel/init', resolveContainer );
+		resolveContainer();
+
+		return () => {
+			window.removeEventListener( 'elementor/panel/init', resolveContainer );
+		};
+	}, [ container ] );
+
+	if ( ! container ) {
 		return null;
 	}
 
-	return <BasePortal container={ containerRef.current } { ...props } />;
+	return <BasePortal container={ container } { ...props } />;
 }

--- a/packages/packages/core/editor-panels/src/location.ts
+++ b/packages/packages/core/editor-panels/src/location.ts
@@ -1,3 +1,38 @@
+import { type ComponentType } from 'react';
 import { createLocation } from '@elementor/locations';
 
-export const { inject: injectIntoPanels, useInjections: usePanelsInjections } = createLocation();
+type PanelsInjectionMeta = {
+	keepMounted?: boolean;
+};
+
+export type PanelsInjection = {
+	id: string;
+	component: ComponentType;
+	keepMounted?: boolean;
+};
+
+const panelsMeta = new Map< string, PanelsInjectionMeta >();
+
+const { inject: baseInject, useInjections: baseUseInjections } = createLocation();
+
+export function injectIntoPanels( {
+	id,
+	component,
+	keepMounted,
+}: {
+	id: string;
+	component: ComponentType;
+	keepMounted?: boolean;
+} ) {
+	panelsMeta.set( id, { keepMounted } );
+	baseInject( { id, component } );
+}
+
+export function usePanelsInjections(): PanelsInjection[] {
+	const injections = baseUseInjections();
+
+	return injections.map( ( injection ) => ( {
+		...injection,
+		keepMounted: panelsMeta.get( injection.id )?.keepMounted ?? false,
+	} ) );
+}


### PR DESCRIPTION
## Summary
- Add optional `keepMounted` flag to `@elementor/editor-panels` (`PanelDeclaration`, `createPanel`, `registerPanel`; default `false`)
- Persistent panels stay mounted when closed and toggle visibility via CSS instead of unmounting
- Resolve `#elementor-panel-inner` reactively on `elementor/panel/init` so persistent panels mount reliably at editor init
- Unit test coverage for keep-mounted panel behavior

## Test plan
- [ ] Register a panel with `keepMounted: true` — open shows content, close hides it without unmounting
- [ ] Reopen the panel — component state/DOM is preserved (no remount)
- [ ] Register a panel without `keepMounted` — close still unmounts (existing behavior unchanged)
- [ ] Run `npm run test -- --testPathPattern=editor-panels/src/__tests__/api.test` in `packages/`

## Jira
[ED-25222](https://elementor.atlassian.net/browse/ED-25222)

Made with [Cursor](https://cursor.com)

[ED-25222]: https://elementor.atlassian.net/browse/ED-25222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds opt-in persistence for editor panels so they remain mounted in the DOM even when closed, enabling stateful panels that don't remount on reopen (ED-25222).

## 2. What Changed (Where)

- `api.ts`: Added `keepMounted` option to `PanelDeclaration` type and `createPanel`/`registerPanel` functions
- `location.ts`: New metadata layer wrapping `createLocation` to track `keepMounted` per panel
- `panels.tsx`: Replaced single-panel rendering with conditional logic for persistent vs. transient panels
- `portal.tsx`: Switched from `useRef` to `useState` + effect for lazy container resolution
- `api.test.tsx`: Added test verifying persistent panels stay mounted but hidden when closed

## 3. How It Works

Panels are now categorized at render time: persistent panels (keepMounted=true) render always with `display:none` when closed, while transient panels render only when open. Panel metadata is stored separately in `location.ts` and merged into injections via `usePanelsInjections()`. Portal container resolution deferred to effect to handle async initialization.

## 4. Risks

Portal container lazy-resolution could theoretically render `null` longer on slow init, but effect includes event listener fallback. Persistent panels always occupy DOM slots—verify no memory/style bleeding in complex panel hierarchies.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
