### PR TITLE
Internal: MCP build-composition V3 settings-first POC and V4 layout hints

### DIFF
--- a/modules/mcp/abilities/appliers/element-config-applier.php
+++ b/modules/mcp/abilities/appliers/element-config-applier.php
@@ -62,15 +62,15 @@ class Element_Config_Applier {
 
 			if ( V3_Node_Bridge::is_v3_node( $node ) ) {
 				$widget_type = (string) $tag;
-				$filter = V3_Non_Style_Allowlist::filter( $widget_type, $settings );
+				$controls = is_array( $widget_configs[ $widget_type ]['controls'] ?? null )
+					? $widget_configs[ $widget_type ]['controls']
+					: [];
+
+				$filter = V3_Non_Style_Allowlist::filter( $widget_type, $settings, $controls );
 				if ( $filter['error'] ) {
 					$errors[] = sprintf( '[%s] %s', $config_id, $filter['error']->get_error_message() );
 					continue;
 				}
-
-				$controls = is_array( $widget_configs[ $widget_type ]['controls'] ?? null )
-					? $widget_configs[ $widget_type ]['controls']
-					: [];
 
 				$hoist_outcome = $this->get_v3_dynamic_hoister()->hoist( $widget_type, $filter['allowed'], $controls );
 
@@ -177,12 +177,19 @@ class Element_Config_Applier {
 			$canonical = Prop_Canonicalizer::resolve_canonical_key( $schema, $name, $alias_map );
 
 			if ( null === $canonical ) {
-				$warnings[] = sprintf(
+				$warning = sprintf(
 					'[%s] Property "%s" is not supported on element type "%s" and was skipped.',
 					$config_id,
 					$name,
 					$element_type
 				);
+
+				$hint_suffix = V4_Legacy_Key_Hints::warning_suffix( $element_type, $name, $config_id );
+				if ( null !== $hint_suffix ) {
+					$warning .= ' ' . $hint_suffix;
+				}
+
+				$warnings[] = $warning;
 				continue;
 			}
 

--- a/modules/mcp/abilities/appliers/style-applier.php
+++ b/modules/mcp/abilities/appliers/style-applier.php
@@ -32,10 +32,17 @@ class Style_Applier {
 	 * @param array<string, array&> $config_id_index Index of subtree refs.
 	 * @param array<string, string> $styles          Per-config-id CSS strings.
 	 * @param string                $style_apply_mode `patch` or `replace`.
-	 * @param array<string, array>  $widget_configs  Optional widget_type => config map (used for V3 mapping).
+	 * @param array<string, array>  $widget_configs       Optional widget_type => config map (used for V3 mapping).
+	 * @param bool                  $v3_settings_first    When true, V3 widgets ignore CSS style input (build-composition POC).
 	 * @return array{error: \WP_Error|null, warnings: string[]}
 	 */
-	public function apply( array $config_id_index, array $styles, string $style_apply_mode = 'patch', array $widget_configs = [] ): array {
+	public function apply(
+		array $config_id_index,
+		array $styles,
+		string $style_apply_mode = 'patch',
+		array $widget_configs = [],
+		bool $v3_settings_first = false
+	): array {
 		if ( empty( $styles ) ) {
 			return [
 				'error'    => null,
@@ -60,7 +67,7 @@ class Style_Applier {
 			$node = &$config_id_index[ $config_id ];
 
 			if ( V3_Node_Bridge::is_v3_node( $node ) ) {
-				$v3_warnings = $this->apply_v3_style( $node, $css_string, $style_apply_mode, $widget_configs );
+				$v3_warnings = $this->apply_v3_style( $node, $css_string, $style_apply_mode, $widget_configs, $v3_settings_first );
 				foreach ( $v3_warnings as $warning ) {
 					$warnings[] = sprintf( '[%s] %s', $config_id, $warning );
 				}
@@ -135,9 +142,27 @@ class Style_Applier {
 	 * @param array<string, array> $widget_configs
 	 * @return string[] Warnings (without config-id prefix).
 	 */
-	private function apply_v3_style( array &$node, string $css_string, string $style_apply_mode = 'patch', array $widget_configs = [] ): array {
+	private function apply_v3_style(
+		array &$node,
+		string $css_string,
+		string $style_apply_mode = 'patch',
+		array $widget_configs = [],
+		bool $v3_settings_first = false
+	): array {
 		$warnings = [];
 		$widget_type = $node['widgetType'] ?? '';
+		$is_empty_css = '' === trim( $css_string );
+
+		if ( $v3_settings_first && ! $is_empty_css ) {
+			$warnings[] = sprintf(
+				/* translators: %s: V3 widget type name. */
+				__( 'V3 widget "%s" ignores the "style" input — put visual styling directly in element_config (keys visible in elementor/get-widget-schema).', 'elementor' ),
+				is_string( $widget_type ) ? $widget_type : ''
+			);
+
+			return $warnings;
+		}
+
 		$widget_config = [];
 
 		if ( is_string( $widget_type ) && '' !== $widget_type ) {
@@ -146,7 +171,6 @@ class Style_Applier {
 				?? [];
 		}
 
-		$is_empty_css = '' === trim( $css_string );
 		$is_replace = 'replace' === $style_apply_mode;
 
 		if ( $is_replace ) {

--- a/modules/mcp/abilities/appliers/v3/v3-advanced-basics-schema.php
+++ b/modules/mcp/abilities/appliers/v3/v3-advanced-basics-schema.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\Mcp\Abilities\Utils\V3_Json_Schema_Builder;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Shared JSON Schema for V3 Advanced-tab basics (padding, margin, border, background).
+ */
+class V3_Advanced_Basics_Schema {
+
+	const WIDGET_TYPE = 'v3-advanced-basics';
+
+	const RESOURCE_URI = 'elementor://widgets/schema/v3-advanced-basics';
+
+	private static ?array $cached_schema = null;
+
+	/**
+	 * @return array<string, array>
+	 */
+	public static function build(): array {
+		if ( null !== self::$cached_schema ) {
+			return self::$cached_schema;
+		}
+
+		$controls = self::canonical_control_stubs();
+		$keys = array_keys( $controls );
+		$built = V3_Json_Schema_Builder::build( $controls, $keys );
+
+		self::$cached_schema = [
+			'type' => 'object',
+			'widget_version' => 'v3',
+			'description' => 'Shared Advanced-tab basics for all V3 widgets: padding, margin, border, and background.',
+			'properties' => $built['properties'],
+			'required' => $built['required'],
+			'additionalProperties' => false,
+		];
+
+		return self::$cached_schema;
+	}
+
+	/**
+	 * @param array<string, mixed> $controls
+	 * @return array<string, array{ '$ref': string }>
+	 */
+	public static function property_refs_for_controls( array $controls ): array {
+		$canonical = self::build()['properties'] ?? [];
+		$refs = [];
+
+		foreach ( $controls as $control_key => $control ) {
+			if ( ! is_string( $control_key ) || '' === $control_key || ! is_array( $control ) ) {
+				continue;
+			}
+
+			if ( ! V3_Style_Setting_Keys::is_advanced_basic_control( $control_key, $control ) ) {
+				continue;
+			}
+
+			if ( ! isset( $canonical[ $control_key ] ) ) {
+				continue;
+			}
+
+			$refs[ $control_key ] = [
+				'$ref' => self::RESOURCE_URI . '#/properties/' . $control_key,
+			];
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * @return array<string, array<string, mixed>>
+	 */
+	private static function canonical_control_stubs(): array {
+		$controls = [];
+
+		foreach ( self::canonical_key_names() as $key ) {
+			$controls[ $key ] = self::control_stub_for_key( $key );
+		}
+
+		return $controls;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private static function canonical_key_names(): array {
+		$keys = [];
+
+		foreach ( V3_Style_Setting_Keys::ADVANCED_BASIC_PREFIXES as $prefix ) {
+			$keys[] = $prefix;
+			foreach ( V3_Style_Setting_Keys::RESPONSIVE_SUFFIXES as $suffix ) {
+				$keys[] = $prefix . $suffix;
+			}
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * @param string $key
+	 * @return array<string, mixed>
+	 */
+	private static function control_stub_for_key( string $key ): array {
+		$base = [
+			'tab' => V3_Style_Setting_Keys::TAB_ADVANCED,
+		];
+
+		if ( str_ends_with( $key, '_color' ) || $key === '_background_color' ) {
+			return array_merge( $base, [ 'type' => 'color' ] );
+		}
+
+		if ( str_ends_with( $key, '_image' ) ) {
+			return array_merge( $base, [ 'type' => 'media' ] );
+		}
+
+		if ( str_ends_with( $key, '_border' ) || $key === '_background_background' ) {
+			return array_merge( $base, [
+				'type' => 'select',
+				'options' => [
+					'' => '',
+					'solid' => 'solid',
+				],
+			] );
+		}
+
+		if (
+			str_ends_with( $key, '_width' )
+			|| str_ends_with( $key, '_radius' )
+			|| str_ends_with( $key, '_padding' )
+			|| str_ends_with( $key, '_margin' )
+		) {
+			return array_merge( $base, [ 'type' => 'dimensions' ] );
+		}
+
+		if ( str_ends_with( $key, '_position' ) || str_ends_with( $key, '_size' ) || str_ends_with( $key, '_repeat' ) ) {
+			return array_merge( $base, [
+				'type' => 'select',
+				'options' => [
+					'' => '',
+					'center center' => 'center center',
+				],
+			] );
+		}
+
+		return array_merge( $base, [ 'type' => 'string' ] );
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/v3-allowed-setting-keys.php
+++ b/modules/mcp/abilities/appliers/v3/v3-allowed-setting-keys.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Derives the full V3 element_config allowlist from widget controls (no per-key registry).
+ */
+class V3_Allowed_Setting_Keys {
+
+	/**
+	 * @param array<string, mixed> $controls Widget controls from get_config()['controls'].
+	 * @return string[]
+	 */
+	public static function from_controls( array $controls ): array {
+		return V3_Style_Setting_Keys::from_controls( $controls );
+	}
+
+	/**
+	 * @param string $widget_type
+	 * @return string[]
+	 */
+	public static function for_widget_type( string $widget_type ): array {
+		$config = Widget_Context_Helper::get_widget_config( $widget_type );
+		$controls = is_array( $config['controls'] ?? null ) ? $config['controls'] : [];
+
+		return self::from_controls( $controls );
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/v3-non-style-allowlist.php
+++ b/modules/mcp/abilities/appliers/v3/v3-non-style-allowlist.php
@@ -2,22 +2,30 @@
 
 namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
 
+use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
- * Validates V3 element_config settings against the per-widget non-style allowlist.
+ * Validates V3 element_config settings against keys derived from the widget controls stack.
  */
 class V3_Non_Style_Allowlist {
 
 	/**
 	 * @param string               $widget_type
 	 * @param array<string, mixed> $settings
+	 * @param array<string, mixed> $controls Optional widget controls stack; resolved from config when omitted.
 	 * @return array{allowed: array<string, mixed>, rejected: string[], error: \WP_Error|null}
 	 */
-	public static function filter( string $widget_type, array $settings ): array {
-		$allowed_keys = V3_Widget_Bridge_Registry::get_non_style_keys( $widget_type );
+	public static function filter( string $widget_type, array $settings, array $controls = [] ): array {
+		if ( empty( $controls ) ) {
+			$config = Widget_Context_Helper::get_widget_config( $widget_type );
+			$controls = is_array( $config['controls'] ?? null ) ? $config['controls'] : [];
+		}
+
+		$allowed_keys = V3_Allowed_Setting_Keys::from_controls( $controls );
 		$allowed_lookup = array_fill_keys( $allowed_keys, true );
 
 		$allowed = [];
@@ -45,7 +53,7 @@ class V3_Non_Style_Allowlist {
 		}
 
 		$available = empty( $allowed_keys )
-			? '(none — this V3 widget has no settable behavior keys; use style for visuals)'
+			? '(none — this V3 widget has no settable keys in element_config)'
 			: implode( ', ', $allowed_keys );
 
 		return [
@@ -54,7 +62,7 @@ class V3_Non_Style_Allowlist {
 			'error' => new \WP_Error(
 				'elementor_invalid_settings',
 				sprintf(
-					'V3 widget "%s" does not allow settings: %s. Allowed non-style keys: %s. Visual styling must go through the style (CSS) input.',
+					'V3 widget "%s" does not allow settings: %s. Allowed keys: %s. Use elementor/get-widget-schema for the full list.',
 					$widget_type,
 					implode( ', ', $rejected ),
 					$available

--- a/modules/mcp/abilities/appliers/v3/v3-style-setting-keys.php
+++ b/modules/mcp/abilities/appliers/v3/v3-style-setting-keys.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Derives V3 element_config keys from the widget controls stack:
+ * all Content (general) and Style tab controls, plus curated Advanced-tab basics.
+ */
+class V3_Style_Setting_Keys {
+
+	const TAB_CONTENT = 'content';
+
+	const TAB_STYLE = 'style';
+
+	const TAB_ADVANCED = 'advanced';
+
+	const LAYOUT_CONTROL_TYPES = [ 'section', 'tab', 'tabs' ];
+
+	const NON_DATA_CONTROL_TYPES = [
+		'heading',
+		'hidden',
+		'raw_html',
+		'button',
+		'divider',
+		'notice',
+		'alert',
+		'deprecated_notice',
+	];
+
+	const ADVANCED_BASIC_PREFIXES = [
+		'_padding',
+		'_margin',
+		'_border_border',
+		'_border_width',
+		'_border_color',
+		'_border_radius',
+		'_background_background',
+		'_background_color',
+		'_background_image',
+		'_background_position',
+		'_background_size',
+		'_background_repeat',
+	];
+
+	const RESPONSIVE_SUFFIXES = [ '_tablet', '_mobile' ];
+
+	/**
+	 * Keys accepted in element_config: Content + Style + Advanced basics.
+	 *
+	 * @param array<string, mixed> $controls Widget controls from Widget_Base::get_controls().
+	 * @return string[]
+	 */
+	public static function from_controls( array $controls ): array {
+		$keys = array_merge(
+			self::content_and_style_keys_from_controls( $controls ),
+			self::advanced_basic_keys_from_controls( $controls )
+		);
+
+		return array_values( array_unique( $keys ) );
+	}
+
+	/**
+	 * Keys emitted inline in per-widget JSON Schema (Content + Style only).
+	 *
+	 * @param array<string, mixed> $controls
+	 * @return string[]
+	 */
+	public static function content_and_style_keys_from_controls( array $controls ): array {
+		$keys = [];
+
+		foreach ( $controls as $control_key => $control ) {
+			if ( ! is_string( $control_key ) || '' === $control_key || ! is_array( $control ) ) {
+				continue;
+			}
+
+			if ( ! self::is_content_or_style_control( $control_key, $control ) ) {
+				continue;
+			}
+
+			$keys[] = $control_key;
+		}
+
+		return array_values( array_unique( $keys ) );
+	}
+
+	/**
+	 * @param array<string, mixed> $controls
+	 * @return string[]
+	 */
+	public static function advanced_basic_keys_from_controls( array $controls ): array {
+		$keys = [];
+
+		foreach ( $controls as $control_key => $control ) {
+			if ( ! is_string( $control_key ) || '' === $control_key || ! is_array( $control ) ) {
+				continue;
+			}
+
+			if ( ! self::is_advanced_basic_control( $control_key, $control ) ) {
+				continue;
+			}
+
+			$keys[] = $control_key;
+		}
+
+		return array_values( array_unique( $keys ) );
+	}
+
+	/**
+	 * @param string               $control_key
+	 * @param array<string, mixed> $control
+	 */
+	public static function is_allowed_setting_key( string $control_key, array $control ): bool {
+		return self::is_content_or_style_control( $control_key, $control )
+			|| self::is_advanced_basic_control( $control_key, $control );
+	}
+
+	/**
+	 * @param string               $control_key
+	 * @param array<string, mixed> $control
+	 */
+	public static function is_content_or_style_control( string $control_key, array $control ): bool {
+		if ( ! self::is_data_control( $control_key, $control ) ) {
+			return false;
+		}
+
+		$tab = is_string( $control['tab'] ?? null ) ? $control['tab'] : self::TAB_CONTENT;
+
+		return self::TAB_CONTENT === $tab || self::TAB_STYLE === $tab;
+	}
+
+	/**
+	 * @param string               $control_key
+	 * @param array<string, mixed> $control
+	 */
+	public static function is_advanced_basic_control( string $control_key, array $control ): bool {
+		if ( ! self::is_data_control( $control_key, $control ) ) {
+			return false;
+		}
+
+		if ( ! self::is_advanced_basic_key( $control_key ) ) {
+			return false;
+		}
+
+		$tab = $control['tab'] ?? null;
+
+		if ( ! is_string( $tab ) ) {
+			return true;
+		}
+
+		return self::TAB_ADVANCED === $tab;
+	}
+
+	/**
+	 * @param string               $control_key
+	 * @param array<string, mixed> $control
+	 */
+	private static function is_data_control( string $control_key, array $control ): bool {
+		$control_type = is_string( $control['type'] ?? null ) ? $control['type'] : null;
+
+		if ( $control_type && in_array( $control_type, self::LAYOUT_CONTROL_TYPES, true ) ) {
+			return false;
+		}
+
+		if ( $control_type && in_array( $control_type, self::NON_DATA_CONTROL_TYPES, true ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private static function is_advanced_basic_key( string $key ): bool {
+		foreach ( self::ADVANCED_BASIC_PREFIXES as $prefix ) {
+			if ( $key === $prefix ) {
+				return true;
+			}
+
+			foreach ( self::RESPONSIVE_SUFFIXES as $suffix ) {
+				if ( $key === $prefix . $suffix ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/v3-widget-bridge-registry.php
+++ b/modules/mcp/abilities/appliers/v3/v3-widget-bridge-registry.php
@@ -72,6 +72,19 @@ class V3_Widget_Bridge_Registry {
 			'theme-post-featured-image' => self::theme_post_featured_image(),
 			'theme-post-excerpt' => self::theme_post_excerpt(),
 			'theme-archive-title' => self::theme_archive_title(),
+			'slides' => self::empty_entry(),
+			'price-table' => self::empty_entry(),
+			'call-to-action' => self::empty_entry(),
+		];
+	}
+
+	/**
+	 * @return array{non_style_keys: string[], style_overrides: array<string, array>}
+	 */
+	private static function empty_entry(): array {
+		return [
+			'non_style_keys' => [],
+			'style_overrides' => [],
 		];
 	}
 

--- a/modules/mcp/abilities/appliers/v4-legacy-key-hints.php
+++ b/modules/mcp/abilities/appliers/v4-legacy-key-hints.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Maps legacy V3-style element_config keys to V4 style CSS guidance for skipped-property warnings.
+ */
+class V4_Legacy_Key_Hints {
+
+	const LAYOUT_ELEMENT_TYPES = [ 'e-flexbox', 'e-div-block' ];
+
+	const LAYOUT_HINTS = [
+		'flex_direction' => 'flex-direction',
+		'flex_align_items' => 'align-items',
+		'flex_justify_content' => 'justify-content',
+		'gap' => 'gap',
+		'flex_gap' => 'gap',
+		'content_width' => 'max-width',
+		'width' => 'max-width',
+	];
+
+	const BUTTON_HINTS = [
+		'size' => 'padding and font-size',
+		'align' => 'text-align on the parent container',
+	];
+
+	public static function hint_for( string $element_type, string $property ): ?string {
+		if ( in_array( $element_type, self::LAYOUT_ELEMENT_TYPES, true ) ) {
+			return self::LAYOUT_HINTS[ $property ] ?? null;
+		}
+
+		if ( 'e-button' === $element_type ) {
+			return self::BUTTON_HINTS[ $property ] ?? null;
+		}
+
+		return null;
+	}
+
+	public static function warning_suffix( string $element_type, string $property, string $config_id ): ?string {
+		$hint = self::hint_for( $element_type, $property );
+
+		if ( null === $hint ) {
+			return null;
+		}
+
+		if ( str_contains( $hint, ' on the parent' ) ) {
+			return sprintf(
+				'Use `%s` in the `style` CSS string instead (e.g. "style": { "<parent-config-id>": "text-align: center; ..." }).',
+				$hint
+			);
+		}
+
+		if ( str_contains( $hint, ' and ' ) ) {
+			return sprintf(
+				'Use `%s` in the `style` CSS string instead (e.g. "style": { "%s": "padding: 1rem 2.5rem; font-size: 1rem; ..." }).',
+				$hint,
+				$config_id
+			);
+		}
+
+		return sprintf(
+			'Use `%s` in the `style` CSS string instead (e.g. "style": { "%s": "%s: column; ..." }).',
+			$hint,
+			$config_id,
+			$hint
+		);
+	}
+}

--- a/modules/mcp/abilities/build-composition-ability.php
+++ b/modules/mcp/abilities/build-composition-ability.php
@@ -153,7 +153,13 @@ class Build_Composition_Ability extends Abstract_Ability {
 		}
 
 		$style_applier = new Style_Applier( $this->create_css_converter( $variables_service ), $this->get_active_breakpoints() );
-		$style_result = $style_applier->apply( $index, $this->as_map( $input['style'] ?? [] ), 'patch', $widget_configs );
+		$style_result = $style_applier->apply(
+			$index,
+			$this->as_map( $input['style'] ?? [] ),
+			'patch',
+			$widget_configs,
+			true
+		);
 		if ( $style_result['error'] ) {
 			return $style_result['error'];
 		}

--- a/modules/mcp/abilities/get-widget-schema-ability.php
+++ b/modules/mcp/abilities/get-widget-schema-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Advanced_Basics_Schema;
 use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
 use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 
@@ -54,6 +55,10 @@ class Get_Widget_Schema_Ability extends Abstract_Ability {
 				__( 'widget_type is required.', 'elementor' ),
 				[ 'status' => \WP_Http::BAD_REQUEST ]
 			);
+		}
+
+		if ( V3_Advanced_Basics_Schema::WIDGET_TYPE === $widget_type ) {
+			return V3_Advanced_Basics_Schema::build();
 		}
 
 		$config = Widget_Context_Helper::get_widget_config( $widget_type );

--- a/modules/mcp/abilities/list-widget-schemas-ability.php
+++ b/modules/mcp/abilities/list-widget-schemas-ability.php
@@ -48,8 +48,25 @@ class List_Widget_Schemas_Ability extends Abstract_Ability {
 		$input = is_array( $input ) ? $input : [];
 		$summary = ! empty( $input['summary'] );
 
-		$widgets = array_filter(
-			Widget_Context_Helper::get_llm_eligible_widgets(),
+		$widgets = Widget_Context_Helper::get_llm_eligible_widgets();
+
+		if ( $summary ) {
+			$widgets = $this->filter_widgets_for_summary( $widgets );
+			return $this->build_summaries( $widgets );
+		}
+
+		$widgets = $this->filter_widgets_for_full_schemas( $widgets );
+
+		return $this->build_schemas( $widgets );
+	}
+
+	/**
+	 * @param array<string, array> $widgets
+	 * @return array<string, array>
+	 */
+	private function filter_widgets_for_summary( array $widgets ): array {
+		return array_filter(
+			$widgets,
 			static function ( $config, $type ) {
 				if ( Widget_Context_Helper::VERSION_V4 === Widget_Context_Helper::get_widget_version( $config ) ) {
 					return true;
@@ -59,12 +76,21 @@ class List_Widget_Schemas_Ability extends Abstract_Ability {
 			},
 			ARRAY_FILTER_USE_BOTH
 		);
+	}
 
-		if ( $summary ) {
-			return $this->build_summaries( $widgets );
-		}
-
-		return $this->build_schemas( $widgets );
+	/**
+	 * Full schema dump: V4 only. V3 schemas are large — fetch per type via get-widget-schema.
+	 *
+	 * @param array<string, array> $widgets
+	 * @return array<string, array>
+	 */
+	private function filter_widgets_for_full_schemas( array $widgets ): array {
+		return array_filter(
+			$widgets,
+			static function ( $config ) {
+				return Widget_Context_Helper::VERSION_V4 === Widget_Context_Helper::get_widget_version( $config );
+			}
+		);
 	}
 
 	private function build_summaries( array $widgets ): array {
@@ -75,6 +101,7 @@ class List_Widget_Schemas_Ability extends Abstract_Ability {
 			$summaries[] = [
 				'type' => $full_summary['type'],
 				'description' => $full_summary['description'] ?? null,
+				'version' => $full_summary['version'] ?? null,
 			];
 		}
 

--- a/modules/mcp/abilities/utils/widget-context-helper.php
+++ b/modules/mcp/abilities/utils/widget-context-helper.php
@@ -7,7 +7,8 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Base\Object_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Utils\Plain_Llm_Schema_Converter;
 use Elementor\Modules\GlobalClasses\Utils\Atomic_Elements_Utils;
-use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Widget_Bridge_Registry;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Advanced_Basics_Schema;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Style_Setting_Keys;
 use Elementor\Plugin;
 use Elementor\Utils;
 
@@ -36,9 +37,12 @@ class Widget_Context_Helper {
 		'theme-post-featured-image',
 		'theme-post-excerpt',
 		'theme-archive-title',
+		'slides',
+		'price-table',
+		'call-to-action',
 	];
 
-	const V3_FALLBACK_MESSAGE = '`properties` lists the only keys accepted in `element_config` / `manage-elements.settings` for this widget. Put all visual styling in the `style` (CSS) input.';
+	const V3_FALLBACK_MESSAGE = '`properties` lists Content, Style, and core Advanced-tab keys accepted in `element_config`. Set behavior and visual styling there directly. Do NOT send a `style` CSS string for V3 widgets.';
 
 	const V3_FALLBACK_FIELDS_NOTE = 'All properties are optional. Object-typed properties describe common shapes but do not include exhaustive inner validation.';
 
@@ -152,15 +156,21 @@ class Widget_Context_Helper {
 				return null;
 			}
 
-			$allowed_keys = V3_Widget_Bridge_Registry::get_non_style_keys( $widget_type );
-			$built = V3_Json_Schema_Builder::build( $config['controls'], $allowed_keys );
+			$controls = is_array( $config['controls'] ) ? $config['controls'] : [];
+			$schema_keys = V3_Style_Setting_Keys::content_and_style_keys_from_controls( $controls );
+			$built = V3_Json_Schema_Builder::build( $controls, $schema_keys );
+			$properties = array_merge(
+				$built['properties'],
+				V3_Advanced_Basics_Schema::property_refs_for_controls( $controls )
+			);
 
 			return [
 				'type' => 'object',
 				'widget_version' => self::VERSION_V3,
 				'message' => self::V3_FALLBACK_MESSAGE,
 				'fields_note' => self::V3_FALLBACK_FIELDS_NOTE,
-				'properties' => $built['properties'],
+				'advanced_basics_ref' => V3_Advanced_Basics_Schema::RESOURCE_URI,
+				'properties' => $properties,
 				'required' => $built['required'],
 				'additionalProperties' => false,
 			];

--- a/modules/mcp/static-resources/abilities/build-composition.md
+++ b/modules/mcp/static-resources/abilities/build-composition.md
@@ -85,6 +85,31 @@ Some elements have internal tree structures (nesting). When using these elements
 - Retry on errors up to 10x
 - Check `llm_guidance.default_settings` in widget schemas — omit only keys listed there from element_config unless the user explicitly asks to change them
 
+## V4 layout & sizing live in `style`, not `element_config`
+On V4 elements (`e-flexbox`, `e-div-block`, `e-button`, `e-heading`, `e-paragraph`, etc.), layout, spacing, color, and typography are **CSS** — put them in the `style` parameter. Do **NOT** send legacy V3 container or style keys in `element_config`; they are skipped with a warning that names the correct `style` property.
+
+**Not valid on V4 `element_config`:** `flex_direction`, `flex_align_items`, `flex_justify_content`, `gap`, `flex_gap`, `content_width`, `width`, `align`, `size` (button), `padding_*` groups, `margin_*` groups, `background_*` groups.
+
+**Use in `style` instead:** `flex-direction`, `align-items`, `justify-content`, `gap`, `max-width`, `text-align`, `padding`, `margin`, `background`, `font-size`.
+
+```json
+"element_config": {
+  "hero-section": {}
+},
+"style": {
+  "hero-section": "flex-direction: column; align-items: center; justify-content: center; gap: 1.5rem; padding: 7rem 2rem; background-color: #1b4332;"
+}
+```
+
+## V3 WIDGETS (legacy)
+V3 widgets (`widget_version: "v3"` in `elementor/get-widget-schema`) accept **all Content and Style tab settings** plus core Advanced-tab basics (`_padding`, `_margin`, border, background) directly in `element_config`. Keys are derived from the widget controls stack — use `elementor/get-widget-schema` for the full list.
+
+- Put behavior AND visual styling in `element_config` using flat V3 setting keys (e.g. `menu_typography_font_size`, `color_menu_item`, `_padding`).
+- **Do NOT send `style` CSS for V3 widgets** — it is dropped with a warning. Use native V3 setting keys so inner elements receive styles automatically.
+- Responsive variants use V3 suffixes: `padding_horizontal_menu_item_tablet`, `_padding_mobile`, etc. There is no `@media` on this path.
+- Advanced-tab basics (`_padding`, `_margin`, border, background) use `$ref` to `elementor://widgets/schema/v3-advanced-basics` in each widget schema — fetch that URI once for full shapes.
+- Typography group gates: set `menu_typography_typography` to `"custom"` before font subkeys apply.
+
 ## element_config FORMAT
 Match the widget schema shape:
 - **string / enum / url**: plain string (`"h2"`, `"https://example.com"`)
@@ -228,7 +253,7 @@ Section with heading + button (NO explicit heights - content sizes naturally):
     }
   },
   "style": {
-    "Main Section": "padding: 6rem 4rem; background: linear-gradient(135deg, #faf8f5 0%, #f0ebe4 100%); @media(--mobile) { padding: 3rem 1.5rem; }",
+    "Main Section": "display: flex; flex-direction: column; align-items: center; gap: 1.5rem; padding: 6rem 4rem; background: linear-gradient(135deg, #faf8f5 0%, #f0ebe4 100%); @media(--mobile) { padding: 3rem 1.5rem; }",
     "Section Title": "font-size: 3.5rem; color: #2d2a26; &:hover { color: var(--wc26-gold); } @media(--mobile) { font-size: 2.25rem; } @media(--tablet) { font-size: 2.75rem; }"
   }
 }

--- a/modules/mcp/static-resources/abilities/get-widget-schema.md
+++ b/modules/mcp/static-resources/abilities/get-widget-schema.md
@@ -2,4 +2,6 @@ Returns the JSON Schema for a single widget type's settings, including default v
 
 Use `elementor/list-widget-schemas` with `summary=true` first to discover valid `widget_type` values. Types not returned by that endpoint are not supported by this tool and must be edited directly in the Elementor editor (call fails with `elementor_v3_not_supported`).
 
+For V3 widgets, fetch the per-widget schema here. Shared Advanced-tab basics (`_padding`, `_margin`, border, background) are aliased via `$ref` to `elementor://widgets/schema/v3-advanced-basics` — or fetch `widget_type: "v3-advanced-basics"` directly.
+
 Values in the returned schema are plain JSON. Send settings in `build-composition.element_config` and `manage-elements.settings` using this shape directly (scalars as scalars, dynamic tags as `{ name, settings }`). Only keys listed under `properties` are accepted; put all visual styling in the `style` (CSS) input.

--- a/modules/mcp/static-resources/abilities/list-widget-schemas.md
+++ b/modules/mcp/static-resources/abilities/list-widget-schemas.md
@@ -1,7 +1,7 @@
 Returns widget information for every widget type this tool can configure. Types absent from this list must be edited manually in the Elementor editor.
 
-Default mode: Returns a map of `widget_type` to JSON Schema. Prefer `elementor/get-widget-schema` when only one widget type is needed.
+Default mode (`content: all`): Returns a map of `widget_type` to JSON Schema for **V4 widgets only**. Legacy V3 widget schemas are omitted from bulk responses — call `elementor/get-widget-schema` per V3 type (e.g. `nav-menu`, `slides`) or read `elementor://widgets/schema/v3-advanced-basics` for shared Advanced-tab keys.
 
-With `summary=true`: Returns `{ widgets: [{ type, description }, ...] }` for widget discovery. Use this mode first to discover which widget types exist before fetching full schemas or building compositions.
+With `summary=true`: Returns `{ widgets: [{ type, description, version? }, ...] }` for discovery, including allowlisted V3 types. Use this mode first to discover widget types before fetching individual schemas.
 
 Values in the returned schemas are plain JSON. Send settings in `build-composition.element_config` and `manage-elements.settings` using this shape directly. Only keys listed under `properties` are accepted; put all visual styling in the `style` (CSS) input.

--- a/packages/packages/core/editor-canvas/src/mcp/resources/widgets-schema-resource.ts
+++ b/packages/packages/core/editor-canvas/src/mcp/resources/widgets-schema-resource.ts
@@ -5,6 +5,8 @@ export const CANVAS_SERVER_NAME = 'editor-canvas';
 
 export const WIDGET_SCHEMA_URI = 'elementor://widgets/schema/{widgetType}';
 export const WIDGET_SCHEMA_FULL_URI = `${ CANVAS_SERVER_NAME }_${ WIDGET_SCHEMA_URI }`;
+export const V3_ADVANCED_BASICS_WIDGET_TYPE = 'v3-advanced-basics';
+export const V3_ADVANCED_BASICS_SCHEMA_URI = `elementor://widgets/schema/${ V3_ADVANCED_BASICS_WIDGET_TYPE }`;
 export const STYLE_SCHEMA_URI = 'elementor://styles/schema/{category}';
 export const BEST_PRACTICES_URI = 'elementor://style/best-practices';
 export const BEST_PRACTICES_FULL_URI = `${ CANVAS_SERVER_NAME }_${ BEST_PRACTICES_URI }`;
@@ -47,12 +49,17 @@ export const initWidgetsSchemaResource = ( reg: MCPRegistryEntry ) => {
 			list: async () => {
 				const widgetTypes = await listWidgetTypes();
 
-				return {
-					resources: widgetTypes.map( ( widgetType ) => ( {
-						uri: `elementor://widgets/schema/${ widgetType }`,
-						name: 'Widget schema for ' + widgetType,
-					} ) ),
-				};
+				const resources = widgetTypes.map( ( widgetType ) => ( {
+					uri: `elementor://widgets/schema/${ widgetType }`,
+					name: 'Widget schema for ' + widgetType,
+				} ) );
+
+				resources.push( {
+					uri: V3_ADVANCED_BASICS_SCHEMA_URI,
+					name: 'Shared V3 Advanced-tab basics schema',
+				} );
+
+				return { resources };
 			},
 		} ),
 		{

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-element-config-applier.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-element-config-applier.php
@@ -271,6 +271,91 @@ class Test_Element_Config_Applier extends TestCase {
 		$this->assertStringContainsString( 'name="post-url"', $node['settings']['__dynamic__']['link'] );
 	}
 
+	public function test_apply__v4_unknown_property_warning_includes_legacy_key_hint() {
+		$applier = $this->make_applier();
+
+		$hero_section = [
+			'widgetType' => 'e-flexbox',
+			'settings' => [],
+		];
+		$index = [ 'hero-section' => &$hero_section ];
+
+		$result = $applier->apply(
+			$index,
+			[
+				'hero-section' => [
+					'flex_direction' => 'column',
+				],
+			],
+			[
+				'e-flexbox' => [ 'class' => Optional_Settings_Widget::class ],
+			]
+		);
+
+		$this->assertNull( $result['error'] );
+		$this->assertCount( 1, $result['warnings'] );
+		$this->assertStringContainsString( 'flex_direction', $result['warnings'][0] );
+		$this->assertStringContainsString( 'flex-direction', $result['warnings'][0] );
+		$this->assertStringContainsString( 'style', $result['warnings'][0] );
+	}
+
+	public function test_apply__v4_button_size_warning_includes_style_hint() {
+		$applier = $this->make_applier();
+
+		$hero_cta = [
+			'widgetType' => 'e-button',
+			'settings' => [],
+		];
+		$index = [ 'hero-cta' => &$hero_cta ];
+
+		$result = $applier->apply(
+			$index,
+			[
+				'hero-cta' => [
+					'size' => 'lg',
+				],
+			],
+			[
+				'e-button' => [ 'class' => Optional_Settings_Widget::class ],
+			]
+		);
+
+		$this->assertNull( $result['error'] );
+		$this->assertCount( 1, $result['warnings'] );
+		$this->assertStringContainsString( 'size', $result['warnings'][0] );
+		$this->assertStringContainsString( 'padding and font-size', $result['warnings'][0] );
+		$this->assertStringContainsString( 'style', $result['warnings'][0] );
+	}
+
+	public function test_apply__v4_unknown_property_warning_stays_terse() {
+		$applier = $this->make_applier();
+
+		$hero_title = [
+			'widgetType' => 'mock-widget',
+			'settings' => [],
+		];
+		$index = [ 'hero-title' => &$hero_title ];
+
+		$result = $applier->apply(
+			$index,
+			[
+				'hero-title' => [
+					'xyz_foo' => 'bar',
+				],
+			],
+			[
+				'mock-widget' => [ 'class' => Optional_Settings_Widget::class ],
+			]
+		);
+
+		$this->assertNull( $result['error'] );
+		$this->assertCount( 1, $result['warnings'] );
+		$this->assertSame(
+			'[hero-title] Property "xyz_foo" is not supported on element type "mock-widget" and was skipped.',
+			$result['warnings'][0]
+		);
+	}
+
 	public function test_apply__reports_settings_and_component_errors_together() {
 		// Arrange
 		$applier = $this->make_applier();
@@ -316,6 +401,14 @@ class Plain_Settings_Widget {
 			'title' => String_Prop_Type::make()->required(),
 			'count' => Number_Prop_Type::make(),
 			'visible' => Boolean_Prop_Type::make(),
+		];
+	}
+}
+
+class Optional_Settings_Widget {
+	public static function get_props_schema(): array {
+		return [
+			'count' => Number_Prop_Type::make(),
 		];
 	}
 }

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-style-applier.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-style-applier.php
@@ -256,6 +256,35 @@ namespace {
 			$this->assertStringContainsString( 'nonexistent', $result['error']->get_error_message() );
 		}
 
+		public function test_apply__v3_settings_first_drops_css_with_warning() {
+			// Arrange.
+			$applier = $this->make_applier( $this->make_converter() );
+			$node = [
+				'id' => 'elem-1',
+				'elType' => 'widget',
+				'widgetType' => 'theme-post-title',
+				'settings' => [],
+				'styles' => [],
+			];
+			$index = [ 'post-title' => &$node ];
+
+			// Act.
+			$result = $applier->apply(
+				$index,
+				[ 'post-title' => 'color: red;' ],
+				'patch',
+				[],
+				true
+			);
+
+			// Assert.
+			$this->assertNull( $result['error'] );
+			$this->assertNotEmpty( $result['warnings'] );
+			$this->assertStringContainsString( 'ignores the "style" input', $result['warnings'][0] );
+			$this->assertArrayNotHasKey( 'title_color', $node['settings'] );
+			$this->assertArrayNotHasKey( 'custom_css', $node['settings'] );
+		}
+
 		public function test_apply__v3_maps_css_to_settings_and_falls_back_unmapped_to_custom_css() {
 			// Arrange.
 			$converter = new Css_Converter( new Converter_Registry(), new Null_Failure_Reporter() );

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-advanced-basics-schema.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-advanced-basics-schema.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Advanced_Basics_Schema;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Advanced_Basics_Schema extends TestCase {
+
+	public function test_build__returns_cached_schema_with_properties() {
+		// Act.
+		$schema = V3_Advanced_Basics_Schema::build();
+
+		// Assert.
+		$this->assertSame( 'object', $schema['type'] );
+		$this->assertIsArray( $schema['properties'] );
+		$this->assertNotEmpty( $schema['properties'] );
+		$this->assertSame( V3_Advanced_Basics_Schema::build(), $schema );
+	}
+
+	public function test_property_refs_for_controls__uses_ref_not_inline_schema() {
+		// Arrange.
+		$controls = [
+			'_padding' => [
+				'type' => 'dimensions',
+				'tab' => 'advanced',
+			],
+			'title_color' => [
+				'type' => 'color',
+				'tab' => 'style',
+			],
+		];
+
+		// Act.
+		$refs = V3_Advanced_Basics_Schema::property_refs_for_controls( $controls );
+
+		// Assert.
+		$this->assertArrayHasKey( '_padding', $refs );
+		$this->assertSame(
+			V3_Advanced_Basics_Schema::RESOURCE_URI . '#/properties/_padding',
+			$refs['_padding']['$ref']
+		);
+		$this->assertArrayNotHasKey( 'title_color', $refs );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-non-style-allowlist.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-non-style-allowlist.php
@@ -12,15 +12,37 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Test_V3_Non_Style_Allowlist extends TestCase {
 
-	public function test_filter__allows_whitelisted_keys_for_nav_menu() {
+	private function nav_menu_controls(): array {
+		return [
+			'menu' => [
+				'type' => 'text',
+				'tab' => 'content',
+			],
+			'layout' => [
+				'type' => 'text',
+				'tab' => 'content',
+			],
+			'menu_typography_font_size' => [
+				'type' => 'slider',
+				'tab' => 'style',
+			],
+			'_padding' => [
+				'type' => 'dimensions',
+				'tab' => 'advanced',
+			],
+		];
+	}
+
+	public function test_filter__allows_content_tab_keys() {
 		// Arrange.
 		$settings = [
 			'menu' => 'primary',
 			'layout' => 'horizontal',
 		];
+		$controls = $this->nav_menu_controls();
 
 		// Act.
-		$result = V3_Non_Style_Allowlist::filter( 'nav-menu', $settings );
+		$result = V3_Non_Style_Allowlist::filter( 'nav-menu', $settings, $controls );
 
 		// Assert.
 		$this->assertNull( $result['error'] );
@@ -28,33 +50,63 @@ class Test_V3_Non_Style_Allowlist extends TestCase {
 		$this->assertEmpty( $result['rejected'] );
 	}
 
-	public function test_filter__rejects_unknown_and_style_keys() {
+	public function test_filter__allows_style_and_advanced_basic_keys() {
+		// Arrange.
+		$settings = [
+			'menu_typography_font_size' => [ 'unit' => 'px', 'size' => 20 ],
+			'_padding' => [
+				'top' => '10',
+				'right' => '10',
+				'bottom' => '10',
+				'left' => '10',
+				'unit' => 'px',
+				'isLinked' => true,
+			],
+		];
+		$controls = $this->nav_menu_controls();
+
+		// Act.
+		$result = V3_Non_Style_Allowlist::filter( 'nav-menu', $settings, $controls );
+
+		// Assert.
+		$this->assertNull( $result['error'] );
+		$this->assertSame( $settings, $result['allowed'] );
+		$this->assertEmpty( $result['rejected'] );
+	}
+
+	public function test_filter__rejects_unknown_keys() {
 		// Arrange.
 		$settings = [
 			'menu' => 'primary',
-			'title_color' => '#ff0000',
-			'typography_font_size' => [ 'unit' => 'px', 'size' => 16 ],
+			'made_up_key' => 'value',
 		];
+		$controls = $this->nav_menu_controls();
 
 		// Act.
-		$result = V3_Non_Style_Allowlist::filter( 'nav-menu', $settings );
+		$result = V3_Non_Style_Allowlist::filter( 'nav-menu', $settings, $controls );
 
 		// Assert.
 		$this->assertNotNull( $result['error'] );
 		$this->assertSame( 'elementor_invalid_settings', $result['error']->get_error_code() );
 		$this->assertSame( [ 'menu' => 'primary' ], $result['allowed'] );
-		$this->assertContains( 'title_color', $result['rejected'] );
-		$this->assertContains( 'typography_font_size', $result['rejected'] );
+		$this->assertContains( 'made_up_key', $result['rejected'] );
 	}
 
-	public function test_filter__theme_post_content_has_no_non_style_keys() {
-		// Arrange / Act.
-		$result = V3_Non_Style_Allowlist::filter( 'theme-post-content', [ 'align' => 'center' ] );
+	public function test_filter__theme_post_content_allows_style_tab_align() {
+		// Arrange.
+		$controls = [
+			'align' => [
+				'type' => 'choose',
+				'tab' => 'style',
+			],
+		];
+
+		// Act.
+		$result = V3_Non_Style_Allowlist::filter( 'theme-post-content', [ 'align' => 'center' ], $controls );
 
 		// Assert.
-		$this->assertNotNull( $result['error'] );
-		$this->assertEmpty( $result['allowed'] );
-		$this->assertSame( [], V3_Widget_Bridge_Registry::get_non_style_keys( 'theme-post-content' ) );
+		$this->assertNull( $result['error'] );
+		$this->assertSame( [ 'align' => 'center' ], $result['allowed'] );
 	}
 
 	public function test_registry__covers_all_allowlisted_widgets() {
@@ -65,11 +117,13 @@ class Test_V3_Non_Style_Allowlist extends TestCase {
 			'theme-post-featured-image',
 			'theme-post-excerpt',
 			'theme-archive-title',
+			'slides',
+			'price-table',
+			'call-to-action',
 		];
 
 		foreach ( $types as $type ) {
 			$this->assertNotNull( V3_Widget_Bridge_Registry::get( $type ), "Missing registry entry for {$type}" );
-			$this->assertIsArray( V3_Widget_Bridge_Registry::get_style_overrides( $type ) );
 		}
 	}
 }

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-style-setting-keys.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-style-setting-keys.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Style_Setting_Keys;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Style_Setting_Keys extends TestCase {
+
+	public function test_from_controls__includes_content_style_and_advanced_basics() {
+		// Arrange.
+		$controls = [
+			'menu' => [
+				'type' => 'text',
+				'tab' => 'content',
+			],
+			'color_menu_item' => [
+				'type' => 'color',
+				'tab' => 'style',
+			],
+			'menu_typography_font_size' => [
+				'type' => 'slider',
+				'tab' => 'style',
+			],
+			'_padding' => [
+				'type' => 'dimensions',
+				'tab' => 'advanced',
+			],
+			'_padding_tablet' => [
+				'type' => 'dimensions',
+				'tab' => 'advanced',
+			],
+			'_element_width' => [
+				'type' => 'select',
+				'tab' => 'advanced',
+			],
+			'section_style' => [
+				'type' => 'section',
+				'tab' => 'style',
+			],
+			'style_heading' => [
+				'type' => 'heading',
+				'tab' => 'style',
+			],
+		];
+
+		// Act.
+		$keys = V3_Style_Setting_Keys::from_controls( $controls );
+
+		// Assert.
+		$this->assertContains( 'menu', $keys );
+		$this->assertContains( 'color_menu_item', $keys );
+		$this->assertContains( 'menu_typography_font_size', $keys );
+		$this->assertContains( '_padding', $keys );
+		$this->assertContains( '_padding_tablet', $keys );
+		$this->assertNotContains( '_element_width', $keys );
+		$this->assertNotContains( 'section_style', $keys );
+		$this->assertNotContains( 'style_heading', $keys );
+	}
+
+	public function test_from_controls__defaults_missing_tab_to_content() {
+		// Arrange.
+		$controls = [
+			'layout' => [
+				'type' => 'select',
+			],
+		];
+
+		// Act.
+		$keys = V3_Style_Setting_Keys::from_controls( $controls );
+
+		// Assert.
+		$this->assertSame( [ 'layout' ], $keys );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-get-widget-schema-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-get-widget-schema-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Tests\Phpunit\Modules\Mcp;
 
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Advanced_Basics_Schema;
 use Elementor\Modules\Mcp\Abilities\Get_Widget_Schema_Ability;
 use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 use Elementor\Plugin;
@@ -43,6 +44,35 @@ class Test_Get_Widget_Schema_Ability extends Elementor_Test_Base {
 		$this->assertSame( \WP_Http::BAD_REQUEST, $data['status'] );
 		$this->assertSame( 'fake-v3', $data['widget_type'] );
 		$this->assertSame( 'v3', $data['version'] );
+	}
+
+	public function test_execute__returns_v3_advanced_basics_schema() {
+		$this->act_as_admin();
+
+		$result = $this->ability->execute( [ 'widget_type' => V3_Advanced_Basics_Schema::WIDGET_TYPE ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( Widget_Context_Helper::VERSION_V3, $result['widget_version'] );
+		$this->assertArrayHasKey( 'properties', $result );
+		$this->assertNotEmpty( $result['properties'] );
+	}
+
+	public function test_execute__allowlisted_v3_schema_uses_advanced_basics_ref() {
+		$this->act_as_admin();
+		$this->given_widget_manager_with_fake_v3_widget( 'nav-menu', [
+			'menu' => [ 'type' => 'select', 'default' => '' ],
+			'_padding' => [ 'type' => 'dimensions', 'tab' => 'advanced' ],
+		] );
+
+		$result = $this->ability->execute( [ 'widget_type' => 'nav-menu' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( V3_Advanced_Basics_Schema::RESOURCE_URI, $result['advanced_basics_ref'] );
+		$this->assertArrayHasKey( '_padding', $result['properties'] );
+		$this->assertSame(
+			V3_Advanced_Basics_Schema::RESOURCE_URI . '#/properties/_padding',
+			$result['properties']['_padding']['$ref']
+		);
 	}
 
 	public function test_execute__returns_v3_fallback_for_allowlisted_widget() {

--- a/tests/phpunit/elementor/modules/mcp/test-list-widget-schemas-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-list-widget-schemas-ability.php
@@ -35,22 +35,24 @@ class Test_List_Widget_Schemas_Ability extends Elementor_Test_Base {
 		parent::tearDown();
 	}
 
-	public function test_execute__includes_allowlisted_v3_and_excludes_other_v3() {
+	public function test_execute__full_schemas_exclude_v3_but_summary_includes_them() {
 		$this->act_as_admin();
 		$this->given_widget_manager_with_v3_widgets( [
 			'nav-menu' => [ 'menu' => [ 'type' => 'select' ] ],
 			'fake-v3' => [ 'title' => [ 'type' => 'text' ] ],
 		] );
 
-		$result = $this->ability->execute( [] );
+		$full = $this->ability->execute( [] );
+		$this->assertIsArray( $full );
+		$this->assertArrayNotHasKey( 'nav-menu', $full );
 
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'nav-menu', $result );
-		$this->assertSame( Widget_Context_Helper::VERSION_V3, $result['nav-menu']['widget_version'] );
-		$this->assertArrayNotHasKey( 'fake-v3', $result );
+		$summary = $this->ability->execute( [ 'summary' => true ] );
+		$types = array_column( $summary['widgets'], 'type' );
+		$this->assertContains( 'nav-menu', $types );
+		$this->assertNotContains( 'fake-v3', $types );
 	}
 
-	public function test_execute__summary_includes_allowlisted_v3_type() {
+	public function test_execute__includes_allowlisted_v3_in_summary_only() {
 		$this->act_as_admin();
 		$this->given_widget_manager_with_v3_widgets( [
 			'nav-menu' => [ 'menu' => [ 'type' => 'select' ] ],


### PR DESCRIPTION
## Summary

- **V3 settings-first POC:** Allowlisted V3 widgets (`slides`, `price-table`, `call-to-action`, plus existing allowlist) accept Content/Style tab controls and curated Advanced-tab basics (`_padding`, `_margin`, border, background) directly in `element_config`. `style` CSS for V3 widgets is warned and dropped in `build-composition`.
- **Shared advanced-basics schema:** Advanced-tab basics are exposed via `elementor://widgets/schema/v3-advanced-basics` and referenced with `$ref` in per-widget schemas instead of duplicating property definitions.
- **Schema listing:** `list-widget-schemas` full mode (`content: all`) returns V4 only; V3 types remain in `summary=true` and via `get-widget-schema` per widget type.
- **V4 legacy-key hints:** When agents send V3-style keys on V4 elements (e.g. `flex_direction` on `e-flexbox`, `size` on `e-button`), skipped-property warnings now point to the correct `style` CSS property.
- **Docs:** `build-composition.md` documents V4 layout in `style` vs `element_config`, V3 settings-only path, and updated examples.

## Jira

Add `ED-XXXXX` to the PR title or body before merge (required by CI).

## Test plan

- [ ] `tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/mcp/abilities/appliers/test-element-config-applier.php --filter 'test_apply__v4_'`
- [ ] `tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-style-setting-keys.php`
- [ ] `tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-advanced-basics-schema.php`
- [ ] `tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-non-style-allowlist.php`
- [ ] `tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/mcp/abilities/appliers/test-style-applier.php --filter 'v3_settings_first'`
- [ ] Full MCP PHPUnit suite with WP bootstrap: `test-get-widget-schema-ability.php`, `test-list-widget-schemas-ability.php`
- [ ] Manual: `build-composition` with V3 `price-table` + `style` → warning, settings persist via `element_config`
- [ ] Manual: `build-composition` with `e-flexbox` + `flex_direction` in `element_config` → warning includes `flex-direction` style hint


Made with [Cursor](https://cursor.com)