### PR TITLE
Internal: Retry HTTP 429 responses in the editor ajax module [ED-25172]

### DIFF
--- a/core/common/modules/ajax/assets/js/ajax.js
+++ b/core/common/modules/ajax/assets/js/ajax.js
@@ -1,3 +1,7 @@
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 1000;
+const RETRY_MAX_DELAY_MS = 30000;
+
 export default class extends elementorModules.Module {
 	getDefaultSettings() {
 		return {
@@ -248,7 +252,117 @@ export default class extends elementorModules.Module {
 	}
 
 	send( action, options ) {
-		return jQuery.ajax( this.prepareSend( action, options ) );
+		const ajaxParams = this.prepareSend( action, options );
+
+		let attempt = 0;
+		let aborted = false;
+		let settled = false;
+		let jqXhr = null;
+		let retryTimer = null;
+
+		// Callers treat the return value as a jqXHR-like promise, so this deferred is
+		// settled with the outcome of the final attempt to keep .done/.fail working
+		// across retries.
+		const deferred = jQuery.Deferred();
+
+		const originalSuccess = ajaxParams.success;
+		const originalError = ajaxParams.error;
+
+		if ( originalSuccess ) {
+			ajaxParams.success = ( response ) => {
+				jqXhr = null;
+				settled = true;
+
+				deferred.resolve( response );
+
+				originalSuccess( response );
+			};
+		}
+
+		// Hosts rate-limit admin-ajax.php, and a burst of editor requests can draw HTTP
+		// 429 responses that would otherwise leave components unloaded. Only 429 is
+		// retried: the host rejects it before processing, so re-sending is safe even for
+		// the POSTs this module always issues; a 5xx may follow a partial write.
+		ajaxParams.error = ( errorJqXHR, textStatus, errorThrown ) => {
+			jqXhr = null;
+
+			if ( aborted || 'abort' === textStatus || 429 !== errorJqXHR.status || attempt >= MAX_RETRIES ) {
+				settled = true;
+
+				deferred.reject( errorJqXHR, textStatus, errorThrown );
+
+				if ( originalError ) {
+					originalError( errorJqXHR, textStatus, errorThrown );
+				}
+
+				return;
+			}
+
+			attempt += 1;
+
+			retryTimer = setTimeout( () => {
+				jqXhr = jQuery.ajax( ajaxParams );
+			}, Math.min( getRetryDelayMs( errorJqXHR ), RETRY_MAX_DELAY_MS ) );
+		};
+
+		// Retry-After carries seconds or an HTTP-date; anything unparsable falls back to
+		// exponential backoff. The delay is capped so a far-future header cannot freeze
+		// pending editor work.
+		function getRetryDelayMs( failedRequest ) {
+			const header = failedRequest.getResponseHeader && failedRequest.getResponseHeader( 'Retry-After' );
+
+			// Strict digits-only check keeps coercive junk ("0x10", "-5") out of the
+			// seconds branch.
+			if ( header && /^\d+(\.\d+)?$/.test( header.trim() ) ) {
+				return Math.max( 0, Number( header ) * 1000 );
+			}
+
+			if ( header ) {
+				const date = Date.parse( header );
+
+				if ( ! Number.isNaN( date ) ) {
+					return Math.max( 0, date - Date.now() );
+				}
+			}
+
+			return RETRY_BASE_DELAY_MS * Math.pow( 2, attempt - 1 );
+		}
+
+		jqXhr = jQuery.ajax( ajaxParams );
+
+		return Object.assign( deferred.promise(), {
+			abort: () => {
+				if ( settled ) {
+					return;
+				}
+
+				aborted = true;
+
+				clearTimeout( retryTimer );
+
+				if ( jqXhr ) {
+					jqXhr.abort( 'Request canceled' );
+				} else {
+					// No request is in flight during a backoff wait, so settle the
+					// callers the same way an in-flight abort would.
+					const syntheticJqXHR = {
+						status: 0,
+						statusText: 'abort',
+						readyState: 0,
+						getResponseHeader: () => null,
+						getAllResponseHeaders: () => '',
+					};
+
+					settled = true;
+
+					deferred.reject( syntheticJqXHR, 'abort', 'Request canceled' );
+
+					if ( originalError ) {
+						originalError( syntheticJqXHR, 'abort', 'Request canceled' );
+					}
+				}
+			},
+		} );
 	}
 
 	addRequestCache( request, data ) {

--- a/tests/jest/unit/core/common/modules/ajax/assets/js/ajax.test.js
+++ b/tests/jest/unit/core/common/modules/ajax/assets/js/ajax.test.js
@@ -154,3 +154,311 @@ describe( 'Ajax batch requests', () => {
 		expect( cached ).toEqual( { status: 'resolved', data: { id: 1 } } );
 	} );
 } );
+
+describe( 'Ajax HTTP 429 retry', () => {
+	let ajax, sentRequests, sentXhrs;
+
+	const settleDeferred = ( deferred ) => {
+		const state = { status: 'pending' };
+
+		deferred
+			.done( ( data ) => Object.assign( state, { status: 'resolved', data } ) )
+			.fail( ( data ) => Object.assign( state, { status: 'rejected', data } ) );
+
+		return state;
+	};
+
+	const flushBatch = () => jest.advanceTimersByTime( BATCH_DEBOUNCE );
+
+	const respondToLastRequest = ( responses ) =>
+		sentRequests[ sentRequests.length - 1 ].success( { success: true, data: { responses } } );
+
+	// Invokes the jQuery error callback with a fake jqXHR carrying the given status and,
+	// optionally, a Retry-After header.
+	const failSendingRequest = ( status, retryAfter ) => {
+		const jqXHR = {
+			status,
+			getResponseHeader: ( header ) => ( 'Retry-After' === header ? retryAfter : null ),
+		};
+
+		sentRequests[ sentRequests.length - 1 ].error( jqXHR, 'error', status );
+	};
+
+	beforeEach( () => {
+		jest.resetModules();
+		jest.useFakeTimers();
+
+		sentRequests = [];
+		sentXhrs = [];
+
+		global.jQuery = jQuery;
+		global._ = {
+			has: ( object, key ) => Object.prototype.hasOwnProperty.call( object, key ),
+			debounce: ( callback, wait ) => {
+				let timer;
+
+				return ( ...args ) => {
+					clearTimeout( timer );
+
+					timer = setTimeout( () => callback( ...args ), wait );
+				};
+			},
+		};
+		global.elementorModules = {
+			Module: require( 'elementor-assets-js/modules/imports/module' ),
+		};
+		global.elementorCommon = {
+			config: {
+				ajax: {
+					url: 'https://example.com/wp-admin/admin-ajax.php',
+				},
+			},
+			helpers: {
+				cloneObject: ( object ) => JSON.parse( JSON.stringify( object ) ),
+			},
+		};
+
+		jest.spyOn( jQuery, 'ajax' ).mockImplementation( ( options ) => {
+			sentRequests.push( options );
+
+			const xhr = { abort: jest.fn() };
+
+			sentXhrs.push( xhr );
+
+			return xhr;
+		} );
+
+		const Ajax = require( 'elementor-common-modules/ajax/assets/js/ajax' ).default;
+
+		ajax = new Ajax( { nonce: 'nonce' } );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+
+		delete global.jQuery;
+		delete global._;
+		delete global.elementorCommon;
+	} );
+
+	const triggerBatchedLoad = () => {
+		const request = { action: 'get_document_config', unique_id: 'document-1', data: { id: 1 } };
+
+		const first = settleDeferred( ajax.load( { ...request } ) );
+		const second = settleDeferred( ajax.load( { ...request } ) );
+
+		return { first, second };
+	};
+
+	it( 'should retry a 429 without a Retry-After header using exponential backoff', () => {
+		// Arrange
+		const { first, second } = triggerBatchedLoad();
+
+		flushBatch();
+
+		// Act: first attempt returns 429 with no Retry-After.
+		failSendingRequest( 429, null );
+
+		// The first retry runs after 1000ms; it succeeds.
+		jest.advanceTimersByTime( 1000 );
+		respondToLastRequest( { 'document-1': { success: true, data: { id: 1 } } } );
+
+		// Assert
+		expect( sentRequests ).toHaveLength( 2 );
+		expect( first ).toEqual( { status: 'resolved', data: { id: 1 } } );
+		expect( second ).toEqual( { status: 'resolved', data: { id: 1 } } );
+	} );
+
+	it( 'should wait for the Retry-After delay in seconds before retrying', () => {
+		// Arrange
+		const { first, second } = triggerBatchedLoad();
+
+		flushBatch();
+
+		// Act: first attempt returns 429 telling us to wait 2s.
+		failSendingRequest( 429, '2' );
+
+		// The retry must not have fired before the header delay elapses.
+		jest.advanceTimersByTime( 1000 );
+		expect( sentRequests ).toHaveLength( 1 );
+
+		// After the 2s delay the retry fires and succeeds.
+		jest.advanceTimersByTime( 1000 );
+		respondToLastRequest( { 'document-1': { success: true, data: { id: 1 } } } );
+
+		// Assert
+		expect( sentRequests ).toHaveLength( 2 );
+		expect( first ).toEqual( { status: 'resolved', data: { id: 1 } } );
+		expect( second ).toEqual( { status: 'resolved', data: { id: 1 } } );
+	} );
+
+	it( 'should wait for a Retry-After HTTP-date before retrying', () => {
+		// Arrange
+		const { first, second } = triggerBatchedLoad();
+
+		flushBatch();
+
+		const retryAt = new Date( Date.now() + 2000 ).toUTCString();
+
+		// Act: first attempt returns 429 with an HTTP-date Retry-After 2s from now.
+		failSendingRequest( 429, retryAt );
+
+		jest.advanceTimersByTime( 1000 );
+		expect( sentRequests ).toHaveLength( 1 );
+
+		jest.advanceTimersByTime( 1000 );
+		respondToLastRequest( { 'document-1': { success: true, data: { id: 1 } } } );
+
+		// Assert
+		expect( sentRequests ).toHaveLength( 2 );
+		expect( first ).toEqual( { status: 'resolved', data: { id: 1 } } );
+		expect( second ).toEqual( { status: 'resolved', data: { id: 1 } } );
+	} );
+
+	it( 'should reject callers and make no further attempt after exhausting retries', () => {
+		// Arrange
+		const { first, second } = triggerBatchedLoad();
+
+		// Act: every attempt returns 429 with a 1s Retry-After, four times in a row.
+		for ( let attempt = 0; attempt <= 3; attempt += 1 ) {
+			if ( 0 === attempt ) {
+				flushBatch();
+			} else {
+				jest.advanceTimersByTime( 1000 );
+			}
+
+			failSendingRequest( 429, '1' );
+		}
+
+		jest.advanceTimersByTime( 4000 );
+
+		// Assert: initial send plus three retries, then both callers reject.
+		expect( sentRequests ).toHaveLength( 4 );
+		expect( first.status ).toBe( 'rejected' );
+		expect( second.status ).toBe( 'rejected' );
+	} );
+
+	it( 'should not retry a 500 response', () => {
+		// Arrange
+		const { first, second } = triggerBatchedLoad();
+
+		flushBatch();
+
+		// Act
+		failSendingRequest( 500 );
+
+		jest.advanceTimersByTime( 4000 );
+
+		// Assert: a single attempt, and the callers are rejected.
+		expect( sentRequests ).toHaveLength( 1 );
+		expect( first.status ).toBe( 'rejected' );
+		expect( second.status ).toBe( 'rejected' );
+	} );
+
+	it( 'should not send another request after abort during the retry wait', () => {
+		// Arrange: immediately:true stores the abortable wrapper on the deferred.
+		const request = { action: 'get_document_config', unique_id: 'document-1', data: { id: 1 } };
+		const deferred = ajax.load( { ...request }, true );
+		const first = settleDeferred( deferred );
+
+		// Act: 429 schedules a 2s retry, then the caller cancels during that wait.
+		failSendingRequest( 429, '2' );
+
+		deferred.jqXhr.abort( 'Request canceled' );
+
+		jest.advanceTimersByTime( 2000 );
+
+		// Assert
+		expect( sentRequests ).toHaveLength( 1 );
+		expect( first.status ).toBe( 'rejected' );
+	} );
+
+	it( 'should resolve both callers when a retry succeeds after repeated 429s', () => {
+		// Arrange
+		const { first, second } = triggerBatchedLoad();
+
+		flushBatch();
+
+		// Act: two 429s, then a successful response.
+		failSendingRequest( 429 );
+		jest.advanceTimersByTime( 1000 );
+		failSendingRequest( 429 );
+		jest.advanceTimersByTime( 2000 );
+		respondToLastRequest( { 'document-1': { success: true, data: { id: 1 } } } );
+
+		// Assert
+		expect( sentRequests ).toHaveLength( 3 );
+		expect( first ).toEqual( { status: 'resolved', data: { id: 1 } } );
+		expect( second ).toEqual( { status: 'resolved', data: { id: 1 } } );
+	} );
+
+	it( 'should fall back to exponential backoff when Retry-After is unparsable', () => {
+		// Arrange
+		const { first, second } = triggerBatchedLoad();
+
+		flushBatch();
+
+		// Act: "not-a-date" is neither digits nor an HTTP-date, so backoff (1000ms) applies.
+		failSendingRequest( 429, 'not-a-date' );
+
+		jest.advanceTimersByTime( 999 );
+		expect( sentRequests ).toHaveLength( 1 );
+
+		jest.advanceTimersByTime( 1 );
+		respondToLastRequest( { 'document-1': { success: true, data: { id: 1 } } } );
+
+		// Assert
+		expect( sentRequests ).toHaveLength( 2 );
+		expect( first ).toEqual( { status: 'resolved', data: { id: 1 } } );
+		expect( second ).toEqual( { status: 'resolved', data: { id: 1 } } );
+	} );
+
+	it( 'should cap a large Retry-After delay at 30 seconds', () => {
+		// Arrange
+		const { first, second } = triggerBatchedLoad();
+
+		flushBatch();
+
+		// Act: header asks for 120s; the wait is capped at RETRY_MAX_DELAY_MS (30s).
+		failSendingRequest( 429, '120' );
+
+		jest.advanceTimersByTime( 30000 );
+
+		respondToLastRequest( { 'document-1': { success: true, data: { id: 1 } } } );
+
+		// Assert
+		expect( sentRequests ).toHaveLength( 2 );
+		expect( first ).toEqual( { status: 'resolved', data: { id: 1 } } );
+		expect( second ).toEqual( { status: 'resolved', data: { id: 1 } } );
+	} );
+
+	it( 'should abort a request that is in flight when abort is called', () => {
+		// Arrange: immediately:true stores the wrapper on the deferred.
+		const request = { action: 'get_document_config', unique_id: 'document-1', data: { id: 1 } };
+		const deferred = ajax.load( { ...request }, true );
+
+		settleDeferred( deferred );
+
+		// Act: cancel while the first attempt is still in flight.
+		deferred.jqXhr.abort( 'Request canceled' );
+
+		// Assert
+		expect( sentXhrs[ 0 ].abort ).toHaveBeenCalledWith( 'Request canceled' );
+	} );
+
+	it( 'should ignore abort after the request has settled', () => {
+		// Arrange: immediately:true stores the wrapper on the deferred.
+		const request = { action: 'get_document_config', unique_id: 'document-1', data: { id: 1 } };
+		const deferred = ajax.load( { ...request }, true );
+		const first = settleDeferred( deferred );
+
+		respondToLastRequest( { 'document-1': { success: true, data: { id: 1 } } } );
+
+		// Act: a late abort (e.g. from a stale handle) must not re-settle anything.
+		expect( () => deferred.jqXhr.abort() ).not.toThrow();
+
+		// Assert
+		expect( sentRequests ).toHaveLength( 1 );
+		expect( first ).toEqual( { status: 'resolved', data: { id: 1 } } );
+	} );
+} );

--- a/tests/jest/unit/core/common/modules/ajax/assets/js/mock/jquery.js
+++ b/tests/jest/unit/core/common/modules/ajax/assets/js/mock/jquery.js
@@ -67,6 +67,45 @@ const createDeferred = () => {
 
 			return deferred;
 		},
+
+		promise() {
+			const promise = {
+				done: ( callback ) => {
+					deferred.done( callback );
+
+					return promise;
+				},
+
+				fail: ( callback ) => {
+					deferred.fail( callback );
+
+					return promise;
+				},
+
+				always: ( callback ) => {
+					deferred.always( callback );
+
+					return promise;
+				},
+
+				state: () => deferred.state,
+
+				promise: () => promise,
+
+				then: ( onDone, onFail ) => {
+					const next = createDeferred();
+
+					deferred.done( ( value ) => next.resolve( onDone ? onDone( value ) : value ) );
+					deferred.fail( ( value ) => next.reject( onFail ? onFail( value ) : value ) );
+
+					return next.promise();
+				},
+
+				catch: ( onFail ) => promise.then( undefined, onFail ),
+			};
+
+			return promise;
+		},
 	};
 
 	return deferred;


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Editor: retry HTTP 429 responses from admin-ajax.php so components finish loading on hosts that rate-limit the editor.

## Description
An explanation of what is done in this PR

Opening the editor on a page with several components fires a burst of `admin-ajax.php` requests. Hosts that rate-limit those requests answer with HTTP 429, and the editor never retried, so some components stayed unloaded. #36804 already merged those requests into a single batched `elementor_ajax` call; this PR finishes the issue by retrying when a 429 still comes back.

`send()` in `core/common/modules/ajax/assets/js/ajax.js` now wraps `jQuery.ajax` with a small retry loop:

- Only HTTP 429 is retried. The host rejects it before processing, so re-sending is safe even though this module always POSTs. A 5xx may arrive after a partial write and is not retried.
- The `Retry-After` header is honored when present, parsed as seconds or an HTTP-date. Without it the delay is exponential backoff (1s, 2s, 4s).
- Any wait is capped at 30 seconds and there are at most 3 retries, so a bad header cannot freeze pending editor work.
- The returned value keeps a jqXHR-like promise surface (`done` / `fail` / `always` / `then`) settled with the outcome of the final attempt, and its `abort()` still cancels in-flight requests and scheduled retries, so `cancelRequest()` keeps working.

## Test instructions
This PR can be tested by following these steps:

1. Open the editor on a page that uses several components (nested included). In the Network tab filtered to `admin-ajax.php`, confirm the component document requests still arrive as one batched `elementor_ajax` request per nesting level.
2. Throttle the network or mock a 429 response with a `Retry-After` header for that request.
3. Expected result: the editor waits for the header delay, sends one or more retries (up to three), and the components finish loading instead of staying missing.
4. Regression check: cancelling a request while it is in flight or during a retry wait still settles its callers immediately.

Automated: `npm run test:jest` covers the new behavior in `tests/jest/unit/core/common/modules/ajax/assets/js/ajax.test.js` (15 tests: exponential backoff, Retry-After seconds / HTTP-date / unparsable fallback, 30 second cap, retry exhaustion, no retry on 500, abort in flight / during wait / after settlement).

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #36647
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Rate-limited hosts return HTTP 429s during editor ajax bursts, leaving components unloaded. This adds exponential backoff retry logic with Retry-After header support, capping delays at 30s to prevent editor freezing.

## 2. What Changed (Where)

- **ajax.js**: Replaced single `jQuery.ajax()` call with retry wrapper handling 429s, state tracking (attempt/aborted/settled), and deferred settling across retries.
- **jquery.js mock**: Added `promise()` method supporting `.done()/.fail()/.then()/.catch()` chaining for test compatibility.
- **ajax.test.js**: Added 9 test cases covering exponential backoff, Retry-After parsing (seconds/HTTP-date), max retry exhaustion, abort during wait, and delay capping.

## 3. How It Works

Entry: `send()` wraps `jQuery.ajax()` in a deferred + state machine. On 429: parses Retry-After header (numeric seconds or HTTP-date), falls back to exponential backoff (1s → 2s → 4s), retries up to 3 times. Non-429 errors or abort immediately reject. Success resolves both the deferred and any pending callers. Abort clears retry timers and either cancels in-flight requests or creates synthetic jqXHR if waiting.

## 4. Risks

**Backoff delay parsing**: Strict regex (`/^\d+(\.\d+)?$/`) rejects negative/hex values safely, but edge case where Date.parse accepts invalid inputs mitigated by `Number.isNaN()` check. **30s cap**: Prevents unbounded delays but could silently drop legitimate long Retry-After headers—acceptable for editor UX. **State machine correctness**: Multiple entry points (success, error, abort) with settled flag prevent double-settling; test coverage validates.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
