### PR TITLE
Fix: Swap Import and Export icons in design system header menu [ED-25311]

### DIFF
--- a/packages/packages/core/editor-design-system/src/components/design-system-header-menu.tsx
+++ b/packages/packages/core/editor-design-system/src/components/design-system-header-menu.tsx
@@ -102,13 +102,13 @@ export const DesignSystemHeaderMenu = () => {
 			>
 				<MenuItem onClick={ handleImport } disabled={ isImporting }>
 					<ListItemIcon>
-						<UploadIcon fontSize="tiny" />
+						<DownloadIcon fontSize="tiny" />
 					</ListItemIcon>
 					<ListItemText>{ __( 'Import', 'elementor' ) }</ListItemText>
 				</MenuItem>
 				<MenuItem onClick={ handleExport } disabled={ isExporting }>
 					<ListItemIcon>
-						<DownloadIcon fontSize="tiny" />
+						<UploadIcon fontSize="tiny" />
 					</ListItemIcon>
 					<ListItemText>{ __( 'Export', 'elementor' ) }</ListItemText>
 				</MenuItem>


### PR DESCRIPTION
## Summary
- Swap the Import and Export icons in the design system header menu so each action shows the correct icon.

## Test plan
- [ ] Open the editor design system panel as an admin user.
- [ ] Open the three-dot menu in the header.
- [ ] Confirm Import shows the download icon and Export shows the upload icon.

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Icons for Import and Export menu items were reversed—Import showed upload icon, Export showed download icon. Swapping them to match semantic expectations (ED-25311).

## 2. What Changed (Where)

- `design-system-header-menu.tsx`: Import MenuItem now uses `DownloadIcon`, Export MenuItem now uses `UploadIcon`.

## 3. How It Works

No behavior change—purely visual. Icon components already imported; only swapping which component renders in each MenuItem's ListItemIcon slot.

## 4. Risks

None. Trivial icon swap with no logic implications or side effects.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
