### PR TITLE
CI: Trigger PR workflows on release/beta and release/stable [ED-25426]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ on:
   push:
     branches:
       - 'main'
+      - 'release/beta'
+      - 'release/stable'
       - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'

--- a/.github/workflows/css-file-check.yml
+++ b/.github/workflows/css-file-check.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'main'
+      - 'release/beta'
+      - 'release/stable'
       - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'

--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -9,6 +9,8 @@ on:
     types: [closed]
     branches:
       - main
+      - release/beta
+      - release/stable
       - '[0-9].[0-9][0-9]'
       - '[0-9][0-9].[0-9][0-9]'
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'main'
+      - 'release/beta'
+      - 'release/stable'
       - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'

--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'main'
+      - 'release/beta'
+      - 'release/stable'
       - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'

--- a/.github/workflows/pr-cancel-superseded.yml
+++ b/.github/workflows/pr-cancel-superseded.yml
@@ -5,6 +5,8 @@ on:
     types: [synchronize]
     branches:
       - main
+      - release/beta
+      - release/stable
       - '[0-9].[0-9][0-9]'
 
 permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
     branches:
       - main
+      - release/beta
+      - release/stable
       - '[0-9].[0-9][0-9]'
 
 permissions:


### PR DESCRIPTION
## Summary
- Add `release/beta` and `release/stable` alongside existing numbered version branch triggers (`[0-9].[0-9][0-9]`) in core workflows
- Updated workflows:
  - `pr.yml`
  - `pr-cancel-superseded.yml`
  - `build.yml`
  - `css-file-check.yml`
  - `lighthouse.yml`
  - `performance-check.yml`
  - `latest-release.yml`

## Jira
https://elementor.atlassian.net/browse/ED-25426

## Test plan
- [ ] Push to `release/beta` triggers `build.yml`, `css-file-check.yml`, `performance-check.yml`, and `lighthouse.yml`
- [ ] Push to `release/stable` triggers the same push workflows
- [ ] PRs targeting `release/beta` or `release/stable` trigger `pr.yml` and `pr-cancel-superseded.yml`
- [ ] Merging a PR into release branches still triggers `latest-release.yml`
- [ ] Existing triggers for `main` and version branches remain unchanged


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Release workflows (beta/stable branches) weren't triggering CI pipelines. This adds branch patterns to existing workflow triggers so release branches get the same validation as main.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| 6 workflow files | Added `release/beta` and `release/stable` to branch triggers |

## 3. How It Works

GitHub Actions now evaluates release branch pushes/PRs against the same workflow conditions as main—no behavior changes, just extended branch scope.

## 4. Risks

None. Additive change with no conditional logic modifications or breaking alterations.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
