### PR TITLE
Fix: Carousel promotion. flaky test

### DIFF
--- a/tests/playwright/sanity/modules/promotions/carousel-promotion.test.ts
+++ b/tests/playwright/sanity/modules/promotions/carousel-promotion.test.ts
@@ -2,8 +2,14 @@ import { parallelTest as test } from '../../../parallelTest';
 import WpAdminPage from '../../../pages/wp-admin-page';
 import { expect } from '@playwright/test';
 import { wpCli } from '../../../assets/wp-cli';
-import { getPromotionWidgetByType, openPromotionPopover } from './promotion-popover-helper';
+import {
+	expandPanelCategory,
+	getPromotionWidgetByType,
+	openPromotionPopover,
+	searchPanelWidgets,
+} from './promotion-popover-helper';
 import _path from 'path';
+import { timeouts } from '../../../config/timeouts';
 
 const CAROUSEL_PROMOTION_CONTENT_PATTERN = /engaging slideshows with customizable slides/i;
 const categorySelector = '#elementor-panel-category-v4-elements';
@@ -14,17 +20,26 @@ test.describe( 'Carousel promotion test @promotions', () => {
 		await wpCli( 'wp elementor experiments activate e_atomic_elements' );
 	} );
 
+	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+		await wpAdmin.resetExperiments();
+		await page.close();
+	} );
+
 	test( 'Carousel widget visible in Atomic Elements with nested-carousel icon', async ( { page, apiRequests }, testInfo ) => {
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
 		await wpAdmin.openNewPage();
 
 		const category = page.locator( categorySelector );
-		await category.locator( '.elementor-panel-category-title' ).click();
-		await expect( category.locator( '.elementor-panel-category-items' ) ).toBeVisible();
+		await expandPanelCategory( category );
 
 		const carouselWidget = getPromotionWidgetByType( category, 'e-carousel' );
-		await carouselWidget.scrollIntoViewIfNeeded();
-		await expect( carouselWidget ).toBeVisible();
+		await expect( carouselWidget ).toBeVisible( { timeout: timeouts.longAction } );
+		await carouselWidget.evaluate( ( element ) => {
+			element.scrollIntoView( { block: 'center', inline: 'nearest', behavior: 'instant' } );
+		} );
 		await expect( carouselWidget.locator( '.eicon-nested-carousel' ) ).toHaveCount( 1 );
 	} );
 
@@ -32,14 +47,12 @@ test.describe( 'Carousel promotion test @promotions', () => {
 		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
 		await wpAdmin.openNewPage();
 
-		const category = page.locator( categorySelector );
-		await category.locator( '.elementor-panel-category-title' ).click();
-		await expect( category.locator( '.elementor-panel-category-items' ) ).toBeVisible();
+		await searchPanelWidgets( page, 'Carousel' );
 
-		const carouselWidget = getPromotionWidgetByType( category, 'e-carousel' );
-		await expect( carouselWidget ).toBeVisible();
+		const carouselWidget = page.locator( '[data-library-element-type="e-carousel"]' ).first();
+		await expect( carouselWidget ).toBeVisible( { timeout: timeouts.longAction } );
 
-		const popover = await openPromotionPopover( carouselWidget );
+		const popover = await openPromotionPopover( carouselWidget, { hasText: 'Carousel' } );
 		await expect( popover.getByText( 'Carousel', { exact: true } ) ).toBeVisible();
 		await expect( popover.getByText( CAROUSEL_PROMOTION_CONTENT_PATTERN ) ).toBeVisible();
 		await expect( popover.getByRole( 'link', { name: 'Upgrade now' } ) ).toHaveAttribute( 'href', /go-pro-carousel-modal/ );

--- a/tests/playwright/sanity/modules/promotions/carousel-promotion.test.ts
+++ b/tests/playwright/sanity/modules/promotions/carousel-promotion.test.ts
@@ -2,6 +2,7 @@ import { parallelTest as test } from '../../../parallelTest';
 import WpAdminPage from '../../../pages/wp-admin-page';
 import { expect } from '@playwright/test';
 import { wpCli } from '../../../assets/wp-cli';
+import { DriverFactory } from '../../../drivers/driver-factory';
 import {
 	expandPanelCategory,
 	getPromotionWidgetByType,
@@ -21,11 +22,7 @@ test.describe( 'Carousel promotion test @promotions', () => {
 	} );
 
 	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
-		const wpAdmin = new WpAdminPage( page, testInfo, apiRequests );
-		await wpAdmin.resetExperiments();
-		await page.close();
+		await DriverFactory.resetExperiments( browser, testInfo, apiRequests );
 	} );
 
 	test( 'Carousel widget visible in Atomic Elements with nested-carousel icon', async ( { page, apiRequests }, testInfo ) => {

--- a/tests/playwright/sanity/modules/promotions/promotion-popover-helper.ts
+++ b/tests/playwright/sanity/modules/promotions/promotion-popover-helper.ts
@@ -1,7 +1,8 @@
-import { expect, type Locator } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 import { timeouts } from '../../../config/timeouts';
 
 export const promotionPopoverSelector = '.MuiTooltip-tooltip > .MuiBox-root';
+const WIDGET_SEARCH_INPUT = 'input#elementor-panel-elements-search-input';
 
 export function getPromotionWidget( category: Locator, widgetTitle: string ): Locator {
 	return category.locator( '.elementor-element' ).filter( { hasText: widgetTitle } ).first();
@@ -11,11 +12,55 @@ export function getPromotionWidgetByType( category: Locator, elementType: string
 	return category.locator( `[data-library-element-type="${ elementType }"]` ).first();
 }
 
-export async function openPromotionPopover( widget: Locator ): Promise<Locator> {
-	await widget.scrollIntoViewIfNeeded();
-	await widget.click( { force: true } );
+/**
+ * Category titles toggle. Clicking an already-open accordion collapses it and hides the tiles
+ * mid-animation — the original carousel flake.
+ */
+export async function expandPanelCategory( category: Locator ): Promise<void> {
+	const items = category.locator( '.elementor-panel-category-items' );
+	const isActive = await category.evaluate( ( element ) => element.classList.contains( 'elementor-active' ) );
 
-	const popover = widget.page().locator( promotionPopoverSelector );
+	if ( ! isActive ) {
+		await category.locator( '.elementor-panel-category-title' ).click();
+	}
+
+	await expect( items ).toBeVisible();
+	await expect.poll(
+		async () => items.evaluate( ( element ) => element.getBoundingClientRect().height ),
+		{ timeout: timeouts.longAction },
+	).toBeGreaterThan( 20 );
+}
+
+export async function searchPanelWidgets( page: Page, searchTerm: string ): Promise<void> {
+	const searchInput = page.locator( WIDGET_SEARCH_INPUT );
+	await expect( searchInput ).toBeVisible();
+	await searchInput.fill( searchTerm );
+	await searchInput.dispatchEvent( 'input' );
+}
+
+function getWidgetWrapper( widget: Locator ): Locator {
+	return widget.locator( 'xpath=ancestor::div[contains(@class,"elementor-element-wrapper")][1]' );
+}
+
+export async function openPromotionPopover(
+	widget: Locator,
+	options?: { hasText?: string | RegExp },
+): Promise<Locator> {
+	const wrapper = getWidgetWrapper( widget );
+
+	await wrapper.evaluate( ( element ) => {
+		element.scrollIntoView( { block: 'center', inline: 'nearest', behavior: 'instant' } );
+	} );
+	await expect( wrapper ).toBeVisible();
+
+	// Promotion cards open on mousedown of the wrapper (not the inner button). Skip force:
+	// actionability waits until the tile is stable after accordion/search layout.
+	await wrapper.click();
+
+	const popover = options?.hasText
+		? widget.page().locator( promotionPopoverSelector ).filter( { hasText: options.hasText } )
+		: widget.page().locator( promotionPopoverSelector );
+
 	await expect( popover ).toBeVisible( { timeout: timeouts.longAction } );
 
 	return popover;

--- a/tests/playwright/sanity/modules/promotions/promotion-popover-helper.ts
+++ b/tests/playwright/sanity/modules/promotions/promotion-popover-helper.ts
@@ -3,6 +3,7 @@ import { timeouts } from '../../../config/timeouts';
 
 export const promotionPopoverSelector = '.MuiTooltip-tooltip > .MuiBox-root';
 const WIDGET_SEARCH_INPUT = 'input#elementor-panel-elements-search-input';
+const MIN_EXPANDED_CATEGORY_ITEMS_HEIGHT = 20;
 
 export function getPromotionWidget( category: Locator, widgetTitle: string ): Locator {
 	return category.locator( '.elementor-element' ).filter( { hasText: widgetTitle } ).first();
@@ -15,6 +16,8 @@ export function getPromotionWidgetByType( category: Locator, elementType: string
 /**
  * Category titles toggle. Clicking an already-open accordion collapses it and hides the tiles
  * mid-animation — the original carousel flake.
+ *
+ * @param {Locator} category Panel category root (`#elementor-panel-category-*`).
  */
 export async function expandPanelCategory( category: Locator ): Promise<void> {
 	const items = category.locator( '.elementor-panel-category-items' );
@@ -28,7 +31,7 @@ export async function expandPanelCategory( category: Locator ): Promise<void> {
 	await expect.poll(
 		async () => items.evaluate( ( element ) => element.getBoundingClientRect().height ),
 		{ timeout: timeouts.longAction },
-	).toBeGreaterThan( 20 );
+	).toBeGreaterThan( MIN_EXPANDED_CATEGORY_ITEMS_HEIGHT );
 }
 
 export async function searchPanelWidgets( page: Page, searchTerm: string ): Promise<void> {


### PR DESCRIPTION
## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ ] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Stabilizes flaky E2E tests for Carousel promotions (ED-25382) by addressing race conditions caused by accordion animations and unstable element actionability.

## 2. What Changed (Where)
- `promotion-popover-helper.ts`: Added robust category expansion, widget searching, and improved popover triggering.
- `carousel-promotion.test.ts`: Updated tests to use new helpers and added experiment reset logic.

## 3. How It Works
- `expandPanelCategory` now checks for active state and polls element height to ensure animations complete.
- `openPromotionPopover` replaces `force: true` with `scrollIntoView` and standard clicks to ensure actionability.
- Tests now leverage `searchPanelWidgets` to isolate target elements more reliably.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
