### PR TITLE
Internal: Changelog for v4.2.8 [ED-25257]

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= 4.2.8 - 2026-08-17 =
+
+* Fix: Test Editor top bar integrations may not appear in non-English languages
+
 = 4.2.2 - 2026-08-06 =
 
 * Fix: Editor top bar integrations may not appear in non-English languages

--- a/readme.txt
+++ b/readme.txt
@@ -360,6 +360,10 @@ If you want to contribute, go to our [Elementor GitHub Repository](https://githu
 
 == Changelog ==
 
+= 4.2.8 - 2026-08-17 =
+
+* Fix: Test Editor top bar integrations may not appear in non-English languages
+
 = 4.2.2 - 2026-08-06 =
 
 * Fix: Editor top bar integrations may not appear in non-English languages


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds the v4.2.8 changelog entry to the 4.2 release line (`release/stable`).

## Changelog

```
= 4.2.8 - 2026-08-17 =

* Fix: Test Editor top bar integrations may not appear in non-English languages
```

## Jira
[ED-25257](https://elementor.atlassian.net/browse/ED-25257)

## Test instructions
`changelog.txt` and `readme.txt` both carry the new 4.2.8 section at the top of the changelog, and `VERSION=4.2.8 node ./.github/scripts/verify-version-changelog.js` passes.

## Related
Same entry for `main`: `changelog-4.2.8-to-main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c61ffa9-7651-486b-8ecc-30fbaff89a73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c61ffa9-7651-486b-8ecc-30fbaff89a73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ED-25257]: https://elementor.atlassian.net/browse/ED-25257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ