### PR TITLE
Internal: Add Angie in panels as additional experiment [ED-25410]

### DIFF
--- a/modules/widget-creation/module.php
+++ b/modules/widget-creation/module.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\WidgetCreation;
 
 use Elementor\Core\Base\Module as BaseModule;
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\Core\Utils\Hints;
 use Elementor\Elements_Manager;
 use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
@@ -14,6 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Module extends BaseModule {
 	const EXPERIMENT_NAME = Atomic_Widgets_Module::EXPERIMENT_NAME;
+	const ANGIE_IN_PANELS_EXPERIMENT_NAME = 'e_angie_in_panels';
 	const MODULE_NAME = 'widget-creation';
 
 	const PACKAGES = [
@@ -26,13 +28,29 @@ class Module extends BaseModule {
 		return self::MODULE_NAME;
 	}
 
+	public static function get_angie_in_panels_experimental_data(): array {
+		return [
+			'name' => self::ANGIE_IN_PANELS_EXPERIMENT_NAME,
+			'title' => esc_html__( 'Angie in editor panels', 'elementor' ),
+			'description' => esc_html__( 'Load Angie inside the native Elementor editor panel instead of the legacy push sidebar.', 'elementor' ),
+			'hidden' => true,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,
+		];
+	}
+
 	public function __construct() {
 		parent::__construct();
+		$this->register_angie_in_panels_experiment();
 		AngiePromotion::init();
 
 		add_filter( 'elementor/editor/v2/packages', fn( $packages ) => $this->add_packages( $packages ) );
 		add_action( 'elementor/elements/categories_registered', [ $this, 'maybe_register_custom_widgets_category_fallback' ], 100 );
 		add_action( 'rest_api_init', fn() => $this->register_consent_route() );
+	}
+
+	private function register_angie_in_panels_experiment(): void {
+		Plugin::$instance->experiments->add_feature( self::get_angie_in_panels_experimental_data() );
 	}
 
 	private function register_consent_route(): void {

--- a/tests/phpunit/elementor/modules/widget-creation/test-angie-in-panels-experiment.php
+++ b/tests/phpunit/elementor/modules/widget-creation/test-angie-in-panels-experiment.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Elementor\Modules\WidgetCreation;
+
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\WidgetCreation\Module;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Angie_In_Panels_Experiment extends Elementor_Test_Base {
+
+	private $original_experiment_default_state;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_experiment_default_state = Plugin::$instance->experiments
+			->get_features( Module::ANGIE_IN_PANELS_EXPERIMENT_NAME )['default'];
+	}
+
+	public function tear_down() {
+		Plugin::$instance->experiments->set_feature_default_state(
+			Module::ANGIE_IN_PANELS_EXPERIMENT_NAME,
+			$this->original_experiment_default_state
+		);
+
+		delete_option( Experiments_Manager::OPTION_PREFIX . Module::ANGIE_IN_PANELS_EXPERIMENT_NAME );
+
+		parent::tear_down();
+	}
+
+	public function test_experiment_is_registered_as_default_inactive() {
+		// Arrange
+		$data = Module::get_angie_in_panels_experimental_data();
+
+		// Act & Assert
+		$this->assertSame( Module::ANGIE_IN_PANELS_EXPERIMENT_NAME, $data['name'] );
+		$this->assertTrue( $data['hidden'] );
+		$this->assertSame( Experiments_Manager::STATE_INACTIVE, $data['default'] );
+		$this->assertSame( Experiments_Manager::RELEASE_STATUS_DEV, $data['release_status'] );
+	}
+
+	public function test_experiment_can_be_activated() {
+		// Arrange
+		Plugin::$instance->experiments->set_feature_default_state(
+			Module::ANGIE_IN_PANELS_EXPERIMENT_NAME,
+			Experiments_Manager::STATE_ACTIVE
+		);
+
+		// Act
+		$is_active = Plugin::$instance->experiments->is_feature_active( Module::ANGIE_IN_PANELS_EXPERIMENT_NAME );
+
+		// Assert
+		$this->assertTrue( $is_active );
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Angie native panel loading in 4.3 needs a release gate so the editor panel APIs can ship without enabling Angie-in-panel UX for all sites by default.

PR #37061 registered `e_angie_in_panels` by overriding `Module::EXPERIMENT_NAME`, which replaced the existing atomic-widgets alias used across the widget-creation module.

## Solution

Register `e_angie_in_panels` as an **additional** hidden experiment (default inactive) without overriding `EXPERIMENT_NAME`:

- Keep `EXPERIMENT_NAME = Atomic_Widgets_Module::EXPERIMENT_NAME`
- Add `ANGIE_IN_PANELS_EXPERIMENT_NAME = 'e_angie_in_panels'`
- Register via `add_feature()` in the constructor (same pattern as component variants / atomic-widgets secondary experiments)

When active, Angie reads it via `elementorCommon.config.experimentalFeatures` or `is_feature_active( 'e_angie_in_panels' )`.

## Stack

- Supersedes the experiment registration approach in #37061
- Pairs with elementor-ai PR https://github.com/elementor/elementor-ai/pull/4291 (gates Angie panel registration on `e_angie_in_panels`)
- Jira: https://elementor.atlassian.net/browse/ED-25410

## Test plan

- [ ] `composer run test -- --filter Test_Angie_In_Panels_Experiment`
- [ ] Experiment appears in Elementor → Settings → Features (hidden experiments visible when `ELEMENTOR_SHOW_HIDDEN_EXPERIMENTS` is on)
- [ ] Default state is inactive; activating enables `is_feature_active( 'e_angie_in_panels' )`
- [ ] `Module::EXPERIMENT_NAME` still aliases `e_atomic_elements`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04237-2945-7e8a-8e91-21d5c7e14e5f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04237-2945-7e8a-8e91-21d5c7e14e5f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

