### PR TITLE
Internal: MCP Connection Page analytics registrar [ED-25436]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=7.4",
         "automattic/jetpack-autoloader": "^5",
-        "elementor/elementor-mcp-composer": "^1.0.8",
+        "elementor/elementor-mcp-composer": "^1.0.9",
         "elementor/wp-one-package": "1.0.68"
     },
     "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d862f3626d34cbd19f508122d054b32",
+    "content-hash": "0c867a2c5ed61fc3043ff038fabb0431",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -72,10 +72,10 @@
         },
         {
             "name": "elementor/elementor-mcp-composer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/elementor-mcp-composer/1.0.8"
+                "url": "https://composer.elementor.com/download/elementor/elementor-mcp-composer/1.0.9"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^5",
@@ -109,7 +109,7 @@
                 "proprietary"
             ],
             "description": "Reusable Composer package for Elementor MCP integrations.",
-            "time": "2026-08-27T07:56:13+00:00"
+            "time": "2026-08-30T14:08:53+00:00"
         },
         {
             "name": "elementor/wp-notifications-package",

--- a/modules/mcp/admin-menu-items/editor-one-mcp-menu.php
+++ b/modules/mcp/admin-menu-items/editor-one-mcp-menu.php
@@ -6,6 +6,7 @@ use Elementor\Core\Admin\Menu\Interfaces\Admin_Menu_Item_With_Page;
 use Elementor\Core\Admin\EditorOneMenu\Interfaces\Menu_Item_Third_Level_Interface;
 use Elementor\MCP\Composer\Admin\Page;
 use Elementor\Modules\EditorOne\Classes\Menu_Config;
+use Elementor\Modules\Mcp\Module;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -62,6 +63,7 @@ class Editor_One_Mcp_Menu implements Menu_Item_Third_Level_Interface, Admin_Menu
 	}
 
 	public function render() {
+		Module::instance()->enqueue_analytics_registrar();
 		$this->page->render();
 	}
 }

--- a/modules/mcp/assets/dev/js/mcp-analytics-registrar.js
+++ b/modules/mcp/assets/dev/js/mcp-analytics-registrar.js
@@ -2,8 +2,7 @@
 	const MCP_INTERACTION_EVENT = 'elementor/mcp/interaction';
 
 	const FIXED_PROPS = {
-		app_type: 'infra',
-		appType: 'infra',
+		app_type: 'wpadmin',
 		window_name: 'elementor_mcp',
 		target_location: 'main_content',
 	};

--- a/modules/mcp/assets/dev/js/mcp-analytics-registrar.js
+++ b/modules/mcp/assets/dev/js/mcp-analytics-registrar.js
@@ -1,11 +1,115 @@
-(function() {
-	const composer = window.elementorMcpComposer;
+( function() {
+	const MCP_INTERACTION_EVENT = 'elementor/mcp/interaction';
 
-	if ( ! composer || 'function' !== typeof composer.registerEventHandler ) {
-		return;
+	const FIXED_PROPS = {
+		app_type: 'infra',
+		appType: 'infra',
+		window_name: 'elementor_mcp',
+		target_location: 'main_content',
+	};
+
+	function buildMixpanelEvent( detail ) {
+		switch ( detail.name ) {
+			case 'viewed':
+				return [ 'mcp_connection_page_viewed', {
+					...FIXED_PROPS,
+					target_location: 'page',
+					interaction_type: 'view',
+					target_type: 'page',
+					target_name: 'elementor_mcp',
+					interaction_result: 'page_loaded',
+					client: detail.client,
+					mode: detail.mode,
+				} ];
+			case 'learn_more_clicked':
+				return [ 'mcp_learn_more_clicked', {
+					...FIXED_PROPS,
+					target_location: 'header',
+					interaction_type: 'click',
+					target_type: 'link',
+					target_name: 'what_is_mcp',
+					interaction_result: 'link_clicked',
+				} ];
+			case 'client_selected':
+				return [ 'mcp_client_selected', {
+					...FIXED_PROPS,
+					interaction_type: 'click',
+					target_type: 'tab',
+					target_name: 'client_tab',
+					interaction_result: 'client_switched',
+					client: detail.client,
+					previous_client: detail.previous_client,
+				} ];
+			case 'mode_switched':
+				return [ 'mcp_setup_mode_switched', {
+					...FIXED_PROPS,
+					interaction_type: 'click',
+					target_type: 'link',
+					target_name: 'setup_mode_toggle',
+					interaction_result: 'mode_switched',
+					mode: detail.mode,
+					client: detail.client,
+				} ];
+			case 'credentials_generated':
+				return [ 'mcp_credentials_generated', {
+					...FIXED_PROPS,
+					interaction_type: 'click',
+					target_type: 'button',
+					target_name: 'generate_credentials',
+					interaction_result: 'credentials_generated',
+					client: detail.client,
+					mode: detail.mode,
+				} ];
+			case 'credentials_generation_failed':
+				return [ 'mcp_credentials_generation_failed', {
+					...FIXED_PROPS,
+					interaction_type: 'click',
+					target_type: 'button',
+					target_name: 'generate_credentials',
+					interaction_result: 'generation_failed',
+					client: detail.client,
+					mode: detail.mode,
+					error_reason: detail.error_reason,
+				} ];
+			case 'config_copied': {
+				const props = {
+					...FIXED_PROPS,
+					interaction_type: 'click',
+					target_type: 'button',
+					target_name: 'copy_config',
+					interaction_result: 'config_copied',
+					client: detail.client,
+					mode: detail.mode,
+					copy_target: detail.copy_target,
+				};
+
+				if ( detail.os ) {
+					props.os = detail.os;
+				}
+
+				return [ 'mcp_config_copied', props ];
+			}
+			default:
+				return null;
+		}
 	}
 
-	composer.registerEventHandler(function( name, props ) {
-		window.elementorCommon?.eventsManager?.dispatchEvent?.( name, props );
-	}, { priority: 10 } );
+	window.addEventListener( MCP_INTERACTION_EVENT, function( event ) {
+		const detail = event.detail;
+
+		if ( ! detail || ! detail.name ) {
+			return;
+		}
+
+		const built = buildMixpanelEvent( detail );
+
+		if ( ! built ) {
+			return;
+		}
+
+		const eventName = built[ 0 ];
+		const props = built[ 1 ];
+
+		window.elementorCommon?.eventsManager?.dispatchEvent?.( eventName, props );
+	} );
 } )();

--- a/modules/mcp/assets/dev/js/mcp-analytics-registrar.js
+++ b/modules/mcp/assets/dev/js/mcp-analytics-registrar.js
@@ -1,0 +1,11 @@
+( function () {
+	const composer = window.elementorMcpComposer;
+
+	if ( ! composer || 'function' !== typeof composer.registerEventHandler ) {
+		return;
+	}
+
+	composer.registerEventHandler( function ( name, props ) {
+		window.elementorCommon?.eventsManager?.dispatchEvent?.( name, props );
+	}, { priority: 10 } );
+} )();

--- a/modules/mcp/assets/dev/js/mcp-analytics-registrar.js
+++ b/modules/mcp/assets/dev/js/mcp-analytics-registrar.js
@@ -1,11 +1,11 @@
-( function () {
+(function() {
 	const composer = window.elementorMcpComposer;
 
 	if ( ! composer || 'function' !== typeof composer.registerEventHandler ) {
 		return;
 	}
 
-	composer.registerEventHandler( function ( name, props ) {
+	composer.registerEventHandler(function( name, props ) {
 		window.elementorCommon?.eventsManager?.dispatchEvent?.( name, props );
 	}, { priority: 10 } );
 } )();

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -19,10 +19,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Module extends BaseModule {
 
+	const ANALYTICS_REGISTRAR_HANDLE = 'elementor-mcp-analytics-registrar';
+
 	private Ability_Registry $registry;
 
 	public function get_name() {
 		return 'mcp';
+	}
+
+	public function enqueue_analytics_registrar(): void {
+		wp_enqueue_script(
+			self::ANALYTICS_REGISTRAR_HANDLE,
+			$this->get_js_assets_url( 'mcp-analytics-registrar' ),
+			[ 'elementor-common', \Elementor\MCP\Composer\Admin\Page::SCRIPT_HANDLE ],
+			ELEMENTOR_VERSION,
+			true
+		);
 	}
 
 	public static function is_active() {

--- a/scripts/vite/shared/entries.mjs
+++ b/scripts/vite/shared/entries.mjs
@@ -76,6 +76,7 @@ export const BASE_ENTRIES = {
 	'pro-install-events': 'modules/pro-install/assets/js/pro-install-events.js',
 	'design-system-sync': 'modules/design-system-sync/assets/js/design-system-sync-handler.js',
 	'assets-manager': 'modules/assets-manager/assets/js/assets-manager.js',
+	'mcp-analytics-registrar': 'modules/mcp/assets/dev/js/mcp-analytics-registrar.js',
 };
 
 /**

--- a/tests/jest/unit/modules/mcp/assets/dev/js/mcp-analytics-registrar.test.js
+++ b/tests/jest/unit/modules/mcp/assets/dev/js/mcp-analytics-registrar.test.js
@@ -1,0 +1,73 @@
+const MCP_INTERACTION_EVENT = 'elementor/mcp/interaction';
+const REGISTRAR_PATH = '../../../../../../../../modules/mcp/assets/dev/js/mcp-analytics-registrar';
+
+describe( 'mcp-analytics-registrar', () => {
+	afterEach( () => {
+		delete window.elementorCommon;
+		jest.resetModules();
+	} );
+
+	test( 'does not throw when elementorCommon is missing', () => {
+		delete window.elementorCommon;
+
+		jest.isolateModules( () => {
+			expect( () => require( REGISTRAR_PATH ) ).not.toThrow();
+		} );
+	} );
+
+	test( 'dispatches mapped MCP events to elementorCommon.eventsManager', () => {
+		const dispatchEvent = jest.fn();
+
+		window.elementorCommon = {
+			eventsManager: {
+				dispatchEvent,
+			},
+		};
+
+		jest.isolateModules( () => {
+			require( REGISTRAR_PATH );
+
+			window.dispatchEvent(
+				new CustomEvent( MCP_INTERACTION_EVENT, {
+					detail: {
+						name: 'viewed',
+						client: 'cursor',
+						mode: 'auto',
+					},
+				} )
+			);
+		} );
+
+		expect( dispatchEvent ).toHaveBeenCalledWith(
+			'mcp_connection_page_viewed',
+			expect.objectContaining( {
+				app_type: 'wpadmin',
+				interaction_result: 'page_loaded',
+				client: 'cursor',
+				mode: 'auto',
+			} )
+		);
+	} );
+
+	test( 'ignores interaction events without a name', () => {
+		const dispatchEvent = jest.fn();
+
+		window.elementorCommon = {
+			eventsManager: {
+				dispatchEvent,
+			},
+		};
+
+		jest.isolateModules( () => {
+			require( REGISTRAR_PATH );
+
+			window.dispatchEvent(
+				new CustomEvent( MCP_INTERACTION_EVENT, {
+					detail: {},
+				} )
+			);
+		} );
+
+		expect( dispatchEvent ).not.toHaveBeenCalled();
+	} );
+} );

--- a/tests/jest/unit/modules/mcp/assets/dev/js/mcp-analytics-registrar.test.js
+++ b/tests/jest/unit/modules/mcp/assets/dev/js/mcp-analytics-registrar.test.js
@@ -34,7 +34,7 @@ describe( 'mcp-analytics-registrar', () => {
 						client: 'cursor',
 						mode: 'auto',
 					},
-				} )
+				} ),
 			);
 		} );
 
@@ -45,7 +45,7 @@ describe( 'mcp-analytics-registrar', () => {
 				interaction_result: 'page_loaded',
 				client: 'cursor',
 				mode: 'auto',
-			} )
+			} ),
 		);
 	} );
 
@@ -64,7 +64,7 @@ describe( 'mcp-analytics-registrar', () => {
 			window.dispatchEvent(
 				new CustomEvent( MCP_INTERACTION_EVENT, {
 					detail: {},
-				} )
+				} ),
 			);
 		} );
 


### PR DESCRIPTION
## Summary

Listen for MCP Connection Page interaction events on the `elementor/mcp/interaction` CustomEvent bus and forward them to Core's Mixpanel pipeline via `elementorCommon.eventsManager.dispatchEvent`.

Core owns the interaction→Mixpanel mapping and `app_type: 'infra'`. The composer emits semantic interaction details only; Core maps them to the final `mcp_*` event names and props.

The registrar script is enqueued when the MCP admin page renders, with deps on `elementor-common` and the composer page bundle (`elementor-mcp-page`) so the listener is attached before the composer's mount-time `viewed` event.

Depends on elementor-mcp-composer PR https://github.com/elementor/elementor-mcp-composer/pull/40.

## Angie

Angie registers its own listener on the same CustomEvent bus with `app_type: 'angie'`. Both Core and Angie fire independently when both are present.

## Jira

[ED-25436](https://elementor.atlassian.net/browse/ED-25436)

[ED-25436]: https://elementor.atlassian.net/browse/ED-25436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Implements analytics tracking for the MCP connection page (ED-25436) by mapping internal interaction events to Mixpanel events via a new registrar script.

## 2. What Changed (Where)

| File | Change |
| :--- | :--- |
| `editor-one-mcp-menu.php` | Calls registrar enqueue during page render. |
| `module.php` | Added `enqueue_analytics_registrar` method and handle constant. |
| `mcp-analytics-registrar.js` | New JS utility mapping `elementor/mcp/interaction` to `eventsManager` calls. |
| `entries.mjs` | Registered new JS entry point for Vite. |
| `composer.json` | Bumped `elementor-mcp-composer` to `^1.0.9`. |
| `mcp-analytics-registrar.test.js` | Unit tests for event mapping and safety checks. |

## 3. How It Works
The `Editor_One_Mcp_Menu` triggers the enqueue of `mcp-analytics-registrar.js`. This script listens for a custom window event (`elementor/mcp/interaction`), translates the payload using a switch-case mapper, and forwards the result to the global `elementorCommon.eventsManager`.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
