### PR TITLE
Internal: Cherry-pick PR 36982 to 4.02: Harden permissions action against substring matches [ED-25304]

### DIFF
--- a/.github/workflows/permissions/action.yml
+++ b/.github/workflows/permissions/action.yml
@@ -25,7 +25,9 @@ runs:
           echo "Pass validation in the development environment"
           exit 0
         fi
-        if ! echo "${{ inputs.DEPLOYMENT_PERMITTED }}" | grep -iq "${{ github.actor }}"; then
+        permitted=",$(echo "${{ inputs.DEPLOYMENT_PERMITTED }}" | tr -d '[:space:]'),"
+        actor=",${{ github.actor }},"
+        if ! echo "$permitted" | grep -Fiq "$actor"; then
          echo "::error::No deployment permissions have been granted to the user : ${{ github.actor }}"
          exit 1
         fi


### PR DESCRIPTION
Cherry-pick of #36982 to the 4.02 release branch.

## Changes

- Wrap `DEPLOYMENT_PERMITTED` and `github.actor` in comma delimiters before `grep -F` in `.github/workflows/permissions/action.yml`, so the permissions check requires a full-token match instead of a substring match.

## Original PR

#36982

## Jira

[ED-25304](https://elementor.atlassian.net/browse/ED-25304)

Made with [Cursor](https://cursor.com)

[ED-25304]: https://elementor.atlassian.net/browse/ED-25304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Fixes substring matching vulnerability in deployment permissions check (ED-25304). Previous regex allowed `user` to match `superuser`, creating privilege escalation risk.

## 2. What Changed (Where)

`.github/workflows/permissions/action.yml`: Replaced substring-prone `grep -i` with exact-match logic using comma delimiters and `grep -F`.

## 3. How It Works

Wraps both permitted list and actor name with commas, then uses fixed-string grep (`-F`) to prevent regex interpretation. Whitespace normalization ensures consistent delimiter placement.

## 4. Risks

None—stricter matching only rejects previously-unsafe cases. Requires permission list format discipline (comma-separated values).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
