### PR TITLE
Internal: Set Play as the default state for Background Video [ED-25345]

### DIFF
--- a/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video.php
+++ b/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video.php
@@ -113,6 +113,7 @@ class Atomic_Background_Video extends Atomic_Element_Base {
 			'show_controls' => Boolean_Prop_Type::make()->default( true ),
 			'state' => String_Prop_Type::make()
 				->enum( [ 'playing', 'paused' ] )
+				->default( 'playing' )
 				->set_dependencies( $state_dependencies )
 				->meta( Overridable_Prop_Type::ignore() ),
 			'attributes' => Attributes_Prop_Type::make()->meta( Overridable_Prop_Type::ignore() ),

--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-background-video.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-background-video.php
@@ -1,0 +1,19 @@
+<?php
+
+use Elementor\Modules\AtomicWidgets\Elements\Atomic_Background_Video\Atomic_Background_Video;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Test_Atomic_Background_Video extends Elementor_Test_Base {
+
+	public function test_state_defaults_to_playing() {
+		$schema = Atomic_Background_Video::get_props_schema();
+		$state = $schema['state'];
+
+		$this->assertSame( 'playing', $state->get_default()['value'] );
+		$this->assertTrue( $state->validate( $state->get_default() ) );
+	}
+}


### PR DESCRIPTION
## Summary
- Set the Background Video element `state` prop default to `playing` so Play is selected when the element is first added to the canvas.
- Add a PHPUnit test asserting the default state value.

## Jira
https://elementor.atlassian.net/browse/ED-25345

## Test plan
- [ ] Add a Background Video element to the canvas and confirm **Play** is selected in the States toggle.
- [ ] Confirm the element renders in the playing state by default.
- [ ] Switch to **Pause** manually and confirm the paused state still works.
- [ ] Run `tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-background-video.php`.
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Sets 'playing' as the default state for background videos (ED-25345) to ensure consistent playback behavior.

## 2. What Changed (Where)
* `atomic-background-video.php`: Added 'playing' default value to the state property schema.
* `test-atomic-background-video.php`: Added unit test to verify the default state value.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
