### PR TITLE
Internal: Update menu location [ED-25245]

### DIFF
--- a/core/admin/editor-one-menu/elementor-one-menu-manager.php
+++ b/core/admin/editor-one-menu/elementor-one-menu-manager.php
@@ -252,14 +252,11 @@ class Elementor_One_Menu_Manager {
 		$callback = $has_page ? [ $item, 'render' ] : '';
 		$capability = $item->get_capability();
 		$position = $item->get_position();
-		$menu_label = method_exists( $item, 'get_wp_menu_label' )
-			? $item->get_wp_menu_label()
-			: $item->get_label();
 
 		return add_submenu_page(
 			$parent_slug,
 			$page_title,
-			$menu_label,
+			$item->get_label(),
 			$capability,
 			$item_slug,
 			$callback,

--- a/core/admin/editor-one-menu/elementor-one-menu-manager.php
+++ b/core/admin/editor-one-menu/elementor-one-menu-manager.php
@@ -80,21 +80,31 @@ class Elementor_One_Menu_Manager {
 	 * TODO: This can be removed in v4.1.0 [ED-22806]
 	 */
 	public function register_pro_submenus(): void {
-		if ( ! $this->is_pro_module_enabled &&
-			Utils::has_pro() &&
-			class_exists( '\ElementorPro\License\API' ) &&
-			\ElementorPro\License\API::is_license_active()
-		) {
-			add_submenu_page(
-				Menu_Config::ELEMENTOR_HOME_MENU_SLUG,
-				esc_html__( 'Theme Builder', 'elementor' ),
-				esc_html__( 'Theme Builder', 'elementor' ),
-				Menu_Config::CAPABILITY_EDIT_POSTS,
-				'elementor-theme-builder',
-				'',
-				70
-			);
+		if ( $this->is_pro_module_enabled ) {
+			return;
+		}
 
+		$has_active_pro = Utils::has_pro() &&
+			class_exists( '\ElementorPro\License\API' ) &&
+			\ElementorPro\License\API::is_license_active();
+
+		$is_free = ! Utils::has_pro();
+
+		if ( ! $is_free && ! $has_active_pro ) {
+			return;
+		}
+
+		add_submenu_page(
+			Menu_Config::ELEMENTOR_HOME_MENU_SLUG,
+			esc_html__( 'Theme Builder', 'elementor' ),
+			esc_html__( 'Theme Builder', 'elementor' ),
+			Menu_Config::CAPABILITY_EDIT_POSTS,
+			'elementor-theme-builder',
+			'',
+			70
+		);
+
+		if ( $has_active_pro ) {
 			add_submenu_page(
 				Menu_Config::ELEMENTOR_HOME_MENU_SLUG,
 				esc_html__( 'Submissions', 'elementor' ),
@@ -242,11 +252,14 @@ class Elementor_One_Menu_Manager {
 		$callback = $has_page ? [ $item, 'render' ] : '';
 		$capability = $item->get_capability();
 		$position = $item->get_position();
+		$menu_label = method_exists( $item, 'get_wp_menu_label' )
+			? $item->get_wp_menu_label()
+			: $item->get_label();
 
 		return add_submenu_page(
 			$parent_slug,
 			$page_title,
-			$item->get_label(),
+			$menu_label,
 			$capability,
 			$item_slug,
 			$callback,
@@ -299,6 +312,8 @@ class Elementor_One_Menu_Manager {
 			Menu_Config::EDITOR_MENU_SLUG,
 			'elementor-theme-builder',
 			'e-form-submissions',
+			'elementor-license',
+			'elementor-connect-account',
 		];
 
 		$this->iterate_all_flyout_items( function( string $item_slug, Menu_Item_Interface $item ) use ( $protected_wp_menu_slugs ) {

--- a/modules/editor-one/classes/menu-config.php
+++ b/modules/editor-one/classes/menu-config.php
@@ -40,6 +40,15 @@ class Menu_Config {
 		return apply_filters( 'elementor/editor-one/menu/excluded_level3_slugs', $default_slugs );
 	}
 
+	public static function get_excluded_flyout_menu_level3_slugs(): array {
+		$default_slugs = [
+			'e-form-submissions',
+		];
+
+		return apply_filters( 'elementor/editor-one/menu/excluded_flyout_menu_level3_slugs', $default_slugs );
+	}
+
+
 	public static function get_legacy_slug_mapping(): array {
 		$default_mapping = [
 			self::LEGACY_TEMPLATES_SLUG => self::TEMPLATES_GROUP_ID,

--- a/modules/editor-one/classes/menu-data-provider.php
+++ b/modules/editor-one/classes/menu-data-provider.php
@@ -290,36 +290,22 @@ class Menu_Data_Provider {
 	}
 
 	private function build_level3_flyout_items(): array {
-		return $this->build_flyout_items( false );
+		return $this->build_flyout_items( false, Menu_Config::get_excluded_level3_slugs() );
 	}
 
 	private function build_flyout_items_with_expanded_third_party(): array {
-		$items = $this->build_flyout_items( true );
-
-		if ( ! Utils::has_pro() ) {
-			$items[] = $this->build_theme_builder_flyout_item();
-		}
-
-		return $items;
+		return $this->build_flyout_items(
+			true,
+			array_merge(
+				Menu_Config::get_excluded_level3_slugs(),
+				Menu_Config::get_excluded_flyout_menu_level3_slugs()
+			)
+		);
 	}
 
-	private function build_theme_builder_flyout_item(): array {
-		return [
-			'slug' => 'elementor-theme-builder',
-			'label' => esc_html__( 'Theme Builder', 'elementor' ),
-			'url' => $this->get_theme_builder_url(),
-			'icon' => 'theme-builder',
-			'group_id' => '',
-			'priority' => 50,
-			'has_divider_before' => false,
-			'event_id' => 'theme_builder',
-		];
-	}
-
-	private function build_flyout_items( bool $expand_third_party ): array {
+	private function build_flyout_items( bool $expand_third_party, array $excluded_slugs ): array {
 		$items = [];
 		$existing_slugs = [];
-		$excluded_slugs = Menu_Config::get_excluded_level3_slugs();
 		$excluded_level4_slugs = $expand_third_party ? Menu_Config::get_excluded_level4_slugs() : [];
 
 		foreach ( $this->level3_items as $group_items ) {

--- a/modules/pro-install/editor-one-connect-account-menu-item.php
+++ b/modules/pro-install/editor-one-connect-account-menu-item.php
@@ -33,10 +33,6 @@ class Editor_One_Connect_Account_Menu_Item implements Menu_Item_Interface {
 	}
 
 	public function get_label(): string {
-		return esc_html__( 'License', 'elementor' );
-	}
-
-	public function get_wp_menu_label(): string {
 		return esc_html__( 'Connect Account', 'elementor' );
 	}
 

--- a/modules/pro-install/editor-one-connect-account-menu-item.php
+++ b/modules/pro-install/editor-one-connect-account-menu-item.php
@@ -25,7 +25,7 @@ class Editor_One_Connect_Account_Menu_Item implements Menu_Item_Interface {
 	}
 
 	public function get_parent_slug(): string {
-		return Menu_Config::ELEMENTOR_MENU_SLUG;
+		return Menu_Config::ELEMENTOR_HOME_MENU_SLUG;
 	}
 
 	public function is_visible(): bool {
@@ -33,6 +33,10 @@ class Editor_One_Connect_Account_Menu_Item implements Menu_Item_Interface {
 	}
 
 	public function get_label(): string {
+		return esc_html__( 'License', 'elementor' );
+	}
+
+	public function get_wp_menu_label(): string {
 		return esc_html__( 'Connect Account', 'elementor' );
 	}
 

--- a/modules/promotions/admin-menu-items/editor-one-submissions-menu.php
+++ b/modules/promotions/admin-menu-items/editor-one-submissions-menu.php
@@ -20,7 +20,7 @@ class Editor_One_Submissions_Menu extends Base_Promotion_Template implements Men
 	}
 
 	public function get_parent_slug(): string {
-		return Menu_Config::ELEMENTOR_MENU_SLUG;
+		return Menu_Config::ELEMENTOR_HOME_MENU_SLUG;
 	}
 
 	public function get_label(): string {

--- a/tests/phpunit/elementor/modules/editor-one/test-menu-data-provider.php
+++ b/tests/phpunit/elementor/modules/editor-one/test-menu-data-provider.php
@@ -214,6 +214,18 @@ class Test_Menu_Data_Provider extends Elementor_Test_Base {
 		$this->assertEquals( $custom_url, $data['items'][0]['url'] );
 	}
 
+	public function test_get_third_level_data__excludes_submissions_only_from_flyout_menu() {
+		$this->set_admin_user();
+		$item = $this->create_test_item( 'e-form-submissions', Menu_Config::EDITOR_GROUP_ID, true );
+		$this->provider->register_level3_item( $item );
+
+		$editor_one_menu = $this->provider->get_third_level_data( Menu_Data_Provider::THIRD_LEVEL_EDITOR_FLYOUT );
+		$flyout_menu = $this->provider->get_third_level_data( Menu_Data_Provider::THIRD_LEVEL_FLYOUT_MENU );
+
+		$this->assertContains( 'e-form-submissions', array_column( $editor_one_menu['items'], 'slug' ) );
+		$this->assertNotContains( 'e-form-submissions', array_column( $flyout_menu['items'], 'slug' ) );
+	}
+
 	public function test_get_third_level_data__expands_third_party_children() {
 		$this->set_admin_user();
 		$parent = $this->createMock( Menu_Item_Third_Level_Interface::class );


### PR DESCRIPTION
## Summary
- Show Theme Builder and Submissions under the Elementor One WordPress menu for free users and inactive-license Pro installs.
- Keep Submissions in Elementor One while excluding it from the collapsed flyout.
- Keep License in Elementor One for free users, and show Connect Account in the WP sidebar via `get_wp_menu_label()`.

## Test plan
- [ ] Free site: Elementor One sidebar shows Theme Builder, Submissions, and Connect Account
- [ ] Free site: Elementor One flyout/system menu shows License, not Connect Account
- [ ] Free site: Submissions is not in the collapsed WP flyout
- [ ] Pro active: no duplicate Theme Builder / Submissions / License items
- [ ] Related PHPUnit menu provider tests pass
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Reorganizing Elementor menu structure to consolidate Pro/premium features under the main Elementor home menu instead of scattered locations. Aligns menu hierarchy and clarifies licensing state logic (ED-25245).

## 2. What Changed (Where)

- **elementor-one-menu-manager.php**: Refactored Pro submenu registration logic; extracts Theme Builder + Submissions under home menu with clearer license checks; adds protected menu slugs list for flyout hiding
- **menu-config.php**: New filter hook for excluded flyout-specific menu items
- **menu-data-provider.php**: Consolidated flyout item building logic; removed hardcoded Theme Builder item construction; parametrized excluded slug handling
- **editor-one-connect-account-menu-item.php**: Changed parent from `ELEMENTOR_MENU_SLUG` to `ELEMENTOR_HOME_MENU_SLUG`; split label into display (`get_label`) and WP menu (`get_wp_menu_label`)
- **editor-one-submissions-menu.php**: Changed parent slug to `ELEMENTOR_HOME_MENU_SLUG`
- **test-menu-data-provider.php**: Added test verifying Submissions excluded from flyout menu but included in Editor One menu

## 3. How It Works

Pro submenu registration now checks: (1) Pro module enabled → skip; (2) License active → show Submissions; (3) Free only → show Theme Builder. Menu items use conditional labels via new `get_wp_menu_label()` method for flyout vs. WordPress admin distinction. Flyout exclusion list now differentiates level3 vs. flyout-specific items to allow Submissions in Editor One while hiding from flyout.

## 4. Risks

Minor: Menu items with `get_wp_menu_label()` method rely on duck typing—missing method falls back to `get_label()`. Verify all menu items implement the new method or test fallback thoroughly. Filter hook `excluded_flyout_menu_level3_slugs` is new surface; document expectations for third-party extensions.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
