### PR TITLE
Internal: Scope superseded PR run cancellation to stale runs [ED-24997]

### DIFF
--- a/.github/actions/restore-dependencies-cache/action.yml
+++ b/.github/actions/restore-dependencies-cache/action.yml
@@ -1,5 +1,5 @@
 name: Restore dependency cache
-description: Restore node_modules, packages/node_modules, and vendor from the PR CI cache.
+description: Restore node_modules, packages/node_modules, vendor, and vendor_prefixed from the PR CI cache.
 
 inputs:
   fail-on-cache-miss:
@@ -30,7 +30,8 @@ runs:
           node_modules
           packages/node_modules
           vendor
-        key: deps-v2-${{ runner.os }}-${{ hashFiles('package-lock.json', 'composer.lock') }}
+          vendor_prefixed
+        key: deps-v3-${{ runner.os }}-${{ hashFiles('package-lock.json', 'composer.lock') }}
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss == 'true' }}
     - name: Install dependencies on cache miss
       if: inputs.install-on-miss == 'true' && steps.deps-cache.outputs.cache-hit != 'true'
@@ -46,4 +47,5 @@ runs:
           node_modules
           packages/node_modules
           vendor
+          vendor_prefixed
         key: ${{ steps.deps-cache.outputs.cache-primary-key }}

--- a/.github/workflows/playwright-suite.yml
+++ b/.github/workflows/playwright-suite.yml
@@ -85,6 +85,8 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
+        with:
+          install-on-miss: 'true'
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/pr-cancel-superseded.yml
+++ b/.github/workflows/pr-cancel-superseded.yml
@@ -21,37 +21,26 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const branch = context.payload.pull_request.head.ref;
-            const activeRuns = [];
+            const currentSha = context.payload.pull_request.head.sha;
+            const supersededRuns = new Map();
 
-            for (const status of ['in_progress', 'queued', 'pending']) {
-              let page = 1;
+            for (const status of ['in_progress', 'queued', 'pending', 'requested', 'waiting']) {
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner,
+                repo,
+                workflow_id: 'pr.yml',
+                branch,
+                status,
+                per_page: 100,
+              });
 
-              while (true) {
-                const { data } = await github.rest.actions.listWorkflowRunsForRepo({
-                  owner,
-                  repo,
-                  workflow_id: 'pr.yml',
-                  branch,
-                  status,
-                  per_page: 100,
-                  page,
-                });
-
-                activeRuns.push(...data.workflow_runs);
-
-                if (data.workflow_runs.length < 100) {
-                  break;
-                }
-
-                page += 1;
+              for (const run of runs.filter((candidate) => candidate.head_sha !== currentSha)) {
+                supersededRuns.set(run.id, run);
               }
             }
 
-            const uniqueRuns = [...new Map(activeRuns.map((run) => [run.id, run])).values()]
-              .sort((left, right) => right.id - left.id);
-
-            for (const run of uniqueRuns.slice(1)) {
-              core.info(`Cancelling superseded PR workflow run ${run.id} (${run.status})`);
+            for (const run of supersededRuns.values()) {
+              core.info(`Cancelling superseded PR workflow run ${run.id} (${run.status}, sha ${run.head_sha})`);
 
               try {
                 await github.rest.actions.cancelWorkflowRun({

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -143,6 +143,8 @@ jobs:
           echo "PLUGIN_ZIP_FILENAME=$PLUGIN_ZIP_FILENAME" >> $GITHUB_ENV
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
+        with:
+          install-on-miss: 'true'
       - name: Build plugin
         uses: ./.github/workflows/build-plugin
         with:
@@ -241,6 +243,8 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
+        with:
+          install-on-miss: 'true'
       - name: Build tools
         run: npm run build:tools
       - name: Run Lint
@@ -266,6 +270,8 @@ jobs:
         run: composer config --global --unset github-oauth.github.com || true
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
+        with:
+          install-on-miss: 'true'
       - name: Install PHP lint dependencies
         run: |
           composer install
@@ -327,6 +333,8 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
+        with:
+          install-on-miss: 'true'
       - name: Run Jest
         run: npm run test
 
@@ -347,6 +355,8 @@ jobs:
           package-manager-cache: false
       - name: Restore dependency cache
         uses: ./.github/actions/restore-dependencies-cache
+        with:
+          install-on-miss: 'true'
       - name: Build tools
         run: npm run build:tools
       - name: Run QUnit


### PR DESCRIPTION
## Summary
`listWorkflowRunsForRepo` (`GET /repos/{owner}/{repo}/actions/runs`) does not accept `workflow_id`, so the parameter was silently ignored and the cancel job matched **every** workflow on the branch. It then sorted by run id and cancelled everything except the highest id, which meant it cancelled its own run plus unrelated PR checks.

- Query the per-workflow endpoint (`listWorkflowRuns`) so only `pr.yml` runs are considered.
- Cancel only runs whose `head_sha` no longer matches the pull request head, instead of id sorting.
- Include `requested` and `waiting` statuses, and replace the manual pagination loop with `github.paginate`.

## Evidence
Reproduced in Pro on [run 32257997692](https://github.com/elementor/elementor-pro/actions/runs/32257997692), where the job cancelled itself. Core ships the same script, so it has the same defect.

Confirmed against the live API — the repo-wide endpoint with `workflow_id=pr.yml` returns runs from many workflows, while the per-workflow endpoint returns only `pr.yml`.

## Jira
ED-24997

## Test plan
- [ ] Push twice in quick succession and confirm only the stale `pr.yml` run is cancelled
- [ ] Confirm `Cancel superseded PR runs` completes successfully instead of cancelling itself
- [ ] Confirm unrelated PR checks are no longer cancelled

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

ED-24997: Refine PR run cancellation to only kill truly superseded runs (different SHA), not all older runs on the same branch. Previous logic cancelled all but the latest run regardless of whether they were actually stale.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `.github/workflows/pr-cancel-superseded.yml` | Replaced pagination + sorting logic with SHA-based deduplication; now cancels only runs with different head_sha than current PR |
| `.github/actions/restore-dependencies-cache/action.yml` | Added `vendor_prefixed` to cache paths; bumped cache key from v2→v3 |
| `.github/workflows/pr.yml`, `playwright-suite.yml` | Added `install-on-miss: 'true'` to all restore-dependencies-cache invocations (5 jobs) |

## 3. How It Works

New cancellation logic:
1. Fetch all in_progress/queued/pending/requested/waiting runs for the PR workflow on this branch
2. Filter out runs matching `currentSha` (the triggering PR's commit)
3. Cancel remaining runs—these are genuinely superseded by a newer push to the branch

Cache improvements mirror the scope: `vendor_prefixed` directory added to cached artifacts and key incremented to invalidate stale caches.

## 4. Risks

Minor: Cache key bump (v2→v3) will cause one-time cache miss across all workflows, triggering `install-on-miss` fallback. The new `install-on-miss` flags ensure jobs recover gracefully. PR cancellation is safer now—only false negatives if GitHub's run statuses are eventually consistent, but that's existing platform behavior.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
