### PR TITLE
Fix: Ignore non-200 remote responses in atomic SVG src transformer [ED-25530]

### DIFF
--- a/modules/atomic-widgets/props-resolver/transformers/svg-src-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/svg-src-transformer.php
@@ -14,6 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Svg_Src_Transformer extends Transformer_Base {
 	const SVG_INLINE_STYLES = 'width: 100%; height: 100%; overflow: unset;';
 
+	private const HTTP_OK = 200;
+
 	public function transform( $value, Props_Resolver_Context $context ) {
 		$id = isset( $value['id'] ) ? (int) $value['id'] : null;
 		$url = $value['url'] ?? null;
@@ -49,33 +51,49 @@ class Svg_Src_Transformer extends Transformer_Base {
 			return null;
 		}
 
-		$local_path = $this->resolve_local_path( $url );
-
-		if ( $local_path ) {
-			$content = Utils::file_get_contents( $local_path );
-
-			if ( $content ) {
-				return $content;
-			}
-		}
-
-		$response = wp_safe_remote_get( $url );
-
-		if ( ! is_wp_error( $response ) ) {
-			return $response['body'];
-		}
-
-		return null;
+		return $this->is_same_site_url( $url )
+			? $this->fetch_local_svg_content( $url )
+			: $this->fetch_remote_svg_content( $url );
 	}
 
-	private function resolve_local_path( string $url ): ?string {
-		$site_url = site_url();
+	private function fetch_local_svg_content( string $url ): ?string {
+		$local_path = $this->resolve_local_path( $url );
 
-		if ( 0 !== strpos( $url, $site_url ) ) {
+		if ( ! $local_path ) {
 			return null;
 		}
 
-		$relative = substr( $url, strlen( $site_url ) );
+		$content = Utils::file_get_contents( $local_path );
+
+		return $content ? $content : null;
+	}
+
+	private function fetch_remote_svg_content( string $url ): ?string {
+		$response = wp_safe_remote_get( $url );
+
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		if ( self::HTTP_OK !== wp_remote_retrieve_response_code( $response ) ) {
+			return null;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+
+		return $body ? $body : null;
+	}
+
+	private function is_same_site_url( string $url ): bool {
+		return 0 === strpos( $url, site_url() );
+	}
+
+	private function resolve_local_path( string $url ): ?string {
+		if ( ! $this->is_same_site_url( $url ) ) {
+			return null;
+		}
+
+		$relative = substr( $url, strlen( site_url() ) );
 		$path = ABSPATH . ltrim( $relative, '/' );
 
 		return file_exists( $path ) ? $path : null;

--- a/modules/atomic-widgets/props-resolver/transformers/svg-src-transformer.php
+++ b/modules/atomic-widgets/props-resolver/transformers/svg-src-transformer.php
@@ -14,8 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Svg_Src_Transformer extends Transformer_Base {
 	const SVG_INLINE_STYLES = 'width: 100%; height: 100%; overflow: unset;';
 
-	private const HTTP_OK = 200;
-
 	public function transform( $value, Props_Resolver_Context $context ) {
 		$id = isset( $value['id'] ) ? (int) $value['id'] : null;
 		$url = $value['url'] ?? null;
@@ -51,9 +49,9 @@ class Svg_Src_Transformer extends Transformer_Base {
 			return null;
 		}
 
-		return $this->is_same_site_url( $url )
-			? $this->fetch_local_svg_content( $url )
-			: $this->fetch_remote_svg_content( $url );
+		$local_content = $this->fetch_local_svg_content( $url );
+
+		return $local_content ? $local_content : $this->fetch_remote_svg_content( $url );
 	}
 
 	private function fetch_local_svg_content( string $url ): ?string {
@@ -75,7 +73,7 @@ class Svg_Src_Transformer extends Transformer_Base {
 			return null;
 		}
 
-		if ( self::HTTP_OK !== wp_remote_retrieve_response_code( $response ) ) {
+		if ( \WP_Http::OK !== (int) wp_remote_retrieve_response_code( $response ) ) {
 			return null;
 		}
 
@@ -84,16 +82,14 @@ class Svg_Src_Transformer extends Transformer_Base {
 		return $body ? $body : null;
 	}
 
-	private function is_same_site_url( string $url ): bool {
-		return 0 === strpos( $url, site_url() );
-	}
-
 	private function resolve_local_path( string $url ): ?string {
-		if ( ! $this->is_same_site_url( $url ) ) {
+		$site_url = site_url();
+
+		if ( 0 !== strpos( $url, $site_url ) ) {
 			return null;
 		}
 
-		$relative = substr( $url, strlen( site_url() ) );
+		$relative = substr( $url, strlen( $site_url ) );
 		$path = ABSPATH . ltrim( $relative, '/' );
 
 		return file_exists( $path ) ? $path : null;

--- a/tests/phpunit/elementor/modules/atomic-widgets/props-resolver/transformers/test-svg-src-transformer.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/props-resolver/transformers/test-svg-src-transformer.php
@@ -11,23 +11,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Test_Svg_Src_Transformer extends Elementor_Test_Base {
-	const HTTP_NOT_FOUND = 404;
-
-	const HTTP_OK = 200;
-
 	const SVG_MARKUP = '<svg viewBox="0 0 24 24"><path d="M0 0"/></svg>';
 
 	const NOT_FOUND_PAGE_WITH_SVG = '<html><body><h1>Not found</h1>' . self::SVG_MARKUP . '</body></html>';
 
 	private Svg_Src_Transformer $transformer;
 
-	private int $http_request_count = 0;
-
 	public function setUp(): void {
 		parent::setUp();
 
 		$this->transformer = new Svg_Src_Transformer();
-		$this->http_request_count = 0;
 	}
 
 	public function tearDown(): void {
@@ -36,23 +29,22 @@ class Test_Svg_Src_Transformer extends Elementor_Test_Base {
 		parent::tearDown();
 	}
 
-	public function test_transform__does_not_request_remotely_when_local_file_is_missing() {
+	public function test_transform__returns_empty_html_when_missing_local_file_responds_with_error_status() {
 		// Arrange.
-		$this->mock_http_response( self::HTTP_OK, self::SVG_MARKUP );
+		$this->mock_http_response( \WP_Http::NOT_FOUND, self::NOT_FOUND_PAGE_WITH_SVG );
 		$value = [ 'url' => site_url( '/wp-content/uploads/deleted-icon.svg' ) ];
 
 		// Act.
 		$result = $this->transformer->transform( $value, Props_Resolver_Context::make() );
 
 		// Assert.
-		$this->assertSame( 0, $this->http_request_count );
 		$this->assertSame( '', $result['html'] );
 		$this->assertSame( $value['url'], $result['url'] );
 	}
 
 	public function test_transform__returns_empty_html_when_remote_responds_with_error_status() {
 		// Arrange.
-		$this->mock_http_response( self::HTTP_NOT_FOUND, self::NOT_FOUND_PAGE_WITH_SVG );
+		$this->mock_http_response( \WP_Http::NOT_FOUND, self::NOT_FOUND_PAGE_WITH_SVG );
 		$value = [ 'url' => 'https://example.com/missing-icon.svg' ];
 
 		// Act.
@@ -64,7 +56,7 @@ class Test_Svg_Src_Transformer extends Elementor_Test_Base {
 
 	public function test_transform__returns_inline_svg_when_remote_responds_successfully() {
 		// Arrange.
-		$this->mock_http_response( self::HTTP_OK, self::SVG_MARKUP );
+		$this->mock_http_response( \WP_Http::OK, self::SVG_MARKUP );
 		$value = [ 'url' => 'https://example.com/icon.svg' ];
 
 		// Act.
@@ -79,8 +71,6 @@ class Test_Svg_Src_Transformer extends Elementor_Test_Base {
 		add_filter(
 			'pre_http_request',
 			function () use ( $status_code, $body ) {
-				++$this->http_request_count;
-
 				return [
 					'headers' => [],
 					'body' => $body,

--- a/tests/phpunit/elementor/modules/atomic-widgets/props-resolver/transformers/test-svg-src-transformer.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/props-resolver/transformers/test-svg-src-transformer.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Elementor\Testing\Modules\AtomicWidgets\PropsResolver\Transformers;
+
+use Elementor\Modules\AtomicWidgets\PropsResolver\Props_Resolver_Context;
+use Elementor\Modules\AtomicWidgets\PropsResolver\Transformers\Svg_Src_Transformer;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Svg_Src_Transformer extends Elementor_Test_Base {
+	const HTTP_NOT_FOUND = 404;
+
+	const HTTP_OK = 200;
+
+	const SVG_MARKUP = '<svg viewBox="0 0 24 24"><path d="M0 0"/></svg>';
+
+	const NOT_FOUND_PAGE_WITH_SVG = '<html><body><h1>Not found</h1>' . self::SVG_MARKUP . '</body></html>';
+
+	private Svg_Src_Transformer $transformer;
+
+	private int $http_request_count = 0;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->transformer = new Svg_Src_Transformer();
+		$this->http_request_count = 0;
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'pre_http_request' );
+
+		parent::tearDown();
+	}
+
+	public function test_transform__does_not_request_remotely_when_local_file_is_missing() {
+		// Arrange.
+		$this->mock_http_response( self::HTTP_OK, self::SVG_MARKUP );
+		$value = [ 'url' => site_url( '/wp-content/uploads/deleted-icon.svg' ) ];
+
+		// Act.
+		$result = $this->transformer->transform( $value, Props_Resolver_Context::make() );
+
+		// Assert.
+		$this->assertSame( 0, $this->http_request_count );
+		$this->assertSame( '', $result['html'] );
+		$this->assertSame( $value['url'], $result['url'] );
+	}
+
+	public function test_transform__returns_empty_html_when_remote_responds_with_error_status() {
+		// Arrange.
+		$this->mock_http_response( self::HTTP_NOT_FOUND, self::NOT_FOUND_PAGE_WITH_SVG );
+		$value = [ 'url' => 'https://example.com/missing-icon.svg' ];
+
+		// Act.
+		$result = $this->transformer->transform( $value, Props_Resolver_Context::make() );
+
+		// Assert.
+		$this->assertSame( '', $result['html'] );
+	}
+
+	public function test_transform__returns_inline_svg_when_remote_responds_successfully() {
+		// Arrange.
+		$this->mock_http_response( self::HTTP_OK, self::SVG_MARKUP );
+		$value = [ 'url' => 'https://example.com/icon.svg' ];
+
+		// Act.
+		$result = $this->transformer->transform( $value, Props_Resolver_Context::make() );
+
+		// Assert.
+		$this->assertStringContainsString( '<svg', $result['html'] );
+		$this->assertStringContainsString( 'fill="currentColor"', $result['html'] );
+	}
+
+	private function mock_http_response( int $status_code, string $body ): void {
+		add_filter(
+			'pre_http_request',
+			function () use ( $status_code, $body ) {
+				++$this->http_request_count;
+
+				return [
+					'headers' => [],
+					'body' => $body,
+					'response' => [
+						'code' => $status_code,
+						'message' => '',
+					],
+					'cookies' => [],
+					'filename' => null,
+				];
+			}
+		);
+	}
+}

--- a/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-svg.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/test-atomic-svg.php
@@ -28,15 +28,11 @@ class Test_Atomic_Svg extends Elementor_Test_Base {
 
 		add_filter( 'pre_http_request', function( $preempt, $args, $url ) {
 			if ( $url === self::TEST_RESOURCES_DIR . 'test.svg' ) {
-				return [
-					'body' => '<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h100v100H0z"/></svg>',
-				];
+				return $this->mock_http_response( '<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h100v100H0z"/></svg>' );
 			}
 
 			if ( $url === Atomic_Svg::DEFAULT_SVG_URL ) {
-				return [
-					'body' => file_get_contents( Atomic_Svg::DEFAULT_SVG_PATH ),
-				];
+				return $this->mock_http_response( file_get_contents( Atomic_Svg::DEFAULT_SVG_PATH ) );
 			}
 
 			return $preempt;
@@ -352,5 +348,18 @@ class Test_Atomic_Svg extends Elementor_Test_Base {
 		// Assert.
 		$this->assertStringContainsString( 'id="my-custom-id"', $rendered_output );
 		$this->assertStringNotContainsString( 'id=&quot;', $rendered_output );
+	}
+
+	private function mock_http_response( string $body ) : array {
+		return [
+			'headers' => [],
+			'body' => $body,
+			'response' => [
+				'code' => WP_Http::OK,
+				'message' => 'OK',
+			],
+			'cookies' => [],
+			'filename' => null,
+		];
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR Checklist

- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type

- [x] Bugfix

## Summary

This PR can be summarized in the following changelog entry:

* Fix: A missing or unreachable SVG file no longer renders unrelated markup taken from the server's error page

## Description

`Svg_Src_Transformer::fetch_svg_content()` falls back to `wp_safe_remote_get()` and read `$response['body']` after only an `is_wp_error()` check. A 404/403/500 is not a `WP_Error`, so the error page HTML was treated as SVG source and passed to `process_svg()`. Because `WP_HTML_Tag_Processor::next_tag( 'svg' )` scans the whole document rather than just the root element, any inline `<svg>` on that error page (theme logo, social icons) was sanitized and rendered as the widget's icon. The result was silently wrong output instead of an empty icon.

Remote responses are now accepted only with HTTP 200, using `wp_remote_retrieve_response_code()` / `wp_remote_retrieve_body()` and `WP_Http::OK`.

### On the loopback request for deleted local attachments

The first revision of this PR also made same-site URLs skip the remote fallback entirely, since `resolve_local_path()` had already proven the file missing via `file_exists()`. **That was reverted** — it is incorrect. `resolve_local_path()` conflates "the file is gone" with "the URL could not be mapped to a path", and its naive `site_url()` → `ABSPATH` mapping legitimately fails to resolve files that do exist: a moved `WP_CONTENT_DIR`, symlinked plugins, or a `WP_HOME`/`WP_SITEURL` mismatch. In those setups the remote fetch is a working fallback, and skipping it turned existing SVGs into empty icons.

`Test_Atomic_Svg` demonstrated this: three snapshot tests failed because the default SVG (`ELEMENTOR_ASSETS_URL`) does not resolve under `ABSPATH` in the test environment and was then denied its fallback.

So the wasted loopback request for a genuinely deleted attachment still happens. Avoiding it safely needs a way to distinguish an unresolvable URL from a resolved-but-missing file, which is a larger change than this fix warrants. Worth a follow-up if it shows up in profiling.

Remote `Content-Type` is also still unvalidated; the sanitizer limits the blast radius there, and it was left out to keep this change minimal.

### Test changes

* Added `Test_Svg_Src_Transformer` covering a 404 for a same-site URL, a 404 for an external URL whose body contains an `<svg>`, and a successful 200 fetch.
* `Test_Atomic_Svg`'s `pre_http_request` mocks returned only a `body` key. That is not a valid HTTP response shape, so `wp_remote_retrieve_response_code()` had nothing to read. They now return a full response array with `WP_Http::OK`, via a small `mock_http_response()` helper.

## Test instructions

This PR can be tested by following these steps:

* Point an SVG prop at an external URL that returns 404 with an HTML body containing an inline `<svg>`. The widget should render an empty icon; before this change it rendered the `<svg>` scraped from that error page.
* Point an SVG prop at an external URL returning a real SVG with 200. It should still render inline with `fill="currentColor"`.
* Delete the file behind an SVG attachment while keeping the attachment record. The widget should render an empty icon rather than whatever the 404 page contains.
* `vendor/bin/phpunit --filter 'Test_Svg_Src_Transformer|Test_Atomic_Svg'`

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Verified locally against MySQL + the WordPress test library: `Test_Svg_Src_Transformer` and `Test_Atomic_Svg` pass (15 tests, 23 assertions), as do the neighbouring `Test_Icon_Transformer`, `Test_Svg_Src_To_Icon_Migration` and `Test_Atomic_Accordion` suites (44 tests, 230 assertions). PHPCS is clean on the changed files.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3cbfdbd-3e3d-4c4b-aaf9-127fda76aa34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3cbfdbd-3e3d-4c4b-aaf9-127fda76aa34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

