### PR TITLE
Fix: correct eleven doc paths that point at files which no longer exist

### DIFF
--- a/docs/atomic-builder/editor-packages/overview.md
+++ b/docs/atomic-builder/editor-packages/overview.md
@@ -72,7 +72,7 @@ See [extending-editor.md](extending-editor.md).
 | Component | Path |
 |-----------|------|
 | Loader | `core/editor/loader/editor-loader.php` |
-| Bundler | `.grunt-config/webpack.packages.js` |
+| Bundler | `scripts/vite/build-packages.mjs` (`npm run packages:assets`) |
 | Entry | `core/editor/loader/js/editor-loader.js` |
 | Pluggable UI | `@elementor/locations` → `createLocation()` |
 

--- a/docs/modules/nested-tabs/index.md
+++ b/docs/modules/nested-tabs/index.md
@@ -90,9 +90,9 @@
 			* Custom Views:
 				* __View__ `modules/nested-tabs/assets/js/editor/views/view.js` - The actual view of the widget.
 			* Custom Empty widget views:
-				* __Empty View__ `modules/nested-tabs/assets/js/editor/views/empty.js` - The view that will be rendered when the widget is empty.
-				* __Select Preset View__ `modules/nested-tabs/assets/js/editor/views/select-preset.js` - will be rendered when select preset selected.
-				* __Add Section Area View__ `modules/nested-tabs/assets/js/editor/views/add-section-area.js` - The default that will be rendered on the __Empty View__.
+				* __Empty View__ `modules/nested-elements/assets/js/editor/views/empty.js` - The view that will be rendered when the widget is empty.
+				* __Select Preset View__ `modules/nested-elements/assets/js/editor/views/select-preset.js` - will be rendered when select preset selected.
+				* __Add Section Area View__ `modules/nested-elements/assets/js/editor/views/add-section-area.js` - The default that will be rendered on the __Empty View__.
 		* Frontend scripts:
 			* __NestedTabs__ Handler `modules/nested-tabs/assets/js/frontend/handlers/nested-tabs.js`
 		* Frontend styles:
@@ -395,7 +395,7 @@ export default class YourCustomHandler extends elementorModules.frontend.handler
 - The view logic is handles the clicks on the widget, that's what it used in this scenario, if there is no custom logic, the default nested view can be used:       - `$e.components.get( 'nested-elements/nested-repeater' ).exports.NestedViewBase`.
 
 ## `assets/js/editor/views/add-section-area.js` - Custom `AddSectionArea` for nested tabs.
-* **Link to the actual file** - [add-section-area.js](../../../modules/nested-tabs/assets/js/editor/views/add-section-area.js)
+* **Link to the actual file** - [add-section-area.js](../../../modules/nested-elements/assets/js/editor/views/add-section-area.js)
 ```javascript
 import { useEffect, useRef } from 'react';
 
@@ -462,7 +462,7 @@ AddSectionArea.propTypes = {
 };
 ```
 ## `assets/js/editor/views/empty.js` - Custom empty-view for the widget.
-* **Link to the actual file** - [empty.js](../../../modules/nested-tabs/assets/js/editor/views/empty.js)
+* **Link to the actual file** - [empty.js](../../../modules/nested-elements/assets/js/editor/views/empty.js)
 
 ![img](./_images/1.jpg)
 * The view should be `React` component, it will be the empty view for the widget children, in this case, the tabs.
@@ -490,7 +490,7 @@ AddSectionArea.propTypes = {
     ```
     - This component determines which component to print `SelectPreset` or `AddSectionArea`.
 ## `assets/js/editor/views/select-preset.js` - Custom react component to print the presets available for children containers.
-* **Link to the actual file** - [select-preset.js](../../../modules/nested-tabs/assets/js/editor/views/select-preset.js)
+* **Link to the actual file** - [select-preset.js](../../../modules/nested-elements/assets/js/editor/views/select-preset.js)
 
 ![img](./_images/2.jpg)
 ```javascript

--- a/docs/modules/web-cli/assets/js/core/hooks/data.md
+++ b/docs/modules/web-cli/assets/js/core/hooks/data.md
@@ -2,10 +2,10 @@
 *  **Description**: `$e.hooks.data` API is a manager of _DATA_ hooks that allows you to create custom **data manipulation** 
 of *elementor* data model, and create dependencies. The _hooks_ are attached
 to  `$e.commands`, and each **hook** is being fired _before/after/catch_ a command, that's being executed by `$e.run()`
-*  **Location**: *core/common/assets/js/api/core/hooks/data.js*
+*  **Location**: *modules/web-cli/assets/js/core/hooks/data.js*
 *  **Parent**: [`{HooksBase}`](#HooksBase)
 *  **Methods**: Please look at parent: `{HooksBase}` for all the methods.
-* ***Important***: All hooks should be created by extending [`{( $e.modules.hookData )}`](#e-modules-hooks-data) located at: `core/common/assets/js/api/modules/hooks/data/`.
+* ***Important***: All hooks should be created by extending [`{( $e.modules.hookData )}`](#e-modules-hooks-data) located at: `modules/web-cli/assets/js/modules/hooks/data/`.
 	
 	| Class                             | Description                                                                                            
 	|-----------------------------------|--------------------------------------------------------------------------------

--- a/docs/modules/web-cli/assets/js/core/hooks/ui.md
+++ b/docs/modules/web-cli/assets/js/core/hooks/ui.md
@@ -3,10 +3,10 @@
 that runs *before/after/catch* the command without affecting the *elementor* data model and history.
 The __hooks__ are attached to `$e.commands`, and each _event_ is being fired when a command is running.
 Mainly used for UI/View manipulation.
-*  **Location**: *core/common/assets/js/api/core/hooks/ui.js*
+*  **Location**: *modules/web-cli/assets/js/core/hooks/ui.js*
 *  **Parent**: [`{HooksBase}`](#HooksBase)
 *  **Methods**: Please look at parent: `{HooksBase}` for all the methods.
-* ***Important***: All hooks should be created by extending [`{( $e.modules.hookUI )}`](#e-modules-hooks-ui) located at: `core/common/assets/js/api/modules/hooks/ui/`.
+* ***Important***: All hooks should be created by extending [`{( $e.modules.hookUI )}`](#e-modules-hooks-ui) located at: `modules/web-cli/assets/js/modules/hooks/ui/`.
 	
 	| Class                           | Description                                                                                            
 	|---------------------------------|--------------------------------------------------------------------------------


### PR DESCRIPTION
Eleven paths in `docs/` point at files that are no longer there. Each one below is followed by how the replacement was established, so none of it has to be taken on trust.

### `docs/atomic-builder/editor-packages/overview.md`

The Internals table names the bundler as `.grunt-config/webpack.packages.js`. That went in the Vite migration (a097e8e2f8, 2026-08-03) and `.grunt-config/` now holds only `webpack.alias.js`. `scripts/vite/README.md` says it plainly: the build is Vite and Rolldown, and there is no Grunt and no Webpack. And package bundles are produced by `scripts/vite/build-packages.mjs`, which `package.json` exposes as `npm run packages:assets`.

### `docs/modules/nested-tabs/index.md`

Six references to `empty.js`, `select-preset.js` and `add-section-area.js` under `modules/nested-tabs/assets/js/editor/views/`. Those three moved to `modules/nested-elements/` in bd01d35eb9 (2023-01-03, "Create Nested base infrastructure"); the nested-tabs directory now contains `view.js` alone. Three of the six are the bulleted list near the top, and three are the "Link to the actual file" links further down, which currently 404.

`view.js` did stay behind, so the two references to it are correct and are left alone.

### `docs/modules/web-cli/assets/js/core/hooks/{data,ui}.md`

Four references under `core/common/assets/js/api/`, which was extracted in 91c5cc53ef (2022-03-09, "Extract Web-CLI to external module"). The whole tree is gone. The replacement is not a guess: `modules/web-cli/assets/js/api.js` imports these as `./modules/hooks/data/` and `./modules/hooks/ui/`, and `modules/web-cli/assets/js/core/hooks/` holds `base.js`, `data.js` and `ui.js`.

Docs only, eleven lines, no code touched. Every claimed path was checked against `main` as it stands today rather than against a local checkout.

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Eleven documentation files contain stale file paths referencing code that has been moved or reorganized. This PR corrects the paths to reflect current repository structure, preventing user confusion and broken documentation references.

## 2. What Changed (Where)

- **overview.md**: Webpack bundler path → Vite build script (`scripts/vite/build-packages.mjs`)
- **nested-tabs/index.md**: Three view file paths migrated from `nested-tabs/` → `nested-elements/` module; updated three inline links
- **web-cli hooks docs**: Location paths changed from `core/common/assets/js/api/` → `modules/web-cli/assets/js/` for both data.js and ui.js

## 3. How It Works

Documentation references updated to match actual file locations post-refactor. No logic or functionality changes, purely informational corrections pointing to correct source files and build tooling.

## 4. Risks

None. Pure documentation fixes with zero impact on runtime or build systems.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

