### PR TITLE
Fix: Cherry-pick PR 36594 to 4.02: Cache validity flags to check against actual files [ED-24903]

### DIFF
--- a/modules/atomic-widgets/styles/atomic-styles-manager.php
+++ b/modules/atomic-widgets/styles/atomic-styles-manager.php
@@ -125,14 +125,16 @@ class Atomic_Styles_Manager {
 
 				$breakpoint_path = array_merge( $path, [ $breakpoint_key ] );
 
+				// `CSS_Files_Manager::get()` owns the per-breakpoint decision: it consults the
+				// cache-validity leaf under `$breakpoint_path` (including the `should_exist`
+				// meta), regenerates when the cache is invalid or when a should-be-present file
+				// is missing on disk, and validates the leaf on success. See ED-24903.
 				$style_file = $this->css_files_manager->get(
 					$this->convert_path_to_handle( $breakpoint_path ),
 					$breakpoint_media,
 					$render_css,
-					$this->cache_validity->is_valid( $breakpoint_path )
+					$breakpoint_path
 				);
-
-				$this->cache_validity->validate( $breakpoint_path );
 
 				if ( ! $style_file ) {
 					continue;

--- a/modules/atomic-widgets/styles/css-files-manager.php
+++ b/modules/atomic-widgets/styles/css-files-manager.php
@@ -2,61 +2,150 @@
 
 namespace Elementor\Modules\AtomicWidgets\Styles;
 
+use Elementor\Modules\AtomicWidgets\Styles\CacheValidity\Cache_Validity;
+
 class CSS_Files_Manager {
 	const DEFAULT_CSS_DIR = 'elementor/css/';
 	const FILE_EXTENSION = '.css';
 	// Read and write permissions for the owner
 	const PERMISSIONS = 0644;
 
-	public function get( string $handle, string $media, callable $get_css, bool $is_valid_cache ): ?Style_File {
-		$filesystem = $this->get_filesystem();
-		$path = $this->get_path( $handle );
+	private Cache_Validity $cache_validity;
 
-		if ( $is_valid_cache ) {
-			if ( ! $filesystem->exists( $path ) ) {
+	public function __construct( ?Cache_Validity $cache_validity = null ) {
+		$this->cache_validity = $cache_validity ?? new Cache_Validity();
+	}
+
+	/**
+	 * Return the CSS file to enqueue for the given cache path, generating it on demand.
+	 *
+	 * The `should_exist` meta flag distinguishes an intentionally empty file from one
+	 * that went missing after being generated, and cache is regenerated whenever it's
+	 * invalid or the expected file can't be found on disk.
+	 *
+	 * @param string        $handle
+	 * @param string        $media
+	 * @param callable      $get_css
+	 * @param array<string> $cache_path Cache-validity leaf path.
+	 * @return Style_File|null
+	 */
+	public function get( string $handle, string $media, callable $get_css, array $cache_path ): ?Style_File {
+		$path = $this->get_path( $handle );
+		$is_cache_valid = $this->cache_validity->is_valid( $cache_path );
+		$should_exist = $this->get_should_exist_meta( $cache_path );
+
+		if ( $is_cache_valid ) {
+			if ( false === $should_exist ) {
 				return null;
 			}
 
-			// Return the existing file
-			return Style_File::create(
-				$this->sanitize_handle( $handle ),
-				$this->get_filesystem_path( $this->get_path( $handle ) ),
-				$this->get_url( $handle ),
-				$media,
-			);
+			if ( $this->has_non_empty_file( $path ) ) {
+				return $this->create_style_file( $handle, $path, $media );
+			}
 		}
 
 		$css = $get_css();
 
 		if ( empty( $css ) ) {
+			// Nothing to serve for this path; purge any stale file and record the state
+			// so we don't try to regenerate on every subsequent request.
+			$this->delete_if_exists( $path );
+			$this->cache_validity->validate( $cache_path, [ 'should_exist' => false ] );
+
 			return null;
 		}
 
 		$filesystem_path = $this->get_filesystem_path( $path );
 
-		$is_created = $filesystem->put_contents( $filesystem_path, $css, self::PERMISSIONS );
-
-		if ( false === $is_created ) {
+		if ( ! $this->write_atomically( $filesystem_path, $css ) ) {
+			// Hard write failure: leave the cache invalid so the next request retries.
 			return null;
 		}
 
+		$this->cache_validity->validate( $cache_path, [ 'should_exist' => true ] );
+
+		return $this->create_style_file( $handle, $path, $media );
+	}
+
+	public function delete( string $handle ): void {
+		$this->delete_if_exists( $this->get_path( $handle ) );
+	}
+
+	private function get_should_exist_meta( array $cache_path ): ?bool {
+		$meta = $this->cache_validity->get_meta( $cache_path );
+
+		if ( ! is_array( $meta ) || ! array_key_exists( 'should_exist', $meta ) ) {
+			return null;
+		}
+
+		return (bool) $meta['should_exist'];
+	}
+
+	private function create_style_file( string $handle, string $path, string $media ): Style_File {
 		return Style_File::create(
 			$this->sanitize_handle( $handle ),
-			$filesystem_path,
+			$this->get_filesystem_path( $path ),
 			$this->get_url( $handle ),
 			$media
 		);
 	}
 
-	public function delete( string $handle ): void {
+	private function has_non_empty_file( string $path ): bool {
 		$filesystem = $this->get_filesystem();
-		$path = $this->get_path( $handle );
+
+		if ( ! $filesystem->exists( $path ) ) {
+			return false;
+		}
+
+		$size = $filesystem->size( $path );
+
+		// `size()` may return false on filesystems that don't support it; treat that as
+		// "we don't know" and fall back to trusting the existence check.
+		if ( false === $size ) {
+			return true;
+		}
+
+		return $size > 0;
+	}
+
+	private function delete_if_exists( string $path ): void {
+		$filesystem = $this->get_filesystem();
 
 		if ( ! $filesystem->exists( $path ) ) {
 			return;
 		}
 
 		$filesystem->delete( $path );
+	}
+
+	/**
+	 * Write to a temp file first and then move it into place. The move step is atomic on
+	 * POSIX filesystems, so the public URL cannot serve a partial or zero-byte asset while a
+	 * concurrent render is in progress. If the atomic move is not supported by the current
+	 * filesystem adapter, fall back to a direct write.
+	 */
+	private function write_atomically( string $filesystem_path, string $css ): bool {
+		$filesystem = $this->get_filesystem();
+
+		$tmp_path = $filesystem_path . '.tmp-' . wp_generate_password( 8, false, false );
+
+		$is_written = $filesystem->put_contents( $tmp_path, $css, self::PERMISSIONS );
+
+		if ( false === $is_written ) {
+			return false;
+		}
+
+		if ( ! method_exists( $filesystem, 'move' ) || ! $filesystem->move( $tmp_path, $filesystem_path, true ) ) {
+			$fallback = $filesystem->put_contents( $filesystem_path, $css, self::PERMISSIONS );
+
+			if ( $filesystem->exists( $tmp_path ) ) {
+				$filesystem->delete( $tmp_path );
+			}
+
+			return false !== $fallback;
+		}
+
+		return true;
 	}
 
 	private function get_filesystem(): \WP_Filesystem_Base {

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/test-atomic-styles-manager.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/test-atomic-styles-manager.php
@@ -27,6 +27,10 @@ class Test_Atomic_Styles_Manager extends Elementor_Test_Base {
 		// Mock the filesystem
 		$this->filesystemMock = $this->createMock( WP_Filesystem_Base::class );
 		$this->filesystemMock->method( 'abspath' )->willReturn( ABSPATH );
+		// Atomic write does put_contents(tmp) then move(tmp, final). Default `move` to true so
+		// tests that don't care about the write pipeline don't spuriously fall back to a direct
+		// overwrite.
+		$this->filesystemMock->method( 'move' )->willReturn( true );
 
 		global $wp_filesystem;
 		$wp_filesystem = $this->filesystemMock;
@@ -297,6 +301,13 @@ class Test_Atomic_Styles_Manager extends Elementor_Test_Base {
 			return $this->get_test_style_defs();
 		};
 
+		// After the first render, self-heal now checks that the on-disk file exists and is
+		// non-empty before trusting the cache. Simulate a healthy filesystem so the second
+		// render treats the cache as valid.
+		$this->filesystemMock->method( 'put_contents' )->willReturn( true );
+		$this->filesystemMock->method( 'exists' )->willReturn( true );
+		$this->filesystemMock->method( 'size' )->willReturn( 1024 );
+
 		add_action( 'elementor/atomic-widgets/styles/register', function ( $styles_manager ) use ( $get_style_defs ) {
 			$styles_manager->register( [ $this->test_style_key ], $get_style_defs );
 		}, 10, 1 );
@@ -554,5 +565,142 @@ class Test_Atomic_Styles_Manager extends Elementor_Test_Base {
 		} );
 
 		$this->assertCount( 2, $remaining_files_with_key, 'All files not nested under the provided keys should remain' );
+	}
+
+	public function test_self_heal__regenerates_across_renders_when_file_goes_missing() {
+		// Arrange.
+		$styles_manager = new Atomic_Styles_Manager();
+		$styles_manager->register_hooks();
+
+		$call_count = 0;
+		$get_style_defs = function () use ( &$call_count ) {
+			++$call_count;
+			return $this->get_test_style_defs();
+		};
+
+		$this->filesystemMock->method( 'put_contents' )->willReturn( true );
+
+		// Simulate an unhealthy filesystem: files never observed on disk. That mimics the
+		// external-eviction scenario the manager needs to self-heal from (ED-24903).
+		$this->filesystemMock->method( 'exists' )->willReturn( false );
+		$this->filesystemMock->method( 'size' )->willReturn( 0 );
+
+		add_action( 'elementor/atomic-widgets/styles/register', function ( $styles_manager ) use ( $get_style_defs ) {
+			$styles_manager->register( [ $this->test_style_key ], $get_style_defs );
+		}, 10, 1 );
+
+		do_action( 'elementor/post/render', 1 );
+		do_action( 'elementor/frontend/after_enqueue_post_styles' );
+
+		$this->assertEquals( 1, $call_count, 'First render invokes get_styles once' );
+
+		// Act - second render: files are still missing on disk.
+		do_action( 'elementor/frontend/after_enqueue_post_styles' );
+
+		// Assert - CSS_Files_Manager notices the missing files (should_exist=true but exists=false)
+		// and re-invokes get_styles to regenerate.
+		$this->assertEquals(
+			2,
+			$call_count,
+			'get_styles must be called again when should_exist=true but the file is missing on disk'
+		);
+	}
+
+	public function test_self_heal__legit_empty_breakpoint_stays_cached_across_renders() {
+		// Arrange.
+		$styles_manager = new Atomic_Styles_Manager();
+		$styles_manager->register_hooks();
+
+		$call_count = 0;
+		// Only desktop; other breakpoints legitimately have no CSS for this style.
+		$get_style_defs = function () use ( &$call_count ) {
+			++$call_count;
+			return [
+				'test-style' => [
+					'id' => 'test-style',
+					'type' => 'class',
+					'variants' => [
+						[
+							'meta' => [ 'breakpoint' => 'desktop' ],
+							'props' => [ 'color' => 'red' ],
+						],
+					],
+				],
+			];
+		};
+
+		$this->filesystemMock->method( 'put_contents' )->willReturn( true );
+		// Desktop file exists after the write; all other breakpoints (mobile, tablet, ...)
+		// legitimately have no file. The manager must not treat their absence as broken cache.
+		$this->filesystemMock->method( 'exists' )
+			->willReturnCallback( fn( $path ) => str_contains( $path, '-desktop.css' ) );
+		$this->filesystemMock->method( 'size' )->willReturn( 512 );
+
+		add_action( 'elementor/atomic-widgets/styles/register', function ( $styles_manager ) use ( $get_style_defs ) {
+			$styles_manager->register( [ $this->test_style_key ], $get_style_defs );
+		}, 10, 1 );
+
+		do_action( 'elementor/post/render', 1 );
+		do_action( 'elementor/frontend/after_enqueue_post_styles' );
+
+		$this->assertEquals( 1, $call_count );
+
+		// Act - second render.
+		do_action( 'elementor/frontend/after_enqueue_post_styles' );
+
+		// Assert - no regeneration for breakpoints that legitimately produced no CSS.
+		$this->assertEquals(
+			1,
+			$call_count,
+			'Empty breakpoints must not force a regeneration on subsequent requests'
+		);
+	}
+
+	public function test_write_failure__does_not_mark_breakpoint_cache_valid() {
+		// Arrange.
+		$styles_manager = new Atomic_Styles_Manager();
+		$styles_manager->register_hooks();
+
+		$get_style_defs = function () {
+			return [
+				'test-style' => [
+					'id' => 'test-style',
+					'type' => 'class',
+					'variants' => [
+						[
+							'meta' => [ 'breakpoint' => 'desktop' ],
+							'props' => [ 'color' => 'red' ],
+						],
+					],
+				],
+			];
+		};
+
+		// Simulate a filesystem where the atomic write leg fails: tmp write returns false.
+		$this->filesystemMock->method( 'put_contents' )->willReturn( false );
+
+		add_action( 'elementor/atomic-widgets/styles/register', function ( $styles_manager ) use ( $get_style_defs ) {
+			$styles_manager->register( [ $this->test_style_key ], $get_style_defs );
+		}, 10, 1 );
+
+		do_action( 'elementor/post/render', 1 );
+
+		// Act.
+		do_action( 'elementor/frontend/after_enqueue_post_styles' );
+
+		// Assert.
+		$cache_validity = new Cache_Validity();
+
+		$this->assertFalse(
+			$cache_validity->is_valid( [ $this->test_style_key, 'desktop' ] ),
+			'Write failures must leave the breakpoint cache invalid so the next request retries'
+		);
+
+		global $wp_styles;
+		$this->assertArrayNotHasKey(
+			$this->test_style_key . '-desktop',
+			$wp_styles->registered,
+			'A failed write must not enqueue a broken asset URL'
+		);
 	}
 }

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/test-css-files-manager.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/test-css-files-manager.php
@@ -1,24 +1,30 @@
 <?php
 namespace Elementor\Testing\Modules\AtomicWidgets\Styles;
 
+use Elementor\Modules\AtomicWidgets\Styles\CacheValidity\Cache_Validity;
 use Elementor\Modules\AtomicWidgets\Styles\CSS_Files_Manager;
 use ElementorEditorTesting\Elementor_Test_Base;
 use WP_Filesystem_Base;
 
 class Test_Css_Files_Manager extends Elementor_Test_Base {
 	private $filesystemMock;
+	private Cache_Validity $cache_validity;
 
 	public function setUp(): void {
 		parent::setUp();
 
 		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 
-		// Mock the filesystem
-		$this->filesystemMock = $this->createMock(WP_Filesystem_Base::class);
-		$this->filesystemMock->method('abspath')->willReturn(ABSPATH);
+		$this->filesystemMock = $this->getMockBuilder( WP_Filesystem_Base::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'exists', 'delete', 'put_contents', 'get_contents', 'abspath', 'size', 'move' ] )
+			->getMock();
+		$this->filesystemMock->method( 'abspath' )->willReturn( ABSPATH );
 
 		global $wp_filesystem;
 		$wp_filesystem = $this->filesystemMock;
+
+		$this->cache_validity = new Cache_Validity();
 	}
 
 	public function tearDown(): void {
@@ -28,32 +34,207 @@ class Test_Css_Files_Manager extends Elementor_Test_Base {
 		$wp_filesystem = null;
 	}
 
-	public function test_get__creates_file() {
+	private function make_manager(): CSS_Files_Manager {
+		return new CSS_Files_Manager( $this->cache_validity );
+	}
+
+	public function test_get__renders_and_writes_atomically_when_cache_is_invalid() {
 		// Arrange.
-		$get_css = function() {
-			return 'body { margin: 0; }';
-		};
+		$get_css = fn() => 'body { margin: 0; }';
 
-		$this->filesystemMock->method('put_contents')->willReturn(true);
+		$put_contents_paths = [];
 
-		// Assert.
-		$this->filesystemMock->expects($this->once())
-			->method('put_contents')
-			->with(
-				$this->callback(function($path) {
-					return str_contains($path, CSS_Files_Manager::DEFAULT_CSS_DIR . 'test-style.css');
-				}),
-				'body { margin: 0; }',
-				0644
-			);
+		$this->filesystemMock->method( 'put_contents' )
+			->willReturnCallback( function ( $path, $content ) use ( &$put_contents_paths ) {
+				$put_contents_paths[] = $path;
+				$this->assertEquals( 'body { margin: 0; }', $content );
+				return true;
+			} );
+
+		$this->filesystemMock->expects( $this->once() )
+			->method( 'move' )
+			->willReturnCallback( function ( $src, $dst, $overwrite ) {
+				$this->assertStringContainsString( CSS_Files_Manager::DEFAULT_CSS_DIR . 'test-style.css.tmp-', $src );
+				$this->assertStringEndsWith( CSS_Files_Manager::DEFAULT_CSS_DIR . 'test-style.css', $dst );
+				$this->assertTrue( $overwrite );
+				return true;
+			} );
 
 		// Act.
-		$result = ( new CSS_Files_Manager() )->get( 'test-style(/../..$', 'all', $get_css, false );
+		$file = $this->make_manager()->get( 'test-style', 'all', $get_css, [ 'atomic-test', 'render' ] );
 
 		// Assert.
-		$this->assertEquals(
-			'test-style',
-			$result->get_handle()
+		$this->assertNotNull( $file, 'A style file is returned on a successful write' );
+		$this->assertEquals( 'test-style', $file->get_handle() );
+		$this->assertCount( 1, $put_contents_paths, 'Only one write happens, to the temp path' );
+		$this->assertStringContainsString( CSS_Files_Manager::DEFAULT_CSS_DIR . 'test-style.css.tmp-', $put_contents_paths[0] );
+
+		// Cache should be validated with `should_exist = true` on success.
+		$this->assertTrue(
+			$this->cache_validity->is_valid( [ 'atomic-test', 'render' ] ),
+			'Successful write must validate the cache leaf'
 		);
+		$this->assertEquals(
+			[ 'should_exist' => true ],
+			$this->cache_validity->get_meta( [ 'atomic-test', 'render' ] ),
+			'Leaf meta must record should_exist = true'
+		);
+	}
+
+	public function test_get__with_empty_css_deletes_stale_file_and_records_should_exist_false() {
+		// Arrange.
+		$get_css = fn() => '';
+
+		$this->filesystemMock->method( 'exists' )->willReturn( true );
+
+		$this->filesystemMock->expects( $this->once() )
+			->method( 'delete' )
+			->with( $this->stringContains( CSS_Files_Manager::DEFAULT_CSS_DIR . 'empty-style.css' ) );
+
+		$this->filesystemMock->expects( $this->never() )->method( 'put_contents' );
+		$this->filesystemMock->expects( $this->never() )->method( 'move' );
+
+		// Act.
+		$file = $this->make_manager()->get( 'empty-style', 'all', $get_css, [ 'atomic-test', 'empty' ] );
+
+		// Assert.
+		$this->assertNull( $file, 'No file is returned when CSS is empty' );
+
+		$this->assertTrue(
+			$this->cache_validity->is_valid( [ 'atomic-test', 'empty' ] ),
+			'Empty-CSS state is a legit cached outcome and must validate the leaf'
+		);
+		$this->assertEquals(
+			[ 'should_exist' => false ],
+			$this->cache_validity->get_meta( [ 'atomic-test', 'empty' ] ),
+			'Leaf meta must record should_exist = false so subsequent requests skip the render'
+		);
+	}
+
+	public function test_get__leaves_cache_invalid_when_write_fails() {
+		// Arrange.
+		$get_css = fn() => 'body { color: red; }';
+
+		$this->filesystemMock->method( 'put_contents' )->willReturn( false );
+		$this->filesystemMock->expects( $this->never() )->method( 'move' );
+
+		// Act.
+		$file = $this->make_manager()->get( 'failing-style', 'all', $get_css, [ 'atomic-test', 'fail' ] );
+
+		// Assert.
+		$this->assertNull( $file );
+		$this->assertFalse(
+			$this->cache_validity->is_valid( [ 'atomic-test', 'fail' ] ),
+			'A hard write failure must leave the leaf invalid so the next request retries'
+		);
+	}
+
+	public function test_get__returns_existing_file_on_cache_hit_when_should_exist_is_true() {
+		// Arrange - seed the cache: previous render succeeded, file is present on disk.
+		$this->cache_validity->validate( [ 'atomic-test', 'hit' ], [ 'should_exist' => true ] );
+
+		$this->filesystemMock->method( 'exists' )->willReturn( true );
+		$this->filesystemMock->method( 'size' )->willReturn( 1024 );
+
+		// Act.
+		$file = $this->make_manager()->get(
+			'cached-style',
+			'all',
+			function () {
+				$this->fail( 'CSS should not be rendered when the cache is valid and the file is healthy.' );
+			},
+			[ 'atomic-test', 'hit' ]
+		);
+
+		// Assert.
+		$this->assertNotNull( $file );
+		$this->assertEquals( 'cached-style', $file->get_handle() );
+	}
+
+	public function test_get__returns_null_without_rendering_when_should_exist_is_false() {
+		// Arrange - cached state where a prior render produced no CSS.
+		$this->cache_validity->validate( [ 'atomic-test', 'skip' ], [ 'should_exist' => false ] );
+
+		$this->filesystemMock->expects( $this->never() )->method( 'exists' );
+		$this->filesystemMock->expects( $this->never() )->method( 'put_contents' );
+
+		// Act.
+		$file = $this->make_manager()->get(
+			'skipped-style',
+			'all',
+			function () {
+				$this->fail( 'CSS must not be rendered when the cache says should_exist = false.' );
+			},
+			[ 'atomic-test', 'skip' ]
+		);
+
+		// Assert.
+		$this->assertNull( $file );
+	}
+
+	public function test_get__self_heals_and_regenerates_when_should_exist_but_file_missing() {
+		// Arrange - the cache says the file should be present, but the filesystem disagrees.
+		$this->cache_validity->validate( [ 'atomic-test', 'heal' ], [ 'should_exist' => true ] );
+
+		$call_count = 0;
+		$get_css = function () use ( &$call_count ) {
+			++$call_count;
+			return 'body { color: blue; }';
+		};
+
+		$this->filesystemMock->method( 'exists' )->willReturn( false );
+		$this->filesystemMock->method( 'put_contents' )->willReturn( true );
+		$this->filesystemMock->method( 'move' )->willReturn( true );
+
+		// Act.
+		$file = $this->make_manager()->get( 'ghost-style', 'all', $get_css, [ 'atomic-test', 'heal' ] );
+
+		// Assert.
+		$this->assertNotNull( $file, 'Manager must self-heal by regenerating when the file went missing' );
+		$this->assertEquals( 1, $call_count, 'The CSS callback must be invoked exactly once during self-heal' );
+	}
+
+	public function test_get__self_heals_when_should_exist_but_file_is_zero_bytes() {
+		// Arrange - file is present but truncated to zero bytes (partial write, external cleanup, ...).
+		$this->cache_validity->validate( [ 'atomic-test', 'zero' ], [ 'should_exist' => true ] );
+
+		$this->filesystemMock->method( 'exists' )->willReturn( true );
+		$this->filesystemMock->method( 'size' )->willReturn( 0 );
+		$this->filesystemMock->method( 'put_contents' )->willReturn( true );
+		$this->filesystemMock->method( 'move' )->willReturn( true );
+
+		$get_css_called = false;
+		$get_css = function () use ( &$get_css_called ) {
+			$get_css_called = true;
+			return '.non-empty { }';
+		};
+
+		// Act.
+		$file = $this->make_manager()->get( 'zero-byte-style', 'all', $get_css, [ 'atomic-test', 'zero' ] );
+
+		// Assert.
+		$this->assertNotNull( $file );
+		$this->assertTrue( $get_css_called, 'A zero-byte file must trigger regeneration' );
+	}
+
+	public function test_get__legacy_leaf_without_should_exist_meta_falls_back_to_file_existence() {
+		// Arrange - simulate a pre-existing leaf (predates the should_exist meta).
+		$this->cache_validity->validate( [ 'atomic-test', 'legacy' ] );
+
+		$this->filesystemMock->method( 'exists' )->willReturn( true );
+		$this->filesystemMock->method( 'size' )->willReturn( 512 );
+
+		// Act.
+		$file = $this->make_manager()->get(
+			'legacy-style',
+			'all',
+			function () {
+				$this->fail( 'Legacy leaf with an existing file must not force a regen.' );
+			},
+			[ 'atomic-test', 'legacy' ]
+		);
+
+		// Assert.
+		$this->assertNotNull( $file );
 	}
 }


### PR DESCRIPTION
## Summary

Cherry-picks [#36594](https://github.com/elementor/elementor/pull/36594) (commit `5d1a711bdb`, ED-24903) to the 4.02 release branch.

The fix moves the cache-validity decision into `CSS_Files_Manager::get()`, which now returns early on a warm cache without writing. In 4.2.1 the atomic-widgets style render loop ended every iteration with an unconditional `$this->cache_validity->validate( \$breakpoint_path )` — one `update_option()` per (enabled breakpoint + desktop) x style group, i.e. ~145 calls on a page that renders ~20 posts. Reported by an Automattic VIP customer as a considerable slowdown.

## Why cherry-pick

The fix is on `main` (targeted for 4.3.0) but is in no released 4.2.x. There are zero commits in the atomic-styles path between `4.2.1` and `4.2.3`, so the customer gets nothing from upgrading within 4.2.

## Cherry-pick cleanliness

- Both production files on `elementor/4.02` were byte-identical to `5d1a711bdb^`.
- `DEFAULT_CSS_DIR` correctly stays `elementor/css/` (main has since moved to `css/` under ED-24868, which is not carried).
- Test file has a minor context-line auto-merge for an unrelated font-quoting change (lines 128, 188) — the fix's test hunks (lines 27, 301, 566) don't overlap.
- Pro is unaffected: nothing in Pro calls `CSS_Files_Manager`; the `Cache_Validity` class API is unchanged.

## Risk

The main behavior change: on a hard CSS write failure the cache is now left invalid so the next request retries, rather than being incorrectly marked valid. This is a correctness fix, but on infrastructures where writes to the uploads dir are persistently failing it converts ~145 cheap no-op `update_option()` calls into a full `\$get_css()` per breakpoint per request. Verify the customer's `wp-content/uploads/elementor/css/*.css` files are present and non-empty before shipping.

Expected first-load side effect: one write per empty-breakpoint leaf to record `should_exist => false`, then converges to zero.

## Test plan

- [ ] CI: PHPUnit atomic-widgets/styles suite
- [ ] CI: Playwright
- [ ] Manual: render a page with global classes and atomic widgets, confirm no unconditional `update_option` calls on subsequent loads

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Fixes ED-24903 where the system blindly trusted cache validity flags even if the corresponding CSS files were missing or truncated on disk. This ensures "self-healing" by regenerating assets when disk state diverges from cache metadata.

## 2. What Changed (Where)
* `atomic-styles-manager.php`: Passes the cache path to the manager and removes direct validation calls.
* `css-files-manager.php`: Implements `should_exist` metadata tracking and atomic file writes.
* `test-atomic-styles-manager.php` & `test-css-files-manager.php`: Added comprehensive tests for self-healing and write failures.

## 3. How It Works
`CSS_Files_Manager::get` now checks both the `Cache_Validity` flag and the actual file existence/size. If a file is expected (`should_exist => true`) but missing or empty, it triggers regeneration. New assets are written to a temporary file and moved atomically to prevent serving partial CSS during concurrent requests.

## 4. Risks
Atomic moves via `filesystem->move` may not be supported by all adapters; the code includes a direct-write fallback to maintain compatibility.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
