### PR TITLE
Internal: MCP Connection Page analytics listener [ED-25436]

### DIFF
--- a/modules/mcp/admin-menu-items/editor-one-mcp-menu.php
+++ b/modules/mcp/admin-menu-items/editor-one-mcp-menu.php
@@ -6,6 +6,7 @@ use Elementor\Core\Admin\Menu\Interfaces\Admin_Menu_Item_With_Page;
 use Elementor\Core\Admin\EditorOneMenu\Interfaces\Menu_Item_Third_Level_Interface;
 use Elementor\MCP\Composer\Admin\Page;
 use Elementor\Modules\EditorOne\Classes\Menu_Config;
+use Elementor\Modules\Mcp\Module;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -62,6 +63,7 @@ class Editor_One_Mcp_Menu implements Menu_Item_Third_Level_Interface, Admin_Menu
 	}
 
 	public function render() {
+		Module::instance()->enqueue_analytics_listener();
 		$this->page->render();
 	}
 }

--- a/modules/mcp/assets/dev/js/mcp-analytics-listener.js
+++ b/modules/mcp/assets/dev/js/mcp-analytics-listener.js
@@ -1,0 +1,101 @@
+const MCP_INTERACTION_EVENT = 'elementor/mcp/interaction';
+
+const FIXED_PROPS = {
+	app_type: 'infra',
+	window_name: 'elementor_mcp',
+	target_location: 'main_content',
+};
+
+const HANDLERS = {
+	viewed: ( d ) => [ 'mcp_connection_page_viewed', {
+		...FIXED_PROPS,
+		target_location: 'page',
+		interaction_type: 'view',
+		target_type: 'page',
+		target_name: 'elementor_mcp',
+		interaction_result: 'page_loaded',
+		client: d.client,
+		mode: d.mode,
+	} ],
+	learn_more_clicked: () => [ 'mcp_learn_more_clicked', {
+		...FIXED_PROPS,
+		target_location: 'header',
+		interaction_type: 'click',
+		target_type: 'link',
+		target_name: 'what_is_mcp',
+		interaction_result: 'link_clicked',
+	} ],
+	client_selected: ( d ) => [ 'mcp_client_selected', {
+		...FIXED_PROPS,
+		interaction_type: 'click',
+		target_type: 'tab',
+		target_name: 'client_tab',
+		interaction_result: 'client_switched',
+		client: d.client,
+		client_previous: d.previous_client,
+	} ],
+	mode_switched: ( d ) => [ 'mcp_setup_mode_switched', {
+		...FIXED_PROPS,
+		interaction_type: 'click',
+		target_type: 'link',
+		target_name: 'setup_mode_toggle',
+		interaction_result: 'mode_switched',
+		mode: d.mode,
+		client: d.client,
+	} ],
+	credentials_generated: ( d ) => [ 'mcp_credentials_generated', {
+		...FIXED_PROPS,
+		interaction_type: 'click',
+		target_type: 'button',
+		target_name: 'generate_credentials',
+		interaction_result: 'credentials_generated',
+		client: d.client,
+		mode: d.mode,
+	} ],
+	credentials_generation_failed: ( d ) => [ 'mcp_credentials_generation_failed', {
+		...FIXED_PROPS,
+		interaction_type: 'click',
+		target_type: 'button',
+		target_name: 'generate_credentials',
+		interaction_result: 'generation_failed',
+		client: d.client,
+		mode: d.mode,
+		error_reason: d.error_reason,
+	} ],
+	config_copied: ( d ) => {
+		const props = {
+			...FIXED_PROPS,
+			interaction_type: 'click',
+			target_type: 'button',
+			target_name: 'copy_config',
+			interaction_result: 'config_copied',
+			client: d.client,
+			mode: d.mode,
+			copy_target: d.copy_target,
+		};
+
+		if ( d.os ) {
+			props.os = d.os;
+		}
+
+		return [ 'mcp_config_copied', props ];
+	},
+};
+
+window.addEventListener( MCP_INTERACTION_EVENT, ( event ) => {
+	const detail = event.detail;
+
+	if ( ! detail || 'string' !== typeof detail.name ) {
+		return;
+	}
+
+	const build = HANDLERS[ detail.name ];
+
+	if ( ! build ) {
+		return;
+	}
+
+	const [ eventName, props ] = build( detail );
+
+	window.elementorCommon?.eventsManager?.dispatchEvent( eventName, props );
+} );

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -19,10 +19,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Module extends BaseModule {
 
+	const ANALYTICS_LISTENER_HANDLE = 'elementor-mcp-analytics-listener';
+
 	private Ability_Registry $registry;
 
 	public function get_name() {
 		return 'mcp';
+	}
+
+	public function enqueue_analytics_listener(): void {
+		wp_enqueue_script(
+			self::ANALYTICS_LISTENER_HANDLE,
+			$this->get_js_assets_url( 'mcp-analytics-listener' ),
+			[ 'elementor-common' ],
+			ELEMENTOR_VERSION,
+			true
+		);
 	}
 
 	public static function is_active() {

--- a/scripts/vite/shared/entries.mjs
+++ b/scripts/vite/shared/entries.mjs
@@ -76,6 +76,7 @@ export const BASE_ENTRIES = {
 	'pro-install-events': 'modules/pro-install/assets/js/pro-install-events.js',
 	'design-system-sync': 'modules/design-system-sync/assets/js/design-system-sync-handler.js',
 	'assets-manager': 'modules/assets-manager/assets/js/assets-manager.js',
+	'mcp-analytics-listener': 'modules/mcp/assets/dev/js/mcp-analytics-listener.js',
 };
 
 /**


### PR DESCRIPTION
## Summary

Ships the Core-side listener for ED-25436. The MCP Connection Page (delivered by `elementor/elementor-mcp-composer`) now dispatches a namespaced `window` CustomEvent — `elementor/mcp/interaction` — at each user interaction. This PR attaches a listener on the MCP admin screen, whitelists the payload, and maps it to the 7 Mixpanel events + fixed properties specified by the ticket.

- New `modules/mcp/assets/dev/js/mcp-analytics-listener.js` — the listener. Validates `detail.name` against a known enum (`viewed`, `learn_more_clicked`, `client_selected`, `mode_switched`, `credentials_generated`, `credentials_generation_failed`, `config_copied`) and dispatches through `elementorCommon.eventsManager.dispatchEvent` with `app_type: 'infra'`, `window_name: 'elementor_mcp'`, plus the per-event fixed `interaction_type`/`target_type`/`target_name`/`interaction_result`/`target_location` values from the ticket. Consent gating is not duplicated here — `dispatchEvent` already short-circuits when `canSendEvents()` is false, per the ticket's ""do not bypass"" rule.
- New entry `mcp-analytics-listener` in `scripts/vite/shared/entries.mjs` so the build pipeline emits `assets/js/mcp-analytics-listener.min.js`.
- `Module::enqueue_analytics_listener()` on `modules/mcp/module.php` — public helper on the base module that enqueues the listener with `elementor-common` as its script dependency (giving us `elementorCommon.eventsManager`).
- `Editor_One_Mcp_Menu::render()` calls that helper before delegating to the composer package's `Page::render()`, so the listener is present on every render of the MCP admin page.

## Design decisions

- **Why validate `detail.name` against a whitelist?** Any script on the admin page can `window.dispatchEvent` a `CustomEvent` with the same name. The whitelist means external code can only replay names we already emit — never inject arbitrary Mixpanel event names.
- **Why not gate on `canSendEvents()` here?** The events-manager already does it inside `dispatchEvent` (see [core/common/modules/events-manager/assets/js/module.js](core/common/modules/events-manager/assets/js/module.js) L75, L177). Duplicating the check risks drifting from the ticket's ""do not bypass"" rule.
- **`app_type` vs `appType` super-property clash:** the events-manager registers `appType: 'Editor'` as a Mixpanel super-property (module.js L56). We send `app_type` (snake_case, distinct key) in `data`, so both land in Mixpanel and downstream infra reads `app_type`. Worth a one-time live verification post-merge.

## Jira

- ED-25436

## Companion PR

- Composer side (dispatches the CustomEvent from the React app): [elementor/elementor-mcp-composer#39](https://github.com/elementor/elementor-mcp-composer/pull/39)

The composer PR must be released (npm version + build) and pulled into Core's `vendor/elementor/elementor-mcp-composer` via `composer update` before events actually fire.

## Test plan

- [ ] On a live wp-admin MCP page, confirm `window.elementorCommon.eventsManager.dispatchEvent` and `window.elementorCommon.config.editor_events` are present (go/no-go from the ticket).
- [ ] With the companion composer bundle in place, walk the page and confirm each of the 7 events lands in Mixpanel:
  - [ ] `mcp_connection_page_viewed` on load with `client=claude_code`, `mode=auto`.
  - [ ] `mcp_learn_more_clicked` on ""What is MCP?"" click.
  - [ ] `mcp_client_selected` on tab switch with `client_previous` set correctly.
  - [ ] `mcp_setup_mode_switched` in both directions with the target mode.
  - [ ] `mcp_credentials_generated` once per client (repeat copy fires only `mcp_config_copied`).
  - [ ] `mcp_credentials_generation_failed` with `error_reason: 'app_passwords_disabled'` when WP Application Passwords are off.
  - [ ] `mcp_config_copied` with the right `copy_target` for each of: setup_prompt, json_config, toml_config, password, file_path (with `os` present only for file_path).
- [ ] Confirm no events fire when tracking consent is off (existing `canSendEvents()` gate).
- [ ] Confirm `app_type=infra` and `window_name=elementor_mcp` are present on all 7 events in Mixpanel — including that `app_type` wins over the dispatcher's `appType: 'Editor'` super-property.
- [ ] Dispatch a fake `CustomEvent('elementor/mcp/interaction', { detail: { name: 'evil', foo: 'bar' } })` from the DevTools console and confirm no Mixpanel event is sent.

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding analytics instrumentation to the MCP Connection Page to track user interactions. Enables product insights on client selection, mode switching, credential generation, and config copying.

## 2. What Changed (Where)

- **editor-one-mcp-menu.php**: Import Module class, call `enqueue_analytics_listener()` in render method
- **module.php**: Add `enqueue_analytics_listener()` method that registers mcp-analytics-listener script with Elementor Common dependency
- **mcp-analytics-listener.js**: New 101-line listener mapping 7 interaction events to analytics events with standardized props
- **entries.mjs**: Register mcp-analytics-listener as base bundle entry point

## 3. How It Works

Page render triggers script enqueue → listener attaches to `elementor/mcp/interaction` custom events → handler maps event name + data to analytics event name and properties → dispatches via `elementor Common.eventsManager`. Fixed props (app_type, window_name) apply globally; event-specific props (client, mode, error_reason) merge per interaction type.

## 4. Risks

None significant. Script is passive listener; no DOM manipulation or side effects. Gracefully handles missing handlers or malformed event details. Dependency on elementorCommon.eventsManager existing (unlikely to break, already used elsewhere).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
