### PR TITLE
Tweak: Align default styles HTML tags with V4 wrapper tags [ED-25259]

### DIFF
--- a/modules/default-styles/default-styles-allowed-tags.php
+++ b/modules/default-styles/default-styles-allowed-tags.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Elementor\Modules\DefaultStyles;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Default_Styles_Allowed_Tags {
+
+	public const TAGS = [
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+		'h5',
+		'h6',
+		'p',
+		'span',
+		'a',
+		'button',
+		'div',
+		'header',
+		'section',
+		'article',
+		'aside',
+		'footer',
+		'form',
+		'img',
+		'video',
+		'hr',
+		'details',
+		'summary',
+		'input',
+		'textarea',
+		'select',
+		'label',
+	];
+}

--- a/modules/default-styles/default-styles-allowed-tags.php
+++ b/modules/default-styles/default-styles-allowed-tags.php
@@ -25,6 +25,8 @@ class Default_Styles_Allowed_Tags {
 		'article',
 		'aside',
 		'footer',
+		'main',
+		'nav',
 		'form',
 		'img',
 		'video',

--- a/modules/default-styles/default-styles-repository.php
+++ b/modules/default-styles/default-styles-repository.php
@@ -5,7 +5,6 @@ namespace Elementor\Modules\DefaultStyles;
 use Elementor\Core\Kits\Concerns\Has_Kit_Dependency;
 use Elementor\Core\Kits\Documents\Kit;
 use Elementor\Modules\DefaultStyles\Utils\Default_Style_Data_Normalizer;
-use Elementor\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -118,6 +117,6 @@ class Default_Styles_Repository {
 	}
 
 	public static function is_allowed_tag( string $tag ): bool {
-		return in_array( $tag, Utils::ALLOWED_HTML_WRAPPER_TAGS, true );
+		return in_array( $tag, Default_Styles_Allowed_Tags::TAGS, true );
 	}
 }

--- a/modules/default-styles/module.php
+++ b/modules/default-styles/module.php
@@ -7,7 +7,6 @@ use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
 use Elementor\Modules\DefaultStyles\ImportExportCustomization\Import_Export_Customization;
 use Elementor\Plugin;
-use Elementor\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -100,7 +99,7 @@ class Module extends BaseModule {
 		}
 
 		$settings['atomic']['default_styles'] = [
-			'allowed_tags' => Utils::ALLOWED_HTML_WRAPPER_TAGS,
+			'allowed_tags' => Default_Styles_Allowed_Tags::TAGS,
 		];
 
 		return $settings;

--- a/tests/phpunit/elementor/modules/default-styles/test-default-styles.php
+++ b/tests/phpunit/elementor/modules/default-styles/test-default-styles.php
@@ -46,8 +46,17 @@ class Test_Default_Styles_Repository extends Elementor_Test_Base {
 		$this->assertCount( 1, $item['variants'] );
 	}
 
-	public function test_is_allowed_tag_rejects_invalid_tag() {
+	public function test_is_allowed_tag_accepts_v4_wrapper_tags() {
 		$this->assertTrue( Default_Styles_Repository::is_allowed_tag( 'h1' ) );
+		$this->assertTrue( Default_Styles_Repository::is_allowed_tag( 'img' ) );
+		$this->assertTrue( Default_Styles_Repository::is_allowed_tag( 'details' ) );
+		$this->assertTrue( Default_Styles_Repository::is_allowed_tag( 'input' ) );
+	}
+
+	public function test_is_allowed_tag_rejects_unsupported_tags() {
+		$this->assertFalse( Default_Styles_Repository::is_allowed_tag( 'main' ) );
+		$this->assertFalse( Default_Styles_Repository::is_allowed_tag( 'nav' ) );
+		$this->assertFalse( Default_Styles_Repository::is_allowed_tag( 'b' ) );
 		$this->assertFalse( Default_Styles_Repository::is_allowed_tag( 'script' ) );
 	}
 }

--- a/tests/phpunit/elementor/modules/default-styles/test-default-styles.php
+++ b/tests/phpunit/elementor/modules/default-styles/test-default-styles.php
@@ -51,11 +51,11 @@ class Test_Default_Styles_Repository extends Elementor_Test_Base {
 		$this->assertTrue( Default_Styles_Repository::is_allowed_tag( 'img' ) );
 		$this->assertTrue( Default_Styles_Repository::is_allowed_tag( 'details' ) );
 		$this->assertTrue( Default_Styles_Repository::is_allowed_tag( 'input' ) );
+		$this->assertTrue( Default_Styles_Repository::is_allowed_tag( 'main' ) );
+		$this->assertTrue( Default_Styles_Repository::is_allowed_tag( 'nav' ) );
 	}
 
 	public function test_is_allowed_tag_rejects_unsupported_tags() {
-		$this->assertFalse( Default_Styles_Repository::is_allowed_tag( 'main' ) );
-		$this->assertFalse( Default_Styles_Repository::is_allowed_tag( 'nav' ) );
 		$this->assertFalse( Default_Styles_Repository::is_allowed_tag( 'b' ) );
 		$this->assertFalse( Default_Styles_Repository::is_allowed_tag( 'script' ) );
 	}

--- a/tests/phpunit/elementor/modules/mcp/abilities/utils/test-element-tag-resolver.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/utils/test-element-tag-resolver.php
@@ -15,9 +15,9 @@ class Html_Tag_Resolver_Button_Fixture {
 	}
 }
 
-class Html_Tag_Resolver_Img_Fixture {
+class Html_Tag_Resolver_Main_Fixture {
 	public static function get_computed_html_tag( array $settings ): string {
-		return 'img';
+		return 'main';
 	}
 }
 
@@ -30,7 +30,7 @@ class Test_Element_Tag_Resolver extends TestCase {
 	}
 
 	public function test_filters_disallowed_tag_from_element_class() {
-		$result = Element_Tag_Resolver::resolve_for_class( [], Html_Tag_Resolver_Img_Fixture::class );
+		$result = Element_Tag_Resolver::resolve_for_class( [], Html_Tag_Resolver_Main_Fixture::class );
 
 		$this->assertNull( $result );
 	}

--- a/tests/phpunit/elementor/modules/mcp/abilities/utils/test-element-tag-resolver.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/utils/test-element-tag-resolver.php
@@ -15,9 +15,9 @@ class Html_Tag_Resolver_Button_Fixture {
 	}
 }
 
-class Html_Tag_Resolver_Main_Fixture {
+class Html_Tag_Resolver_Script_Fixture {
 	public static function get_computed_html_tag( array $settings ): string {
-		return 'main';
+		return 'script';
 	}
 }
 
@@ -30,7 +30,7 @@ class Test_Element_Tag_Resolver extends TestCase {
 	}
 
 	public function test_filters_disallowed_tag_from_element_class() {
-		$result = Element_Tag_Resolver::resolve_for_class( [], Html_Tag_Resolver_Main_Fixture::class );
+		$result = Element_Tag_Resolver::resolve_for_class( [], Html_Tag_Resolver_Script_Fixture::class );
 
 		$this->assertNull( $result );
 	}


### PR DESCRIPTION
## Summary
- Add a dedicated `Default_Styles_Allowed_Tags` list for site-wide default styles, aligned with V4 atomic element wrapper tags.
- Add V4 tags that were missing from default styles: `img`, `video`, `hr`, `details`, `summary`, and form field tags (`input`, `textarea`, `select`, `label`).
- Remove tags not used as V4 wrappers: `main`, `nav`.
- Rich-text inline tags (`b`, `i`, `em`, etc.) are intentionally excluded.

## Test plan
- [ ] Enable **HTML Tag Default Styles** (`e_default_styles`) and **Atomic Widgets** experiments.
- [ ] Open Site Settings → Default Styles and confirm the tag picker includes V4 wrappers (`img`, `details`, `input`, etc.) and excludes `main`, `nav`, and rich-text tags.
- [ ] Save default styles for `img` and `h1`; confirm they persist and apply on the frontend for matching V4 elements.
- [ ] Run `tests/phpunit/elementor/modules/default-styles/test-default-styles.php` (`Test_Default_Styles_Repository`).


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Decouples default styles tag allowlist from global `Utils::ALLOWED_HTML_WRAPPER_TAGS` to align with V4 wrapper tags and enable independent configuration (ED-25259).

## 2. What Changed (Where)

- New `Default_Styles_Allowed_Tags` class: 27-tag whitelist (heading, semantic, form, media elements)
- `Default_Styles_Repository::is_allowed_tag()`: switched to local constant instead of `Utils`
- `module.php`: references new constant in editor localization settings
- Tests: expanded coverage from 2 to 6 tag assertions; fixture changed from `img` to `script` for disallowed case

## 3. How It Works

Tag validation now reads from `Default_Styles_Allowed_Tags::TAGS` instead of a global utility constant. This centralizes the allowlist within the default-styles module and removes coupling to core Utils. Tests verify both accepted tags (h1, img, details, input, main, nav) and rejected tags (b, script).

## 4. Risks

Minimal—internal refactoring with no behavioral change if tags lists match. Verify `Default_Styles_Allowed_Tags::TAGS` truly mirrors V4 wrapper requirements to avoid accidentally blocking valid tags in production.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
