### PR TITLE
CI: Add sync release branches workflow [ED-25426]

### DIFF
--- a/.github/workflows/cherry-pick-release-branches.yml
+++ b/.github/workflows/cherry-pick-release-branches.yml
@@ -1,0 +1,55 @@
+name: Cherry Pick Release Branches
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  cherry-pick:
+    if: >-
+      ${{
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (github.event.pull_request.base.ref == 'release/stable' || github.event.pull_request.base.ref == 'release/beta') &&
+        !contains(github.event.pull_request.title, 'Cherry-pick PR')
+      }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Log trigger and PR information
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          echo "PR #${PR_NUMBER} merged to ${BASE_REF}"
+          echo "Head repository: ${HEAD_REPO}"
+          echo "Merge commit: ${MERGE_SHA}"
+        shell: bash
+
+      - name: Cherry-pick to downstream branches
+        uses: elementor/elementor-editor-github-actions/actions/cherry-pick-release-branches@main
+        with:
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          using-pat: ${{ secrets.GH_PAT != '' }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          pr-number: ${{ github.event.pull_request.number }}
+          merge-sha: ${{ github.event.pull_request.merge_commit_sha }}
+          pr-title: ${{ github.event.pull_request.title }}
+          pr-user-login: ${{ github.event.pull_request.user.login }}
+          pr-url: ${{ github.event.pull_request.html_url }}
+          source-repo: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/cherry-pick-release-branches.yml
+++ b/.github/workflows/cherry-pick-release-branches.yml
@@ -1,4 +1,4 @@
-name: Cherry Pick Release Branches
+name: Sync Release Branches
 
 on:
   pull_request:
@@ -11,13 +11,13 @@ permissions:
   id-token: write
 
 jobs:
-  cherry-pick:
+  sync-release-branches:
     if: >-
       ${{
         github.event.pull_request.merged == true &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         (github.event.pull_request.base.ref == 'release/stable' || github.event.pull_request.base.ref == 'release/beta') &&
-        !contains(github.event.pull_request.title, 'Cherry-pick PR')
+        !startsWith(github.event.pull_request.head.ref, 'sync-pr')
       }}
     runs-on: ubuntu-latest
 
@@ -33,15 +33,17 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           echo "PR #${PR_NUMBER} merged to ${BASE_REF}"
+          echo "Head branch: ${HEAD_REF}"
           echo "Head repository: ${HEAD_REPO}"
           echo "Merge commit: ${MERGE_SHA}"
         shell: bash
 
-      - name: Cherry-pick to downstream branches
+      - name: Create downstream PRs
         uses: elementor/elementor-editor-github-actions/actions/cherry-pick-release-branches@main
         with:
           token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
@@ -53,3 +55,4 @@ jobs:
           pr-user-login: ${{ github.event.pull_request.user.login }}
           pr-url: ${{ github.event.pull_request.html_url }}
           source-repo: ${{ github.event.pull_request.head.repo.full_name }}
+          head-ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/sync-release-branches.yml
+++ b/.github/workflows/sync-release-branches.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types:
       - closed
+    branches:
+      - release/stable
+      - release/beta
 
 permissions:
   contents: write

--- a/.github/workflows/sync-release-branches.yml
+++ b/.github/workflows/sync-release-branches.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
 
       - name: Create downstream PRs
-        uses: elementor/elementor-editor-github-actions/actions/cherry-pick-release-branches@main
+        uses: elementor/elementor-editor-github-actions/actions/sync-release-branches@main
         with:
           token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           using-pat: ${{ secrets.GH_PAT != '' }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sync-release-branches.yml` for the new release branch model
- On merge to `release/stable`, automatically opens PRs to `release/beta` and `main`
- On merge to `release/beta`, automatically opens a PR to `main`
- Uses shared action `elementor/elementor-editor-github-actions/actions/sync-release-branches@main`
- Skips PRs whose head branch starts with `sync-pr` to prevent cascade loops

## Test plan
- [ ] Merge elementor/elementor-editor-github-actions#51 first
- [ ] Merge this PR
- [ ] Merge a test PR to `release/stable` and verify sync PRs are created for `release/beta` and `main`
- [ ] Merge a test PR to `release/beta` and verify sync PR to `main`
- [ ] Verify auto-generated `sync-pr*` PRs do not re-trigger the workflow

## Jira
ED-25426
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Automates cherry-pick propagation from stable/beta release branches to downstream branches, reducing manual sync overhead post-merge (ED-25426).

## 2. What Changed (Where)

- `.github/workflows/sync-release-branches.yml`: New workflow triggering on merged PRs to release/stable and release/beta branches.

## 3. How It Works

Workflow fires on PR merge to release branches (excluding sync-pr prefixed branches), logs merge metadata, then delegates cherry-pick logic to `elementor-editor-github-actions/sync-release-branches` action, passing PR context and authentication.

## 4. Risks

Depends on external action stability and correct `GH_PAT` secret configuration; failed syncs won't block original merges but could silently drop cherry-picks if action fails silently.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
