### PR TITLE
Fix: Grant pull-requests write to Lighthouse build job [ED-25239]

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -82,6 +82,9 @@ jobs:
   build-plugin-lh:
     if: github.event_name == 'push' || github.event_name == 'merge_group'
     name: Lighthouse build artifact
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/build.yml
     with:
       job_name: Lighthouse build artifact


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lighthouse CI was failing at workflow validation because `build-plugin-lh` calls the reusable `build.yml` workflow, which requires `pull-requests: write`. The Lighthouse workflow only granted `pull-requests: read` at the top level.

Added job-level permissions to `build-plugin-lh`, matching the pattern used in `playwright-suite.yml`.

## Jira

ED-25239
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://elementor.slack.com/archives/C0BJ87KE3N1/p1787819138396079?thread_ts=1787819138.396079&cid=C0BJ87KE3N1)

<div><a href="https://cursor.com/agents/bc-309cea77-a083-50c1-8745-7c60129a9502?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-309cea77-a083-50c1-8745-7c60129a9502&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

