### PR TITLE
Fix: Show custom CSS section in default styles panel [ED-25259]

### DIFF
--- a/packages/packages/core/editor-default-styles/src/__tests__/default-styles-tab-embedded.test.tsx
+++ b/packages/packages/core/editor-default-styles/src/__tests__/default-styles-tab-embedded.test.tsx
@@ -22,6 +22,7 @@ jest.mock( '@elementor/editor-editing-panel', () => ( {
 	StyleInheritanceProvider: ( { children }: React.PropsWithChildren ) => children,
 	StyleProvider: ( { children }: React.PropsWithChildren ) => children,
 	StyleSections: () => null,
+	StyleTabSlot: () => null,
 } ) );
 
 jest.mock( '@elementor/editor-responsive', () => ( {

--- a/packages/packages/core/editor-default-styles/src/components/default-styles-tab-embedded.tsx
+++ b/packages/packages/core/editor-default-styles/src/components/default-styles-tab-embedded.tsx
@@ -14,6 +14,7 @@ import {
 	StyleInheritanceProvider,
 	StyleProvider,
 	StyleSections,
+	StyleTabSlot,
 } from '@elementor/editor-editing-panel';
 import { type Element, type ElementType } from '@elementor/editor-elements';
 import { useActiveBreakpoint } from '@elementor/editor-responsive';
@@ -211,6 +212,7 @@ export function DefaultStylesTabEmbedded( { onRequestClose, onExposeCloseAttempt
 												<StyleInheritanceProvider>
 													<SectionsList>
 														<StyleSections />
+														<StyleTabSlot />
 													</SectionsList>
 													<Box
 														sx={ {

--- a/packages/packages/core/editor-editing-panel/src/index.ts
+++ b/packages/packages/core/editor-editing-panel/src/index.ts
@@ -16,7 +16,7 @@ export { SectionsList } from './components/sections-list';
 export { SettingsControl } from './components/settings-control';
 export { SettingsField } from './controls-registry/settings-field';
 export { StyleIndicator } from './components/style-indicator';
-export { injectIntoStyleTab } from './components/style-tab';
+export { injectIntoStyleTab, StyleTabSlot } from './components/style-tab';
 export { StyleSections } from './components/style-sections';
 export {
 	STYLE_SECTION_NAMES,


### PR DESCRIPTION
## Summary

- Render `StyleTabSlot` in the Default Styles panel so injected style-tab sections appear in Design System → Defaults.
- Export `StyleTabSlot` from `@elementor/editor-editing-panel` for reuse outside the element Style tab.
- With Pro (`atomic-custom-css`), users get the real Custom CSS editor; without Pro, the existing promotion section is shown (same as the element Style tab).

## Root cause

Custom CSS is registered via `injectIntoStyleTab` and rendered through `StyleTabSlot` in the element Style tab. The Default Styles panel only rendered `StyleSections`, so the injection slot was never mounted.

## Test plan

- [ ] Open Design System → Defaults → Custom CSS section appears at the bottom of the style sections
- [ ] With Pro: edit and save custom CSS for a tag (e.g. H1), reload → value persists
- [ ] Without Pro: promotion section appears instead of the editor
- [ ] Element Style tab Custom CSS behavior unchanged

## Jira

ED-25259
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Custom CSS section wasn't rendering in the default styles panel. This exposes the `StyleTabSlot` component as a public export to allow custom content injection into the style editing interface.

## 2. What Changed (Where)

- **editor-default-styles**: Added `StyleTabSlot` to style sections rendering pipeline
- **editor-editing-panel**: Exported `StyleTabSlot` alongside existing `injectIntoStyleTab` injection utility
- **Tests**: Mocked `StyleTabSlot` in test suite for consistency

## 3. How It Works

`StyleTabSlot` acts as a render target within the style sections hierarchy. Callers use `injectIntoStyleTab` to populate content that renders at this slot's location, enabling extensible custom CSS UI without modifying core components.

## 4. Risks

None identified. Backward compatible—`injectIntoStyleTab` remains unchanged; `StyleTabSlot` is additive to the export surface.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
