### PR TITLE
Fix: Keep unpublished preview CSS out of the live post stylesheet

### DIFF
--- a/core/files/css/post-preview.php
+++ b/core/files/css/post-preview.php
@@ -50,6 +50,22 @@ class Post_Preview extends Post_Local_Cache {
 	}
 
 	/**
+	 * Write preview CSS to a dedicated file.
+	 *
+	 * `Post_Preview` reads element data from the autosave/draft but used to
+	 * inherit the published `post-{id}.css` path. That made editor preview
+	 * overwrite live CSS (and keep the same `?ver=`) before publish.
+	 *
+	 * @since 4.3.0
+	 * @access protected
+	 *
+	 * @return string
+	 */
+	protected function get_css_file_name() {
+		return static::FILE_PREFIX . $this->get_post_id() . '-preview.css';
+	}
+
+	/**
 	 * Get file handle ID.
 	 *
 	 * Retrieve the handle ID for the previewed post CSS file.

--- a/core/files/css/post.php
+++ b/core/files/css/post.php
@@ -55,7 +55,22 @@ class Post extends Base {
 	public function __construct( $post_id ) {
 		$this->post_id = $post_id;
 
-		parent::__construct( static::FILE_PREFIX . $post_id . '.css' );
+		parent::__construct( $this->get_css_file_name() );
+	}
+
+	/**
+	 * CSS file name written under uploads/elementor/css/.
+	 *
+	 * Preview subclasses override this so unpublished drafts never overwrite
+	 * the published stylesheet.
+	 *
+	 * @since 4.3.0
+	 * @access protected
+	 *
+	 * @return string
+	 */
+	protected function get_css_file_name() {
+		return static::FILE_PREFIX . $this->post_id . '.css';
 	}
 
 	/**

--- a/tests/phpunit/elementor/core/files/css/test-post-preview.php
+++ b/tests/phpunit/elementor/core/files/css/test-post-preview.php
@@ -1,0 +1,49 @@
+<?php
+namespace Elementor\Tests\Phpunit\Elementor\Core\Files\Css;
+
+use Elementor\Core\Files\CSS\Post;
+use Elementor\Core\Files\CSS\Post_Preview;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Post_Preview extends Elementor_Test_Base {
+
+	public function test_preview_uses_dedicated_css_file_not_published_path() {
+		// Arrange.
+		$post_id = $this->factory()->create_and_get_default_post()->ID;
+		$revision_id = $this->factory()->post->create( [
+			'post_type' => 'revision',
+			'post_parent' => $post_id,
+			'post_status' => 'inherit',
+		] );
+
+		// Act.
+		$published = new Post( $post_id );
+		$preview = new Post_Preview( $revision_id );
+
+		// Assert.
+		$this->assertSame( 'post-' . $post_id . '.css', $published->get_file_name() );
+		$this->assertSame( 'post-' . $post_id . '-preview.css', $preview->get_file_name() );
+		$this->assertNotSame(
+			$published->get_path(),
+			$preview->get_path(),
+			'Unpublished preview CSS must not share the live post stylesheet path.'
+		);
+	}
+
+	public function test_published_post_css_keeps_live_file_name() {
+		// Arrange.
+		$post_id = $this->factory()->create_and_get_default_post()->ID;
+
+		// Act.
+		$published = new Post( $post_id );
+
+		// Assert.
+		$this->assertSame( 'post-' . $post_id . '.css', $published->get_file_name() );
+		$this->assertStringEndsWith( 'post-' . $post_id . '.css', $published->get_path() );
+		$this->assertStringNotContainsString( '-preview.css', $published->get_file_name() );
+	}
+}


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines

## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Unpublished editor preview CSS no longer overwrites the live `post-{id}.css` file

## Description

When CSS Print Method is External File, `Post_Preview` reads element data from the autosave/draft but inherited the published file name from the parent post. `Base::write()` then replaced `uploads/elementor/css/post-{id}.css` with unpublished styles. The `?ver=` query arg stayed the same (preview meta is in-memory only), so the overwrite could also stick in CDN/browser caches.

Preview CSS is now written to `post-{id}-preview.css`. The published stylesheet is left untouched until the document is actually published. The editor still enqueues the preview file because the URL is derived from the same file name.

## Test instructions

1. Elementor → Settings → Advanced → set CSS Print Method to External File.
2. Create a page, add a Heading, set color `#756CDB`, Publish.
3. Confirm `wp-content/uploads/elementor/css/post-{id}.css` contains `#756CDB`.
4. Open the page in the editor, change the heading color to `#ABCDEF`. Do not publish.
5. Re-read `post-{id}.css` — it must still contain `#756CDB`.
6. Confirm a `post-{id}-preview.css` file exists with `#ABCDEF`.
7. Front-end of the published page still uses the original color.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #36851
