### PR TITLE
Internal: Update mcp composer package version [ED-25441]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=7.4",
         "automattic/jetpack-autoloader": "^5",
-        "elementor/elementor-mcp-composer": "^1.0.9",
+        "elementor/elementor-mcp-composer": "^1.0.10",
         "elementor/wp-one-package": "1.0.68"
     },
     "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c867a2c5ed61fc3043ff038fabb0431",
+    "content-hash": "fe0f81a7de8f7ffdd9e9321976b5d101",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -72,10 +72,10 @@
         },
         {
             "name": "elementor/elementor-mcp-composer",
-            "version": "1.0.9",
+            "version": "1.0.10",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/elementor-mcp-composer/1.0.9"
+                "url": "https://composer.elementor.com/download/elementor/elementor-mcp-composer/1.0.10"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^5",
@@ -109,7 +109,7 @@
                 "proprietary"
             ],
             "description": "Reusable Composer package for Elementor MCP integrations.",
-            "time": "2026-08-30T14:08:53+00:00"
+            "time": "2026-08-31T09:29:38+00:00"
         },
         {
             "name": "elementor/wp-notifications-package",
@@ -4890,13 +4890,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
     },


### PR DESCRIPTION
## Summary
- Bumps `elementor/elementor-mcp-composer` from `^1.0.9` to `^1.0.10`
- Updates `composer.lock` accordingly


## Test plan
- [ ] Composer lock updated correctly
- [ ] MCP setup page loads as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Update the `elementor-mcp-composer` package to version `^1.0.10` as per ED-25441.

## 2. What Changed (Where)
- `composer.json`: Bumped `elementor/elementor-mcp-composer` from `^1.0.9` to `^1.0.10`.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
