### PR TITLE
fix: alpine.js never starts if init() runs after DOMContentLoaded

### DIFF
--- a/packages/packages/core/alpinejs/src/__tests__/init.test.ts
+++ b/packages/packages/core/alpinejs/src/__tests__/init.test.ts
@@ -1,0 +1,73 @@
+import { Alpine } from '@alpinejs/csp';
+import { init } from '../init';
+
+jest.mock( '@alpinejs/csp', () => ( {
+	Alpine: {
+		start: jest.fn(),
+	},
+} ) );
+
+function setReadyState( readyState: DocumentReadyState ) {
+	Object.defineProperty( document, 'readyState', {
+		value: readyState,
+		configurable: true,
+	} );
+}
+
+describe( 'init', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'starts Alpine immediately when the document has already finished loading', () => {
+		// Arrange.
+		setReadyState( 'complete' );
+
+		// Act.
+		init();
+
+		// Assert.
+		expect( Alpine.start ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'starts Alpine immediately when the document is interactive', () => {
+		// Arrange.
+		setReadyState( 'interactive' );
+
+		// Act.
+		init();
+
+		// Assert.
+		expect( Alpine.start ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'waits for `DOMContentLoaded` when the document is still loading', () => {
+		// Arrange.
+		setReadyState( 'loading' );
+
+		// Act.
+		init();
+
+		// Assert.
+		expect( Alpine.start ).not.toHaveBeenCalled();
+
+		// Act.
+		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+
+		// Assert.
+		expect( Alpine.start ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'never starts Alpine twice if `DOMContentLoaded` fires again', () => {
+		// Arrange.
+		setReadyState( 'loading' );
+		init();
+
+		// Act.
+		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+
+		// Assert.
+		expect( Alpine.start ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/packages/packages/core/alpinejs/src/init.ts
+++ b/packages/packages/core/alpinejs/src/init.ts
@@ -1,11 +1,20 @@
 import { Alpine } from '@alpinejs/csp';
 
 export function init() {
-	document.addEventListener(
-		'DOMContentLoaded',
-		() => {
-			Alpine.start();
-		},
-		{ once: true }
-	);
+	// `DOMContentLoaded` only ever fires once per document. If this module loads after that
+	// point (e.g. the editor canvas iframe finishes loading before this async chunk executes),
+	// the listener below would never run and Alpine would never start.
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener(
+			'DOMContentLoaded',
+			() => {
+				Alpine.start();
+			},
+			{ once: true }
+		);
+
+		return;
+	}
+
+	Alpine.start();
 }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md

## PR Type
- [x] Bugfix

## Summary
This PR can be summarized in the following changelog entry:
* Fix: Alpine.js never starts if init() runs after DOMContentLoaded

## Description
`@elementor/alpinejs`'s `init()` only ever attached a one-shot `DOMContentLoaded` listener to call `Alpine.start()`. That event fires exactly once per document; if `init()` runs after it has already fired (e.g. the editor canvas iframe finishes its own document load before this async chunk executes), the listener never runs and Alpine never starts.

This left Atomic Tabs (and any other Alpine-driven atomic widget) permanently uninitialized in the editor canvas: no `_x_dataStack`, no `aria-selected`, tab content panels stuck on their SSR `hidden` state. Manually calling `window.elementorV2.alpinejs.init()` from the console only "fixed" it on documents where `DOMContentLoaded` hadn't fired yet - matching the reported behavior of the workaround being session/timing dependent.

The fix checks `document.readyState` first: if the document has already finished loading, start Alpine immediately instead of waiting for an event that will never fire again.

## Test instructions
1. Create a Theme Builder Header (or any V4 document) containing Atomic Tabs (`e-tabs`) with several triggers and content panels.
2. Open the document in the editor (Atomic Editor enabled).
3. Confirm the default tab trigger is selected (`aria-selected="true"`) and its content panel is visible on load, without needing any manual console workaround.
4. Unit tests: `npx jest --config=./packages/jest.config.js packages/packages/core/alpinejs`

## Quality assurance
- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #36443
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Alpine.js initialization was unconditionally listening for `DOMContentLoaded`, which never fires if the init module loads after that event. Affects async-loaded chunks in iframes or deferred scripts.

## 2. What Changed (Where)

- `init.ts`: Added `document.readyState` check to immediately start Alpine if DOM is already loaded, otherwise register listener with `{ once: true }`
- `init.test.ts`: New test suite covering three states (complete/interactive/loading) and idempotency

## 3. How It Works

On `init()` call: if `readyState === 'loading'`, attach `DOMContentLoaded` listener; otherwise call `Alpine.start()` immediately. The `{ once: true }` flag prevents double-start if event fires multiple times (browser quirk edge case).

## 4. Risks

None. Defensive fix with good test coverage. Edge case where browser fires `DOMContentLoaded` twice is already handled.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
