### PR TITLE
CI: Cherry-pick PR 36764 to 4.02: Add Jira release link to Slack release announcement [ED-25187]

### DIFF
--- a/.github/scripts/get-jira-release-url.sh
+++ b/.github/scripts/get-jira-release-url.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -uo pipefail
+
+JIRA_PROJECT_KEY="${JIRA_PROJECT_KEY:-ED}"
+JIRA_SITE_URL="${JIRA_SITE_URL:-https://elementor.atlassian.net}"
+JIRA_BETA_VERSION_PREFIX="${JIRA_BETA_VERSION_PREFIX:-}"
+CURL_CONNECT_TIMEOUT_SECONDS=10
+CURL_MAX_TIME_SECONDS=30
+
+skip() {
+  echo "::warning::$1 Skipping Jira release link."
+  echo "jira_release_url=" >> "$GITHUB_OUTPUT"
+  exit 0
+}
+
+if [ -z "${JIRA_API_EMAIL:-}" ] || [ -z "${JIRA_API_TOKEN:-}" ]; then
+  skip "JIRA_API_EMAIL/JIRA_API_TOKEN not set."
+fi
+
+# GA fixVersions are named "v<version>" (e.g. "v4.2.2" for release 4.2.2).
+# Beta fixVersions are named "<prefix>v<version> - Beta <n>" (e.g. "v4.3.0 - Beta 1",
+# or "Pro v4.3.0 - Beta 1" for Elementor Pro).
+if [[ "$RELEASE_VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-beta([0-9]+)$ ]]; then
+  VERSION_NAME="${JIRA_BETA_VERSION_PREFIX}v${BASH_REMATCH[1]} - Beta ${BASH_REMATCH[2]}"
+else
+  VERSION_NAME="v${RELEASE_VERSION}"
+fi
+
+VERSIONS_RESPONSE=$(curl -s --write-out '\n%{http_code}' \
+  --connect-timeout "$CURL_CONNECT_TIMEOUT_SECONDS" --max-time "$CURL_MAX_TIME_SECONDS" \
+  -u "${JIRA_API_EMAIL}:${JIRA_API_TOKEN}" \
+  "${JIRA_SITE_URL}/rest/api/3/project/${JIRA_PROJECT_KEY}/versions")
+VERSIONS_HTTP_CODE=$(echo "$VERSIONS_RESPONSE" | tail -n1)
+VERSIONS_JSON=$(echo "$VERSIONS_RESPONSE" | sed '$d')
+
+if [ "$VERSIONS_HTTP_CODE" != "200" ]; then
+  skip "Fetching Jira versions for project ${JIRA_PROJECT_KEY} returned HTTP ${VERSIONS_HTTP_CODE}: ${VERSIONS_JSON:0:300}"
+fi
+
+VERSION_ID=$(echo "$VERSIONS_JSON" | jq -r --arg name "$VERSION_NAME" \
+  '[.[] | select(.name == $name)] | first | .id // empty')
+
+if [ -z "$VERSION_ID" ]; then
+  skip "No Jira fixVersion named '${VERSION_NAME}' found in project ${JIRA_PROJECT_KEY}."
+fi
+
+echo "jira_release_url=${JIRA_SITE_URL}/projects/${JIRA_PROJECT_KEY}/versions/${VERSION_ID}/tab/release-report-all-issues" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/prepare-slack-release-announcement.sh
+++ b/.github/scripts/prepare-slack-release-announcement.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -eo pipefail
+
+if [ -z "$SLACK_RELEASE_ANNOUNCEMENT_COPY" ]; then
+  echo "SLACK_RELEASE_ANNOUNCEMENT_COPY organization variable is not set."
+  exit 1
+fi
+
+PAYLOAD=$(echo "$SLACK_RELEASE_ANNOUNCEMENT_COPY" | jq -c \
+  --arg channel "$CHANNEL" \
+  --arg release_url "$RELEASE_URL" \
+  --arg released_by "$RELEASED_BY" \
+  --arg version "$RELEASE_VERSION" \
+  --arg jira_release_url "${JIRA_RELEASE_URL:-}" \
+  '
+  def apply_announcement_tokens($text; $product_display_name; $distribution_note; $jira_release_link; $release_line):
+    $text
+    | gsub("\\{product_display_name\\}"; $product_display_name)
+    | gsub("\\{version\\}"; $version)
+    | gsub("\\{released_by\\}"; $released_by)
+    | gsub("\\{release_url\\}"; $release_url)
+    | gsub("\\{distribution_note\\}"; $distribution_note)
+    | gsub("\\{jira_release_link\\}"; $jira_release_link)
+    | gsub("\\{release_line\\}"; $release_line);
+
+  . as $copy |
+  ($copy.distribution_notes[$channel] // "") as $channel_note |
+  (if $channel_note == "" then "" else "\n\n" + $channel_note end) as $distribution_note |
+  (if $jira_release_url == "" then "" else "\n\n📋 <" + $jira_release_url + "|View Jira Release>" end) as $jira_release_link |
+  (if $jira_release_url == "" then "" else "GitHub Release *" + $version + "*\n" end) as $release_line |
+  {
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: (
+            $copy.opening_line + "\n\n" +
+            apply_announcement_tokens($copy.version_headline; $copy.product_display_name; $distribution_note; $jira_release_link; $release_line)
+          )
+        }
+      },
+      { type: "divider" },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: apply_announcement_tokens($copy.release_details; $copy.product_display_name; $distribution_note; $jira_release_link; $release_line)
+        },
+        accessory: {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: $copy.action_button_label,
+            emoji: true
+          },
+          value: "open-release",
+          url: $release_url,
+          action_id: "button-action"
+        }
+      }
+    ]
+  }
+  ')
+
+{
+  echo 'payload<<EOF'
+  echo "$PAYLOAD"
+  echo 'EOF'
+} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/one-click-release.yml
+++ b/.github/workflows/one-click-release.yml
@@ -145,6 +145,16 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run }}
           PACKAGE_VERSION : ${{ env.PACKAGE_VERSION }}
 
+      - name: Get Jira release URL
+        if: github.event.inputs.dry_run == 'false'
+        id: get_jira_release_url
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_NAME }}
+          JIRA_API_EMAIL: ${{ secrets.JIRA_API_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          bash "${GITHUB_WORKSPACE}/.github/scripts/get-jira-release-url.sh"
+
       - name: Prepare Slack release announcement
         if: github.event.inputs.dry_run == 'false'
         id: prepare_slack_announcement
@@ -154,69 +164,9 @@ jobs:
           RELEASE_VERSION: ${{ env.RELEASE_NAME }}
           RELEASED_BY: ${{ github.actor }}
           SLACK_RELEASE_ANNOUNCEMENT_COPY: ${{ vars.SLACK_RELEASE_ANNOUNCEMENT_COPY }}
+          JIRA_RELEASE_URL: ${{ steps.get_jira_release_url.outputs.jira_release_url }}
         run: |
-          if [ -z "$SLACK_RELEASE_ANNOUNCEMENT_COPY" ]; then
-            echo "SLACK_RELEASE_ANNOUNCEMENT_COPY organization variable is not set."
-            exit 1
-          fi
-
-          PAYLOAD=$(echo "$SLACK_RELEASE_ANNOUNCEMENT_COPY" | jq -c \
-            --arg channel "$CHANNEL" \
-            --arg release_url "$RELEASE_URL" \
-            --arg released_by "$RELEASED_BY" \
-            --arg version "$RELEASE_VERSION" \
-            '
-            def apply_announcement_tokens($text; $product_display_name; $distribution_note):
-              $text
-              | gsub("\\{product_display_name\\}"; $product_display_name)
-              | gsub("\\{version\\}"; $version)
-              | gsub("\\{released_by\\}"; $released_by)
-              | gsub("\\{release_url\\}"; $release_url)
-              | gsub("\\{distribution_note\\}"; $distribution_note);
-
-            . as $copy |
-            ($copy.distribution_notes[$channel] // "") as $channel_note |
-            (if $channel_note == "" then "" else "\n\n" + $channel_note end) as $distribution_note |
-            {
-              blocks: [
-                {
-                  type: "section",
-                  text: {
-                    type: "mrkdwn",
-                    text: (
-                      $copy.opening_line + "\n\n" +
-                      apply_announcement_tokens($copy.version_headline; $copy.product_display_name; $distribution_note)
-                    )
-                  }
-                },
-                { type: "divider" },
-                {
-                  type: "section",
-                  text: {
-                    type: "mrkdwn",
-                    text: apply_announcement_tokens($copy.release_details; $copy.product_display_name; $distribution_note)
-                  },
-                  accessory: {
-                    type: "button",
-                    text: {
-                      type: "plain_text",
-                      text: $copy.action_button_label,
-                      emoji: true
-                    },
-                    value: "open-release",
-                    url: $release_url,
-                    action_id: "button-action"
-                  }
-                }
-              ]
-            }
-            ')
-
-          {
-            echo 'payload<<EOF'
-            echo "$PAYLOAD"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+          bash "${GITHUB_WORKSPACE}/.github/scripts/prepare-slack-release-announcement.sh"
 
       - name: Post To Slack Created Release
         if: github.event.inputs.dry_run == 'false'


### PR DESCRIPTION
## Description

Cherry-pick of #36764 onto the `4.02` maintenance branch, adapted since this branch predates the `controlled-release.yml`/`release-tag-creation.yml`/`publish-release.yml` split that exists on `main` — this branch's release process still runs entirely through `one-click-release.yml`.

## Why this is needed now

The `4.2.2` release (built from this branch) posted to `#release` with literal, unsubstituted `{jira_release_link}` and `{release_line}` tokens:

> We just released Elementor
> `4.2.2`{release_line}Created by Svitlana-Dykun
>
> **Note**: Existing sites will receive this update after a 6-hour delay (ref: ...){jira_release_link}

Root cause: `SLACK_RELEASE_ANNOUNCEMENT_COPY` is a live, branch-independent repo variable. When it was updated on `main` to include `{jira_release_link}`/`{release_line}` as part of #36764, every branch — including this one — started reading the new template text, but this branch's `one-click-release.yml` still had the old inline `jq` payload logic with no idea how to substitute those tokens.

## Changes

- Added `.github/scripts/get-jira-release-url.sh` and `.github/scripts/prepare-slack-release-announcement.sh` (same as on `main`, includes the later beta-fixVersion-lookup and `release_line` fixes).
- `one-click-release.yml` now delegates to these shared scripts instead of its own inline `jq`.
- Did **not** port `controlled-release.yml`/`publish-release.yml`/`release-tag-creation.yml` — those don't exist on this branch and aren't part of its release flow.

## Test plan
- [ ] Dry-run `one-click-release.yml` on this branch and confirm the Slack payload has no literal `{...}` tokens for both GA and beta

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding Jira release link to Slack release announcements (ED-25187). Extracted announcement logic into reusable scripts for cleaner CI pipeline and future maintainability.

## 2. What Changed (Where)

- Two new scripts: `get-jira-release-url.sh` queries Jira API for release version ID; `prepare-slack-release-announcement.sh` generates Slack payload with Jira link
- `one-click-release.yml` refactored: inline Slack payload logic moved to script, new step fetches Jira URL before announcement prep

## 3. How It Works

New workflow step calls `get-jira-release-url.sh` to fetch Jira version ID via REST API, outputs `jira_release_url`. Announcement script receives this URL, conditionally injects Jira release link into Slack message blocks via jq token substitution.

## 4. Risks

API credentials (`JIRA_API_EMAIL`, `JIRA_API_TOKEN`) required but already handled via secrets. Missing credentials gracefully skipped. Version name mismatch (beta prefix handling) could silently return empty URL—caught by version validation check.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
