### PR TITLE
CI: Pass zip path to get-release-name in Publish Release [ED-25464]

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -102,6 +102,7 @@ jobs:
       - name: Get release name
         uses: ./.github/workflows/get-release-name
         with:
+          BUILD_ZIP_FILE_PATH: ${{ env.REPO_NAME }}-${{ env.VERSION }}.zip
           PLUGIN_NAME: ${{ env.REPO_NAME }}
 
       - name: Unzip build artifact


### PR DESCRIPTION
## Summary
- Get release name needs the downloaded zip path, and Publish Release was not passing it after the unzip follow-up landed.
- Pass `BUILD_ZIP_FILE_PATH` as `{repo}-{version}.zip`, matching the draft-release workflow.

## Test plan
- [ ] Re-run **Publish Release** for an existing tag (for example `4.3.0-beta1`)
- [ ] Confirm **Get release name** reads Version from the zip and sets `RELEASE_NAME`
- [ ] Confirm **Publish to WordPress.org SVN** still unpacks `elementor/` and commits the tag

## Jira
[ED-25464](https://elementor.atlassian.net/browse/ED-25464)

[ED-25464]: https://elementor.atlassian.net/browse/ED-25464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The `get-release-name` workflow action was missing the zip file path input, causing it to potentially fail or use incorrect paths during release publication. ED-25464.

## 2. What Changed (Where)

- `.github/workflows/publish-release.yml`: Added `BUILD_ZIP_FILE_PATH` input parameter to `get-release-name` action step, passing the computed zip filename.

## 3. How It Works

The workflow now explicitly passes the zip file path (`${{ env.REPO_NAME }}-${{ env.VERSION }}.zip`) to the downstream action, matching the file downloaded in the previous step. This ensures `get-release-name` operates on the correct artifact.

## 4. Risks

None—straightforward input passing. Assumes `get-release-name` action expects this parameter; no breaking changes to existing workflow logic.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
