### PR TITLE
Internal: [V4] add fa group filter [ED-25517]

### DIFF
--- a/packages/packages/libs/editor-controls/src/controls/icon-library/__tests__/font-awesome-7-catalog.test.ts
+++ b/packages/packages/libs/editor-controls/src/controls/icon-library/__tests__/font-awesome-7-catalog.test.ts
@@ -103,6 +103,38 @@ describe( 'font-awesome-7-catalog', () => {
 		expect( filterFontAwesome7Icons( icons, undefined ) ).toHaveLength( 2 );
 	} );
 
+	it( 'filters by library and applies search within the active library', () => {
+		// Arrange.
+		const icons = [
+			createIcon(),
+			createIcon( {
+				id: 'fa-regular:star',
+				library: 'fa-regular',
+				value: 'fa-regular fa-star',
+			} ),
+			createIcon( {
+				id: 'fa-brands:github',
+				name: 'github',
+				label: 'github',
+				library: 'fa-brands',
+				value: 'fa-brands fa-github',
+				aliases: [],
+			} ),
+		];
+
+		// Act / Assert.
+		expect( filterFontAwesome7Icons( icons, '', [] ) ).toHaveLength( 3 );
+		expect( filterFontAwesome7Icons( icons, '', [ 'fa-solid' ] ) ).toEqual( [ icons[ 0 ] ] );
+		expect( filterFontAwesome7Icons( icons, '', [ 'fa-regular' ] ) ).toEqual( [ icons[ 1 ] ] );
+		expect( filterFontAwesome7Icons( icons, '', [ 'fa-brands' ] ) ).toEqual( [ icons[ 2 ] ] );
+		expect( filterFontAwesome7Icons( icons, 'star', [ 'fa-regular' ] ) ).toEqual( [ icons[ 1 ] ] );
+		expect( filterFontAwesome7Icons( icons, 'github', [ 'fa-solid' ] ) ).toEqual( [] );
+		expect( filterFontAwesome7Icons( icons, '', [ 'fa-solid', 'fa-brands' ] ) ).toEqual( [
+			icons[ 0 ],
+			icons[ 2 ],
+		] );
+	} );
+
 	it( 'normalizes fas and fa-solid selected values', () => {
 		// Arrange / Act / Assert.
 		expect( createIconSelectionValue( 'fa-solid', 'star' ) ).toBe( 'fa-solid fa-star' );

--- a/packages/packages/libs/editor-controls/src/controls/icon-library/__tests__/icon-library-popover.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/icon-library/__tests__/icon-library-popover.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ThemeProvider } from '@elementor/ui';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import {
 	ICON_LIBRARY_ROW_HEIGHT,
@@ -54,6 +54,17 @@ describe( 'IconLibraryPopover', () => {
 			width: 512,
 			height: 512,
 			paths: [ 'M1 1h10v10H1z' ],
+		},
+		{
+			id: 'fa-brands:github',
+			name: 'github',
+			label: 'github',
+			library: 'fa-brands',
+			value: 'fa-brands fa-github',
+			aliases: [],
+			width: 496,
+			height: 512,
+			paths: [ 'M2 2h10v10H2z' ],
 		},
 	];
 
@@ -109,6 +120,97 @@ describe( 'IconLibraryPopover', () => {
 
 		// Assert.
 		expect( screen.getByRole( 'option', { name: /star/i } ) ).toHaveAttribute( 'aria-selected', 'true' );
+	} );
+
+	it( 'filters by library without clearing the search query', () => {
+		// Arrange.
+		jest.useFakeTimers();
+
+		render(
+			<ThemeProvider>
+				<IconLibraryPopover
+					open
+					selectedIconClass={ null }
+					selectedIconLibrary={ null }
+					onSelect={ jest.fn() }
+					onClose={ jest.fn() }
+				/>
+			</ThemeProvider>
+		);
+
+		const search = screen.getByPlaceholderText( 'Search' );
+
+		// Act.
+		fireEvent.change( search, { target: { value: 'star' } } );
+		act( () => {
+			jest.advanceTimersByTime( ICON_LIBRARY_SEARCH_DEBOUNCE_DELAY );
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Filter by library' } ) );
+		expect( screen.getByRole( 'menuitemcheckbox', { name: 'All icons' } ) ).toBeChecked();
+		fireEvent.click( screen.getByRole( 'menuitemcheckbox', { name: 'Font Awesome - Regular' } ) );
+
+		// Assert.
+		expect( search ).toHaveValue( 'star' );
+		expect( screen.getByRole( 'menuitemcheckbox', { name: 'Font Awesome - Regular' } ) ).toBeChecked();
+		expect( screen.getByText( /Sorry, nothing matched/ ) ).toBeInTheDocument();
+
+		// Act.
+		fireEvent.click( screen.getByRole( 'menuitemcheckbox', { name: 'Font Awesome - Solid' } ) );
+		fireEvent.keyDown( screen.getByRole( 'menu' ), { key: 'Escape' } );
+
+		// Assert.
+		expect( search ).toHaveValue( 'star' );
+		expect( screen.getByRole( 'button', { name: 'Filter by library, active' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'option', { name: /star/i } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'option', { name: /github/i } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'supports keyboard navigation and restores focus when the filter menu closes', async () => {
+		// Arrange.
+		render(
+			<ThemeProvider>
+				<IconLibraryPopover
+					open
+					selectedIconClass={ null }
+					selectedIconLibrary={ null }
+					onSelect={ jest.fn() }
+					onClose={ jest.fn() }
+				/>
+			</ThemeProvider>
+		);
+
+		const filterButton = screen.getByRole( 'button', { name: 'Filter by library' } );
+
+		// Act.
+		act( () => filterButton.focus() );
+		fireEvent.click( filterButton );
+
+		const menu = screen.getByRole( 'menu', { name: 'Filter by library' } );
+		const allIconsOption = screen.getByRole( 'menuitemcheckbox', { name: 'All icons' } );
+
+		// Assert.
+		expect( filterButton ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect( allIconsOption ).toBeChecked();
+		await waitFor( () => expect( allIconsOption ).toHaveFocus() );
+
+		// Act.
+		fireEvent.keyDown( menu, { key: 'ArrowDown' } );
+
+		const regularOption = screen.getByRole( 'menuitemcheckbox', { name: 'Font Awesome - Regular' } );
+
+		expect( regularOption ).toHaveFocus();
+
+		fireEvent.keyDown( regularOption, { key: 'Enter' } );
+
+		// Assert.
+		expect( regularOption ).toBeChecked();
+
+		// Act.
+		fireEvent.keyDown( menu, { key: 'Escape' } );
+
+		// Assert.
+		expect( filterButton ).toHaveFocus();
+		expect( filterButton ).toHaveAttribute( 'aria-expanded', 'false' );
 	} );
 
 	it( 'filters by search and shows an empty state', () => {
@@ -167,5 +269,35 @@ describe( 'IconLibraryPopover', () => {
 
 		// Assert.
 		expect( screen.getByText( /Icons couldn't be loaded/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'resets the library filter when closed', () => {
+		// Arrange.
+		const onClose = jest.fn();
+
+		render(
+			<ThemeProvider>
+				<IconLibraryPopover
+					open
+					selectedIconClass={ null }
+					selectedIconLibrary={ null }
+					onSelect={ jest.fn() }
+					onClose={ onClose }
+				/>
+			</ThemeProvider>
+		);
+
+		// Act.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Filter by library' } ) );
+		fireEvent.click( screen.getByRole( 'menuitemcheckbox', { name: 'Font Awesome - Brands' } ) );
+		fireEvent.keyDown( screen.getByRole( 'menu' ), { key: 'Escape' } );
+		fireEvent.click( screen.getByRole( 'button', { name: 'close' } ) );
+
+		// Assert.
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
+		expect( screen.getByRole( 'button', { name: 'Filter by library' } ) ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Filter by library' } ) );
+		expect( screen.getByRole( 'menuitemcheckbox', { name: 'All icons' } ) ).toBeChecked();
 	} );
 } );

--- a/packages/packages/libs/editor-controls/src/controls/icon-library/font-awesome-7-catalog.ts
+++ b/packages/packages/libs/editor-controls/src/controls/icon-library/font-awesome-7-catalog.ts
@@ -8,10 +8,13 @@ import {
 
 export { FONT_AWESOME_7_LIBRARIES, getFontAwesome7EditorConfig } from './font-awesome-7-data';
 
+export type FontAwesome7Library = ( typeof FONT_AWESOME_7_LIBRARIES )[ number ][ 'library' ];
+export type FontAwesome7LibraryFilter = FontAwesome7Library[];
+
 export type FontAwesome7Icon = FontAwesome7IconDefinition & {
 	id: string;
 	label: string;
-	library: string;
+	library: FontAwesome7Library;
 	value: string;
 };
 
@@ -37,14 +40,20 @@ export async function loadFontAwesome7Catalog( signal?: AbortSignal ): Promise< 
 	return catalogs.flat();
 }
 
-export function filterFontAwesome7Icons( icons: FontAwesome7Icon[], searchValue?: string | null ): FontAwesome7Icon[] {
+export function filterFontAwesome7Icons(
+	icons: FontAwesome7Icon[],
+	searchValue?: string | null,
+	libraries: FontAwesome7LibraryFilter = []
+): FontAwesome7Icon[] {
 	const query = searchValue?.trim().toLowerCase() ?? '';
+	const libraryIcons =
+		libraries.length === 0 ? icons : icons.filter( ( icon ) => libraries.includes( icon.library ) );
 
 	if ( query === '' ) {
-		return icons;
+		return libraryIcons;
 	}
 
-	return icons.filter( ( icon ) => {
+	return libraryIcons.filter( ( icon ) => {
 		if ( icon.name.includes( query ) || icon.label.toLowerCase().includes( query ) ) {
 			return true;
 		}
@@ -93,7 +102,7 @@ export function findFontAwesome7Icon(
 	} );
 }
 
-function toCatalogIcon( icon: FontAwesome7IconDefinition, library: string ): FontAwesome7Icon {
+function toCatalogIcon( icon: FontAwesome7IconDefinition, library: FontAwesome7Library ): FontAwesome7Icon {
 	return {
 		...icon,
 		id: `${ library }:${ icon.name }`,

--- a/packages/packages/libs/editor-controls/src/controls/icon-library/icon-library-filter.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/icon-library/icon-library-filter.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import { CheckIcon, FilterIcon, LibraryIcon, ListIcon, StarFilledIcon, StarIcon } from '@elementor/icons';
+import {
+	bindMenu,
+	bindTrigger,
+	Box,
+	Menu,
+	MenuItem,
+	Stack,
+	ToggleButton,
+	Tooltip,
+	Typography,
+	usePopupState,
+} from '@elementor/ui';
+import { __ } from '@wordpress/i18n';
+
+import {
+	FONT_AWESOME_7_LIBRARIES,
+	type FontAwesome7Library,
+	type FontAwesome7LibraryFilter,
+} from './font-awesome-7-catalog';
+
+const FILTER_MENU_WIDTH = 280;
+const FILTER_INDICATOR_SIZE = 6;
+const FILTER_INDICATOR_OFFSET = 4;
+
+type IconLibraryFilterProps = {
+	value: FontAwesome7LibraryFilter;
+	onChange: ( value: FontAwesome7LibraryFilter ) => void;
+};
+
+export const IconLibraryFilter = ( { value, onChange }: IconLibraryFilterProps ) => {
+	const popupState = usePopupState( {
+		variant: 'popover',
+		popupId: 'icon-library-filter-menu',
+	} );
+	const options = [
+		{ value: 'fa-regular', label: __( 'Font Awesome - Regular', 'elementor' ), Icon: StarIcon },
+		{ value: 'fa-solid', label: __( 'Font Awesome - Solid', 'elementor' ), Icon: StarFilledIcon },
+		{ value: 'fa-brands', label: __( 'Font Awesome - Brands', 'elementor' ), Icon: LibraryIcon },
+	] satisfies Array< { value: FontAwesome7Library; label: string; Icon: typeof StarIcon } >;
+	const isFiltered = value.length > 0;
+	const filterButtonLabel = isFiltered
+		? __( 'Filter by library, active', 'elementor' )
+		: __( 'Filter by library', 'elementor' );
+
+	const handleAllIconsClick = () => {
+		onChange( [] );
+	};
+
+	const handleLibraryClick = ( library: FontAwesome7Library ) => {
+		const nextValue = value.includes( library )
+			? value.filter( ( selectedLibrary ) => selectedLibrary !== library )
+			: [ ...value, library ];
+
+		onChange( nextValue.length === FONT_AWESOME_7_LIBRARIES.length ? [] : nextValue );
+	};
+
+	return (
+		<>
+			<Tooltip title={ __( 'Filter by library', 'elementor' ) } placement="top">
+				<ToggleButton
+					aria-label={ filterButtonLabel }
+					value="filter"
+					size="tiny"
+					selected={ popupState.isOpen }
+					sx={ { position: 'relative', flexShrink: 0 } }
+					{ ...bindTrigger( popupState ) }
+					aria-expanded={ popupState.isOpen }
+				>
+					<FilterIcon fontSize="tiny" />
+					{ isFiltered ? (
+						<Box
+							component="span"
+							aria-hidden="true"
+							sx={ {
+								position: 'absolute',
+								insetBlockStart: FILTER_INDICATOR_OFFSET,
+								insetInlineEnd: FILTER_INDICATOR_OFFSET,
+								width: FILTER_INDICATOR_SIZE,
+								height: FILTER_INDICATOR_SIZE,
+								borderRadius: '50%',
+								bgcolor: 'secondary.main',
+							} }
+						/>
+					) : null }
+				</ToggleButton>
+			</Tooltip>
+			<Menu
+				{ ...bindMenu( popupState ) }
+				MenuListProps={ {
+					dense: true,
+					autoFocusItem: true,
+					'aria-label': __( 'Filter by library', 'elementor' ),
+				} }
+				sx={ { '& .MuiPaper-root': { minWidth: FILTER_MENU_WIDTH } } }
+			>
+				<MenuItem
+					role="menuitemcheckbox"
+					aria-checked={ ! isFiltered }
+					selected={ ! isFiltered }
+					onClick={ handleAllIconsClick }
+				>
+					{ renderFilterMenuItemContent( __( 'All icons', 'elementor' ), ListIcon, ! isFiltered ) }
+				</MenuItem>
+				{ options.map( ( { value: library, label, Icon } ) => (
+					<MenuItem
+						key={ library }
+						role="menuitemcheckbox"
+						aria-checked={ value.includes( library ) }
+						selected={ value.includes( library ) }
+						onClick={ () => handleLibraryClick( library ) }
+					>
+						{ renderFilterMenuItemContent( label, Icon, value.includes( library ) ) }
+					</MenuItem>
+				) ) }
+			</Menu>
+		</>
+	);
+};
+
+const renderFilterMenuItemContent = ( label: string, Icon: typeof ListIcon, selected: boolean ) => (
+	<Stack direction="row" alignItems="center" gap={ 1 } width="100%">
+		<Icon fontSize="tiny" />
+		<Typography variant="caption" flex={ 1 }>
+			{ label }
+		</Typography>
+		{ selected ? <CheckIcon fontSize="tiny" /> : null }
+	</Stack>
+);

--- a/packages/packages/libs/editor-controls/src/controls/icon-library/icon-library-filter.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/icon-library/icon-library-filter.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useId } from 'react';
 import { CheckIcon, FilterIcon, LibraryIcon, ListIcon, StarFilledIcon, StarIcon } from '@elementor/icons';
 import {
 	bindMenu,
@@ -23,6 +24,32 @@ import {
 const FILTER_MENU_WIDTH = 280;
 const FILTER_INDICATOR_SIZE = 6;
 const FILTER_INDICATOR_OFFSET = 4;
+const LIBRARY_FILTER_ORDER = {
+	regular: 0,
+	solid: 1,
+	brands: 2,
+} as const;
+
+const LIBRARY_FILTER_CONFIG: Record<
+	FontAwesome7Library,
+	{ getLabel: () => string; Icon: typeof StarIcon; order: number }
+> = {
+	'fa-regular': {
+		getLabel: () => __( 'Font Awesome - Regular', 'elementor' ),
+		Icon: StarIcon,
+		order: LIBRARY_FILTER_ORDER.regular,
+	},
+	'fa-solid': {
+		getLabel: () => __( 'Font Awesome - Solid', 'elementor' ),
+		Icon: StarFilledIcon,
+		order: LIBRARY_FILTER_ORDER.solid,
+	},
+	'fa-brands': {
+		getLabel: () => __( 'Font Awesome - Brands', 'elementor' ),
+		Icon: LibraryIcon,
+		order: LIBRARY_FILTER_ORDER.brands,
+	},
+};
 
 type IconLibraryFilterProps = {
 	value: FontAwesome7LibraryFilter;
@@ -30,15 +57,17 @@ type IconLibraryFilterProps = {
 };
 
 export const IconLibraryFilter = ( { value, onChange }: IconLibraryFilterProps ) => {
+	const popupId = useId();
 	const popupState = usePopupState( {
 		variant: 'popover',
-		popupId: 'icon-library-filter-menu',
+		popupId,
 	} );
-	const options = [
-		{ value: 'fa-regular', label: __( 'Font Awesome - Regular', 'elementor' ), Icon: StarIcon },
-		{ value: 'fa-solid', label: __( 'Font Awesome - Solid', 'elementor' ), Icon: StarFilledIcon },
-		{ value: 'fa-brands', label: __( 'Font Awesome - Brands', 'elementor' ), Icon: LibraryIcon },
-	] satisfies Array< { value: FontAwesome7Library; label: string; Icon: typeof StarIcon } >;
+	const options = FONT_AWESOME_7_LIBRARIES.map( ( { library } ) => ( {
+		value: library,
+		label: LIBRARY_FILTER_CONFIG[ library ].getLabel(),
+		Icon: LIBRARY_FILTER_CONFIG[ library ].Icon,
+		order: LIBRARY_FILTER_CONFIG[ library ].order,
+	} ) ).sort( ( firstOption, secondOption ) => firstOption.order - secondOption.order );
 	const isFiltered = value.length > 0;
 	const filterButtonLabel = isFiltered
 		? __( 'Filter by library, active', 'elementor' )

--- a/packages/packages/libs/editor-controls/src/controls/icon-library/icon-library-filter.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/icon-library/icon-library-filter.tsx
@@ -151,7 +151,7 @@ export const IconLibraryFilter = ( { value, onChange }: IconLibraryFilterProps )
 const renderFilterMenuItemContent = ( label: string, Icon: typeof ListIcon, selected: boolean ) => (
 	<Stack direction="row" alignItems="center" gap={ 1 } width="100%">
 		<Icon fontSize="tiny" />
-		<Typography variant="caption" flex={ 1 }>
+		<Typography variant="caption" sx={ { flex: 1 } }>
 			{ label }
 		</Typography>
 		{ selected ? <CheckIcon fontSize="tiny" /> : null }

--- a/packages/packages/libs/editor-controls/src/controls/icon-library/icon-library-popover.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/icon-library/icon-library-popover.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import {
 	PopoverBody,
 	PopoverHeader,
@@ -18,8 +18,10 @@ import {
 	filterFontAwesome7Icons,
 	findFontAwesome7Icon,
 	type FontAwesome7Icon,
+	type FontAwesome7LibraryFilter,
 } from './font-awesome-7-catalog';
 import { FontAwesomeGlyph } from './font-awesome-glyph';
+import { IconLibraryFilter } from './icon-library-filter';
 import { useFontAwesome7Catalog } from './use-font-awesome-7-catalog';
 
 export const ICON_LIBRARY_POPOVER_WIDTH = 300;
@@ -60,9 +62,13 @@ export const IconLibraryPopover = ( {
 		handleChange: handleSearchChange,
 		setImmediateValue: setSearchValue,
 	} = useDebounceState( { delay: ICON_LIBRARY_SEARCH_DEBOUNCE_DELAY } );
+	const [ activeLibraries, setActiveLibraries ] = useState< FontAwesome7LibraryFilter >( [] );
 	const { data: icons = [], isLoading } = useFontAwesome7Catalog( open );
 
-	const items = useMemo( () => createIconLibraryItems( icons, searchValue ), [ icons, searchValue ] );
+	const items = useMemo(
+		() => createIconLibraryItems( icons, searchValue, activeLibraries ),
+		[ activeLibraries, icons, searchValue ]
+	);
 	const selectedValue = useMemo(
 		() => findFontAwesome7Icon( icons, selectedIconClass, selectedIconLibrary )?.id,
 		[ icons, selectedIconClass, selectedIconLibrary ]
@@ -70,6 +76,7 @@ export const IconLibraryPopover = ( {
 
 	const handleClose = () => {
 		setSearchValue( '' );
+		setActiveLibraries( [] );
 		onClose();
 	};
 
@@ -98,13 +105,16 @@ export const IconLibraryPopover = ( {
 				icon={ <ComponentsIcon fontSize="tiny" /> }
 				sx={ { pl: ICON_LIBRARY_INLINE_SPACING, pr: 0.5 } }
 			/>
-			<SearchField
-				value={ searchInputValue }
-				onSearch={ handleSearchChange }
-				placeholder={ __( 'Search', 'elementor' ) }
-				id="icon-library-search"
-				sx={ { px: ICON_LIBRARY_INLINE_SPACING, pb: 1 } }
-			/>
+			<Stack direction="row" alignItems="center" gap={ 1 } sx={ { px: ICON_LIBRARY_INLINE_SPACING, pb: 1 } }>
+				<SearchField
+					value={ searchInputValue }
+					onSearch={ handleSearchChange }
+					placeholder={ __( 'Search', 'elementor' ) }
+					id="icon-library-search"
+					sx={ { flex: 1, px: 0, pb: 0 } }
+				/>
+				<IconLibraryFilter value={ activeLibraries } onChange={ setActiveLibraries } />
+			</Stack>
 			<Divider />
 			<Box sx={ { flex: 1, overflow: 'auto', minHeight: 0 } }>
 				<IconLibraryContent
@@ -112,6 +122,7 @@ export const IconLibraryPopover = ( {
 					items={ items }
 					selectedValue={ selectedValue }
 					searchValue={ searchValue }
+					isCatalogAvailable={ icons.length > 0 }
 					onSelect={ handleSelect }
 					onClose={ handleClose }
 					onClearSearch={ handleClearSearch }
@@ -126,6 +137,7 @@ type IconLibraryContentProps = {
 	items: IconLibraryItem[];
 	selectedValue: string | undefined;
 	searchValue: string;
+	isCatalogAvailable: boolean;
 	onSelect: ( id: string ) => void;
 	onClose: () => void;
 	onClearSearch: () => void;
@@ -136,6 +148,7 @@ const IconLibraryContent = ( {
 	items,
 	selectedValue,
 	searchValue,
+	isCatalogAvailable,
 	onSelect,
 	onClose,
 	onClearSearch,
@@ -153,7 +166,13 @@ const IconLibraryContent = ( {
 			onClose={ onClose }
 			itemHeight={ ICON_LIBRARY_ROW_HEIGHT }
 			menuItemContentTemplate={ IconLibraryRow }
-			noResultsComponent={ <IconLibraryEmptyState searchValue={ searchValue } onClear={ onClearSearch } /> }
+			noResultsComponent={
+				<IconLibraryEmptyState
+					searchValue={ searchValue }
+					isCatalogAvailable={ isCatalogAvailable }
+					onClear={ onClearSearch }
+				/>
+			}
 			data-testid="icon-library-list"
 		/>
 	);
@@ -165,8 +184,16 @@ const IconLibraryLoadingState = () => (
 	</Stack>
 );
 
-const IconLibraryEmptyState = ( { searchValue, onClear }: { searchValue: string; onClear: () => void } ) => {
-	if ( searchValue.trim() === '' ) {
+const IconLibraryEmptyState = ( {
+	searchValue,
+	isCatalogAvailable,
+	onClear,
+}: {
+	searchValue: string;
+	isCatalogAvailable: boolean;
+	onClear: () => void;
+} ) => {
+	if ( ! isCatalogAvailable ) {
 		return <CatalogUnavailable />;
 	}
 
@@ -218,17 +245,25 @@ const NoResults = ( { searchValue, onClear }: { searchValue: string; onClear: ()
 		<Typography align="center" variant="subtitle2" color="text.secondary">
 			{ __( 'Sorry, nothing matched', 'elementor' ) }
 		</Typography>
-		<Typography align="center" variant="subtitle2" color="text.secondary" noWrap sx={ { maxWidth: '80%' } }>
-			&ldquo;{ searchValue }&rdquo;.
-		</Typography>
-		<Link color="secondary" variant="caption" component="button" type="button" onClick={ onClear }>
-			{ __( 'Clear & try again', 'elementor' ) }
-		</Link>
+		{ searchValue ? (
+			<>
+				<Typography align="center" variant="subtitle2" color="text.secondary" noWrap sx={ { maxWidth: '80%' } }>
+					&ldquo;{ searchValue }&rdquo;.
+				</Typography>
+				<Link color="secondary" variant="caption" component="button" type="button" onClick={ onClear }>
+					{ __( 'Clear & try again', 'elementor' ) }
+				</Link>
+			</>
+		) : null }
 	</Stack>
 );
 
-const createIconLibraryItems = ( icons: FontAwesome7Icon[], searchValue: string ): IconLibraryItem[] =>
-	filterFontAwesome7Icons( icons, searchValue ).map( ( icon ) => ( {
+const createIconLibraryItems = (
+	icons: FontAwesome7Icon[],
+	searchValue: string,
+	libraries: FontAwesome7LibraryFilter
+): IconLibraryItem[] =>
+	filterFontAwesome7Icons( icons, searchValue, libraries ).map( ( icon ) => ( {
 		...icon,
 		type: 'item',
 		value: icon.id,

--- a/tests/playwright/sanity/modules/v4-tests/atomic-svg-icon-library.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-svg-icon-library.test.ts
@@ -47,6 +47,16 @@ test.describe( 'Atomic SVG icon library @v4-tests', () => {
 			await expect( popover ).toHaveScreenshot( 'icon-library-popover.png', SCREENSHOT_OPTIONS );
 		} );
 
+		await test.step( 'Library filter menu matches expected visuals', async () => {
+			await popover.getByRole( 'button', { name: 'Filter by library' } ).click();
+
+			const filterMenu = page.getByRole( 'menu', { name: 'Filter by library' } );
+
+			await expect( filterMenu ).toBeVisible();
+			await expect( filterMenu ).toHaveScreenshot( 'icon-library-filter-menu.png', SCREENSHOT_OPTIONS );
+			await page.keyboard.press( 'Escape' );
+		} );
+
 		await test.step( 'Library filter composes with search', async () => {
 			const search = popover.getByPlaceholder( 'Search' );
 

--- a/tests/playwright/sanity/modules/v4-tests/atomic-svg-icon-library.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/atomic-svg-icon-library.test.ts
@@ -43,7 +43,31 @@ test.describe( 'Atomic SVG icon library @v4-tests', () => {
 		await test.step( 'Icon library popover lists glyphs', async () => {
 			await page.getByRole( 'button', { name: 'Icon library' } ).click();
 			await expect( popover.getByRole( 'option' ).first() ).toBeVisible();
+			await expect( popover.getByRole( 'button', { name: 'Filter by library' } ) ).toBeVisible();
 			await expect( popover ).toHaveScreenshot( 'icon-library-popover.png', SCREENSHOT_OPTIONS );
+		} );
+
+		await test.step( 'Library filter composes with search', async () => {
+			const search = popover.getByPlaceholder( 'Search' );
+
+			await search.fill( 'github' );
+			await popover.getByRole( 'button', { name: /^Filter by library/ } ).click();
+			await page.getByRole( 'menuitemcheckbox', { name: 'Font Awesome - Solid' } ).click();
+			await page.keyboard.press( 'Escape' );
+			await expect( popover.getByText( /Sorry, nothing matched/ ) ).toBeVisible();
+			await expect( search ).toHaveValue( 'github' );
+
+			await popover.getByRole( 'button', { name: /^Filter by library/ } ).click();
+			await page.getByRole( 'menuitemcheckbox', { name: 'Font Awesome - Brands' } ).click();
+			await page.keyboard.press( 'Escape' );
+			await expect( popover.getByRole( 'option', { name: /github/i } ).first() ).toBeVisible();
+			await expect( popover.getByRole( 'button', { name: 'Filter by library, active' } ) ).toBeVisible();
+
+			await popover.getByRole( 'button', { name: /^Filter by library/ } ).click();
+			await page.getByRole( 'menuitemcheckbox', { name: 'All icons' } ).click();
+			await page.keyboard.press( 'Escape' );
+			await search.fill( '' );
+			await expect( popover.getByRole( 'option' ).first() ).toBeVisible();
 		} );
 
 		await test.step( 'Hovered row is visually highlighted', async () => {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Implements a library-based filtering system for Font Awesome 7 icons (ED-2517) to allow users to isolate specific icon sets (Solid, Regular, Brands) and combine this with existing search functionality.

## 2. What Changed (Where)
* `font-awesome-7-catalog.ts`: Added `FontAwesome7Library` types and updated `filterFontAwesome7Icons` to support library filtering.
* `icon-library-filter.tsx`: New component for the filter dropdown menu and state management.
* `icon-library-popover.tsx`: Integrated the filter UI and linked active library state to icon rendering.
* `__tests__/`: Added unit and Playwright tests for filter logic, keyboard navigation, and visual regressions.

## 3. How It Works
The `IconLibraryPopover` maintains a list of `activeLibraries`. When these are passed to `filterFontAwesome7Icons`, it first narrows the icon set by library before applying the text-based search query. Closing the popover resets the filter state.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
