### PR TITLE
Fix: Prevent OOM in revisions panel on posts with bloated postmeta [ED-25525]

### DIFF
--- a/modules/history/revisions-manager.php
+++ b/modules/history/revisions-manager.php
@@ -119,7 +119,9 @@ class Revisions_Manager {
 
 		$default_query_args = [
 			'posts_per_page' => self::MAX_REVISIONS_TO_DISPLAY,
-			'meta_key' => '_elementor_data',
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'no_found_rows' => true,
 		];
 
 		$query_args = array_merge( $default_query_args, $query_args );


### PR DESCRIPTION
## Summary

Users reported the Elementor editor "PHP overloading" on pages with heavy draft/revision history. Reproduced a hard PHP fatal:

```
PHP Fatal error: Allowed memory size of 268435456 bytes exhausted
(tried to allocate 2114584 bytes) in wp-includes/class-wpdb.php on line 2324
```

**Root cause.** `Revisions_Manager::get_revisions()` calls `wp_get_post_revisions()` with default `WP_Query` behavior, which primes the post meta cache for every returned revision. When a page has accumulated many revisions (each carrying a copy of `_elementor_data`), WordPress runs a single `SELECT` that pulls every meta row for all revision IDs into PHP memory — even though the revisions panel only renders `id`, `author`, `date`, and `type`.

The additional `'meta_key' => '_elementor_data'` filter added another postmeta JOIN with no functional value (Elementor creates the revisions and always writes this key).

## Change

Single-file diff in `modules/history/revisions-manager.php`, inside the default query args of `get_revisions()`:

- Add `'update_post_meta_cache' => false` — the actual fix. Stops WP from loading every revision's `_elementor_data` blob just to render a list of dates and authors.
- Add `'update_post_term_cache' => false` — revisions carry no terms.
- Add `'no_found_rows' => true` — no pagination on this list.
- Drop `'meta_key' => '_elementor_data'` — redundant JOIN; the panel does not depend on this filter and all Elementor revisions have the key.

The click-to-open-revision path (`ajax_get_revision_data` → `$revision->get_settings()` / `get_elements_data()`) is unchanged and still loads a single revision's full payload on demand.

## Benchmark

Real end-to-end AJAX benchmark against `admin-ajax.php` on a page with 100 revisions × 2 MB `_elementor_data` per revision, 256 MB PHP `memory_limit`:

| Condition     | HTTP | Cold   | Warm avg |
|---------------|------|--------|----------|
| Without patch | 500  | 231 ms | (fatal)  |
| With patch    | 200  | 55 ms  | 35 ms    |

Fatal captured verbatim in `wp-content/debug.log` for the without-patch run.

Isolated `get_revisions()` micro-benchmark (50 revisions × 500 KB, cache flushed between runs, 3 runs):

| Metric              | Without patch | With patch | Delta       |
|---------------------|---------------|------------|-------------|
| Wall time (avg)     | 40.5 ms       | 4.2 ms     | ~10× faster |
| Real memory delta   | 25 MB         | 204 KB     | ~125× less  |
| Peak spike (cold)   | +74 MB        | negligible | 🔥          |
| SQL queries         | 5             | 4          | -1          |

## Test plan

- [ ] Open the editor on a page with many revisions — panel opens without a 500.
- [ ] Click a revision in the panel — full elements load and preview switches as before.
- [ ] Save the editor — post-save `on_ajax_save_builder_data` still returns `latest_revisions` and `revisions_ids` with the same shape.
- [ ] `revisions_ids` list is unchanged.
- [ ] No regression on posts with zero revisions.

## Follow-ups (not in this PR)

- Write-side bloat: `Db::copy_elementor_meta()` duplicates the entire parent postmeta into every revision. Whitelisting to the keys actually needed for restore would fix the root cause of `wp_postmeta` growth.
- Optional `wp_revisions_to_keep` filter for Elementor post types.

Ref: ED-25525

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Prevents Out-Of-Memory (OOM) errors when loading the revisions panel for posts with excessive postmeta [ED-25525].

## 2. What Changed (Where)
- `modules/history/revisions-manager.php`: Optimized `wp_get_post_revisions` query arguments.

## 3. How It Works
* Disables automatic metadata and term cache updates during revision retrieval.
* Sets `no_found_rows` to true to skip unnecessary SQL count queries.
* Removes `_elementor_data` meta key filter from default query args.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[ED-25525]: https://elementor.atlassian.net/browse/ED-25525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ