### PR TITLE
Fix: Let V4 button text wrap with themes that set nowrap

### DIFF
--- a/modules/atomic-widgets/elements/atomic-button/atomic-button.php
+++ b/modules/atomic-widgets/elements/atomic-button/atomic-button.php
@@ -126,6 +126,7 @@ class Atomic_Button extends Atomic_Widget_Base {
 			'unit' => 'px',
 		] );
 		$align_text_value = String_Prop_Type::generate( 'center' );
+		$white_space_value = String_Prop_Type::generate( 'normal' );
 
 		return [
 			'base' => Style_Definition::make()
@@ -137,6 +138,7 @@ class Atomic_Button extends Atomic_Widget_Base {
 						->add_prop( 'border-radius', $border_radius_value )
 						->add_prop( 'border-width', $border_width_value )
 						->add_prop( 'text-align', $align_text_value )
+						->add_prop( 'white-space', $white_space_value )
 				),
 		];
 	}

--- a/modules/atomic-widgets/styles/style-schema.php
+++ b/modules/atomic-widgets/styles/style-schema.php
@@ -191,6 +191,15 @@ class Style_Schema {
 				'lowercase',
 			] )
 				->description( 'Controls the capitalization of text. CSS values: none, capitalize, uppercase, lowercase' ),
+			'white-space' => String_Prop_Type::make()->enum( [
+				'normal',
+				'nowrap',
+				'pre',
+				'pre-line',
+				'pre-wrap',
+				'break-spaces',
+			] )
+				->description( 'Controls how white space inside the text is handled. CSS values: normal, nowrap, pre, pre-line, pre-wrap, break-spaces' ),
 			'direction' => String_Prop_Type::make()->enum( [
 				'ltr',
 				'rtl',

--- a/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-button.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-button.php
@@ -1,12 +1,37 @@
 <?php
 
 use Elementor\Modules\AtomicWidgets\Elements\Atomic_Button\Atomic_Button;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 use Elementor\Plugin;
 use ElementorEditorTesting\Elementor_Test_Base;
 use Spatie\Snapshots\MatchesSnapshots;
 
 class Test_Atomic_Button extends Elementor_Test_Base {
 	use MatchesSnapshots;
+
+	public function test__base_styles_include_white_space_normal(): void {
+		// Arrange.
+		$mock = [
+			'id' => 'e8e55a1',
+			'elType' => 'widget',
+			'settings' => [],
+			'widgetType' => Atomic_Button::get_element_type(),
+		];
+
+		$widget_instance = Plugin::$instance->elements_manager->create_element_instance( $mock );
+
+		// Act.
+		$base_styles = $widget_instance->get_base_styles();
+		$base_style_id = Atomic_Button::get_element_type() . '-base';
+		$props = $base_styles[ $base_style_id ]['variants'][0]['props'];
+
+		// Assert.
+		$this->assertArrayHasKey( 'white-space', $props );
+		$this->assertEquals(
+			String_Prop_Type::generate( 'normal' ),
+			$props['white-space']
+		);
+	}
 
 	public function test__render_button(): void {
 		// Arrange.


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: V4 button text no longer overflows when a theme sets `white-space: nowrap` on buttons.

## Description
An explanation of what is done in this PR

* The V4 button widget renders a native `<button>` element when it has no link. Themes such as Hello Elementor ship a reset rule that sets `white-space: nowrap` on all buttons. When the button is narrower than its label, the label overflows instead of wrapping.

* This change sets `white-space: normal` in the button base style so the label wraps inside the button, and adds `white-space` to the atomic style schema so the base style prop can be emitted. The `white-space` prop is whitelisted with the CSS values `normal`, `nowrap`, `pre`, `pre-line`, `pre-wrap`, and `break-spaces`.

* The fix is plugin-side, so it works with any theme that resets button `white-space`, not only Hello Elementor.

## Test instructions
This PR can be tested by following these steps:

1. Activate the Hello Elementor theme and make sure the Atomic Widgets and Editor V4 experiments are enabled under Elementor > Settings > Features.
2. Add a Button widget (V4 / atomic).
3. Set its Width to something narrow, for example 200px.
4. Type a long label that will not fit in 200px, for example `A very long button label that should wrap onto multiple lines`.
5. Save and view the page. Expected: the label wraps onto multiple lines and stays inside the button. Before the fix it overflowed on one line.
6. Repeat with a linked button (give it a URL). The label should still wrap the same way.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #36602
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Themes that set `white-space: nowrap` override button text wrapping behavior. This fix adds explicit `white-space: normal` to V4 button base styles, ensuring text wraps regardless of theme settings (ticket #36602).

## 2. What Changed (Where)

- **atomic-button.php**: Added `white-space: normal` to base styles via String_Prop_Type.
- **style-schema.php**: Registered `white-space` property with all valid CSS enum values.
- **test-atomic-button.php**: Added test verifying base styles include `white-space: normal`.

## 3. How It Works

Button renders with base styles containing `white-space: normal`, which overrides parent theme's `nowrap` declarations in CSS specificity cascade. Schema registration enables the property for other widgets.

## 4. Risks

None — change is additive and CSS specificity favors element styles over theme. Test validates correct default behavior.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
