### PR TITLE
Internal: Add WPVIP fallback for base_dir realpath resolution [ED-24868]

### DIFF
--- a/core/files/base.php
+++ b/core/files/base.php
@@ -579,34 +579,48 @@ abstract class Base {
 	 * ancestor lets us still resolve symlinks and reject paths whose real location
 	 * escapes the allowed roots.
 	 *
+	 * WPVIP compatibility: on object-store-backed filesystems (VIP File System),
+	 * `realpath()` is documented as unreliable and may return false even on valid
+	 * paths. When that happens we fall back to the normalized input, preserving
+	 * the original string-prefix semantics rather than silently rejecting the
+	 * path. Symlink protection is sacrificed only on filesystems that don't
+	 * expose real paths in the first place.
+	 *
 	 * @since 4.4.0
 	 * @access private
 	 * @static
 	 *
 	 * @param string $path Filesystem path.
 	 *
-	 * @return string|false Normalized realpath, or false if none could be resolved.
+	 * @return string|false Normalized path (from realpath when available, otherwise
+	 *                      the normalized input), or false when the input is empty.
 	 */
 	private static function resolve_deepest_existing( $path ) {
-		$current = wp_normalize_path( untrailingslashit( (string) $path ) );
+		$normalized = wp_normalize_path( untrailingslashit( (string) $path ) );
+
+		if ( '' === $normalized ) {
+			return false;
+		}
+
+		$current = $normalized;
 
 		while ( '' !== $current && ! file_exists( $current ) ) {
 			$parent = wp_normalize_path( dirname( $current ) );
 
 			if ( $parent === $current ) {
-				return false;
+				return $normalized;
 			}
 
 			$current = $parent;
 		}
 
-		if ( '' === $current ) {
-			return false;
-		}
-
 		$real = realpath( $current );
 
-		return $real ? untrailingslashit( wp_normalize_path( $real ) ) : false;
+		if ( $real ) {
+			return untrailingslashit( wp_normalize_path( $real ) );
+		}
+
+		return $normalized;
 	}
 
 	/**


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/main/.github/CONTRIBUTING.md

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes on POSIX, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other

## Summary

Follow-up to [#36859](https://github.com/elementor/elementor/pull/36859) and [#37066](https://github.com/elementor/elementor/pull/37066) (ED-24868). Preemptive compatibility fix ahead of a WP VIP test round on the ` e_optimized_css_files` filter feature.

Falls back to a normalized string path when ` realpath()` returns false, so ` is_path_within_allowed_roots()` doesn't silently reject valid filter values on WPVIP's object-store-backed uploads.

## Description

WPVIP's ` /wp-content/uploads/` path is mapped to VIP File System (an object store, not a real POSIX filesystem). WPVIP [documents](https://docs.wpvip.com/technical-references/vip-file-system/#h-known-limitations) ` realpath()` as unreliable on that filesystem — it can return ` false` on paths that are structurally valid.

The current implementation of ` resolve_deepest_existing()` returns ` false` when ` realpath()` fails, which then feeds into an ` array_filter` in ` is_path_within_allowed_roots()`. Net effect on VIP: the ` uploads/` root can silently disappear from the allowed-roots list, causing a legitimate filter value to be rejected with ` _doing_it_wrong` and falling back to defaults.

Fix: fall back to the ` wp_normalize_path` of the input when ` realpath()` doesn't yield anything. This restores Ron's original string-prefix behavior on filesystems where realpath is not meaningful, while keeping the symlink-safe realpath check on POSIX where it does work. Symlink protection is only sacrificed on filesystems that don't expose real paths in the first place — which is the correct tradeoff.

No behavior change on POSIX filesystems, where ` realpath()` succeeds and takes the existing branch.

## Test instructions

- [ ] Existing PHPUnit ` Test_Base_Path_Filters` suite still passes (POSIX regression check).
- [ ] On a WPVIP staging environment with the ` e_optimized_css_files` experiment active, register both ` elementor/files/base_dir` and ` elementor/files/base_url` pointing at a writable location and confirm CSS files are generated there without ` _doing_it_wrong` warnings.
- [ ] With only ` elementor/files/base_url` filtered (CDN scenario), confirm default write path still works and enqueue URLs reflect the filter.
- [ ] Confirm the symlink-escape regression test still passes on POSIX (realpath still resolves and rejects escapes).

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended  <!-- POSIX behavior is covered by existing tests; VFS behavior needs the VIP build to validate -->
- [ ] Docs have been added / updated (for bug fixes / features)

## Jira

[ED-24868](https://elementor.atlassian.net/browse/ED-24868)

Made with [Cursor](https://cursor.com)

[ED-24868]: https://elementor.atlassian.net/browse/ED-24868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

WPVIP's object-store filesystem makes `realpath()` unreliable—it returns false on valid paths. This breaks path validation. Trade-off: sacrifice symlink protection on VIP to preserve functionality where real paths aren't exposed.

## 2. What Changed (Where)

`core/files/base.php` — `resolve_deepest_existing()`: now normalizes input upfront, falls back to normalized path when `realpath()` fails, returns false only on empty input.

## 3. How It Works

Normalize input → walk up to existing ancestor → call `realpath()` on found ancestor → if `realpath()` succeeds, return normalized result; if it fails, return the normalized input instead of false.

## 4. Risks

Symlink escape detection weakens on VIP filesystems (documented trade-off). No regression risk for standard filesystems—logic is identical when `realpath()` succeeds.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
