### PR TITLE
Internal: Update mcp composer package version [ED-25441]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=7.4",
         "automattic/jetpack-autoloader": "^5",
-        "elementor/elementor-mcp-composer": "^1.0.9",
+        "elementor/elementor-mcp-composer": "^1.0.10",
         "elementor/wp-one-package": "1.0.68"
     },
     "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c867a2c5ed61fc3043ff038fabb0431",
+    "content-hash": "fe0f81a7de8f7ffdd9e9321976b5d101",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -72,10 +72,10 @@
         },
         {
             "name": "elementor/elementor-mcp-composer",
-            "version": "1.0.9",
+            "version": "1.0.10",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.elementor.com/download/elementor/elementor-mcp-composer/1.0.9"
+                "url": "https://composer.elementor.com/download/elementor/elementor-mcp-composer/1.0.10"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^5",
@@ -109,7 +109,7 @@
                 "proprietary"
             ],
             "description": "Reusable Composer package for Elementor MCP integrations.",
-            "time": "2026-08-30T14:08:53+00:00"
+            "time": "2026-08-31T09:29:38+00:00"
         },
         {
             "name": "elementor/wp-notifications-package",
@@ -4890,13 +4890,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
     },

--- a/tests/phpunit/elementor/modules/mcp/test-shared-registry-bridge.php
+++ b/tests/phpunit/elementor/modules/mcp/test-shared-registry-bridge.php
@@ -33,7 +33,7 @@ class Test_Shared_Registry_Bridge extends TestCase {
 				continue;
 			}
 
-			$this->assertGreaterThanOrEqual( '1.0.4', $package['version'] );
+			$this->assertTrue( version_compare( $package['version'], '1.0.4', '>=' ), "Expected version >= 1.0.4, got {$package['version']}" );
 			return;
 		}
 
@@ -59,22 +59,21 @@ class Test_Shared_Registry_Bridge extends TestCase {
 		$this->assertStringContainsString( 'return 25;', $source );
 	}
 
-	public function test_connector_page_is_always_registered_when_mcp_is_active(): void {
+	public function test_connector_page_is_gated_by_hidden_inactive_experiment(): void {
 		$module_source = file_get_contents(
 			dirname( __DIR__, 5 ) . '/modules/mcp/module.php'
 		);
 
-		$this->assertStringNotContainsString( 'mcp_connector', $module_source );
-		$this->assertStringNotContainsString( 'is_connector_page_active', $module_source );
-		$this->assertStringContainsString( '$menu_data_provider->register_menu(', $module_source );
-		$this->assertStringContainsString( 'new Editor_One_Mcp_Menu()', $module_source );
+		$this->assertStringContainsString( "const CONNECTOR_EXPERIMENT_NAME = 'mcp_connector';", $module_source );
+		$this->assertStringContainsString( "'hidden' => true,", $module_source );
+		$this->assertStringContainsString( 'Experiments_Manager::STATE_INACTIVE', $module_source );
+		$this->assertStringContainsString( 'if ( ! self::is_connector_page_active() ) {', $module_source );
 
 		$menu_source = file_get_contents(
 			dirname( __DIR__, 5 ) . '/modules/mcp/admin-menu-items/editor-one-mcp-menu.php'
 		);
 
-		$this->assertStringContainsString( 'return true;', $menu_source );
-		$this->assertStringNotContainsString( 'is_connector_page_active', $menu_source );
+		$this->assertStringContainsString( 'Module::is_connector_page_active()', $menu_source );
 	}
 
 	public function test_editor_one_mcp_menu_registers_after_submissions(): void {

--- a/tests/phpunit/elementor/modules/mcp/test-shared-registry-bridge.php
+++ b/tests/phpunit/elementor/modules/mcp/test-shared-registry-bridge.php
@@ -59,21 +59,22 @@ class Test_Shared_Registry_Bridge extends TestCase {
 		$this->assertStringContainsString( 'return 25;', $source );
 	}
 
-	public function test_connector_page_is_gated_by_hidden_inactive_experiment(): void {
+	public function test_connector_page_is_always_registered_when_mcp_is_active(): void {
 		$module_source = file_get_contents(
 			dirname( __DIR__, 5 ) . '/modules/mcp/module.php'
 		);
 
-		$this->assertStringContainsString( "const CONNECTOR_EXPERIMENT_NAME = 'mcp_connector';", $module_source );
-		$this->assertStringContainsString( "'hidden' => true,", $module_source );
-		$this->assertStringContainsString( 'Experiments_Manager::STATE_INACTIVE', $module_source );
-		$this->assertStringContainsString( 'if ( ! self::is_connector_page_active() ) {', $module_source );
+		$this->assertStringNotContainsString( 'mcp_connector', $module_source );
+		$this->assertStringNotContainsString( 'is_connector_page_active', $module_source );
+		$this->assertStringContainsString( '$menu_data_provider->register_menu(', $module_source );
+		$this->assertStringContainsString( 'new Editor_One_Mcp_Menu()', $module_source );
 
 		$menu_source = file_get_contents(
 			dirname( __DIR__, 5 ) . '/modules/mcp/admin-menu-items/editor-one-mcp-menu.php'
 		);
 
-		$this->assertStringContainsString( 'Module::is_connector_page_active()', $menu_source );
+		$this->assertStringContainsString( 'return true;', $menu_source );
+		$this->assertStringNotContainsString( 'is_connector_page_active', $menu_source );
 	}
 
 	public function test_editor_one_mcp_menu_registers_after_submissions(): void {


### PR DESCRIPTION
## Summary
- Bumps `elementor/elementor-mcp-composer` from `^1.0.9` to `^1.0.10`
- Updates `composer.lock` accordingly


## Test plan
- [ ] Composer lock updated correctly
- [ ] MCP setup page loads as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Bumping mcp-composer to 1.0.10 (from 1.0.9). Updates version validation baseline in tests. [ED-25441]

## 2. What Changed (Where)

- `composer.json`: Dependency version pinned to `^1.0.10`
- `test-shared-registry-bridge.php`: Version assertion refactored from `assertGreaterThanOrEqual` to `version_compare` with explicit threshold check (still `>=1.0.4`)

## 3. How It Works

Test now uses semantic version comparison via `version_compare()` instead of string comparison, ensuring robust handling of version formats. Threshold remains unchanged at 1.0.4, only the assertion mechanism evolved.

## 4. Risks

None. Test assertion strengthened (semver-aware), actual minimum requirement unchanged. Safe maintenance bump.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-25441]: https://elementor.atlassian.net/browse/ED-25441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ