### PR TITLE
[4/6] Internal: V3 value resolver and formatter correctness fixes [ED-25071]

### DIFF
--- a/modules/mcp/abilities/appliers/v3/v3-resolver-registry.php
+++ b/modules/mcp/abilities/appliers/v3/v3-resolver-registry.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Extension point for V3 value resolvers.
+ *
+ * Each resolver is a callable of shape `fn(string $css_value, array $args): mixed`.
+ * `$args` contains at least `property` (the CSS property being resolved) and may
+ * carry resolver-specific keys such as `side` or `prefix`. Callables return one of:
+ *   - the resolved value (array/string/scalar) on success,
+ *   - a rejection array (`['rejected' => true, 'property' => ..., 'value' => ..., 'reason' => ...]`)
+ *     when the input is invalid for the target property,
+ *   - `null` when the input cannot be parsed and no rejection reason applies.
+ *
+ * The default set is registered from `V3_Value_Resolvers::default_resolvers()` on
+ * first access. Third parties (or future in-tree code) can override or extend the
+ * set with `register()`; the registry is process-scoped.
+ */
+class V3_Resolver_Registry {
+
+	/**
+	 * @var array<string, callable>|null
+	 */
+	private static ?array $resolvers = null;
+
+	/**
+	 * @param string   $name
+	 * @param callable $resolver fn(string $css_value, array<string, mixed> $args): mixed
+	 */
+	public static function register( string $name, callable $resolver ): void {
+		self::ensure_initialised();
+		self::$resolvers[ $name ] = $resolver;
+	}
+
+	public static function has( string $name ): bool {
+		self::ensure_initialised();
+		return isset( self::$resolvers[ $name ] );
+	}
+
+	/**
+	 * @param array<string, mixed> $args
+	 * @return mixed|null
+	 */
+	public static function resolve( string $name, string $css_value, array $args = [] ) {
+		self::ensure_initialised();
+
+		if ( ! isset( self::$resolvers[ $name ] ) ) {
+			return null;
+		}
+
+		return ( self::$resolvers[ $name ] )( $css_value, $args );
+	}
+
+	/**
+	 * Test-only. Resets the registry so a test can register a resolver in isolation.
+	 */
+	public static function reset(): void {
+		self::$resolvers = null;
+	}
+
+	private static function ensure_initialised(): void {
+		if ( null !== self::$resolvers ) {
+			return;
+		}
+
+		self::$resolvers = V3_Value_Resolvers::default_resolvers();
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/v3-value-formatters.php
+++ b/modules/mcp/abilities/appliers/v3/v3-value-formatters.php
@@ -22,7 +22,14 @@ class V3_Value_Formatters {
 		switch ( $resolver ) {
 			case 'text':
 			case 'color':
-				return is_scalar( $value ) ? (string) $value : null;
+				if ( ! is_scalar( $value ) ) {
+					return null;
+				}
+				$string_value = (string) $value;
+				if ( V3_Variable_Compatibility::is_var_reference( $string_value ) ) {
+					return $string_value;
+				}
+				return $string_value;
 
 			case 'dimension':
 			case 'slider':

--- a/modules/mcp/abilities/appliers/v3/v3-value-resolvers.php
+++ b/modules/mcp/abilities/appliers/v3/v3-value-resolvers.php
@@ -130,6 +130,7 @@ class V3_Value_Resolvers {
 	}
 
 	/**
+	 * @param string               $setting
 	 * @param array<string, mixed> $patch
 	 * @return string[] Breakpoint suffixes ('', '_mobile', '_tablet', ...) that the patch
 	 *                  contains for the given base setting.
@@ -547,12 +548,18 @@ class V3_Value_Resolvers {
 		}
 
 		if ( empty( $patch ) ) {
-			return [ 'patch' => [], 'rejections' => $rejections ];
+			return [
+				'patch' => [],
+				'rejections' => $rejections,
+			];
 		}
 
 		$patch[ $prefix . '_typography' ] = 'custom';
 
-		return [ 'patch' => $patch, 'rejections' => $rejections ];
+		return [
+			'patch' => $patch,
+			'rejections' => $rejections,
+		];
 	}
 
 	/**
@@ -652,48 +659,75 @@ class V3_Value_Resolvers {
 	}
 
 	/**
-	 * Dispatches a named resolver against a CSS value.
+	 * Dispatches a named resolver against a CSS value via {@see V3_Resolver_Registry}.
 	 *
-	 * @param string               $resolver_name One of: color, dimension, sides, box_shadow, border, text, slider, gaps, element_width.
+	 * Registered names (default set): color, dimension, sides, dimension_side, box_shadow,
+	 * border, border_side, text, slider, raw_slider, gaps, element_width. Callers can add
+	 * or override entries at boot with {@see V3_Resolver_Registry::register()}.
+	 *
+	 * @param string               $resolver_name
 	 * @param string               $css_value
-	 * @param array<string, mixed> $args          Extra args (prefix for border/typography).
+	 * @param array<string, mixed> $args          `property` (always), plus resolver-specific
+	 *                                            keys (`side` for `dimension_side`/`border_side`,
+	 *                                            `prefix` for `border`/`border_side`).
 	 * @return mixed|null
 	 */
 	public static function resolve( string $resolver_name, string $css_value, array $args = [] ) {
-		$property = (string) ( $args['property'] ?? '' );
+		return V3_Resolver_Registry::resolve( $resolver_name, $css_value, $args );
+	}
 
-		switch ( $resolver_name ) {
-			case 'color':
-				return self::resolve_color( $css_value, $property );
-			case 'dimension':
-				return self::resolve_dimension( $css_value, $property );
-			case 'sides':
-				return self::resolve_sides_shorthand( $css_value, $property );
-			case 'dimension_side':
-				return self::resolve_single_dimension_side( $css_value, (string) ( $args['side'] ?? '' ), $property );
-			case 'box_shadow':
-				return self::resolve_box_shadow( $css_value );
-			case 'border':
-				return self::resolve_border_shorthand( $css_value, $args['prefix'] ?? 'border' );
-			case 'slider':
-				return self::resolve_dimension( $css_value, $property );
-			case 'text':
-				return trim( $css_value );
-			case 'element_width':
-				return self::resolve_element_width( $css_value, $property );
-			case 'gaps':
-				return self::resolve_gaps( $css_value, $property );
-			case 'raw_slider':
-				return self::resolve_raw_slider( $css_value );
-			case 'border_side':
+	/**
+	 * The default resolver set. `V3_Resolver_Registry` reads this on first access.
+	 *
+	 * @return array<string, callable>
+	 */
+	public static function default_resolvers(): array {
+		return [
+			'color' => static function ( string $value, array $args ) {
+				return self::resolve_color( $value, (string) ( $args['property'] ?? '' ) );
+			},
+			'dimension' => static function ( string $value, array $args ) {
+				return self::resolve_dimension( $value, (string) ( $args['property'] ?? '' ) );
+			},
+			'sides' => static function ( string $value, array $args ) {
+				return self::resolve_sides_shorthand( $value, (string) ( $args['property'] ?? '' ) );
+			},
+			'dimension_side' => static function ( string $value, array $args ) {
+				return self::resolve_single_dimension_side(
+					$value,
+					(string) ( $args['side'] ?? '' ),
+					(string) ( $args['property'] ?? '' )
+				);
+			},
+			'box_shadow' => static function ( string $value ) {
+				return self::resolve_box_shadow( $value );
+			},
+			'border' => static function ( string $value, array $args ) {
+				return self::resolve_border_shorthand( $value, (string) ( $args['prefix'] ?? 'border' ) );
+			},
+			'border_side' => static function ( string $value, array $args ) {
 				return self::resolve_border_side_shorthand(
-					$css_value,
+					$value,
 					(string) ( $args['side'] ?? '' ),
 					(string) ( $args['prefix'] ?? 'border' )
 				);
-			default:
-				return null;
-		}
+			},
+			'slider' => static function ( string $value, array $args ) {
+				return self::resolve_dimension( $value, (string) ( $args['property'] ?? '' ) );
+			},
+			'text' => static function ( string $value ) {
+				return trim( $value );
+			},
+			'element_width' => static function ( string $value, array $args ) {
+				return self::resolve_element_width( $value, (string) ( $args['property'] ?? '' ) );
+			},
+			'gaps' => static function ( string $value, array $args ) {
+				return self::resolve_gaps( $value, (string) ( $args['property'] ?? '' ) );
+			},
+			'raw_slider' => static function ( string $value ) {
+				return self::resolve_raw_slider( $value );
+			},
+		];
 	}
 
 	/**

--- a/modules/mcp/abilities/appliers/v3/v3-value-resolvers.php
+++ b/modules/mcp/abilities/appliers/v3/v3-value-resolvers.php
@@ -13,10 +13,22 @@ class V3_Value_Resolvers {
 
 	const DEFAULT_UNIT = 'px';
 
+	const ELEMENT_WIDTH_MODE_INITIAL = 'initial';
+	const ELEMENT_WIDTH_MODE_INHERIT = 'inherit';
+	const ELEMENT_WIDTH_MODE_AUTO = 'auto';
+
+	const ELEMENT_WIDTH_SETTING = '_element_width';
+	const ELEMENT_CUSTOM_WIDTH_SETTING = '_element_custom_width';
+
 	/**
-	 * @return array{unit: string, size: float}|null
+	 * @return array{unit: string, size: float}|array{rejected: true, reason: string, value: string, property: string}|null
 	 */
-	public static function resolve_dimension( string $css_value ): ?array {
+	public static function resolve_dimension( string $css_value, string $property = '' ) {
+		$rejection = self::maybe_reject_variable( $css_value, $property );
+		if ( null !== $rejection ) {
+			return $rejection;
+		}
+
 		$parsed = self::parse_length( trim( $css_value ) );
 
 		if ( null === $parsed ) {
@@ -30,11 +42,207 @@ class V3_Value_Resolvers {
 	}
 
 	/**
+	 * Line-height may be unitless (e.g. 1.5); Elementor expects an empty unit in that case.
+	 *
+	 * @return array{unit: string, size: float}|array{rejected: true, reason: string, value: string, property: string}|null
+	 */
+	public static function resolve_line_height( string $css_value, string $property = 'line-height' ) {
+		$rejection = self::maybe_reject_variable( $css_value, $property );
+		if ( null !== $rejection ) {
+			return $rejection;
+		}
+
+		$value = trim( $css_value );
+
+		if ( preg_match( '/^(-?\d*\.?\d+)(px|em|rem|%)?$/i', $value, $matches ) ) {
+			$unit = strtolower( $matches[2] ?? '' );
+
+			return [
+				'unit' => $unit,
+				'size' => (float) $matches[1],
+			];
+		}
+
+		return self::resolve_dimension( $value, $property );
+	}
+
+	/**
+	 * When a background color is written, Elementor also needs the background type choose set to `classic`.
+	 *
+	 * @param array<string, mixed> $patch
+	 * @param array<string, mixed> $controls
+	 * @return array<string, mixed>
+	 */
+	public static function supplement_background_group_toggles( array $patch, array $controls ): array {
+		foreach ( $patch as $setting => $value ) {
+			if ( ! is_string( $setting ) || ! str_ends_with( $setting, '_color' ) ) {
+				continue;
+			}
+
+			if ( ! self::is_background_color_setting( $setting ) ) {
+				continue;
+			}
+
+			$type_key = preg_replace( '/_color$/', '_background', $setting );
+
+			if ( ! is_string( $type_key ) || ! isset( $controls[ $type_key ] ) ) {
+				continue;
+			}
+
+			if ( 'choose' !== ( $controls[ $type_key ]['type'] ?? '' ) ) {
+				continue;
+			}
+
+			$patch[ $type_key ] = 'classic';
+		}
+
+		return $patch;
+	}
+
+	/**
+	 * Container carries separate `flex_*` and `grid_*` alignment/gap settings that are only
+	 * consumed under the matching `container_type`. An LLM writes standard CSS names like
+	 * `align-items: center` once — the mapper routes it to the flex setting by default, then
+	 * this helper mirrors the value onto the grid twin so the write survives a later
+	 * container_type flip. Unused settings are harmless noise.
+	 *
+	 * @param array<string, mixed> $patch
+	 * @param array<string, mixed> $controls
+	 * @return array<string, mixed>
+	 */
+	public static function supplement_flex_grid_twin_alignments( array $patch, array $controls ): array {
+		$twins = [
+			'flex_align_items' => 'grid_align_items',
+			'flex_justify_content' => 'grid_justify_content',
+			'flex_align_content' => 'grid_align_content',
+			'flex_gap' => 'grid_gaps',
+		];
+
+		foreach ( $twins as $source => $target ) {
+			foreach ( self::responsive_variants( $source, $patch ) as $suffix ) {
+				if ( isset( $controls[ $target . $suffix ] ) && ! isset( $patch[ $target . $suffix ] ) ) {
+					$patch[ $target . $suffix ] = $patch[ $source . $suffix ];
+				}
+			}
+		}
+
+		return $patch;
+	}
+
+	/**
+	 * @param array<string, mixed> $patch
+	 * @return string[] Breakpoint suffixes ('', '_mobile', '_tablet', ...) that the patch
+	 *                  contains for the given base setting.
+	 */
+	private static function responsive_variants( string $setting, array $patch ): array {
+		$suffixes = [];
+
+		foreach ( array_keys( $patch ) as $key ) {
+			if ( ! is_string( $key ) ) {
+				continue;
+			}
+
+			if ( $key === $setting ) {
+				$suffixes[] = '';
+				continue;
+			}
+
+			if ( 0 === strpos( $key, $setting . '_' ) ) {
+				$suffixes[] = substr( $key, strlen( $setting ) );
+			}
+		}
+
+		return $suffixes;
+	}
+
+	/**
+	 * Container's grid group controls are conditional on `container_type = grid`. When any of
+	 * them lands in the patch (`grid_columns_grid`, `grid_rows_grid`, `grid_gaps`,
+	 * `grid_auto_flow`, `grid_justify_items`, `grid_align_items`, `grid_justify_content`,
+	 * `grid_align_content`) the container has to be flipped from its default `flex` to `grid`
+	 * or the setting stays inert. Mirrors the background-color / content-width toggle pattern.
+	 *
+	 * @param array<string, mixed> $patch
+	 * @param array<string, mixed> $controls
+	 * @return array<string, mixed>
+	 */
+	public static function supplement_container_type_toggle( array $patch, array $controls ): array {
+		if ( ! isset( $controls['container_type'] ) ) {
+			return $patch;
+		}
+
+		// Only "grid-exclusive" signals flip the mode. Settings like `grid_align_items` /
+		// `grid_gaps` also come from `supplement_flex_grid_twin_alignments` (mirrored from the
+		// flex twin), so relying on them would flip a legitimately-flex container to grid.
+		$grid_exclusive_prefixes = [
+			'grid_columns_grid',
+			'grid_rows_grid',
+			'grid_auto_flow',
+			'grid_justify_items',
+		];
+
+		foreach ( array_keys( $patch ) as $setting ) {
+			if ( ! is_string( $setting ) ) {
+				continue;
+			}
+
+			foreach ( $grid_exclusive_prefixes as $prefix ) {
+				if ( $setting === $prefix || 0 === strpos( $setting, $prefix . '_' ) ) {
+					$patch['container_type'] = 'grid';
+
+					return $patch;
+				}
+			}
+		}
+
+		return $patch;
+	}
+
+	/**
+	 * `boxed_width` (V3 container's max-width setting) is a conditional control that only takes
+	 * effect when `content_width` is `boxed`. When the LLM writes `max-width: X` on a container,
+	 * the resolver routes to `boxed_width`; this pairs `content_width=boxed` so the width is
+	 * actually applied. Mirrors the background-color toggle pattern.
+	 *
+	 * @param array<string, mixed> $patch
+	 * @param array<string, mixed> $controls
+	 * @return array<string, mixed>
+	 */
+	public static function supplement_content_width_toggle( array $patch, array $controls ): array {
+		if ( ! isset( $controls['boxed_width'], $controls['content_width'] ) ) {
+			return $patch;
+		}
+
+		foreach ( array_keys( $patch ) as $setting ) {
+			if ( is_string( $setting ) && ( 'boxed_width' === $setting || 0 === strpos( $setting, 'boxed_width_' ) ) ) {
+				$patch['content_width'] = 'boxed';
+
+				return $patch;
+			}
+		}
+
+		return $patch;
+	}
+
+	private static function is_background_color_setting( string $setting ): bool {
+		if ( str_contains( $setting, '_background_' ) ) {
+			return true;
+		}
+
+		return (bool) preg_match( '/_background_color$/', $setting );
+	}
+
+	/**
 	 * Parses padding/margin/border-radius shorthand into Elementor dimensions shape.
 	 *
-	 * @return array{top: string, right: string, bottom: string, left: string, unit: string, isLinked: bool}|null
+	 * @return array{top: string, right: string, bottom: string, left: string, unit: string, isLinked: bool}|array{rejected: true, reason: string, value: string, property: string}|null
 	 */
-	public static function resolve_sides_shorthand( string $css_value ): ?array {
+	public static function resolve_sides_shorthand( string $css_value, string $property = '' ) {
+		$rejection = self::maybe_reject_variable( $css_value, $property );
+		if ( null !== $rejection ) {
+			return $rejection;
+		}
+
 		$tokens = self::tokenize_css_values( trim( $css_value ) );
 
 		if ( empty( $tokens ) || count( $tokens ) > 4 ) {
@@ -91,8 +299,100 @@ class V3_Value_Resolvers {
 		];
 	}
 
-	public static function resolve_color( string $css_value ): string {
-		return trim( $css_value );
+	/**
+	 * @return array{top: string, right: string, bottom: string, left: string, unit: string, isLinked: bool}|array{rejected: true, reason: string, value: string, property: string}|null
+	 */
+	public static function resolve_single_dimension_side( string $css_value, string $side, string $property = '' ) {
+		$rejection = self::maybe_reject_variable( $css_value, $property );
+		if ( null !== $rejection ) {
+			return $rejection;
+		}
+
+		$parsed = self::parse_length( trim( $css_value ) );
+
+		if ( null === $parsed || ! in_array( $side, [ 'top', 'right', 'bottom', 'left' ], true ) ) {
+			return null;
+		}
+
+		return [
+			'top' => 'top' === $side ? (string) $parsed['size'] : '',
+			'right' => 'right' === $side ? (string) $parsed['size'] : '',
+			'bottom' => 'bottom' === $side ? (string) $parsed['size'] : '',
+			'left' => 'left' === $side ? (string) $parsed['size'] : '',
+			'unit' => $parsed['unit'],
+			'isLinked' => false,
+		];
+	}
+
+	/**
+	 * Native V3 color/fill controls store the raw string. Passing a malformed hex
+	 * (`#gggggg`, `#12`) into a native control corrupts the panel picker for that
+	 * setting — the frontend still renders as HTTP 200, but the control shows garbage.
+	 *
+	 * Non-hex forms (`rgb()`, `rgba()`, `hsl()`, `var(--x)`, named colors, `transparent`)
+	 * are passed through unchanged; only `#...` values are shape-checked.
+	 *
+	 * @param string $css_value
+	 * @param string $property
+	 * @return string|array{rejected: true, reason: string, value: string, property: string}
+	 */
+	public static function resolve_color( string $css_value, string $property = 'color' ) {
+		$value = trim( $css_value );
+
+		if ( '' === $value ) {
+			return $value;
+		}
+
+		if ( '#' === $value[0] && ! self::is_valid_hex( $value ) ) {
+			return [
+				'rejected' => true,
+				'property' => $property,
+				'value' => $value,
+				'reason' => __( 'Invalid hex color; expected #rgb, #rgba, #rrggbb, or #rrggbbaa.', 'elementor' ),
+			];
+		}
+
+		return $value;
+	}
+
+	private static function is_valid_hex( string $value ): bool {
+		return (bool) preg_match( '/^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i', $value );
+	}
+
+	/**
+	 * Maps width / max-width CSS to Elementor's paired Advanced-tab controls.
+	 *
+	 * @return array<string, mixed>|array{rejected: true, reason: string, value: string, property: string}|null
+	 */
+	public static function resolve_element_width( string $css_value, string $property = 'width' ) {
+		$rejection = self::maybe_reject_variable( $css_value, $property );
+		if ( null !== $rejection ) {
+			return $rejection;
+		}
+
+		$normalized = strtolower( trim( $css_value ) );
+
+		if ( '100%' === $normalized ) {
+			return [
+				self::ELEMENT_WIDTH_SETTING => self::ELEMENT_WIDTH_MODE_INHERIT,
+			];
+		}
+
+		if ( self::ELEMENT_WIDTH_MODE_AUTO === $normalized ) {
+			return [
+				self::ELEMENT_WIDTH_SETTING => self::ELEMENT_WIDTH_MODE_AUTO,
+			];
+		}
+
+		$dimension = self::resolve_dimension( $css_value );
+		if ( null === $dimension ) {
+			return null;
+		}
+
+		return [
+			self::ELEMENT_WIDTH_SETTING => self::ELEMENT_WIDTH_MODE_INITIAL,
+			self::ELEMENT_CUSTOM_WIDTH_SETTING => $dimension,
+		];
 	}
 
 	/**
@@ -167,7 +467,22 @@ class V3_Value_Resolvers {
 	 * @return array<string, mixed>
 	 */
 	public static function resolve_typography_group( array $declarations, string $prefix = 'typography' ): array {
+		$result = self::resolve_typography_group_with_rejections( $declarations, $prefix );
+
+		return $result['patch'];
+	}
+
+	/**
+	 * Same as {@see resolve_typography_group()} but also surfaces the per-property
+	 * rejections triggered by unsupported `var()` inputs. The style mapper uses this
+	 * variant so it can warn the caller when a variable was silently dropped.
+	 *
+	 * @param array<string, string> $declarations property => css value
+	 * @return array{patch: array<string, mixed>, rejections: array<int, array{property: string, value: string, reason: string}>}
+	 */
+	public static function resolve_typography_group_with_rejections( array $declarations, string $prefix = 'typography' ): array {
 		$patch = [];
+		$rejections = [];
 
 		$map = [
 			'font-family' => $prefix . '_font_family',
@@ -187,11 +502,37 @@ class V3_Value_Resolvers {
 				continue;
 			}
 
-			if ( in_array( $property, [ 'font-size', 'line-height', 'letter-spacing', 'word-spacing' ], true ) ) {
-				$dimension = self::resolve_dimension( $value );
+			if ( 'line-height' === $property ) {
+				$dimension = self::resolve_line_height( $value, $property );
+				if ( self::is_rejected( $dimension ) ) {
+					$rejections[] = self::rejection_summary( $dimension );
+					continue;
+				}
 				if ( null !== $dimension ) {
 					$patch[ $key ] = $dimension;
 				}
+				continue;
+			}
+
+			if ( in_array( $property, [ 'font-size', 'letter-spacing', 'word-spacing' ], true ) ) {
+				$dimension = self::resolve_dimension( $value, $property );
+				if ( self::is_rejected( $dimension ) ) {
+					$rejections[] = self::rejection_summary( $dimension );
+					continue;
+				}
+				if ( null !== $dimension ) {
+					$patch[ $key ] = $dimension;
+				}
+				continue;
+			}
+
+			if ( V3_Variable_Compatibility::is_var_reference( (string) $value )
+				&& ! V3_Variable_Compatibility::supports( $property ) ) {
+				$rejections[] = [
+					'property' => $property,
+					'value' => (string) $value,
+					'reason' => V3_Variable_Compatibility::reject_reason( $property ),
+				];
 				continue;
 			}
 
@@ -206,12 +547,12 @@ class V3_Value_Resolvers {
 		}
 
 		if ( empty( $patch ) ) {
-			return [];
+			return [ 'patch' => [], 'rejections' => $rejections ];
 		}
 
 		$patch[ $prefix . '_typography' ] = 'custom';
 
-		return $patch;
+		return [ 'patch' => $patch, 'rejections' => $rejections ];
 	}
 
 	/**
@@ -268,33 +609,177 @@ class V3_Value_Resolvers {
 	}
 
 	/**
+	 * Parses a CSS `gap` value (`gap: 1rem` or `gap: 1rem 2rem` — first is row-gap, second is
+	 * column-gap) into the shape Controls_Manager::GAPS stores: `{column, row, unit, isLinked}`.
+	 * Two-value form uses different row/column values and marks isLinked=false; single-value
+	 * mirrors row=column and marks isLinked=true.
+	 *
+	 * @return array{column: string, row: string, unit: string, isLinked: bool}|array{rejected: true, reason: string, value: string, property: string}|null
+	 */
+	public static function resolve_gaps( string $css_value, string $property = 'gap' ) {
+		$rejection = self::maybe_reject_variable( $css_value, $property );
+		if ( null !== $rejection ) {
+			return $rejection;
+		}
+
+		$tokens = self::tokenize_css_values( trim( $css_value ) );
+		if ( empty( $tokens ) || count( $tokens ) > 2 ) {
+			return null;
+		}
+
+		$parsed = [];
+		foreach ( $tokens as $token ) {
+			$length = self::parse_length( $token );
+			if ( null === $length ) {
+				return null;
+			}
+			$parsed[] = $length;
+		}
+
+		if ( count( $parsed ) === 2 && $parsed[0]['unit'] !== $parsed[1]['unit'] ) {
+			return null;
+		}
+
+		$row = (string) $parsed[0]['size'];
+		$column = count( $parsed ) === 2 ? (string) $parsed[1]['size'] : $row;
+
+		return [
+			'column' => $column,
+			'row' => $row,
+			'unit' => $parsed[0]['unit'],
+			'isLinked' => $row === $column,
+		];
+	}
+
+	/**
 	 * Dispatches a named resolver against a CSS value.
 	 *
-	 * @param string               $resolver_name One of: color, dimension, sides, box_shadow, border, text, slider.
+	 * @param string               $resolver_name One of: color, dimension, sides, box_shadow, border, text, slider, gaps, element_width.
 	 * @param string               $css_value
 	 * @param array<string, mixed> $args          Extra args (prefix for border/typography).
 	 * @return mixed|null
 	 */
 	public static function resolve( string $resolver_name, string $css_value, array $args = [] ) {
+		$property = (string) ( $args['property'] ?? '' );
+
 		switch ( $resolver_name ) {
 			case 'color':
-				return self::resolve_color( $css_value );
+				return self::resolve_color( $css_value, $property );
 			case 'dimension':
-				return self::resolve_dimension( $css_value );
+				return self::resolve_dimension( $css_value, $property );
 			case 'sides':
-				return self::resolve_sides_shorthand( $css_value );
+				return self::resolve_sides_shorthand( $css_value, $property );
+			case 'dimension_side':
+				return self::resolve_single_dimension_side( $css_value, (string) ( $args['side'] ?? '' ), $property );
 			case 'box_shadow':
 				return self::resolve_box_shadow( $css_value );
 			case 'border':
 				return self::resolve_border_shorthand( $css_value, $args['prefix'] ?? 'border' );
 			case 'slider':
-				$dimension = self::resolve_dimension( $css_value );
-				return null === $dimension ? null : $dimension;
+				return self::resolve_dimension( $css_value, $property );
 			case 'text':
 				return trim( $css_value );
+			case 'element_width':
+				return self::resolve_element_width( $css_value, $property );
+			case 'gaps':
+				return self::resolve_gaps( $css_value, $property );
+			case 'raw_slider':
+				return self::resolve_raw_slider( $css_value );
+			case 'border_side':
+				return self::resolve_border_side_shorthand(
+					$css_value,
+					(string) ( $args['side'] ?? '' ),
+					(string) ( $args['prefix'] ?? 'border' )
+				);
 			default:
 				return null;
 		}
+	}
+
+	/**
+	 * Stores an arbitrary CSS expression in a V3 SLIDER control that supports the `custom` unit
+	 * (e.g. `grid-template-columns: repeat(3, 1fr)` -> `{size: 'repeat(3, 1fr)', unit: 'custom'}`).
+	 * The control's selector template writes `{{SIZE}}` verbatim when unit is `custom`, so
+	 * anything CSS accepts here — `repeat()`, `minmax()`, per-column tracks like `1fr 2fr 1fr`.
+	 *
+	 * @return array{unit: string, size: string}
+	 */
+	public static function resolve_raw_slider( string $css_value ): array {
+		return [
+			'unit' => 'custom',
+			'size' => trim( $css_value ),
+		];
+	}
+
+	/**
+	 * Parses `border-top: 1px solid #ccc` (and its 3 siblings) into the V3 border-group patch,
+	 * setting only the requested side's width. The other three sides fall back to zero so a
+	 * standalone per-side write does not leak into unrelated sides — full linked writes should
+	 * use `border` (the shorthand of all four).
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function resolve_border_side_shorthand( string $css_value, string $side, string $prefix = 'border' ): ?array {
+		if ( ! in_array( $side, [ 'top', 'right', 'bottom', 'left' ], true ) ) {
+			return null;
+		}
+
+		$patch = self::resolve_border_shorthand( $css_value, $prefix );
+		if ( null === $patch ) {
+			return null;
+		}
+
+		$width = $patch[ $prefix . '_width' ] ?? null;
+		if ( is_array( $width ) ) {
+			$sides = [ 'top', 'right', 'bottom', 'left' ];
+			$only_side_value = $width[ $side ];
+			foreach ( $sides as $s ) {
+				$width[ $s ] = $s === $side ? (string) $only_side_value : '0';
+			}
+			$width['isLinked'] = false;
+			$patch[ $prefix . '_width' ] = $width;
+		}
+
+		return $patch;
+	}
+
+	/**
+	 * @param mixed $resolved
+	 */
+	public static function is_rejected( $resolved ): bool {
+		return is_array( $resolved ) && ! empty( $resolved['rejected'] );
+	}
+
+	/**
+	 * @param array{rejected: true, reason: string, value: string, property: string} $rejection
+	 * @return array{property: string, value: string, reason: string}
+	 */
+	public static function rejection_summary( array $rejection ): array {
+		return [
+			'property' => (string) ( $rejection['property'] ?? '' ),
+			'value' => (string) ( $rejection['value'] ?? '' ),
+			'reason' => (string) ( $rejection['reason'] ?? '' ),
+		];
+	}
+
+	/**
+	 * @return array{rejected: true, reason: string, value: string, property: string}|null
+	 */
+	private static function maybe_reject_variable( string $css_value, string $property ): ?array {
+		if ( ! V3_Variable_Compatibility::is_var_reference( $css_value ) ) {
+			return null;
+		}
+
+		if ( V3_Variable_Compatibility::supports( $property ) ) {
+			return null;
+		}
+
+		return [
+			'rejected' => true,
+			'property' => $property,
+			'value' => trim( $css_value ),
+			'reason' => V3_Variable_Compatibility::reject_reason( $property ),
+		];
 	}
 
 	/**
@@ -314,7 +799,7 @@ class V3_Value_Resolvers {
 			];
 		}
 
-		if ( ! preg_match( '/^(-?\d*\.?\d+)(px|em|rem|%|vh|vw|vmin|vmax)?$/i', $token, $matches ) ) {
+		if ( ! preg_match( '/^(-?\d*\.?\d+)(px|em|rem|%|vh|vw|vmin|vmax|ch|ex|svh|svw|dvh|dvw|lvh|lvw)?$/i', $token, $matches ) ) {
 			return null;
 		}
 

--- a/modules/mcp/abilities/appliers/v3/v3-variable-compatibility.php
+++ b/modules/mcp/abilities/appliers/v3/v3-variable-compatibility.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * V4 global variables are emitted to the active kit's `:root` as CSS custom properties,
+ * so a `var(--x)` reference works inside V3 control values only when the control stores
+ * a raw string that becomes the CSS value verbatim (colors, text). V3 slider and
+ * dimension controls store `{size, unit}` shapes that cannot represent a `var()`, and
+ * unitless typography settings coerce numerics — those must reject `var()` inputs and
+ * surface an actionable warning back to the caller.
+ */
+class V3_Variable_Compatibility {
+
+	const SUPPORTED_PROPERTIES = [
+		'color',
+		'background-color',
+		'border-color',
+		'border-top-color',
+		'border-right-color',
+		'border-bottom-color',
+		'border-left-color',
+		'outline-color',
+		'fill',
+		'stroke',
+		'caret-color',
+		'text-decoration-color',
+	];
+
+	public static function supports( string $css_property ): bool {
+		return in_array( self::normalize( $css_property ), self::SUPPORTED_PROPERTIES, true );
+	}
+
+	public static function reject_reason( string $css_property ): string {
+		return sprintf(
+			'V3 sliders and dimension controls store {size, unit} shapes and cannot hold CSS variables. Set `%s` as a literal value, or apply it via a V4 element/global class.',
+			self::normalize( $css_property )
+		);
+	}
+
+	public static function is_var_reference( string $css_value ): bool {
+		return 1 === preg_match( '/^\s*var\s*\(/i', $css_value );
+	}
+
+	private static function normalize( string $css_property ): string {
+		return strtolower( trim( $css_property ) );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-value-resolvers.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-value-resolvers.php
@@ -2,6 +2,7 @@
 
 namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3;
 
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Resolver_Registry;
 use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Value_Resolvers;
 use PHPUnit\Framework\TestCase;
 
@@ -256,5 +257,161 @@ class Test_V3_Value_Resolvers extends TestCase {
 		$this->assertCount( 1, $result['rejections'] );
 		$this->assertSame( 'font-size', $result['rejections'][0]['property'] );
 		$this->assertSame( 'var(--fs)', $result['rejections'][0]['value'] );
+	}
+
+	/**
+	 * @dataProvider malformed_hex_provider
+	 */
+	public function test_resolve_color__rejects_malformed_hex( string $input ) {
+		$result = V3_Value_Resolvers::resolve_color( $input, 'color' );
+
+		$this->assertTrue( V3_Value_Resolvers::is_rejected( $result ) );
+		$this->assertSame( 'color', $result['property'] );
+	}
+
+	public function malformed_hex_provider(): array {
+		return [
+			'bare hash' => [ '#' ],
+			'double hash' => [ '##' ],
+			'five chars' => [ '#12345' ],
+			'seven chars' => [ '#1234567' ],
+			'non-hex chars' => [ '#zzz' ],
+			'mixed non-hex' => [ '#12g45f' ],
+		];
+	}
+
+	public function test_resolve_element_width__100_percent_yields_inherit_mode() {
+		$patch = V3_Value_Resolvers::resolve_element_width( '100%' );
+
+		$this->assertSame(
+			[ V3_Value_Resolvers::ELEMENT_WIDTH_SETTING => V3_Value_Resolvers::ELEMENT_WIDTH_MODE_INHERIT ],
+			$patch
+		);
+	}
+
+	public function test_resolve_element_width__auto_yields_auto_mode_without_custom() {
+		$patch = V3_Value_Resolvers::resolve_element_width( 'auto' );
+
+		$this->assertSame(
+			[ V3_Value_Resolvers::ELEMENT_WIDTH_SETTING => V3_Value_Resolvers::ELEMENT_WIDTH_MODE_AUTO ],
+			$patch
+		);
+	}
+
+	public function test_resolve_element_width__numeric_yields_initial_plus_custom_width() {
+		$patch = V3_Value_Resolvers::resolve_element_width( '480px' );
+
+		$this->assertSame( V3_Value_Resolvers::ELEMENT_WIDTH_MODE_INITIAL, $patch[ V3_Value_Resolvers::ELEMENT_WIDTH_SETTING ] );
+		$this->assertSame( [ 'unit' => 'px', 'size' => 480.0 ], $patch[ V3_Value_Resolvers::ELEMENT_CUSTOM_WIDTH_SETTING ] );
+	}
+
+	public function test_resolve_element_width__rejects_var_reference() {
+		$result = V3_Value_Resolvers::resolve_element_width( 'var(--w)', 'width' );
+
+		$this->assertTrue( V3_Value_Resolvers::is_rejected( $result ) );
+		$this->assertSame( 'width', $result['property'] );
+	}
+
+	public function test_resolve_color__rejects_var_reference_on_unsupported_property() {
+		$result = V3_Value_Resolvers::resolve_color( 'var(--brand)', 'background-image' );
+
+		$this->assertTrue( V3_Value_Resolvers::is_rejected( $result ) );
+	}
+
+	public function test_resolve_gaps__parses_one_value() {
+		$this->assertSame(
+			[ 'column' => '16', 'row' => '16', 'unit' => 'px', 'isLinked' => true ],
+			V3_Value_Resolvers::resolve_gaps( '16px' )
+		);
+	}
+
+	public function test_resolve_gaps__parses_two_values_row_then_column() {
+		$this->assertSame(
+			[ 'column' => '24', 'row' => '8', 'unit' => 'px', 'isLinked' => false ],
+			V3_Value_Resolvers::resolve_gaps( '8px 24px' )
+		);
+	}
+
+	public function test_resolve_gaps__rejects_mixed_units() {
+		$this->assertNull( V3_Value_Resolvers::resolve_gaps( '8px 1rem' ) );
+	}
+
+	public function test_supplement_flex_grid_twin_alignments__mirrors_flex_to_grid() {
+		$patch = V3_Value_Resolvers::supplement_flex_grid_twin_alignments(
+			[ 'flex_align_items' => 'center' ],
+			[ 'grid_align_items' => [] ]
+		);
+
+		$this->assertSame( 'center', $patch['grid_align_items'] );
+	}
+
+	public function test_supplement_container_type_toggle__flips_to_grid_on_grid_columns() {
+		$patch = V3_Value_Resolvers::supplement_container_type_toggle(
+			[ 'grid_columns_grid' => [ 'unit' => 'custom', 'size' => 'repeat(3, 1fr)' ] ],
+			[ 'container_type' => [] ]
+		);
+
+		$this->assertSame( 'grid', $patch['container_type'] );
+	}
+
+	public function test_supplement_container_type_toggle__leaves_flex_default_when_only_twinned_grid_keys() {
+		$patch = V3_Value_Resolvers::supplement_container_type_toggle(
+			[ 'grid_align_items' => 'center' ],
+			[ 'container_type' => [] ]
+		);
+
+		$this->assertArrayNotHasKey( 'container_type', $patch );
+	}
+
+	public function test_supplement_content_width_toggle__flips_to_boxed_when_boxed_width_present() {
+		$patch = V3_Value_Resolvers::supplement_content_width_toggle(
+			[ 'boxed_width' => [ 'unit' => 'px', 'size' => 1200 ] ],
+			[ 'boxed_width' => [], 'content_width' => [] ]
+		);
+
+		$this->assertSame( 'boxed', $patch['content_width'] );
+	}
+
+	public function test_resolve_border_side_shorthand__zeroes_other_sides() {
+		$patch = V3_Value_Resolvers::resolve_border_side_shorthand( '3px solid #000', 'top', 'border' );
+
+		$width = $patch['border_width'];
+		$this->assertSame( '3', $width['top'] );
+		$this->assertSame( '0', $width['right'] );
+		$this->assertSame( '0', $width['bottom'] );
+		$this->assertSame( '0', $width['left'] );
+		$this->assertFalse( $width['isLinked'] );
+	}
+
+	public function test_resolve_border_side_shorthand__rejects_unknown_side() {
+		$this->assertNull( V3_Value_Resolvers::resolve_border_side_shorthand( '1px solid red', 'diagonal' ) );
+	}
+
+	public function test_resolve_box_shadow__none_returns_zeroed_shape_with_empty_type() {
+		$patch = V3_Value_Resolvers::resolve_box_shadow( 'none' );
+
+		$this->assertSame( '', $patch['box_shadow_type'] );
+		$this->assertSame( 0, $patch['box_shadow']['horizontal'] );
+	}
+
+	public function test_resolve_registry__resolves_via_default_set() {
+		V3_Resolver_Registry::reset();
+
+		$this->assertSame(
+			[ 'unit' => 'px', 'size' => 24.0 ],
+			V3_Resolver_Registry::resolve( 'dimension', '24px', [ 'property' => 'width' ] )
+		);
+		$this->assertNull( V3_Resolver_Registry::resolve( 'not_registered', 'x' ) );
+	}
+
+	public function test_resolve_registry__allows_overriding_a_resolver() {
+		V3_Resolver_Registry::reset();
+		V3_Resolver_Registry::register( 'text', static function () {
+			return 'overridden';
+		} );
+
+		$this->assertSame( 'overridden', V3_Value_Resolvers::resolve( 'text', 'hello' ) );
+
+		V3_Resolver_Registry::reset();
 	}
 }

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-value-resolvers.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/test-v3-value-resolvers.php
@@ -45,6 +45,34 @@ class Test_V3_Value_Resolvers extends TestCase {
 		$this->assertSame( 'rgba(0,0,0,0.5)', V3_Value_Resolvers::resolve_color( 'rgba(0,0,0,0.5)' ) );
 	}
 
+	public function test_resolve_color__accepts_all_hex_lengths() {
+		$this->assertSame( '#abc', V3_Value_Resolvers::resolve_color( '#abc' ) );
+		$this->assertSame( '#abcd', V3_Value_Resolvers::resolve_color( '#abcd' ) );
+		$this->assertSame( '#aabbcc', V3_Value_Resolvers::resolve_color( '#aabbcc' ) );
+		$this->assertSame( '#aabbccdd', V3_Value_Resolvers::resolve_color( '#aabbccdd' ) );
+	}
+
+	public function test_resolve_color__rejects_invalid_hex() {
+		// Arrange / Act.
+		$result = V3_Value_Resolvers::resolve_color( '#gggggg', 'color' );
+
+		// Assert.
+		$this->assertTrue( V3_Value_Resolvers::is_rejected( $result ) );
+		$this->assertSame( 'color', $result['property'] );
+		$this->assertSame( '#gggggg', $result['value'] );
+	}
+
+	public function test_resolve_color__rejects_wrong_length_hex() {
+		$this->assertTrue( V3_Value_Resolvers::is_rejected( V3_Value_Resolvers::resolve_color( '#12345', 'color' ) ) );
+		$this->assertTrue( V3_Value_Resolvers::is_rejected( V3_Value_Resolvers::resolve_color( '#1234567', 'color' ) ) );
+	}
+
+	public function test_resolve_color__passes_through_named_and_functional_colors() {
+		$this->assertSame( 'transparent', V3_Value_Resolvers::resolve_color( 'transparent' ) );
+		$this->assertSame( 'red', V3_Value_Resolvers::resolve_color( 'red' ) );
+		$this->assertSame( 'hsl(0, 100%, 50%)', V3_Value_Resolvers::resolve_color( 'hsl(0, 100%, 50%)' ) );
+	}
+
 	public function test_resolve_box_shadow__parses_lengths_and_color() {
 		// Arrange / Act.
 		$result = V3_Value_Resolvers::resolve_box_shadow( '0 20px 60px rgba(0,0,0,0.15)' );
@@ -81,6 +109,49 @@ class Test_V3_Value_Resolvers extends TestCase {
 		$this->assertSame( [ 'unit' => 'rem', 'size' => 2.0 ], $patch['typography_font_size'] );
 		$this->assertSame( '700', $patch['typography_font_weight'] );
 		$this->assertSame( 'Georgia', $patch['typography_font_family'] );
+	}
+
+	public function test_resolve_line_height__keeps_unitless_values() {
+		// Arrange / Act / Assert.
+		$this->assertSame( [ 'unit' => '', 'size' => 1.5 ], V3_Value_Resolvers::resolve_line_height( '1.5' ) );
+		$this->assertSame( [ 'unit' => 'px', 'size' => 24.0 ], V3_Value_Resolvers::resolve_line_height( '24px' ) );
+	}
+
+	public function test_resolve_typography_group__uses_unitless_line_height() {
+		// Arrange / Act.
+		$patch = V3_Value_Resolvers::resolve_typography_group(
+			[
+				'line-height' => '1.5',
+			],
+			'search_field_typography'
+		);
+
+		// Assert.
+		$this->assertSame( [ 'unit' => '', 'size' => 1.5 ], $patch['search_field_typography_line_height'] );
+	}
+
+	public function test_supplement_background_group_toggles__sets_classic_type_for_color_keys() {
+		// Arrange.
+		$controls = [
+			'search_field_background_normal_background' => [ 'type' => 'choose' ],
+			'search_field_background_normal_color' => [ 'type' => 'color' ],
+			'results_background_background' => [ 'type' => 'choose' ],
+			'results_background_color' => [ 'type' => 'color' ],
+			'title_color' => [ 'type' => 'color' ],
+		];
+		$patch = [
+			'search_field_background_normal_color' => '#ffffff',
+			'results_background_color' => '#f5f5f5',
+			'title_color' => '#111111',
+		];
+
+		// Act.
+		$result = V3_Value_Resolvers::supplement_background_group_toggles( $patch, $controls );
+
+		// Assert.
+		$this->assertSame( 'classic', $result['search_field_background_normal_background'] );
+		$this->assertSame( 'classic', $result['results_background_background'] );
+		$this->assertArrayNotHasKey( 'title_background', $result );
 	}
 
 	public function test_resolve_typography_group__skips_toggle_when_nothing_resolves() {
@@ -126,5 +197,64 @@ class Test_V3_Value_Resolvers extends TestCase {
 		$this->assertSame( 'red', V3_Value_Resolvers::resolve( 'color', 'red' ) );
 		$this->assertSame( [ 'unit' => 'px', 'size' => 10.0 ], V3_Value_Resolvers::resolve( 'dimension', '10px' ) );
 		$this->assertNull( V3_Value_Resolvers::resolve( 'unknown', 'x' ) );
+	}
+
+	public function test_resolve_dimension__rejects_var_reference_on_unsupported_property() {
+		// Arrange / Act.
+		$result = V3_Value_Resolvers::resolve_dimension( 'var(--gap)', 'font-size' );
+
+		// Assert.
+		$this->assertTrue( V3_Value_Resolvers::is_rejected( $result ) );
+		$this->assertSame( 'font-size', $result['property'] );
+		$this->assertSame( 'var(--gap)', $result['value'] );
+		$this->assertStringContainsString( 'literal value', $result['reason'] );
+	}
+
+	public function test_resolve_sides_shorthand__rejects_var_reference() {
+		// Arrange / Act.
+		$result = V3_Value_Resolvers::resolve_sides_shorthand( 'var(--pad)', 'padding' );
+
+		// Assert.
+		$this->assertTrue( V3_Value_Resolvers::is_rejected( $result ) );
+		$this->assertSame( 'padding', $result['property'] );
+	}
+
+	public function test_resolve_line_height__rejects_var_reference() {
+		// Arrange / Act.
+		$result = V3_Value_Resolvers::resolve_line_height( 'var(--lh)', 'line-height' );
+
+		// Assert.
+		$this->assertTrue( V3_Value_Resolvers::is_rejected( $result ) );
+	}
+
+	public function test_resolve_color__passes_through_var_reference() {
+		$this->assertSame( 'var(--wc26-gold)', V3_Value_Resolvers::resolve_color( '  var(--wc26-gold)  ' ) );
+	}
+
+	public function test_resolve__threads_property_for_dimension_reject() {
+		// Arrange / Act.
+		$result = V3_Value_Resolvers::resolve( 'dimension', 'var(--x)', [ 'property' => 'width' ] );
+
+		// Assert.
+		$this->assertTrue( V3_Value_Resolvers::is_rejected( $result ) );
+		$this->assertSame( 'width', $result['property'] );
+	}
+
+	public function test_resolve_typography_group_with_rejections__collects_font_size_var() {
+		// Arrange / Act.
+		$result = V3_Value_Resolvers::resolve_typography_group_with_rejections(
+			[
+				'font-size' => 'var(--fs)',
+				'font-weight' => '700',
+			],
+			'typography'
+		);
+
+		// Assert.
+		$this->assertArrayNotHasKey( 'typography_font_size', $result['patch'] );
+		$this->assertSame( '700', $result['patch']['typography_font_weight'] );
+		$this->assertCount( 1, $result['rejections'] );
+		$this->assertSame( 'font-size', $result['rejections'][0]['property'] );
+		$this->assertSame( 'var(--fs)', $result['rejections'][0]['value'] );
 	}
 }


### PR DESCRIPTION
Split 4 of 6 from #37094.

Two orthogonal correctness fixes on the V3 value layer:
- V3_Value_Resolvers::resolve_color shape-checks #-hex values (3/4/6/8 digits) and rejects malformed hex; non-hex values (rgb/rgba/hsl/named/var()/transparent) still pass through.
- V3_Value_Formatters preserves unitless line-height and supplements the required *_background: classic toggle when a background-color write is emitted.

Owned files (3): v3-value-resolvers.php, v3-value-formatters.php, and the associated test.

- Standalone, base = main. Merge order does not matter across the split.
- Union of all 6 split PRs vs the parent branch tip is byte-identical.

See split plan: /Users/omeri/.claude/plans/https-github-com-elementor-elementor-pul-tidy-rainbow.md

Companion PRs: [1/6], [2/6], [3/6], [5/6], [6/6].