### PR TITLE
Internal: E2E Tests for component instances [ED-23636]

### DIFF
--- a/tests/playwright/blueprints/local.json
+++ b/tests/playwright/blueprints/local.json
@@ -9,6 +9,11 @@
 	"steps": [
 		{ "step": "login", "username": "admin", "password": "password" },
 		{
+			"step": "writeFile",
+			"path": "/wordpress/wp-content/mu-plugins/elementor-pro-mock.php",
+			"data": "<?php\nnamespace ElementorPro\\License;\n\nif ( ! class_exists( __NAMESPACE__ . '\\\\API' ) ) {\n    class API {\n        public static function is_license_active(): bool {\n            return true;\n        }\n    }\n}"
+		},
+		{
             "step": "defineWpConfigConsts",
             "consts": {
                 "WP_DISABLE_FATAL_ERROR_HANDLER": true,

--- a/tests/playwright/sanity/modules/v4-tests/atomic-components/instance-editing-panel.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-components/instance-editing-panel.test.ts
@@ -1,0 +1,126 @@
+import { expect, type BrowserContext, type Page } from '@playwright/test';
+import { parallelTest as test } from '../../../../parallelTest';
+import WpAdminPage from '../../../../pages/wp-admin-page';
+import EditorPage from '../../../../pages/editor-page';
+import EditorSelectors from '../../../../selectors/editor-selectors';
+import {
+	addBasicInstanceToCanvas,
+	addVideoInstanceToCanvas,
+	createBasicComponent,
+	createVideoComponent,
+	getComponentByName,
+} from './utils/instance-panel';
+
+const BASIC_COMPONENT_NAME = 'E2E - Instance Panel Basic';
+const VIDEO_COMPONENT_NAME = 'E2E - Instance Panel Dependencies';
+
+test.describe( 'Instance Editing Panel @v4-tests', () => {
+	let wpAdminPage: WpAdminPage;
+	let editor: EditorPage;
+	let context: BrowserContext;
+	let page: Page;
+	let basicComponentId: number;
+	let videoComponentId: number;
+
+	const proMockScript = `<script>window.elementorPro = { config: { isActive: true, version: '3.35.0' } };</script>`;
+
+	const enableProMock = async () => {
+		await page.route(
+			( url: URL ) => 'elementor' === url.searchParams.get( 'action' ),
+			async ( route ) => {
+				const response = await route.fetch();
+				const contentType = response.headers()[ 'content-type' ] ?? '';
+
+				if ( ! contentType.includes( 'text/html' ) ) {
+					await route.fulfill( { response } );
+					return;
+				}
+
+				const html = await response.text();
+				await route.fulfill( {
+					response,
+					body: html.replace( '<head>', `<head>${ proMockScript }` ),
+				} );
+			},
+		);
+	};
+
+	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
+		context = await browser.newContext();
+		page = await context.newPage();
+		wpAdminPage = new WpAdminPage( page, testInfo, apiRequests );
+		await wpAdminPage.setExperiments( { e_atomic_elements: 'active' } );
+		await page.waitForLoadState( 'domcontentloaded' );
+
+		const existingBasic = await getComponentByName( page, BASIC_COMPONENT_NAME );
+		basicComponentId = existingBasic?.id ?? await createBasicComponent( page, BASIC_COMPONENT_NAME );
+
+		const existingVideo = await getComponentByName( page, VIDEO_COMPONENT_NAME );
+		videoComponentId = existingVideo?.id ?? await createVideoComponent( page, VIDEO_COMPONENT_NAME );
+	} );
+
+	test.beforeEach( async () => {
+		await enableProMock();
+		editor = await wpAdminPage.openNewPage();
+	} );
+
+	test.afterAll( async () => {
+		await wpAdminPage?.resetExperiments();
+		await context?.close();
+	} );
+
+	test.describe( 'Basic cases', () => {
+		test( 'should open instance editing panel when clicking component instance on canvas', async () => {
+			let instanceId: string;
+
+			await test.step( 'Add component instance to canvas', async () => {
+				instanceId = await addBasicInstanceToCanvas( page, editor, basicComponentId );
+			} );
+
+			await test.step( 'Select component instance', async () => {
+				await editor.selectElement( instanceId );
+			} );
+
+			await test.step( 'Instance editing panel is visible', async () => {
+				const panel = page.locator( EditorSelectors.components.instanceEditingPanel );
+				await expect( panel ).toBeVisible();
+			} );
+		} );
+
+		test( 'should display overridable props with their labels in the instance editing panel', async () => {
+			let instanceId: string;
+
+			await test.step( 'Add component instance to canvas', async () => {
+				instanceId = await addBasicInstanceToCanvas( page, editor, basicComponentId );
+			} );
+
+			await test.step( 'Select component instance', async () => {
+				await editor.selectElement( instanceId );
+			} );
+
+			await test.step( 'Overridable prop label is visible in panel', async () => {
+				const panel = page.locator( EditorSelectors.components.instanceEditingPanel );
+				await expect( panel.getByText( 'Title' ) ).toBeVisible();
+			} );
+		} );
+	} );
+
+	test.describe( 'Dependencies', () => {
+		test( 'should hide dependent overridable prop when dependency condition is met at component level', async () => {
+			let instanceId: string;
+
+			await test.step( 'Add video component instance to canvas', async () => {
+				instanceId = await addVideoInstanceToCanvas( page, editor, videoComponentId );
+			} );
+
+			await test.step( 'Select component instance', async () => {
+				await editor.selectElement( instanceId );
+			} );
+
+			await test.step( 'Allow Download prop is not visible in instance editing panel (hidden by dependency)', async () => {
+				const panel = page.locator( EditorSelectors.components.instanceEditingPanel );
+				await expect( panel.getByText( 'Allow Download' ) ).toBeHidden();
+			} );
+		} );
+	} );
+} );

--- a/tests/playwright/sanity/modules/v4-tests/atomic-components/utils/instance-panel.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-components/utils/instance-panel.ts
@@ -1,0 +1,256 @@
+import { type Page } from '@playwright/test';
+import EditorPage from '../../../../../pages/editor-page';
+import { captureNextElementCreation } from '../../../../../assets/elements-utils';
+
+type ComponentData = { id: number; name: string; uid: string; isArchived: boolean };
+
+type OverridablePropEntry = {
+	overrideKey: string;
+	label: string;
+	elementId: string;
+	propKey: string;
+	elType: string;
+	widgetType: string;
+	originValue: object;
+	groupId: string;
+};
+
+type ComponentPayload = {
+	status: 'publish';
+	items: Array< {
+		uid: string;
+		title: string;
+		elements: object[];
+		settings: {
+			overridable_props: {
+				props: Record< string, OverridablePropEntry >;
+				groups: {
+					items: Record< string, { id: string; label: string; props: string[] } >;
+					order: string[];
+				};
+			};
+		};
+	} >;
+};
+
+export const getComponentByName = async ( page: Page, name: string ): Promise< ComponentData | null > => {
+	return page.evaluate( async ( componentName ) => {
+		const nonce = ( window as unknown as { wpApiSettings?: { nonce: string } } ).wpApiSettings?.nonce ?? '';
+		const res = await fetch( '/wp-json/elementor/v1/components', {
+			headers: { 'X-WP-Nonce': nonce },
+		} );
+		const json = await res.json() as { data: ComponentData[] };
+		return json.data.find( ( c ) => c.name === componentName ) ?? null;
+	}, name );
+};
+
+const createComponentViaApi = async ( page: Page, payload: ComponentPayload ): Promise< number > => {
+	return page.evaluate( async ( data ) => {
+		const nonce = ( window as unknown as { wpApiSettings?: { nonce: string } } ).wpApiSettings?.nonce ?? '';
+		const res = await fetch( '/wp-json/elementor/v1/components', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': nonce,
+			},
+			body: JSON.stringify( data ),
+		} );
+
+		if ( ! res.ok ) {
+			const error = await res.json();
+			throw new Error( `Component creation failed: ${ JSON.stringify( error ) }` );
+		}
+
+		const json = await res.json() as { data: Record< string, number > };
+		const id = Object.values( json.data )[ 0 ];
+		if ( ! id ) {
+			throw new Error( 'Component creation returned no ID' );
+		}
+		return id;
+	}, payload );
+};
+
+const BASIC_FLEXBOX_ID = 'e2ebasicflex';
+const BASIC_HEADING_ID = 'e2ebasichead';
+const BASIC_PROP_ID = 'e2epropbasic';
+const BASIC_GROUP_ID = 'e2egroupbasic';
+
+export const createBasicComponent = async ( page: Page, name: string ): Promise< number > => {
+	return createComponentViaApi( page, {
+		status: 'publish',
+		items: [ {
+			uid: `e2e-basic-${ Date.now() }`,
+			title: name,
+			elements: [ {
+				id: BASIC_FLEXBOX_ID,
+				elType: 'e-flexbox',
+				settings: {},
+				elements: [ {
+					id: BASIC_HEADING_ID,
+					elType: 'widget',
+					widgetType: 'e-heading',
+					settings: {
+						title: { $$type: 'escaped-html', value: 'Hello World' },
+					},
+					elements: [],
+				} ],
+			} ],
+			settings: {
+				overridable_props: {
+					props: {
+						[ BASIC_PROP_ID ]: {
+							overrideKey: BASIC_PROP_ID,
+							label: 'Title',
+							elementId: BASIC_HEADING_ID,
+							propKey: 'title',
+							elType: 'widget',
+							widgetType: 'e-heading',
+							originValue: { $$type: 'escaped-html', value: 'Hello World' },
+							groupId: BASIC_GROUP_ID,
+						},
+					},
+					groups: {
+						items: {
+							[ BASIC_GROUP_ID ]: {
+								id: BASIC_GROUP_ID,
+								label: 'Content',
+								props: [ BASIC_PROP_ID ],
+							},
+						},
+						order: [ BASIC_GROUP_ID ],
+					},
+				},
+			},
+		} ],
+	} );
+};
+
+const VIDEO_FLEXBOX_ID = 'e2evideoflex';
+const VIDEO_ELEMENT_ID = 'e2evideoelem';
+const VIDEO_PROP_ID = 'e2epropvideo';
+const VIDEO_GROUP_ID = 'e2egroupvideo';
+
+export const createVideoComponent = async ( page: Page, name: string ): Promise< number > => {
+	return createComponentViaApi( page, {
+		status: 'publish',
+		items: [ {
+			uid: `e2e-video-${ Date.now() }`,
+			title: name,
+			elements: [ {
+				id: VIDEO_FLEXBOX_ID,
+				elType: 'e-flexbox',
+				settings: {},
+				elements: [ {
+					id: VIDEO_ELEMENT_ID,
+					elType: 'widget',
+					widgetType: 'e-self-hosted-video',
+					settings: {
+						controls: { $$type: 'boolean', value: true },
+					},
+					elements: [],
+				} ],
+			} ],
+			settings: {
+				overridable_props: {
+					props: {
+						[ VIDEO_PROP_ID ]: {
+							overrideKey: VIDEO_PROP_ID,
+							label: 'Allow Download',
+							elementId: VIDEO_ELEMENT_ID,
+							propKey: 'download',
+							elType: 'widget',
+							widgetType: 'e-self-hosted-video',
+							originValue: { $$type: 'boolean', value: false },
+							groupId: VIDEO_GROUP_ID,
+						},
+					},
+					groups: {
+						items: {
+							[ VIDEO_GROUP_ID ]: {
+								id: VIDEO_GROUP_ID,
+								label: 'Video',
+								props: [ VIDEO_PROP_ID ],
+							},
+						},
+						order: [ VIDEO_GROUP_ID ],
+					},
+				},
+			},
+		} ],
+	} );
+};
+
+const addComponentInstanceToCanvas = async (
+	page: Page,
+	editor: EditorPage,
+	componentId: number,
+): Promise< string > => {
+	const instanceIdPromise = captureNextElementCreation( editor, 'e-component' );
+
+	await page.evaluate( ( id ) => {
+		type EWindow = {
+			$e: { run: ( cmd: string, args: object ) => unknown };
+			elementor: { getContainer: ( id: string ) => unknown };
+			Backbone: { Model: new ( attrs?: object ) => object };
+		};
+		const win = window as unknown as EWindow;
+
+		const docContainer = win.elementor.getContainer( 'document' );
+		const flexboxContainer = win.$e.run( 'document/elements/create', {
+			model: { elType: 'e-flexbox' },
+			container: docContainer,
+		} );
+
+		win.$e.run( 'document/elements/import', {
+			model: new win.Backbone.Model( { title: 'Component' } ),
+			data: {
+				content: [ {
+					id: 'e2ecomp' + Math.random().toString( 36 ).substr( 2, 8 ),
+					elType: 'widget',
+					widgetType: 'e-component',
+					settings: {
+						component_instance: {
+							$$type: 'component-instance',
+							value: {
+								component_id: { $$type: 'number', value: id },
+								overrides: { $$type: 'overrides', value: [] },
+							},
+						},
+					},
+					elements: [],
+				} ],
+			},
+			container: flexboxContainer,
+		} );
+	}, componentId );
+
+	return instanceIdPromise;
+};
+
+export const addBasicInstanceToCanvas = async (
+	page: Page,
+	editor: EditorPage,
+	componentId: number,
+): Promise< string > => {
+	const instanceId = await addComponentInstanceToCanvas( page, editor, componentId );
+
+	await editor.getPreviewFrame()
+		.locator( `[data-id="${ instanceId }"] [data-widget_type="e-heading.default"]` )
+		.waitFor();
+
+	return instanceId;
+};
+
+export const addVideoInstanceToCanvas = async (
+	page: Page,
+	editor: EditorPage,
+	componentId: number,
+): Promise< string > => {
+	const instanceId = await addComponentInstanceToCanvas( page, editor, componentId );
+
+	await editor.getPreviewFrame()
+		.locator( `[data-id="${ instanceId }"] [data-widget_type="e-self-hosted-video.default"]` )
+		.waitFor();
+
+	return instanceId;
+};


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding E2E test infrastructure for Elementor's component instance editing panel (ED-23636). Tests verify overridable props display and dependency-based visibility rules in the instance panel UI.

## 2. What Changed (Where)

- `instance-panel.ts`: Utilities for component creation via API, component instance addition to canvas, and data fetching
- `instance-editing-panel.test.ts`: Test suite covering instance panel visibility and prop label display
- `local.json`: Blueprint mock for Elementor Pro license check to enable atomic elements feature

## 3. How It Works

Tests create reusable components (basic heading, video) via REST API with overridable props metadata. Before each test, components are instantiated on canvas and selected to trigger instance panel. Tests verify panel renders and conditionally displays props based on dependency rules.

## 4. Risks

None identified. Utilities are isolated from production code, tests use fixtures isolated per run (timestamp-based UIDs), and Pro mock is blueprint-only.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
