### PR TITLE
Fix: Allow deselecting Background Video states [ED-25504]

### DIFF
--- a/modules/atomic-widgets/controls/types/toggle-control.php
+++ b/modules/atomic-widgets/controls/types/toggle-control.php
@@ -13,6 +13,7 @@ class Toggle_Control extends Atomic_Control_Base {
 	private string $size = 'tiny';
 	private bool $exclusive = true;
 	private bool $convert_options = false;
+	private bool $allow_empty = false;
 
 	public function get_type(): string {
 		return 'toggle';
@@ -56,6 +57,12 @@ class Toggle_Control extends Atomic_Control_Base {
 		return $this;
 	}
 
+	public function set_allow_empty( bool $allow_empty ): self {
+		$this->allow_empty = $allow_empty;
+
+		return $this;
+	}
+
 	/**
 	 * Whether to convert the v3 options to v4 compatible
 	 *
@@ -75,6 +82,7 @@ class Toggle_Control extends Atomic_Control_Base {
 			'size' => $this->size,
 			'exclusive' => $this->exclusive,
 			'convertOptions' => $this->convert_options,
+			'allowEmpty' => $this->allow_empty,
 		];
 	}
 }

--- a/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video.php
+++ b/modules/atomic-widgets/elements/atomic-background-video/atomic-background-video.php
@@ -151,6 +151,7 @@ class Atomic_Background_Video extends Atomic_Element_Base {
 							'paused' => [ 'title' => esc_html__( 'Pause', 'elementor' ) ],
 						] )
 						->set_exclusive( true )
+						->set_allow_empty( true )
 						->set_convert_options( true )
 						->set_size( 'tiny' )
 						->set_full_width( true ),

--- a/modules/atomic-widgets/elements/atomic-background-video/handlers/background-video-handler.js
+++ b/modules/atomic-widgets/elements/atomic-background-video/handlers/background-video-handler.js
@@ -1,6 +1,6 @@
 import { register } from '@elementor/frontend-handlers';
 import { Alpine } from '@elementor/alpinejs';
-import { getEditorState, isEditorPreview } from './editor-background-video-state';
+import { getEditorState, isEditorPreview, resolveDesignTimeState } from './editor-background-video-state';
 
 const PLAYING_CLASS = 'e--playing';
 const PAUSED_CLASS = 'e--paused';
@@ -74,7 +74,7 @@ register( {
 			isPlaying: video ? ! video.paused : false,
 			isEditor: isEditorPreview(),
 			get editorState() {
-				return getEditorState( elementId, settings.state || 'playing' );
+				return getEditorState( elementId, resolveDesignTimeState( settings.state ) );
 			},
 
 			get previewState() {

--- a/modules/atomic-widgets/elements/atomic-background-video/handlers/background-video-preview-handler.js
+++ b/modules/atomic-widgets/elements/atomic-background-video/handlers/background-video-preview-handler.js
@@ -1,6 +1,6 @@
 import { register } from '@elementor/frontend-handlers';
 import { refreshTree } from '@elementor/alpinejs';
-import { setEditorState } from './editor-background-video-state';
+import { resolveDesignTimeState, setEditorState } from './editor-background-video-state';
 import { CONTROLS_ELEMENT_TYPE, PAUSE_ELEMENT_TYPE, PLAY_ELEMENT_TYPE } from './background-video-handler';
 
 register( {
@@ -9,7 +9,7 @@ register( {
 	callback: ( { element, settings, listenToChildren } ) => {
 		const elementId = element.dataset.id;
 
-		setEditorState( elementId, settings.state || 'playing' );
+		setEditorState( elementId, resolveDesignTimeState( settings.state ) );
 		refreshTree( element );
 
 		listenToChildren( [ PLAY_ELEMENT_TYPE, PAUSE_ELEMENT_TYPE, CONTROLS_ELEMENT_TYPE ] )

--- a/modules/atomic-widgets/elements/atomic-background-video/handlers/editor-background-video-state.js
+++ b/modules/atomic-widgets/elements/atomic-background-video/handlers/editor-background-video-state.js
@@ -1,9 +1,11 @@
 import { Alpine } from '@elementor/alpinejs';
 
 const STORE_NAME = 'editor-background-video-state';
+const PLAYING_STATE = 'playing';
+const PAUSED_STATE = 'paused';
 
 /**
- * @typedef {Record<string, 'playing' | 'paused'>} BackgroundVideoState
+ * @typedef {Record<string, 'playing' | 'paused' | ''>} BackgroundVideoState
  */
 
 function ensureStore() {
@@ -14,7 +16,19 @@ function ensureStore() {
 	return /** @type {BackgroundVideoState} */ ( Alpine.store( STORE_NAME ) );
 }
 
-export function getEditorState( elementId, fallback = 'playing' ) {
+export function resolveDesignTimeState( state, fallback = PLAYING_STATE ) {
+	if ( PLAYING_STATE === state || PAUSED_STATE === state ) {
+		return state;
+	}
+
+	if ( '' === state ) {
+		return '';
+	}
+
+	return fallback;
+}
+
+export function getEditorState( elementId, fallback = PLAYING_STATE ) {
 	const store = ensureStore();
 
 	return store[ elementId ] ?? fallback;

--- a/modules/atomic-widgets/module.php
+++ b/modules/atomic-widgets/module.php
@@ -664,6 +664,7 @@ class Module extends BaseModule {
 			// No state pinned (editor "States" unselected): hide both buttons. The two `:not` guards lift
 			// specificity above the atomic base style so `display: none` wins. On the frontend Alpine always
 			// sets one of the state classes from real playback, so exactly one button shows there.
+			'.e-background-video:not(.e-background-video--playing):not(.e-background-video--paused) .e-background-video__controls,',
 			'.e-background-video:not(.e-background-video--playing):not(.e-background-video--paused) .e-background-video__play,',
 			'.e-background-video:not(.e-background-video--playing):not(.e-background-video--paused) .e-background-video__pause { display: none; }',
 			// Accordion: `<summary>` already loses its native marker via `display: flex` on the header's

--- a/packages/packages/libs/editor-controls/src/controls/__tests__/toggle-control.test.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/__tests__/toggle-control.test.tsx
@@ -48,6 +48,37 @@ describe( 'ToggleControl', () => {
 				value: 'value2',
 			} );
 		} );
+
+		it( 'should persist an empty string when allowEmpty is true and the selected option is clicked', () => {
+			const props = {
+				setValue,
+				value: { $$type: 'string', value: 'value1' },
+				propType,
+			};
+
+			renderControl( <ToggleControl options={ mockOptions } exclusive={ true } allowEmpty={ true } />, props );
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Option 1' } ) );
+
+			expect( setValue ).toHaveBeenCalledWith( {
+				$$type: 'string',
+				value: '',
+			} );
+		} );
+
+		it( 'should not persist an empty string when allowEmpty is false and the selected option is clicked', () => {
+			const props = {
+				setValue,
+				value: { $$type: 'string', value: 'value1' },
+				propType,
+			};
+
+			renderControl( <ToggleControl options={ mockOptions } exclusive={ true } />, props );
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Option 1' } ) );
+
+			expect( setValue ).toHaveBeenCalledWith( null );
+		} );
 	} );
 
 	describe( ' non-exclusive mode', () => {

--- a/packages/packages/libs/editor-controls/src/controls/toggle-control.tsx
+++ b/packages/packages/libs/editor-controls/src/controls/toggle-control.tsx
@@ -14,6 +14,7 @@ export type ToggleControlProps< T extends PropValue > = {
 	exclusive?: boolean;
 	maxItems?: number;
 	convertOptions?: boolean;
+	allowEmpty?: boolean;
 };
 
 export const ToggleControl = createControl(
@@ -24,6 +25,7 @@ export const ToggleControl = createControl(
 		exclusive = true,
 		maxItems,
 		convertOptions = false,
+		allowEmpty = false,
 	}: ToggleControlProps< StringPropValue[ 'value' ] > ) => {
 		const { value, setValue, placeholder, disabled } = useBoundProp( stringPropTypeUtil );
 
@@ -54,11 +56,20 @@ export const ToggleControl = createControl(
 			placeholder,
 		};
 
+		const handleExclusiveToggle = ( selectedValue: StringPropValue[ 'value' ] | null ) => {
+			if ( allowEmpty && ! selectedValue ) {
+				setValue( '' );
+				return;
+			}
+
+			setValue( selectedValue );
+		};
+
 		return exclusive ? (
 			<ControlToggleButtonGroup
 				{ ...toggleButtonGroupProps }
-				value={ value ?? null }
-				onChange={ setValue }
+				value={ value || null }
+				onChange={ handleExclusiveToggle }
 				disabled={ disabled }
 				exclusive={ true }
 			/>

--- a/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-background-video.php
+++ b/tests/phpunit/elementor/modules/atomic-widgets/elements/test-atomic-background-video.php
@@ -24,4 +24,14 @@ class Test_Atomic_Background_Video extends Elementor_Test_Base {
 		$this->assertSame( 'playing', $schema['state']->get_default()['value'] );
 		$this->assertSame( [ 'playing', 'paused' ], $schema['state']->get_enum() );
 	}
+
+	public function test_empty_state_value_is_valid() {
+		$schema = $this->get_define_props_schema();
+
+		$this->assertTrue( $schema['state']->validate( [
+			'$$type' => 'string',
+			'value' => '',
+		] ) );
+		$this->assertTrue( $schema['state']->validate( null ) );
+	}
 }

--- a/tests/playwright/sanity/modules/v4-tests/background-video.test.ts
+++ b/tests/playwright/sanity/modules/v4-tests/background-video.test.ts
@@ -64,4 +64,24 @@ test.describe( 'Background Video @v4-tests', () => {
 		await expect( previewRoot ).toHaveClass( /e-background-video--paused/ );
 		await expect( previewRoot ).not.toHaveClass( /e-background-video--playing/ );
 	} );
+
+	test( 'User can deselect the active Background Video state', async () => {
+		const elementId = await editor.addElement( { elType: elementType }, 'document' );
+
+		await editor.selectElement( elementId );
+		await editor.v4Panel.openTab( 'general' );
+
+		const statesField = editor.page.locator( '[data-type="settings-field"]' ).filter( { hasText: 'States' } );
+		const playButton = statesField.getByRole( 'button', { name: 'Play' } );
+
+		await playButton.click();
+
+		await expect( playButton ).toHaveAttribute( 'aria-pressed', 'false' );
+		await expect( statesField.getByRole( 'button', { name: 'Pause' } ) ).toHaveAttribute( 'aria-pressed', 'false' );
+
+		const previewRoot = editor.getPreviewFrame().locator( editor.getWidgetSelector( elementId ) );
+		await expect( previewRoot ).not.toHaveClass( /e-background-video--playing/ );
+		await expect( previewRoot ).not.toHaveClass( /e-background-video--paused/ );
+		await expect( editor.getPreviewFrame().locator( `${ editor.getWidgetSelector( elementId ) } .e-background-video__controls` ) ).toBeHidden();
+	} );
 } );


### PR DESCRIPTION
## Summary
- Exclusive Background Video state toggles can be clicked again to deselect Play or Pause
- When neither state is selected, the canvas overlay is not shown
- Toggle Control supports an empty exclusive value so the editor does not restore Play after deselect

## Test plan
- [ ] Add a Background Video element and confirm Play is selected by default
- [ ] Click the selected Play state again; neither Play nor Pause is selected and the overlay is gone
- [ ] Click Pause; the overlay shows Pause. Click Pause again; neither state is selected and the overlay is gone
- [ ] Click Play; the overlay returns

## Jira
[ED-25504](https://elementor.atlassian.net/browse/ED-25504)

[ED-25504]: https://elementor.atlassian.net/browse/ED-25504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Allows users to deselect the "States" (Play/Pause) for Background Video widgets. Previously, the `Toggle_Control` forced a selection, preventing a neutral state where all controls are hidden in the editor. Fixes ED-25504.

## 2. What Changed (Where)

| File | Change |
| :--- | :--- |
| `toggle-control.php` / `.tsx` | Added `allowEmpty` property to enable null/empty value persistence. |
| `atomic-background-video.php` | Enabled `set_allow_empty(true)` for the States control. |
| `module.php` | CSS to hide controls when neither play nor pause state is active. |
| `editor-background-video-state.js` | Added `resolveDesignTimeState` to handle empty state values. |
| `background-video-handler.js` / `preview-handler.js` | Updated to use `resolveDesignTimeState` instead of hardcoded 'playing' fallback. |
| `test-atomic-background-video.php` / `toggle-control.test.tsx` / `background-video.test.ts` | Added validation for empty state values and deselection behavior. |

## 3. How It Works
The `Toggle_Control` now supports an `allowEmpty` flag; when true and an active option is clicked, it sets the value to an empty string. The background video logic replaces hardcoded 'playing' fallbacks with `resolveDesignTimeState`, which explicitly permits the empty string to propagate to the frontend, triggering CSS that hides the control UI.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
