### PR TITLE
Fix: Unzip plugin zip before WordPress.org SVN publish [ED-25464]

### DIFF
--- a/.github/scripts/publish-to-wordpress-org.sh
+++ b/.github/scripts/publish-to-wordpress-org.sh
@@ -21,6 +21,16 @@ echo "Publish version: ${PLUGIN_VERSION}"
 ELEMENTOR_PATH="$GITHUB_WORKSPACE/elementor"
 SVN_PATH="$GITHUB_WORKSPACE/svn"
 
+if [[ ! -d "$ELEMENTOR_PATH" ]]; then
+	ZIP_FILE="$GITHUB_WORKSPACE/elementor-${PLUGIN_VERSION}.zip"
+	if [[ ! -f "$ZIP_FILE" ]]; then
+		echo "Built plugin folder not found at ${ELEMENTOR_PATH} and ${ZIP_FILE} does not exist"
+		exit 1
+	fi
+	echo "Unzipping ${ZIP_FILE} into ${GITHUB_WORKSPACE}"
+	unzip -o "$ZIP_FILE" -d "$GITHUB_WORKSPACE"
+fi
+
 cd $ELEMENTOR_PATH
 mkdir -p $SVN_PATH
 cd $SVN_PATH

--- a/.github/scripts/publish-to-wordpress-org.sh
+++ b/.github/scripts/publish-to-wordpress-org.sh
@@ -21,17 +21,6 @@ echo "Publish version: ${PLUGIN_VERSION}"
 ELEMENTOR_PATH="$GITHUB_WORKSPACE/elementor"
 SVN_PATH="$GITHUB_WORKSPACE/svn"
 
-if [[ ! -d "$ELEMENTOR_PATH" ]]; then
-	ZIP_FILE="$GITHUB_WORKSPACE/elementor-${PLUGIN_VERSION}.zip"
-	if [[ ! -f "$ZIP_FILE" ]]; then
-		echo "Built plugin folder not found at ${ELEMENTOR_PATH} and ${ZIP_FILE} does not exist"
-		exit 1
-	fi
-	echo "Unzipping ${ZIP_FILE} into ${GITHUB_WORKSPACE}"
-	unzip -o "$ZIP_FILE" -d "$GITHUB_WORKSPACE"
-fi
-
-cd $ELEMENTOR_PATH
 mkdir -p $SVN_PATH
 cd $SVN_PATH
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -101,6 +101,18 @@ jobs:
           BUILD_ZIP_FILE_PATH: ${{ github.event.repository.name }}-${{ inputs.version }}.zip
           PLUGIN_NAME: ${{ github.event.repository.name }}
 
+      - name: Unzip build artifact
+        run: unzip -o ${{ github.event.repository.name }}-${{ inputs.version }}.zip -d $GITHUB_WORKSPACE
+
+      - name: Validate build files
+        if: github.repository_owner == 'elementor'
+        env:
+          PLUGIN_VERSION: ${{ env.RELEASE_NAME }}
+          CHANNEL: ${{ inputs.channel == 'beta' && 'beta' || 'ga' }}
+          PACKAGE_VERSION: ${{ inputs.version }}
+        run: |
+          bash "${GITHUB_WORKSPACE}/.github/scripts/validate-build-files.sh"
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,7 +11,7 @@ on:
         required: false
         type: boolean
         default: false
-        description: 'Mark as pre-release on GitHub (skips the entire publish workflow — no WordPress.org SVN, Slack, beta→dev cascade, or npm packages publish)'
+        description: 'Mark as pre-release on GitHub (skips the entire publish workflow — no WordPress.org SVN, Slack, beta cascade, or npm packages publish)'
       channel:
         required: false
         type: choice
@@ -19,7 +19,7 @@ on:
           - stable
           - beta
         default: 'stable'
-        description: 'Release channel. Controls the beta→dev cascade and the npm dist-tag.'
+        description: 'Release channel. Controls the beta cascade and the npm dist-tag.'
 
   workflow_call:
     inputs:
@@ -78,6 +78,10 @@ jobs:
     permissions:
       contents: write
 
+    env:
+      REPO_NAME: ${{ github.event.repository.name }}
+      VERSION: ${{ inputs.version }}
+
     outputs:
       CLEAN_PACKAGE_VERSION: ${{ steps.output-data.outputs.CLEAN_PACKAGE_VERSION }}
       VERSION_SUFFIX: ${{ steps.output-data.outputs.VERSION_SUFFIX }}
@@ -87,37 +91,42 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.version }}
+          ref: ${{ env.VERSION }}
           fetch-depth: 0
 
       - name: Download built release asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release download "${{ inputs.version }}" --pattern 'elementor-*.zip' --clobber
+        run: gh release download "${{ env.VERSION }}" --pattern "${{ env.REPO_NAME }}-*.zip" --clobber
 
       - name: Get release name
         uses: ./.github/workflows/get-release-name
         with:
-          BUILD_ZIP_FILE_PATH: ${{ github.event.repository.name }}-${{ inputs.version }}.zip
-          PLUGIN_NAME: ${{ github.event.repository.name }}
+          PLUGIN_NAME: ${{ env.REPO_NAME }}
 
       - name: Unzip build artifact
-        run: unzip -o ${{ github.event.repository.name }}-${{ inputs.version }}.zip -d $GITHUB_WORKSPACE
+        env:
+          ELEMENTOR_PATH: ${{ github.workspace }}/${{ env.REPO_NAME }}
+          ZIP_FILE: ${{ env.REPO_NAME }}-${{ env.VERSION }}.zip
+        run: |
+          mkdir -p "$ELEMENTOR_PATH"
+          echo "Unzipping ${ZIP_FILE} into ${ELEMENTOR_PATH}"
+          unzip -o "$ZIP_FILE" -d "$ELEMENTOR_PATH"
 
       - name: Validate build files
         if: github.repository_owner == 'elementor'
         env:
           PLUGIN_VERSION: ${{ env.RELEASE_NAME }}
           CHANNEL: ${{ inputs.channel == 'beta' && 'beta' || 'ga' }}
-          PACKAGE_VERSION: ${{ inputs.version }}
+          PACKAGE_VERSION: ${{ env.VERSION }}
         run: |
           bash "${GITHUB_WORKSPACE}/.github/scripts/validate-build-files.sh"
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: ${{ inputs.version }}
-          name: ${{ inputs.version }}
+          tag_name: ${{ env.VERSION }}
+          name: ${{ env.VERSION }}
           files: elementor-*.zip
           prerelease: ${{ inputs.prerelease }}
           draft: false
@@ -128,21 +137,9 @@ jobs:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           CHANNEL: ${{ inputs.channel == 'beta' && 'beta' || 'ga' }}
-          PACKAGE_VERSION: ${{ inputs.version }}
+          PACKAGE_VERSION: ${{ env.VERSION }}
         run: |
           bash "${GITHUB_WORKSPACE}/.github/scripts/publish-to-wordpress-org.sh"
-
-      - name: Release Dev From Beta
-        if: inputs.channel == 'beta'
-        uses: ./.github/workflows/release-dev-from-beta
-        with:
-          BUILD_ZIP_FILE_PATH: ${{ github.event.repository.name }}-${{ env.RELEASE_FILENAME }}.zip
-          PLUGIN_NAME: ${{ github.event.repository.name }}
-          REPOSITORY_OWNER: ${{ github.repository_owner }}
-          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          DRY_RUN: 'false'
-          PACKAGE_VERSION: ${{ inputs.version }}
 
       - name: Get Jira release URL
         id: get_jira_release_url


### PR DESCRIPTION
## Summary
- Publish Release downloaded the built zip but never unpacked it, so WordPress.org SVN publish failed looking for `$GITHUB_WORKSPACE/elementor` ([Controlled Release #82](https://github.com/elementor/elementor/actions/runs/33491940822/job/99809638275)).
- Unzip and validate the zip in `publish-release.yml` the same way as `build-draft-release.yml`.
- If the plugin folder is still missing, `publish-to-wordpress-org.sh` unzips `elementor-${PLUGIN_VERSION}.zip`.

## Test plan
- [ ] Merge this PR
- [ ] Re-run **Publish Release** for `4.3.0-beta1` (GitHub release already exists; SVN and beta→dev still need to run)
- [ ] Confirm **Publish to WordPress.org SVN** unpacks `elementor/` and commits the tag
- [ ] Confirm the beta→dev cascade still runs after SVN
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
The SVN publish process lacked the actual plugin source files because the build artifact remained zipped. This change ensures the zip is extracted to the workspace before the SVN script executes.

## 2. What Changed (Where)
- `.github/scripts/publish-to-wordpress-org.sh`: Removed redundant `cd` command.
- `.github/workflows/publish-release.yml`: Added unzipping step, introduced `REPO_NAME`/`VERSION` env vars, and updated inputs.

## 3. How It Works
The workflow now downloads the release asset using `gh release download`, creates a dedicated directory, and extracts the contents via `unzip -o` before triggering the validation and SVN publish scripts.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
