### PR TITLE
Internal: Cherry-pick PR 37073 to release/beta: Fix MCP factual schema and runtime errors [ED-25171]

### DIFF
--- a/docs/atomic-builder/mcp/abilities/build-composition.md
+++ b/docs/atomic-builder/mcp/abilities/build-composition.md
@@ -64,7 +64,7 @@ Example:
   "element_config": {
     "hero-title": {
       "tag": "h2",
-      "title": { "content": "Welcome", "children": [] }
+      "title": "Welcome"
     }
   },
   "style": {
@@ -77,14 +77,14 @@ Example:
 }
 ```
 
-Prefer **longhand** CSS properties; shorthand may fall back to `custom_css` (stripped on Pro 3.35+).
+CSS `style` strings are converted to native atomic styles when possible; some shapes fall back to `custom_css` and `animation` is dropped. Prefer `@media(--breakpoint)` over pixel queries, single-value `gap`, literal `box-shadow`, and `padding` / `margin` shorthands.
 
 ### element_config format
 
 Plain JSON matching `elementor/get-widget-schema` output — no `$$type` wrappers for standard props:
 
 - Strings/enums: `"h2"`, `"https://example.com"`
-- html-v3: `{ "content": "Hello", "children": [] }`
+- Text (`title` on `e-heading`, `paragraph` on `e-paragraph`, `text` on `e-button`): plain string (`"Welcome"`) — not `{ content, children }`
 - Dynamic (where allowed): `{ "name": "post-title", "settings": { } }` — read `elementor://dynamic-tags`
 - Image: `{ "src": { "url": "https://example.com/photo.jpg" }, "size": "full" }`
 

--- a/modules/mcp/abilities/manage-component-ability.php
+++ b/modules/mcp/abilities/manage-component-ability.php
@@ -510,7 +510,7 @@ class Manage_Component_Ability extends Abstract_Ability {
 		$editor_url = $component->get_edit_url();
 
 		return [
-			'editor_url' => $editor_url,
+			'edit_url' => $editor_url,
 			'llm_instructions' => sprintf(
 				/* translators: %s: Component editor URL. */
 				__( 'You MUST show the user this link to review the component: %s', 'elementor' ),
@@ -583,7 +583,7 @@ class Manage_Component_Ability extends Abstract_Ability {
 					'items' => [ 'type' => 'integer' ],
 					'description' => 'archive only.',
 				],
-				'editor_url' => [
+				'edit_url' => [
 					'type' => 'string',
 					'description' => 'Component documents have no public permalink; this is the editor URL to review the change.',
 				],

--- a/modules/mcp/static-resources/abilities/build-composition.md
+++ b/modules/mcp/static-resources/abilities/build-composition.md
@@ -55,20 +55,32 @@ Some elements have internal tree structures (nesting). When using these elements
 - Map configuration-id → element_config (props) + style (plain CSS string) + classes (global class labels)
 - **element_config uses plain JSON values** — send scalars and objects exactly as shown in the widget schema.
 - **Prop names must come from the widget schema (use elementor/get-widget-schema tool with the widget type). Unknown/unsupported keys are NOT rejected — they are skipped and reported in `warnings`, and the build still succeeds. Prefer valid keys so props are not silently dropped.**
-- style is a plain CSS string (e.g. `color: red; padding-top: 1rem;`); supports `&:hover`/`&:focus`/`&:active` nesting and `@media (--breakpoint)` blocks (e.g. `@media (--mobile) { font-size: 2rem; }`); the server converts it to native styles. **Use Elementor breakpoint names only** (`--mobile`, `--tablet`, `--laptop`, etc.) — raw pixel queries like `@media (max-width: 768px)` are NOT converted to variants and fall back to `custom_css`, which is stripped by Pro 3.35+.
+- style is a plain CSS string (e.g. `color: red; padding-top: 1rem;`); supports `&:hover`/`&:focus`/`&:active` nesting and `@media(--breakpoint)` blocks (e.g. `@media(--mobile) { font-size: 2rem; }`). The server converts most declarations into native atomic styles. See **Style conversion** below.
 - classes is configuration-id → array of existing global class **labels** from [elementor://global-classes]
-- **CSS shorthand properties may fall back to custom_css which is stripped by Pro 3.35+; prefer longhand properties (e.g., `padding-top`, `padding-right` instead of `padding`)**
-- **box-shadow**: literal values only — `var(...)` wrappers are not supported.
 - LINKS: a `link` prop is valid only when the target widget's schema (via `elementor/get-widget-schema`) includes a `link` property. On widgets without it, `link` is skipped and reported in `warnings` (the composition still builds) — wrap the element in a linkable container instead. Plain link shape: `{ "destination": "https://example.com", "isTargetBlank": true, "tag": "a" }`
-- Retry on errors up to 10x
 - Check `llm_guidance.default_settings` in widget schemas — omit only keys listed there from element_config unless the user explicitly asks to change them
+
+### Style conversion
+The server converts most CSS into **native atomic styles** (breakpoint variants, pseudo-states). Some value shapes fall back to `custom_css`; `animation` and `animation-*` are dropped.
+
+**When easy, prefer native-friendly shapes** (fallbacks are fine when the design needs them):
+- Breakpoints: `@media(--mobile)` — not `@media (max-width: 768px)`
+- Gap: single value `gap: 1rem` — not two-value `gap: 1rem 2rem` / `row-gap`
+- Borders: shorthand `border` / `border-width` — per-side `border-color` / `border-style` may fall back
+- Border-radius: simple values — not elliptical slash form (`10px / 20px`)
+- Transform: `rotate()` / `scale()` / `translate()` — not `matrix()`, `skew()`, `perspective`, `rotate3d`
+- Transition: property list — easing and delay may be dropped
+- Box-shadow: literal values (fully supported) — not `var(...)` inside the shadow
+- Font family & `var()`: one Google Font or one kit variable label — see GLOBAL VARIABLES
+
+**`padding` / `margin` shorthands are supported** — use them; do not split into longhand unnecessarily.
 
 ## element_config FORMAT
 Match the widget schema shape:
 - **string / enum / url**: plain string (`"h2"`, `"https://example.com"`)
 - **number**: plain number (`42`)
 - **boolean**: plain boolean (`true`)
-- **html-v3** (title, paragraph, etc.): `{ "content": "Hello", "children": [] }` — `children` is a plain array of child node objects
+- **text** (`title` on `e-heading`, `paragraph` on `e-paragraph`, `text` on `e-button`): plain string (`"Welcome"`). Do NOT wrap in `{ content, children }`.
 - **dynamic** (where schema allows): `{ "name": "<tag from elementor://dynamic-tags>", "settings": { ... } }` — settings use plain values per the tag schema; omit `group`
 - **image**: two forms, `id` and `url` are mutually exclusive — send one, not both:
   - Library asset (from `elementor/list-assets` tool): `{ "src": { "id": 123 }, "size": "full" }`.
@@ -87,7 +99,7 @@ Read [elementor://global-variables] before styling. Create or update via `elemen
 - `font-family: var(--font-heading)` or `font-size: var(--spacing-lg, 1.5rem)`
 - Literal `font-family` values MUST be a single Google Font family name (e.g. `Playfair Display`). NEVER pass fallback stacks (`Inter, sans-serif`) or generic families as the primary value.
 - Do NOT use the internal `e-gv-` id prefix (e.g. `var(--e-gv-wc26-gold)` is wrong; use `var(--wc26-gold)`)
-- Unrecognized variable references fall back to `custom_css`, which may not render on Pro 3.35+
+- Unrecognized variable references fall back to `custom_css`
 
 ## GLOBAL CLASSES
 Read [elementor://global-classes] before composing. Create or update via `elementor/manage-classes`. Use `elementor/reorder-classes` when conflicting global class declarations need a priority change. Use class **labels** from that list — not internal ids.
@@ -207,7 +219,7 @@ Section with heading + button (NO explicit heights - content sizes naturally):
   "element_config": {
     "Section Title": {
       "tag": "h2",
-      "title": { "content": "Welcome", "children": [] }
+      "title": "Welcome"
     }
   },
   "style": {

--- a/modules/mcp/static-resources/abilities/manage-component.md
+++ b/modules/mcp/static-resources/abilities/manage-component.md
@@ -17,7 +17,7 @@ Requires `title` (2-200 chars). Choose ONE source for the initial content, or om
 - **xml_structure**: same tag language as `elementor/build-composition` (`element_config`, `classes`, `style`, `interactions`). It must contain exactly one root element, and every element needs a unique `configuration-id`.
 - **source_post_id** + **element_id**: copy an existing element (and its children) from another document — get `element_id` from `elementor/get-page-structure`. All ids are regenerated on the copy.
 
-Optionally attach `overridable_props` (see below). Returns `component_id`, `uid`, `editor_url`.
+Optionally attach `overridable_props` (see below). Returns `component_id`, `uid`, `edit_url`.
 
 `xml_structure` may contain self-closing `<e-component configuration-id="…"/>` nodes to instance other components (leaf tag; no children inside `<e-component>`). `configuration-id` identifies the instance within the request; configure the reusable component it references via `element_config` using the flat `{ component_id, overrides? }` shape documented in `build-composition.md` COMPONENTS section.
 
@@ -94,7 +94,7 @@ Example — a `Cards Grid` wrapper that re-exposes `caption`/`image` from each n
   "title": "Hero Section",
   "xml_structure": "<e-flexbox configuration-id=\"hero\"><e-heading configuration-id=\"hero-title\"></e-heading></e-flexbox>",
   "element_config": {
-    "hero-title": { "title": { "content": "Welcome", "children": [] } }
+    "hero-title": { "title": "Welcome" }
   },
   "overridable_props": {
     "heading-text": {
@@ -107,4 +107,4 @@ Example — a `Cards Grid` wrapper that re-exposes `caption`/`image` from each n
 ```
 
 # FURTHER INSTRUCTIONS
-Every successful response includes `editor_url` and `llm_instructions` — components have no public permalink, so you MUST share `editor_url` with the user to review the change.
+Every successful response includes `edit_url` and `llm_instructions` — components have no public permalink, so you MUST share `edit_url` with the user to review the change.

--- a/modules/mcp/static-resources/abilities/read-resource.md
+++ b/modules/mcp/static-resources/abilities/read-resource.md
@@ -4,7 +4,3 @@ Input:
 - uri (required): The resource URI to read, as returned by list-resources.
 
 Returns the resource content along with its MIME type. Text resources (markdown, plain text) return content as a string. JSON resources are serialized to a JSON string.
-
-Common resources:
-- elementor://style/best-practices — Design quality guidelines for distinctive aesthetics
-- elementor://variables/tools/manage-global-variable-guide — Guide for the manage-global-variable tool

--- a/tests/phpunit/elementor/modules/mcp/test-manage-component-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-component-ability.php
@@ -198,7 +198,7 @@ class Test_Manage_Component_Ability extends Elementor_Test_Base {
 		$this->assertTrue( $result['success'] );
 		$this->assertArrayHasKey( 'component_id', $result );
 		$this->assertArrayHasKey( 'uid', $result );
-		$this->assertArrayHasKey( 'editor_url', $result );
+		$this->assertArrayHasKey( 'edit_url', $result );
 
 		$component = ( new Components_Repository() )->get( $result['component_id'], false );
 		$this->assertSame( [], $component->get_elements_data() );


### PR DESCRIPTION
Cherry-pick of #37073 to the release/beta branch.

## Changes

- Fix `html-v3` text prop examples in `build-composition.md` (plain string, not `{content, children}`)
- Remove stale Pro 3.35+ version pins; replace incorrect padding-shorthand advice with validated CSS trap list
- Rename `manage-component` `editor_url` → `edit_url`
- Remove stale hand-maintained `read-resource` catalog hints
- Remove orphan "Retry on errors up to 10x" instruction

## Original PR

#37073

## Jira

[ED-25171](https://elementor.atlassian.net/browse/ED-25171)

Made with [Cursor](https://cursor.com)

[ED-25171]: https://elementor.atlassian.net/browse/ED-25171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Cherry-pick fixing inconsistent field naming (`editor_url` → `edit_url`) in MCP component schema and documentation. Aligns runtime behavior with factual schema spec and corrects misconceptions about text prop format. Ticket: ED-25171.

## 2. What Changed (Where)

| Component | Change |
|-----------|--------|
| `manage-component-ability.php` | Renamed `editor_url` → `edit_url` in return array and schema definition |
| `test-manage-component-ability.php` | Updated assertion to match new field name |
| Documentation (3 files) | Clarified text props use plain strings, not `{ content, children }`; expanded CSS style conversion rules; removed deprecated shorthand warnings |

## 3. How It Works

The ability now returns `edit_url` consistently across both the actual response and its OpenAPI schema definition. Documentation corrections clarify that heading/paragraph/button `title` props expect scalars (`"Welcome"`), not wrapped objects—eliminating a common implementation error. CSS guidance expanded to specify native-friendly patterns (breakpoint names, gap syntax, border forms) that avoid `custom_css` fallback.

## 4. Risks

Minimal. Field rename is internal to MCP responses; LLM consumers need updated docs (already fixed). Test covers the new field. No backward compatibility concern since this targets release/beta branch.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
