### PR TITLE
Internal: Relax base path filters to support CDN and WPML use cases [ED-24868]

### DIFF
--- a/core/files/base.php
+++ b/core/files/base.php
@@ -56,10 +56,6 @@ abstract class Base {
 			return $dir;
 		}
 
-		if ( ! self::is_base_paths_filter_pair_valid() ) {
-			return $dir;
-		}
-
 		/**
 		 * Elementor files base directory.
 		 *
@@ -67,8 +63,10 @@ abstract class Base {
 		 * Applies to all `Elementor\Core\Files\Base` consumers (Post CSS, Global CSS,
 		 * Frontend CSS, Google Fonts, atomic CSS, etc.) — not only atomic CSS.
 		 *
-		 * Must be set together with `elementor/files/base_url`. Setting only one of the
-		 * two is rejected and both fall back to their defaults.
+		 * Can be filtered independently of `elementor/files/base_url`:
+		 *  - Filter both to relocate Elementor files (e.g. WP VIP where `uploads/` is read-only).
+		 *  - Filter only `elementor/files/base_url` (leaving this untouched) to serve files
+		 *    from a CDN or an alternate URL (e.g. WPML sub-folder) while keeping local writes.
 		 *
 		 * Only available when the `e_optimized_css_files` experiment is active.
 		 *
@@ -96,10 +94,6 @@ abstract class Base {
 			return $url;
 		}
 
-		if ( ! self::is_base_paths_filter_pair_valid() ) {
-			return $url;
-		}
-
 		/**
 		 * Elementor files base URL.
 		 *
@@ -107,8 +101,11 @@ abstract class Base {
 		 * Applies to all `Elementor\Core\Files\Base` consumers (Post CSS, Global CSS,
 		 * Frontend CSS, Google Fonts, atomic CSS, etc.) — not only atomic CSS.
 		 *
-		 * Must be set together with `elementor/files/base_dir`. Setting only one of the
-		 * two is rejected and both fall back to their defaults.
+		 * Accepts absolute (`https://cdn.example.com/…`) and protocol-relative
+		 * (`//cdn.example.com/…`) URLs. Can be filtered independently of
+		 * `elementor/files/base_dir` — filter only this hook to serve files from a
+		 * CDN or an alternate URL (e.g. WPML sub-folder) while keeping local writes
+		 * at the default location.
 		 *
 		 * Only available when the `e_optimized_css_files` experiment is active.
 		 *
@@ -374,34 +371,6 @@ abstract class Base {
 	}
 
 	/**
-	 * Ensure `elementor/files/base_dir` and `elementor/files/base_url` are either both
-	 * filtered or both unfiltered. Setting only one produces a mismatched write vs.
-	 * enqueue location and yields 404s for every generated asset.
-	 *
-	 * @since 4.4.0
-	 * @access private
-	 * @static
-	 *
-	 * @return bool True when the pair is safe to apply (both set or both unset).
-	 */
-	private static function is_base_paths_filter_pair_valid() {
-		$has_dir_filter = (bool) has_filter( 'elementor/files/base_dir' );
-		$has_url_filter = (bool) has_filter( 'elementor/files/base_url' );
-
-		if ( $has_dir_filter === $has_url_filter ) {
-			return true;
-		}
-
-		_doing_it_wrong(
-			__METHOD__,
-			'The `elementor/files/base_dir` and `elementor/files/base_url` filters must be set together. Falling back to defaults.',
-			'4.4.0'
-		);
-
-		return false;
-	}
-
-	/**
 	 * Validate a filtered base directory path.
 	 *
 	 * @since 4.4.0
@@ -482,10 +451,10 @@ abstract class Base {
 
 		$url = trailingslashit( $url );
 
-		if ( ! wp_http_validate_url( $url ) ) {
+		if ( ! self::is_valid_base_url( $url ) ) {
 			_doing_it_wrong(
 				__METHOD__,
-				'The `elementor/files/base_url` filter must return a valid URL.',
+				'The `elementor/files/base_url` filter must return an absolute or protocol-relative http(s) URL.',
 				'4.4.0'
 			);
 
@@ -493,6 +462,44 @@ abstract class Base {
 		}
 
 		return $url;
+	}
+
+	/**
+	 * Lightweight structural check for the base URL filter.
+	 *
+	 * Intentionally avoids `wp_http_validate_url()` which performs DNS lookups and
+	 * rejects protocol-relative and RFC1918 URLs — none of which we want when the
+	 * URL is only being prepended to CSS asset paths (CDN endpoints, WPML sub-folder
+	 * rewrites, etc.). We only enforce that the value looks like an absolute or
+	 * protocol-relative http/https URL with a host.
+	 *
+	 * @since 4.4.0
+	 * @access private
+	 * @static
+	 *
+	 * @param string $url Candidate URL (already normalized to a trailing slash).
+	 *
+	 * @return bool
+	 */
+	private static function is_valid_base_url( $url ) {
+		$is_protocol_relative = 0 === strpos( $url, '//' );
+		$parsable = $is_protocol_relative ? 'https:' . $url : $url;
+
+		$parts = wp_parse_url( $parsable );
+
+		if ( ! is_array( $parts ) || empty( $parts['host'] ) ) {
+			return false;
+		}
+
+		if ( ! $is_protocol_relative ) {
+			$scheme = isset( $parts['scheme'] ) ? strtolower( $parts['scheme'] ) : '';
+
+			if ( ! in_array( $scheme, [ 'http', 'https' ], true ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/phpunit/elementor/core/files/test-base-path-filters.php
+++ b/tests/phpunit/elementor/core/files/test-base-path-filters.php
@@ -201,23 +201,60 @@ class Test_Base_Path_Filters extends Elementor_Test_Base {
 		$this->assertSame( $this->get_default_base_dir(), Base::get_base_uploads_dir() );
 	}
 
-	public function test_get_base_uploads_dir__only_dir_filter_set__falls_back_to_default() {
+	public function test_url_only_override__applies_url_and_dir_stays_default() {
 		$this->activate_experiment();
-		$this->expect_doing_it_wrong( 'Elementor\Core\Files\Base::is_base_paths_filter_pair_valid' );
+
+		$cdn_url = 'https://cdn.example.com/wp-content/uploads/elementor/';
+
+		add_filter( 'elementor/files/base_url', function () use ( $cdn_url ) {
+			return $cdn_url;
+		} );
+
+		$this->assertSame( $this->get_default_base_dir(), Base::get_base_uploads_dir(), 'base_dir must fall through to the WP uploads default when only base_url is filtered' );
+		$this->assertSame( trailingslashit( $cdn_url ), Base::get_base_uploads_url() );
+	}
+
+	public function test_dir_only_override__applies_dir_and_url_stays_default() {
+		$this->activate_experiment();
 
 		add_filter( 'elementor/files/base_dir', function () {
 			return $this->custom_base_dir;
 		} );
 
-		$this->assertSame( $this->get_default_base_dir(), Base::get_base_uploads_dir() );
+		$this->assertSame( trailingslashit( wp_normalize_path( $this->custom_base_dir ) ), Base::get_base_uploads_dir() );
+		$this->assertSame( $this->get_default_base_url(), Base::get_base_uploads_url(), 'base_url must fall through to the WP uploads default when only base_dir is filtered' );
 	}
 
-	public function test_get_base_uploads_url__only_url_filter_set__falls_back_to_default() {
+	public function test_get_base_uploads_url__experiment_active__accepts_cross_domain_cdn_url() {
 		$this->activate_experiment();
-		$this->expect_doing_it_wrong( 'Elementor\Core\Files\Base::is_base_paths_filter_pair_valid' );
+
+		$cdn_url = 'https://cdn.example.com/elementor/';
+
+		add_filter( 'elementor/files/base_url', function () use ( $cdn_url ) {
+			return $cdn_url;
+		} );
+
+		$this->assertSame( trailingslashit( $cdn_url ), Base::get_base_uploads_url() );
+	}
+
+	public function test_get_base_uploads_url__experiment_active__accepts_protocol_relative_url() {
+		$this->activate_experiment();
+
+		$cdn_url = '//cdn.example.com/elementor/';
+
+		add_filter( 'elementor/files/base_url', function () use ( $cdn_url ) {
+			return $cdn_url;
+		} );
+
+		$this->assertSame( trailingslashit( $cdn_url ), Base::get_base_uploads_url() );
+	}
+
+	public function test_get_base_uploads_url__experiment_active__rejects_javascript_scheme() {
+		$this->activate_experiment();
+		$this->expect_doing_it_wrong( 'Elementor\Core\Files\Base::validate_base_url' );
 
 		add_filter( 'elementor/files/base_url', function () {
-			return $this->custom_base_url;
+			return 'javascript:alert(1)/';
 		} );
 
 		$this->assertSame( $this->get_default_base_url(), Base::get_base_uploads_url() );


### PR DESCRIPTION
## Summary

Manual cherry-pick of #37066 to `release/beta` as a replacement for the stuck automated cherry-pick PR #37069.

Relaxes the `elementor/files/base_dir` and `elementor/files/base_url` filters to support independent CDN and WPML use cases.

## Test plan

- [ ] CI passes on this PR
- [ ] Run PHPUnit: `vendor/bin/phpunit --filter Test_Base_Path_Filters`
- [ ] Close or supersede #37069 once this PR merges

## Jira

[ED-24868](https://elementor.atlassian.net/browse/ED-24868)

Made with [Cursor](https://cursor.com)

[ED-24868]: https://elementor.atlassian.net/browse/ED-24868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ