### PR TITLE
Internal: Content-only access for the v4 atomic editor - full stack CI [ED-25430]

### DIFF
--- a/core/role-manager/content-only-save-guard.php
+++ b/core/role-manager/content-only-save-guard.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Elementor\Core\RoleManager;
+
+use Elementor\Core\Base\Document;
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Content_Only_Save_Guard {
+
+	private const DESIGN_CAPABILITY = 'design';
+
+	private const FIELD_ELEMENTS = 'elements';
+
+	private const FIELD_INTERACTIONS = 'interactions';
+
+	private const FIELD_SETTINGS = 'settings';
+
+	private const FIELD_STYLES = 'styles';
+
+	private const SETTING_CLASSES = 'classes';
+
+	public function register(): void {
+		add_filter( 'elementor/document/save/data', [ $this, 'filter_save_data' ], 10, 2 );
+	}
+
+	public function filter_save_data( array $data, Document $document ): array {
+		if ( Plugin::$instance->role_manager->user_can( self::DESIGN_CAPABILITY ) ) {
+			return $data;
+		}
+
+		if ( empty( $data[ self::FIELD_ELEMENTS ] ) || ! is_array( $data[ self::FIELD_ELEMENTS ] ) ) {
+			return $data;
+		}
+
+		// Restore persisted design values instead of stripping them — the editor posts the full tree on every save.
+		$persisted_map = $this->build_elements_map_by_id( $document->get_elements_data() ?? [] );
+		$had_overrides = false;
+
+		$data[ self::FIELD_ELEMENTS ] = $this->sanitize_elements_tree(
+			$data[ self::FIELD_ELEMENTS ],
+			$persisted_map,
+			$had_overrides
+		);
+
+		if ( $had_overrides ) {
+			Plugin::$instance->logger->warning(
+				'Restored design fields for a content-only user during document save.',
+				[
+					'document_id' => $document->get_main_id(),
+				]
+			);
+		}
+
+		return $data;
+	}
+
+	private function build_elements_map_by_id( array $elements ): array {
+		$map = [];
+
+		foreach ( $elements as $element ) {
+			if ( ! is_array( $element ) ) {
+				continue;
+			}
+
+			$id = $element['id'] ?? '';
+
+			if ( $id ) {
+				$map[ $id ] = $element;
+			}
+
+			$children = $element[ self::FIELD_ELEMENTS ] ?? [];
+
+			if ( is_array( $children ) && ! empty( $children ) ) {
+				$map = array_merge( $map, $this->build_elements_map_by_id( $children ) );
+			}
+		}
+
+		return $map;
+	}
+
+	private function sanitize_elements_tree( array $elements, array $persisted_map, bool &$had_overrides ): array {
+		foreach ( $elements as $index => $element ) {
+			if ( ! is_array( $element ) ) {
+				continue;
+			}
+
+			$elements[ $index ] = $this->sanitize_element_design_fields( $element, $persisted_map, $had_overrides );
+		}
+
+		return $elements;
+	}
+
+	private function sanitize_element_design_fields( array $element, array $persisted_map, bool &$had_overrides ): array {
+		$id = $element['id'] ?? '';
+		$persisted = ( $id && isset( $persisted_map[ $id ] ) ) ? $persisted_map[ $id ] : null;
+
+		if ( $persisted ) {
+			$element = $this->restore_design_fields( $element, $persisted, $had_overrides );
+		} else {
+			$element = $this->strip_design_fields( $element, $had_overrides );
+		}
+
+		$children = $element[ self::FIELD_ELEMENTS ] ?? [];
+
+		if ( is_array( $children ) && ! empty( $children ) ) {
+			$element[ self::FIELD_ELEMENTS ] = $this->sanitize_elements_tree( $children, $persisted_map, $had_overrides );
+		}
+
+		return $element;
+	}
+
+	private function restore_design_fields( array $incoming, array $persisted, bool &$had_overrides ): array {
+		$incoming = $this->restore_top_level_field( $incoming, $persisted, self::FIELD_STYLES, $had_overrides );
+		$incoming = $this->restore_top_level_field( $incoming, $persisted, self::FIELD_INTERACTIONS, $had_overrides );
+
+		return $this->restore_settings_classes( $incoming, $persisted, $had_overrides );
+	}
+
+	private function restore_top_level_field( array $incoming, array $persisted, string $field, bool &$had_overrides ): array {
+		$incoming_has = array_key_exists( $field, $incoming );
+		$persisted_has = array_key_exists( $field, $persisted );
+
+		if ( $persisted_has ) {
+			if ( ! $incoming_has || $incoming[ $field ] !== $persisted[ $field ] ) {
+				$had_overrides = true;
+			}
+
+			$incoming[ $field ] = $persisted[ $field ];
+
+			return $incoming;
+		}
+
+		if ( $incoming_has ) {
+			$had_overrides = true;
+			unset( $incoming[ $field ] );
+		}
+
+		return $incoming;
+	}
+
+	private function restore_settings_classes( array $incoming, array $persisted, bool &$had_overrides ): array {
+		$persisted_settings = $persisted[ self::FIELD_SETTINGS ] ?? [];
+		$incoming_settings = $incoming[ self::FIELD_SETTINGS ] ?? [];
+		$persisted_has = is_array( $persisted_settings ) && array_key_exists( self::SETTING_CLASSES, $persisted_settings );
+		$incoming_has = is_array( $incoming_settings ) && array_key_exists( self::SETTING_CLASSES, $incoming_settings );
+
+		if ( $persisted_has ) {
+			if ( ! $incoming_has || $incoming_settings[ self::SETTING_CLASSES ] !== $persisted_settings[ self::SETTING_CLASSES ] ) {
+				$had_overrides = true;
+			}
+
+			$incoming[ self::FIELD_SETTINGS ][ self::SETTING_CLASSES ] = $persisted_settings[ self::SETTING_CLASSES ];
+
+			return $incoming;
+		}
+
+		if ( $incoming_has ) {
+			$had_overrides = true;
+			unset( $incoming[ self::FIELD_SETTINGS ][ self::SETTING_CLASSES ] );
+		}
+
+		return $incoming;
+	}
+
+	private function strip_design_fields( array $element, bool &$had_overrides ): array {
+		if ( array_key_exists( self::FIELD_STYLES, $element ) ) {
+			$had_overrides = true;
+			unset( $element[ self::FIELD_STYLES ] );
+		}
+
+		if ( array_key_exists( self::FIELD_INTERACTIONS, $element ) ) {
+			$had_overrides = true;
+			unset( $element[ self::FIELD_INTERACTIONS ] );
+		}
+
+		if (
+			isset( $element[ self::FIELD_SETTINGS ] )
+			&& is_array( $element[ self::FIELD_SETTINGS ] )
+			&& array_key_exists( self::SETTING_CLASSES, $element[ self::FIELD_SETTINGS ] )
+		) {
+			$had_overrides = true;
+			unset( $element[ self::FIELD_SETTINGS ][ self::SETTING_CLASSES ] );
+		}
+
+		return $element;
+	}
+}

--- a/core/role-manager/content-only-save-guard.php
+++ b/core/role-manager/content-only-save-guard.php
@@ -24,7 +24,8 @@ class Content_Only_Save_Guard {
 	private const SETTING_CLASSES = 'classes';
 
 	public function register(): void {
-		add_filter( 'elementor/document/save/data', [ $this, 'filter_save_data' ], 10, 2 );
+		// Runs late so no other callback can reintroduce design fields after the guard has cleared them.
+		add_filter( 'elementor/document/save/data', [ $this, 'filter_save_data' ], 99, 2 );
 	}
 
 	public function filter_save_data( array $data, Document $document ): array {
@@ -61,6 +62,12 @@ class Content_Only_Save_Guard {
 	private function build_elements_map_by_id( array $elements ): array {
 		$map = [];
 
+		$this->build_elements_map_by_id_into( $elements, $map );
+
+		return $map;
+	}
+
+	private function build_elements_map_by_id_into( array $elements, array &$map ): void {
 		foreach ( $elements as $element ) {
 			if ( ! is_array( $element ) ) {
 				continue;
@@ -75,11 +82,9 @@ class Content_Only_Save_Guard {
 			$children = $element[ self::FIELD_ELEMENTS ] ?? [];
 
 			if ( is_array( $children ) && ! empty( $children ) ) {
-				$map = array_merge( $map, $this->build_elements_map_by_id( $children ) );
+				$this->build_elements_map_by_id_into( $children, $map );
 			}
 		}
-
-		return $map;
 	}
 
 	private function sanitize_elements_tree( array $elements, array $persisted_map, bool &$had_overrides ): array {

--- a/core/role-manager/role-manager.php
+++ b/core/role-manager/role-manager.php
@@ -323,5 +323,8 @@ class Role_Manager extends Settings_Page {
 		add_action( 'elementor/role/restrictions/controls', [ $this, 'get_go_pro_link_html' ] );
 
 		add_filter( 'elementor/editor/user/restrictions', [ $this, 'get_role_manager_advanced_options' ] );
+
+		$content_only_save_guard = new Content_Only_Save_Guard();
+		$content_only_save_guard->register();
 	}
 }

--- a/includes/user-data.php
+++ b/includes/user-data.php
@@ -64,6 +64,8 @@ class User_Data {
 		$data = [
 			'suppressedMessages' => $suppressed_messages,
 			'capabilities' => $capabilities,
+			// array_values, because array_unique in the role manager can leave non-sequential keys, which json_encode would emit as an object.
+			'restrictions' => array_values( Plugin::$instance->role_manager->get_user_restrictions_array() ),
 		];
 
 		return new \WP_REST_Response( $data, 200 );

--- a/packages/packages/core/editor-editing-panel/package.json
+++ b/packages/packages/core/editor-editing-panel/package.json
@@ -42,6 +42,7 @@
     "@elementor/editor": "4.4.0",
     "@elementor/editor-canvas": "4.4.0",
     "@elementor/editor-controls": "4.4.0",
+    "@elementor/editor-current-user": "4.4.0",
     "@elementor/editor-documents": "4.4.0",
     "@elementor/editor-elements": "4.4.0",
     "@elementor/editor-interactions": "4.4.0",

--- a/packages/packages/core/editor-editing-panel/src/components/__tests__/editing-panel-tabs.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/__tests__/editing-panel-tabs.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createMockElementType, renderWithTheme } from 'test-utils';
-import { useUserRestrictions } from '@elementor/editor-current-user';
+import { useHasContentOnlyAccess } from '@elementor/editor-current-user';
 import { getWidgetsCache } from '@elementor/editor-elements';
 import { fireEvent, screen } from '@testing-library/react';
 
@@ -40,18 +40,6 @@ const STYLE_TAB_PANEL_TEXT = 'Style tab panel';
 const INTERACTIONS_TAB_PANEL_TEXT = 'Interactions tab panel';
 const INFOTIP_ROOT_SELECTOR = '[class*="MuiInfotip-root"]';
 
-const unrestrictedUser = {
-	isRestricted: () => false,
-	restrictions: [] as string[],
-	hasContentOnlyAccess: false,
-};
-
-const contentOnlyUser = {
-	isRestricted: ( restriction: string ) => restriction === 'design',
-	restrictions: [ 'design' ],
-	hasContentOnlyAccess: true,
-};
-
 const renderEditingPanelTabs = ( elementTypeKey: string = ELEMENT_TYPE ) => {
 	const element = { id: ELEMENT_ID, type: elementTypeKey };
 	const elementType = createMockElementType( { key: elementTypeKey, title: 'Heading' } );
@@ -82,7 +70,7 @@ const hasInfotipTrigger = ( tab: HTMLElement ) => {
 
 describe( '<EditingPanelTabs />', () => {
 	beforeEach( () => {
-		jest.mocked( useUserRestrictions ).mockReturnValue( unrestrictedUser );
+		jest.mocked( useHasContentOnlyAccess ).mockReturnValue( false );
 		jest.mocked( getWidgetsCache ).mockReturnValue( {} );
 		jest.mocked( useDefaultPanelSettings ).mockReturnValue( {
 			defaultSectionsExpanded: {
@@ -116,7 +104,7 @@ describe( '<EditingPanelTabs />', () => {
 
 	it( 'should render Style and Interactions tabs disabled for a content-only user', () => {
 		// Arrange
-		jest.mocked( useUserRestrictions ).mockReturnValue( contentOnlyUser );
+		jest.mocked( useHasContentOnlyAccess ).mockReturnValue( true );
 		renderEditingPanelTabs();
 
 		// Act
@@ -135,7 +123,7 @@ describe( '<EditingPanelTabs />', () => {
 
 	it( 'should force the General tab when a content-only user stored tab was Style', () => {
 		// Arrange
-		jest.mocked( useUserRestrictions ).mockReturnValue( contentOnlyUser );
+		jest.mocked( useHasContentOnlyAccess ).mockReturnValue( true );
 		jest.mocked( useStateByElement ).mockReturnValue( [ 'style', jest.fn() ] );
 		renderEditingPanelTabs();
 
@@ -152,7 +140,7 @@ describe( '<EditingPanelTabs />', () => {
 
 	it( 'should attach the content-only infotip to the restricted tabs', () => {
 		// Arrange
-		jest.mocked( useUserRestrictions ).mockReturnValue( contentOnlyUser );
+		jest.mocked( useHasContentOnlyAccess ).mockReturnValue( true );
 
 		// Act
 		renderEditingPanelTabs();
@@ -164,7 +152,7 @@ describe( '<EditingPanelTabs />', () => {
 
 	it( 'should not attach the content-only infotip for an unrestricted user', () => {
 		// Arrange
-		jest.mocked( useUserRestrictions ).mockReturnValue( unrestrictedUser );
+		jest.mocked( useHasContentOnlyAccess ).mockReturnValue( false );
 
 		// Act
 		renderEditingPanelTabs();
@@ -189,7 +177,7 @@ describe( '<EditingPanelTabs />', () => {
 
 	it( 'should keep the Style tab enabled for a promoted element when the user has content-only access', () => {
 		// Arrange
-		jest.mocked( useUserRestrictions ).mockReturnValue( contentOnlyUser );
+		jest.mocked( useHasContentOnlyAccess ).mockReturnValue( true );
 		jest.mocked( getWidgetsCache ).mockReturnValue( {
 			[ PROMOTED_ELEMENT_TYPE ]: {
 				title: 'Promoted widget',

--- a/packages/packages/core/editor-editing-panel/src/components/__tests__/editing-panel-tabs.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/__tests__/editing-panel-tabs.test.tsx
@@ -1,0 +1,214 @@
+import * as React from 'react';
+import { createMockElementType, renderWithTheme } from 'test-utils';
+import { useUserRestrictions } from '@elementor/editor-current-user';
+import { getWidgetsCache } from '@elementor/editor-elements';
+import { fireEvent, screen } from '@testing-library/react';
+
+import { ElementProvider } from '../../contexts/element-context';
+import { useDefaultPanelSettings } from '../../hooks/use-default-panel-settings';
+import { useStateByElement } from '../../hooks/use-state-by-element';
+import { ContentOnlyInfotip } from '../content-only-infotip';
+import { EditingPanelTabs } from '../editing-panel-tabs';
+
+jest.mock( '@elementor/editor-current-user' );
+jest.mock( '@elementor/editor-elements', () => ( {
+	...jest.requireActual( '@elementor/editor-elements' ),
+	getWidgetsCache: jest.fn(),
+} ) );
+jest.mock( '../../hooks/use-default-panel-settings' );
+jest.mock( '../../hooks/use-state-by-element' );
+jest.mock( '../interactions-tab', () => ( {
+	InteractionsTab: () => <div>Interactions tab panel</div>,
+} ) );
+jest.mock( '../settings-tab', () => ( {
+	SettingsTab: () => <div>Settings tab panel</div>,
+} ) );
+jest.mock( '../style-tab', () => ( {
+	StyleTab: () => <div>Style tab panel</div>,
+	stickyHeaderStyles: {},
+} ) );
+
+const ELEMENT_ID = 'test-element-id';
+const ELEMENT_TYPE = 'atomic-heading';
+const PROMOTED_ELEMENT_TYPE = 'promoted-widget';
+const LEARN_MORE_URL = 'https://go.elementor.com/content-only-access-infotip';
+const TAB_GENERAL = 'General';
+const TAB_STYLE = 'Style';
+const TAB_INTERACTIONS = 'Interactions';
+const SETTINGS_TAB_PANEL_TEXT = 'Settings tab panel';
+const STYLE_TAB_PANEL_TEXT = 'Style tab panel';
+const INTERACTIONS_TAB_PANEL_TEXT = 'Interactions tab panel';
+const INFOTIP_ROOT_SELECTOR = '[class*="MuiInfotip-root"]';
+
+const unrestrictedUser = {
+	isRestricted: () => false,
+	restrictions: [] as string[],
+	hasContentOnlyAccess: false,
+};
+
+const contentOnlyUser = {
+	isRestricted: ( restriction: string ) => restriction === 'design',
+	restrictions: [ 'design' ],
+	hasContentOnlyAccess: true,
+};
+
+const renderEditingPanelTabs = ( elementTypeKey: string = ELEMENT_TYPE ) => {
+	const element = { id: ELEMENT_ID, type: elementTypeKey };
+	const elementType = createMockElementType( { key: elementTypeKey, title: 'Heading' } );
+
+	return renderWithTheme(
+		<ElementProvider element={ element } elementType={ elementType } settings={ {} }>
+			<EditingPanelTabs />
+		</ElementProvider>
+	);
+};
+
+const getTabByName = ( name: string ) => screen.getByRole( 'tab', { name } );
+
+const expectTabEnabled = ( tab: HTMLElement ) => {
+	expect( tab ).toBeEnabled();
+	expect( tab ).not.toHaveClass( 'Mui-disabled' );
+};
+
+const expectTabDisabled = ( tab: HTMLElement ) => {
+	expect( tab ).toBeDisabled();
+	expect( tab ).toHaveClass( 'Mui-disabled' );
+};
+
+const hasInfotipTrigger = ( tab: HTMLElement ) => {
+	// eslint-disable-next-line testing-library/no-node-access
+	return Boolean( tab.querySelector( INFOTIP_ROOT_SELECTOR ) );
+};
+
+describe( '<EditingPanelTabs />', () => {
+	beforeEach( () => {
+		jest.mocked( useUserRestrictions ).mockReturnValue( unrestrictedUser );
+		jest.mocked( getWidgetsCache ).mockReturnValue( {} );
+		jest.mocked( useDefaultPanelSettings ).mockReturnValue( {
+			defaultSectionsExpanded: {
+				settings: [],
+				style: [],
+			},
+			defaultTab: 'settings',
+		} );
+		jest.mocked( useStateByElement ).mockReturnValue( [ 'settings', jest.fn() ] );
+	} );
+
+	it( 'should render General, Style and Interactions tabs enabled for an unrestricted user', () => {
+		// Arrange
+		renderEditingPanelTabs();
+
+		// Act
+		const generalTab = getTabByName( TAB_GENERAL );
+		const styleTab = getTabByName( TAB_STYLE );
+		const interactionsTab = getTabByName( TAB_INTERACTIONS );
+
+		// Assert
+		expectTabEnabled( generalTab );
+		expectTabEnabled( styleTab );
+		expectTabEnabled( interactionsTab );
+		expect( screen.getByText( SETTINGS_TAB_PANEL_TEXT ) ).toBeInTheDocument();
+		fireEvent.click( styleTab );
+		expect( screen.getByText( STYLE_TAB_PANEL_TEXT ) ).toBeInTheDocument();
+		fireEvent.click( interactionsTab );
+		expect( screen.getByText( INTERACTIONS_TAB_PANEL_TEXT ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render Style and Interactions tabs disabled for a content-only user', () => {
+		// Arrange
+		jest.mocked( useUserRestrictions ).mockReturnValue( contentOnlyUser );
+		renderEditingPanelTabs();
+
+		// Act
+		const generalTab = getTabByName( TAB_GENERAL );
+		const styleTab = getTabByName( TAB_STYLE );
+		const interactionsTab = getTabByName( TAB_INTERACTIONS );
+
+		// Assert
+		expectTabEnabled( generalTab );
+		expectTabDisabled( styleTab );
+		expectTabDisabled( interactionsTab );
+		expect( screen.getByText( SETTINGS_TAB_PANEL_TEXT ) ).toBeInTheDocument();
+		expect( screen.queryByText( STYLE_TAB_PANEL_TEXT ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( INTERACTIONS_TAB_PANEL_TEXT ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should force the General tab when a content-only user stored tab was Style', () => {
+		// Arrange
+		jest.mocked( useUserRestrictions ).mockReturnValue( contentOnlyUser );
+		jest.mocked( useStateByElement ).mockReturnValue( [ 'style', jest.fn() ] );
+		renderEditingPanelTabs();
+
+		// Act
+		const generalTab = getTabByName( TAB_GENERAL );
+		const styleTab = getTabByName( TAB_STYLE );
+
+		// Assert
+		expect( generalTab ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( styleTab ).toHaveAttribute( 'aria-selected', 'false' );
+		expect( screen.getByText( SETTINGS_TAB_PANEL_TEXT ) ).toBeInTheDocument();
+		expect( screen.queryByText( STYLE_TAB_PANEL_TEXT ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should attach the content-only infotip to the restricted tabs', () => {
+		// Arrange
+		jest.mocked( useUserRestrictions ).mockReturnValue( contentOnlyUser );
+
+		// Act
+		renderEditingPanelTabs();
+
+		// Assert
+		expect( hasInfotipTrigger( getTabByName( TAB_STYLE ) ) ).toBe( true );
+		expect( hasInfotipTrigger( getTabByName( TAB_INTERACTIONS ) ) ).toBe( true );
+	} );
+
+	it( 'should not attach the content-only infotip for an unrestricted user', () => {
+		// Arrange
+		jest.mocked( useUserRestrictions ).mockReturnValue( unrestrictedUser );
+
+		// Act
+		renderEditingPanelTabs();
+
+		// Assert
+		expect( hasInfotipTrigger( getTabByName( TAB_STYLE ) ) ).toBe( false );
+		expect( hasInfotipTrigger( getTabByName( TAB_INTERACTIONS ) ) ).toBe( false );
+	} );
+
+	it( 'should render the content-only infotip copy', () => {
+		// Arrange
+		renderWithTheme( <ContentOnlyInfotip>{ TAB_STYLE }</ContentOnlyInfotip> );
+
+		// Act
+		fireEvent.mouseEnter( screen.getByText( TAB_STYLE ) );
+
+		// Assert
+		expect( screen.getByText( 'Content-only access' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Your Site Admin has limited this role to content editing.' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Learn More' } ) ).toHaveAttribute( 'href', LEARN_MORE_URL );
+	} );
+
+	it( 'should keep the Style tab enabled for a promoted element when the user has content-only access', () => {
+		// Arrange
+		jest.mocked( useUserRestrictions ).mockReturnValue( contentOnlyUser );
+		jest.mocked( getWidgetsCache ).mockReturnValue( {
+			[ PROMOTED_ELEMENT_TYPE ]: {
+				title: 'Promoted widget',
+				controls: {},
+				meta: { is_pro_promotion: true },
+			},
+		} );
+		renderEditingPanelTabs( PROMOTED_ELEMENT_TYPE );
+
+		// Act
+		const styleTab = getTabByName( TAB_STYLE );
+		const interactionsTab = getTabByName( TAB_INTERACTIONS );
+
+		// Assert
+		expect( screen.queryByRole( 'tab', { name: TAB_GENERAL } ) ).not.toBeInTheDocument();
+		expectTabEnabled( styleTab );
+		expectTabEnabled( interactionsTab );
+		expect( screen.getByText( STYLE_TAB_PANEL_TEXT ) ).toBeInTheDocument();
+		fireEvent.click( interactionsTab );
+		expect( screen.getByText( INTERACTIONS_TAB_PANEL_TEXT ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/packages/core/editor-editing-panel/src/components/__tests__/editing-panel.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/__tests__/editing-panel.test.tsx
@@ -1,16 +1,26 @@
 import * as React from 'react';
 import { createMockElementType, renderWithTheme } from 'test-utils';
+import { useUserRestrictions } from '@elementor/editor-current-user';
 import { type Element, type ElementType, useSelectedElementSettings } from '@elementor/editor-elements';
 import { screen } from '@testing-library/react';
 
 import { EditingPanel } from '../editing-panel';
 
+jest.mock( '@elementor/editor-current-user' );
 jest.mock( '@elementor/editor-elements', () => ( {
 	...jest.requireActual( '@elementor/editor-elements' ),
 	useSelectedElementSettings: jest.fn(),
 } ) );
 
 describe( '<EditingPanel />', () => {
+	beforeEach( () => {
+		jest.mocked( useUserRestrictions ).mockReturnValue( {
+			isRestricted: () => false,
+			restrictions: [],
+			hasContentOnlyAccess: false,
+		} );
+	} );
+
 	it( 'should render the selected element editing panel', () => {
 		// Arrange
 		jest.mocked( useSelectedElementSettings ).mockReturnValue( {

--- a/packages/packages/core/editor-editing-panel/src/components/__tests__/editing-panel.test.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/__tests__/editing-panel.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createMockElementType, renderWithTheme } from 'test-utils';
-import { useUserRestrictions } from '@elementor/editor-current-user';
+import { useHasContentOnlyAccess } from '@elementor/editor-current-user';
 import { type Element, type ElementType, useSelectedElementSettings } from '@elementor/editor-elements';
 import { screen } from '@testing-library/react';
 
@@ -14,11 +14,7 @@ jest.mock( '@elementor/editor-elements', () => ( {
 
 describe( '<EditingPanel />', () => {
 	beforeEach( () => {
-		jest.mocked( useUserRestrictions ).mockReturnValue( {
-			isRestricted: () => false,
-			restrictions: [],
-			hasContentOnlyAccess: false,
-		} );
+		jest.mocked( useHasContentOnlyAccess ).mockReturnValue( false );
 	} );
 
 	it( 'should render the selected element editing panel', () => {

--- a/packages/packages/core/editor-editing-panel/src/components/content-only-infotip.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/content-only-infotip.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { type PropsWithChildren, useState } from 'react';
+import { InfoCircleFilledIcon } from '@elementor/icons';
+import { Alert, AlertTitle, Box, Infotip, Link } from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+const LEARN_MORE_URL = 'https://go.elementor.com/content-only-access-infotip';
+
+const INFOTIP_WIDTH = 300;
+
+export const ContentOnlyInfotip = ( { children }: PropsWithChildren ) => {
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	return (
+		<Infotip
+			open={ isOpen }
+			placement="bottom"
+			color="secondary"
+			content={
+				<Alert color="secondary" icon={ <InfoCircleFilledIcon /> } size="small">
+					<AlertTitle>{ __( 'Content-only access', 'elementor' ) }</AlertTitle>
+					<Box component="span">
+						{ __( 'Your Site Admin has limited this role to content editing.', 'elementor' ) }{ ' ' }
+						<Link href={ LEARN_MORE_URL } target="_blank" color="info.main">
+							{ __( 'Learn More', 'elementor' ) }
+						</Link>
+					</Box>
+				</Alert>
+			}
+			slotProps={ { popper: { sx: { width: INFOTIP_WIDTH } } } }
+		>
+			{ /* A disabled MUI tab sets pointer-events: none, so the trigger has to opt back in to receive hover. */ }
+			<Box
+				component="span"
+				sx={ { pointerEvents: 'auto' } }
+				onMouseEnter={ () => setIsOpen( true ) }
+				onMouseLeave={ () => setIsOpen( false ) }
+			>
+				{ children }
+			</Box>
+		</Infotip>
+	);
+};

--- a/packages/packages/core/editor-editing-panel/src/components/content-only-infotip.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/content-only-infotip.tsx
@@ -21,13 +21,21 @@ export const ContentOnlyInfotip = ( { children }: PropsWithChildren ) => {
 					<AlertTitle>{ __( 'Content-only access', 'elementor' ) }</AlertTitle>
 					<Box component="span">
 						{ __( 'Your Site Admin has limited this role to content editing.', 'elementor' ) }{ ' ' }
-						<Link href={ LEARN_MORE_URL } target="_blank" color="info.main">
+						<Link href={ LEARN_MORE_URL } target="_blank" rel="noreferrer" color="info.main">
 							{ __( 'Learn More', 'elementor' ) }
 						</Link>
 					</Box>
 				</Alert>
 			}
-			slotProps={ { popper: { sx: { width: INFOTIP_WIDTH } } } }
+			slotProps={ {
+				popper: {
+					sx: { width: INFOTIP_WIDTH },
+					// The popper is portaled, so it needs its own hover handlers to stay open while the pointer
+					// travels from the tab to the "Learn More" link.
+					onMouseEnter: () => setIsOpen( true ),
+					onMouseLeave: () => setIsOpen( false ),
+				},
+			} }
 		>
 			{ /* A disabled MUI tab sets pointer-events: none, so the trigger has to opt back in to receive hover. */ }
 			<Box

--- a/packages/packages/core/editor-editing-panel/src/components/editing-panel-tabs.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/editing-panel-tabs.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react';
 import * as React from 'react';
+import { useUserRestrictions } from '@elementor/editor-current-user';
 import { getWidgetsCache } from '@elementor/editor-elements';
 import { Divider, Stack, Tab, TabPanel, Tabs, useTabs } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
@@ -8,11 +9,16 @@ import { useElement } from '../contexts/element-context';
 import { ScrollProvider } from '../contexts/scroll-context';
 import { useDefaultPanelSettings } from '../hooks/use-default-panel-settings';
 import { useStateByElement } from '../hooks/use-state-by-element';
+import { ContentOnlyInfotip } from './content-only-infotip';
 import { InteractionsTab } from './interactions-tab';
 import { SettingsTab } from './settings-tab';
 import { stickyHeaderStyles, StyleTab } from './style-tab';
 
 type TabValue = 'settings' | 'style' | 'interactions';
+
+const CONTENT_ONLY_TAB: TabValue = 'settings';
+
+const DESIGN_TABS: TabValue[] = [ 'style', 'interactions' ];
 
 export const EditingPanelTabs = () => {
 	const { element } = useElement();
@@ -31,10 +37,24 @@ const PanelTabContent = () => {
 	const editorDefaults = useDefaultPanelSettings();
 	const defaultComponentTab = editorDefaults.defaultTab as TabValue;
 	const isPromotedElement = !! getWidgetsCache()?.[ element.type ]?.meta?.is_pro_promotion;
+	const { hasContentOnlyAccess } = useUserRestrictions();
+
+	// A promoted element has no General tab, and its Style tab only renders an upsell, so restricting it would leave the panel empty.
+	const areDesignTabsRestricted = hasContentOnlyAccess && ! isPromotedElement;
 
 	const [ storedTab, setCurrentTab ] = useStateByElement< TabValue >( 'tab', defaultComponentTab );
-	const currentTab = isPromotedElement && storedTab === 'settings' ? 'style' : storedTab;
+	const currentTab = resolveCurrentTab( { storedTab, isPromotedElement, areDesignTabsRestricted } );
 	const { getTabProps, getTabPanelProps, getTabsProps } = useTabs< TabValue >( currentTab );
+
+	const getDesignTabProps = ( tab: TabValue ) => ( {
+		...getTabProps( tab ),
+		disabled: areDesignTabsRestricted,
+		sx: areDesignTabsRestricted ? { pointerEvents: 'auto' } : undefined,
+	} );
+
+	const withRestrictionInfotip = ( label: string ) =>
+		areDesignTabsRestricted ? <ContentOnlyInfotip>{ label }</ContentOnlyInfotip> : label;
+
 	return (
 		<ScrollProvider>
 			<Stack direction="column" sx={ { width: '100%' } }>
@@ -45,6 +65,10 @@ const PanelTabContent = () => {
 						sx={ { mt: 0.5 } }
 						{ ...getTabsProps() }
 						onChange={ ( _: unknown, newValue: TabValue ) => {
+							if ( areDesignTabsRestricted && DESIGN_TABS.includes( newValue ) ) {
+								return;
+							}
+
 							getTabsProps().onChange( _, newValue );
 							setCurrentTab( newValue );
 						} }
@@ -52,8 +76,14 @@ const PanelTabContent = () => {
 						{ ! isPromotedElement && (
 							<Tab label={ __( 'General', 'elementor' ) } { ...getTabProps( 'settings' ) } />
 						) }
-						<Tab label={ __( 'Style', 'elementor' ) } { ...getTabProps( 'style' ) } />
-						<Tab label={ __( 'Interactions', 'elementor' ) } { ...getTabProps( 'interactions' ) } />
+						<Tab
+							label={ withRestrictionInfotip( __( 'Style', 'elementor' ) ) }
+							{ ...getDesignTabProps( 'style' ) }
+						/>
+						<Tab
+							label={ withRestrictionInfotip( __( 'Interactions', 'elementor' ) ) }
+							{ ...getDesignTabProps( 'interactions' ) }
+						/>
 					</Tabs>
 					<Divider />
 				</Stack>
@@ -62,13 +92,37 @@ const PanelTabContent = () => {
 						<SettingsTab />
 					</TabPanel>
 				) }
-				<TabPanel { ...getTabPanelProps( 'style' ) } disablePadding>
-					<StyleTab />
-				</TabPanel>
-				<TabPanel { ...getTabPanelProps( 'interactions' ) } disablePadding>
-					<InteractionsTab />
-				</TabPanel>
+				{ ! areDesignTabsRestricted && (
+					<>
+						<TabPanel { ...getTabPanelProps( 'style' ) } disablePadding>
+							<StyleTab />
+						</TabPanel>
+						<TabPanel { ...getTabPanelProps( 'interactions' ) } disablePadding>
+							<InteractionsTab />
+						</TabPanel>
+					</>
+				) }
 			</Stack>
 		</ScrollProvider>
 	);
+};
+
+const resolveCurrentTab = ( {
+	storedTab,
+	isPromotedElement,
+	areDesignTabsRestricted,
+}: {
+	storedTab: TabValue;
+	isPromotedElement: boolean;
+	areDesignTabsRestricted: boolean;
+} ): TabValue => {
+	if ( areDesignTabsRestricted && DESIGN_TABS.includes( storedTab ) ) {
+		return CONTENT_ONLY_TAB;
+	}
+
+	if ( isPromotedElement && storedTab === 'settings' ) {
+		return 'style';
+	}
+
+	return storedTab;
 };

--- a/packages/packages/core/editor-editing-panel/src/components/editing-panel-tabs.tsx
+++ b/packages/packages/core/editor-editing-panel/src/components/editing-panel-tabs.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import * as React from 'react';
-import { useUserRestrictions } from '@elementor/editor-current-user';
+import { useHasContentOnlyAccess } from '@elementor/editor-current-user';
 import { getWidgetsCache } from '@elementor/editor-elements';
 import { Divider, Stack, Tab, TabPanel, Tabs, useTabs } from '@elementor/ui';
 import { __ } from '@wordpress/i18n';
@@ -37,7 +37,7 @@ const PanelTabContent = () => {
 	const editorDefaults = useDefaultPanelSettings();
 	const defaultComponentTab = editorDefaults.defaultTab as TabValue;
 	const isPromotedElement = !! getWidgetsCache()?.[ element.type ]?.meta?.is_pro_promotion;
-	const { hasContentOnlyAccess } = useUserRestrictions();
+	const hasContentOnlyAccess = useHasContentOnlyAccess();
 
 	// A promoted element has no General tab, and its Style tab only renders an upsell, so restricting it would leave the panel empty.
 	const areDesignTabsRestricted = hasContentOnlyAccess && ! isPromotedElement;

--- a/packages/packages/core/editor-global-classes/src/__tests__/sync-with-document-save.test.ts
+++ b/packages/packages/core/editor-global-classes/src/__tests__/sync-with-document-save.test.ts
@@ -1,5 +1,5 @@
 import { createMockStyleDefinition } from 'test-utils';
-import { getCurrentUser } from '@elementor/editor-current-user';
+import { getCurrentUser, isContentOnlyUser } from '@elementor/editor-current-user';
 import {
 	__privateRunCommandSync as runCommandSync,
 	type HookOptions,
@@ -30,6 +30,8 @@ describe( 'syncWithDocumentSave', () => {
 		jest.mocked( getCurrentUser ).mockReturnValue( {
 			capabilities: [ UPDATE_CLASS_CAPABILITY_KEY ],
 		} as never );
+
+		jest.mocked( isContentOnlyUser ).mockReturnValue( false );
 	} );
 
 	it( 'should sync global classes dirty state with the document dirty state', () => {
@@ -105,6 +107,37 @@ describe( 'syncWithDocumentSave', () => {
 			unsubscribe();
 		}
 	);
+
+	it( 'should not save global classes for content-only users', async () => {
+		// Arrange.
+		const triggerHook = mockRegisterDataHook();
+
+		jest.mocked( isContentOnlyUser ).mockReturnValue( true );
+
+		const unsubscribe = syncWithDocumentSave();
+
+		const styleDefinition = createMockStyleDefinition();
+
+		dispatch( slice.actions.add( styleDefinition ) );
+
+		// Act.
+		await triggerHook( 'dependency', 'document/save/save', { status: 'publish' } );
+
+		// Assert.
+		expect( apiClient.publish ).not.toHaveBeenCalled();
+
+		expect( selectIsDirty( getState() ) ).toBe( true );
+		expect( selectPreviewInitialData( getState() ) ).toEqual( {
+			items: {},
+			order: [],
+		} );
+		expect( selectFrontendInitialData( getState() ) ).toEqual( {
+			items: {},
+			order: [],
+		} );
+
+		unsubscribe();
+	} );
 
 	it( 'should not save global classes when the user does not have the capability', async () => {
 		// Arrange.

--- a/packages/packages/core/editor-global-classes/src/sync-with-document-save.ts
+++ b/packages/packages/core/editor-global-classes/src/sync-with-document-save.ts
@@ -1,4 +1,4 @@
-import { getCurrentUser } from '@elementor/editor-current-user';
+import { getCurrentUser, isContentOnlyUser } from '@elementor/editor-current-user';
 import { setDocumentModifiedStatus } from '@elementor/editor-documents';
 import { registerDataHook } from '@elementor/editor-v1-adapters';
 import { __getState as getState, __subscribeWithSelector as subscribeWithSelector } from '@elementor/store';
@@ -32,7 +32,7 @@ function triggerSave( panelActions?: { open: () => void }, context: 'preview' | 
 	const user = getCurrentUser();
 	const canEdit = user?.capabilities.includes( UPDATE_CLASS_CAPABILITY_KEY );
 
-	if ( ! canEdit ) {
+	if ( ! canEdit || isContentOnlyUser() ) {
 		return null;
 	}
 

--- a/packages/packages/core/editor-styles-repository/src/hooks/__tests__/use-user-styles-capability.test.ts
+++ b/packages/packages/core/editor-styles-repository/src/hooks/__tests__/use-user-styles-capability.test.ts
@@ -1,4 +1,4 @@
-import { DESIGN_RESTRICTION, useCurrentUserCapabilities, useUserRestrictions } from '@elementor/editor-current-user';
+import { useCurrentUserCapabilities, useHasContentOnlyAccess } from '@elementor/editor-current-user';
 import { renderHook } from '@testing-library/react';
 
 import { documentElementsStylesProvider } from '../../providers/document-elements-styles-provider';
@@ -31,11 +31,7 @@ const deniedCapabilities = {
 
 describe( 'useUserStylesCapability', () => {
 	beforeEach( () => {
-		jest.mocked( useUserRestrictions ).mockReturnValue( {
-			isRestricted: () => false,
-			restrictions: undefined,
-			hasContentOnlyAccess: false,
-		} );
+		jest.mocked( useHasContentOnlyAccess ).mockReturnValue( false );
 
 		jest.mocked( useCurrentUserCapabilities ).mockReturnValue( {
 			capabilities: [ UPDATE_CAPABILITY ],
@@ -46,11 +42,7 @@ describe( 'useUserStylesCapability', () => {
 
 	it( 'should deny all capabilities for content-only users on a provider without capabilities', () => {
 		// Arrange
-		jest.mocked( useUserRestrictions ).mockReturnValue( {
-			isRestricted: ( restriction ) => restriction === DESIGN_RESTRICTION,
-			restrictions: [ DESIGN_RESTRICTION ],
-			hasContentOnlyAccess: true,
-		} );
+		jest.mocked( useHasContentOnlyAccess ).mockReturnValue( true );
 
 		jest.mocked( stylesRepository.getProviderByKey ).mockReturnValue( documentElementsStylesProvider );
 
@@ -63,11 +55,7 @@ describe( 'useUserStylesCapability', () => {
 
 	it( 'should deny all capabilities for content-only users on a provider with capabilities', () => {
 		// Arrange
-		jest.mocked( useUserRestrictions ).mockReturnValue( {
-			isRestricted: ( restriction ) => restriction === DESIGN_RESTRICTION,
-			restrictions: [ DESIGN_RESTRICTION ],
-			hasContentOnlyAccess: true,
-		} );
+		jest.mocked( useHasContentOnlyAccess ).mockReturnValue( true );
 
 		jest.mocked( stylesRepository.getProviderByKey ).mockReturnValue( providerWithCapabilities as StylesProvider );
 

--- a/packages/packages/core/editor-styles-repository/src/hooks/__tests__/use-user-styles-capability.test.ts
+++ b/packages/packages/core/editor-styles-repository/src/hooks/__tests__/use-user-styles-capability.test.ts
@@ -1,0 +1,80 @@
+import { DESIGN_RESTRICTION, useCurrentUserCapabilities, useUserRestrictions } from '@elementor/editor-current-user';
+import { renderHook } from '@testing-library/react';
+
+import { documentElementsStylesProvider } from '../../providers/document-elements-styles-provider';
+import { stylesRepository } from '../../styles-repository';
+import { type StylesProvider } from '../../types';
+import { useUserStylesCapability } from '../use-user-styles-capability';
+
+jest.mock( '@elementor/editor-current-user' );
+jest.mock( '../../styles-repository' );
+
+const UPDATE_CAPABILITY = 'update_style';
+const PROVIDER_WITH_CAPABILITIES_KEY = 'provider-with-capabilities';
+
+const providerWithCapabilities: Pick< StylesProvider, 'getKey' | 'capabilities' > = {
+	getKey: () => PROVIDER_WITH_CAPABILITIES_KEY,
+	capabilities: {
+		create: UPDATE_CAPABILITY,
+		delete: UPDATE_CAPABILITY,
+		update: UPDATE_CAPABILITY,
+		updateProps: UPDATE_CAPABILITY,
+	},
+};
+
+const deniedCapabilities = {
+	create: false,
+	delete: false,
+	update: false,
+	updateProps: false,
+};
+
+describe( 'useUserStylesCapability', () => {
+	beforeEach( () => {
+		jest.mocked( useUserRestrictions ).mockReturnValue( {
+			isRestricted: () => false,
+			restrictions: undefined,
+			hasContentOnlyAccess: false,
+		} );
+
+		jest.mocked( useCurrentUserCapabilities ).mockReturnValue( {
+			capabilities: [ UPDATE_CAPABILITY ],
+			canUser: ( capability ) => capability === UPDATE_CAPABILITY,
+			isAdmin: false,
+		} );
+	} );
+
+	it( 'should deny all capabilities for content-only users on a provider without capabilities', () => {
+		// Arrange
+		jest.mocked( useUserRestrictions ).mockReturnValue( {
+			isRestricted: ( restriction ) => restriction === DESIGN_RESTRICTION,
+			restrictions: [ DESIGN_RESTRICTION ],
+			hasContentOnlyAccess: true,
+		} );
+
+		jest.mocked( stylesRepository.getProviderByKey ).mockReturnValue( documentElementsStylesProvider );
+
+		// Act
+		const { result } = renderHook( () => useUserStylesCapability() );
+
+		// Assert
+		expect( result.current.userCan( 'document-elements-42' ) ).toEqual( deniedCapabilities );
+	} );
+
+	it( 'should deny all capabilities for content-only users on a provider with capabilities', () => {
+		// Arrange
+		jest.mocked( useUserRestrictions ).mockReturnValue( {
+			isRestricted: ( restriction ) => restriction === DESIGN_RESTRICTION,
+			restrictions: [ DESIGN_RESTRICTION ],
+			hasContentOnlyAccess: true,
+		} );
+
+		jest.mocked( stylesRepository.getProviderByKey ).mockReturnValue( providerWithCapabilities as StylesProvider );
+
+		// Act
+		const { result } = renderHook( () => useUserStylesCapability() );
+
+		// Assert
+		expect( result.current.userCan( PROVIDER_WITH_CAPABILITIES_KEY ) ).toEqual( deniedCapabilities );
+	} );
+} );

--- a/packages/packages/core/editor-styles-repository/src/hooks/use-user-styles-capability.ts
+++ b/packages/packages/core/editor-styles-repository/src/hooks/use-user-styles-capability.ts
@@ -1,4 +1,4 @@
-import { useCurrentUserCapabilities } from '@elementor/editor-current-user';
+import { useCurrentUserCapabilities, useUserRestrictions } from '@elementor/editor-current-user';
 
 import { stylesRepository } from '../styles-repository';
 import { type UserCapabilities } from '../types';
@@ -14,10 +14,22 @@ const DEFAULT_CAPABILITIES: UserCan = {
 	updateProps: true,
 };
 
+const DENIED_CAPABILITIES: UserCan = {
+	create: false,
+	delete: false,
+	update: false,
+	updateProps: false,
+};
+
 export const useUserStylesCapability = () => {
 	const { capabilities } = useCurrentUserCapabilities();
+	const { hasContentOnlyAccess } = useUserRestrictions();
 
 	const userCan = ( providerKey: string ): UserCan => {
+		if ( hasContentOnlyAccess ) {
+			return DENIED_CAPABILITIES;
+		}
+
 		const provider = stylesRepository.getProviderByKey( providerKey );
 
 		if ( ! provider?.capabilities ) {

--- a/packages/packages/core/editor-styles-repository/src/hooks/use-user-styles-capability.ts
+++ b/packages/packages/core/editor-styles-repository/src/hooks/use-user-styles-capability.ts
@@ -1,4 +1,4 @@
-import { useCurrentUserCapabilities, useUserRestrictions } from '@elementor/editor-current-user';
+import { useCurrentUserCapabilities, useHasContentOnlyAccess } from '@elementor/editor-current-user';
 
 import { stylesRepository } from '../styles-repository';
 import { type UserCapabilities } from '../types';
@@ -23,7 +23,7 @@ const DENIED_CAPABILITIES: UserCan = {
 
 export const useUserStylesCapability = () => {
 	const { capabilities } = useCurrentUserCapabilities();
-	const { hasContentOnlyAccess } = useUserRestrictions();
+	const hasContentOnlyAccess = useHasContentOnlyAccess();
 
 	const userCan = ( providerKey: string ): UserCan => {
 		if ( hasContentOnlyAccess ) {

--- a/packages/packages/libs/editor-current-user/src/__tests__/is-content-only-user.test.ts
+++ b/packages/packages/libs/editor-current-user/src/__tests__/is-content-only-user.test.ts
@@ -1,0 +1,45 @@
+import { type UserModel } from '../api';
+import { getCurrentUser } from '../get-current-user';
+import { isContentOnlyUser } from '../is-content-only-user';
+import { DESIGN_RESTRICTION } from '../use-user-restrictions';
+
+jest.mock( '../get-current-user' );
+
+describe( 'isContentOnlyUser', () => {
+	it( 'should return true when the design restriction is present', () => {
+		// Arrange
+		jest.mocked( getCurrentUser ).mockReturnValue( {
+			restrictions: [ DESIGN_RESTRICTION ],
+		} as UserModel );
+
+		// Act
+		const result = isContentOnlyUser();
+
+		// Assert
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should return false when the design restriction is absent', () => {
+		// Arrange
+		jest.mocked( getCurrentUser ).mockReturnValue( {
+			restrictions: [ 'json-upload' ],
+		} as UserModel );
+
+		// Act
+		const result = isContentOnlyUser();
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return false when there is no cached user', () => {
+		// Arrange
+		jest.mocked( getCurrentUser ).mockReturnValue( undefined );
+
+		// Act
+		const result = isContentOnlyUser();
+
+		// Assert
+		expect( result ).toBe( false );
+	} );
+} );

--- a/packages/packages/libs/editor-current-user/src/__tests__/use-user-restrictions.test.ts
+++ b/packages/packages/libs/editor-current-user/src/__tests__/use-user-restrictions.test.ts
@@ -3,6 +3,7 @@ import { renderHook } from '@testing-library/react';
 
 import { type User } from '../types';
 import { useCurrentUser } from '../use-current-user';
+import { useHasContentOnlyAccess } from '../use-has-content-only-access';
 import { DESIGN_RESTRICTION, useUserRestrictions } from '../use-user-restrictions';
 
 jest.mock( '../use-current-user' );
@@ -14,19 +15,7 @@ const mockRestrictions = ( restrictions: string[] ) => {
 };
 
 describe( 'useUserRestrictions', () => {
-	it( 'should report content-only access when the design restriction is present', () => {
-		// Arrange
-		mockRestrictions( [ DESIGN_RESTRICTION ] );
-
-		// Act
-		const { result } = renderHook( () => useUserRestrictions() );
-
-		// Assert
-		expect( result.current.hasContentOnlyAccess ).toBe( true );
-		expect( result.current.isRestricted( DESIGN_RESTRICTION ) ).toBe( true );
-	} );
-
-	it( 'should not report content-only access for unrelated restrictions', () => {
+	it( 'should report the restrictions it was given', () => {
 		// Arrange
 		mockRestrictions( [ 'json-upload' ] );
 
@@ -34,11 +23,12 @@ describe( 'useUserRestrictions', () => {
 		const { result } = renderHook( () => useUserRestrictions() );
 
 		// Assert
-		expect( result.current.hasContentOnlyAccess ).toBe( false );
+		expect( result.current.restrictions ).toEqual( [ 'json-upload' ] );
 		expect( result.current.isRestricted( 'json-upload' ) ).toBe( true );
+		expect( result.current.isRestricted( DESIGN_RESTRICTION ) ).toBe( false );
 	} );
 
-	it( 'should not report content-only access while the user data is unavailable', () => {
+	it( 'should report nothing as restricted while the user data is unavailable', () => {
 		// Arrange
 		jest.mocked( useCurrentUser ).mockReturnValue( {} as UseQueryResult< User, Error > );
 
@@ -46,7 +36,42 @@ describe( 'useUserRestrictions', () => {
 		const { result } = renderHook( () => useUserRestrictions() );
 
 		// Assert
-		expect( result.current.hasContentOnlyAccess ).toBe( false );
 		expect( result.current.restrictions ).toBeUndefined();
+		expect( result.current.isRestricted( DESIGN_RESTRICTION ) ).toBe( false );
+	} );
+} );
+
+describe( 'useHasContentOnlyAccess', () => {
+	it( 'should report content-only access when the design restriction is present', () => {
+		// Arrange
+		mockRestrictions( [ DESIGN_RESTRICTION ] );
+
+		// Act
+		const { result } = renderHook( () => useHasContentOnlyAccess() );
+
+		// Assert
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'should not report content-only access for unrelated restrictions', () => {
+		// Arrange
+		mockRestrictions( [ 'json-upload' ] );
+
+		// Act
+		const { result } = renderHook( () => useHasContentOnlyAccess() );
+
+		// Assert
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'should not report content-only access while the user data is unavailable', () => {
+		// Arrange
+		jest.mocked( useCurrentUser ).mockReturnValue( {} as UseQueryResult< User, Error > );
+
+		// Act
+		const { result } = renderHook( () => useHasContentOnlyAccess() );
+
+		// Assert
+		expect( result.current ).toBe( false );
 	} );
 } );

--- a/packages/packages/libs/editor-current-user/src/__tests__/use-user-restrictions.test.ts
+++ b/packages/packages/libs/editor-current-user/src/__tests__/use-user-restrictions.test.ts
@@ -1,0 +1,52 @@
+import { type UseQueryResult } from '@elementor/query';
+import { renderHook } from '@testing-library/react';
+
+import { type User } from '../types';
+import { useCurrentUser } from '../use-current-user';
+import { DESIGN_RESTRICTION, useUserRestrictions } from '../use-user-restrictions';
+
+jest.mock( '../use-current-user' );
+
+const mockRestrictions = ( restrictions: string[] ) => {
+	jest.mocked( useCurrentUser ).mockReturnValue( {
+		data: { restrictions },
+	} as UseQueryResult< User, Error > );
+};
+
+describe( 'useUserRestrictions', () => {
+	it( 'should report content-only access when the design restriction is present', () => {
+		// Arrange
+		mockRestrictions( [ DESIGN_RESTRICTION ] );
+
+		// Act
+		const { result } = renderHook( () => useUserRestrictions() );
+
+		// Assert
+		expect( result.current.hasContentOnlyAccess ).toBe( true );
+		expect( result.current.isRestricted( DESIGN_RESTRICTION ) ).toBe( true );
+	} );
+
+	it( 'should not report content-only access for unrelated restrictions', () => {
+		// Arrange
+		mockRestrictions( [ 'json-upload' ] );
+
+		// Act
+		const { result } = renderHook( () => useUserRestrictions() );
+
+		// Assert
+		expect( result.current.hasContentOnlyAccess ).toBe( false );
+		expect( result.current.isRestricted( 'json-upload' ) ).toBe( true );
+	} );
+
+	it( 'should not report content-only access while the user data is unavailable', () => {
+		// Arrange
+		jest.mocked( useCurrentUser ).mockReturnValue( {} as UseQueryResult< User, Error > );
+
+		// Act
+		const { result } = renderHook( () => useUserRestrictions() );
+
+		// Assert
+		expect( result.current.hasContentOnlyAccess ).toBe( false );
+		expect( result.current.restrictions ).toBeUndefined();
+	} );
+} );

--- a/packages/packages/libs/editor-current-user/src/api.ts
+++ b/packages/packages/libs/editor-current-user/src/api.ts
@@ -11,6 +11,7 @@ type GetUserPayload = {
 export type UserModel = {
 	suppressedMessages: string[];
 	capabilities: string[];
+	restrictions: string[];
 };
 
 const getUserPayload: GetUserPayload = { params: { context: 'edit' } };
@@ -20,9 +21,9 @@ export const apiClient = {
 		httpService()
 			.get< UserModel >( RESOURCE_URL, getUserPayload )
 			.then( ( res ) => {
-				const { capabilities = [], suppressedMessages = [] } = res.data;
+				const { capabilities = [], suppressedMessages = [], restrictions = [] } = res.data;
 
-				return { capabilities, suppressedMessages };
+				return { capabilities, suppressedMessages, restrictions };
 			} ),
 	update: ( data: Partial< User > ) =>
 		httpService().patch< Partial< UserModel > >( RESOURCE_URL, {

--- a/packages/packages/libs/editor-current-user/src/index.ts
+++ b/packages/packages/libs/editor-current-user/src/index.ts
@@ -1,6 +1,7 @@
 export { useSuppressedMessage } from './use-suppressed-message';
 export { useCurrentUserCapabilities } from './use-current-user-capabilities';
 export { getCurrentUser } from './get-current-user';
+export { isContentOnlyUser } from './is-content-only-user';
 export { ensureUser } from './ensure-current-user';
 export { onSetUser } from './on-set-user';
 export { useCurrentUser } from './use-current-user';

--- a/packages/packages/libs/editor-current-user/src/index.ts
+++ b/packages/packages/libs/editor-current-user/src/index.ts
@@ -6,3 +6,4 @@ export { onSetUser } from './on-set-user';
 export { useCurrentUser } from './use-current-user';
 export { useUpdateCurrentUser } from './use-update-current-user';
 export { DESIGN_RESTRICTION, useUserRestrictions } from './use-user-restrictions';
+export { useHasContentOnlyAccess } from './use-has-content-only-access';

--- a/packages/packages/libs/editor-current-user/src/index.ts
+++ b/packages/packages/libs/editor-current-user/src/index.ts
@@ -5,3 +5,4 @@ export { ensureUser } from './ensure-current-user';
 export { onSetUser } from './on-set-user';
 export { useCurrentUser } from './use-current-user';
 export { useUpdateCurrentUser } from './use-update-current-user';
+export { DESIGN_RESTRICTION, useUserRestrictions } from './use-user-restrictions';

--- a/packages/packages/libs/editor-current-user/src/is-content-only-user.ts
+++ b/packages/packages/libs/editor-current-user/src/is-content-only-user.ts
@@ -1,0 +1,6 @@
+import { getCurrentUser } from './get-current-user';
+import { DESIGN_RESTRICTION } from './use-user-restrictions';
+
+export const isContentOnlyUser = () => {
+	return Boolean( getCurrentUser()?.restrictions?.includes( DESIGN_RESTRICTION ) );
+};

--- a/packages/packages/libs/editor-current-user/src/types.ts
+++ b/packages/packages/libs/editor-current-user/src/types.ts
@@ -1,4 +1,5 @@
 export type User = {
 	suppressedMessages: string[];
 	capabilities: string[];
+	restrictions: string[];
 };

--- a/packages/packages/libs/editor-current-user/src/use-has-content-only-access.ts
+++ b/packages/packages/libs/editor-current-user/src/use-has-content-only-access.ts
@@ -1,0 +1,3 @@
+import { DESIGN_RESTRICTION, useUserRestrictions } from './use-user-restrictions';
+
+export const useHasContentOnlyAccess = () => useUserRestrictions().isRestricted( DESIGN_RESTRICTION );

--- a/packages/packages/libs/editor-current-user/src/use-user-restrictions.ts
+++ b/packages/packages/libs/editor-current-user/src/use-user-restrictions.ts
@@ -10,6 +10,5 @@ export const useUserRestrictions = () => {
 	return {
 		isRestricted,
 		restrictions: data?.restrictions,
-		hasContentOnlyAccess: isRestricted( DESIGN_RESTRICTION ),
 	};
 };

--- a/packages/packages/libs/editor-current-user/src/use-user-restrictions.ts
+++ b/packages/packages/libs/editor-current-user/src/use-user-restrictions.ts
@@ -1,0 +1,15 @@
+import { useCurrentUser } from './use-current-user';
+
+export const DESIGN_RESTRICTION = 'design';
+
+export const useUserRestrictions = () => {
+	const { data } = useCurrentUser();
+
+	const isRestricted = ( restriction: string ) => Boolean( data?.restrictions?.includes( restriction ) );
+
+	return {
+		isRestricted,
+		restrictions: data?.restrictions,
+		hasContentOnlyAccess: isRestricted( DESIGN_RESTRICTION ),
+	};
+};

--- a/tests/phpunit/elementor/core/role-manager/test-content-only-save-guard.php
+++ b/tests/phpunit/elementor/core/role-manager/test-content-only-save-guard.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace Elementor\Testing\Core\RoleManager;
+
+use Elementor\Core\Base\Document;
+use Elementor\Core\RoleManager\Content_Only_Save_Guard;
+use Elementor\Core\RoleManager\Role_Manager;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Content_Only_Save_Guard extends Elementor_Test_Base {
+
+	private Content_Only_Save_Guard $guard;
+
+	private $original_role_manager = null;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->guard = new Content_Only_Save_Guard();
+	}
+
+	public function tearDown(): void {
+		if ( $this->original_role_manager ) {
+			Plugin::$instance->role_manager = $this->original_role_manager;
+			$this->original_role_manager = null;
+		}
+
+		parent::tearDown();
+	}
+
+	public function test_filter_save_data__restores_persisted_design_fields_for_existing_elements() {
+		// Arrange
+		$this->mock_user_can_design( false );
+
+		$persisted_styles = [ 'id' => 'style-1', 'type' => 'class' ];
+		$persisted_interactions = [ 'items' => [ [ 'id' => 'interaction-1' ] ], 'version' => 1 ];
+		$persisted_classes = [ '$$type' => 'classes', 'value' => [ 'my-class' ] ];
+
+		$persisted_element = $this->make_element(
+			'heading-1',
+			[
+				'styles' => $persisted_styles,
+				'interactions' => $persisted_interactions,
+				'settings' => [
+					'title' => [ '$$type' => 'string', 'value' => 'Persisted title' ],
+					'classes' => $persisted_classes,
+				],
+			]
+		);
+
+		$incoming_element = $this->make_element(
+			'heading-1',
+			[
+				'styles' => [ 'id' => 'style-2', 'type' => 'class' ],
+				'interactions' => [ 'items' => [ [ 'id' => 'interaction-2' ] ], 'version' => 1 ],
+				'settings' => [
+					'title' => [ '$$type' => 'string', 'value' => 'Incoming title' ],
+					'classes' => [ '$$type' => 'classes', 'value' => [ 'tampered-class' ] ],
+				],
+			]
+		);
+
+		$document = $this->create_document_mock( [ $persisted_element ] );
+		$data = [ 'elements' => [ $incoming_element ] ];
+
+		// Act
+		$result = $this->guard->filter_save_data( $data, $document );
+
+		// Assert
+		$saved_element = $result['elements'][0];
+
+		$this->assertSame( $persisted_styles, $saved_element['styles'] );
+		$this->assertSame( $persisted_interactions, $saved_element['interactions'] );
+		$this->assertSame( $persisted_classes, $saved_element['settings']['classes'] );
+		$this->assertSame( 'Incoming title', $saved_element['settings']['title']['value'] );
+	}
+
+	public function test_filter_save_data__strips_design_fields_from_new_elements() {
+		// Arrange
+		$this->mock_user_can_design( false );
+
+		$new_element = $this->make_element(
+			'heading-new',
+			[
+				'styles' => [ 'id' => 'style-new' ],
+				'interactions' => [ 'items' => [ [ 'id' => 'interaction-new' ] ], 'version' => 1 ],
+				'settings' => [
+					'title' => [ '$$type' => 'string', 'value' => 'New heading' ],
+					'classes' => [ '$$type' => 'classes', 'value' => [ 'new-class' ] ],
+				],
+			]
+		);
+
+		$document = $this->create_document_mock( [] );
+		$data = [ 'elements' => [ $new_element ] ];
+
+		// Act
+		$result = $this->guard->filter_save_data( $data, $document );
+
+		// Assert
+		$saved_element = $result['elements'][0];
+
+		$this->assertArrayNotHasKey( 'styles', $saved_element );
+		$this->assertArrayNotHasKey( 'interactions', $saved_element );
+		$this->assertArrayNotHasKey( 'classes', $saved_element['settings'] );
+		$this->assertSame( 'New heading', $saved_element['settings']['title']['value'] );
+	}
+
+	public function test_filter_save_data__preserves_non_design_settings_for_restricted_users() {
+		// Arrange
+		$this->mock_user_can_design( false );
+
+		$persisted_element = $this->make_element(
+			'heading-1',
+			[
+				'settings' => [
+					'title' => [ '$$type' => 'string', 'value' => 'Old title' ],
+				],
+			]
+		);
+
+		$incoming_element = $this->make_element(
+			'heading-1',
+			[
+				'settings' => [
+					'title' => [ '$$type' => 'string', 'value' => 'Updated title' ],
+					'link' => [ '$$type' => 'link', 'value' => [ 'url' => 'https://example.com' ] ],
+				],
+			]
+		);
+
+		$document = $this->create_document_mock( [ $persisted_element ] );
+		$data = [ 'elements' => [ $incoming_element ] ];
+
+		// Act
+		$result = $this->guard->filter_save_data( $data, $document );
+
+		// Assert
+		$saved_element = $result['elements'][0 ];
+
+		$this->assertSame( 'Updated title', $saved_element['settings']['title']['value'] );
+		$this->assertSame( 'https://example.com', $saved_element['settings']['link']['value']['url'] );
+	}
+
+	public function test_filter_save_data__does_not_change_data_for_unrestricted_users() {
+		// Arrange
+		$this->mock_user_can_design( true );
+
+		$incoming_element = $this->make_element(
+			'heading-1',
+			[
+				'styles' => [ 'id' => 'style-1' ],
+				'interactions' => [ 'items' => [], 'version' => 1 ],
+				'settings' => [
+					'title' => [ '$$type' => 'string', 'value' => 'Title' ],
+					'classes' => [ '$$type' => 'classes', 'value' => [ 'my-class' ] ],
+				],
+			]
+		);
+
+		$document = $this->create_document_mock( [] );
+		$data = [ 'elements' => [ $incoming_element ] ];
+
+		// Act
+		$result = $this->guard->filter_save_data( $data, $document );
+
+		// Assert
+		$this->assertSame( $data, $result );
+	}
+
+	public function test_filter_save_data__handles_nested_elements_recursively() {
+		// Arrange
+		$this->mock_user_can_design( false );
+
+		$persisted_child = $this->make_element(
+			'child-1',
+			[
+				'styles' => [ 'id' => 'child-style' ],
+				'interactions' => [ 'items' => [ [ 'id' => 'child-interaction' ] ], 'version' => 1 ],
+				'settings' => [
+					'classes' => [ '$$type' => 'classes', 'value' => [ 'child-class' ] ],
+				],
+			]
+		);
+
+		$persisted_container = $this->make_element(
+			'container-1',
+			[
+				'elType' => 'container',
+				'widgetType' => null,
+				'elements' => [ $persisted_child ],
+			]
+		);
+
+		$incoming_child = $this->make_element(
+			'child-1',
+			[
+				'styles' => [ 'id' => 'tampered-style' ],
+				'interactions' => [ 'items' => [ [ 'id' => 'tampered-interaction' ] ], 'version' => 1 ],
+				'settings' => [
+					'classes' => [ '$$type' => 'classes', 'value' => [ 'tampered-class' ] ],
+				],
+			]
+		);
+
+		$incoming_container = $this->make_element(
+			'container-1',
+			[
+				'elType' => 'container',
+				'widgetType' => null,
+				'elements' => [ $incoming_child ],
+			]
+		);
+
+		$document = $this->create_document_mock( [ $persisted_container ] );
+		$data = [ 'elements' => [ $incoming_container ] ];
+
+		// Act
+		$result = $this->guard->filter_save_data( $data, $document );
+
+		// Assert
+		$saved_child = $result['elements'][0]['elements'][0];
+
+		$this->assertSame( $persisted_child['styles'], $saved_child['styles'] );
+		$this->assertSame( $persisted_child['interactions'], $saved_child['interactions'] );
+		$this->assertSame( $persisted_child['settings']['classes'], $saved_child['settings']['classes'] );
+	}
+
+	private function mock_user_can_design( bool $can_design ): void {
+		$role_manager = $this->getMockBuilder( Role_Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'user_can' ] )
+			->getMock();
+
+		$role_manager->method( 'user_can' )
+			->with( 'design' )
+			->willReturn( $can_design );
+
+		$this->original_role_manager = Plugin::$instance->role_manager;
+		Plugin::$instance->role_manager = $role_manager;
+	}
+
+	private function create_document_mock( array $persisted_elements, int $document_id = 123 ): Document {
+		$document = $this->getMockBuilder( Document::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_elements_data', 'get_main_id' ] )
+			->getMock();
+
+		$document->method( 'get_elements_data' )->willReturn( $persisted_elements );
+		$document->method( 'get_main_id' )->willReturn( $document_id );
+
+		return $document;
+	}
+
+	private function make_element( string $id, array $overrides = [] ): array {
+		return array_merge(
+			[
+				'id' => $id,
+				'elType' => 'widget',
+				'widgetType' => 'atomic-heading',
+				'settings' => [],
+				'elements' => [],
+			],
+			$overrides
+		);
+	}
+}

--- a/tests/phpunit/elementor/includes/test-user-data.php
+++ b/tests/phpunit/elementor/includes/test-user-data.php
@@ -40,6 +40,35 @@ class Test_User_Data extends Elementor_Test_Base {
 		$this->assertContains( 'manage_options', $data['capabilities'] );
 	}
 
+	public function test_get_current_user__returns_role_manager_restrictions() {
+		// Arrange
+		$this->act_as( 'editor' );
+		add_filter( 'elementor/editor/user/restrictions', function( $restrictions ) {
+			$restrictions['editor'] = [ 'design' ];
+
+			return $restrictions;
+		} );
+
+		// Act
+		$response = $this->make_get_request();
+
+		// Assert
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( [ 'design' ], $response->get_data()['restrictions'] );
+	}
+
+	public function test_get_current_user__returns_empty_restrictions_for_unrestricted_role() {
+		// Arrange
+		$this->act_as( 'editor' );
+
+		// Act
+		$response = $this->make_get_request();
+
+		// Assert
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( [], $response->get_data()['restrictions'] );
+	}
+
 	public function test_get_current_user__returns_empty_suppressed_messages_when_none_set() {
 		// Arrange
 		$this->act_as_admin();

--- a/tests/phpunit/elementor/includes/test-user-data.php
+++ b/tests/phpunit/elementor/includes/test-user-data.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elementor\Testing\Includes;
 
+use Elementor\Core\RoleManager\Role_Manager;
+use Elementor\Plugin;
 use Elementor\User;
 use Elementor\User_Data;
 use ElementorEditorTesting\Elementor_Test_Base;
@@ -11,6 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Test_User_Data extends Elementor_Test_Base {
 
+	private $original_role_manager = null;
+
 	public function setUp(): void {
 		parent::setUp();
 
@@ -18,6 +22,15 @@ class Test_User_Data extends Elementor_Test_Base {
 		$wp_rest_server = new \WP_REST_Server();
 
 		do_action( 'rest_api_init' );
+	}
+
+	public function tearDown(): void {
+		if ( $this->original_role_manager ) {
+			Plugin::$instance->role_manager = $this->original_role_manager;
+			$this->original_role_manager = null;
+		}
+
+		parent::tearDown();
 	}
 
 	public function test_get_current_user__returns_user_data_when_logged_in() {
@@ -42,24 +55,21 @@ class Test_User_Data extends Elementor_Test_Base {
 
 	public function test_get_current_user__returns_role_manager_restrictions() {
 		// Arrange
-		$this->act_as( 'editor' );
-		add_filter( 'elementor/editor/user/restrictions', function( $restrictions ) {
-			$restrictions['editor'] = [ 'design' ];
-
-			return $restrictions;
-		} );
+		$this->act_as_admin();
+		$this->mock_user_restrictions( [ 'design', 'json-upload' ] );
 
 		// Act
 		$response = $this->make_get_request();
 
 		// Assert
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame( [ 'design' ], $response->get_data()['restrictions'] );
+		$this->assertSame( [ 'design', 'json-upload' ], $response->get_data()['restrictions'] );
 	}
 
 	public function test_get_current_user__returns_empty_restrictions_for_unrestricted_role() {
 		// Arrange
-		$this->act_as( 'editor' );
+		$this->act_as_admin();
+		$this->mock_user_restrictions( [] );
 
 		// Act
 		$response = $this->make_get_request();
@@ -67,6 +77,19 @@ class Test_User_Data extends Elementor_Test_Base {
 		// Assert
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [], $response->get_data()['restrictions'] );
+	}
+
+	public function test_get_current_user__reindexes_restrictions_so_they_serialize_as_a_json_array() {
+		// Arrange
+		$this->act_as_admin();
+		$this->mock_user_restrictions( [ 0 => 'design', 2 => 'json-upload' ] );
+
+		// Act
+		$response = $this->make_get_request();
+
+		// Assert
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( '["design","json-upload"]', wp_json_encode( $response->get_data()['restrictions'] ) );
 	}
 
 	public function test_get_current_user__returns_empty_suppressed_messages_when_none_set() {
@@ -227,6 +250,24 @@ class Test_User_Data extends Elementor_Test_Base {
 		$this->assertSame( 200, $final_get_response->get_status() );
 		$final_data = $final_get_response->get_data();
 		$this->assertSame( $messages, $final_data['suppressedMessages'] );
+	}
+
+	/**
+	 * Role_Manager::get_user_restrictions() memoizes into a method level static, so the
+	 * restrictions cannot be varied per test through the filter. Substituting the manager
+	 * keeps each test isolated and asserts the REST payload rather than the role plumbing.
+	 */
+	private function mock_user_restrictions( array $restrictions ) {
+		$role_manager = $this->getMockBuilder( Role_Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_user_restrictions_array' ] )
+			->getMock();
+
+		$role_manager->method( 'get_user_restrictions_array' )->willReturn( $restrictions );
+
+		$this->original_role_manager = Plugin::$instance->role_manager;
+
+		Plugin::$instance->role_manager = $role_manager;
 	}
 
 	private function setup_user_with_suppressed_messages( array $messages ) {

--- a/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
@@ -36,7 +36,7 @@ test.describe( 'Content-only editing panel access @v4-tests', () => {
 			e_atomic_elements: 'active',
 			e_opt_in_v4: 'active',
 		} );
-		// wpCli runs through docker compose without a shell, so the JSON must not be shell-quoted.
+		// The wpCli helper runs through docker compose without a shell, so the JSON must not be shell-quoted.
 		await wpCli( `wp option update ${ ROLE_MANAGER_OPTION } ${ JSON.stringify( CONTENT_ONLY_ROLE_RESTRICTIONS ) } --format=json` );
 
 		contentOnlyUser = await apiRequests.createNewUser( request, {

--- a/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
@@ -1,0 +1,131 @@
+import { expect } from '@playwright/test';
+import { wpCli } from '../../../assets/wp-cli';
+import { timeouts } from '../../../config/timeouts';
+import WpAdminPage from '../../../pages/wp-admin-page';
+import { parallelTest as test } from '../../../parallelTest';
+import EditorSelectors from '../../../selectors/editor-selectors';
+
+const ROLE_MANAGER_OPTION = 'elementor_role-manager';
+const DESIGN_RESTRICTION = 'design';
+const EDITOR_ROLE = 'editor';
+const CONTENT_ONLY_ROLE_RESTRICTIONS = { [ EDITOR_ROLE ]: [ DESIGN_RESTRICTION ] };
+const TAB_GENERAL = 'General';
+const TAB_STYLE = 'Style';
+const TAB_INTERACTIONS = 'Interactions';
+const INFOTIP_TITLE = 'Content-only access';
+const INFOTIP_BODY = 'Your Site Admin has limited this role to content editing.';
+const INFOTIP_LEARN_MORE_LABEL = 'Learn More';
+const INFOTIP_LEARN_MORE_URL = 'https://go.elementor.com/content-only-access-infotip';
+const HEADING_WIDGET = EditorSelectors.v4.atoms.heading;
+const UPDATED_HEADING_TEXT = 'Content-only heading edit';
+
+test.describe( 'Content-only editing panel access @v4-tests', () => {
+	let contentOnlyUser: { id: string; username: string; password: string };
+	let sharedPostId: string;
+	let headingWidgetId: string;
+
+	test.beforeAll( async ( { browser, apiRequests, request }, testInfo ) => {
+		const adminContext = await browser.newContext( { storageState: undefined } );
+		const adminPage = await adminContext.newPage();
+		const adminWpAdmin = new WpAdminPage( adminPage, testInfo, apiRequests );
+
+		await adminWpAdmin.customLogin( process.env.USERNAME || 'admin', process.env.PASSWORD || 'password' );
+		await adminWpAdmin.setExperiments( {
+			e_atomic_elements: 'active',
+			e_opt_in_v4: 'active',
+		} );
+		await wpCli( `wp option update ${ ROLE_MANAGER_OPTION } '${ JSON.stringify( CONTENT_ONLY_ROLE_RESTRICTIONS ) }' --format=json` );
+
+		contentOnlyUser = await apiRequests.createNewUser( request, {
+			username: 'contentOnlyEditor',
+			password: 'password',
+			email: 'content-only-editor@test.com',
+			roles: [ EDITOR_ROLE ],
+		} );
+
+		const editor = await adminWpAdmin.openNewPage();
+		const postIdMatch = adminPage.url().match( /post=(\d+)/ );
+		sharedPostId = postIdMatch?.[ 1 ] ?? '';
+
+		const containerId = await editor.addElement( { elType: 'container' }, 'document' );
+		headingWidgetId = await editor.addWidget( { widgetType: HEADING_WIDGET, container: containerId } );
+
+		await adminContext.close();
+	} );
+
+	test.afterAll( async ( { browser, apiRequests, request }, testInfo ) => {
+		if ( contentOnlyUser?.id ) {
+			try {
+				await apiRequests.deleteUser( request, contentOnlyUser.id );
+			} catch {
+				// Cleanup should not fail the test run.
+			}
+		}
+
+		const cleanupContext = await browser.newContext( { storageState: undefined } );
+		const cleanupPage = await cleanupContext.newPage();
+		const cleanupWpAdmin = new WpAdminPage( cleanupPage, testInfo, apiRequests );
+
+		await cleanupWpAdmin.customLogin( process.env.USERNAME || 'admin', process.env.PASSWORD || 'password' );
+		await wpCli( `wp option delete ${ ROLE_MANAGER_OPTION }` );
+		await cleanupWpAdmin.resetExperiments();
+		await cleanupContext.close();
+	} );
+
+	test( 'content-only editor sees restricted panel tabs while admin does not', async ( { browser, apiRequests, page }, testInfo ) => {
+		const editorContext = await browser.newContext( { storageState: undefined } );
+		const editorPage = await editorContext.newPage();
+		const wpAdmin = new WpAdminPage( editorPage, testInfo, apiRequests );
+
+		await wpAdmin.customLogin( contentOnlyUser.username, contentOnlyUser.password );
+		const editor = await wpAdmin.editExistingPostWithElementor( sharedPostId, { page: editorPage, testInfo } );
+		await editor.selectElement( headingWidgetId );
+
+		const generalTab = editorPage.getByRole( 'tab', { name: TAB_GENERAL } );
+		const styleTab = editorPage.getByRole( 'tab', { name: TAB_STYLE } );
+		const interactionsTab = editorPage.getByRole( 'tab', { name: TAB_INTERACTIONS } );
+
+		await test.step( 'Style and Interactions tabs are present but disabled; General is enabled and selected', async () => {
+			await expect( generalTab ).toBeVisible();
+			await expect( styleTab ).toBeVisible();
+			await expect( interactionsTab ).toBeVisible();
+			await expect( generalTab ).toBeEnabled();
+			await expect( generalTab ).toHaveAttribute( 'aria-selected', 'true' );
+			await expect( styleTab ).toBeDisabled();
+			await expect( interactionsTab ).toBeDisabled();
+		} );
+
+		await test.step( 'Hovering the disabled Style tab shows the content-only infotip', async () => {
+			await styleTab.hover();
+			await expect( editorPage.getByText( INFOTIP_TITLE ) ).toBeVisible( { timeout: timeouts.action } );
+			await expect( editorPage.getByText( INFOTIP_BODY ) ).toBeVisible();
+			const learnMoreLink = editorPage.getByRole( 'link', { name: INFOTIP_LEARN_MORE_LABEL } );
+			await expect( learnMoreLink ).toBeVisible();
+			await expect( learnMoreLink ).toHaveAttribute( 'href', INFOTIP_LEARN_MORE_URL );
+		} );
+
+		await test.step( 'Content-only user can edit a General tab control', async () => {
+			const panelInlineEditor = editor.getPanelInlineEditor();
+			await expect( panelInlineEditor ).toBeVisible();
+			await panelInlineEditor.clear();
+			await panelInlineEditor.fill( UPDATED_HEADING_TEXT );
+
+			const headingOnCanvas = editor.getPreviewFrame().locator(
+				`.elementor-element-${ headingWidgetId } ${ EditorSelectors.v4.atomSelectors.heading.base }`,
+			);
+			await expect( headingOnCanvas ).toHaveText( UPDATED_HEADING_TEXT, { timeout: timeouts.longAction } );
+		} );
+
+		await editorContext.close();
+
+		await test.step( 'Administrator sees all editing panel tabs enabled on the same page', async () => {
+			const adminWpAdmin = new WpAdminPage( page, testInfo, apiRequests );
+			const adminEditor = await adminWpAdmin.editExistingPostWithElementor( sharedPostId, { page, testInfo } );
+			await adminEditor.selectElement( headingWidgetId );
+
+			await expect( page.getByRole( 'tab', { name: TAB_GENERAL } ) ).toBeEnabled();
+			await expect( page.getByRole( 'tab', { name: TAB_STYLE } ) ).toBeEnabled();
+			await expect( page.getByRole( 'tab', { name: TAB_INTERACTIONS } ) ).toBeEnabled();
+		} );
+	} );
+} );

--- a/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
@@ -57,6 +57,9 @@ test.describe( 'Content-only editing panel access @v4-tests', () => {
 		const containerId = await editor.addElement( { elType: 'container' }, 'document' );
 		headingWidgetId = await editor.addWidget( { widgetType: HEADING_WIDGET, container: containerId } );
 
+		// The content-only user opens this post in a separate context, so the heading has to be persisted.
+		await editor.publishPage();
+
 		await adminContext.close();
 	} );
 

--- a/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
@@ -21,6 +21,17 @@ const INFOTIP_LEARN_MORE_URL = 'https://go.elementor.com/content-only-access-inf
 const HEADING_WIDGET = EditorSelectors.v4.atoms.heading;
 const UPDATED_HEADING_TEXT = 'Content-only heading edit';
 
+// Elementor shows a modal "Take Over" confirm when another user still holds the post lock, and it
+// swallows pointer events on the panel. The lock outlives a closed browser context, so it has to be
+// released whenever this spec hands the same document to a different user.
+const clearPostLock = async ( postId: string ) => {
+	try {
+		await wpCli( `wp post meta delete ${ postId } _edit_lock` );
+	} catch {
+		// The wp-cli call exits non-zero when the lock was never written, which is fine.
+	}
+};
+
 test.describe( 'Content-only editing panel access @v4-tests', () => {
 	let contentOnlyUser: { id: string; username: string; password: string };
 	let sharedPostId: string;
@@ -61,6 +72,8 @@ test.describe( 'Content-only editing panel access @v4-tests', () => {
 		await editor.publishPage();
 
 		await adminContext.close();
+
+		await clearPostLock( sharedPostId );
 	} );
 
 	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
@@ -131,6 +144,8 @@ test.describe( 'Content-only editing panel access @v4-tests', () => {
 		} );
 
 		await editorContext.close();
+
+		await clearPostLock( sharedPostId );
 
 		await test.step( 'Administrator sees all editing panel tabs enabled on the same page', async () => {
 			const adminWpAdmin = new WpAdminPage( page, testInfo, apiRequests );

--- a/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
@@ -36,7 +36,8 @@ test.describe( 'Content-only editing panel access @v4-tests', () => {
 			e_atomic_elements: 'active',
 			e_opt_in_v4: 'active',
 		} );
-		await wpCli( `wp option update ${ ROLE_MANAGER_OPTION } '${ JSON.stringify( CONTENT_ONLY_ROLE_RESTRICTIONS ) }' --format=json` );
+		// wpCli runs through docker compose without a shell, so the JSON must not be shell-quoted.
+		await wpCli( `wp option update ${ ROLE_MANAGER_OPTION } ${ JSON.stringify( CONTENT_ONLY_ROLE_RESTRICTIONS ) } --format=json` );
 
 		contentOnlyUser = await apiRequests.createNewUser( request, {
 			username: 'contentOnlyEditor',

--- a/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import { wpCli } from '../../../assets/wp-cli';
 import { timeouts } from '../../../config/timeouts';
+import EditorPage from '../../../pages/editor-page';
 import WpAdminPage from '../../../pages/wp-admin-page';
 import { parallelTest as test } from '../../../parallelTest';
 import EditorSelectors from '../../../selectors/editor-selectors';
@@ -12,6 +13,7 @@ const CONTENT_ONLY_ROLE_RESTRICTIONS = { [ EDITOR_ROLE ]: [ DESIGN_RESTRICTION ]
 const TAB_GENERAL = 'General';
 const TAB_STYLE = 'Style';
 const TAB_INTERACTIONS = 'Interactions';
+const INFOTIP_POPPER_SELECTOR = '.MuiTooltip-tooltip';
 const INFOTIP_TITLE = 'Content-only access';
 const INFOTIP_BODY = 'Your Site Admin has limited this role to content editing.';
 const INFOTIP_LEARN_MORE_LABEL = 'Learn More';
@@ -43,9 +45,12 @@ test.describe( 'Content-only editing panel access @v4-tests', () => {
 			roles: [ EDITOR_ROLE ],
 		} );
 
-		const editor = await adminWpAdmin.openNewPage();
-		const postIdMatch = adminPage.url().match( /post=(\d+)/ );
-		sharedPostId = postIdMatch?.[ 1 ] ?? '';
+		sharedPostId = await adminWpAdmin.createNewPostWithAPI();
+		await adminPage.waitForLoadState( 'load', { timeout: timeouts.action } );
+		await adminWpAdmin.waitForPanel();
+		await adminWpAdmin.closeAnnouncementsIfVisible();
+
+		const editor = new EditorPage( adminPage, testInfo );
 
 		const containerId = await editor.addElement( { elType: 'container' }, 'document' );
 		headingWidgetId = await editor.addWidget( { widgetType: HEADING_WIDGET, container: containerId } );
@@ -66,10 +71,15 @@ test.describe( 'Content-only editing panel access @v4-tests', () => {
 		const cleanupPage = await cleanupContext.newPage();
 		const cleanupWpAdmin = new WpAdminPage( cleanupPage, testInfo, apiRequests );
 
-		await cleanupWpAdmin.customLogin( process.env.USERNAME || 'admin', process.env.PASSWORD || 'password' );
-		await wpCli( `wp option delete ${ ROLE_MANAGER_OPTION }` );
-		await cleanupWpAdmin.resetExperiments();
-		await cleanupContext.close();
+		try {
+			await cleanupWpAdmin.customLogin( process.env.USERNAME || 'admin', process.env.PASSWORD || 'password' );
+			await wpCli( `wp option delete ${ ROLE_MANAGER_OPTION }` );
+			await cleanupWpAdmin.resetExperiments();
+		} catch {
+			// Cleanup should not fail the test run.
+		} finally {
+			await cleanupContext.close();
+		}
 	} );
 
 	test( 'content-only editor sees restricted panel tabs while admin does not', async ( { browser, apiRequests, page }, testInfo ) => {
@@ -97,9 +107,13 @@ test.describe( 'Content-only editing panel access @v4-tests', () => {
 
 		await test.step( 'Hovering the disabled Style tab shows the content-only infotip', async () => {
 			await styleTab.hover();
-			await expect( editorPage.getByText( INFOTIP_TITLE ) ).toBeVisible( { timeout: timeouts.action } );
-			await expect( editorPage.getByText( INFOTIP_BODY ) ).toBeVisible();
-			const learnMoreLink = editorPage.getByRole( 'link', { name: INFOTIP_LEARN_MORE_LABEL } );
+
+			// The infotip renders in a portal, so scope the assertions to the popper itself.
+			const infotip = editorPage.locator( INFOTIP_POPPER_SELECTOR ).filter( { hasText: INFOTIP_TITLE } );
+
+			await expect( infotip ).toBeVisible( { timeout: timeouts.action } );
+			await expect( infotip.getByText( INFOTIP_BODY ) ).toBeVisible();
+			const learnMoreLink = infotip.getByRole( 'link', { name: INFOTIP_LEARN_MORE_LABEL } );
 			await expect( learnMoreLink ).toBeVisible();
 			await expect( learnMoreLink ).toHaveAttribute( 'href', INFOTIP_LEARN_MORE_URL );
 		} );

--- a/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/content-only-editing-panel.test.ts
@@ -26,12 +26,13 @@ test.describe( 'Content-only editing panel access @v4-tests', () => {
 	let sharedPostId: string;
 	let headingWidgetId: string;
 
-	test.beforeAll( async ( { browser, apiRequests, request }, testInfo ) => {
-		const adminContext = await browser.newContext( { storageState: undefined } );
+	test.beforeAll( async ( { browser, apiRequests }, testInfo ) => {
+		// Keep the worker's admin storage state: the shared apiRequests nonce is bound to that
+		// session, so a freshly logged-in context would be rejected with an invalid nonce.
+		const adminContext = await browser.newContext();
 		const adminPage = await adminContext.newPage();
 		const adminWpAdmin = new WpAdminPage( adminPage, testInfo, apiRequests );
 
-		await adminWpAdmin.customLogin( process.env.USERNAME || 'admin', process.env.PASSWORD || 'password' );
 		await adminWpAdmin.setExperiments( {
 			e_atomic_elements: 'active',
 			e_opt_in_v4: 'active',
@@ -39,7 +40,7 @@ test.describe( 'Content-only editing panel access @v4-tests', () => {
 		// The wpCli helper runs through docker compose without a shell, so the JSON must not be shell-quoted.
 		await wpCli( `wp option update ${ ROLE_MANAGER_OPTION } ${ JSON.stringify( CONTENT_ONLY_ROLE_RESTRICTIONS ) } --format=json` );
 
-		contentOnlyUser = await apiRequests.createNewUser( request, {
+		contentOnlyUser = await apiRequests.createNewUser( adminPage.context().request, {
 			username: 'contentOnlyEditor',
 			password: 'password',
 			email: 'content-only-editor@test.com',
@@ -59,21 +60,16 @@ test.describe( 'Content-only editing panel access @v4-tests', () => {
 		await adminContext.close();
 	} );
 
-	test.afterAll( async ( { browser, apiRequests, request }, testInfo ) => {
-		if ( contentOnlyUser?.id ) {
-			try {
-				await apiRequests.deleteUser( request, contentOnlyUser.id );
-			} catch {
-				// Cleanup should not fail the test run.
-			}
-		}
-
-		const cleanupContext = await browser.newContext( { storageState: undefined } );
+	test.afterAll( async ( { browser, apiRequests }, testInfo ) => {
+		const cleanupContext = await browser.newContext();
 		const cleanupPage = await cleanupContext.newPage();
 		const cleanupWpAdmin = new WpAdminPage( cleanupPage, testInfo, apiRequests );
 
 		try {
-			await cleanupWpAdmin.customLogin( process.env.USERNAME || 'admin', process.env.PASSWORD || 'password' );
+			if ( contentOnlyUser?.id ) {
+				await apiRequests.deleteUser( cleanupPage.context().request, contentOnlyUser.id );
+			}
+
 			await wpCli( `wp option delete ${ ROLE_MANAGER_OPTION }` );
 			await cleanupWpAdmin.resetExperiments();
 		} catch {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI-only integration PR. It contains the combined diff of the five review PRs for "Access to edit content only" in the v4 atomic editor, targeting `main` so the full `PR` workflow (Lint JS/PHP, Jest, QUnit, PHPUnit matrix, Playwright) actually runs against the complete feature.

The stacked PRs each target the previous phase branch, and `.github/workflows/pr.yml` only triggers on PRs whose base is `main` or a release branch. That means phases 2-5 get no test runs on their own. This PR exists to produce those results for the stack as a whole.

**Review the individual phases, not this PR:**

1. [#37219](https://github.com/elementor/elementor/pull/37219) - Expose role manager restrictions to the v4 editor
2. [#37220](https://github.com/elementor/elementor/pull/37220) - Disable Style and Interactions tabs for content-only roles
3. [#37221](https://github.com/elementor/elementor/pull/37221) - Deny style editing surfaces outside the panel tabs
4. [#37222](https://github.com/elementor/elementor/pull/37222) - Enforce content-only access on document save
5. [#37225](https://github.com/elementor/elementor/pull/37225) - Add content-only editing panel e2e coverage

## What the feature does

When a role is restricted to "Access to edit content only" (the `design` restriction in the Role Manager), the v4 editing panel keeps the Style and Interactions tabs visible but disabled, with an infotip explaining the restriction and linking to docs. The General tab stays fully functional. The restriction is also enforced beyond the tabs: style provider capabilities are denied, global class saving is skipped, and a save guard on `elementor/document/save/data` restores persisted design fields for existing elements and strips them from new ones, so a restricted user cannot lose or overwrite design data.

## CI status

Green across the board on this branch: Lint JS, Lint PHP, Jest, QUnit, the full PHPUnit matrix (WP latest/6.9/6.8 x PHP 7.4-8.3), all 24 Playwright shards, and Pull Request Validations.

The new e2e spec landed on Playwright shard 13 and needed four fixes found by these runs, all in the spec rather than the feature:

- The `wpCli` helper runs through docker compose without a shell, so the shell-quoted JSON reached wp-cli verbatim and was rejected as invalid.
- The shared `apiRequests` nonce is bound to the worker's admin storage state, so creating the user and page from a freshly logged-in context failed with `rest_cookie_invalid_nonce`.
- The fixture heading was created in the admin editor session but never published, so the content-only user opened a document without it.
- Elementor's modal "Take Over" confirm appears while another user still holds the post lock and intercepted the pointer events the infotip hover needs, so the spec now releases `_edit_lock` when it hands the document to a different user.

## Jira

ED-25430

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72354742-39d3-4852-8f9f-bab3d4184b56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72354742-39d3-4852-8f9f-bab3d4184b56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Implementing content-only access for v4 atomic editor — users with design restrictions can edit content but cannot modify styles, interactions, or class settings. Backend guards against tampering; frontend UI disables restricted tabs with contextual infotips.

## 2. What Changed (Where)

| Core | Frontend |
|------|----------|
| New `Content_Only_Save_Guard` — filters saves, restores persisted design fields for existing elements, strips them from new ones | `EditingPanelTabs` — disables Style/Interactions tabs, routes stored tab state back to General for restricted users |
| `Role_Manager` registers guard on init | `ContentOnlyInfotip` component with learn-more link |
| `User_Data` REST endpoint exports `restrictions` array | `useUserRestrictions()` hook exposes `hasContentOnlyAccess` flag |
| `editor-current-user` lib adds `isContentOnlyUser()` and `useUserRestrictions()` exports | `useUserStylesCapability` denies all style ops for content-only users |
| | Global classes sync skips save for content-only users |

## 3. How It Works

Frontend checks `restrictions` from user payload; if `design` restriction present, `areDesignTabsRestricted` gates Style/Interactions tabs (disabled, non-clickable, wrapped in infotip). On backend, `Content_Only_Save_Guard` runs late in save filter: maps persisted elements by ID, recursively walks incoming tree comparing by ID. For matched IDs, restores `styles`, `interactions`, and `settings.classes` from persisted. For new elements (no ID match), strips those fields entirely. Logs warnings on overrides. Content-only users' saves are structurally valid but design-sanitized; no tampering survives round-trip.

## 4. Risks

**Memoization footgun**: `Role_Manager::get_user_restrictions()` memoizes in method-level static; tests mock the manager to isolate per-test state — appropriate given the constraint, but document this coupling if extending. 

**Recursive tree walk**: Guard assumes well-formed element trees; malformed nesting (circular refs, missing IDs) could cause silent data loss. Unlikely in practice (editor constructs), but no explicit validation.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
