### PR TITLE
Internal: Add V3 Heading map foundation [ED-25529]

### DIFF
--- a/modules/mcp/abilities/appliers/v3/maps/heading-map.php
+++ b/modules/mcp/abilities/appliers/v3/maps/heading-map.php
@@ -11,9 +11,28 @@ return [
 	'description' => 'V3 heading. Exposed only when the V4 atomic experiment is off; when V4 is on, use `e-heading` instead.',
 	'catalog_visibility' => 'v4_disabled',
 	'settings' => [
-		'title' => [],
-		'link' => [],
-		'header_size' => [],
+		'title' => [
+			'type' => 'string',
+		],
+		'link' => [
+			'type' => 'object',
+			'properties' => [
+				'url' => [ 'type' => 'string' ],
+				'is_external' => [
+					'type' => 'string',
+					'enum' => [ 'on', '' ],
+				],
+				'nofollow' => [
+					'type' => 'string',
+					'enum' => [ 'on', '' ],
+				],
+			],
+		],
+		'header_size' => [
+			'type' => 'string',
+			'enum' => [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'span', 'p' ],
+			'default' => 'h2',
+		],
 	],
 	'default_style_target' => 'heading',
 	'style_targets' => [

--- a/modules/mcp/abilities/appliers/v3/maps/heading-map.php
+++ b/modules/mcp/abilities/appliers/v3/maps/heading-map.php
@@ -1,0 +1,30 @@
+<?php
+
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\Style_Control_Target;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'widget_type' => 'heading',
+	'description' => 'V3 heading. Exposed only when the V4 atomic experiment is off; when V4 is on, use `e-heading` instead.',
+	'catalog_visibility' => 'v4_disabled',
+	'settings' => [
+		'title' => [],
+		'link' => [],
+		'header_size' => [],
+	],
+	'default_style_target' => 'heading',
+	'style_targets' => [
+		'heading' => [
+			'label' => 'Heading',
+			'css_properties' => [
+				'color' => [
+					'default' => Style_Control_Target::control( 'title_color', 'color' ),
+					'hover' => Style_Control_Target::control( 'title_hover_color', 'color' ),
+				],
+			],
+		],
+	],
+];

--- a/modules/mcp/abilities/appliers/v3/maps/registered-maps.php
+++ b/modules/mcp/abilities/appliers/v3/maps/registered-maps.php
@@ -1,0 +1,9 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return [
+	'heading' => __DIR__ . '/heading-map.php',
+];

--- a/modules/mcp/abilities/appliers/v3/maps/style-control-target.php
+++ b/modules/mcp/abilities/appliers/v3/maps/style-control-target.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Style_Control_Target {
+
+	const KIND_SIMPLE = 'simple';
+
+	/**
+	 * @return array{kind: string, resolver: string, responsive: bool, destinations: array<int, array{setting: string, shape: string, resolver: string}>}
+	 */
+	public static function control( string $setting, string $resolver, bool $responsive = false ): array {
+		return [
+			'kind' => self::KIND_SIMPLE,
+			'resolver' => $resolver,
+			'responsive' => $responsive,
+			'destinations' => [
+				[
+					'setting' => $setting,
+					'shape' => 'string',
+					'resolver' => $resolver,
+				],
+			],
+		];
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/maps/v3-widget-map-compiler.php
+++ b/modules/mcp/abilities/appliers/v3/maps/v3-widget-map-compiler.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class V3_Widget_Map_Compiler {
+
+	const ERROR_CODE = 'elementor_v3_map_invalid';
+
+	const CATALOG_VISIBILITY_ALWAYS = 'always';
+	const CATALOG_VISIBILITY_V4_DISABLED = 'v4_disabled';
+
+	const REQUIRED_FIELDS = [
+		'widget_type',
+		'description',
+		'catalog_visibility',
+		'settings',
+		'default_style_target',
+		'style_targets',
+	];
+
+	const COMPATIBLE_CONTROL_TYPES = [
+		'color' => [ 'color' ],
+	];
+
+	/**
+	 * @param array<string, mixed> $map
+	 * @param array<string, mixed> $controls
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public function compile( array $map, array $controls, ?string $expected_widget_type = null ) {
+		$shape_error = $this->validate_map_shape( $map, $expected_widget_type );
+
+		if ( $shape_error instanceof WP_Error ) {
+			return $shape_error;
+		}
+
+		return $this->validate_style_targets( $map, $controls );
+	}
+
+	/**
+	 * @param array<string, mixed> $map
+	 * @return WP_Error|null
+	 */
+	private function validate_map_shape( array $map, ?string $expected_widget_type ) {
+		foreach ( self::REQUIRED_FIELDS as $field ) {
+			if ( ! array_key_exists( $field, $map ) || ( is_string( $map[ $field ] ) && '' === $map[ $field ] ) ) {
+				return $this->error( 'missing_field', $field );
+			}
+		}
+
+		if ( null !== $expected_widget_type && $expected_widget_type !== $map['widget_type'] ) {
+			return $this->error( 'widget_type_mismatch', $map['widget_type'] );
+		}
+
+		if ( ! in_array( $map['catalog_visibility'], [ self::CATALOG_VISIBILITY_ALWAYS, self::CATALOG_VISIBILITY_V4_DISABLED ], true ) ) {
+			return $this->error( 'invalid_visibility', $map['catalog_visibility'] );
+		}
+
+		if ( ! is_array( $map['settings'] ) || ! is_array( $map['style_targets'] ) || empty( $map['style_targets'] ) ) {
+			return $this->error( 'missing_field', 'style_targets' );
+		}
+
+		if ( ! isset( $map['style_targets'][ $map['default_style_target'] ] ) ) {
+			return $this->error( 'missing_default_style_target', $map['default_style_target'] );
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param array<string, mixed> $map
+	 * @param array<string, mixed> $controls
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private function validate_style_targets( array $map, array $controls ) {
+		foreach ( $map['style_targets'] as $alias => $target ) {
+			if ( ! is_string( $alias ) || 1 !== preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $alias ) ) {
+				return $this->error( 'invalid_alias', (string) $alias );
+			}
+
+			if ( ! is_array( $target ) || ! is_array( $target['css_properties'] ?? null ) ) {
+				return $this->error( 'missing_field', 'css_properties' );
+			}
+
+			foreach ( $target['css_properties'] as $property => $states ) {
+				if ( ! is_array( $states ) ) {
+					return $this->error( 'missing_field', (string) $property );
+				}
+
+				foreach ( $states as $descriptor ) {
+					$descriptor_error = $this->validate_descriptor( $descriptor, $controls );
+
+					if ( $descriptor_error instanceof WP_Error ) {
+						return $descriptor_error;
+					}
+				}
+			}
+		}
+
+		return $map;
+	}
+
+	/**
+	 * @param mixed                $descriptor
+	 * @param array<string, mixed> $controls
+	 * @return WP_Error|null
+	 */
+	private function validate_descriptor( $descriptor, array $controls ) {
+		if ( ! is_array( $descriptor ) || ! is_string( $descriptor['kind'] ?? null ) ) {
+			return $this->error( 'invalid_descriptor_kind', '' );
+		}
+
+		if ( Style_Control_Target::KIND_SIMPLE !== $descriptor['kind'] ) {
+			return $this->error( 'invalid_descriptor_kind', $descriptor['kind'] );
+		}
+
+		$destinations = $descriptor['destinations'] ?? null;
+
+		if ( ! is_array( $destinations ) || empty( $destinations ) ) {
+			return $this->error( 'missing_field', 'destinations' );
+		}
+
+		foreach ( $destinations as $destination ) {
+			$setting = $destination['setting'] ?? null;
+
+			if ( ! is_string( $setting ) || '' === $setting ) {
+				return $this->error( 'missing_control', '' );
+			}
+
+			if ( ! isset( $controls[ $setting ] ) ) {
+				return $this->error( 'missing_control', $setting );
+			}
+
+			$resolver = $destination['resolver'] ?? $descriptor['resolver'] ?? '';
+			$control_type = $controls[ $setting ]['type'] ?? '';
+
+			if ( ! $this->is_resolver_compatible( $resolver, $control_type ) ) {
+				return $this->error( 'incompatible_resolver', $setting );
+			}
+		}
+
+		return null;
+	}
+
+	private function is_resolver_compatible( string $resolver, string $control_type ): bool {
+		$allowed = self::COMPATIBLE_CONTROL_TYPES[ $resolver ] ?? null;
+
+		if ( null === $allowed ) {
+			return true;
+		}
+
+		return in_array( $control_type, $allowed, true );
+	}
+
+	private function error( string $reason, string $detail ): WP_Error {
+		return new WP_Error(
+			self::ERROR_CODE,
+			$reason,
+			[
+				'reason' => $reason,
+				'detail' => $detail,
+			]
+		);
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/maps/v3-widget-map-compiler.php
+++ b/modules/mcp/abilities/appliers/v3/maps/v3-widget-map-compiler.php
@@ -28,6 +28,8 @@ class V3_Widget_Map_Compiler {
 		'color' => [ 'color' ],
 	];
 
+	const ALLOWED_STATE_KEYS = [ 'default', 'hover' ];
+
 	/**
 	 * @param array<string, mixed> $map
 	 * @param array<string, mixed> $controls
@@ -93,7 +95,11 @@ class V3_Widget_Map_Compiler {
 					return $this->error( 'missing_field', (string) $property );
 				}
 
-				foreach ( $states as $descriptor ) {
+				foreach ( $states as $state_key => $descriptor ) {
+					if ( ! in_array( $state_key, self::ALLOWED_STATE_KEYS, true ) ) {
+						return $this->error( 'invalid_state_key', (string) $state_key );
+					}
+
 					$descriptor_error = $this->validate_descriptor( $descriptor, $controls );
 
 					if ( $descriptor_error instanceof WP_Error ) {

--- a/modules/mcp/abilities/appliers/v3/maps/v3-widget-map-registry.php
+++ b/modules/mcp/abilities/appliers/v3/maps/v3-widget-map-registry.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps;
+
+use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
+use Elementor\Modules\Mcp\Module as Mcp_Module;
+use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
+use Elementor\Plugin;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class V3_Widget_Map_Registry {
+
+	const MAPS_DIR = __DIR__;
+
+	/**
+	 * @var self|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * @var V3_Widget_Map_Compiler
+	 */
+	private $compiler;
+
+	/**
+	 * @var callable
+	 */
+	private $is_experiment_active;
+
+	/**
+	 * @var callable
+	 */
+	private $is_atomic_active;
+
+	/**
+	 * @var callable
+	 */
+	private $get_controls;
+
+	/**
+	 * @var array<string, array<string, mixed>>
+	 */
+	private $maps;
+
+	/**
+	 * @var array<string, array<string, mixed>|WP_Error>
+	 */
+	private $cache = [];
+
+	/**
+	 * @param V3_Widget_Map_Compiler                        $compiler
+	 * @param callable(): bool                              $is_experiment_active
+	 * @param callable(): bool                              $is_atomic_active
+	 * @param callable(string): (array<string, mixed>|null) $get_controls
+	 * @param array<string, array<string, mixed>>           $maps
+	 */
+	public function __construct(
+		V3_Widget_Map_Compiler $compiler,
+		callable $is_experiment_active,
+		callable $is_atomic_active,
+		callable $get_controls,
+		array $maps = []
+	) {
+		$this->compiler = $compiler;
+		$this->is_experiment_active = $is_experiment_active;
+		$this->is_atomic_active = $is_atomic_active;
+		$this->get_controls = $get_controls;
+		$this->maps = $maps;
+	}
+
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = self::create_default();
+		}
+
+		return self::$instance;
+	}
+
+	public static function create_default(): self {
+		return new self(
+			new V3_Widget_Map_Compiler(),
+			static fn() => Plugin::$instance->experiments->is_feature_active( Mcp_Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME ),
+			static fn() => Plugin::$instance->experiments->is_feature_active( Atomic_Widgets_Module::EXPERIMENT_NAME ),
+			static function ( string $widget_type ): ?array {
+				$widget = Plugin::$instance->widgets_manager->get_widget_types( $widget_type );
+
+				if ( ! $widget || ! method_exists( $widget, 'get_stack' ) ) {
+					return null;
+				}
+
+				$widget->get_stack();
+				$controls = $widget->get_controls();
+
+				return is_array( $controls ) ? $controls : null;
+			},
+			self::load_map_files()
+		);
+	}
+
+	/**
+	 * @return array<string, array<string, mixed>>
+	 */
+	private static function load_map_files(): array {
+		$maps = [];
+		$files = [
+			'heading' => self::MAPS_DIR . '/heading-map.php',
+		];
+
+		foreach ( $files as $widget_type => $path ) {
+			if ( ! is_readable( $path ) ) {
+				continue;
+			}
+
+			$map = require $path;
+
+			if ( is_array( $map ) ) {
+				$maps[ $widget_type ] = $map;
+			}
+		}
+
+		return $maps;
+	}
+
+	public static function reset_instance(): void {
+		self::$instance = null;
+	}
+
+	public function has_registered_map( string $widget_type ): bool {
+		return isset( $this->maps[ $widget_type ] );
+	}
+
+	public function is_experiment_active(): bool {
+		$callback = $this->is_experiment_active;
+
+		return (bool) $callback();
+	}
+
+	public function is_supported( string $widget_type ): bool {
+		if ( ! $this->is_experiment_active() ) {
+			return Widget_Context_Helper::is_v3_allowlisted( $widget_type );
+		}
+
+		$compiled = $this->get_compiled_map( $widget_type );
+
+		if ( null === $compiled || $compiled instanceof WP_Error ) {
+			return false;
+		}
+
+		if ( V3_Widget_Map_Compiler::CATALOG_VISIBILITY_ALWAYS === $compiled['catalog_visibility'] ) {
+			return true;
+		}
+
+		$is_atomic_active = $this->is_atomic_active;
+
+		return ! (bool) $is_atomic_active();
+	}
+
+	/**
+	 * @return array<string, mixed>|WP_Error|null
+	 */
+	public function get_compiled_map( string $widget_type ) {
+		if ( ! $this->is_experiment_active() ) {
+			return null;
+		}
+
+		if ( ! isset( $this->maps[ $widget_type ] ) ) {
+			return null;
+		}
+
+		if ( array_key_exists( $widget_type, $this->cache ) ) {
+			return $this->cache[ $widget_type ];
+		}
+
+		$get_controls = $this->get_controls;
+		$controls = $get_controls( $widget_type ) ?? [];
+		$compiled = $this->compiler->compile( $this->maps[ $widget_type ], $controls, $widget_type );
+
+		$this->cache[ $widget_type ] = $compiled;
+
+		return $compiled;
+	}
+
+	/**
+	 * @param array<string, mixed> $compiled_map
+	 * @return array{targets: array<string, string[]>}
+	 */
+	public function build_public_style_targets( array $compiled_map ): array {
+		$targets = [];
+
+		foreach ( $compiled_map['style_targets'] as $alias => $target ) {
+			if ( ! is_string( $alias ) || ! is_array( $target['css_properties'] ?? null ) ) {
+				continue;
+			}
+
+			$targets[ $alias ] = array_values( array_map( 'strval', array_keys( $target['css_properties'] ) ) );
+		}
+
+		return [ 'targets' => $targets ];
+	}
+}

--- a/modules/mcp/abilities/appliers/v3/maps/v3-widget-map-registry.php
+++ b/modules/mcp/abilities/appliers/v3/maps/v3-widget-map-registry.php
@@ -15,6 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class V3_Widget_Map_Registry {
 
 	const MAPS_DIR = __DIR__;
+	const REGISTERED_MAPS_FILE = __DIR__ . '/registered-maps.php';
 
 	/**
 	 * @var self|null
@@ -106,9 +107,11 @@ class V3_Widget_Map_Registry {
 	 */
 	private static function load_map_files(): array {
 		$maps = [];
-		$files = [
-			'heading' => self::MAPS_DIR . '/heading-map.php',
-		];
+		$files = is_readable( self::REGISTERED_MAPS_FILE ) ? require self::REGISTERED_MAPS_FILE : [];
+
+		if ( ! is_array( $files ) ) {
+			return $maps;
+		}
 
 		foreach ( $files as $widget_type => $path ) {
 			if ( ! is_readable( $path ) ) {
@@ -144,9 +147,9 @@ class V3_Widget_Map_Registry {
 			return Widget_Context_Helper::is_v3_allowlisted( $widget_type );
 		}
 
-		$compiled = $this->get_compiled_map( $widget_type );
+		$compiled = $this->get_validation_contract( $widget_type );
 
-		if ( null === $compiled || $compiled instanceof WP_Error ) {
+		if ( null === $compiled ) {
 			return false;
 		}
 
@@ -160,9 +163,43 @@ class V3_Widget_Map_Registry {
 	}
 
 	/**
+	 * Internal shape used by our system (is_supported, description lookup, etc.).
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public function get_validation_contract( string $widget_type ): ?array {
+		$compiled = $this->compile( $widget_type );
+
+		if ( null === $compiled || $compiled instanceof WP_Error ) {
+			return null;
+		}
+
+		return $compiled;
+	}
+
+	/**
+	 * Public shape exposed to the LLM as the widget contract.
+	 *
+	 * @return array{description: string, properties: array<string, array<string, mixed>>, style_targets: array{targets: array<string, string[]>}}|null
+	 */
+	public function get_llm_contract( string $widget_type ): ?array {
+		$compiled = $this->get_validation_contract( $widget_type );
+
+		if ( null === $compiled ) {
+			return null;
+		}
+
+		return [
+			'description' => (string) ( $compiled['description'] ?? '' ),
+			'properties' => is_array( $compiled['settings'] ?? null ) ? $compiled['settings'] : [],
+			'style_targets' => $this->build_style_targets_shape( $compiled ),
+		];
+	}
+
+	/**
 	 * @return array<string, mixed>|WP_Error|null
 	 */
-	public function get_compiled_map( string $widget_type ) {
+	private function compile( string $widget_type ) {
 		if ( ! $this->is_experiment_active() ) {
 			return null;
 		}
@@ -188,7 +225,7 @@ class V3_Widget_Map_Registry {
 	 * @param array<string, mixed> $compiled_map
 	 * @return array{targets: array<string, string[]>}
 	 */
-	public function build_public_style_targets( array $compiled_map ): array {
+	private function build_style_targets_shape( array $compiled_map ): array {
 		$targets = [];
 
 		foreach ( $compiled_map['style_targets'] as $alias => $target ) {

--- a/modules/mcp/abilities/get-widget-schema-ability.php
+++ b/modules/mcp/abilities/get-widget-schema-ability.php
@@ -69,7 +69,7 @@ class Get_Widget_Schema_Ability extends Abstract_Ability {
 
 		$is_v3 = Widget_Context_Helper::VERSION_V3 === Widget_Context_Helper::get_widget_version( $config );
 
-		if ( $is_v3 && ! Widget_Context_Helper::is_v3_allowlisted( $widget_type ) ) {
+		if ( $is_v3 && ! Widget_Context_Helper::is_v3_supported( $widget_type ) ) {
 			return new \WP_Error(
 				'elementor_v3_not_supported',
 				__( 'This is a legacy V3 widget and cannot be modified through this MCP. Edit V3 widgets directly in the Elementor editor.', 'elementor' ),
@@ -82,7 +82,34 @@ class Get_Widget_Schema_Ability extends Abstract_Ability {
 		}
 
 		if ( $is_v3 ) {
-			return Widget_Context_Helper::build_widget_schema( $widget_type, $config );
+			$schema = Widget_Context_Helper::build_widget_schema( $widget_type, $config );
+
+			if ( null === $schema && Widget_Context_Helper::is_standardized_maps_active() ) {
+				$compiled_map = \Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\V3_Widget_Map_Registry::instance()->get_compiled_map( $widget_type );
+
+				if ( $compiled_map instanceof \WP_Error ) {
+					return new \WP_Error(
+						$compiled_map->get_error_code(),
+						$compiled_map->get_error_message(),
+						[
+							'status' => \WP_Http::INTERNAL_SERVER_ERROR,
+							'widget_type' => $widget_type,
+							'reason' => $compiled_map->get_error_data()['reason'] ?? null,
+						]
+					);
+				}
+			}
+
+			if ( null === $schema ) {
+				return new \WP_Error(
+					'elementor_not_found',
+					/* translators: %s: widget type */
+					sprintf( __( 'Unknown widget type: %s.', 'elementor' ), $widget_type ),
+					[ 'status' => \WP_Http::NOT_FOUND ]
+				);
+			}
+
+			return $schema;
 		}
 
 		$all_widget_configs = Widget_Context_Helper::get_llm_eligible_widgets();

--- a/modules/mcp/abilities/get-widget-schema-ability.php
+++ b/modules/mcp/abilities/get-widget-schema-ability.php
@@ -84,22 +84,6 @@ class Get_Widget_Schema_Ability extends Abstract_Ability {
 		if ( $is_v3 ) {
 			$schema = Widget_Context_Helper::build_widget_schema( $widget_type, $config );
 
-			if ( null === $schema && Widget_Context_Helper::is_standardized_maps_active() ) {
-				$compiled_map = \Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\V3_Widget_Map_Registry::instance()->get_compiled_map( $widget_type );
-
-				if ( $compiled_map instanceof \WP_Error ) {
-					return new \WP_Error(
-						$compiled_map->get_error_code(),
-						$compiled_map->get_error_message(),
-						[
-							'status' => \WP_Http::INTERNAL_SERVER_ERROR,
-							'widget_type' => $widget_type,
-							'reason' => $compiled_map->get_error_data()['reason'] ?? null,
-						]
-					);
-				}
-			}
-
 			if ( null === $schema ) {
 				return new \WP_Error(
 					'elementor_not_found',

--- a/modules/mcp/abilities/list-widget-schemas-ability.php
+++ b/modules/mcp/abilities/list-widget-schemas-ability.php
@@ -55,7 +55,7 @@ class List_Widget_Schemas_Ability extends Abstract_Ability {
 					return true;
 				}
 
-				return Widget_Context_Helper::is_v3_allowlisted( (string) $type );
+				return Widget_Context_Helper::is_v3_supported( (string) $type );
 			},
 			ARRAY_FILTER_USE_BOTH
 		);
@@ -87,7 +87,13 @@ class List_Widget_Schemas_Ability extends Abstract_Ability {
 		$schemas = [];
 
 		foreach ( $widgets as $widget_type => $config ) {
-			$schemas[ $widget_type ] = Widget_Context_Helper::build_widget_schema( $widget_type, $config, $parents_index );
+			$schema = Widget_Context_Helper::build_widget_schema( $widget_type, $config, $parents_index );
+
+			if ( null === $schema ) {
+				continue;
+			}
+
+			$schemas[ $widget_type ] = $schema;
 		}
 
 		return $schemas;

--- a/modules/mcp/abilities/utils/widget-context-helper.php
+++ b/modules/mcp/abilities/utils/widget-context-helper.php
@@ -327,11 +327,10 @@ class Widget_Context_Helper {
 		}
 
 		if ( null !== $widget_type && self::is_v3_supported( $widget_type ) ) {
-			$registry = V3_Widget_Map_Registry::instance();
-			$compiled_map = $registry->get_compiled_map( $widget_type );
+			$contract = V3_Widget_Map_Registry::instance()->get_validation_contract( $widget_type );
 
-			if ( is_array( $compiled_map ) && is_string( $compiled_map['description'] ?? null ) && '' !== $compiled_map['description'] ) {
-				return $compiled_map['description'];
+			if ( is_array( $contract ) && is_string( $contract['description'] ?? null ) && '' !== $contract['description'] ) {
+				return $contract['description'];
 			}
 
 			if ( self::is_v3_allowlisted( $widget_type ) ) {
@@ -359,24 +358,23 @@ class Widget_Context_Helper {
 	}
 
 	private static function build_standardized_v3_widget_schema( string $widget_type, array $config ): ?array {
-		$registry = V3_Widget_Map_Registry::instance();
-		$compiled_map = $registry->get_compiled_map( $widget_type );
+		$contract = V3_Widget_Map_Registry::instance()->get_llm_contract( $widget_type );
 
-		if ( ! is_array( $compiled_map ) ) {
+		if ( null === $contract ) {
 			return null;
 		}
 
-		$allowed_keys = array_keys( $compiled_map['settings'] ?? [] );
-		$built = V3_Json_Schema_Builder::build( $config['controls'] ?? [], $allowed_keys );
+		$description = '' !== $contract['description']
+			? $contract['description']
+			: self::get_description( $config, $widget_type );
 
 		return self::filter_nulls( [
 			'type' => 'object',
 			'widget_version' => self::VERSION_V3,
-			'description' => self::get_description( $config, $widget_type ),
-			'properties' => $built['properties'],
-			'required' => $built['required'],
+			'description' => $description,
+			'properties' => $contract['properties'],
 			'additionalProperties' => false,
-			'style_targets' => $registry->build_public_style_targets( $compiled_map ),
+			'style_targets' => $contract['style_targets'],
 		] );
 	}
 }

--- a/modules/mcp/abilities/utils/widget-context-helper.php
+++ b/modules/mcp/abilities/utils/widget-context-helper.php
@@ -8,6 +8,7 @@ use Elementor\Modules\AtomicWidgets\PropTypes\Contracts\Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Escaped_Html_Prop_Type;
 use Elementor\Modules\AtomicWidgets\PropTypes\Utils\Plain_Llm_Schema_Converter;
 use Elementor\Modules\GlobalClasses\Utils\Atomic_Elements_Utils;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\V3_Widget_Map_Registry;
 use Elementor\Modules\Mcp\Abilities\Appliers\V3\V3_Widget_Bridge_Registry;
 use Elementor\Plugin;
 use Elementor\Utils;
@@ -47,18 +48,21 @@ class Widget_Context_Helper {
 	 * @return array<string, array> widget_type => config, filtered to widgets eligible for LLM use.
 	 */
 	public static function get_llm_eligible_widgets(): array {
-		$all_types = array_merge(
-			Plugin::$instance->widgets_manager->get_widget_types(),
-			Plugin::$instance->elements_manager->get_element_types()
-		);
-
 		$eligible = [];
 
-		foreach ( $all_types as $type => $instance ) {
-			if ( self::is_v3_allowlisted( (string) $type ) && method_exists( $instance, 'get_stack' ) ) {
+		foreach ( Plugin::$instance->widgets_manager->get_widget_types() as $type => $instance ) {
+			if ( self::should_initialize_v3_controls_stack( (string) $type ) && method_exists( $instance, 'get_stack' ) ) {
 				$instance->get_stack();
 			}
 
+			$config = $instance->get_config();
+
+			if ( self::is_widget_eligible_for_llm( $config ) ) {
+				$eligible[ $type ] = $config;
+			}
+		}
+
+		foreach ( Plugin::$instance->elements_manager->get_element_types() as $type => $instance ) {
 			$config = $instance->get_config();
 
 			if ( self::is_widget_eligible_for_llm( $config ) ) {
@@ -76,7 +80,7 @@ class Widget_Context_Helper {
 			return null;
 		}
 
-		if ( self::is_v3_allowlisted( $widget_type ) && method_exists( $instance, 'get_stack' ) ) {
+		if ( self::should_initialize_v3_controls_stack( $widget_type ) && method_exists( $instance, 'get_stack' ) ) {
 			$instance->get_stack();
 		}
 
@@ -109,6 +113,14 @@ class Widget_Context_Helper {
 
 	public static function is_v3_allowlisted( string $widget_type ): bool {
 		return in_array( $widget_type, self::V3_ALLOWLIST, true );
+	}
+
+	public static function is_v3_supported( string $widget_type ): bool {
+		return V3_Widget_Map_Registry::instance()->is_supported( $widget_type );
+	}
+
+	public static function is_standardized_maps_active(): bool {
+		return V3_Widget_Map_Registry::instance()->is_experiment_active();
 	}
 
 	public static function build_widget_summary( string $widget_type, array $config ): array {
@@ -151,6 +163,10 @@ class Widget_Context_Helper {
 		if ( ! $props_schema ) {
 			if ( ! self::has_v3_controls( $config['controls'] ?? null ) ) {
 				return null;
+			}
+
+			if ( self::is_standardized_maps_active() ) {
+				return self::build_standardized_v3_widget_schema( $widget_type, $config );
 			}
 
 			$allowed_keys = V3_Widget_Bridge_Registry::get_non_style_keys( $widget_type );
@@ -310,8 +326,17 @@ class Widget_Context_Helper {
 			return $description;
 		}
 
-		if ( null !== $widget_type && self::is_v3_allowlisted( $widget_type ) ) {
-			return V3_Widget_Bridge_Registry::get_description( $widget_type );
+		if ( null !== $widget_type && self::is_v3_supported( $widget_type ) ) {
+			$registry = V3_Widget_Map_Registry::instance();
+			$compiled_map = $registry->get_compiled_map( $widget_type );
+
+			if ( is_array( $compiled_map ) && is_string( $compiled_map['description'] ?? null ) && '' !== $compiled_map['description'] ) {
+				return $compiled_map['description'];
+			}
+
+			if ( self::is_v3_allowlisted( $widget_type ) ) {
+				return V3_Widget_Bridge_Registry::get_description( $widget_type );
+			}
 		}
 
 		return null;
@@ -319,5 +344,39 @@ class Widget_Context_Helper {
 
 	private static function filter_nulls( array $data ): array {
 		return array_filter( $data, fn( $value ) => null !== $value );
+	}
+
+	private static function should_initialize_v3_controls_stack( string $widget_type ): bool {
+		if ( self::is_v3_allowlisted( $widget_type ) ) {
+			return true;
+		}
+
+		if ( ! self::is_standardized_maps_active() ) {
+			return false;
+		}
+
+		return V3_Widget_Map_Registry::instance()->has_registered_map( $widget_type );
+	}
+
+	private static function build_standardized_v3_widget_schema( string $widget_type, array $config ): ?array {
+		$registry = V3_Widget_Map_Registry::instance();
+		$compiled_map = $registry->get_compiled_map( $widget_type );
+
+		if ( ! is_array( $compiled_map ) ) {
+			return null;
+		}
+
+		$allowed_keys = array_keys( $compiled_map['settings'] ?? [] );
+		$built = V3_Json_Schema_Builder::build( $config['controls'] ?? [], $allowed_keys );
+
+		return self::filter_nulls( [
+			'type' => 'object',
+			'widget_version' => self::VERSION_V3,
+			'description' => self::get_description( $config, $widget_type ),
+			'properties' => $built['properties'],
+			'required' => $built['required'],
+			'additionalProperties' => false,
+			'style_targets' => $registry->build_public_style_targets( $compiled_map ),
+		] );
 	}
 }

--- a/modules/mcp/module.php
+++ b/modules/mcp/module.php
@@ -3,6 +3,7 @@
 namespace Elementor\Modules\Mcp;
 
 use Elementor\Core\Base\Module as BaseModule;
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\MCP\Composer\Mcp\Registry as Shared_Registry;
 use Elementor\Modules\EditorOne\Classes\Menu_Data_Provider;
 use Elementor\Modules\Mcp\Abilities\Abstract_Ability;
@@ -11,6 +12,7 @@ use Elementor\Modules\Mcp\Preview\Public_Preview_Handler;
 use Elementor\Modules\Mcp\Registry\Ability_Registry;
 use Elementor\Modules\Mcp\RestApi\Mcp_Proxy_REST_API;
 use Elementor\Modules\Mcp\Utils\Editor_Sync_State;
+use Elementor\Plugin;
 use WP\MCP\Core\McpAdapter;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -20,6 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Module extends BaseModule {
 
 	const ANALYTICS_REGISTRAR_HANDLE = 'elementor-mcp-analytics-registrar';
+	const V3_STANDARDIZED_MAPS_EXPERIMENT_NAME = 'e_mcp_v3_standardized_maps';
 
 	private Ability_Registry $registry;
 
@@ -43,8 +46,21 @@ class Module extends BaseModule {
 			class_exists( Shared_Registry::class );
 	}
 
+	public static function get_v3_standardized_maps_experimental_data(): array {
+		return [
+			'name' => self::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME,
+			'title' => esc_html__( 'MCP V3 standardized maps', 'elementor' ),
+			'description' => esc_html__( 'Serve MCP V3 widgets from explicit compiled maps instead of inferred runtime capabilities.', 'elementor' ),
+			'hidden' => true,
+			'default' => Experiments_Manager::STATE_INACTIVE,
+			'release_status' => Experiments_Manager::RELEASE_STATUS_DEV,
+		];
+	}
+
 	public function __construct() {
 		parent::__construct();
+
+		$this->register_v3_standardized_maps_experiment();
 
 		$this->registry = self::build_core_registry();
 
@@ -60,6 +76,10 @@ class Module extends BaseModule {
 		add_action( 'wp_abilities_api_init', [ $this, 'register_abilities' ] );
 		add_action( 'init', [ $this, 'register_shared_registry_slugs' ], 5 );
 		add_action( 'elementor/editor-one/menu/register', [ $this, 'register_editor_one_menu' ], Editor_One_Mcp_Menu::REGISTER_PRIORITY_AFTER_SUBMISSIONS );
+	}
+
+	private function register_v3_standardized_maps_experiment(): void {
+		Plugin::$instance->experiments->add_feature( self::get_v3_standardized_maps_experimental_data() );
 	}
 
 	public function registry(): Ability_Registry {

--- a/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/maps/test-v3-widget-map-compiler.php
+++ b/tests/phpunit/elementor/modules/mcp/abilities/appliers/v3/maps/test-v3-widget-map-compiler.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Elementor\Testing\Modules\Mcp\Abilities\Appliers\V3\Maps;
+
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\Style_Control_Target;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\V3_Widget_Map_Compiler;
+use PHPUnit\Framework\TestCase;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_V3_Widget_Map_Compiler extends TestCase {
+
+	private function reason( WP_Error $error ): string {
+		$data = $error->get_error_data( $error->get_error_code() );
+
+		return is_array( $data ) ? (string) ( $data['reason'] ?? '' ) : '';
+	}
+
+	private function valid_map(): array {
+		return [
+			'widget_type' => 'heading',
+			'description' => 'Heading widget.',
+			'catalog_visibility' => V3_Widget_Map_Compiler::CATALOG_VISIBILITY_V4_DISABLED,
+			'settings' => [
+				'title' => [ 'type' => 'string' ],
+			],
+			'default_style_target' => 'heading',
+			'style_targets' => [
+				'heading' => [
+					'label' => 'Heading',
+					'css_properties' => [
+						'color' => [
+							'default' => Style_Control_Target::control( 'title_color', 'color' ),
+						],
+					],
+				],
+			],
+		];
+	}
+
+	private function controls(): array {
+		return [
+			'title_color' => [ 'type' => 'color' ],
+			'title_size' => [ 'type' => 'number' ],
+		];
+	}
+
+	public function test_compile__returns_map_on_valid_input() {
+		// Arrange.
+		$compiler = new V3_Widget_Map_Compiler();
+
+		// Act.
+		$result = $compiler->compile( $this->valid_map(), $this->controls(), 'heading' );
+
+		// Assert.
+		$this->assertIsArray( $result );
+		$this->assertSame( 'heading', $result['widget_type'] );
+	}
+
+	public function test_compile__errors_when_control_is_missing() {
+		// Arrange.
+		$compiler = new V3_Widget_Map_Compiler();
+		$map = $this->valid_map();
+		$map['style_targets']['heading']['css_properties']['color']['default'] = Style_Control_Target::control( 'nonexistent_color', 'color' );
+
+		// Act.
+		$result = $compiler->compile( $map, $this->controls(), 'heading' );
+
+		// Assert.
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'missing_control', $this->reason( $result ) );
+	}
+
+	public function test_compile__errors_when_resolver_incompatible_with_control_type() {
+		// Arrange.
+		$compiler = new V3_Widget_Map_Compiler();
+		$map = $this->valid_map();
+		$map['style_targets']['heading']['css_properties']['color']['default'] = Style_Control_Target::control( 'title_size', 'color' );
+
+		// Act.
+		$result = $compiler->compile( $map, $this->controls(), 'heading' );
+
+		// Assert.
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'incompatible_resolver', $this->reason( $result ) );
+	}
+
+	public function test_compile__errors_when_alias_is_invalid() {
+		// Arrange.
+		$compiler = new V3_Widget_Map_Compiler();
+		$map = $this->valid_map();
+		$map['style_targets']['Invalid_Alias'] = $map['style_targets']['heading'];
+		unset( $map['style_targets']['heading'] );
+		$map['default_style_target'] = 'Invalid_Alias';
+
+		// Act.
+		$result = $compiler->compile( $map, $this->controls(), 'heading' );
+
+		// Assert.
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_alias', $this->reason( $result ) );
+	}
+
+	public function test_compile__errors_when_widget_type_mismatch() {
+		// Arrange.
+		$compiler = new V3_Widget_Map_Compiler();
+
+		// Act.
+		$result = $compiler->compile( $this->valid_map(), $this->controls(), 'button' );
+
+		// Assert.
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'widget_type_mismatch', $this->reason( $result ) );
+	}
+
+	public function test_compile__errors_when_state_key_is_invalid() {
+		// Arrange.
+		$compiler = new V3_Widget_Map_Compiler();
+		$map = $this->valid_map();
+		$map['style_targets']['heading']['css_properties']['color']['defualt'] = Style_Control_Target::control( 'title_color', 'color' );
+		unset( $map['style_targets']['heading']['css_properties']['color']['default'] );
+
+		// Act.
+		$result = $compiler->compile( $map, $this->controls(), 'heading' );
+
+		// Assert.
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_state_key', $this->reason( $result ) );
+	}
+}

--- a/tests/phpunit/elementor/modules/mcp/test-get-widget-schema-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-get-widget-schema-ability.php
@@ -2,8 +2,12 @@
 
 namespace Elementor\Tests\Phpunit\Modules\Mcp;
 
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
+use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\V3_Widget_Map_Registry;
 use Elementor\Modules\Mcp\Abilities\Get_Widget_Schema_Ability;
 use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
+use Elementor\Modules\Mcp\Module as Mcp_Module;
 use Elementor\Plugin;
 use Elementor\Widgets_Manager;
 use ElementorEditorTesting\Elementor_Test_Base;
@@ -20,15 +24,68 @@ class Test_Get_Widget_Schema_Ability extends Elementor_Test_Base {
 	private Get_Widget_Schema_Ability $ability;
 	private Widgets_Manager $original_widgets_manager;
 
+	/**
+	 * @var array<string, string>
+	 */
+	private array $original_experiment_states = [];
+
 	public function setUp(): void {
 		parent::setUp();
 		$this->ability = new Get_Widget_Schema_Ability();
 		$this->original_widgets_manager = Plugin::$instance->widgets_manager;
+		$this->set_experiment_state( Mcp_Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME, Experiments_Manager::STATE_INACTIVE );
 	}
 
 	public function tearDown(): void {
+		foreach ( $this->original_experiment_states as $experiment_name => $default_state ) {
+			Plugin::$instance->experiments->set_feature_default_state( $experiment_name, $default_state );
+			delete_option( Experiments_Manager::OPTION_PREFIX . $experiment_name );
+		}
+
+		V3_Widget_Map_Registry::reset_instance();
 		Plugin::$instance->widgets_manager = $this->original_widgets_manager;
 		parent::tearDown();
+	}
+
+	public function test_execute__rejects_heading_when_standardized_maps_inactive() {
+		$this->act_as_admin();
+		$this->given_widget_manager_with_registered_heading();
+		$this->set_experiment_state( Mcp_Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME, Experiments_Manager::STATE_INACTIVE );
+
+		$result = $this->ability->execute( [ 'widget_type' => 'heading' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_v3_not_supported', $result->get_error_code() );
+	}
+
+	public function test_execute__returns_standardized_heading_schema_when_experiment_active() {
+		$this->act_as_admin();
+		$this->given_widget_manager_with_registered_heading();
+		$this->set_experiment_state( Mcp_Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME, Experiments_Manager::STATE_ACTIVE );
+		$this->set_experiment_state( Atomic_Widgets_Module::EXPERIMENT_NAME, Experiments_Manager::STATE_INACTIVE );
+
+		$result = $this->ability->execute( [ 'widget_type' => 'heading' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( Widget_Context_Helper::VERSION_V3, $result['widget_version'] );
+		$this->assertArrayNotHasKey( 'message', $result );
+		$this->assertArrayHasKey( 'title', $result['properties'] );
+		$this->assertArrayHasKey( 'link', $result['properties'] );
+		$this->assertArrayHasKey( 'header_size', $result['properties'] );
+		$this->assertSame( [ 'color' ], $result['style_targets']['targets']['heading'] );
+		$this->assertStringContainsString( 'e-heading', $result['description'] );
+	}
+
+	public function test_execute__rejects_heading_when_atomic_elements_active() {
+		$this->act_as_admin();
+		$this->given_widget_manager_with_registered_heading();
+		$this->set_experiment_state( Mcp_Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME, Experiments_Manager::STATE_ACTIVE );
+		$this->set_experiment_state( Atomic_Widgets_Module::EXPERIMENT_NAME, Experiments_Manager::STATE_ACTIVE );
+
+		$result = $this->ability->execute( [ 'widget_type' => 'heading' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'elementor_v3_not_supported', $result->get_error_code() );
 	}
 
 	public function test_execute__rejects_v3_widget_type() {
@@ -113,5 +170,27 @@ class Test_Get_Widget_Schema_Ability extends Elementor_Test_Base {
 			}
 		);
 		Plugin::$instance->widgets_manager = $widgets_manager;
+	}
+
+	private function given_widget_manager_with_registered_heading(): void {
+		$heading = $this->original_widgets_manager->get_widget_types( 'heading' );
+		$heading->get_stack();
+	}
+
+	private function set_experiment_state( string $experiment_name, string $state ): void {
+		if ( ! array_key_exists( $experiment_name, $this->original_experiment_states ) ) {
+			$features = Plugin::$instance->experiments->get_features( $experiment_name );
+
+			if ( empty( $features ) && Mcp_Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME === $experiment_name ) {
+				Plugin::$instance->experiments->add_feature( Mcp_Module::get_v3_standardized_maps_experimental_data() );
+				$features = Plugin::$instance->experiments->get_features( $experiment_name );
+			}
+
+			$this->original_experiment_states[ $experiment_name ] = $features['default'] ?? Experiments_Manager::STATE_DEFAULT;
+		}
+
+		Plugin::$instance->experiments->set_feature_default_state( $experiment_name, $state );
+		delete_option( Experiments_Manager::OPTION_PREFIX . $experiment_name );
+		V3_Widget_Map_Registry::reset_instance();
 	}
 }

--- a/tests/phpunit/elementor/modules/mcp/test-list-widget-schemas-ability.php
+++ b/tests/phpunit/elementor/modules/mcp/test-list-widget-schemas-ability.php
@@ -2,9 +2,14 @@
 
 namespace Elementor\Tests\Phpunit\Modules\Mcp;
 
+use Elementor\Core\Experiments\Manager as Experiments_Manager;
 use Elementor\Elements_Manager;
+use Elementor\Modules\AtomicWidgets\Module as Atomic_Widgets_Module;
+use Elementor\Modules\Mcp\Abilities\Appliers\V3\Maps\V3_Widget_Map_Registry;
+use Elementor\Modules\Mcp\Abilities\Get_Widget_Schema_Ability;
 use Elementor\Modules\Mcp\Abilities\List_Widget_Schemas_Ability;
 use Elementor\Modules\Mcp\Abilities\Utils\Widget_Context_Helper;
+use Elementor\Modules\Mcp\Module as Mcp_Module;
 use Elementor\Plugin;
 use Elementor\Widgets_Manager;
 use ElementorEditorTesting\Elementor_Test_Base;
@@ -19,20 +24,70 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Test_List_Widget_Schemas_Ability extends Elementor_Test_Base {
 
 	private List_Widget_Schemas_Ability $ability;
+	private Get_Widget_Schema_Ability $get_schema_ability;
 	private Widgets_Manager $original_widgets_manager;
 	private Elements_Manager $original_elements_manager;
+
+	/**
+	 * @var array<string, string>
+	 */
+	private array $original_experiment_states = [];
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->ability = new List_Widget_Schemas_Ability();
+		$this->get_schema_ability = new Get_Widget_Schema_Ability();
 		$this->original_widgets_manager = Plugin::$instance->widgets_manager;
 		$this->original_elements_manager = Plugin::$instance->elements_manager;
+		$this->set_experiment_state( Mcp_Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME, Experiments_Manager::STATE_INACTIVE );
 	}
 
 	public function tearDown(): void {
+		foreach ( $this->original_experiment_states as $experiment_name => $default_state ) {
+			Plugin::$instance->experiments->set_feature_default_state( $experiment_name, $default_state );
+			delete_option( Experiments_Manager::OPTION_PREFIX . $experiment_name );
+		}
+
+		V3_Widget_Map_Registry::reset_instance();
 		Plugin::$instance->widgets_manager = $this->original_widgets_manager;
 		Plugin::$instance->elements_manager = $this->original_elements_manager;
 		parent::tearDown();
+	}
+
+	public function test_execute__includes_heading_when_standardized_maps_active_and_atomic_inactive() {
+		$this->act_as_admin();
+		$this->given_managers_with_registered_heading();
+		$this->set_experiment_state( Mcp_Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME, Experiments_Manager::STATE_ACTIVE );
+		$this->set_experiment_state( Atomic_Widgets_Module::EXPERIMENT_NAME, Experiments_Manager::STATE_INACTIVE );
+
+		$result = $this->ability->execute( [] );
+
+		$this->assertArrayHasKey( 'heading', $result );
+		$this->assertSame( [ 'color' ], $result['heading']['style_targets']['targets']['heading'] );
+	}
+
+	public function test_execute__excludes_heading_when_atomic_elements_active() {
+		$this->act_as_admin();
+		$this->given_managers_with_registered_heading();
+		$this->set_experiment_state( Mcp_Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME, Experiments_Manager::STATE_ACTIVE );
+		$this->set_experiment_state( Atomic_Widgets_Module::EXPERIMENT_NAME, Experiments_Manager::STATE_ACTIVE );
+
+		$result = $this->ability->execute( [] );
+
+		$this->assertArrayNotHasKey( 'heading', $result );
+	}
+
+	public function test_execute__list_and_get_agree_for_heading_schema() {
+		$this->act_as_admin();
+		$this->given_managers_with_registered_heading();
+		$this->set_experiment_state( Mcp_Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME, Experiments_Manager::STATE_ACTIVE );
+		$this->set_experiment_state( Atomic_Widgets_Module::EXPERIMENT_NAME, Experiments_Manager::STATE_INACTIVE );
+
+		$list_result = $this->ability->execute( [] );
+		$get_result = $this->get_schema_ability->execute( [ 'widget_type' => 'heading' ] );
+
+		$this->assertIsArray( $get_result );
+		$this->assertSame( $get_result, $list_result['heading'] );
 	}
 
 	public function test_execute__includes_allowlisted_v3_and_excludes_other_v3() {
@@ -153,5 +208,31 @@ class Test_List_Widget_Schemas_Ability extends Elementor_Test_Base {
 		$elements_manager = $this->createMock( Elements_Manager::class );
 		$elements_manager->method( 'get_element_types' )->willReturn( [] );
 		Plugin::$instance->elements_manager = $elements_manager;
+	}
+
+	private function given_managers_with_registered_heading(): void {
+		$heading = $this->original_widgets_manager->get_widget_types( 'heading' );
+		$heading->get_stack();
+
+		$elements_manager = $this->createMock( Elements_Manager::class );
+		$elements_manager->method( 'get_element_types' )->willReturn( [] );
+		Plugin::$instance->elements_manager = $elements_manager;
+	}
+
+	private function set_experiment_state( string $experiment_name, string $state ): void {
+		if ( ! array_key_exists( $experiment_name, $this->original_experiment_states ) ) {
+			$features = Plugin::$instance->experiments->get_features( $experiment_name );
+
+			if ( empty( $features ) && Mcp_Module::V3_STANDARDIZED_MAPS_EXPERIMENT_NAME === $experiment_name ) {
+				Plugin::$instance->experiments->add_feature( Mcp_Module::get_v3_standardized_maps_experimental_data() );
+				$features = Plugin::$instance->experiments->get_features( $experiment_name );
+			}
+
+			$this->original_experiment_states[ $experiment_name ] = $features['default'] ?? Experiments_Manager::STATE_DEFAULT;
+		}
+
+		Plugin::$instance->experiments->set_feature_default_state( $experiment_name, $state );
+		delete_option( Experiments_Manager::OPTION_PREFIX . $experiment_name );
+		V3_Widget_Map_Registry::reset_instance();
 	}
 }


### PR DESCRIPTION
## Summary
- register a hidden, default-inactive experiment for standardized V3 MCP maps
- add the minimal map compiler, registry, and simple control descriptor required by Heading
- expose the Heading settings schema and supported style properties through widget schema abilities when enabled
- preserve the existing six-widget V3 schema path when the experiment is disabled

## Testing
- [x] `vendor/bin/phpunit --filter 'Test_(Get_Widget_Schema_Ability|List_Widget_Schemas_Ability)'`
- [x] PHPCS on all changed PHP files
- [x] PHP syntax checks on all changed production files

## Rollout
The experiment remains hidden and inactive by default. No build, update, style-write, or readback paths change in this PR.

Ref: ED-25529
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Implements a foundation for standardized V3 widget maps (ED-2529) to replace runtime inference with explicit, compiled schemas for LLM consumption. This improves reliability and allows fine-grained control over which V3 widgets are MCP-eligible.

## 2. What Changed (Where)

| File | Change |
| :--- | :--- |
| `heading-map.php` | Defined schema for the Heading widget. |
| `registered-maps.php` | Registry mapping widget types to map files. |
| `style-control-target.php` | Helper for defining CSS property targets. |
| `v3-widget-map-compiler.php` | Logic to validate and compile map shapes against actual controls. |
| `v3-widget-map-registry.php` | Singleton managing map loading, compilation, and LLM contract generation. |
| `get-widget-schema-ability.php` | Updated to use standardized maps for V3 widgets. |
| `list-widget-schemas-ability.php` | Updated to filter V3 widgets based on map support. |
| `widget-context-helper.php` | Integrated registry checks and standardized schema building. |
| `module.php` | Added `e_mcp_v3_standardized_maps` experiment. |
| `tests/...` | Added comprehensive unit tests for compiler and abilities. |

## 3. How It Works
The `V3_Widget_Map_Registry` loads defined maps and uses `V3_Widget_Map_Compiler` to verify that the map's requested controls actually exist on the widget instance. When the experiment is active, `Widget_Context_Helper` bypasses bridge inference to serve the explicit LLM contract (description, properties, and style targets) defined in the map.

## 4. Risks
* **Control Mismatches**: If a widget's controls change but the map isn't updated, the compiler will return a `WP_Error`, making the widget unsupported. Mitigation: High test coverage for compiler validation.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
