### PR TITLE
[2/6] Internal: V3 render probe and patch bisector [ED-25071]

### DIFF
--- a/modules/mcp/abilities/appliers/v3/v3-patch-bisector.php
+++ b/modules/mcp/abilities/appliers/v3/v3-patch-bisector.php
@@ -12,14 +12,18 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Split logic is group-aware: sibling keys of a V3 group control (e.g. `typography_typography`
  * and its `typography_font_size` companion) must move together, otherwise probing "half" of a
  * group produces a shape that fatals for a reason unrelated to what the LLM actually caused.
+ *
+ * Consumed by [6/6]'s `Build_Composition_Applier`/`Update_Style_Applier`: on a failed
+ * `V3_Render_Probe`, the applier calls `find_offending()` with a `probe` callable that wraps
+ * `V3_Render_Probe::probe()`; the returned keys are surfaced back as actionable warnings.
  */
 class V3_Patch_Bisector {
 
 	/**
-	 * @param array<string, mixed>            $base
-	 * @param array<string, mixed>            $patch
-	 * @param callable                        $probe  fn(array $settings): bool -- true when render is OK.
-	 * @param array<string, string[]>         $groups Optional. Group name => member setting keys.
+	 * @param array<string, mixed>    $base
+	 * @param array<string, mixed>    $patch
+	 * @param callable                $probe  fn(array $settings): bool -- true when render is OK.
+	 * @param array<string, string[]> $groups Optional. Group name => member setting keys.
 	 * @return string[]
 	 */
 	public static function find_offending( array $base, array $patch, callable $probe, array $groups = [] ): array {

--- a/modules/mcp/abilities/appliers/v3/v3-patch-bisector.php
+++ b/modules/mcp/abilities/appliers/v3/v3-patch-bisector.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Narrows a failing settings patch to the minimal set of keys that trip the render probe.
+ *
+ * Split logic is group-aware: sibling keys of a V3 group control (e.g. `typography_typography`
+ * and its `typography_font_size` companion) must move together, otherwise probing "half" of a
+ * group produces a shape that fatals for a reason unrelated to what the LLM actually caused.
+ */
+class V3_Patch_Bisector {
+
+	/**
+	 * @param array<string, mixed>            $base
+	 * @param array<string, mixed>            $patch
+	 * @param callable                        $probe  fn(array $settings): bool -- true when render is OK.
+	 * @param array<string, string[]>         $groups Optional. Group name => member setting keys.
+	 * @return string[]
+	 */
+	public static function find_offending( array $base, array $patch, callable $probe, array $groups = [] ): array {
+		if ( empty( $patch ) ) {
+			return [];
+		}
+
+		$units = self::partition_into_units( array_keys( $patch ), $groups );
+		$budget = 2 * self::ceil_log2( max( 1, count( $units ) ) ) + count( $units );
+		$counter = 0;
+
+		$full_fails = self::probe_fails( $units, $base, $patch, $probe, $counter, $budget );
+		if ( null === $full_fails ) {
+			return array_keys( $patch );
+		}
+		if ( ! $full_fails ) {
+			return [];
+		}
+
+		$offending_units = self::bisect( $units, $base, $patch, $probe, $counter, $budget );
+
+		if ( null === $offending_units ) {
+			return array_keys( $patch );
+		}
+
+		$keys = [];
+		foreach ( $offending_units as $unit ) {
+			foreach ( $unit as $key ) {
+				$keys[] = $key;
+			}
+		}
+
+		return array_values( array_unique( $keys ) );
+	}
+
+	/**
+	 * @param string[]                $patch_keys
+	 * @param array<string, string[]> $groups
+	 * @return array<int, string[]>
+	 */
+	private static function partition_into_units( array $patch_keys, array $groups ): array {
+		$patch_set = array_flip( $patch_keys );
+		$units = [];
+		$assigned = [];
+
+		foreach ( $groups as $members ) {
+			$group_members = [];
+			foreach ( $members as $member ) {
+				if ( isset( $patch_set[ $member ] ) && ! isset( $assigned[ $member ] ) ) {
+					$group_members[] = $member;
+					$assigned[ $member ] = true;
+				}
+			}
+			if ( ! empty( $group_members ) ) {
+				sort( $group_members );
+				$units[] = $group_members;
+			}
+		}
+
+		foreach ( $patch_keys as $key ) {
+			if ( isset( $assigned[ $key ] ) ) {
+				continue;
+			}
+			$units[] = [ $key ];
+			$assigned[ $key ] = true;
+		}
+
+		usort( $units, static fn( $a, $b ) => strcmp( $a[0], $b[0] ) );
+
+		return $units;
+	}
+
+	/**
+	 * @param array<int, string[]> $units
+	 * @param array<string, mixed> $base
+	 * @param array<string, mixed> $patch
+	 * @return array<int, string[]>|null Null when budget exhausted.
+	 */
+	private static function bisect(
+		array $units,
+		array $base,
+		array $patch,
+		callable $probe,
+		int &$counter,
+		int $budget
+	): ?array {
+		if ( count( $units ) <= 1 ) {
+			return $units;
+		}
+
+		$mid = intdiv( count( $units ), 2 );
+		$left = array_slice( $units, 0, $mid );
+		$right = array_slice( $units, $mid );
+
+		$left_fails = self::probe_fails( $left, $base, $patch, $probe, $counter, $budget );
+		if ( null === $left_fails ) {
+			return null;
+		}
+
+		$right_fails = self::probe_fails( $right, $base, $patch, $probe, $counter, $budget );
+		if ( null === $right_fails ) {
+			return null;
+		}
+
+		if ( $left_fails && ! $right_fails ) {
+			return self::bisect( $left, $base, $patch, $probe, $counter, $budget );
+		}
+		if ( $right_fails && ! $left_fails ) {
+			return self::bisect( $right, $base, $patch, $probe, $counter, $budget );
+		}
+		if ( $left_fails && $right_fails ) {
+			$left_min = self::bisect( $left, $base, $patch, $probe, $counter, $budget );
+			if ( null === $left_min ) {
+				return null;
+			}
+			$right_min = self::bisect( $right, $base, $patch, $probe, $counter, $budget );
+			if ( null === $right_min ) {
+				return null;
+			}
+			return array_merge( $left_min, $right_min );
+		}
+
+		return $units;
+	}
+
+	/**
+	 * @param array<int, string[]> $units
+	 * @param array<string, mixed> $base
+	 * @param array<string, mixed> $patch
+	 * @return bool|null Null when budget exhausted.
+	 */
+	private static function probe_fails(
+		array $units,
+		array $base,
+		array $patch,
+		callable $probe,
+		int &$counter,
+		int $budget
+	): ?bool {
+		if ( $counter >= $budget ) {
+			return null;
+		}
+		$counter++;
+
+		$candidate = $base;
+		foreach ( $units as $unit ) {
+			foreach ( $unit as $key ) {
+				if ( array_key_exists( $key, $patch ) ) {
+					$candidate[ $key ] = $patch[ $key ];
+				}
+			}
+		}
+
+		return ! (bool) $probe( $candidate );
+	}
+
+	private static function ceil_log2( int $n ): int {
+		if ( $n <= 1 ) {
+			return 1;
+		}
+		return (int) ceil( log( $n, 2 ) );
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/v3-render-probe.php
+++ b/modules/mcp/abilities/appliers/v3/v3-render-probe.php
@@ -12,9 +12,22 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Instantiates a widget with a candidate settings array and probe-renders it to detect
  * fatal shapes (e.g. slider control receiving a plain string) before the write is committed.
  *
- * The probe is fail-open: any unexpected condition (missing widget class, V4 atomic widget,
- * probe exceeding the time budget) returns `ok=true` so a legitimate write is never blocked
- * by the safety net itself.
+ * Consumed by [6/6]'s style-write pipeline (`Update_Style_Applier` / `Build_Composition_Applier`);
+ * lives here so [6/6] can depend on a stable API rather than importing the probe out of a WIP file.
+ *
+ * Design notes:
+ *  - Uses `clone $prototype` + reflection injection instead of `new $class( $data, $args )` on
+ *    purpose. The stock `Widget_Base` constructor runs skin registration, control stack init,
+ *    and other setup that itself can fatal on malformed settings — which is exactly the shape
+ *    we want to catch at render time, not at construction time. Cloning the type-instance
+ *    prototype (already fully initialised by the widgets manager) and swapping only its `data`
+ *    payload isolates the probe to a single `render_content()` invocation.
+ *  - Fail-open by contract: any unexpected condition (missing widget class, V4 atomic widget,
+ *    probe exceeding the time budget, reflection failure) returns `ok=true` so a legitimate
+ *    write is never blocked by the safety net itself.
+ *  - `\Throwable` catches PHP 7-style `\Error` (including `TypeError`, `ParseError`) so an
+ *    uncaught fatal inside `render_content()` becomes `ok=false` + populated `error_class`
+ *    instead of tearing down the request.
  */
 class V3_Render_Probe {
 
@@ -58,6 +71,7 @@ class V3_Render_Probe {
 	}
 
 	/**
+	 * @param object               $widget
 	 * @param array<string, mixed> $settings
 	 */
 	private static function inject_settings( object $widget, array $settings ): bool {
@@ -88,7 +102,8 @@ class V3_Render_Probe {
 			if ( $class->hasProperty( 'data' ) ) {
 				return $class->getProperty( 'data' );
 			}
-			$class = $class->getParentClass() ?: null;
+			$parent = $class->getParentClass();
+			$class = false === $parent ? null : $parent;
 		}
 
 		return null;
@@ -103,6 +118,7 @@ class V3_Render_Probe {
 		$error_class = null;
 
 		set_error_handler( static function ( $severity, $message, $file, $line ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Message is thrown, not emitted.
 			throw new \ErrorException( $message, 0, $severity, $file, $line );
 		}, E_ERROR | E_RECOVERABLE_ERROR | E_USER_ERROR );
 

--- a/modules/mcp/abilities/appliers/v3/v3-render-probe.php
+++ b/modules/mcp/abilities/appliers/v3/v3-render-probe.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Instantiates a widget with a candidate settings array and probe-renders it to detect
+ * fatal shapes (e.g. slider control receiving a plain string) before the write is committed.
+ *
+ * The probe is fail-open: any unexpected condition (missing widget class, V4 atomic widget,
+ * probe exceeding the time budget) returns `ok=true` so a legitimate write is never blocked
+ * by the safety net itself.
+ */
+class V3_Render_Probe {
+
+	const TIMEOUT_MS = 250;
+
+	/**
+	 * @param string               $widget_type
+	 * @param array<string, mixed> $settings
+	 * @return array{ok: bool, error: ?string, error_class: ?string, timed_out: bool}
+	 */
+	public static function probe( string $widget_type, array $settings ): array {
+		$widget = self::clone_widget_instance( $widget_type );
+
+		if ( null === $widget || self::is_atomic_widget( $widget ) ) {
+			return self::ok_result();
+		}
+
+		if ( ! self::inject_settings( $widget, $settings ) ) {
+			return self::ok_result();
+		}
+
+		return self::run_render( $widget );
+	}
+
+	private static function clone_widget_instance( string $widget_type ): ?object {
+		if ( ! isset( Plugin::$instance->widgets_manager ) ) {
+			return null;
+		}
+
+		$prototype = Plugin::$instance->widgets_manager->get_widget_types( $widget_type );
+
+		if ( ! is_object( $prototype ) || ! method_exists( $prototype, 'render_content' ) ) {
+			return null;
+		}
+
+		return clone $prototype;
+	}
+
+	private static function is_atomic_widget( object $widget ): bool {
+		return method_exists( $widget, 'get_props_schema' );
+	}
+
+	/**
+	 * @param array<string, mixed> $settings
+	 */
+	private static function inject_settings( object $widget, array $settings ): bool {
+		try {
+			$reflection = new \ReflectionClass( $widget );
+			$data_property = self::find_data_property( $reflection );
+
+			if ( null === $data_property ) {
+				return false;
+			}
+
+			$data_property->setAccessible( true );
+			$current = $data_property->getValue( $widget );
+			$current = is_array( $current ) ? $current : [];
+			$current['settings'] = $settings;
+			$data_property->setValue( $widget, $current );
+
+			return true;
+		} catch ( \Throwable $_e ) {
+			return false;
+		}
+	}
+
+	private static function find_data_property( \ReflectionClass $reflection ): ?\ReflectionProperty {
+		$class = $reflection;
+
+		while ( $class ) {
+			if ( $class->hasProperty( 'data' ) ) {
+				return $class->getProperty( 'data' );
+			}
+			$class = $class->getParentClass() ?: null;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @return array{ok: bool, error: ?string, error_class: ?string, timed_out: bool}
+	 */
+	private static function run_render( object $widget ): array {
+		$started_at = hrtime( true );
+		$error_message = null;
+		$error_class = null;
+
+		set_error_handler( static function ( $severity, $message, $file, $line ) {
+			throw new \ErrorException( $message, 0, $severity, $file, $line );
+		}, E_ERROR | E_RECOVERABLE_ERROR | E_USER_ERROR );
+
+		ob_start();
+
+		try {
+			$widget->render_content();
+		} catch ( \Throwable $e ) {
+			$error_message = $e->getMessage();
+			$error_class = get_class( $e );
+		} finally {
+			if ( ob_get_level() > 0 ) {
+				ob_end_clean();
+			}
+			restore_error_handler();
+		}
+
+		$elapsed_ms = ( hrtime( true ) - $started_at ) / 1e6;
+
+		if ( $elapsed_ms > self::TIMEOUT_MS ) {
+			return [
+				'ok' => true,
+				'error' => null,
+				'error_class' => null,
+				'timed_out' => true,
+			];
+		}
+
+		return [
+			'ok' => null === $error_message,
+			'error' => $error_message,
+			'error_class' => $error_class,
+			'timed_out' => false,
+		];
+	}
+
+	/**
+	 * @return array{ok: bool, error: ?string, error_class: ?string, timed_out: bool}
+	 */
+	private static function ok_result(): array {
+		return [
+			'ok' => true,
+			'error' => null,
+			'error_class' => null,
+			'timed_out' => false,
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-patch-bisector.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-patch-bisector.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3;
+
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Patch_Bisector;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Patch_Bisector extends TestCase {
+
+	public function test_find_offending__returns_empty_when_patch_is_empty() {
+		// Arrange.
+		$probe = static fn() => true;
+
+		// Act.
+		$result = V3_Patch_Bisector::find_offending( [], [], $probe );
+
+		// Assert.
+		$this->assertSame( [], $result );
+	}
+
+	public function test_find_offending__isolates_single_bad_key() {
+		// Arrange.
+		$patch = [ 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4 ];
+		$probe = static fn( array $settings ) => ! array_key_exists( 'c', $settings );
+
+		// Act.
+		$result = V3_Patch_Bisector::find_offending( [], $patch, $probe );
+
+		// Assert.
+		$this->assertSame( [ 'c' ], $result );
+	}
+
+	public function test_find_offending__isolates_multiple_bad_keys_on_both_sides() {
+		// Arrange.
+		$patch = [ 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4 ];
+		$probe = static function ( array $settings ) {
+			return ! ( array_key_exists( 'a', $settings ) || array_key_exists( 'd', $settings ) );
+		};
+
+		// Act.
+		$result = V3_Patch_Bisector::find_offending( [], $patch, $probe );
+
+		// Assert.
+		sort( $result );
+		$this->assertSame( [ 'a', 'd' ], $result );
+	}
+
+	public function test_find_offending__returns_empty_when_no_key_is_bad() {
+		// Arrange.
+		$patch = [ 'a' => 1, 'b' => 2 ];
+		$probe = static fn() => true;
+
+		// Act.
+		$result = V3_Patch_Bisector::find_offending( [], $patch, $probe );
+
+		// Assert.
+		$this->assertSame( [], $result );
+	}
+
+	public function test_find_offending__returns_all_keys_when_all_bad() {
+		// Arrange.
+		$patch = [ 'a' => 1, 'b' => 2, 'c' => 3 ];
+		$probe = static fn() => false;
+
+		// Act.
+		$result = V3_Patch_Bisector::find_offending( [], $patch, $probe );
+
+		// Assert.
+		sort( $result );
+		$this->assertSame( [ 'a', 'b', 'c' ], $result );
+	}
+
+	public function test_find_offending__treats_group_members_as_atomic_unit() {
+		// Arrange.
+		$patch = [
+			'typography_typography' => 'custom',
+			'typography_font_size' => [ 'unit' => 'px', 'size' => 42 ],
+			'color' => '#ff0000',
+		];
+		$groups = [
+			'typography' => [ 'typography_typography', 'typography_font_size' ],
+		];
+		$probe = static function ( array $settings ) {
+			$has_typography = array_key_exists( 'typography_typography', $settings );
+			$has_size = array_key_exists( 'typography_font_size', $settings );
+			return $has_typography === $has_size;
+		};
+
+		// Act.
+		$result = V3_Patch_Bisector::find_offending( [], $patch, $probe, $groups );
+
+		// Assert.
+		$this->assertSame( [], $result, 'Group applied atomically should never appear split during bisection.' );
+	}
+
+	public function test_find_offending__returns_group_members_together_when_group_is_bad() {
+		// Arrange.
+		$patch = [
+			'typography_typography' => 'custom',
+			'typography_font_size' => [ 'unit' => 'px', 'size' => 42 ],
+			'color' => '#ff0000',
+		];
+		$groups = [
+			'typography' => [ 'typography_typography', 'typography_font_size' ],
+		];
+		$probe = static function ( array $settings ) {
+			return ! array_key_exists( 'typography_font_size', $settings );
+		};
+
+		// Act.
+		$result = V3_Patch_Bisector::find_offending( [], $patch, $probe, $groups );
+
+		// Assert.
+		sort( $result );
+		$this->assertSame( [ 'typography_font_size', 'typography_typography' ], $result );
+	}
+
+	public function test_find_offending__does_not_mutate_inputs() {
+		// Arrange.
+		$base = [ 'existing' => 'v' ];
+		$patch = [ 'a' => 1, 'b' => 2 ];
+		$base_snapshot = $base;
+		$patch_snapshot = $patch;
+
+		// Act.
+		V3_Patch_Bisector::find_offending( $base, $patch, static fn() => false );
+
+		// Assert.
+		$this->assertSame( $base_snapshot, $base );
+		$this->assertSame( $patch_snapshot, $patch );
+	}
+
+	public function test_find_offending__falls_back_to_full_patch_when_budget_exhausted() {
+		// Arrange: 16-key all-fail patch exceeds the 2*log2(n)+n = 24 probe budget when
+		// every recursion probes both halves; bisector must fail-closed with the full patch.
+		$patch = array_fill_keys( range( 'a', 'p' ), 1 );
+		$probe = static fn() => false;
+
+		// Act.
+		$result = V3_Patch_Bisector::find_offending( [], $patch, $probe );
+
+		// Assert.
+		sort( $result );
+		$this->assertSame( array_keys( $patch ), $result );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-render-probe.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-render-probe.php
@@ -136,6 +136,21 @@ namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3 {
 			$this->assertTrue( $result['timed_out'] );
 		}
 
+		public function test_probe__catches_error_subclass_from_render() {
+			// A PHP TypeError is a `\Error` (7+), not an `\Exception`. Verify the outer
+			// `catch ( \Throwable )` catches it and surfaces the class name.
+			$widget = $this->make_probe_widget( static function () {
+				throw new \TypeError( 'shape mismatch' );
+			} );
+			$this->install_widgets_manager( [ 'type-error-widget' => $widget ] );
+
+			$result = V3_Render_Probe::probe( 'type-error-widget', [] );
+
+			$this->assertFalse( $result['ok'] );
+			$this->assertSame( \TypeError::class, $result['error_class'] );
+			$this->assertStringContainsString( 'shape mismatch', (string) $result['error'] );
+		}
+
 		public function test_probe__injects_settings_via_data_property() {
 			// Arrange.
 			$captured = null;

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-render-probe.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-render-probe.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Elementor {
+	if ( ! class_exists( 'Elementor\Plugin' ) ) {
+		class Plugin {
+			public static $instance = null;
+		}
+	}
+}
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3 {
+
+	use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Render_Probe;
+	use Elementor\Plugin;
+	use PHPUnit\Framework\TestCase;
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+	}
+
+	class Test_V3_Render_Probe extends TestCase {
+
+		private $original_plugin_instance;
+
+		protected function setUp(): void {
+			$this->original_plugin_instance = Plugin::$instance;
+		}
+
+		protected function tearDown(): void {
+			Plugin::$instance = $this->original_plugin_instance;
+		}
+
+		public function test_probe__returns_ok_when_widgets_manager_missing() {
+			// Arrange.
+			Plugin::$instance = null;
+
+			// Act.
+			$result = V3_Render_Probe::probe( 'anything', [] );
+
+			// Assert.
+			$this->assertTrue( $result['ok'] );
+			$this->assertFalse( $result['timed_out'] );
+			$this->assertNull( $result['error'] );
+		}
+
+		public function test_probe__returns_ok_when_widget_type_is_unknown() {
+			// Arrange.
+			$this->install_widgets_manager( [] );
+
+			// Act.
+			$result = V3_Render_Probe::probe( 'unknown', [] );
+
+			// Assert.
+			$this->assertTrue( $result['ok'] );
+		}
+
+		public function test_probe__returns_ok_for_atomic_widget_stub() {
+			// Arrange.
+			$stub = new class {
+				public static function get_props_schema(): array {
+					return [];
+				}
+				public function render_content(): void {
+					throw new \RuntimeException( 'should never be reached' );
+				}
+			};
+			$this->install_widgets_manager( [ 'atomic' => $stub ] );
+
+			// Act.
+			$result = V3_Render_Probe::probe( 'atomic', [ 'foo' => 'bar' ] );
+
+			// Assert.
+			$this->assertTrue( $result['ok'] );
+			$this->assertNull( $result['error'] );
+		}
+
+		public function test_probe__returns_ok_for_widget_that_renders_cleanly() {
+			// Arrange.
+			$widget = $this->make_probe_widget( static function ( array $settings ) {
+				return;
+			} );
+			$this->install_widgets_manager( [ 'ok-widget' => $widget ] );
+
+			// Act.
+			$result = V3_Render_Probe::probe( 'ok-widget', [ 'title' => 'Hello' ] );
+
+			// Assert.
+			$this->assertTrue( $result['ok'] );
+			$this->assertNull( $result['error'] );
+			$this->assertFalse( $result['timed_out'] );
+		}
+
+		public function test_probe__catches_throwable_from_render() {
+			// Arrange.
+			$widget = $this->make_probe_widget( static function ( array $settings ) {
+				throw new \RuntimeException( 'boom: ' . ( $settings['line_height'] ?? 'n/a' ) );
+			} );
+			$this->install_widgets_manager( [ 'fatal-widget' => $widget ] );
+
+			// Act.
+			$result = V3_Render_Probe::probe( 'fatal-widget', [ 'line_height' => '1.5' ] );
+
+			// Assert.
+			$this->assertFalse( $result['ok'] );
+			$this->assertSame( \RuntimeException::class, $result['error_class'] );
+			$this->assertStringContainsString( 'boom: 1.5', (string) $result['error'] );
+		}
+
+		public function test_probe__promotes_php_error_to_exception() {
+			// Arrange.
+			$widget = $this->make_probe_widget( static function () {
+				trigger_error( 'promoted', E_USER_ERROR );
+			} );
+			$this->install_widgets_manager( [ 'error-widget' => $widget ] );
+
+			// Act.
+			$result = V3_Render_Probe::probe( 'error-widget', [] );
+
+			// Assert.
+			$this->assertFalse( $result['ok'] );
+			$this->assertNotNull( $result['error'] );
+		}
+
+		public function test_probe__returns_timed_out_when_render_exceeds_budget() {
+			// Arrange.
+			$widget = $this->make_probe_widget( static function () {
+				usleep( ( V3_Render_Probe::TIMEOUT_MS + 50 ) * 1000 );
+			} );
+			$this->install_widgets_manager( [ 'slow-widget' => $widget ] );
+
+			// Act.
+			$result = V3_Render_Probe::probe( 'slow-widget', [] );
+
+			// Assert.
+			$this->assertTrue( $result['ok'] );
+			$this->assertTrue( $result['timed_out'] );
+		}
+
+		public function test_probe__injects_settings_via_data_property() {
+			// Arrange.
+			$captured = null;
+			$widget = $this->make_probe_widget( static function ( array $settings ) use ( &$captured ) {
+				$captured = $settings;
+			} );
+			$this->install_widgets_manager( [ 'capture-widget' => $widget ] );
+
+			// Act.
+			V3_Render_Probe::probe( 'capture-widget', [ 'a' => 1, 'b' => 2 ] );
+
+			// Assert.
+			$this->assertSame( [ 'a' => 1, 'b' => 2 ], $captured );
+		}
+
+		/**
+		 * @param callable(array):void $on_render
+		 */
+		private function make_probe_widget( callable $on_render ): object {
+			return new class( $on_render ) {
+				private $data = [];
+				private $on_render;
+
+				public function __construct( callable $on_render ) {
+					$this->on_render = $on_render;
+				}
+
+				public function render_content(): void {
+					( $this->on_render )( $this->data['settings'] ?? [] );
+				}
+			};
+		}
+
+		/**
+		 * @param array<string, object> $widgets_by_type
+		 */
+		private function install_widgets_manager( array $widgets_by_type ): void {
+			$manager = new class( $widgets_by_type ) {
+				private array $widgets;
+
+				public function __construct( array $widgets ) {
+					$this->widgets = $widgets;
+				}
+
+				public function get_widget_types( $type ) {
+					return $this->widgets[ $type ] ?? null;
+				}
+			};
+
+			$plugin_stub = new class {
+				public $widgets_manager;
+			};
+			$plugin_stub->widgets_manager = $manager;
+
+			Plugin::$instance = $plugin_stub;
+		}
+	}
+}


### PR DESCRIPTION
Split 2 of 6 from #37094.

Adds V3 diagnostic tooling: a render probe and a patch bisector, plus their tests. Pure additive infra — nothing else in this split depends on it, but it makes debugging V3 write failures on the other split PRs cheap.

Owned files (4): v3-render-probe.php, v3-patch-bisector.php, and their tests.

- Standalone, base = main. Merge order does not matter across the split.
- Union of all 6 split PRs vs the parent branch tip is byte-identical.

See split plan: /Users/omeri/.claude/plans/https-github-com-elementor-elementor-pul-tidy-rainbow.md

Companion PRs: [1/6], [3/6], [4/6], [5/6], [6/6].