### PR TITLE
Fix: Print WordPress media templates on the editor footer

### DIFF
--- a/core/editor/editor.php
+++ b/core/editor/editor.php
@@ -136,6 +136,11 @@ class Editor {
 		add_action( 'wp_head', [ $this, 'editor_head_trigger' ], 30 );
 
 		// Handle `wp_footer`
+		// Re-attach core media templates after wiping `wp_footer`. `wp_enqueue_media()`
+		// hooks `wp_print_media_templates` there; if it already ran this request
+		// (or the editor loader pulls in `wp-media` without calling it), the
+		// templates never print and media-editor.js throws before bootstrap.
+		add_action( 'wp_footer', 'wp_print_media_templates', 10 );
 		add_action( 'wp_footer', 'wp_print_footer_scripts', 20 );
 		add_action( 'wp_footer', 'wp_auth_check_html', 30 );
 		add_action( 'wp_footer', [ $this, 'wp_footer' ] );

--- a/tests/phpunit/elementor/core/editor/test-editor-media-templates.php
+++ b/tests/phpunit/elementor/core/editor/test-editor-media-templates.php
@@ -1,0 +1,82 @@
+<?php
+namespace Elementor\Tests\Phpunit\Elementor\Core\Editor;
+
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Editor_Media_Templates extends Elementor_Test_Base {
+
+	/**
+	 * @var array<string, \WP_Hook>|null
+	 */
+	private $hooks_snapshot;
+
+	/**
+	 * @var array<string, int>|null
+	 */
+	private $actions_snapshot;
+
+	public function tearDown(): void {
+		$this->restore_hook_snapshot();
+		unset( $_REQUEST['post'], $_REQUEST['action'] );
+		$this->elementor()->editor->set_edit_mode( null );
+
+		parent::tearDown();
+	}
+
+	public function test_init__reattaches_media_templates_after_wiping_wp_footer() {
+		// Arrange.
+		$this->act_as_admin();
+		$post_id = $this->factory()->create_and_get_default_post()->ID;
+
+		$_REQUEST['post'] = $post_id;
+		$_REQUEST['action'] = 'elementor';
+
+		add_action( 'wp_footer', 'wp_print_media_templates', 10 );
+		$this->assertNotFalse(
+			has_action( 'wp_footer', 'wp_print_media_templates' ),
+			'Precondition: media templates are hooked before the editor wipes wp_footer.'
+		);
+
+		$this->snapshot_hooks();
+
+		// Act.
+		ob_start();
+		$this->elementor()->editor->init( false );
+		ob_end_clean();
+
+		// Assert.
+		$this->assertSame(
+			10,
+			has_action( 'wp_footer', 'wp_print_media_templates' ),
+			'Editor must re-hook wp_print_media_templates after remove_all_actions( wp_footer ).'
+		);
+		$this->assertSame( 20, has_action( 'wp_footer', 'wp_print_footer_scripts' ) );
+	}
+
+	private function snapshot_hooks() {
+		global $wp_filter, $wp_actions;
+
+		$this->hooks_snapshot = [];
+		foreach ( $wp_filter as $tag => $hook ) {
+			$this->hooks_snapshot[ $tag ] = clone $hook;
+		}
+		$this->actions_snapshot = $wp_actions;
+	}
+
+	private function restore_hook_snapshot() {
+		global $wp_filter, $wp_actions;
+
+		if ( null === $this->hooks_snapshot ) {
+			return;
+		}
+
+		$wp_filter = $this->hooks_snapshot;
+		$wp_actions = $this->actions_snapshot;
+		$this->hooks_snapshot = null;
+		$this->actions_snapshot = null;
+	}
+}


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines

## PR Type
- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Restore WordPress media templates on the editor page so the editor can bootstrap

## Description

`Editor::init()` removes every `wp_footer` callback and only re-adds `wp_print_footer_scripts`, `wp_auth_check_html`, and the editor footer. Core `wp_print_media_templates()` is not restored.

If `wp_enqueue_media()` already ran earlier in the request, or the editor loader registers `wp-media` / `media-models` without calling `wp_enqueue_media()`, the Underscore templates (`#tmpl-uploader-editor`, `#tmpl-uploader-inline`, `#tmpl-uploader-window`) never print. `media-editor.js` then throws `Template not found: #tmpl-uploader-editor` and Elementor never defines `elementorConfig`.

This re-hooks `wp_print_media_templates` on `wp_footer` at priority 10, before footer scripts.

Safe Mode being a silent no-op is out of scope here.

## Test instructions

1. WordPress 7.1, Elementor latest, Hello Elementor, no other plugins.
2. Open any page with `?action=elementor`.
3. The editor should load (no infinite overlay).
4. In the page source / DOM, `#tmpl-uploader-editor` should exist.
5. Console should not show `Template not found: #tmpl-uploader-editor`.
6. Media controls (image widget) still open the media modal.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #37026
