### PR TITLE
Fix: Preserve flex-basis auto for partial flex prop values [ED-25496]

### DIFF
--- a/modules/atomic-widgets/props-resolver/transformers/styles/flex-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/styles/flex-transformer.php
@@ -10,6 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Flex_Transformer extends Transformer_Base {
+	const DEFAULT_FLEX_GROW = 0;
+	const DEFAULT_FLEX_SHRINK = 1;
+	const DEFAULT_FLEX_BASIS = 'auto';
+
 	public function transform( $value, Props_Resolver_Context $context ) {
 		$grow = $value['flexGrow'] ?? null;
 		$shrink = $value['flexShrink'] ?? null;
@@ -23,45 +27,13 @@ class Flex_Transformer extends Transformer_Base {
 			return null;
 		}
 
-		$basis_value = $this->transform_basis_value( $basis );
+		$grow_out = $has_grow ? $grow : self::DEFAULT_FLEX_GROW;
+		$shrink_out = $has_shrink ? $shrink : self::DEFAULT_FLEX_SHRINK;
+		$basis_out = $has_basis ? $this->transform_basis_value( $basis ) : self::DEFAULT_FLEX_BASIS;
 
-		if ( $has_grow && $has_shrink && $has_basis ) {
-			return "{$grow} {$shrink} {$basis_value}";
-		}
-
-		if ( $has_grow && $has_shrink && ! $has_basis ) {
-			return "{$grow} {$shrink}";
-		}
-
-		if ( $has_grow && ! $has_shrink && $has_basis ) {
-			return "{$grow} 1 {$basis_value}";
-		}
-
-		if ( ! $has_grow && $has_shrink && $has_basis ) {
-			return "0 {$shrink} {$basis_value}";
-		}
-
-		if ( $has_grow && ! $has_shrink && ! $has_basis ) {
-			return "{$grow}";
-		}
-
-		if ( ! $has_grow && $has_shrink && ! $has_basis ) {
-			return "0 {$shrink}";
-		}
-
-		if ( ! $has_grow && ! $has_shrink && $has_basis ) {
-			return "0 1 {$basis_value}";
-		}
-
-		return null;
+		return "{$grow_out} {$shrink_out} {$basis_out}";
 	}
 
-	/**
-	 * Transform basis value to string format
-	 *
-	 * @param mixed $basis The basis value
-	 * @return string
-	 */
 	private function transform_basis_value( $basis ) {
 		if ( is_array( $basis ) && isset( $basis['size'] ) ) {
 			$unit = $basis['unit'] ?? '';

--- a/packages/packages/core/editor-canvas/src/__tests__/flex-transformer.test.ts
+++ b/packages/packages/core/editor-canvas/src/__tests__/flex-transformer.test.ts
@@ -68,7 +68,7 @@ describe( 'flexTransformer', () => {
 	} );
 
 	describe( 'when only two values are provided', () => {
-		it( 'should return "grow shrink" when grow and shrink are set', () => {
+		it( 'should return "grow shrink auto" when grow and shrink are set', () => {
 			// Arrange.
 			const value: Flex = {
 				flexGrow: 1,
@@ -80,7 +80,7 @@ describe( 'flexTransformer', () => {
 			const result = flexTransformer( value, { key: 'flex' } );
 
 			// Assert.
-			expect( result ).toBe( '1 2' );
+			expect( result ).toBe( '1 2 auto' );
 		} );
 
 		it( 'should return "grow 1 basis" when grow and basis are set', () => {
@@ -115,7 +115,7 @@ describe( 'flexTransformer', () => {
 	} );
 
 	describe( 'when only one value is provided', () => {
-		it( 'should return "grow" when only grow is set', () => {
+		it( 'should return "grow 1 auto" when only grow is set', () => {
 			// Arrange.
 			const value: Flex = {
 				flexGrow: 1,
@@ -127,10 +127,10 @@ describe( 'flexTransformer', () => {
 			const result = flexTransformer( value, { key: 'flex' } );
 
 			// Assert.
-			expect( result ).toBe( '1' );
+			expect( result ).toBe( '1 1 auto' );
 		} );
 
-		it( 'should return "0 shrink" when only shrink is set', () => {
+		it( 'should return "0 shrink auto" when only shrink is set', () => {
 			// Arrange.
 			const value: Flex = {
 				flexGrow: null,
@@ -142,7 +142,7 @@ describe( 'flexTransformer', () => {
 			const result = flexTransformer( value, { key: 'flex' } );
 
 			// Assert.
-			expect( result ).toBe( '0 2' );
+			expect( result ).toBe( '0 2 auto' );
 		} );
 
 		it( 'should return "0 1 basis" when only basis is set', () => {
@@ -238,8 +238,8 @@ describe( 'flexTransformer', () => {
 		} );
 	} );
 
-	describe( 'CSS shorthand behavior', () => {
-		it( 'should follow CSS flex shorthand rules for single value', () => {
+	describe( 'CSS initial values for omitted longhands', () => {
+		it( 'should default shrink and basis when only grow is set', () => {
 			// Arrange.
 			const value: Flex = {
 				flexGrow: 2,
@@ -251,10 +251,10 @@ describe( 'flexTransformer', () => {
 			const result = flexTransformer( value, { key: 'flex' } );
 
 			// Assert.
-			expect( result ).toBe( '2' );
+			expect( result ).toBe( '2 1 auto' );
 		} );
 
-		it( 'should follow CSS flex shorthand rules for two values', () => {
+		it( 'should default basis when grow and shrink are set', () => {
 			// Arrange.
 			const value: Flex = {
 				flexGrow: 1,
@@ -266,7 +266,7 @@ describe( 'flexTransformer', () => {
 			const result = flexTransformer( value, { key: 'flex' } );
 
 			// Assert.
-			expect( result ).toBe( '1 2' );
+			expect( result ).toBe( '1 2 auto' );
 		} );
 	} );
 } );

--- a/packages/packages/core/editor-canvas/src/transformers/styles/flex-transformer.ts
+++ b/packages/packages/core/editor-canvas/src/transformers/styles/flex-transformer.ts
@@ -6,6 +6,13 @@ type Flex = {
 	flexBasis?: { size: number; unit: string } | string | null;
 };
 
+const DEFAULT_FLEX_GROW = 0;
+const DEFAULT_FLEX_SHRINK = 1;
+const DEFAULT_FLEX_BASIS = 'auto';
+
+const formatBasis = ( basis: NonNullable< Flex[ 'flexBasis' ] > ) =>
+	typeof basis === 'object' && basis.size !== undefined ? `${ basis.size }${ basis.unit || '' }` : basis;
+
 export const flexTransformer = createTransformer( ( value: Flex ) => {
 	const grow = value.flexGrow;
 	const shrink = value.flexShrink;
@@ -19,37 +26,9 @@ export const flexTransformer = createTransformer( ( value: Flex ) => {
 		return null;
 	}
 
-	if ( hasGrow && hasShrink && hasBasis ) {
-		return `${ grow } ${ shrink } ${
-			typeof basis === 'object' && basis.size !== undefined ? `${ basis.size }${ basis.unit || '' }` : basis
-		}`;
-	}
+	const growOut = hasGrow ? grow : DEFAULT_FLEX_GROW;
+	const shrinkOut = hasShrink ? shrink : DEFAULT_FLEX_SHRINK;
+	const basisOut = hasBasis ? formatBasis( basis ) : DEFAULT_FLEX_BASIS;
 
-	if ( hasGrow && hasShrink && ! hasBasis ) {
-		return `${ grow } ${ shrink }`;
-	}
-	if ( hasGrow && ! hasShrink && hasBasis ) {
-		return `${ grow } 1 ${
-			typeof basis === 'object' && basis.size !== undefined ? `${ basis.size }${ basis.unit || '' }` : basis
-		}`;
-	}
-	if ( ! hasGrow && hasShrink && hasBasis ) {
-		return `0 ${ shrink } ${
-			typeof basis === 'object' && basis.size !== undefined ? `${ basis.size }${ basis.unit || '' }` : basis
-		}`;
-	}
-
-	if ( hasGrow && ! hasShrink && ! hasBasis ) {
-		return `${ grow }`;
-	}
-	if ( ! hasGrow && hasShrink && ! hasBasis ) {
-		return `0 ${ shrink }`;
-	}
-	if ( ! hasGrow && ! hasShrink && hasBasis ) {
-		return `0 1 ${
-			typeof basis === 'object' && basis.size !== undefined ? `${ basis.size }${ basis.unit || '' }` : basis
-		}`;
-	}
-
-	return null;
+	return `${ growOut } ${ shrinkOut } ${ basisOut }`;
 } );

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render_atomic_widget_styles__append_css_of_styles_with_flex_partial_values__1.txt
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/__snapshots__/Test_Styles_Renderer__test_render_atomic_widget_styles__append_css_of_styles_with_flex_partial_values__1.txt
@@ -1,1 +1,1 @@
-.test-style-grow-only{flex:2;}.test-style-grow-shrink{flex:1 2;}.test-style-basis-only{flex:0 1 100px;}
+.test-style-grow-only{flex:2 1 auto;}.test-style-grow-shrink{flex:1 2 auto;}.test-style-basis-only{flex:0 1 100px;}

--- a/tests/phpunit/elementor/modules/atomic-widgets/styles/test-styles-renderer.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/styles/test-styles-renderer.php
@@ -1439,6 +1439,32 @@ class Test_Styles_Renderer extends Elementor_Test_Base {
 		$this->assertMatchesSnapshot( $css );
 	}
 
+	public function test_render_atomic_widget_styles__flex_shrink_only_preserves_basis_auto() {
+		// Arrange.
+		$styles = [
+			[
+				'id' => 'test-style-shrink-only',
+				'type' => 'class',
+				'variants' => [
+					[
+						'props' => [
+							'flex' => Props_Factory::flex( null, 0 ),
+						],
+						'meta' => [],
+					],
+				],
+			],
+		];
+
+		$stylesRenderer = Styles_Renderer::make( [], '' );
+
+		// Act.
+		$css = $stylesRenderer->render( $styles );
+
+		// Assert.
+		$this->assertSame( '.test-style-shrink-only{flex:0 0 auto;}', $css );
+	}
+
 	public function test_render__style_variant_with_custom_css() {
 		// Arrange.
 		$styles = [


### PR DESCRIPTION
## Summary
- Fix render-time `Flex_Transformer` (PHP + editor-canvas TS) to always emit a full 3-value `flex` shorthand with CSS initial values for unauthored longhands (`grow=0`, `shrink=1`, `basis=auto`).
- Prevents lone `flex-shrink` (e.g. from MCP/css-to-atomic) from rendering `flex: 0 0`, which browsers resolve to `flex-basis: 0` and collapses elements to zero width.
- Add PHPUnit regression for shrink-only partial flex props; update Jest and styles-renderer snapshot expectations.

## Test plan
- [x] `npx jest --config='./packages/jest.config.js' packages/packages/core/editor-canvas/src/__tests__/flex-transformer.test.ts`
- [x] `composer run test -- --filter Test_Styles_Renderer`
- [ ] Apply `flex-shrink: 0` via MCP on an `e-flexbox` element and confirm frontend computed `flex-basis` is `auto` and intrinsic width is preserved

Fixes https://elementor.atlassian.net/browse/ED-25496

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Fixes ED-25496 where partial flex properties omitted the `flex-basis: auto` default, causing inconsistent CSS shorthand output. The goal is to ensure the `flex` shorthand always expands to a full three-value declaration.

## 2. What Changed (Where)
* `flex-transformer.php`: Replaced conditional logic with constant defaults for grow, shrink, and basis.
* `flex-transformer.ts`: Mirrored PHP logic to use explicit defaults for TypeScript transformer.
* `test-styles-renderer.php` & `flex-transformer.test.ts`: Updated tests to assert full three-value shorthand.

## 3. How It Works
The transformers now identify if any flex property is present; if so, they apply `DEFAULT_FLEX_GROW (0)`, `DEFAULT_FLEX_SHRINK (1)`, and `DEFAULT_FLEX_BASIS ('auto')` to any missing values before returning a concatenated string.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
