### PR TITLE
Tweak: Add flexbox widget description for MCP clarity [ED-000]

### DIFF
--- a/modules/atomic-widgets/elements/flexbox/flexbox.php
+++ b/modules/atomic-widgets/elements/flexbox/flexbox.php
@@ -36,6 +36,8 @@ class Flexbox extends Atomic_Element_Base {
 		return 'e-flexbox';
 	}
 
+	public static $widget_description = 'A container (div) with flex display and flex-direction row by default.';
+
 	public static function get_element_type(): string {
 		return 'e-flexbox';
 	}


### PR DESCRIPTION
## Summary
- Add `$widget_description` to `e-flexbox` so MCP/widget schema callers know it defaults to `flex-direction: row`

## Test plan
- [ ] Confirm `elementor-list-widget-schemas` / `elementor-get-widget-schema` for `e-flexbox` includes the new description
- [ ] Verify no change to editor rendering or flexbox behavior


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding widget description metadata to Flexbox element for improved MCP (Model Context Protocol) clarity and discoverability. Straightforward documentation addition.

## 2. What Changed (Where)

- `flexbox.php`: Added `$widget_description` static property describing Flexbox as a flex container with row direction default.

## 3. How It Works

Static property exposes widget purpose to introspection tools and MCP clients without affecting runtime behavior or element initialization.

## 4. Risks

None — metadata-only change, no functional impact.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
