### PR TITLE
Fix: MCP wrap, copy overrides, duplicate ids, and invalid interactions [ED-25455]

### DIFF
--- a/modules/mcp/abilities/build-composition/widget-type-resolver.php
+++ b/modules/mcp/abilities/build-composition/widget-type-resolver.php
@@ -42,6 +42,52 @@ class Widget_Type_Resolver {
 	}
 
 	/**
+	 * @return array{configs: array<string, array>, errors: string[]}
+	 */
+	public function collect_used_with_errors( \DOMDocument $dom ): array {
+		$configs = [];
+		$errors = [];
+		$seen_unknown = [];
+
+		foreach ( $this->xml_parser->iterate_all_descendants( $dom ) as $node ) {
+			$tag = $this->xml_parser->get_tag_name( $node );
+
+			if ( isset( $configs[ $tag ] ) || isset( $seen_unknown[ $tag ] ) ) {
+				continue;
+			}
+
+			$config = $this->resolve_type_config( $tag );
+			if ( is_wp_error( $config ) ) {
+				$seen_unknown[ $tag ] = true;
+				$errors[] = $config->get_error_message();
+				continue;
+			}
+			$configs[ $tag ] = $config;
+		}
+
+		return [
+			'configs' => $configs,
+			'errors' => $errors,
+		];
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function collect_child_type_and_required_child_errors( \DOMDocument $dom, array $widget_configs ): array {
+		$root = $this->xml_parser->get_root( $dom );
+		if ( ! $root ) {
+			return [];
+		}
+
+		$errors = [];
+		$this->collect_child_type_errors( $root, $widget_configs, $errors );
+		$this->collect_required_child_errors( $root, $widget_configs, $errors );
+
+		return $errors;
+	}
+
+	/**
 	 * @return \WP_Error|null
 	 */
 	public function validate_child_types( \DOMDocument $dom, array $widget_configs ) {

--- a/modules/mcp/abilities/build-composition/widget-type-resolver.php
+++ b/modules/mcp/abilities/build-composition/widget-type-resolver.php
@@ -42,11 +42,11 @@ class Widget_Type_Resolver {
 	}
 
 	/**
-	 * @return array{configs: array<string, array>, errors: string[]}
+	 * @return array{configs: array<string, array>, unknown_tag_errors: string[]}
 	 */
-	public function collect_used_with_errors( \DOMDocument $dom ): array {
+	public function collect_referenced_widget_configs( \DOMDocument $dom ): array {
 		$configs = [];
-		$errors = [];
+		$unknown_tag_errors = [];
 		$seen_unknown = [];
 
 		foreach ( $this->xml_parser->iterate_all_descendants( $dom ) as $node ) {
@@ -59,7 +59,7 @@ class Widget_Type_Resolver {
 			$config = $this->resolve_type_config( $tag );
 			if ( is_wp_error( $config ) ) {
 				$seen_unknown[ $tag ] = true;
-				$errors[] = $config->get_error_message();
+				$unknown_tag_errors[] = $config->get_error_message();
 				continue;
 			}
 			$configs[ $tag ] = $config;
@@ -67,7 +67,7 @@ class Widget_Type_Resolver {
 
 		return [
 			'configs' => $configs,
-			'errors' => $errors,
+			'unknown_tag_errors' => $unknown_tag_errors,
 		];
 	}
 

--- a/modules/mcp/abilities/build-composition/xml-parser.php
+++ b/modules/mcp/abilities/build-composition/xml-parser.php
@@ -94,8 +94,8 @@ class Xml_Parser {
 		return $descendants;
 	}
 
-	public function validate_unique_configuration_ids( \DOMDocument $dom ): ?\WP_Error {
-		$seen = [];
+	public function collect_duplicate_configuration_id_errors( \DOMDocument $dom ): array {
+		$counts = [];
 
 		foreach ( $this->iterate_all_descendants( $dom ) as $node ) {
 			$configuration_id = $this->get_configuration_id( $node );
@@ -103,21 +103,40 @@ class Xml_Parser {
 				continue;
 			}
 
-			if ( isset( $seen[ $configuration_id ] ) ) {
-				return new \WP_Error(
-					'elementor_duplicate_configuration_id',
-					sprintf(
-						/* translators: %s: duplicate configuration-id value */
-						__( 'Duplicate configuration-id "%s". Each element must have a unique configuration-id.', 'elementor' ),
-						$configuration_id
-					),
-					[ 'status' => \WP_Http::BAD_REQUEST ]
-				);
+			if ( ! isset( $counts[ $configuration_id ] ) ) {
+				$counts[ $configuration_id ] = 0;
 			}
 
-			$seen[ $configuration_id ] = true;
+			$counts[ $configuration_id ]++;
 		}
 
-		return null;
+		$errors = [];
+		foreach ( $counts as $configuration_id => $count ) {
+			if ( $count <= 1 ) {
+				continue;
+			}
+
+			$errors[] = sprintf(
+				/* translators: %s: duplicate configuration-id value */
+				__( 'Duplicate configuration-id "%s". Each element must have a unique configuration-id.', 'elementor' ),
+				$configuration_id
+			);
+		}
+
+		return $errors;
+	}
+
+	public function validate_unique_configuration_ids( \DOMDocument $dom ): ?\WP_Error {
+		$errors = $this->collect_duplicate_configuration_id_errors( $dom );
+
+		if ( empty( $errors ) ) {
+			return null;
+		}
+
+		return new \WP_Error(
+			'elementor_duplicate_configuration_id',
+			implode( ' ', $errors ),
+			[ 'status' => \WP_Http::BAD_REQUEST ]
+		);
 	}
 }

--- a/modules/mcp/abilities/build-composition/xml-parser.php
+++ b/modules/mcp/abilities/build-composition/xml-parser.php
@@ -93,4 +93,31 @@ class Xml_Parser {
 		}
 		return $descendants;
 	}
+
+	public function validate_unique_configuration_ids( \DOMDocument $dom ): ?\WP_Error {
+		$seen = [];
+
+		foreach ( $this->iterate_all_descendants( $dom ) as $node ) {
+			$configuration_id = $this->get_configuration_id( $node );
+			if ( null === $configuration_id || '' === $configuration_id ) {
+				continue;
+			}
+
+			if ( isset( $seen[ $configuration_id ] ) ) {
+				return new \WP_Error(
+					'elementor_duplicate_configuration_id',
+					sprintf(
+						/* translators: %s: duplicate configuration-id value */
+						__( 'Duplicate configuration-id "%s". Each element must have a unique configuration-id.', 'elementor' ),
+						$configuration_id
+					),
+					[ 'status' => \WP_Http::BAD_REQUEST ]
+				);
+			}
+
+			$seen[ $configuration_id ] = true;
+		}
+
+		return null;
+	}
 }

--- a/modules/mcp/abilities/manage-component-ability.php
+++ b/modules/mcp/abilities/manage-component-ability.php
@@ -456,7 +456,7 @@ class Manage_Component_Ability extends Abstract_Ability {
 		}
 
 		return [
-			'elements' => $this->assign_element_ids( [ $found ] ),
+			'elements' => $this->assign_element_ids( $this->preserve_source_ids_as_titles( [ $found ] ) ),
 			'warnings' => [],
 		];
 	}
@@ -492,6 +492,21 @@ class Manage_Component_Ability extends Abstract_Ability {
 	 * address elements by the identifier the caller used in `xml_structure` — see
 	 * `Overridable_Props_Builder::find_element_ref`.
 	 */
+	private function preserve_source_ids_as_titles( array $elements ): array {
+		return array_map( function ( array $element ) {
+			$title = $element['editor_settings']['title'] ?? '';
+			if ( '' === $title && ! empty( $element['id'] ) ) {
+				$element['editor_settings']['title'] = (string) $element['id'];
+			}
+
+			if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
+				$element['elements'] = $this->preserve_source_ids_as_titles( $element['elements'] );
+			}
+
+			return $element;
+		}, $elements );
+	}
+
 	private function assign_element_ids( array $elements ): array {
 		return array_map( fn( array $element ) => $this->assign_element_id( $element ), $elements );
 	}

--- a/modules/mcp/abilities/manage-component-ability.php
+++ b/modules/mcp/abilities/manage-component-ability.php
@@ -92,9 +92,10 @@ class Manage_Component_Ability extends Abstract_Ability {
 			return $source_result;
 		}
 		[ 'elements' => $elements, 'warnings' => $warnings ] = $source_result;
+		$source_id_map = $source_result['source_id_map'] ?? [];
 
 		$settings = [];
-		$overridable_error = $this->apply_overridable_props( $elements, $input, $settings );
+		$overridable_error = $this->apply_overridable_props( $elements, $input, $settings, $source_id_map );
 		if ( is_wp_error( $overridable_error ) ) {
 			return $overridable_error;
 		}
@@ -363,7 +364,7 @@ class Manage_Component_Ability extends Abstract_Ability {
 	}
 
 	/**
-	 * @return array{elements: array[], warnings: string[]}|\WP_Error
+	 * @return array{elements: array[], warnings: string[], source_id_map?: array<string,string>}|\WP_Error
 	 */
 	private function resolve_create_elements( array $input ) {
 		$has_xml = ! empty( $input['xml_structure'] ) && is_string( $input['xml_structure'] );
@@ -429,7 +430,7 @@ class Manage_Component_Ability extends Abstract_Ability {
 	}
 
 	/**
-	 * @return array{elements: array[], warnings: string[]}|\WP_Error
+	 * @return array{elements: array[], warnings: string[], source_id_map: array<string,string>}|\WP_Error
 	 */
 	private function copy_elements_from_source( array $input ) {
 		$source_post_id = (int) $input['source_post_id'];
@@ -455,9 +456,13 @@ class Manage_Component_Ability extends Abstract_Ability {
 			return $this->not_found( __( 'element_id was not found on source_post_id.', 'elementor' ) );
 		}
 
+		$source_id_map = [];
+		$elements = $this->assign_element_ids_recording_source_ids( [ $found ], $source_id_map );
+
 		return [
-			'elements' => $this->assign_element_ids( $this->preserve_source_ids_as_titles( [ $found ] ) ),
+			'elements' => $elements,
 			'warnings' => [],
+			'source_id_map' => $source_id_map,
 		];
 	}
 
@@ -467,14 +472,21 @@ class Manage_Component_Ability extends Abstract_Ability {
 	 * payload itself is left to the component document's save hook, which already
 	 * parses and persists it for every component save.
 	 *
+	 * @param array<string,string> $source_id_map old-source-id => new-machine-id, when the tree
+	 *                                            came from `copy_elements_from_source`. Used to
+	 *                                            let callers address targets by the ids they
+	 *                                            saw on the source document, before id regeneration.
+	 *
 	 * @return \WP_Error|null
 	 */
-	private function apply_overridable_props( array &$elements, array $input, array &$settings ) {
+	private function apply_overridable_props( array &$elements, array $input, array &$settings, array $source_id_map = [] ) {
 		if ( ! is_array( $input['overridable_props'] ?? null ) || empty( $input['overridable_props'] ) ) {
 			return null;
 		}
 
-		$builder_result = Overridable_Props_Builder::make( $this->get_repository() )->build( $elements, $input['overridable_props'] );
+		$definitions = $this->remap_overridable_targets( $input['overridable_props'], $source_id_map );
+
+		$builder_result = Overridable_Props_Builder::make( $this->get_repository() )->build( $elements, $definitions );
 		if ( is_wp_error( $builder_result ) ) {
 			return $builder_result;
 		}
@@ -485,26 +497,30 @@ class Manage_Component_Ability extends Abstract_Ability {
 	}
 
 	/**
-	 * Compiled subtrees have no ids yet (`Subtree_Builder` never sets one), and copied
-	 * subtrees carry ids from another document that would collide here. Both paths need
-	 * fresh, slug-safe machine ids; the caller's configuration-id stays on
-	 * `editor_settings.title` so `overridable_props.target` and other tools can still
-	 * address elements by the identifier the caller used in `xml_structure` — see
-	 * `Overridable_Props_Builder::find_element_ref`.
+	 * Rewrites `overridable_props[*].target` from source-document ids to the freshly assigned
+	 * ids, so callers can keep referencing the elements by the ids they observed on the source.
+	 * Unknown targets pass through untouched so the xml_structure `configuration-id` path (which
+	 * resolves via `editor_settings.title` in `Overridable_Props_Builder::find_element_ref`) and
+	 * regular id targets still work.
+	 *
+	 * @param array<string,string> $source_id_map
 	 */
-	private function preserve_source_ids_as_titles( array $elements ): array {
-		return array_map( function ( array $element ) {
-			$title = $element['editor_settings']['title'] ?? '';
-			if ( '' === $title && ! empty( $element['id'] ) ) {
-				$element['editor_settings']['title'] = (string) $element['id'];
-			}
+	private function remap_overridable_targets( array $definitions, array $source_id_map ): array {
+		if ( empty( $source_id_map ) ) {
+			return $definitions;
+		}
 
-			if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
-				$element['elements'] = $this->preserve_source_ids_as_titles( $element['elements'] );
+		foreach ( $definitions as $override_key => &$definition ) {
+			if ( ! is_array( $definition ) ) {
+				continue;
 			}
+			$target = $definition['target'] ?? null;
+			if ( is_string( $target ) && isset( $source_id_map[ $target ] ) ) {
+				$definition['target'] = $source_id_map[ $target ];
+			}
+		}
 
-			return $element;
-		}, $elements );
+		return $definitions;
 	}
 
 	private function assign_element_ids( array $elements ): array {
@@ -516,6 +532,38 @@ class Manage_Component_Ability extends Abstract_Ability {
 
 		if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
 			$element['elements'] = array_map( fn( array $child ) => $this->assign_element_id( $child ), $element['elements'] );
+		}
+
+		return $element;
+	}
+
+	/**
+	 * Regenerates ids like `assign_element_ids`, but records the mapping from each element's
+	 * old id to its new id so callers can keep addressing the tree by pre-regeneration ids.
+	 *
+	 * @param array<string,string> $source_id_map Populated by reference.
+	 */
+	private function assign_element_ids_recording_source_ids( array $elements, array &$source_id_map ): array {
+		return array_map(
+			fn( array $element ) => $this->assign_element_id_recording_source_id( $element, $source_id_map ),
+			$elements
+		);
+	}
+
+	private function assign_element_id_recording_source_id( array $element, array &$source_id_map ): array {
+		$old_id = isset( $element['id'] ) ? (string) $element['id'] : '';
+
+		$element['id'] = Document_Mutator::instance()->generate_id();
+
+		if ( '' !== $old_id ) {
+			$source_id_map[ $old_id ] = $element['id'];
+		}
+
+		if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
+			$element['elements'] = array_map(
+				fn( array $child ) => $this->assign_element_id_recording_source_id( $child, $source_id_map ),
+				$element['elements']
+			);
 		}
 
 		return $element;

--- a/modules/mcp/abilities/manage-component-ability.php
+++ b/modules/mcp/abilities/manage-component-ability.php
@@ -472,6 +472,9 @@ class Manage_Component_Ability extends Abstract_Ability {
 	 * payload itself is left to the component document's save hook, which already
 	 * parses and persists it for every component save.
 	 *
+	 * @param array[]              $elements
+	 * @param array                $input
+	 * @param array                $settings
 	 * @param array<string,string> $source_id_map old-source-id => new-machine-id, when the tree
 	 *                                            came from `copy_elements_from_source`. Used to
 	 *                                            let callers address targets by the ids they
@@ -503,6 +506,7 @@ class Manage_Component_Ability extends Abstract_Ability {
 	 * resolves via `editor_settings.title` in `Overridable_Props_Builder::find_element_ref`) and
 	 * regular id targets still work.
 	 *
+	 * @param array                $definitions
 	 * @param array<string,string> $source_id_map
 	 */
 	private function remap_overridable_targets( array $definitions, array $source_id_map ): array {
@@ -541,6 +545,7 @@ class Manage_Component_Ability extends Abstract_Ability {
 	 * Regenerates ids like `assign_element_ids`, but records the mapping from each element's
 	 * old id to its new id so callers can keep addressing the tree by pre-regeneration ids.
 	 *
+	 * @param array[]              $elements
 	 * @param array<string,string> $source_id_map Populated by reference.
 	 */
 	private function assign_element_ids_recording_source_ids( array $elements, array &$source_id_map ): array {

--- a/modules/mcp/abilities/manage-component-ability.php
+++ b/modules/mcp/abilities/manage-component-ability.php
@@ -544,10 +544,11 @@ class Manage_Component_Ability extends Abstract_Ability {
 	 * @param array<string,string> $source_id_map Populated by reference.
 	 */
 	private function assign_element_ids_recording_source_ids( array $elements, array &$source_id_map ): array {
-		return array_map(
-			fn( array $element ) => $this->assign_element_id_recording_source_id( $element, $source_id_map ),
-			$elements
-		);
+		$result = [];
+		foreach ( $elements as $element ) {
+			$result[] = $this->assign_element_id_recording_source_id( $element, $source_id_map );
+		}
+		return $result;
 	}
 
 	private function assign_element_id_recording_source_id( array $element, array &$source_id_map ): array {
@@ -560,10 +561,7 @@ class Manage_Component_Ability extends Abstract_Ability {
 		}
 
 		if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
-			$element['elements'] = array_map(
-				fn( array $child ) => $this->assign_element_id_recording_source_id( $child, $source_id_map ),
-				$element['elements']
-			);
+			$element['elements'] = $this->assign_element_ids_recording_source_ids( $element['elements'], $source_id_map );
 		}
 
 		return $element;

--- a/modules/mcp/abilities/manage-elements-ability.php
+++ b/modules/mcp/abilities/manage-elements-ability.php
@@ -400,6 +400,25 @@ class Manage_Elements_Ability extends Abstract_Ability {
 		$variables_service = $this->create_variables_service();
 		$warnings = [];
 
+		if ( null !== $interactions ) {
+			if ( ! is_array( $interactions ) ) {
+				return new \WP_Error( 'invalid_input', __( 'interactions must be an array of interaction items.', 'elementor' ) );
+			}
+			if ( ! Plugin::$instance->experiments->is_feature_active( Interactions_Module::EXPERIMENT_NAME ) ) {
+				return new \WP_Error(
+					'elementor_invalid_interactions',
+					__( 'Interactions experiment is not active. Interactions were not applied.', 'elementor' ),
+					[ 'status' => \WP_Http::BAD_REQUEST ]
+				);
+			}
+			$interactions_applier = new Interactions_Applier( $this->get_plain_values_resolver() );
+			$interactions_result = $interactions_applier->apply( $index, [ $element_id => $interactions ] );
+			if ( $interactions_result['error'] ) {
+				return $interactions_result['error'];
+			}
+			$warnings = array_merge( $warnings, $interactions_result['warnings'] );
+		}
+
 		if ( ! empty( $settings ) ) {
 			if ( Element_Config_Applier::COMPONENT_INSTANCE_WIDGET_TYPE === $element_type ) {
 				$component_applier = new Component_Instance_Applier( new Components_Repository(), $this->get_plain_values_resolver() );
@@ -440,26 +459,6 @@ class Manage_Elements_Ability extends Abstract_Ability {
 				return $style_result['error'];
 			}
 			$warnings = array_merge( $warnings, $style_result['warnings'] );
-		}
-
-		if ( null !== $interactions ) {
-			if ( ! is_array( $interactions ) ) {
-				return new \WP_Error( 'invalid_input', __( 'interactions must be an array of interaction items.', 'elementor' ) );
-			}
-			if ( ! Plugin::$instance->experiments->is_feature_active( Interactions_Module::EXPERIMENT_NAME ) ) {
-				return new \WP_Error(
-					'elementor_invalid_interactions',
-					__( 'Interactions experiment is not active. Interactions were not applied.', 'elementor' ),
-					[ 'status' => \WP_Http::BAD_REQUEST ]
-				);
-			} else {
-				$interactions_applier = new Interactions_Applier( $this->get_plain_values_resolver() );
-				$interactions_result = $interactions_applier->apply( $index, [ $element_id => $interactions ] );
-				if ( $interactions_result['error'] ) {
-					return $interactions_result['error'];
-				}
-				$warnings = array_merge( $warnings, $interactions_result['warnings'] );
-			}
 		}
 
 		return [

--- a/modules/mcp/abilities/manage-elements-ability.php
+++ b/modules/mcp/abilities/manage-elements-ability.php
@@ -447,7 +447,11 @@ class Manage_Elements_Ability extends Abstract_Ability {
 				return new \WP_Error( 'invalid_input', __( 'interactions must be an array of interaction items.', 'elementor' ) );
 			}
 			if ( ! Plugin::$instance->experiments->is_feature_active( Interactions_Module::EXPERIMENT_NAME ) ) {
-				$warnings[] = __( 'Interactions experiment is not active. Interactions were not applied.', 'elementor' );
+				return new \WP_Error(
+					'elementor_invalid_interactions',
+					__( 'Interactions experiment is not active. Interactions were not applied.', 'elementor' ),
+					[ 'status' => \WP_Http::BAD_REQUEST ]
+				);
 			} else {
 				$interactions_applier = new Interactions_Applier( $this->get_plain_values_resolver() );
 				$interactions_result = $interactions_applier->apply( $index, [ $element_id => $interactions ] );

--- a/modules/mcp/abilities/utils/composition-compiler.php
+++ b/modules/mcp/abilities/utils/composition-compiler.php
@@ -64,24 +64,12 @@ final class Composition_Compiler {
 			return $dom;
 		}
 
-		$duplicate_id_error = $xml_parser->validate_unique_configuration_ids( $dom );
-		if ( $duplicate_id_error ) {
-			return $duplicate_id_error;
+		$pre_apply_error = $this->collect_pre_apply_errors( $dom, $xml_parser, $type_resolver, $document_tree, $parent_id );
+		if ( is_wp_error( $pre_apply_error ) ) {
+			return $pre_apply_error;
 		}
 
-		$form_structure_error = ( new Form_Structure_Validator( $xml_parser ) )->validate(
-			$dom,
-			$document_tree,
-			$parent_id
-		);
-		if ( $form_structure_error ) {
-			return $form_structure_error;
-		}
-
-		$widget_configs = $type_resolver->collect_used( $dom );
-		if ( is_wp_error( $widget_configs ) ) {
-			return $widget_configs;
-		}
+		$widget_configs = $pre_apply_error['widget_configs'];
 
 		$wrapping_result = $this->wrap_document_root_content( $dom, $widget_configs, $parent_id, $type_resolver, $xml_parser );
 		if ( is_wp_error( $wrapping_result ) ) {
@@ -90,9 +78,13 @@ final class Composition_Compiler {
 
 		$widget_configs = $wrapping_result['widget_configs'];
 
-		$child_type_error = $type_resolver->validate_child_types( $dom, $widget_configs );
-		if ( $child_type_error ) {
-			return $child_type_error;
+		$child_type_errors = $type_resolver->collect_child_type_and_required_child_errors( $dom, $widget_configs );
+		if ( ! empty( $child_type_errors ) ) {
+			return new \WP_Error(
+				'elementor_invalid_child_type',
+				implode( ' ', $child_type_errors ),
+				[ 'status' => \WP_Http::BAD_REQUEST ]
+			);
 		}
 
 		$subtrees = $subtree_builder->build( $dom, $widget_configs );
@@ -137,6 +129,76 @@ final class Composition_Compiler {
 			'dom' => $dom,
 			'xml_parser' => $xml_parser,
 		];
+	}
+
+	/**
+	 * Runs every validator that can safely execute before appliers touch the tree, then
+	 * returns a single WP_Error carrying all messages, or the resolved widget configs.
+	 *
+	 * @return array{widget_configs: array<string, array>}|\WP_Error
+	 */
+	private function collect_pre_apply_errors(
+		\DOMDocument $dom,
+		Xml_Parser $xml_parser,
+		Widget_Type_Resolver $type_resolver,
+		array $document_tree,
+		string $parent_id
+	) {
+		$errors_by_code = [];
+
+		$duplicate_id_errors = $xml_parser->collect_duplicate_configuration_id_errors( $dom );
+		if ( ! empty( $duplicate_id_errors ) ) {
+			$errors_by_code['elementor_duplicate_configuration_id'] = $duplicate_id_errors;
+		}
+
+		$form_structure_errors = ( new Form_Structure_Validator( $xml_parser ) )
+			->collect_errors( $dom, $document_tree, $parent_id );
+		if ( ! empty( $form_structure_errors ) ) {
+			$errors_by_code['elementor_invalid_form_structure'] = $form_structure_errors;
+		}
+
+		$type_resolution = $type_resolver->collect_used_with_errors( $dom );
+		if ( ! empty( $type_resolution['errors'] ) ) {
+			$errors_by_code['elementor_unknown_type'] = $type_resolution['errors'];
+		}
+
+		if ( ! empty( $errors_by_code ) ) {
+			return $this->build_aggregated_error( $errors_by_code );
+		}
+
+		return [
+			'widget_configs' => $type_resolution['configs'],
+		];
+	}
+
+	/**
+	 * @param array<string, string[]> $errors_by_code
+	 */
+	private function build_aggregated_error( array $errors_by_code ): \WP_Error {
+		$primary_code = array_key_first( $errors_by_code );
+		$all_messages = [];
+		foreach ( $errors_by_code as $messages ) {
+			foreach ( $messages as $message ) {
+				$all_messages[] = $message;
+			}
+		}
+
+		$aggregated = new \WP_Error(
+			$primary_code,
+			implode( ' ', $all_messages ),
+			[ 'status' => \WP_Http::BAD_REQUEST ]
+		);
+
+		foreach ( $errors_by_code as $code => $messages ) {
+			foreach ( $messages as $index => $message ) {
+				if ( $code === $primary_code && 0 === $index ) {
+					continue;
+				}
+				$aggregated->add( $code, $message, [ 'status' => \WP_Http::BAD_REQUEST ] );
+			}
+		}
+
+		return $aggregated;
 	}
 
 	private function wrap_document_root_content(

--- a/modules/mcp/abilities/utils/composition-compiler.php
+++ b/modules/mcp/abilities/utils/composition-compiler.php
@@ -34,7 +34,6 @@ final class Composition_Compiler {
 
 	private const DEFAULT_PARENT_ID = 'document';
 	private const DOCUMENT_ROOT_WRAPPER = 'e-div-block';
-	private const COMPONENT_INSTANCE_WIDGET_TYPE = 'e-component';
 
 	public const COMPONENT_PARENT_ID = 'component';
 
@@ -63,6 +62,11 @@ final class Composition_Compiler {
 		$dom = $xml_parser->parse( (string) ( $input['xml_structure'] ?? '' ) );
 		if ( is_wp_error( $dom ) ) {
 			return $dom;
+		}
+
+		$duplicate_id_error = $xml_parser->validate_unique_configuration_ids( $dom );
+		if ( $duplicate_id_error ) {
+			return $duplicate_id_error;
 		}
 
 		$form_structure_error = ( new Form_Structure_Validator( $xml_parser ) )->validate(
@@ -164,10 +168,6 @@ final class Composition_Compiler {
 			$config = $widget_configs[ $tag ] ?? [];
 
 			if ( 'widget' !== ( $config['elType'] ?? null ) ) {
-				continue;
-			}
-
-			if ( self::COMPONENT_INSTANCE_WIDGET_TYPE === ( $config['widgetType'] ?? null ) ) {
 				continue;
 			}
 

--- a/modules/mcp/abilities/utils/composition-compiler.php
+++ b/modules/mcp/abilities/utils/composition-compiler.php
@@ -64,12 +64,21 @@ final class Composition_Compiler {
 			return $dom;
 		}
 
-		$pre_apply_error = $this->collect_pre_apply_errors( $dom, $xml_parser, $type_resolver, $document_tree, $parent_id );
-		if ( is_wp_error( $pre_apply_error ) ) {
-			return $pre_apply_error;
-		}
+		[
+			'configs' => $widget_configs,
+			'unknown_tag_errors' => $unknown_widget_tag_errors,
+		] = $type_resolver->collect_referenced_widget_configs( $dom );
 
-		$widget_configs = $pre_apply_error['widget_configs'];
+		$validation_error = $this->validate_xml_before_apply(
+			$dom,
+			$xml_parser,
+			$document_tree,
+			$parent_id,
+			$unknown_widget_tag_errors
+		);
+		if ( $validation_error ) {
+			return $validation_error;
+		}
 
 		$wrapping_result = $this->wrap_document_root_content( $dom, $widget_configs, $parent_id, $type_resolver, $xml_parser );
 		if ( is_wp_error( $wrapping_result ) ) {
@@ -132,30 +141,29 @@ final class Composition_Compiler {
 	}
 
 	/**
-	 * Runs every validator that can safely execute before appliers touch the tree, then
-	 * returns a single WP_Error carrying all messages, or the resolved widget configs.
+	 * @param \DOMDocument $dom
+	 * @param Xml_Parser   $xml_parser
+	 * @param array        $document_tree
+	 * @param string       $parent_id
+	 * @param string[]     $unknown_widget_tag_errors
 	 *
-	 * @return array{widget_configs: array<string, array>}|\WP_Error
+	 * @return \WP_Error|null
 	 */
-	private function collect_pre_apply_errors(
+	private function validate_xml_before_apply(
 		\DOMDocument $dom,
 		Xml_Parser $xml_parser,
-		Widget_Type_Resolver $type_resolver,
 		array $document_tree,
-		string $parent_id
+		string $parent_id,
+		array $unknown_widget_tag_errors
 	) {
-		$type_resolution = $type_resolver->collect_used_with_errors( $dom );
-
 		$errors = array_merge(
 			$this->tag_errors( 'elementor_duplicate_configuration_id', $xml_parser->collect_duplicate_configuration_id_errors( $dom ) ),
 			$this->tag_errors( 'elementor_invalid_form_structure', ( new Form_Structure_Validator( $xml_parser ) )->collect_errors( $dom, $document_tree, $parent_id ) ),
-			$this->tag_errors( 'elementor_unknown_type', $type_resolution['errors'] ?? [] ),
+			$this->tag_errors( 'elementor_unknown_type', $unknown_widget_tag_errors ),
 		);
 
 		if ( empty( $errors ) ) {
-			return [
-				'widget_configs' => $type_resolution['configs'],
-			];
+			return null;
 		}
 
 		$status = [ 'status' => \WP_Http::BAD_REQUEST ];

--- a/modules/mcp/abilities/utils/composition-compiler.php
+++ b/modules/mcp/abilities/utils/composition-compiler.php
@@ -144,61 +144,45 @@ final class Composition_Compiler {
 		array $document_tree,
 		string $parent_id
 	) {
-		$errors_by_code = [];
-
-		$duplicate_id_errors = $xml_parser->collect_duplicate_configuration_id_errors( $dom );
-		if ( ! empty( $duplicate_id_errors ) ) {
-			$errors_by_code['elementor_duplicate_configuration_id'] = $duplicate_id_errors;
-		}
-
-		$form_structure_errors = ( new Form_Structure_Validator( $xml_parser ) )
-			->collect_errors( $dom, $document_tree, $parent_id );
-		if ( ! empty( $form_structure_errors ) ) {
-			$errors_by_code['elementor_invalid_form_structure'] = $form_structure_errors;
-		}
-
 		$type_resolution = $type_resolver->collect_used_with_errors( $dom );
-		if ( ! empty( $type_resolution['errors'] ) ) {
-			$errors_by_code['elementor_unknown_type'] = $type_resolution['errors'];
-		}
 
-		if ( ! empty( $errors_by_code ) ) {
-			return $this->build_aggregated_error( $errors_by_code );
-		}
-
-		return [
-			'widget_configs' => $type_resolution['configs'],
-		];
-	}
-
-	/**
-	 * @param array<string, string[]> $errors_by_code
-	 */
-	private function build_aggregated_error( array $errors_by_code ): \WP_Error {
-		$primary_code = array_key_first( $errors_by_code );
-		$all_messages = [];
-		foreach ( $errors_by_code as $messages ) {
-			foreach ( $messages as $message ) {
-				$all_messages[] = $message;
-			}
-		}
-
-		$aggregated = new \WP_Error(
-			$primary_code,
-			implode( ' ', $all_messages ),
-			[ 'status' => \WP_Http::BAD_REQUEST ]
+		$errors = array_merge(
+			$this->tag_errors( 'elementor_duplicate_configuration_id', $xml_parser->collect_duplicate_configuration_id_errors( $dom ) ),
+			$this->tag_errors( 'elementor_invalid_form_structure', ( new Form_Structure_Validator( $xml_parser ) )->collect_errors( $dom, $document_tree, $parent_id ) ),
+			$this->tag_errors( 'elementor_unknown_type', $type_resolution['errors'] ?? [] ),
 		);
 
-		foreach ( $errors_by_code as $code => $messages ) {
-			foreach ( $messages as $index => $message ) {
-				if ( $code === $primary_code && 0 === $index ) {
-					continue;
-				}
-				$aggregated->add( $code, $message, [ 'status' => \WP_Http::BAD_REQUEST ] );
-			}
+		if ( empty( $errors ) ) {
+			return [
+				'widget_configs' => $type_resolution['configs'],
+			];
+		}
+
+		$status = [ 'status' => \WP_Http::BAD_REQUEST ];
+		$joined = implode( ' ', array_column( $errors, 'message' ) );
+
+		$aggregated = new \WP_Error( $errors[0]['code'], $joined, $status );
+		foreach ( array_slice( $errors, 1 ) as $error ) {
+			$aggregated->add( $error['code'], $error['message'], $status );
 		}
 
 		return $aggregated;
+	}
+
+	/**
+	 * @param string   $code     Error code to tag each message with.
+	 * @param string[] $messages List of error messages.
+	 *
+	 * @return array<int, array{code: string, message: string}>
+	 */
+	private function tag_errors( string $code, array $messages ): array {
+		return array_map(
+			fn ( $message ) => [
+				'code' => $code,
+				'message' => $message,
+			],
+			$messages
+		);
 	}
 
 	private function wrap_document_root_content(

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-component-instance-applier.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-component-instance-applier.php
@@ -352,9 +352,10 @@ class Test_Component_Instance_Applier extends Elementor_Test_Base {
 		$this->assertSame( 'e-heading', $elements[0]['elements'][0]['widgetType'] );
 	}
 
-	public function test_build_composition__rejects_component_instance_as_direct_document_child() {
+	public function test_build_composition__wraps_component_instance_as_direct_document_child() {
 		// Arrange
 		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
 		$component_id = $this->create_component( 'Hero Component' );
 		$post_id = $this->create_real_document();
 		$ability = new Build_Composition_Ability( Document_Mutator::instance() );
@@ -371,10 +372,14 @@ class Test_Component_Instance_Applier extends Elementor_Test_Base {
 		] );
 
 		// Assert
-		$this->assertWPError( $result );
-		$this->assertSame( 'elementor_invalid_parent', $result->get_error_code() );
-		$this->assertStringContainsString( 'e-component', $result->get_error_message() );
-		$this->assertEmpty( Plugin::$instance->documents->get( $post_id )->get_elements_data() );
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : 'unknown' );
+		$this->assertTrue( $result['success'] );
+		$this->assertStringContainsString( 'e-div-block', $result['warnings'][0] ?? '' );
+		$this->assertStringContainsString( '<e-div-block', $result['resolved_xml'] );
+
+		$elements = Plugin::$instance->documents->get( $post_id )->get_elements_data();
+		$this->assertSame( 'e-div-block', $elements[0]['elType'] );
+		$this->assertSame( 'e-component', $elements[0]['elements'][0]['widgetType'] );
 	}
 
 	public function test_apply__allows_expired_tier_to_edit_a_component_document() {

--- a/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
@@ -207,7 +207,27 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 			'empty error message' => [ '<e-form><e-form-submit-button/><e-form-error-message/></e-form>', 'elementor_invalid_form_structure' ],
 			'multiple submit buttons' => [ '<e-form><e-form-submit-button/><e-form-submit-button/></e-form>', 'elementor_invalid_form_structure' ],
 			'nested form' => [ '<e-form><e-form-submit-button/><e-form><e-form-submit-button/></e-form></e-form>', 'elementor_invalid_form_structure' ],
+			'duplicate configuration-id' => [ '<e-heading configuration-id="dup"/><e-heading configuration-id="dup"/>', 'elementor_duplicate_configuration_id' ],
 		];
+	}
+
+	public function test_execute__duplicate_configuration_id_is_rejected_on_dry_run() {
+		// Arrange
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		$ability = new Build_Composition_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'post_id' => $post_id,
+			'dry_run' => true,
+			'xml_structure' => '<e-heading configuration-id="dup"/><e-heading configuration-id="dup"/>',
+		] );
+
+		// Assert
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_duplicate_configuration_id', $result->get_error_code() );
+		$this->assertEmpty( Plugin::$instance->documents->get( $post_id )->get_elements_data() );
 	}
 
 	public function test_execute__valid_form_structure_passes_form_validation() {

--- a/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-build-composition-ability.php
@@ -207,7 +207,15 @@ class Test_Build_Composition_Ability extends Elementor_Test_Base {
 			'empty error message' => [ '<e-form><e-form-submit-button/><e-form-error-message/></e-form>', 'elementor_invalid_form_structure' ],
 			'multiple submit buttons' => [ '<e-form><e-form-submit-button/><e-form-submit-button/></e-form>', 'elementor_invalid_form_structure' ],
 			'nested form' => [ '<e-form><e-form-submit-button/><e-form><e-form-submit-button/></e-form></e-form>', 'elementor_invalid_form_structure' ],
-			'duplicate configuration-id' => [ '<e-heading configuration-id="dup"/><e-heading configuration-id="dup"/>', 'elementor_duplicate_configuration_id' ],
+			'multiple duplicate configuration-ids' => [
+				'<e-heading configuration-id="dup-a"/><e-heading configuration-id="dup-a"/><e-heading configuration-id="dup-b"/><e-heading configuration-id="dup-b"/>',
+				'elementor_duplicate_configuration_id',
+			],
+			'duplicate configuration-id and invalid child type' => [
+				'<e-heading configuration-id="dup"/><e-heading configuration-id="dup"/><e-heading configuration-id="h1"><e-paragraph configuration-id="p1"/></e-heading>',
+				'elementor_duplicate_configuration_id',
+			],
+			'multiple unknown types' => [ '<nonexistent-widget/><another-nonexistent-widget/>', 'elementor_unknown_type' ],
 		];
 	}
 

--- a/tests/phpunit/elementor/modules/mcp/test-manage-component-overridable-props.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-component-overridable-props.php
@@ -156,6 +156,8 @@ class Test_Manage_Component_Overridable_Props extends Elementor_Test_Base {
 		$this->assertSame( 'overridable', $heading['settings']['tag']['$$type'] );
 		$this->assertArrayHasKey( 'heading_tag', $component->get_overridable_props()->props );
 		$this->assertNotSame( 'source-heading-id', $heading['id'] );
+		$this->assertNotSame( 'source-heading-id', $heading['editor_settings']['title'] ?? null, 'Source id must not leak into editor_settings.title.' );
+		$this->assertNotSame( 'source-wrap-id', $component->get_elements_data()[0]['editor_settings']['title'] ?? null, 'Source id must not leak into editor_settings.title.' );
 	}
 
 	public function test_create__copy_from_source_does_not_clobber_existing_editor_settings_title() {

--- a/tests/phpunit/elementor/modules/mcp/test-manage-component-overridable-props.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-component-overridable-props.php
@@ -111,6 +111,87 @@ class Test_Manage_Component_Overridable_Props extends Elementor_Test_Base {
 		$this->assertArrayHasKey( 'heading_tag', $component->get_overridable_props()->props );
 	}
 
+	public function test_create__copy_from_source_applies_overridable_props_using_live_source_ids() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$post_id = $this->create_real_document();
+		$this->given_document_with_elements( $post_id, [
+			[
+				'id' => 'source-wrap-id',
+				'elType' => 'e-flexbox',
+				'settings' => [],
+				'elements' => [
+					[
+						'id' => 'source-heading-id',
+						'elType' => 'widget',
+						'widgetType' => 'e-heading',
+						'settings' => [],
+						'elements' => [],
+					],
+				],
+			],
+		] );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Copied Overridable Hero',
+			'source_post_id' => $post_id,
+			'element_id' => 'source-wrap-id',
+			'overridable_props' => [
+				'heading_tag' => [
+					'target' => 'source-heading-id',
+					'prop_key' => 'tag',
+					'label' => 'Heading Tag',
+				],
+			],
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$component = ( new Components_Repository() )->get( $result['component_id'], false );
+		$heading = $component->get_elements_data()[0]['elements'][0];
+		$this->assertSame( 'overridable', $heading['settings']['tag']['$$type'] );
+		$this->assertArrayHasKey( 'heading_tag', $component->get_overridable_props()->props );
+		$this->assertNotSame( 'source-heading-id', $heading['id'] );
+	}
+
+	public function test_create__copy_from_source_does_not_clobber_existing_editor_settings_title() {
+		// Arrange
+		$this->act_as_admin();
+		Mock_Pro_License_API::set_license_state( true );
+		$post_id = $this->create_real_document();
+		$this->given_document_with_elements( $post_id, [
+			[
+				'id' => 'source-heading-id',
+				'elType' => 'widget',
+				'widgetType' => 'e-heading',
+				'settings' => [],
+				'elements' => [],
+				'editor_settings' => [
+					'title' => 'Keep Me',
+				],
+			],
+		] );
+		$ability = new Manage_Component_Ability();
+
+		// Act
+		$result = $ability->execute( [
+			'action' => 'create',
+			'title' => 'Copied Labeled Heading',
+			'source_post_id' => $post_id,
+			'element_id' => 'source-heading-id',
+		] );
+
+		// Assert
+		$this->assertIsArray( $result, 'Expected success array but got: ' . $this->error_message( $result ) );
+		$copied = ( new Components_Repository() )->get( $result['component_id'], false )->get_elements_data()[0];
+		$this->assertSame( 'Keep Me', $copied['editor_settings']['title'] );
+		$this->assertNotSame( 'source-heading-id', $copied['id'] );
+	}
+
 	public function test_create__persists_widgets_cache_key_as_widget_type_for_atomic_elements() {
 		// Arrange
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
@@ -11,6 +11,8 @@ use Elementor\Modules\GlobalClasses\Global_Class_Post;
 use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
 use Elementor\Modules\GlobalClasses\Global_Classes_Labels;
 use Elementor\Modules\GlobalClasses\Global_Classes_Order;
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\Interactions\Module as Interactions_Module;
 use Elementor\Modules\Mcp\Abilities\Build_Composition_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Elements_Ability;
 use Elementor\Plugin;
@@ -1015,23 +1017,25 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$post_id = $this->create_real_document();
 		$heading_id = $this->given_heading_on_document( $post_id );
 
-		$result = ( new Manage_Elements_Ability() )->execute( [
-			'post_id' => $post_id,
-			'operations' => [
-				[
-					'action' => 'update',
-					'element_id' => $heading_id,
-					'interactions' => [
-						[
-							'trigger' => 'scrollIn',
-							'action' => [
-								'type' => 'play',
+		$result = $this->with_interactions_inactive( function () use ( $post_id, $heading_id ) {
+			return ( new Manage_Elements_Ability() )->execute( [
+				'post_id' => $post_id,
+				'operations' => [
+					[
+						'action' => 'update',
+						'element_id' => $heading_id,
+						'interactions' => [
+							[
+								'trigger' => 'scrollIn',
+								'action' => [
+									'type' => 'play',
+								],
 							],
 						],
 					],
 				],
-			],
-		] );
+			] );
+		} );
 
 		$this->assertIsArray( $result );
 		$this->assertSame( 'error', $result['results'][0]['status'] ?? null );
@@ -1360,5 +1364,18 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		Global_Classes_Labels::make( $kit )->set_labels( [ $class_id => $label ] );
 
 		return $class_id;
+	}
+
+	private function with_interactions_inactive( callable $callback ) {
+		$experiments = Plugin::$instance->experiments;
+		$original_state = $experiments->get_features( Interactions_Module::EXPERIMENT_NAME )['state'];
+		$feature_option_key = $experiments->get_feature_option_key( Interactions_Module::EXPERIMENT_NAME );
+		update_option( $feature_option_key, Experiments_Manager::STATE_INACTIVE );
+
+		try {
+			return $callback();
+		} finally {
+			update_option( $feature_option_key, $original_state );
+		}
 	}
 }

--- a/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
@@ -11,8 +11,6 @@ use Elementor\Modules\GlobalClasses\Global_Class_Post;
 use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
 use Elementor\Modules\GlobalClasses\Global_Classes_Labels;
 use Elementor\Modules\GlobalClasses\Global_Classes_Order;
-use Elementor\Core\Experiments\Manager as Experiments_Manager;
-use Elementor\Modules\Interactions\Module as Interactions_Module;
 use Elementor\Modules\Mcp\Abilities\Build_Composition_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Elements_Ability;
 use Elementor\Plugin;
@@ -1012,44 +1010,6 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertSame( 'hover', $interactions['items'][1]['value']['trigger']['value'] );
 	}
 
-	public function test_execute__update_rejects_short_interaction_payload() {
-		$this->act_as_admin();
-		$post_id = $this->create_real_document();
-		$heading_id = $this->given_heading_on_document( $post_id );
-
-		$result = $this->with_interactions_inactive( function () use ( $post_id, $heading_id ) {
-			return ( new Manage_Elements_Ability() )->execute( [
-				'post_id' => $post_id,
-				'operations' => [
-					[
-						'action' => 'update',
-						'element_id' => $heading_id,
-						'interactions' => [
-							[
-								'trigger' => 'scrollIn',
-								'action' => [
-									'type' => 'play',
-								],
-							],
-						],
-					],
-				],
-			] );
-		} );
-
-		$this->assertIsArray( $result );
-		$this->assertSame( 'error', $result['results'][0]['status'] ?? null );
-		$this->assertSame( 'elementor_invalid_interactions', $result['results'][0]['code'] ?? null );
-
-		$node = $this->find_element_in_document( $post_id, $heading_id );
-		$interactions = $node['interactions'] ?? null;
-		if ( is_string( $interactions ) ) {
-			$interactions = json_decode( $interactions, true );
-		}
-		$items = is_array( $interactions ) ? ( $interactions['items'] ?? $interactions ) : $interactions;
-		$this->assertTrue( empty( $items ) );
-	}
-
 	public function test_bulk__partial_failure_still_saves_valid_ops() {
 		$this->act_as_admin();
 		$post_id = $this->create_real_document();
@@ -1364,18 +1324,5 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		Global_Classes_Labels::make( $kit )->set_labels( [ $class_id => $label ] );
 
 		return $class_id;
-	}
-
-	private function with_interactions_inactive( callable $callback ) {
-		$experiments = Plugin::$instance->experiments;
-		$original_state = $experiments->get_features( Interactions_Module::EXPERIMENT_NAME )['state'];
-		$feature_option_key = $experiments->get_feature_option_key( Interactions_Module::EXPERIMENT_NAME );
-		update_option( $feature_option_key, Experiments_Manager::STATE_INACTIVE );
-
-		try {
-			return $callback();
-		} finally {
-			update_option( $feature_option_key, $original_state );
-		}
 	}
 }

--- a/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
@@ -1010,6 +1010,42 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertSame( 'hover', $interactions['items'][1]['value']['trigger']['value'] );
 	}
 
+	public function test_execute__update_rejects_short_interaction_payload() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		$heading_id = $this->given_heading_on_document( $post_id );
+
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $heading_id,
+					'interactions' => [
+						[
+							'trigger' => 'scrollIn',
+							'action' => [
+								'type' => 'play',
+							],
+						],
+					],
+				],
+			],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'error', $result['results'][0]['status'] ?? null );
+		$this->assertSame( 'elementor_invalid_interactions', $result['results'][0]['code'] ?? null );
+
+		$node = $this->find_element_in_document( $post_id, $heading_id );
+		$interactions = $node['interactions'] ?? null;
+		if ( is_string( $interactions ) ) {
+			$interactions = json_decode( $interactions, true );
+		}
+		$items = is_array( $interactions ) ? ( $interactions['items'] ?? $interactions ) : $interactions;
+		$this->assertTrue( empty( $items ) );
+	}
+
 	public function test_bulk__partial_failure_still_saves_valid_ops() {
 		$this->act_as_admin();
 		$post_id = $this->create_real_document();

--- a/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-manage-elements-ability.php
@@ -3,6 +3,7 @@
 namespace Elementor\Tests\Phpunit\Modules\Mcp;
 
 use Elementor\Core\Documents_Manager;
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\Elements_Manager;
 use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Tags_Editor_Config;
 use Elementor\Modules\AtomicWidgets\DynamicTags\Dynamic_Tags_Module;
@@ -11,6 +12,7 @@ use Elementor\Modules\GlobalClasses\Global_Class_Post;
 use Elementor\Modules\GlobalClasses\Global_Class_Post_Type;
 use Elementor\Modules\GlobalClasses\Global_Classes_Labels;
 use Elementor\Modules\GlobalClasses\Global_Classes_Order;
+use Elementor\Modules\Interactions\Module as Interactions_Module;
 use Elementor\Modules\Mcp\Abilities\Build_Composition_Ability;
 use Elementor\Modules\Mcp\Abilities\Manage_Elements_Ability;
 use Elementor\Plugin;
@@ -1010,6 +1012,84 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		$this->assertSame( 'hover', $interactions['items'][1]['value']['trigger']['value'] );
 	}
 
+	public function test_execute__update_rejects_interactions_when_experiment_inactive() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		$heading_id = $this->given_heading_on_document( $post_id );
+
+		$result = $this->with_interactions_inactive( function () use ( $post_id, $heading_id ) {
+			return ( new Manage_Elements_Ability() )->execute( [
+				'post_id' => $post_id,
+				'operations' => [
+					[
+						'action' => 'update',
+						'element_id' => $heading_id,
+						'interactions' => [
+							[
+								'trigger' => 'scrollIn',
+								'action' => [
+									'type' => 'play',
+								],
+							],
+						],
+					],
+				],
+			] );
+		} );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'error', $result['results'][0]['status'] ?? null );
+		$this->assertSame( 'elementor_invalid_interactions', $result['results'][0]['code'] ?? null );
+
+		$node = $this->find_element_in_document( $post_id, $heading_id );
+		$interactions = $node['interactions'] ?? null;
+		if ( is_string( $interactions ) ) {
+			$interactions = json_decode( $interactions, true );
+		}
+		$items = is_array( $interactions ) ? ( $interactions['items'] ?? $interactions ) : $interactions;
+		$this->assertTrue( empty( $items ) );
+	}
+
+	public function test_bulk__failed_interactions_update_does_not_persist_settings() {
+		$this->act_as_admin();
+		$post_id = $this->create_real_document();
+		$heading_id = $this->given_heading_on_document( $post_id );
+
+		$result = ( new Manage_Elements_Ability() )->execute( [
+			'post_id' => $post_id,
+			'operations' => [
+				[
+					'action' => 'update',
+					'element_id' => $heading_id,
+					'settings' => [
+						'title' => 'Saved',
+					],
+				],
+				[
+					'action' => 'update',
+					'element_id' => $heading_id,
+					'settings' => [
+						'title' => 'Leaked',
+					],
+					'interactions' => [
+						[
+							'unknown_field' => 'nope',
+						],
+					],
+				],
+			],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'partial_error', $result['status'] );
+		$this->assertSame( 'ok', $result['results'][0]['status'] );
+		$this->assertSame( 'error', $result['results'][1]['status'] );
+		$this->assertSame( 'elementor_invalid_interactions', $result['results'][1]['code'] );
+
+		$node = $this->find_element_in_document( $post_id, $heading_id );
+		$this->assertSame( 'Saved', $node['settings']['title']['value'] );
+	}
+
 	public function test_bulk__partial_failure_still_saves_valid_ops() {
 		$this->act_as_admin();
 		$post_id = $this->create_real_document();
@@ -1324,5 +1404,23 @@ class Test_Manage_Elements_Ability extends Elementor_Test_Base {
 		Global_Classes_Labels::make( $kit )->set_labels( [ $class_id => $label ] );
 
 		return $class_id;
+	}
+
+	private function with_interactions_inactive( callable $callback ) {
+		$experiments = Plugin::$instance->experiments;
+		$name = Interactions_Module::EXPERIMENT_NAME;
+		$original_default = $experiments->get_features( $name )['default'];
+		$feature_option_key = $experiments->get_feature_option_key( $name );
+		$original_option = get_option( $feature_option_key );
+
+		$experiments->set_feature_default_state( $name, Experiments_Manager::STATE_INACTIVE );
+		update_option( $feature_option_key, Experiments_Manager::STATE_INACTIVE );
+
+		try {
+			return $callback();
+		} finally {
+			$experiments->set_feature_default_state( $name, $original_default );
+			update_option( $feature_option_key, $original_option );
+		}
 	}
 }


### PR DESCRIPTION
## Summary
Fixes four MCP contract bugs found in QA. Approaches below; each change is the smallest one that matches the documented API.

## Approaches

### ED-25455 — `e-component` skipped by document-root auto-wrap
**Problem:** `wrap_document_root_content` treated `e-component` as a special case and skipped it. A root `<e-component/>` never got the `e-div-block` wrapper, then child-type validation failed (`cannot be a direct child of the document`). Other root widgets (heading, nav) were already auto-wrapped.

**Approach:** Remove the `COMPONENT_INSTANCE_WIDGET_TYPE` short-circuit so any root widget, including `e-component`, uses the existing wrap path. No new wrapper type and no per-widget carve-out. The old PHPUnit that expected `elementor_invalid_parent` now asserts wrap + persist.

**Rejected:** Leaving components as illegal document children — that contradicts the auto-wrap contract the rest of compose already uses.

### ED-25456 — copy path `overridable_props.target` cannot find live source ids
**Problem:** `copy_elements_from_source` regenerates element ids before `Overridable_Props_Builder` runs. Callers pass `overridable_props.target` using the live source ids from `get-page-structure`, so `find_element_ref` cannot resolve the target and create succeeds without override envelopes.

**Approach:** Record an explicit `old_id → new_id` map while regenerating ids (`assign_element_ids_recording_source_ids`), return it from `copy_elements_from_source`, and rewrite `overridable_props[*].target` through that map before calling `Overridable_Props_Builder::build`. Unknown targets pass through untouched so the xml_structure `configuration-id` path (resolved via `editor_settings.title`) still works. `editor_settings.title` stays a user-facing label only.

**Rejected:** Stamping source ids into `editor_settings.title` before id regeneration — it overloads a UI field, pollutes the structure panel, and conflates the xml `configuration-id` alias path with an internal copy remap.

### ED-25457 — duplicate `configuration-id` last-wins
**Problem:** Tool text already requires unique `configuration-id`s. `index_by_config_id` overwrote the first node, so settings/style/interactions keyed by that id applied last-wins with no error.

**Approach:** Hard-fail at parse, before wrap/apply. `Xml_Parser::validate_unique_configuration_ids` walks the DOM (reuse `iterate_all_descendants`) and returns `elementor_duplicate_configuration_id` naming the duplicated value. Missing ids stay allowed (existing XML without the attribute still works). Same error on dry_run and save.

**Rejected:** Silent rename of the second occurrence — that hides data loss on maps keyed by id.

### ED-25458 — short interaction payloads succeed with empty interactions
**Problem (live MCP):** `manage-elements` update with `{ trigger, action: {…} }` returned status `ok` and left `interactions: []`. On this site the interactions experiment was off; that path only appended a warning and still marked the op successful, so the agent treated a no-op as success.

**Approach:** If interactions are present on the op and the experiment is inactive, return `WP_Error` (`elementor_invalid_interactions`, 400) instead of warning + ok. When the experiment is on, the existing applier already errors on unresolvable shapes.

**Rejected:** Keeping the warning — MCP clients ignore it and retry nothing. The ticket is specifically about lying success.

## Test plan
- [x] `build-composition` with a root `<e-component/>` wraps in `e-div-block` and saves (verified via local MCP on page 53343).
- [x] `manage-component` create from `source_post_id` + `element_id` with `overridable_props.target` set to the live source id plants overrides (verified via local MCP: source page 53347 → component 53352).
- [x] Copy does not overwrite an existing `editor_settings.title` on the source element (covered by PHPUnit; id-map approach does not write titles).
- [x] `build-composition` (dry_run and save) with two tags sharing `configuration-id` returns `elementor_duplicate_configuration_id` (verified via local MCP dry_run).
- [x] Unique `configuration-id` compositions still succeed.
- [ ] `manage-elements` update that sets interactions while the experiment is off returns `elementor_invalid_interactions` and does not persist items (PHPUnit only; local site has interactions experiment active).

## Jira
[ED-25455](https://elementor.atlassian.net/browse/ED-25455)
[ED-25456](https://elementor.atlassian.net/browse/ED-25456)
[ED-25457](https://elementor.atlassian.net/browse/ED-25457)
[ED-25458](https://elementor.atlassian.net/browse/ED-25458)

[ED-25455]: https://elementor.atlassian.net/browse/ED-25455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
ED-25455: Fixes MCP contract violations regarding duplicate configuration IDs, missing XML structure validation, and incorrect overridable property mapping during element copying.

## 2. What Changed (Where)

| File | Change |
| :--- | :--- |
| `widget-type-resolver.php` | Added referenced config collection and child type validation. |
| `xml-parser.php` | Implemented duplicate `configuration-id` detection and validation. |
| `manage-component-ability.php` | Added ID remapping for overridable props when copying elements. |
| `manage-elements-ability.php` | Moved interaction application and added strict experiment validation. |
| `composition-compiler.php` | Consolidated XML validation (duplicates, structure, types) before application. |
| `tests/...` | Added regression tests for duplicates, wrapping, and interaction failures. |

## 3. How It Works
The `Composition_Compiler` now executes a pre-flight validation check via `validate_xml_before_apply` to catch duplicate IDs or unknown types before modifying the document. To fix the copy-override bug, `Manage_Component_Ability` now generates a `source_id_map` during ID regeneration, allowing `remap_overridable_targets` to update target IDs from the source document to the new machine IDs.

## 4. Risks
Interactions now return a `WP_Error` instead of a warning when the experiment is inactive, which may break clients expecting a success response with warnings.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
