### PR TITLE
Fix: Interaction animation overriding V4 button hover transform

### DIFF
--- a/modules/interactions/assets/js/interactions-shared-utils.js
+++ b/modules/interactions/assets/js/interactions-shared-utils.js
@@ -248,6 +248,26 @@ export function getTransformBaselineFromComputedStyle( element ) {
 	};
 }
 
+export function shouldResetElementStyles( keyframes ) {
+	// An inline style only needs clearing when the animation's end state matches
+	// the CSS default. "In" animations (fade in, slide in, scale in) end at
+	// opacity 1 / x 0 / y 0 / scale 1, so the inline value after the animation is
+	// redundant with the stylesheet and would otherwise mask `:hover` rules.
+	// "Out" and scrollOut animations end off-identity and must stay in place.
+	const lastKeyframe = Object.keys( keyframes ).reduce( ( acc, key ) => {
+		const values = keyframes[ key ];
+		acc[ key ] = values[ values.length - 1 ];
+		return acc;
+	}, {} );
+
+	const resetOpacity = undefined === lastKeyframe.opacity || isNearOne( lastKeyframe.opacity );
+	const resetScale = undefined === lastKeyframe.scale || isNearOne( lastKeyframe.scale );
+	const resetX = undefined === lastKeyframe.x || isNearZero( lastKeyframe.x );
+	const resetY = undefined === lastKeyframe.y || isNearZero( lastKeyframe.y );
+
+	return resetOpacity && resetScale && resetX && resetY;
+}
+
 export function preserveTransformKeyframes( keyframes, baseline ) {
 	if ( ! baseline ) {
 		return keyframes;
@@ -314,4 +334,5 @@ window.elementorModules.interactions = {
 	resetElementStyles,
 	getTransformBaselineFromComputedStyle,
 	preserveTransformKeyframes,
+	shouldResetElementStyles,
 };

--- a/modules/interactions/assets/js/interactions-utils.js
+++ b/modules/interactions/assets/js/interactions-utils.js
@@ -13,6 +13,7 @@ import {
 	resetElementStyles,
 	getTransformBaselineFromComputedStyle,
 	preserveTransformKeyframes,
+	shouldResetElementStyles,
 } from './interactions-shared-utils.js';
 
 function isSupportedInteraction( animationConfig ) {
@@ -47,6 +48,7 @@ export {
 	resetElementStyles,
 	getTransformBaselineFromComputedStyle,
 	preserveTransformKeyframes,
+	shouldResetElementStyles,
 };
 
 export function getKeyframes( effect, type, direction ) {

--- a/modules/interactions/assets/js/interactions.js
+++ b/modules/interactions/assets/js/interactions.js
@@ -11,9 +11,27 @@ import {
 	getInViewFunction,
 	waitForAnimateFunction,
 	parseInteractionsData,
+	resetElementStyles,
+	shouldResetElementStyles,
 } from './interactions-utils.js';
 
 import { initBreakpoints } from './interactions-breakpoints.js';
+
+function restoreElementStyles( element, transition, keyframes ) {
+	element.style.transition = transition;
+
+	// Clear the inline transform/opacity left behind once the animation reaches a
+	// state that already matches the stylesheet default, so it does not mask
+	// `:hover` (and manually authored) CSS on the same element.
+	if ( shouldResetElementStyles( keyframes ) ) {
+		requestAnimationFrame( () => {
+			resetElementStyles( element );
+			// ResetElementStyles also clears transition; restore it so an
+			// authored inline transition is not removed by the cleanup.
+			element.style.transition = transition;
+		} );
+	}
+}
 
 function scrollOutAnimation( element, transition, animConfig, keyframes, resetKeyframes, options, animateFunc, inViewFunc ) {
 	const viewOptions = { amount: 0.85, root: null };
@@ -36,7 +54,7 @@ function scrollInAnimation( element, transition, animConfig, keyframes, options,
 	const viewOptions = { amount: 0, root: null };
 	const stop = inViewFunc( element, () => {
 		animateFunc( element, keyframes, options ).then( () => {
-			element.style.transition = transition;
+			restoreElementStyles( element, transition, keyframes );
 		} );
 		if ( false === animConfig.replay ) {
 			stop();
@@ -46,7 +64,7 @@ function scrollInAnimation( element, transition, animConfig, keyframes, options,
 
 function defaultAnimation( element, transition, keyframes, options, animateFunc ) {
 	animateFunc( element, keyframes, options ).then( () => {
-		element.style.transition = transition;
+		restoreElementStyles( element, transition, keyframes );
 	} );
 }
 

--- a/tests/jest/unit/modules/interactions/assets/js/interactions-utils.test.js
+++ b/tests/jest/unit/modules/interactions/assets/js/interactions-utils.test.js
@@ -2,6 +2,7 @@ import {
 	getKeyframes,
 	getTransformBaselineFromComputedStyle,
 	preserveTransformKeyframes,
+	shouldResetElementStyles,
 	parseAnimationName,
 	skipInteraction,
 	extractAnimationConfig,
@@ -632,6 +633,25 @@ describe( 'interactions-utils', () => {
 
 			const result = extractInteractionId( interaction );
 			expect( result ).toBe( 'temp-abc123xyz' );
+		} );
+	} );
+
+	describe( 'shouldResetElementStyles', () => {
+		it( 'returns true for an "in" end state that matches the CSS default', () => {
+			expect( shouldResetElementStyles( { scale: [ 0, 1 ] } ) ).toBe( true );
+			expect( shouldResetElementStyles( { x: [ -100, 0 ], y: [ 50, 0 ] } ) ).toBe( true );
+			expect( shouldResetElementStyles( { opacity: [ 0, 1 ] } ) ).toBe( true );
+			expect( shouldResetElementStyles( { opacity: [ 0, 1 ], x: [ -50, 0 ] } ) ).toBe( true );
+		} );
+
+		it( 'returns false for an "out" end state that is off-identity', () => {
+			expect( shouldResetElementStyles( { opacity: [ 1, 0 ] } ) ).toBe( false );
+			expect( shouldResetElementStyles( { scale: [ 1, 0 ] } ) ).toBe( false );
+			expect( shouldResetElementStyles( { x: [ 0, -100 ] } ) ).toBe( false );
+		} );
+
+		it( 'returns true when no end state differs from the CSS default', () => {
+			expect( shouldResetElementStyles( {} ) ).toBe( true );
 		} );
 	} );
 } );

--- a/tests/jest/unit/modules/interactions/assets/js/interactions.test.js
+++ b/tests/jest/unit/modules/interactions/assets/js/interactions.test.js
@@ -21,6 +21,30 @@ function installMotionMocks( { animate, inView, scroll } ) {
 	};
 }
 
+function applyLastKeyframeStyles( element, keyframes ) {
+	if ( keyframes.opacity ) {
+		element.style.opacity = String( keyframes.opacity[ keyframes.opacity.length - 1 ] );
+	}
+
+	if ( keyframes.scale || keyframes.x || keyframes.y || keyframes.scaleX || keyframes.scaleY ) {
+		element.style.transform = 'matrix(1, 0, 0, 1, 0, 0)';
+	}
+}
+
+function createStyleWritingAnimate() {
+	return jest.fn( ( element, keyframes ) => {
+		applyLastKeyframeStyles( element, keyframes );
+		return Promise.resolve();
+	} );
+}
+
+function runRafSync() {
+	jest.spyOn( window, 'requestAnimationFrame' ).mockImplementation( ( callback ) => {
+		callback( 0 );
+		return 0;
+	} );
+}
+
 describe( 'Interactions', () => {
 	beforeAll( () => {
 		stubInteractionsConfig();
@@ -237,5 +261,184 @@ describe( 'Interactions', () => {
 
 		expect( animate ).toHaveBeenCalledTimes( 2 );
 		expect( stopObserving ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'clears leftover inline transform after a load scale-in animation completes', async () => {
+		runRafSync();
+		const animate = createStyleWritingAnimate();
+		installMotionMocks( { animate, inView: jest.fn(), scroll: jest.fn() } );
+
+		const element = document.createElement( 'div' );
+		element.setAttribute( 'data-interaction-id', 'scale-in-hover' );
+		document.body.appendChild( element );
+
+		const script = document.createElement( 'script' );
+		script.id = 'elementor-interactions-data';
+		script.type = 'application/json';
+		script.textContent = JSON.stringify( [
+			{
+				elementId: 'scale-in-hover',
+				interactions: [
+					{
+						trigger: 'load',
+						breakpoints: { excluded: [] },
+						animation: {
+							effect: 'scale',
+							type: 'in',
+							direction: '',
+							timing_config: { duration: 600, delay: 0 },
+							config: { replay: false, easing: 'easeIn' },
+						},
+					},
+				],
+			},
+		] );
+		document.body.appendChild( script );
+
+		jest.isolateModules( () => {
+			require( 'elementor/modules/interactions/assets/js/interactions.js' );
+		} );
+
+		await flushPromises();
+
+		expect( element.style.transform ).toBe( '' );
+		expect( element.style.opacity ).toBe( '' );
+	} );
+
+	it( 'clears leftover inline opacity after a load fade-in animation completes', async () => {
+		runRafSync();
+		const animate = createStyleWritingAnimate();
+		installMotionMocks( { animate, inView: jest.fn(), scroll: jest.fn() } );
+
+		const element = document.createElement( 'div' );
+		element.setAttribute( 'data-interaction-id', 'fade-in-hover' );
+		document.body.appendChild( element );
+
+		const script = document.createElement( 'script' );
+		script.id = 'elementor-interactions-data';
+		script.type = 'application/json';
+		script.textContent = JSON.stringify( [
+			{
+				elementId: 'fade-in-hover',
+				interactions: [
+					{
+						trigger: 'load',
+						breakpoints: { excluded: [] },
+						animation: {
+							effect: 'fade',
+							type: 'in',
+							direction: '',
+							timing_config: { duration: 600, delay: 0 },
+							config: { replay: false, easing: 'easeIn' },
+						},
+					},
+				],
+			},
+		] );
+		document.body.appendChild( script );
+
+		jest.isolateModules( () => {
+			require( 'elementor/modules/interactions/assets/js/interactions.js' );
+		} );
+
+		await flushPromises();
+
+		expect( element.style.opacity ).toBe( '' );
+		expect( element.style.transform ).toBe( '' );
+	} );
+
+	it( 'does not clear inline styles after a load slide-out animation completes', async () => {
+		runRafSync();
+		const animate = createStyleWritingAnimate();
+		installMotionMocks( { animate, inView: jest.fn(), scroll: jest.fn() } );
+
+		const element = document.createElement( 'div' );
+		element.setAttribute( 'data-interaction-id', 'slide-out-hold' );
+		document.body.appendChild( element );
+
+		const script = document.createElement( 'script' );
+		script.id = 'elementor-interactions-data';
+		script.type = 'application/json';
+		script.textContent = JSON.stringify( [
+			{
+				elementId: 'slide-out-hold',
+				interactions: [
+					{
+						trigger: 'load',
+						breakpoints: { excluded: [] },
+						animation: {
+							effect: 'slide',
+							type: 'out',
+							direction: 'left',
+							timing_config: { duration: 600, delay: 0 },
+							config: { replay: false, easing: 'easeIn' },
+						},
+					},
+				],
+			},
+		] );
+		document.body.appendChild( script );
+
+		jest.isolateModules( () => {
+			require( 'elementor/modules/interactions/assets/js/interactions.js' );
+		} );
+
+		await flushPromises();
+
+		expect( element.style.transform ).toBe( 'matrix(1, 0, 0, 1, 0, 0)' );
+	} );
+
+	it( 'clears leftover inline styles after a scrollIn animation completes', async () => {
+		runRafSync();
+		const animate = createStyleWritingAnimate();
+
+		const element = document.createElement( 'div' );
+		element.setAttribute( 'data-interaction-id', 'scroll-in-hover' );
+		element.style.transition = 'opacity 0.3s';
+		document.body.appendChild( element );
+
+		const inView = jest.fn( ( el, callback ) => {
+			// Defer so the handler's `stop` closure is initialized before it runs,
+			// matching scrollIn's real async in-view behavior.
+			Promise.resolve().then( () => callback() );
+			return jest.fn();
+		} );
+		installMotionMocks( { animate, inView, scroll: jest.fn() } );
+
+		const script = document.createElement( 'script' );
+		script.id = 'elementor-interactions-data';
+		script.type = 'application/json';
+		script.textContent = JSON.stringify( [
+			{
+				elementId: 'scroll-in-hover',
+				interactions: [
+					{
+						trigger: 'scrollIn',
+						breakpoints: { excluded: [] },
+						animation: {
+							effect: 'fade',
+							type: 'in',
+							direction: '',
+							timing_config: { duration: 600, delay: 0 },
+							config: { replay: false, easing: 'easeIn' },
+						},
+					},
+				],
+			},
+		] );
+		document.body.appendChild( script );
+
+		jest.isolateModules( () => {
+			require( 'elementor/modules/interactions/assets/js/interactions.js' );
+		} );
+
+		// Deferred inView callback, then animation.then() + rAF reset.
+		await flushPromises();
+		await flushPromises();
+
+		expect( element.style.opacity ).toBe( '' );
+		expect( element.style.transform ).toBe( '' );
+		// The authored inline transition must survive the cleanup.
+		expect( element.style.transition ).toBe( 'opacity 0.3s' );
 	} );
 } );


### PR DESCRIPTION
## PR Checklist
<!--
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Interaction animation overriding V4 button hover transform

## Description
An explanation of what is done in this PR

When an interaction animation (Slide, Fade, or Scale) runs on the published page, Motion.js leaves an inline `transform` and `opacity` on the element after it finishes. An inline value always beats the matching stylesheet rule, so a V4 button Hover Transform Scale, and any manually authored opacity, stopped working once an interaction was applied.

The editor preview already clears these styles when an animation completes. This adds the same cleanup to the frontend handler, gated so it only runs when the finished animation state matches the CSS default (opacity 1, scale 1, x 0, y 0). Animations that intentionally end off-identity (out and scrollOut) are left untouched, so an element that should stay hidden still does.

## Test instructions
This PR can be tested by following these steps:

1. Enable the Atomic Widgets and Interactions experiments.
2. Add an atomic Button. Set Hover -> Transform -> Scale to a value above 1 (for example 1.1).
3. Add a Scale interaction on the same button (trigger Load, type In). Publish and reload the front end.
4. After the scale-in animation finishes, hover the button. Expected: the button scales on hover.
5. Repeat with a Slide-in interaction instead of Scale-in. Expected: hover scale still works after the slide finishes.
6. Set a Style -> Opacity value that is not 1 (for example 0.6) and add a Fade-in interaction. Expected: the element fades in, then returns to the authored opacity.
7. Add a Fade-out or scrollOut interaction. Expected: the element ends hidden and stays hidden. It must not jump back to visible.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #36995

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Interaction animations were leaving inline transform/opacity styles that masked CSS `:hover` rules on V4 buttons. "In" animations (fade/scale/slide in) end at identity state and should clean up; "out" animations end off-identity and must persist.

## 2. What Changed (Where)

- **interactions-shared-utils.js**: Added `shouldResetElementStyles()` to detect when animation end state matches CSS defaults
- **interactions.js**: Introduced `restoreElementStyles()` wrapper; replaced direct `element.style.transition` assignments with conditional style cleanup
- **interactions-utils.js**: Re-exported new utility function
- **Test files**: Added comprehensive test coverage for reset logic and edge cases

## 3. How It Works

After animation completes, `restoreElementStyles()` checks if final keyframe state equals CSS defaults via `shouldResetElementStyles()`. If true, it schedules a rAF to call `resetElementStyles()` (which clears inline transform/opacity), then restores any authored transition to prevent loss of intentional inline styles. "Out" animations skip cleanup since their end state is off-identity.

## 4. Risks

Minimal—change is additive with feature-flag semantics (only resets when safe). rAF scheduling ensures no FOUC. Existing transition restoration preserves authored styles. Test coverage validates both "in" (should reset) and "out" (should not) cases.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
