### PR TITLE
Fix: Two robustness bugs found while investigating Pro 4.02 vs Core main compatibility failures

### DIFF
--- a/app/assets/js/event-track/wp-dashboard-tracking.js
+++ b/app/assets/js/event-track/wp-dashboard-tracking.js
@@ -224,7 +224,7 @@ export default class WpDashboardTracking {
 	}
 
 	static isNavigatingAwayFromElementor( targetUrl ) {
-		if ( ! targetUrl ) {
+		if ( ! targetUrl || 'string' !== typeof targetUrl ) {
 			return false;
 		}
 
@@ -233,6 +233,26 @@ export default class WpDashboardTracking {
 		}
 
 		return ! this.isElementorPage( targetUrl );
+	}
+
+	/**
+	 * Get a form's submission URL as a string.
+	 *
+	 * `HTMLFormElement.action` is normally a string, but it gets shadowed by a form control
+	 * (e.g. `<input name="action">`) when the form contains a named element called "action" -
+	 * a common WordPress admin-post/admin-ajax pattern. In that case `form.action` resolves to
+	 * that element instead of the URL, so we fall back to the raw attribute.
+	 *
+	 * @param {HTMLFormElement} form
+	 *
+	 * @return {string}
+	 */
+	static getFormActionUrl( form ) {
+		if ( 'string' === typeof form.action ) {
+			return form.action;
+		}
+
+		return form.getAttribute( 'action' ) || window.location.href;
 	}
 
 	static isLinkOpeningInNewTab( link ) {
@@ -263,10 +283,12 @@ export default class WpDashboardTracking {
 
 		const handleFormSubmit = ( event ) => {
 			const form = event.target;
-			if ( form.action ) {
-				if ( ! this.sessionEnded && this.isNavigatingAwayFromElementor( form.action ) ) {
+			const targetUrl = this.getFormActionUrl( form );
+
+			if ( targetUrl ) {
+				if ( ! this.sessionEnded && this.isNavigatingAwayFromElementor( targetUrl ) ) {
 					this.trackSessionEnd( 'navigate_away' );
-				} else if ( this.isElementorPage( form.action ) ) {
+				} else if ( this.isElementorPage( targetUrl ) ) {
 					this.isNavigatingToElementor = true;
 				}
 			}

--- a/assets/dev/js/editor/editor-base.js
+++ b/assets/dev/js/editor/editor-base.js
@@ -1304,7 +1304,13 @@ export default class EditorBase extends Marionette.Application {
 
 		this.trigger( 'preview:loaded', ! this.loaded /* IsFirst */ );
 
-		$e.internal( 'editor/documents/attach-preview' ).then( () => jQuery( '#elementor-loading, #elementor-preview-loading' ).fadeOut( 600 ) );
+		$e.internal( 'editor/documents/attach-preview' )
+			.catch( ( error ) => {
+				// Surface the failure instead of leaving the loading indicator visible forever.
+				// eslint-disable-next-line no-console
+				console.error( 'Elementor: Failed to attach the document to the preview.', error );
+			} )
+			.finally( () => jQuery( '#elementor-loading, #elementor-preview-loading' ).fadeOut( 600 ) );
 
 		this.loaded = true;
 	}

--- a/tests/jest/unit/app/event-track/wp-dashboard-tracking.test.js
+++ b/tests/jest/unit/app/event-track/wp-dashboard-tracking.test.js
@@ -97,4 +97,55 @@ describe( 'WpDashboardTracking', () => {
 			} );
 		} );
 	} );
+
+	describe( 'isNavigatingAwayFromElementor', () => {
+		test( 'does not throw and returns false when given a non-string value', () => {
+			jest.isolateModules( () => {
+				const WpDashboardTracking = require( 'elementor-app/event-track/wp-dashboard-tracking' ).default;
+
+				// A form control named "action" (e.g. `<input name="action">`) shadows
+				// `HTMLFormElement.action`, so callers may accidentally pass a DOM element here.
+				const shadowedFormAction = document.createElement( 'input' );
+
+				expect( () => WpDashboardTracking.isNavigatingAwayFromElementor( shadowedFormAction ) ).not.toThrow();
+				expect( WpDashboardTracking.isNavigatingAwayFromElementor( shadowedFormAction ) ).toBe( false );
+			} );
+		} );
+	} );
+
+	describe( 'getFormActionUrl', () => {
+		test( 'returns the string action when it is not shadowed by a form control', () => {
+			jest.isolateModules( () => {
+				const WpDashboardTracking = require( 'elementor-app/event-track/wp-dashboard-tracking' ).default;
+
+				const form = document.createElement( 'form' );
+				form.setAttribute( 'action', 'https://example.com/wp-admin/edit.php' );
+
+				expect( WpDashboardTracking.getFormActionUrl( form ) ).toBe( 'https://example.com/wp-admin/edit.php' );
+			} );
+		} );
+
+		test( 'falls back to the raw attribute when a named "action" control shadows form.action', () => {
+			jest.isolateModules( () => {
+				const WpDashboardTracking = require( 'elementor-app/event-track/wp-dashboard-tracking' ).default;
+
+				const form = document.createElement( 'form' );
+				form.setAttribute( 'action', 'https://example.com/wp-admin/edit.php?post_type=elementor_library' );
+
+				const actionInput = document.createElement( 'input' );
+				actionInput.setAttribute( 'type', 'hidden' );
+				actionInput.setAttribute( 'name', 'action' );
+				actionInput.setAttribute( 'value', 'elementor_new_post' );
+				form.appendChild( actionInput );
+
+				// Real browsers shadow `HTMLFormElement.action` with a named form control
+				// (e.g. `<input name="action">`, the WordPress admin-post/admin-ajax convention).
+				// jsdom does not replicate that quirk, so we simulate it directly here.
+				Object.defineProperty( form, 'action', { value: actionInput, configurable: true } );
+
+				expect( WpDashboardTracking.getFormActionUrl( form ) )
+					.toBe( 'https://example.com/wp-admin/edit.php?post_type=elementor_library' );
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While investigating the mass failures in [elementor-pro's "Playwright - Custom Core" run #32825911830](https://github.com/elementor/elementor-pro/actions/runs/32825911830) (Pro `4.02` against Core `main`), I found and fixed two independent, reproducible bugs in Core. Neither is a *new* regression introduced specifically on `main` — both are pre-existing robustness gaps that happen to matter more once a component fails against `main` for other, still-unexplained reasons. See the companion [elementor-pro PR](https://github.com/elementor/elementor-pro/pull/new/cursor/fix-experiments-activation-blueprint-e431) for a related test-tooling fix.

## 1. `WpDashboardTracking` crashes when a submitted form has a control named "action"

`HTMLFormElement.action` is shadowed by a descendant form control named `action` (e.g. `<input name="action">`) — the standard WordPress admin-post/admin-ajax routing pattern used throughout `wp-admin`, including Elementor's own "New Template" modal (`includes/admin-templates/new-template.php`).

`WpDashboardTracking.handleFormSubmit()` read `form.action` directly and passed it to `isNavigatingAwayFromElementor()`, which called `.startsWith()` on it, throwing:

```
TypeError: targetUrl.startsWith is not a function
    at WpDashboardTracking.isNavigatingAwayFromElementor (.../admin.js:...)
    at HTMLDocument.handleFormSubmit (.../admin.js:...)
```

Confirmed with a real browser (not jsdom, which doesn't replicate this shadowing quirk) on **both** Core `4.02` and `main` — this bug has existed for a while, it isn't new. It fires on every form submission on any Elementor admin page (`isElementorPage()` — `elementor_library`, `e-floating-buttons`, etc.), which includes the "New Template" flow used by most Pro Playwright helpers (`createNewTemplate()` for Loop Builder, Taxonomy Filter, Theme Builder templates, etc.).

**Fix:** added `getFormActionUrl()` to fall back to the raw `action` attribute when `form.action` isn't a string, and guarded `isNavigatingAwayFromElementor()` against non-string input. Added unit tests reproducing the shadowing via `Object.defineProperty` (jsdom doesn't implement the native shadowing behavior).

## 2. Editor gets stuck on the loading screen forever if `attach-preview` rejects

`$e.internal( 'editor/documents/attach-preview' )` ends in `AttachPreview.attachDocumentToPreview()`, a plain `new Promise((resolve, reject) => { ... })` that rejects when the expected `.elementor-{id}` element isn't found in the preview iframe. `editor-base.js` only had a `.then()` on this call (no `.catch()`), so on rejection the callback that hides `#elementor-loading` / `#elementor-preview-loading` never runs — the loading spinner stays up forever, even though the rest of the editor (top bar, panels) and the actual preview iframe content loaded and rendered correctly.

I confirmed this exact symptom in a real CI trace/accessibility snapshot from the failing run: the editor shell and iframe content were fully rendered, with `#elementor-loading` still `[active]` and showing "Loading". This matches the majority failure pattern in that run (24 of 30 failing jobs timed out waiting for `#elementor-loading`/`.elementor-panel-loading`).

**Fix:** added `.catch()` (log the error) + `.finally()` (always hide the loading indicators) so a failed attach surfaces an error instead of hanging indefinitely. This does **not** explain *why* `attachDocumentToPreview` rejects more often against `main` — that needs further investigation with a full CI-parity environment (Docker/wp-env, real Pro license, WooCommerce, multiple workers), which I couldn't fully replicate locally (I used `wp-playground`, which surfaced the mechanism but not the trigger).

## Testing

- Added/ran Jest unit tests for `WpDashboardTracking` (`npx jest --config='./tests/jest/jest.config.js' tests/jest/unit/app/event-track/wp-dashboard-tracking.test.js`) — all pass.
- Linted both changed files (`npx eslint ...`) — clean.
- Reproduced bug 1 live in a browser via `wp-playground` running Pro `4.02` mounted against both Core `4.02` and Core `main`; confirmed the exact same `TypeError` on both, and confirmed it disappears after the fix (rebuilt Core, restarted `wp-playground`, re-ran the repro).
- Bug 2 is derived from static analysis of the real CI Playwright trace (screenshot + accessibility snapshot + network log, all `200`s, no console errors) plus the `$e.commandsInternal` promise-chain code path; I was not able to reproduce the rejection itself locally (would need the full Docker/wp-env + real Pro license + WooCommerce CI setup).

## Related

- Elementor Pro PR: test-tooling fix for `wp-playground` blueprints failing hard against Core `main` (unrelated cause, found during the same investigation, does not affect the actual CI workflow that failed since it uses Docker wp-env instead of `wp-playground`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42c91c89-1eb8-409d-a8bd-a044c8fbe431?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42c91c89-1eb8-409d-a8bd-a044c8fbe431&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

