### PR TITLE
Fix: Mark Elementor MCP abilities as public so adapters can discover tools

### DIFF
--- a/modules/mcp/abilities/abstract-ability.php
+++ b/modules/mcp/abilities/abstract-ability.php
@@ -51,6 +51,11 @@ abstract class Abstract_Ability {
 	public function register(): void {
 		$definition = $this->definition()->to_array();
 		$definition['execute_callback'] = [ $this, 'execute_guarded' ];
+		$meta = is_array( $definition['meta'] ?? null ) ? $definition['meta'] : [];
+		$mcp = is_array( $meta['mcp'] ?? null ) ? $meta['mcp'] : [];
+		$mcp['public'] = true;
+		$meta['mcp'] = $mcp;
+		$definition['meta'] = $meta;
 		wp_register_ability( $this->get_id(), $definition );
 	}
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Mark registered Elementor MCP abilities as `mcp.public` so WordPress MCP adapters can discover tools, not only resources.

## Description

WordPress MCP adapter discovery (and the default MCP server) only exposes abilities with `meta.mcp.public === true`. Elementor resources already set that flag; tools register with annotations only and no `mcp` meta, so they are invisible to `/mcp` consumers while resources still appear.

`Abstract_Ability::register()` now sets `$meta['mcp']['public'] = true` for every ability, merging into existing resource `mcp` meta.

## Test instructions

This PR can be tested by following these steps:

1. Enable the Elementor MCP WP Abilities experiment on WordPress 6.9+.
2. Register abilities (load wp-admin / run `wp_get_abilities()`).
3. Confirm tool abilities such as `elementor/get-page-structure` have `meta.mcp.public === true`.
4. Confirm resource abilities such as `elementor/global-classes-resource` still have `type`, `uri`, and `public`.
5. Confirm MCP adapter discover lists Elementor tools, not only resources.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

MCP abilities weren't discoverable by adapters because the `public` flag wasn't being set in the ability metadata during registration. This fix ensures adapters can find and interact with Elementor MCP abilities.

## 2. What Changed (Where)

- `modules/mcp/abilities/abstract-ability.php`: Added `public: true` to MCP metadata in the `register()` method, ensuring proper metadata structure initialization before passing to `wp_register_ability()`.

## 3. How It Works

The change intercepts the ability definition during registration, safely extracts/initializes the nested `meta['mcp']` object, sets `public: true`, and rebuilds the definition structure before WordPress registration. Defensive null-coalescing handles missing intermediate keys.

## 4. Risks

Minimal. Change only affects registration pathway and uses safe array checks. Could theoretically override existing `public` values in `meta.mcp`, but that's the intended behavior for consistency across all MCP abilities.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
