### PR TITLE
Fix: Stabilize Core publishPage Playwright helper and CI reporting [ED-24997]

### DIFF
--- a/.github/workflows/playwright-suite.yml
+++ b/.github/workflows/playwright-suite.yml
@@ -46,7 +46,7 @@ jobs:
   Playwright:
     name: Playwright test - ${{ matrix.shardIndex }} on PHP (${{ needs.get-php-version.outputs.php_version }})
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     needs: [build-plugin, prepare-caller-build, get-php-version]
     permissions:
       contents: read
@@ -371,14 +371,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate a token
         id: generate-token
-        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) }}
+        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) && secrets.TEST_CONFIGURATION_APP_ID != '' }}
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.TEST_CONFIGURATION_APP_ID }}
           private-key: ${{ secrets.TEST_CONFIGURATION_APP_PRIVATE_KEY }}
           owner: elementor
       - name: Checkout private action repository
-        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) }}
+        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) && secrets.TEST_CONFIGURATION_APP_ID != '' }}
         uses: actions/checkout@v6
         with:
           repository: elementor/elementor-tests-configuration
@@ -388,7 +388,7 @@ jobs:
           ref: main
       - name: Map GitHub user to Slack
         id: map_user
-        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) }}
+        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) && secrets.TEST_CONFIGURATION_APP_ID != '' }}
         uses: ./elementor-tests-configuration/.github/actions/map-github-to-slack
         with:
           github_user: ${{ github.actor }}
@@ -396,7 +396,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           SLACK_TOKEN: ${{ secrets.CLOUD_SLACK_BOT_TOKEN }}
       - name: Send slack message
-        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) }}
+        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) && secrets.TEST_CONFIGURATION_APP_ID != '' }}
         uses: ./.github/workflows/post-to-slack
         with:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/playwright-suite.yml
+++ b/.github/workflows/playwright-suite.yml
@@ -371,14 +371,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate a token
         id: generate-token
-        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) && secrets.TEST_CONFIGURATION_APP_ID != '' }}
+        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) }}
+        continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.TEST_CONFIGURATION_APP_ID }}
           private-key: ${{ secrets.TEST_CONFIGURATION_APP_PRIVATE_KEY }}
           owner: elementor
       - name: Checkout private action repository
-        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) && secrets.TEST_CONFIGURATION_APP_ID != '' }}
+        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) && steps.generate-token.outcome == 'success' }}
         uses: actions/checkout@v6
         with:
           repository: elementor/elementor-tests-configuration
@@ -388,7 +389,7 @@ jobs:
           ref: main
       - name: Map GitHub user to Slack
         id: map_user
-        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) && secrets.TEST_CONFIGURATION_APP_ID != '' }}
+        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) && steps.generate-token.outcome == 'success' }}
         uses: ./elementor-tests-configuration/.github/actions/map-github-to-slack
         with:
           github_user: ${{ github.actor }}
@@ -396,7 +397,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           SLACK_TOKEN: ${{ secrets.CLOUD_SLACK_BOT_TOKEN }}
       - name: Send slack message
-        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) && secrets.TEST_CONFIGURATION_APP_ID != '' }}
+        if: ${{ needs.Playwright.result == 'failure' && (github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/3.')))) && steps.generate-token.outcome == 'success' }}
         uses: ./.github/workflows/post-to-slack
         with:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/tests/playwright/pages/editor-page.ts
+++ b/tests/playwright/pages/editor-page.ts
@@ -957,9 +957,19 @@ export default class EditorPage extends BasePage {
 	 * @return {Promise<void>}
 	 */
 	async publishPage(): Promise<void> {
+		const saveResponsePromise = this.page.waitForResponse(
+			( response ) =>
+				response.url().includes( 'admin-ajax.php' ) &&
+				'POST' === response.request().method() &&
+				( response.request().postData() ?? '' ).includes( 'save_builder' ),
+			{ timeout: timeouts.longAction },
+		);
+
 		await this.clickTopBarItem( TopBarSelectors.publish );
-		await this.page.waitForLoadState();
-		await this.page.locator( EditorSelectors.panels.topBar.wrapper + ' button[disabled]', { hasText: 'Publish' } ).waitFor( { timeout: timeouts.heavyAction } );
+		await saveResponsePromise;
+
+		const publishButton = this.page.locator( EditorSelectors.panels.topBar.wrapper ).getByRole( 'button', { name: TopBarSelectors.publish.attributeValue } );
+		await expect( publishButton ).toBeDisabled();
 	}
 
 	/**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Playwright shards across ready PRs were failing on v4 publish flows because Core's `publishPage()` waited for a disabled Publish button without confirming the `save_builder` save completed. This aligns Core with the Pro Playwright page object pattern.

Also hardens scheduled-run reporting when `TEST_CONFIGURATION_APP_ID` is unset, and raises Playwright shard timeout to 30 minutes for heavy v4 suites.

## Changes

- **`tests/playwright/pages/editor-page.ts`**: Wait for `save_builder` admin-ajax response before asserting Publish is disabled (same approach as elementor-pro).
- **`.github/workflows/playwright-suite.yml`**: Skip Slack notification steps when `TEST_CONFIGURATION_APP_ID` is empty; increase shard `timeout-minutes` from 20 to 30.

## Test plan

- [ ] Mark PR ready for review and confirm previously failing v4 Playwright shards (8, 12, 14–17, elements-regression-atomic) pass
- [ ] Confirm scheduled `main` Playwright run no longer fails the Test Results job solely due to missing app token
- [ ] Confirm no regression on shards that already passed

## Jira

ED-24997
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01def-9c87-70dd-8358-d7668952f8d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01def-9c87-70dd-8358-d7668952f8d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The `publishPage()` helper was flaky due to unreliable load state detection. This stabilizes it by waiting for the specific save_builder AJAX response and polling button disabled state, plus hardens CI reporting with token generation safety and conditional step execution.

## 2. What Changed (Where)

- **editor-page.ts**: Replaced generic `waitForLoadState()` with targeted AJAX response interception and explicit disabled button verification
- **.github/workflows/playwright-suite.yml**: Increased job timeout 20→30 minutes, added `continue-on-error` to token generation, gated reporting steps on token success

## 3. How It Works

The publishPage flow now: (1) sets up listener for admin-ajax.php POST containing 'save_builder', (2) clicks publish button, (3) awaits that specific response, (4) verifies publish button reaches disabled state. CI reporting steps now gracefully degrade if private repo token generation fails, preventing cascading failures.

## 4. Risks

Minimal—the response matcher is specific to the save operation, timeout increase is reasonable for CI, and token generation failure is gracefully handled. Only risk: if save_builder AJAX never fires, test hangs at 30s timeout instead of previous undefined state. Mitigated by explicit timeout constant.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
