### PR TITLE
Fix: Default styles Immer error on first use [ED-25259]

### DIFF
--- a/modules/default-styles/default-styles-rest-api.php
+++ b/modules/default-styles/default-styles-rest-api.php
@@ -99,7 +99,7 @@ class Default_Styles_REST_API {
 	private function all( \WP_REST_Request $request ) {
 		$items = $this->get_repository()->all();
 
-		return Response_Builder::make( empty( $items ) ? [] : (object) $items )->build();
+		return Response_Builder::make( (object) $items )->build();
 	}
 
 	private function get_one( \WP_REST_Request $request ) {

--- a/packages/packages/core/editor-default-styles/src/__tests__/store.test.ts
+++ b/packages/packages/core/editor-default-styles/src/__tests__/store.test.ts
@@ -1,0 +1,63 @@
+import {
+	__createStore as createStore,
+	__dispatch as dispatch,
+	__getState as getState,
+	__registerSlice as registerSlice,
+} from '@elementor/store';
+
+import { selectData, selectIsDirty, slice } from '../store';
+
+const DESKTOP_META = { breakpoint: 'desktop', state: null } as const;
+
+function updateDisplayProp( id: string ) {
+	dispatch(
+		slice.actions.updateProps( {
+			id,
+			meta: DESKTOP_META,
+			props: { display: 'block' },
+		} )
+	);
+}
+
+describe( 'defaultStyles store', () => {
+	beforeEach( () => {
+		registerSlice( slice );
+		createStore();
+	} );
+
+	it( 'should normalize array payloads from load and allow updateProps', () => {
+		dispatch(
+			slice.actions.load( {
+				data: [] as never,
+			} )
+		);
+
+		expect( selectData( getState() ) ).toEqual( {} );
+
+		updateDisplayProp( 'h1' );
+
+		const style = selectData( getState() ).h1;
+
+		expect( style ).toBeDefined();
+		expect( style?.variants ).toHaveLength( 1 );
+		expect( style?.variants[ 0 ]?.props ).toEqual( { display: 'block' } );
+		expect( selectIsDirty( getState() ) ).toBe( true );
+	} );
+
+	it( 'should allow updateProps after loading an empty object map', () => {
+		dispatch(
+			slice.actions.load( {
+				data: {},
+			} )
+		);
+
+		updateDisplayProp( 'h1' );
+
+		const style = selectData( getState() ).h1;
+
+		expect( style ).toBeDefined();
+		expect( style?.variants ).toHaveLength( 1 );
+		expect( style?.variants[ 0 ]?.props ).toEqual( { display: 'block' } );
+		expect( selectIsDirty( getState() ) ).toBe( true );
+	} );
+} );

--- a/packages/packages/core/editor-default-styles/src/store.ts
+++ b/packages/packages/core/editor-default-styles/src/store.ts
@@ -42,8 +42,10 @@ export const slice = createSlice( {
 				data: Record< StyleDefinitionID, StyleDefinition >;
 			} >
 		) {
-			state.initialData = structuredClone( data );
-			state.data = structuredClone( data );
+			const normalizedData = Array.isArray( data ) ? {} : data;
+
+			state.initialData = structuredClone( normalizedData );
+			state.data = structuredClone( normalizedData );
 			state.isDirty = false;
 		},
 

--- a/tests/phpunit/elementor/modules/default-styles/test-default-styles-rest-api.php
+++ b/tests/phpunit/elementor/modules/default-styles/test-default-styles-rest-api.php
@@ -46,7 +46,7 @@ class Test_Default_Styles_REST_API extends Elementor_Test_Base {
 		$response = rest_do_request( $request );
 
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame( [], $response->get_data()['data'] );
+		$this->assertEquals( (object) [], $response->get_data()['data'] );
 	}
 
 	public function test_all__returns_saved_styles() {


### PR DESCRIPTION
## Summary
- Return an empty object map (`{}`) from `GET /elementor/v1/default-styles` when no styles exist, matching the global-classes map convention.
- Normalize array payloads in the default-styles store `load` reducer so legacy/cached `[]` responses cannot crash Immer on `updateProps`.
- Add regression tests (Jest store test + updated PHPUnit assertion).

## Root cause
When default styles were empty on first use, the API returned `data: []`. The store loaded that into `state.data` as an array, and Immer rejected string-key assignments like `state.data['h1'] = style` when clicking the Display control.

## Test plan
- [x] `npm run test:packages -- --testPathPattern=editor-default-styles` (14 tests pass)
- [x] `composer run test -- --filter test_all__returns_empty_when_no_styles`
- [ ] Open Default Styles with no saved styles, select a tag, change Display control — no Immer error in console
- [ ] Save changes and reload — styles persist correctly


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Immer fails when the Redux store receives an array instead of an object for default styles. First-time API responses return `[]`, triggering immutability violations. ED-25259.

## 2. What Changed (Where)

- **default-styles-rest-api.php**: Removed conditional empty check; always cast `$items` to object to ensure consistent type
- **store.ts**: Added array-to-object normalization in `load` reducer to handle API array payloads
- **Tests**: Updated REST API test assertion from `assertSame` to `assertEquals` for object comparison; added store tests covering array/empty-object payloads

## 3. How It Works

API returns array `[]` → REST endpoint now casts to `(object) []` (empty object) → store reducer detects array payload and normalizes to `{}` → Immer operates on object, not array → subsequent `updateProps` mutations work correctly.

## 4. Risks

Minimal. Type safety is preserved (payload already typed as `Record`). The normalization is defensive and idempotent—both `[]` and `{}` normalize to `{}`. Edge case of mixed array/object responses is now handled consistently.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
