### PR TITLE
Internal: Prevent silent loss of global classes on concurrent saves

### DIFF
--- a/modules/global-classes/global-classes-repository.php
+++ b/modules/global-classes/global-classes-repository.php
@@ -18,6 +18,13 @@ class Global_Classes_Repository {
 	const META_KEY_FRONTEND = '_elementor_global_classes';
 	const META_KEY_PREVIEW = '_elementor_global_classes_preview';
 
+	/**
+	 * Optimistic-concurrency token written to the active Kit on every successful
+	 * global-classes save. Clients send it back on their next save so a stale or
+	 * overlapping write can be rejected instead of silently overwriting the kit index.
+	 */
+	const META_KEY_VERSION = '_elementor_global_classes_version';
+
 	const CONTEXT_FRONTEND = 'frontend';
 	const CONTEXT_PREVIEW = 'preview';
 
@@ -68,6 +75,33 @@ class Global_Classes_Repository {
 
 	public function get_order(): array {
 		return Global_Classes_Order::make( $this->get_kit() )->set_preview( $this->is_preview() )->get_order();
+	}
+
+	/**
+	 * Current optimistic-concurrency version of the kit's global classes index.
+	 * Returns 0 when no client has saved with a version yet.
+	 */
+	public function get_version(): int {
+		$kit = $this->get_kit();
+
+		if ( ! $kit ) {
+			return 0;
+		}
+
+		return (int) $kit->get_meta( self::META_KEY_VERSION );
+	}
+
+	/**
+	 * Advance the kit's global classes version after a successful save.
+	 */
+	public function bump_version(): void {
+		$kit = $this->get_kit();
+
+		if ( ! $kit ) {
+			return;
+		}
+
+		$kit->update_meta( self::META_KEY_VERSION, $this->get_version() + 1 );
 	}
 
 	public function update_order_and_labels( array $order, array $new_labels ): void {

--- a/modules/global-classes/global-classes-rest-api.php
+++ b/modules/global-classes/global-classes-rest-api.php
@@ -20,6 +20,16 @@ class Global_Classes_REST_API {
 	const API_BASE_POST = self::API_BASE . '/post';
 	const API_BASE_STYLES = self::API_BASE . '/styles';
 	const MAX_ITEMS = 1000;
+
+	/**
+	 * Per-kit mutex that serializes the read-modify-write of a global-classes
+	 * save. Mirrors the spinlock pattern used by the component lock managers,
+	 * but keys on the kit so two overlapping saves cannot overwrite each other.
+	 */
+	const LOCK_GROUP = 'elementor_global_classes_lock';
+	const LOCK_ACQUIRE_ATTEMPTS = 20;
+	const LOCK_ACQUIRE_DELAY_US = 100000;
+
 	private ?Global_Classes_Repository $repository = null;
 	private ?Global_Classes_Relations $relations = null;
 	private ?Kit $kit = null;
@@ -56,6 +66,39 @@ class Global_Classes_REST_API {
 		}
 
 		return $this->relations;
+	}
+
+	private function lock_key( int $kit_id ): string {
+		return 'elementor_global_classes_' . $kit_id;
+	}
+
+	/**
+	 * Acquire the per-kit global-classes write lock.
+	 *
+	 * Returns the lock token on success or null if it could not be acquired
+	 * within the give-up budget. The token must be passed to release_lock().
+	 */
+	private function acquire_lock( int $kit_id ): ?string {
+		$key = $this->lock_key( $kit_id );
+		$token = wp_generate_uuid4();
+
+		for ( $attempt = 0; $attempt < self::LOCK_ACQUIRE_ATTEMPTS; $attempt++ ) {
+			if ( wp_cache_add( $key, $token, self::LOCK_GROUP ) ) {
+				return $token;
+			}
+
+			usleep( self::LOCK_ACQUIRE_DELAY_US );
+		}
+
+		return null;
+	}
+
+	private function release_lock( int $kit_id, string $token ): void {
+		$key = $this->lock_key( $kit_id );
+
+		if ( wp_cache_get( $key, self::LOCK_GROUP ) === $token ) {
+			wp_cache_delete( $key, self::LOCK_GROUP );
+		}
 	}
 
 	private function register_routes() {
@@ -221,6 +264,11 @@ class Global_Classes_REST_API {
 							'type' => 'string',
 						],
 					],
+					'version' => [
+						'type' => 'integer',
+						'required' => false,
+						'description' => 'Optimistic-concurrency token from the last index read. When present and stale, the save is rejected with a conflict instead of overwriting the kit index.',
+					],
 				],
 			],
 		] );
@@ -239,7 +287,9 @@ class Global_Classes_REST_API {
 			];
 		}
 
-		return Response_Builder::make( $list )->build();
+		return Response_Builder::make( $list )
+			->set_meta( [ 'version' => $this->get_repository()->get_version() ] )
+			->build();
 	}
 
 	private function styles_for_post( \WP_REST_Request $request ) {
@@ -310,9 +360,46 @@ class Global_Classes_REST_API {
 		$added_ids = $changes['added'] ?? [];
 		$deleted_ids = $changes['deleted'] ?? [];
 		$order = $request->get_param( 'order' ) ?? [];
+		$requested_version = $request->get_param( 'version' );
 
 		$repository = $this->get_repository()->set_preview( $is_preview );
+		$kit = $this->get_kit();
+		$kit_id = $kit ? (int) $kit->get_main_id() : null;
+
+		$lock_token = $kit_id ? $this->acquire_lock( $kit_id ) : null;
+
+		if ( null === $lock_token ) {
+			return Error_Builder::make( 'global_classes_conflict' )
+				->set_status( 409 )
+				->set_message( __( 'Global classes are currently being updated by another request. Please try again.', 'elementor' ) )
+				->build();
+		}
+
+		try {
+			return $this->put_serialized( $request, $repository, $changes, $added_ids, $deleted_ids, $order, $requested_version );
+		} finally {
+			if ( $kit_id ) {
+				$this->release_lock( $kit_id, $lock_token );
+			}
+		}
+	}
+
+	private function put_serialized( \WP_REST_Request $request, Global_Classes_Repository $repository, array $changes, array $added_ids, array $deleted_ids, array $order, $requested_version ) {
+		// Read the authoritative list inside the lock so a concurrent save cannot
+		// interleave between this read and the index rewrite below.
 		$all_label_by_id = $repository->all_labels();
+
+		// Optimistic-concurrency guard: a client that sends an outdated version is
+		// editing against a stale baseline. Reject before any mutation instead of
+		// letting this request silently overwrite classes another save already wrote.
+		if ( null !== $requested_version && (int) $requested_version !== $repository->get_version() ) {
+			return Error_Builder::make( 'global_classes_conflict' )
+				->set_status( 409 )
+				->set_meta( [ 'version' => $repository->get_version() ] )
+				->set_message( __( 'Global classes changed since this page was loaded. Refresh to reload the latest classes.', 'elementor' ) )
+				->build();
+		}
+
 		$existing_label_list = $this->global_classes_existing_label_list( $all_label_by_id, $deleted_ids );
 		$total_count = count( $all_label_by_id ) - count( $deleted_ids ) + count( $added_ids );
 
@@ -385,6 +472,9 @@ class Global_Classes_REST_API {
 			'modified' => $changes['modified'] ?? [],
 			'order' => isset( $changes['order'] ) && $changes['order'], // boolean indicating if the order has changed
 		], $order_result->unwrap() );
+
+		// Advance the concurrency token only after a successful, conflict-free commit.
+		$repository->bump_version();
 
 		if ( $duplicate_validation_result ) {
 			return Response_Builder::make( [

--- a/packages/packages/core/editor-global-classes/src/__tests__/save-global-classes.test.ts
+++ b/packages/packages/core/editor-global-classes/src/__tests__/save-global-classes.test.ts
@@ -1,18 +1,39 @@
 import { createMockStyleDefinition } from 'test-utils';
+import { getCurrentDocument } from '@elementor/editor-documents';
 import { getCurrentUser } from '@elementor/editor-current-user';
 import {
 	__createStore as createStore,
 	__dispatch as dispatch,
+	__getState as getState,
 	__registerSlice as registerSlice,
 } from '@elementor/store';
 
-import { apiClient } from '../api';
+import { apiClient, isConflictError } from '../api';
+import { selectVersion } from '../store';
 import { UPDATE_CLASS_CAPABILITY_KEY } from '../capabilities';
 import { saveGlobalClasses } from '../save-global-classes';
 import { slice } from '../store';
 
-jest.mock( '../api' );
+// Keep the real guards/helpers so a 409 error still routes into the retry path;
+// only the HTTP client (apiClient) is mocked.
+jest.mock( '../api', () => {
+	const actual = jest.requireActual( '../api' );
+
+	return {
+		__esModule: true,
+		API_ERROR_CODES: actual.API_ERROR_CODES,
+		isConflictError: actual.isConflictError,
+		apiClient: {
+			all: jest.fn(),
+			getByIds: jest.fn(),
+			getStylesForPost: jest.fn(),
+			publish: jest.fn(),
+			saveDraft: jest.fn(),
+		},
+	};
+} );
 jest.mock( '@elementor/editor-current-user' );
+jest.mock( '@elementor/editor-documents' );
 
 const classLabelsFor = ( order: string[], items: Record< string, ReturnType< typeof createMockStyleDefinition > > ) =>
 	Object.fromEntries( order.map( ( id ) => [ id, items[ id ]?.label ?? id ] ) );
@@ -28,6 +49,8 @@ describe( 'saveGlobalClasses', () => {
 
 		jest.mocked( apiClient.publish ).mockResolvedValue( {} as never );
 		jest.mocked( apiClient.saveDraft ).mockResolvedValue( {} as never );
+
+		jest.mocked( getCurrentDocument ).mockReturnValue( { id: 123 } as never );
 	} );
 
 	it( 'should not mark lazily loaded classes as added', async () => {
@@ -67,6 +90,7 @@ describe( 'saveGlobalClasses', () => {
 				modified: [],
 				order: false,
 			},
+			version: 0,
 		} );
 	} );
 
@@ -98,6 +122,7 @@ describe( 'saveGlobalClasses', () => {
 				modified: [],
 				order: true,
 			},
+			version: 0,
 		} );
 	} );
 
@@ -171,5 +196,59 @@ describe( 'saveGlobalClasses', () => {
 				},
 			} )
 		);
+	} );
+
+	it( 'should rebase, update the version and retry once when the server rejects with a conflict', async () => {
+		// Arrange
+		const staleClass = createMockStyleDefinition( { id: 'class-1', label: 'Stale' } );
+		const freshClass = createMockStyleDefinition( { id: 'class-1', label: 'Fresh' } );
+		const order = [ 'class-1' ];
+		const freshVersion = 7;
+
+		const freshIndex = {
+			data: {
+				data: [ { id: 'class-1', label: 'Fresh' } ],
+				meta: { version: freshVersion },
+			},
+		} as never;
+
+		const freshStyles = {
+			data: {
+				data: { 'class-1': freshClass },
+				meta: { order },
+			},
+		} as never;
+
+		jest.mocked( apiClient.publish )
+			.mockRejectedValueOnce( { response: { status: 409 } } as never )
+			.mockResolvedValueOnce( {} as never );
+
+		jest.mocked( apiClient.all ).mockResolvedValue( freshIndex );
+		jest.mocked( apiClient.getStylesForPost ).mockResolvedValue( freshStyles );
+
+		dispatch(
+			slice.actions.load( {
+				frontend: { items: { 'class-1': staleClass }, order },
+				preview: { items: { 'class-1': staleClass }, order },
+				classLabels: classLabelsFor( order, { 'class-1': staleClass } ),
+				version: { frontend: 3, preview: 3 },
+			} )
+		);
+
+		const conflictSpy = jest.spyOn( window, 'dispatchEvent' );
+
+		// Act
+		await saveGlobalClasses( { context: 'frontend' } );
+
+		// Assert - two publish attempts, rebased onto the fresh version.
+		expect( apiClient.publish ).toHaveBeenCalledTimes( 2 );
+		expect( apiClient.publish ).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining( { version: freshVersion } )
+		);
+		expect( selectVersion( getState(), 'frontend' ) ).toBe( freshVersion );
+
+		// The conflict was announced so the UI can surface a non-blocking notice.
+		expect( conflictSpy ).toHaveBeenCalledWith( expect.objectContaining( { type: 'classes:conflict' } ) );
 	} );
 } );

--- a/packages/packages/core/editor-global-classes/src/__tests__/sync-with-document-save.test.ts
+++ b/packages/packages/core/editor-global-classes/src/__tests__/sync-with-document-save.test.ts
@@ -84,6 +84,7 @@ describe( 'syncWithDocumentSave', () => {
 					modified: [],
 					order: true,
 				},
+				version: 0,
 			} );
 
 			const isPublish = status === 'publish';

--- a/packages/packages/core/editor-global-classes/src/api.ts
+++ b/packages/packages/core/editor-global-classes/src/api.ts
@@ -17,7 +17,12 @@ export type GlobalClassIndexEntry = {
 	label: string;
 };
 
-export type GlobalClassesIndexHttpResponse = HttpResponse< GlobalClassIndexEntry[], Record< string, never > >;
+export type GlobalClassesIndexHttpResponse = HttpResponse<
+	GlobalClassIndexEntry[],
+	{
+		version: number;
+	}
+>;
 
 export type StyleDefinitionsNullableMap = Record< StyleDefinitionID, StyleDefinition | null >;
 
@@ -34,6 +39,10 @@ type UpdatePayload = GlobalClasses & {
 		deleted: StyleDefinitionID[];
 		modified: StyleDefinitionID[];
 	};
+	// Optimistic-concurrency token returned by the last index read. The server rejects
+	// a save with a 409 when the stored version has advanced past this one, which means
+	// this edit was based on a stale snapshot and must be retried against fresh data.
+	version?: number;
 };
 
 export type ApiContext = 'preview' | 'frontend';
@@ -69,4 +78,9 @@ export const apiClient = {
 
 export const API_ERROR_CODES = {
 	DUPLICATED_LABEL: 'DUPLICATED_LABEL',
+	CONFLICT: 'global_classes_conflict',
 };
+
+export function isConflictError( error: unknown ): boolean {
+	return ( error as { response?: { status?: number } } )?.response?.status === 409;
+}

--- a/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/class-manager/__tests__/class-manager-panel.test.tsx
@@ -173,6 +173,7 @@ describe( 'ClassManagerPanel', () => {
 				items: {},
 				order: [ 'class-1', 'class-2' ],
 				changes: { added: [], deleted: [], modified: [], order: true },
+				version: 0,
 			} );
 		} );
 	} );
@@ -202,6 +203,7 @@ describe( 'ClassManagerPanel', () => {
 				items: {},
 				order: [ 'class-2' ],
 				changes: { added: [], deleted: [ 'class-1' ], modified: [], order: true },
+				version: 0,
 			} );
 		} );
 	} );
@@ -233,6 +235,7 @@ describe( 'ClassManagerPanel', () => {
 				},
 				order: [ 'class-2', 'class-1' ],
 				changes: { added: [], deleted: [], modified: [ 'class-1' ], order: false },
+				version: 0,
 			} );
 		} );
 	} );
@@ -319,6 +322,7 @@ describe( 'ClassManagerPanel', () => {
 				items: {},
 				order: [ 'class-1', 'class-2' ],
 				changes: { added: [], deleted: [], modified: [], order: true },
+				version: 0,
 			} );
 		} );
 
@@ -433,6 +437,7 @@ describe( 'ClassManagerPanel', () => {
 				items: {},
 				order: [ 'class-1' ],
 				changes: { added: [], deleted: [ 'class-2' ], modified: [], order: true },
+				version: 0,
 			} );
 		} );
 	} );

--- a/packages/packages/core/editor-global-classes/src/load-document-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/load-document-classes.ts
@@ -61,6 +61,10 @@ export async function loadCurrentDocumentClasses() {
 			preview: { items: previewItems, order: previewOrder },
 			frontend: { items: frontendItems, order: frontendOrder },
 			classLabels,
+			version: {
+				preview: previewIndexRes.data.meta.version ?? 0,
+				frontend: frontendIndexRes.data.meta.version ?? 0,
+			},
 		} )
 	);
 }

--- a/packages/packages/core/editor-global-classes/src/save-global-classes.tsx
+++ b/packages/packages/core/editor-global-classes/src/save-global-classes.tsx
@@ -1,11 +1,20 @@
 import * as React from 'react';
+import { getCurrentDocument } from '@elementor/editor-documents';
 import { openDialog } from '@elementor/editor-ui';
 import { __dispatch as dispatch, __getState as getState } from '@elementor/store';
 import { hash } from '@elementor/utils';
 
-import { API_ERROR_CODES, apiClient, type ApiContext } from './api';
+import { API_ERROR_CODES, apiClient, isConflictError, type ApiContext } from './api';
 import { DuplicateLabelDialog } from './components/class-manager/duplicate-label-dialog';
-import { type GlobalClasses, selectData, selectFrontendInitialData, selectPreviewInitialData, slice } from './store';
+import {
+	type GlobalClasses,
+	selectData,
+	selectFrontendInitialData,
+	selectPreviewInitialData,
+	selectVersion,
+	slice,
+} from './store';
+import { styleDefinitionsMapWithoutNull } from './load-document-classes';
 import { trackGlobalClasses } from './utils/tracking';
 
 type Options = {
@@ -13,10 +22,55 @@ type Options = {
 	onApprove?: () => void;
 };
 
+const INDEX_ORDER_CONFLICT_EVENT = 'classes:conflict';
+
 export async function saveGlobalClasses( { context, onApprove }: Options ) {
-	const state = selectData( getState() );
+	let lastResponse;
+
+	try {
+		lastResponse = await persistGlobalClasses( { context, onApprove } );
+	} catch ( error ) {
+		// The save was based on a stale snapshot: another save already changed the
+		// kit's classes since this client's last index read. Re-fetch, rebase, re-diff
+		// and retry once against the fresh baseline. A class whose loss had already
+		// committed on the server is re-added by the re-diff (self-heal).
+		if ( ! isConflictError( error ) ) {
+			throw error;
+		}
+
+		window.dispatchEvent( new CustomEvent( INDEX_ORDER_CONFLICT_EVENT ) );
+
+		await rebaseToServer( context );
+
+		lastResponse = await persistGlobalClasses( { context, onApprove } );
+	}
+
+	if (
+		lastResponse?.data?.data?.code === API_ERROR_CODES.DUPLICATED_LABEL
+	) {
+		dispatch( slice.actions.updateMultiple( lastResponse.data.data.modifiedLabels ) );
+
+		trackGlobalClasses( {
+			event: 'classPublishConflict',
+			numOfConflicts: Object.keys( lastResponse.data.data.modifiedLabels ).length,
+		} );
+
+		openDialog( {
+			component: (
+				<DuplicateLabelDialog
+					modifiedLabels={ lastResponse.data.data.modifiedLabels || [] }
+					onApprove={ onApprove }
+				/>
+			),
+		} );
+	}
+}
+
+async function persistGlobalClasses( { context, onApprove }: Options ) {
 	const apiAction = context === 'preview' ? apiClient.saveDraft : apiClient.publish;
 	const currentContext = context === 'preview' ? selectPreviewInitialData : selectFrontendInitialData;
+
+	const state = selectData( getState() );
 	const changes = calculateChanges( state, currentContext( getState() ) );
 
 	const touchedIds = [ ...changes.added, ...changes.modified ];
@@ -28,29 +82,45 @@ export async function saveGlobalClasses( { context, onApprove }: Options ) {
 		items: touchedItems,
 		order: state.order,
 		changes,
+		version: selectVersion( getState(), context ),
 	} );
 
-	dispatch( slice.actions.reset( { context } ) );
+	// A successful save establishes the new baseline, unless a duplicate-label
+	// response carried server-side label modifications that must be folded in first.
+	if ( response?.data?.data?.code !== API_ERROR_CODES.DUPLICATED_LABEL ) {
+		dispatch( slice.actions.reset( { context } ) );
+	}
 
 	window.dispatchEvent( new CustomEvent( 'classes:updated', { detail: { context } } ) );
 
-	if ( response?.data?.data?.code === API_ERROR_CODES.DUPLICATED_LABEL ) {
-		dispatch( slice.actions.updateMultiple( response.data.data.modifiedLabels ) );
+	return response;
+}
 
-		trackGlobalClasses( {
-			event: 'classPublishConflict',
-			numOfConflicts: Object.keys( response.data.data.modifiedLabels ).length,
-		} );
+async function rebaseToServer( context: ApiContext ) {
+	const [ serverIndexRes, serverPostRes ] = await Promise.all( [
+		apiClient.all( context ),
+		getCurrentDocument()?.id
+			? apiClient.getStylesForPost( getCurrentDocument().id, context )
+			: Promise.resolve( null ),
+	] );
 
-		openDialog( {
-			component: (
-				<DuplicateLabelDialog
-					modifiedLabels={ response.data.data.modifiedLabels || [] }
-					onApprove={ onApprove }
-				/>
-			),
-		} );
+	if ( ! serverPostRes ) {
+		return;
 	}
+
+	const serverItems = styleDefinitionsMapWithoutNull( serverPostRes.data.data );
+	const server: GlobalClasses = {
+		items: serverItems,
+		order: serverIndexRes.data.data.map( ( entry ) => entry.id ),
+	};
+
+	dispatch(
+		slice.actions.rebaseToServer( {
+			context,
+			server,
+			version: serverIndexRes.data.meta.version ?? 0,
+		} )
+	);
 }
 
 function calculateChanges( state: GlobalClasses, initialData: GlobalClasses ) {

--- a/packages/packages/core/editor-global-classes/src/store.ts
+++ b/packages/packages/core/editor-global-classes/src/store.ts
@@ -24,12 +24,21 @@ export type GlobalClasses = {
 	order: StyleDefinitionID[];
 };
 
+// The optimistic-concurrency token the server returned with the last index read for
+// each context. A save sends it back so the server can reject (409) a save that was
+// based on a stale snapshot instead of silently overwriting newer classes.
+export type GlobalClassesVersion = number;
+
 type GlobalClassesState = {
 	data: GlobalClasses;
 	classLabels: Record< StyleDefinitionID, string >;
 	initialData: {
 		frontend: GlobalClasses;
 		preview: GlobalClasses;
+	};
+	version: {
+		frontend: number;
+		preview: number;
 	};
 	isDirty: boolean;
 };
@@ -50,6 +59,10 @@ const initialState: GlobalClassesState = {
 		frontend: { items: {}, order: [] },
 		preview: { items: {}, order: [] },
 	},
+	version: {
+		frontend: 0,
+		preview: 0,
+	},
 	isDirty: false,
 };
 
@@ -65,17 +78,25 @@ export const slice = createSlice( {
 		load(
 			state,
 			{
-				payload: { frontend, preview, classLabels },
+				payload: { frontend, preview, classLabels, version = { frontend: 0, preview: 0 } },
 			}: PayloadAction< {
 				frontend: GlobalClasses;
 				preview: GlobalClasses;
 				classLabels: Record< StyleDefinitionID, string >;
+				version?: {
+					frontend: number;
+					preview: number;
+				};
 			} >
 		) {
 			state.initialData.frontend = frontend;
 			state.initialData.preview = preview;
 			state.data = preview;
 			state.classLabels = classLabels;
+			state.version = {
+				frontend: version.frontend ?? 0,
+				preview: version.preview ?? 0,
+			};
 
 			state.isDirty = false;
 		},
@@ -191,6 +212,62 @@ export const slice = createSlice( {
 			}
 
 			state.initialData.preview = state.data;
+		},
+
+		/**
+		 * Rebase the working data and the concurrency baseline onto the server state a
+		 * save just 409-conflicted against. [server] carries the full item definitions
+		 * (post fetch) and the authoritative order (index fetch) for the conflicted
+		 * context. The other context keeps the items it already owns (merge instead of
+		 * replace) so lazily-loaded class data is not dropped when only a concurrent
+		 * order change caused the conflict. The retry then re-diffs and saves against
+		 * the fresh baseline.
+		 */
+		rebaseToServer(
+			state,
+			{
+				payload: { context, server, version = 0 },
+			}: PayloadAction< {
+				context: ApiContext;
+				server: GlobalClasses;
+				version?: number;
+			} >
+		) {
+			state.version[ context ] = version;
+
+			const other = context === 'frontend' ? 'preview' : 'frontend';
+			state.data = {
+				items: {
+					...state.initialData[ context ].items,
+					...server.items,
+				},
+				order: server.order,
+			};
+
+			state.initialData[ context ] = {
+				items: {
+					...state.initialData[ context ].items,
+					...server.items,
+				},
+				order: server.order,
+			};
+
+			state.initialData[ other ] = {
+				...state.initialData[ other ],
+				items: {
+					...state.initialData[ other ].items,
+					...server.items,
+				},
+				order: server.order,
+			};
+
+			for ( const [ id, item ] of Object.entries( server.items ) ) {
+				if ( ! ( id in state.classLabels ) ) {
+					state.classLabels[ id ] = item.label;
+				}
+			}
+
+			state.isDirty = true;
 		},
 
 		undo( state ) {
@@ -326,6 +403,13 @@ export const selectFrontendInitialData = ( state: SliceState< typeof slice > ) =
 
 export const selectPreviewInitialData = ( state: SliceState< typeof slice > ) =>
 	state[ SLICE_NAME ].initialData.preview;
+
+export const selectVersion = ( state: SliceState< typeof slice >, context: ApiContext ) =>
+	state[ SLICE_NAME ].version[ context ];
+
+export const selectFrontendVersion = ( state: SliceState< typeof slice > ) => state[ SLICE_NAME ].version.frontend;
+
+export const selectPreviewVersion = ( state: SliceState< typeof slice > ) => state[ SLICE_NAME ].version.preview;
 
 export const selectOrder = createSelector( selectData, ( { order } ) => order );
 

--- a/tests/phpunit/elementor/modules/global-classes/test-global-classes-lock.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-global-classes-lock.php
@@ -1,0 +1,135 @@
+<?php
+namespace Elementor\Testing\Modules\GlobalClasses;
+
+use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
+use Elementor\Modules\GlobalClasses\Global_Classes_Labels;
+use Elementor\Modules\GlobalClasses\Global_Classes_Order;
+use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
+use Elementor\Modules\GlobalClasses\Global_Classes_REST_API;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+use Elementor\Modules\GlobalClasses\Database\Migrations\Add_Capabilities;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * The per-kit write lock serializes overlapping global-classes saves so an old (un-versioned)
+ * client cannot clobber a concurrent write. These tests drive the lock through the cache
+ * primitives the REST layer uses.
+ */
+class Test_Global_Classes_Lock extends Elementor_Test_Base {
+
+	/**
+	 * @var Kit
+	 */
+	private $kit;
+
+	private $kit_id;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+
+		$wp_rest_server = new \WP_REST_Server();
+
+		$role = get_role( 'administrator' );
+		$role->add_cap( Add_Capabilities::UPDATE_CLASS );
+
+		do_action( 'rest_api_init' );
+
+		( new Global_Class_Post_Type() )->register_post_type();
+
+		$this->kit = Plugin::$instance->kits_manager->get_active_kit();
+		$this->kit_id = (int) $this->kit->get_main_id();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		$role = get_role( 'administrator' );
+		$role->remove_cap( Add_Capabilities::UPDATE_CLASS );
+
+		$this->kit->delete_meta( Global_Classes_Repository::META_KEY_FRONTEND );
+		$this->kit->delete_meta( Global_Classes_Repository::META_KEY_PREVIEW );
+		$this->kit->delete_meta( Global_Classes_Labels::META_KEY_FRONTEND );
+		$this->kit->delete_meta( Global_Classes_Labels::META_KEY_PREVIEW );
+		$this->kit->delete_meta( Global_Classes_Order::META_KEY );
+		$this->kit->delete_meta( Global_Classes_Repository::META_KEY_VERSION );
+
+		wp_cache_delete( $this->lock_key(), Global_Classes_REST_API::LOCK_GROUP );
+
+		foreach ( get_posts( [
+			'post_type' => Global_Class_Post_Type::CPT,
+			'post_status' => 'any',
+			'posts_per_page' => -1,
+			'fields' => 'ids',
+		] ) as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+	}
+
+	public function test_put__times_out_when_lock_is_held_and_returns_409() {
+		// Arrange - another request holds the per-kit lock (stale lock left behind).
+		$this->act_as_admin();
+		wp_cache_add( $this->lock_key(), 'other-request-token', Global_Classes_REST_API::LOCK_GROUP );
+
+		$class = $this->create_global_class( 'g-1' );
+
+		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
+		$request->set_body_params( [
+			'items' => [ 'g-1' => $class ],
+			'order' => [ 'g-1' ],
+			'changes' => [ 'added' => [ 'g-1' ], 'deleted' => [], 'modified' => [] ],
+		] );
+
+		// Act.
+		$response = rest_do_request( $request );
+
+		// Assert - could not acquire the lock within the budget -> conflict, nothing written.
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'global_classes_conflict', $response->get_data()['code'] );
+		$snapshot = ( new Global_Classes_Repository( $this->kit ) )->all_labels();
+		$this->assertArrayNotHasKey( 'g-1', $snapshot );
+	}
+
+	public function test_put__succeeds_when_lock_is_released() {
+		// Arrange - a lock held then released is not blocking.
+		$this->act_as_admin();
+		wp_cache_add( $this->lock_key(), 'other-request-token', Global_Classes_REST_API::LOCK_GROUP );
+		wp_cache_delete( $this->lock_key(), Global_Classes_REST_API::LOCK_GROUP );
+
+		$class = $this->create_global_class( 'g-1' );
+
+		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
+		$request->set_body_params( [
+			'items' => [ 'g-1' => $class ],
+			'order' => [ 'g-1' ],
+			'changes' => [ 'added' => [ 'g-1' ], 'deleted' => [], 'modified' => [] ],
+		] );
+
+		// Act.
+		$response = rest_do_request( $request );
+
+		// Assert.
+		$this->assertSame( 204, $response->get_status() );
+		$snapshot = ( new Global_Classes_Repository( $this->kit ) )->all_labels();
+		$this->assertArrayHasKey( 'g-1', $snapshot );
+	}
+
+	private function lock_key(): string {
+		return 'elementor_global_classes_' . $this->kit_id;
+	}
+
+	private function create_global_class( string $id ) {
+		return [
+			'id' => $id,
+			'label' => $id,
+			'type' => 'class',
+			'variants' => [],
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-global-classes-rest-api.php
@@ -94,6 +94,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$this->kit->delete_meta( Global_Classes_Labels::META_KEY_FRONTEND );
 		$this->kit->delete_meta( Global_Classes_Labels::META_KEY_PREVIEW );
 		$this->kit->delete_meta( Global_Classes_Order::META_KEY );
+		$this->kit->delete_meta( Global_Classes_Repository::META_KEY_VERSION );
 		$this->delete_all_global_class_posts();
 	}
 
@@ -120,7 +121,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		];
 
 		$this->assertEquals( $expected_list, $response->get_data()['data'] );
-		$this->assertEquals( [], $response->get_data()['meta'] );
+		$this->assertEquals( [ 'version' => 0 ], $response->get_data()['meta'] );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
@@ -149,7 +150,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		];
 
 		$this->assertEquals( $expected_list, $response->get_data()['data'] );
-		$this->assertEquals( [], $response->get_data()['meta'] );
+		$this->assertEquals( [ 'version' => 0 ], $response->get_data()['meta'] );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
@@ -163,7 +164,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 
 		// Assert
 		$this->assertEquals( [], $response->get_data()['data'] );
-		$this->assertEquals( [], $response->get_data()['meta'] );
+		$this->assertEquals( [ 'version' => 0 ], $response->get_data()['meta'] );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
@@ -1289,7 +1290,7 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		];
 
 		$this->assertEquals( $expected_list, $response->get_data()['data'] );
-		$this->assertEquals( [], $response->get_data()['meta'] );
+		$this->assertEquals( [ 'version' => 0 ], $response->get_data()['meta'] );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
@@ -1406,6 +1407,200 @@ class Test_Global_Classes_Rest_Api extends Elementor_Test_Base {
 		$this->assertNotNull( $data['data']->{'g-4-123'} );
 		$this->assertTrue( property_exists( $data['data'], 'g-missing' ) );
 		$this->assertNull( $data['data']->{'g-missing'} );
+	}
+
+	public function test_put__without_version_succeeds_and_bumps() {
+		// Arrange - old clients send no version token; the save must still work (back-compat).
+		$this->act_as_admin();
+
+		$class_1 = $this->create_global_class( 'g-1' );
+
+		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
+		$request->set_body_params( [
+			'items' => [ 'g-1' => $class_1 ],
+			'order' => [ 'g-1' ],
+			'changes' => [
+				'added' => [ 'g-1' ],
+				'deleted' => [],
+				'modified' => [],
+			],
+		] );
+
+		// Act.
+		$response = rest_do_request( $request );
+
+		// Assert - 204, class persisted, version advanced for newer clients.
+		$this->assertSame( 204, $response->get_status() );
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
+		$this->assertArrayHasKey( 'g-1', $classes['items'] );
+		$this->assertSame( 1, Global_Classes_Repository::make()->get_version() );
+	}
+
+	public function test_put__with_matching_version_succeeds_and_bumps() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$class_1 = $this->create_global_class( 'g-1' );
+		$this->seed_global_classes_posts( [ 'items' => [ 'g-1' => $class_1 ], 'order' => [ 'g-1' ] ] );
+		Global_Classes_Repository::make()->bump_version();
+
+		$class_2 = $this->create_global_class( 'g-2' );
+
+		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
+		$request->set_body_params( [
+			'items' => [ 'g-2' => $class_2 ],
+			'order' => [ 'g-1', 'g-2' ],
+			'changes' => [
+				'added' => [ 'g-2' ],
+				'deleted' => [],
+				'modified' => [],
+			],
+			'version' => 1,
+		] );
+
+		// Act.
+		$response = rest_do_request( $request );
+
+		// Assert.
+		$this->assertSame( 204, $response->get_status() );
+		$this->assertSame( 2, Global_Classes_Repository::make()->get_version() );
+	}
+
+	public function test_put__with_stale_version_returns_409_and_does_not_mutate() {
+		// Arrange - a save sent a version that no longer matches the stored one.
+		$this->act_as_admin();
+
+		$class_1 = $this->create_global_class( 'g-1' );
+		$this->seed_global_classes_posts( [ 'items' => [ 'g-1' => $class_1 ], 'order' => [ 'g-1' ] ] );
+		Global_Classes_Repository::make()->bump_version();
+
+		$class_2 = $this->create_global_class( 'g-2' );
+
+		$request = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
+		$request->set_body_params( [
+			'items' => [ 'g-2' => $class_2 ],
+			'order' => [ 'g-1', 'g-2' ],
+			'changes' => [
+				'added' => [ 'g-2' ],
+				'deleted' => [],
+				'modified' => [],
+			],
+			// Client edited against the pre-bump snapshot -> must be rejected.
+			'version' => 0,
+		] );
+
+		// Act.
+		$response = rest_do_request( $request );
+
+		// Assert - 409 conflict, nothing persisted, version untouched.
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'global_classes_conflict', $response->get_data()['code'] );
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
+		$this->assertArrayNotHasKey( 'g-2', $classes['items'] );
+		$this->assertSame( 1, Global_Classes_Repository::make()->get_version() );
+	}
+
+	public function test_get__returns_current_version() {
+		// Arrange.
+		$this->act_as_admin();
+		Global_Classes_Repository::make()->bump_version();
+		Global_Classes_Repository::make()->bump_version();
+
+		// Act.
+		$request = new \WP_REST_Request( 'GET', '/elementor/v1/global-classes' );
+		$response = rest_do_request( $request );
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 2, $response->get_data()['meta']['version'] );
+	}
+
+	/**
+	 * Regression for #36961 / #36852: a save based on a stale snapshot must not
+	 * silently drop a class that a concurrent save just committed. When the stale
+	 * client sends its (old) version, the write is rejected with a 409 instead of
+	 * clobbering the newer order/labels.
+	 */
+	public function test_put__interleaved_stale_snapshot_does_not_lose_class() {
+		// Arrange.
+		$this->act_as_admin();
+
+		$class_a = $this->create_global_class( 'g-a' );
+		$class_b = $this->create_global_class( 'g-b' );
+
+		// Both saves read this baseline (g-a + g-b present).
+		$this->seed_global_classes_posts( [
+			'items' => [ 'g-a' => $class_a, 'g-b' => $class_b ],
+			'order' => [ 'g-a', 'g-b' ],
+		] );
+		$repo = Global_Classes_Repository::make();
+		$repo->bump_version(); // baseline version = 1
+
+		// First save (newer) commits with version=1.
+		$first = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
+		$first->set_body_params( [
+			'items' => [],
+			'order' => [ 'g-a', 'g-b' ],
+			'changes' => [ 'added' => [], 'deleted' => [ 'g-b' ], 'modified' => [] ],
+			'version' => 1,
+		] );
+		rest_do_request( $first );
+
+		// Second save (stale client still on version=1 - now stale) tries to drop g-a.
+		$second = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
+		$second->set_body_params( [
+			'items' => [],
+			'order' => [ 'g-a' ],
+			'changes' => [ 'added' => [], 'deleted' => [ 'g-a' ], 'modified' => [] ],
+			'version' => 1,
+		] );
+
+		// Act.
+		$response = rest_do_request( $second );
+
+		// Assert - stale write rejected; the newer state (g-b dropped, g-a kept) intact.
+		$this->assertSame( 409, $response->get_status() );
+		$classes = $this->get_repository_snapshot( Global_Classes_Repository::CONTEXT_FRONTEND );
+		$this->assertSame( [ 'g-a' ], $classes['order'] );
+	}
+
+	public function test_put__preview_then_frontend_publish_with_version() {
+		// Arrange - draft save bumps the shared version, a frontend publish against the
+		// now-stale version is rejected rather than overwriting the draft-only class.
+		$this->act_as_admin();
+
+		$class_1 = $this->create_global_class( 'g-1' );
+		$this->seed_global_classes_posts( [ 'items' => [ 'g-1' => $class_1 ], 'order' => [ 'g-1' ] ] );
+		$repo = Global_Classes_Repository::make();
+		$repo->bump_version(); // version = 1
+
+		$draft_class = $this->create_global_class( 'g-draft' );
+
+		$preview = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
+		$preview->set_body_params( [
+			'context' => Global_Classes_Repository::CONTEXT_PREVIEW,
+			'items' => [ 'g-draft' => $draft_class ],
+			'order' => [ 'g-1', 'g-draft' ],
+			'changes' => [ 'added' => [ 'g-draft' ], 'deleted' => [], 'modified' => [] ],
+			'version' => 1,
+		] );
+		rest_do_request( $preview );
+
+		// Frontend publish still on version=1 (stale now) - rejected.
+		$frontend = new \WP_REST_Request( 'PUT', '/elementor/v1/global-classes' );
+		$frontend->set_body_params( [
+			'items' => [],
+			'order' => [ 'g-1' ],
+			'changes' => [ 'added' => [], 'deleted' => [], 'modified' => [] ],
+			'version' => 1,
+		] );
+
+		// Act.
+		$response = rest_do_request( $frontend );
+
+		// Assert.
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 2, Global_Classes_Repository::make()->get_version() );
 	}
 
 	public function test_register_routes__endpoints_exist() {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Prevent silent loss of Global Classes when two saves overlap.

## Description
An explanation of what is done in this PR

A global-classes PUT performs an unlocked read-modify-write on the kit index, and a single document save can fire two such PUTs (publish and draft rounds) as independent, un-awaited promises. When the two reads happen against the same pre-race snapshot, the second wholesale rewrite of the order/labels kit meta silently drops classes the first committed. Refreshing then shows some classes missing from the Class Manager, exactly the symptom in #36961 and #36852.

This PR adds two additive server-side layers plus a backward-compatible client retry:

- A per-kit optimistic-concurrency version stored on the kit meta. `GET global-classes` now returns it in `meta.version`. A `PUT` that supplies a stale version is rejected with `409` before any mutation, instead of silently overwriting the index.
- A short per-kit `wp_cache` spinlock (mirroring the existing component spinlock pattern) held only across the read-merge-apply of a PUT. This serializes overlapping un-versioned clients (older 4.x releases that send no version). A lock that cannot be acquired within the give-up budget returns `409`.
- On a `409` the editor re-fetches the index, rebases onto the server state, re-diffs and retries once, so a class whose loss already committed on the server is re-added.

Old clients send no version and are unaffected. The version guard and the `409` response are purely additive, and the lock is released in a `finally` block so a stale lock cannot persist.

## Test instructions
This PR can be tested by following these steps:

1. Add several Global Classes in a page's Class Manager.
2. Edit the page and publish it, then refresh.
3. Repeat the save/refresh cycle a few times, and confirm every added class still appears in the Class Manager.
4. (Regression) Edit and delete one class, publish, refresh. Confirm the deletion sticks and no other class disappears.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #36961
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Concurrent saves to global classes can silently lose data when overlapping requests both read stale baselines, then overwrite each other without detection. This adds optimistic concurrency control via version tokens to serialize writes and reject stale edits before mutation.

## 2. What Changed (Where)

- **PHP backend**: Added `META_KEY_VERSION` constant, `get_version()` / `bump_version()` methods, per-kit write locks using `wp_cache`, and 409 conflict responses when version mismatches detected.
- **REST API**: Wrapped save logic in `acquire_lock()` / `release_lock()`, refactored save into `put_serialized()` to check version before mutations, bumps version post-commit.
- **TypeScript store & API**: Added `version` field to state, request payload, and HTTP response metadata; `rebaseToServer()` reducer for retry-after-conflict flow.
- **Save logic**: Catches 409 errors, re-fetches server state, rebases working copy, retries—self-heals by re-diffing against fresh baseline.
- **Tests**: Lock behavior, version mismatches, interleaved conflicts, cross-context state consistency.

## 3. How It Works

Client reads index (captures version V), edits locally. On save: acquire per-kit lock → read authoritative state inside lock → compare client's version against current → reject if stale (409) → commit and bump version. On 409: re-fetch fresh baseline with new version, rebase working changes onto it, retry save. Lock ensures read-modify-write atomicity; version guards against stale snapshots.

## 4. Risks

- **Lock timeout (20 attempts, 2s total)**: Pathological contention could exceed budget; 409 response is safe but user must retry manually. Mitigated by spinlock pattern proven in existing lock managers.
- **Race in lock release**: Deleted lock could be re-acquired before token check; mitigated by token validation in `release_lock()`.
- **Backward compat**: Old clients omit version → treated as unversioned (pass through); new clients seeing old (v0) responses work fine. Safe.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
