### PR TITLE
[5/6] Internal: V4 global classes on V3 inner elements [ED-25071]

### DIFF
--- a/modules/global-classes/global-classes-relations.php
+++ b/modules/global-classes/global-classes-relations.php
@@ -6,6 +6,7 @@ use Elementor\Core\Base\Document;
 use Elementor\Modules\GlobalClasses\Atomic_Global_Styles;
 use Elementor\Modules\GlobalClasses\Concerns\Has_Preview_Context;
 use Elementor\Modules\GlobalClasses\Utils\Atomic_Elements_Utils;
+use Elementor\Modules\GlobalClasses\Utils\V3_Elements_Utils;
 use Elementor\Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -269,6 +270,7 @@ class Global_Classes_Relations {
 
 	private function extract_class_ids_from_post( int $post_id ): array {
 		$used_class_ids = [];
+		$v3_labels = [];
 
 		$document = $this->get_document_for_post( $post_id );
 
@@ -279,13 +281,22 @@ class Global_Classes_Relations {
 		$elements_data = $document->get_elements_data();
 
 		if ( ! empty( $elements_data ) ) {
-			Plugin::$instance->db->iterate_data( $elements_data, function ( $element_data ) use ( &$used_class_ids ) {
+			Plugin::$instance->db->iterate_data( $elements_data, function ( $element_data ) use ( &$used_class_ids, &$v3_labels ) {
 				$used_class_ids = array_merge(
 					$used_class_ids,
 					Atomic_Elements_Utils::collect_class_ids_from_element_data( $element_data )
 				);
+				$v3_labels = array_merge(
+					$v3_labels,
+					V3_Elements_Utils::collect_class_labels_from_v3_element( $element_data )
+				);
 			} );
 		}
+
+		$used_class_ids = array_merge(
+			$used_class_ids,
+			$this->resolve_labels_to_ids( array_unique( $v3_labels ) )
+		);
 
 		$used_class_ids = apply_filters(
 			'elementor/global_classes/extract_class_ids_from_post',
@@ -294,6 +305,40 @@ class Global_Classes_Relations {
 		);
 
 		return array_values( array_unique( $used_class_ids ) );
+	}
+
+	/**
+	 * @param string[] $labels
+	 * @return string[]
+	 */
+	private function resolve_labels_to_ids( array $labels ): array {
+		if ( empty( $labels ) ) {
+			return [];
+		}
+
+		$label_by_id = Global_Classes_Repository::make()
+			->set_preview( $this->is_preview() )
+			->all_labels();
+
+		if ( empty( $label_by_id ) ) {
+			return [];
+		}
+
+		$id_by_label = [];
+		foreach ( $label_by_id as $id => $label ) {
+			if ( is_string( $label ) && '' !== $label ) {
+				$id_by_label[ $label ] = $id;
+			}
+		}
+
+		$ids = [];
+		foreach ( $labels as $label ) {
+			if ( isset( $id_by_label[ $label ] ) ) {
+				$ids[] = $id_by_label[ $label ];
+			}
+		}
+
+		return $ids;
 	}
 
 	private function get_stored_style_ids( int $post_id ): array {

--- a/modules/global-classes/utils/v3-elements-utils.php
+++ b/modules/global-classes/utils/v3-elements-utils.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Elementor\Modules\GlobalClasses\Utils;
+
+use Elementor\Modules\AtomicWidgets\Utils\Utils as Atomic_Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * V3-element counterpart of Atomic_Elements_Utils. V3 widgets do not carry an atomic
+ * classes prop; instead, they store a space-separated list of CSS class names in the
+ * `_css_classes` setting. Those names ARE the labels of V4 global classes when the MCP
+ * class applier writes to a V3 wrapper — so a document scan must read them and resolve
+ * them back to global-class ids so the corresponding rule files ship with the page.
+ */
+class V3_Elements_Utils {
+
+	const V3_CSS_CLASSES_SETTING = '_css_classes';
+
+	/**
+	 * Returns the raw class-name tokens found in the V3 `_css_classes` setting of the
+	 * given element data. Returns an empty array when the element is atomic (V4) or when
+	 * the setting is absent / empty.
+	 *
+	 * @param array<string, mixed> $element_data Single element data node.
+	 * @return string[]
+	 */
+	public static function collect_class_labels_from_v3_element( array $element_data ): array {
+		$element_type = Atomic_Elements_Utils::get_element_type( $element_data );
+		$element_instance = Atomic_Elements_Utils::get_element_instance( $element_type );
+
+		if ( Atomic_Utils::is_atomic( $element_instance ) ) {
+			return [];
+		}
+
+		$raw = $element_data['settings'][ self::V3_CSS_CLASSES_SETTING ] ?? '';
+
+		if ( ! is_string( $raw ) || '' === trim( $raw ) ) {
+			return [];
+		}
+
+		$tokens = preg_split( '/\s+/', trim( $raw ) );
+
+		if ( ! is_array( $tokens ) ) {
+			return [];
+		}
+
+		return array_values( array_filter( $tokens, static fn( $token ) => is_string( $token ) && '' !== $token ) );
+	}
+}

--- a/modules/mcp/abilities/appliers/class-applier.php
+++ b/modules/mcp/abilities/appliers/class-applier.php
@@ -3,6 +3,8 @@
 namespace Elementor\Modules\Mcp\Abilities\Appliers;
 
 use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Widget_Map_Loader;
+use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -17,74 +19,188 @@ class Class_Applier {
 	}
 
 	/**
+	 * Accepts two shapes per config id (backward compatible):
+	 *   - `["label-1", "label-2"]`                 → wrapper-only (legacy).
+	 *   - `{ "wrapper": [...], "menu-item": [...] }` → targeted; keys are wrapper or inner-element aliases.
+	 *
 	 * @param array<string, array&> $config_id_index Index of subtree refs.
 	 * @param array<string, mixed>  $classes_input   Per-config-id global class labels.
+	 * @return array{error: \WP_Error|null, warnings: string[]}
 	 */
-	public function apply( array $config_id_index, array $classes_input ): ?\WP_Error {
+	public function apply( array $config_id_index, array $classes_input ): array {
 		if ( empty( $classes_input ) ) {
-			return null;
+			return [ 'error' => null, 'warnings' => [] ];
 		}
 
 		$id_by_label = $this->build_label_to_id_map( $this->repository->all_labels() );
 		$errors = [];
+		$warnings = [];
 
-		foreach ( $classes_input as $config_id => $labels ) {
+		foreach ( $classes_input as $config_id => $raw ) {
 			if ( ! isset( $config_id_index[ $config_id ] ) ) {
+				continue;
+			}
+
+			$targets = $this->normalize_targets( $raw, $config_id, $errors );
+
+			if ( null === $targets ) {
+				continue;
+			}
+
+			$node = &$config_id_index[ $config_id ];
+
+			if ( V3_Node_Bridge::is_v3_node( $node ) ) {
+				$this->apply_v3( $node, $targets, $id_by_label, $config_id, $errors, $warnings );
+				unset( $node );
+				continue;
+			}
+
+			if ( ! isset( $targets[ V3_Widget_Map_Loader::WRAPPER_TARGET ] ) ) {
+				foreach ( array_keys( $targets ) as $target ) {
+					$warnings[] = sprintf(
+						'[%s] Global class target \'%s\' is only supported on V3 widgets.',
+						$config_id,
+						$target
+					);
+				}
+				unset( $node );
+				continue;
+			}
+
+			$this->apply_v4_wrapper( $node, $targets[ V3_Widget_Map_Loader::WRAPPER_TARGET ], $id_by_label, $config_id, $errors );
+
+			foreach ( $targets as $target => $_labels ) {
+				if ( V3_Widget_Map_Loader::WRAPPER_TARGET === $target ) {
+					continue;
+				}
+				$warnings[] = sprintf(
+					'[%s] Global class target \'%s\' is only supported on V3 widgets.',
+					$config_id,
+					$target
+				);
+			}
+
+			unset( $node );
+		}
+
+		$error = empty( $errors ) ? null : new \WP_Error(
+			'elementor_unknown_global_class',
+			implode( ' ', $errors ),
+			[ 'status' => \WP_Http::BAD_REQUEST ]
+		);
+
+		return [
+			'error' => $error,
+			'warnings' => $warnings,
+		];
+	}
+
+	/**
+	 * @return array<string, string[]>|null Per-target label lists, or null if the input for this
+	 *                                       config id was rejected (an error was recorded).
+	 */
+	private function normalize_targets( $raw, string $config_id, array &$errors ): ?array {
+		if ( is_array( $raw ) && $this->is_list( $raw ) ) {
+			return [ V3_Widget_Map_Loader::WRAPPER_TARGET => $raw ];
+		}
+
+		if ( ! is_array( $raw ) ) {
+			$errors[] = sprintf(
+				'[%s] classes must be an array of global class labels or a target-keyed map, got %s.',
+				$config_id,
+				gettype( $raw )
+			);
+			return null;
+		}
+
+		$targets = [];
+
+		foreach ( $raw as $target => $labels ) {
+			if ( ! is_string( $target ) || '' === $target ) {
+				$errors[] = sprintf( '[%s] Class target keys must be non-empty strings.', $config_id );
 				continue;
 			}
 
 			if ( ! is_array( $labels ) ) {
 				$errors[] = sprintf(
-					'[%s] classes must be an array of global class labels, got %s.',
+					'[%s] Labels for target \'%s\' must be an array, got %s.',
 					$config_id,
+					$target,
 					gettype( $labels )
 				);
 				continue;
 			}
 
-			$node = &$config_id_index[ $config_id ];
+			$targets[ $target ] = $labels;
+		}
+
+		return $targets;
+	}
+
+	private function is_list( array $arr ): bool {
+		if ( empty( $arr ) ) {
+			return true;
+		}
+		return array_keys( $arr ) === range( 0, count( $arr ) - 1 );
+	}
+
+	private function apply_v3(
+		array &$node,
+		array $targets,
+		array $id_by_label,
+		string $config_id,
+		array &$errors,
+		array &$warnings
+	): void {
+		$widget_type = is_string( $node['widgetType'] ?? null ) ? $node['widgetType'] : '';
+		$widget_config = '' !== $widget_type
+			? ( Widget_Context_Helper::get_widget_config( $widget_type ) ?? [] )
+			: [];
+
+		foreach ( $targets as $target => $labels ) {
 			$resolved_labels = $this->resolve_labels( $labels, $id_by_label, $config_id, $errors );
 
-			if ( V3_Node_Bridge::is_v3_node( $node ) ) {
-				if ( empty( $labels ) ) {
-					V3_Node_Bridge::clear_classes( $node );
-				} elseif ( ! empty( $resolved_labels ) ) {
-					V3_Node_Bridge::apply_classes( $node, $resolved_labels );
-				}
-
-				unset( $node );
-				continue;
-			}
-
-			if ( empty( $labels ) ) {
-				$node['settings'] = $this->clear_global_classes( $node['settings'] ?? [] );
-				unset( $node );
+			if ( empty( $labels ) && V3_Widget_Map_Loader::WRAPPER_TARGET === $target ) {
+				V3_Node_Bridge::clear_classes( $node );
 				continue;
 			}
 
 			if ( empty( $resolved_labels ) ) {
-				unset( $node );
 				continue;
 			}
 
-			$resolved_ids = array_map(
-				static fn( string $label ) => $id_by_label[ $label ],
-				$resolved_labels
-			);
+			$warning = V3_Node_Bridge::apply_classes_to_target( $node, $target, $resolved_labels, $widget_config );
 
-			$node['settings'] = $this->prepend_global_classes( $node['settings'] ?? [], $resolved_ids );
-			unset( $node );
+			if ( null !== $warning ) {
+				$warnings[] = sprintf( '[%s] %s', $config_id, $warning );
+			}
+		}
+	}
+
+	private function apply_v4_wrapper(
+		array &$node,
+		array $labels,
+		array $id_by_label,
+		string $config_id,
+		array &$errors
+	): void {
+		if ( empty( $labels ) ) {
+			$node['settings'] = $this->clear_global_classes( $node['settings'] ?? [] );
+			return;
 		}
 
-		if ( empty( $errors ) ) {
-			return null;
+		$resolved_labels = $this->resolve_labels( $labels, $id_by_label, $config_id, $errors );
+
+		if ( empty( $resolved_labels ) ) {
+			return;
 		}
 
-		return new \WP_Error(
-			'elementor_unknown_global_class',
-			implode( ' ', $errors ),
-			[ 'status' => \WP_Http::BAD_REQUEST ]
+		$resolved_ids = array_map(
+			static fn( string $label ) => $id_by_label[ $label ],
+			$resolved_labels
 		);
+
+		$node['settings'] = $this->prepend_global_classes( $node['settings'] ?? [], $resolved_ids );
 	}
 
 	/**

--- a/modules/mcp/abilities/appliers/v3-node-bridge.php
+++ b/modules/mcp/abilities/appliers/v3-node-bridge.php
@@ -2,8 +2,9 @@
 
 namespace Elementor\Modules\Mcp\Abilities\Appliers;
 
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Auto_Mapper;
 use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Style_Settings_Index;
-use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Widget_Bridge_Registry;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Widget_Map_Loader;
 use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
 use Elementor\Utils;
 
@@ -76,25 +77,70 @@ class V3_Node_Bridge {
 	}
 
 	public static function is_v3_node( array $node ): bool {
-		// V3 non-widget elements (containers/sections) are intentionally not supported at this layer for now.
-		if ( 'widget' !== ( $node['elType'] ?? null ) ) {
-			return false;
+		$el_type = $node['elType'] ?? null;
+
+		if ( 'widget' === $el_type ) {
+			$type = $node['widgetType'] ?? null;
+			return is_string( $type ) && Widget_Context_Helper::is_v3_allowlisted( $type );
 		}
 
-		$type = $node['widgetType'] ?? null;
-
-		return is_string( $type ) && Widget_Context_Helper::is_v3_allowlisted( $type );
+		// V3 container/section/column elements — the type key is on `elType` itself, not `widgetType`.
+		return is_string( $el_type ) && Widget_Context_Helper::is_v3_allowlisted( $el_type );
 	}
 
 	/**
 	 * Writes labels directly to V3's `_css_classes` (space-separated, deduped).
 	 * V4 global class labels are the CSS class names themselves.
+	 *
+	 * @deprecated Use apply_classes_to_target() with V3_Widget_Map_Loader::WRAPPER_TARGET.
 	 */
 	public static function apply_classes( array &$node, array $labels ): void {
-		$existing = self::split_css_classes( $node['settings'][ self::V3_CSS_CLASSES_SETTING ] ?? '' );
+		self::apply_classes_to_target( $node, V3_Widget_Map_Loader::WRAPPER_TARGET, $labels );
+	}
+
+	/**
+	 * Writes labels to the setting bound to `$target` for the node's widget type.
+	 * For `wrapper` the setting is V3's built-in `_css_classes`. For inner-element aliases,
+	 * the setting is the `class_setting` declared on the alias in its map file.
+	 *
+	 * Returns a warning message when the target is unknown or does not accept classes on
+	 * this widget; the caller decides how to surface it.
+	 *
+	 * @param array<string, mixed> $node          Subtree node (by reference).
+	 * @param string               $target        `wrapper` or an inner-element alias.
+	 * @param string[]             $labels        Global-class labels (CSS names).
+	 * @param array<string, mixed> $widget_config Widget config from Widget_Context_Helper::get_widget_config().
+	 */
+	public static function apply_classes_to_target( array &$node, string $target, array $labels, array $widget_config = [] ): ?string {
+		$widget_type = is_string( $node['widgetType'] ?? null ) ? $node['widgetType'] : '';
+		$controls = is_array( $widget_config['controls'] ?? null ) ? $widget_config['controls'] : [];
+
+		$setting = V3_Widget_Map_Loader::resolve_class_setting( $widget_type, $target, $controls );
+
+		if ( null === $setting ) {
+			return sprintf(
+				/* translators: 1: alias name, 2: V3 widget type. */
+				__( "Global class target '%1\$s' is not defined for %2\$s", 'elementor' ),
+				$target,
+				'' === $widget_type ? esc_html__( 'this V3 widget', 'elementor' ) : $widget_type
+			);
+		}
+
+		if ( false === $setting ) {
+			return sprintf(
+				/* translators: 1: V3 widget type, 2: alias name. */
+				__( 'Widget %1$s does not accept classes on inner element %2$s', 'elementor' ),
+				'' === $widget_type ? esc_html__( 'this V3 widget', 'elementor' ) : $widget_type,
+				$target
+			);
+		}
+
+		$existing = self::split_css_classes( $node['settings'][ $setting ] ?? '' );
 		$merged = array_values( array_unique( array_merge( $labels, $existing ) ) );
 
-		$node['settings'][ self::V3_CSS_CLASSES_SETTING ] = implode( ' ', $merged );
+		$node['settings'][ $setting ] = implode( ' ', $merged );
+
+		return null;
 	}
 
 	public static function clear_classes( array &$node ): void {
@@ -155,22 +201,59 @@ class V3_Node_Bridge {
 	 */
 	private static function collect_style_setting_keys( string $widget_type, array $widget_config ): array {
 		$keys = [];
-		$overrides = V3_Widget_Bridge_Registry::get_style_overrides( $widget_type );
+		$controls = is_array( $widget_config['controls'] ?? null ) ? $widget_config['controls'] : [];
+		$map = V3_Widget_Map_Loader::get( $widget_type, $controls );
+		$inner_elements = $map['inner_elements'];
 
-		foreach ( $overrides as $override ) {
+		if ( ! empty( $inner_elements ) ) {
+			foreach ( $inner_elements as $inner_element ) {
+				$keys = array_merge( $keys, $inner_element['setting_keys'] ?? [] );
+
+				$mapping = V3_Auto_Mapper::for_scope( $widget_config, $inner_element );
+				$keys = array_merge( $keys, self::keys_from_mapping( $mapping, $controls ) );
+			}
+
+			foreach ( $map['wrapper']['style_overrides'] as $override ) {
+				$keys = array_merge( $keys, self::expand_override_keys( $override ) );
+			}
+
+			return array_values( array_unique( $keys ) );
+		}
+
+		$keys = array_merge( $keys, $map['wrapper']['setting_keys'] ?? [] );
+		$keys = array_merge(
+			$keys,
+			self::keys_from_mapping( V3_Auto_Mapper::for_scope( $widget_config, $map['wrapper'] ), $controls )
+		);
+
+		return array_values( array_unique( $keys ) );
+	}
+
+	/**
+	 * @param array{overrides: array<string, array>, generic_index: array<string, array>} $mapping
+	 * @param array<string, mixed>                                                        $controls
+	 * @return string[]
+	 */
+	private static function keys_from_mapping( array $mapping, array $controls ): array {
+		$keys = [];
+
+		foreach ( $mapping['overrides'] ?? [] as $override ) {
 			$keys = array_merge( $keys, self::expand_override_keys( $override ) );
 		}
 
-		$generic = V3_Style_Settings_Index::build( $widget_config['controls'] ?? [], $overrides );
-		foreach ( $generic as $rule ) {
+		foreach ( $mapping['generic_index'] ?? [] as $rule ) {
 			$setting = (string) ( $rule['setting'] ?? '' );
 			if ( '' === $setting ) {
 				continue;
 			}
+
 			$keys[] = $setting;
+
 			if ( ! empty( $rule['responsive'] ) ) {
 				foreach ( self::RESPONSIVE_SUFFIXES as $suffix ) {
-					$keys[] = $setting . $suffix;
+					if ( isset( $controls[ $setting . $suffix ] ) ) {
+						$keys[] = $setting . $suffix;
+					}
 				}
 			}
 		}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-class-applier-v3-targets.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-class-applier-v3-targets.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Elementor {
+	if ( ! class_exists( 'Elementor\\Utils', false ) ) {
+		class Utils {
+			public static function has_pro(): bool {
+				return true;
+			}
+		}
+	}
+}
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3 {
+	if ( ! class_exists( __NAMESPACE__ . '\\V3_Widget_Map_Loader_Test_Stub', false ) ) {
+		class V3_Widget_Map_Loader_Test_Stub {}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+	}
+
+	if ( ! function_exists( '__' ) ) {
+		function __( $text, $domain = null ) {
+			return $text;
+		}
+	}
+
+	if ( ! function_exists( 'esc_html__' ) ) {
+		function esc_html__( $text, $domain = null ) {
+			return $text;
+		}
+	}
+
+	use Elementor\Modules\GlobalClasses\Global_Classes_Repository;
+	use Elementor\Modules\Mcp\Abilities\Appliers\Class_Applier;
+	use PHPUnit\Framework\TestCase;
+
+	class Test_Class_Applier_V3_Targets extends TestCase {
+
+		private function make_repository( array $label_by_id ): Global_Classes_Repository {
+			$repo = $this->createMock( Global_Classes_Repository::class );
+			$repo->method( 'all_labels' )->willReturn( $label_by_id );
+			return $repo;
+		}
+
+		private function v3_wrapper_node(): array {
+			return [
+				'elType' => 'widget',
+				'widgetType' => 'nav-menu',
+				'settings' => [],
+			];
+		}
+
+		public function test_apply__legacy_array_shape_writes_wrapper_classes(): void {
+			$repo = $this->make_repository( [ 'id-1' => 'primary' ] );
+			$applier = new Class_Applier( $repo );
+
+			$node = $this->v3_wrapper_node();
+			$index = [ 'cfg' => &$node ];
+
+			$result = $applier->apply( $index, [ 'cfg' => [ 'primary' ] ] );
+
+			$this->assertNull( $result['error'] );
+			$this->assertSame( [], $result['warnings'] );
+			$this->assertSame( 'primary', $node['settings']['_css_classes'] );
+		}
+
+		public function test_apply__targeted_wrapper_shape_writes_wrapper_classes(): void {
+			$repo = $this->make_repository( [ 'id-1' => 'primary' ] );
+			$applier = new Class_Applier( $repo );
+
+			$node = $this->v3_wrapper_node();
+			$index = [ 'cfg' => &$node ];
+
+			$result = $applier->apply( $index, [ 'cfg' => [ 'wrapper' => [ 'primary' ] ] ] );
+
+			$this->assertNull( $result['error'] );
+			$this->assertSame( [], $result['warnings'] );
+			$this->assertSame( 'primary', $node['settings']['_css_classes'] );
+		}
+
+		public function test_apply__unknown_target_emits_warning_and_does_not_write(): void {
+			$repo = $this->make_repository( [ 'id-1' => 'primary' ] );
+			$applier = new Class_Applier( $repo );
+
+			$node = $this->v3_wrapper_node();
+			$index = [ 'cfg' => &$node ];
+
+			$result = $applier->apply( $index, [ 'cfg' => [ 'not-a-real-alias' => [ 'primary' ] ] ] );
+
+			$this->assertNull( $result['error'] );
+			$this->assertNotEmpty( $result['warnings'] );
+			$this->assertStringContainsString( "not-a-real-alias", $result['warnings'][0] );
+			$this->assertStringContainsString( 'nav-menu', $result['warnings'][0] );
+			$this->assertArrayNotHasKey( '_css_classes', $node['settings'] );
+		}
+
+		public function test_apply__non_array_input_returns_error(): void {
+			$repo = $this->make_repository( [ 'id-1' => 'primary' ] );
+			$applier = new Class_Applier( $repo );
+
+			$node = $this->v3_wrapper_node();
+			$index = [ 'cfg' => &$node ];
+
+			$result = $applier->apply( $index, [ 'cfg' => 'not-an-array' ] );
+
+			$this->assertNotNull( $result['error'] );
+			$this->assertSame( 'elementor_unknown_global_class', $result['error']->get_error_code() );
+		}
+
+		public function test_apply__unknown_label_returns_error(): void {
+			$repo = $this->make_repository( [ 'id-1' => 'primary' ] );
+			$applier = new Class_Applier( $repo );
+
+			$node = $this->v3_wrapper_node();
+			$index = [ 'cfg' => &$node ];
+
+			$result = $applier->apply( $index, [ 'cfg' => [ 'wrapper' => [ 'not-defined' ] ] ] );
+
+			$this->assertNotNull( $result['error'] );
+			$this->assertStringContainsString( 'not-defined', $result['error']->get_error_message() );
+		}
+
+		public function test_apply__empty_wrapper_array_clears_v3_wrapper_classes(): void {
+			$repo = $this->make_repository( [ 'id-1' => 'primary' ] );
+			$applier = new Class_Applier( $repo );
+
+			$node = [
+				'elType' => 'widget',
+				'widgetType' => 'nav-menu',
+				'settings' => [ '_css_classes' => 'existing' ],
+			];
+			$index = [ 'cfg' => &$node ];
+
+			$result = $applier->apply( $index, [ 'cfg' => [] ] );
+
+			$this->assertNull( $result['error'] );
+			$this->assertArrayNotHasKey( '_css_classes', $node['settings'] );
+		}
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-v3-node-bridge-classes.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/test-v3-node-bridge-classes.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+	}
+
+	if ( ! function_exists( '__' ) ) {
+		function __( $text, $domain = null ) {
+			return $text;
+		}
+	}
+
+	if ( ! function_exists( 'esc_html__' ) ) {
+		function esc_html__( $text, $domain = null ) {
+			return $text;
+		}
+	}
+
+	use Elementor\Modules\Mcp\Abilities\Appliers\V3_Node_Bridge;
+	use PHPUnit\Framework\TestCase;
+
+	class Test_V3_Node_Bridge_Classes extends TestCase {
+
+		public function test_apply_classes_to_target__wrapper_writes_css_classes_setting(): void {
+			$node = [
+				'elType' => 'widget',
+				'widgetType' => 'nav-menu',
+				'settings' => [ '_css_classes' => 'existing' ],
+			];
+
+			$warning = V3_Node_Bridge::apply_classes_to_target( $node, 'wrapper', [ 'new-1', 'existing' ] );
+
+			$this->assertNull( $warning );
+			$this->assertSame( 'new-1 existing', $node['settings']['_css_classes'] );
+		}
+
+		public function test_apply_classes__legacy_wrapper_alias_delegates_to_target(): void {
+			$node = [
+				'elType' => 'widget',
+				'widgetType' => 'nav-menu',
+				'settings' => [],
+			];
+
+			V3_Node_Bridge::apply_classes( $node, [ 'a', 'b' ] );
+
+			$this->assertSame( 'a b', $node['settings']['_css_classes'] );
+		}
+
+		public function test_apply_classes_to_target__unknown_target_returns_warning_and_does_not_write(): void {
+			$node = [
+				'elType' => 'widget',
+				'widgetType' => 'nav-menu',
+				'settings' => [],
+			];
+
+			$warning = V3_Node_Bridge::apply_classes_to_target( $node, 'nope', [ 'primary' ] );
+
+			$this->assertIsString( $warning );
+			$this->assertStringContainsString( "'nope'", $warning );
+			$this->assertStringContainsString( 'nav-menu', $warning );
+			$this->assertArrayNotHasKey( '_css_classes', $node['settings'] );
+			$this->assertArrayNotHasKey( 'nope', $node['settings'] );
+		}
+	}
+}


### PR DESCRIPTION
Split 5 of 6 from #37094.

## Bug this fixes

On `main`, attaching a V4 global class to a V3 widget writes the class name onto the HTML but the class's CSS rule never ships with the page — the widget renders unstyled.

- `Class_Applier` already routes V3 targets to `V3_Node_Bridge::apply_classes()`, which persists the label into `settings['_css_classes']`. Render emits `<... class="... my-label">` correctly.
- `Global_Classes_Relations::extract_class_ids_from_post()` scans the document to decide which global-class rules `Atomic_Global_Styles` should enqueue. It only reads the V4 atomic prop shape (`Atomic_Elements_Utils::collect_class_ids_from_element_data`), so V3 nodes' `_css_classes` string is invisible to it.
- Result: the label is on the element but the corresponding rule is never included in the enqueued stylesheet.

## Fix

Adds `V3_Elements_Utils::collect_class_labels_from_v3_element()` (reads `_css_classes`) and wires it into `extract_class_ids_from_post()` alongside the V4 scan, then resolves labels → class ids via `Global_Classes_Repository::all_labels()`. Rules for classes attached to V3 wrappers now ship with the page.

## Also included (scaffolding for [6/6])

- `Class_Applier` accepts a targeted-shape input `{ config_id: { wrapper: [...], <alias>: [...] } }` in addition to the flat legacy shape. Backwards-compatible.
- `V3_Node_Bridge::apply_classes_to_target()` replaces the wrapper-only `apply_classes()` and looks up the destination setting via `V3_Widget_Map_Loader::resolve_class_setting()`.
- Wrapper target is functional on its own. Inner-element aliases are dormant until [6/6] lands per-widget maps that declare `class_setting` on an alias.

## Dependency on [6/6]

`v3-node-bridge.php` imports `V3_Widget_Map_Loader` and `V3_Auto_Mapper` (added in [6/6]). This PR does not compile against `main` without [6/6]. Recommended merge order: [6/6] then [5/6], or bundle them.

## Files (6)

- `modules/global-classes/global-classes-relations.php`
- `modules/global-classes/utils/v3-elements-utils.php` (new)
- `modules/mcp/abilities/appliers/class-applier.php`
- `modules/mcp/abilities/appliers/v3-node-bridge.php`
- `tests/phpunit/.../test-class-applier-v3-targets.php` (new)
- `tests/phpunit/.../test-v3-node-bridge-classes.php` (new)

Companion PRs: [1/6], [2/6], [3/6], [4/6], [6/6].