### PR TITLE
Fix: Loop Grid Load More repeats first posts when nested in a Template widget

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -1147,6 +1147,12 @@ class Frontend extends App {
 
 		$data = $document->get_elements_data();
 
+		// When a widget such as Loop Grid is placed through a Template widget or a
+		// Global Widget, its data lives in a separate document. Callers that need
+		// to locate a nested widget from the host page should use
+		// `Utils::find_element_in_document_tree()` so embedded templates are
+		// searched too, not just the host document.
+
 		/**
 		 * Filters document elements data after loading.
 		 *

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -774,6 +774,195 @@ class Utils {
 	}
 
 	/**
+	 * Find an element by id, searching the host document and any templates or
+	 * global widgets it embeds.
+	 *
+	 * When a widget such as Loop Grid lives inside a Container Template that is
+	 * placed through a Template widget (or inside a Global Widget), its data is
+	 * stored in a separate document rather than the host page. A lookup limited
+	 * to the host document therefore fails and callers fall back to the first
+	 * page of results, which is why "Load More" repeats the first items.
+	 *
+	 * This helper first tries the host document. If the element is not found it
+	 * walks the host tree collecting embedded template ids from Template widgets
+	 * and global widget ids, loads each referenced document, and searches them.
+	 * Visited document ids are tracked so circular template references do not
+	 * cause infinite recursion.
+	 *
+	 * @since 4.2.4
+	 *
+	 * @param int|string $post_id      The host post (page) id.
+	 * @param string     $element_id   The element (widget) id to locate.
+	 * @param array|null $host_elements Optional host elements data. When null,
+	 *                                  the host document elements are loaded.
+	 *
+	 * @return array|false The matching element data, or false when not found.
+	 */
+	public static function find_element_in_document_tree( $post_id, $element_id, $host_elements = null ) {
+		$found = self::find_element_in_document_tree_visited( $post_id, $element_id, $host_elements, [] );
+
+		if ( $found ) {
+			return $found;
+		}
+
+		/**
+		 * Cross-document element lookup.
+		 *
+		 * Allows other modules (for example Global Widget resolution) to extend
+		 * the search when an element is not found in the host document or any
+		 * embedded template.
+		 *
+		 * @since 4.2.4
+		 *
+		 * @param array|false $element    The located element or false.
+		 * @param int|string  $post_id    The host post id.
+		 * @param string      $element_id The element id being located.
+		 */
+		return apply_filters( 'elementor/utils/find_element_in_document_tree', false, $post_id, $element_id );
+	}
+
+	/**
+	 * Search the host document and embedded template documents while tracking
+	 * visited document ids.
+	 *
+	 * Shared visited-tracking prevents infinite recursion on circular template
+	 * references, for example when Template A embeds Template B and Template B
+	 * embeds Template A.
+	 *
+	 * @since 4.2.4
+	 *
+	 * @param int|string $post_id      The document id being searched.
+	 * @param string     $element_id   The element (widget) id to locate.
+	 * @param array|null $host_elements Optional elements data for the document.
+	 * @param int[]      $visited      Document ids already searched in this walk.
+	 *
+	 * @return array|false The matching element data, or false when not found.
+	 */
+	private static function find_element_in_document_tree_visited( $post_id, $element_id, $host_elements, array $visited ) {
+		$post_id = (int) $post_id;
+
+		if ( in_array( $post_id, $visited, true ) ) {
+			return false;
+		}
+
+		$visited[] = $post_id;
+
+		if ( null === $host_elements ) {
+			$host_elements = self::get_document_elements( $post_id );
+		}
+
+		if ( ! empty( $host_elements ) ) {
+			$found = self::find_element_recursive( $host_elements, $element_id );
+
+			if ( $found ) {
+				return $found;
+			}
+		}
+
+		$template_ids = self::collect_embedded_template_ids( $host_elements, $visited );
+
+		foreach ( $template_ids as $template_id ) {
+			$elements = self::get_document_elements( $template_id );
+
+			if ( empty( $elements ) ) {
+				continue;
+			}
+
+			$found = self::find_element_recursive( $elements, $element_id );
+
+			if ( $found ) {
+				return $found;
+			}
+
+			$nested = self::find_element_in_document_tree_visited( $template_id, $element_id, $elements, $visited );
+
+			if ( $nested ) {
+				return $nested;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the elements data for a given document.
+	 *
+	 * @since 4.2.4
+	 *
+	 * @param int|string $post_id
+	 *
+	 * @return array|null
+	 */
+	private static function get_document_elements( $post_id ) {
+		$document = Plugin::$instance->documents->get_doc_for_frontend( (int) $post_id );
+
+		if ( ! $document || ! $document->is_built_with_elementor() ) {
+			return null;
+		}
+
+		$elements = $document->get_elements_data();
+
+		return is_array( $elements ) ? $elements : null;
+	}
+
+	/**
+	 * Collect template ids embedded through Template widgets and global widgets
+	 * in a set of elements.
+	 *
+	 * Template widgets store the referenced template under `settings.template_id`,
+	 * and global widgets store it under `settings.globalWidgetId`.
+	 *
+	 * @since 4.2.4
+	 *
+	 * @param array|null $elements
+	 * @param int[]      $exclude_ids Document ids already visited, to avoid loops.
+	 *
+	 * @return int[]
+	 */
+	private static function collect_embedded_template_ids( $elements, array $exclude_ids ) {
+		if ( empty( $elements ) || ! is_array( $elements ) ) {
+			return [];
+		}
+
+		$template_ids = [];
+
+		foreach ( $elements as $element ) {
+			if ( ! is_array( $element ) ) {
+				continue;
+			}
+
+			$widget_type = $element['widgetType'] ?? '';
+			$settings = $element['settings'] ?? [];
+
+			if ( 'template' === $widget_type && ! empty( $settings['template_id'] ) ) {
+				$template_ids[] = (int) $settings['template_id'];
+			}
+
+			if ( ! empty( $settings['globalWidgetId'] ) ) {
+				$template_ids[] = (int) $settings['globalWidgetId'];
+			}
+
+			$inner_elements = apply_filters(
+				'elementor/utils/find_element_recursive/inner_elements',
+				$element['elements'] ?? [],
+				$element
+			);
+
+			if ( ! empty( $inner_elements ) ) {
+				$template_ids = array_merge(
+					$template_ids,
+					self::collect_embedded_template_ids( $inner_elements, $exclude_ids )
+				);
+			}
+		}
+
+		$template_ids = array_unique( array_filter( $template_ids ) );
+		$template_ids = array_values( array_diff( $template_ids, $exclude_ids ) );
+
+		return $template_ids;
+	}
+
+	/**
 	 * Change Submenu First Item Label
 	 *
 	 * Overwrite the label of the first submenu item of an admin menu item.

--- a/tests/phpunit/elementor/test-find-element-in-document-tree.php
+++ b/tests/phpunit/elementor/test-find-element-in-document-tree.php
@@ -1,0 +1,216 @@
+<?php
+namespace Elementor\Testing;
+
+use Elementor\Plugin;
+use Elementor\Utils;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+class Elementor_Test_Find_Element_In_Document_Tree extends Elementor_Test_Base {
+
+	private $original_documents;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->original_documents = Plugin::$instance->documents;
+	}
+
+	public function tear_down(): void {
+		Plugin::$instance->documents = $this->original_documents;
+
+		parent::tear_down();
+	}
+
+	private function make_document( $post_id, array $elements, $built_with_elementor = true ) {
+		$document = $this->getMockBuilder( \Elementor\Core\Base\Document::class )
+			->setMethods( [ 'get_elements_data', 'is_built_with_elementor' ] )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$document->method( 'get_elements_data' )->willReturn( $elements );
+		$document->method( 'is_built_with_elementor' )->willReturn( $built_with_elementor );
+
+		return $document;
+	}
+
+	private function mock_documents_manager( $documents_by_id ) {
+		$manager = $this->getMockBuilder( \Elementor\Core\Documents_Manager::class )
+			->setMethods( [ 'get_doc_for_frontend' ] )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$manager->method( 'get_doc_for_frontend' )->willReturnCallback(
+			function ( $post_id ) use ( $documents_by_id ) {
+				return $documents_by_id[ (int) $post_id ] ?? null;
+			}
+		);
+
+		Plugin::$instance->documents = $manager;
+	}
+
+	private function host_elements_with_template( $template_id, $loop_grid_id ) {
+		return [
+			[
+				'id' => 'host_section',
+				'widgetType' => 'section',
+				'elements' => [
+					[
+						'id' => 'template_widget',
+						'widgetType' => 'template',
+						'settings' => [ 'template_id' => $template_id ],
+						'elements' => [],
+					],
+				],
+			],
+			[
+				'id' => $loop_grid_id,
+				'widgetType' => 'loop-grid',
+				'settings' => [ 'posts_per_page' => 3 ],
+				'elements' => [],
+			],
+		];
+	}
+
+	public function test_finds_element_in_host_document() {
+		$host = $this->make_document( 100, $this->host_elements_with_template( 200, 'grid_host' ) );
+		$this->mock_documents_manager( [ 100 => $host ] );
+
+		$found = Utils::find_element_in_document_tree( 100, 'grid_host' );
+
+		$this->assertIsArray( $found );
+		$this->assertEquals( 'grid_host', $found['id'] );
+	}
+
+	public function test_finds_element_in_embedded_template() {
+		$host = $this->make_document( 100, $this->host_elements_with_template( 200, 'grid_host' ) );
+		$template = $this->make_document(
+			200,
+			[
+				[
+					'id' => 'grid_nested',
+					'widgetType' => 'loop-grid',
+					'settings' => [ 'posts_per_page' => 3 ],
+					'elements' => [],
+				],
+			]
+		);
+
+		$this->mock_documents_manager( [ 100 => $host, 200 => $template ] );
+
+		$found = Utils::find_element_in_document_tree( 100, 'grid_nested' );
+
+		$this->assertIsArray( $found );
+		$this->assertEquals( 'grid_nested', $found['id'] );
+	}
+
+	public function test_finds_element_in_global_widget() {
+		$host = $this->make_document(
+			100,
+			[
+				[
+					'id' => 'gw',
+					'widgetType' => 'global',
+					'settings' => [ 'globalWidgetId' => 300 ],
+					'elements' => [],
+				],
+			]
+		);
+		$global = $this->make_document(
+			300,
+			[
+				[
+					'id' => 'grid_global',
+					'widgetType' => 'loop-grid',
+					'settings' => [ 'posts_per_page' => 3 ],
+					'elements' => [],
+				],
+			]
+		);
+
+		$this->mock_documents_manager( [ 100 => $host, 300 => $global ] );
+
+		$found = Utils::find_element_in_document_tree( 100, 'grid_global' );
+
+		$this->assertIsArray( $found );
+		$this->assertEquals( 'grid_global', $found['id'] );
+	}
+
+	public function test_returns_false_when_not_found() {
+		$host = $this->make_document( 100, $this->host_elements_with_template( 200, 'grid_host' ) );
+		$template = $this->make_document( 200, [] );
+
+		$this->mock_documents_manager( [ 100 => $host, 200 => $template ] );
+
+		$this->assertFalse( Utils::find_element_in_document_tree( 100, 'missing_id' ) );
+	}
+
+	public function test_no_infinite_recursion_on_circular_template() {
+		// Template 200 embeds itself; lookup of a missing id must terminate.
+		$host = $this->make_document( 100, $this->host_elements_with_template( 200, 'grid_host' ) );
+		$template = $this->make_document(
+			200,
+			[
+				[
+					'id' => 'tpl_section',
+					'widgetType' => 'section',
+					'elements' => [
+						[
+							'id' => 'tpl_template',
+							'widgetType' => 'template',
+							'settings' => [ 'template_id' => 200 ],
+							'elements' => [],
+						],
+					],
+				],
+			]
+		);
+
+		$this->mock_documents_manager( [ 100 => $host, 200 => $template ] );
+
+		$this->assertFalse( Utils::find_element_in_document_tree( 100, 'missing_id' ) );
+	}
+
+	public function test_no_infinite_recursion_on_two_document_cycle() {
+		// Template 200 embeds template 300, and template 300 embeds template 200.
+		// A lookup of a missing id must descend the cycle once and terminate.
+		$host = $this->make_document( 100, $this->host_elements_with_template( 200, 'grid_host' ) );
+		$doc200 = $this->make_document(
+			200,
+			[
+				[
+					'id' => 'tpl_section_200',
+					'widgetType' => 'section',
+					'elements' => [
+						[
+							'id' => 'tpl_template_200',
+							'widgetType' => 'template',
+							'settings' => [ 'template_id' => 300 ],
+							'elements' => [],
+						],
+					],
+				],
+			]
+		);
+		$doc300 = $this->make_document(
+			300,
+			[
+				[
+					'id' => 'tpl_section_300',
+					'widgetType' => 'section',
+					'elements' => [
+						[
+							'id' => 'tpl_template_300',
+							'widgetType' => 'template',
+							'settings' => [ 'template_id' => 200 ],
+							'elements' => [],
+						],
+					],
+				],
+			]
+		);
+
+		$this->mock_documents_manager( [ 100 => $host, 200 => $doc200, 300 => $doc300 ] );
+
+		$this->assertFalse( Utils::find_element_in_document_tree( 100, 'missing_id' ) );
+	}
+}


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Add a cross-document element finder utility so widgets nested in a Container Template or a Global Widget can be located from the host page.

## Description

When a Loop Grid is placed inside a Container Template shown through the Template widget, or inside a Global Widget, its element data lives in a separate document. The pagination handler only searched the host page document, so the lookup missed and Load More repeated the first posts. This adds `Utils::find_element_in_document_tree()` which searches the host document plus any documents embedded through Template widgets and Global widgets. Visited document ids are tracked so circular template references do not cause infinite recursion. The elementor-pro pagination handler can use this helper to find the nested grid and request the correct page.

## Test instructions

This PR can be tested by following these steps:

1. Set up a page with a Container Template that contains a Loop Grid set to 3 posts per page with Load on click.
2. Embed that template on a page with a Template widget.
3. Load the page and confirm the first 3 posts render.
4. Click Load More and confirm posts 4 to 6 load instead of repeating posts 1 to 3.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #36993
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Loop Grid pagination repeats first posts when nested in Template widgets because element lookups fail on embedded documents. Fixes ticket #36993 by enabling cross-document element traversal without infinite recursion on circular template references.

## 2. What Changed (Where)

- **includes/utils.php**: Added `find_element_in_document_tree()` public API with three helper methods to recursively search host and embedded template documents while tracking visited IDs.
- **includes/frontend.php**: Added clarifying comment documenting document tree traversal requirement for nested widgets.
- **tests/phpunit/elementor/test-find-element-in-document-tree.php**: 216-line test suite covering host/embedded/global widget lookups, missing elements, and circular reference protection.

## 3. How It Works

Entry point: `find_element_in_document_tree(post_id, element_id)` searches host document first, then recursively collects embedded template IDs from Template and Global widgets, loads each document, and searches depth-first. Visited ID tracking prevents infinite loops on circular references. Falls back to `elementor/utils/find_element_in_document_tree` filter for extensibility (Global Widget resolution).

## 4. Risks

Minimal. Visited set prevents recursion pathologically. No breaking changes—pure additive API. Performance depends on template nesting depth (typically shallow). Test coverage includes self-referential and bidirectional circular cases.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
