### PR TITLE
Fix: Background Video component creation and exposed controls issues [ED-25333]

### DIFF
--- a/modules/components/prop-types/overridable-prop-type.php
+++ b/modules/components/prop-types/overridable-prop-type.php
@@ -43,7 +43,16 @@ class Overridable_Prop_Type extends Plain_Prop_Type {
 			return false;
 		}
 
-		return $origin_prop_type->validate( $value['origin_value'] );
+		return $origin_prop_type->validate( self::normalize_origin_value( $value['origin_value'] ) );
+	}
+
+	/**
+	 * Exposing a prop that has no value must persist `origin_value: null`. Editor versions that
+	 * wrote an empty object instead left components permanently unsavable, so treat any empty
+	 * `origin_value` as "no value" and let `sanitize_value()` normalize it away on the next save.
+	 */
+	private static function normalize_origin_value( $origin_value ) {
+		return ( is_array( $origin_value ) && empty( $origin_value ) ) ? null : $origin_value;
 	}
 
 	protected function sanitize_value( $value ): ?array {
@@ -54,6 +63,8 @@ class Overridable_Prop_Type extends Plain_Prop_Type {
 		if ( ! $origin_prop_type ) {
 			return null;
 		}
+
+		$origin_value = self::normalize_origin_value( $origin_value );
 
 		$sanitized_override_key = sanitize_key( $override_key );
 		$sanitized_origin_value = is_null( $origin_value ) ? null : $origin_prop_type->sanitize( $origin_value );

--- a/modules/components/transformers/overridable-transformer.php
+++ b/modules/components/transformers/overridable-transformer.php
@@ -32,7 +32,7 @@ class Overridable_Transformer extends Transformer_Base {
 		return $result;
 	}
 
-	private function is_origin_value_override( array $origin_value ): bool {
+	private function is_origin_value_override( ?array $origin_value ): bool {
 		return isset( $origin_value['$$type'] ) && Override_Prop_Type::get_key() === $origin_value['$$type'];
 	}
 

--- a/packages/packages/core/editor-components/src/component-overridable-transformer.ts
+++ b/packages/packages/core/editor-components/src/component-overridable-transformer.ts
@@ -10,10 +10,8 @@ export const componentOverridableTransformer = createTransformer(
 		const overrideValue = overrides?.[ value.override_key as keyof typeof overrides ];
 
 		if ( overrideValue ) {
-			const isOverride = isOriginValueOverride( value.origin_value );
-
-			if ( isOverride ) {
-				return transformOverride( value, options, overrideValue );
+			if ( isOriginValueOverride( value.origin_value ) ) {
+				return transformOverride( value.origin_value, options, overrideValue );
 			}
 
 			return overrideValue;
@@ -24,7 +22,7 @@ export const componentOverridableTransformer = createTransformer(
 );
 
 function transformOverride(
-	value: ComponentOverridable,
+	originValue: TransformablePropValue< string >,
 	options: {
 		key: string;
 	},
@@ -36,7 +34,7 @@ function transformOverride(
 		return null;
 	}
 
-	const transformedValue = transformer( value.origin_value.value, options );
+	const transformedValue = transformer( originValue.value, options );
 
 	if ( ! transformedValue ) {
 		return null;
@@ -49,6 +47,8 @@ function transformOverride(
 	};
 }
 
-function isOriginValueOverride( originValue: TransformablePropValue< string > ): boolean {
-	return originValue.$$type === 'override';
+function isOriginValueOverride(
+	originValue: TransformablePropValue< string > | null
+): originValue is TransformablePropValue< string > {
+	return originValue?.$$type === 'override';
 }

--- a/packages/packages/core/editor-components/src/prop-types/__tests__/component-overridable-prop-type.test.ts
+++ b/packages/packages/core/editor-components/src/prop-types/__tests__/component-overridable-prop-type.test.ts
@@ -1,0 +1,31 @@
+import { componentOverridablePropTypeUtil } from '../component-overridable-prop-type';
+
+describe( 'componentOverridablePropTypeUtil', () => {
+	it( 'should treat an exposed prop with no value as valid when origin_value is null', () => {
+		// Arrange
+		const prop = {
+			$$type: 'overridable',
+			value: { override_key: 'source', origin_value: null },
+		};
+
+		// Act
+		const result = componentOverridablePropTypeUtil.extract( prop );
+
+		// Assert
+		expect( result ).toEqual( { override_key: 'source', origin_value: null } );
+	} );
+
+	it( 'should reject an empty origin_value, so the prop reads as never exposed', () => {
+		// Arrange
+		const prop = {
+			$$type: 'overridable',
+			value: { override_key: 'source', origin_value: {} },
+		};
+
+		// Act
+		const result = componentOverridablePropTypeUtil.extract( prop );
+
+		// Assert
+		expect( result ).toBeNull();
+	} );
+} );

--- a/packages/packages/core/editor-components/src/types.ts
+++ b/packages/packages/core/editor-components/src/types.ts
@@ -89,7 +89,7 @@ export type ExtendedWindow = Window & {
 
 export type ComponentOverridable = {
 	override_key: string;
-	origin_value: TransformablePropValue< string >;
+	origin_value: TransformablePropValue< string > | null;
 };
 
 export type ComponentRenderContext = RenderContext< {

--- a/packages/packages/core/editor-components/src/utils/__tests__/component-overridable-transformer.test.ts
+++ b/packages/packages/core/editor-components/src/utils/__tests__/component-overridable-transformer.test.ts
@@ -74,6 +74,42 @@ describe( 'componentOverridableTransformer', () => {
 		expect( result ).toEqual( TEST_OVERRIDE_VALUE );
 	} );
 
+	it( 'should return the override value when origin value is null', () => {
+		// Arrange
+		const value: ComponentOverridable = {
+			override_key: TEST_OVERRIDE_KEY,
+			origin_value: null,
+		};
+		const options: TransformerOptions = {
+			...TEST_OPTIONS,
+			renderContext: { overrides: { [ TEST_OVERRIDE_KEY ]: TEST_OVERRIDE_VALUE } },
+		};
+
+		// Act
+		const result = componentOverridableTransformer( value, options );
+
+		// Assert
+		expect( result ).toEqual( TEST_OVERRIDE_VALUE );
+	} );
+
+	it( 'should return null when origin value is null and no override matches', () => {
+		// Arrange
+		const value: ComponentOverridable = {
+			override_key: TEST_OVERRIDE_KEY,
+			origin_value: null,
+		};
+		const options: TransformerOptions = {
+			...TEST_OPTIONS,
+			renderContext: { overrides: { 'different-key': TEST_OVERRIDE_VALUE } },
+		};
+
+		// Act
+		const result = componentOverridableTransformer( value, options );
+
+		// Assert
+		expect( result ).toBeNull();
+	} );
+
 	it( 'should transform override when origin value is an override type', () => {
 		// Arrange
 		const TRANSFORMED_KEY = 'transformed-key';

--- a/tests/phpunit/elementor/modules/components/prop-types/test-overridable-prop-type.php
+++ b/tests/phpunit/elementor/modules/components/prop-types/test-overridable-prop-type.php
@@ -3,7 +3,7 @@
 namespace Elementor\Testing\Modules\Components\PropTypes;
 
 use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
-use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Number_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Video_Src_Prop_Type;
 use Elementor\Modules\Components\PropTypes\Overridable_Prop_Type;
 use ElementorEditorTesting\Elementor_Test_Base;
 
@@ -121,6 +121,48 @@ class Test_Overridable_Prop_Type extends Elementor_Test_Base {
 			'$$type' => 'overridable',
 			'value' => [
 				'override_key' => 'my-override-key',
+				'origin_value' => null,
+			],
+		], $result );
+	}
+
+	public function test_validate__passes_with_empty_origin_value_for_video_src() {
+		// Arrange — simulates legacy Pro writing `{}` when exposing an empty video source.
+		$prop_type = Overridable_Prop_Type::make()
+			->set_origin_prop_type( Video_Src_Prop_Type::make() );
+
+		// Act
+		$result = $prop_type->validate( [
+			'$$type' => 'overridable',
+			'value' => [
+				'override_key' => 'source',
+				'origin_value' => [],
+			],
+		] );
+
+		// Assert
+		$this->assertTrue( $result );
+	}
+
+	public function test_sanitize__normalizes_empty_origin_value_to_null_for_video_src() {
+		// Arrange — Core-only fix must accept legacy `{}` and persist canonical `null`.
+		$prop_type = Overridable_Prop_Type::make()
+			->set_origin_prop_type( Video_Src_Prop_Type::make() );
+
+		// Act
+		$result = $prop_type->sanitize( [
+			'$$type' => 'overridable',
+			'value' => [
+				'override_key' => 'source',
+				'origin_value' => [],
+			],
+		] );
+
+		// Assert
+		$this->assertEquals( [
+			'$$type' => 'overridable',
+			'value' => [
+				'override_key' => 'source',
 				'origin_value' => null,
 			],
 		], $result );

--- a/tests/phpunit/elementor/modules/components/prop-types/test-overridable-prop-type.php
+++ b/tests/phpunit/elementor/modules/components/prop-types/test-overridable-prop-type.php
@@ -84,6 +84,48 @@ class Test_Overridable_Prop_Type extends Elementor_Test_Base {
 		$this->assertTrue( $result );
 	}
 
+	public function test_validate__passes_with_empty_origin_value() {
+		// Arrange
+		$prop_type = Overridable_Prop_Type::make()
+			->set_origin_prop_type( String_Prop_Type::make() );
+
+		// Act
+		$result = $prop_type->validate( [
+			'$$type' => 'overridable',
+			'value' => [
+				'override_key' => 'my-override-key',
+				'origin_value' => [],
+			],
+		] );
+
+		// Assert
+		$this->assertTrue( $result );
+	}
+
+	public function test_sanitize__normalizes_empty_origin_value_to_null() {
+		// Arrange
+		$prop_type = Overridable_Prop_Type::make()
+			->set_origin_prop_type( String_Prop_Type::make() );
+
+		// Act
+		$result = $prop_type->sanitize( [
+			'$$type' => 'overridable',
+			'value' => [
+				'override_key' => 'my-override-key',
+				'origin_value' => [],
+			],
+		] );
+
+		// Assert
+		$this->assertEquals( [
+			'$$type' => 'overridable',
+			'value' => [
+				'override_key' => 'my-override-key',
+				'origin_value' => null,
+			],
+		], $result );
+	}
+
 	public function test_sanitize__handles_null_origin_value() {
 		// Arrange
 		$prop_type = Overridable_Prop_Type::make()

--- a/tests/phpunit/elementor/modules/components/test-overridable-props-parsing.php
+++ b/tests/phpunit/elementor/modules/components/test-overridable-props-parsing.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Elementor\Testing\Modules\Components;
+
+use Elementor\Modules\AtomicWidgets\Parsers\Props_Parser;
+use Elementor\Modules\AtomicWidgets\PropTypes\Video_Src_Prop_Type;
+use Elementor\Modules\Components\Overridable_Schema_Extender;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Covers the full save chain for an exposed prop that has no value:
+ * Props_Parser -> Union_Prop_Type -> Overridable_Prop_Type -> Video_Src_Prop_Type.
+ *
+ * `source` on Background Video is the reproduction case from ED-25333 — it declares no
+ * top-level default, so exposing it while empty is what produced an unsavable document.
+ */
+class Test_Overridable_Props_Parsing extends Elementor_Test_Base {
+
+	private function get_schema(): array {
+		return Overridable_Schema_Extender::make()->get_extended_schema( [
+			'source' => Video_Src_Prop_Type::make()->alias( 'video', 'src' ),
+		] );
+	}
+
+	private function make_exposed_source( $origin_value ): array {
+		return [
+			'source' => [
+				'$$type' => 'overridable',
+				'value' => [
+					'override_key' => 'source',
+					'origin_value' => $origin_value,
+				],
+			],
+		];
+	}
+
+	public function test_parse__normalizes_legacy_empty_origin_value_to_null() {
+		// Arrange — an editor version that wrote `{}` instead of `null` for a valueless prop.
+		$parser = Props_Parser::make( $this->get_schema() );
+
+		// Act
+		$result = $parser->parse( $this->make_exposed_source( [] ) );
+
+		// Assert
+		$this->assertTrue( $result->is_valid(), $result->errors()->to_string() );
+		$this->assertNull( $result->unwrap()['source']['value']['origin_value'] );
+	}
+
+	public function test_parse__accepts_null_origin_value() {
+		// Arrange
+		$parser = Props_Parser::make( $this->get_schema() );
+
+		// Act
+		$result = $parser->parse( $this->make_exposed_source( null ) );
+
+		// Assert
+		$this->assertTrue( $result->is_valid(), $result->errors()->to_string() );
+		$this->assertNull( $result->unwrap()['source']['value']['origin_value'] );
+	}
+
+	public function test_parse__preserves_a_populated_origin_value() {
+		// Arrange
+		$origin_value = [
+			'$$type' => 'video-src',
+			'value' => [
+				'id' => null,
+				'url' => [ '$$type' => 'url', 'value' => 'https://example.com/video.mp4' ],
+			],
+		];
+
+		$parser = Props_Parser::make( $this->get_schema() );
+
+		// Act
+		$result = $parser->parse( $this->make_exposed_source( $origin_value ) );
+
+		// Assert
+		$this->assertTrue( $result->is_valid(), $result->errors()->to_string() );
+		$this->assertEquals( $origin_value, $result->unwrap()['source']['value']['origin_value'] );
+	}
+}

--- a/tests/phpunit/elementor/modules/components/transformers/test-overridable-transformer.php
+++ b/tests/phpunit/elementor/modules/components/transformers/test-overridable-transformer.php
@@ -134,6 +134,58 @@ class Test_Overridable_Transformer extends Elementor_Test_Base {
         $this->assertEquals( $origin_value, $result );
     }
 
+    public function test_overridable_transformer_returns_override_value_when_origin_value_is_null() {
+        // Arrange.
+        $transformer = new Overridable_Transformer();
+
+        $value = [
+            'override_key' => 'my-override-key',
+            'origin_value' => null,
+        ];
+
+        $override_value = [
+            '$$type' => 'video-src',
+            'value' => [
+                'id' => [ '$$type' => 'video-attachment-id', 'value' => 12 ],
+                'url' => null,
+            ],
+        ];
+
+        $context = [ 'overrides' => [ 'my-override-key' => $override_value ] ];
+
+        // Act.
+        Render_Context::push( Overridable_Transformer::class, $context );
+        $result = $transformer->transform( $value, Props_Resolver_Context::make() );
+        Render_Context::pop( Overridable_Transformer::class );
+
+        // Assert.
+        $this->assertEquals( $override_value, $result );
+    }
+
+    public function test_overridable_transformer_returns_null_when_origin_value_is_null_and_no_matching_override() {
+        // Arrange.
+        $transformer = new Overridable_Transformer();
+
+        $value = [
+            'override_key' => 'my-override-key',
+            'origin_value' => null,
+        ];
+
+        $context = [
+            'overrides' => [
+                'other-override-key' => [ '$$type' => 'string', 'value' => 'Other Override Text' ],
+            ],
+        ];
+
+        // Act.
+        Render_Context::push( Overridable_Transformer::class, $context );
+        $result = $transformer->transform( $value, Props_Resolver_Context::make() );
+        Render_Context::pop( Overridable_Transformer::class );
+
+        // Assert.
+        $this->assertNull( $result );
+    }
+
     public function test_overridable_transformer_handles_override_original_value_when_matching_override_is_found() {
         // Arrange.
         $transformer = new Overridable_Transformer();


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Fixes ED-25333 where Background Video components became unsavable because certain editor versions persisted empty objects instead of `null` for exposed props with no value. The change ensures consistent normalization of these "empty" states to prevent validation failures.

## 2. What Changed (Where)

| File | Change |
| :--- | :--- |
| `overridable-prop-type.php` | Added `normalize_origin_value` to treat empty arrays as `null`. |
| `overridable-transformer.php` | Updated `is_origin_value_override` to handle nullable `origin_value`. |
| `component-overridable-transformer.ts` | Updated transformer and types to support nullable `origin_value`. |
| `types.ts` | Changed `ComponentOverridable.origin_value` type to include `null`. |
| `tests/...` | Added comprehensive PHPUnit and Jest tests for null/empty normalization. |

## 3. How It Works
The `Overridable_Prop_Type` now intercepts `origin_value` during validation and sanitization, converting `[]` to `null` via `normalize_origin_value`. This ensures the underlying prop type (e.g., `Video_Src_Prop_Type`) receives a canonical `null` rather than an invalid empty array, allowing the document to be saved and validated.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-25333]: https://elementor.atlassian.net/browse/ED-25333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ