### PR TITLE
Internal: Unskip bdthemes-prime-slider-lite in plugin tester [ED-25213]

### DIFF
--- a/tests/playwright/sanity/plugin-tester-generator.ts
+++ b/tests/playwright/sanity/plugin-tester-generator.ts
@@ -11,7 +11,7 @@ const pluginList: { pluginName: string, installSource: 'api' | 'cli' | 'zip', ha
 	{ pluginName: 'jetgridbuilder', installSource: 'api' },
 	{ pluginName: 'the-plus-addons-for-elementor-page-builder', installSource: 'api' },
 	{ pluginName: 'stratum', installSource: 'api' },
-	// { pluginName: 'bdthemes-prime-slider-lite', installSource: 'api' },
+	{ pluginName: 'bdthemes-prime-slider-lite', installSource: 'api' },
 	{ pluginName: 'addon-elements-for-elementor-page-builder', installSource: 'api' },
 	{ pluginName: 'anywhere-elementor', installSource: 'api' },
 	{ pluginName: 'astra-sites', installSource: 'api', hasInstallationPage: true },


### PR DESCRIPTION
## Summary
- Re-enables `bdthemes-prime-slider-lite` in the plugin tester suite after it was temporarily commented out in #36824 (WP.org API 500).
- Keeps the existing Polylang / HFE onboarding dismissals from #36824.

## Test plan
- [ ] Confirm `plugin_tester` Playwright shard installs `bdthemes-prime-slider-lite` via API without hard failure
- [ ] Confirm section + container plugin tester screenshots still pass for that plugin
- [ ] Confirm Polylang and HFE cases still dismiss onboarding and reach the editor


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Unskipping `bdthemes-prime-slider-lite` plugin in the Playwright plugin tester to resume test coverage for this integration (ED-25213).

## 2. What Changed (Where)

`tests/playwright/sanity/plugin-tester-generator.ts`: Uncommented and activated `bdthemes-prime-slider-lite` entry in the `pluginList` array (line 14).

## 3. How It Works

The plugin tester iterates through `pluginList` during test generation. Moving this plugin from a commented-out state to active re-enables its installation and testing via the API source.

## 4. Risks

None. Straightforward reactivation of previously tested plugin with no logic changes.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
