### PR TITLE
Fix: Register list-components MCP ability unconditionally [ED-25344]

### DIFF
--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -6,7 +6,6 @@ use Elementor\Core\Base\Module as BaseModule;
 use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\MCP\Composer\Mcp\Registry as Shared_Registry;
 use Elementor\Plugin;
-use Elementor\Modules\Components\Module as Components_Module;
 use Elementor\Modules\EditorOne\Classes\Menu_Data_Provider;
 use Elementor\Modules\Mcp\Abilities\Abstract_Ability;
 use Elementor\Modules\Mcp\AdminMenuItems\Editor_One_Mcp_Menu;
@@ -152,17 +151,10 @@ class Module extends BaseModule {
 			new Abilities\Interactions_Schema_Resource_Ability(),
 			new Abilities\List_Resources_Ability( $registry ),
 			new Abilities\Read_Resource_Ability( $registry ),
+			new Abilities\List_Components_Ability(),
 		];
 
-		if ( self::is_components_active() ) {
-			$abilities[] = new Abilities\List_Components_Ability();
-		}
-
 		return $abilities;
-	}
-
-	private static function is_components_active(): bool {
-		return class_exists( Components_Module::class ) && Components_Module::is_experiment_active();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Register `List_Components_Ability` unconditionally in the MCP core registry
- Remove the construction-time `is_components_active()` gate that always evaluated to false

## Problem

`elementor/list-components` never registered because MCP builds its ability registry in the module constructor, before `atomic-widgets` registers the `e_atomic_elements` experiment. The `is_components_active()` check always returned false regardless of experiment settings.

## Test plan

- [x] `vendor/bin/phpunit --filter Test_List_Components_Ability` (12 tests)
- [x] `vendor/bin/phpunit --filter 'Test_Shared_Registry_Bridge|Test_Mcp_Proxy_REST_API'` (20 tests)
- [ ] Confirm `elementor/list-components` appears in MCP abilities when atomic elements is enabled

Fixes ED-25344

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

List_Components_Ability should be available unconditionally in MCP, not gated behind a Components module experiment flag (ED-25344). Removes experiment-dependent initialization logic to ensure consistent ability registration.

## 2. What Changed (Where)

- `modules/mcp/module.php`: Removed `Components_Module` import and `is_components_active()` check; moved `List_Components_Ability` instantiation into unconditional abilities array.

## 3. How It Works

Ability registration now happens directly in the main abilities list construction without conditional logic. The removed `is_components_active()` method checked if Components module existed and its experiment was active—this gate is eliminated entirely.

## 4. Risks

If Components_Ability has unmet dependencies (requires Components module at runtime), registering it unconditionally could cause initialization failures. Verify List_Components_Ability gracefully handles absence of underlying Components infrastructure.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
