### PR TITLE
Fix: Prevent conversion banner from displacing Add Plugin button [ED-25354]

### DIFF
--- a/modules/promotions/conversion-banner.php
+++ b/modules/promotions/conversion-banner.php
@@ -249,6 +249,7 @@ class Conversion_Banner {
 
 	private function get_allowed_admin_pages(): array {
 		$default = [ 'selector' => self::DEFAULT_SELECTOR ];
+		$plugin_pages = [ 'selector' => '.wrap hr.wp-header-end' ];
 
 		return [
 			'dashboard' => [ 'selector' => '#wpbody #wpbody-content .wrap h1' ],
@@ -279,9 +280,9 @@ class Conversion_Banner {
 			'themes' => $default,
 			'nav-menus' => $default,
 			'theme-editor' => $default,
-			'plugins' => $default,
-			'plugin-install' => $default,
-			'plugin-editor' => $default,
+			'plugins' => $plugin_pages,
+			'plugin-install' => $plugin_pages,
+			'plugin-editor' => $plugin_pages,
 		];
 	}
 }


### PR DESCRIPTION
## Summary
- Anchor the conversion banner after `.wrap hr.wp-header-end` on plugin admin screens instead of after `.wrap h1`.
- Prevents the full-width banner from inserting between the page title and the inline **Add Plugin** action button.
- Applies the same placement to `plugins`, `plugin-install`, and `plugin-editor` screens.

## Test plan
- [ ] Open **Plugins** in wp-admin without Elementor Pro active; confirm **Add Plugin** stays inline with the **Plugins** heading.
- [ ] Confirm the conversion banner renders below the header row, not between the title and action button.
- [ ] Repeat on **Add Plugin** and **Plugin Editor** screens.

## Jira
[ED-25354](https://elementor.atlassian.net/browse/ED-25354)
<img width="537" height="234" alt="image" src="https://github.com/user-attachments/assets/b872a452-a621-40e9-8557-869cbb0d9de2" />

Made with [Cursor](https://cursor.com)

[ED-25354]: https://elementor.atlassian.net/browse/ED-25354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Conversion banner was using the default selector (h1) on plugin pages, which positioned it above the "Add Plugin" button, causing layout displacement. Custom selector targets the header separator instead, preventing overlap.

## 2. What Changed (Where)

`modules/promotions/conversion-banner.php`: Introduced `$plugin_pages` selector config targeting `.wrap hr.wp-header-end`, applied to `plugins`, `plugin-install`, and `plugin-editor` pages instead of `$default`.

## 3. How It Works

Banner placement queries page-specific selectors from `get_allowed_admin_pages()`. Plugin pages now use header separator selector rather than h1, positioning banner below the action button.

## 4. Risks

None identified. Change is surgical — only affects plugin admin pages with explicit selector targeting, no broader selector precedence shifts.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
