### PR TITLE
Fix: Skip global-related option write when no relations changed [ED-24868]

### DIFF
--- a/modules/global-classes/atomic-global-styles.php
+++ b/modules/global-classes/atomic-global-styles.php
@@ -197,6 +197,10 @@ class Atomic_Global_Styles {
 			$added_posts = array_diff( $new_related_posts, $old_related_posts );
 			$removed_posts = array_diff( $old_related_posts, $new_related_posts );
 
+			if ( empty( $added_posts ) && empty( $removed_posts ) ) {
+				continue;
+			}
+
 			$cache_validity->validate( $forward_path, $new_related_posts );
 
 			foreach ( $added_posts as $added_post ) {

--- a/tests/phpunit/elementor/modules/global-classes/test-atomic-global-styles.php
+++ b/tests/phpunit/elementor/modules/global-classes/test-atomic-global-styles.php
@@ -697,6 +697,69 @@ class Test_Atomic_Global_Styles extends Elementor_Test_Base {
 		);
 	}
 
+	public function test_register_styles__does_not_rewrite_global_related_option_on_identical_re_render() {
+		// Arrange.
+		$relations = new Global_Classes_Relations();
+		$global_classes = new Atomic_Global_Styles( $relations );
+		$global_classes->register_hooks();
+
+		$parent_id = $this->factory()->post->create();
+		$child_id  = $this->factory()->post->create();
+
+		$relations->set_styles_for_post( $parent_id, [ 'g-4-124' ] );
+		$relations->set_styles_for_post( $child_id, [ 'g-4-123' ] );
+
+		Global_Classes_Repository::make()->put(
+			$this->mock_global_classes['items'],
+			$this->mock_global_classes['order']
+		);
+
+		add_filter( 'elementor/document/related_posts', function( $related, $post_id ) use ( $parent_id, $child_id ) {
+			if ( (int) $post_id === $parent_id ) {
+				$related[] = $child_id;
+			}
+			return $related;
+		}, 10, 2 );
+
+		$this->mock_atomic_styles_manager->method( 'register' );
+
+		$related_option = 'elementor_atomic_cache_validity__' . Atomic_Global_Styles::STYLES_KEY . '_' . Atomic_Global_Styles::RELATED_KEY;
+		$reverse_option = 'elementor_atomic_cache_validity__' . Atomic_Global_Styles::STYLES_KEY . '_' . Atomic_Global_Styles::RELATED_REVERSE_KEY;
+
+		$related_writes = 0;
+		$reverse_writes = 0;
+
+		$count_related = function ( $value ) use ( &$related_writes ) {
+			$related_writes++;
+			return $value;
+		};
+		$count_reverse = function ( $value ) use ( &$reverse_writes ) {
+			$reverse_writes++;
+			return $value;
+		};
+
+		add_filter( "pre_update_option_{$related_option}", $count_related );
+		add_filter( "pre_update_option_{$reverse_option}", $count_reverse );
+
+		// Act: first render seeds the relation maps.
+		do_action( 'elementor/atomic-widgets/styles/register', $this->mock_atomic_styles_manager, [ $parent_id, $child_id ] );
+
+		$related_writes_after_first_render = $related_writes;
+		$reverse_writes_after_first_render = $reverse_writes;
+
+		// Act: identical re-render must not touch the cache-validity options at all.
+		do_action( 'elementor/atomic-widgets/styles/register', $this->mock_atomic_styles_manager, [ $parent_id, $child_id ] );
+
+		remove_filter( "pre_update_option_{$related_option}", $count_related );
+		remove_filter( "pre_update_option_{$reverse_option}", $count_reverse );
+
+		// Assert: first render performs the initial writes; second render does not call update_option at all.
+		$this->assertGreaterThan( 0, $related_writes_after_first_render, 'First render should seed the forward relation option.' );
+		$this->assertGreaterThan( 0, $reverse_writes_after_first_render, 'First render should seed the reverse relation option.' );
+		$this->assertSame( $related_writes_after_first_render, $related_writes, 'Identical re-render must not call update_option on the forward relation option.' );
+		$this->assertSame( $reverse_writes_after_first_render, $reverse_writes, 'Identical re-render must not call update_option on the reverse relation option.' );
+	}
+
 	private function create_atomic_global_styles(): Atomic_Global_Styles {
 		$relations = new Global_Classes_Relations();
 


### PR DESCRIPTION
## Summary

Follow-up to the VIP performance thread. Ron's [#36594](https://github.com/elementor/elementor/pull/36594) already removed the unconditional `Cache_Validity::validate()` in the atomic-widgets render loop. This PR removes the one remaining unconditional write on the same front-end code path — the "second record mapping which Global Classes are used by which pages" from the customer report.

`Atomic_Global_Styles::persist_relation_maps()` computed both `\$added_posts` and `\$removed_posts` diffs and then called `\$cache_validity->validate(\$forward_path, ...)` regardless of whether either was non-empty. Result: one `get_option()` + full-tree serialization + equality check per rendered post per front-end request, even on identical re-renders.

Added an early `continue` when both diffs are empty. The rest of the loop body is only the add/remove reverse-relation calls, which are no-ops in that case, so the change is exactly equivalent when there is nothing to update.

## Consumers verified safe when the forward node is never created

- `get_meta()` is read only here, behind `?? []`
- `Cache_Validity_Item::invalidate_nested_node()` returns early when the node doesn't exist
- `Atomic_Styles_Manager::clear_styles()` returns early when `get_node()` is null

## Side benefit

Stops creating a `global_related` child for every post that has no embedded posts, which directly slows the unbounded growth of `elementor_atomic_cache_validity__global_related` in the common case.

## Test

New AAA test `test_register_styles__does_not_rewrite_global_related_option_on_identical_re_render`. Note on mechanism: WordPress' `update_option` action fires only after the unchanged-value early return in `wp-includes/option.php` (line 923) — so it would produce (1, 0) both with and without the guard. To detect the guard we hook `pre_update_option_{option}`, which fires on every `update_option()` **call**. The test seeds via one render, snapshots the counters, does an identical re-render, and asserts no additional `update_option()` calls on either the forward or reverse relation options.

## Test plan

- [x] `php -l` clean
- [x] PHPCS `--standard=ruleset.xml` clean (only pre-existing warnings on untouched lines)
- [ ] CI: PHPUnit `Test_Atomic_Global_Styles`
- [ ] CI: Playwright

## Follow-up

Will cherry-pick to `elementor/4.02` once merged, alongside [#37115](https://github.com/elementor/elementor/pull/37115) (cherry-pick of #36594), so the VIP customer gets both fixes in a 4.2 patch release.

## Jira

Umbrella ED-24868 (Optimized CSS files). If a dedicated sub-ticket has been created for this guard, please update the title.

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Redundant option writes on identical re-renders waste I/O; this guards against persisting unchanged relation maps when no posts were added or removed (ED-24868).

## 2. What Changed (Where)

- **atomic-global-styles.php**: Added early-continue guard when added/removed posts are both empty
- **test-atomic-global-styles.php**: Added test verifying option writes don't occur on unchanged re-renders

## 3. How It Works

During style registration, the code now compares new vs. old related posts. If `$added_posts` and `$removed_posts` are both empty (identical state), it skips the cache validation and relation persistence entirely—short-circuiting unnecessary option updates.

## 4. Risks

None apparent. Logic is defensive (empty check before operations), maintains existing behavior when relations change, and has test coverage.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
