### PR TITLE
Internal: Gate V4-only MCP abilities by atomic experiment [ED-25071]

### DIFF
--- a/modules/mcp/abilities/abstract-ability.php
+++ b/modules/mcp/abilities/abstract-ability.php
@@ -100,6 +100,10 @@ abstract class Abstract_Ability {
 		return true;
 	}
 
+	public function is_available_for_current_mode(): bool {
+		return true;
+	}
+
 	private function is_resource(): bool {
 		return self::KIND_RESOURCE === ( $this->mcp_meta()['type'] ?? null );
 	}

--- a/modules/mcp/abilities/appliers/interactions-applier.php
+++ b/modules/mcp/abilities/appliers/interactions-applier.php
@@ -34,9 +34,20 @@ class Interactions_Applier {
 		}
 
 		$errors = [];
+		$warnings = [];
 
 		foreach ( $interactions as $config_id => $items ) {
 			if ( ! isset( $index[ $config_id ] ) ) {
+				continue;
+			}
+
+			if ( V3_Node_Bridge::is_v3_node( $index[ $config_id ] ) ) {
+				$widget_type = (string) ( $index[ $config_id ]['widgetType'] ?? '' );
+				$warnings[] = sprintf(
+					/* translators: %s: V3 widget type name. */
+					__( 'Interactions are V4-only. Skipped for V3 widget %s.', 'elementor' ),
+					$widget_type
+				);
 				continue;
 			}
 
@@ -72,13 +83,13 @@ class Interactions_Applier {
 					implode( ' ', $errors ),
 					[ 'status' => \WP_Http::BAD_REQUEST ]
 				),
-				'warnings' => [],
+				'warnings' => $warnings,
 			];
 		}
 
 		return [
 			'error' => null,
-			'warnings' => [],
+			'warnings' => $warnings,
 		];
 	}
 

--- a/modules/mcp/abilities/get-default-styles-ability.php
+++ b/modules/mcp/abilities/get-default-styles-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
 use Elementor\Modules\DefaultStyles\Default_Styles_Repository;
 use Elementor\Modules\Mcp\Abilities\Utils\Element_Default_Styles_Builder;
 
@@ -19,6 +20,10 @@ class Get_Default_Styles_Ability extends Abstract_Ability {
 
 	protected function get_ability_id(): string {
 		return 'elementor/get-default-styles';
+	}
+
+	public function is_available_for_current_mode(): bool {
+		return AtomicWidgetsModule::is_active();
 	}
 
 	protected function get_definition(): Ability_Definition {

--- a/modules/mcp/abilities/global-classes-resource-ability.php
+++ b/modules/mcp/abilities/global-classes-resource-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
 use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
 use Elementor\Plugin;
 
@@ -20,6 +21,10 @@ class Global_Classes_Resource_Ability extends Abstract_Ability {
 
 	protected function get_ability_id(): string {
 		return 'elementor/global-classes-resource';
+	}
+
+	public function is_available_for_current_mode(): bool {
+		return AtomicWidgetsModule::is_active();
 	}
 
 	protected function get_definition(): Ability_Definition {

--- a/modules/mcp/abilities/global-variables-resource-ability.php
+++ b/modules/mcp/abilities/global-variables-resource-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
 use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
 use Elementor\Modules\Variables\Services\Variables_Service;
 use Elementor\Modules\Variables\Storage\Variables_Repository;
@@ -16,6 +17,10 @@ class Global_Variables_Resource_Ability extends Abstract_Ability {
 
 	protected function get_ability_id(): string {
 		return 'elementor/global-variables-resource';
+	}
+
+	public function is_available_for_current_mode(): bool {
+		return AtomicWidgetsModule::is_active();
 	}
 
 	protected function get_definition(): Ability_Definition {

--- a/modules/mcp/abilities/interactions-schema-resource-ability.php
+++ b/modules/mcp/abilities/interactions-schema-resource-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
 use Elementor\Modules\Interactions\Props\Interaction_Item_Prop_Type;
 use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 
@@ -14,6 +15,10 @@ class Interactions_Schema_Resource_Ability extends Abstract_Ability {
 
 	protected function get_ability_id(): string {
 		return 'elementor/interactions-schema-resource';
+	}
+
+	public function is_available_for_current_mode(): bool {
+		return AtomicWidgetsModule::is_active();
 	}
 
 	protected function get_definition(): Ability_Definition {

--- a/modules/mcp/abilities/list-components-ability.php
+++ b/modules/mcp/abilities/list-components-ability.php
@@ -5,6 +5,7 @@ namespace Elementor\Modules\Mcp\Abilities;
 use Elementor\Modules\Components\Components_Access_Controller;
 use Elementor\Modules\Components\Components_Repository;
 use Elementor\Modules\Components\Documents\Component_Overridable_Prop;
+use Elementor\Modules\Components\Module as Components_Module;
 use Elementor\Modules\Components\Utils\Parsing_Utils;
 use Elementor\Modules\Mcp\Abilities\Utils\Prompt_Loader;
 use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
@@ -17,6 +18,10 @@ class List_Components_Ability extends Abstract_Ability {
 
 	protected function get_ability_id(): string {
 		return 'elementor/list-components';
+	}
+
+	public function is_available_for_current_mode(): bool {
+		return Components_Module::is_experiment_active();
 	}
 
 	public function is_exposed_via_proxy(): bool {

--- a/modules/mcp/abilities/manage-classes-ability.php
+++ b/modules/mcp/abilities/manage-classes-ability.php
@@ -43,6 +43,10 @@ class Manage_Classes_Ability extends Abstract_Ability {
 		return 'elementor/manage-classes';
 	}
 
+	public function is_available_for_current_mode(): bool {
+		return AtomicWidgetsModule::is_active();
+	}
+
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Manage Global Classes', 'elementor' ),

--- a/modules/mcp/abilities/manage-component-ability.php
+++ b/modules/mcp/abilities/manage-component-ability.php
@@ -9,6 +9,7 @@ use Elementor\Modules\Components\Circular_Dependency_Validator;
 use Elementor\Modules\Components\Components_Access_Controller;
 use Elementor\Modules\Components\Components_Repository;
 use Elementor\Modules\Components\Documents\Component as Component_Document;
+use Elementor\Modules\Components\Module as Components_Module;
 use Elementor\Modules\Components\Non_Atomic_Widget_Validator;
 use Elementor\Modules\Components\Save_Components_Validator;
 use Elementor\Modules\Mcp\Abilities\Utils\Composition_Compiler;
@@ -37,6 +38,10 @@ class Manage_Component_Ability extends Abstract_Ability {
 
 	protected function get_ability_id(): string {
 		return 'elementor/manage-component';
+	}
+
+	public function is_available_for_current_mode(): bool {
+		return Components_Module::is_experiment_active();
 	}
 
 	protected function get_definition(): Ability_Definition {

--- a/modules/mcp/abilities/manage-default-styles-ability.php
+++ b/modules/mcp/abilities/manage-default-styles-ability.php
@@ -38,6 +38,10 @@ class Manage_Default_Styles_Ability extends Abstract_Ability {
 		return 'elementor/manage-default-styles';
 	}
 
+	public function is_available_for_current_mode(): bool {
+		return AtomicWidgetsModule::is_active();
+	}
+
 	protected function get_definition(): Ability_Definition {
 		return new Ability_Definition(
 			__( 'Manage Default Styles (Site-Wide)', 'elementor' ),

--- a/modules/mcp/abilities/manage-variable-ability.php
+++ b/modules/mcp/abilities/manage-variable-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
 use Elementor\Modules\Mcp\Abilities\Utils\Bulk_Operations_Result;
 use Elementor\Modules\Variables\Services\Batch_Operations\Batch_Processor;
 use Elementor\Modules\Variables\Services\Variables_Service;
@@ -29,6 +30,10 @@ class Manage_Variable_Ability extends Abstract_Ability {
 
 	protected function get_ability_id(): string {
 		return 'elementor/manage-global-variable';
+	}
+
+	public function is_available_for_current_mode(): bool {
+		return AtomicWidgetsModule::is_active();
 	}
 
 	protected function get_definition(): Ability_Definition {

--- a/modules/mcp/abilities/manage-variable-guide-ability.php
+++ b/modules/mcp/abilities/manage-variable-guide-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
 use Elementor\Utils as ElementorUtils;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,6 +14,10 @@ class Manage_Variable_Guide_Ability extends Abstract_Ability {
 
 	protected function get_ability_id(): string {
 		return 'elementor/manage-global-variable-guide';
+	}
+
+	public function is_available_for_current_mode(): bool {
+		return AtomicWidgetsModule::is_active();
 	}
 
 	protected function get_definition(): Ability_Definition {

--- a/modules/mcp/abilities/reorder-classes-ability.php
+++ b/modules/mcp/abilities/reorder-classes-ability.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Modules\Mcp\Abilities;
 
+use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
 use Elementor\Modules\GlobalClasses\Database\Migrations\Add_Capabilities;
 use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
 use Elementor\Plugin;
@@ -23,6 +24,10 @@ class Reorder_Classes_Ability extends Abstract_Ability {
 
 	protected function get_ability_id(): string {
 		return 'elementor/reorder-classes';
+	}
+
+	public function is_available_for_current_mode(): bool {
+		return AtomicWidgetsModule::is_active();
 	}
 
 	protected function get_definition(): Ability_Definition {

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -108,6 +108,10 @@ class Module extends BaseModule {
 		$registry = new Ability_Registry();
 
 		foreach ( self::get_core_abilities( $registry ) as $ability ) {
+			if ( ! $ability->is_available_for_current_mode() ) {
+				continue;
+			}
+
 			$registry->add( $ability );
 		}
 

--- a/modules/mcp/static-resources/abilities/build-composition.md
+++ b/modules/mcp/static-resources/abilities/build-composition.md
@@ -13,6 +13,8 @@ If the user asks about a header, footer, 404, single, archive, or search-results
 # TOOL SUPPORT
 Discover valid `widget_type` values via `elementor/list-widget-schemas?summary=true`. Any type it lists is workable through the same uniform contract (`element_config`, `style`, `classes`, `interactions`); anything it does not list must be edited manually in the Elementor editor.
 
+Note: some MCP tools (components, classes, default styles, global variables, interactions schema) are only registered when the V4 atomic-elements experiment is active.
+
 # WORKFLOW
 1. Check/create global variables via `elementor/manage-global-variable`
 2. Check/create global classes via `elementor/manage-classes`

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-interactions-applier-v3-guard.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-interactions-applier-v3-guard.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp\Abilities\Appliers;
+
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
+use Elementor\Modules\Mcp\Abilities\Appliers\Interactions_Applier;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @group Elementor\Modules\Mcp
+ */
+class Test_Interactions_Applier_V3_Guard extends Elementor_Test_Base {
+
+	public function test_apply__v3_node_is_skipped_with_warning_and_no_write() {
+		// Arrange.
+		$this->with_atomic_experiment( Experiments_Manager::STATE_INACTIVE, function () {
+			$applier = new Interactions_Applier();
+			$index = [
+				'legacy' => [
+					'elType' => 'widget',
+					'widgetType' => 'heading',
+					'settings' => [],
+				],
+			];
+
+			// Act.
+			$result = $applier->apply( $index, [
+				'legacy' => [ $this->valid_interaction() ],
+			] );
+
+			// Assert.
+			$this->assertNull( $result['error'] );
+			$this->assertNotEmpty( $result['warnings'] );
+			$this->assertStringContainsString( 'V4-only', $result['warnings'][0] );
+			$this->assertStringContainsString( 'heading', $result['warnings'][0] );
+			$this->assertArrayNotHasKey( 'interactions', $index['legacy'] );
+		} );
+	}
+
+	public function test_apply__non_v3_node_is_unaffected_by_guard() {
+		// Arrange.
+		$applier = new Interactions_Applier();
+		$index = [
+			'atomic' => [
+				'elType' => 'widget',
+				'widgetType' => 'e-heading',
+				'settings' => [],
+			],
+		];
+
+		// Act.
+		$result = $applier->apply( $index, [
+			'atomic' => [ $this->valid_interaction() ],
+		] );
+
+		// Assert: no V3 warning; result may still error/succeed based on resolver,
+		// but the V3 guard specifically should not fire on an atomic widget.
+		foreach ( (array) $result['warnings'] as $warning ) {
+			$this->assertStringNotContainsString( 'V4-only', (string) $warning );
+		}
+	}
+
+	private function valid_interaction(): array {
+		return [
+			'trigger' => 'load',
+			'animation' => [
+				'effect' => 'fade',
+				'type' => 'in',
+				'direction' => '',
+				'timing_config' => [
+					'duration' => [ 'size' => 600, 'unit' => 'ms' ],
+					'delay'    => [ 'size' => 0,   'unit' => 'ms' ],
+				],
+				'config' => [
+					'easing' => 'easeIn',
+				],
+			],
+			'breakpoints' => [
+				'excluded' => [],
+			],
+		];
+	}
+
+	private function with_atomic_experiment( string $state, callable $callback ): void {
+		$experiments = Plugin::$instance->experiments;
+		$feature_option_key = $experiments->get_feature_option_key( AtomicWidgetsModule::EXPERIMENT_NAME );
+		$original_state = get_option( $feature_option_key );
+
+		update_option( $feature_option_key, $state );
+
+		try {
+			$callback();
+		} finally {
+			if ( false === $original_state ) {
+				delete_option( $feature_option_key );
+			} else {
+				update_option( $feature_option_key, $original_state );
+			}
+		}
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-ability-availability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-ability-availability.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Modules\Mcp;
+
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\AtomicWidgets\Module as AtomicWidgetsModule;
+use Elementor\Modules\Mcp\Module as Mcp_Module;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @group Elementor\Modules\Mcp
+ */
+class Test_Ability_Availability extends Elementor_Test_Base {
+
+	const V4_ONLY_ABILITY_IDS = [
+		'elementor/manage-component',
+		'elementor/list-components',
+		'elementor/manage-classes',
+		'elementor/reorder-classes',
+		'elementor/global-classes-resource',
+		'elementor/manage-default-styles',
+		'elementor/get-default-styles',
+		'elementor/manage-global-variable',
+		'elementor/global-variables-resource',
+		'elementor/manage-global-variable-guide',
+		'elementor/interactions-schema-resource',
+	];
+
+	const ALWAYS_AVAILABLE_ABILITY_IDS = [
+		'elementor/get-page-structure',
+		'elementor/build-composition',
+		'elementor/manage-elements',
+		'elementor/create-page',
+		'elementor/publish-document',
+	];
+
+	public function test_v4_only_abilities_are_omitted_when_atomic_experiment_is_inactive() {
+		// Arrange.
+		$this->with_atomic_experiment( Experiments_Manager::STATE_INACTIVE, function () {
+			$registry = Mcp_Module::build_core_registry();
+
+			$ids = array_map(
+				static fn ( $ability ) => $ability->get_id(),
+				$registry->all()
+			);
+
+			// Assert.
+			foreach ( self::V4_ONLY_ABILITY_IDS as $ability_id ) {
+				$this->assertNotContains( $ability_id, $ids, sprintf( 'V4-only ability %s should be omitted when atomic experiment is off.', $ability_id ) );
+			}
+
+			foreach ( self::ALWAYS_AVAILABLE_ABILITY_IDS as $ability_id ) {
+				$this->assertContains( $ability_id, $ids, sprintf( 'Always-available ability %s should be registered regardless of experiment state.', $ability_id ) );
+			}
+		} );
+	}
+
+	public function test_v4_only_abilities_are_registered_when_atomic_experiment_is_active() {
+		// Arrange.
+		$this->with_atomic_experiment( Experiments_Manager::STATE_ACTIVE, function () {
+			$registry = Mcp_Module::build_core_registry();
+
+			$ids = array_map(
+				static fn ( $ability ) => $ability->get_id(),
+				$registry->all()
+			);
+
+			// Assert.
+			foreach ( self::V4_ONLY_ABILITY_IDS as $ability_id ) {
+				$this->assertContains( $ability_id, $ids, sprintf( 'V4-only ability %s should be registered when atomic experiment is on.', $ability_id ) );
+			}
+		} );
+	}
+
+	public function test_shared_registry_slug_list_reflects_gating() {
+		// Arrange.
+		$this->with_atomic_experiment( Experiments_Manager::STATE_INACTIVE, function () {
+			$registry = Mcp_Module::build_core_registry();
+
+			$tool_ids = array_map(
+				static fn ( $ability ) => $ability->get_id(),
+				$registry->tools()
+			);
+
+			$resource_ids = array_map(
+				static fn ( $ability ) => $ability->get_id(),
+				$registry->resources()
+			);
+
+			$all_exposed = array_merge( $tool_ids, $resource_ids );
+
+			// Assert.
+			foreach ( self::V4_ONLY_ABILITY_IDS as $ability_id ) {
+				$this->assertNotContains( $ability_id, $all_exposed, sprintf( 'V4-only ability %s should not appear in tool/resource lists when atomic experiment is off.', $ability_id ) );
+			}
+		} );
+	}
+
+	private function with_atomic_experiment( string $state, callable $callback ): void {
+		$experiments = Plugin::$instance->experiments;
+		$feature_option_key = $experiments->get_feature_option_key( AtomicWidgetsModule::EXPERIMENT_NAME );
+		$original_state = get_option( $feature_option_key );
+
+		update_option( $feature_option_key, $state );
+
+		try {
+			$callback();
+		} finally {
+			if ( false === $original_state ) {
+				delete_option( $feature_option_key );
+			} else {
+				update_option( $feature_option_key, $original_state );
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Gates every V4-only MCP ability by the AtomicWidgets experiment: when V4 is off, listing / calling those abilities returns a `V4 atomic experiment is off` error instead of a runtime failure.
- Ability files touched (each: +5 -0 gate additions): `get-default-styles-ability`, `global-classes-resource-ability`, `global-variables-resource-ability`, `interactions-schema-resource-ability`, `list-components-ability`, `manage-classes-ability`, `manage-component-ability`, `manage-default-styles-ability`, `manage-variable-ability`, `manage-variable-guide-ability`, `reorder-classes-ability`.
- Plus `abstract-ability.php` (gate helper), `module.php` (registration guard), and `build-composition.md` (2-line doc addition).

## Extracted from
This is PR 1 of the 9-way split of #37094 (ED-25071). See the parent PR for full context — this cherry-picks commit `d1c46a21` from the accumulated branch and is standalone against `main`.

## Test plan
- [ ] `tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/mcp/test-ability-availability.php`
- [ ] `tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/mcp/abilities/appliers/test-interactions-applier-v3-guard.php`
- [ ] MCP smoke on V4-off site: calling `elementor/manage-classes` returns an experiment-gated error rather than a stack trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Prevents V4-specific MCP abilities from being registered or applied when the Atomic Widgets experiment is inactive, avoiding compatibility issues with V3 nodes [ED-25071].

## 2. What Changed (Where)

| File | Change |
| :--- | :--- |
| `Abstract_Ability.php` | Added `is_available_for_current_mode()` hook for availability gating. |
| `Module.php` | Filters core registry based on ability availability. |
| `Interactions_Applier.php` | Added V3 node guard to skip interactions with a warning. |
| `abilities/*.php` | Implemented availability checks using `AtomicWidgetsModule` or `Components_Module`. |
| `tests/**/*` | Added unit tests for ability gating and V3 interaction guards. |
| `build-composition.md` | Updated documentation regarding experimental tool registration. |

## 3. How It Works
The `Module::build_core_registry` now calls `is_available_for_current_mode()` on each ability; if the relevant experiment (Atomic Widgets or Components) is inactive, the ability is skipped. For interactions, the applier explicitly checks `V3_Node_Bridge::is_v3_node` to block writes and emit warnings for legacy widgets.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-25071]: https://elementor.atlassian.net/browse/ED-25071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ