### PR TITLE
CI: Cherry-pick PR 37079 to release/beta: Trigger PR workflows on release/beta [ED-25426]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ on:
   push:
     branches:
       - 'main'
+      - 'release/beta'
+      - 'release/stable'
       - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'

--- a/.github/workflows/css-file-check.yml
+++ b/.github/workflows/css-file-check.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'main'
+      - 'release/beta'
+      - 'release/stable'
       - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'

--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -9,6 +9,8 @@ on:
     types: [closed]
     branches:
       - main
+      - release/beta
+      - release/stable
       - '[0-9].[0-9][0-9]'
       - '[0-9][0-9].[0-9][0-9]'
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'main'
+      - 'release/beta'
+      - 'release/stable'
       - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'

--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'main'
+      - 'release/beta'
+      - 'release/stable'
       - '[0-9].[0-9][0-9]'
     paths-ignore:
       - '**.md'

--- a/.github/workflows/pr-cancel-superseded.yml
+++ b/.github/workflows/pr-cancel-superseded.yml
@@ -5,6 +5,8 @@ on:
     types: [synchronize]
     branches:
       - main
+      - release/beta
+      - release/stable
       - '[0-9].[0-9][0-9]'
 
 permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
     branches:
       - main
+      - release/beta
+      - release/stable
       - '[0-9].[0-9][0-9]'
 
 permissions:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Cherry-pick https://github.com/elementor/elementor/pull/37079 onto `release/beta` so PRs targeting this branch actually run CI.
- `pr.yml` on `release/beta` still listed only `main` and numbered version branches, so GitHub skipped the PR workflow for `release/beta` targets even after the `main` merge.
- Same branch filters as #37079: add `release/beta` and `release/stable` to:
  - `pr.yml`
  - `pr-cancel-superseded.yml`
  - `build.yml`
  - `css-file-check.yml`
  - `lighthouse.yml`
  - `performance-check.yml`
  - `latest-release.yml`

## Jira
https://elementor.atlassian.net/browse/ED-25426

## Test plan
- [x] Confirm no duplicate open PR already cherry-picks #37079 onto `release/beta`
- [x] YAML-parse updated workflows and confirm `pull_request` / `push` branch lists include `release/beta` and `release/stable`
- [ ] After this PR is opened, confirm the `PR` workflow starts (the updated `pr.yml` is in the merge commit)
- [ ] Existing PRs targeting `release/beta` start running CI only after this lands on the base branch

## Duplicate-PR check
- Core #37079 is already merged to `main` (do not reopen).
- Pro already has open https://github.com/elementor/elementor-pro/pull/7524 — no new Pro PR.

## PR Type
- [x] CI related changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28458d8b-a412-4eae-9978-f4bd22eb5a92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28458d8b-a412-4eae-9978-f4bd22eb5a92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Enable CI workflows to run on `release/beta` and `release/stable` branches alongside existing triggers. Addresses ED-25426.

## 2. What Changed (Where)

- `.github/workflows/build.yml`, `css-file-check.yml`, `lighthouse.yml`, `performance-check.yml`: Added `release/beta` and `release/stable` to push branch triggers
- `.github/workflows/latest-release.yml`, `pr-cancel-superseded.yml`, `pr.yml`: Added release branches to pull_request branch filters

## 3. How It Works

Workflows now activate on push/PR events targeting release branches with same conditions as main branch (path-ignore rules apply). No new logic—purely expanding existing branch filters.

## 4. Risks

Minimal. Straightforward configuration change. Verify workflows actually run on release branches post-merge; GH Actions branch filtering occasionally exhibits edge cases with protected branches.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
