### PR TITLE
CI: Remove release validation step [ED 25464]

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -107,21 +107,11 @@ jobs:
 
       - name: Unzip build artifact
         env:
-          ELEMENTOR_PATH: ${{ github.workspace }}/${{ env.REPO_NAME }}
+          ELEMENTOR_PATH: ${{ github.workspace }}
           ZIP_FILE: ${{ env.REPO_NAME }}-${{ env.VERSION }}.zip
         run: |
-          mkdir -p "$ELEMENTOR_PATH"
           echo "Unzipping ${ZIP_FILE} into ${ELEMENTOR_PATH}"
           unzip -o "$ZIP_FILE" -d "$ELEMENTOR_PATH"
-
-      - name: Validate build files
-        if: github.repository_owner == 'elementor'
-        env:
-          PLUGIN_VERSION: ${{ env.RELEASE_NAME }}
-          CHANNEL: ${{ inputs.channel == 'beta' && 'beta' || 'ga' }}
-          PACKAGE_VERSION: ${{ env.VERSION }}
-        run: |
-          bash "${GITHUB_WORKSPACE}/.github/scripts/validate-build-files.sh"
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2


### PR DESCRIPTION
## Summary
- Remove the **Validate build files** step from Publish Release; the release zip was already validated when the draft release was built.
- Unzip the release asset into the workspace root (same as draft release), so `elementor/` lands at `$GITHUB_WORKSPACE/elementor` for SVN publish.

## Test plan
- [ ] Re-run **Publish Release** for an existing tag (for example `4.3.0-beta1`)
- [ ] Confirm the workflow skips validation and proceeds to SVN publish
- [ ] Confirm **Publish to WordPress.org SVN** finds `$GITHUB_WORKSPACE/elementor` and commits the tag

## Jira
[ED-25464](https://elementor.atlassian.net/browse/ED-25464)

[ED-25464]: https://elementor.atlassian.net/browse/ED-25464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Removes the build file validation step from the release pipeline (ED-25464) to streamline the publishing process.

## 2. What Changed (Where)
- `.github/workflows/publish-release.yml`: Removed `Validate build files` step and simplified unzip pathing.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
