### PR TITLE
Fix: Preserve live component overrides after child reconciliation [ED-25117]

### DIFF
--- a/packages/packages/core/editor-components/src/utils/__tests__/reconcile-component-instance-elements.test.ts
+++ b/packages/packages/core/editor-components/src/utils/__tests__/reconcile-component-instance-elements.test.ts
@@ -129,7 +129,7 @@ describe( 'reconcileComponentInstanceElements', () => {
 		expect( result[ 0 ].elements ).toEqual( [] );
 	} );
 
-	it( 'unwraps overridable settings so the rendered element sees plain values', () => {
+	it( 'preserves overridable wrappers while evaluating dependencies with overrides', () => {
 		// Arrange.
 		const elements = [
 			createParent( {
@@ -144,10 +144,19 @@ describe( 'reconcileComponentInstanceElements', () => {
 		];
 
 		// Act.
-		const result = reconcileComponentInstanceElements( elements );
+		const result = reconcileComponentInstanceElements( elements, {
+			show_child_override: { $$type: 'boolean', value: false },
+		} );
 
 		// Assert.
-		expect( result[ 0 ].settings?.show_child ).toEqual( { $$type: 'boolean', value: true } );
+		expect( result[ 0 ].settings?.show_child ).toEqual( {
+			$$type: 'overridable',
+			value: {
+				override_key: 'show_child_override',
+				origin_value: { $$type: 'boolean', value: true },
+			},
+		} );
+		expect( result[ 0 ].elements ).toEqual( [] );
 	} );
 
 	it( 'derives ids for the whole inserted subtree instead of random ones', () => {

--- a/packages/packages/core/editor-components/src/utils/reconcile-component-instance-elements.ts
+++ b/packages/packages/core/editor-components/src/utils/reconcile-component-instance-elements.ts
@@ -93,7 +93,6 @@ function reconcileElementTree( element: V1ElementData, overridesMapping: Overrid
 
 	return {
 		...element,
-		settings: effectiveSettings,
 		elements: reconciledChildren,
 	};
 }


### PR DESCRIPTION
## Summary
- Preserve authored `overridable` settings in component canvas child models
- Continue evaluating `children_dependencies` against effective instance override values
- Add regression coverage for both wrapper preservation and dependency reconciliation

## Test plan
- [x] `npm run test:packages -- packages/packages/core/editor-components/src/utils/__tests__/reconcile-component-instance-elements.test.ts` (11 passed)
- [x] Pro Playwright targeted override tests (2 passed)
- [x] Pro `atomic-components.test.ts`: all four previously broken override cases passed; 8 passed overall, with two unrelated failures in component-list timing and image-upload network idle

## Jira
[ED-25117](https://elementor.atlassian.net/browse/ED-25117)

[ED-25117]: https://elementor.atlassian.net/browse/ED-25117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Component instance reconciliation was stripping live overrides from settings during child tree processing. The fix preserves the overridable wrapper structure so live overrides remain accessible post-reconciliation (ED-25117).

## 2. What Changed (Where)

- `reconcile-component-instance-elements.ts`: Removed `settings: effectiveSettings` assignment that unwrapped overridable values during tree reconciliation
- `reconcile-component-instance-elements.test.ts`: Updated test expectations to verify overridable wrappers persist with override metadata intact

## 3. How It Works

The reconciliation function now returns the original element structure without re-assigning computed `effectiveSettings`. This preserves the `$$type: 'overridable'` wrapper with override_key and origin_value, allowing consumers to access live overrides while child elements are still reconciled normally.

## 4. Risks

Minimal — the change is subtractive. Verify no dependent code relied on receiving unwrapped settings from this function's output. The test confirms the intended behavior works as designed.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
