### PR TITLE
Tweak: Improved the text of the Elementor switch mode button in the WordPress editor [ED-25500]

### DIFF
--- a/assets/dev/js/admin/admin.js
+++ b/assets/dev/js/admin/admin.js
@@ -61,13 +61,13 @@ import 'elementor-app/event-track/wp-dashboard-tracking';
 
 				if ( self.isElementorMode() ) {
 					elementorCommon.dialogsManager.createWidget( 'confirm', {
-						message: __( 'Please note that you are switching to WordPress default editor. Your current layout, design and content might break.', 'elementor' ),
-						headerMessage: __( 'Back to WordPress Editor', 'elementor' ),
+						message: __( 'This page was built with Elementor. You\'re about to switch to editing with the WordPress editor. Your current layout, design and content may break and need to be rebuilt. Are you sure you want to continue?', 'elementor' ),
+						headerMessage: __( 'Edit with WordPress?', 'elementor' ),
 						strings: {
 							confirm: __( 'Continue', 'elementor' ),
 							cancel: __( 'Cancel', 'elementor' ),
 						},
-						defaultOption: 'confirm',
+						defaultOption: 'cancel',
 						onConfirm() {
 							self.elements.$switchModeInput.val( '' );
 							self.toggleStatus();

--- a/assets/dev/js/admin/admin.js
+++ b/assets/dev/js/admin/admin.js
@@ -61,7 +61,7 @@ import 'elementor-app/event-track/wp-dashboard-tracking';
 
 				if ( self.isElementorMode() ) {
 					elementorCommon.dialogsManager.createWidget( 'confirm', {
-						message: __( 'This page was built with Elementor. You\'re about to switch to editing with the WordPress editor. Your current layout, design and content may break and need to be rebuilt. Are you sure you want to continue?', 'elementor' ),
+						message: __( 'You are about to switch this page from the Elementor editor to the WordPress editor. Your current layout, design, and content may break and need to be rebuilt. Are you sure you want to continue?', 'elementor' ),
 						headerMessage: __( 'Edit with WordPress?', 'elementor' ),
 						strings: {
 							confirm: __( 'Continue', 'elementor' ),

--- a/assets/dev/js/admin/gutenberg.js
+++ b/assets/dev/js/admin/gutenberg.js
@@ -129,13 +129,13 @@
 			self.cache.$switchModeButton.on( 'click', function() {
 				if ( self.isElementorMode ) {
 					elementorCommon.dialogsManager.createWidget( 'confirm', {
-						message: __( 'Please note that you are switching to WordPress default editor. Your current layout, design and content might break.', 'elementor' ),
-						headerMessage: __( 'Back to WordPress Editor', 'elementor' ),
+						message: __( 'This page was built with Elementor. You\'re about to switch to editing with the WordPress editor. Your current layout, design and content may break and need to be rebuilt. Are you sure you want to continue?', 'elementor' ),
+						headerMessage: __( 'Edit with WordPress?', 'elementor' ),
 						strings: {
 							confirm: __( 'Continue', 'elementor' ),
 							cancel: __( 'Cancel', 'elementor' ),
 						},
-						defaultOption: 'confirm',
+						defaultOption: 'cancel',
 						onConfirm() {
 							const wpEditor = wp.data.dispatch( 'core/editor' );
 

--- a/assets/dev/js/admin/gutenberg.js
+++ b/assets/dev/js/admin/gutenberg.js
@@ -129,7 +129,7 @@
 			self.cache.$switchModeButton.on( 'click', function() {
 				if ( self.isElementorMode ) {
 					elementorCommon.dialogsManager.createWidget( 'confirm', {
-						message: __( 'This page was built with Elementor. You\'re about to switch to editing with the WordPress editor. Your current layout, design and content may break and need to be rebuilt. Are you sure you want to continue?', 'elementor' ),
+						message: __( 'You are about to switch this page from the Elementor editor to the WordPress editor. Your current layout, design, and content may break and need to be rebuilt. Are you sure you want to continue?', 'elementor' ),
 						headerMessage: __( 'Edit with WordPress?', 'elementor' ),
 						strings: {
 							confirm: __( 'Continue', 'elementor' ),

--- a/core/admin/admin.php
+++ b/core/admin/admin.php
@@ -243,8 +243,8 @@ class Admin extends App {
 			<input id="elementor-switch-mode-input" type="hidden" name="_elementor_post_mode" value="<?php echo esc_attr( $document->is_built_with_elementor() ); ?>" />
 			<button id="elementor-switch-mode-button" type="button" class="button button-primary button-hero">
 				<span class="elementor-switch-mode-on">
-					<i class="eicon-arrow-<?php echo ( is_rtl() ) ? 'right' : 'left'; ?>" aria-hidden="true"></i>
-					<?php echo esc_html__( 'Back to WordPress Editor', 'elementor' ); ?>
+					<i class="eicon-wordpress" aria-hidden="true"></i>
+					<?php echo esc_html__( 'Edit with WordPress', 'elementor' ); ?>
 				</span>
 				<span class="elementor-switch-mode-off">
 					<i class="eicon-elementor-square" aria-hidden="true"></i>

--- a/modules/gutenberg/module.php
+++ b/modules/gutenberg/module.php
@@ -95,7 +95,10 @@ class Module extends BaseModule {
 		<script id="elementor-gutenberg-button-switch-mode" type="text/html">
 			<div id="elementor-switch-mode">
 				<button id="elementor-switch-mode-button" type="button" class="button button-primary button-large">
-					<span class="elementor-switch-mode-on"><?php echo esc_html__( '&#8592; Back to WordPress Editor', 'elementor' ); ?></span>
+					<span class="elementor-switch-mode-on">
+						<i class="eicon-wordpress" aria-hidden="true"></i>
+						<?php echo esc_html__( 'Edit with WordPress', 'elementor' ); ?>
+					</span>
 					<span class="elementor-switch-mode-off">
 						<i class="eicon-elementor-square" aria-hidden="true"></i>
 						<?php echo esc_html__( 'Edit with Elementor', 'elementor' ); ?>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR Type
- [x] Other... Please describe: Tweak

## Summary

This PR can be summarized in the following changelog entry:

* Tweak: Renamed the "Back to WordPress Editor" switch mode button to "Edit with WordPress" and replaced the arrow icon with the WordPress icon

## Description

Users often clicked the "Back to WordPress Editor" button in the Block Editor top bar without understanding it switches the page editing mode, which can break layouts. This tweak renames the button to **Edit with WordPress** and replaces the arrow icon with `eicon-wordpress` so it mirrors the adjacent **Edit with Elementor** button pattern.

Changes:
- `core/admin/admin.php` — classic editor switch mode button label and icon
- `modules/gutenberg/module.php` — Block Editor top bar switch mode button label and icon
- `assets/dev/js/admin/admin.js` — classic editor confirmation dialog header and message text
- `assets/dev//js/admin/gutenberg.js` — Block Editor confirmation dialog header and message text

## Test instructions

1. Open a page built with Elementor in the WordPress Block Editor.
2. Confirm the top bar button reads **Edit with WordPress** with the WordPress icon (not a back arrow).
3. Click the button and confirm the existing confirmation dialog still appears, contains the new header and message texts, and switching modes works as before.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes ED-25500


<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Improved UX messaging when switching from Elementor to WordPress editor. The old "Back to WordPress Editor" copy was vague; new messaging emphasizes destructive risk and uses a safer default action (cancel).

## 2. What Changed (Where)

- **core/admin/admin.php**: Replaced arrow icon + "Back to WordPress Editor" text with WordPress icon + "Edit with WordPress"
- **modules/gutenberg/module.php**: Wrapped Gutenberg button text in `elementor-switch-mode-on` span with matching icon/copy
- **assets/dev/js/admin/admin.js** & **gutenberg.js**: Updated confirmation dialog with explicit warning about potential breakage; changed default button from "confirm" to "cancel"

## 3. How It Works

User clicks mode-switch button → confirmation dialog shows warning about layout/content risk → defaults to "Cancel" instead of "Continue", forcing explicit user intent before destructive action.

## 4. Risks

Minor: hardcoded strings assume WordPress icon + label exist in icon library. Localization already handled via `esc_html__()`. Dialog copy is more alarming but accurately reflects the destructive nature of the operation.
