### PR TITLE
Internal: Add dormant MCP V3 map contract [ED-25529]

### DIFF
--- a/bin/capture-v3-controls.php
+++ b/bin/capture-v3-controls.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Captures a live V3 widget's controls to a JSON fixture the MCP V3 parity test suite reads.
+ *
+ * The core PHPUnit run does not boot the WordPress runtime, so widget controls that the MCP
+ * mapper needs to introspect are checked in as JSON. This script exists to (re-)generate
+ * those checked-in dumps in one place instead of hand-authoring them.
+ *
+ * Usage (WP-CLI, from any WordPress install with Elementor active):
+ *
+ *     wp eval-file wp-content/plugins/elementor/bin/capture-v3-controls.php -- <widget-type> [<widget-type>...]
+ *
+ * Or against the launch-widget list used by the compiled-map parity suite:
+ *
+ *     wp eval-file wp-content/plugins/elementor/bin/capture-v3-controls.php -- --allowlist
+ *
+ * Each captured widget is written to:
+ *
+ *     tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/<widget-type>.json
+ *
+ * shape: `{ "controls": { <setting-key>: <control-config>, ... } }`. The shared Advanced-tab
+ * controls live in `advanced-shared.json` and are merged in by the fixture loader — do not
+ * duplicate them per widget.
+ *
+ * @package Elementor
+ */
+
+use Elementor\Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	fwrite( STDERR, "This script must be executed through wp eval-file.\n" );
+	exit( 1 );
+}
+
+if ( ! defined( 'ELEMENTOR_VERSION' ) ) {
+	fwrite( STDERR, "Elementor is not active on this WordPress install.\n" );
+	exit( 1 );
+}
+
+$launch_widget_types = [
+	'button',
+	'container',
+	'divider',
+	'heading',
+	'html',
+	'icon',
+	'image',
+	'nav-menu',
+	'spacer',
+	'text-editor',
+	'theme-archive-title',
+	'theme-post-content',
+	'theme-post-excerpt',
+	'theme-post-featured-image',
+	'theme-post-title',
+];
+
+$fixtures_dir = __DIR__ . '/../tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls';
+
+if ( ! is_dir( $fixtures_dir ) ) {
+	fwrite( STDERR, sprintf( "Fixtures directory not found: %s\n", $fixtures_dir ) );
+	exit( 1 );
+}
+
+$args = array_values( array_filter( $argv ?? [], static fn( $arg ) => 0 !== strpos( (string) $arg, '--wp-' ) ) );
+array_shift( $args ); // drop the script path
+
+if ( empty( $args ) ) {
+	fwrite( STDERR, "No widget types provided. Pass one or more widget types, or --allowlist.\n" );
+	exit( 1 );
+}
+
+$widget_types = in_array( '--allowlist', $args, true )
+	? $launch_widget_types
+	: $args;
+
+$widgets_manager = Plugin::$instance->widgets_manager;
+$elements_manager = Plugin::$instance->elements_manager;
+
+foreach ( $widget_types as $widget_type ) {
+	$instance = $widgets_manager->get_widget_types( $widget_type )
+		?? $elements_manager->get_element_types( $widget_type );
+
+	if ( ! $instance || ! method_exists( $instance, 'get_controls' ) ) {
+		fwrite( STDERR, sprintf( "Skipped `%s`: not a registered V3 widget/element.\n", $widget_type ) );
+		continue;
+	}
+
+	if ( method_exists( $instance, 'get_stack' ) ) {
+		$instance->get_stack();
+	}
+
+	$controls = (array) $instance->get_controls();
+
+	// Advanced-tab controls are identical across every V3 widget/element; they are stored
+	// separately in `advanced-shared.json` and merged in by the fixture loader. Drop them
+	// from the per-widget capture so the fixtures stay minimal and diffs stay meaningful.
+	$shared_advanced = shared_advanced_keys( $fixtures_dir );
+
+	$filtered = array_diff_key( $controls, array_flip( $shared_advanced ) );
+
+	$fixture_path = $fixtures_dir . '/' . $widget_type . '.json';
+	$json = json_encode(
+		[ 'controls' => $filtered ],
+		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+	);
+
+	if ( false === $json ) {
+		fwrite( STDERR, sprintf( "Skipped `%s`: json_encode failed.\n", $widget_type ) );
+		continue;
+	}
+
+	file_put_contents( $fixture_path, $json . "\n" );
+
+	fwrite( STDOUT, sprintf( "Captured `%s` (%d controls) → %s\n", $widget_type, count( $filtered ), $fixture_path ) );
+}
+
+/**
+ * @return string[]
+ */
+function shared_advanced_keys( string $fixtures_dir ): array {
+	$path = $fixtures_dir . '/advanced-shared.json';
+
+	if ( ! is_readable( $path ) ) {
+		return [];
+	}
+
+	$decoded = json_decode( (string) file_get_contents( $path ), true );
+
+	return is_array( $decoded['controls'] ?? null ) ? array_keys( $decoded['controls'] ) : [];
+}

--- a/modules/mcp/abilities/appliers/v3/maps/style-control-target.php
+++ b/modules/mcp/abilities/appliers/v3/maps/style-control-target.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Style_Control_Target {
+
+	const KIND_SIMPLE = 'simple';
+	const KIND_TYPOGRAPHY = 'typography';
+	const KIND_BORDER = 'border';
+	const KIND_BOX_SHADOW = 'box-shadow';
+	const KIND_SPACING = 'spacing';
+
+	const KINDS = [
+		self::KIND_SIMPLE,
+		self::KIND_TYPOGRAPHY,
+		self::KIND_BORDER,
+		self::KIND_BOX_SHADOW,
+		self::KIND_SPACING,
+	];
+
+	const TYPOGRAPHY_TEXT_PROPERTIES = [
+		'font-family' => 'font_family',
+		'font-weight' => 'font_weight',
+		'font-style' => 'font_style',
+		'text-transform' => 'text_transform',
+		'text-decoration' => 'text_decoration',
+	];
+
+	const TYPOGRAPHY_DIMENSION_PROPERTIES = [
+		'font-size' => 'font_size',
+		'line-height' => 'line_height',
+		'letter-spacing' => 'letter_spacing',
+		'word-spacing' => 'word_spacing',
+	];
+
+	/**
+	 * @return array{kind: string, resolver: string, responsive: bool, destinations: array<int, array{setting: string, shape: string, resolver: string}>}
+	 */
+	public static function control( string $setting, string $resolver, bool $responsive = false ): array {
+		return [
+			'kind' => self::KIND_SIMPLE,
+			'resolver' => $resolver,
+			'responsive' => $responsive,
+			'destinations' => [
+				[
+					'setting' => $setting,
+					'shape' => self::shape_for_resolver( $resolver ),
+					'resolver' => $resolver,
+				],
+			],
+		];
+	}
+
+	/**
+	 * @return array{kind: string, resolver: string, responsive: bool, destinations: array<int, array{setting: string, shape: string, resolver: string}>}
+	 */
+	public static function typography( string $prefix, bool $responsive = true ): array {
+		$destinations = [
+			[
+				'setting' => $prefix . '_typography',
+				'shape' => 'string',
+				'resolver' => 'text',
+			],
+		];
+
+		foreach ( self::TYPOGRAPHY_TEXT_PROPERTIES as $suffix ) {
+			$destinations[] = [
+				'setting' => $prefix . '_' . $suffix,
+				'shape' => 'string',
+				'resolver' => 'text',
+			];
+		}
+
+		foreach ( self::TYPOGRAPHY_DIMENSION_PROPERTIES as $suffix ) {
+			$destinations[] = [
+				'setting' => $prefix . '_' . $suffix,
+				'shape' => 'dimension',
+				'resolver' => 'dimension',
+			];
+		}
+
+		return [
+			'kind' => self::KIND_TYPOGRAPHY,
+			'resolver' => 'typography',
+			'responsive' => $responsive,
+			'destinations' => $destinations,
+		];
+	}
+
+	/**
+	 * @return array{kind: string, resolver: string, responsive: bool, destinations: array<int, array{setting: string, shape: string, resolver: string}>}
+	 */
+	public static function border( string $prefix, bool $responsive = true ): array {
+		return [
+			'kind' => self::KIND_BORDER,
+			'resolver' => 'border',
+			'responsive' => $responsive,
+			'destinations' => [
+				[
+					'setting' => $prefix . '_border',
+					'shape' => 'string',
+					'resolver' => 'text',
+				],
+				[
+					'setting' => $prefix . '_width',
+					'shape' => 'sides',
+					'resolver' => 'sides',
+				],
+				[
+					'setting' => $prefix . '_color',
+					'shape' => 'string',
+					'resolver' => 'color',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @return array{kind: string, resolver: string, responsive: bool, destinations: array<int, array{setting: string, shape: string, resolver: string}>}
+	 */
+	public static function box_shadow( string $prefix, bool $responsive = false ): array {
+		return [
+			'kind' => self::KIND_BOX_SHADOW,
+			'resolver' => 'box_shadow',
+			'responsive' => $responsive,
+			'destinations' => [
+				[
+					'setting' => $prefix . '_box_shadow_type',
+					'shape' => 'string',
+					'resolver' => 'text',
+				],
+				[
+					'setting' => $prefix . '_box_shadow',
+					'shape' => 'box_shadow',
+					'resolver' => 'box_shadow',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @return array{kind: string, resolver: string, responsive: bool, destinations: array<int, array{setting: string, shape: string, resolver: string}>}
+	 */
+	public static function spacing( string $setting, bool $responsive = true ): array {
+		return [
+			'kind' => self::KIND_SPACING,
+			'resolver' => 'sides',
+			'responsive' => $responsive,
+			'destinations' => [
+				[
+					'setting' => $setting,
+					'shape' => 'sides',
+					'resolver' => 'sides',
+				],
+			],
+		];
+	}
+
+	public static function shape_for_resolver( string $resolver ): string {
+		switch ( $resolver ) {
+			case 'dimension':
+			case 'slider':
+				return 'dimension';
+			case 'sides':
+			case 'dimension_side':
+				return 'sides';
+			case 'box_shadow':
+				return 'box_shadow';
+			case 'border':
+				return 'border';
+			default:
+				return 'string';
+		}
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/maps/v3-widget-map-compiler.php
+++ b/modules/mcp/abilities/appliers/v3/maps/v3-widget-map-compiler.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class V3_Widget_Map_Compiler {
+
+	const ERROR_CODE = 'elementor_v3_map_invalid';
+
+	const CATALOG_VISIBILITY_ALWAYS = 'always';
+	const CATALOG_VISIBILITY_V4_DISABLED = 'v4_disabled';
+
+	const REQUIRED_FIELDS = [
+		'widget_type',
+		'description',
+		'catalog_visibility',
+		'settings',
+		'default_style_target',
+		'style_targets',
+	];
+
+	const COMPATIBLE_CONTROL_TYPES = [
+		'color' => [ 'color' ],
+		'dimension' => [ 'slider' ],
+		'slider' => [ 'slider' ],
+		'sides' => [ 'dimensions' ],
+		'dimension_side' => [ 'dimensions' ],
+		'box_shadow' => [ 'box_shadow' ],
+		'text' => [ 'text', 'textarea', 'select', 'choose', 'switcher', 'number', 'hidden', 'popover_toggle', 'font', 'animation', 'visual_choice' ],
+		'typography' => [ 'popover_toggle', 'font', 'select', 'slider' ],
+		'border' => [ 'select', 'dimensions', 'color' ],
+	];
+
+	const GROUP_KINDS = [
+		Style_Control_Target::KIND_TYPOGRAPHY,
+		Style_Control_Target::KIND_BORDER,
+		Style_Control_Target::KIND_BOX_SHADOW,
+	];
+
+	/**
+	 * @param array<string, mixed> $map
+	 * @param array<string, mixed> $controls
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public function compile( array $map, array $controls, ?string $expected_widget_type = null ) {
+		$shape_error = $this->validate_map_shape( $map, $expected_widget_type );
+
+		if ( $shape_error instanceof WP_Error ) {
+			return $shape_error;
+		}
+
+		$nested_error = $this->validate_settings( $map['settings'] );
+
+		if ( $nested_error instanceof WP_Error ) {
+			return $nested_error;
+		}
+
+		return $this->validate_style_targets( $map, $controls );
+	}
+
+	/**
+	 * @param array<string, mixed> $map
+	 * @return WP_Error|null
+	 */
+	private function validate_map_shape( array $map, ?string $expected_widget_type ) {
+		foreach ( self::REQUIRED_FIELDS as $field ) {
+			if ( ! array_key_exists( $field, $map ) || ( is_string( $map[ $field ] ) && '' === $map[ $field ] ) ) {
+				return $this->error( 'missing_field', $field );
+			}
+		}
+
+		if ( null !== $expected_widget_type && $expected_widget_type !== $map['widget_type'] ) {
+			return $this->error( 'widget_type_mismatch', $map['widget_type'] );
+		}
+
+		if ( ! in_array( $map['catalog_visibility'], [ self::CATALOG_VISIBILITY_ALWAYS, self::CATALOG_VISIBILITY_V4_DISABLED ], true ) ) {
+			return $this->error( 'invalid_visibility', $map['catalog_visibility'] );
+		}
+
+		if ( ! is_array( $map['settings'] ) || ! is_array( $map['style_targets'] ) || empty( $map['style_targets'] ) ) {
+			return $this->error( 'missing_field', 'style_targets' );
+		}
+
+		if ( ! isset( $map['style_targets'][ $map['default_style_target'] ] ) ) {
+			return $this->error( 'missing_default_style_target', $map['default_style_target'] );
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param array<string, mixed> $settings
+	 * @return WP_Error|null
+	 */
+	private function validate_settings( array $settings ) {
+		foreach ( $settings as $schema ) {
+			if ( ! is_array( $schema ) ) {
+				continue;
+			}
+
+			if ( $this->schema_has_nested_repeater( $schema ) ) {
+				return $this->error( 'nested_repeater', 'settings' );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param array<string, mixed> $map
+	 * @param array<string, mixed> $controls
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private function validate_style_targets( array $map, array $controls ) {
+		foreach ( $map['style_targets'] as $alias => $target ) {
+			if ( ! is_string( $alias ) || 1 !== preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $alias ) ) {
+				return $this->error( 'invalid_alias', (string) $alias );
+			}
+
+			if ( ! is_array( $target ) || ! is_array( $target['css_properties'] ?? null ) ) {
+				return $this->error( 'missing_field', 'css_properties' );
+			}
+
+			foreach ( $target['css_properties'] as $property => $states ) {
+				if ( ! is_array( $states ) ) {
+					return $this->error( 'missing_field', (string) $property );
+				}
+
+				foreach ( $states as $descriptor ) {
+					$descriptor_error = $this->validate_descriptor( $descriptor, $controls );
+
+					if ( $descriptor_error instanceof WP_Error ) {
+						return $descriptor_error;
+					}
+				}
+			}
+		}
+
+		return $map;
+	}
+
+	/**
+	 * @param mixed                $descriptor
+	 * @param array<string, mixed> $controls
+	 * @return WP_Error|null
+	 */
+	private function validate_descriptor( $descriptor, array $controls ) {
+		if ( ! is_array( $descriptor ) || ! is_string( $descriptor['kind'] ?? null ) ) {
+			return $this->error( 'invalid_descriptor_kind', '' );
+		}
+
+		if ( ! in_array( $descriptor['kind'], Style_Control_Target::KINDS, true ) ) {
+			return $this->error( 'invalid_descriptor_kind', $descriptor['kind'] );
+		}
+
+		$destinations = $descriptor['destinations'] ?? null;
+
+		if ( ! is_array( $destinations ) || empty( $destinations ) ) {
+			return $this->error( 'missing_field', 'destinations' );
+		}
+
+		foreach ( $destinations as $destination ) {
+			$setting = $destination['setting'] ?? null;
+
+			if ( ! is_string( $setting ) || '' === $setting ) {
+				return $this->error( 'missing_control', '' );
+			}
+
+			if ( ! isset( $controls[ $setting ] ) ) {
+				$reason = in_array( $descriptor['kind'], self::GROUP_KINDS, true )
+					? 'incomplete_group_destination'
+					: 'missing_control';
+
+				return $this->error( $reason, $setting );
+			}
+
+			$resolver = $destination['resolver'] ?? $descriptor['resolver'] ?? '';
+			$control_type = $controls[ $setting ]['type'] ?? '';
+
+			if ( ! $this->is_resolver_compatible( $resolver, $control_type ) ) {
+				return $this->error( 'incompatible_resolver', $setting );
+			}
+		}
+
+		return null;
+	}
+
+	private function is_resolver_compatible( string $resolver, string $control_type ): bool {
+		$allowed = self::COMPATIBLE_CONTROL_TYPES[ $resolver ] ?? null;
+
+		if ( null === $allowed ) {
+			return true;
+		}
+
+		return in_array( $control_type, $allowed, true );
+	}
+
+	/**
+	 * @param array<string, mixed> $schema
+	 */
+	private function schema_has_nested_repeater( array $schema, bool $inside_repeater = false ): bool {
+		$is_repeater = 'repeater' === ( $schema['type'] ?? null );
+
+		if ( $is_repeater && $inside_repeater ) {
+			return true;
+		}
+
+		$fields = $schema['fields'] ?? [];
+
+		if ( ! is_array( $fields ) ) {
+			return false;
+		}
+
+		foreach ( $fields as $field ) {
+			if ( is_array( $field ) && $this->schema_has_nested_repeater( $field, $inside_repeater || $is_repeater ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private function error( string $reason, string $detail ): WP_Error {
+		return new WP_Error(
+			self::ERROR_CODE,
+			$reason,
+			[
+				'reason' => $reason,
+				'detail' => $detail,
+			]
+		);
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/maps/v3-widget-map-registry.php
+++ b/modules/mcp/abilities/appliers/v3/maps/v3-widget-map-registry.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class V3_Widget_Map_Registry {
+
+	/**
+	 * @var V3_Widget_Map_Compiler
+	 */
+	private $compiler;
+
+	/**
+	 * @var callable
+	 */
+	private $is_experiment_active;
+
+	/**
+	 * @var callable
+	 */
+	private $is_atomic_active;
+
+	/**
+	 * @var callable
+	 */
+	private $get_controls;
+
+	/**
+	 * @var array<string, array<string, mixed>>
+	 */
+	private $maps;
+
+	/**
+	 * @var array<string, array<string, mixed>|WP_Error>
+	 */
+	private $cache = [];
+
+	/**
+	 * @param V3_Widget_Map_Compiler                        $compiler
+	 * @param callable(): bool                              $is_experiment_active
+	 * @param callable(): bool                              $is_atomic_active
+	 * @param callable(string): (array<string, mixed>|null) $get_controls
+	 * @param array<string, array<string, mixed>>           $maps
+	 */
+	public function __construct(
+		V3_Widget_Map_Compiler $compiler,
+		callable $is_experiment_active,
+		callable $is_atomic_active,
+		callable $get_controls,
+		array $maps = []
+	) {
+		$this->compiler = $compiler;
+		$this->is_experiment_active = $is_experiment_active;
+		$this->is_atomic_active = $is_atomic_active;
+		$this->get_controls = $get_controls;
+		$this->maps = $maps;
+	}
+
+	public function is_experiment_active(): bool {
+		$callback = $this->is_experiment_active;
+
+		return (bool) $callback();
+	}
+
+	public function is_supported( string $widget_type ): bool {
+		$compiled = $this->get_compiled_map( $widget_type );
+
+		if ( null === $compiled || $compiled instanceof WP_Error ) {
+			return false;
+		}
+
+		if ( V3_Widget_Map_Compiler::CATALOG_VISIBILITY_ALWAYS === $compiled['catalog_visibility'] ) {
+			return true;
+		}
+
+		$is_atomic_active = $this->is_atomic_active;
+
+		return ! (bool) $is_atomic_active();
+	}
+
+	/**
+	 * @return array<string, mixed>|WP_Error|null
+	 */
+	public function get_compiled_map( string $widget_type ) {
+		if ( ! $this->is_experiment_active() ) {
+			return null;
+		}
+
+		if ( ! isset( $this->maps[ $widget_type ] ) ) {
+			return null;
+		}
+
+		if ( array_key_exists( $widget_type, $this->cache ) ) {
+			return $this->cache[ $widget_type ];
+		}
+
+		$get_controls = $this->get_controls;
+		$controls = $get_controls( $widget_type ) ?? [];
+		$compiled = $this->compiler->compile( $this->maps[ $widget_type ], $controls, $widget_type );
+
+		$this->cache[ $widget_type ] = $compiled;
+
+		return $compiled;
+	}
+}

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\Mcp;
 
 use Elementor\Core\Base\Module as BaseModule;
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\MCP\Composer\Mcp\Registry as Shared_Registry;
 use Elementor\Modules\EditorOne\Classes\Menu_Data_Provider;
 use Elementor\Modules\Mcp\Abilities\Abstract_Ability;
@@ -11,6 +12,7 @@ use Elementor\Modules\Mcp\Preview\Public_Preview_Handler;
 use Elementor\Modules\Mcp\Registry\Ability_Registry;
 use Elementor\Modules\Mcp\RestApi\Mcp_Proxy_REST_API;
 use Elementor\Modules\Mcp\Utils\Editor_Sync_State;
+use Elementor\Plugin;
 use WP\MCP\Core\McpAdapter;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -20,6 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Module extends BaseModule {
 
 	const ANALYTICS_REGISTRAR_HANDLE = 'elementor-mcp-analytics-registrar';
+	const V3_STANDARDIZED_MAPS_EXPERIMENT_NAME = 'e_mcp_v3_standardized_maps';
 
 	private Ability_Registry $registry;
 
@@ -43,8 +46,21 @@ class Module extends BaseModule {
 			class_exists( Shared_Registry::class );
 	}
 
+	public static function get_v3_standardized_maps_experimental_data(): array {
+		return [
+			'name' => self::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME,
+			'title' => esc_html__( 'MCP V3 standardized maps', 'elementor' ),
+			'description' => esc_html__( 'Serve MCP V3 widgets from explicit compiled maps instead of inferred runtime capabilities.', 'elementor' ),
+			'hidden' => true,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,
+		];
+	}
+
 	public function __construct() {
 		parent::__construct();
+
+		$this->register_v3_standardized_maps_experiment();
 
 		$this->registry = self::build_core_registry();
 
@@ -60,6 +76,10 @@ class Module extends BaseModule {
 		add_action( 'wp_abilities_api_init', [ $this, 'register_abilities' ] );
 		add_action( 'init', [ $this, 'register_shared_registry_slugs' ], 5 );
 		add_action( 'elementor/editor-one/menu/register', [ $this, 'register_editor_one_menu' ], Editor_One_Mcp_Menu::REGISTER_PRIORITY_AFTER_SUBMISSIONS );
+	}
+
+	private function register_v3_standardized_maps_experiment(): void {
+		Plugin::$instance->experiments->add_feature( self::get_v3_standardized_maps_experimental_data() );
 	}
 
 	public function registry(): Ability_Registry {

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/advanced-shared.json
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/advanced-shared.json
@@ -1,0 +1,2495 @@
+{
+    "controls": {
+        "_section_style": {
+            "type": "section",
+            "tab": "advanced",
+            "label": "Layout"
+        },
+        "_title": {
+            "type": "hidden",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Title"
+        },
+        "_margin": {
+            "type": "dimensions",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Margin",
+            "selectors": {
+                "{{WRAPPER}}": "margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} calc(var(--kit-widget-spacing, 0px) + {{BOTTOM}}{{UNIT}}) {{LEFT}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "_padding": {
+            "type": "dimensions",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Padding",
+            "selectors": {
+                "{{WRAPPER}}": "padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "_element_width": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Width",
+            "selectors": {
+                "{{WRAPPER}}": "width: {{VALUE}}; max-width: {{VALUE}}"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_element_width_tablet": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Width",
+            "selectors": {
+                "{{WRAPPER}}": "width: {{VALUE}}; max-width: {{VALUE}}"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_element_width_mobile": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Width",
+            "selectors": {
+                "{{WRAPPER}}": "width: {{VALUE}}; max-width: {{VALUE}}"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_element_custom_width": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Custom Width",
+            "selectors": {
+                "{{WRAPPER}}": "--container-widget-width: {{SIZE}}{{UNIT}}; --container-widget-flex-grow: 0; width: var( --container-widget-width, {{SIZE}}{{UNIT}} ); max-width: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "_heading_grid_item": {
+            "type": "heading",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Grid Item"
+        },
+        "_grid_column": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Column Span",
+            "selectors": {
+                "{{WRAPPER}}": "grid-column: span {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_grid_column_custom": {
+            "type": "text",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Custom",
+            "selectors": {
+                "{{WRAPPER}}": "grid-column: {{VALUE}}"
+            },
+            "responsive": []
+        },
+        "_grid_row": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Row Span",
+            "selectors": {
+                "{{WRAPPER}}": "grid-row: span {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_grid_row_custom": {
+            "type": "text",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Custom",
+            "selectors": {
+                "{{WRAPPER}}": "grid-row: {{VALUE}}"
+            },
+            "responsive": []
+        },
+        "_flex_align_self": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Align Self",
+            "selectors": {
+                "{{WRAPPER}}.elementor-element": "--align-self: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_flex_order": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Order",
+            "selectors": {
+                "{{WRAPPER}}.elementor-element": "--order: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_flex_order_custom": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Custom Order",
+            "selectors": {
+                "{{WRAPPER}}.elementor-element": "--order: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_flex_size": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Size",
+            "selectors": {
+                "{{WRAPPER}}.elementor-element": "{{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_flex_grow": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Flex Grow",
+            "selectors": {
+                "{{WRAPPER}}.elementor-element": "--flex-grow: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_flex_shrink": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Flex Shrink",
+            "selectors": {
+                "{{WRAPPER}}.elementor-element": "--flex-shrink: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_element_vertical_align": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Vertical Align",
+            "selectors": {
+                "{{WRAPPER}}": "align-self: {{VALUE}}"
+            },
+            "responsive": []
+        },
+        "_position_description": {
+            "type": "alert",
+            "tab": "advanced",
+            "section": "_section_style"
+        },
+        "_position": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Position"
+        },
+        "_offset_orientation_h": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Horizontal Orientation"
+        },
+        "_offset_x": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Offset",
+            "selectors": {
+                "body:not(.rtl) {{WRAPPER}}": "left: {{SIZE}}{{UNIT}}",
+                "body.rtl {{WRAPPER}}": "right: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "_offset_x_end": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Offset",
+            "selectors": {
+                "body:not(.rtl) {{WRAPPER}}": "right: {{SIZE}}{{UNIT}}",
+                "body.rtl {{WRAPPER}}": "left: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "_offset_orientation_v": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Vertical Orientation"
+        },
+        "_offset_y": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Offset",
+            "selectors": {
+                "{{WRAPPER}}": "top: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "_offset_y_end": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Offset",
+            "selectors": {
+                "{{WRAPPER}}": "bottom: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "_z_index": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Z-Index",
+            "selectors": {
+                "{{WRAPPER}}": "z-index: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_element_id": {
+            "type": "text",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "CSS ID"
+        },
+        "_css_classes": {
+            "type": "text",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "CSS Classes"
+        },
+        "e_display_conditions_trigger": {
+            "type": "raw_html",
+            "tab": "advanced",
+            "section": "_section_style"
+        },
+        "e_display_conditions": {
+            "type": "hidden",
+            "tab": "advanced",
+            "section": "_section_style"
+        },
+        "_element_cache": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_style",
+            "label": "Cache Settings"
+        },
+        "section_effects": {
+            "type": "section",
+            "tab": "advanced",
+            "label": "Motion Effects"
+        },
+        "ai_animation": {
+            "type": "raw_html",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Animate With AI"
+        },
+        "motion_fx_motion_fx_scrolling": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Scrolling Effects"
+        },
+        "motion_fx_translateY_effect": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Vertical Scroll"
+        },
+        "motion_fx_translateY_direction": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Direction"
+        },
+        "motion_fx_translateY_speed": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Speed"
+        },
+        "motion_fx_translateY_affectedRange": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Viewport"
+        },
+        "motion_fx_translateX_effect": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Horizontal Scroll"
+        },
+        "motion_fx_translateX_direction": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Direction"
+        },
+        "motion_fx_translateX_speed": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Speed"
+        },
+        "motion_fx_translateX_affectedRange": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Viewport"
+        },
+        "motion_fx_opacity_effect": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Transparency"
+        },
+        "motion_fx_opacity_direction": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Direction"
+        },
+        "motion_fx_opacity_level": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Level"
+        },
+        "motion_fx_opacity_range": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Viewport"
+        },
+        "motion_fx_blur_effect": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Blur"
+        },
+        "motion_fx_blur_direction": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Direction"
+        },
+        "motion_fx_blur_level": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Level"
+        },
+        "motion_fx_blur_range": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Viewport"
+        },
+        "motion_fx_rotateZ_effect": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Rotate"
+        },
+        "motion_fx_rotateZ_direction": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Direction"
+        },
+        "motion_fx_rotateZ_speed": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Speed"
+        },
+        "motion_fx_rotateZ_affectedRange": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Viewport"
+        },
+        "motion_fx_scale_effect": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Scale"
+        },
+        "motion_fx_scale_direction": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Direction"
+        },
+        "motion_fx_scale_speed": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Speed"
+        },
+        "motion_fx_scale_range": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Viewport"
+        },
+        "motion_fx_transform_origin_x": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "X Anchor Point",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-origin-x: {{VALUE}}"
+            }
+        },
+        "motion_fx_transform_origin_y": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Y Anchor Point",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-origin-y: {{VALUE}}"
+            }
+        },
+        "motion_fx_devices": {
+            "type": "select2",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Apply Effects On"
+        },
+        "motion_fx_range": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Effects Relative To"
+        },
+        "motion_fx_motion_fx_mouse": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Mouse Effects"
+        },
+        "motion_fx_mouseTrack_effect": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Mouse Track"
+        },
+        "motion_fx_mouseTrack_direction": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Direction"
+        },
+        "motion_fx_mouseTrack_speed": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Speed"
+        },
+        "motion_fx_tilt_effect": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "3D Tilt"
+        },
+        "motion_fx_tilt_direction": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Direction"
+        },
+        "motion_fx_tilt_speed": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Speed"
+        },
+        "handle_motion_fx_asset_loading": {
+            "type": "hidden",
+            "tab": "advanced",
+            "section": "section_effects"
+        },
+        "sticky": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Sticky"
+        },
+        "sticky_on": {
+            "type": "select2",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Sticky On"
+        },
+        "sticky_offset": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Sticky Offset",
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "sticky_offset_tablet": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Sticky Offset",
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "sticky_offset_mobile": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Sticky Offset",
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "sticky_effects_offset": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Effects Offset",
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "sticky_effects_offset_tablet": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Effects Offset",
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "sticky_effects_offset_mobile": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Effects Offset",
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "sticky_anchor_link_offset": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Anchor Offset",
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "sticky_anchor_link_offset_tablet": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Anchor Offset",
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "sticky_anchor_link_offset_mobile": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Anchor Offset",
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "anchor_offset_description": {
+            "type": "raw_html",
+            "tab": "advanced",
+            "section": "section_effects"
+        },
+        "sticky_parent": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Stay In Column"
+        },
+        "sticky_divider": {
+            "type": "divider",
+            "tab": "advanced",
+            "section": "section_effects"
+        },
+        "_animation": {
+            "type": "animation",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Entrance Animation",
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_animation_tablet": {
+            "type": "animation",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Entrance Animation",
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_animation_mobile": {
+            "type": "animation",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Entrance Animation",
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "animation_duration": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Animation Duration"
+        },
+        "_animation_delay": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "section_effects",
+            "label": "Animation Delay (ms)"
+        },
+        "_section_transform": {
+            "type": "section",
+            "tab": "advanced",
+            "label": "Transform"
+        },
+        "_tabs_positioning": {
+            "type": "tabs",
+            "tab": "advanced",
+            "section": "_section_transform"
+        },
+        "_tab_positioning": {
+            "type": "tab",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Normal"
+        },
+        "_transform_rotate_popover": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate"
+        },
+        "_transform_rotateZ_effect": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-rotateZ: {{SIZE}}deg"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_rotateZ_effect_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-rotateZ: {{SIZE}}deg"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_rotateZ_effect_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-rotateZ: {{SIZE}}deg"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_rotate_3d": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "3D Rotate",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-rotateX: 1{{UNIT}};  --e-transform-perspective: 20px;"
+            }
+        },
+        "_transform_rotateX_effect": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate X (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-rotateX: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_rotateX_effect_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate X (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-rotateX: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_rotateX_effect_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate X (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-rotateX: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_rotateY_effect": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate Y (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-rotateY: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_rotateY_effect_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate Y (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-rotateY: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_rotateY_effect_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate Y (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-rotateY: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_perspective_effect": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Perspective (px)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-perspective: {{SIZE}}px"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_perspective_effect_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Perspective (px)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-perspective: {{SIZE}}px"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_perspective_effect_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Perspective (px)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-perspective: {{SIZE}}px"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_translate_popover": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset"
+        },
+        "_transform_translateX_effect": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset X",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-translateX: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_translateX_effect_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset X",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-translateX: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_translateX_effect_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset X",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-translateX: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_translateY_effect": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset Y",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-translateY: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_translateY_effect_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset Y",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-translateY: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_translateY_effect_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset Y",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-translateY: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_scale_popover": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale"
+        },
+        "_transform_keep_proportions": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Keep Proportions"
+        },
+        "_transform_scale_effect": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-scale: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_scale_effect_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-scale: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_scale_effect_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-scale: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_scaleX_effect": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale X",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-scaleX: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_scaleX_effect_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale X",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-scaleX: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_scaleX_effect_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale X",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-scaleX: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_scaleY_effect": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale Y",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-scaleY: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_scaleY_effect_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale Y",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-scaleY: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_scaleY_effect_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale Y",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-scaleY: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_skew_popover": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew"
+        },
+        "_transform_skewX_effect": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew X (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-skewX: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_skewX_effect_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew X (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-skewX: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_skewX_effect_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew X (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-skewX: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_skewY_effect": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew Y (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-skewY: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_skewY_effect_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew Y (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-skewY: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_skewY_effect_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew Y (deg)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-skewY: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_flipX_effect": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Flip Horizontal",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-flipX: -1"
+            }
+        },
+        "_transform_flipY_effect": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Flip Vertical",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-flipY: -1"
+            }
+        },
+        "_tab_positioning_hover": {
+            "type": "tab",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Hover"
+        },
+        "ai_hover_animation": {
+            "type": "raw_html",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Animate With AI"
+        },
+        "_transform_rotate_popover_hover": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate"
+        },
+        "_transform_rotateZ_effect_hover": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-rotateZ: {{SIZE}}deg"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_rotateZ_effect_hover_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-rotateZ: {{SIZE}}deg"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_rotateZ_effect_hover_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-rotateZ: {{SIZE}}deg"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_rotate_3d_hover": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "3D Rotate",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-rotateX: 1{{UNIT}};  --e-transform-perspective: 20px;"
+            }
+        },
+        "_transform_rotateX_effect_hover": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate X (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-rotateX: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_rotateX_effect_hover_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate X (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-rotateX: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_rotateX_effect_hover_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate X (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-rotateX: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_rotateY_effect_hover": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate Y (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-rotateY: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_rotateY_effect_hover_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate Y (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-rotateY: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_rotateY_effect_hover_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Rotate Y (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-rotateY: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_perspective_effect_hover": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Perspective (px)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-perspective: {{SIZE}}px"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_perspective_effect_hover_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Perspective (px)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-perspective: {{SIZE}}px"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_perspective_effect_hover_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Perspective (px)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-perspective: {{SIZE}}px"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_translate_popover_hover": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset"
+        },
+        "_transform_translateX_effect_hover": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset X",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-translateX: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_translateX_effect_hover_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset X",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-translateX: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_translateX_effect_hover_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset X",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-translateX: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_translateY_effect_hover": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset Y",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-translateY: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_translateY_effect_hover_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset Y",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-translateY: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_translateY_effect_hover_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Offset Y",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-translateY: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_scale_popover_hover": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale"
+        },
+        "_transform_keep_proportions_hover": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Keep Proportions"
+        },
+        "_transform_scale_effect_hover": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-scale: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_scale_effect_hover_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-scale: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_scale_effect_hover_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-scale: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_scaleX_effect_hover": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale X",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-scaleX: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_scaleX_effect_hover_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale X",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-scaleX: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_scaleX_effect_hover_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale X",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-scaleX: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_scaleY_effect_hover": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale Y",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-scaleY: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_scaleY_effect_hover_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale Y",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-scaleY: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_scaleY_effect_hover_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Scale Y",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-scaleY: {{SIZE}};"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_skew_popover_hover": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew"
+        },
+        "_transform_skewX_effect_hover": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew X (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-skewX: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_skewX_effect_hover_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew X (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-skewX: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_skewX_effect_hover_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew X (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-skewX: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_skewY_effect_hover": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew Y (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-skewY: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "desktop"
+            }
+        },
+        "_transform_skewY_effect_hover_tablet": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew Y (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-skewY: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "tablet"
+            }
+        },
+        "_transform_skewY_effect_hover_mobile": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Skew Y (deg)",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-skewY: {{SIZE}}deg;"
+            },
+            "responsive": {
+                "max": "mobile"
+            }
+        },
+        "_transform_flipX_effect_hover": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Flip Horizontal",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-flipX: -1"
+            }
+        },
+        "_transform_flipY_effect_hover": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Flip Vertical",
+            "selectors": {
+                "{{WRAPPER}}:hover": "--e-transform-flipY: -1"
+            }
+        },
+        "_transform_transition_hover": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Transition Duration (ms)",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-transition-duration: {{SIZE}}ms"
+            }
+        },
+        "motion_fx_transform_x_anchor_point": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "X Anchor Point",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-origin-x: {{VALUE}}"
+            },
+            "responsive": []
+        },
+        "motion_fx_transform_y_anchor_point": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_transform",
+            "label": "Y Anchor Point",
+            "selectors": {
+                "{{WRAPPER}}": "--e-transform-origin-y: {{VALUE}}"
+            },
+            "responsive": []
+        },
+        "_section_background": {
+            "type": "section",
+            "tab": "advanced",
+            "label": "Background"
+        },
+        "_tabs_background": {
+            "type": "tabs",
+            "tab": "advanced",
+            "section": "_section_background"
+        },
+        "_tab_background_normal": {
+            "type": "tab",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Normal"
+        },
+        "_background_background": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Background Type"
+        },
+        "_background_gradient_notice": {
+            "type": "alert",
+            "tab": "advanced",
+            "section": "_section_background"
+        },
+        "_background_color": {
+            "type": "color",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Color",
+            "selectors": {
+                "{{WRAPPER}}": "background-color: {{VALUE}};"
+            }
+        },
+        "_background_color_stop": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Location",
+            "responsive": []
+        },
+        "_background_color_b": {
+            "type": "color",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Second Color"
+        },
+        "_background_color_b_stop": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Location",
+            "responsive": []
+        },
+        "_background_gradient_type": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Type"
+        },
+        "_background_gradient_angle": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Angle",
+            "selectors": {
+                "{{WRAPPER}}": "background-color: transparent; background-image: linear-gradient({{SIZE}}{{UNIT}}, {{_background_color.VALUE}} {{_background_color_stop.SIZE}}{{_background_color_stop.UNIT}}, {{_background_color_b.VALUE}} {{_background_color_b_stop.SIZE}}{{_background_color_b_stop.UNIT}})"
+            },
+            "responsive": []
+        },
+        "_background_gradient_position": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Position",
+            "selectors": {
+                "{{WRAPPER}}": "background-color: transparent; background-image: radial-gradient(at {{VALUE}}, {{_background_color.VALUE}} {{_background_color_stop.SIZE}}{{_background_color_stop.UNIT}}, {{_background_color_b.VALUE}} {{_background_color_b_stop.SIZE}}{{_background_color_b_stop.UNIT}})"
+            },
+            "responsive": []
+        },
+        "_background_image": {
+            "type": "media",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Image",
+            "selectors": {
+                "{{WRAPPER}}": "background-image: url(\"{{URL}}\");"
+            },
+            "responsive": []
+        },
+        "_background_position": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Position",
+            "selectors": {
+                "{{WRAPPER}}": "background-position: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_background_xpos": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "X Position",
+            "selectors": {
+                "{{WRAPPER}}": "background-position: {{SIZE}}{{UNIT}} {{_background_ypos.SIZE}}{{_background_ypos.UNIT}}"
+            },
+            "responsive": []
+        },
+        "_background_ypos": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Y Position",
+            "selectors": {
+                "{{WRAPPER}}": "background-position: {{_background_xpos.SIZE}}{{_background_xpos.UNIT}} {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "_background_attachment": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Attachment",
+            "selectors": {
+                "(desktop+){{WRAPPER}}": "background-attachment: {{VALUE}};"
+            }
+        },
+        "_background_attachment_alert": {
+            "type": "raw_html",
+            "tab": "advanced",
+            "section": "_section_background"
+        },
+        "_background_repeat": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Repeat",
+            "selectors": {
+                "{{WRAPPER}}": "background-repeat: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_background_size": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Display Size",
+            "selectors": {
+                "{{WRAPPER}}": "background-size: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_background_bg_width": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Width",
+            "selectors": {
+                "{{WRAPPER}}": "background-size: {{SIZE}}{{UNIT}} auto"
+            },
+            "responsive": []
+        },
+        "_background_video_link": {
+            "type": "text",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Video Link"
+        },
+        "_background_video_start": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Start Time"
+        },
+        "_background_video_end": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "End Time"
+        },
+        "_background_play_once": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Play Once"
+        },
+        "_background_play_on_mobile": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Play On Mobile"
+        },
+        "_background_privacy_mode": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Privacy Mode"
+        },
+        "_background_video_fallback": {
+            "type": "media",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Background Fallback",
+            "selectors": {
+                "{{WRAPPER}}": "background: url(\"{{URL}}\") 50% 50%; background-size: cover;"
+            }
+        },
+        "_background_slideshow_gallery": {
+            "type": "gallery",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Images"
+        },
+        "_background_slideshow_loop": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Infinite Loop"
+        },
+        "_background_slideshow_slide_duration": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Duration (ms)"
+        },
+        "_background_slideshow_slide_transition": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Transition"
+        },
+        "_background_slideshow_transition_duration": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Transition Duration (ms)"
+        },
+        "_background_slideshow_background_size": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Background Size",
+            "selectors": {
+                "{{WRAPPER}} .elementor-background-slideshow__slide__image": "background-size: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_background_slideshow_background_position": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Background Position",
+            "selectors": {
+                "{{WRAPPER}} .elementor-background-slideshow__slide__image": "background-position: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_background_slideshow_lazyload": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Lazyload"
+        },
+        "_background_slideshow_ken_burns": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Ken Burns Effect"
+        },
+        "_background_slideshow_ken_burns_zoom_direction": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Direction"
+        },
+        "_tab_background_hover": {
+            "type": "tab",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Hover"
+        },
+        "_background_hover_background": {
+            "type": "choose",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Background Type"
+        },
+        "_background_hover_gradient_notice": {
+            "type": "alert",
+            "tab": "advanced",
+            "section": "_section_background"
+        },
+        "_background_hover_color": {
+            "type": "color",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Color",
+            "selectors": {
+                "{{WRAPPER}}:hover": "background-color: {{VALUE}};"
+            }
+        },
+        "_background_hover_color_stop": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Location",
+            "responsive": []
+        },
+        "_background_hover_color_b": {
+            "type": "color",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Second Color"
+        },
+        "_background_hover_color_b_stop": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Location",
+            "responsive": []
+        },
+        "_background_hover_gradient_type": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Type"
+        },
+        "_background_hover_gradient_angle": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Angle",
+            "selectors": {
+                "{{WRAPPER}}:hover": "background-color: transparent; background-image: linear-gradient({{SIZE}}{{UNIT}}, {{_background_hover_color.VALUE}} {{_background_hover_color_stop.SIZE}}{{_background_hover_color_stop.UNIT}}, {{_background_hover_color_b.VALUE}} {{_background_hover_color_b_stop.SIZE}}{{_background_hover_color_b_stop.UNIT}})"
+            },
+            "responsive": []
+        },
+        "_background_hover_gradient_position": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Position",
+            "selectors": {
+                "{{WRAPPER}}:hover": "background-color: transparent; background-image: radial-gradient(at {{VALUE}}, {{_background_hover_color.VALUE}} {{_background_hover_color_stop.SIZE}}{{_background_hover_color_stop.UNIT}}, {{_background_hover_color_b.VALUE}} {{_background_hover_color_b_stop.SIZE}}{{_background_hover_color_b_stop.UNIT}})"
+            },
+            "responsive": []
+        },
+        "_background_hover_image": {
+            "type": "media",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Image",
+            "selectors": {
+                "{{WRAPPER}}:hover": "background-image: url(\"{{URL}}\");"
+            },
+            "responsive": []
+        },
+        "_background_hover_position": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Position",
+            "selectors": {
+                "{{WRAPPER}}:hover": "background-position: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_background_hover_xpos": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "X Position",
+            "selectors": {
+                "{{WRAPPER}}:hover": "background-position: {{SIZE}}{{UNIT}} {{_background_hover_ypos.SIZE}}{{_background_hover_ypos.UNIT}}"
+            },
+            "responsive": []
+        },
+        "_background_hover_ypos": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Y Position",
+            "selectors": {
+                "{{WRAPPER}}:hover": "background-position: {{_background_hover_xpos.SIZE}}{{_background_hover_xpos.UNIT}} {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "_background_hover_attachment": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Attachment",
+            "selectors": {
+                "(desktop+){{WRAPPER}}:hover": "background-attachment: {{VALUE}};"
+            }
+        },
+        "_background_hover_attachment_alert": {
+            "type": "raw_html",
+            "tab": "advanced",
+            "section": "_section_background"
+        },
+        "_background_hover_repeat": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Repeat",
+            "selectors": {
+                "{{WRAPPER}}:hover": "background-repeat: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_background_hover_size": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Display Size",
+            "selectors": {
+                "{{WRAPPER}}:hover": "background-size: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_background_hover_bg_width": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Width",
+            "selectors": {
+                "{{WRAPPER}}:hover": "background-size: {{SIZE}}{{UNIT}} auto"
+            },
+            "responsive": []
+        },
+        "_background_hover_video_link": {
+            "type": "text",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Video Link"
+        },
+        "_background_hover_video_start": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Start Time"
+        },
+        "_background_hover_video_end": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "End Time"
+        },
+        "_background_hover_play_once": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Play Once"
+        },
+        "_background_hover_play_on_mobile": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Play On Mobile"
+        },
+        "_background_hover_privacy_mode": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Privacy Mode"
+        },
+        "_background_hover_video_fallback": {
+            "type": "media",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Background Fallback",
+            "selectors": {
+                "{{WRAPPER}}:hover": "background: url(\"{{URL}}\") 50% 50%; background-size: cover;"
+            }
+        },
+        "_background_hover_slideshow_gallery": {
+            "type": "gallery",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Images"
+        },
+        "_background_hover_slideshow_loop": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Infinite Loop"
+        },
+        "_background_hover_slideshow_slide_duration": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Duration (ms)"
+        },
+        "_background_hover_slideshow_slide_transition": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Transition"
+        },
+        "_background_hover_slideshow_transition_duration": {
+            "type": "number",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Transition Duration (ms)"
+        },
+        "_background_hover_slideshow_background_size": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Background Size",
+            "selectors": {
+                "{{WRAPPER}} .elementor-background-slideshow__slide__image": "background-size: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_background_hover_slideshow_background_position": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Background Position",
+            "selectors": {
+                "{{WRAPPER}} .elementor-background-slideshow__slide__image": "background-position: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_background_hover_slideshow_lazyload": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Lazyload"
+        },
+        "_background_hover_slideshow_ken_burns": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Ken Burns Effect"
+        },
+        "_background_hover_slideshow_ken_burns_zoom_direction": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Direction"
+        },
+        "_background_hover_transition": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_background",
+            "label": "Transition Duration (s)",
+            "selectors": {
+                "{{WRAPPER}}": "transition: background {{SIZE}}s"
+            }
+        },
+        "_section_border": {
+            "type": "section",
+            "tab": "advanced",
+            "label": "Border"
+        },
+        "_tabs_border": {
+            "type": "tabs",
+            "tab": "advanced",
+            "section": "_section_border"
+        },
+        "_tab_border_normal": {
+            "type": "tab",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Normal"
+        },
+        "_border_border": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Border Type",
+            "selectors": {
+                "{{WRAPPER}}": "border-style: {{VALUE}};"
+            }
+        },
+        "_border_width": {
+            "type": "dimensions",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Border Width",
+            "selectors": {
+                "{{WRAPPER}}": "border-width: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "_border_color": {
+            "type": "color",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Border Color",
+            "selectors": {
+                "{{WRAPPER}}": "border-color: {{VALUE}};"
+            }
+        },
+        "_border_radius": {
+            "type": "dimensions",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Border Radius",
+            "selectors": {
+                "{{WRAPPER}}": "border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "_box_shadow_box_shadow_type": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Box Shadow"
+        },
+        "_box_shadow_box_shadow": {
+            "type": "box_shadow",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Box Shadow",
+            "selectors": {
+                "{{WRAPPER}}": "box-shadow: {{HORIZONTAL}}px {{VERTICAL}}px {{BLUR}}px {{SPREAD}}px {{COLOR}} {{_box_shadow_box_shadow_position.VALUE}};"
+            }
+        },
+        "_box_shadow_box_shadow_position": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Position"
+        },
+        "_tab_border_hover": {
+            "type": "tab",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Hover"
+        },
+        "_border_hover_border": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Border Type",
+            "selectors": {
+                "{{WRAPPER}}:hover": "border-style: {{VALUE}};"
+            }
+        },
+        "_border_hover_width": {
+            "type": "dimensions",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Border Width",
+            "selectors": {
+                "{{WRAPPER}}:hover": "border-width: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "_border_hover_color": {
+            "type": "color",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Border Color",
+            "selectors": {
+                "{{WRAPPER}}:hover": "border-color: {{VALUE}};"
+            }
+        },
+        "_border_radius_hover": {
+            "type": "dimensions",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Border Radius",
+            "selectors": {
+                "{{WRAPPER}}:hover": "border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "_box_shadow_hover_box_shadow_type": {
+            "type": "popover_toggle",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Box Shadow"
+        },
+        "_box_shadow_hover_box_shadow": {
+            "type": "box_shadow",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Box Shadow",
+            "selectors": {
+                "{{WRAPPER}}:hover": "box-shadow: {{HORIZONTAL}}px {{VERTICAL}}px {{BLUR}}px {{SPREAD}}px {{COLOR}} {{_box_shadow_hover_box_shadow_position.VALUE}};"
+            }
+        },
+        "_box_shadow_hover_box_shadow_position": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Position"
+        },
+        "_border_hover_transition": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_border",
+            "label": "Transition Duration (s)",
+            "selectors": {
+                "{{WRAPPER}}": "transition: background {{_background_hover_transition.SIZE}}s, border {{SIZE}}s, border-radius {{SIZE}}s, box-shadow {{SIZE}}s"
+            }
+        },
+        "_section_masking": {
+            "type": "section",
+            "tab": "advanced",
+            "label": "Mask"
+        },
+        "_mask_switch": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_masking",
+            "label": "Mask"
+        },
+        "_mask_shape": {
+            "type": "visual_choice",
+            "tab": "advanced",
+            "section": "_section_masking",
+            "label": "Shape",
+            "selectors": {
+                "{{WRAPPER}}:not( .elementor-widget-image ), {{WRAPPER}}.elementor-widget-image img": "-webkit-mask-image: url( http://test.local/wp-content/plugins/elementor/assets/mask-shapes/{{VALUE}}.svg );"
+            }
+        },
+        "_mask_image": {
+            "type": "media",
+            "tab": "advanced",
+            "section": "_section_masking",
+            "label": "Image",
+            "selectors": {
+                "{{WRAPPER}}:not( .elementor-widget-image ), {{WRAPPER}}.elementor-widget-image img": "-webkit-mask-image: url( {{URL}} );"
+            },
+            "responsive": []
+        },
+        "_mask_size": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_masking",
+            "label": "Size",
+            "selectors": {
+                "{{WRAPPER}}:not( .elementor-widget-image ), {{WRAPPER}}.elementor-widget-image img": "-webkit-mask-size: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_mask_size_scale": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_masking",
+            "label": "Scale",
+            "selectors": {
+                "{{WRAPPER}}:not( .elementor-widget-image ), {{WRAPPER}}.elementor-widget-image img": "-webkit-mask-size: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "_mask_position": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_masking",
+            "label": "Position",
+            "selectors": {
+                "{{WRAPPER}}:not( .elementor-widget-image ), {{WRAPPER}}.elementor-widget-image img": "-webkit-mask-position: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_mask_position_x": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_masking",
+            "label": "X Position",
+            "selectors": {
+                "{{WRAPPER}}:not( .elementor-widget-image ), {{WRAPPER}}.elementor-widget-image img": "-webkit-mask-position-x: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "_mask_position_y": {
+            "type": "slider",
+            "tab": "advanced",
+            "section": "_section_masking",
+            "label": "Y Position",
+            "selectors": {
+                "{{WRAPPER}}:not( .elementor-widget-image ), {{WRAPPER}}.elementor-widget-image img": "-webkit-mask-position-y: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "_mask_repeat": {
+            "type": "select",
+            "tab": "advanced",
+            "section": "_section_masking",
+            "label": "Repeat",
+            "selectors": {
+                "{{WRAPPER}}:not( .elementor-widget-image ), {{WRAPPER}}.elementor-widget-image img": "-webkit-mask-repeat: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "_section_responsive": {
+            "type": "section",
+            "tab": "advanced",
+            "label": "Responsive"
+        },
+        "responsive_description": {
+            "type": "raw_html",
+            "tab": "advanced",
+            "section": "_section_responsive"
+        },
+        "hide_desktop": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_responsive",
+            "label": "Hide On Desktop"
+        },
+        "hide_tablet": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_responsive",
+            "label": "Hide On Tablet Portrait"
+        },
+        "hide_mobile": {
+            "type": "switcher",
+            "tab": "advanced",
+            "section": "_section_responsive",
+            "label": "Hide On Mobile Portrait"
+        },
+        "_section_attributes": {
+            "type": "section",
+            "tab": "advanced",
+            "label": "Attributes"
+        },
+        "_attributes": {
+            "type": "textarea",
+            "tab": "advanced",
+            "section": "_section_attributes",
+            "label": "Custom Attributes"
+        },
+        "section_custom_css": {
+            "type": "section",
+            "tab": "advanced",
+            "label": "Custom CSS"
+        },
+        "custom_css": {
+            "type": "code",
+            "tab": "advanced",
+            "section": "section_custom_css",
+            "label": "Add your own custom CSS"
+        }
+    }
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/nav-menu.json
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/nav-menu.json
@@ -1,0 +1,810 @@
+{
+    "controls": {
+        "section_layout": {
+            "type": "section",
+            "tab": "content",
+            "label": "Layout"
+        },
+        "menu_name": {
+            "type": "text",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Menu Name"
+        },
+        "menu": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Menu"
+        },
+        "layout": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Layout"
+        },
+        "align_items": {
+            "type": "choose",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Alignment"
+        },
+        "pointer": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Pointer"
+        },
+        "animation_line": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Animation"
+        },
+        "animation_framed": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Animation"
+        },
+        "animation_background": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Animation"
+        },
+        "animation_text": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Animation"
+        },
+        "submenu_icon": {
+            "type": "icons",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Submenu Indicator"
+        },
+        "heading_mobile_dropdown": {
+            "type": "heading",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Mobile Dropdown"
+        },
+        "dropdown": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Breakpoint"
+        },
+        "full_width": {
+            "type": "switcher",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Full Width"
+        },
+        "text_align": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Text Align"
+        },
+        "toggle": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Toggle Button"
+        },
+        "nav_icon_options": {
+            "type": "tabs",
+            "tab": "content",
+            "section": "section_layout"
+        },
+        "nav_icon_normal_options": {
+            "type": "tab",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Normal"
+        },
+        "toggle_icon_normal": {
+            "type": "icons",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Icon"
+        },
+        "nav_icon_hover_options": {
+            "type": "tab",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Hover"
+        },
+        "toggle_icon_hover_animation": {
+            "type": "hover_animation",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Hover Animation"
+        },
+        "nav_icon_active_options": {
+            "type": "tab",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Active"
+        },
+        "toggle_icon_active": {
+            "type": "icons",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Icon"
+        },
+        "toggle_align": {
+            "type": "choose",
+            "tab": "content",
+            "section": "section_layout",
+            "label": "Toggle Align",
+            "selectors": {
+                "{{WRAPPER}} .elementor-menu-toggle": "{{VALUE}}"
+            }
+        },
+        "section_style_main-menu": {
+            "type": "section",
+            "tab": "style",
+            "label": "Main Menu"
+        },
+        "menu_typography_typography": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Typography"
+        },
+        "menu_typography_font_family": {
+            "type": "font",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Family",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu .elementor-item": "font-family: \"{{VALUE}}\", Sans-serif;"
+            }
+        },
+        "menu_typography_font_size": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Size",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu .elementor-item": "font-size: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "menu_typography_font_weight": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Weight",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu .elementor-item": "font-weight: {{VALUE}};"
+            }
+        },
+        "menu_typography_text_transform": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Transform",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu .elementor-item": "text-transform: {{VALUE}};"
+            }
+        },
+        "menu_typography_font_style": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Style",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu .elementor-item": "font-style: {{VALUE}};"
+            }
+        },
+        "menu_typography_text_decoration": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Decoration",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu .elementor-item": "text-decoration: {{VALUE}};"
+            }
+        },
+        "menu_typography_line_height": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Line Height",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu .elementor-item": "line-height: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "menu_typography_letter_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Letter Spacing",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu .elementor-item": "letter-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "menu_typography_word_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Word Spacing",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu .elementor-item": "word-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "tabs_menu_item_style": {
+            "type": "tabs",
+            "tab": "style",
+            "section": "section_style_main-menu"
+        },
+        "tab_menu_item_normal": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Normal"
+        },
+        "color_menu_item": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Text Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--main .elementor-item": "color: {{VALUE}}; fill: {{VALUE}};"
+            }
+        },
+        "tab_menu_item_hover": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Hover"
+        },
+        "color_menu_item_hover": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Text Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--main .elementor-item:hover,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--main .elementor-item.elementor-item-active,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--main .elementor-item.highlighted,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--main .elementor-item:focus": "color: {{VALUE}}; fill: {{VALUE}};"
+            }
+        },
+        "color_menu_item_hover_pointer_bg": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Text Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--main .elementor-item:hover,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--main .elementor-item.elementor-item-active,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--main .elementor-item.highlighted,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--main .elementor-item:focus": "color: {{VALUE}}"
+            }
+        },
+        "pointer_color_menu_item_hover": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Pointer Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--main:not(.e--pointer-framed) .elementor-item:before,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--main:not(.e--pointer-framed) .elementor-item:after": "background-color: {{VALUE}}",
+                "{{WRAPPER}} .e--pointer-framed .elementor-item:before,\n\t\t\t\t\t{{WRAPPER}} .e--pointer-framed .elementor-item:after": "border-color: {{VALUE}}"
+            }
+        },
+        "tab_menu_item_active": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Active"
+        },
+        "color_menu_item_active": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Text Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--main .elementor-item.elementor-item-active": "color: {{VALUE}}"
+            }
+        },
+        "pointer_color_menu_item_active": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Pointer Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--main:not(.e--pointer-framed) .elementor-item.elementor-item-active:before,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--main:not(.e--pointer-framed) .elementor-item.elementor-item-active:after": "background-color: {{VALUE}}",
+                "{{WRAPPER}} .e--pointer-framed .elementor-item.elementor-item-active:before,\n\t\t\t\t\t{{WRAPPER}} .e--pointer-framed .elementor-item.elementor-item-active:after": "border-color: {{VALUE}}"
+            }
+        },
+        "nav_menu_divider": {
+            "type": "switcher",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Divider",
+            "selectors": {
+                "{{WRAPPER}}": "--e-nav-menu-divider-content: \"\";"
+            }
+        },
+        "nav_menu_divider_style": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Style",
+            "selectors": {
+                "{{WRAPPER}}": "--e-nav-menu-divider-style: {{VALUE}}"
+            }
+        },
+        "nav_menu_divider_weight": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Width",
+            "selectors": {
+                "{{WRAPPER}}": "--e-nav-menu-divider-width: {{SIZE}}{{UNIT}}"
+            }
+        },
+        "nav_menu_divider_height": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Height",
+            "selectors": {
+                "{{WRAPPER}}": "--e-nav-menu-divider-height: {{SIZE}}{{UNIT}}"
+            }
+        },
+        "nav_menu_divider_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Color",
+            "selectors": {
+                "{{WRAPPER}}": "--e-nav-menu-divider-color: {{VALUE}}"
+            }
+        },
+        "hr": {
+            "type": "divider",
+            "tab": "style",
+            "section": "section_style_main-menu"
+        },
+        "pointer_width": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Pointer Width",
+            "selectors": {
+                "{{WRAPPER}} .e--pointer-framed .elementor-item:before": "border-width: {{SIZE}}{{UNIT}}",
+                "{{WRAPPER}} .e--pointer-framed.e--animation-draw .elementor-item:before": "border-width: 0 0 {{SIZE}}{{UNIT}} {{SIZE}}{{UNIT}}",
+                "{{WRAPPER}} .e--pointer-framed.e--animation-draw .elementor-item:after": "border-width: {{SIZE}}{{UNIT}} {{SIZE}}{{UNIT}} 0 0",
+                "{{WRAPPER}} .e--pointer-framed.e--animation-corners .elementor-item:before": "border-width: {{SIZE}}{{UNIT}} 0 0 {{SIZE}}{{UNIT}}",
+                "{{WRAPPER}} .e--pointer-framed.e--animation-corners .elementor-item:after": "border-width: 0 {{SIZE}}{{UNIT}} {{SIZE}}{{UNIT}} 0",
+                "{{WRAPPER}} .e--pointer-underline .elementor-item:after,\n\t\t\t\t\t {{WRAPPER}} .e--pointer-overline .elementor-item:before,\n\t\t\t\t\t {{WRAPPER}} .e--pointer-double-line .elementor-item:before,\n\t\t\t\t\t {{WRAPPER}} .e--pointer-double-line .elementor-item:after": "height: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "padding_horizontal_menu_item": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Horizontal Padding",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--main .elementor-item": "padding-left: {{SIZE}}{{UNIT}}; padding-right: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "padding_vertical_menu_item": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Vertical Padding",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--main .elementor-item": "padding-top: {{SIZE}}{{UNIT}}; padding-bottom: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "menu_space_between": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Space Between",
+            "selectors": {
+                "{{WRAPPER}}": "--e-nav-menu-horizontal-menu-item-margin: calc( {{SIZE}}{{UNIT}} / 2 );",
+                "{{WRAPPER}} .elementor-nav-menu--main:not(.elementor-nav-menu--layout-horizontal) .elementor-nav-menu > li:not(:last-child)": "margin-bottom: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "border_radius_menu_item": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_main-menu",
+            "label": "Border Radius",
+            "selectors": {
+                "{{WRAPPER}} .elementor-item:before": "border-radius: {{SIZE}}{{UNIT}}",
+                "{{WRAPPER}} .e--animation-shutter-in-horizontal .elementor-item:before": "border-radius: {{SIZE}}{{UNIT}} {{SIZE}}{{UNIT}} 0 0",
+                "{{WRAPPER}} .e--animation-shutter-in-horizontal .elementor-item:after": "border-radius: 0 0 {{SIZE}}{{UNIT}} {{SIZE}}{{UNIT}}",
+                "{{WRAPPER}} .e--animation-shutter-in-vertical .elementor-item:before": "border-radius: 0 {{SIZE}}{{UNIT}} {{SIZE}}{{UNIT}} 0",
+                "{{WRAPPER}} .e--animation-shutter-in-vertical .elementor-item:after": "border-radius: {{SIZE}}{{UNIT}} 0 0 {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "section_style_dropdown": {
+            "type": "section",
+            "tab": "style",
+            "label": "Dropdown"
+        },
+        "dropdown_description": {
+            "type": "raw_html",
+            "tab": "style",
+            "section": "section_style_dropdown"
+        },
+        "tabs_dropdown_item_style": {
+            "type": "tabs",
+            "tab": "style",
+            "section": "section_style_dropdown"
+        },
+        "tab_dropdown_item_normal": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Normal"
+        },
+        "color_dropdown_item": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Text Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown a, {{WRAPPER}} .elementor-menu-toggle": "color: {{VALUE}}; fill: {{VALUE}};"
+            }
+        },
+        "background_color_dropdown_item": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Background Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown": "background-color: {{VALUE}}"
+            }
+        },
+        "tab_dropdown_item_hover": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Hover"
+        },
+        "color_dropdown_item_hover": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Text Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown a:hover,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--dropdown a:focus,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--dropdown a.elementor-item-active,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--dropdown a.highlighted,\n\t\t\t\t\t{{WRAPPER}} .elementor-menu-toggle:hover,\n\t\t\t\t\t{{WRAPPER}} .elementor-menu-toggle:focus": "color: {{VALUE}}"
+            }
+        },
+        "background_color_dropdown_item_hover": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Background Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown a:hover,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--dropdown a:focus,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--dropdown a.elementor-item-active,\n\t\t\t\t\t{{WRAPPER}} .elementor-nav-menu--dropdown a.highlighted": "background-color: {{VALUE}}"
+            }
+        },
+        "tab_dropdown_item_active": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Active"
+        },
+        "color_dropdown_item_active": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Text Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown a.elementor-item-active": "color: {{VALUE}}"
+            }
+        },
+        "background_color_dropdown_item_active": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Background Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown a.elementor-item-active": "background-color: {{VALUE}}"
+            }
+        },
+        "dropdown_typography_typography": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Typography"
+        },
+        "dropdown_typography_font_family": {
+            "type": "font",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Family",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown .elementor-item, {{WRAPPER}} .elementor-nav-menu--dropdown  .elementor-sub-item": "font-family: \"{{VALUE}}\", Sans-serif;"
+            }
+        },
+        "dropdown_typography_font_size": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Size",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown .elementor-item, {{WRAPPER}} .elementor-nav-menu--dropdown  .elementor-sub-item": "font-size: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "dropdown_typography_font_weight": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Weight",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown .elementor-item, {{WRAPPER}} .elementor-nav-menu--dropdown  .elementor-sub-item": "font-weight: {{VALUE}};"
+            }
+        },
+        "dropdown_typography_text_transform": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Transform",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown .elementor-item, {{WRAPPER}} .elementor-nav-menu--dropdown  .elementor-sub-item": "text-transform: {{VALUE}};"
+            }
+        },
+        "dropdown_typography_font_style": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Style",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown .elementor-item, {{WRAPPER}} .elementor-nav-menu--dropdown  .elementor-sub-item": "font-style: {{VALUE}};"
+            }
+        },
+        "dropdown_typography_text_decoration": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Decoration",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown .elementor-item, {{WRAPPER}} .elementor-nav-menu--dropdown  .elementor-sub-item": "text-decoration: {{VALUE}};"
+            }
+        },
+        "dropdown_typography_letter_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Letter Spacing",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown .elementor-item, {{WRAPPER}} .elementor-nav-menu--dropdown  .elementor-sub-item": "letter-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "dropdown_typography_word_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Word Spacing",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown .elementor-item, {{WRAPPER}} .elementor-nav-menu--dropdown  .elementor-sub-item": "word-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "dropdown_border_border": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Border Type",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown": "border-style: {{VALUE}};"
+            }
+        },
+        "dropdown_border_width": {
+            "type": "dimensions",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Border Width",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown": "border-width: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "dropdown_border_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Border Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown": "border-color: {{VALUE}};"
+            }
+        },
+        "dropdown_border_radius": {
+            "type": "dimensions",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Border Radius",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown": "border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};",
+                "{{WRAPPER}} .elementor-nav-menu--dropdown li:first-child a": "border-top-left-radius: {{TOP}}{{UNIT}}; border-top-right-radius: {{RIGHT}}{{UNIT}};",
+                "{{WRAPPER}} .elementor-nav-menu--dropdown li:last-child a": "border-bottom-right-radius: {{BOTTOM}}{{UNIT}}; border-bottom-left-radius: {{LEFT}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "dropdown_box_shadow_box_shadow_type": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Box Shadow"
+        },
+        "dropdown_box_shadow_box_shadow": {
+            "type": "box_shadow",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Box Shadow",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--main .elementor-nav-menu--dropdown, {{WRAPPER}} .elementor-nav-menu__container.elementor-nav-menu--dropdown": "box-shadow: {{HORIZONTAL}}px {{VERTICAL}}px {{BLUR}}px {{SPREAD}}px {{COLOR}} {{dropdown_box_shadow_box_shadow_position.VALUE}};"
+            }
+        },
+        "padding_horizontal_dropdown_item": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Horizontal Padding",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown a": "padding-left: {{SIZE}}{{UNIT}}; padding-right: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "padding_vertical_dropdown_item": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Vertical Padding",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown a": "padding-top: {{SIZE}}{{UNIT}}; padding-bottom: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "heading_dropdown_divider": {
+            "type": "heading",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Divider"
+        },
+        "dropdown_divider_border": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Border Type",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown li:not(:last-child)": "border-style: {{VALUE}};"
+            }
+        },
+        "dropdown_divider_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Border Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown li:not(:last-child)": "border-color: {{VALUE}};"
+            }
+        },
+        "dropdown_divider_width": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Border Width",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--dropdown li:not(:last-child)": "border-bottom-width: {{SIZE}}{{UNIT}}"
+            }
+        },
+        "dropdown_top_distance": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_dropdown",
+            "label": "Distance",
+            "selectors": {
+                "{{WRAPPER}} .elementor-nav-menu--main > .elementor-nav-menu > li > .elementor-nav-menu--dropdown, {{WRAPPER}} .elementor-nav-menu__container.elementor-nav-menu--dropdown": "margin-top: {{SIZE}}{{UNIT}} !important"
+            },
+            "responsive": []
+        },
+        "style_toggle": {
+            "type": "section",
+            "tab": "style",
+            "label": "Toggle Button"
+        },
+        "tabs_toggle_style": {
+            "type": "tabs",
+            "tab": "style",
+            "section": "style_toggle"
+        },
+        "tab_toggle_style_normal": {
+            "type": "tab",
+            "tab": "style",
+            "section": "style_toggle",
+            "label": "Normal"
+        },
+        "toggle_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "style_toggle",
+            "label": "Color",
+            "selectors": {
+                "{{WRAPPER}} div.elementor-menu-toggle": "color: {{VALUE}}",
+                "{{WRAPPER}} div.elementor-menu-toggle svg": "fill: {{VALUE}}"
+            }
+        },
+        "toggle_background_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "style_toggle",
+            "label": "Background Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-menu-toggle": "background-color: {{VALUE}}"
+            }
+        },
+        "tab_toggle_style_hover": {
+            "type": "tab",
+            "tab": "style",
+            "section": "style_toggle",
+            "label": "Hover"
+        },
+        "toggle_color_hover": {
+            "type": "color",
+            "tab": "style",
+            "section": "style_toggle",
+            "label": "Color",
+            "selectors": {
+                "{{WRAPPER}} div.elementor-menu-toggle:hover, {{WRAPPER}} div.elementor-menu-toggle:focus": "color: {{VALUE}}",
+                "{{WRAPPER}} div.elementor-menu-toggle:hover svg, {{WRAPPER}} div.elementor-menu-toggle:focus svg": "fill: {{VALUE}}"
+            }
+        },
+        "toggle_background_color_hover": {
+            "type": "color",
+            "tab": "style",
+            "section": "style_toggle",
+            "label": "Background Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-menu-toggle:hover, {{WRAPPER}} .elementor-menu-toggle:focus": "background-color: {{VALUE}}"
+            }
+        },
+        "toggle_size": {
+            "type": "slider",
+            "tab": "style",
+            "section": "style_toggle",
+            "label": "Size",
+            "selectors": {
+                "{{WRAPPER}}": "--nav-menu-icon-size: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "toggle_border_width": {
+            "type": "slider",
+            "tab": "style",
+            "section": "style_toggle",
+            "label": "Border Width",
+            "selectors": {
+                "{{WRAPPER}} .elementor-menu-toggle": "border-width: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "toggle_border_radius": {
+            "type": "slider",
+            "tab": "style",
+            "section": "style_toggle",
+            "label": "Border Radius",
+            "selectors": {
+                "{{WRAPPER}} .elementor-menu-toggle": "border-radius: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        }
+    }
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/theme-archive-title.json
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/theme-archive-title.json
@@ -1,0 +1,239 @@
+{
+    "controls": {
+        "section_title": {
+            "type": "section",
+            "tab": "content",
+            "label": "Heading"
+        },
+        "title": {
+            "type": "textarea",
+            "tab": "content",
+            "section": "section_title",
+            "label": "Title"
+        },
+        "link": {
+            "type": "url",
+            "tab": "content",
+            "section": "section_title",
+            "label": "Link"
+        },
+        "size": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_title",
+            "label": "Size"
+        },
+        "header_size": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_title",
+            "label": "HTML Tag"
+        },
+        "section_title_style": {
+            "type": "section",
+            "tab": "style",
+            "label": "Heading"
+        },
+        "align": {
+            "type": "choose",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Alignment",
+            "selectors": {
+                "{{WRAPPER}}": "text-align: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "typography_typography": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Typography"
+        },
+        "typography_font_family": {
+            "type": "font",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Family",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "font-family: \"{{VALUE}}\", Sans-serif;"
+            }
+        },
+        "typography_font_size": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Size",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "font-size: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "typography_font_weight": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Weight",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "font-weight: {{VALUE}};"
+            }
+        },
+        "typography_text_transform": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Transform",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "text-transform: {{VALUE}};"
+            }
+        },
+        "typography_font_style": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Style",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "font-style: {{VALUE}};"
+            }
+        },
+        "typography_text_decoration": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Decoration",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "text-decoration: {{VALUE}};"
+            }
+        },
+        "typography_line_height": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Line Height",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "line-height: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "typography_letter_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Letter Spacing",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "letter-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "typography_word_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Word Spacing",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "word-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "text_stroke_text_stroke_type": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Text Stroke"
+        },
+        "text_stroke_text_stroke": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Text Stroke",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "-webkit-text-stroke-width: {{SIZE}}{{UNIT}}; stroke-width: {{SIZE}}{{UNIT}};"
+            },
+            "selector": "{{WRAPPER}}",
+            "responsive": []
+        },
+        "text_stroke_stroke_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Stroke Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "-webkit-text-stroke-color: {{VALUE}}; stroke: {{VALUE}};"
+            },
+            "selector": "{{WRAPPER}}"
+        },
+        "text_shadow_text_shadow_type": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Text Shadow"
+        },
+        "text_shadow_text_shadow": {
+            "type": "text_shadow",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Text Shadow",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "text-shadow: {{HORIZONTAL}}px {{VERTICAL}}px {{BLUR}}px {{COLOR}};"
+            }
+        },
+        "blend_mode": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Blend Mode",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "mix-blend-mode: {{VALUE}}"
+            }
+        },
+        "separator": {
+            "type": "divider",
+            "tab": "style",
+            "section": "section_title_style"
+        },
+        "title_colors": {
+            "type": "tabs",
+            "tab": "style",
+            "section": "section_title_style"
+        },
+        "title_colors_normal": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Normal"
+        },
+        "title_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Text Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "color: {{VALUE}};"
+            }
+        },
+        "title_colors_hover": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Hover"
+        },
+        "title_hover_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Link Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title a:hover, {{WRAPPER}} .elementor-heading-title a:focus": "color: {{VALUE}};"
+            }
+        },
+        "title_hover_color_transition_duration": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Transition Duration",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title a": "transition-duration: {{SIZE}}{{UNIT}};"
+            }
+        }
+    }
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/theme-post-content.json
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/theme-post-content.json
@@ -1,0 +1,119 @@
+{
+    "controls": {
+        "section_style": {
+            "type": "section",
+            "tab": "style",
+            "label": "Style"
+        },
+        "align": {
+            "type": "choose",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Alignment",
+            "selectors": {
+                "{{WRAPPER}}": "text-align: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "text_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Text Color",
+            "selectors": {
+                "{{WRAPPER}}": "color: {{VALUE}};"
+            }
+        },
+        "typography_typography": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Typography"
+        },
+        "typography_font_family": {
+            "type": "font",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Family",
+            "selectors": {
+                "{{WRAPPER}}": "font-family: \"{{VALUE}}\", Sans-serif;"
+            }
+        },
+        "typography_font_size": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Size",
+            "selectors": {
+                "{{WRAPPER}}": "font-size: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "typography_font_weight": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Weight",
+            "selectors": {
+                "{{WRAPPER}}": "font-weight: {{VALUE}};"
+            }
+        },
+        "typography_text_transform": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Transform",
+            "selectors": {
+                "{{WRAPPER}}": "text-transform: {{VALUE}};"
+            }
+        },
+        "typography_font_style": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Style",
+            "selectors": {
+                "{{WRAPPER}}": "font-style: {{VALUE}};"
+            }
+        },
+        "typography_text_decoration": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Decoration",
+            "selectors": {
+                "{{WRAPPER}}": "text-decoration: {{VALUE}};"
+            }
+        },
+        "typography_line_height": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Line Height",
+            "selectors": {
+                "{{WRAPPER}}": "line-height: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "typography_letter_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Letter Spacing",
+            "selectors": {
+                "{{WRAPPER}}": "letter-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "typography_word_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Word Spacing",
+            "selectors": {
+                "{{WRAPPER}}": "word-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        }
+    }
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/theme-post-excerpt.json
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/theme-post-excerpt.json
@@ -1,0 +1,203 @@
+{
+    "controls": {
+        "section_content": {
+            "type": "section",
+            "tab": "content",
+            "label": "Content"
+        },
+        "excerpt": {
+            "type": "text",
+            "tab": "content",
+            "section": "section_content"
+        },
+        "section_style": {
+            "type": "section",
+            "tab": "style",
+            "label": "Style"
+        },
+        "align": {
+            "type": "choose",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Alignment",
+            "selectors": {
+                "{{WRAPPER}}": "text-align: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "typography_typography": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Typography"
+        },
+        "typography_font_family": {
+            "type": "font",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Family",
+            "selectors": {
+                "{{WRAPPER}}": "font-family: \"{{VALUE}}\", Sans-serif;"
+            }
+        },
+        "typography_font_size": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Size",
+            "selectors": {
+                "{{WRAPPER}}": "font-size: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "typography_font_weight": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Weight",
+            "selectors": {
+                "{{WRAPPER}}": "font-weight: {{VALUE}};"
+            }
+        },
+        "typography_text_transform": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Transform",
+            "selectors": {
+                "{{WRAPPER}}": "text-transform: {{VALUE}};"
+            }
+        },
+        "typography_font_style": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Style",
+            "selectors": {
+                "{{WRAPPER}}": "font-style: {{VALUE}};"
+            }
+        },
+        "typography_text_decoration": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Decoration",
+            "selectors": {
+                "{{WRAPPER}}": "text-decoration: {{VALUE}};"
+            }
+        },
+        "typography_line_height": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Line Height",
+            "selectors": {
+                "{{WRAPPER}}": "line-height: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "typography_letter_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Letter Spacing",
+            "selectors": {
+                "{{WRAPPER}}": "letter-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "typography_word_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Word Spacing",
+            "selectors": {
+                "{{WRAPPER}}": "word-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "text_shadow_text_shadow_type": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Text Shadow"
+        },
+        "text_shadow_text_shadow": {
+            "type": "text_shadow",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Text Shadow",
+            "selectors": {
+                "{{WRAPPER}}": "text-shadow: {{HORIZONTAL}}px {{VERTICAL}}px {{BLUR}}px {{COLOR}};"
+            }
+        },
+        "paragraph_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Paragraph Spacing",
+            "selectors": {
+                "{{WRAPPER}}": "margin-bottom: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "separator": {
+            "type": "divider",
+            "tab": "style",
+            "section": "section_style"
+        },
+        "link_colors": {
+            "type": "tabs",
+            "tab": "style",
+            "section": "section_style"
+        },
+        "colors_normal": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Normal"
+        },
+        "title_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Text Color",
+            "selectors": {
+                "{{WRAPPER}}": "color: {{VALUE}};"
+            }
+        },
+        "link_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Link Color",
+            "selectors": {
+                "{{WRAPPER}} a": "color: {{VALUE}};"
+            }
+        },
+        "colors_hover": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Hover"
+        },
+        "link_hover_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Link Color",
+            "selectors": {
+                "{{WRAPPER}} a:hover, {{WRAPPER}} a:focus": "color: {{VALUE}};"
+            }
+        },
+        "link_hover_color_transition_duration": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style",
+            "label": "Transition Duration",
+            "selectors": {
+                "{{WRAPPER}} a": "transition-duration: {{SIZE}}{{UNIT}};"
+            }
+        }
+    }
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/theme-post-featured-image.json
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/theme-post-featured-image.json
@@ -1,0 +1,457 @@
+{
+    "controls": {
+        "section_image": {
+            "type": "section",
+            "tab": "content",
+            "label": "Image"
+        },
+        "image": {
+            "type": "media",
+            "tab": "content",
+            "section": "section_image",
+            "label": "Choose Image"
+        },
+        "image_size": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_image",
+            "label": "Image Resolution"
+        },
+        "image_custom_dimension": {
+            "type": "image_dimensions",
+            "tab": "content",
+            "section": "section_image",
+            "label": "Image Dimension"
+        },
+        "caption_source": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_image",
+            "label": "Caption"
+        },
+        "caption": {
+            "type": "text",
+            "tab": "content",
+            "section": "section_image",
+            "label": "Custom Caption"
+        },
+        "link_to": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_image",
+            "label": "Link"
+        },
+        "link": {
+            "type": "url",
+            "tab": "content",
+            "section": "section_image",
+            "label": "Link"
+        },
+        "open_lightbox": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_image",
+            "label": "Lightbox"
+        },
+        "section_style_image": {
+            "type": "section",
+            "tab": "style",
+            "label": "Image"
+        },
+        "align": {
+            "type": "choose",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Alignment",
+            "selectors": {
+                "{{WRAPPER}}": "text-align: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "width": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Width",
+            "selectors": {
+                "{{WRAPPER}} img": "width: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "space": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Max Width",
+            "selectors": {
+                "{{WRAPPER}} img": "max-width: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "height": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Height",
+            "selectors": {
+                "{{WRAPPER}} img": "height: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "object-fit": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Object Fit",
+            "selectors": {
+                "{{WRAPPER}} img": "object-fit: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "object-position": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Object Position",
+            "selectors": {
+                "{{WRAPPER}} img": "object-position: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "separator_panel_style": {
+            "type": "divider",
+            "tab": "style",
+            "section": "section_style_image"
+        },
+        "image_effects": {
+            "type": "tabs",
+            "tab": "style",
+            "section": "section_style_image"
+        },
+        "normal": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Normal"
+        },
+        "opacity": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Opacity",
+            "selectors": {
+                "{{WRAPPER}} img": "opacity: {{SIZE}};"
+            }
+        },
+        "css_filters_css_filter": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "CSS Filters"
+        },
+        "css_filters_blur": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Blur",
+            "selectors": {
+                "{{WRAPPER}} img": "filter: brightness( {{css_filters_brightness.SIZE}}% ) contrast( {{css_filters_contrast.SIZE}}% ) saturate( {{css_filters_saturate.SIZE}}% ) blur( {{css_filters_blur.SIZE}}px ) hue-rotate( {{css_filters_hue.SIZE}}deg )"
+            }
+        },
+        "css_filters_brightness": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Brightness"
+        },
+        "css_filters_contrast": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Contrast"
+        },
+        "css_filters_saturate": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Saturation"
+        },
+        "css_filters_hue": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Hue"
+        },
+        "hover": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Hover"
+        },
+        "opacity_hover": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Opacity",
+            "selectors": {
+                "{{WRAPPER}}:hover img": "opacity: {{SIZE}};"
+            }
+        },
+        "css_filters_hover_css_filter": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "CSS Filters"
+        },
+        "css_filters_hover_blur": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Blur",
+            "selectors": {
+                "{{WRAPPER}}:hover img": "filter: brightness( {{css_filters_hover_brightness.SIZE}}% ) contrast( {{css_filters_hover_contrast.SIZE}}% ) saturate( {{css_filters_hover_saturate.SIZE}}% ) blur( {{css_filters_hover_blur.SIZE}}px ) hue-rotate( {{css_filters_hover_hue.SIZE}}deg )"
+            }
+        },
+        "css_filters_hover_brightness": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Brightness"
+        },
+        "css_filters_hover_contrast": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Contrast"
+        },
+        "css_filters_hover_saturate": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Saturation"
+        },
+        "css_filters_hover_hue": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Hue"
+        },
+        "background_hover_transition": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Transition Duration (s)",
+            "selectors": {
+                "{{WRAPPER}} img": "transition-duration: {{SIZE}}s"
+            }
+        },
+        "hover_animation": {
+            "type": "hover_animation",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Hover Animation"
+        },
+        "image_border_border": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Border Type",
+            "selectors": {
+                "{{WRAPPER}} img": "border-style: {{VALUE}};"
+            }
+        },
+        "image_border_width": {
+            "type": "dimensions",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Border Width",
+            "selectors": {
+                "{{WRAPPER}} img": "border-width: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "image_border_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Border Color",
+            "selectors": {
+                "{{WRAPPER}} img": "border-color: {{VALUE}};"
+            }
+        },
+        "image_border_radius": {
+            "type": "dimensions",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Border Radius",
+            "selectors": {
+                "{{WRAPPER}} img": "border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};"
+            },
+            "responsive": []
+        },
+        "image_box_shadow_box_shadow_type": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Box Shadow"
+        },
+        "image_box_shadow_box_shadow": {
+            "type": "box_shadow",
+            "tab": "style",
+            "section": "section_style_image",
+            "label": "Box Shadow",
+            "selectors": {
+                "{{WRAPPER}} img": "box-shadow: {{HORIZONTAL}}px {{VERTICAL}}px {{BLUR}}px {{SPREAD}}px {{COLOR}} {{image_box_shadow_box_shadow_position.VALUE}};"
+            }
+        },
+        "section_style_caption": {
+            "type": "section",
+            "tab": "style",
+            "label": "Caption"
+        },
+        "caption_align": {
+            "type": "choose",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Alignment",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "text-align: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "text_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Text Color",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "color: {{VALUE}};"
+            }
+        },
+        "caption_background_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Background Color",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "background-color: {{VALUE}};"
+            }
+        },
+        "caption_typography_typography": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Typography"
+        },
+        "caption_typography_font_family": {
+            "type": "font",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Family",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "font-family: \"{{VALUE}}\", Sans-serif;"
+            }
+        },
+        "caption_typography_font_size": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Size",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "font-size: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "caption_typography_font_weight": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Weight",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "font-weight: {{VALUE}};"
+            }
+        },
+        "caption_typography_text_transform": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Transform",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "text-transform: {{VALUE}};"
+            }
+        },
+        "caption_typography_font_style": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Style",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "font-style: {{VALUE}};"
+            }
+        },
+        "caption_typography_text_decoration": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Decoration",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "text-decoration: {{VALUE}};"
+            }
+        },
+        "caption_typography_line_height": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Line Height",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "line-height: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "caption_typography_letter_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Letter Spacing",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "letter-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "caption_typography_word_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Word Spacing",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "word-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "caption_text_shadow_text_shadow_type": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Text Shadow"
+        },
+        "caption_text_shadow_text_shadow": {
+            "type": "text_shadow",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Text Shadow",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "text-shadow: {{HORIZONTAL}}px {{VERTICAL}}px {{BLUR}}px {{COLOR}};"
+            }
+        },
+        "caption_space": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_style_caption",
+            "label": "Spacing",
+            "selectors": {
+                "{{WRAPPER}} .widget-image-caption": "margin-block-start: {{SIZE}}{{UNIT}};"
+            },
+            "responsive": []
+        }
+    }
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/theme-post-title.json
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/controls/theme-post-title.json
@@ -1,0 +1,239 @@
+{
+    "controls": {
+        "section_title": {
+            "type": "section",
+            "tab": "content",
+            "label": "Heading"
+        },
+        "title": {
+            "type": "textarea",
+            "tab": "content",
+            "section": "section_title",
+            "label": "Title"
+        },
+        "link": {
+            "type": "url",
+            "tab": "content",
+            "section": "section_title",
+            "label": "Link"
+        },
+        "size": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_title",
+            "label": "Size"
+        },
+        "header_size": {
+            "type": "select",
+            "tab": "content",
+            "section": "section_title",
+            "label": "HTML Tag"
+        },
+        "section_title_style": {
+            "type": "section",
+            "tab": "style",
+            "label": "Heading"
+        },
+        "align": {
+            "type": "choose",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Alignment",
+            "selectors": {
+                "{{WRAPPER}}": "text-align: {{VALUE}};"
+            },
+            "responsive": []
+        },
+        "typography_typography": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Typography"
+        },
+        "typography_font_family": {
+            "type": "font",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Family",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "font-family: \"{{VALUE}}\", Sans-serif;"
+            }
+        },
+        "typography_font_size": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Size",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "font-size: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "typography_font_weight": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Weight",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "font-weight: {{VALUE}};"
+            }
+        },
+        "typography_text_transform": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Transform",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "text-transform: {{VALUE}};"
+            }
+        },
+        "typography_font_style": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Style",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "font-style: {{VALUE}};"
+            }
+        },
+        "typography_text_decoration": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Decoration",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "text-decoration: {{VALUE}};"
+            }
+        },
+        "typography_line_height": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Line Height",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "line-height: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "typography_letter_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Letter Spacing",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "letter-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "typography_word_spacing": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Word Spacing",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "word-spacing: {{SIZE}}{{UNIT}}"
+            },
+            "responsive": []
+        },
+        "text_stroke_text_stroke_type": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Text Stroke"
+        },
+        "text_stroke_text_stroke": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Text Stroke",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "-webkit-text-stroke-width: {{SIZE}}{{UNIT}}; stroke-width: {{SIZE}}{{UNIT}};"
+            },
+            "selector": "{{WRAPPER}}",
+            "responsive": []
+        },
+        "text_stroke_stroke_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Stroke Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "-webkit-text-stroke-color: {{VALUE}}; stroke: {{VALUE}};"
+            },
+            "selector": "{{WRAPPER}}"
+        },
+        "text_shadow_text_shadow_type": {
+            "type": "popover_toggle",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Text Shadow"
+        },
+        "text_shadow_text_shadow": {
+            "type": "text_shadow",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Text Shadow",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "text-shadow: {{HORIZONTAL}}px {{VERTICAL}}px {{BLUR}}px {{COLOR}};"
+            }
+        },
+        "blend_mode": {
+            "type": "select",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Blend Mode",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "mix-blend-mode: {{VALUE}}"
+            }
+        },
+        "separator": {
+            "type": "divider",
+            "tab": "style",
+            "section": "section_title_style"
+        },
+        "title_colors": {
+            "type": "tabs",
+            "tab": "style",
+            "section": "section_title_style"
+        },
+        "title_colors_normal": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Normal"
+        },
+        "title_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Text Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title": "color: {{VALUE}};"
+            }
+        },
+        "title_colors_hover": {
+            "type": "tab",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Hover"
+        },
+        "title_hover_color": {
+            "type": "color",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Link Color",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title a:hover, {{WRAPPER}} .elementor-heading-title a:focus": "color: {{VALUE}};"
+            }
+        },
+        "title_hover_color_transition_duration": {
+            "type": "slider",
+            "tab": "style",
+            "section": "section_title_style",
+            "label": "Transition Duration",
+            "selectors": {
+                "{{WRAPPER}} .elementor-heading-title a": "transition-duration: {{SIZE}}{{UNIT}};"
+            }
+        }
+    }
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/button.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/button.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'button',
+	'expected_supported' => [ 'color', 'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left', 'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left', 'font-family', 'font-size', 'font-weight', 'line-height', 'letter-spacing', 'background-color', 'border-radius' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => null,
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/container.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/container.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'container',
+	'expected_supported' => [ 'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left', 'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left', 'background-color', 'background-color@hover', 'flex-direction', 'flex-wrap', 'justify-content', 'align-items', 'align-content', 'gap', 'display', 'border-style', 'border-color', 'border-width', 'border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width', 'border-radius', 'border-top', 'border-right', 'border-bottom', 'border-left', 'border', 'min-height', 'max-width', 'position', 'z-index', 'overflow', 'flex-grow', 'flex-shrink', 'align-self', 'order' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => [ '_element_id' ],
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/divider.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/divider.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'divider',
+	'expected_supported' => [ 'border-width', 'border-top-width', 'border-color', 'border-style', 'padding', 'margin' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => null,
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/heading.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/heading.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'heading',
+	'expected_supported' => [ 'color', 'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left', 'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left', 'font-family', 'font-size', 'font-weight', 'line-height', 'letter-spacing', 'text-align', 'max-width' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => null,
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/html.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/html.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'html',
+	'expected_supported' => [ 'padding', 'margin' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => null,
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/icon.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/icon.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'icon',
+	'expected_supported' => [ 'color', 'font-size', 'padding', 'margin' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => null,
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/image.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/image.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'image',
+	'expected_supported' => [ 'width', 'max-width', 'padding', 'margin', 'border-radius' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => null,
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/nav-menu.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/nav-menu.php
@@ -1,0 +1,24 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'nav-menu',
+	'expected_supported' => [
+		'color',
+		'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
+		'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
+		'font-family', 'font-size', 'font-weight', 'line-height', 'letter-spacing',
+	],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => [
+		'menu_name', 'menu', 'layout', 'align_items', 'pointer',
+		'animation_line', 'animation_framed', 'animation_background', 'animation_text',
+		'submenu_icon', 'dropdown', 'full_width', 'text_align',
+		'toggle', 'toggle_icon_normal', 'toggle_icon_hover_animation', 'toggle_icon_active', 'toggle_align',
+		'_element_id',
+	],
+	'expected_inner_aliases' => [ 'main-menu', 'dropdown', 'toggle' ],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/spacer.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/spacer.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'spacer',
+	'expected_supported' => [ 'height', 'padding', 'margin' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => null,
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/text-editor.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/text-editor.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'text-editor',
+	'expected_supported' => [ 'color', 'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left', 'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left', 'font-family', 'font-size', 'font-weight', 'line-height', 'letter-spacing' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => null,
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/theme-archive-title.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/theme-archive-title.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'theme-archive-title',
+	'expected_supported' => [ 'color', 'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left', 'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left', 'font-family', 'font-size', 'font-weight', 'line-height', 'letter-spacing' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => [ 'title', 'link', 'size', 'header_size', '_element_id' ],
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/theme-post-content.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/theme-post-content.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'theme-post-content',
+	'expected_supported' => [ 'color', 'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left', 'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left', 'font-family', 'font-size', 'font-weight', 'line-height', 'letter-spacing' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => [ '_element_id' ],
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/theme-post-excerpt.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/theme-post-excerpt.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'theme-post-excerpt',
+	'expected_supported' => [ 'color', 'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left', 'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left', 'font-family', 'font-size', 'font-weight', 'line-height', 'letter-spacing' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => [ 'excerpt', '_element_id' ],
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/theme-post-featured-image.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/theme-post-featured-image.php
@@ -1,0 +1,13 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'theme-post-featured-image',
+	'expected_supported' => [ 'width', 'max-width', 'border-radius' ],
+	'expected_unsupported' => [ 'transform', 'animation', 'animation-name', 'filter', '-webkit-mask' ],
+	'expected_non_style_keys' => [ 'image', 'image_size', 'image_custom_dimension', 'caption_source', 'caption', 'link_to', 'link', 'open_lightbox', '_element_id' ],
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/theme-post-title.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/parity/theme-post-title.php
@@ -1,0 +1,48 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+ * Parity fixture for the V3 `theme-post-title` widget.
+ *
+ * Concretely: the LLM should be able to write the same core visual language on this widget
+ * as on any headline — color, typography, spacing, alignment, size — but transforms,
+ * animations and other non-native properties must stay in custom_css.
+ */
+
+return [
+	'widget_type' => 'theme-post-title',
+
+	'expected_supported' => [
+		'color',
+		'text-align',
+		'padding',
+		'padding-top',
+		'padding-right',
+		'padding-bottom',
+		'padding-left',
+		'margin',
+		'margin-top',
+		'margin-right',
+		'margin-bottom',
+		'margin-left',
+		'font-family',
+		'font-size',
+		'font-weight',
+		'line-height',
+		'letter-spacing',
+	],
+
+	'expected_unsupported' => [
+		'transform',
+		'animation',
+		'animation-name',
+		'-webkit-mask',
+	],
+
+	'expected_non_style_keys' => [ 'title', 'link', 'size', 'header_size', '_element_id' ],
+
+	'expected_inner_aliases' => [],
+];

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/v3-widget-fixtures.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/fixtures/v3-widget-fixtures.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3\Fixtures;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Loads checked-in control dumps for MCP V3 widgets whose runtime controls are
+ * unavailable in Core PHPUnit (Pro widgets). The Advanced tab is identical
+ * across V3 widgets, so it is stored once and merged here.
+ */
+class V3_Widget_Fixtures {
+
+	const SHARED_ADVANCED_FILE = 'advanced-shared.json';
+
+	/**
+	 * @var array<string, array<string, mixed>>
+	 */
+	private static $cache = [];
+
+	/**
+	 * @return string[]
+	 */
+	public static function widget_types(): array {
+		return [
+			'nav-menu',
+			'theme-archive-title',
+			'theme-post-content',
+			'theme-post-excerpt',
+			'theme-post-featured-image',
+			'theme-post-title',
+		];
+	}
+
+	/**
+	 * @return array{controls: array<string, array<string, mixed>>}
+	 */
+	public static function widget_config( string $widget_type ): array {
+		if ( ! isset( self::$cache[ $widget_type ] ) ) {
+			self::$cache[ $widget_type ] = [
+				'controls' => array_merge(
+					self::read_controls( $widget_type . '.json' ),
+					self::read_controls( self::SHARED_ADVANCED_FILE )
+				),
+			];
+		}
+
+		return self::$cache[ $widget_type ];
+	}
+
+	/**
+	 * @return array<string, array<string, mixed>>
+	 */
+	private static function read_controls( string $file_name ): array {
+		return self::read_json( __DIR__ . '/controls/' . $file_name )['controls'] ?? [];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private static function read_json( string $path ): array {
+		if ( ! is_readable( $path ) ) {
+			throw new \RuntimeException( sprintf( 'Missing V3 fixture: %s', $path ) );
+		}
+
+		$decoded = json_decode( (string) file_get_contents( $path ), true );
+
+		if ( ! is_array( $decoded ) ) {
+			throw new \RuntimeException( sprintf( 'Invalid V3 fixture: %s', $path ) );
+		}
+
+		return $decoded;
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/maps/test-v3-widget-map-compiler.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/maps/test-v3-widget-map-compiler.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3\Maps;
+
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\Style_Control_Target;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\V3_Widget_Map_Compiler;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Widget_Map_Compiler extends TestCase {
+
+	private V3_Widget_Map_Compiler $compiler;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->compiler = new V3_Widget_Map_Compiler();
+	}
+
+	public function test_compile__returns_compiled_map_for_valid_single_target() {
+		$result = $this->compiler->compile( $this->single_target_map(), $this->heading_controls() );
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertSame( 'heading', $result['widget_type'] );
+		$this->assertSame( 'heading', $result['default_style_target'] );
+		$this->assertSame( [ 'color' ], array_keys( $result['style_targets']['heading']['css_properties'] ) );
+	}
+
+	public function test_compile__returns_compiled_map_for_valid_multi_target() {
+		$result = $this->compiler->compile( $this->multi_target_map(), $this->nav_menu_controls() );
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertSame( [ 'main-menu', 'toggle' ], array_keys( $result['style_targets'] ) );
+		$this->assertTrue( $result['style_targets']['toggle']['css_properties']['font-size']['default']['responsive'] );
+	}
+
+	public function test_compile__returns_error_when_required_field_missing() {
+		$map = $this->single_target_map();
+		unset( $map['description'] );
+
+		$result = $this->compiler->compile( $map, $this->heading_controls() );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'elementor_v3_map_invalid', $result->get_error_code() );
+		$this->assertSame( 'missing_field', $result->get_error_data( 'elementor_v3_map_invalid' )['reason'] );
+	}
+
+	public function test_compile__returns_error_when_catalog_visibility_invalid() {
+		$map = $this->single_target_map();
+		$map['catalog_visibility'] = 'sometimes';
+
+		$result = $this->compiler->compile( $map, $this->heading_controls() );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'invalid_visibility', $result->get_error_data( 'elementor_v3_map_invalid' )['reason'] );
+	}
+
+	public function test_compile__returns_error_when_default_style_target_missing() {
+		$map = $this->single_target_map();
+		$map['default_style_target'] = 'missing-target';
+
+		$result = $this->compiler->compile( $map, $this->heading_controls() );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'missing_default_style_target', $result->get_error_data( 'elementor_v3_map_invalid' )['reason'] );
+	}
+
+	public function test_compile__returns_error_when_style_target_alias_invalid() {
+		$map = $this->single_target_map();
+		$map['style_targets'] = [
+			'Heading Body' => $map['style_targets']['heading'],
+		];
+		$map['default_style_target'] = 'Heading Body';
+
+		$result = $this->compiler->compile( $map, $this->heading_controls() );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'invalid_alias', $result->get_error_data( 'elementor_v3_map_invalid' )['reason'] );
+	}
+
+	public function test_compile__returns_error_when_descriptor_kind_invalid() {
+		$map = $this->single_target_map();
+		$map['style_targets']['heading']['css_properties']['color']['default'] = [
+			'kind' => 'unknown',
+			'destinations' => [],
+		];
+
+		$result = $this->compiler->compile( $map, $this->heading_controls() );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'invalid_descriptor_kind', $result->get_error_data( 'elementor_v3_map_invalid' )['reason'] );
+	}
+
+	public function test_compile__returns_error_when_destination_control_missing() {
+		$map = $this->single_target_map();
+		$map['style_targets']['heading']['css_properties']['color']['default'] = Style_Control_Target::control( 'missing_color', 'color' );
+
+		$result = $this->compiler->compile( $map, $this->heading_controls() );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'missing_control', $result->get_error_data( 'elementor_v3_map_invalid' )['reason'] );
+	}
+
+	public function test_compile__returns_error_when_resolver_incompatible_with_control() {
+		$map = $this->single_target_map();
+		$map['style_targets']['heading']['css_properties']['color']['default'] = Style_Control_Target::control( 'title', 'color' );
+
+		$result = $this->compiler->compile( $map, $this->heading_controls() );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'incompatible_resolver', $result->get_error_data( 'elementor_v3_map_invalid' )['reason'] );
+	}
+
+	public function test_compile__returns_error_when_group_destination_incomplete() {
+		$map = $this->single_target_map();
+		$map['style_targets']['heading']['css_properties']['font-size'] = [
+			'default' => Style_Control_Target::typography( 'typography' ),
+		];
+
+		$result = $this->compiler->compile( $map, [
+			'title_color' => [ 'type' => 'color' ],
+			'typography_typography' => [ 'type' => 'popover_toggle' ],
+			'typography_font_family' => [ 'type' => 'font' ],
+		] );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'incomplete_group_destination', $result->get_error_data( 'elementor_v3_map_invalid' )['reason'] );
+	}
+
+	public function test_compile__returns_error_when_settings_contain_nested_repeater() {
+		$map = $this->single_target_map();
+		$map['settings']['items'] = [
+			'type' => 'repeater',
+			'fields' => [
+				'nested' => [
+					'type' => 'repeater',
+					'fields' => [
+						'label' => [ 'type' => 'text' ],
+					],
+				],
+			],
+		];
+
+		$result = $this->compiler->compile( $map, $this->heading_controls() );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'nested_repeater', $result->get_error_data( 'elementor_v3_map_invalid' )['reason'] );
+	}
+
+	public function test_compile__returns_error_when_widget_type_mismatch() {
+		$map = $this->single_target_map();
+		$map['widget_type'] = 'button';
+
+		$result = $this->compiler->compile( $map, $this->heading_controls(), 'heading' );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'widget_type_mismatch', $result->get_error_data( 'elementor_v3_map_invalid' )['reason'] );
+	}
+
+	private function single_target_map(): array {
+		return [
+			'widget_type' => 'heading',
+			'description' => 'Heading widget.',
+			'catalog_visibility' => 'v4_disabled',
+			'settings' => [
+				'title' => [ 'type' => 'text' ],
+			],
+			'default_style_target' => 'heading',
+			'style_targets' => [
+				'heading' => [
+					'label' => 'Heading',
+					'css_properties' => [
+						'color' => [
+							'default' => Style_Control_Target::control( 'title_color', 'color' ),
+						],
+					],
+				],
+			],
+		];
+	}
+
+	private function multi_target_map(): array {
+		return [
+			'widget_type' => 'nav-menu',
+			'description' => 'Navigation menu.',
+			'catalog_visibility' => 'always',
+			'settings' => [
+				'layout' => [ 'type' => 'select' ],
+			],
+			'default_style_target' => 'main-menu',
+			'style_targets' => [
+				'main-menu' => [
+					'label' => 'Main menu items',
+					'css_properties' => [
+						'color' => [
+							'default' => Style_Control_Target::control( 'color_menu_item', 'color' ),
+							'hover' => Style_Control_Target::control( 'color_menu_item_hover', 'color' ),
+						],
+					],
+				],
+				'toggle' => [
+					'label' => 'Mobile toggle',
+					'css_properties' => [
+						'font-size' => [
+							'default' => Style_Control_Target::control( 'toggle_size', 'dimension', true ),
+						],
+					],
+				],
+			],
+		];
+	}
+
+	private function heading_controls(): array {
+		return [
+			'title' => [ 'type' => 'text' ],
+			'title_color' => [ 'type' => 'color' ],
+		];
+	}
+
+	private function nav_menu_controls(): array {
+		return [
+			'layout' => [ 'type' => 'select' ],
+			'color_menu_item' => [ 'type' => 'color' ],
+			'color_menu_item_hover' => [ 'type' => 'color' ],
+			'toggle_size' => [ 'type' => 'slider' ],
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/maps/test-v3-widget-map-registry.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/maps/test-v3-widget-map-registry.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3\Maps;
+
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\Style_Control_Target;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\V3_Widget_Map_Compiler;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\V3_Widget_Map_Registry;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Widget_Map_Registry extends TestCase {
+
+	private int $compile_calls;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->compile_calls = 0;
+	}
+
+	public function test_get_compiled_map__does_not_compile_when_experiment_inactive() {
+		$registry = $this->registry( false, true, [
+			'heading' => $this->valid_heading_map(),
+		] );
+
+		$result = $registry->get_compiled_map( 'heading' );
+
+		$this->assertNull( $result );
+		$this->assertSame( 0, $this->compile_calls );
+	}
+
+	public function test_get_compiled_map__returns_compiled_map_when_experiment_active() {
+		$registry = $this->registry( true, false, [
+			'heading' => $this->valid_heading_map(),
+		] );
+
+		$result = $registry->get_compiled_map( 'heading' );
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertSame( 'heading', $result['widget_type'] );
+		$this->assertGreaterThan( 0, $this->compile_calls );
+	}
+
+	public function test_get_compiled_map__caches_invalid_map_as_wp_error() {
+		$map = $this->valid_heading_map();
+		unset( $map['description'] );
+
+		$registry = $this->registry( true, false, [
+			'heading' => $map,
+		] );
+
+		$first = $registry->get_compiled_map( 'heading' );
+		$second = $registry->get_compiled_map( 'heading' );
+
+		$this->assertTrue( is_wp_error( $first ) );
+		$this->assertSame( $first, $second );
+		$this->assertSame( 1, $this->compile_calls );
+	}
+
+	public function test_is_supported__returns_false_for_missing_map() {
+		$registry = $this->registry( true, false, [] );
+
+		$this->assertFalse( $registry->is_supported( 'heading' ) );
+		$this->assertNull( $registry->get_compiled_map( 'heading' ) );
+	}
+
+	public function test_is_supported__returns_false_for_v4_disabled_when_atomic_active() {
+		$registry = $this->registry( true, true, [
+			'heading' => $this->valid_heading_map(),
+		] );
+
+		$this->assertFalse( $registry->is_supported( 'heading' ) );
+	}
+
+	public function test_is_supported__allows_always_visibility_when_atomic_active() {
+		$map = $this->valid_heading_map();
+		$map['catalog_visibility'] = 'always';
+
+		$registry = $this->registry( true, true, [
+			'heading' => $map,
+		] );
+
+		$this->assertTrue( $registry->is_supported( 'heading' ) );
+	}
+
+	public function test_get_compiled_map__isolates_invalid_map_from_valid_sibling() {
+		$invalid = $this->valid_heading_map();
+		unset( $invalid['description'] );
+
+		$registry = $this->registry( true, false, [
+			'heading' => $invalid,
+			'nav-menu' => $this->valid_nav_menu_map(),
+		] );
+
+		$heading = $registry->get_compiled_map( 'heading' );
+		$nav_menu = $registry->get_compiled_map( 'nav-menu' );
+
+		$this->assertTrue( is_wp_error( $heading ) );
+		$this->assertFalse( is_wp_error( $nav_menu ) );
+		$this->assertSame( 'nav-menu', $nav_menu['widget_type'] );
+	}
+
+	private function registry( bool $experiment_active, bool $atomic_active, array $maps ): V3_Widget_Map_Registry {
+		$compiler = new V3_Widget_Map_Compiler();
+		$controls = [
+			'heading' => [
+				'title' => [ 'type' => 'text' ],
+				'title_color' => [ 'type' => 'color' ],
+			],
+			'nav-menu' => [
+				'layout' => [ 'type' => 'select' ],
+				'color_menu_item' => [ 'type' => 'color' ],
+			],
+		];
+
+		return new V3_Widget_Map_Registry(
+			$compiler,
+			static function () use ( $experiment_active ): bool {
+				return $experiment_active;
+			},
+			static function () use ( $atomic_active ): bool {
+				return $atomic_active;
+			},
+			function ( string $widget_type ) use ( $controls ): ?array {
+				++$this->compile_calls;
+				return $controls[ $widget_type ] ?? null;
+			},
+			$maps
+		);
+	}
+
+	private function valid_heading_map(): array {
+		return [
+			'widget_type' => 'heading',
+			'description' => 'Heading widget.',
+			'catalog_visibility' => 'v4_disabled',
+			'settings' => [
+				'title' => [ 'type' => 'text' ],
+			],
+			'default_style_target' => 'heading',
+			'style_targets' => [
+				'heading' => [
+					'label' => 'Heading',
+					'css_properties' => [
+						'color' => [
+							'default' => Style_Control_Target::control( 'title_color', 'color' ),
+						],
+					],
+				],
+			],
+		];
+	}
+
+	private function valid_nav_menu_map(): array {
+		return [
+			'widget_type' => 'nav-menu',
+			'description' => 'Navigation menu.',
+			'catalog_visibility' => 'always',
+			'settings' => [
+				'layout' => [ 'type' => 'select' ],
+			],
+			'default_style_target' => 'main-menu',
+			'style_targets' => [
+				'main-menu' => [
+					'label' => 'Main menu',
+					'css_properties' => [
+						'color' => [
+							'default' => Style_Control_Target::control( 'color_menu_item', 'color' ),
+						],
+					],
+				],
+			],
+		];
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/support/parity-fixture-loader.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/support/parity-fixture-loader.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3\Support;
+
+use Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3\Fixtures\V3_Widget_Fixtures;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Loads parity fixtures for compiled explicit V3 maps. Each fixture describes
+ * the LLM-facing contract a compiled map must satisfy: supported CSS properties
+ * per target, unsupported properties, settings keys, and catalog visibility.
+ */
+class Parity_Fixture_Loader {
+
+	const FIXTURES_DIR = __DIR__ . '/../fixtures/parity/';
+
+	const LAUNCH_WIDGET_TYPES = [
+		'button',
+		'container',
+		'divider',
+		'heading',
+		'html',
+		'icon',
+		'image',
+		'nav-menu',
+		'spacer',
+		'text-editor',
+		'theme-archive-title',
+		'theme-post-content',
+		'theme-post-excerpt',
+		'theme-post-featured-image',
+		'theme-post-title',
+	];
+
+	/**
+	 * @return array<string, array<string, mixed>> widget_type => fixture
+	 */
+	public static function all(): array {
+		$fixtures = [];
+
+		foreach ( glob( self::FIXTURES_DIR . '*.php' ) ?: [] as $path ) {
+			$fixture = require $path;
+
+			if ( ! is_array( $fixture ) ) {
+				throw new \RuntimeException( sprintf( 'Parity fixture %s must return an array.', basename( $path ) ) );
+			}
+
+			self::assert_shape( $fixture, basename( $path ) );
+
+			$fixtures[ (string) $fixture['widget_type'] ] = $fixture;
+		}
+
+		ksort( $fixtures );
+
+		return $fixtures;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public static function compiled_expectations( array $fixture ): array {
+		$style_targets = $fixture['expected_style_targets'] ?? null;
+
+		if ( ! is_array( $style_targets ) ) {
+			$aliases = $fixture['expected_style_target_aliases'] ?? $fixture['expected_inner_aliases'] ?? [];
+			$supported = $fixture['expected_supported'] ?? [];
+			$style_targets = [];
+
+			if ( is_array( $aliases ) && ! empty( $aliases ) ) {
+				foreach ( $aliases as $alias ) {
+					$style_targets[ $alias ] = $supported;
+				}
+			} elseif ( is_array( $supported ) ) {
+				$style_targets = [ (string) $fixture['widget_type'] => $supported ];
+			}
+		}
+
+		return [
+			'widget_type' => $fixture['widget_type'],
+			'catalog_visibility' => $fixture['expected_catalog_visibility'] ?? null,
+			'default_style_target' => $fixture['expected_default_style_target'] ?? null,
+			'settings' => $fixture['expected_settings'] ?? $fixture['expected_non_style_keys'] ?? null,
+			'style_targets' => $style_targets,
+			'unsupported' => $fixture['expected_unsupported'] ?? [],
+		];
+	}
+
+	/**
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function controls( string $widget_type ): array {
+		return V3_Widget_Fixtures::widget_config( $widget_type )['controls'];
+	}
+
+	public static function has_controls( string $widget_type ): bool {
+		return is_readable( __DIR__ . '/../fixtures/controls/' . $widget_type . '.json' );
+	}
+
+	/**
+	 * @param array<string, mixed> $fixture
+	 */
+	private static function assert_shape( array $fixture, string $file_name ): void {
+		if ( ! is_string( $fixture['widget_type'] ?? null ) || '' === $fixture['widget_type'] ) {
+			throw new \RuntimeException( sprintf( 'Parity fixture %s has an invalid `widget_type`.', $file_name ) );
+		}
+
+		$has_supported = array_key_exists( 'expected_supported', $fixture ) || array_key_exists( 'expected_style_targets', $fixture );
+		$has_unsupported = array_key_exists( 'expected_unsupported', $fixture );
+
+		if ( ! $has_supported || ! $has_unsupported ) {
+			throw new \RuntimeException( sprintf( 'Parity fixture %s must declare supported and unsupported CSS properties.', $file_name ) );
+		}
+
+		foreach ( [ 'expected_supported', 'expected_unsupported', 'expected_style_targets', 'expected_settings', 'expected_non_style_keys', 'expected_inner_aliases', 'expected_style_target_aliases' ] as $key ) {
+			if ( array_key_exists( $key, $fixture ) && null !== $fixture[ $key ] && ! is_array( $fixture[ $key ] ) ) {
+				throw new \RuntimeException( sprintf( 'Parity fixture %s: `%s` must be an array or null.', $file_name, $key ) );
+			}
+		}
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/support/test-parity-fixture-loader.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/support/test-parity-fixture-loader.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3\Support;
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once __DIR__ . '/parity-fixture-loader.php';
+require_once __DIR__ . '/../fixtures/v3-widget-fixtures.php';
+
+class Test_Parity_Fixture_Loader extends TestCase {
+
+	public function test_all__loads_launch_widget_fixtures() {
+		$fixtures = Parity_Fixture_Loader::all();
+
+		$this->assertSame( Parity_Fixture_Loader::LAUNCH_WIDGET_TYPES, array_keys( $fixtures ) );
+	}
+
+	public function test_compiled_expectations__normalizes_legacy_supported_list() {
+		$fixtures = Parity_Fixture_Loader::all();
+		$heading = Parity_Fixture_Loader::compiled_expectations( $fixtures['heading'] );
+
+		$this->assertSame( 'heading', $heading['widget_type'] );
+		$this->assertContains( 'color', $heading['style_targets']['heading'] );
+		$this->assertContains( 'filter', $heading['unsupported'] );
+	}
+
+	public function test_has_controls__is_true_only_for_captured_widgets() {
+		$this->assertTrue( Parity_Fixture_Loader::has_controls( 'nav-menu' ) );
+		$this->assertFalse( Parity_Fixture_Loader::has_controls( 'heading' ) );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-mcp-v3-standardized-maps-experiment.php
+++ b/tests/phpunit/elementor/modules/mcp/test-mcp-v3-standardized-maps-experiment.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Elementor\Tests\Phpunit\Elementor\Modules\Mcp;
+
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\Mcp\Module;
+use Elementor\Plugin;
+use ElementorEditorTesting\Elementor_Test_Base;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Mcp_V3_Standardized_Maps_Experiment extends Elementor_Test_Base {
+
+	private $original_experiment_default_state;
+
+	public function set_up() {
+		parent::set_up();
+
+		$features = Plugin::$instance->experiments->get_features( Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME );
+
+		if ( empty( $features ) ) {
+			Plugin::$instance->experiments->add_feature( Module::get_v3_standardized_maps_experimental_data() );
+			$features = Plugin::$instance->experiments->get_features( Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME );
+		}
+
+		$this->original_experiment_default_state = $features['default'];
+	}
+
+	public function tear_down() {
+		Plugin::$instance->experiments->set_feature_default_state(
+			Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME,
+			$this->original_experiment_default_state
+		);
+
+		delete_option( Experiments_Manager::OPTION_PREFIX . Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME );
+
+		parent::tear_down();
+	}
+
+	public function test_get_v3_standardized_maps_experimental_data__is_hidden_and_inactive() {
+		$data = Module::get_v3_standardized_maps_experimental_data();
+
+		$this->assertSame( Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME, $data['name'] );
+		$this->assertTrue( $data['hidden'] );
+		$this->assertSame( Experiments_Manager::STATE_INACTIVE, $data['default'] );
+		$this->assertSame( Experiments_Manager::RELEASE_STATUS_DEV, $data['release_status'] );
+		$this->assertArrayNotHasKey( 'new_site', $data );
+	}
+
+	public function test_experiment_can_be_activated() {
+		Plugin::$instance->experiments->set_feature_default_state(
+			Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME,
+			Experiments_Manager::STATE_ACTIVE
+		);
+
+		$is_active = Plugin::$instance->experiments->is_feature_active( Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME );
+
+		$this->assertTrue( $is_active );
+	}
+
+	public function test_get_experimental_data__does_not_gate_the_mcp_module() {
+		$this->assertSame( [], Module::get_experimental_data() );
+	}
+}


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Other... Please describe: Dormant MCP infrastructure behind a hidden inactive experiment. No production path switch.

## Summary

This PR can be summarized in the following changelog entry:

* Internal: Add a hidden inactive MCP V3 standardized-maps experiment and an explicit map compile contract.

## Description

MCP currently infers V3 widget capabilities at runtime. This PR adds the first dormant layer of the standardized-maps rollout so later PRs can compile explicit maps without changing the existing six-widget path.

* Register hidden `e_mcp_v3_standardized_maps` from the MCP module constructor (`default` inactive, `release_status` DEV, no `new_site`, no module-level `get_experimental_data()`).
* Add `Style_Control_Target`, `V3_Widget_Map_Compiler`, and `V3_Widget_Map_Registry`.
* Compile maps against provided widget controls and fail closed per widget for invalid shapes, missing controls, incompatible resolvers, incomplete group destinations, and nested repeaters.
* Flag off does not compile maps. Flag on caches invalid maps as `WP_Error` and keeps valid siblings working.
* Port the capture script and launch-widget control/parity fixtures; rewrite the parity loader around compiled-map expectations.
* Production schema, settings, and style appliers are unchanged.

Jira: https://elementor.atlassian.net/browse/ED-25529

## Test instructions
This PR can be tested by following these steps:

* Run `tests/phpunit/run-unit.sh tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/maps/test-v3-widget-map-compiler.php tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/maps/test-v3-widget-map-registry.php tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/support/test-parity-fixture-loader.php`
* Run `vendor/bin/phpunit --filter Test_Mcp_V3_Standardized_Maps_Experiment`
* Confirm existing MCP V3 schema/build/manage flows are unchanged with the experiment inactive.
* Confirm `wp elementor experiments status e_mcp_v3_standardized_maps` reports a hidden inactive feature after the MCP module constructs.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes ED-25529
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding dormant infrastructure for MCP V3 widget map contracts—an explicit, compilable alternative to runtime capability inference. This enables LLM-facing consistency guarantees: tested CSS property coverage, incompatible resolver detection, and nested-repeater validation before deployment.

## 2. What Changed (Where)

| File | Purpose |
|------|---------|
| `modules/mcp/abilities/appliers/v3/maps/style-control-target.php` | Builder DSL for declaring style target shapes (simple, typography, border, box-shadow, spacing). |
| `modules/mcp/abilities/appliers/v3/maps/v3-widget-map-compiler.php` | Validator: checks map schema, control types, resolver compatibility, rejects nested repeaters. |
| `modules/mcp/abilities/appliers/v3/maps/v3-widget-map-registry.php` | Runtime registry with experiment gating, compilation + caching, atomic visibility logic. |
| `modules/mcp/module.php` | Registers `e_mcp_v3_standardized_maps` experiment (hidden, dev-stage, inactive by default). |
| `bin/capture-v3-controls.php` | WP-CLI script: extracts live widget controls → JSON fixtures, deduplicates advanced tab. |
| `tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/*` | 15 fixture files (controls, parity expectations) + compiler/registry unit tests. |

## 3. How It Works

**Entry**: Experiment activation gates registry lookup. **Compilation**: Map + live controls → compiler validates shape (required fields, aliases, resolver→control compatibility), returns WP_Error on failure. **Cache**: Per-widget; invalid maps cached as errors to prevent replay. **Fixtures**: `V3_Widget_Fixtures` loads checked-in JSON (shared advanced controls merged per-widget); `Parity_Fixture_Loader` normalizes legacy test formats. **CLI**: `capture-v3-controls.php` pulls widget controls, strips advanced tab (reused), writes per-widget JSON.

## 4. Risks

**Schema rigidity**: Invalid maps throw early; no auto-repair. *Mitigation*: Clear validation errors, parity fixtures document expectations per widget. **Control sync drift**: Widget controls evolve; checked-in fixtures stale if not regenerated. *Mitigation*: CLI tooling + documented refresh process (not enforced here).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
