### PR TITLE
Internal: Cherry-pick to release/beta: Exclude components from import/export until full support [ED-25468]

### DIFF
--- a/app/modules/import-export-customization/processes/import.php
+++ b/app/modules/import-export-customization/processes/import.php
@@ -9,6 +9,7 @@ use Elementor\App\Modules\ImportExportCustomization\Compatibility\Customization;
 use Elementor\App\Modules\ImportExportCustomization\Utils;
 use Elementor\Core\Base\Document;
 use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\Components\Utils\Remap_Component_Instance_Ids;
 use Elementor\Plugin;
 
 use Elementor\App\Modules\ImportExportCustomization\Runners\Import\Elementor_Content;
@@ -784,6 +785,7 @@ class Import {
 			$document = Plugin::$instance->documents->get( $new_id );
 
 			if ( isset( $data['elements'] ) ) {
+				$data['elements'] = Remap_Component_Instance_Ids::apply( $data['elements'], $imported_data_replacements['post_ids'] ?? [] );
 				$data['elements'] = $document->on_import_update_dynamic_content( $data['elements'], $imported_data_replacements );
 			}
 

--- a/app/modules/import-export-customization/processes/import.php
+++ b/app/modules/import-export-customization/processes/import.php
@@ -9,7 +9,7 @@ use Elementor\App\Modules\ImportExportCustomization\Compatibility\Customization;
 use Elementor\App\Modules\ImportExportCustomization\Utils;
 use Elementor\Core\Base\Document;
 use Elementor\Core\Kits\Documents\Kit;
-use Elementor\Modules\Components\Utils\Remap_Component_Instance_Ids;
+use Elementor\Modules\Components\Module as Components_Module;
 use Elementor\Plugin;
 
 use Elementor\App\Modules\ImportExportCustomization\Runners\Import\Elementor_Content;
@@ -785,7 +785,7 @@ class Import {
 			$document = Plugin::$instance->documents->get( $new_id );
 
 			if ( isset( $data['elements'] ) ) {
-				$data['elements'] = Remap_Component_Instance_Ids::apply( $data['elements'], $imported_data_replacements['post_ids'] ?? [] );
+				$data['elements'] = Components_Module::prepare_imported_elements( $data['elements'], $imported_data_replacements['post_ids'] ?? [] );
 				$data['elements'] = $document->on_import_update_dynamic_content( $data['elements'], $imported_data_replacements );
 			}
 

--- a/app/modules/import-export-customization/runners/export/elementor-content.php
+++ b/app/modules/import-export-customization/runners/export/elementor-content.php
@@ -3,6 +3,7 @@
 namespace Elementor\App\Modules\ImportExportCustomization\Runners\Export;
 
 use Elementor\App\Modules\ImportExportCustomization\Utils as ImportExportUtils;
+use Elementor\Modules\Components\Module as Components_Module;
 use Elementor\Plugin;
 
 class Elementor_Content extends Export_Runner_Base {
@@ -31,6 +32,8 @@ class Elementor_Content extends Export_Runner_Base {
 		if ( $selected_custom_post_types && ! in_array( 'post', $selected_custom_post_types, true ) ) {
 			$excluded_post_types[] = 'post';
 		}
+
+		$excluded_post_types = array_merge( $excluded_post_types, Components_Module::excluded_import_export_post_types() );
 
 		$elementor_post_types = ImportExportUtils::get_elementor_post_types( $excluded_post_types );
 

--- a/app/modules/import-export-customization/runners/import/elementor-content.php
+++ b/app/modules/import-export-customization/runners/import/elementor-content.php
@@ -2,6 +2,7 @@
 namespace Elementor\App\Modules\ImportExportCustomization\Runners\Import;
 
 use Elementor\App\Modules\ImportExportCustomization\Utils as ImportExportUtils;
+use Elementor\Modules\Components\Module as Components_Module;
 use Elementor\Plugin;
 
 class Elementor_Content extends Import_Runner_Base {
@@ -56,6 +57,8 @@ class Elementor_Content extends Import_Runner_Base {
 		if ( $selected_custom_post_types && ! in_array( 'post', $selected_custom_post_types, true ) ) {
 			$excluded_post_types[] = 'post';
 		}
+
+		$excluded_post_types = array_merge( $excluded_post_types, Components_Module::excluded_import_export_post_types() );
 
 		$post_types = ImportExportUtils::get_elementor_post_types( $excluded_post_types );
 

--- a/app/modules/import-export/processes/import.php
+++ b/app/modules/import-export/processes/import.php
@@ -8,6 +8,7 @@ use Elementor\App\Modules\ImportExport\Compatibility\Kit_Library;
 use Elementor\App\Modules\ImportExport\Utils;
 use Elementor\Core\Base\Document;
 use Elementor\Core\Kits\Documents\Kit;
+use Elementor\Modules\Components\Utils\Remap_Component_Instance_Ids;
 use Elementor\Plugin;
 
 use Elementor\App\Modules\ImportExport\Runners\Import\Elementor_Content;
@@ -740,6 +741,7 @@ class Import {
 			$document = Plugin::$instance->documents->get( $new_id );
 
 			if ( isset( $data['elements'] ) ) {
+				$data['elements'] = Remap_Component_Instance_Ids::apply( $data['elements'], $imported_data_replacements['post_ids'] ?? [] );
 				$data['elements'] = $document->on_import_update_dynamic_content( $data['elements'], $imported_data_replacements );
 			}
 

--- a/app/modules/import-export/processes/import.php
+++ b/app/modules/import-export/processes/import.php
@@ -8,7 +8,7 @@ use Elementor\App\Modules\ImportExport\Compatibility\Kit_Library;
 use Elementor\App\Modules\ImportExport\Utils;
 use Elementor\Core\Base\Document;
 use Elementor\Core\Kits\Documents\Kit;
-use Elementor\Modules\Components\Utils\Remap_Component_Instance_Ids;
+use Elementor\Modules\Components\Module as Components_Module;
 use Elementor\Plugin;
 
 use Elementor\App\Modules\ImportExport\Runners\Import\Elementor_Content;
@@ -741,7 +741,7 @@ class Import {
 			$document = Plugin::$instance->documents->get( $new_id );
 
 			if ( isset( $data['elements'] ) ) {
-				$data['elements'] = Remap_Component_Instance_Ids::apply( $data['elements'], $imported_data_replacements['post_ids'] ?? [] );
+				$data['elements'] = Components_Module::prepare_imported_elements( $data['elements'], $imported_data_replacements['post_ids'] ?? [] );
 				$data['elements'] = $document->on_import_update_dynamic_content( $data['elements'], $imported_data_replacements );
 			}
 

--- a/app/modules/import-export/runners/export/elementor-content.php
+++ b/app/modules/import-export/runners/export/elementor-content.php
@@ -3,6 +3,7 @@
 namespace Elementor\App\Modules\ImportExport\Runners\Export;
 
 use Elementor\App\Modules\ImportExport\Utils as ImportExportUtils;
+use Elementor\Modules\Components\Module as Components_Module;
 use Elementor\Plugin;
 
 class Elementor_Content extends Export_Runner_Base {
@@ -24,7 +25,10 @@ class Elementor_Content extends Export_Runner_Base {
 	}
 
 	public function export( array $data ) {
-		$elementor_post_types = ImportExportUtils::get_elementor_post_types();
+		$elementor_post_types = array_diff(
+			ImportExportUtils::get_elementor_post_types(),
+			Components_Module::excluded_import_export_post_types()
+		);
 
 		$files = [];
 		$manifest = [];

--- a/app/modules/import-export/runners/import/elementor-content.php
+++ b/app/modules/import-export/runners/import/elementor-content.php
@@ -2,6 +2,7 @@
 namespace Elementor\App\Modules\ImportExport\Runners\Import;
 
 use Elementor\App\Modules\ImportExport\Utils as ImportExportUtils;
+use Elementor\Modules\Components\Module as Components_Module;
 use Elementor\Plugin;
 
 class Elementor_Content extends Import_Runner_Base {
@@ -33,7 +34,10 @@ class Elementor_Content extends Import_Runner_Base {
 		$result['content'] = [];
 		$this->import_session_id = $data['session_id'];
 
-		$elementor_post_types = ImportExportUtils::get_elementor_post_types();
+		$elementor_post_types = array_diff(
+			ImportExportUtils::get_elementor_post_types(),
+			Components_Module::excluded_import_export_post_types()
+		);
 
 		foreach ( $elementor_post_types as $post_type ) {
 			if ( empty( $data['manifest']['content'][ $post_type ] ) ) {

--- a/modules/components/module.php
+++ b/modules/components/module.php
@@ -16,6 +16,8 @@ use Elementor\Modules\Components\Transformers\Overridable_Transformer;
 use Elementor\Core\Base\Document;
 use Elementor\Modules\Components\PropTypes\Override_Prop_Type;
 use Elementor\Modules\Components\Transformers\Override_Transformer;
+use Elementor\Modules\Components\Utils\Remap_Component_Instance_Ids;
+use Elementor\Modules\Components\Utils\Strip_Component_Instances;
 use Elementor\Modules\Components\Variants\Component_Variant_Class_Collector;
 use Elementor\Modules\Components\Widgets\Component_Instance;
 use Elementor\Modules\Components\Schema\Overridable_LLM_Filter;
@@ -28,6 +30,22 @@ class Module extends BaseModule {
 	const EXPERIMENT_NAME = AtomicWidgetsModule::EXPERIMENT_NAME;
 	const EXPERIMENT_VARIANTS_NAME = 'e_component_variants';
 	const PACKAGES        = [ 'editor-components' ];
+
+	/**
+	 * Local kill switch for components import/export. Off by default: on export the
+	 * `elementor_component` post type is excluded, on import any `e-component` widgets
+	 * that survived from a foreign zip are stripped. Flip to `true` in the source
+	 * to unblock the flag-on branch when working on the real feature (`Remap_Component_Instance_Ids`
+	 * and its test cover that path today).
+	 *
+	 * Not an experiment on purpose: experiments are serialized into exported kits by
+	 * `Site_Settings::export_experiments()` and rehydrated on import, so a hidden experiment
+	 * here would let a source-site override silently turn the guard off on every destination site.
+	 *
+	 * Remove this constant, `is_import_export_supported()` and every `! is_import_export_supported()`
+	 * branch once components are a first-class part of import/export.
+	 */
+	const IS_IMPORT_EXPORT_SUPPORTED = false;
 
 	/**
 	 * Variants meta must be persisted before `Global_Classes_Relations::on_document_save()`
@@ -65,6 +83,7 @@ class Module extends BaseModule {
 				2
 			);
 		}
+
 		add_filter( 'elementor/global_classes/additional_post_types', fn( $post_types ) => array_merge( $post_types, [ Component_Document::TYPE ] ) );
 		add_filter( 'elementor/utils/find_element_recursive/inner_elements', fn( array $inner_elements, array $element_data ) => $this->get_inner_elements_for_search( $inner_elements, $element_data ), 10, 2 );
 
@@ -87,6 +106,34 @@ class Module extends BaseModule {
 
 	public static function is_variants_experiment_active(): bool {
 		return Plugin::$instance->experiments->is_feature_active( self::EXPERIMENT_VARIANTS_NAME );
+	}
+
+	public static function is_import_export_supported(): bool {
+		return self::IS_IMPORT_EXPORT_SUPPORTED;
+	}
+
+	/**
+	 * Single entry point for import runners to normalize the elements tree of an imported
+	 * document with respect to component instances. When components round-trip is enabled
+	 * (flag on) it rewrites source-site component ids to their destination-site equivalents;
+	 * when disabled (flag off) it strips any `e-component` widget that survived from a
+	 * legacy zip so the destination editor never opens a document with dangling instances.
+	 *
+	 * Kept as a static helper on the module so both `import-export-customization` and legacy
+	 * `import-export` import paths stay in sync when `IS_IMPORT_EXPORT_SUPPORTED` flips.
+	 */
+	public static function prepare_imported_elements( array $elements, array $post_ids_map ): array {
+		return self::is_import_export_supported()
+			? Remap_Component_Instance_Ids::apply( $elements, $post_ids_map )
+			: Strip_Component_Instances::apply( $elements );
+	}
+
+	/**
+	 * Post types that must be excluded from the import/export runners when components
+	 * round-trip is disabled. Same gating as `prepare_imported_elements()`.
+	 */
+	public static function excluded_import_export_post_types(): array {
+		return self::is_import_export_supported() ? [] : [ Component_Document::TYPE ];
 	}
 
 	/**

--- a/modules/components/prop-types/component-instance-prop-type.php
+++ b/modules/components/prop-types/component-instance-prop-type.php
@@ -30,6 +30,12 @@ class Component_Instance_Prop_Type extends Object_Prop_Type {
 		return $settings['component_instance']['value']['component_id']['value'];
 	}
 
+	public static function set_component_id( array $settings, int $component_id ): array {
+		$settings['component_instance']['value']['component_id']['value'] = $component_id;
+
+		return $settings;
+	}
+
 	public function validate_value( $value ): bool {
 		if ( ! parent::validate_value( $value ) ) {
 			return false;

--- a/modules/components/prop-types/component-instance-prop-type.php
+++ b/modules/components/prop-types/component-instance-prop-type.php
@@ -11,8 +11,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Component_Instance_Prop_Type extends Object_Prop_Type {
+	const WIDGET_TYPE = 'e-component';
+
 	public static function get_key(): string {
 		return 'component-instance';
+	}
+
+	public static function is_instance_element( array $element ): bool {
+		return 'widget' === ( $element['elType'] ?? null )
+			&& self::WIDGET_TYPE === ( $element['widgetType'] ?? null );
 	}
 
 	protected function define_shape(): array {

--- a/modules/components/utils/remap-component-instance-ids.php
+++ b/modules/components/utils/remap-component-instance-ids.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Elementor\Modules\Components\Utils;
+
+use Elementor\Modules\Components\PropTypes\Component_Instance_Prop_Type;
+use Elementor\Modules\Components\Widgets\Component_Instance;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Rewrites `component_id` inside every `e-component` widget in an elements tree
+ * so it points at the component post recreated on the destination site instead
+ * of the source-site post id that was serialized in the exported template.
+ *
+ * Used by both website-template (customization) and legacy kit import runners
+ * before documents are saved.
+ */
+class Remap_Component_Instance_Ids {
+	public static function apply( array $elements, array $post_ids_map ): array {
+		if ( empty( $post_ids_map ) ) {
+			return $elements;
+		}
+
+		return array_map(
+			function ( $element ) use ( $post_ids_map ) {
+				return self::remap_element( $element, $post_ids_map );
+			},
+			$elements
+		);
+	}
+
+	private static function remap_element( $element, array $post_ids_map ) {
+		if ( ! is_array( $element ) ) {
+			return $element;
+		}
+
+		if ( self::is_component_instance( $element ) ) {
+			$element['settings'] = self::remap_component_id( $element['settings'] ?? [], $post_ids_map );
+		}
+
+		if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
+			$element['elements'] = self::apply( $element['elements'], $post_ids_map );
+		}
+
+		return $element;
+	}
+
+	private static function is_component_instance( array $element ): bool {
+		return 'widget' === ( $element['elType'] ?? null )
+			&& Component_Instance::get_element_type() === ( $element['widgetType'] ?? null );
+	}
+
+	private static function remap_component_id( array $settings, array $post_ids_map ): array {
+		$source_id = Component_Instance_Prop_Type::extract_component_id( $settings );
+
+		if ( ! is_numeric( $source_id ) || ! isset( $post_ids_map[ (int) $source_id ] ) ) {
+			return $settings;
+		}
+
+		return Component_Instance_Prop_Type::set_component_id( $settings, (int) $post_ids_map[ (int) $source_id ] );
+	}
+}

--- a/modules/components/utils/remap-component-instance-ids.php
+++ b/modules/components/utils/remap-component-instance-ids.php
@@ -3,7 +3,6 @@
 namespace Elementor\Modules\Components\Utils;
 
 use Elementor\Modules\Components\PropTypes\Component_Instance_Prop_Type;
-use Elementor\Modules\Components\Widgets\Component_Instance;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -36,7 +35,7 @@ class Remap_Component_Instance_Ids {
 			return $element;
 		}
 
-		if ( self::is_component_instance( $element ) ) {
+		if ( Component_Instance_Prop_Type::is_instance_element( $element ) ) {
 			$element['settings'] = self::remap_component_id( $element['settings'] ?? [], $post_ids_map );
 		}
 
@@ -45,11 +44,6 @@ class Remap_Component_Instance_Ids {
 		}
 
 		return $element;
-	}
-
-	private static function is_component_instance( array $element ): bool {
-		return 'widget' === ( $element['elType'] ?? null )
-			&& Component_Instance::get_element_type() === ( $element['widgetType'] ?? null );
 	}
 
 	private static function remap_component_id( array $settings, array $post_ids_map ): array {

--- a/modules/components/utils/strip-component-instances.php
+++ b/modules/components/utils/strip-component-instances.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Elementor\Modules\Components\Utils;
+
+use Elementor\Modules\Components\PropTypes\Component_Instance_Prop_Type;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Removes every `e-component` widget from an elements tree.
+ *
+ * Used at import time when components round-trip is disabled, to clean up any dangling
+ * `e-component` widgets that survived from a zip exported before the flag or by an
+ * external site. Dangling instances would point at nonexistent component posts and
+ * either render empty or throw in the editor panel.
+ */
+class Strip_Component_Instances {
+	public static function apply( array $elements ): array {
+		$result = [];
+
+		foreach ( $elements as $element ) {
+			if ( ! is_array( $element ) ) {
+				$result[] = $element;
+				continue;
+			}
+
+			if ( Component_Instance_Prop_Type::is_instance_element( $element ) ) {
+				continue;
+			}
+
+			if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
+				$element['elements'] = self::apply( $element['elements'] );
+			}
+
+			$result[] = $element;
+		}
+
+		return $result;
+	}
+}

--- a/modules/components/widgets/component-instance.php
+++ b/modules/components/widgets/component-instance.php
@@ -18,7 +18,7 @@ class Component_Instance extends Atomic_Widget_Base {
 	use Has_Template;
 
 	public static function get_element_type(): string {
-		return 'e-component';
+		return Component_Instance_Prop_Type::WIDGET_TYPE;
 	}
 
 	public function show_in_panel() {

--- a/tests/phpunit/elementor/modules/components/utils/test-remap-component-instance-ids.php
+++ b/tests/phpunit/elementor/modules/components/utils/test-remap-component-instance-ids.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Elementor\Testing\Modules\Components\Utils;
+
+use Elementor\Modules\Components\Utils\Remap_Component_Instance_Ids;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Remap_Component_Instance_Ids extends Elementor_Test_Base {
+
+	const SOURCE_COMPONENT_ID = 93;
+	const DESTINATION_COMPONENT_ID = 167;
+	const UNMAPPED_COMPONENT_ID = 104;
+
+	public function test_apply__maps_nested_and_leaves_unmapped_untouched() {
+		// Arrange
+		$elements = [
+			[
+				'id' => 'loop-item',
+				'elType' => 'e-collection-loop-item',
+				'elements' => [
+					$this->make_component_instance_element( 'nested-component', self::SOURCE_COMPONENT_ID ),
+				],
+			],
+			$this->make_component_instance_element( 'standalone-component', self::UNMAPPED_COMPONENT_ID ),
+		];
+
+		$post_ids_map = [
+			self::SOURCE_COMPONENT_ID => self::DESTINATION_COMPONENT_ID,
+		];
+
+		// Act
+		$result = Remap_Component_Instance_Ids::apply( $elements, $post_ids_map );
+
+		// Assert
+		$this->assertSame(
+			self::DESTINATION_COMPONENT_ID,
+			$result[0]['elements'][0]['settings']['component_instance']['value']['component_id']['value']
+		);
+		$this->assertSame(
+			self::UNMAPPED_COMPONENT_ID,
+			$result[1]['settings']['component_instance']['value']['component_id']['value']
+		);
+	}
+
+	public function test_apply__empty_map_short_circuits() {
+		// Arrange
+		$elements = [
+			$this->make_component_instance_element( 'standalone-component', self::SOURCE_COMPONENT_ID ),
+		];
+
+		// Act
+		$result = Remap_Component_Instance_Ids::apply( $elements, [] );
+
+		// Assert
+		$this->assertSame( $elements, $result );
+	}
+
+	public function test_apply__ignores_non_component_widgets() {
+		// Arrange
+		$elements = [
+			[
+				'id' => 'button',
+				'elType' => 'widget',
+				'widgetType' => 'e-button',
+				'settings' => [ 'text' => 'Click' ],
+			],
+		];
+
+		// Act
+		$result = Remap_Component_Instance_Ids::apply( $elements, [ self::SOURCE_COMPONENT_ID => self::DESTINATION_COMPONENT_ID ] );
+
+		// Assert
+		$this->assertSame( $elements, $result );
+	}
+
+	private function make_component_instance_element( string $id, int $component_id ): array {
+		return [
+			'id' => $id,
+			'elType' => 'widget',
+			'widgetType' => 'e-component',
+			'settings' => [
+				'component_instance' => [
+					'$$type' => 'component-instance',
+					'value' => [
+						'component_id' => [
+							'$$type' => 'number',
+							'value' => $component_id,
+						],
+					],
+				],
+			],
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/components/utils/test-strip-component-instances.php
+++ b/tests/phpunit/elementor/modules/components/utils/test-strip-component-instances.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Elementor\Testing\Modules\Components\Utils;
+
+use Elementor\Modules\Components\Utils\Strip_Component_Instances;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @group Elementor\Modules\Components
+ */
+class Test_Strip_Component_Instances extends TestCase {
+
+	public function test_apply__removes_top_level_component_instances() {
+		// Arrange
+		$elements = [
+			$this->component_instance( 'ci-1' ),
+			$this->widget( 'button-1', 'e-button' ),
+			$this->component_instance( 'ci-2' ),
+		];
+
+		// Act
+		$result = Strip_Component_Instances::apply( $elements );
+
+		// Assert
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'button-1', $result[0]['id'] );
+	}
+
+	public function test_apply__removes_nested_component_instances_and_preserves_containers() {
+		// Arrange
+		$elements = [
+			[
+				'id' => 'container-1',
+				'elType' => 'container',
+				'elements' => [
+					$this->component_instance( 'ci-1' ),
+					$this->widget( 'heading-1', 'e-heading' ),
+					[
+						'id' => 'inner-container',
+						'elType' => 'container',
+						'elements' => [
+							$this->component_instance( 'ci-2' ),
+						],
+					],
+				],
+			],
+		];
+
+		// Act
+		$result = Strip_Component_Instances::apply( $elements );
+
+		// Assert
+		$this->assertCount( 1, $result );
+		$this->assertCount( 2, $result[0]['elements'] );
+		$this->assertSame( 'heading-1', $result[0]['elements'][0]['id'] );
+		$this->assertSame( 'inner-container', $result[0]['elements'][1]['id'] );
+		$this->assertSame( [], $result[0]['elements'][1]['elements'] );
+	}
+
+	public function test_apply__leaves_non_component_widgets_untouched() {
+		// Arrange
+		$elements = [ $this->widget( 'button-1', 'e-button' ) ];
+
+		// Act
+		$result = Strip_Component_Instances::apply( $elements );
+
+		// Assert
+		$this->assertSame( $elements, $result );
+	}
+
+	private function component_instance( string $id ): array {
+		return [
+			'id' => $id,
+			'elType' => 'widget',
+			'widgetType' => 'e-component',
+			'settings' => [],
+		];
+	}
+
+	private function widget( string $id, string $widget_type ): array {
+		return [
+			'id' => $id,
+			'elType' => 'widget',
+			'widgetType' => $widget_type,
+			'settings' => [],
+		];
+	}
+}


### PR DESCRIPTION
## Summary

Cherry-pick of [#37149](https://github.com/elementor/elementor/pull/37149) and [#37185](https://github.com/elementor/elementor/pull/37185) to `release/beta`.

- **#37149:** Remap `e-component` instance IDs on website template import (legacy + customization paths).
- **#37185:** Temporary exclude-only guard until full component import/export support lands — exclude `elementor_component` posts from kits, strip dangling `e-component` widgets on import, centralize via `Components_Module::prepare_imported_elements()`.

Supersedes the open [#37156](https://github.com/elementor/elementor/pull/37156) cherry-pick (37149 only), which did not include the follow-up exclude/strip behavior.

## Commits

1. `45edb5fd8b` — Fix: Remap e-component instance IDs on website template import [ED-25468] (#37149)
2. `7b9340f652` — Internal: Exclude components from import/export until full support [ED-25468] (#37185)

## Test plan

- [ ] Export a site with nested components — zip should not contain `elementor_component` posts.
- [ ] Import on a fresh site — no component posts created; `e-component` widgets stripped from imported pages.
- [ ] Import a legacy kit (with `e-component` widgets in JSON) — dangling instances stripped without panel errors.
- [ ] Run DB-less unit tests:
  - `tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/components/utils/test-remap-component-instance-ids.php`
  - `tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/components/utils/test-strip-component-instances.php`

Fixes ED-25468

Made with [Cursor](https://cursor.com)

[ED-25468]: https://elementor.atlassian.net/browse/ED-25468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ED-25468]: https://elementor.atlassian.net/browse/ED-25468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Prevents broken site states by excluding Components from import/export processes until full support is implemented (ED-25468). It ensures that unsupported `e-component` widgets are stripped on import rather than leaving dangling instances.

## 2. What Changed (Where)

| File | Change |
| :--- | :--- |
| `modules/components/module.php` | Added `IS_IMPORT_EXPORT_SUPPORTED` kill switch and gating logic. |
| `app/modules/import-export[...]/` | Integrated `Components_Module` to filter post types and prepare elements. |
| `modules/components/utils/` | New `Remap_Component_Instance_Ids` and `Strip_Component_Instances` utility classes. |
| `modules/components/prop-types/` | Added helpers to identify and modify `e-component` widgets. |
| `tests/phpunit/elementor/` | Added unit tests for remapping and stripping utilities. |

## 3. How It Works
The `Components_Module::IS_IMPORT_EXPORT_SUPPORTED` constant acts as a global toggle. When `false` (default), the import/export runners call `excluded_import_export_post_types()` to skip `Component_Document` types and `prepare_imported_elements()` to recursively strip any existing `e-component` widgets from the layout tree.

## 4. Risks
Data loss of component-based layouts during import/export while the feature is disabled; mitigated by the fact that the feature is not yet officially supported for these processes.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
