### PR TITLE
Internal: Persist dependency cache key through save step [ED-24997]

### DIFF
--- a/.github/actions/restore-dependencies-cache/action.yml
+++ b/.github/actions/restore-dependencies-cache/action.yml
@@ -15,6 +15,9 @@ outputs:
   cache-hit:
     description: Whether an exact cache key match was restored.
     value: ${{ steps.deps-cache.outputs.cache-hit }}
+  cache-key:
+    description: The cache key used for restore and save.
+    value: ${{ steps.deps-cache.outputs.cache-primary-key }}
 
 runs:
   using: composite
@@ -43,4 +46,4 @@ runs:
           node_modules
           packages/node_modules
           vendor
-        key: deps-v2-${{ runner.os }}-${{ hashFiles('package-lock.json', 'composer.lock') }}
+        key: ${{ steps.deps-cache.outputs.cache-primary-key }}

--- a/.github/workflows/playwright-suite.yml
+++ b/.github/workflows/playwright-suite.yml
@@ -85,8 +85,6 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
-        with:
-          fail-on-cache-miss: 'true'
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -143,8 +143,6 @@ jobs:
           echo "PLUGIN_ZIP_FILENAME=$PLUGIN_ZIP_FILENAME" >> $GITHUB_ENV
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
-        with:
-          fail-on-cache-miss: 'true'
       - name: Build plugin
         uses: ./.github/workflows/build-plugin
         with:
@@ -243,8 +241,6 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
-        with:
-          fail-on-cache-miss: 'true'
       - name: Build tools
         run: npm run build:tools
       - name: Run Lint
@@ -270,8 +266,6 @@ jobs:
         run: composer config --global --unset github-oauth.github.com || true
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
-        with:
-          fail-on-cache-miss: 'true'
       - name: Install PHP lint dependencies
         run: |
           composer install
@@ -333,8 +327,6 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
-        with:
-          fail-on-cache-miss: 'true'
       - name: Run Jest
         run: npm run test
 
@@ -355,8 +347,6 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
-        with:
-          fail-on-cache-miss: 'true'
       - name: Build tools
         run: npm run build:tools
       - name: Run QUnit


### PR DESCRIPTION
## Summary
- Save the dependency cache with `cache-primary-key` from the restore step so install and downstream jobs use the same key (lockfiles change during `npm ci`, so re-hashing at save time produced a different key).
- Remove `fail-on-cache-miss` from downstream PR and Playwright suite jobs that only restore the install cache.

## Jira
ED-24997

## Test plan
- [ ] Open a PR and confirm `install` saves cache under the same key it restored
- [ ] Confirm `build`, lint, jest, and qunit jobs restore that cache successfully
- [ ] Confirm Playwright suite jobs restore the install cache without hard-failing on miss

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Cache key was lost during save step, causing subsequent runs to create new cache entries instead of reusing existing ones. This PR persists the primary key from restore through to save, ensuring cache efficiency.

## 2. What Changed (Where)
- **restore-dependencies-cache/action.yml**: Added `cache-key` output exposing `cache-primary-key`; save step now uses persisted key instead of recomputing it
- **pr.yml & playwright-suite.yml**: Removed `fail-on-cache-miss: 'true'` from all restore-dependencies-cache calls (6 instances)

## 3. How It Works
Restore step generates and outputs `cache-primary-key` via GitHub Actions cache action. New output exposes this key; save step references it via `${{ steps.deps-cache.outputs.cache-primary-key }}` instead of rebuilding the hash formula, ensuring consistency across restore/save lifecycle.

## 4. Risks
Removing `fail-on-cache-miss` globally relaxes cache guarantees—workflows now proceed on cache miss instead of failing fast. Mitigate by ensuring cache is properly seeded in build/setup workflows; consider re-adding flag to critical paths if silent cache misses prove problematic.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
