### PR TITLE
Fix: Skip cherry-pick-pr branches in sync workflow [ED-25426]

### DIFF
--- a/.github/workflows/sync-release-branches.yml
+++ b/.github/workflows/sync-release-branches.yml
@@ -20,7 +20,8 @@ jobs:
         github.event.pull_request.merged == true &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         (github.event.pull_request.base.ref == 'release/stable' || github.event.pull_request.base.ref == 'release/beta') &&
-        !startsWith(github.event.pull_request.head.ref, 'sync-pr')
+        !startsWith(github.event.pull_request.head.ref, 'sync-pr') &&
+        !startsWith(github.event.pull_request.head.ref, 'cherry-pick-pr')
       }}
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- Skips sync workflow for PRs whose head branch starts with `cherry-pick-pr`
- Prevents legacy/auto cherry-pick PR merges into `release/beta` from opening empty downstream sync PRs

## Test plan
- [ ] Merge elementor/elementor-editor-github-actions sync fix PR first
- [ ] Merge this PR
- [ ] Merge a `cherry-pick-pr*` PR into `release/beta` and confirm no sync PR is created
- [ ] Merge a normal PR into `release/beta` and confirm sync PR to `main` includes changes

## Jira
ED-25426

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Prevents infinite loops or redundant sync triggers caused by automated cherry-pick PRs merging into release branches (ED-25426).

## 2. What Changed (Where)
- `.github/workflows/sync-release-branches.yml`: Added exclusion for `cherry-pick-pr` branch prefixes in job conditional.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
