### PR TITLE
CI: Ask reviewers to please run Custom Core on the draft tag [ED-25478]

### DIFF
--- a/.github/workflows/controlled-release.yml
+++ b/.github/workflows/controlled-release.yml
@@ -94,7 +94,7 @@ jobs:
             echo ""
             echo "[View draft release](https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }})"
             echo ""
-            echo "Run [Playwright - Custom Core](https://github.com/elementor/elementor-pro/actions/workflows/playwright-custom-core.yml) in **elementor-pro**."
+            echo "Please Run [Playwright - Custom Core](https://github.com/elementor/elementor-pro/actions/workflows/playwright-custom-core.yml) in **elementor-pro**."
             echo "Set **core_release_tag** to \`${{ inputs.version }}\` so tests use this draft zip, not the Core branch (which can keep moving)."
             echo ""
             echo "> Before approving: I executed Custom Core against this draft GitHub release."


### PR DESCRIPTION
## Summary
- Follow-up to #37159: the Release Drafted summary now says **Please Run** Playwright Custom Core, so the instruction is a clear request rather than a terse command.

## Test plan
- [ ] Confirm the Release Drafted summary line starts with "Please Run [Playwright - Custom Core]".

## Jira
[ED-25478](https://elementor.atlassian.net/browse/ED-25478)

Made with [Cursor](https://cursor.com)

[ED-25478]: https://elementor.atlassian.net/browse/ED-25478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Improves reviewer compliance for ED-25478 by making the instruction to run Custom Core tests more explicit in the CI summary.

## 2. What Changed (Where)
- `.github/workflows/controlled-release.yml`: Updated GITHUB_STEP_SUMMARY text to emphasize the requirement to run Playwright tests.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
