### PR TITLE
Fix: Atomic widgets render empty HTML tag in editor preview [ED-22046]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
+++ b/modules/atomic-widgets/elements/atomic-heading/atomic-heading.html.twig
@@ -1,6 +1,6 @@
 {% import 'elementor/macros' as m %}
 {%- set classes = settings.classes | merge( [ base_styles.base, m.default_tag_class(settings.tag) ] ) | join(' ') -%}
-<{{ settings.tag | e('html_tag') }} data-interaction-id="{{ interaction_id }}" class="{{ classes }}"
+<{{ settings.tag | default('h2') | e('html_tag') }} data-interaction-id="{{ interaction_id }}" class="{{ classes }}"
 	{{- m.render_custom_attributes(settings) }}>
 {%- set allowed_tags = '<b><strong><sup><sub><s><em><i><u><a><del><span><br>' -%}
 {%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
@@ -11,4 +11,4 @@
 {%- else -%}
 	{{ settings.title | striptags(allowed_tags) | raw }}
 {%- endif %}
-</{{ settings.tag | e('html_tag') }}>
+</{{ settings.tag | default('h2') | e('html_tag') }}>

--- a/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.html.twig
+++ b/modules/atomic-widgets/elements/atomic-paragraph/atomic-paragraph.html.twig
@@ -1,6 +1,6 @@
 {% import 'elementor/macros' as m %}
 {%- set classes = settings.classes | merge( [ base_styles.base, m.default_tag_class(settings.tag) ] ) | join(' ') -%}
-<{{ settings.tag | e('html_tag') }} class="{{ classes }}" data-interaction-id="{{ interaction_id }}"
+<{{ settings.tag | default('p') | e('html_tag') }} class="{{ classes }}" data-interaction-id="{{ interaction_id }}"
 	{{- m.render_custom_attributes(settings) }}>
 {%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
 	<{{ settings.link.tag | default('a') | e('html_tag') }}
@@ -10,4 +10,4 @@
 {%- else -%}
 	{{ settings.paragraph | striptags('<b><strong><sup><sub><s><em><u><ul><ol><li><blockquote><a><del><span><br>') | raw }}
 {%- endif %}
-</{{ settings.tag | e('html_tag') }}>
+</{{ settings.tag | default('p') | e('html_tag') }}>

--- a/modules/atomic-widgets/elements/div-block/div-block.html.twig
+++ b/modules/atomic-widgets/elements/div-block/div-block.html.twig
@@ -3,9 +3,9 @@
 {%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
     {%- set tag = settings.link.tag | default('a') -%}
 {%- endif -%}
-<{{ tag }} class="{{ m.render_base_classes(id, base_styles, settings, [], tag) }} {{ editor_classes | default('') }}"
+<{{ tag | default('div') | e('html_tag') }} class="{{ m.render_base_classes(id, base_styles, settings, [], tag) }} {{ editor_classes | default('') }}"
     {{- ' ' }}{{ m.render_data_attributes(id, type, interaction_id) }}
     {{- m.render_link_attributes(settings.link | default(null)) }}
     {{- m.render_custom_attributes(settings, editor_attributes) }}>
     <!-- elementor-children-placeholder -->
-</{{ tag }}>
+</{{ tag | default('div') | e('html_tag') }}>

--- a/modules/atomic-widgets/elements/flexbox/flexbox.html.twig
+++ b/modules/atomic-widgets/elements/flexbox/flexbox.html.twig
@@ -3,9 +3,9 @@
 {%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
     {%- set tag = settings.link.tag | default('a') -%}
 {%- endif -%}
-<{{ tag }} class="{{ m.render_base_classes(id, base_styles, settings, [], tag) }} {{ editor_classes | default('') }}"
+<{{ tag | default('div') | e('html_tag') }} class="{{ m.render_base_classes(id, base_styles, settings, [], tag) }} {{ editor_classes | default('') }}"
     {{- ' ' }}{{ m.render_data_attributes(id, type, interaction_id) }}
     {{- m.render_link_attributes(settings.link | default(null)) }}
     {{- m.render_custom_attributes(settings, editor_attributes) }}>
     <!-- elementor-children-placeholder -->
-</{{ tag }}>
+</{{ tag | default('div') | e('html_tag') }}>

--- a/modules/atomic-widgets/elements/grid/grid.html.twig
+++ b/modules/atomic-widgets/elements/grid/grid.html.twig
@@ -3,9 +3,9 @@
 {%- if settings.link is defined and settings.link.href is defined and settings.link.href is not empty -%}
     {%- set tag = settings.link.tag | default('a') -%}
 {%- endif -%}
-<{{ tag }} class="{{ m.render_base_classes(id, base_styles, settings, [], tag) }} {{ editor_classes | default('') }}"
+<{{ tag | default('div') | e('html_tag') }} class="{{ m.render_base_classes(id, base_styles, settings, [], tag) }} {{ editor_classes | default('') }}"
     {{- ' ' }}{{ m.render_data_attributes(id, type, interaction_id) }}
     {{- m.render_link_attributes(settings.link | default(null)) }}
     {{- m.render_custom_attributes(settings, editor_attributes) }}>
     <!-- elementor-children-placeholder -->
-</{{ tag }}>
+</{{ tag | default('div') | e('html_tag') }}>

--- a/packages/packages/core/editor-canvas/src/renderers/__tests__/apply-schema-defaults.test.ts
+++ b/packages/packages/core/editor-canvas/src/renderers/__tests__/apply-schema-defaults.test.ts
@@ -1,0 +1,39 @@
+import { type PropsSchema } from '@elementor/editor-props';
+
+import { applySchemaDefaults } from '../apply-schema-defaults';
+
+const str = ( value: string ) => ( { $$type: 'string' as const, value } );
+
+const propsSchema: PropsSchema = {
+	tag: {
+		kind: 'plain',
+		key: 'string',
+		default: str( 'h2' ),
+		settings: {},
+		meta: {},
+		dependencies: undefined,
+		initial_value: null,
+	},
+};
+
+describe( 'applySchemaDefaults', () => {
+	it( 'should apply schema default when a prop is null', () => {
+		const result = applySchemaDefaults( { tag: null }, propsSchema );
+
+		expect( result.tag ).toEqual( str( 'h2' ) );
+	} );
+
+	it( 'should apply schema default when a prop is missing', () => {
+		const result = applySchemaDefaults( {}, propsSchema );
+
+		expect( result.tag ).toEqual( str( 'h2' ) );
+	} );
+
+	it( 'should keep an explicit prop value', () => {
+		const storedTag = str( 'h3' );
+
+		const result = applySchemaDefaults( { tag: storedTag }, propsSchema );
+
+		expect( result.tag ).toBe( storedTag );
+	} );
+} );

--- a/packages/packages/core/editor-canvas/src/renderers/__tests__/create-dom-renderer.test.ts
+++ b/packages/packages/core/editor-canvas/src/renderers/__tests__/create-dom-renderer.test.ts
@@ -109,6 +109,21 @@ describe( 'createDomRenderer', () => {
 		expect( result ).toBe( '<custom-tag></custom-tag>' );
 	} );
 
+	it.each( [
+		{ title: 'null tag', tag: null },
+		{ title: 'undefined tag', tag: undefined },
+		{ title: 'empty tag', tag: '' },
+	] )( 'should render div when html_tag input is $title', async ( { tag } ) => {
+		const domRenderer = createDomRenderer();
+		const template = `<{{ tag | default( 'div' ) | e( 'html_tag' ) }}></{{ tag | default( 'div' ) | e( 'html_tag' ) }}>`;
+
+		domRenderer.register( 'test-template', template );
+
+		const result = await domRenderer.render( 'test-template', { tag } );
+
+		expect( result ).toBe( '<div></div>' );
+	} );
+
 	it( 'should fail closed to div when the localized config is missing, even for an otherwise-safe tag', async () => {
 		// Arrange.
 		delete window.elementorCommon;

--- a/packages/packages/core/editor-canvas/src/renderers/apply-schema-defaults.ts
+++ b/packages/packages/core/editor-canvas/src/renderers/apply-schema-defaults.ts
@@ -1,0 +1,19 @@
+import { type Props, type PropsSchema } from '@elementor/editor-props';
+
+export function applySchemaDefaults( props: Props, schema: PropsSchema ): Props {
+	const propsWithDefaults = { ...props };
+
+	for ( const key of Object.keys( schema ) ) {
+		const propDefault = schema[ key ]?.default;
+
+		if ( propDefault == null ) {
+			continue;
+		}
+
+		if ( propsWithDefaults[ key ] == null ) {
+			propsWithDefaults[ key ] = propDefault;
+		}
+	}
+
+	return propsWithDefaults;
+}

--- a/packages/packages/core/editor-canvas/src/renderers/create-dom-renderer.ts
+++ b/packages/packages/core/editor-canvas/src/renderers/create-dom-renderer.ts
@@ -28,8 +28,12 @@ function getAllowedHtmlWrapperTags(): readonly string[] {
 }
 
 function escapeHtmlTag( value: string ) {
+	if ( value == null || value === '' ) {
+		return 'div';
+	}
+
 	const allowedTags = getAllowedHtmlWrapperTags();
-	const normalizedTag = value?.toLowerCase?.() ?? '';
+	const normalizedTag = value.toLowerCase();
 
 	return allowedTags.includes( normalizedTag ) ? value : 'div';
 }

--- a/packages/packages/core/editor-canvas/src/renderers/create-props-resolver.ts
+++ b/packages/packages/core/editor-canvas/src/renderers/create-props-resolver.ts
@@ -10,6 +10,7 @@ import {
 
 import { type RenderContext } from '../legacy/types';
 import { type TransformersRegistry } from '../transformers/create-transformers-registry';
+import { applySchemaDefaults } from './apply-schema-defaults';
 import { getMultiPropsValue, isMultiProps } from './multi-props';
 
 type CreatePropResolverArgs = {
@@ -42,10 +43,11 @@ const TRANSFORM_DEPTH_LIMIT = 3;
 export function createPropsResolver( { transformers, schema: initialSchema, onPropResolve }: CreatePropResolverArgs ) {
 	async function resolve( { props, schema, signal, renderContext }: ResolveArgs ): Promise< ResolvedProps > {
 		schema = schema ?? initialSchema;
+		const propsWithDefaults = applySchemaDefaults( props, schema );
 
 		const promises = Promise.all(
 			Object.entries( schema ).map( async ( [ key, type ] ) => {
-				const value = props[ key ] ?? type.default;
+				const value = propsWithDefaults[ key ] ?? type.default;
 				const transformed = ( await transform( { value, key, type, signal, renderContext } ) ) as PropValue;
 
 				onPropResolve?.( { key, value: transformed, propValue: value, propType: type } );


### PR DESCRIPTION
## Summary

- Apply schema defaults in the editor canvas props resolver before Twig rendering, so atomic elements resolve `tag` (and other props) from their schema defaults when model values are null or missing.
- Harden atomic Twig templates: use `| default(...)` before `| e('html_tag')` on heading/paragraph tags, and run container tags through the `html_tag` escaper.
- Fail closed in `escapeHtmlTag` when the value is null or an empty string.

This fixes v4 Playwright failures where preview markup looked like `< class="e-heading-base" ...>` (invalid HTML), widgets were not selectable by class, and flexbox/div-block elements silently failed to mount in the canvas.

## Jira

[ED-22046](https://elementor.atlassian.net/browse/ED-22046)

## Test plan

- [x] `cd packages && npm test -- --testPathPattern="apply-schema-defaults|create-dom-renderer"`
- [ ] Open editor with `e_atomic_elements` + `e_opt_in_v4`, add e-heading and e-flexbox — preview shows valid HTML tags with `data-id` / `.e-heading-base`
- [ ] Run Playwright v4 suite: `npm run test:playwright -- --grep @v4-tests`

Made with [Cursor](https://cursor.com)

[ED-22046]: https://elementor.atlassian.net/browse/ED-22046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Atomic widgets rendered empty HTML tags in editor preview when the `tag` prop was null/undefined. Fix applies schema defaults early and sanitizes null/empty tag values to fallback defaults.

## 2. What Changed (Where)

| Component | Change |
|-----------|--------|
| `apply-schema-defaults.ts` | New utility to populate missing props from schema defaults |
| `create-dom-renderer.ts` | Enhanced `escapeHtmlTag()` to handle null/empty values → `'div'` |
| `create-props-resolver.ts` | Use `applySchemaDefaults` before resolution; switch from inline default fallback |
| Twig templates (5 files) | Add `\| default(...)` filters and HTML tag escaping to opening/closing tags |
| Tests | Added coverage for null/empty tag handling and schema defaults logic |

## 3. How It Works

Props now flow: raw props → `applySchemaDefaults()` fills nulls from schema → individual prop transforms happen with valid values. Twig templates use conditional defaults (`settings.tag \| default('h2')`) plus HTML tag escaping (`\| e('html_tag')`) to prevent empty tag renders. The `escapeHtmlTag()` function now explicitly guards against null/empty/undefined before allowlist checking.

## 4. Risks

Low. Changes are additive (new function, new guards) with backward-compatible defaults. Twig template changes use existing `default` filter and escaping. Test coverage added for edge cases (null, undefined, empty string). Only risk: if schema defaults are misconfigured, props could get unintended fallbacks—but this is better than empty tags.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
