### PR TITLE
Internal: Harden permissions action against substring matches [ED-25304]

### DIFF
--- a/.github/workflows/permissions/action.yml
+++ b/.github/workflows/permissions/action.yml
@@ -25,7 +25,9 @@ runs:
           echo "Pass validation in the development environment"
           exit 0
         fi
-        if ! echo "${{ inputs.DEPLOYMENT_PERMITTED }}" | grep -iq "${{ github.actor }}"; then
+        permitted=",$(echo "${{ inputs.DEPLOYMENT_PERMITTED }}" | tr -d '[:space:]'),"
+        actor=",${{ github.actor }},"
+        if ! echo "$permitted" | grep -Fiq "$actor"; then
          echo "::error::No deployment permissions have been granted to the user : ${{ github.actor }}"
          exit 1
         fi


### PR DESCRIPTION
## Summary

`.github/workflows/permissions/action.yml` currently gates deployments with:

```bash
echo "$DEPLOYMENT_PERMITTED" | grep -iq "$github.actor"
```

That is a substring match — an actor whose handle is a substring of any permitted username passes the check. Concretely, with `DEPLOYMENT_PERMITTED="arielk,manor"`, `github.actor="ari"` is accepted even though `ari` is not on the list.

This PR wraps both sides in comma delimiters and uses `grep -F` so the match requires a full token:

```bash
permitted=",$(echo "$DEPLOYMENT_PERMITTED" | tr -d '[:space:]'),"
actor=",$github.actor,"
if ! echo "$permitted" | grep -Fiq "$actor"; then …
```

Whitespace is stripped from the list so `"a, b, c"` and `"a,b,c"` behave the same. `-F` treats the actor as a literal (no regex surprises).

## Jira

[ED-25304](https://elementor.atlassian.net/browse/ED-25304)

## Test plan

Verified locally with the same shell code path:

- Actor `ariel` against list `ariel,ntnel` → PASS (start of list)
- Actor `ntnel` against list `ariel,ntnel` → PASS (end of list)
- Actor `ari` against list `ariel,ntnel` → FAIL (previously PASS — this is the bug being fixed)
- Actor exact-match, case-insensitive → PASS

Confirm in CI that permitted users can still trigger `one-click-release.yml`, `release-tag-creation.yml`, and `publish-packages.yml`.

Made with [Cursor](https://cursor.com)

[ED-25304]: https://elementor.atlassian.net/browse/ED-25304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The permissions check was vulnerable to substring matches—e.g., user "admin" would pass if "adminreader" was in the permitted list. This hardens the validation by wrapping values with delimiters to enforce exact matches (ED-25304).

## 2. What Changed (Where)

`.github/workflows/permissions/action.yml`: Replaced regex grep with fixed-string grep, added comma delimiters to both permitted list and actor for exact-match validation.

## 3. How It Works

Wraps `DEPLOYMENT_PERMITTED` and `github.actor` with commas, strips whitespace, then uses `grep -Fiq` (fixed-string, case-insensitive) to match exact actor within the delimited list.

## 4. Risks

None significant. The comma-delimiter approach is robust for usernames. Test that comma-containing usernames don't exist in your system; if they do, consider alternative delimiter.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
