### PR TITLE
Fix: Theme Builder backwards compatibility [ED-25418]

### DIFF
--- a/assets/dev/js/editor/regions/panel/footer-back-compat.js
+++ b/assets/dev/js/editor/regions/panel/footer-back-compat.js
@@ -1,0 +1,55 @@
+/**
+ * Back-compat stub for the removed Editor v1 panel footer (ED-24856).
+ *
+ * Elementor Pro < 4.3 still hooks Theme Builder / Popup UI through
+ * `elementor.getPanelView().footer.currentView`. Without this stub, opening
+ * those documents throws and leaves the editor stuck loading (ED-25418).
+ */
+const StubFooterSaverBehavior = Marionette.Behavior.extend( {
+	ui() {
+		return {
+			buttonPreview: '.elementor-panel-footer-back-compat-preview',
+		};
+	},
+
+	onRender() {
+		if ( ! this.ui.buttonPreview.tipsy ) {
+			this.ui.buttonPreview.tipsy = () => this.ui.buttonPreview;
+		}
+	},
+} );
+
+module.exports = Marionette.ItemView.extend( {
+	template: '#tmpl-elementor-panel-footer-back-compat',
+
+	className: 'elementor-panel-footer-back-compat',
+
+	attributes: {
+		'aria-hidden': 'true',
+	},
+
+	behaviors() {
+		return {
+			saver: {
+				behaviorClass: StubFooterSaverBehavior,
+			},
+		};
+	},
+
+	addSubMenuItem( subMenuName, itemData ) {
+		const $newItem = jQuery( '<div>', {
+			id: 'elementor-panel-footer-sub-menu-item-' + itemData.name,
+			class: 'elementor-panel-footer-sub-menu-item',
+		} );
+
+		if ( itemData.callback ) {
+			$newItem.on( 'click', itemData.callback );
+		}
+
+		return $newItem;
+	},
+
+	removeSubMenuItem( subMenuName, itemData ) {
+		return jQuery( '#elementor-panel-footer-sub-menu-item-' + itemData.name ).remove();
+	},
+} );

--- a/assets/dev/js/editor/regions/panel/footer-back-compat.js
+++ b/assets/dev/js/editor/regions/panel/footer-back-compat.js
@@ -28,12 +28,28 @@ module.exports = Marionette.ItemView.extend( {
 		'aria-hidden': 'true',
 	},
 
+	ui: {},
+
+	initialize() {
+		// Pro 4.2.x assigns `footerView.ui.menuConditions` before Marionette binds ui hashes.
+		this.ui = this.ui || {};
+	},
+
 	behaviors() {
 		return {
 			saver: {
 				behaviorClass: StubFooterSaverBehavior,
 			},
 		};
+	},
+
+	onRender() {
+		const saverIndex = Object.keys( this.behaviors() ).indexOf( 'saver' );
+		const behavior = this._behaviors?.[ saverIndex ];
+
+		if ( behavior?.ui?.buttonPreview?.length && ! behavior.ui.buttonPreview.tipsy ) {
+			behavior.ui.buttonPreview.tipsy = () => behavior.ui.buttonPreview;
+		}
 	},
 
 	addSubMenuItem( subMenuName, itemData ) {

--- a/assets/dev/js/editor/regions/panel/layout.js
+++ b/assets/dev/js/editor/regions/panel/layout.js
@@ -14,6 +14,7 @@ PanelLayoutView = Marionette.LayoutView.extend( {
 	regions: {
 		content: '#elementor-panel-content-wrapper',
 		header: '#elementor-panel-header-wrapper',
+		footer: '#elementor-panel-footer',
 		modeSwitcher: '#elementor-mode-switcher',
 	},
 
@@ -151,13 +152,17 @@ PanelLayoutView = Marionette.LayoutView.extend( {
 	},
 
 	onBeforeShow() {
-		var PanelHeaderItemView = require( 'elementor-regions/panel/header' );
+		var PanelHeaderItemView = require( 'elementor-regions/panel/header' ),
+			PanelFooterBackCompatView = require( 'elementor-regions/panel/footer-back-compat' );
 
 		// Edit Mode
 		this.showChildView( 'modeSwitcher', new EditModeItemView() );
 
 		// Header
 		this.showChildView( 'header', new PanelHeaderItemView() );
+
+		// Back-compat for Elementor Pro < 4.3 (ED-25418).
+		this.showChildView( 'footer', new PanelFooterBackCompatView() );
 
 		// Added Editor events
 		this.updateScrollbar = _.throttle( this.updateScrollbar, 100 );

--- a/assets/dev/scss/editor/panel/_compatibility.scss
+++ b/assets/dev/scss/editor/panel/_compatibility.scss
@@ -2,6 +2,11 @@
 // Compatibility
 //
 
+// Hidden stub for Elementor Pro < 4.3 panel footer API (ED-25418).
+#elementor-panel-footer.elementor-panel-footer-back-compat-wrapper {
+	display: none !important;
+}
+
 // WP Media Modal Compatibility
 .media-modal.wp-core-ui {
 	color-scheme: light; //light mode only

--- a/includes/editor-templates/panel.php
+++ b/includes/editor-templates/panel.php
@@ -16,7 +16,12 @@ $editing_panel_sticky_promotion = $show_editing_panel_sticky_promotion ? Filtere
 	</div>
 	<header id="elementor-panel-header-wrapper"></header>
 	<main id="elementor-panel-content-wrapper"></main>
+	<footer id="elementor-panel-footer" class="elementor-panel-footer-back-compat-wrapper" hidden></footer>
 	<div id="elementor-mode-switcher"></div>
+</script>
+
+<script type="text/template" id="tmpl-elementor-panel-footer-back-compat">
+	<button type="button" class="elementor-panel-footer-back-compat-preview" tabindex="-1" hidden></button>
 </script>
 
 <script type="text/template" id="tmpl-elementor-panel-menu">


### PR DESCRIPTION
## Summary

- Adds a hidden panel footer back-compat stub so Elementor Pro < 4.3 can open Theme Builder and Popup documents on Core 4.3+ without infinite loading.
- Core 4.3 removed the v1 panel footer in ED-24856; Pro 4.2.2 still calls `elementor.getPanelView().footer.currentView` when opening theme templates, which throws and blocks editor init.
- The stub implements the legacy footer API (`addSubMenuItem`, `removeSubMenuItem`, saver `buttonPreview`) without restoring the deprecated visible footer UI.

## Jira

https://elementor.atlassian.net/browse/ED-25418

## Test plan

- [ ] Core 4.3+ with Pro 4.2.2: WP Admin → Templates → Theme Builder → Add New → Header → editor loads (no infinite spinner)
- [ ] Core 4.3+ with Pro 4.3+: Theme Builder header/footer and Popup editors still load normally
- [ ] Regular page/post editor loads without console errors related to panel footer
- [ ] Confirm `#elementor-panel-footer` remains hidden and v2 app bar controls still work


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Prevents editor crashes in Elementor Pro < 4.3 (ED-25418) by restoring a removed panel footer API stub required by Theme Builder and Popup UI.

## 2. What Changed (Where)
- `includes/editor-templates/panel.php`: Added footer and button HTML templates.
- `assets/dev/js/editor/regions/panel/footer-back-compat.js`: Implemented Marionette stub view with mock behaviors.
- `assets/dev/js/editor/regions/panel/layout.js`: Registered footer region and integrated the compat view.
- `assets/dev/scss/editor/panel/_compatibility.scss`: Added CSS to keep the stub hidden.

## 3. How It Works
`PanelLayoutView` initializes `PanelFooterBackCompatView` into the footer region on show, providing the expected object structure and methods (`addSubMenuItem`) to satisfy legacy Pro hooks.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
