### PR TITLE
Tweak: Update Angie banner copy and card design [ED-25505]

### DIFF
--- a/packages/packages/core/editor-app-bar/src/extensions/angie/angie-consts.ts
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/angie-consts.ts
@@ -15,9 +15,8 @@ export const ANGIE_DESCRIPTION = __(
 );
 
 export const AI_WIDGET_CTA_VIEWED_EVENT = 'ai_widget_cta_viewed' as const;
-// TODO(ED-25505): Replace with final card image URL when asset is ready.
 export const ANGIE_TOP_BAR_PROMOTION_IMAGE_URL =
-	'https://assets.elementor.com/packages/v1/images/angie-modal-promotion.png';
+	'https://assets.elementor.com/packages/v1/images/angie-top-bar-promotion-0926.svg';
 export const ANGIE_TOP_BAR_DESCRIPTION = __(
 	'Describe what you want to build in plain language and Angie generates it in native Elementor structure, fully editable and customizable.',
 	'elementor'

--- a/packages/packages/core/editor-app-bar/src/extensions/angie/angie-consts.ts
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/angie-consts.ts
@@ -15,6 +15,10 @@ export const ANGIE_DESCRIPTION = __(
 );
 
 export const AI_WIDGET_CTA_VIEWED_EVENT = 'ai_widget_cta_viewed' as const;
+// TODO(ED-25505): Replace with final card image URL when asset is ready.
 export const ANGIE_TOP_BAR_PROMOTION_IMAGE_URL =
-	'https://assets.elementor.com/packages/v1/images/angie-top-bar-promotion.svg';
-export const ANGIE_TOP_BAR_DESCRIPTION = __( 'Build custom widgets using simple instructions.', 'elementor' );
+	'https://assets.elementor.com/packages/v1/images/angie-modal-promotion.png';
+export const ANGIE_TOP_BAR_DESCRIPTION = __(
+	'Describe what you want to build in plain language and Angie generates it in native Elementor structure, fully editable and customizable.',
+	'elementor'
+);

--- a/packages/packages/core/editor-app-bar/src/extensions/angie/components/__tests__/angie-guide-card.test.tsx
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/components/__tests__/angie-guide-card.test.tsx
@@ -12,7 +12,7 @@ const defaultProps = {
 };
 
 describe( 'AngieGuideCard', () => {
-	it( 'renders the Try for free button when onInstall is provided', () => {
+	it( 'renders the Build with Angie button when onInstall is provided', () => {
 		// Arrange.
 		const onInstall = jest.fn();
 
@@ -20,15 +20,15 @@ describe( 'AngieGuideCard', () => {
 		renderWithTheme( <AngieGuideCard { ...defaultProps } onInstall={ onInstall } /> );
 
 		// Assert.
-		expect( screen.getByRole( 'button', { name: /try for free/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /build with angie/i } ) ).toBeInTheDocument();
 	} );
 
-	it( 'does not render the Try for free button when onInstall is not provided', () => {
+	it( 'does not render the Build with Angie button when onInstall is not provided', () => {
 		// Act.
 		renderWithTheme( <AngieGuideCard { ...defaultProps } /> );
 
 		// Assert.
-		expect( screen.queryByRole( 'button', { name: /try for free/i } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /build with angie/i } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'always renders the Learn More button regardless of onInstall', () => {

--- a/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
@@ -17,7 +17,14 @@ export function AngieGuideCard( { imageUrl, description, learnMoreUrl, onInstall
 				<Image
 					src={ imageUrl }
 					alt={ __( 'Angie', 'elementor' ) }
-					sx={ { width: '100%', maxHeight: 200, objectFit: 'cover', objectPosition: 'center top', borderRadius: 1, display: 'block' } }
+					sx={ {
+						width: '100%',
+						maxHeight: 200,
+						objectFit: 'cover',
+						objectPosition: 'center top',
+						borderRadius: 1,
+						display: 'block',
+					} }
 				/>
 				<CloseButton
 					sx={ {

--- a/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
@@ -20,13 +20,16 @@ export function AngieGuideCard( { imageUrl, description, learnMoreUrl, onInstall
 					sx={ { width: '100%', maxHeight: 200, objectFit: 'cover', objectPosition: 'center top', borderRadius: 1, display: 'block' } }
 				/>
 				<CloseButton
-					edge="end"
 					sx={ {
 						position: 'absolute',
-						top: 16,
-						right: 16,
+						top: 24,
+						insetInlineEnd: 24,
 						color: 'common.white',
 						filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.6))',
+						'&:hover': {
+							bgcolor: 'rgba(255,255,255,0.2)',
+							color: 'common.white',
+						},
 					} }
 					slotProps={ { icon: { fontSize: 'small' } } }
 					onClick={ onClose }

--- a/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
@@ -18,11 +18,17 @@ export function AngieGuideCard( { imageUrl, description, learnMoreUrl, onInstall
 					<Image
 						src={ imageUrl }
 						alt={ __( 'Angie', 'elementor' ) }
-						sx={ { height: 150, width: '100%', borderRadius: 1, display: 'block' } }
+						sx={ { width: '100%', borderRadius: 1, display: 'block' } }
 					/>
 					<CloseButton
 						edge="end"
-						sx={ { position: 'absolute', top: 16, right: 16 } }
+						sx={ {
+							position: 'absolute',
+							top: 16,
+							right: 16,
+							bgcolor: 'rgba(255,255,255,0.75)',
+							'&:hover': { bgcolor: 'rgba(255,255,255,0.95)' },
+						} }
 						slotProps={ { icon: { fontSize: 'small' } } }
 						onClick={ onClose }
 					/>

--- a/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Box, Button, CloseButton, Image, Stack, Typography } from '@elementor/ui';
+import { Box, Button, ClickAwayListener, CloseButton, Image, Stack, Typography } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 type Props = {
@@ -12,62 +12,64 @@ type Props = {
 
 export function AngieGuideCard( { imageUrl, description, learnMoreUrl, onInstall, onClose }: Props ) {
 	return (
-		<Stack sx={ { width: 296 } } data-testid="e-angie-guide-card">
-			<Box sx={ { position: 'relative', p: 1.5 } }>
-				<Image
-					src={ imageUrl }
-					alt={ __( 'Angie', 'elementor' ) }
-					sx={ {
-						width: '100%',
-						maxHeight: 200,
-						objectFit: 'cover',
-						objectPosition: 'center top',
-						borderRadius: 1,
-						display: 'block',
-					} }
-				/>
-				<CloseButton
-					sx={ {
-						position: 'absolute',
-						top: 15,
-						insetInlineEnd: 15,
-						color: 'common.white',
-						filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.6))',
-						'&:hover': {
-							bgcolor: 'rgba(255,255,255,0.2)',
+		<ClickAwayListener onClickAway={ onClose }>
+			<Stack sx={ { width: 296 } } data-testid="e-angie-guide-card">
+				<Box sx={ { position: 'relative', p: 1.5 } }>
+					<Image
+						src={ imageUrl }
+						alt={ __( 'Angie', 'elementor' ) }
+						sx={ {
+							width: '100%',
+							maxHeight: 200,
+							objectFit: 'cover',
+							objectPosition: 'center top',
+							borderRadius: 1,
+							display: 'block',
+						} }
+					/>
+					<CloseButton
+						sx={ {
+							position: 'absolute',
+							top: 15,
+							insetInlineEnd: 15,
 							color: 'common.white',
-						},
-					} }
-					slotProps={ { icon: { fontSize: 'small' } } }
-					onClick={ onClose }
-				/>
-			</Box>
-			<Stack px={ 2 } pt={ 0.5 } pb={ 0.5 }>
-				<Typography variant="subtitle2">{ __( 'Generate full pages with AI', 'elementor' ) }</Typography>
-			</Stack>
-			<Stack px={ 2 } pt={ 0.5 } pb={ 1.5 }>
-				<Typography variant="body2" color="secondary">
-					{ description }
-				</Typography>
-			</Stack>
-			<Stack direction="row" justifyContent="flex-end" gap={ 1 } pb={ 1.5 } px={ 2 }>
-				<Button
-					variant="text"
-					size="small"
-					color="secondary"
-					onClick={ () => {
-						window.open( learnMoreUrl, '_blank', 'noopener,noreferrer' );
-						onClose();
-					} }
-				>
-					{ __( 'Learn More', 'elementor' ) }
-				</Button>
-				{ onInstall && (
-					<Button variant="contained" size="small" color="primary" onClick={ onInstall }>
-						{ __( 'Build with Angie', 'elementor' ) }
+							filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.6))',
+							'&:hover': {
+								bgcolor: 'rgba(255,255,255,0.2)',
+								color: 'common.white',
+							},
+						} }
+						slotProps={ { icon: { fontSize: 'small' } } }
+						onClick={ onClose }
+					/>
+				</Box>
+				<Stack px={ 2 } pt={ 0.5 } pb={ 0.5 }>
+					<Typography variant="subtitle2">{ __( 'Generate full pages with AI', 'elementor' ) }</Typography>
+				</Stack>
+				<Stack px={ 2 } pt={ 0.5 } pb={ 1.5 }>
+					<Typography variant="body2" color="secondary">
+						{ description }
+					</Typography>
+				</Stack>
+				<Stack direction="row" justifyContent="flex-end" gap={ 1 } pb={ 1.5 } px={ 2 }>
+					<Button
+						variant="text"
+						size="small"
+						color="secondary"
+						onClick={ () => {
+							window.open( learnMoreUrl, '_blank', 'noopener,noreferrer' );
+							onClose();
+						} }
+					>
+						{ __( 'Learn More', 'elementor' ) }
 					</Button>
-				) }
+					{ onInstall && (
+						<Button variant="contained" size="small" color="primary" onClick={ onInstall }>
+							{ __( 'Build with Angie', 'elementor' ) }
+						</Button>
+					) }
+				</Stack>
 			</Stack>
-		</Stack>
+		</ClickAwayListener>
 	);
 }

--- a/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Chip, ClickAwayListener, CloseButton, Image, Stack, Typography } from '@elementor/ui';
+import { Box, Button, ClickAwayListener, CloseButton, Image, Stack, Typography } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 type Props = {
@@ -14,23 +14,28 @@ export function AngieGuideCard( { imageUrl, description, learnMoreUrl, onInstall
 	return (
 		<ClickAwayListener onClickAway={ onClose }>
 			<Stack sx={ { width: 296 } } data-testid="e-angie-guide-card">
-				<Stack direction="row" alignItems="center" gap={ 1 } py={ 1 } px={ 2 }>
-					<Typography variant="subtitle2">{ __( 'Meet Angie', 'elementor' ) }</Typography>
-					<Chip label={ __( 'New', 'elementor' ) } size="small" color="info" variant="standard" />
+				<Box sx={ { position: 'relative', p: 1.5 } }>
+					<Image
+						src={ imageUrl }
+						alt={ __( 'Angie', 'elementor' ) }
+						sx={ { height: 150, width: '100%', borderRadius: 1, display: 'block' } }
+					/>
 					<CloseButton
 						edge="end"
-						sx={ { ml: 'auto' } }
+						sx={ { position: 'absolute', top: 16, right: 16 } }
 						slotProps={ { icon: { fontSize: 'small' } } }
 						onClick={ onClose }
 					/>
+				</Box>
+				<Stack px={ 2 } pt={ 0.5 } pb={ 0.5 }>
+					<Typography variant="subtitle2">{ __( 'Generate full pages with AI', 'elementor' ) }</Typography>
 				</Stack>
-				<Image src={ imageUrl } alt={ __( 'Angie', 'elementor' ) } sx={ { height: 150, width: '100%' } } />
-				<Stack px={ 2 } pt={ 1.5 } pb={ 1 }>
+				<Stack px={ 2 } pt={ 0.5 } pb={ 1.5 }>
 					<Typography variant="body2" color="secondary">
 						{ description }
 					</Typography>
 				</Stack>
-				<Stack direction="row" justifyContent="flex-end" gap={ 1 } pt={ 1 } pb={ 1.5 } px={ 2 }>
+				<Stack direction="row" justifyContent="flex-end" gap={ 1 } pb={ 1.5 } px={ 2 }>
 					<Button
 						variant="text"
 						size="small"
@@ -43,8 +48,8 @@ export function AngieGuideCard( { imageUrl, description, learnMoreUrl, onInstall
 						{ __( 'Learn More', 'elementor' ) }
 					</Button>
 					{ onInstall && (
-						<Button variant="contained" size="small" color="accent" onClick={ onInstall }>
-							{ __( 'Try for free', 'elementor' ) }
+						<Button variant="contained" size="small" color="primary" onClick={ onInstall }>
+							{ __( 'Build with Angie', 'elementor' ) }
 						</Button>
 					) }
 				</Stack>

--- a/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
@@ -22,8 +22,8 @@ export function AngieGuideCard( { imageUrl, description, learnMoreUrl, onInstall
 				<CloseButton
 					sx={ {
 						position: 'absolute',
-						top: 24,
-						insetInlineEnd: 24,
+						top: 15,
+						insetInlineEnd: 15,
 						color: 'common.white',
 						filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.6))',
 						'&:hover': {

--- a/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Box, Button, ClickAwayListener, CloseButton, Image, Stack, Typography } from '@elementor/ui';
+import { Box, Button, CloseButton, Image, Stack, Typography } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
 
 type Props = {
@@ -12,54 +12,52 @@ type Props = {
 
 export function AngieGuideCard( { imageUrl, description, learnMoreUrl, onInstall, onClose }: Props ) {
 	return (
-		<ClickAwayListener onClickAway={ onClose }>
-			<Stack sx={ { width: 296 } } data-testid="e-angie-guide-card">
-				<Box sx={ { position: 'relative', p: 1.5 } }>
-					<Image
-						src={ imageUrl }
-						alt={ __( 'Angie', 'elementor' ) }
-						sx={ { width: '100%', maxHeight: 200, objectFit: 'cover', objectPosition: 'center top', borderRadius: 1, display: 'block' } }
-					/>
-					<CloseButton
-						edge="end"
-						sx={ {
-							position: 'absolute',
-							top: 16,
-							right: 16,
-							color: 'common.white',
-							filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.6))',
-						} }
-						slotProps={ { icon: { fontSize: 'small' } } }
-						onClick={ onClose }
-					/>
-				</Box>
-				<Stack px={ 2 } pt={ 0.5 } pb={ 0.5 }>
-					<Typography variant="subtitle2">{ __( 'Generate full pages with AI', 'elementor' ) }</Typography>
-				</Stack>
-				<Stack px={ 2 } pt={ 0.5 } pb={ 1.5 }>
-					<Typography variant="body2" color="secondary">
-						{ description }
-					</Typography>
-				</Stack>
-				<Stack direction="row" justifyContent="flex-end" gap={ 1 } pb={ 1.5 } px={ 2 }>
-					<Button
-						variant="text"
-						size="small"
-						color="secondary"
-						onClick={ () => {
-							window.open( learnMoreUrl, '_blank', 'noopener,noreferrer' );
-							onClose();
-						} }
-					>
-						{ __( 'Learn More', 'elementor' ) }
-					</Button>
-					{ onInstall && (
-						<Button variant="contained" size="small" color="primary" onClick={ onInstall }>
-							{ __( 'Build with Angie', 'elementor' ) }
-						</Button>
-					) }
-				</Stack>
+		<Stack sx={ { width: 296 } } data-testid="e-angie-guide-card">
+			<Box sx={ { position: 'relative', p: 1.5 } }>
+				<Image
+					src={ imageUrl }
+					alt={ __( 'Angie', 'elementor' ) }
+					sx={ { width: '100%', maxHeight: 200, objectFit: 'cover', objectPosition: 'center top', borderRadius: 1, display: 'block' } }
+				/>
+				<CloseButton
+					edge="end"
+					sx={ {
+						position: 'absolute',
+						top: 16,
+						right: 16,
+						color: 'common.white',
+						filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.6))',
+					} }
+					slotProps={ { icon: { fontSize: 'small' } } }
+					onClick={ onClose }
+				/>
+			</Box>
+			<Stack px={ 2 } pt={ 0.5 } pb={ 0.5 }>
+				<Typography variant="subtitle2">{ __( 'Generate full pages with AI', 'elementor' ) }</Typography>
 			</Stack>
-		</ClickAwayListener>
+			<Stack px={ 2 } pt={ 0.5 } pb={ 1.5 }>
+				<Typography variant="body2" color="secondary">
+					{ description }
+				</Typography>
+			</Stack>
+			<Stack direction="row" justifyContent="flex-end" gap={ 1 } pb={ 1.5 } px={ 2 }>
+				<Button
+					variant="text"
+					size="small"
+					color="secondary"
+					onClick={ () => {
+						window.open( learnMoreUrl, '_blank', 'noopener,noreferrer' );
+						onClose();
+					} }
+				>
+					{ __( 'Learn More', 'elementor' ) }
+				</Button>
+				{ onInstall && (
+					<Button variant="contained" size="small" color="primary" onClick={ onInstall }>
+						{ __( 'Build with Angie', 'elementor' ) }
+					</Button>
+				) }
+			</Stack>
+		</Stack>
 	);
 }

--- a/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-card.tsx
@@ -18,7 +18,7 @@ export function AngieGuideCard( { imageUrl, description, learnMoreUrl, onInstall
 					<Image
 						src={ imageUrl }
 						alt={ __( 'Angie', 'elementor' ) }
-						sx={ { width: '100%', borderRadius: 1, display: 'block' } }
+						sx={ { width: '100%', maxHeight: 200, objectFit: 'cover', objectPosition: 'center top', borderRadius: 1, display: 'block' } }
 					/>
 					<CloseButton
 						edge="end"
@@ -26,8 +26,8 @@ export function AngieGuideCard( { imageUrl, description, learnMoreUrl, onInstall
 							position: 'absolute',
 							top: 16,
 							right: 16,
-							bgcolor: 'rgba(255,255,255,0.75)',
-							'&:hover': { bgcolor: 'rgba(255,255,255,0.95)' },
+							color: 'common.white',
+							filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.6))',
 						} }
 						slotProps={ { icon: { fontSize: 'small' } } }
 						onClick={ onClose }

--- a/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-location.tsx
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-location.tsx
@@ -43,6 +43,27 @@ export function AngieGuideLocation() {
 		};
 	}, [] );
 
+	useEffect( () => {
+		if ( ! isOpen ) {
+			return;
+		}
+
+		const handleMouseDown = ( e: MouseEvent ) => {
+			const card = document.querySelector( '[data-testid="e-angie-guide-card"]' );
+			const button = document.querySelector( `[aria-label="${ ANGIE_BUTTON_ARIA_LABEL }"]` );
+
+			if ( card && ! card.contains( e.target as Node ) && button && ! button.contains( e.target as Node ) ) {
+				setAnchorEl( null );
+			}
+		};
+
+		document.addEventListener( 'mousedown', handleMouseDown );
+
+		return () => {
+			document.removeEventListener( 'mousedown', handleMouseDown );
+		};
+	}, [ isOpen ] );
+
 	const handleClose = () => setAnchorEl( null );
 
 	const handleInstall = async () => {

--- a/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-location.tsx
+++ b/packages/packages/core/editor-app-bar/src/extensions/angie/components/angie-guide-location.tsx
@@ -43,27 +43,6 @@ export function AngieGuideLocation() {
 		};
 	}, [] );
 
-	useEffect( () => {
-		if ( ! isOpen ) {
-			return;
-		}
-
-		const handleMouseDown = ( e: MouseEvent ) => {
-			const card = document.querySelector( '[data-testid="e-angie-guide-card"]' );
-			const button = document.querySelector( `[aria-label="${ ANGIE_BUTTON_ARIA_LABEL }"]` );
-
-			if ( card && ! card.contains( e.target as Node ) && button && ! button.contains( e.target as Node ) ) {
-				setAnchorEl( null );
-			}
-		};
-
-		document.addEventListener( 'mousedown', handleMouseDown );
-
-		return () => {
-			document.removeEventListener( 'mousedown', handleMouseDown );
-		};
-	}, [ isOpen ] );
-
 	const handleClose = () => setAnchorEl( null );
 
 	const handleInstall = async () => {

--- a/packages/packages/core/editor-widget-creation/src/components/__tests__/create-widget.test.tsx
+++ b/packages/packages/core/editor-widget-creation/src/components/__tests__/create-widget.test.tsx
@@ -167,9 +167,9 @@ describe( 'CreateWidget — analytics instrumentation', () => {
 				dispatchCreateWidgetEvent( { prompt: 'Build me a widget', entry_point: 'top_bar_icon' } );
 			} );
 
-			// Check terms and click Install & Activate to trigger the failure.
+			// Check terms and click Install and activate to trigger the failure.
 			fireEvent.click( screen.getByRole( 'checkbox' ) );
-			const installButton = screen.getByRole( 'button', { name: /Install & Activate/i } );
+			const installButton = screen.getByRole( 'button', { name: /Install and activate/i } );
 
 			fireEvent.click( installButton );
 
@@ -201,9 +201,9 @@ describe( 'CreateWidget — analytics instrumentation', () => {
 				dispatchCreateWidgetEvent( { prompt: 'Build me a widget', entry_point: 'top_bar_icon' } );
 			} );
 
-			// Check terms and click Install & Activate.
+			// Check terms and click Install and activate.
 			fireEvent.click( screen.getByRole( 'checkbox' ) );
-			const installButton = screen.getByRole( 'button', { name: /Install & Activate/i } );
+			const installButton = screen.getByRole( 'button', { name: /Install and activate/i } );
 
 			fireEvent.click( installButton );
 
@@ -226,7 +226,7 @@ describe( 'CreateWidget — analytics instrumentation', () => {
 	} );
 
 	describe( 'consent saving', () => {
-		it( 'saves consent to DB when Install & Activate is clicked', async () => {
+		it( 'saves consent to DB when Install and activate is clicked', async () => {
 			// Arrange.
 			mockIsAngieAvailable.mockReturnValue( false );
 			mockInstallAngiePlugin.mockResolvedValue( { success: true } );
@@ -238,7 +238,7 @@ describe( 'CreateWidget — analytics instrumentation', () => {
 
 			// Act — check terms then click the button.
 			fireEvent.click( screen.getByRole( 'checkbox' ) );
-			fireEvent.click( screen.getByRole( 'button', { name: /Install & Activate/i } ) );
+			fireEvent.click( screen.getByRole( 'button', { name: /Install and activate/i } ) );
 
 			// Assert.
 			await waitFor( () => {
@@ -258,7 +258,7 @@ describe( 'CreateWidget — analytics instrumentation', () => {
 
 			// Act — check terms then click the button.
 			fireEvent.click( screen.getByRole( 'checkbox' ) );
-			fireEvent.click( screen.getByRole( 'button', { name: /Install & Activate/i } ) );
+			fireEvent.click( screen.getByRole( 'button', { name: /Install and activate/i } ) );
 
 			// Assert.
 			await waitFor( () => {
@@ -280,7 +280,7 @@ describe( 'CreateWidget — analytics instrumentation', () => {
 
 			// Act — check terms then install.
 			fireEvent.click( screen.getByRole( 'checkbox' ) );
-			const installButton = screen.getByRole( 'button', { name: /Install & Activate/i } );
+			const installButton = screen.getByRole( 'button', { name: /Install and activate/i } );
 
 			fireEvent.click( installButton );
 
@@ -307,7 +307,7 @@ describe( 'CreateWidget — analytics instrumentation', () => {
 
 			// Act — check terms then install.
 			fireEvent.click( screen.getByRole( 'checkbox' ) );
-			const installButton = screen.getByRole( 'button', { name: /Install & Activate/i } );
+			const installButton = screen.getByRole( 'button', { name: /Install and activate/i } );
 
 			fireEvent.click( installButton );
 
@@ -329,7 +329,7 @@ describe( 'CreateWidget — analytics instrumentation', () => {
 
 			// Act — check terms then install.
 			fireEvent.click( screen.getByRole( 'checkbox' ) );
-			const installButton = screen.getByRole( 'button', { name: /Install & Activate/i } );
+			const installButton = screen.getByRole( 'button', { name: /Install and activate/i } );
 
 			fireEvent.click( installButton );
 
@@ -357,7 +357,7 @@ describe( 'CreateWidget — analytics instrumentation', () => {
 
 			// Act — check terms then install.
 			fireEvent.click( screen.getByRole( 'checkbox' ) );
-			const installButton = screen.getByRole( 'button', { name: /Install & Activate/i } );
+			const installButton = screen.getByRole( 'button', { name: /Install and activate/i } );
 
 			fireEvent.click( installButton );
 
@@ -391,7 +391,7 @@ describe( 'CreateWidget — analytics instrumentation', () => {
 
 			// Trigger install failure so the fallback button appears — check terms first.
 			fireEvent.click( screen.getByRole( 'checkbox' ) );
-			fireEvent.click( screen.getByRole( 'button', { name: /Install & Activate/i } ) );
+			fireEvent.click( screen.getByRole( 'button', { name: /Install and activate/i } ) );
 
 			await waitFor( () => {
 				expect( screen.getByRole( 'button', { name: /Install Manually/i } ) ).toBeInTheDocument();
@@ -416,7 +416,7 @@ describe( 'CreateWidget — analytics instrumentation', () => {
 
 			// Trigger install failure so the fallback button appears — check terms first.
 			fireEvent.click( screen.getByRole( 'checkbox' ) );
-			fireEvent.click( screen.getByRole( 'button', { name: /Install & Activate/i } ) );
+			fireEvent.click( screen.getByRole( 'button', { name: /Install and activate/i } ) );
 
 			await waitFor( () => {
 				expect( screen.getByRole( 'button', { name: /Install Manually/i } ) ).toBeInTheDocument();

--- a/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
+++ b/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
@@ -124,16 +124,22 @@ function CreateWidgetModal( { prompt, entryPoint, onClose }: CreateWidgetModalPr
 								<Typography variant="h4" fontWeight={ 600 } color="text.secondary">
 									{ installState === 'error'
 										? __( 'Installation failed', 'elementor' )
-										: __( 'Create custom widgets with Angie', 'elementor' ) }
+										: (
+											<>
+												{ __( 'Pages, layouts,', 'elementor' ) }
+												<br />
+												{ __( 'widgets and more', 'elementor' ) }
+											</>
+										) }
 								</Typography>
-								<Typography variant="body2">
+								<Typography variant="body2" fontWeight={ 500 }>
 									{ installState === 'error'
 										? __(
 												"We couldn't install Angie automatically. Click below to install it manually.",
 												'elementor'
 										  )
 										: __(
-												'Build custom widgets, sections, and code using simple instructions. Install once to start building directly from the editor.',
+												'Ask Angie to build you full pages, custom widgets, snippets, and code directly in Elementor. Install and activate Angie once on this site to start building.',
 												'elementor'
 										  ) }
 								</Typography>
@@ -154,7 +160,10 @@ function CreateWidgetModal( { prompt, entryPoint, onClose }: CreateWidgetModalPr
 												{ interpolateLinks(
 													sprintf(
 														// translators: %1$s is the Terms link, %2$s is the Privacy Policy link.
-														__( 'I agree to the %1$s & %2$s.', 'elementor' ),
+														__(
+															'By installing, you agree to our %1$s & %2$s.',
+															'elementor'
+														),
 														'{{terms}}',
 														'{{privacy}}'
 													),
@@ -193,7 +202,7 @@ function CreateWidgetModal( { prompt, entryPoint, onClose }: CreateWidgetModalPr
 									>
 										{ installState === 'installing'
 											? __( 'Installing…', 'elementor' )
-											: __( 'Install & Activate', 'elementor' ) }
+											: __( 'Install and activate', 'elementor' ) }
 									</Button>
 								) }
 							</Stack>

--- a/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
+++ b/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
@@ -41,7 +41,8 @@ type CreateWidgetModalProps = {
 };
 
 const CREATE_WIDGET_EVENT = 'elementor/editor/create-widget';
-const ANGIE_MODAL_PROMOTION_IMAGE_URL = 'https://assets.elementor.com/packages/v1/images/angie-top-bar-promotion-modal-0926.png';
+const ANGIE_MODAL_PROMOTION_IMAGE_URL =
+	'https://assets.elementor.com/packages/v1/images/angie-top-bar-promotion-modal-0926.png';
 const ANGIE_CTA_CLICKED_EVENT = 'ai_widget_cta_clicked' as const;
 const ANGIE_INSTALL_STARTED_EVENT = 'angie_install_started' as const;
 const ANGIE_INSTALL_COMPLETED_EVENT = 'angie_install_completed' as const;

--- a/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
+++ b/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
@@ -122,15 +122,15 @@ function CreateWidgetModal( { prompt, entryPoint, onClose }: CreateWidgetModalPr
 						<Stack justifyContent="space-between" p={ 4 }>
 							<Stack gap={ 2.5 } justifyContent="center" sx={ { flex: 1, paddingInlineEnd: 2.5 } }>
 								<Typography variant="h4" fontWeight={ 600 } color="text.secondary">
-									{ installState === 'error'
-										? __( 'Installation failed', 'elementor' )
-										: (
-											<>
-												{ __( 'Pages, layouts,', 'elementor' ) }
-												<br />
-												{ __( 'widgets and more', 'elementor' ) }
-											</>
-										) }
+									{ installState === 'error' ? (
+										__( 'Installation failed', 'elementor' )
+									) : (
+										<>
+											{ __( 'Pages, layouts,', 'elementor' ) }
+											<br />
+											{ __( 'widgets and more', 'elementor' ) }
+										</>
+									) }
 								</Typography>
 								<Typography variant="body2" fontWeight={ 500 }>
 									{ installState === 'error'

--- a/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
+++ b/packages/packages/core/editor-widget-creation/src/components/create-widget.tsx
@@ -41,7 +41,7 @@ type CreateWidgetModalProps = {
 };
 
 const CREATE_WIDGET_EVENT = 'elementor/editor/create-widget';
-const ANGIE_MODAL_PROMOTION_IMAGE_URL = 'https://assets.elementor.com/packages/v1/images/angie-modal-promotion.png';
+const ANGIE_MODAL_PROMOTION_IMAGE_URL = 'https://assets.elementor.com/packages/v1/images/angie-top-bar-promotion-modal-0926.png';
 const ANGIE_CTA_CLICKED_EVENT = 'ai_widget_cta_clicked' as const;
 const ANGIE_INSTALL_STARTED_EVENT = 'angie_install_started' as const;
 const ANGIE_INSTALL_COMPLETED_EVENT = 'angie_install_completed' as const;


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Feature

## Summary

This PR can be summarized in the following changelog entry:

*Update Angie top-bar card and install modal copy and layout*

## Description

Updates the Angie promotion UI in two places:

**Top-bar card (`editor-app-bar`):**
- Replaced the "Meet Angie" / "New" chip header with a padded image block; close button moves inside the image area (top-right)
- New card title: "Generate full pages with AI"
- Updated description copy
- Renamed CTA button: "Build with Angie" (was "Try for free")
- Removed "Learn More" secondary button
- Placeholder image URL used temporarily; final asset to follow

**Install modal (`editor-widget-creation`):**
- New two-line title: "Pages, layouts, / widgets and more"
- Updated description copy
- Updated terms checkbox copy: "By installing, you agree to our …"
- Renamed install button: "Install and activate" (was "Install & Activate")
- Description text weight bumped to 500

## Test instructions

1. Open the Elementor editor on a site without Angie installed.
2. Click the Angie icon in the top bar — verify the card shows the new layout (image with close button inside, "Generate full pages with AI" title, "Build with Angie" CTA).
3. Click "Build with Angie" — verify the install modal opens with the new title, description, terms text, and button label.
4. Verify the close button (X) in the card is inside the image area (top-right corner).
5. On a site where Angie is already installed, verify clicking the Angie icon opens Angie directly without showing the card/modal.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

UX refresh for Angie banner and card components (ED-25505). Updates promotional imagery, copy, and button labels to improve clarity and conversion messaging.

## 2. What Changed (Where)

- **angie-consts.ts**: New banner image URL and description constant for top bar promotion
- **angie-guide-card.tsx**: Redesigned card layout—image wraps in Box with positioned close button overlay, new title ("Generate full pages with AI"), updated button text ("Build with Angie"), improved spacing/styling
- **create-widget.tsx**: Modal copy refresh—header now conditional with multi-line text, description text enhanced, button label changed ("Install and activate"), terms checkbox label rewording
- **Tests**: Updated test selectors and assertions to match new button/copy text

## 3. How It Works

Card now leads with full-width image (200px max-height, cover fit) topped with shadowed close button overlay. Content flows: title → description → dual-button footer. Modal heading toggles between "Installation failed" and multi-line feature description based on `installState`.

## 4. Risks

Minor: hardcoded image URLs (0926 versioned assets) could stale if CDN path conventions change. Test coverage preserves all prior scenarios—low regression risk.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
