### PR TITLE
Internal: Prefer V4 dynamic tags over V3 post widgets in MCP [ED-25343]

### DIFF
--- a/modules/mcp/abilities/appliers/v3/v3-widget-bridge-registry.php
+++ b/modules/mcp/abilities/appliers/v3/v3-widget-bridge-registry.php
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class V3_Widget_Bridge_Registry {
 
 	/**
-	 * @return array{non_style_keys: string[], style_overrides: array<string, array>}|null
+	 * @return array{non_style_keys: string[], style_overrides: array<string, array>, description?: string}|null
 	 */
 	public static function get( string $widget_type ): ?array {
 		$entries = self::entries();
@@ -59,6 +59,13 @@ class V3_Widget_Bridge_Registry {
 		$entry = self::get( $widget_type );
 
 		return $entry['style_overrides'] ?? [];
+	}
+
+	public static function get_description( string $widget_type ): ?string {
+		$entry = self::get( $widget_type );
+		$description = $entry['description'] ?? null;
+
+		return is_string( $description ) && '' !== $description ? $description : null;
 	}
 
 	/**
@@ -148,6 +155,7 @@ class V3_Widget_Bridge_Registry {
 
 	private static function theme_post_content(): array {
 		return [
+			'description' => 'Single-template body slot only. Exactly one per single template, wrapped in an `e-div-block`. Do NOT place inside loop items, archives, headers, footers, or components — the loop already repeats the article body.',
 			'non_style_keys' => [],
 			'style_overrides' => array_merge(
 				self::typography_overrides( 'typography' ),
@@ -167,6 +175,7 @@ class V3_Widget_Bridge_Registry {
 
 	private static function theme_post_title(): array {
 		return [
+			'description' => 'Prefer `e-heading` with a `post-title` dynamic tag. Use this V3 widget only when the V4 equivalent is not viable.',
 			'non_style_keys' => [
 				'title',
 				'link',
@@ -191,6 +200,7 @@ class V3_Widget_Bridge_Registry {
 
 	private static function theme_post_excerpt(): array {
 		return [
+			'description' => 'Prefer `e-heading` or `e-paragraph` with a `post-excerpt` dynamic tag.',
 			'non_style_keys' => [
 				'excerpt',
 			],
@@ -217,6 +227,7 @@ class V3_Widget_Bridge_Registry {
 
 	private static function theme_post_featured_image(): array {
 		return [
+			'description' => 'Prefer `e-image` with a `featured-image` dynamic tag on `src`. Use this V3 widget only when the V4 equivalent is not viable.',
 			'non_style_keys' => [
 				'image',
 				'image_size',

--- a/modules/mcp/abilities/utils/widget-context-helper.php
+++ b/modules/mcp/abilities/utils/widget-context-helper.php
@@ -114,7 +114,7 @@ class Widget_Context_Helper {
 		return self::filter_nulls( [
 			'type' => $widget_type,
 			'version' => self::get_widget_version( $config ),
-			'description' => self::get_description( $config ),
+			'description' => self::get_description( $config, $widget_type ),
 		] );
 	}
 
@@ -155,15 +155,16 @@ class Widget_Context_Helper {
 			$allowed_keys = V3_Widget_Bridge_Registry::get_non_style_keys( $widget_type );
 			$built = V3_Json_Schema_Builder::build( $config['controls'], $allowed_keys );
 
-			return [
+			return self::filter_nulls( [
 				'type' => 'object',
 				'widget_version' => self::VERSION_V3,
+				'description' => self::get_description( $config, $widget_type ),
 				'message' => self::V3_FALLBACK_MESSAGE,
 				'fields_note' => self::V3_FALLBACK_FIELDS_NOTE,
 				'properties' => $built['properties'],
 				'required' => $built['required'],
 				'additionalProperties' => false,
-			];
+			] );
 		}
 
 		$properties = self::build_configurable_properties_schema( $props_schema );
@@ -171,7 +172,7 @@ class Widget_Context_Helper {
 		return self::filter_nulls( [
 			'type' => 'object',
 			'properties' => $properties,
-			'description' => self::get_description( $config ),
+			'description' => self::get_description( $config, $widget_type ),
 			'llm_guidance' => Llm_Guidance_Builder::build( $config, $widget_type, $parents_index ),
 		] );
 	}
@@ -302,10 +303,18 @@ class Widget_Context_Helper {
 		return (bool) $prop_type->get_meta_item( 'llm_configurable', false );
 	}
 
-	private static function get_description( array $config ): ?string {
+	private static function get_description( array $config, ?string $widget_type = null ): ?string {
 		$description = $config['meta']['description'] ?? null;
 
-		return is_string( $description ) ? $description : null;
+		if ( is_string( $description ) && '' !== $description ) {
+			return $description;
+		}
+
+		if ( null !== $widget_type && self::is_v3_allowlisted( $widget_type ) ) {
+			return V3_Widget_Bridge_Registry::get_description( $widget_type );
+		}
+
+		return null;
 	}
 
 	private static function filter_nulls( array $data ): array {

--- a/modules/mcp/static-resources/wordpress/best-practices.md
+++ b/modules/mcp/static-resources/wordpress/best-practices.md
@@ -2,6 +2,9 @@
 
 Opinionated guidance for building WordPress sites with Elementor via MCP. Load before making structural decisions about pages, posts, and theme templates.
 
+## Widget selection: V4 + dynamic tag over V3 post-* widgets
+Title, featured image, excerpt, price, meta, CTA link → V4 widget (`e-heading`, `e-image`, `e-paragraph`, `e-button`) + a dynamic tag from [elementor://dynamic-tags]. Do NOT use the V3 `theme-post-title` / `theme-post-featured-image` / `theme-post-excerpt` widgets when a V4 + dynamic tag combination works — reserve them for cases where the V4 equivalent is not viable. This applies everywhere: singles, archives, loop items, and standalone pages.
+
 ## Repeating layouts / detail pages
 When the user describes a design that repeats across posts or pages ("each project", "the product detail page", "make every blog post look like this", "each item links to a page like this"), that is ONE `single` / `single-<cpt>` template driven by dynamic data — NOT N duplicated pages. Never loop `elementor/manage-site-parts` `action: create` to make one page per item.
 
@@ -27,6 +30,7 @@ Every single template has one optional editorial slot: a `theme-post-content` wi
 
 - Wrap with `e-div-block`, NOT `e-flexbox` — a row-direction default would squeeze the article body. Style the wrapper's `max-width` / `padding`.
 - Exactly one `theme-post-content` per single template.
+- `theme-post-content` is for the single-template body slot ONLY — never place it inside a loop item, archive, header, footer, or reusable component; the surrounding loop already repeats the article body.
 
 ### Dynamic tags for the rest
 Title, featured image, excerpt, meta, price, CTA link all use dynamic tags on regular widgets (`e-heading` title, `e-image` src, `e-button` link). Read [elementor://dynamic-tags] for allowed tag names. Do NOT hard-code per-post values — the same template renders every post.

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-non-style-allowlist.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-non-style-allowlist.php
@@ -87,7 +87,7 @@ class Test_V3_Non_Style_Allowlist extends TestCase {
 		$description = V3_Widget_Bridge_Registry::get_description( 'theme-post-content' );
 
 		$this->assertNotNull( $description );
-		$this->assertStringContainsString( 'single-template', $description );
+		$this->assertStringContainsStringIgnoringCase( 'single-template', $description );
 		$this->assertStringContainsString( 'loop', $description );
 	}
 

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-non-style-allowlist.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-non-style-allowlist.php
@@ -72,4 +72,31 @@ class Test_V3_Non_Style_Allowlist extends TestCase {
 			$this->assertIsArray( V3_Widget_Bridge_Registry::get_style_overrides( $type ) );
 		}
 	}
+
+	public function test_get_description__returns_v4_preference_hint_for_post_widgets() {
+		$this->assertStringContainsString( 'e-heading', V3_Widget_Bridge_Registry::get_description( 'theme-post-title' ) );
+		$this->assertStringContainsString( 'post-title', V3_Widget_Bridge_Registry::get_description( 'theme-post-title' ) );
+
+		$this->assertStringContainsString( 'e-image', V3_Widget_Bridge_Registry::get_description( 'theme-post-featured-image' ) );
+		$this->assertStringContainsString( 'featured-image', V3_Widget_Bridge_Registry::get_description( 'theme-post-featured-image' ) );
+
+		$this->assertStringContainsString( 'post-excerpt', V3_Widget_Bridge_Registry::get_description( 'theme-post-excerpt' ) );
+	}
+
+	public function test_get_description__theme_post_content_forbids_loop_placement() {
+		$description = V3_Widget_Bridge_Registry::get_description( 'theme-post-content' );
+
+		$this->assertNotNull( $description );
+		$this->assertStringContainsString( 'single-template', $description );
+		$this->assertStringContainsString( 'loop', $description );
+	}
+
+	public function test_get_description__nav_menu_and_archive_title_have_no_v4_hint() {
+		$this->assertNull( V3_Widget_Bridge_Registry::get_description( 'nav-menu' ) );
+		$this->assertNull( V3_Widget_Bridge_Registry::get_description( 'theme-archive-title' ) );
+	}
+
+	public function test_get_description__unknown_widget_returns_null() {
+		$this->assertNull( V3_Widget_Bridge_Registry::get_description( 'unknown-widget' ) );
+	}
 }

--- a/tests/phpunit/elementor/modules/mcp/test-list-widget-schemas-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-list-widget-schemas-ability.php
@@ -69,7 +69,7 @@ class Test_List_Widget_Schemas_Ability extends Elementor_Test_Base {
 		$this->assertStringContainsString( 'e-heading', $descriptions_by_type['theme-post-title'] );
 		$this->assertStringContainsString( 'e-image', $descriptions_by_type['theme-post-featured-image'] );
 		$this->assertStringContainsString( 'post-excerpt', $descriptions_by_type['theme-post-excerpt'] );
-		$this->assertStringContainsString( 'single-template', $descriptions_by_type['theme-post-content'] );
+		$this->assertStringContainsStringIgnoringCase( 'single-template', $descriptions_by_type['theme-post-content'] );
 		$this->assertStringContainsString( 'loop', $descriptions_by_type['theme-post-content'] );
 	}
 

--- a/tests/phpunit/elementor/modules/mcp/test-list-widget-schemas-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-list-widget-schemas-ability.php
@@ -50,6 +50,41 @@ class Test_List_Widget_Schemas_Ability extends Elementor_Test_Base {
 		$this->assertArrayNotHasKey( 'fake-v3', $result );
 	}
 
+	public function test_execute__summary_falls_back_to_registry_description_for_v3_post_widgets() {
+		$this->act_as_admin();
+		$this->given_widget_manager_with_v3_widgets_no_description( [
+			'theme-post-title' => [ 'title' => [ 'type' => 'text' ] ],
+			'theme-post-featured-image' => [ 'image' => [ 'type' => 'media' ] ],
+			'theme-post-excerpt' => [ 'excerpt' => [ 'type' => 'text' ] ],
+			'theme-post-content' => [ 'align' => [ 'type' => 'select' ] ],
+		] );
+
+		$result = $this->ability->execute( [ 'summary' => true ] );
+
+		$descriptions_by_type = [];
+		foreach ( $result['widgets'] as $summary ) {
+			$descriptions_by_type[ $summary['type'] ] = $summary['description'] ?? null;
+		}
+
+		$this->assertStringContainsString( 'e-heading', $descriptions_by_type['theme-post-title'] );
+		$this->assertStringContainsString( 'e-image', $descriptions_by_type['theme-post-featured-image'] );
+		$this->assertStringContainsString( 'post-excerpt', $descriptions_by_type['theme-post-excerpt'] );
+		$this->assertStringContainsString( 'single-template', $descriptions_by_type['theme-post-content'] );
+		$this->assertStringContainsString( 'loop', $descriptions_by_type['theme-post-content'] );
+	}
+
+	public function test_execute__schema_falls_back_to_registry_description_for_v3_post_widgets() {
+		$this->act_as_admin();
+		$this->given_widget_manager_with_v3_widgets_no_description( [
+			'theme-post-title' => [ 'title' => [ 'type' => 'text' ] ],
+		] );
+
+		$result = $this->ability->execute( [] );
+
+		$this->assertArrayHasKey( 'theme-post-title', $result );
+		$this->assertStringContainsString( 'e-heading', $result['theme-post-title']['description'] );
+	}
+
 	public function test_execute__summary_includes_allowlisted_v3_type() {
 		$this->act_as_admin();
 		$this->given_widget_manager_with_v3_widgets( [
@@ -70,23 +105,34 @@ class Test_List_Widget_Schemas_Ability extends Elementor_Test_Base {
 	/**
 	 * @param array<string, array> $widgets_by_type widget_type => controls
 	 */
-	private function given_widget_manager_with_v3_widgets( array $widgets_by_type ): void {
+	private function given_widget_manager_with_v3_widgets_no_description( array $widgets_by_type ): void {
+		$this->given_widget_manager_with_v3_widgets( $widgets_by_type, null );
+	}
+
+	/**
+	 * @param array<string, array> $widgets_by_type widget_type => controls
+	 */
+	private function given_widget_manager_with_v3_widgets( array $widgets_by_type, ?string $description = 'Fake V3 widget' ): void {
 		$instances = [];
 
 		foreach ( $widgets_by_type as $type => $controls ) {
-			$instances[ $type ] = new class( $controls ) {
+			$instances[ $type ] = new class( $controls, $description ) {
 				private array $controls;
+				private ?string $description;
 
-				public function __construct( array $controls ) {
+				public function __construct( array $controls, ?string $description ) {
 					$this->controls = $controls;
+					$this->description = $description;
 				}
 
 				public function get_config(): array {
+					$meta = null === $this->description ? [] : [ 'description' => $this->description ];
+
 					return [
 						'controls' => $this->controls,
 						'atomic_props_schema' => null,
 						'title' => 'Fake V3',
-						'meta' => [ 'description' => 'Fake V3 widget' ],
+						'meta' => $meta,
 					];
 				}
 			};

--- a/tests/phpunit/elementor/modules/mcp/test-wordpress-best-practices-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-wordpress-best-practices-ability.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp;
+
+use Elementor\Modules\Mcp\Abilities\Wordpress_Best_Practices_Ability;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Locks in the LLM-facing phrasing that steers widget selection away from V3
+ * post-* widgets and keeps `theme-post-content` out of loop items.
+ *
+ * @group Elementor\Modules\Mcp
+ */
+class Test_Wordpress_Best_Practices_Ability extends TestCase {
+
+	public function test_execute__pushes_v4_plus_dynamic_tag_over_v3_post_widgets() {
+		$ability = new Wordpress_Best_Practices_Ability();
+
+		$content = $ability->execute();
+
+		$this->assertIsString( $content );
+		$this->assertStringContainsString( 'theme-post-title', $content );
+		$this->assertStringContainsString( 'theme-post-featured-image', $content );
+		$this->assertStringContainsString( 'theme-post-excerpt', $content );
+		$this->assertStringContainsString( 'e-heading', $content );
+		$this->assertStringContainsString( 'e-image', $content );
+	}
+
+	public function test_execute__forbids_theme_post_content_inside_loop_items() {
+		$ability = new Wordpress_Best_Practices_Ability();
+
+		$content = $ability->execute();
+
+		$this->assertStringContainsString( 'single-template body slot', $content );
+		$this->assertStringContainsString( 'loop item', $content );
+	}
+}


### PR DESCRIPTION
## Summary
- Add per-widget V4-preference hints to the V3 bridge registry, surfaced in `list-widget-schemas` summaries and schemas so the LLM sees "prefer `e-heading` + `post-title` dynamic tag" instead of bare `theme-post-title`
- Tighten `wordpress/best-practices.md` to prefer V4 + dynamic tags over V3 post-* widgets, and restrict `theme-post-content` to the single-template body slot (not loop items)

## Test plan
- [ ] `tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-non-style-allowlist.php`
- [ ] `tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/mcp/test-wordpress-best-practices-ability.php`
- [ ] Ask MCP to build a post loop — should use `e-heading`/`e-image` + dynamic tags, not V3 post widgets
- [ ] Ask MCP to build a single template — should place exactly one `theme-post-content` in the body slot, not inside loop items


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
ED-25343: LLMs lack guidance to prefer modern V4 widgets with dynamic tags over legacy V3 post widgets, leading to suboptimal widget selection in MCP.

## 2. What Changed (Where)
| File | Change |
| :--- | :--- |
| `v3-widget-bridge-registry.php` | Added `description` field to registry and getter method. |
| `widget-context-helper.php` | Updated `get_description` to fallback to registry hints. |
| `best-practices.md` | Added explicit V4 preference and `theme-post-content` placement rules. |
| `tests/...` | Added unit tests for registry descriptions and best practices. |

## 3. How It Works
`Widget_Context_Helper` now attempts to resolve a widget's description from its config; if missing, it queries `V3_Widget_Bridge_Registry` for preference hints (e.g., "Prefer e-heading with post-title dynamic tag") before returning null.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
