### PR TITLE
Internal: Cherry-pick PR 36965 to 4.02: Cancel superseded PR runs and fix npm cache in PR workflow [ED-24997]

### DIFF
--- a/.github/actions/restore-dependencies-cache/action.yml
+++ b/.github/actions/restore-dependencies-cache/action.yml
@@ -1,5 +1,5 @@
 name: Restore dependency cache
-description: Restore node_modules, packages/node_modules, and vendor from the PR CI cache.
+description: Restore node_modules, packages/node_modules, vendor, and vendor_prefixed from the PR CI cache.
 
 inputs:
   fail-on-cache-miss:
@@ -30,7 +30,8 @@ runs:
           node_modules
           packages/node_modules
           vendor
-        key: deps-v2-${{ runner.os }}-${{ hashFiles('package-lock.json', 'composer.lock') }}
+          vendor_prefixed
+        key: deps-v3-${{ runner.os }}-${{ hashFiles('package-lock.json', 'composer.lock') }}
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss == 'true' }}
     - name: Install dependencies on cache miss
       if: inputs.install-on-miss == 'true' && steps.deps-cache.outputs.cache-hit != 'true'
@@ -46,4 +47,5 @@ runs:
           node_modules
           packages/node_modules
           vendor
+          vendor_prefixed
         key: ${{ steps.deps-cache.outputs.cache-primary-key }}

--- a/.github/actions/restore-dependencies-cache/action.yml
+++ b/.github/actions/restore-dependencies-cache/action.yml
@@ -15,6 +15,9 @@ outputs:
   cache-hit:
     description: Whether an exact cache key match was restored.
     value: ${{ steps.deps-cache.outputs.cache-hit }}
+  cache-key:
+    description: The cache key used for restore and save.
+    value: ${{ steps.deps-cache.outputs.cache-primary-key }}
 
 runs:
   using: composite
@@ -43,4 +46,4 @@ runs:
           node_modules
           packages/node_modules
           vendor
-        key: deps-v2-${{ runner.os }}-${{ hashFiles('package-lock.json', 'composer.lock') }}
+        key: ${{ steps.deps-cache.outputs.cache-primary-key }}

--- a/.github/actions/restore-dependencies-cache/action.yml
+++ b/.github/actions/restore-dependencies-cache/action.yml
@@ -1,0 +1,46 @@
+name: Restore dependency cache
+description: Restore node_modules, packages/node_modules, and vendor from the PR CI cache.
+
+inputs:
+  fail-on-cache-miss:
+    description: Fail the step when the cache entry is missing.
+    required: false
+    default: 'false'
+  install-on-miss:
+    description: Install dependencies and save the cache when restore misses.
+    required: false
+    default: 'false'
+
+outputs:
+  cache-hit:
+    description: Whether an exact cache key match was restored.
+    value: ${{ steps.deps-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Restore dependency cache
+      uses: actions/cache/restore@v5
+      id: deps-cache
+      with:
+        path: |
+          node_modules
+          packages/node_modules
+          vendor
+        key: deps-v2-${{ runner.os }}-${{ hashFiles('package-lock.json', 'composer.lock') }}
+        fail-on-cache-miss: ${{ inputs.fail-on-cache-miss == 'true' }}
+    - name: Install dependencies on cache miss
+      if: inputs.install-on-miss == 'true' && steps.deps-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        npm run install:ci
+        npm run composer:no-dev
+    - name: Save dependency cache
+      if: inputs.install-on-miss == 'true' && steps.deps-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: |
+          node_modules
+          packages/node_modules
+          vendor
+        key: deps-v2-${{ runner.os }}-${{ hashFiles('package-lock.json', 'composer.lock') }}

--- a/.github/workflows/install-dependencies/action.yml
+++ b/.github/workflows/install-dependencies/action.yml
@@ -7,7 +7,6 @@ runs:
     - name: Mask GitHub token
       shell: bash
       run: echo "::add-mask::${{ github.token }}"
-    # Using PHP 7.4 to make sure it'll bundle the polyfills for PHP >= 8.0
     - name: Setup PHP 7.4
       id: setup-php
       uses: shivammathur/setup-php@v2
@@ -16,7 +15,7 @@ runs:
     - name: Remove Composer GitHub OAuth token
       shell: bash
       run: composer config --global --unset github-oauth.github.com || true
-    - shell: bash
-      run: |
-        npm run install:ci
-        npm run composer:no-dev
+    - name: Restore and install dependencies
+      uses: ./.github/actions/restore-dependencies-cache
+      with:
+        install-on-miss: 'true'

--- a/.github/workflows/playwright-suite.yml
+++ b/.github/workflows/playwright-suite.yml
@@ -317,7 +317,6 @@ jobs:
       - name: Build test report
         run: |
           if [ -d "./allure-results" ] && [ -n "$(find ./allure-results -type f 2>/dev/null | head -1)" ]; then
-            node .github/scripts/retag-playwright-traces.js ./allure-results
             npx allure generate --clean allure-results -o allure-report || mkdir -p allure-report
           else
             echo "No allure-results found. Creating empty report directory."
@@ -393,7 +392,7 @@ jobs:
         with:
           github_user: ${{ github.actor }}
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.PUBLIC_CLOUD_DEVOPS_TOKEN }}
           SLACK_TOKEN: ${{ secrets.CLOUD_SLACK_BOT_TOKEN }}
       - name: Send slack message
         if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) }}

--- a/.github/workflows/playwright-suite.yml
+++ b/.github/workflows/playwright-suite.yml
@@ -85,6 +85,8 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
+        with:
+          install-on-miss: 'true'
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/playwright-suite.yml
+++ b/.github/workflows/playwright-suite.yml
@@ -85,8 +85,6 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
-        with:
-          fail-on-cache-miss: 'true'
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/playwright-suite.yml
+++ b/.github/workflows/playwright-suite.yml
@@ -12,10 +12,6 @@ on:
         required: false
         default: ''
 
-concurrency:
-  group: ${{ inputs.pull_request_number != '' && format('pr-{0}-playwright', inputs.pull_request_number) || format('playwright-suite-{0}', github.ref) }}
-  cancel-in-progress: ${{ inputs.pull_request_number != '' }}
-
 permissions:
   contents: read
 
@@ -50,6 +46,7 @@ jobs:
   Playwright:
     name: Playwright test - ${{ matrix.shardIndex }} on PHP (${{ needs.get-php-version.outputs.php_version }})
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     needs: [build-plugin, prepare-caller-build, get-php-version]
     permissions:
       contents: read
@@ -85,10 +82,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24.15.0
-          cache: 'npm'
-      - name: Install dependencies
-        run: |
-          npm run install:ci
+          package-manager-cache: false
+      - name: Restore dependency cache
+        uses: ./.github/actions/restore-dependencies-cache
+        with:
+          fail-on-cache-miss: 'true'
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:
@@ -321,6 +319,7 @@ jobs:
       - name: Build test report
         run: |
           if [ -d "./allure-results" ] && [ -n "$(find ./allure-results -type f 2>/dev/null | head -1)" ]; then
+            node .github/scripts/retag-playwright-traces.js ./allure-results
             npx allure generate --clean allure-results -o allure-report || mkdir -p allure-report
           else
             echo "No allure-results found. Creating empty report directory."
@@ -396,7 +395,7 @@ jobs:
         with:
           github_user: ${{ github.actor }}
         env:
-          GH_TOKEN: ${{ secrets.PUBLIC_CLOUD_DEVOPS_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           SLACK_TOKEN: ${{ secrets.CLOUD_SLACK_BOT_TOKEN }}
       - name: Send slack message
         if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -96,6 +96,7 @@ jobs:
   PlaywrightWithTag:
     name: Playwright test - tagged tests on PHP (${{ needs.get-php-version.outputs.php_version }})
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     needs: [build-plugin, get-php-version]
     permissions:
       contents: read

--- a/.github/workflows/plugin-upgrade-test.yml
+++ b/.github/workflows/plugin-upgrade-test.yml
@@ -27,6 +27,7 @@ jobs:
   run-upgrade-test:
     name: Playwright plugin upgrade test
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     needs: [build-plugin]
     if: ${{ github.event.pull_request.title == null || needs.build-plugin.outputs.changelog_diff }}
     steps:

--- a/.github/workflows/pr-cancel-superseded.yml
+++ b/.github/workflows/pr-cancel-superseded.yml
@@ -21,37 +21,26 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const branch = context.payload.pull_request.head.ref;
-            const activeRuns = [];
+            const currentSha = context.payload.pull_request.head.sha;
+            const supersededRuns = new Map();
 
-            for (const status of ['in_progress', 'queued', 'pending']) {
-              let page = 1;
+            for (const status of ['in_progress', 'queued', 'pending', 'requested', 'waiting']) {
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner,
+                repo,
+                workflow_id: 'pr.yml',
+                branch,
+                status,
+                per_page: 100,
+              });
 
-              while (true) {
-                const { data } = await github.rest.actions.listWorkflowRunsForRepo({
-                  owner,
-                  repo,
-                  workflow_id: 'pr.yml',
-                  branch,
-                  status,
-                  per_page: 100,
-                  page,
-                });
-
-                activeRuns.push(...data.workflow_runs);
-
-                if (data.workflow_runs.length < 100) {
-                  break;
-                }
-
-                page += 1;
+              for (const run of runs.filter((candidate) => candidate.head_sha !== currentSha)) {
+                supersededRuns.set(run.id, run);
               }
             }
 
-            const uniqueRuns = [...new Map(activeRuns.map((run) => [run.id, run])).values()]
-              .sort((left, right) => right.id - left.id);
-
-            for (const run of uniqueRuns.slice(1)) {
-              core.info(`Cancelling superseded PR workflow run ${run.id} (${run.status})`);
+            for (const run of supersededRuns.values()) {
+              core.info(`Cancelling superseded PR workflow run ${run.id} (${run.status}, sha ${run.head_sha})`);
 
               try {
                 await github.rest.actions.cancelWorkflowRun({

--- a/.github/workflows/pr-cancel-superseded.yml
+++ b/.github/workflows/pr-cancel-superseded.yml
@@ -1,0 +1,65 @@
+name: PR Cancel Superseded Runs
+
+on:
+  pull_request:
+    types: [synchronize]
+    branches:
+      - main
+      - '[0-9].[0-9][0-9]'
+
+permissions:
+  actions: write
+
+jobs:
+  cancel-superseded-runs:
+    name: Cancel superseded PR runs
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Cancel older PR workflow runs on this branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const branch = context.payload.pull_request.head.ref;
+            const activeRuns = [];
+
+            for (const status of ['in_progress', 'queued', 'pending']) {
+              let page = 1;
+
+              while (true) {
+                const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                  owner,
+                  repo,
+                  workflow_id: 'pr.yml',
+                  branch,
+                  status,
+                  per_page: 100,
+                  page,
+                });
+
+                activeRuns.push(...data.workflow_runs);
+
+                if (data.workflow_runs.length < 100) {
+                  break;
+                }
+
+                page += 1;
+              }
+            }
+
+            const uniqueRuns = [...new Map(activeRuns.map((run) => [run.id, run])).values()]
+              .sort((left, right) => right.id - left.id);
+
+            for (const run of uniqueRuns.slice(1)) {
+              core.info(`Cancelling superseded PR workflow run ${run.id} (${run.status})`);
+
+              try {
+                await github.rest.actions.cancelWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: run.id,
+                });
+              } catch (error) {
+                core.warning(`Failed to cancel run ${run.id}: ${error.message}`);
+              }
+            }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -206,24 +206,6 @@ jobs:
           echo "  Size: $(du -sh elementor | cut -f1)"
           echo "  URL: https://github.com/elementor/elementor/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload-artifact.outputs.artifact-id }}"
 
-  playground-preview:
-    needs: [build]
-    if: |
-      always() &&
-      needs.build.result == 'success' &&
-      startsWith(github.repository, 'elementor/') &&
-      github.event.action != 'ready_for_review' &&
-      github.event.action != 'labeled'
-    permissions:
-      contents: read
-      actions: read
-      deployments: write
-    uses: ./.github/workflows/playground-preview.yml
-    with:
-      artifact_name: ${{ needs.build.outputs.artifact_name }}
-      pr_number: ${{ github.event.pull_request.number }}
-      head_sha: ${{ github.event.pull_request.head.sha }}
-
   lint-js:
     name: Lint JS
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -143,6 +143,8 @@ jobs:
           echo "PLUGIN_ZIP_FILENAME=$PLUGIN_ZIP_FILENAME" >> $GITHUB_ENV
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
+        with:
+          install-on-miss: 'true'
       - name: Build plugin
         uses: ./.github/workflows/build-plugin
         with:
@@ -223,6 +225,8 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
+        with:
+          install-on-miss: 'true'
       - name: Build tools
         run: npm run build:tools
       - name: Run Lint
@@ -248,6 +252,8 @@ jobs:
         run: composer config --global --unset github-oauth.github.com || true
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
+        with:
+          install-on-miss: 'true'
       - name: Install PHP lint dependencies
         run: |
           composer install
@@ -309,6 +315,8 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
+        with:
+          install-on-miss: 'true'
       - name: Run Jest
         run: npm run test
 
@@ -329,6 +337,8 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
+        with:
+          install-on-miss: 'true'
       - name: Build tools
         run: npm run build:tools
       - name: Run QUnit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,14 +2,10 @@ name: PR
 
 on:
   pull_request:
-    types: [labeled, opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     branches:
       - main
       - '[0-9].[0-9][0-9]'
-
-concurrency:
-  group: pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -17,11 +13,14 @@ permissions:
   id-token: write
   actions: read
   statuses: write
+  deployments: write
 
 jobs:
   set-pending-playwright-on-draft:
     name: Set Pending Playwright Status on Draft
-    if: github.event.pull_request.draft == true
+    if: |
+      github.event.pull_request.draft == true &&
+      github.event.action != 'ready_for_review'
     runs-on: ubuntu-22.04
     permissions:
       statuses: write
@@ -110,23 +109,12 @@ jobs:
           php-version: '7.4'
       - name: Remove Composer GitHub OAuth token
         run: composer config --global --unset github-oauth.github.com || true
-      - name: Restore dependency cache
-        uses: actions/cache@v5
-        id: deps-cache
-        with:
-          path: |
-            node_modules
-            packages/node_modules
-            vendor
-          key: deps-v2-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/composer.lock') }}
       - name: Install dependencies
-        if: steps.deps-cache.outputs.cache-hit != 'true'
-        run: |
-          npm run install:ci
-          npm run composer:no-dev
+        uses: ./.github/workflows/install-dependencies
 
   build:
     name: Build plugin
+    needs: [install]
     runs-on: ubuntu-22.04
     if: startsWith( github.repository, 'elementor/' )
     outputs:
@@ -138,7 +126,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24.15.0
-          cache: 'npm'
+          package-manager-cache: false
       - name: Set ENV variables
         id: set_env
         run: |
@@ -153,8 +141,10 @@ jobs:
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
           echo "PLUGIN_FOLDER_FILENAME=$PLUGIN_FOLDER_FILENAME" >> $GITHUB_ENV
           echo "PLUGIN_ZIP_FILENAME=$PLUGIN_ZIP_FILENAME" >> $GITHUB_ENV
-      - name: Install dependencies
-        uses: ./.github/workflows/install-dependencies
+      - name: Restore dependency cache
+        uses: ./.github/actions/restore-dependencies-cache
+        with:
+          fail-on-cache-miss: 'true'
       - name: Build plugin
         uses: ./.github/workflows/build-plugin
         with:
@@ -176,7 +166,10 @@ jobs:
           compression-level: 9
           retention-days: 3
       - name: Find existing comment on PR (Elementor repo)
-        if: startsWith( github.event.pull_request.head.repo.full_name, 'elementor/' )
+        if: |
+          startsWith(github.event.pull_request.head.repo.full_name, 'elementor/') &&
+          github.event.action != 'ready_for_review' &&
+          github.event.action != 'labeled'
         uses: peter-evans/find-comment@v4
         id: find
         with:
@@ -184,7 +177,10 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: 'Elementor Build'
       - name: Comment build info on PR (Elementor repo)
-        if: startsWith( github.event.pull_request.head.repo.full_name, 'elementor/' )
+        if: |
+          startsWith(github.event.pull_request.head.repo.full_name, 'elementor/') &&
+          github.event.action != 'ready_for_review' &&
+          github.event.action != 'labeled'
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find.outputs.comment-id }}
@@ -212,11 +208,31 @@ jobs:
           echo "  Size: $(du -sh elementor | cut -f1)"
           echo "  URL: https://github.com/elementor/elementor/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload-artifact.outputs.artifact-id }}"
 
+  playground-preview:
+    needs: [build]
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      startsWith(github.repository, 'elementor/') &&
+      github.event.action != 'ready_for_review' &&
+      github.event.action != 'labeled'
+    permissions:
+      contents: read
+      actions: read
+      deployments: write
+    uses: ./.github/workflows/playground-preview.yml
+    with:
+      artifact_name: ${{ needs.build.outputs.artifact_name }}
+      pr_number: ${{ github.event.pull_request.number }}
+      head_sha: ${{ github.event.pull_request.head.sha }}
+
   lint-js:
     name: Lint JS
     runs-on: ubuntu-22.04
     needs: [install, detect-changes]
-    if: needs.detect-changes.outputs.js == 'true'
+    if: |
+      github.event.action != 'ready_for_review' &&
+      needs.detect-changes.outputs.js == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6
@@ -226,14 +242,9 @@ jobs:
           node-version: 24.15.0
           package-manager-cache: false
       - name: Restore dependency cache
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/restore-dependencies-cache
         with:
-          path: |
-            node_modules
-            packages/node_modules
-            vendor
-          key: deps-v2-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/composer.lock') }}
-          fail-on-cache-miss: true
+          fail-on-cache-miss: 'true'
       - name: Build tools
         run: npm run build:tools
       - name: Run Lint
@@ -243,7 +254,9 @@ jobs:
     name: Lint PHP
     runs-on: ubuntu-22.04
     needs: [install, detect-changes]
-    if: needs.detect-changes.outputs.php == 'true'
+    if: |
+      github.event.action != 'ready_for_review' &&
+      needs.detect-changes.outputs.php == 'true'
     steps:
       - name: Mask GitHub token
         run: echo "::add-mask::${{ secrets.GITHUB_TOKEN }}"
@@ -256,14 +269,9 @@ jobs:
       - name: Remove Composer GitHub OAuth token
         run: composer config --global --unset github-oauth.github.com || true
       - name: Restore dependency cache
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/restore-dependencies-cache
         with:
-          path: |
-            node_modules
-            packages/node_modules
-            vendor
-          key: deps-v2-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/composer.lock') }}
-          fail-on-cache-miss: true
+          fail-on-cache-miss: 'true'
       - name: Install PHP lint dependencies
         run: |
           composer install
@@ -312,7 +320,9 @@ jobs:
     name: Jest
     runs-on: ubuntu-22.04
     needs: [install, detect-changes]
-    if: needs.detect-changes.outputs.js == 'true'
+    if: |
+      github.event.action != 'ready_for_review' &&
+      needs.detect-changes.outputs.js == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6
@@ -322,14 +332,9 @@ jobs:
           node-version: 24.15.0
           package-manager-cache: false
       - name: Restore dependency cache
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/restore-dependencies-cache
         with:
-          path: |
-            node_modules
-            packages/node_modules
-            vendor
-          key: deps-v2-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/composer.lock') }}
-          fail-on-cache-miss: true
+          fail-on-cache-miss: 'true'
       - name: Run Jest
         run: npm run test
 
@@ -337,7 +342,9 @@ jobs:
     name: QUnit
     runs-on: ubuntu-22.04
     needs: [install, detect-changes]
-    if: needs.detect-changes.outputs.js == 'true'
+    if: |
+      github.event.action != 'ready_for_review' &&
+      needs.detect-changes.outputs.js == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6
@@ -347,14 +354,9 @@ jobs:
           node-version: 24.15.0
           package-manager-cache: false
       - name: Restore dependency cache
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/restore-dependencies-cache
         with:
-          path: |
-            node_modules
-            packages/node_modules
-            vendor
-          key: deps-v2-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/composer.lock') }}
-          fail-on-cache-miss: true
+          fail-on-cache-miss: 'true'
       - name: Build tools
         run: npm run build:tools
       - name: Run QUnit
@@ -363,7 +365,9 @@ jobs:
   phpunit:
     name: PHPUnit
     needs: [install, detect-changes]
-    if: needs.detect-changes.outputs.php == 'true'
+    if: |
+      github.event.action != 'ready_for_review' &&
+      needs.detect-changes.outputs.php == 'true'
     uses: ./.github/workflows/phpunit-runner.yml
     with:
       job_name: PHPUnit (PR)
@@ -496,7 +500,7 @@ jobs:
       - js-qunit
       - phpunit
       - playwright
-    if: always()
+    if: always() && !cancelled()
     steps:
       - name: Validate required checks
         env:
@@ -508,6 +512,9 @@ jobs:
           QUNIT_RESULT: ${{ needs.js-qunit.result }}
           PHPUNIT_RESULT: ${{ needs.phpunit.result }}
           PLAYWRIGHT_RESULT: ${{ needs.playwright.result }}
+          JS_CHANGED: ${{ needs.detect-changes.outputs.js == 'true' }}
+          PHP_CHANGED: ${{ needs.detect-changes.outputs.php == 'true' }}
+          PLAYWRIGHT_ONLY_EVENT: ${{ github.event.action == 'ready_for_review' }}
           PLAYWRIGHT_REQUIRED: ${{ (needs.detect-changes.outputs.playwright == 'true' || contains(github.event.pull_request.labels.*.name, 'run-tests') || contains(github.event.pull_request.labels.*.name, 'full-browser-compatibility')) && !github.event.pull_request.draft }}
         run: |
           is_ok() {
@@ -518,20 +525,32 @@ jobs:
           }
 
           FAILED=0
-          for RESULT in \
-            "$INSTALL_RESULT" \
-            "$BUILD_RESULT" \
-            "$LINT_JS_RESULT" \
-            "$LINT_PHP_RESULT" \
-            "$JEST_RESULT" \
-            "$QUNIT_RESULT" \
-            "$PHPUNIT_RESULT"
-          do
+          for RESULT in "$INSTALL_RESULT" "$BUILD_RESULT"; do
             if ! is_ok "$RESULT"; then
               echo "Check failed with result: $RESULT"
               FAILED=1
             fi
           done
+
+          if [ "$PLAYWRIGHT_ONLY_EVENT" != "true" ]; then
+            if [ "$JS_CHANGED" = "true" ]; then
+              for RESULT in "$LINT_JS_RESULT" "$JEST_RESULT" "$QUNIT_RESULT"; do
+                if ! is_ok "$RESULT"; then
+                  echo "Check failed with result: $RESULT"
+                  FAILED=1
+                fi
+              done
+            fi
+
+            if [ "$PHP_CHANGED" = "true" ]; then
+              for RESULT in "$LINT_PHP_RESULT" "$PHPUNIT_RESULT"; do
+                if ! is_ok "$RESULT"; then
+                  echo "Check failed with result: $RESULT"
+                  FAILED=1
+                fi
+              done
+            fi
+          fi
 
           if [ "$PLAYWRIGHT_REQUIRED" = "true" ]; then
             if [ "$PLAYWRIGHT_RESULT" != "success" ]; then

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -143,8 +143,6 @@ jobs:
           echo "PLUGIN_ZIP_FILENAME=$PLUGIN_ZIP_FILENAME" >> $GITHUB_ENV
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
-        with:
-          fail-on-cache-miss: 'true'
       - name: Build plugin
         uses: ./.github/workflows/build-plugin
         with:
@@ -243,8 +241,6 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
-        with:
-          fail-on-cache-miss: 'true'
       - name: Build tools
         run: npm run build:tools
       - name: Run Lint
@@ -270,8 +266,6 @@ jobs:
         run: composer config --global --unset github-oauth.github.com || true
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
-        with:
-          fail-on-cache-miss: 'true'
       - name: Install PHP lint dependencies
         run: |
           composer install
@@ -333,8 +327,6 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
-        with:
-          fail-on-cache-miss: 'true'
       - name: Run Jest
         run: npm run test
 
@@ -355,8 +347,6 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
-        with:
-          fail-on-cache-miss: 'true'
       - name: Build tools
         run: npm run build:tools
       - name: Run QUnit


### PR DESCRIPTION
Cherry-pick of #36965 to the 4.02 release branch.

## Changes
- Cancel superseded PR workflow runs on code pushes via dedicated `pr-cancel-superseded.yml`
- Route build and Playwright jobs through shared `deps-v2` node_modules cache
- Remove Playwright reusable-workflow concurrency groups that blocked cancellation
- Cap Playwright shard jobs at 20 minutes
- Drive validation from `detect-changes` outputs; handle `labeled`/`ready_for_review` without full CI reruns

## Original PR
#36965

## Jira
[ED-24997](https://elementor.atlassian.net/browse/ED-24997)

Made with [Cursor](https://cursor.com)

[ED-24997]: https://elementor.atlassian.net/browse/ED-24997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick of PR #36965 to 4.02 branch addressing workflow inefficiencies: eliminates duplicate workflow runs on PR synchronize events and fixes npm caching configuration that was causing dependency cache misses.

## 2. What Changed (Where)

- New reusable action `.github/actions/restore-dependencies-cache` centralizes cache restore/install logic with fallback install-on-miss support
- New workflow `.github/workflows/pr-cancel-superseded.yml` cancels in-progress PR runs when branch updates (replaces inline concurrency)
- `pr.yml`: Removed global concurrency block; added per-job skip conditions for draft/ready_for_review events; migrated to new cache action; restructured validation to conditionally check linting/testing based on change detection
- `playwright.yml`, `playwright-suite.yml`, `plugin-upgrade-test.yml`: Added timeout-minutes; switched from `cache: 'npm'` to `package-manager-cache: false` + new cache action

## 3. How It Works

Previously, workflows relied on GitHub's global `concurrency` to cancel runs, which was coarse-grained. New approach: separate dedicated workflow triggers on `synchronize` to explicitly cancel superseded runs via Actions API. Cache refactored into composable action that auto-installs on miss (`install-on-miss: true`), replacing inline bash runs. Job conditions now skip non-essential checks (lint/test/phpunit) when only draft status changes or files didn't change, reducing noise.

## 4. Risks

Minor: New cache action assumes npm/composer scripts (`npm run install:ci`) exist—breaking if scripts removed. Separate cancel workflow adds GitHub API call latency (negligible). Validation logic now more complex with conditional branching—verify `detect-changes` outputs propagate correctly across all paths.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
