### PR TITLE
CI: Point Custom Core at draft GitHub release tag [ED-25478]

### DIFF
--- a/.github/workflows/controlled-release.yml
+++ b/.github/workflows/controlled-release.yml
@@ -94,7 +94,10 @@ jobs:
             echo ""
             echo "[View draft release](https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }})"
             echo ""
-            echo "> Before approving: I executed custom core with the build that was created by this action."
+            echo "Please Run [Playwright - Custom Core](https://github.com/elementor/elementor-pro/actions/workflows/playwright-custom-core.yml) in **elementor-pro**."
+            echo "Set **core_release_tag** to \`${{ inputs.version }}\` so tests use this draft zip, not the Core branch (which can keep moving)."
+            echo ""
+            echo "> Before approving: I executed Custom Core against this draft GitHub release."
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ── Job 5 ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- After a Controlled Release draft is created, the run summary tells reviewers to please run Playwright Custom Core in elementor-pro with `core_release_tag` set to this version.
- That uses the draft zip instead of the Core branch, which can keep receiving commits.

## Test plan
- [ ] Run Controlled Release through Build & Draft Release on a beta flow.
- [ ] Confirm the Release Drafted summary includes "Please Run" plus the Custom Core workflow link and the version tag to paste.

## Jira
[ED-25478](https://elementor.atlassian.net/browse/ED-25478)

Made with [Cursor](https://cursor.com)

[ED-25478]: https://elementor.atlassian.net/browse/ED-25478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Prevents race conditions in testing by directing reviewers to run Playwright tests against the specific draft release zip rather than the evolving Core branch (ED-25478).

## 2. What Changed (Where)
- `.github/workflows/controlled-release.yml`: Updated the job summary to provide explicit instructions and links for running Custom Core tests.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
