### PR TITLE
Fix: Preserve global-class styles across component document switches [ED-25509]

### DIFF
--- a/packages/packages/core/editor-components/src/init.ts
+++ b/packages/packages/core/editor-components/src/init.ts
@@ -24,6 +24,7 @@ import { LoadTemplateComponents } from './components/load-template-components';
 import { COMPONENT_WIDGET_TYPE, createComponentType } from './create-component-type';
 import { PopulateStore } from './populate-store';
 import { initCircularNestingPrevention } from './prevent-circular-nesting';
+import { loadAncestorDocumentsAssets } from './store/actions/load-ancestor-documents-assets';
 import { loadComponentsAssets } from './store/actions/load-components-assets';
 import { removeComponentStyles } from './store/actions/remove-component-styles';
 import { slice } from './store/store';
@@ -66,6 +67,7 @@ export function init() {
 		removeComponentStyles( id );
 
 		void loadComponentsAssets( ( config?.elements as V1ElementData[] ) ?? [] );
+		void loadAncestorDocumentsAssets();
 	} );
 
 	embeddedDocumentsManager.onDocumentLoad( ( _documentId, data ) => {

--- a/packages/packages/core/editor-components/src/store/actions/__tests__/load-ancestor-documents-assets.test.ts
+++ b/packages/packages/core/editor-components/src/store/actions/__tests__/load-ancestor-documents-assets.test.ts
@@ -1,0 +1,98 @@
+import { getV1DocumentsManager } from '@elementor/editor-documents';
+import { embeddedDocumentsManager } from '@elementor/editor-embedded-documents-manager';
+import { __getState as getState } from '@elementor/store';
+
+import { getComponentDocumentData } from '../../../utils/component-document-data';
+import { loadAncestorDocumentsAssets } from '../load-ancestor-documents-assets';
+
+jest.mock( '@elementor/store', () => ( {
+	...jest.requireActual( '@elementor/store' ),
+	__getState: jest.fn(),
+} ) );
+
+jest.mock( '@elementor/editor-documents' );
+jest.mock( '@elementor/editor-embedded-documents-manager' );
+jest.mock( '../../../utils/component-document-data' );
+
+const INITIAL_PAGE_ID = 100;
+const OUTER_COMPONENT_ID = 200;
+const INNER_COMPONENT_ID = 300;
+
+function mockState( currentComponentId: number | null, pathIds: number[] ) {
+	jest.mocked( getState ).mockReturnValue( {
+		components: {
+			currentComponentId,
+			path: pathIds.map( ( componentId ) => ( { componentId } ) ),
+		},
+	} );
+}
+
+describe( 'loadAncestorDocumentsAssets', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		jest.mocked( getV1DocumentsManager ).mockReturnValue( {
+			getInitialId: () => INITIAL_PAGE_ID,
+		} as ReturnType< typeof getV1DocumentsManager > );
+
+		jest.mocked( getComponentDocumentData ).mockImplementation( ( id ) =>
+			Promise.resolve( { id, elements: [] } as unknown as Awaited<
+				ReturnType< typeof getComponentDocumentData >
+			> )
+		);
+	} );
+
+	it( 'does nothing when no component is being edited', async () => {
+		// Arrange
+		mockState( null, [] );
+
+		// Act
+		await loadAncestorDocumentsAssets();
+
+		// Assert
+		expect( getComponentDocumentData ).not.toHaveBeenCalled();
+		expect( embeddedDocumentsManager.setDocument ).not.toHaveBeenCalled();
+	} );
+
+	it( 'seeds initial page doc when editing a top-level component', async () => {
+		// Arrange
+		mockState( OUTER_COMPONENT_ID, [ OUTER_COMPONENT_ID ] );
+
+		// Act
+		await loadAncestorDocumentsAssets();
+
+		// Assert
+		expect( getComponentDocumentData ).toHaveBeenCalledTimes( 1 );
+		expect( getComponentDocumentData ).toHaveBeenCalledWith( INITIAL_PAGE_ID );
+		expect( embeddedDocumentsManager.setDocument ).toHaveBeenCalledWith(
+			INITIAL_PAGE_ID,
+			expect.objectContaining( { id: INITIAL_PAGE_ID } )
+		);
+	} );
+
+	it( 'seeds initial page + outer component when editing a nested component', async () => {
+		// Arrange
+		mockState( INNER_COMPONENT_ID, [ OUTER_COMPONENT_ID, INNER_COMPONENT_ID ] );
+
+		// Act
+		await loadAncestorDocumentsAssets();
+
+		// Assert
+		expect( getComponentDocumentData ).toHaveBeenCalledWith( INITIAL_PAGE_ID );
+		expect( getComponentDocumentData ).toHaveBeenCalledWith( OUTER_COMPONENT_ID );
+		expect( getComponentDocumentData ).not.toHaveBeenCalledWith( INNER_COMPONENT_ID );
+		expect( embeddedDocumentsManager.setDocument ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'skips docs that failed to load', async () => {
+		// Arrange
+		mockState( OUTER_COMPONENT_ID, [ OUTER_COMPONENT_ID ] );
+		jest.mocked( getComponentDocumentData ).mockResolvedValueOnce( null );
+
+		// Act
+		await loadAncestorDocumentsAssets();
+
+		// Assert
+		expect( embeddedDocumentsManager.setDocument ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/packages/core/editor-components/src/store/actions/load-ancestor-documents-assets.ts
+++ b/packages/packages/core/editor-components/src/store/actions/load-ancestor-documents-assets.ts
@@ -1,0 +1,42 @@
+import { getV1DocumentsManager } from '@elementor/editor-documents';
+import { embeddedDocumentsManager } from '@elementor/editor-embedded-documents-manager';
+import { __getState as getState } from '@elementor/store';
+
+import { type ComponentsSlice, selectCurrentComponentId, selectPath } from '../../store/store';
+import { getComponentDocumentData } from '../../utils/component-document-data';
+
+export async function loadAncestorDocumentsAssets() {
+	const ancestorIds = getAncestorDocumentIds();
+
+	if ( ancestorIds.length === 0 ) {
+		return;
+	}
+
+	await Promise.all(
+		ancestorIds.map( async ( id ) => {
+			const document = await getComponentDocumentData( id );
+
+			if ( document ) {
+				embeddedDocumentsManager.setDocument( id, document );
+			}
+		} )
+	);
+}
+
+function getAncestorDocumentIds(): number[] {
+	const state = getState() as ComponentsSlice;
+	const currentComponentId = selectCurrentComponentId( state );
+
+	if ( currentComponentId === null ) {
+		return [];
+	}
+
+	const path = selectPath( state );
+	const pathAncestors = path
+		.filter( ( item ) => item.componentId !== currentComponentId )
+		.map( ( item ) => item.componentId );
+
+	const initialId = getV1DocumentsManager().getInitialId();
+
+	return [ ...new Set( [ initialId, ...pathAncestors ] ) ];
+}

--- a/packages/packages/core/editor-global-classes/src/__tests__/load-document-classes.test.ts
+++ b/packages/packages/core/editor-global-classes/src/__tests__/load-document-classes.test.ts
@@ -1,11 +1,20 @@
+import { getV1CurrentDocument } from '@elementor/editor-documents';
+
 import { apiClient } from '../api';
-import { addDocumentClasses } from '../load-document-classes';
+import { addDocumentClasses, loadCurrentDocumentClasses } from '../load-document-classes';
+
+jest.mock( '@elementor/editor-documents' );
 
 jest.mock( '../api', () => ( {
 	apiClient: {
 		all: jest.fn(),
 		getStylesForPost: jest.fn(),
 	},
+} ) );
+
+jest.mock( '@elementor/store', () => ( {
+	...jest.requireActual( '@elementor/store' ),
+	__dispatch: jest.fn(),
 } ) );
 
 describe( 'addDocumentClasses', () => {
@@ -21,5 +30,29 @@ describe( 'addDocumentClasses', () => {
 
 		expect( mockGetStylesForPost ).toHaveBeenCalledWith( 99, 'preview' );
 		expect( mockGetStylesForPost ).toHaveBeenCalledWith( 99, 'frontend' );
+	} );
+} );
+
+describe( 'loadCurrentDocumentClasses', () => {
+	const mockAll = jest.mocked( apiClient.all );
+	const mockGetStylesForPost = jest.mocked( apiClient.getStylesForPost );
+	const mockGetV1CurrentDocument = jest.mocked( getV1CurrentDocument );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockAll.mockResolvedValue( { data: { data: [] } } as never );
+		mockGetStylesForPost.mockResolvedValue( { data: { data: {} } } as never );
+	} );
+
+	it( 'reads the current document from the V1 documents manager (fresh at attach-preview time)', async () => {
+		// Arrange - V1 already reflects the new doc during attach-preview
+		mockGetV1CurrentDocument.mockReturnValue( { id: 123 } as never );
+
+		// Act
+		await loadCurrentDocumentClasses();
+
+		// Assert - classes are fetched for the current V1 doc, not a stale V2 one
+		expect( mockGetStylesForPost ).toHaveBeenCalledWith( 123, 'preview' );
+		expect( mockGetStylesForPost ).toHaveBeenCalledWith( 123, 'frontend' );
 	} );
 } );

--- a/packages/packages/core/editor-global-classes/src/__tests__/store.test.ts
+++ b/packages/packages/core/editor-global-classes/src/__tests__/store.test.ts
@@ -159,6 +159,67 @@ describe( 'store', () => {
 		} );
 	} );
 
+	describe( 'load', () => {
+		it( 'preserves already-loaded class definitions when the payload has empty items (no flash on doc switch)', () => {
+			// Arrange - simulate a doc that has classes already loaded into data.items
+			const existing = createMockStyleDefinition( { id: 'existing', label: 'Existing' } );
+			const order = [ 'existing' ];
+
+			dispatch(
+				slice.actions.load( {
+					frontend: { items: { existing }, order },
+					preview: { items: { existing }, order },
+					classLabels: classLabelsFor( order, { existing } ),
+				} )
+			);
+
+			// Act - the "reset order/labels baseline" step of loadCurrentDocumentClasses
+			// dispatches load({items: {}, order: freshOrder}) before the current doc's items arrive.
+			// Without item preservation this wiped state.data.items and caused a visible flash.
+			dispatch(
+				slice.actions.load( {
+					frontend: { items: {}, order },
+					preview: { items: {}, order },
+					classLabels: classLabelsFor( order, { existing } ),
+				} )
+			);
+
+			// Assert - definition survived the reset step; class order/labels are still fresh.
+			const data = selectData( getState() );
+			expect( data.items ).toEqual( { existing } );
+			expect( data.order ).toEqual( order );
+			expect( selectClassLabels( getState() ) ).toEqual( { existing: existing.label } );
+		} );
+
+		it( 'lets fresh payload items override stale ones on subsequent loads', () => {
+			// Arrange - a class is already loaded with an older label
+			const stale = createMockStyleDefinition( { id: 'shared', label: 'Old' } );
+			const order = [ 'shared' ];
+
+			dispatch(
+				slice.actions.load( {
+					frontend: { items: { shared: stale }, order },
+					preview: { items: { shared: stale }, order },
+					classLabels: classLabelsFor( order, { shared: stale } ),
+				} )
+			);
+
+			// Act - re-load with a fresh definition for the same id
+			const fresh = createMockStyleDefinition( { id: 'shared', label: 'New' } );
+			dispatch(
+				slice.actions.load( {
+					frontend: { items: { shared: fresh }, order },
+					preview: { items: { shared: fresh }, order },
+					classLabels: classLabelsFor( order, { shared: fresh } ),
+				} )
+			);
+
+			// Assert - fresh values win over stale ones during the merge
+			expect( selectData( getState() ).items ).toEqual( { shared: fresh } );
+			expect( selectClassLabels( getState() ) ).toEqual( { shared: fresh.label } );
+		} );
+	} );
+
 	describe( 'updateAfterTemplateImport', () => {
 		it( 'should add imported classes to all data sources without resetting existing data', () => {
 			// Arrange - simulate initial state with existing classes

--- a/packages/packages/core/editor-global-classes/src/components/__tests__/logic-hooks.test.tsx
+++ b/packages/packages/core/editor-global-classes/src/components/__tests__/logic-hooks.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createMockHttpResponse, createMockStyleDefinition, renderWithStore } from 'test-utils';
-import { getCurrentDocument } from '@elementor/editor-documents';
+import { getV1CurrentDocument } from '@elementor/editor-documents';
 import { type HttpResponse } from '@elementor/http-client';
 import { __createStore as createStore, __registerSlice as registerSlice } from '@elementor/store';
 import { waitFor } from '@testing-library/react';
@@ -18,7 +18,7 @@ jest.mock( '../../api', () => ( {
 } ) );
 
 jest.mock( '@elementor/editor-documents', () => ( {
-	getCurrentDocument: jest.fn(),
+	getV1CurrentDocument: jest.fn(),
 } ) );
 
 jest.mock( '@elementor/editor-v1-adapters', () => ( {
@@ -32,7 +32,7 @@ describe( '<LogicHooks />', () => {
 	beforeEach( () => {
 		registerSlice( slice );
 		store = createStore();
-		jest.mocked( getCurrentDocument ).mockReturnValue( { id: 1 } as never );
+		jest.mocked( getV1CurrentDocument ).mockReturnValue( { id: 1 } as never );
 	} );
 
 	it( 'should load document classes on mount', async () => {

--- a/packages/packages/core/editor-global-classes/src/load-document-classes.ts
+++ b/packages/packages/core/editor-global-classes/src/load-document-classes.ts
@@ -1,4 +1,4 @@
-import { getCurrentDocument } from '@elementor/editor-documents';
+import { getV1CurrentDocument } from '@elementor/editor-documents';
 import { type StyleDefinition, type StyleDefinitionID } from '@elementor/editor-styles';
 import { __dispatch as dispatch } from '@elementor/store';
 
@@ -43,7 +43,7 @@ export async function loadCurrentDocumentClasses() {
 	// without it we won't be able to properly resolve the styles' class names
 	resetGlobalClassesState( previewOrder, classLabels );
 
-	const postId = getCurrentDocument()?.id;
+	const postId = getV1CurrentDocument()?.id;
 	if ( ! postId ) {
 		return;
 	}

--- a/packages/packages/core/editor-global-classes/src/store.ts
+++ b/packages/packages/core/editor-global-classes/src/store.ts
@@ -74,8 +74,17 @@ export const slice = createSlice( {
 		) {
 			state.initialData.frontend = frontend;
 			state.initialData.preview = preview;
-			state.data = preview;
-			state.classLabels = classLabels;
+
+			// Merge (instead of replace) so definitions previously loaded for other documents
+			// (e.g. embedded components rendered on the current page) don't disappear between
+			// the "reset order/labels" step and the "load current document items" step in
+			// loadCurrentDocumentClasses. Fresh values in the payload always win.
+			state.data = {
+				items: { ...state.data.items, ...preview.items },
+				order: preview.order,
+			};
+
+			state.classLabels = { ...state.classLabels, ...classLabels };
 
 			state.isDirty = false;
 		},


### PR DESCRIPTION
## Summary

When entering or exiting edit mode of a component (including a nested component), classes applied on the main page were losing their styling — flashing off during the switch, and in some paths staying unstyled until the editor was reloaded. This PR fixes two runtime-state defects and one missing repopulation path.

## Root causes

1. **Stale current-document read on `attach-preview`.** `loadCurrentDocumentClasses` was reading the current document from the V2 documents store via `getCurrentDocument()`. V2's `activeId` is only synced from V1 on `editor/documents/open` (see `syncActiveDocument` in `editor-documents/src/sync/sync-store.ts`), but `editor/documents/open` fires *after* `editor/documents/attach-preview`. So at attach-preview time V2 still returned the previous document — the hook fetched classes for the wrong post, wiped state, and repopulated with those wrong classes. Result: classes on the doc we just switched *to* were dropped.
2. **Item wipe caused a visible flash.** `loadCurrentDocumentClasses` did a two-step dispatch — first a "reset order/labels baseline" `load({ items: {}, ... })`, then a final `load({ items: currentDocItems, ... })`. Because `slice.actions.load` replaced `state.data` outright, `state.data.items` was empty in between the two dispatches for the duration of the styles ajax round-trip — every class rendered with an empty `placeholderDefinition`.
3. **Ancestor local styles were not re-registered.** `embeddedDocumentsManager.reset()` runs on every `attach-preview` and wipes the embedded-documents styles provider. Only components referenced from the *current* doc's `elements` were re-seeded, so main-page (and outer component) local styles disappeared while editing a nested component.

## Changes

- `editor-global-classes/load-document-classes.ts` — use `getV1CurrentDocument()` (fresh at attach-preview) instead of V2's `getCurrentDocument()` (stale until `open`). Same pattern `editor-components/init.ts` already uses.
- `editor-global-classes/store.ts` — `slice.actions.load` now merges `state.data.items` and `state.classLabels` with the payload instead of replacing them. Order and `initialData` still come from the payload (order is the authoritative live list; `initialData` is the undo baseline). Fresh values in the payload win over stale entries. Bounded memory (`MAX_CLASSES = 1000` in `globalClassesStylesProvider`).
- `editor-components/init.ts` + new `store/actions/load-ancestor-documents-assets.ts` — on every `attach-preview`, seed the initial page doc plus every component in the current path (except the current one) into the embedded-documents manager so their local styles land in the embedded-documents styles provider. Uses `getComponentDocumentData` which shares its ajax cache with the V1 documents manager, so no extra network round-trips.

## Test plan

- Unit: `editor-global-classes` (110/110) and `editor-components` (240/240) suites pass locally.
- New unit tests:
  - `store.test.ts` — `load` preserves already-loaded definitions when the payload has empty items (direct regression for the flash); fresh payload wins over stale entries.
  - `load-document-classes.test.ts` — `loadCurrentDocumentClasses` reads from `getV1CurrentDocument`.
  - `load-ancestor-documents-assets.test.ts` — no-op when no component is being edited; seeds initial page for top-level component edit; seeds initial + outer for nested; skips docs that fail to load.
- Manual acceptance:
  - Enter edit mode of a top-level component from a page that uses global classes → main page classes stay applied, no flash.
  - Enter edit mode of a nested component (component inside another component) → main page and outer component classes/local styles stay applied.
  - Exit nested → outer → main page: no flash, no dropped classes at any level.

## Related

- Jira: ED-25509

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
ED-25509: Prevents style "flashing" and loss of global-class definitions when switching between component documents by preserving existing style data during state updates.

## 2. What Changed (Where)
| File | Change |
| :--- | :--- |
| `init.ts` | Triggers ancestor document asset loading on init. |
| `load-ancestor-documents-assets.ts` | New: Fetches and seeds ancestor documents into the manager. |
| `load-document-classes.ts` | Switches to `getV1CurrentDocument` for fresh document ID retrieval. |
| `store.ts` | Updates `load` reducer to merge items/labels instead of replacing them. |
| `**/__tests__/**` | Added unit tests for ancestor loading and style preservation. |

## 3. How It Works
`init()` now calls `loadAncestorDocumentsAssets`, which identifies the document hierarchy via `selectPath` and seeds the `embeddedDocumentsManager`. In the global classes store, the `load` action now merges new style definitions into the existing `data.items` and `classLabels` maps, ensuring styles from nested components persist while the current document's styles are being fetched.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
