### PR TITLE
Internal: Deactivation feedback dialog layout [ED-25425]

### DIFF
--- a/assets/dev/scss/admin/_feedback.scss
+++ b/assets/dev/scss/admin/_feedback.scss
@@ -55,10 +55,11 @@
 		background-color: transparent;
 		color: var(--e-a-color-txt);
 		margin-block: 10px 0;
-		margin-inline: 30px 0;	
+		margin-inline: 30px 0;
 		padding: 5px;
 		box-shadow: none;
 		width: 92%;
+		flex-basis: 100%;
 	}
 
 	.dialog-buttons-wrapper {
@@ -133,4 +134,5 @@
 	align-items: center;
 	line-height: 2;
 	overflow: hidden;
+	flex-wrap: wrap;
 }


### PR DESCRIPTION
## Summary

Fixes two UI issues in the "Quick Feedback" modal shown when deactivating Elementor Free.

- **"I found a better plugin"** — "Please share which plugin" text input was appearing inline with the label (same row), clipped by `overflow: hidden`
- **"I have Elementor Pro"** — orange warning message was appearing inline with the label instead of below it

**Root cause:** `.elementor-deactivate-feedback-dialog-input-wrapper` is a flex row without `flex-wrap`. All children (radio, label, text input/alert) rendered on one line.

**Fix:** Two CSS additions in `assets/dev/scss/admin/_feedback.scss`:
- `flex-wrap: wrap` on the wrapper
- `flex-basis: 100%` on `.elementor-feedback-text`

## Images
**Before**
<img width="588" height="459" alt="image" src="https://github.com/user-attachments/assets/e56e3213-3314-468d-8e59-e708297f279d" />


**After**
<img width="621" height="501" alt="image" src="https://github.com/user-attachments/assets/f897da16-8613-4298-9858-affd5eb4f1e0" />



## Test plan
- [ ] Go to WP Admin → Plugins → Deactivate Elementor Free
- [ ] Select "I found a better plugin" → text input appears below the label on a new line
- [ ] Select "I have Elementor Pro" → orange warning appears below the label on a new line
- [ ] All other options are unaffected

Jira: [ED-25425](https://elementor.atlassian.net/browse/ED-25425)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Deactivation feedback dialog had layout issues with text overflow and improper spacing. ED-25425 fixes flexbox constraints to ensure proper text containment and wrapping.

## 2. What Changed (Where)
- `_feedback.scss`: Added `margin-inline: 30px 0` and `flex-basis: 100%` to `.elementor-feedback-text`; added `flex-wrap: wrap` to `.elementor-deactivate-feedback-dialog-input-wrapper`

## 3. How It Works
`flex-basis: 100%` forces textarea to full flex container width, while `flex-wrap: wrap` allows input wrapper contents to wrap when constrained. Margin-inline provides consistent horizontal spacing.

## 4. Risks
None—purely layout fixes with no behavior changes or cross-browser concerns.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
