### PR TITLE
Fix: Hide Angie promo top bar action after Angie loads [ED-24890]

### DIFF
--- a/packages/packages/core/editor-app-bar/src/extensions/angie/hooks/use-action-props.ts
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/hooks/use-action-props.ts
@@ -1,13 +1,13 @@
 import { useEffect } from 'react';
-import { isAngieAvailable } from '@elementor/editor-mcp';
 import { trackEvent } from '@elementor/events';
 import { AngieIcon } from '@elementor/icons';
 import { __ } from '@wordpress/i18n';
 
+import { useIsAngieAvailable } from '../../../hooks/use-is-angie-available';
 import { AI_WIDGET_CTA_VIEWED_EVENT, ANGIE_GUIDE_TOGGLE_EVENT } from '../angie-consts';
 
 export function useActionProps() {
-	const hasAngieInstalled = isAngieAvailable();
+	const hasAngieInstalled = useIsAngieAvailable();
 	const visible = ! hasAngieInstalled;
 
 	useEffect( () => {

--- a/packages/packages/core/editor-app-bar/src/hooks/__tests__/use-is-angie-available.test.ts
+++ b/packages/packages/core/editor-app-bar/src/hooks/__tests__/use-is-angie-available.test.ts
@@ -8,20 +8,19 @@ jest.mock( '@elementor/editor-mcp', () => ( {
 
 import { useIsAngieAvailable } from '../use-is-angie-available';
 
-type MutationCallback = MutationCallback;
+type ObserverCallback = MutationCallback;
 
 class MockMutationObserver {
 	static instances: MockMutationObserver[] = [];
-	callback: MutationCallback;
+	callback: ObserverCallback;
+	disconnect = jest.fn();
 
-	constructor( callback: MutationCallback ) {
+	constructor( callback: ObserverCallback ) {
 		this.callback = callback;
 		MockMutationObserver.instances.push( this );
 	}
 
 	observe() {}
-
-	disconnect() {}
 
 	trigger() {
 		this.callback( [], this as unknown as MutationObserver );
@@ -80,5 +79,6 @@ describe( 'useIsAngieAvailable', () => {
 
 		// Assert.
 		expect( result.current ).toBe( true );
+		expect( MockMutationObserver.instances[ 0 ]?.disconnect ).toHaveBeenCalled();
 	} );
 } );

--- a/packages/packages/core/editor-app-bar/src/hooks/__tests__/use-is-angie-available.test.ts
+++ b/packages/packages/core/editor-app-bar/src/hooks/__tests__/use-is-angie-available.test.ts
@@ -1,0 +1,84 @@
+import { act, renderHook } from '@testing-library/react';
+
+const mockIsAngieAvailable = jest.fn();
+
+jest.mock( '@elementor/editor-mcp', () => ( {
+	isAngieAvailable: () => mockIsAngieAvailable(),
+} ) );
+
+import { useIsAngieAvailable } from '../use-is-angie-available';
+
+type MutationCallback = MutationCallback;
+
+class MockMutationObserver {
+	static instances: MockMutationObserver[] = [];
+	callback: MutationCallback;
+
+	constructor( callback: MutationCallback ) {
+		this.callback = callback;
+		MockMutationObserver.instances.push( this );
+	}
+
+	observe() {}
+
+	disconnect() {}
+
+	trigger() {
+		this.callback( [], this as unknown as MutationObserver );
+	}
+}
+
+describe( 'useIsAngieAvailable', () => {
+	const originalMutationObserver = globalThis.MutationObserver;
+
+	beforeEach( () => {
+		mockIsAngieAvailable.mockReset();
+		MockMutationObserver.instances = [];
+		globalThis.MutationObserver = MockMutationObserver as unknown as typeof MutationObserver;
+	} );
+
+	afterEach( () => {
+		globalThis.MutationObserver = originalMutationObserver;
+	} );
+
+	it( 'should return true when Angie is already available', () => {
+		// Arrange.
+		mockIsAngieAvailable.mockReturnValue( true );
+
+		// Act.
+		const { result } = renderHook( () => useIsAngieAvailable() );
+
+		// Assert.
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'should return false when Angie is not available yet', () => {
+		// Arrange.
+		mockIsAngieAvailable.mockReturnValue( false );
+
+		// Act.
+		const { result } = renderHook( () => useIsAngieAvailable() );
+
+		// Assert.
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'should update when Angie becomes available after mount', () => {
+		// Arrange.
+		mockIsAngieAvailable.mockReturnValue( false );
+
+		const { result } = renderHook( () => useIsAngieAvailable() );
+
+		expect( result.current ).toBe( false );
+
+		// Act.
+		mockIsAngieAvailable.mockReturnValue( true );
+
+		act( () => {
+			MockMutationObserver.instances[ 0 ]?.trigger();
+		} );
+
+		// Assert.
+		expect( result.current ).toBe( true );
+	} );
+} );

--- a/packages/packages/core/editor-app-bar/src/hooks/use-is-angie-available.ts
+++ b/packages/packages/core/editor-app-bar/src/hooks/use-is-angie-available.ts
@@ -16,6 +16,7 @@ export function useIsAngieAvailable(): boolean {
 
 		const observer = new MutationObserver( () => {
 			if ( isAngieAvailable() ) {
+				observer.disconnect();
 				setAvailable( true );
 			}
 		} );

--- a/packages/packages/core/editor-app-bar/src/hooks/use-is-angie-available.ts
+++ b/packages/packages/core/editor-app-bar/src/hooks/use-is-angie-available.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { isAngieAvailable } from '@elementor/editor-mcp';
+
+export function useIsAngieAvailable(): boolean {
+	const [ available, setAvailable ] = useState( () => isAngieAvailable() );
+
+	useEffect( () => {
+		if ( available ) {
+			return;
+		}
+
+		if ( isAngieAvailable() ) {
+			setAvailable( true );
+			return;
+		}
+
+		const observer = new MutationObserver( () => {
+			if ( isAngieAvailable() ) {
+				setAvailable( true );
+			}
+		} );
+
+		observer.observe( document.body, {
+			childList: true,
+			subtree: true,
+		} );
+
+		return () => observer.disconnect();
+	}, [ available ] );
+
+	return available;
+}


### PR DESCRIPTION
The editor app bar promo Angie action checked isAngieAvailable only once at render time. When Angie mounted its iframe later, the promo button stayed visible alongside the real Angie control.

Add a reactive hook that observes DOM changes until Angie becomes available, and use it for the promo action visibility.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The promo bar was showing Angie as unavailable even after it loaded. Switching from a synchronous check to a reactive hook enables the UI to update when Angie becomes available post-mount (ED-24890).

## 2. What Changed (Where)

- `use-action-props.ts`: Replaced direct `isAngieAvailable()` call with `useIsAngieAvailable()` hook import
- `use-is-angie-available.ts`: New hook wraps availability check with state management and DOM observer
- `use-is-angie-available.test.ts`: Added 3 test cases covering initial availability, delayed availability, state updates

## 3. How It Works

Hook initializes with current availability state. If Angie isn't ready, a `MutationObserver` watches `document.body` for DOM changes. When `isAngieAvailable()` returns true, state updates trigger re-render and observer disconnects. Early exit if already available prevents unnecessary observers.

## 4. Risks

Observer runs on every mount with false initial state—could create multiple instances if component remounts before Angie loads. Dependency array `[available]` causes re-subscription on state change, which is intentional but could thrash if availability toggles. Consider adding a "seen true" guard to prevent re-observing after first success.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
